### PR TITLE
feat(proxy): emit match_query in rendered iron-proxy config

### DIFF
--- a/services/api/api/proxy_config.py
+++ b/services/api/api/proxy_config.py
@@ -99,9 +99,9 @@ def _secret_action_block(secret: HttpSecret) -> tuple[str, dict[str, Any]]:
     """Return the ``replace``/``inject`` block iron-proxy expects for *secret*.
 
     Replace mode emits the ``proxy_value`` placeholder plus the scan locations
-    (``match_headers``, optional ``match_path``; iron-proxy always scans the
-    query string). Inject mode emits the target iron-proxy writes itself — a
-    header (with an optional Go-template ``formatter``) or a query parameter.
+    (``match_headers``, optional ``match_path``, optional ``match_query``).
+    Inject mode emits the target iron-proxy writes itself — a header (with an
+    optional Go-template ``formatter``) or a query parameter.
     """
     if secret.mode is SecretMode.REPLACE:
         block: dict[str, Any] = {
@@ -110,6 +110,8 @@ def _secret_action_block(secret: HttpSecret) -> tuple[str, dict[str, Any]]:
         }
         if secret.match_path:
             block["match_path"] = True
+        if secret.match_query:
+            block["match_query"] = True
         return "replace", block
     if secret.inject_query_param:
         return "inject", {"query_param": secret.inject_query_param}

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -88,9 +88,8 @@ class HttpSecret:
     value resolved from ``secret_ref`` (env var or 1Password item).
     ``match_headers`` names the exact headers iron-proxy scans — each entry is a
     literal header name or a ``/.../``-delimited regex. ``match_path`` also
-    scans the URL path. iron-proxy always scans the query string, so
-    ``match_query`` carries no extra config; it just records that the secret
-    rides in the query and lets such a secret skip ``match_headers``.
+    scans the URL path. ``match_query`` also scans the query string. At least
+    one of the three must be set.
 
     Inject mode: iron-proxy adds the credential itself and the tool never sees
     it. Set ``inject_header`` (optionally with a Go-template ``inject_formatter``

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -457,6 +457,7 @@ def test_render_emits_header_and_gcp_auth_transforms(
     assert entry["replace"]["proxy_value"] == "OPENAI_API_KEY"
     assert entry["replace"]["match_headers"] == ["Authorization"]
     assert "match_path" not in entry["replace"]
+    assert "match_query" not in entry["replace"]
     assert entry["rules"] == [{"host": "api.openai.com"}]
 
 
@@ -478,9 +479,9 @@ def test_render_replace_secret_emits_query_and_path_locations(
     entry = secrets_block["config"]["secrets"][0]
     replace_block = entry["replace"]
     assert replace_block["proxy_value"] == "ETHERSCAN_API_KEY"
-    # Query-only secrets carry no headers — iron-proxy always scans the query.
     assert replace_block["match_headers"] == []
     assert replace_block["match_path"] is True
+    assert replace_block["match_query"] is True
     assert entry["rules"] == [{"host": "api.etherscan.io"}]
 
 

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ironsh/iron-proxy:0.32.0@sha256:d55ae000173e52abcea40d26d7906c41bfc4ed42da3cac86541651bf1c976b8e
+FROM ironsh/iron-proxy:0.34.0@sha256:d5691525185f9cfe30244f36c888cde0eb5b1ce54dd5f6fd3ac76978b9fe5fef
 
 USER root
 RUN apk add --no-cache curl jq


### PR DESCRIPTION
Wires the existing ``match_query`` flag on ``HttpSecret`` through to the rendered iron-proxy ``secrets`` transform, alongside ``match_headers`` and ``match_path``. Bumps iron-proxy to 0.34.0, which is the version that adds the ``match_query`` config knob.