### PR TITLE
Avoid warning status for nonzero command exits

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -154,4 +154,53 @@ describe('AgentSessionRenderer', () => {
       sources: undefined
     })
   })
+
+  it('clears assistant status even when closing the stream fails', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async (params: any) => {
+            calls.push({ method: 'assistant.threads.setStatus', params })
+            return { ok: true }
+          }
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: false, error: 'stream_already_closed' }
+        }
+      }
+    }
+
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+
+    await renderer.text(sessionId, 'Finished reply')
+    await expect(renderer.done(sessionId)).rejects.toThrow('stream_already_closed')
+
+    expect(calls.at(-1)).toEqual({
+      method: 'assistant.threads.setStatus',
+      params: {
+        channel_id: 'C123',
+        thread_ts: '1778866921.505479',
+        status: ''
+      }
+    })
+  })
 })

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -126,16 +126,18 @@ export class AgentSessionRenderer {
     state.done = true
     state.footer = footer
 
-    for (const segment of state.segments) {
-      balancePendingMarkdown(segment)
-      await this.flushText(state, segment, { force: true })
-      const finalTaskUpdates = finalizeOpenTasks(segment)
-      for (const task of finalTaskUpdates) await this.flushTask(state, segment, task)
-      await this.closeTextStream(state, segment)
+    try {
+      for (const segment of state.segments) {
+        balancePendingMarkdown(segment)
+        await this.flushText(state, segment, { force: true })
+        const finalTaskUpdates = finalizeOpenTasks(segment)
+        for (const task of finalTaskUpdates) await this.flushTask(state, segment, task)
+        await this.closeTextStream(state, segment)
+      }
+    } finally {
+      await this.setStatus(sessionId, '')
+      sessions.delete(sessionId)
     }
-
-    await this.setStatus(sessionId, '')
-    sessions.delete(sessionId)
   }
 
   private async setStatus(sessionId: string, status: string): Promise<void> {
@@ -290,8 +292,8 @@ export class AgentSessionRenderer {
     chunks: AnyChunk[]
   ): Promise<void> {
     if (state.statusCleared || !hasVisibleStreamChunks(chunks)) return
-    state.statusCleared = true
     await this.setStatus(state.id, '')
+    state.statusCleared = true
   }
 
   private planPrefix(state: AgentSessionState, segment: Segment): AnyChunk[] {

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -82,6 +82,125 @@ describe('CodexSessionRenderer', () => {
     })
   })
 
+  it('does not mark completed commands as errors just because their exit code is non-zero', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async (params: any) => {
+            calls.push({ method: 'assistant.threads.setStatus', params })
+            return { ok: true }
+          }
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        }
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: {
+        id: 'cmd-1',
+        type: 'commandExecution',
+        command: 'test -f optional-file',
+        exitCode: 1
+      }
+    })
+
+    const taskUpdates = calls
+      .flatMap(call => call.params.chunks ?? [])
+      .filter(chunk => chunk.type === 'task_update')
+
+    expect(taskUpdates.at(-1)).toMatchObject({
+      type: 'task_update',
+      id: 'cmd-1',
+      title: 'Run command: test -f optional-file',
+      status: 'complete',
+      output: 'exit code 1'
+    })
+  })
+
+  it('still marks explicitly failed commands as errors', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async (params: any) => {
+            calls.push({ method: 'assistant.threads.setStatus', params })
+            return { ok: true }
+          }
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        }
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: {
+        id: 'cmd-1',
+        type: 'commandExecution',
+        command: 'pnpm test',
+        status: 'failed',
+        exitCode: 1
+      }
+    })
+
+    const taskUpdates = calls
+      .flatMap(call => call.params.chunks ?? [])
+      .filter(chunk => chunk.type === 'task_update')
+
+    expect(taskUpdates.at(-1)).toMatchObject({
+      type: 'task_update',
+      id: 'cmd-1',
+      title: 'Run command: pnpm test',
+      status: 'error',
+      output: 'exit code 1'
+    })
+  })
+
   it('pretty prints JSON command output before streaming it', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -471,7 +471,7 @@ function itemStatus(item: any, eventType: string, exitCode?: number | null): Har
   const status = String(item.status ?? '').toLowerCase()
   if (status === 'failed' || status === 'declined') return 'error'
   if (status === 'completed' || eventType === 'item.completed') {
-    return exitCode === 0 || exitCode === null || exitCode === undefined ? 'complete' : 'error'
+    return 'complete'
   }
   return 'in_progress'
 }


### PR DESCRIPTION
## Summary
- Treat completed Codex command steps as complete even when the command exit code is non-zero.
- Keep explicitly failed/declined command statuses rendering as errors.
- Add Slackbot renderer tests for non-zero exits and explicit failures.

## Tests
- bun test src/slack/codex-session.test.ts
- corepack pnpm --filter slackbot test

## Notes
- corepack pnpm --filter slackbot check:types is currently blocked by existing unrelated test fixture type errors in src/centaur/final-delivery.test.ts and src/index.test.ts.