### PR TITLE
fix(slack): show session title on final delivery

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -183,6 +183,17 @@ def prompt_identity(
     return prompt_ref, sha
 
 
+def _agent_session_title(*, persona_id: str | None, engine: str | None, harness: str | None) -> str:
+    parts = ["Centaur"]
+    persona = (persona_id or "").strip()
+    runtime = (engine or harness or "codex").strip()
+    if persona:
+        parts.append(persona)
+    if runtime and runtime != persona:
+        parts.append(runtime)
+    return " · ".join(parts)
+
+
 def flatten_event_parts(event: dict[str, Any]) -> list[dict[str, Any]]:
     message = event.get("message") if isinstance(event, dict) else None
     if not isinstance(message, dict):
@@ -1796,6 +1807,11 @@ async def _mark_execution_terminal(
                 "thread_key": thread_key,
                 "status": status,
                 "terminal_reason": terminal_reason,
+                "session_title": _agent_session_title(
+                    persona_id=persona_id,
+                    engine=engine,
+                    harness=harness,
+                ),
                 "result_text": result_text,
                 **({"error_text": error_text} if error_text else {}),
                 **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
@@ -1817,6 +1833,11 @@ async def _mark_execution_terminal(
             "thread_key": thread_key,
             "status": status,
             "terminal_reason": terminal_reason,
+            "session_title": _agent_session_title(
+                persona_id=persona_id,
+                engine=engine,
+                harness=harness,
+            ),
             "result_text": result_text,
             **({"error_text": error_text} if error_text else {}),
             **({"repo_context": repo_context} if repo_context else {}),

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -14,6 +14,16 @@ import pytest
 from api.sandbox.base import SandboxSession
 
 
+def test_agent_session_title_formats_base_and_persona_runs():
+    from api.runtime_control import _agent_session_title
+
+    assert _agent_session_title(persona_id=None, engine=None, harness="codex") == "Centaur · codex"
+    assert (
+        _agent_session_title(persona_id="invest", engine="amp", harness="invest")
+        == "Centaur · invest · amp"
+    )
+
+
 def _auth(api_key: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {api_key}"}
 
@@ -1388,6 +1398,7 @@ async def test_worker_sanitizes_raw_harness_auth_failure_after_retry(db_pool):
         "Please retry in a moment."
     )
     assert final_payload["error_text"] == "Unauthorized Check your access token."
+    assert final_payload["session_title"] == "Centaur · amp"
     stop_session_mock.assert_awaited_once_with(thread_key)
 
 

--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -43,7 +43,10 @@ describe('final delivery polling', () => {
                       recipient_team_id: 'T123',
                       recipient_user_id: 'U123'
                     },
-                    final_payload: { result_text: 'done once' }
+                    final_payload: {
+                      session_title: 'Centaur · codex',
+                      result_text: 'done once'
+                    }
                   }
                 ]
               : []
@@ -95,6 +98,9 @@ describe('final delivery polling', () => {
         fetchCalls.filter(call => call.path === '/agent/final-deliveries/exe-duplicate-guard/delivered')
       ).toHaveLength(1)
       expect(slackCalls.filter(call => call.method === 'chat.startStream')).toHaveLength(1)
+      expect(
+        (slackCalls.find(call => call.method === 'chat.startStream')?.params as any).chunks[0]
+      ).toEqual({ type: 'plan_update', title: 'Centaur · codex' })
       expect(slackCalls.filter(call => call.method === 'chat.stopStream')).toHaveLength(1)
     } finally {
       globalThis.fetch = originalFetch

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -70,10 +70,15 @@ async function deliver(client: WebClient, delivery: any): Promise<void> {
     parentTs: threadTs,
     recipientTeamId: String(meta.team_id ?? delivery.team_id ?? target.teamId ?? ''),
     recipientUserId: String(meta.recipient_user_id ?? meta.user_id ?? delivery.user_id ?? ''),
-    title: 'Execution steps'
+    title: sessionTitle(payload)
   })
   await renderer.text(sessionId, extractText(payload))
   await renderer.done(sessionId, deliveryFooter(payload))
+}
+
+function sessionTitle(payload: any): string {
+  const title = String(payload?.session_title ?? payload?.title ?? '').trim()
+  return title || 'Execution steps'
 }
 
 function extractText(payload: any): string {

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -51,6 +51,7 @@ describe('AgentSessionRenderer', () => {
     const start = calls.find(call => call.method === 'chat.startStream')
     expect(start?.params.task_display_mode).toBe('plan')
     expect(start?.params.chunks).toEqual([
+      { type: 'plan_update', title: 'Centaur execution' },
       {
         type: 'markdown_text',
         text: '```python\nprint("Hello, world!")\n```\n\nTiny keys wake up\n'
@@ -68,7 +69,6 @@ describe('AgentSessionRenderer', () => {
 
     const appends = calls.filter(call => call.method === 'chat.appendStream')
     expect(appends[0]?.params.chunks).toEqual([
-      { type: 'plan_update', title: 'Centaur execution' },
       {
         type: 'task_update',
         id: 'sleep-1',

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -253,7 +253,7 @@ export class AgentSessionRenderer {
     if (!markdown) return
     segment.pendingText = ''
     segment.streamedText += markdown
-    await this.streamChunks(state, segment, [markdownChunk(markdown)])
+    await this.streamChunks(state, segment, [...this.planPrefix(state, segment), markdownChunk(markdown)])
   }
 
   private async flushTask(


### PR DESCRIPTION
## Summary
- Include the compact `Centaur · {persona} · {runtime}` session title in final-delivery payloads.
- Use that title when Slackbot renders final-delivery streams instead of hardcoded `Execution steps`.
- Emit the plan title for text-only streams, not only task-update streams.

## Why
PR #845 fixed title computation, but this thread still rendered through the final-delivery fallback. That fallback did not carry the title, and text-only streams did not emit the plan header, so the visible Slack reply still had no persona/harness header.

## Verification
- `uv run ruff check api/runtime_control.py tests/test_agent_control_plane.py`
- `uv run pytest tests/test_agent_control_plane.py -k agent_session_title`
- `uv run pytest tests/test_workflow_engine_title.py`
- `corepack pnpm --filter slackbot test -- final-delivery.test.ts agent-session.test.ts codex-session.test.ts`
