### PR TITLE
Preserve Slack Connect recipient team

### DIFF
--- a/services/slackbot/src/centaur/handoff.test.ts
+++ b/services/slackbot/src/centaur/handoff.test.ts
@@ -123,4 +123,48 @@ describe('CentaurHandoff', () => {
       globalThis.fetch = originalFetch
     }
   })
+
+  it('uses recipient_team_id for Slack Connect delivery routing', async () => {
+    const originalFetch = globalThis.fetch
+    let capturedInit: RequestInit | undefined
+    const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedInit = init
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    })
+    globalThis.fetch = fetchMock as any
+    try {
+      const handoff = new CentaurHandoff(config)
+      const event: NormalizedSlackEvent = {
+        thread_key: 'slack:THOME:C123:1778883099.579529',
+        message_id: 'slack:THOME:C123:1778883099.579529',
+        team_id: 'THOME',
+        recipient_team_id: 'TEXTERNAL',
+        user_id: 'UEXTERNAL',
+        channel_id: 'C123',
+        thread_ts: '1778883099.579529',
+        is_mention: true,
+        parts: [{ type: 'text', text: 'hello' }],
+        slack: {
+          event_ts: '1778883100.000000',
+          message_ts: '1778883099.579529',
+          user_team: 'TEXTERNAL'
+        }
+      }
+
+      await handoff.emit(event)
+
+      const bodyText = capturedInit?.body
+      expect(typeof bodyText).toBe('string')
+      if (typeof bodyText !== 'string') throw new Error('expected JSON request body')
+      const body = JSON.parse(bodyText) as {
+        input: { delivery: { recipient_team_id: string; recipient_user_id: string } }
+      }
+      expect(body.input.delivery).toMatchObject({
+        recipient_team_id: 'TEXTERNAL',
+        recipient_user_id: 'UEXTERNAL'
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })

--- a/services/slackbot/src/centaur/handoff.ts
+++ b/services/slackbot/src/centaur/handoff.ts
@@ -35,7 +35,9 @@ export class CentaurHandoff {
             source: 'slackbot',
             slack: {
               message_ts: event.slack.message_ts,
-              enterprise_id: event.slack.enterprise_id
+              enterprise_id: event.slack.enterprise_id,
+              user_team: event.slack.user_team,
+              source_team: event.slack.source_team
             },
             is_mention: event.is_mention
           },
@@ -44,7 +46,7 @@ export class CentaurHandoff {
             channel: event.channel_id,
             thread_ts: event.thread_ts,
             recipient_user_id: event.user_id,
-            recipient_team_id: event.team_id
+            recipient_team_id: event.recipient_team_id ?? event.team_id
           }
         }
       })

--- a/services/slackbot/src/slack/normalize.test.ts
+++ b/services/slackbot/src/slack/normalize.test.ts
@@ -108,6 +108,35 @@ describe('normalizeSlackEnvelope', () => {
     }
   })
 
+  it('preserves Slack Connect user_team as recipient_team_id without changing thread key', async () => {
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'THOME',
+        event_id: 'Ev-slack-connect',
+        event: {
+          type: 'app_mention',
+          user: 'UEXTERNAL',
+          user_team: 'TEXTERNAL',
+          source_team: 'TEXTERNAL',
+          team: 'THOME',
+          channel: 'C123',
+          channel_type: 'channel',
+          thread_ts: '1778875060.000100',
+          ts: '1778875070.942789',
+          text: '<@UBOT> hello'
+        }
+      },
+      botUserId: 'UBOT',
+      client
+    })
+
+    expect(normalized?.thread_key).toBe('slack:THOME:C123:1778875060.000100')
+    expect(normalized?.team_id).toBe('THOME')
+    expect(normalized?.recipient_team_id).toBe('TEXTERNAL')
+    expect(normalized?.slack.user_team).toBe('TEXTERNAL')
+  })
+
   it('backfills prior Slack thread messages for mid-thread mentions', async () => {
     const replies = mock(async () => ({
       ok: true,

--- a/services/slackbot/src/slack/normalize.ts
+++ b/services/slackbot/src/slack/normalize.ts
@@ -5,6 +5,8 @@ type SlackMessageEvent = {
   type?: string
   subtype?: string
   user?: string
+  user_team?: string
+  source_team?: string
   bot_id?: string
   channel?: string
   channel_type?: string
@@ -75,6 +77,7 @@ export async function normalizeSlackEnvelope(opts: {
     thread_key: `slack:${teamId}:${event.channel}:${threadTs}`,
     message_id: `slack:${teamId}:${event.channel}:${event.ts}`,
     team_id: teamId,
+    recipient_team_id: recipientSlackTeamId(event) ?? teamId,
     user_id: event.user,
     channel_id: event.channel,
     thread_ts: threadTs,
@@ -85,9 +88,18 @@ export async function normalizeSlackEnvelope(opts: {
       event_id: opts.envelope.event_id,
       event_ts: event.event_ts,
       message_ts: event.ts,
-      enterprise_id: opts.envelope.enterprise_id
+      enterprise_id: opts.envelope.enterprise_id,
+      user_team: event.user_team,
+      source_team: event.source_team
     }
   }
+}
+
+function recipientSlackTeamId(event: SlackMessageEvent): string | undefined {
+  for (const candidate of [event.user_team, event.source_team, event.team]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim()
+  }
+  return undefined
 }
 
 function isMessageLikeEvent(event: SlackMessageEvent): boolean {

--- a/services/slackbot/src/slack/types.ts
+++ b/services/slackbot/src/slack/types.ts
@@ -24,6 +24,7 @@ export type NormalizedSlackEvent = {
   thread_key: string
   message_id: string
   team_id: string
+  recipient_team_id?: string
   user_id: string
   channel_id: string
   thread_ts: string
@@ -41,6 +42,8 @@ export type NormalizedSlackEvent = {
     event_ts?: string
     message_ts: string
     enterprise_id?: string
+    user_team?: string
+    source_team?: string
   }
 }
 


### PR DESCRIPTION
## Summary
- Preserve Slack Connect actor team as normalized recipient_team_id
- Use recipient_team_id for Slack delivery while keeping thread keys on the installed team
- Add normalization and handoff coverage for Slack Connect routing

## Test
- corepack pnpm --filter slackbot test