### PR TITLE
docs(security): add dedicated security page and align iron-proxy claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The main directories are:
 - [`services/api`](services/api/) — control plane for agents, tools, workflows, auth, and durable state
 - [`services/slackbot`](services/slackbot/) — Slack event handling and Slack delivery
 - [`services/sandbox`](services/sandbox/) — agent container image and harness adapter
-- [iron-proxy](https://iron.sh) ([service](services/iron-proxy/)) — controlled outbound access and credential injection
+- [iron-proxy](https://docs.iron.sh) ([service](services/iron-proxy/)) — controlled outbound access and credential injection
 - [`tools`](tools/) — tool plugins
 - [`workflows`](workflows/) — workflow plugins
 
@@ -134,7 +134,7 @@ for `SLACK_SIGNING_SECRET`.
 
 What they are for:
 
-- `OP_SERVICE_ACCOUNT_TOKEN`: lets [iron-proxy](https://iron.sh) resolve 1Password-backed runtime secrets
+- `OP_SERVICE_ACCOUNT_TOKEN`: lets [iron-proxy](https://docs.iron.sh) resolve 1Password-backed runtime secrets
 - `OP_VAULT`: the 1Password vault name or id to read from
 - `SLACK_BOT_TOKEN`: Slack bot token for the local Slackbot service
 - `SLACK_SIGNING_SECRET`: verifies incoming Slack requests
@@ -187,14 +187,13 @@ Use workflows when a task should run longer than one request, wait for something
 
 Centaur is designed around practical isolation and auditability:
 
-- each conversation runs in a Kubernetes sandbox
-- sandboxes call tools through the Centaur API
-- sandbox network access is restricted
-- real credentials are injected only at the controlled network boundary
+- each conversation runs in a Kubernetes sandbox with a default-deny NetworkPolicy
+- sandboxes call tools through the Centaur API and reach the outside world only through a per-sandbox [iron-proxy](https://docs.iron.sh)
+- sandboxes only ever see placeholder strings for upstream credentials; real values are swapped in by iron-proxy only on outbound requests to the specific hosts and headers a secret is bound to
 - messages, executions, events, and delivery state are persisted
 - outbound activity can be audited
 
-This gives agents useful power without treating them like trusted production services.
+See [Security](docs/pages/security.mdx) for the full threat model and the mechanisms behind each of these points, including known limitations like the shared credential vault.
 
 ## Documentation
 

--- a/docs/pages/architecture.mdx
+++ b/docs/pages/architecture.mdx
@@ -22,7 +22,7 @@ an event trail clients can replay.
 | Control | Persist requests and coordinate runtime state. | FastAPI, Postgres, execution worker. |
 | Execution | Run one assigned agent session per thread. | Kubernetes sandbox pods. |
 | Capabilities | Give agents approved actions. | Tool plugins, workflow engine, overlays. |
-| Secrets and egress | Let agents call third-party APIs without receiving raw keys. | Kubernetes Secret, [iron-proxy](https://docs.iron.sh), per-sandbox proxy config. |
+| Secrets and egress | Let agents call third-party APIs without receiving raw keys. | Kubernetes Secret, [iron-proxy](https://docs.iron.sh), per-sandbox proxy token mapping. |
 
 ## Durable API lifecycle
 
@@ -98,13 +98,14 @@ sleep for minutes or days, and parent/child workflow trees.
 ## Secrets and outbound requests
 
 Agents and tools refer to credentials by name, such as `OPENAI_API_KEY` or
-`secret("CRM_API_TOKEN")`. The API renders an [iron-proxy](https://docs.iron.sh) config from the tool
-secret declarations and the configured secret source. In production, [iron-proxy](https://docs.iron.sh)
-swaps placeholder names for real keys on outbound requests.
+`secret("CRM_API_TOKEN")`. The sandbox container only ever holds those
+placeholder names; the real values live on a per-sandbox
+[iron-proxy](https://docs.iron.sh) pod, bound to specific upstream hosts
+and request locations, and substituted on the wire when an outbound
+request matches.
 
-Prompts, transcripts, sandbox files, and logs can contain secret names without
-containing the raw credential. The proxy injects the real value for allowlisted
-hosts.
+See [Security](/security) for the full threat model and what it does
+and does not protect against.
 
 ## Failure model
 

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -74,8 +74,9 @@ Minimum keys:
 | `SLACK_BOT_TOKEN` | Slackbot | Bot User OAuth Token from the Slack app. |
 | `SLACK_SIGNING_SECRET` | Slackbot/API | Used to verify Slack webhook signatures. |
 | `SLACKBOT_API_KEY` | Slackbot to API | Static service token; API bootstraps it into Postgres on startup with `agent` scope. |
-| `OP_SERVICE_ACCOUNT_TOKEN` | [iron-proxy](https://docs.iron.sh) 1Password source | Needed when `ironProxy.secretSource` is `onepassword`. |
-| `OP_VAULT` | [iron-proxy](https://docs.iron.sh) 1Password source | Vault name or id used for `op://` references. |
+| `OP_CONNECT_TOKEN` | [iron-proxy](https://docs.iron.sh) 1Password Connect source (preferred) | Needed when `ironProxy.secretSource` is `onepassword-connect`. |
+| `OP_SERVICE_ACCOUNT_TOKEN` | [iron-proxy](https://docs.iron.sh) 1Password service-account source | Needed when `ironProxy.secretSource` is `onepassword`. |
+| `OP_VAULT` | [iron-proxy](https://docs.iron.sh) 1Password source | Vault name or id used for `op://` references (either mode). |
 
 `SLACKBOT_API_KEY` is not created with the admin API during initial boot, because
 the API process requires it before it can start. Generate a high-entropy value,
@@ -93,12 +94,18 @@ Store one secret per enabled harness credential:
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 
 In normal sandbox mode, containers receive placeholder values such as
-`OPENAI_API_KEY=OPENAI_API_KEY`. [iron-proxy](https://docs.iron.sh) replaces those placeholders with real
-secrets only for allowlisted upstream hosts.
+`OPENAI_API_KEY=OPENAI_API_KEY`. [iron-proxy](https://docs.iron.sh) swaps the
+placeholder for the real key on outbound requests, only on the hosts and
+headers the secret is bound to.
 
 When `ironProxy.secretSource` is `onepassword`, [iron-proxy](https://docs.iron.sh) resolves these values
 from `op://$OP_VAULT/<SECRET_NAME>/credential`. For example, store the default
 Codex credential in a 1Password item named `OPENAI_API_KEY`.
+
+Whatever source you pick, the vault is shared across the whole deployment,
+so any thread can use any configured credential. Per-user and per-channel
+scoping is on the roadmap; until then, scope tool and harness access
+accordingly. See [Security](/security) for the full threat model.
 
 ## 4. Configure Slack
 
@@ -141,8 +148,14 @@ api:
   warmPoolEnabled: true
 
 ironProxy:
-  secretSource: onepassword
+  secretSource: onepassword-connect
   secretTtl: 10m
+
+onepasswordConnect:
+  connect:
+    create: true
+    credentialsName: centaur-onepassword-connect-credentials
+    credentialsKey: 1password-credentials.json
 
 sandbox:
   image:

--- a/docs/pages/extend/tools.mdx
+++ b/docs/pages/extend/tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: Creating Tools
-description: Add Centaur tool plugins with client.py, pyproject metadata, allowed hosts, and secret placeholders.
+description: Add Centaur tool plugins with client.py, pyproject metadata, and typed secret declarations.
 ---
 
 # Creating Tools
@@ -34,13 +34,25 @@ build-backend = "hatchling.build"
 
 [tool.ai-v2]
 module = "client.py"
-hosts = ["warehouse.internal.example.com"]
-secrets = ["WAREHOUSE_API_KEY"]
+secrets = [
+    {type = "http", name = "WAREHOUSE_API_KEY", match_headers = ["Authorization"], hosts = ["warehouse.internal.example.com"]},
+]
 ```
 
-`hosts` is the outbound allowlist used by the proxy secret-injection path.
-`secrets` declares the placeholder values that the tool can request with
-`secret(...)`.
+Each entry in `secrets` declares one credential the tool can request with
+`secret(...)`. The fields tell iron-proxy what to swap and where:
+
+- `type = "http"` is the common case: an HTTP credential injected into outbound
+  requests. Other types include `oauth_token`, `gcp_auth`, and `pg_dsn` for
+  upstreams that need OAuth, Google service-account auth, or proxied Postgres.
+- `name` is the placeholder string the sandbox sees and what
+  `secret("...")` looks up.
+- `match_headers`, `match_query`, or `match_path` tell iron-proxy where in the
+  request the placeholder is allowed to appear. At least one is required.
+- `hosts` is the upstream allowlist for this secret. iron-proxy will only
+  inject the real value on requests to these hosts.
+
+Use `optional_secrets` for credentials the tool can run without.
 
 ## Write the client
 

--- a/docs/pages/secrets/environment.mdx
+++ b/docs/pages/secrets/environment.mdx
@@ -49,22 +49,21 @@ Secret from your shell environment.
 For:
 
 ```toml
-secrets = ["WAREHOUSE_API_KEY"]
+secrets = [
+    {type = "http", name = "WAREHOUSE_API_KEY", match_headers = ["Authorization"], hosts = ["warehouse.internal.example.com"]},
+]
 ```
 
-Centaur uses:
+the sandbox sees `WAREHOUSE_API_KEY` as a placeholder. In `env` mode,
+[iron-proxy](https://docs.iron.sh) reads the real value from an environment
+variable of the same name on the proxy container and substitutes it on
+outbound requests to `warehouse.internal.example.com` whose `Authorization`
+header contains the placeholder.
 
-- secret name: `WAREHOUSE_API_KEY`
-- secret reference: `WAREHOUSE_API_KEY`
-- placeholder value seen by the tool: `WAREHOUSE_API_KEY`
+## Other secret types
 
-In `env` mode, [iron-proxy](https://docs.iron.sh) reads the real value from the environment variable
-named by the secret reference.
-
-## Advanced secret entries
-
-Most tools should use the string form. The parser also supports explicit secret
-tables for special cases:
+`type = "http"` covers most cases. The parser also supports specialized types
+for upstreams that need more than a header swap:
 
 ```toml
 [[tool.ai-v2.secrets]]
@@ -81,7 +80,8 @@ database = "analytics"
 
 Use `gcp_auth` when [iron-proxy](https://docs.iron.sh) should mint Google OAuth tokens for Google APIs.
 Use `pg_dsn` when a sandbox needs a proxied Postgres DSN instead of a raw
-database URL.
+database URL. Use `oauth_token` for OAuth2 access-token minting against a
+named token endpoint.
 
 ## Verify
 
@@ -94,4 +94,4 @@ kubectl exec -n centaur-system deploy/centaur-centaur-api -- env | \
 
 Then call a tool that uses the secret and check that the upstream request works.
 If it fails, check the Kubernetes Secret key name, `ironProxy.secretSource`,
-tool `hosts`, and the declared `secrets`.
+and the secret entry's `hosts` and `match_*` fields.

--- a/docs/pages/secrets/onepassword.mdx
+++ b/docs/pages/secrets/onepassword.mdx
@@ -9,7 +9,46 @@ Use 1Password when you want tool and harness credentials to stay out of sandbox
 pods and out of the API process. Sandboxes receive placeholders. [iron-proxy](https://docs.iron.sh)
 resolves the real credential and injects it only for allowed upstream hosts.
 
-## Configure the chart
+There are two source modes:
+
+- `onepassword-connect` runs an in-cluster 1Password Connect server and has
+  iron-proxy talk to it with a Connect token. **This is the preferred mode
+  for production**, mostly because the service-account SDK is rate-limited
+  by 1Password and Connect is not. Under any non-trivial agent load you
+  will hit those limits with the SDK. Connect resolves locally against the
+  in-cluster server and stays out of the way.
+- `onepassword` uses a 1Password service-account token directly from
+  iron-proxy. Simpler to set up and fine for local development or low-volume
+  deployments, but expect throttling once real traffic shows up.
+
+## Configure the chart (Connect, preferred)
+
+```yaml
+ironProxy:
+  secretSource: onepassword-connect
+  secretTtl: 10m
+
+onepasswordConnect:
+  connect:
+    create: true
+    credentialsName: centaur-onepassword-connect-credentials
+    credentialsKey: 1password-credentials.json
+
+secretManager:
+  existingSecretName: centaur-infra-env
+  envPrefix: ""
+```
+
+The credentials Secret must contain `1password-credentials.json`; local
+bootstrap creates it when `OP_CONNECT_CREDENTIALS_FILE` points at that file.
+The infra Secret must include:
+
+```text
+OP_CONNECT_TOKEN
+OP_VAULT
+```
+
+## Configure the chart (service account)
 
 ```yaml
 ironProxy:
@@ -47,8 +86,9 @@ For the normal tool declaration:
 
 ```toml
 [tool.ai-v2]
-hosts = ["warehouse.internal.example.com"]
-secrets = ["WAREHOUSE_API_KEY"]
+secrets = [
+    {type = "http", name = "WAREHOUSE_API_KEY", match_headers = ["Authorization"], hosts = ["warehouse.internal.example.com"]},
+]
 ```
 
 Create a 1Password item named `WAREHOUSE_API_KEY` in `OP_VAULT`, with the value
@@ -59,8 +99,9 @@ op://$OP_VAULT/WAREHOUSE_API_KEY/credential
 ```
 
 The tool sees `WAREHOUSE_API_KEY` as a placeholder. For requests to
-`warehouse.internal.example.com`, [iron-proxy](https://docs.iron.sh) replaces that placeholder with the
-real 1Password value.
+`warehouse.internal.example.com` whose `Authorization` header contains the
+placeholder, [iron-proxy](https://docs.iron.sh) replaces it with the real
+1Password value.
 
 ## Harness credentials
 
@@ -73,34 +114,6 @@ Store enabled harness credentials the same way:
 | `ANTHROPIC_API_KEY` | Claude Code and pi-mono |
 
 Each item should live in `OP_VAULT` with its value in `credential`.
-
-## 1Password Connect
-
-Use service-account mode (`ironProxy.secretSource: onepassword`) unless your
-cluster already standardizes on an in-cluster 1Password Connect deployment.
-Connect mode is useful when operators want all 1Password access to go through a
-Connect server and token instead of direct service-account resolution from the
-proxy.
-
-If your cluster should run 1Password Connect with this chart, use:
-
-```yaml
-ironProxy:
-  secretSource: onepassword-connect
-
-onepasswordConnect:
-  connect:
-    create: true
-    credentialsName: centaur-onepassword-connect-credentials
-    credentialsKey: 1password-credentials.json
-```
-
-This mode resolves the same `op://$OP_VAULT/<secret_ref>/credential` references,
-but through the in-cluster Connect service.
-
-The credentials Secret must contain `1password-credentials.json`; local
-bootstrap creates it when `OP_CONNECT_CREDENTIALS_FILE` points at that file. The
-infra Secret must also include `OP_CONNECT_TOKEN`.
 
 ## Verify
 
@@ -120,5 +133,5 @@ kubectl get secret -n centaur-system centaur-infra-env -o jsonpath='{.data.OP_CO
 ```
 
 Then run a tool or harness call that reaches an allowed host. If injection
-fails, check the tool's `hosts`, declared `secrets`, item name, `OP_VAULT`, and
-whether the item has a `credential` field.
+fails, check the secret entry's `hosts` and `match_*` fields, the 1Password
+item name, `OP_VAULT`, and whether the item has a `credential` field.

--- a/docs/pages/security.mdx
+++ b/docs/pages/security.mdx
@@ -1,0 +1,143 @@
+---
+title: Security
+description: "Centaur's threat model and the mechanisms that defend against it: sandbox isolation, NetworkPolicy egress restriction, and iron-proxy secret binding."
+---
+
+# Security
+
+Centaur runs untrusted code on behalf of users: agent harnesses execute
+model-generated commands, tools fetch and act on external data, and
+prompts can be influenced by anyone whose content reaches the thread.
+This page describes what Centaur defends against and the mechanisms
+that do the defending.
+
+## Threat model
+
+The realistic threats are:
+
+- **Prompt injection and adversarial inputs.** A malicious instruction
+  in a Slack message, a tool response, a webpage the agent fetched, or
+  a file in the sandbox can cause the agent to take unintended actions:
+  exfiltrate data, call a sensitive tool, or attempt to reach an
+  attacker-controlled host.
+- **Compromised or malicious dependencies.** Tool code, agent harness
+  binaries, or libraries pulled into the sandbox could try to phone
+  home, mine credentials, or open a reverse shell.
+- **Credential abuse.** Anything that does run in the sandbox has the
+  potential to try to extract, log, or misuse the credentials a tool
+  needs to do its job.
+
+Centaur is not trying to defend against a fully privileged attacker
+already on the host or in the cluster control plane. The model is
+defense in depth for what runs inside the sandbox.
+
+## Mitigations
+
+### Sandbox isolation
+
+Each thread runs in its own Kubernetes pod, created and torn down by
+the API. Pods are short-lived and run a restricted container security
+context (no privilege escalation, all capabilities dropped). Code
+that runs in the sandbox cannot reach other sandboxes' filesystems,
+processes, or networking.
+
+### Network policy
+
+The Helm chart applies a default-deny NetworkPolicy to every pod in
+the namespace. Sandbox pods can only communicate with the Centaur
+API and their own dedicated per-sandbox iron-proxy pod. Nothing else
+in the cluster or on the internet is directly reachable. Because
+iron-proxy is per-sandbox rather than shared, a compromise of one
+sandbox's proxy cannot leak into another sandbox.
+
+### Egress policy
+
+All outbound traffic from the sandbox routes through iron-proxy, so
+egress policy is enforced in one place. By default the policy is
+open.
+
+To lock egress down, edit `services/api/api/iron-proxy.base.yaml` and
+replace:
+
+```yaml
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "*"
+```
+
+with the explicit list of hostnames (or globs like `*.anthropic.com`)
+your tools actually need. iron-proxy will reject everything else with
+a 403. See the [iron-proxy configuration reference](https://docs.iron.sh/reference/configuration/)
+for the full set of allowlist options.
+
+### Credentials
+
+Tool and harness credentials never reach the sandbox. Tools declare
+their secrets in `pyproject.toml`:
+
+```toml
+[tool.ai-v2]
+secrets = [
+    {type = "http", name = "WAREHOUSE_API_KEY", match_headers = ["Authorization"], hosts = ["warehouse.internal.example.com"]},
+]
+```
+
+Three properties of this declaration matter:
+
+- **Placeholders, not values.** The sandbox sees the literal string
+  `WAREHOUSE_API_KEY`. iron-proxy substitutes the real credential on
+  outbound requests; the value is never present in the sandbox's
+  environment, files, prompts, or logs.
+- **Bound to specific hosts.** The substitution only happens for the
+  hosts listed in `hosts`. A leaked placeholder cannot be redirected
+  to an attacker-controlled host.
+- **Bound to specific locations.** `match_headers`, `match_query`, or
+  `match_path` constrain where the placeholder is allowed to appear.
+  The placeholder cannot be smuggled out in a different field or
+  header.
+
+Other typed variants (`oauth_token`, `gcp_auth`, `pg_dsn`) extend the
+same pattern to OAuth2 token minting, Google service-account auth,
+and proxied Postgres connections. See
+[Creating Tools](/extend/tools) for the full schema.
+
+### Audit trail
+
+Every agent turn (user input, sandbox assignment, execution,
+streamed events, tool calls, final delivery) is persisted in
+Postgres. iron-proxy emits structured logs for every outbound
+request, including which secret was substituted and which transforms
+ran. Together they make it possible to reconstruct what an agent did
+and what credentials it reached for.
+
+## What this does not protect against
+
+A few honest caveats:
+
+- **Credentials are deployment-scoped, not yet user-scoped.** Tool
+  and harness secrets live in a single vault (a Kubernetes Secret or
+  a 1Password vault) that every sandbox in the deployment draws from,
+  so a tool's reach is the same regardless of which user invokes it.
+  Per-user and per-channel scoping is on the roadmap. A thread in
+  `#payments` would get the payments `GITHUB_TOKEN` rather than a
+  deployment-wide one, and a DM would resolve to the invoking user's
+  credentials. Until that lands, pick which tools and harnesses an
+  installation exposes with the current scope in mind.
+- **The default egress allowlist is permissive.** Leaving it open is
+  a deliberate UX choice. An open configuration lets users start
+  using agents immediately and develop an allowlist over time. If
+  you want maximal security, lock down the allowlist up front.
+- **Agents have broad permissions inside the sandbox.** They can
+  read and write the sandbox filesystem, run shell commands, and
+  call any Centaur tool their API token allows. The containment is
+  at the sandbox boundary, not inside it.
+- **Undesirable agent behavior in general.** Network and credential
+  controls limit the blast radius (real keys cannot leak, credentialed
+  calls cannot be redirected) but they do not prevent the agent from
+  doing something unwanted with the capabilities it legitimately has,
+  whether the cause is prompt injection, a confused model, an
+  over-eager harness, or buggy tool code. Tool design, especially for
+  destructive operations, should assume the agent will occasionally do
+  the wrong thing.

--- a/docs/pages/what-is-centaur.mdx
+++ b/docs/pages/what-is-centaur.mdx
@@ -29,9 +29,7 @@ This creates a narrow and auditable boundary for agent capabilities. Teams decid
 
 ## Credential-Safe Automation
 
-Sandbox pods receive stub keys and scoped Centaur API tokens. Real upstream credentials stay out of the sandbox and are injected at the network boundary by the firewall/proxy path only for approved destinations.
-
-The result is a practical security model for agents that need to call high-value systems: agents can use GitHub, model providers, data tools, or internal services without raw long-lived secrets sitting in their workspace.
+Sandboxes only ever see placeholder strings for upstream credentials. Real values live on [iron-proxy](https://docs.iron.sh), bound to specific hosts and headers, and are swapped in on the fly when a request matches. Agents can call GitHub, model providers, data tools, or internal services without raw long-lived secrets sitting in their workspace.
 
 ## Durable Workflows
 

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -8,6 +8,7 @@ export const sidebar = [
       { text: 'Quickstart', link: '/quickstart' },
       { text: 'Deploying in Production', link: '/deploying-in-production' },
       { text: 'Architecture', link: '/architecture' },
+      { text: 'Security', link: '/security' },
     ],
   },
   {

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -48,6 +48,11 @@ export default defineConfig({
       link: '/architecture',
       match: (path) => path === '/architecture',
     },
+    {
+      text: 'Security',
+      link: '/security',
+      match: (path) => path === '/security',
+    },
   ],
   socials: [{ icon: 'github', link: 'https://github.com/paradigmxyz/centaur' }],
   search: {
@@ -56,6 +61,7 @@ export default defineConfig({
       if (documentId.includes('quickstart')) return 4
       if (documentId.includes('extend/')) return 3.8
       if (documentId.includes('secrets/')) return 3.8
+      if (documentId.includes('security')) return 3.6
       if (documentId.includes('deploying-in-production')) return 3.5
       if (documentId.includes('architecture')) return 3
       return 1


### PR DESCRIPTION
Adds a Security page covering the threat model and mitigations (sandbox isolation, network policy, egress policy, credentials, audit trail), with honest notes on the deployment-scoped credential vault, the permissive default egress allowlist, and the broad permissions agents have inside the sandbox.

Updates the existing docs to match: typed `secrets` declarations across tool and secrets pages, 1Password Connect called out as the preferred source, and the architecture/README cross-references now point at the new page instead of restating the model.