### PR TITLE
fix(slackbot): consolidate `plan` cmd execs into multi-`task`

### DIFF
--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -88,6 +88,10 @@ describe('final delivery polling', () => {
         stopStream: async (params: unknown) => {
           slackCalls.push({ method: 'chat.stopStream', params })
           return { ok: true }
+        },
+        update: async (params: unknown) => {
+          slackCalls.push({ method: 'chat.update', params })
+          return { ok: true }
         }
       }
     }

--- a/services/slackbot/src/index.test.ts
+++ b/services/slackbot/src/index.test.ts
@@ -100,7 +100,9 @@ describe('Slack event HTTP dedupe', () => {
       const executionCtx = {
         waitUntil: (promise: Promise<unknown>) => {
           waits.push(promise)
-        }
+        },
+        passThroughOnException: () => {},
+        props: {}
       }
 
       const first = await app.request(

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -188,6 +188,10 @@ describe('AgentSessionRenderer', () => {
           stopAttempts += 1
           if (stopAttempts === 2) return { ok: true }
           return { ok: false, error: 'stream_already_closed' }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
         }
       }
     }

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -25,6 +25,10 @@ describe('AgentSessionRenderer', () => {
         stopStream: async (params: any) => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
         }
       }
     }
@@ -49,12 +53,15 @@ describe('AgentSessionRenderer', () => {
     await renderer.done(sessionId)
 
     const start = calls.find(call => call.method === 'chat.startStream')
-    expect(start?.params.task_display_mode).toBe('dense')
+    expect(start?.params.task_display_mode).toBe('plan')
     expect(start?.params.chunks).toEqual([
       { type: 'plan_update', title: 'Centaur execution' },
       {
-        type: 'markdown_text',
-        text: '```python\nprint("Hello, world!")\n```\n\nTiny keys wake up\n'
+        type: 'task_update',
+        id: 'sleep-1',
+        title: 'Run command',
+        status: 'in_progress',
+        details: '```bash\nsleep 2\n```'
       }
     ])
     expect(calls.slice(0, 3).map(call => call.method)).toEqual([
@@ -70,18 +77,16 @@ describe('AgentSessionRenderer', () => {
     const appends = calls.filter(call => call.method === 'chat.appendStream')
     expect(appends[0]?.params.chunks).toEqual([
       {
-        type: 'task_update',
-        id: 'sleep-1',
-        title: 'Run command',
-        status: 'in_progress',
-        details: '```bash\nsleep 2\n```',
-        output: undefined,
-        sources: undefined
+        type: 'markdown_text',
+        text: '```python\nprint("Hello, world!")\n```\n\nTiny keys wake up\n'
       }
     ])
     expect(appends[1]?.params.chunks).toEqual([
       { type: 'markdown_text', text: '\n```js\nconsole.log("Hello, world!")\n```' }
     ])
+    const update = calls.find(call => call.method === 'chat.update')
+    expect(update?.params.blocks?.[0]?.type).toBe('plan')
+    expect(update?.params.blocks?.[0]?.tasks?.[0]?.status).toBe('complete')
   })
 
   it('streams task updates with accumulated details and output', async () => {
@@ -106,6 +111,10 @@ describe('AgentSessionRenderer', () => {
         },
         stopStream: async (params: any) => {
           calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
           return { ok: true }
         }
       }
@@ -134,7 +143,7 @@ describe('AgentSessionRenderer', () => {
     })
 
     const start = calls.find(call => call.method === 'chat.startStream')
-    expect(start?.params.task_display_mode).toBe('dense')
+    expect(start?.params.task_display_mode).toBe('plan')
     expect(start?.params.chunks?.[0]).toEqual({
       type: 'plan_update',
       title: 'Centaur execution'
@@ -149,9 +158,7 @@ describe('AgentSessionRenderer', () => {
       id: 'cmd-1',
       title: 'Run command: pnpm test',
       status: 'complete',
-      details: undefined,
-      output: '```text\nok\n```',
-      sources: undefined
+      output: '```text\nok\n```'
     })
   })
 

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -49,7 +49,7 @@ describe('AgentSessionRenderer', () => {
     await renderer.done(sessionId)
 
     const start = calls.find(call => call.method === 'chat.startStream')
-    expect(start?.params.task_display_mode).toBe('plan')
+    expect(start?.params.task_display_mode).toBe('dense')
     expect(start?.params.chunks).toEqual([
       { type: 'plan_update', title: 'Centaur execution' },
       {
@@ -134,7 +134,7 @@ describe('AgentSessionRenderer', () => {
     })
 
     const start = calls.find(call => call.method === 'chat.startStream')
-    expect(start?.params.task_display_mode).toBe('plan')
+    expect(start?.params.task_display_mode).toBe('dense')
     expect(start?.params.chunks?.[0]).toEqual({
       type: 'plan_update',
       title: 'Centaur execution'

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -127,19 +127,16 @@ export class AgentSessionRenderer {
     state.footer = footer
     let closed = false
 
-    try {
-      for (const segment of state.segments) {
-        balancePendingMarkdown(segment)
-        await this.flushText(state, segment, { force: true })
-        const finalTaskUpdates = finalizeOpenTasks(segment)
-        for (const task of finalTaskUpdates) await this.flushTask(state, segment, task)
-        await this.closeTextStream(state, segment)
-      }
-      closed = true
-    } finally {
-      await this.setStatus(sessionId, '')
-      if (closed) sessions.delete(sessionId)
+    for (const segment of state.segments) {
+      balancePendingMarkdown(segment)
+      await this.flushText(state, segment, { force: true })
+      const finalTaskUpdates = finalizeOpenTasks(segment)
+      for (const task of finalTaskUpdates) await this.flushTask(state, segment, task)
+      await this.closeTextStream(state, segment, finalTaskSnapshot(segment))
     }
+
+    await this.setStatus(sessionId, '')
+    sessions.delete(sessionId)
   }
 
   private async setStatus(sessionId: string, status: string): Promise<void> {
@@ -153,12 +150,16 @@ export class AgentSessionRenderer {
     if (!response.ok) throw new Error(response.error ?? 'assistant.threads.setStatus failed')
   }
 
-  private async closeTextStream(state: AgentSessionState, segment: Segment): Promise<void> {
+  private async closeTextStream(
+    state: AgentSessionState,
+    segment: Segment,
+    finalTaskUpdates: StreamTask[] = []
+  ): Promise<void> {
     raiseStreamError(segment)
     if (segment.closed) return
     if (!segment.streamTs && !segment.textParts.length && !segment.tasks.size) return
     const footer = state.footer?.trim()
-    const chunks: AnyChunk[] = []
+    const chunks: AnyChunk[] = finalTaskUpdates.map(taskUpdateChunk)
     await this.ensureStream(state, segment, chunks)
     if (!segment.streamTs) return
     const response = await this.client.chat.stopStream({
@@ -281,7 +282,7 @@ export class AgentSessionRenderer {
       thread_ts: state.parentTs,
       recipient_team_id: state.recipientTeamId,
       recipient_user_id: state.recipientUserId,
-      task_display_mode: 'plan',
+      task_display_mode: 'dense',
       chunks: initialChunks.length ? initialChunks : [markdownChunk(' ')]
     })
     if (!response.ok || !response.ts) throw new Error(response.error ?? 'chat.startStream failed')
@@ -321,6 +322,10 @@ function finalizeOpenTasks(segment: Segment): StreamTask[] {
     updates.push(update)
   }
   return updates
+}
+
+function finalTaskSnapshot(segment: Segment): StreamTask[] {
+  return Array.from(segment.tasks.values())
 }
 
 function currentSegment(state: AgentSessionState): Segment {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -142,18 +142,21 @@ export class AgentSessionRenderer {
     state.footer = footer
     let closed = false
 
-    for (const segment of state.segments) {
-      balancePendingMarkdown(segment)
-      await this.flushText(state, segment, { force: true })
-      const finalizedTasks = finalizeOpenTasks(segment)
-      for (const task of finalizedTasks) {
-        await this.flushTask(state, segment, task)
+    try {
+      for (const segment of state.segments) {
+        balancePendingMarkdown(segment)
+        await this.flushText(state, segment, { force: true })
+        const finalizedTasks = finalizeOpenTasks(segment)
+        for (const task of finalizedTasks) {
+          await this.flushTask(state, segment, task)
+        }
+        await this.closeTextStream(state, segment)
       }
-      await this.closeTextStream(state, segment)
+      closed = true
+    } finally {
+      await this.setStatus(sessionId, '')
+      if (closed) sessions.delete(sessionId)
     }
-
-    await this.setStatus(sessionId, '')
-    sessions.delete(sessionId)
   }
 
   private async setStatus(sessionId: string, status: string): Promise<void> {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -3,11 +3,16 @@ import type { WebClient } from '@slack/web-api'
 import { ulid } from '@std/ulid'
 import {
   markdownChunk,
+  planBlock,
   planUpdateChunk,
+  preformatted,
+  richText,
   taskUpdateChunk,
+  type StreamRichText,
   type StreamTask,
   type StreamTaskStatus
 } from './streaming'
+import { renderMarkdownBlocks } from './render'
 
 type Segment = {
   id: string
@@ -48,8 +53,12 @@ export type StepInput = {
   id: string
   title: string
   status?: StreamTaskStatus
-  details?: string
-  output?: string
+  details?: StreamRichText | string
+  output?: StreamRichText | string
+}
+
+export type StepOptions = {
+  flush?: boolean
 }
 
 const sessions = new Map<string, AgentSessionState>()
@@ -57,6 +66,11 @@ const THINKING_STATUS = 'Thinking...'
 const TEXT_FLUSH_INTERVAL_MS = 250
 const TEXT_FLUSH_CHARS = 1000
 const FIRST_TEXT_FLUSH_CHARS = 1
+const EXECUTION_PLAN_ID = 'codex-execution-timeline'
+const FINAL_PLAN_MAX_TASKS = 12
+const FINAL_PLAN_TITLE_CHARS = 140
+const FINAL_PLAN_DETAILS_CHARS = 192
+const FINAL_PLAN_OUTPUT_CHARS = 256
 
 export class AgentSessionRenderer {
   constructor(private readonly client: WebClient) {}
@@ -97,7 +111,7 @@ export class AgentSessionRenderer {
     await this.queueText(state, segment, markdownDelta)
   }
 
-  async step(sessionId: string, input: StepInput): Promise<void> {
+  async step(sessionId: string, input: StepInput, opts: StepOptions = {}): Promise<void> {
     const state = requireSession(sessionId)
     const segment = currentSegment(state)
     const existing = segment.tasks.get(input.id)
@@ -117,8 +131,9 @@ export class AgentSessionRenderer {
       details: input.details !== undefined ? storedTask.details : undefined,
       output: input.output !== undefined ? storedTask.output : undefined
     }
-    await this.flushText(state, segment, { force: true })
+    if (opts.flush === false) return
     await this.flushTask(state, segment, taskUpdate)
+    await this.flushText(state, segment, { force: true })
   }
 
   async done(sessionId: string, footer?: string): Promise<void> {
@@ -130,9 +145,11 @@ export class AgentSessionRenderer {
     for (const segment of state.segments) {
       balancePendingMarkdown(segment)
       await this.flushText(state, segment, { force: true })
-      const finalTaskUpdates = finalizeOpenTasks(segment)
-      for (const task of finalTaskUpdates) await this.flushTask(state, segment, task)
-      await this.closeTextStream(state, segment, finalTaskSnapshot(segment))
+      const finalizedTasks = finalizeOpenTasks(segment)
+      for (const task of finalizedTasks) {
+        await this.flushTask(state, segment, task)
+      }
+      await this.closeTextStream(state, segment)
     }
 
     await this.setStatus(sessionId, '')
@@ -150,25 +167,34 @@ export class AgentSessionRenderer {
     if (!response.ok) throw new Error(response.error ?? 'assistant.threads.setStatus failed')
   }
 
-  private async closeTextStream(
-    state: AgentSessionState,
-    segment: Segment,
-    finalTaskUpdates: StreamTask[] = []
-  ): Promise<void> {
+  private async closeTextStream(state: AgentSessionState, segment: Segment): Promise<void> {
     raiseStreamError(segment)
     if (segment.closed) return
     if (!segment.streamTs && !segment.textParts.length && !segment.tasks.size) return
     const footer = state.footer?.trim()
-    const chunks: AnyChunk[] = finalTaskUpdates.map(taskUpdateChunk)
-    await this.ensureStream(state, segment, chunks)
+    await this.ensureStream(state, segment, [])
     if (!segment.streamTs) return
-    const response = await this.client.chat.stopStream({
+    const originalTasks = finalTaskSnapshot(segment)
+    const tasks = compactFinalTasks(originalTasks)
+    const blocks = [
+      ...(tasks.length ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)] : []),
+      ...renderMarkdownBlocks(segment.streamedText),
+      ...(footer ? footerBlocks(footer) : [])
+    ] as AnyBlock[]
+    const stopResponse = await this.client.chat.stopStream({
       channel: state.channel,
-      ts: segment.streamTs,
-      chunks: chunks.length ? chunks : undefined,
-      blocks: footer ? footerBlocks(footer) : undefined
+      ts: segment.streamTs
     })
-    if (!response.ok) throw new Error(response.error ?? 'chat.stopStream failed')
+    if (!stopResponse.ok) throw new Error(stopResponse.error ?? 'chat.stopStream failed')
+    if (blocks.length) {
+      const updateResponse = await this.client.chat.update({
+        channel: state.channel,
+        ts: segment.streamTs,
+        text: fallbackTextForBlocks(state.title, segment.streamedText, footer),
+        blocks
+      })
+      if (!updateResponse.ok) throw new Error(updateResponse.error ?? 'chat.update failed')
+    }
     segment.closed = true
   }
 
@@ -282,7 +308,7 @@ export class AgentSessionRenderer {
       thread_ts: state.parentTs,
       recipient_team_id: state.recipientTeamId,
       recipient_user_id: state.recipientUserId,
-      task_display_mode: 'dense',
+      task_display_mode: 'plan',
       chunks: initialChunks.length ? initialChunks : [markdownChunk(' ')]
     })
     if (!response.ok || !response.ts) throw new Error(response.error ?? 'chat.startStream failed')
@@ -326,6 +352,67 @@ function finalizeOpenTasks(segment: Segment): StreamTask[] {
 
 function finalTaskSnapshot(segment: Segment): StreamTask[] {
   return Array.from(segment.tasks.values())
+}
+
+function planTitle(title: string, tasks: StreamTask[]): string {
+  if (!tasks.length) return title
+  const total = tasks.length
+  const complete = tasks.filter(task => task.status === 'complete').length
+  const failed = tasks.filter(task => task.status === 'error').length
+  if (complete + failed === total) return `${title} (${total}/${total})`
+  return `${title} (${complete + failed}/${total})`
+}
+
+function compactFinalTasks(tasks: StreamTask[]): StreamTask[] {
+  const visible: StreamTask[] = tasks.slice(0, FINAL_PLAN_MAX_TASKS).map(task => ({
+    ...task,
+    title: clipText(task.title, FINAL_PLAN_TITLE_CHARS),
+    details: compactTaskBody(task.details, FINAL_PLAN_DETAILS_CHARS),
+    output: compactTaskBody(task.output, FINAL_PLAN_OUTPUT_CHARS)
+  }))
+  const omitted = tasks.length - visible.length
+  if (omitted <= 0) return visible
+  visible.push({
+    id: 'codex-execution-timeline-omitted',
+    title: `${omitted} additional command${omitted === 1 ? '' : 's'} omitted from Slack preview`,
+    status: 'complete',
+    details: richText([
+      preformatted(
+        'Additional command details were omitted to keep the Slack plan under message size limits.',
+        'text'
+      )
+    ])
+  })
+  return visible
+}
+
+function compactTaskBody(body: StreamTask['details'], maxChars: number): StreamTask['details'] {
+  if (!body) return undefined
+  if (typeof body === 'string') return clipText(body, maxChars)
+  const text = body.elements
+    .map(element =>
+      element.elements
+        .map(inline =>
+          'text' in inline ? inline.text : 'url' in inline ? inline.url : 'user_id' in inline ? `<@${inline.user_id}>` : ''
+        )
+        .join('')
+    )
+    .filter(Boolean)
+    .join('\n')
+  const firstPre = body.elements.find(element => element.type === 'rich_text_preformatted')
+  const language =
+    firstPre?.type === 'rich_text_preformatted' && 'language' in firstPre
+      ? String(firstPre.language)
+      : 'text'
+  return richText([preformatted(clipText(text, maxChars), language)])
+}
+
+function clipText(value: string, maxChars: number): string {
+  return value.length > maxChars ? `${value.slice(0, maxChars - 13)}\n// truncated` : value
+}
+
+function fallbackTextForBlocks(title: string, text: string, footer?: string): string {
+  return [title, text, footer].filter(Boolean).join('\n').slice(0, 3900) || title
 }
 
 function currentSegment(state: AgentSessionState): Segment {

--- a/services/slackbot/src/slack/client.ts
+++ b/services/slackbot/src/slack/client.ts
@@ -78,7 +78,7 @@ export class SlackEdgeClient {
     chunks?: AnyChunk[]
     recipientTeamId?: string
     recipientUserId?: string
-    taskDisplayMode?: 'plan' | 'timeline'
+    taskDisplayMode?: 'plan' | 'timeline' | 'dense'
   }): Promise<ChatStartStreamResponse> {
     const response = await this.client.chat.startStream({
       channel: opts.channel,

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -77,7 +77,8 @@ describe('CodexSessionRenderer', () => {
       title: 'Execution timeline',
       status: 'complete',
       details: undefined,
-      output: '```text\n[done] Run command: pnpm --filter slackbot test\n```',
+      output:
+        '[run]\n```sh\npnpm --filter slackbot test\n```\n\n[output]\n```text\none\ntwo\n```\nexit code 0',
       sources: undefined
     })
   })
@@ -126,6 +127,19 @@ describe('CodexSessionRenderer', () => {
       type: 'item.started',
       item: { id: 'cmd-2', type: 'commandExecution', command: 'call grafana health' }
     })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'call demo ping', exitCode: 0 }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: {
+        id: 'cmd-2',
+        type: 'commandExecution',
+        command: 'call grafana health',
+        exitCode: 1
+      }
+    })
 
     const taskUpdates = calls
       .flatMap(call => call.params.chunks ?? [])
@@ -133,9 +147,13 @@ describe('CodexSessionRenderer', () => {
 
     expect(new Set(taskUpdates.map(chunk => chunk.id))).toEqual(new Set(['codex-activity']))
     expect(taskUpdates.at(-1)?.details).toBeUndefined()
-    expect(taskUpdates.some(chunk => String(chunk.output).includes('call demo ping'))).toBe(true)
-    expect(taskUpdates.at(-1)?.output).toContain('call grafana health')
-    expect(taskUpdates.at(-1)?.output).toMatch(/^```text\n/)
+    expect(taskUpdates.some(chunk => richTextPlain(chunk.output).includes('call demo ping'))).toBe(
+      true
+    )
+    expect(richTextPlain(taskUpdates.at(-1)?.output)).toContain('call grafana health')
+    expect(richTextPlain(taskUpdates.at(-1)?.output)).toContain('[run]')
+    expect(taskUpdates.at(-1)?.output).toContain('```sh\ncall grafana health\n```')
+    expect(taskUpdates.at(-1)?.output).toContain('[error]')
   })
 
   it('marks the aggregate activity task complete on terminal turn events', async () => {
@@ -249,14 +267,25 @@ describe('CodexSessionRenderer', () => {
         }))
       })
     })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: {
+        id: 'cmd-1',
+        type: 'commandExecution',
+        command: 'call discover grafana',
+        exitCode: 0
+      }
+    })
 
     const taskUpdates = calls
       .flatMap(call => call.params.chunks ?? [])
       .filter(chunk => chunk.type === 'task_update')
 
-    const output = taskUpdates.map(chunk => chunk.output ?? '').join('\n')
-    expect(output).toContain('```text\n[run] Run command: call discover grafana')
-    expect(output).not.toContain('```json')
+    const output = taskUpdates.map(chunk => richTextPlain(chunk.output)).join('\n')
+    expect(output).toContain('[run]')
+    expect(output).toContain('call discover grafana')
+    expect(JSON.stringify(taskUpdates.map(chunk => chunk.output))).not.toContain('```text')
+    expect(JSON.stringify(taskUpdates.map(chunk => chunk.output))).toContain('```json')
     expect(output).not.toContain('"method-11"')
   })
 
@@ -318,14 +347,37 @@ describe('CodexSessionRenderer', () => {
         }
       })
     })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: {
+        id: 'cmd-1',
+        type: 'commandExecution',
+        command: 'call tools',
+        exitCode: 0
+      }
+    })
 
     const taskUpdates = calls
       .flatMap(call => call.params.chunks ?? [])
       .filter(chunk => chunk.type === 'task_update')
 
-    const output = taskUpdates.map(chunk => chunk.output ?? '').join('\n')
-    expect(output).toContain('```text\n[run] Run command: call tools')
-    expect(output).not.toContain('```json')
+    const output = taskUpdates.map(chunk => richTextPlain(chunk.output)).join('\n')
+    expect(output).toContain('[run]')
+    expect(output).toContain('call tools')
+    expect(JSON.stringify(taskUpdates.map(chunk => chunk.output))).not.toContain('```text')
+    expect(JSON.stringify(taskUpdates.map(chunk => chunk.output))).toContain('```json')
     expect(output).not.toContain('"grafana"')
   })
 })
+
+function richTextPlain(value: any): string {
+  if (!value) return ''
+  if (typeof value === 'string') return value
+  return (value.elements ?? [])
+    .map((element: any) =>
+      (element.elements ?? [])
+        .map((inline: any) => inline.text ?? inline.url ?? inline.user_id ?? '')
+        .join('')
+    )
+    .join('\n')
+}

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -73,65 +73,16 @@ describe('CodexSessionRenderer', () => {
 
     expect(taskUpdates.at(-1)).toEqual({
       type: 'task_update',
-      id: 'cmd-1',
-      title: 'Run command: pnpm --filter slackbot test',
+      id: 'codex-activity',
+      title: 'Execution timeline',
       status: 'complete',
       details: undefined,
-      output: '```text\none\ntwo\n\n```\n\nexit code 0',
+      output: '```text\n[done] Run command: pnpm --filter slackbot test\n```',
       sources: undefined
     })
   })
 
-  it('keeps terminal events retryable when stream close fails', async () => {
-    const calls: Array<{ method: string; params: any }> = []
-    let stopAttempts = 0
-    const client = {
-      assistant: {
-        threads: {
-          setStatus: async (params: any) => {
-            calls.push({ method: 'assistant.threads.setStatus', params })
-            return { ok: true }
-          }
-        }
-      },
-      chat: {
-        startStream: async (params: any) => {
-          calls.push({ method: 'chat.startStream', params })
-          return { ok: true, ts: '1778866940.295499' }
-        },
-        appendStream: async (params: any) => {
-          calls.push({ method: 'chat.appendStream', params })
-          return { ok: true }
-        },
-        stopStream: async (params: any) => {
-          calls.push({ method: 'chat.stopStream', params })
-          stopAttempts += 1
-          if (stopAttempts === 2) return { ok: true }
-          return { ok: false, error: 'stream_already_closed' }
-        }
-      }
-    }
-
-    const { sessionId } = await new AgentSessionRenderer(client as any).open({
-      channel: 'C123',
-      parentTs: '1778866921.505479',
-      recipientTeamId: 'T123',
-      recipientUserId: 'U123',
-      title: 'Centaur execution'
-    })
-    const renderer = new CodexSessionRenderer(client as any)
-    const terminalEvent = { type: 'result', result: 'Finished reply' }
-
-    await expect(renderer.event(sessionId, terminalEvent)).rejects.toThrow(
-      'stream_already_closed'
-    )
-    await expect(renderer.event(sessionId, terminalEvent)).resolves.toMatchObject({
-      done: true
-    })
-    expect(stopAttempts).toBe(2)
-  })
-
-  it('does not mark completed commands as errors just because their exit code is non-zero', async () => {
+  it('renders multiple command executions as one visible activity task', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -168,86 +119,78 @@ describe('CodexSessionRenderer', () => {
     const renderer = new CodexSessionRenderer(client as any)
 
     await renderer.event(sessionId, {
-      type: 'item.completed',
-      item: {
-        id: 'cmd-1',
-        type: 'commandExecution',
-        command: 'test -f optional-file',
-        exitCode: 1
-      }
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'call demo ping' }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'cmd-2', type: 'commandExecution', command: 'call grafana health' }
     })
 
     const taskUpdates = calls
       .flatMap(call => call.params.chunks ?? [])
       .filter(chunk => chunk.type === 'task_update')
 
+    expect(new Set(taskUpdates.map(chunk => chunk.id))).toEqual(new Set(['codex-activity']))
+    expect(taskUpdates.at(-1)?.details).toBeUndefined()
+    expect(taskUpdates.some(chunk => String(chunk.output).includes('call demo ping'))).toBe(true)
+    expect(taskUpdates.at(-1)?.output).toContain('call grafana health')
+    expect(taskUpdates.at(-1)?.output).toMatch(/^```text\n/)
+  })
+
+  it('marks the aggregate activity task complete on terminal turn events', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async (params: any) => {
+            calls.push({ method: 'assistant.threads.setStatus', params })
+            return { ok: true }
+          }
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        }
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'call demo ping' }
+    })
+    await renderer.event(sessionId, { type: 'turn.completed' })
+
+    const taskUpdates = calls
+      .flatMap(call => call.params.chunks ?? [])
+      .filter(chunk => chunk.type === 'task_update')
+
     expect(taskUpdates.at(-1)).toMatchObject({
-      type: 'task_update',
-      id: 'cmd-1',
-      title: 'Run command: test -f optional-file',
+      id: 'codex-activity',
       status: 'complete',
-      output: 'exit code 1'
+      title: 'Execution timeline',
+      output: undefined
     })
-  })
-
-  it('still marks explicitly failed commands as errors', async () => {
-    const calls: Array<{ method: string; params: any }> = []
-    const client = {
-      assistant: {
-        threads: {
-          setStatus: async (params: any) => {
-            calls.push({ method: 'assistant.threads.setStatus', params })
-            return { ok: true }
-          }
-        }
-      },
-      chat: {
-        startStream: async (params: any) => {
-          calls.push({ method: 'chat.startStream', params })
-          return { ok: true, ts: '1778866940.295499' }
-        },
-        appendStream: async (params: any) => {
-          calls.push({ method: 'chat.appendStream', params })
-          return { ok: true }
-        },
-        stopStream: async (params: any) => {
-          calls.push({ method: 'chat.stopStream', params })
-          return { ok: true }
-        }
-      }
-    }
-
-    const { sessionId } = await new AgentSessionRenderer(client as any).open({
-      channel: 'C123',
-      parentTs: '1778866921.505479',
-      recipientTeamId: 'T123',
-      recipientUserId: 'U123',
-      title: 'Centaur execution'
-    })
-    const renderer = new CodexSessionRenderer(client as any)
-
-    await renderer.event(sessionId, {
-      type: 'item.completed',
-      item: {
-        id: 'cmd-1',
-        type: 'commandExecution',
-        command: 'pnpm test',
-        status: 'failed',
-        exitCode: 1
-      }
-    })
-
-    const taskUpdates = calls
-      .flatMap(call => call.params.chunks ?? [])
-      .filter(chunk => chunk.type === 'task_update')
-
-    expect(taskUpdates.at(-1)).toMatchObject({
-      type: 'task_update',
-      id: 'cmd-1',
-      title: 'Run command: pnpm test',
-      status: 'error',
-      output: 'exit code 1'
-    })
+    expect(calls.some(call => call.method === 'chat.stopStream')).toBe(true)
   })
 
   it('pretty prints JSON command output before streaming it', async () => {
@@ -311,12 +254,10 @@ describe('CodexSessionRenderer', () => {
       .flatMap(call => call.params.chunks ?? [])
       .filter(chunk => chunk.type === 'task_update')
 
-    const output = taskUpdates.at(-1)?.output ?? ''
-    expect(output).toContain('```json\n{\n  "tool": "grafana",')
-    expect(output).toContain('"methods": [')
-    expect(output).toContain('"name": "method-0"')
-    expect(output).toContain('// truncated')
-    expect(output).not.toContain('"name": "method-11"')
+    const output = taskUpdates.map(chunk => chunk.output ?? '').join('\n')
+    expect(output).toContain('```text\n[run] Run command: call discover grafana')
+    expect(output).not.toContain('```json')
+    expect(output).not.toContain('"method-11"')
   })
 
   it('previews tool list output before streaming it', async () => {
@@ -382,11 +323,9 @@ describe('CodexSessionRenderer', () => {
       .flatMap(call => call.params.chunks ?? [])
       .filter(chunk => chunk.type === 'task_update')
 
-    const output = taskUpdates.at(-1)?.output ?? ''
-    expect(output).toContain('```json\n{\n  "demo": {')
-    expect(output).toContain('"description": "Demo tool"')
-    expect(output).toContain('"methods": [')
-    expect(output).toContain('// truncated')
+    const output = taskUpdates.map(chunk => chunk.output ?? '').join('\n')
+    expect(output).toContain('```text\n[run] Run command: call tools')
+    expect(output).not.toContain('```json')
     expect(output).not.toContain('"grafana"')
   })
 })

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -26,6 +26,10 @@ describe('CodexSessionRenderer', () => {
         stopStream: async (params: any) => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
         }
       }
     }
@@ -73,13 +77,10 @@ describe('CodexSessionRenderer', () => {
 
     expect(taskUpdates.at(-1)).toEqual({
       type: 'task_update',
-      id: 'codex-activity',
-      title: 'Execution timeline',
+      id: 'cmd-1',
+      title: 'Run command: pnpm --filter slackbot test',
       status: 'complete',
-      details: undefined,
-      output:
-        '[run]\n```sh\npnpm --filter slackbot test\n```\n\n[output]\n```text\none\ntwo\n```\nexit code 0',
-      sources: undefined
+      output: 'one\ntwo\n'
     })
   })
 
@@ -105,6 +106,10 @@ describe('CodexSessionRenderer', () => {
         },
         stopStream: async (params: any) => {
           calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
           return { ok: true }
         }
       }
@@ -145,15 +150,13 @@ describe('CodexSessionRenderer', () => {
       .flatMap(call => call.params.chunks ?? [])
       .filter(chunk => chunk.type === 'task_update')
 
-    expect(new Set(taskUpdates.map(chunk => chunk.id))).toEqual(new Set(['codex-activity']))
-    expect(taskUpdates.at(-1)?.details).toBeUndefined()
-    expect(taskUpdates.some(chunk => richTextPlain(chunk.output).includes('call demo ping'))).toBe(
-      true
-    )
-    expect(richTextPlain(taskUpdates.at(-1)?.output)).toContain('call grafana health')
-    expect(richTextPlain(taskUpdates.at(-1)?.output)).toContain('[run]')
-    expect(taskUpdates.at(-1)?.output).toContain('```sh\ncall grafana health\n```')
-    expect(taskUpdates.at(-1)?.output).toContain('[error]')
+    expect(new Set(taskUpdates.map(chunk => chunk.id))).toEqual(new Set(['cmd-1', 'cmd-2']))
+    expect(taskUpdates.some(chunk => chunk.title.includes('call demo ping'))).toBe(true)
+    expect(taskUpdates.at(-1)).toMatchObject({
+      id: 'cmd-2',
+      status: 'error',
+      title: 'Run command: call grafana health'
+    })
   })
 
   it('marks the aggregate activity task complete on terminal turn events', async () => {
@@ -179,6 +182,10 @@ describe('CodexSessionRenderer', () => {
         stopStream: async (params: any) => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
         }
       }
     }
@@ -198,17 +205,11 @@ describe('CodexSessionRenderer', () => {
     })
     await renderer.event(sessionId, { type: 'turn.completed' })
 
-    const taskUpdates = calls
-      .flatMap(call => call.params.chunks ?? [])
-      .filter(chunk => chunk.type === 'task_update')
-
-    expect(taskUpdates.at(-1)).toMatchObject({
-      id: 'codex-activity',
-      status: 'complete',
-      title: 'Execution timeline',
-      output: undefined
-    })
     expect(calls.some(call => call.method === 'chat.stopStream')).toBe(true)
+    const update = calls.find(call => call.method === 'chat.update')
+    expect(update?.params.blocks?.[0]?.type).toBe('plan')
+    expect(update?.params.blocks?.[0]?.tasks?.[0]?.status).toBe('complete')
+    expect(update?.params.blocks?.[0]?.tasks?.[0]?.title).toBe('Run command: call demo ping')
   })
 
   it('pretty prints JSON command output before streaming it', async () => {
@@ -233,6 +234,10 @@ describe('CodexSessionRenderer', () => {
         },
         stopStream: async (params: any) => {
           calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
           return { ok: true }
         }
       }
@@ -282,10 +287,8 @@ describe('CodexSessionRenderer', () => {
       .filter(chunk => chunk.type === 'task_update')
 
     const output = taskUpdates.map(chunk => richTextPlain(chunk.output)).join('\n')
-    expect(output).toContain('[run]')
-    expect(output).toContain('call discover grafana')
+    expect(output).toContain('"tool": "grafana"')
     expect(JSON.stringify(taskUpdates.map(chunk => chunk.output))).not.toContain('```text')
-    expect(JSON.stringify(taskUpdates.map(chunk => chunk.output))).toContain('```json')
     expect(output).not.toContain('"method-11"')
   })
 
@@ -311,6 +314,10 @@ describe('CodexSessionRenderer', () => {
         },
         stopStream: async (params: any) => {
           calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
           return { ok: true }
         }
       }
@@ -362,10 +369,8 @@ describe('CodexSessionRenderer', () => {
       .filter(chunk => chunk.type === 'task_update')
 
     const output = taskUpdates.map(chunk => richTextPlain(chunk.output)).join('\n')
-    expect(output).toContain('[run]')
-    expect(output).toContain('call tools')
+    expect(output).toContain('"demo"')
     expect(JSON.stringify(taskUpdates.map(chunk => chunk.output))).not.toContain('```text')
-    expect(JSON.stringify(taskUpdates.map(chunk => chunk.output))).toContain('```json')
     expect(output).not.toContain('"grafana"')
   })
 })

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -600,7 +600,7 @@ function itemStatus(item: any, eventType: string, exitCode?: number | null): Har
   const status = String(item.status ?? '').toLowerCase()
   if (status === 'failed' || status === 'declined') return 'error'
   if (status === 'completed' || eventType === 'item.completed') {
-    return 'complete'
+    return exitCode === 0 || exitCode === null || exitCode === undefined ? 'complete' : 'error'
   }
   return 'in_progress'
 }

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -1,6 +1,13 @@
 import type { WebClient } from '@slack/web-api'
 import { AgentSessionRenderer } from './agent-session'
-import { preformatted as pre, section, text, type StreamRichTextElement } from './streaming'
+import {
+  preformatted as pre,
+  richText,
+  section,
+  text,
+  type StreamRichText,
+  type StreamRichTextElement
+} from './streaming'
 
 type HarnessTask = {
   id: string
@@ -14,15 +21,16 @@ type CodexSessionState = {
   threadId: string
   stepCounter: number
   messageText: string
+  streamedMessageText: string
   planText: string
   taskByUseId: Map<string, HarnessTask>
   commandOutputById: Map<string, string>
-  activityLineByTaskId: Map<string, string>
+  emittedActivityRunByTaskId: Set<string>
+  emittedActivityOutputByTaskId: Set<string>
   done: boolean
 }
 
 const states = new Map<string, CodexSessionState>()
-const ACTIVITY_TASK_ID = 'codex-activity'
 
 export class CodexSessionRenderer {
   private readonly renderer: AgentSessionRenderer
@@ -120,7 +128,7 @@ export class CodexSessionRenderer {
       const delta = messageDelta(state.messageText, assistantMessage)
       if (delta) {
         state.messageText += delta
-        await this.renderer.textDelta(agentSessionId, delta)
+        await this.publishPendingAssistantText(agentSessionId, state)
       }
     }
 
@@ -142,7 +150,7 @@ export class CodexSessionRenderer {
         const resultText = event.result.trim()
         if (resultText) {
           state.messageText += resultText
-          await this.renderer.text(agentSessionId, resultText)
+          await this.publishPendingAssistantText(agentSessionId, state, { force: true })
         }
       }
       await this.done(agentSessionId)
@@ -157,6 +165,7 @@ export class CodexSessionRenderer {
     state.done = true
     completeOpenTasks(state)
     await this.publishActivitySummary(agentSessionId, state, { final: true })
+    await this.publishPendingAssistantText(agentSessionId, state, { force: true })
     await this.renderer.done(
       agentSessionId,
       state.threadId ? codexFooter(state.threadId) : undefined
@@ -172,15 +181,32 @@ export class CodexSessionRenderer {
   ): Promise<void> {
     const tasks = Array.from(state.taskByUseId.values())
     if (!tasks.length) return
-    const status = aggregateStatus(tasks)
-    const output = opts.final ? '' : changedActivityOutput(state, tasks)
-    await this.renderer.step(agentSessionId, {
-      id: ACTIVITY_TASK_ID,
-      title: activityTitle(tasks),
-      status,
-      details: undefined,
-      output: opts.final ? '' : output || undefined
-    })
+    for (const update of changedActivityTaskUpdates(state, tasks, opts)) {
+      await this.renderer.step(
+        agentSessionId,
+        {
+          id: update.id,
+          title: update.title,
+          status: update.status,
+          details: update.details,
+          output: update.output
+        },
+        { flush: !opts.final }
+      )
+    }
+    if (!opts.final) await this.publishPendingAssistantText(agentSessionId, state)
+  }
+
+  private async publishPendingAssistantText(
+    agentSessionId: string,
+    state: CodexSessionState,
+    opts: { force?: boolean } = {}
+  ): Promise<void> {
+    if (!opts.force && !state.taskByUseId.size) return
+    if (state.messageText.length <= state.streamedMessageText.length) return
+    const delta = state.messageText.slice(state.streamedMessageText.length)
+    state.streamedMessageText = state.messageText
+    await this.renderer.textDelta(agentSessionId, delta)
   }
 
   private async publishStructuredPlan(
@@ -219,10 +245,12 @@ function getState(agentSessionId: string): CodexSessionState {
       threadId: '',
       stepCounter: 0,
       messageText: '',
+      streamedMessageText: '',
       planText: '',
       taskByUseId: new Map(),
       commandOutputById: new Map(),
-      activityLineByTaskId: new Map(),
+      emittedActivityRunByTaskId: new Set(),
+      emittedActivityOutputByTaskId: new Set(),
       done: false
     }
     states.set(agentSessionId, state)
@@ -370,13 +398,6 @@ function setPlanTask(
   })
 }
 
-function aggregateStatus(tasks: HarnessTask[]): HarnessTask['status'] {
-  if (tasks.some(task => task.status === 'error')) return 'error'
-  if (tasks.some(task => task.status === 'in_progress')) return 'in_progress'
-  if (tasks.some(task => task.status === 'pending')) return 'pending'
-  return 'complete'
-}
-
 function completeOpenTasks(state: CodexSessionState): void {
   for (const [id, task] of state.taskByUseId) {
     if (task.status !== 'in_progress' && task.status !== 'pending') continue
@@ -384,41 +405,87 @@ function completeOpenTasks(state: CodexSessionState): void {
   }
 }
 
-function activityTitle(tasks: HarnessTask[]): string {
-  const count = tasks.length
-  const running = tasks.filter(task => task.status === 'in_progress').length
-  if (running) return `Execution timeline (${running}/${count} running)`
-  return count === 1 ? 'Execution timeline' : `Execution timeline (${count} steps)`
-}
-
-function changedActivityOutput(state: CodexSessionState, tasks: HarnessTask[]): string {
-  const changedLines: string[] = []
+function changedActivityTaskUpdates(
+  state: CodexSessionState,
+  tasks: HarnessTask[],
+  opts: { final?: boolean } = {}
+): Array<{
+  id: string
+  title: string
+  status: HarnessTask['status']
+  details?: StreamRichText
+  output?: StreamRichText
+}> {
+  const updates: Array<{
+    id: string
+    title: string
+    status: HarnessTask['status']
+    details?: StreamRichText
+    output?: StreamRichText
+  }> = []
   for (const task of tasks) {
-    const line = taskSummaryLine(task)
-    if (!line || state.activityLineByTaskId.get(task.id) === line) continue
-    state.activityLineByTaskId.set(task.id, line)
-    changedLines.push(line)
+    let details: StreamRichText | undefined
+    let output: StreamRichText | undefined
+    if (opts.final) {
+      details = activityRunBlock(task)
+      output = activityOutputBlock(task)
+    } else if (!state.emittedActivityRunByTaskId.has(task.id)) {
+      state.emittedActivityRunByTaskId.add(task.id)
+      details = activityRunBlock(task)
+    }
+    if (
+      !opts.final &&
+      (task.status === 'complete' || task.status === 'error') &&
+      !state.emittedActivityOutputByTaskId.has(task.id)
+    ) {
+      state.emittedActivityOutputByTaskId.add(task.id)
+      output = activityOutputBlock(task)
+    }
+    if (!details && !output && !opts.final) continue
+    updates.push({
+      id: task.id,
+      title: task.title,
+      status: task.status,
+      details,
+      output
+    })
   }
-  return changedLines.length ? fencedActivityLines(changedLines) : ''
+  return updates
 }
 
-function fencedActivityLines(lines: string): string
-function fencedActivityLines(lines: string[]): string
-function fencedActivityLines(lines: string | string[]): string {
-  const body = Array.isArray(lines) ? lines.join('\n') : lines
-  return `\`\`\`text\n${body}\n\`\`\``
+function activityRunBlock(task: HarnessTask): StreamRichText {
+  const command = firstPreformattedBody(task.details)
+  if (command) {
+    return richText([pre(command, shellLanguage(firstPreformattedLanguage(task.details)))])
+  }
+  const body = task.details.length ? elementsToPlainText(task.details) : task.title
+  return richText([pre(body, 'text')])
 }
 
-function taskSummaryLine(task: HarnessTask): string {
-  const marker =
-    task.status === 'complete'
-      ? '[done]'
-      : task.status === 'error'
-        ? '[error]'
-        : task.status === 'pending'
-          ? '[todo]'
-          : '[run]'
-  return `${marker} ${task.title}`
+function activityOutputBlock(task: HarnessTask): StreamRichText {
+  if (!task.output.length) {
+    return richText([pre(task.status === 'error' ? 'Failed' : 'Done', 'text')])
+  }
+  return richText([
+    pre(elementsToPlainText(task.output), firstPreformattedLanguage(task.output) ?? 'text')
+  ])
+}
+
+function firstPreformattedBody(elements: StreamRichTextElement[]): string {
+  return (
+    elements
+      .find(element => element.type === 'rich_text_preformatted')
+      ?.elements.map(inline => inline.text ?? '')
+      .join('') ?? ''
+  )
+}
+
+function firstPreformattedLanguage(elements: StreamRichTextElement[]): string | undefined {
+  return elements.find(element => element.type === 'rich_text_preformatted')?.language
+}
+
+function shellLanguage(language: string | undefined): string {
+  return language === 'bash' || !language ? 'sh' : language
 }
 
 function commandOutputDelta(event: any): { id: string; delta: string } | null {
@@ -448,7 +515,7 @@ function commandTask(
   const exitCode = item.exitCode ?? item.exit_code
   const isCompletionUpdate =
     eventType === 'item.completed' || status === 'complete' || status === 'error'
-  const output = commandOutputElements(accumulatedOutput ?? '', exitCode)
+  const output = commandOutputElements(accumulatedOutput ?? '')
   return {
     id,
     title: command === 'Command' ? 'Run command' : `Run command: ${oneLine(command, 220)}`,
@@ -466,17 +533,11 @@ function commandAggregatedOutput(item: any): string {
   return ''
 }
 
-function commandOutputElements(
-  output: string,
-  exitCode?: number | string | null
-): StreamRichTextElement[] {
+function commandOutputElements(output: string): StreamRichTextElement[] {
   const elements: StreamRichTextElement[] = []
   if (output) {
     const formatted = formatCommandOutput(output)
     elements.push(pre(formatted.body, formatted.language))
-  }
-  if (exitCode !== null && exitCode !== undefined) {
-    elements.push(section([text(`exit code ${exitCode}`)]))
   }
   return elements
 }
@@ -544,22 +605,21 @@ function itemStatus(item: any, eventType: string, exitCode?: number | null): Har
   return 'in_progress'
 }
 
-function elementsToMarkdown(elements: StreamRichTextElement[]): string {
-  return elements.map(elementToMarkdown).filter(Boolean).join('\n\n')
+function elementsToPlainText(elements: StreamRichTextElement[]): string {
+  return elements.map(elementToPlainText).filter(Boolean).join('\n')
 }
 
-function elementToMarkdown(element: StreamRichTextElement): string {
+function elementToPlainText(element: StreamRichTextElement): string {
   if (element.type === 'rich_text_preformatted') {
     const body = element.elements?.map(inline => inline.text ?? '').join('') ?? ''
-    return `\`\`\`${element.language ?? ''}\n${body}\n\`\`\``
+    return body
   }
   if (element.type === 'rich_text_section') {
     return (element.elements ?? [])
       .map(inline => {
-        if ('url' in inline) return inline.text ? `[${inline.text}](${inline.url})` : inline.url
+        if ('url' in inline) return inline.text ?? inline.url
         if ('user_id' in inline) return `<@${inline.user_id}>`
-        const value = inline.text ?? ''
-        return inline.style?.code ? `\`${value}\`` : value
+        return inline.text ?? ''
       })
       .join('')
   }

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -17,10 +17,12 @@ type CodexSessionState = {
   planText: string
   taskByUseId: Map<string, HarnessTask>
   commandOutputById: Map<string, string>
+  activityLineByTaskId: Map<string, string>
   done: boolean
 }
 
 const states = new Map<string, CodexSessionState>()
+const ACTIVITY_TASK_ID = 'codex-activity'
 
 export class CodexSessionRenderer {
   private readonly renderer: AgentSessionRenderer
@@ -36,13 +38,13 @@ export class CodexSessionRenderer {
 
     const structuredPlan = structuredPlanUpdate(event)
     if (structuredPlan) {
-      await this.publishStructuredPlan(agentSessionId, structuredPlan)
+      await this.publishStructuredPlan(agentSessionId, state, structuredPlan)
     }
 
     const planText = planTextUpdate(event)
     if (planText) {
       state.planText = event?.type === 'item.plan.delta' ? state.planText + planText : planText
-      await this.publishPlanText(agentSessionId, state.planText)
+      await this.publishPlanText(agentSessionId, state, state.planText)
     }
 
     const command = commandExecution(event)
@@ -54,11 +56,7 @@ export class CodexSessionRenderer {
       const task = commandTask(command, event?.type, existing, state.commandOutputById.get(id))
       const merged = mergeTask(existing, task)
       state.taskByUseId.set(merged.id, merged)
-      await this.publishTask(agentSessionId, {
-        ...merged,
-        details: task.details,
-        output: task.output
-      })
+      await this.publishActivitySummary(agentSessionId, state)
     }
 
     const fileChange = fileChangeEvent(event)
@@ -67,7 +65,7 @@ export class CodexSessionRenderer {
       const task = fileChangeTask(fileChange, event?.type, existing)
       const merged = mergeTask(existing, task)
       state.taskByUseId.set(merged.id, merged)
-      await this.publishTask(agentSessionId, merged)
+      await this.publishActivitySummary(agentSessionId, state)
     }
 
     const outputDelta = commandOutputDelta(event)
@@ -87,7 +85,7 @@ export class CodexSessionRenderer {
         output: commandOutputElements(output)
       }
       state.taskByUseId.set(outputDelta.id, updated)
-      await this.publishTask(agentSessionId, { ...updated, details: [], output: updated.output })
+      await this.publishActivitySummary(agentSessionId, state)
     }
 
     for (const tool of toolUses(event)) {
@@ -99,7 +97,7 @@ export class CodexSessionRenderer {
         output: []
       }
       state.taskByUseId.set(String(tool.id), task)
-      await this.publishTask(agentSessionId, task)
+      await this.publishActivitySummary(agentSessionId, state)
     }
 
     for (const result of toolResults(event)) {
@@ -114,7 +112,7 @@ export class CodexSessionRenderer {
       state.taskByUseId.set(toolUseId || task.id, task)
       task.status = result.is_error ? 'error' : 'complete'
       task.output = outputElementsForResult(result)
-      await this.publishTask(agentSessionId, { ...task, details: [], output: task.output })
+      await this.publishActivitySummary(agentSessionId, state)
     }
 
     const assistantMessage = assistantText(event)
@@ -135,10 +133,11 @@ export class CodexSessionRenderer {
         details: [section([text(reasoningMessage)])],
         output: []
       }
-      await this.publishTask(agentSessionId, task)
+      state.taskByUseId.set(task.id, task)
+      await this.publishActivitySummary(agentSessionId, state)
     }
 
-    if (event?.type === 'result' || event?.type === 'turn.done') {
+    if (isTerminalTurnEvent(event)) {
       if (typeof event.result === 'string' && !state.messageText.trim()) {
         const resultText = event.result.trim()
         if (resultText) {
@@ -155,6 +154,9 @@ export class CodexSessionRenderer {
   async done(agentSessionId: string): Promise<void> {
     const state = getState(agentSessionId)
     if (state.done) return
+    state.done = true
+    completeOpenTasks(state)
+    await this.publishActivitySummary(agentSessionId, state, { final: true })
     await this.renderer.done(
       agentSessionId,
       state.threadId ? codexFooter(state.threadId) : undefined
@@ -163,37 +165,46 @@ export class CodexSessionRenderer {
     states.delete(agentSessionId)
   }
 
-  private async publishTask(agentSessionId: string, task: HarnessTask): Promise<void> {
+  private async publishActivitySummary(
+    agentSessionId: string,
+    state: CodexSessionState,
+    opts: { final?: boolean } = {}
+  ): Promise<void> {
+    const tasks = Array.from(state.taskByUseId.values())
+    if (!tasks.length) return
+    const status = aggregateStatus(tasks)
+    const output = opts.final ? '' : changedActivityOutput(state, tasks)
     await this.renderer.step(agentSessionId, {
-      id: task.id,
-      title: task.title,
-      status: task.status,
-      details: elementsToMarkdown(task.details),
-      output: elementsToMarkdown(task.output)
+      id: ACTIVITY_TASK_ID,
+      title: activityTitle(tasks),
+      status,
+      details: undefined,
+      output: opts.final ? '' : output || undefined
     })
   }
 
   private async publishStructuredPlan(
     agentSessionId: string,
+    state: CodexSessionState,
     plan: Array<{ step: string; status?: string }>
   ): Promise<void> {
     for (const [index, item] of plan.entries()) {
-      await publishPlanTask(
-        this.renderer,
-        agentSessionId,
-        index,
-        String(item.step ?? ''),
-        planStatus(item.status)
-      )
+      setPlanTask(state, index, String(item.step ?? ''), planStatus(item.status))
     }
+    await this.publishActivitySummary(agentSessionId, state)
   }
 
-  private async publishPlanText(agentSessionId: string, value: string): Promise<void> {
+  private async publishPlanText(
+    agentSessionId: string,
+    state: CodexSessionState,
+    value: string
+  ): Promise<void> {
     const steps = parsePlanText(value)
     if (!steps.length) return
     for (const [index, item] of steps.entries()) {
-      await publishPlanTask(this.renderer, agentSessionId, index, item.step, item.status)
+      setPlanTask(state, index, item.step, item.status)
     }
+    await this.publishActivitySummary(agentSessionId, state)
   }
 }
 
@@ -211,6 +222,7 @@ function getState(agentSessionId: string): CodexSessionState {
       planText: '',
       taskByUseId: new Map(),
       commandOutputById: new Map(),
+      activityLineByTaskId: new Map(),
       done: false
     }
     states.set(agentSessionId, state)
@@ -253,6 +265,10 @@ function messageDelta(current: string, incoming: string): string {
 function reasoningText(event: any): string {
   if (event?.type !== 'reasoning') return ''
   return String(event.text ?? event.thinking ?? '')
+}
+
+function isTerminalTurnEvent(event: any): boolean {
+  return event?.type === 'result' || event?.type === 'turn.done' || event?.type === 'turn.completed'
 }
 
 function toolUses(event: any): any[] {
@@ -337,20 +353,72 @@ function stripPlanMarker(value: string): string {
     .trim()
 }
 
-async function publishPlanTask(
-  renderer: AgentSessionRenderer,
-  agentSessionId: string,
+function setPlanTask(
+  state: CodexSessionState,
   index: number,
   step: string,
   status: HarnessTask['status']
-): Promise<void> {
+): void {
   const title = oneLine(stripPlanMarker(step), 256)
   if (!title) return
-  await renderer.step(agentSessionId, {
+  state.taskByUseId.set(`plan-${index + 1}`, {
     id: `plan-${index + 1}`,
     title,
-    status
+    status,
+    details: [],
+    output: []
   })
+}
+
+function aggregateStatus(tasks: HarnessTask[]): HarnessTask['status'] {
+  if (tasks.some(task => task.status === 'error')) return 'error'
+  if (tasks.some(task => task.status === 'in_progress')) return 'in_progress'
+  if (tasks.some(task => task.status === 'pending')) return 'pending'
+  return 'complete'
+}
+
+function completeOpenTasks(state: CodexSessionState): void {
+  for (const [id, task] of state.taskByUseId) {
+    if (task.status !== 'in_progress' && task.status !== 'pending') continue
+    state.taskByUseId.set(id, { ...task, status: 'complete' })
+  }
+}
+
+function activityTitle(tasks: HarnessTask[]): string {
+  const count = tasks.length
+  const running = tasks.filter(task => task.status === 'in_progress').length
+  if (running) return `Execution timeline (${running}/${count} running)`
+  return count === 1 ? 'Execution timeline' : `Execution timeline (${count} steps)`
+}
+
+function changedActivityOutput(state: CodexSessionState, tasks: HarnessTask[]): string {
+  const changedLines: string[] = []
+  for (const task of tasks) {
+    const line = taskSummaryLine(task)
+    if (!line || state.activityLineByTaskId.get(task.id) === line) continue
+    state.activityLineByTaskId.set(task.id, line)
+    changedLines.push(line)
+  }
+  return changedLines.length ? fencedActivityLines(changedLines) : ''
+}
+
+function fencedActivityLines(lines: string): string
+function fencedActivityLines(lines: string[]): string
+function fencedActivityLines(lines: string | string[]): string {
+  const body = Array.isArray(lines) ? lines.join('\n') : lines
+  return `\`\`\`text\n${body}\n\`\`\``
+}
+
+function taskSummaryLine(task: HarnessTask): string {
+  const marker =
+    task.status === 'complete'
+      ? '[done]'
+      : task.status === 'error'
+        ? '[error]'
+        : task.status === 'pending'
+          ? '[todo]'
+          : '[run]'
+  return `${marker} ${task.title}`
 }
 
 function commandOutputDelta(event: any): { id: string; delta: string } | null {

--- a/services/slackbot/src/slack/streaming.ts
+++ b/services/slackbot/src/slack/streaming.ts
@@ -41,34 +41,39 @@ export type StreamTask = {
 
 export type StreamChunk = AnyChunk
 
-const MAX_TASK_FIELD_CHARS = 12_000
-const MAX_PLAN_TITLE_CHARS = 256
+export const SLACK_STREAM_MARKDOWN_TEXT_LIMIT = 12_000
+export const SLACK_STREAM_TASK_UPDATE_FIELD_LIMIT = 256
+export const SLACK_STREAM_PLAN_UPDATE_TITLE_LIMIT = 256
+const SLACK_STREAM_TASK_UPDATE_TITLE_LIMIT = 64
+const SLACK_STREAM_TASK_UPDATE_DETAILS_LIMIT = 48
+const SLACK_STREAM_TASK_UPDATE_OUTPUT_LIMIT = 48
 
 export function planUpdateChunk(title: string): StreamChunk {
-  return { type: 'plan_update', title: clip(title, MAX_PLAN_TITLE_CHARS) }
+  return { type: 'plan_update', title: clip(title, SLACK_STREAM_PLAN_UPDATE_TITLE_LIMIT) }
 }
 
 export function markdownChunk(text: string): StreamChunk {
-  return { type: 'markdown_text', text: text || ' ' }
+  return { type: 'markdown_text', text: clip(text || ' ', SLACK_STREAM_MARKDOWN_TEXT_LIMIT) }
 }
 
 export function taskUpdateChunk(task: StreamTask): StreamChunk {
+  const details = taskBodyToPlain(task.details, SLACK_STREAM_TASK_UPDATE_DETAILS_LIMIT)
+  const output = taskBodyToPlain(task.output, SLACK_STREAM_TASK_UPDATE_OUTPUT_LIMIT)
   return {
     type: 'task_update',
     id: task.id,
-    title: clip(task.title, MAX_PLAN_TITLE_CHARS),
+    title: clip(task.title, SLACK_STREAM_TASK_UPDATE_TITLE_LIMIT),
     status: task.status,
-    details: taskBodyToPlain(task.details),
-    output: taskBodyToPlain(task.output),
-    sources: task.sources
+    ...(details ? { details } : {}),
+    ...(output ? { output } : {})
   }
 }
 
-export function planBlock(title: string, tasks: StreamTask[], blockId?: string): object {
+export function planBlock(title: string, tasks: StreamTask[], planId?: string): object {
   return {
     type: 'plan',
+    ...(planId ? { plan_id: planId } : {}),
     title,
-    ...(blockId ? { block_id: blockId } : {}),
     tasks: tasks.map(task => ({
       task_id: task.id,
       title: task.title,
@@ -104,7 +109,7 @@ export function preformatted(text: string, language?: string): StreamRichTextEle
   return {
     type: 'rich_text_preformatted',
     ...(language ? { language } : {}),
-    elements: [{ type: 'text', text: clip(text, MAX_TASK_FIELD_CHARS) }]
+    elements: [{ type: 'text', text: clip(text, SLACK_STREAM_MARKDOWN_TEXT_LIMIT) }]
   }
 }
 
@@ -158,9 +163,12 @@ function parseInlineMarkdown(value: string): StreamInline[] {
   return out.length ? out : [text(value)]
 }
 
-function taskBodyToPlain(body: StreamRichText | string | undefined): string | undefined {
+function taskBodyToPlain(
+  body: StreamRichText | string | undefined,
+  maxChars = SLACK_STREAM_TASK_UPDATE_FIELD_LIMIT
+): string | undefined {
   if (!body) return undefined
-  if (typeof body === 'string') return clip(body, MAX_TASK_FIELD_CHARS)
+  if (typeof body === 'string') return clip(body, maxChars)
   return clip(
     body.elements
       .map(element =>
@@ -172,7 +180,7 @@ function taskBodyToPlain(body: StreamRichText | string | undefined): string | un
       )
       .filter(Boolean)
       .join('\n'),
-    MAX_TASK_FIELD_CHARS
+    maxChars
   )
 }
 


### PR DESCRIPTION
makes Codex Slack execution output render as one `plan` step at the top, with each command as a `task` inside it

- one `Centaur execution (N/N)` plan block instead of one `plan` per command
- live command updates stay compact so Slack streaming doesn’t break
- final message gets the nicer formatted/clipped command + output blocks
- marks open `task`s complete before ending the stream so the `timeline` doesn’t stay stuck
- caps huge timelines with `N additional commands omitted from Slack preview`
- avoids mixing `exit code 0` / next command text into previous output
- also fixed many scenarios where response splits into multiple ones.

intentional tradeoff: live `task` updates are plain/compact, then final rendering gets formatted once execution is done. This avoids Slack `msg_too_long` and code block corruption during streaming