### PR TITLE
Serve docs under /docs route

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vocs dev",
     "prebuild": "bash scripts/build-md.sh",
-    "build": "vocs build",
+    "build": "VOCS_BASE_PATH=/docs vocs build && node scripts/prepare-docs-route.mjs",
     "preview": "vocs preview",
     "cf:dev": "npm run build && wrangler dev",
     "deploy": "npm run build && wrangler deploy"

--- a/docs/scripts/prepare-docs-route.mjs
+++ b/docs/scripts/prepare-docs-route.mjs
@@ -1,0 +1,19 @@
+import { cp, mkdir, readdir, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const distDir = new URL('../dist/', import.meta.url)
+const docsDir = new URL('../dist/docs/', import.meta.url)
+
+await rm(docsDir, { recursive: true, force: true })
+await mkdir(docsDir, { recursive: true })
+
+const entries = (await readdir(distDir)).filter((entry) => entry !== 'docs')
+
+await Promise.all(
+  entries.map((entry) =>
+    cp(new URL(entry, distDir), new URL(join('docs', entry), distDir), {
+      recursive: true,
+      force: true,
+    }),
+  ),
+)

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -4,8 +4,7 @@
   "compatibility_date": "2026-05-05",
   "routes": [
     {
-      "pattern": "centaur.run",
-      "custom_domain": true
+      "pattern": "centaur.run/docs*"
     }
   ],
   "assets": {


### PR DESCRIPTION
## Summary
- route the Centaur docs Worker at `centaur.run/docs*` instead of the root custom domain
- build Vocs with `/docs` as the production base path
- mirror the generated dist under `dist/docs/` so Cloudflare Assets can serve prefixed paths

## Verification
- `npm --prefix docs run build`
- confirmed `docs/dist/docs/index.html`, `docs/dist/docs/quickstart/index.html`, and `docs/dist/docs/assets/` are generated

Requested review: <@U0ANX3AM5RR>