### PR TITLE
docs: route docs to subdomain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,6 @@ concurrency:
 permissions:
   contents: read
   deployments: write
-  issues: write
-  pull-requests: write
 
 jobs:
   build-and-deploy:
@@ -90,13 +88,3 @@ jobs:
             echo
             echo "$DEPLOYMENT_URL"
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Preview URL
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
-        with:
-          header: deploy-${{ matrix.worker.name }}
-          message: |
-            | Worker | Preview |
-            |--------|---------|
-            | ${{ matrix.worker.name }} | ${{ steps.preview.outputs.deployment-url }} |

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -2,8 +2,6 @@ import { defineConfig } from 'vocs'
 
 import { sidebar } from './sidebar.js'
 
-const basePath = process.env.VOCS_BASE_PATH || undefined
-
 export default defineConfig({
   rootDir: '.',
   title: 'Centaur',
@@ -11,7 +9,6 @@ export default defineConfig({
   description: 'The production control plane for shared AI agents, tools, workflows, and sandboxes.',
   iconUrl: '/centaur.png',
   logoUrl: '/centaur.png',
-  ...(basePath ? { basePath } : {}),
   editLink: {
     pattern: 'https://github.com/paradigmxyz/centaur/edit/main/docs/pages/:path',
     text: 'Edit this page',

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -4,7 +4,7 @@
   "compatibility_date": "2026-05-05",
   "routes": [
     {
-      "pattern": "centaur.run",
+      "pattern": "docs.centaur.run",
       "custom_domain": true
     }
   ],


### PR DESCRIPTION
Deploy the docs Worker on docs.centaur.run as a custom domain instead of using path-based /docs routing.

Closes paradigmxyz/centaur#10