### PR TITLE
fix: set docs Cloudflare zone

### DIFF
--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -5,6 +5,7 @@
   "routes": [
     {
       "pattern": "docs.centaur.run",
+      "zone_name": "centaur.run",
       "custom_domain": true
     }
   ],


### PR DESCRIPTION
Tell Wrangler that docs.centaur.run belongs to the centaur.run zone so deploys can create the custom domain.