### PR TITLE
ci: remove docs preview comment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,6 @@ concurrency:
 permissions:
   contents: read
   deployments: write
-  issues: write
-  pull-requests: write
 
 jobs:
   build-and-deploy:
@@ -90,13 +88,3 @@ jobs:
             echo
             echo "$DEPLOYMENT_URL"
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Preview URL
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
-        with:
-          header: deploy-${{ matrix.worker.name }}
-          message: |
-            | Worker | Preview |
-            |--------|---------|
-            | ${{ matrix.worker.name }} | ${{ steps.preview.outputs.deployment-url }} |


### PR DESCRIPTION
Stop posting an empty sticky PR comment when the Cloudflare preview upload does not return a deployment URL.

The workflow still writes the preview URL to the GitHub Actions job summary when Cloudflare provides one.