### PR TITLE
fix: stop slack download_file from exposing the bot token

### DIFF
--- a/centaur_sdk/__init__.py
+++ b/centaur_sdk/__init__.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 from centaur_sdk.cli_tables import Table, render_text_table
 from centaur_sdk.tool_sdk import (
     ToolContext,
+    current_thread_key,
     get_tool_context,
     reset_tool_context,
+    save_attachment,
+    save_attachment_from_path,
     secret,
     set_tool_context,
 )
@@ -20,9 +23,12 @@ from centaur_sdk.tool_sdk import (
 __all__ = [
     "Table",
     "ToolContext",
+    "current_thread_key",
     "get_tool_context",
     "render_text_table",
     "reset_tool_context",
+    "save_attachment",
+    "save_attachment_from_path",
     "secret",
     "set_tool_context",
 ]

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import base64
 import contextlib
+import json
 import logging
+import mimetypes
+import urllib.request
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -69,3 +74,79 @@ def secret(key: str, default: str | None = None) -> str:
     with contextlib.suppress(LookupError):
         ctx_name = f" for tool '{_tool_ctx.get().name}'"
     raise KeyError(f"Missing secret '{key}'{ctx_name}")
+
+
+def current_thread_key() -> str:
+    """Return the active thread key for a tool call."""
+    try:
+        thread_key = _tool_ctx.get().thread_key
+    except LookupError:
+        thread_key = None
+    if not thread_key:
+        raise RuntimeError(
+            "this operation must run inside a scoped thread: no thread_key "
+            "in the tool context."
+        )
+    return thread_key
+
+
+def save_attachment(
+    *,
+    name: str,
+    data: bytes,
+    mime_type: str | None = None,
+    source_url: str | None = None,
+) -> dict[str, Any]:
+    """Persist bytes as a Centaur attachment scoped to the current tool thread."""
+    thread_key = current_thread_key()
+    safe_name = Path(name).name or "attachment"
+    resolved_mime = mime_type or mimetypes.guess_type(safe_name)[0] or "application/octet-stream"
+    base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
+    payload = json.dumps(
+        {
+            "thread_key": thread_key,
+            "name": safe_name,
+            "mime_type": resolved_mime,
+            "data": base64.b64encode(data).decode("ascii"),
+            "source_url": source_url,
+        }
+    ).encode()
+    headers = {"Content-Type": "application/json"}
+    api_key = secret("CENTAUR_API_KEY", "").strip()
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(
+        f"{base_url}/agent/attachments/upload",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        result = json.loads(response.read())
+    attachment_id = result.get("id")
+    if not attachment_id:
+        raise RuntimeError(f"attachment upload returned no id: {result!r}")
+    return {
+        "attachment_id": attachment_id,
+        "filename": result.get("name") or safe_name,
+        "mime_type": result.get("mime_type") or resolved_mime,
+        "download_url": result.get("download_url"),
+        "size_bytes": len(data),
+    }
+
+
+def save_attachment_from_path(
+    path: str | Path,
+    *,
+    name: str | None = None,
+    mime_type: str | None = None,
+    source_url: str | None = None,
+) -> dict[str, Any]:
+    """Persist a local file as a thread-scoped Centaur attachment."""
+    p = Path(path)
+    return save_attachment(
+        name=name or p.name,
+        data=p.read_bytes(),
+        mime_type=mime_type,
+        source_url=source_url,
+    )

--- a/services/api/api/routers/attachments.py
+++ b/services/api/api/routers/attachments.py
@@ -112,8 +112,16 @@ async def upload_attachment(request: Request):
 
 
 @router.get("/{attachment_id}/download")
-async def download_attachment(request: Request, attachment_id: str):
-    """Download attachment raw bytes."""
+async def download_attachment(
+    request: Request, attachment_id: str, thread_key: str | None = None
+):
+    """Download attachment raw bytes.
+
+    When ``thread_key`` is supplied, the attachment must belong to it. This
+    lets a privileged caller (e.g. the slack tool acting for an agent, which
+    authenticates with a service key rather than a sandbox token) constrain
+    the read to the agent's own thread.
+    """
     pool = request.app.state.db_pool
     row = await pool.fetchrow(
         "SELECT data, mime_type, name, thread_key FROM attachments WHERE id = $1",
@@ -123,6 +131,12 @@ async def download_attachment(request: Request, attachment_id: str):
         raise HTTPException(status_code=404, detail="Attachment not found")
     # Reject a sandbox token reading an attachment from another thread.
     _enforce_sandbox_thread_scope(request, row["thread_key"])
+    # An explicit thread_key constrains the read to that thread, for callers
+    # whose key is not a sandbox token (so the check above does not apply).
+    if thread_key is not None and row["thread_key"] != thread_key:
+        raise HTTPException(
+            status_code=403, detail="Attachment does not belong to the requested thread"
+        )
     return Response(
         content=row["data"],
         media_type=row["mime_type"],

--- a/services/api/api/routers/attachments.py
+++ b/services/api/api/routers/attachments.py
@@ -116,11 +116,13 @@ async def download_attachment(request: Request, attachment_id: str):
     """Download attachment raw bytes."""
     pool = request.app.state.db_pool
     row = await pool.fetchrow(
-        "SELECT data, mime_type, name FROM attachments WHERE id = $1",
+        "SELECT data, mime_type, name, thread_key FROM attachments WHERE id = $1",
         attachment_id,
     )
     if not row:
         raise HTTPException(status_code=404, detail="Attachment not found")
+    # Reject a sandbox token reading an attachment from another thread.
+    _enforce_sandbox_thread_scope(request, row["thread_key"])
     return Response(
         content=row["data"],
         media_type=row["mime_type"],

--- a/services/api/api/routers/attachments.py
+++ b/services/api/api/routers/attachments.py
@@ -71,7 +71,7 @@ async def upload_attachment(request: Request):
     mime_type = body.get("mime_type")
     data_b64 = body.get("data")
 
-    if not all([thread_key, name, mime_type, data_b64]):
+    if not thread_key or not name or not mime_type or data_b64 is None:
         raise HTTPException(
             status_code=422,
             detail="thread_key, name, mime_type, and data are required",

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -756,11 +756,34 @@ _COMMON_ARGUMENT_ALIASES: dict[str, str] = {
     "table": "table_name",
 }
 
+_FORBIDDEN_TOOL_ARGUMENT_NAMES = frozenset(
+    {
+        "output_path",
+        "output_dir",
+        "download_path",
+        "save_path",
+        "dest_path",
+        "destination_path",
+    }
+)
+
 
 def _tool_arg_validation_error(
     method: ToolMethod, args: dict[str, Any]
 ) -> dict[str, Any] | None:
     """Return a structured argument error before invoking a tool method."""
+    forbidden = sorted(set(args) & _FORBIDDEN_TOOL_ARGUMENT_NAMES)
+    if forbidden:
+        return {
+            "error": "tool_argument_validation_failed",
+            "message": (
+                "Forbidden argument(s): "
+                f"{', '.join(forbidden)}. Tools may not write API-process files "
+                "to caller-supplied paths; return Centaur attachments instead."
+            ),
+            "forbidden_args": forbidden,
+        }
+
     sig = inspect.signature(method.fn)
     params = sig.parameters
     accepts_var_kwargs = any(

--- a/services/api/tests/test_attachments.py
+++ b/services/api/tests/test_attachments.py
@@ -432,6 +432,15 @@ async def test_download_attachment_enforces_sandbox_thread_scope():
     resp = await download_attachment(_request(None), "att-x")
     assert resp.status_code == 200
 
+    # Explicit thread_key must match the attachment's thread, regardless of
+    # token type (used by privileged callers acting for an agent).
+    with pytest.raises(HTTPException) as excinfo:
+        await download_attachment(_request(None), "att-x", thread_key="test:other-thread")
+    assert excinfo.value.status_code == 403
+
+    resp = await download_attachment(_request(None), "att-x", thread_key="test:owner-thread")
+    assert resp.status_code == 200
+
 
 # ── Integration: upload endpoint roundtrip ─────────────────────────────────
 

--- a/services/api/tests/test_attachments.py
+++ b/services/api/tests/test_attachments.py
@@ -387,6 +387,52 @@ async def test_nonexistent_attachment_404(client, api_key):
     assert resp.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_download_attachment_enforces_sandbox_thread_scope():
+    """download_attachment refuses a sandbox token scoped to another thread.
+
+    Exercises the handler directly: the HTTP path can't be used because
+    verify_api_key bypasses auth for loopback clients, so a test client never
+    carries sandbox claims.
+    """
+    import types
+
+    from fastapi import HTTPException
+
+    from api.routers.attachments import download_attachment
+
+    row = {
+        "data": SAMPLE_PNG,
+        "mime_type": "image/png",
+        "name": "secret.png",
+        "thread_key": "test:owner-thread",
+    }
+
+    class _Pool:
+        async def fetchrow(self, _sql, _attachment_id):
+            return row
+
+    def _request(sandbox_claims):
+        return types.SimpleNamespace(
+            app=types.SimpleNamespace(state=types.SimpleNamespace(db_pool=_Pool())),
+            state=types.SimpleNamespace(sandbox_claims=sandbox_claims),
+        )
+
+    # Sandbox token scoped to a different thread → 403
+    with pytest.raises(HTTPException) as excinfo:
+        await download_attachment(_request({"thread_key": "test:other-thread"}), "att-x")
+    assert excinfo.value.status_code == 403
+
+    # Sandbox token scoped to the owning thread → serves the bytes
+    resp = await download_attachment(_request({"thread_key": "test:owner-thread"}), "att-x")
+    assert resp.status_code == 200
+    assert resp.body == SAMPLE_PNG
+
+    # Non-sandbox caller (no claims) → unaffected
+    resp = await download_attachment(_request(None), "att-x")
+    assert resp.status_code == 200
+
+
 # ── Integration: upload endpoint roundtrip ─────────────────────────────────
 
 

--- a/services/api/tests/test_tool_manager.py
+++ b/services/api/tests/test_tool_manager.py
@@ -219,6 +219,24 @@ class TestToolArgValidation:
             is None
         )
 
+    def test_forbidden_path_argument_is_rejected(self):
+        def fn(output_path: str):
+            return output_path
+
+        error = _tool_arg_validation_error(
+            ToolMethod("drive_download", fn),
+            {"output_path": "/app/tools/productivity/gsuite/client.py"},
+        )
+
+        assert error == {
+            "error": "tool_argument_validation_failed",
+            "message": (
+                "Forbidden argument(s): output_path. Tools may not write API-process "
+                "files to caller-supplied paths; return Centaur attachments instead."
+            ),
+            "forbidden_args": ["output_path"],
+        }
+
 
 # ---------------------------------------------------------------------------
 # _to_toon

--- a/tools/productivity/gsuite/cli.py
+++ b/tools/productivity/gsuite/cli.py
@@ -1,8 +1,8 @@
 """CLI for GSuite operations - Gmail, Calendar, Drive."""
 
 import typer
-from rich.console import Console
 from centaur_sdk import Table
+from rich.console import Console
 
 app = typer.Typer(name="gsuite", help="GSuite CLI for AI agents - Gmail, Calendar, Drive")
 console = Console()
@@ -507,7 +507,7 @@ def drive_download(
     """
     from pathlib import Path
 
-    from .client import drive_download as download, drive_get
+    from .client import _drive_download_bytes, drive_get
 
     try:
         file_info = drive_get(file_id)
@@ -516,7 +516,8 @@ def drive_download(
         if output_path.is_dir():
             output_path = output_path / file_info["name"]
 
-        download(file_id, str(output_path))
+        _metadata, data = _drive_download_bytes(file_id)
+        output_path.write_bytes(data)
         console.print(f"[green]✓ Downloaded {file_info['name']}[/]")
         console.print(f"[dim]{output_path.absolute()}[/]")
     except Exception as e:
@@ -856,7 +857,7 @@ def drive_export(
         gsuite drive export "1abc123" -f txt -o doc.txt  # Export as text file
         gsuite drive export "1abc123" -f csv             # Export Sheet as CSV
     """
-    from .client import drive_export as export_file, drive_get, docs_get_text
+    from .client import _drive_export_bytes, drive_get, docs_get_text
 
     try:
         file_info = drive_get(file_id)
@@ -874,16 +875,17 @@ def drive_export(
             return
 
         # For other formats, use Drive export
-        result = export_file(file_id, format, output)
+        metadata, _mime_type, data = _drive_export_bytes(file_id, format)
         if output:
-            console.print(f"[green]✓ Exported {file_info['name']} to {result}[/]")
+            with open(output, "wb") as f:
+                f.write(data)
+            console.print(f"[green]✓ Exported {file_info['name']} to {output}[/]")
         else:
             # If no output specified, print the content for text formats
             if format in ("txt", "csv", "html"):
-                with open(result, "r") as f:
-                    console.print(f.read())
+                console.print(data.decode("utf-8", errors="replace"))
             else:
-                console.print(f"[green]✓ Exported to {result}[/]")
+                console.print(f"[green]✓ Exported {metadata.get('name') or file_id}[/]")
     except Exception as e:
         console.print(f"[red]Error: {e}[/]")
         raise typer.Exit(1)

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit
 
 import httplib2
 import socks
+from centaur_sdk import save_attachment
 from google.auth.credentials import AnonymousCredentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
@@ -684,19 +685,15 @@ def drive_list(
     ]
 
 
-def drive_download(file_id: str, output_path: str) -> str:
-    """Download a file from Google Drive.
-
-    Args:
-        file_id: The file ID
-        output_path: Local path to save the file
-
-    Returns:
-        The output path
-    """
+def _drive_download_bytes(file_id: str) -> tuple[dict, bytes]:
     import io
 
     service = get_drive_service()
+    metadata = service.files().get(
+        fileId=file_id,
+        fields="name,mimeType,webViewLink",
+        supportsAllDrives=True,
+    ).execute()
 
     request = service.files().get_media(fileId=file_id, supportsAllDrives=True)
     fh = io.BytesIO()
@@ -706,10 +703,25 @@ def drive_download(file_id: str, output_path: str) -> str:
     while not done:
         _, done = downloader.next_chunk()
 
-    with open(output_path, "wb") as f:
-        f.write(fh.getvalue())
+    return metadata, fh.getvalue()
 
-    return output_path
+
+def drive_download(file_id: str) -> dict:
+    """Download a file from Google Drive into a thread-scoped Centaur attachment.
+
+    Args:
+        file_id: The file ID
+
+    Returns:
+        Attachment metadata
+    """
+    metadata, data = _drive_download_bytes(file_id)
+    return save_attachment(
+        name=metadata.get("name") or f"drive-{file_id}",
+        mime_type=metadata.get("mimeType") or "application/octet-stream",
+        data=data,
+        source_url=metadata.get("webViewLink"),
+    )
 
 
 def drive_upload(
@@ -1168,19 +1180,8 @@ def drive_setup_channel_permissions(
     return results
 
 
-def drive_export(file_id: str, export_format: str = "txt", output_path: str | None = None) -> str:
-    """Export a Google Docs/Sheets/Slides file to a specific format.
-
-    Args:
-        file_id: The file ID
-        export_format: Export format (txt, pdf, docx, html, csv, xlsx, pptx)
-        output_path: Optional output path (defaults to temp file)
-
-    Returns:
-        The output path
-    """
+def _drive_export_bytes(file_id: str, export_format: str = "txt") -> tuple[dict, str, bytes]:
     import io
-    import tempfile
 
     service = get_drive_service()
 
@@ -1202,9 +1203,11 @@ def drive_export(file_id: str, export_format: str = "txt", output_path: str | No
             f"Unsupported export format: {export_format}. Supported: {list(format_map.keys())}"
         )
 
-    # Determine output path
-    if not output_path:
-        output_path = tempfile.mktemp(suffix=f".{export_format}")
+    metadata = service.files().get(
+        fileId=file_id,
+        fields="name,webViewLink",
+        supportsAllDrives=True,
+    ).execute()
 
     # Export the file
     request = service.files().export_media(fileId=file_id, mimeType=mime_type)
@@ -1215,10 +1218,27 @@ def drive_export(file_id: str, export_format: str = "txt", output_path: str | No
     while not done:
         _, done = downloader.next_chunk()
 
-    with open(output_path, "wb") as f:
-        f.write(fh.getvalue())
+    return metadata, mime_type, fh.getvalue()
 
-    return output_path
+
+def drive_export(file_id: str, export_format: str = "txt") -> dict:
+    """Export a Google Docs/Sheets/Slides file into a thread-scoped attachment.
+
+    Args:
+        file_id: The file ID
+        export_format: Export format (txt, pdf, docx, html, csv, xlsx, pptx)
+
+    Returns:
+        Attachment metadata
+    """
+    metadata, mime_type, data = _drive_export_bytes(file_id, export_format)
+    stem = Path(metadata.get("name") or f"drive-{file_id}").stem
+    return save_attachment(
+        name=f"{stem}.{export_format}",
+        mime_type=mime_type,
+        data=data,
+        source_url=metadata.get("webViewLink"),
+    )
 
 
 # Docs functions
@@ -2618,17 +2638,16 @@ class GSuiteClient:
         """
         return drive_get(file_id)
 
-    def drive_download(self, file_id: str, output_path: str) -> str:
-        """Download a file from Google Drive.
+    def drive_download(self, file_id: str) -> dict:
+        """Download a file from Google Drive into a thread-scoped attachment.
 
         Args:
             file_id: The file ID
-            output_path: Local path to save the file
 
         Returns:
-            The output path
+            Attachment metadata
         """
-        return drive_download(file_id, output_path)
+        return drive_download(file_id)
 
     def drive_upload(
         self,
@@ -2788,20 +2807,17 @@ class GSuiteClient:
         """
         return drive_setup_channel_permissions(file_id, channel_member_emails, requester_email)
 
-    def drive_export(
-        self, file_id: str, export_format: str = "txt", output_path: str | None = None
-    ) -> str:
-        """Export a Google Docs/Sheets/Slides file to a specific format.
+    def drive_export(self, file_id: str, export_format: str = "txt") -> dict:
+        """Export a Google Docs/Sheets/Slides file into a thread-scoped attachment.
 
         Args:
             file_id: The file ID
             export_format: Export format (txt, pdf, docx, html, csv, xlsx, pptx)
-            output_path: Optional output path (defaults to temp file)
 
         Returns:
-            The output path
+            Attachment metadata
         """
-        return drive_export(file_id, export_format=export_format, output_path=output_path)
+        return drive_export(file_id, export_format=export_format)
 
     # --- Docs ---
 

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -457,6 +457,7 @@ def upload(
         slack upload eng-ai file1.png file2.jpg -c "Here are the screenshots"
         slack upload eng-ai report.pdf --thread 1234567890.123456
     """
+    import base64
     from pathlib import Path
 
     from .client import upload_file
@@ -468,9 +469,12 @@ def upload(
             raise typer.Exit(1)
 
         try:
+            # Read the file locally and hand the bytes to the tool: upload_file
+            # takes no local path (it runs server-side; see client.py).
             result = upload_file(
-                channel,
-                str(path.absolute()),
+                channel=channel,
+                content_base64=base64.b64encode(path.read_bytes()).decode(),
+                filename=path.name,
                 title=path.name,
                 comment=comment if file_path == files[0] else None,  # Only comment on first file
                 thread_ts=thread,
@@ -748,10 +752,11 @@ def files(
         slack files "https://..." --download
         slack files "https://..." -d -o /tmp/slack-files
     """
+    import base64
     import re
     from pathlib import Path
 
-    from .client import _download_file, get_message_files
+    from .client import download_file, get_message_files
 
     if permalink.startswith("https://"):
         match = re.search(r"/archives/([A-Z0-9]+)/p(\d+)", permalink)
@@ -784,8 +789,9 @@ def files(
 
             out_path = output_dir / f["name"]
             try:
-                _download_file(f["url_private"], str(out_path))
-                console.print(f"[green]✓ Downloaded {f['name']}[/] ({f['size']} bytes)")
+                result = download_file(f["url_private"])
+                out_path.write_bytes(base64.b64decode(result["content_base64"]))
+                console.print(f"[green]✓ Downloaded {f['name']}[/] ({result['size_bytes']} bytes)")
                 console.print(f"[dim]{out_path.absolute()}[/]")
             except Exception as e:
                 console.print(f"[red]Error downloading {f['name']}: {e}[/]")

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -751,7 +751,7 @@ def files(
     import re
     from pathlib import Path
 
-    from .client import download_file, get_message_files
+    from .client import _download_file, get_message_files
 
     if permalink.startswith("https://"):
         match = re.search(r"/archives/([A-Z0-9]+)/p(\d+)", permalink)
@@ -784,7 +784,7 @@ def files(
 
             out_path = output_dir / f["name"]
             try:
-                download_file(f["url_private"], str(out_path))
+                _download_file(f["url_private"], str(out_path))
                 console.print(f"[green]✓ Downloaded {f['name']}[/] ({f['size']} bytes)")
                 console.print(f"[dim]{out_path.absolute()}[/]")
             except Exception as e:

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -752,11 +752,10 @@ def files(
         slack files "https://..." --download
         slack files "https://..." -d -o /tmp/slack-files
     """
-    import base64
     import re
     from pathlib import Path
 
-    from .client import download_file, get_message_files
+    from .client import _fetch_slack_file, get_message_files
 
     if permalink.startswith("https://"):
         match = re.search(r"/archives/([A-Z0-9]+)/p(\d+)", permalink)
@@ -789,9 +788,9 @@ def files(
 
             out_path = output_dir / f["name"]
             try:
-                result = download_file(f["url_private"])
-                out_path.write_bytes(base64.b64decode(result["content_base64"]))
-                console.print(f"[green]✓ Downloaded {f['name']}[/] ({result['size_bytes']} bytes)")
+                _filename, _mime_type, body = _fetch_slack_file(f["url_private"])
+                out_path.write_bytes(body)
+                console.print(f"[green]✓ Downloaded {f['name']}[/] ({len(body)} bytes)")
                 console.print(f"[dim]{out_path.absolute()}[/]")
             except Exception as e:
                 console.print(f"[red]Error downloading {f['name']}: {e}[/]")

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, ClassVar
-from urllib.parse import urljoin, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
@@ -1595,13 +1595,37 @@ class SlackClient:
             preview["file_type"] = "video"
         return preview
 
+    @staticmethod
+    def _require_thread_key() -> str:
+        """Return the thread_key the tool is running in, or raise.
+
+        Attachment reads and writes are scoped to this so an agent can only
+        touch its own conversation's files.
+        """
+        try:
+            thread_key = get_tool_context().thread_key
+        except LookupError:
+            thread_key = None
+        if not thread_key:
+            raise RuntimeError(
+                "this operation must run inside a Slack thread: no thread_key "
+                "in the tool context to scope the attachment to."
+            )
+        return thread_key
+
     def _download_attachment_bytes(
         self,
         *,
         attachment_id: str | None = None,
         attachment_url: str | None = None,
     ) -> bytes:
-        """Fetch artifact bytes from Centaur's existing attachment API."""
+        """Fetch artifact bytes from Centaur's attachment API.
+
+        The fetch is constrained to the tool's own thread: the request carries
+        the caller's thread_key and the API rejects an attachment that belongs
+        to a different thread, so an agent cannot read another conversation's
+        files by guessing or replaying an attachment id.
+        """
         path = attachment_url
         if attachment_id:
             path = f"/agent/attachments/{attachment_id}/download"
@@ -1618,13 +1642,24 @@ class SlackClient:
             if not path.startswith("/agent/attachments/"):
                 raise ValueError("attachment_url must be a Centaur attachment download path")
             url = urljoin(f"{base_url}/", path.lstrip("/"))
+
+        # Scope the read to this tool's thread.
+        thread_key = self._require_thread_key()
+        sep = "&" if urlparse(url).query else "?"
+        url = f"{url}{sep}thread_key={quote(thread_key, safe='')}"
+
         headers: dict[str, str] = {}
         api_key = secret("CENTAUR_API_KEY", "").strip()
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
         request = urllib.request.Request(url, headers=headers)
         with urllib.request.urlopen(request, timeout=30) as response:
-            return response.read()
+            body = response.read(self._MAX_DOWNLOAD_BYTES + 1)
+        if len(body) > self._MAX_DOWNLOAD_BYTES:
+            raise ValueError(
+                f"Attachment exceeds the {self._MAX_DOWNLOAD_BYTES}-byte limit"
+            )
+        return body
 
     def upload_file(
         self,
@@ -1878,15 +1913,7 @@ class SlackClient:
         The attachment is scoped to the thread the tool is running in, read
         from the tool context.
         """
-        try:
-            thread_key = get_tool_context().thread_key
-        except LookupError:
-            thread_key = None
-        if not thread_key:
-            raise RuntimeError(
-                "download_file must run inside a Slack thread: no thread_key in "
-                "the tool context to scope the attachment to."
-            )
+        thread_key = self._require_thread_key()
 
         base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
         payload = json.dumps(

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1838,7 +1838,7 @@ class SlackClient:
 
     # A tool result is held in memory and base64-encoded into the response, so
     # cap what download_file will return regardless of Slack's own file size.
-    _MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024
+    _MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
 
     def download_file(self, url: str) -> dict:
         """Download a Slack file and return its content as base64.

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1836,32 +1836,24 @@ class SlackClient:
 
         return files
 
-    # A tool result is held in memory and base64-encoded into the response, so
-    # cap what download_file will return regardless of Slack's own file size.
+    # download_file buffers the file in memory before storing it, so cap the
+    # size regardless of Slack's own (much larger) per-file limit.
     _MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
 
-    def download_file(self, url: str) -> dict:
-        """Download a Slack file and return its content as base64.
+    def _fetch_slack_file(self, url: str) -> tuple[str, str, bytes]:
+        """Download a Slack file's bytes: returns ``(filename, mime_type, body)``.
 
-        ``url`` must be an ``https://files.slack.com/`` URL — i.e. a file's
-        ``url_private`` from get_message_files. The bot token is sent only to
-        that host, so it can never be aimed at a Slack API endpoint that would
-        echo the credential back in its response. Nothing is written to disk:
-        the bytes are returned to the caller, which can re-upload or inspect
-        them.
-
-        Returns a dict with ``filename``, ``mime_type``, ``size_bytes`` and
-        ``content_base64``.
+        ``url`` must be an ``https://files.slack.com/`` URL. The bot token is
+        sent only to that host, so it can never be aimed at a Slack API
+        endpoint (e.g. api.test) that would echo the credential back.
         """
-        import urllib.request
-
         if not self.token:
             raise RuntimeError("SLACK_BOT_TOKEN not set")
 
         parsed = urlparse(url)
         if parsed.scheme != "https" or (parsed.hostname or "").lower() != "files.slack.com":
             raise ValueError(
-                "download_file only accepts https://files.slack.com/ URLs; "
+                "Slack file downloads only accept https://files.slack.com/ URLs; "
                 f"refusing {url!r}"
             )
 
@@ -1876,11 +1868,76 @@ class SlackClient:
                 f"Slack file exceeds the {self._MAX_DOWNLOAD_BYTES}-byte download limit"
             )
 
+        return Path(parsed.path).name or "slack-file", mime_type, body
+
+    def _store_attachment(
+        self, *, name: str, mime_type: str, data: bytes, source_url: str
+    ) -> str:
+        """Persist bytes as a Centaur attachment; returns the attachment id.
+
+        The attachment is scoped to the thread the tool is running in, read
+        from the tool context.
+        """
+        try:
+            thread_key = get_tool_context().thread_key
+        except LookupError:
+            thread_key = None
+        if not thread_key:
+            raise RuntimeError(
+                "download_file must run inside a Slack thread: no thread_key in "
+                "the tool context to scope the attachment to."
+            )
+
+        base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
+        payload = json.dumps(
+            {
+                "thread_key": thread_key,
+                "name": name,
+                "mime_type": mime_type,
+                "data": base64.b64encode(data).decode(),
+                "source_url": source_url,
+            }
+        ).encode()
+        headers = {"Content-Type": "application/json"}
+        api_key = secret("CENTAUR_API_KEY", "").strip()
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        request = urllib.request.Request(
+            f"{base_url}/agent/attachments/upload",
+            data=payload,
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            result = json.loads(response.read())
+        attachment_id = result.get("id")
+        if not attachment_id:
+            raise RuntimeError(f"attachment upload returned no id: {result!r}")
+        return attachment_id
+
+    def download_file(self, url: str) -> dict:
+        """Download a Slack file into a Centaur attachment.
+
+        ``url`` must be a file's ``url_private`` from get_message_files (an
+        ``https://files.slack.com/`` URL).
+
+        The file is stored as a Centaur attachment instead of being returned
+        inline, so it never enters the agent's context. Pass the returned
+        ``attachment_id`` to upload_file to re-share the file in Slack, or read
+        it back through the attachments API.
+
+        Returns a dict with ``attachment_id``, ``filename``, ``mime_type`` and
+        ``size_bytes``.
+        """
+        filename, mime_type, body = self._fetch_slack_file(url)
+        attachment_id = self._store_attachment(
+            name=filename, mime_type=mime_type, data=body, source_url=url
+        )
         return {
-            "filename": Path(parsed.path).name or "slack-file",
+            "attachment_id": attachment_id,
+            "filename": filename,
             "mime_type": mime_type,
             "size_bytes": len(body),
-            "content_base64": base64.b64encode(body).decode(),
         }
 
     def search_files(
@@ -2175,6 +2232,10 @@ def get_message_files(*args, **kwargs):
 
 def download_file(*args, **kwargs):
     return _client().download_file(*args, **kwargs)
+
+
+def _fetch_slack_file(*args, **kwargs):
+    return _client()._fetch_slack_file(*args, **kwargs)
 
 
 def dump_channel_with_threads(*args, **kwargs):

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1842,12 +1842,30 @@ class SlackClient:
 
         return files
 
-    def download_file(self, url: str, output_path: str) -> str:
-        """Download a Slack file to local path."""
+    def _download_file(self, url: str, output_path: str) -> str:
+        """Download a Slack file to a local path (CLI helper, not a tool method).
+
+        Underscore-prefixed so it is NOT discovered as a remote tool method.
+        Tool methods run in-process on the API server, so attaching the bot
+        token to a caller-controlled URL is a credential-exfiltration
+        primitive: pointing it at e.g. ``slack.com/api/api.test`` makes Slack
+        echo the bot token straight back in the response body.
+
+        The URL is restricted to ``files.slack.com`` so the bot token only
+        ever rides on genuine file downloads (``url_private``), never on Slack
+        API endpoints.
+        """
         import urllib.request
 
         if not self.token:
             raise RuntimeError("SLACK_BOT_TOKEN not set")
+
+        parsed = urlparse(url)
+        if parsed.scheme != "https" or (parsed.hostname or "").lower() != "files.slack.com":
+            raise ValueError(
+                "download_file only accepts https://files.slack.com/ URLs; "
+                f"refusing {url!r}"
+            )
 
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
         req = urllib.request.Request(url, headers={"Authorization": f"Bearer {self.token}"})
@@ -2146,8 +2164,8 @@ def get_message_files(*args, **kwargs):
     return _client().get_message_files(*args, **kwargs)
 
 
-def download_file(*args, **kwargs):
-    return _client().download_file(*args, **kwargs)
+def _download_file(*args, **kwargs):
+    return _client()._download_file(*args, **kwargs)
 
 
 def dump_channel_with_threads(*args, **kwargs):

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1867,8 +1867,8 @@ class SlackClient:
 
         req = urllib.request.Request(url, headers={"Authorization": f"Bearer {self.token}"})
         with urllib.request.urlopen(req) as response:
-            # Read one byte past the cap so an oversized file is detected
-            # without ever buffering the whole thing.
+            # Read one byte past the cap so an oversized file is rejected
+            # without buffering an unbounded response.
             body = response.read(self._MAX_DOWNLOAD_BYTES + 1)
             mime_type = response.headers.get_content_type()
         if len(body) > self._MAX_DOWNLOAD_BYTES:

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1630,7 +1630,6 @@ class SlackClient:
         self,
         channel: str | None = None,
         channel_id: str | None = None,
-        file_path: str | None = None,
         title: str | None = None,
         comment: str | None = None,
         thread_ts: str | None = None,
@@ -1642,7 +1641,12 @@ class SlackClient:
     ) -> dict:
         """Upload a file to Slack.
 
-        Accepts one of: file_path, content_base64, attachment_id, or attachment_url.
+        Accepts one of: content_base64, attachment_id, or attachment_url.
+        There is deliberately no local-path option: this tool runs in-process
+        on the API server, so a caller-supplied path would read the API host's
+        filesystem (secrets, configs) and exfiltrate it to Slack. Sandboxes
+        pass bytes via content_base64 or a Centaur attachment handle instead.
+
         If channel/thread_ts are omitted and the tool runs in an active Slack
         thread, the destination is inferred from tool context.
 
@@ -1668,16 +1672,6 @@ class SlackClient:
             if content_base64:
                 upload_bytes = base64.b64decode(content_base64)
                 effective_filename = filename or "upload.png"
-            elif file_path:
-                path = Path(file_path)
-                if not path.exists():
-                    raise FileNotFoundError(
-                        "File not found: "
-                        f"{file_path}. If this file was generated in another sandbox, "
-                        "upload via content_base64 or a Centaur attachment_id instead."
-                    )
-                effective_filename = filename or path.name
-                upload_bytes = path.read_bytes()
             elif attachment_id or attachment_url:
                 upload_bytes = self._download_attachment_bytes(
                     attachment_id=attachment_id,
@@ -1686,7 +1680,7 @@ class SlackClient:
                 effective_filename = filename or f"{attachment_id or 'attachment'}.bin"
             else:
                 raise ValueError(
-                    "One of file_path, content_base64, attachment_id, or attachment_url is required"
+                    "One of content_base64, attachment_id, or attachment_url is required"
                 )
             kwargs["content"] = upload_bytes
             kwargs["filename"] = effective_filename
@@ -1842,18 +1836,22 @@ class SlackClient:
 
         return files
 
-    def _download_file(self, url: str, output_path: str) -> str:
-        """Download a Slack file to a local path (CLI helper, not a tool method).
+    # A tool result is held in memory and base64-encoded into the response, so
+    # cap what download_file will return regardless of Slack's own file size.
+    _MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024
 
-        Underscore-prefixed so it is NOT discovered as a remote tool method.
-        Tool methods run in-process on the API server, so attaching the bot
-        token to a caller-controlled URL is a credential-exfiltration
-        primitive: pointing it at e.g. ``slack.com/api/api.test`` makes Slack
-        echo the bot token straight back in the response body.
+    def download_file(self, url: str) -> dict:
+        """Download a Slack file and return its content as base64.
 
-        The URL is restricted to ``files.slack.com`` so the bot token only
-        ever rides on genuine file downloads (``url_private``), never on Slack
-        API endpoints.
+        ``url`` must be an ``https://files.slack.com/`` URL — i.e. a file's
+        ``url_private`` from get_message_files. The bot token is sent only to
+        that host, so it can never be aimed at a Slack API endpoint that would
+        echo the credential back in its response. Nothing is written to disk:
+        the bytes are returned to the caller, which can re-upload or inspect
+        them.
+
+        Returns a dict with ``filename``, ``mime_type``, ``size_bytes`` and
+        ``content_base64``.
         """
         import urllib.request
 
@@ -1867,12 +1865,23 @@ class SlackClient:
                 f"refusing {url!r}"
             )
 
-        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
         req = urllib.request.Request(url, headers={"Authorization": f"Bearer {self.token}"})
-        with urllib.request.urlopen(req) as response, open(output_path, "wb") as f:
-            f.write(response.read())
+        with urllib.request.urlopen(req) as response:
+            # Read one byte past the cap so an oversized file is detected
+            # without ever buffering the whole thing.
+            body = response.read(self._MAX_DOWNLOAD_BYTES + 1)
+            mime_type = response.headers.get_content_type()
+        if len(body) > self._MAX_DOWNLOAD_BYTES:
+            raise ValueError(
+                f"Slack file exceeds the {self._MAX_DOWNLOAD_BYTES}-byte download limit"
+            )
 
-        return output_path
+        return {
+            "filename": Path(parsed.path).name or "slack-file",
+            "mime_type": mime_type,
+            "size_bytes": len(body),
+            "content_base64": base64.b64encode(body).decode(),
+        }
 
     def search_files(
         self,
@@ -2164,8 +2173,8 @@ def get_message_files(*args, **kwargs):
     return _client().get_message_files(*args, **kwargs)
 
 
-def _download_file(*args, **kwargs):
-    return _client()._download_file(*args, **kwargs)
+def download_file(*args, **kwargs):
+    return _client().download_file(*args, **kwargs)
 
 
 def dump_channel_with_threads(*args, **kwargs):

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -17,7 +17,7 @@ from urllib.parse import quote, urljoin, urlparse
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-from centaur_sdk.tool_sdk import get_tool_context, secret
+from centaur_sdk.tool_sdk import get_tool_context, save_attachment, secret
 
 # Cache for channel list to avoid repeated API calls
 
@@ -1913,34 +1913,12 @@ class SlackClient:
         The attachment is scoped to the thread the tool is running in, read
         from the tool context.
         """
-        thread_key = self._require_thread_key()
-
-        base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
-        payload = json.dumps(
-            {
-                "thread_key": thread_key,
-                "name": name,
-                "mime_type": mime_type,
-                "data": base64.b64encode(data).decode(),
-                "source_url": source_url,
-            }
-        ).encode()
-        headers = {"Content-Type": "application/json"}
-        api_key = secret("CENTAUR_API_KEY", "").strip()
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-        request = urllib.request.Request(
-            f"{base_url}/agent/attachments/upload",
-            data=payload,
-            headers=headers,
-            method="POST",
-        )
-        with urllib.request.urlopen(request, timeout=30) as response:
-            result = json.loads(response.read())
-        attachment_id = result.get("id")
-        if not attachment_id:
-            raise RuntimeError(f"attachment upload returned no id: {result!r}")
-        return attachment_id
+        return save_attachment(
+            name=name,
+            mime_type=mime_type,
+            data=data,
+            source_url=source_url,
+        )["attachment_id"]
 
     def download_file(self, url: str) -> dict:
         """Download a Slack file into a Centaur attachment.

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -547,6 +547,46 @@ def test_download_file_requires_thread_context(monkeypatch: pytest.MonkeyPatch) 
         client.download_file("https://files.slack.com/files-pri/T1-F1/report.pdf")
 
 
+def test_download_attachment_bytes_scopes_request_to_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An attachment fetch carries the tool's thread_key so the API can reject
+    a cross-thread read."""
+    import urllib.request
+
+    client, _ = _make_client()
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api:8000")
+    captured: dict = {}
+
+    def fake_urlopen(req, *args, **kwargs):
+        captured["url"] = req.full_url
+        return _FakeHTTPResponse(b"file-bytes", "application/octet-stream")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    token = set_tool_context(ToolContext(name="slack", thread_key="slack:C1:1.2"))
+    try:
+        body = client._download_attachment_bytes(attachment_id="att-xyz")
+    finally:
+        reset_tool_context(token)
+
+    assert body == b"file-bytes"
+    assert captured["url"] == (
+        "http://api:8000/agent/attachments/att-xyz/download"
+        "?thread_key=slack%3AC1%3A1.2"
+    )
+
+
+def test_download_attachment_bytes_requires_thread_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _make_client()
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api:8000")
+
+    with pytest.raises(RuntimeError, match="thread"):
+        client._download_attachment_bytes(attachment_id="att-xyz")
+
+
 def test_native_search_uses_dedicated_search_client() -> None:
     client, fake_bot_client = _make_client()
     fake_search_client = _FakeWebClient()

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -408,13 +408,20 @@ def test_upload_file_infers_slack_thread_from_tool_context() -> None:
     assert fake_web_client.last_kwargs["initial_comment"] == "Uploaded `chart.png`."
 
 
-def test_upload_file_missing_path_points_to_artifact_handle() -> None:
+def test_upload_file_rejects_local_path_argument() -> None:
+    """upload_file must not accept a local path: it runs server-side, so a
+    caller path would read the API host's filesystem."""
     client, _ = _make_client()
 
-    with pytest.raises(FileNotFoundError) as excinfo:
+    with pytest.raises(TypeError):
         client.upload_file("paradigm-pulse", file_path="/tmp/missing-chart.png")
 
-    assert "Centaur attachment_id" in str(excinfo.value)
+
+def test_upload_file_requires_a_content_source() -> None:
+    client, _ = _make_client()
+
+    with pytest.raises(ValueError, match="content_base64, attachment_id, or attachment_url"):
+        client.upload_file("paradigm-pulse")
 
 
 def test_attachment_url_must_use_centaur_api(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -446,6 +453,67 @@ def test_upload_file_can_infer_destination_without_channel_arg() -> None:
     assert fake_web_client.last_kwargs is not None
     assert fake_web_client.last_kwargs["channel"] == "C123"
     assert fake_web_client.last_kwargs["thread_ts"] == "1777910337.403889"
+
+
+class _FakeHTTPResponse:
+    """Minimal stand-in for urllib's HTTPResponse context manager."""
+
+    def __init__(self, body: bytes, content_type: str) -> None:
+        self._body = body
+        self._content_type = content_type
+
+    def __enter__(self) -> "_FakeHTTPResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def read(self, _amt: int = -1) -> bytes:
+        return self._body
+
+    @property
+    def headers(self) -> "email.message.Message":
+        import email.message
+
+        msg = email.message.Message()
+        msg["Content-Type"] = self._content_type
+        return msg
+
+
+def test_download_file_rejects_non_files_host() -> None:
+    client, _ = _make_client()
+    client.token = "SLACK_BOT_TOKEN"
+
+    with pytest.raises(ValueError, match="files.slack.com"):
+        client.download_file("https://slack.com/api/api.test?x=SLACK_BOT_TOKEN")
+
+    with pytest.raises(ValueError, match="files.slack.com"):
+        client.download_file("http://files.slack.com/files-pri/T1-F1/report.pdf")
+
+
+def test_download_file_returns_base64(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.request
+
+    client, _ = _make_client()
+    client.token = "SLACK_BOT_TOKEN"
+    captured: dict = {}
+
+    def fake_urlopen(req, *args, **kwargs):
+        captured["url"] = req.full_url
+        captured["auth"] = req.get_header("Authorization")
+        return _FakeHTTPResponse(b"%PDF-1.4 report", "application/pdf")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = client.download_file("https://files.slack.com/files-pri/T1-F1/report.pdf")
+
+    assert captured["auth"] == "Bearer SLACK_BOT_TOKEN"
+    assert result == {
+        "filename": "report.pdf",
+        "mime_type": "application/pdf",
+        "size_bytes": 15,
+        "content_base64": "JVBERi0xLjQgcmVwb3J0",
+    }
 
 
 def test_native_search_uses_dedicated_search_client() -> None:

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 import pytest
@@ -491,29 +492,59 @@ def test_download_file_rejects_non_files_host() -> None:
         client.download_file("http://files.slack.com/files-pri/T1-F1/report.pdf")
 
 
-def test_download_file_returns_base64(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_download_file_stores_attachment(monkeypatch: pytest.MonkeyPatch) -> None:
     import urllib.request
 
     client, _ = _make_client()
     client.token = "SLACK_BOT_TOKEN"
-    captured: dict = {}
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api:8000")
+    posted: dict = {}
 
     def fake_urlopen(req, *args, **kwargs):
-        captured["url"] = req.full_url
-        captured["auth"] = req.get_header("Authorization")
-        return _FakeHTTPResponse(b"%PDF-1.4 report", "application/pdf")
+        if "files.slack.com" in req.full_url:
+            assert req.get_header("Authorization") == "Bearer SLACK_BOT_TOKEN"
+            return _FakeHTTPResponse(b"%PDF-1.4 report", "application/pdf")
+        if req.full_url.endswith("/agent/attachments/upload"):
+            posted["body"] = json.loads(req.data)
+            return _FakeHTTPResponse(
+                json.dumps({"id": "att-abc123", "name": "report.pdf"}).encode(),
+                "application/json",
+            )
+        raise AssertionError(f"unexpected url {req.full_url}")
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
 
-    result = client.download_file("https://files.slack.com/files-pri/T1-F1/report.pdf")
+    token = set_tool_context(ToolContext(name="slack", thread_key="slack:C1:1.2"))
+    try:
+        result = client.download_file("https://files.slack.com/files-pri/T1-F1/report.pdf")
+    finally:
+        reset_tool_context(token)
 
-    assert captured["auth"] == "Bearer SLACK_BOT_TOKEN"
     assert result == {
+        "attachment_id": "att-abc123",
         "filename": "report.pdf",
         "mime_type": "application/pdf",
         "size_bytes": 15,
-        "content_base64": "JVBERi0xLjQgcmVwb3J0",
     }
+    assert posted["body"]["thread_key"] == "slack:C1:1.2"
+    assert posted["body"]["name"] == "report.pdf"
+    assert posted["body"]["mime_type"] == "application/pdf"
+    assert base64.b64decode(posted["body"]["data"]) == b"%PDF-1.4 report"
+
+
+def test_download_file_requires_thread_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.request
+
+    client, _ = _make_client()
+    client.token = "SLACK_BOT_TOKEN"
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda req, *a, **k: _FakeHTTPResponse(b"data", "application/octet-stream"),
+    )
+
+    with pytest.raises(RuntimeError, match="thread"):
+        client.download_file("https://files.slack.com/files-pri/T1-F1/report.pdf")
 
 
 def test_native_search_uses_dedicated_search_client() -> None:

--- a/tools/research/archiver/client.py
+++ b/tools/research/archiver/client.py
@@ -7,6 +7,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from centaur_sdk import save_attachment_from_path
+
 from .download.orchestrator import download_source
 from .ingest.parse import parse_manifest
 from .utils import (
@@ -21,29 +23,62 @@ from .utils import (
 class ArchiverClient:
     """Extraction-first client for investment document parsing."""
 
+    def _attach_download_payload(self, payload: dict, manifest_path: Path) -> dict:
+        attachments: list[dict[str, Any]] = []
+        for record in payload.get("files") or []:
+            raw_path = record.get("file_path")
+            if not raw_path:
+                continue
+            path = Path(raw_path)
+            if not path.exists() or not path.is_file():
+                continue
+            attachment = save_attachment_from_path(
+                path,
+                name=record.get("filename") or path.name,
+                mime_type=record.get("mime_type"),
+                source_url=record.get("source_url") or payload.get("source_url"),
+            )
+            attachments.append({**attachment, "source_type": record.get("source_type")})
+
+        manifest_attachment = save_attachment_from_path(
+            manifest_path,
+            name="manifest.json",
+            mime_type="application/json",
+            source_url=payload.get("source_url"),
+        )
+        return {
+            **payload,
+            "files": [
+                {k: v for k, v in record.items() if k != "file_path"}
+                for record in payload.get("files") or []
+            ],
+            "attachments": attachments,
+            "manifest_attachment": manifest_attachment,
+        }
+
     def download(
         self,
         source_url: str,
-        output_dir: str,
         company: str | None = None,
         account: str | None = None,
         password: str | None = None,
         email: str | None = None,
         max_depth: int = 3,
     ) -> dict:
-        output_dir = Path(output_dir)
-        payload = download_source(
-            source_url=source_url,
-            output_dir=output_dir,
-            company=company,
-            account=account,
-            password=password,
-            email=email,
-            max_depth=max_depth,
-        )
-        manifest_path = output_dir / "manifest.json"
-        manifest_path.write_text(dump_json(payload))
-        return {**payload, "manifest_path": str(manifest_path)}
+        with tempfile.TemporaryDirectory(prefix="centaur-archiver-") as tmpdir:
+            output_dir = Path(tmpdir)
+            payload = download_source(
+                source_url=source_url,
+                output_dir=output_dir,
+                company=company,
+                account=account,
+                password=password,
+                email=email,
+                max_depth=max_depth,
+            )
+            manifest_path = output_dir / "manifest.json"
+            manifest_path.write_text(dump_json(payload))
+            return self._attach_download_payload(payload, manifest_path)
 
     def _manifest_with_context(
         self, manifest_path: Path, context: dict | None
@@ -134,7 +169,6 @@ class ArchiverClient:
     def extract_source(
         self,
         source_url: str,
-        output_dir: str,
         company: str | None = None,
         account: str | None = None,
         password: str | None = None,
@@ -143,35 +177,38 @@ class ArchiverClient:
         context: dict | None = None,
     ) -> dict:
         """Download source and run Reducto extraction in one call."""
-        download_payload = self.download(
-            source_url=source_url,
-            output_dir=output_dir,
-            company=company,
-            account=account,
-            password=password,
-            email=email,
-            max_depth=max_depth,
-        )
-        if download_payload.get("status") != "ok":
-            return {
-                "status": "error",
-                "error": download_payload.get("error") or "Download stage failed",
-                "source": source_url,
-                "manifest_path": download_payload.get("manifest_path"),
-                "download": download_payload,
-                "files": download_payload.get("files") or [],
-            }
-        if not download_payload.get("files"):
-            return {
-                "status": "error",
-                "error": "Download stage produced no files",
-                "source": source_url,
-                "manifest_path": download_payload.get("manifest_path"),
-                "download": download_payload,
-                "files": [],
-            }
-        manifest_path = Path(output_dir) / "manifest.json"
-        return self.extract_manifest(str(manifest_path), context=context)
+        with tempfile.TemporaryDirectory(prefix="centaur-archiver-") as tmpdir:
+            output_dir = Path(tmpdir)
+            payload = download_source(
+                source_url=source_url,
+                output_dir=output_dir,
+                company=company,
+                account=account,
+                password=password,
+                email=email,
+                max_depth=max_depth,
+            )
+            manifest_path = output_dir / "manifest.json"
+            manifest_path.write_text(dump_json(payload))
+            attached_download = self._attach_download_payload(payload, manifest_path)
+            if payload.get("status") != "ok":
+                return {
+                    "status": "error",
+                    "error": payload.get("error") or "Download stage failed",
+                    "source": source_url,
+                    "download": attached_download,
+                    "files": attached_download.get("files") or [],
+                }
+            if not payload.get("files"):
+                return {
+                    "status": "error",
+                    "error": "Download stage produced no files",
+                    "source": source_url,
+                    "download": attached_download,
+                    "files": [],
+                }
+            extracted = self.extract_manifest(str(manifest_path), context=context)
+            return {**extracted, "download": attached_download}
 
 
 def _client() -> ArchiverClient:

--- a/tools/research/archiver/tests/test_docsend_fallback.py
+++ b/tools/research/archiver/tests/test_docsend_fallback.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import importlib
-import json
 import sys
-import tempfile
 import types
 import unittest
 from dataclasses import dataclass
@@ -97,25 +95,30 @@ class DocsendFallbackTest(unittest.TestCase):
                     "_run_standalone_docsend_fallback",
                     return_value=fallback_payload,
                 ):
-                    client = client_module.ArchiverClient()
-                    with tempfile.TemporaryDirectory() as tmpdir:
+                    def fake_attach(path, **kwargs):
+                        return {
+                            "attachment_id": f"att-{Path(path).name}",
+                            "filename": kwargs.get("name") or Path(path).name,
+                            "mime_type": kwargs.get("mime_type") or "application/octet-stream",
+                            "size_bytes": Path(path).stat().st_size,
+                        }
+
+                    with patch.object(client_module, "save_attachment_from_path", side_effect=fake_attach):
+                        client = client_module.ArchiverClient()
                         result = client.extract_source(
                             source_url="https://docsend.com/view/example",
-                            output_dir=tmpdir,
                             company="Example",
                         )
-
-                        manifest_path = Path(result["manifest_path"])
-                        self.assertTrue(manifest_path.exists())
-                        manifest = json.loads(manifest_path.read_text())
 
                 self.assertEqual(result["status"], "error")
                 self.assertIn("password-protected", result["error"])
                 self.assertNotEqual(result["error"], "Download stage failed")
                 self.assertEqual(result["download"]["blocker"]["kind"], "passcode_required")
                 self.assertEqual(result["download"]["blocker"]["required_input"], "password")
-                self.assertEqual(manifest["blocker"]["kind"], "passcode_required")
-                self.assertEqual(manifest["details"]["status"], "passcode_required")
+                self.assertEqual(
+                    result["download"]["manifest_attachment"]["attachment_id"],
+                    "att-manifest.json",
+                )
         finally:
             sys.path = [entry for entry in sys.path if entry != str(REPO_ROOT)]
             _clear_archiver_modules()


### PR DESCRIPTION
Hardens the slack tool's file download/upload paths. Both run in-process on the API server, so a caller-controlled path or URL is a host-filesystem / credential primitive.

**`download_file`** previously took an `output_path` and wrote to the API host's filesystem, and accepted an arbitrary URL — pointed at `slack.com/api/api.test` it made Slack echo the bot token straight back in the response. It is now an attachment-producing tool:

- URL restricted to `https://files.slack.com` (where real `url_private` files live) via `urlparse` host matching, so the bot token can't be aimed at a Slack API endpoint.
- The downloaded bytes are stored as a Centaur attachment (scoped to the thread from tool context) and the tool returns `{attachment_id, filename, mime_type, size_bytes}` — no base64 blob dumped into the agent's context. The `attachment_id` round-trips into `upload_file(attachment_id=...)` for re-sharing.
- 10 MiB size cap.

**`upload_file`** loses its `file_path` argument: a caller-supplied server-side path let it read the API host's filesystem (secrets, configs) and post it to Slack. Callers use `content_base64` or a Centaur attachment handle. The sandbox `slack-upload.sh` helper and the CLI already base64-encode locally.

CLI (`slack files --download` / `slack upload`) and tests updated.