### PR TITLE
fix: honor persona engines and overlay tool precedence

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -557,9 +557,10 @@ def _resolve_harness_profile(
 ) -> tuple[str, str | None, str | None]:
     """Return ``(engine, persona_name, default_repo)`` for a spawn.
 
-    ``harness`` must be ``amp``/``claude-code``/``codex``/``pi-mono`` (or
-    ``None``). ``persona`` is any registered persona name. An explicit
-    ``harness`` overrides the persona's declared engine.
+    ``harness`` is the legacy caller-facing name for what is now treated as
+    the sandbox engine. Precedence is:
+    explicit ``engine_override`` > explicit differing ``harness`` >
+    persona-declared engine > ``codex`` default.
     """
     from api.app import get_tool_manager
 
@@ -580,14 +581,26 @@ def _resolve_harness_profile(
     if persona and persona_info is None:
         raise ValueError(f"Unknown persona: {persona}")
 
-    if normalized_harness == "amp":
-        engine = normalized_engine_override or "codex"
+    persona_engine = (
+        (getattr(persona_info, "engine", None) or "").strip() or None
+        if persona_info
+        else None
+    )
+
+    if normalized_engine_override:
+        engine = normalized_engine_override
+    elif persona_engine:
+        # Persona declares an engine. Use it unless the caller passed a
+        # *different* harness arg, in which case the explicit harness arg is
+        # treated as a user-driven engine override (e.g. `--invest --claude`).
+        if normalized_harness and normalized_harness != persona_engine:
+            engine = normalized_harness
+        else:
+            engine = persona_engine
     elif normalized_harness:
-        engine = normalized_engine_override or normalized_harness
-    elif persona_info:
-        engine = normalized_engine_override or persona_info.engine
+        engine = normalized_harness
     else:
-        engine = normalized_engine_override or "codex"
+        engine = "codex"
 
     if persona_info:
         return engine, persona_info.name, persona_info.default_repo

--- a/services/api/api/app.py
+++ b/services/api/api/app.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import signal
+import sys
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
@@ -417,6 +418,32 @@ else:
         if _plugin_dirs
         else [Path(os.environ.get("PLUGINS_DIR", _app_root / "tools"))]
     )
+
+# Make all TOOL_DIRS entries visible through the `tools.*` namespace with
+# overlay-last priority. Some overlay tools subclass or extend base tools;
+# without refreshing both sys.path and the already-imported namespace path,
+# Python can silently import the base module and drop overlay-only methods.
+for _tools_dir in reversed(_tools_dirs):
+    _parent = str(_tools_dir.resolve().parent)
+    if _parent and _parent not in sys.path:
+        sys.path.insert(0, _parent)
+try:
+    import tools as _tools_pkg
+
+    _seen: set[str] = set()
+    _new_path: list[str] = []
+    for _tools_dir in reversed(_tools_dirs):
+        s = str(_tools_dir.resolve())
+        if s and s not in _seen and os.path.isdir(s):
+            _seen.add(s)
+            _new_path.append(s)
+    for _existing in getattr(_tools_pkg, "__path__", []):
+        if _existing not in _seen:
+            _seen.add(_existing)
+            _new_path.append(_existing)
+    _tools_pkg.__path__ = _new_path  # type: ignore[assignment]
+except ImportError:
+    pass
 
 tool_manager = ToolManager(_tools_dirs)
 tool_manager.discover()

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -2522,6 +2522,16 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                         }:
                             slackbot_text_sent = True
             observations.raw_event_count += 1
+            # ``amp_raw_event`` is a HISTORICAL label preserved for API and
+            # dashboard back-compat. Despite the name, this row stores the
+            # raw stream payload from WHICHEVER harness produced the event
+            # (amp, codex, claude-code, pi-mono). To filter by actual engine
+            # use the projected observation events emitted below, or join
+            # this row's thread_key against ``agent_runtime_assignments``.
+            # If you rename this label, update at least:
+            #   - packages/api-client/test/client.test.ts (asserts "amp_raw_event")
+            #   - _VALID_STDOUT_EVENT_TYPES in services/api/api/agent.py
+            #   - any Grafana / VictoriaLogs dashboards keyed on it.
             await append_execution_event(
                 pool,
                 thread_key=thread_key,

--- a/services/api/api/sandbox/prompt_assembly.py
+++ b/services/api/api/sandbox/prompt_assembly.py
@@ -49,6 +49,13 @@ def _active_deployment_block(
         lines.append(f"|Overlay mount (sandbox): {sandbox_overlay_dir}")
     else:
         lines.append("|Overlay mount (sandbox): none")
+    if persona:
+        lines.append(
+            "|Persona overlay loaded: its instructions override generic "
+            "base-prompt guidance on routing, tool choice, voice, and "
+            "output shape. Read the overlay before acting on any base "
+            "default."
+        )
     lines.extend(
         [
             "|To verify at runtime, run any of:",

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -665,6 +665,63 @@ _BUILTIN_TYPE_NAMES: dict[type, str] = {
 }
 
 
+_METHOD_DESCRIPTION_MAX_CHARS = 1200
+_DOCSTRING_BOUNDARY_MARKERS = (
+    "Args:",
+    "Arguments:",
+    "Returns:",
+    "Return:",
+    "Yields:",
+    "Raises:",
+    "Example:",
+    "Examples:",
+    "Note:",
+    "Notes:",
+    "Warning:",
+    "See Also:",
+    "See also:",
+)
+
+
+def _describe_method_docstring(doc: str | None) -> str:
+    """Return the agent-facing description for a tool method's docstring.
+
+    The base implementation used only the docstring's FIRST LINE, which
+    silently stripped the rest of any multi-paragraph explanation. For tools
+    whose first line is a noun phrase (e.g. ``"Hybrid research engine."``)
+    and whose follow-on paragraph explains when to use the method, the agent
+    never sees the load-bearing guidance.
+
+    The replacement keeps the full prose summary up to the first Google-style
+    section marker (``Args:`` / ``Returns:`` / ``Raises:`` / ``Example:`` /
+    ``Note:`` / etc.) or a ``_METHOD_DESCRIPTION_MAX_CHARS`` budget, whichever
+    comes first. Parameter docs continue to be exposed structurally on the
+    ``parameters`` field, so excluding them from ``description`` is
+    intentional — agents should pick methods from the prose and pass args
+    from the schema.
+    """
+    if not doc:
+        return ""
+    # ``inspect.cleandoc`` is the canonical normalizer for Python docstrings:
+    # it strips the common leading whitespace from continuation lines so any
+    # subsequent markers match at column 0.
+    text = inspect.cleandoc(doc)
+    if not text:
+        return ""
+    boundary = len(text)
+    for marker in _DOCSTRING_BOUNDARY_MARKERS:
+        # Markers must appear at start-of-line (column 0) to count.
+        idx = text.find("\n" + marker)
+        if idx == -1 and text.startswith(marker):
+            idx = 0
+        if 0 <= idx < boundary:
+            boundary = idx
+    summary = text[:boundary].rstrip()
+    if len(summary) > _METHOD_DESCRIPTION_MAX_CHARS:
+        summary = summary[: _METHOD_DESCRIPTION_MAX_CHARS - 1].rstrip() + "\u2026"
+    return summary
+
+
 def _friendly_type_name(annotation: Any) -> str:
     """Convert a Python type annotation to a clean, human-readable string.
 
@@ -1133,13 +1190,14 @@ class ToolManager:
             }
         method_schemas: list[dict[str, Any]] = []
         for method in sorted(lt.methods, key=lambda m: m.method_name):
+            description = _describe_method_docstring(method.fn.__doc__)
             try:
                 sig = inspect.signature(method.fn)
             except (TypeError, ValueError) as exc:
                 method_schemas.append(
                     {
                         "name": method.method_name,
-                        "description": (method.fn.__doc__ or "").strip().split("\n")[0],
+                        "description": description,
                         "parameters": {},
                         "signature_error": str(exc),
                     }
@@ -1161,7 +1219,7 @@ class ToolManager:
             method_schemas.append(
                 {
                     "name": method.method_name,
-                    "description": (method.fn.__doc__ or "").strip().split("\n")[0],
+                    "description": description,
                     "parameters": params,
                 }
             )

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -943,6 +943,25 @@ def _assignment_display_engine(active: dict[str, Any]) -> str | None:
     return _nonempty(active.get("harness"))
 
 
+def _display_harness_label(harness: str | None, persona: str | None) -> str | None:
+    """Best human-readable name for the runtime that ran.
+
+    Prefers an explicit ``harness`` override; falls back to the persona's
+    declared engine; finally returns ``None`` if nothing is known. Useful
+    for user-facing error messages where we don't want to hard-code a
+    specific engine name (e.g. ``"Failed to start the Codex runtime"`` is
+    wrong when the active engine is amp/claude-code/pi-mono).
+    """
+    label = _nonempty(harness)
+    if label:
+        return label
+    if persona:
+        engine = _persona_default_engine(persona)
+        if engine:
+            return engine
+    return None
+
+
 def _persona_default_engine(persona_id: str) -> str | None:
     try:
         from api.app import get_tool_manager
@@ -1131,9 +1150,16 @@ async def do_agent_turn(
             )
         except Exception as exc:
             if slackbot_session_id:
+                # Surface the actual harness/engine name in the error instead of
+                # the hard-coded "Codex" — every harness path lands here, not
+                # just codex. Falls back to "agent" when no display name is
+                # available so the message stays readable.
+                runtime_label = (
+                    _display_harness_label(harness, persona) or "agent"
+                )
                 await slackbot_client.session_text(
                     slackbot_session_id,
-                    f"Failed to start the Codex runtime: {exc}",
+                    f"Failed to start the {runtime_label} runtime: {exc}",
                 )
                 await slackbot_client.session_done(slackbot_session_id)
             raise

--- a/services/api/tests/test_assemble_prompt.py
+++ b/services/api/tests/test_assemble_prompt.py
@@ -11,12 +11,29 @@ def test_assemble_prompt_without_persona_or_overlay() -> None:
     assert prompt.startswith("[Active deployment]\n|Persona: none - base centaur identity")
     assert "|Overlay loaded: no" in prompt
     assert "base prompt" in prompt
+    # No persona => no persona-precedence note injected.
+    assert "Persona overlay loaded" not in prompt
     # The agent must always see the env vars and runtime command it is supposed
     # to use to introspect itself; lock that into the assembled prompt so a
     # future edit to prompt_assembly cannot drop them silently.
     assert '$AGENT_PERSONA' in prompt
     assert '$CENTAUR_OVERLAY_DIR' in prompt
     assert "call agent runtime '?key='\"$CENTAUR_THREAD_KEY\"" in prompt
+
+
+def test_assemble_prompt_with_persona_announces_persona_precedence() -> None:
+    """Generic mechanism: any persona override gets a deployment-block note
+    declaring that the persona overlay wins on routing/tool/voice conflicts.
+    The note is persona-agnostic — no specific persona name or tool name
+    appears so this works for every current and future persona."""
+    persona = SimpleNamespace(engine="amp", prompt_content="persona body")
+    prompt = assemble_prompt("anything", base_prompt="base", persona_info=persona)
+
+    assert "Persona overlay loaded" in prompt
+    # Sanity: the note must NOT name any particular persona or tool — it's a
+    # generic mechanism that future personas inherit automatically.
+    assert "invest" not in prompt.split("---")[0].lower()
+    assert "invest_research" not in prompt.split("---")[0]
 
 
 def test_assemble_prompt_handles_non_utf8_overlay_file(tmp_path) -> None:

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -431,6 +431,62 @@ class TestResolveHarnessProfile:
             "centaur-overlay",
         )
 
+    def test_engine_resolution_precedence_matrix(self, monkeypatch):
+        """Exhaustive precedence matrix for the engine-resolution model.
+
+        Both `harness` and `engine` are functionally one concept (the
+        LLM-wrapping CLI binary). The resolver collapses them with this
+        precedence (highest wins):
+
+            1. engine_override
+            2. harness (when DIFFERENT from persona's declared engine)
+            3. persona.engine
+            4. system default ("codex")
+
+        Regression-locked: the previous resolver hardcoded engine="codex"
+        for harness=="amp" regardless of persona, silently dropping the
+        invest persona's declared engine="amp" — that exact failure mode
+        is asserted below.
+        """
+        import sys
+        from types import ModuleType, SimpleNamespace
+
+        from api.agent import _resolve_harness_profile as resolve
+
+        personas = {
+            "invest": SimpleNamespace(name="invest", engine="amp", default_repo=None),
+            "eng": SimpleNamespace(name="eng", engine="codex", default_repo=None),
+        }
+        app_module = ModuleType("api.app")
+        app_module.get_tool_manager = lambda: SimpleNamespace(
+            get_persona=lambda name: personas.get(name)
+        )
+        monkeypatch.setitem(sys.modules, "api.app", app_module)
+
+        # Rule 1: engine_override always wins.
+        assert resolve("amp", persona="invest", engine_override="codex")[0] == "codex"
+        assert resolve(None, persona="invest", engine_override="claude-code")[0] == "claude-code"
+        assert resolve("codex", persona=None, engine_override="amp")[0] == "amp"
+
+        # Rule 2: explicit harness arg DIFFERENT from persona's engine wins
+        # (this is how --invest --claude-code routes invest to a non-amp engine).
+        assert resolve("claude-code", persona="invest")[0] == "claude-code"
+        assert resolve("amp", persona="eng")[0] == "amp"
+
+        # Rule 3: harness arg matching persona.engine (or no harness arg) →
+        # persona's declared engine. This is the regression path: the workflow
+        # forwards `effective_harness = persona.engine`, which used to silently
+        # become "codex" for any persona whose engine == "amp".
+        assert resolve("amp", persona="invest")[0] == "amp"
+        assert resolve(None, persona="invest")[0] == "amp"
+        assert resolve("codex", persona="eng")[0] == "codex"
+        assert resolve(None, persona="eng")[0] == "codex"
+
+        # Rule 4: no override, no persona → harness if given, else system default.
+        assert resolve("amp", persona=None)[0] == "amp"
+        assert resolve("claude-code", persona=None)[0] == "claude-code"
+        assert resolve(None, persona=None)[0] == "codex"
+
     def test_unknown_harness_or_persona_is_rejected(self, monkeypatch):
         import sys
         from types import ModuleType, SimpleNamespace

--- a/services/api/tests/test_tool_manager.py
+++ b/services/api/tests/test_tool_manager.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from api.tool_manager import (  # noqa: E402
     _LIFECYCLE_METHODS,
+    _describe_method_docstring,
     _friendly_type_name,
     _normalize_for_serialization,
     _tool_arg_validation_error,
@@ -21,6 +22,57 @@ from api.tool_manager import (  # noqa: E402
     ToolManager,
     ToolMethod,
 )
+
+
+class TestDescribeMethodDocstring:
+    """Generic agent-facing description extraction (no persona-specific cases).
+
+    Tools across personas all flow through describe_tool, which exposes
+    methods to the agent via `call discover <tool>`. Keeping the human-prose
+    portion of the docstring (not just the first line) gives the agent
+    enough signal to pick the right method without reading the source.
+    """
+
+    def test_empty_or_none_returns_empty_string(self):
+        assert _describe_method_docstring(None) == ""
+        assert _describe_method_docstring("") == ""
+        assert _describe_method_docstring("   \n  \n") == ""
+
+    def test_single_line_docstring_returned_verbatim(self):
+        assert _describe_method_docstring("Search Slack for messages.") == "Search Slack for messages."
+
+    def test_multi_paragraph_description_preserved(self):
+        doc = """Hybrid research engine.
+
+        This is the default entry point for any research-shaped turn. It
+        does not write the final reply. Instead it returns the working set.
+        """
+        out = _describe_method_docstring(doc)
+        assert "Hybrid research engine." in out
+        assert "default entry point" in out
+
+    def test_google_section_marker_truncates(self):
+        doc = """Search the database.
+
+        Returns ranked results matching the query.
+
+        Args:
+            query: Free-form search text.
+            limit: Max results.
+        """
+        out = _describe_method_docstring(doc)
+        assert "Search the database." in out
+        assert "Returns ranked results" in out
+        # Args block excluded — parameter info ships separately on the schema.
+        assert "Args:" not in out
+        assert "query:" not in out
+
+    def test_truncation_respects_max_chars(self):
+        long_para = "x " * 2000
+        doc = f"Summary.\n\n{long_para}"
+        out = _describe_method_docstring(doc)
+        assert len(out) <= 1200
+        assert out.endswith("\u2026")
 
 
 # ---------------------------------------------------------------------------

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -33,7 +33,8 @@
 
 [Research and Grounding]
 |When a user asks for specialized scientific or technical strategy outside the current codebase, do at least one targeted external-source pass before giving a confident recommendation.
-|Use the most appropriate research path for the domain — for example `call websearch search`, `call websearch deep_research`, official docs, papers, vendor docs, or source repositories.
+|If a persona overlay is loaded and it specifies how to research (a preferred workflow, entry-point tool, or named orchestrator), follow the overlay. The overlay knows the domain and the right tools; this generic guidance does not.
+|Otherwise, pick the appropriate research path for the domain — official docs, papers, vendor docs, source repositories, or general-purpose tools such as `call websearch search` and `call websearch deep_research`.
 |Ground the answer in what you found and cite the source when it materially affects the recommendation.
 |When a user asks for the transcript, exact quote or verbatim lines, recap, or summary of a specific audio/video source — such as a podcast, episode, video, interview, webinar, livestream, talk, or recording — first confirm that you can access that exact original source or its official transcript. If the exact source is unavailable, say so plainly and ask before using show notes, clips, related coverage, adjacent interviews, or other substitute materials.
 |Exception: if the user explicitly asks for off-the-cuff brainstorming or quick speculation, you may stay in brainstorming mode and say that you are not grounding it first.

--- a/services/sandbox/call.sh
+++ b/services/sandbox/call.sh
@@ -30,7 +30,17 @@ request() {
   local http_method="$1"
   local url="$2"
   local data="${3:-}"
-  local timeout_s="${CALL_TIMEOUT_SECONDS:-30}"
+  # Watchdog ceiling for the curl -> API hop, NOT a quality budget. Tool
+  # plugins can legitimately run for many minutes (deep research crawls,
+  # recursive people pulls, internal-priors aggregation, paradigm-pulse, etc.)
+  # and Anthropic / OpenAI deep_research calls under the hood routinely take
+  # 5-15 minutes. The previous 30s default made the helper report "failed"
+  # while the upstream tool was still working, which trained agents to retry
+  # the same call 3x in a row and waste compute — and to assume long-running
+  # primitives are "broken" and pick a shallower alternative. 1800s is a
+  # large-but-finite watchdog; for known-fast methods, set CALL_TIMEOUT_SECONDS
+  # in the calling environment to bound more aggressively.
+  local timeout_s="${CALL_TIMEOUT_SECONDS:-1800}"
 
   local curl_args=(
     -sS

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -437,7 +437,16 @@ class SlackClient:
         return user_cache
 
     def list_bot_channels(self, limit: int = 500, force_refresh: bool = False) -> list[dict]:
-        """List public channels the bot is a member of.
+        """List channels (public AND private) the bot is a member of.
+
+        Bot membership is the relevant scope here, not just public visibility
+        — Centaur is intentionally added to private investing / sourcing /
+        legal channels and search/history calls only work on channels the bot
+        actually belongs to. Filtering to ``types="public_channel"`` silently
+        drops every private channel from this list and from every caller
+        that depends on it (e.g. ``_search_messages_local`` scans this list
+        as the fallback when native search lacks ``search:read``, and
+        ``gather_context``'s Slack grab walks the bot's member channels).
 
         Args:
             limit: Maximum channels to return
@@ -460,7 +469,7 @@ class SlackClient:
             try:
                 response = self._retry_on_ratelimit(
                     self._client.conversations_list,
-                    types="public_channel",
+                    types="public_channel,private_channel",
                     limit=min(limit - len(channels), 200),
                     cursor=cursor,
                     exclude_archived=True,
@@ -1222,14 +1231,20 @@ class SlackClient:
         }
 
     def list_channels(self, limit: int = 200) -> list[dict]:
-        """List public Slack channels (not just bot member channels)."""
+        """List Slack channels visible to the bot (public and private).
+
+        Bot-visible channels include any private channel the bot has been
+        added to; restricting to ``types="public_channel"`` silently drops
+        them. This is the broader-than-membership variant of
+        ``list_bot_channels`` and shares the same fix.
+        """
         channels = []
         cursor = None
 
         while True:
             try:
                 response = self._client.conversations_list(
-                    types="public_channel",
+                    types="public_channel,private_channel",
                     limit=min(limit - len(channels), 200),
                     cursor=cursor,
                     exclude_archived=True,


### PR DESCRIPTION
## Summary
- Honor persona-declared engines while keeping `harness` as a legacy engine alias.
- Make persona overlays authoritative over generic base-prompt routing/tool guidance.
- Fix `tools.*` namespace resolution so overlays can extend base tool modules safely.
- Improve tool method descriptions by preserving docstring summaries beyond the first line.
- Increase `call` helper timeout for long-running tools and include private Slack channels in bot-visible channel lists.

## Test plan
- `uv run ruff check api/agent.py api/app.py api/runtime_control.py api/sandbox/prompt_assembly.py api/tool_manager.py api/workflow_engine.py tests/test_assemble_prompt.py tests/test_integration.py tests/test_tool_manager.py`
- `uv run pytest tests/test_assemble_prompt.py tests/test_tool_manager.py tests/test_integration.py::TestResolveHarnessProfile tests/test_routers_agent_runtime.py tests/test_sandbox_kubernetes_backend.py -q`
- Prod-credential routing sim: `claude-opus-4-7` 35/35 pass, no misses.