### PR TITLE
Fix Slack final delivery recipient team id

### DIFF
--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -102,8 +102,12 @@ describe('final delivery polling', () => {
         fetchCalls.filter(call => call.path === '/agent/final-deliveries/exe-duplicate-guard/delivered')
       ).toHaveLength(1)
       expect(slackCalls.filter(call => call.method === 'chat.startStream')).toHaveLength(1)
+      const startStreamParams = slackCalls.find(call => call.method === 'chat.startStream')
+        ?.params as any
+      expect(startStreamParams.recipient_team_id).toBe('T123')
+      expect(startStreamParams.recipient_user_id).toBe('U123')
       expect(
-        (slackCalls.find(call => call.method === 'chat.startStream')?.params as any).chunks[0]
+        startStreamParams.chunks[0]
       ).toEqual({ type: 'plan_update', title: 'Centaur · codex' })
       expect(slackCalls.filter(call => call.method === 'chat.stopStream')).toHaveLength(1)
     } finally {

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -68,7 +68,9 @@ async function deliver(client: WebClient, delivery: any): Promise<void> {
   const { sessionId } = await renderer.open({
     channel,
     parentTs: threadTs,
-    recipientTeamId: String(meta.team_id ?? delivery.team_id ?? target.teamId ?? ''),
+    recipientTeamId: String(
+      meta.recipient_team_id ?? meta.team_id ?? delivery.team_id ?? target.teamId ?? ''
+    ),
     recipientUserId: String(meta.recipient_user_id ?? meta.user_id ?? delivery.user_id ?? ''),
     title: sessionTitle(payload)
   })


### PR DESCRIPTION
## Summary
- Preserve recipient_team_id when final delivery opens a Slack stream
- Assert final delivery passes Slack-encoded recipient team/user IDs to chat.startStream

## Test
- bun test src/centaur/final-delivery.test.ts