### PR TITLE
fix: API key header casing and bump iron-proxy

### DIFF
--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ironsh/iron-proxy:0.34.0@sha256:d5691525185f9cfe30244f36c888cde0eb5b1ce54dd5f6fd3ac76978b9fe5fef
+FROM ironsh/iron-proxy:0.35.0@sha256:a2b341c26c4e1ee2e56abfbe4799f749ab71695e91e3ea3260732712c5ed1bd0
 
 USER root
 RUN apk add --no-cache curl jq

--- a/tools/crypto/nansen/client.py
+++ b/tools/crypto/nansen/client.py
@@ -76,7 +76,7 @@ class NansenClient:
         url = f"{self.base_url}{endpoint}"
         headers = {
             "Content-Type": "application/json",
-            "apikey": api_key,
+            "apiKey": api_key,
         }
 
         try:


### PR DESCRIPTION
Sets the Nansen client header to `apiKey` (matching the API's expected casing) and bumps iron-proxy from v0.34.0 to v0.35.0.