### PR TITLE
fix: reliably persist harness final results

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -45,7 +45,7 @@ from api.vm_metrics import (
     record_usage_observation,
 )
 from api.sandbox.normalize import normalize_harness_event
-from api.sandbox.harness_protocol import is_turn_done
+from api.sandbox.harness_protocol import extract_result
 from api.sandbox.registry import get_backend
 from api.laminar_tracing import set_trace_context, start_span
 from api.trace_context import get_or_create_thread_trace_id
@@ -2387,13 +2387,27 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
             record_oneshot(harness, status == "completed")
         if user_id:
             record_execution_by_user(user_id, harness, status)
-        nonlocal slackbot_text_sent, slackbot_done
+        nonlocal slackbot_session_id, slackbot_text_sent, slackbot_done
         if slackbot_session_id and not slackbot_done:
-            if result_text.strip() and not slackbot_text_sent:
-                await slackbot_client.session_text(slackbot_session_id, result_text)
-                slackbot_text_sent = True
-            await slackbot_client.session_done(slackbot_session_id, harness_thread_id or None)
-            slackbot_done = True
+            try:
+                if result_text.strip() and not slackbot_text_sent:
+                    await slackbot_client.session_text(slackbot_session_id, result_text)
+                    slackbot_text_sent = True
+                await slackbot_client.session_done(slackbot_session_id, harness_thread_id or None)
+                slackbot_done = True
+            except Exception:
+                log.warning(
+                    "slackbot_live_delivery_finalize_failed",
+                    execution_id=execution_id,
+                    thread_key=thread_key,
+                    exc_info=True,
+                )
+                await _mark_slackbot_live_delivery_failed(
+                    pool,
+                    execution_id,
+                    "finalize_failed",
+                )
+                slackbot_session_id = ""
         await _mark_execution_terminal(
             pool,
             execution_id=execution_id,
@@ -2431,6 +2445,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
     await _touch_execution_progress(pool, execution_id)
 
     turn_done_event: dict[str, Any] | None = None
+    latest_terminal_result_text = ""
     pending_event: asyncio.Task | None = None
     stream = _stream_stdout(
         session,
@@ -2512,6 +2527,12 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
             if payload.get("session_id"):
                 harness_thread_id = str(payload.get("session_id") or "")
             canonical_events = normalize_harness_event(engine, payload)
+            for canonical_event in canonical_events:
+                if canonical_event.get("type") != "result":
+                    continue
+                extracted = extract_result(engine, canonical_event)
+                if extracted:
+                    latest_terminal_result_text = extracted
             if slackbot_session_id:
                 slack_events = canonical_events or [payload]
                 for slack_event in slack_events:
@@ -2652,7 +2673,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 )
                 return
 
-            if payload.get("type") == "turn.done" or is_turn_done(engine, payload):
+            if payload.get("type") == "turn.done":
                 turn_done_event = payload
                 break
     except Exception as exc:
@@ -2759,7 +2780,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         )
         return
 
-    result_text = str(turn_done_event.get("result") or "")
+    result_text = extract_result(engine, turn_done_event) or latest_terminal_result_text
     repo_context = _extract_repo_context(turn_done_event)
     if repo_context:
         await _merge_execution_repo_context(pool, execution_id, repo_context)

--- a/services/api/api/sandbox/harness_protocol.py
+++ b/services/api/api/sandbox/harness_protocol.py
@@ -66,6 +66,15 @@ def is_turn_done(engine: str, event: dict) -> bool:
 def extract_result(engine: str, event: dict) -> str | None:
     """Return the assistant result text from *event*, or ``None``."""
     t = event.get("type", "")
+    if t == "turn.done":
+        result = event.get("result")
+        if isinstance(result, str) and result:
+            return result
+        if isinstance(result, dict):
+            text = result.get("text")
+            if isinstance(text, str) and text:
+                return text
+        return _extract_error_message(event) or None
     if engine in ("amp", "claude-code"):
         if t == "result":
             result = event.get("result")

--- a/services/api/api/sandbox/harness_protocol.py
+++ b/services/api/api/sandbox/harness_protocol.py
@@ -71,6 +71,9 @@ def extract_result(engine: str, event: dict) -> str | None:
             result = event.get("result")
             if isinstance(result, str) and result:
                 return result
+            text = event.get("text")
+            if isinstance(text, str) and text:
+                return text
             return _extract_error_message(event)
         if t == "assistant":
             msg = event.get("message", {})

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -1606,6 +1606,14 @@ async def test_worker_records_projected_observations_and_execution_summary(db_po
                 }
             )
         }
+        # Claude Code/amp canonical terminal result events may arrive before
+        # the synthesized turn.done. The durable worker must not finalize until
+        # turn.done, or result_text can be lost.
+        yield {
+            "data": json.dumps(
+                {"type": "result", "text": "Here is the synthesis."}
+            )
+        }
         yield {
             "data": json.dumps(
                 {"type": "turn.done", "result": "Here is the synthesis."}
@@ -1641,8 +1649,15 @@ async def test_worker_records_projected_observations_and_execution_summary(db_po
     assert "assistant_tool_use_observed" in event_kinds
     assert "tool_result_observed" in event_kinds
     assert "assistant_text_observed" in event_kinds
+    assert "result_observed" in event_kinds
     assert event_kinds.count("usage_observed") == 2
     assert "execution_summary" in event_kinds
+
+    execution_row = await db_pool.fetchrow(
+        "SELECT result_text FROM agent_execution_requests WHERE execution_id = $1",
+        execution_id,
+    )
+    assert execution_row["result_text"] == "Here is the synthesis."
 
     summary_row = await db_pool.fetchrow(
         "SELECT event_json FROM agent_execution_events WHERE execution_id = $1 AND event_kind = 'execution_summary'",

--- a/services/api/tests/test_harness_protocol.py
+++ b/services/api/tests/test_harness_protocol.py
@@ -103,6 +103,11 @@ class TestExtractResult:
     def test_amp_result_event(self):
         assert extract_result("amp", {"type": "result", "result": "hello"}) == "hello"
 
+    def test_claude_code_result_event_with_text_field(self):
+        event = {"type": "result", "text": "final synthesis"}
+
+        assert extract_result("claude-code", event) == "final synthesis"
+
     def test_amp_error_result_uses_error_message(self):
         event = {
             "type": "result",

--- a/services/api/tests/test_harness_protocol.py
+++ b/services/api/tests/test_harness_protocol.py
@@ -100,6 +100,15 @@ class TestIsTurnDone:
 class TestExtractResult:
     # amp / claude-code ---------------------------------------------------
 
+    def test_turn_done_result_event(self):
+        assert extract_result("amp", {"type": "turn.done", "result": "hello"}) == "hello"
+
+    def test_turn_done_dict_result_event(self):
+        assert (
+            extract_result("claude-code", {"type": "turn.done", "result": {"text": "hello"}})
+            == "hello"
+        )
+
     def test_amp_result_event(self):
         assert extract_result("amp", {"type": "result", "result": "hello"}) == "hello"
 

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -82,18 +82,26 @@ function sessionTitle(payload: any): string {
 }
 
 function extractText(payload: any): string {
-  return (
-    (
-      payload?.result_text ??
-      payload?.result ??
-      payload?.text ??
-      payload?.final_text ??
-      payload?.message ??
-      JSON.stringify(payload)
-    )
-      .toString()
-      .trim() || 'Done.'
+  const value = firstNonEmpty(
+    payload?.result_text,
+    payload?.result,
+    payload?.text,
+    payload?.final_text,
+    payload?.message
   )
+  if (value) return value
+
+  const executionId = String(payload?.execution_id ?? '').trim()
+  const suffix = executionId ? ` Execution: \`${executionId}\`.` : ''
+  return `Execution completed, but no final text was captured.${suffix}`
+}
+
+function firstNonEmpty(...values: unknown[]): string {
+  for (const value of values) {
+    const text = value === undefined || value === null ? '' : String(value).trim()
+    if (text) return text
+  }
+  return ''
 }
 
 function deliveryFooter(payload: any): string | undefined {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -500,7 +500,7 @@ function elementToMarkdown(element: StreamRichTextElement): string {
 
 function titleFor(tool: any): string {
   if (tool.name === 'Bash') {
-    const command = stringInput(tool.input, 'cmd')
+    const command = bashCommand(tool.input)
     return command ? `Run command: ${oneLine(command, 220)}` : 'Run command'
   }
   if (tool.name === 'create_file') return 'Create file'
@@ -509,7 +509,7 @@ function titleFor(tool: any): string {
 }
 
 function detailElementsForTool(tool: any): StreamRichTextElement[] {
-  if (tool.name === 'Bash') return [pre(stringInput(tool.input, 'cmd'), 'bash')]
+  if (tool.name === 'Bash') return [pre(bashCommand(tool.input), 'bash')]
   if (tool.name === 'create_file') {
     const path = stringInput(tool.input, 'path', 'file')
     return [
@@ -574,6 +574,10 @@ function stripFence(value: string): string {
     .trim()
     .replace(/^```[a-zA-Z0-9_-]*\n?/, '')
     .replace(/\n?```$/, '')
+}
+
+function bashCommand(input: any): string {
+  return stringInput(input, 'command', stringInput(input, 'cmd'))
 }
 
 function stringInput(input: any, key: string, fallback = ''): string {


### PR DESCRIPTION
## Summary
- Persist terminal harness text from synthesized `turn.done` instead of finalizing early on canonical result events.
- Keep final Slack delivery from silently collapsing empty payloads into `Done.`.
- Render Bash tool commands from both `cmd` and `command` inputs.

## Test plan
- `uv run ruff check api/runtime_control.py api/sandbox/harness_protocol.py tests/test_harness_protocol.py tests/test_agent_control_plane.py`
- `uv run pytest tests/test_harness_protocol.py tests/test_observability.py`
- `bun test src/slack/codex-session.test.ts src/slack/agent-session.test.ts`