### PR TITLE
fix: close auth bypass and execution IDOR

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -53,4 +53,9 @@ RUN chmod +x /entrypoint.sh
 EXPOSE 8000
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/app/.venv/bin/uvicorn", "api.app:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]
+# --forwarded-allow-ips defaults to the loopback address so X-Forwarded-For is
+# only honored from a co-located trusted proxy. Override FORWARDED_ALLOW_IPS
+# with the real proxy IP(s) when fronted by a load balancer. Never set it to
+# "*": that lets any peer spoof X-Forwarded-For: 127.0.0.1 and impersonate the
+# localhost auth bypass in deps.verify_api_key.
+CMD ["/app/.venv/bin/uvicorn", "api.app:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]

--- a/services/api/api/deps.py
+++ b/services/api/api/deps.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
-import ipaddress
 import json
 import os
 import secrets
@@ -19,20 +18,10 @@ from api.api_keys import APIKeyInfo, check_scope, lookup_key
 
 log = structlog.get_logger()
 
-# Only localhost is trusted without an API key (e.g. health checks).
-# All other callers — including sandbox containers on agent_net — must
-# present a valid API key.  The previous "all private IPs" bypass was
-# too broad and allowed sandboxes to hit admin/secrets endpoints.
-_TRUSTED_PREFIXES = ("127.",)
-
-
-def _is_loopback_ip(client_ip: str) -> bool:
-    if not client_ip:
-        return False
-    try:
-        return ipaddress.ip_address(client_ip).is_loopback
-    except ValueError:
-        return client_ip.startswith(_TRUSTED_PREFIXES)
+# Every caller must present a valid API key. There is no IP-based trust:
+# the previous loopback bypass was spoofable via X-Forwarded-For and gave
+# any peer that could reach the API full unauthenticated admin access.
+# Unauthenticated health/readiness probes use the no-auth /health* routes.
 
 
 def _get_sandbox_signing_key() -> str:
@@ -115,17 +104,6 @@ async def verify_api_key(
     x_api_key: Annotated[str | None, Header()] = None,
 ) -> str:
     client_ip = request.client.host if request.client else ""
-    if _is_loopback_ip(client_ip):
-        request.state.api_key_info = APIKeyInfo(
-            id="localhost",
-            name="localhost",
-            key_prefix="",
-            scopes=["*"],
-            created_by="system",
-            source="localhost",
-        )
-        return "localhost-bypass"
-
     token = x_api_key
     if not token:
         auth = request.headers.get("authorization", "")
@@ -176,11 +154,13 @@ def get_key_info(request: Request) -> APIKeyInfo:
     """Retrieve the APIKeyInfo attached during verify_api_key."""
     info = getattr(request.state, "api_key_info", None)
     if info is None:
+        # No key was resolved (verify_api_key did not run, or ran without a
+        # valid key). Fail closed — grant no scopes.
         return APIKeyInfo(
             id="unknown",
             name="unknown",
             key_prefix="",
-            scopes=["*"],
+            scopes=[],
             created_by="system",
             source="unknown",
         )
@@ -227,6 +207,6 @@ async def verify_operator_api_key(
 ) -> str:
     token = await verify_api_key(request, x_api_key)
     key_info = get_key_info(request)
-    if key_info.source == "localhost" or check_scope(key_info, "admin"):
+    if check_scope(key_info, "admin"):
         return token
     raise HTTPException(status_code=403, detail="Operator route requires admin scope")

--- a/services/api/api/routers/agent.py
+++ b/services/api/api/routers/agent.py
@@ -867,6 +867,7 @@ async def execution_status(request: Request, execution_id: str):
     result = await get_execution(pool, execution_id)
     if not result:
         raise HTTPException(status_code=404, detail="execution not found")
+    _enforce_sandbox_thread_scope(request, result["thread_key"])
     return result
 
 
@@ -980,6 +981,12 @@ async def release_thread(request: Request, thread_key: str, body: ReleaseRequest
 @router.post("/executions/{execution_id}/cancel", dependencies=[Depends(require_scope("agent:execute"))])
 async def execution_cancel(request: Request, execution_id: str):
     pool = request.app.state.db_pool
+    # Resolve the execution's thread first so a sandbox token cannot cancel an
+    # execution belonging to a different thread.
+    existing = await get_execution(pool, execution_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="execution not found")
+    _enforce_sandbox_thread_scope(request, existing["thread_key"])
     result = await cancel_execution(pool, execution_id)
     if not result:
         raise HTTPException(status_code=404, detail="execution not found")
@@ -1001,6 +1008,12 @@ async def steer_execution_endpoint(execution_id: str, request: Request):
     Falls back to cancellation if steering fails.
     """
     pool = request.app.state.db_pool
+    # Resolve the execution's thread first so a sandbox token cannot steer (and
+    # thereby inject a user message into) an execution on a different thread.
+    existing = await get_execution(pool, execution_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Execution not found")
+    _enforce_sandbox_thread_scope(request, existing["thread_key"])
     raw_bytes = await request.body()
     raw_body = _json.loads(raw_bytes) if raw_bytes else {}
     body = SteerExecutionRequest.model_validate(raw_body)

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -222,6 +222,10 @@ def _setup_env(pg, run_migrations):
     """Set env vars before any app code is imported."""
     os.environ["DATABASE_URL"] = pg
     os.environ["API_SECRET_KEY"] = "test-secret-key"
+    # Seed a real admin key. bootstrap_service_api_keys() turns LOCAL_DEV_API_KEY
+    # into a DB-backed key with admin scope on app startup, so tests authenticate
+    # the same way production callers do (there is no localhost auth bypass).
+    os.environ["LOCAL_DEV_API_KEY"] = "aiv2_test_local_dev_admin_key"
     os.environ["EXECUTION_WORKER_ENABLED"] = "0"
     os.environ["WORKFLOW_WORKER_ENABLED"] = "0"
     os.environ["WARM_POOL_ENABLED"] = "0"
@@ -246,16 +250,25 @@ async def managed_app(app):
 
 @pytest_asyncio.fixture
 async def client(managed_app):
-    """Async httpx client against the lifespan-managed app."""
+    """Async httpx client against the lifespan-managed app.
+
+    Authenticated as the seeded admin key by default so tests exercise real
+    callers. Tests covering auth failures pass their own Authorization header,
+    which overrides this default.
+    """
     transport = httpx.ASGITransport(app=managed_app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {os.environ['LOCAL_DEV_API_KEY']}"},
+    ) as c:
         yield c
 
 
 @pytest.fixture
 def api_key():
-    """Return the test API key."""
-    return os.environ["API_SECRET_KEY"]
+    """Return the seeded admin API key."""
+    return os.environ["LOCAL_DEV_API_KEY"]
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
Fixes two confirmed security issues.

**Auth bypass:** `verify_api_key` had a localhost path that granted `scopes=["*"]` (full admin) to any loopback client. The API ran uvicorn with `--forwarded-allow-ips *`, so any peer that could reach the API (including a sandbox container on `agent_net`) could spoof `X-Forwarded-For: 127.0.0.1` and take that path unauthenticated. This PR removes the IP-based bypass entirely rather than just fixing the proxy config: every caller now needs a valid API key (DB key or sandbox token), and `verify_operator_api_key` requires the admin scope with no localhost exception. The `get_key_info` no-info fallback now grants no scopes instead of `["*"]`. Unauthenticated health/readiness probes still use the no-auth `/health*` routes. The integration test harness relied on the bypass, so it now seeds a real admin key via `LOCAL_DEV_API_KEY`. The Dockerfile also drops `--forwarded-allow-ips *` as defense in depth.

**IDOR:** `GET /agent/executions/{id}`, `POST /agent/executions/{id}/cancel`, and `POST /agent/executions/{id}/steer` were guarded only by `require_scope("agent:execute")` (which sandbox tokens hold) and never called `_enforce_sandbox_thread_scope`. A sandbox scoped to one thread could read, cancel, or steer executions on any other thread. Each endpoint now resolves the execution's `thread_key` and enforces sandbox scope before acting.