### PR TITLE
Secure tool downloads with thread-scoped attachments

### DIFF
--- a/centaur_sdk/__init__.py
+++ b/centaur_sdk/__init__.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 from centaur_sdk.cli_tables import Table, render_text_table
 from centaur_sdk.tool_sdk import (
     ToolContext,
+    current_thread_key,
     get_tool_context,
     reset_tool_context,
+    save_attachment,
+    save_attachment_from_path,
     secret,
     set_tool_context,
 )
@@ -20,9 +23,12 @@ from centaur_sdk.tool_sdk import (
 __all__ = [
     "Table",
     "ToolContext",
+    "current_thread_key",
     "get_tool_context",
     "render_text_table",
     "reset_tool_context",
+    "save_attachment",
+    "save_attachment_from_path",
     "secret",
     "set_tool_context",
 ]

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import base64
 import contextlib
+import json
 import logging
+import mimetypes
+import urllib.request
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 log = logging.getLogger(__name__)
@@ -69,3 +74,79 @@ def secret(key: str, default: str | None = None) -> str:
     with contextlib.suppress(LookupError):
         ctx_name = f" for tool '{_tool_ctx.get().name}'"
     raise KeyError(f"Missing secret '{key}'{ctx_name}")
+
+
+def current_thread_key() -> str:
+    """Return the active thread key for a tool call."""
+    try:
+        thread_key = _tool_ctx.get().thread_key
+    except LookupError:
+        thread_key = None
+    if not thread_key:
+        raise RuntimeError(
+            "this operation must run inside a scoped thread: no thread_key "
+            "in the tool context."
+        )
+    return thread_key
+
+
+def save_attachment(
+    *,
+    name: str,
+    data: bytes,
+    mime_type: str | None = None,
+    source_url: str | None = None,
+) -> dict[str, Any]:
+    """Persist bytes as a Centaur attachment scoped to the current tool thread."""
+    thread_key = current_thread_key()
+    safe_name = Path(name).name or "attachment"
+    resolved_mime = mime_type or mimetypes.guess_type(safe_name)[0] or "application/octet-stream"
+    base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
+    payload = json.dumps(
+        {
+            "thread_key": thread_key,
+            "name": safe_name,
+            "mime_type": resolved_mime,
+            "data": base64.b64encode(data).decode("ascii"),
+            "source_url": source_url,
+        }
+    ).encode()
+    headers = {"Content-Type": "application/json"}
+    api_key = secret("CENTAUR_API_KEY", "").strip()
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(
+        f"{base_url}/agent/attachments/upload",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        result = json.loads(response.read())
+    attachment_id = result.get("id")
+    if not attachment_id:
+        raise RuntimeError(f"attachment upload returned no id: {result!r}")
+    return {
+        "attachment_id": attachment_id,
+        "filename": result.get("name") or safe_name,
+        "mime_type": result.get("mime_type") or resolved_mime,
+        "download_url": result.get("download_url"),
+        "size_bytes": len(data),
+    }
+
+
+def save_attachment_from_path(
+    path: str | Path,
+    *,
+    name: str | None = None,
+    mime_type: str | None = None,
+    source_url: str | None = None,
+) -> dict[str, Any]:
+    """Persist a local file as a thread-scoped Centaur attachment."""
+    p = Path(path)
+    return save_attachment(
+        name=name or p.name,
+        data=p.read_bytes(),
+        mime_type=mime_type,
+        source_url=source_url,
+    )

--- a/services/api/api/routers/attachments.py
+++ b/services/api/api/routers/attachments.py
@@ -71,7 +71,7 @@ async def upload_attachment(request: Request):
     mime_type = body.get("mime_type")
     data_b64 = body.get("data")
 
-    if not all([thread_key, name, mime_type, data_b64]):
+    if not thread_key or not name or not mime_type or data_b64 is None:
         raise HTTPException(
             status_code=422,
             detail="thread_key, name, mime_type, and data are required",

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -756,11 +756,34 @@ _COMMON_ARGUMENT_ALIASES: dict[str, str] = {
     "table": "table_name",
 }
 
+_FORBIDDEN_TOOL_ARGUMENT_NAMES = frozenset(
+    {
+        "output_path",
+        "output_dir",
+        "download_path",
+        "save_path",
+        "dest_path",
+        "destination_path",
+    }
+)
+
 
 def _tool_arg_validation_error(
     method: ToolMethod, args: dict[str, Any]
 ) -> dict[str, Any] | None:
     """Return a structured argument error before invoking a tool method."""
+    forbidden = sorted(set(args) & _FORBIDDEN_TOOL_ARGUMENT_NAMES)
+    if forbidden:
+        return {
+            "error": "tool_argument_validation_failed",
+            "message": (
+                "Forbidden argument(s): "
+                f"{', '.join(forbidden)}. Tools may not write API-process files "
+                "to caller-supplied paths; return Centaur attachments instead."
+            ),
+            "forbidden_args": forbidden,
+        }
+
     sig = inspect.signature(method.fn)
     params = sig.parameters
     accepts_var_kwargs = any(

--- a/services/api/tests/test_tool_manager.py
+++ b/services/api/tests/test_tool_manager.py
@@ -219,6 +219,24 @@ class TestToolArgValidation:
             is None
         )
 
+    def test_forbidden_path_argument_is_rejected(self):
+        def fn(output_path: str):
+            return output_path
+
+        error = _tool_arg_validation_error(
+            ToolMethod("drive_download", fn),
+            {"output_path": "/app/tools/productivity/gsuite/client.py"},
+        )
+
+        assert error == {
+            "error": "tool_argument_validation_failed",
+            "message": (
+                "Forbidden argument(s): output_path. Tools may not write API-process "
+                "files to caller-supplied paths; return Centaur attachments instead."
+            ),
+            "forbidden_args": ["output_path"],
+        }
+
 
 # ---------------------------------------------------------------------------
 # _to_toon

--- a/tools/productivity/gsuite/cli.py
+++ b/tools/productivity/gsuite/cli.py
@@ -1,8 +1,8 @@
 """CLI for GSuite operations - Gmail, Calendar, Drive."""
 
 import typer
-from rich.console import Console
 from centaur_sdk import Table
+from rich.console import Console
 
 app = typer.Typer(name="gsuite", help="GSuite CLI for AI agents - Gmail, Calendar, Drive")
 console = Console()
@@ -507,7 +507,7 @@ def drive_download(
     """
     from pathlib import Path
 
-    from .client import drive_download as download, drive_get
+    from .client import _drive_download_bytes, drive_get
 
     try:
         file_info = drive_get(file_id)
@@ -516,7 +516,8 @@ def drive_download(
         if output_path.is_dir():
             output_path = output_path / file_info["name"]
 
-        download(file_id, str(output_path))
+        _metadata, data = _drive_download_bytes(file_id)
+        output_path.write_bytes(data)
         console.print(f"[green]✓ Downloaded {file_info['name']}[/]")
         console.print(f"[dim]{output_path.absolute()}[/]")
     except Exception as e:
@@ -856,7 +857,7 @@ def drive_export(
         gsuite drive export "1abc123" -f txt -o doc.txt  # Export as text file
         gsuite drive export "1abc123" -f csv             # Export Sheet as CSV
     """
-    from .client import drive_export as export_file, drive_get, docs_get_text
+    from .client import _drive_export_bytes, drive_get, docs_get_text
 
     try:
         file_info = drive_get(file_id)
@@ -874,16 +875,17 @@ def drive_export(
             return
 
         # For other formats, use Drive export
-        result = export_file(file_id, format, output)
+        metadata, _mime_type, data = _drive_export_bytes(file_id, format)
         if output:
-            console.print(f"[green]✓ Exported {file_info['name']} to {result}[/]")
+            with open(output, "wb") as f:
+                f.write(data)
+            console.print(f"[green]✓ Exported {file_info['name']} to {output}[/]")
         else:
             # If no output specified, print the content for text formats
             if format in ("txt", "csv", "html"):
-                with open(result, "r") as f:
-                    console.print(f.read())
+                console.print(data.decode("utf-8", errors="replace"))
             else:
-                console.print(f"[green]✓ Exported to {result}[/]")
+                console.print(f"[green]✓ Exported {metadata.get('name') or file_id}[/]")
     except Exception as e:
         console.print(f"[red]Error: {e}[/]")
         raise typer.Exit(1)

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit
 
 import httplib2
 import socks
+from centaur_sdk import save_attachment
 from google.auth.credentials import AnonymousCredentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
@@ -684,19 +685,15 @@ def drive_list(
     ]
 
 
-def drive_download(file_id: str, output_path: str) -> str:
-    """Download a file from Google Drive.
-
-    Args:
-        file_id: The file ID
-        output_path: Local path to save the file
-
-    Returns:
-        The output path
-    """
+def _drive_download_bytes(file_id: str) -> tuple[dict, bytes]:
     import io
 
     service = get_drive_service()
+    metadata = service.files().get(
+        fileId=file_id,
+        fields="name,mimeType,webViewLink",
+        supportsAllDrives=True,
+    ).execute()
 
     request = service.files().get_media(fileId=file_id, supportsAllDrives=True)
     fh = io.BytesIO()
@@ -706,10 +703,25 @@ def drive_download(file_id: str, output_path: str) -> str:
     while not done:
         _, done = downloader.next_chunk()
 
-    with open(output_path, "wb") as f:
-        f.write(fh.getvalue())
+    return metadata, fh.getvalue()
 
-    return output_path
+
+def drive_download(file_id: str) -> dict:
+    """Download a file from Google Drive into a thread-scoped Centaur attachment.
+
+    Args:
+        file_id: The file ID
+
+    Returns:
+        Attachment metadata
+    """
+    metadata, data = _drive_download_bytes(file_id)
+    return save_attachment(
+        name=metadata.get("name") or f"drive-{file_id}",
+        mime_type=metadata.get("mimeType") or "application/octet-stream",
+        data=data,
+        source_url=metadata.get("webViewLink"),
+    )
 
 
 def drive_upload(
@@ -1168,19 +1180,8 @@ def drive_setup_channel_permissions(
     return results
 
 
-def drive_export(file_id: str, export_format: str = "txt", output_path: str | None = None) -> str:
-    """Export a Google Docs/Sheets/Slides file to a specific format.
-
-    Args:
-        file_id: The file ID
-        export_format: Export format (txt, pdf, docx, html, csv, xlsx, pptx)
-        output_path: Optional output path (defaults to temp file)
-
-    Returns:
-        The output path
-    """
+def _drive_export_bytes(file_id: str, export_format: str = "txt") -> tuple[dict, str, bytes]:
     import io
-    import tempfile
 
     service = get_drive_service()
 
@@ -1202,9 +1203,11 @@ def drive_export(file_id: str, export_format: str = "txt", output_path: str | No
             f"Unsupported export format: {export_format}. Supported: {list(format_map.keys())}"
         )
 
-    # Determine output path
-    if not output_path:
-        output_path = tempfile.mktemp(suffix=f".{export_format}")
+    metadata = service.files().get(
+        fileId=file_id,
+        fields="name,webViewLink",
+        supportsAllDrives=True,
+    ).execute()
 
     # Export the file
     request = service.files().export_media(fileId=file_id, mimeType=mime_type)
@@ -1215,10 +1218,27 @@ def drive_export(file_id: str, export_format: str = "txt", output_path: str | No
     while not done:
         _, done = downloader.next_chunk()
 
-    with open(output_path, "wb") as f:
-        f.write(fh.getvalue())
+    return metadata, mime_type, fh.getvalue()
 
-    return output_path
+
+def drive_export(file_id: str, export_format: str = "txt") -> dict:
+    """Export a Google Docs/Sheets/Slides file into a thread-scoped attachment.
+
+    Args:
+        file_id: The file ID
+        export_format: Export format (txt, pdf, docx, html, csv, xlsx, pptx)
+
+    Returns:
+        Attachment metadata
+    """
+    metadata, mime_type, data = _drive_export_bytes(file_id, export_format)
+    stem = Path(metadata.get("name") or f"drive-{file_id}").stem
+    return save_attachment(
+        name=f"{stem}.{export_format}",
+        mime_type=mime_type,
+        data=data,
+        source_url=metadata.get("webViewLink"),
+    )
 
 
 # Docs functions
@@ -2618,17 +2638,16 @@ class GSuiteClient:
         """
         return drive_get(file_id)
 
-    def drive_download(self, file_id: str, output_path: str) -> str:
-        """Download a file from Google Drive.
+    def drive_download(self, file_id: str) -> dict:
+        """Download a file from Google Drive into a thread-scoped attachment.
 
         Args:
             file_id: The file ID
-            output_path: Local path to save the file
 
         Returns:
-            The output path
+            Attachment metadata
         """
-        return drive_download(file_id, output_path)
+        return drive_download(file_id)
 
     def drive_upload(
         self,
@@ -2788,20 +2807,17 @@ class GSuiteClient:
         """
         return drive_setup_channel_permissions(file_id, channel_member_emails, requester_email)
 
-    def drive_export(
-        self, file_id: str, export_format: str = "txt", output_path: str | None = None
-    ) -> str:
-        """Export a Google Docs/Sheets/Slides file to a specific format.
+    def drive_export(self, file_id: str, export_format: str = "txt") -> dict:
+        """Export a Google Docs/Sheets/Slides file into a thread-scoped attachment.
 
         Args:
             file_id: The file ID
             export_format: Export format (txt, pdf, docx, html, csv, xlsx, pptx)
-            output_path: Optional output path (defaults to temp file)
 
         Returns:
-            The output path
+            Attachment metadata
         """
-        return drive_export(file_id, export_format=export_format, output_path=output_path)
+        return drive_export(file_id, export_format=export_format)
 
     # --- Docs ---
 

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -17,7 +17,7 @@ from urllib.parse import quote, urljoin, urlparse
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-from centaur_sdk.tool_sdk import get_tool_context, secret
+from centaur_sdk.tool_sdk import get_tool_context, save_attachment, secret
 
 # Cache for channel list to avoid repeated API calls
 
@@ -1913,34 +1913,12 @@ class SlackClient:
         The attachment is scoped to the thread the tool is running in, read
         from the tool context.
         """
-        thread_key = self._require_thread_key()
-
-        base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
-        payload = json.dumps(
-            {
-                "thread_key": thread_key,
-                "name": name,
-                "mime_type": mime_type,
-                "data": base64.b64encode(data).decode(),
-                "source_url": source_url,
-            }
-        ).encode()
-        headers = {"Content-Type": "application/json"}
-        api_key = secret("CENTAUR_API_KEY", "").strip()
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-        request = urllib.request.Request(
-            f"{base_url}/agent/attachments/upload",
-            data=payload,
-            headers=headers,
-            method="POST",
-        )
-        with urllib.request.urlopen(request, timeout=30) as response:
-            result = json.loads(response.read())
-        attachment_id = result.get("id")
-        if not attachment_id:
-            raise RuntimeError(f"attachment upload returned no id: {result!r}")
-        return attachment_id
+        return save_attachment(
+            name=name,
+            mime_type=mime_type,
+            data=data,
+            source_url=source_url,
+        )["attachment_id"]
 
     def download_file(self, url: str) -> dict:
         """Download a Slack file into a Centaur attachment.

--- a/tools/research/archiver/client.py
+++ b/tools/research/archiver/client.py
@@ -7,6 +7,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from centaur_sdk import save_attachment_from_path
+
 from .download.orchestrator import download_source
 from .ingest.parse import parse_manifest
 from .utils import (
@@ -21,29 +23,62 @@ from .utils import (
 class ArchiverClient:
     """Extraction-first client for investment document parsing."""
 
+    def _attach_download_payload(self, payload: dict, manifest_path: Path) -> dict:
+        attachments: list[dict[str, Any]] = []
+        for record in payload.get("files") or []:
+            raw_path = record.get("file_path")
+            if not raw_path:
+                continue
+            path = Path(raw_path)
+            if not path.exists() or not path.is_file():
+                continue
+            attachment = save_attachment_from_path(
+                path,
+                name=record.get("filename") or path.name,
+                mime_type=record.get("mime_type"),
+                source_url=record.get("source_url") or payload.get("source_url"),
+            )
+            attachments.append({**attachment, "source_type": record.get("source_type")})
+
+        manifest_attachment = save_attachment_from_path(
+            manifest_path,
+            name="manifest.json",
+            mime_type="application/json",
+            source_url=payload.get("source_url"),
+        )
+        return {
+            **payload,
+            "files": [
+                {k: v for k, v in record.items() if k != "file_path"}
+                for record in payload.get("files") or []
+            ],
+            "attachments": attachments,
+            "manifest_attachment": manifest_attachment,
+        }
+
     def download(
         self,
         source_url: str,
-        output_dir: str,
         company: str | None = None,
         account: str | None = None,
         password: str | None = None,
         email: str | None = None,
         max_depth: int = 3,
     ) -> dict:
-        output_dir = Path(output_dir)
-        payload = download_source(
-            source_url=source_url,
-            output_dir=output_dir,
-            company=company,
-            account=account,
-            password=password,
-            email=email,
-            max_depth=max_depth,
-        )
-        manifest_path = output_dir / "manifest.json"
-        manifest_path.write_text(dump_json(payload))
-        return {**payload, "manifest_path": str(manifest_path)}
+        with tempfile.TemporaryDirectory(prefix="centaur-archiver-") as tmpdir:
+            output_dir = Path(tmpdir)
+            payload = download_source(
+                source_url=source_url,
+                output_dir=output_dir,
+                company=company,
+                account=account,
+                password=password,
+                email=email,
+                max_depth=max_depth,
+            )
+            manifest_path = output_dir / "manifest.json"
+            manifest_path.write_text(dump_json(payload))
+            return self._attach_download_payload(payload, manifest_path)
 
     def _manifest_with_context(
         self, manifest_path: Path, context: dict | None
@@ -134,7 +169,6 @@ class ArchiverClient:
     def extract_source(
         self,
         source_url: str,
-        output_dir: str,
         company: str | None = None,
         account: str | None = None,
         password: str | None = None,
@@ -143,35 +177,38 @@ class ArchiverClient:
         context: dict | None = None,
     ) -> dict:
         """Download source and run Reducto extraction in one call."""
-        download_payload = self.download(
-            source_url=source_url,
-            output_dir=output_dir,
-            company=company,
-            account=account,
-            password=password,
-            email=email,
-            max_depth=max_depth,
-        )
-        if download_payload.get("status") != "ok":
-            return {
-                "status": "error",
-                "error": download_payload.get("error") or "Download stage failed",
-                "source": source_url,
-                "manifest_path": download_payload.get("manifest_path"),
-                "download": download_payload,
-                "files": download_payload.get("files") or [],
-            }
-        if not download_payload.get("files"):
-            return {
-                "status": "error",
-                "error": "Download stage produced no files",
-                "source": source_url,
-                "manifest_path": download_payload.get("manifest_path"),
-                "download": download_payload,
-                "files": [],
-            }
-        manifest_path = Path(output_dir) / "manifest.json"
-        return self.extract_manifest(str(manifest_path), context=context)
+        with tempfile.TemporaryDirectory(prefix="centaur-archiver-") as tmpdir:
+            output_dir = Path(tmpdir)
+            payload = download_source(
+                source_url=source_url,
+                output_dir=output_dir,
+                company=company,
+                account=account,
+                password=password,
+                email=email,
+                max_depth=max_depth,
+            )
+            manifest_path = output_dir / "manifest.json"
+            manifest_path.write_text(dump_json(payload))
+            attached_download = self._attach_download_payload(payload, manifest_path)
+            if payload.get("status") != "ok":
+                return {
+                    "status": "error",
+                    "error": payload.get("error") or "Download stage failed",
+                    "source": source_url,
+                    "download": attached_download,
+                    "files": attached_download.get("files") or [],
+                }
+            if not payload.get("files"):
+                return {
+                    "status": "error",
+                    "error": "Download stage produced no files",
+                    "source": source_url,
+                    "download": attached_download,
+                    "files": [],
+                }
+            extracted = self.extract_manifest(str(manifest_path), context=context)
+            return {**extracted, "download": attached_download}
 
 
 def _client() -> ArchiverClient:

--- a/tools/research/archiver/tests/test_docsend_fallback.py
+++ b/tools/research/archiver/tests/test_docsend_fallback.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import importlib
-import json
 import sys
-import tempfile
 import types
 import unittest
 from dataclasses import dataclass
@@ -97,25 +95,30 @@ class DocsendFallbackTest(unittest.TestCase):
                     "_run_standalone_docsend_fallback",
                     return_value=fallback_payload,
                 ):
-                    client = client_module.ArchiverClient()
-                    with tempfile.TemporaryDirectory() as tmpdir:
+                    def fake_attach(path, **kwargs):
+                        return {
+                            "attachment_id": f"att-{Path(path).name}",
+                            "filename": kwargs.get("name") or Path(path).name,
+                            "mime_type": kwargs.get("mime_type") or "application/octet-stream",
+                            "size_bytes": Path(path).stat().st_size,
+                        }
+
+                    with patch.object(client_module, "save_attachment_from_path", side_effect=fake_attach):
+                        client = client_module.ArchiverClient()
                         result = client.extract_source(
                             source_url="https://docsend.com/view/example",
-                            output_dir=tmpdir,
                             company="Example",
                         )
-
-                        manifest_path = Path(result["manifest_path"])
-                        self.assertTrue(manifest_path.exists())
-                        manifest = json.loads(manifest_path.read_text())
 
                 self.assertEqual(result["status"], "error")
                 self.assertIn("password-protected", result["error"])
                 self.assertNotEqual(result["error"], "Download stage failed")
                 self.assertEqual(result["download"]["blocker"]["kind"], "passcode_required")
                 self.assertEqual(result["download"]["blocker"]["required_input"], "password")
-                self.assertEqual(manifest["blocker"]["kind"], "passcode_required")
-                self.assertEqual(manifest["details"]["status"], "passcode_required")
+                self.assertEqual(
+                    result["download"]["manifest_attachment"]["attachment_id"],
+                    "att-manifest.json",
+                )
         finally:
             sys.path = [entry for entry in sys.path if entry != str(REPO_ROOT)]
             _clear_archiver_modules()


### PR DESCRIPTION
## Summary
- add shared Centaur SDK helpers for saving bytes/files as thread-scoped attachments
- migrate gsuite Drive download/export and archiver source downloads away from caller-supplied API-process paths
- refactor Slack PR-16 attachment upload path to use the shared helper
- reject dangerous output/download path argument names in tool dispatch for defense in depth

## Tests
- uv run --project services/api pytest services/api/tests/test_attachments.py services/api/tests/test_tool_manager.py
- PYTHONPATH=/home/agent/tmp/centaur/tools/productivity:/home/agent/tmp/centaur uv run --with pytest --with google-api-python-client --with google-auth --with httplib2 --with PySocks pytest tools/productivity/gsuite/test_client.py
- PYTHONPATH=/home/agent/tmp/centaur/tools/productivity:/home/agent/tmp/centaur uv run --project tools/productivity/slack --with pytest pytest tools/productivity/slack/tests/test_client.py
- PYTHONPATH=/home/agent/tmp/centaur/tools/research:/home/agent/tmp/centaur uv run --with pytest pytest tools/research/archiver/tests/test_docsend_fallback.py
- uvx ruff check --select F centaur_sdk/__init__.py centaur_sdk/tool_sdk.py services/api/api/routers/attachments.py services/api/api/tool_manager.py services/api/tests/test_tool_manager.py tools/productivity/gsuite/cli.py tools/productivity/gsuite/client.py tools/productivity/slack/client.py tools/research/archiver/client.py tools/research/archiver/tests/test_docsend_fallback.py