### PR TITLE
fix: log duplicate Slack messages

### DIFF
--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -8,6 +8,7 @@ const config: AppConfig = {
   CENTAUR_API_URL: 'http://centaur-api.test',
   CENTAUR_API_KEY: 'centaur-test-key',
   CENTAUR_SLACK_EVENTS_PATH: '/api/webhooks/slack',
+  RUNTIME_ERROR_ALERT_CHANNEL: '',
   SLACK_EVENT_DEDUP_TTL_MS: 600000,
   SLACK_SIGNATURE_MAX_AGE_SECONDS: 300,
   SLACK_FEEDBACK_COMMANDS: ['/website-feedback'],
@@ -28,7 +29,7 @@ describe('final delivery polling', () => {
     let claimCount = 0
     const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(input instanceof Request ? input.url : input)
-      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      const body = init?.body ? JSON.parse(init.body as string) : undefined
       fetchCalls.push({ path: url.pathname, body })
 
       if (url.pathname === '/agent/final-deliveries/claim') {
@@ -102,9 +103,11 @@ describe('final delivery polling', () => {
         fetchCalls.filter(call => call.path === '/agent/final-deliveries/exe-duplicate-guard/delivered')
       ).toHaveLength(1)
       expect(slackCalls.filter(call => call.method === 'chat.startStream')).toHaveLength(1)
-      expect(
-        (slackCalls.find(call => call.method === 'chat.startStream')?.params as any).chunks[0]
-      ).toEqual({ type: 'plan_update', title: 'Centaur · codex' })
+      const startStream = slackCalls.find(call => call.method === 'chat.startStream')
+      expect((startStream?.params as any)?.chunks[0]).toEqual({
+        type: 'plan_update',
+        title: 'Centaur · codex'
+      })
       expect(slackCalls.filter(call => call.method === 'chat.stopStream')).toHaveLength(1)
     } finally {
       globalThis.fetch = originalFetch

--- a/services/slackbot/src/centaur/handoff.test.ts
+++ b/services/slackbot/src/centaur/handoff.test.ts
@@ -8,6 +8,7 @@ const config: AppConfig = {
   PORT: 3001,
   CENTAUR_API_URL: 'http://centaur-api.test',
   CENTAUR_SLACK_EVENTS_PATH: '/api/webhooks/slack',
+  RUNTIME_ERROR_ALERT_CHANNEL: '',
   SLACK_EVENT_DEDUP_TTL_MS: 600000,
   SLACK_SIGNATURE_MAX_AGE_SECONDS: 300,
   SLACK_FEEDBACK_COMMANDS: ['/website-feedback'],

--- a/services/slackbot/src/config.ts
+++ b/services/slackbot/src/config.ts
@@ -9,6 +9,7 @@ const EnvSchema = z.object({
   CENTAUR_API_URL: z.string().url().default('http://localhost:8000'),
   CENTAUR_API_KEY: z.string().optional(),
   CENTAUR_SLACK_EVENTS_PATH: z.string().default('/api/webhooks/slack'),
+  RUNTIME_ERROR_ALERT_CHANNEL: z.string().default(''),
   SLACK_EVENT_DEDUP_TTL_MS: z.coerce
     .number()
     .int()

--- a/services/slackbot/src/index.test.ts
+++ b/services/slackbot/src/index.test.ts
@@ -19,7 +19,7 @@ describe('Slack event HTTP dedupe', () => {
 
     const originalFetch = globalThis.fetch
     const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
-      const body = JSON.parse(String(init?.body)) as {
+      const body = JSON.parse(init?.body as string) as {
         variables: { input: { title: string; teamId: string; projectId: string } }
       }
       expect(body.variables.input).toMatchObject({
@@ -78,8 +78,10 @@ describe('Slack event HTTP dedupe', () => {
 
     const originalError = console.error
     const originalLog = console.log
+    const originalWarn = console.warn
     console.error = mock(() => {}) as typeof console.error
     console.log = mock(() => {}) as typeof console.log
+    console.warn = mock(() => {}) as typeof console.warn
     try {
       const { app } = await import('./index')
       const body = JSON.stringify({
@@ -118,11 +120,91 @@ describe('Slack event HTTP dedupe', () => {
       expect(await first.json()).toEqual({ ok: true })
       expect(second.status).toBe(200)
       expect(await second.json()).toEqual({ ok: true, duplicate: true })
+      expect(console.warn).toHaveBeenCalledWith('slack_duplicate_event_skipped', {
+        dedupe_key: 'event:Ev-duplicate',
+        event_id: 'Ev-duplicate',
+        team_id: 'T123',
+        channel_id: 'C123',
+        message_ts: '1778883099.579529',
+        thread_ts: '1778883099.579529',
+        event_type: 'app_mention',
+        codex_thread_id: undefined,
+        alert_channel_id: undefined
+      })
       expect(waits).toHaveLength(1)
       await Promise.allSettled(waits)
     } finally {
       console.error = originalError
       console.log = originalLog
+      console.warn = originalWarn
+    }
+  })
+
+  it('logs duplicate Slack messages when Slack event IDs are absent', async () => {
+    process.env.SLACK_SIGNING_SECRET = 'test-signing-secret'
+    process.env.SLACK_EVENT_DEDUP_TTL_MS = '600000'
+    delete process.env.SLACK_BOT_TOKEN
+    delete process.env.SLACKBOT_API_KEY
+    delete process.env.CENTAUR_API_KEY
+
+    const originalError = console.error
+    const originalLog = console.log
+    const originalWarn = console.warn
+    console.error = mock(() => {}) as typeof console.error
+    console.log = mock(() => {}) as typeof console.log
+    console.warn = mock(() => {}) as typeof console.warn
+    try {
+      const { app } = await import('./index')
+      const body = JSON.stringify({
+        type: 'event_callback',
+        team_id: 'T123',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'C123',
+          ts: '1778883099.579530',
+          text: 'Duplicate report for Codex thread `T-019e28c1-08bb-777d-9a2e-74a393296b28`'
+        }
+      })
+      const waits: Promise<unknown>[] = []
+      const executionCtx = {
+        waitUntil: (promise: Promise<unknown>) => {
+          waits.push(promise)
+        }
+      }
+
+      await app.request(
+        '/api/webhooks/slack',
+        signedJsonRequest(body, process.env.SLACK_SIGNING_SECRET),
+        {},
+        executionCtx as any
+      )
+      const second = await app.request(
+        '/api/webhooks/slack',
+        signedJsonRequest(body, process.env.SLACK_SIGNING_SECRET),
+        {},
+        executionCtx as any
+      )
+
+      expect(second.status).toBe(200)
+      expect(await second.json()).toEqual({ ok: true, duplicate: true })
+      expect(console.warn).toHaveBeenCalledWith('slack_duplicate_message_skipped', {
+        dedupe_key: 'message:T123:C123:1778883099.579530',
+        event_id: undefined,
+        team_id: 'T123',
+        channel_id: 'C123',
+        message_ts: '1778883099.579530',
+        thread_ts: '1778883099.579530',
+        event_type: 'message',
+        codex_thread_id: 'T-019e28c1-08bb-777d-9a2e-74a393296b28',
+        alert_channel_id: undefined
+      })
+      expect(waits).toHaveLength(1)
+      await Promise.allSettled(waits)
+    } finally {
+      console.error = originalError
+      console.log = originalLog
+      console.warn = originalWarn
     }
   })
 })

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -12,6 +12,7 @@ import { AgentSessionRenderer } from './slack/agent-session'
 import { authorizeSlackOrg } from './slack/authorization'
 import { CodexSessionRenderer, codexFooter } from './slack/codex-session'
 import { EventDeduper, slackDedupKey } from './slack/dedup'
+import { duplicateSlackAlertText, type DuplicateSlackEventDetails } from './slack/duplicate-alert'
 import { EnvSlackInstallationStore, SlackClientResolver } from './slack/installations'
 import { normalizeSlackEnvelope } from './slack/normalize'
 import { markdownToStreamChunks } from './slack/render'
@@ -20,6 +21,9 @@ import type { SlackEnvelope } from './slack/types'
 import type { AnyBlock, AnyChunk } from '@slack/types'
 
 const config = loadConfig()
+// This is the existing deployments/runtime alert channel wired by the Helm
+// chart from slackbot.runtimeErrorAlertChannel.
+const deploymentAlertChannel = config.RUNTIME_ERROR_ALERT_CHANNEL.trim()
 const resolver = new SlackClientResolver(
   new EnvSlackInstallationStore({
     token: config.SLACK_BOT_TOKEN
@@ -27,6 +31,7 @@ const resolver = new SlackClientResolver(
 )
 const handoff = new CentaurHandoff(config)
 const deduper = new EventDeduper(config.SLACK_EVENT_DEDUP_TTL_MS)
+const CODEX_THREAD_RE = /\b(?:codex|agent|amp)\s+thread\b[^A-Z0-9]*(T-[A-Z0-9-]+)/i
 
 void resolver
   .resolve({})
@@ -107,6 +112,19 @@ const slackHandler = async (c: Context<{ Variables: Variables }>) => {
     messageTs: typeof event?.ts === 'string' ? event.ts : undefined
   })
   if (!deduper.checkAndRemember(key)) {
+    const duplicate = duplicateSlackEventDetails(envelope, event, key)
+    logWarn(
+      key.startsWith('message:')
+        ? 'slack_duplicate_message_skipped'
+        : 'slack_duplicate_event_skipped',
+      {
+        ...duplicate,
+        alert_channel_id: deploymentAlertChannel || undefined
+      }
+    )
+    if (deploymentAlertChannel) {
+      runInBackground(c, notifyDuplicateSlackAlert(duplicate))
+    }
     return c.json({ ok: true, duplicate: true })
   }
 
@@ -383,6 +401,73 @@ if (process.env.NODE_ENV === 'development') showRoutes(app)
 export default {
   port: config.PORT,
   fetch: app.fetch
+}
+
+function duplicateSlackEventDetails(
+  envelope: SlackEnvelope,
+  event: Record<string, unknown> | undefined,
+  dedupeKey: string
+): DuplicateSlackEventDetails {
+  const messageTs = typeof event?.ts === 'string' ? event.ts : undefined
+  return {
+    dedupe_key: dedupeKey,
+    event_id: envelope.event_id,
+    team_id: envelope.team_id,
+    channel_id: typeof event?.channel === 'string' ? event.channel : undefined,
+    message_ts: messageTs,
+    thread_ts: typeof event?.thread_ts === 'string' ? event.thread_ts : messageTs,
+    event_type: typeof event?.type === 'string' ? event.type : undefined,
+    codex_thread_id: codexThreadIdFromSlackEvent(event)
+  }
+}
+
+async function notifyDuplicateSlackAlert(details: DuplicateSlackEventDetails): Promise<void> {
+  if (!deploymentAlertChannel) return
+  try {
+    const { client } = await resolver.resolve({ teamId: details.team_id })
+    await client.chat.postMessage({
+      channel: deploymentAlertChannel,
+      text: duplicateSlackAlertText(details)
+    })
+    logWarn('slack_duplicate_alert_posted', {
+      ...details,
+      alert_channel_id: deploymentAlertChannel,
+      alert_posted: true
+    })
+  } catch (error) {
+    logWarn('slack_duplicate_alert_failed', {
+      ...details,
+      alert_channel_id: deploymentAlertChannel,
+      alert_posted: false,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+function codexThreadIdFromSlackEvent(event: Record<string, unknown> | undefined): string | undefined {
+  if (!event) return undefined
+  for (const key of ['codex_thread_id', 'agent_thread_id', 'thread_id', 'session_id']) {
+    const value = event[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return codexThreadIdFromUnknown(event)
+}
+
+function codexThreadIdFromUnknown(value: unknown): string | undefined {
+  if (typeof value === 'string') return CODEX_THREAD_RE.exec(value)?.[1]
+  if (!value || typeof value !== 'object') return undefined
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = codexThreadIdFromUnknown(item)
+      if (found) return found
+    }
+    return undefined
+  }
+  for (const item of Object.values(value)) {
+    const found = codexThreadIdFromUnknown(item)
+    if (found) return found
+  }
+  return undefined
 }
 
 async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {

--- a/services/slackbot/src/slack/duplicate-alert.test.ts
+++ b/services/slackbot/src/slack/duplicate-alert.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import { duplicateSlackAlertText } from './duplicate-alert'
+
+describe('duplicateSlackAlertText', () => {
+  it('includes Slack and Codex thread identifiers without message text', () => {
+    expect(
+      duplicateSlackAlertText({
+        dedupe_key: 'message:T123:C123:1778883099.579530',
+        event_id: 'Ev123',
+        team_id: 'T123',
+        channel_id: 'C123',
+        thread_ts: '1778883099.579529',
+        message_ts: '1778883099.579530',
+        event_type: 'message',
+        codex_thread_id: 'T-019e28c1-08bb-777d-9a2e-74a393296b28'
+      })
+    ).toBe(
+      [
+        '*Slack duplicate message skipped*',
+        '*Channel:* `C123`',
+        '*Thread:* `1778883099.579529`',
+        '*Message:* `1778883099.579530`',
+        '*Event type:* `message`',
+        '*Event ID:* `Ev123`',
+        '*Codex thread:* `T-019e28c1-08bb-777d-9a2e-74a393296b28`',
+        '*Dedupe key:* `message:T123:C123:1778883099.579530`'
+      ].join('\n')
+    )
+  })
+})

--- a/services/slackbot/src/slack/duplicate-alert.ts
+++ b/services/slackbot/src/slack/duplicate-alert.ts
@@ -1,0 +1,25 @@
+export type DuplicateSlackEventDetails = {
+  dedupe_key: string
+  event_id?: string
+  team_id?: string
+  channel_id?: string
+  message_ts?: string
+  thread_ts?: string
+  event_type?: string
+  codex_thread_id?: string
+}
+
+export function duplicateSlackAlertText(details: DuplicateSlackEventDetails): string {
+  return [
+    '*Slack duplicate message skipped*',
+    details.channel_id ? `*Channel:* \`${details.channel_id}\`` : '',
+    details.thread_ts ? `*Thread:* \`${details.thread_ts}\`` : '',
+    details.message_ts ? `*Message:* \`${details.message_ts}\`` : '',
+    details.event_type ? `*Event type:* \`${details.event_type}\`` : '',
+    details.event_id ? `*Event ID:* \`${details.event_id}\`` : '',
+    details.codex_thread_id ? `*Codex thread:* \`${details.codex_thread_id}\`` : '',
+    `*Dedupe key:* \`${details.dedupe_key}\``
+  ]
+    .filter(Boolean)
+    .join('\n')
+}


### PR DESCRIPTION
## Summary
- log duplicate Slack event/message dedupe hits with stable alertable event names
- include Slack thread identifiers and cached Codex thread id when known
- add Codex thread cache coverage, including Slack Connect team-id fallback

## Tests
- bun test src/index.test.ts src/slack/dedup.test.ts src/slack/codex-thread-cache.test.ts src/centaur/final-delivery.test.ts src/slack/codex-session.test.ts
- bun run check:types
- bunx oxlint --config='oxlint.config.ts' --type-aware --type-check src/index.ts src/index.test.ts src/slack/codex-thread-cache.ts src/slack/codex-thread-cache.test.ts