### PR TITLE
Add ACME templates and model credential wizard

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -58,6 +58,9 @@ _build-agent:
 bootstrap-secrets *args:
     contrib/scripts/bootstrap-k8s-secrets.sh --namespace {{namespace}} {{args}}
 
+model *args:
+    contrib/scripts/configure-model-secrets.sh --namespace {{namespace}} {{args}}
+
 deploy:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/contrib/scripts/configure-model-secrets.sh
+++ b/contrib/scripts/configure-model-secrets.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="centaur"
+SECRET_NAME="centaur-infra-env"
+FORCE=0
+
+usage() {
+  printf '%s\n' "Usage: contrib/scripts/configure-model-secrets.sh [--namespace NAMESPACE] [--secret-name NAME] [--force]"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace|-n)
+      NAMESPACE="${2:?--namespace requires a value}"
+      shift 2
+      ;;
+    --secret-name)
+      SECRET_NAME="${2:?--secret-name requires a value}"
+      shift 2
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "FATAL: required command not found: kubectl" >&2
+  exit 1
+fi
+
+if ! kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" >/dev/null 2>&1; then
+  echo "FATAL: Secret $SECRET_NAME does not exist in namespace $NAMESPACE." >&2
+  echo "Run just bootstrap-secrets first, then rerun just model." >&2
+  exit 1
+fi
+
+ask_replace() {
+  local key="$1"
+  if [[ "$FORCE" == "1" ]]; then
+    return 0
+  fi
+  if ! kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o "jsonpath={.data.${key}}" 2>/dev/null | grep -q .; then
+    return 0
+  fi
+  local answer
+  read -r -p "$key is already present. Replace it? [y/N] " answer
+  [[ "$answer" =~ ^[Yy]$ ]]
+}
+
+read_key() {
+  local label="$1"
+  local key="$2"
+  if ! ask_replace "$key"; then
+    echo "Skipped $key"
+    return
+  fi
+
+  local value
+  read -r -s -p "$label API key for $key: " value
+  printf '\n' >&2
+  if [[ -z "$value" ]]; then
+    echo "Skipped $key"
+    return
+  fi
+  SECRET_ARGS+=("--from-literal=${key}=${value}")
+}
+
+declare -a SECRET_ARGS
+
+echo "Configuring model credentials in Secret $SECRET_NAME in namespace $NAMESPACE."
+echo "Leave a value blank to skip that provider."
+
+read_key "OpenAI" "OPENAI_API_KEY"
+read_key "Anthropic" "ANTHROPIC_API_KEY"
+read_key "Amp" "AMP_API_KEY"
+
+if [[ "${#SECRET_ARGS[@]}" -eq 0 ]]; then
+  echo "No model credentials changed."
+  exit 0
+fi
+
+kubectl -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
+  --dry-run=client -o yaml "${SECRET_ARGS[@]}" |
+  kubectl apply -f - >/dev/null
+
+echo "Updated model credentials in Secret $SECRET_NAME."

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -68,6 +68,9 @@ Application-level model and tool secrets, such as `OPENAI_API_KEY`,
 placeholder values and [iron-proxy](https://docs.iron.sh) injects the real credentials only on approved
 outbound requests.
 
+For local deployments, run `just model` after `just bootstrap-secrets` to
+configure model-provider credentials interactively.
+
 The default harness is `codex`, so `OPENAI_API_KEY` must exist in the configured
 secret source before Slack agent turns can complete. Use explicit harness
 selectors only when you want a non-default harness such as Amp or Claude Code.
@@ -81,8 +84,9 @@ just up
 That runs:
 
 1. `just bootstrap-secrets`
-2. `just build`
-3. `just deploy`
+2. `just model`
+3. `just build`
+4. `just deploy`
 
 Check the namespace:
 

--- a/docs/pages/secrets/model-credentials.mdx
+++ b/docs/pages/secrets/model-credentials.mdx
@@ -1,0 +1,49 @@
+---
+title: Configure Model Credentials
+description: Configure OpenAI, Anthropic, and Amp credentials for Centaur sandboxes.
+---
+
+# Configure Model Credentials
+
+Centaur sandboxes do not receive raw model-provider keys. They receive
+placeholder values such as `OPENAI_API_KEY=OPENAI_API_KEY`; iron-proxy swaps the
+real secret into requests to the allowlisted upstream host.
+
+For local Kubernetes deployments, use the interactive wizard:
+
+```bash
+just model
+```
+
+The wizard patches the Kubernetes Secret consumed by the Helm chart. By default
+it uses namespace `centaur` and Secret `centaur-infra-env`.
+
+## Supported Keys
+
+| Provider | Secret key | Used by |
+| --- | --- | --- |
+| OpenAI | `OPENAI_API_KEY` | Default Codex harness |
+| Anthropic | `ANTHROPIC_API_KEY` | Claude Code and pi-mono harnesses |
+| Amp | `AMP_API_KEY` | Amp harness |
+
+## Options
+
+```bash
+just model --force
+just model --secret-name centaur-infra-env
+CENTAUR_NAMESPACE=centaur-system just model
+```
+
+Run `just bootstrap-secrets` before `just model`; the wizard patches an existing
+Secret and does not create the full infrastructure Secret from scratch.
+
+## 1Password Deployments
+
+For production deployments using 1Password, create items with the same names:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `AMP_API_KEY`
+
+When `ironProxy.secretSource` is `onepassword`, Centaur resolves each value from
+`op://$OP_VAULT/<SECRET_NAME>/credential`.

--- a/docs/public/md/quickstart.md
+++ b/docs/public/md/quickstart.md
@@ -68,6 +68,9 @@ Application-level model and tool secrets, such as `OPENAI_API_KEY`,
 placeholder values and [iron-proxy](https://iron.sh) injects the real credentials only on approved
 outbound requests.
 
+For local deployments, run `just model` after `just bootstrap-secrets` to
+configure model-provider credentials interactively.
+
 The default harness is `codex`, so `OPENAI_API_KEY` must exist in the configured
 secret source before Slack agent turns can complete. Use explicit harness
 selectors only when you want a non-default harness such as Amp or Claude Code.
@@ -81,8 +84,9 @@ just up
 That runs:
 
 1. `just bootstrap-secrets`
-2. `just build`
-3. `just deploy`
+2. `just model`
+3. `just build`
+4. `just deploy`
 
 Check the namespace:
 

--- a/docs/public/md/secrets/model-credentials.md
+++ b/docs/public/md/secrets/model-credentials.md
@@ -1,0 +1,49 @@
+---
+title: Configure Model Credentials
+description: Configure OpenAI, Anthropic, and Amp credentials for Centaur sandboxes.
+---
+
+# Configure Model Credentials
+
+Centaur sandboxes do not receive raw model-provider keys. They receive
+placeholder values such as `OPENAI_API_KEY=OPENAI_API_KEY`; iron-proxy swaps the
+real secret into requests to the allowlisted upstream host.
+
+For local Kubernetes deployments, use the interactive wizard:
+
+```bash
+just model
+```
+
+The wizard patches the Kubernetes Secret consumed by the Helm chart. By default
+it uses namespace `centaur` and Secret `centaur-infra-env`.
+
+## Supported Keys
+
+| Provider | Secret key | Used by |
+| --- | --- | --- |
+| OpenAI | `OPENAI_API_KEY` | Default Codex harness |
+| Anthropic | `ANTHROPIC_API_KEY` | Claude Code and pi-mono harnesses |
+| Amp | `AMP_API_KEY` | Amp harness |
+
+## Options
+
+```bash
+just model --force
+just model --secret-name centaur-infra-env
+CENTAUR_NAMESPACE=centaur-system just model
+```
+
+Run `just bootstrap-secrets` before `just model`; the wizard patches an existing
+Secret and does not create the full infrastructure Secret from scratch.
+
+## 1Password Deployments
+
+For production deployments using 1Password, create items with the same names:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `AMP_API_KEY`
+
+When `ironProxy.secretSource` is `onepassword`, Centaur resolves each value from
+`op://$OP_VAULT/<SECRET_NAME>/credential`.

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -23,6 +23,7 @@ export const sidebar = [
   {
     text: 'Secrets',
     items: [
+      { text: 'Configure Model Credentials', link: '/secrets/model-credentials' },
       { text: 'Use 1Password', link: '/secrets/onepassword' },
       { text: 'Use Environment Variables', link: '/secrets/environment' },
     ],


### PR DESCRIPTION
Adds OSS launch nice-to-haves: model credential wizard/docs plus links to forkable ACME overlay and infra templates.\n\nValidation:\n- bash -n contrib/scripts/configure-model-secrets.sh\n- git diff --check\n- centaur-acme: uv run pytest\n- Docker build attempted but unavailable in sandbox: no Docker daemon