### PR TITLE
fix slackbot final plan delivery

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -874,15 +874,13 @@ async def _mark_slackbot_live_delivery_failed(pool, execution_id: str, reason: s
     await pool.execute(
         "UPDATE agent_execution_requests "
         "SET metadata = jsonb_set("
-        "  metadata - $2::text - $3::text, "
+        "  metadata, "
         "  '{slackbot_live_delivery_failed}', "
-        "  to_jsonb($4::text), "
+        "  to_jsonb($2::text), "
         "  true"
         "), updated_at = NOW() "
         "WHERE execution_id = $1",
         execution_id,
-        _SLACKBOT_LIVE_DELIVERY_METADATA_KEY,
-        _LEGACY_SLACKBOT_LIVE_DELIVERY_METADATA_KEY,
         reason,
     )
 

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -61,6 +61,14 @@ export type StepOptions = {
   flush?: boolean
 }
 
+export type TextOptions = {
+  flush?: boolean
+}
+
+export type DoneOptions = {
+  streamFinalUpdates?: boolean
+}
+
 const sessions = new Map<string, AgentSessionState>()
 const THINKING_STATUS = 'Thinking...'
 const TEXT_FLUSH_INTERVAL_MS = 250
@@ -100,7 +108,11 @@ export class AgentSessionRenderer {
     await this.queueText(state, segment, markdown)
   }
 
-  async textDelta(sessionId: string, markdownDelta: string): Promise<void> {
+  async textDelta(
+    sessionId: string,
+    markdownDelta: string,
+    opts: TextOptions = {}
+  ): Promise<void> {
     if (!markdownDelta) return
     const state = requireSession(sessionId)
     const segment = currentSegment(state)
@@ -108,6 +120,13 @@ export class AgentSessionRenderer {
     const lastIndex = segment.textParts.length - 1
     if (lastIndex >= 0) segment.textParts[lastIndex] += markdownDelta
     else segment.textParts.push(markdownDelta)
+    if (opts.flush === false) {
+      segment.pendingText += normalizeDeltaBoundary(
+        segment.streamedText + segment.pendingText,
+        markdownDelta
+      )
+      return
+    }
     await this.queueText(state, segment, markdownDelta)
   }
 
@@ -136,19 +155,26 @@ export class AgentSessionRenderer {
     await this.flushText(state, segment, { force: true })
   }
 
-  async done(sessionId: string, footer?: string): Promise<void> {
+  async done(sessionId: string, footer?: string, opts: DoneOptions = {}): Promise<void> {
     const state = requireSession(sessionId)
     state.done = true
     state.footer = footer
+    const streamFinalUpdates = opts.streamFinalUpdates ?? true
     let closed = false
 
     try {
       for (const segment of state.segments) {
         balancePendingMarkdown(segment)
-        await this.flushText(state, segment, { force: true })
+        if (streamFinalUpdates) {
+          await this.flushText(state, segment, { force: true })
+        } else {
+          await this.absorbPendingText(segment)
+        }
         const finalizedTasks = finalizeOpenTasks(segment)
-        for (const task of finalizedTasks) {
-          await this.flushTask(state, segment, task)
+        if (streamFinalUpdates) {
+          for (const task of finalizedTasks) {
+            await this.flushTask(state, segment, task)
+          }
         }
         await this.closeTextStream(state, segment)
       }
@@ -268,6 +294,19 @@ export class AgentSessionRenderer {
       segment.pendingTextFlush = undefined
     })
     await segment.pendingTextFlush
+  }
+
+  private async absorbPendingText(segment: Segment): Promise<void> {
+    raiseStreamError(segment)
+    if (segment.pendingTextTimer) {
+      clearTimeout(segment.pendingTextTimer)
+      segment.pendingTextTimer = undefined
+    }
+    if (segment.pendingTextFlush) await segment.pendingTextFlush
+    if (!segment.pendingText) return
+    const markdown = normalizeMarkdownChunk(segment.streamedText, segment.pendingText)
+    segment.pendingText = ''
+    segment.streamedText += markdown
   }
 
   private async flushTextNow(

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -150,7 +150,10 @@ export class CodexSessionRenderer {
         const resultText = event.result.trim()
         if (resultText) {
           state.messageText += resultText
-          await this.publishPendingAssistantText(agentSessionId, state, { force: true })
+          await this.publishPendingAssistantText(agentSessionId, state, {
+            force: true,
+            flush: false
+          })
         }
       }
       await this.done(agentSessionId)
@@ -165,10 +168,11 @@ export class CodexSessionRenderer {
     state.done = true
     completeOpenTasks(state)
     await this.publishActivitySummary(agentSessionId, state, { final: true })
-    await this.publishPendingAssistantText(agentSessionId, state, { force: true })
+    await this.publishPendingAssistantText(agentSessionId, state, { force: true, flush: false })
     await this.renderer.done(
       agentSessionId,
-      state.threadId ? codexFooter(state.threadId) : undefined
+      state.threadId ? codexFooter(state.threadId) : undefined,
+      { streamFinalUpdates: false }
     )
     state.done = true
     states.delete(agentSessionId)
@@ -200,13 +204,13 @@ export class CodexSessionRenderer {
   private async publishPendingAssistantText(
     agentSessionId: string,
     state: CodexSessionState,
-    opts: { force?: boolean } = {}
+    opts: { force?: boolean; flush?: boolean } = {}
   ): Promise<void> {
     if (!opts.force && !state.taskByUseId.size) return
     if (state.messageText.length <= state.streamedMessageText.length) return
     const delta = state.messageText.slice(state.streamedMessageText.length)
     state.streamedMessageText = state.messageText
-    await this.renderer.textDelta(agentSessionId, delta)
+    await this.renderer.textDelta(agentSessionId, delta, { flush: opts.flush })
   }
 
   private async publishStructuredPlan(


### PR DESCRIPTION
bug was that the final live plan update could still hit slack msg_too_long before we got to the final formatted update. when that happened, final delivery fallback could post a second reply and the original plan stayed unformatted.

fix is to skip risky terminal live appends for codex, do the final formatted plan in the final message update, and keep live-delivery metadata so fallback doesn't create a duplicate reply.