### PR TITLE
fix: keep docs mobile nav dark

### DIFF
--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -371,37 +371,6 @@ body,
   letter-spacing: 0.012em;
 }
 
-:root,
-:root.dark {
-  --vocs-color_background: #050506;
-  --vocs-color_background2: #0b0b0d;
-  --vocs-color_background3: #111114;
-  --vocs-color_background4: #19191d;
-  --vocs-color_background5: #202024;
-  --vocs-color_backgroundDark: #050506;
-  --vocs-color_backgroundDarkTint: #111114;
-  --vocs-color_codeBlockBackground: #0b0b0d;
-  --vocs-color_codeInlineBackground: #111114;
-  --vocs-color_codeInlineBorder: rgba(255, 255, 255, 0.12);
-  --vocs-color_codeInlineText: var(--centaur-accent);
-  --vocs-color_border: rgba(255, 255, 255, 0.12);
-  --vocs-color_border2: rgba(255, 255, 255, 0.2);
-  --vocs-color_heading: #f7f7f2;
-  --vocs-color_hr: rgba(255, 255, 255, 0.12);
-  --vocs-color_link: var(--centaur-accent);
-  --vocs-color_linkHover: var(--centaur-accent-hover);
-  --vocs-color_shadow: rgba(0, 0, 0, 0.45);
-  --vocs-color_shadow2: rgba(0, 0, 0, 0.35);
-  --vocs-color_text: #f7f7f2;
-  --vocs-color_text2: #dfdfd8;
-  --vocs-color_text3: #a5a59d;
-  --vocs-color_text4: #76766f;
-  --vocs-color_textAccent: var(--centaur-accent);
-  --vocs-color_textAccentHover: var(--centaur-accent-hover);
-  --vocs-color_textHover: #ffffff;
-  --vocs-color_title: #f7f7f2;
-}
-
 body,
 .vocs_DocsLayout {
   background: #050506;

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -134,10 +134,110 @@ export default defineConfig({
       color: {
         background: {
           light: '#ffffff',
-          dark: '#050505',
+          dark: '#050506',
+        },
+        background2: {
+          light: '#f8f8f8',
+          dark: '#0b0b0d',
+        },
+        background3: {
+          light: '#f1f1f1',
+          dark: '#111114',
+        },
+        background4: {
+          light: '#e8e8e8',
+          dark: '#19191d',
+        },
+        background5: {
+          light: '#dedede',
+          dark: '#202024',
+        },
+        backgroundDark: {
+          light: '#050506',
+          dark: '#050506',
+        },
+        backgroundDarkTint: {
+          light: '#111114',
+          dark: '#111114',
+        },
+        codeBlockBackground: {
+          light: '#0b0b0d',
+          dark: '#0b0b0d',
+        },
+        codeInlineBackground: {
+          light: '#111114',
+          dark: '#111114',
+        },
+        codeInlineBorder: {
+          light: 'rgba(255, 255, 255, 0.12)',
+          dark: 'rgba(255, 255, 255, 0.12)',
+        },
+        codeInlineText: {
+          light: '#00E100',
+          dark: '#00E100',
+        },
+        border: {
+          light: 'rgba(255, 255, 255, 0.12)',
+          dark: 'rgba(255, 255, 255, 0.12)',
+        },
+        border2: {
+          light: 'rgba(255, 255, 255, 0.2)',
+          dark: 'rgba(255, 255, 255, 0.2)',
+        },
+        heading: {
+          light: '#f7f7f2',
+          dark: '#f7f7f2',
+        },
+        hr: {
+          light: 'rgba(255, 255, 255, 0.12)',
+          dark: 'rgba(255, 255, 255, 0.12)',
+        },
+        link: {
+          light: '#00E100',
+          dark: '#00E100',
+        },
+        linkHover: {
+          light: '#35f335',
+          dark: '#35f335',
+        },
+        shadow: {
+          light: 'rgba(0, 0, 0, 0.45)',
+          dark: 'rgba(0, 0, 0, 0.45)',
+        },
+        shadow2: {
+          light: 'rgba(0, 0, 0, 0.35)',
+          dark: 'rgba(0, 0, 0, 0.35)',
         },
         text: {
-          light: '#050505',
+          light: '#f7f7f2',
+          dark: '#f7f7f2',
+        },
+        text2: {
+          light: '#dfdfd8',
+          dark: '#dfdfd8',
+        },
+        text3: {
+          light: '#a5a59d',
+          dark: '#a5a59d',
+        },
+        text4: {
+          light: '#76766f',
+          dark: '#76766f',
+        },
+        textAccent: {
+          light: '#00E100',
+          dark: '#00E100',
+        },
+        textAccentHover: {
+          light: '#35f335',
+          dark: '#35f335',
+        },
+        textHover: {
+          light: '#ffffff',
+          dark: '#ffffff',
+        },
+        title: {
+          light: '#f7f7f2',
           dark: '#f7f7f2',
         },
       },


### PR DESCRIPTION
## Summary
- Move Centaur docs color tokens into Vocs theme variables
- Remove the mobile docs nav CSS hard override
- Remove the large root-level Vocs color variable override block from docs/pages/_root.css

## Test
- npx vocs build

Note: npm run build is still blocked in this sandbox because scripts/build-brand-zip.sh requires zip, which is not installed here.