### PR TITLE
Add Linear issue due date support

### DIFF
--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -184,6 +184,7 @@ def create(
     team: str = typer.Option(..., "--team", "-t", help="Team key (e.g., ENG)"),
     description: str = typer.Option(None, "--description", "-d", help="Issue description"),
     assignee: str = typer.Option(None, "--assignee", "-a", help="Assignee name"),
+    due_date: str = typer.Option(None, "--due-date", help="Due date as YYYY-MM-DD"),
     priority: int = typer.Option(
         None, "--priority", "-p", help="Priority (0=none, 1=urgent, 2=high, 3=medium, 4=low)"
     ),
@@ -233,6 +234,7 @@ def create(
         team_id=team_match["id"],
         description=description,
         assignee_id=assignee_id,
+        due_date=due_date,
         priority=priority,
         parent_id=parent_id,
     )
@@ -247,6 +249,7 @@ def update(
     title: str = typer.Option(None, "--title", help="New title"),
     state: str = typer.Option(None, "--state", "-s", help="New state name"),
     assignee: str = typer.Option(None, "--assignee", "-a", help="Assignee name (or 'me')"),
+    due_date: str = typer.Option(None, "--due-date", help="Due date as YYYY-MM-DD"),
     priority: int = typer.Option(None, "--priority", "-p", help="Priority (0-4)"),
     project: str = typer.Option(None, "--project", help="Project name to add issue to"),
 ):
@@ -310,6 +313,7 @@ def update(
         title=title,
         state_id=state_id,
         assignee_id=assignee_id,
+        due_date=due_date,
         priority=priority,
         project_id=project_id,
     )

--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -103,6 +103,7 @@ class LinearClient:
                     project {{ id name }}
                     cycle {{ id name number }}
                     labels {{ nodes {{ id name color }} }}
+                    dueDate
                     createdAt
                     updatedAt
                     url
@@ -136,6 +137,7 @@ class LinearClient:
                 comments { nodes { id body user { name } createdAt } }
                 parent { id identifier title }
                 children { nodes { id identifier title state { name } } }
+                dueDate
                 createdAt
                 updatedAt
                 url
@@ -156,13 +158,18 @@ class LinearClient:
         project_id: str | None = None,
         cycle_id: str | None = None,
         parent_id: str | None = None,
+        due_date: str | None = None,
     ) -> dict[str, Any]:
-        """Create a new issue."""
+        """Create a new issue.
+
+        Args:
+            due_date: Due date as YYYY-MM-DD.
+        """
         mutation = """
         mutation IssueCreate($input: IssueCreateInput!) {
             issueCreate(input: $input) {
                 success
-                issue { id identifier title url }
+                issue { id identifier title dueDate url }
             }
         }
         """
@@ -183,6 +190,8 @@ class LinearClient:
             input_data["cycleId"] = cycle_id
         if parent_id:
             input_data["parentId"] = parent_id
+        if due_date:
+            input_data["dueDate"] = due_date
 
         result = self._query(mutation, {"input": input_data})
         return result.get("issueCreate", {}).get("issue", {})
@@ -196,13 +205,18 @@ class LinearClient:
         assignee_id: str | None = None,
         priority: int | None = None,
         project_id: str | None = None,
+        due_date: str | None = None,
     ) -> dict[str, Any]:
-        """Update an existing issue."""
+        """Update an existing issue.
+
+        Args:
+            due_date: Due date as YYYY-MM-DD.
+        """
         mutation = """
         mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
             issueUpdate(id: $id, input: $input) {
                 success
-                issue { id identifier title state { name } project { id name } url }
+                issue { id identifier title dueDate state { name } project { id name } url }
             }
         }
         """
@@ -219,6 +233,8 @@ class LinearClient:
             input_data["priority"] = priority
         if project_id:
             input_data["projectId"] = project_id
+        if due_date:
+            input_data["dueDate"] = due_date
 
         result = self._query(mutation, {"id": issue_id, "input": input_data})
         return result.get("issueUpdate", {}).get("issue", {})
@@ -368,6 +384,7 @@ class LinearClient:
                     state { name }
                     assignee { name }
                     team { key }
+                    dueDate
                     url
                 }
             }


### PR DESCRIPTION
## Summary
- add due_date support to Linear issue creation and updates
- include dueDate in Linear issue query responses
- add --due-date to the Linear CLI create/update commands

## Verification
- uv run python -m py_compile tools/productivity/linear/client.py tools/productivity/linear/cli.py
- uv run --with typer --with rich --with httpx --with python-dotenv python - <<'PY'
import inspect
from tools.productivity.linear.client import LinearClient
print(inspect.signature(LinearClient.create_issue))
print(inspect.signature(LinearClient.update_issue))
PY
- uv run --with httpx python - <<'PY'
from tools.productivity.linear.client import LinearClient

calls = []
client = LinearClient.__new__(LinearClient)
client._query = lambda query, variables=None: calls.append(variables) or {"issueCreate": {"issue": {}}, "issueUpdate": {"issue": {}}}
client.create_issue(title="T", team_id="team", due_date="2026-05-21")
client.update_issue(issue_id="MAR-204", due_date="2026-05-21")
assert calls[0]["input"]["dueDate"] == "2026-05-21"
assert calls[1]["input"]["dueDate"] == "2026-05-21"
print("due_date serialization ok")
PY