### PR TITLE
fix: store video inputs as attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ next-env.d.ts
 # TypeScript incremental build state
 *.tsbuildinfo
 _
+.notes

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -578,11 +578,9 @@ async def extract_inline_attachments(
     attachment_ids: list[str] = []
 
     for part in parts:
-        part_type = part.get("type")
         source = part.get("source") if isinstance(part, dict) else None
         if (
-            part_type in {"image", "document"}
-            and isinstance(source, dict)
+            isinstance(source, dict)
             and source.get("type") == "base64"
             and isinstance(source.get("data"), str)
         ):
@@ -601,7 +599,11 @@ async def extract_inline_attachments(
                 if isinstance(part.get("source_path"), str)
                 else None
             )
-            name = _attachment_name_from_source_path(source_path, attachment_id)
+            name = (
+                str(part.get("name"))
+                if isinstance(part.get("name"), str) and part.get("name")
+                else _attachment_name_from_source_path(source_path, attachment_id)
+            )
             await pool.execute(
                 "INSERT INTO attachments (id, thread_key, message_id, name, mime_type, data) "
                 "VALUES ($1, $2, $3, $4, $5, $6)",
@@ -617,6 +619,7 @@ async def extract_inline_attachments(
                     "type": "attachment_ref",
                     "attachment_id": attachment_id,
                     "media_type": media_type,
+                    "name": name,
                     **({"source_path": source_path} if source_path else {}),
                 }
             )
@@ -642,7 +645,11 @@ def event_to_chat_parts(parts: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 if isinstance(part.get("source_path"), str)
                 else None
             )
-            name = _attachment_name_from_source_path(source_path, attachment_id)
+            name = (
+                str(part.get("name"))
+                if isinstance(part.get("name"), str) and part.get("name")
+                else _attachment_name_from_source_path(source_path, attachment_id)
+            )
             chat_parts.append(
                 {
                     "type": "attachment_ref",

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -516,6 +516,89 @@ async def test_message_stores_attachment_refs(client, db_pool, api_key: str):
 
 
 @pytest.mark.asyncio
+async def test_message_extracts_video_file_attachment(client, db_pool, api_key: str):
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}"
+    await _insert_assignment(db_pool, thread_key, generation=3)
+    video_bytes = b"\x00\x00\x00\x18ftypmp42" + (b"video" * 128)
+
+    payload = {
+        "thread_key": thread_key,
+        "assignment_generation": 3,
+        "message_id": "msg-video",
+        "event": {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what happens in this video?"},
+                    {
+                        "type": "file",
+                        "name": "CleanShot demo.mp4",
+                        "mime_type": "video/mp4",
+                        "size": len(video_bytes),
+                        "slack_file_id": "FVID123",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "video/mp4",
+                            "data": base64.b64encode(video_bytes).decode("utf-8"),
+                        },
+                    },
+                ],
+            },
+        },
+    }
+
+    res = await client.post("/agent/message", headers=_auth(api_key), json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["ok"] is True
+    assert len(data["attachment_ids"]) == 1
+
+    request_row = await db_pool.fetchrow(
+        "SELECT event_json FROM agent_message_requests WHERE thread_key = $1 AND message_id = $2",
+        thread_key,
+        "msg-video",
+    )
+    assert request_row is not None
+    event_json = request_row["event_json"]
+    if isinstance(event_json, str):
+        event_json = json.loads(event_json)
+    content = event_json["message"]["content"]
+    assert content[1] == {
+        "type": "attachment_ref",
+        "attachment_id": data["attachment_ids"][0],
+        "media_type": "video/mp4",
+        "name": "CleanShot demo.mp4",
+    }
+
+    chat_row = await db_pool.fetchrow(
+        "SELECT parts FROM chat_messages WHERE thread_key = $1 AND id LIKE $2",
+        thread_key,
+        "%msg-video",
+    )
+    assert chat_row is not None
+    chat_parts = chat_row["parts"]
+    if isinstance(chat_parts, str):
+        chat_parts = json.loads(chat_parts)
+    assert chat_parts[1] == {
+        "type": "attachment_ref",
+        "id": data["attachment_ids"][0],
+        "name": "CleanShot demo.mp4",
+        "mime_type": "video/mp4",
+    }
+    assert "source" not in chat_parts[1]
+
+    attachment_row = await db_pool.fetchrow(
+        "SELECT name, mime_type, data FROM attachments WHERE id = $1",
+        data["attachment_ids"][0],
+    )
+    assert attachment_row is not None
+    assert attachment_row["name"] == "CleanShot demo.mp4"
+    assert attachment_row["mime_type"] == "video/mp4"
+    assert bytes(attachment_row["data"]) == video_bytes
+
+
+@pytest.mark.asyncio
 async def test_execute_rejects_stale_generation(client, db_pool, api_key: str):
     thread_key = f"slack:C-test:{uuid.uuid4().hex}"
     await _insert_assignment(db_pool, thread_key, generation=5)

--- a/services/api/tests/test_attachments.py
+++ b/services/api/tests/test_attachments.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pytest
 
+from api.runtime_control import extract_inline_attachments, event_to_chat_parts
 from api.sandbox.harness_protocol import messages_to_content_blocks
 
 
@@ -98,6 +99,60 @@ class TestAttachmentExtractionPipeline:
         # The document block passes through as-is — NOT a text block
         assert blocks[1]["type"] == "document"
         assert "source" in blocks[1]
+
+    @pytest.mark.asyncio
+    async def test_video_file_block_is_extracted_to_attachment_ref(self):
+        video_bytes = b"\x00\x00\x00\x18ftypmp42" + (b"video" * 16)
+        inserted: list[tuple] = []
+
+        class FakePool:
+            async def execute(self, query, *args):
+                inserted.append(args)
+
+        transformed, attachment_ids = await extract_inline_attachments(
+            FakePool(),
+            thread_key="slack:T:C:1.000000",
+            chat_message_id="msg-video",
+            parts=[
+                {"type": "text", "text": "what happens here?"},
+                {
+                    "type": "file",
+                    "name": "CleanShot demo.mp4",
+                    "mime_type": "video/mp4",
+                    "size": len(video_bytes),
+                    "slack_file_id": "FVID123",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "video/mp4",
+                        "data": base64.b64encode(video_bytes).decode(),
+                    },
+                },
+            ],
+        )
+
+        assert len(attachment_ids) == 1
+        assert transformed == [
+            {"type": "text", "text": "what happens here?"},
+            {
+                "type": "attachment_ref",
+                "attachment_id": attachment_ids[0],
+                "media_type": "video/mp4",
+                "name": "CleanShot demo.mp4",
+            },
+        ]
+        assert inserted[0][1] == "slack:T:C:1.000000"
+        assert inserted[0][2] == "msg-video"
+        assert inserted[0][3] == "CleanShot demo.mp4"
+        assert inserted[0][4] == "video/mp4"
+        assert inserted[0][5] == video_bytes
+
+        chat_parts = event_to_chat_parts(transformed)
+        assert chat_parts[1] == {
+            "type": "attachment_ref",
+            "id": attachment_ids[0],
+            "name": "CleanShot demo.mp4",
+            "mime_type": "video/mp4",
+        }
 
     def test_extracted_attachment_ref_becomes_download_instruction(self):
         """After extraction, attachment_ref parts become text with curl."""

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
     git curl wget ca-certificates gnupg lsb-release sudo \
     build-essential pkg-config cmake ninja-build \
-    ffmpeg ghostscript dvisvgm \
+    ffmpeg ghostscript dvisvgm file \
     libssl-dev libclang-dev protobuf-compiler \
     libcairo2-dev libpango1.0-dev \
     ripgrep fd-find jq tree tmux unzip xz-utils gettext-base \
@@ -71,7 +71,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libcairo-gobject2 libcairo2 libgdk-pixbuf-2.0-0 libxrender1 \
         libasound2t64 libfreetype6 libfontconfig1 libdbus-1-3 libnss3 \
         libnspr4 libatk-bridge2.0-0t64 libdrm2 libxkbcommon0 \
-        libatspi2.0-0t64 libcups2t64 libxshmfence1 libgbm1 file \
+        libatspi2.0-0t64 libcups2t64 libxshmfence1 libgbm1 \
         fonts-noto-color-emoji fonts-noto-cjk fonts-freefont-ttf; \
     else \
       apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
- store Slack-uploaded video/file inputs as Centaur attachments instead of leaving inline base64 in agent message payloads
- preserve original attachment filenames when converting base64 parts into `attachment_ref`s
- add regression coverage for `video/mp4` file parts and attachment-ref conversion