### PR TITLE
fix: publish docs preview urls

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,12 +74,19 @@ jobs:
       - name: Preview
         id: preview
         if: ${{ github.event_name == 'pull_request' && env.CLOUDFLARE_ACCOUNT_ID != '' && env.CLOUDFLARE_API_TOKEN != '' }}
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: ${{ matrix.worker.directory }}
-          command: versions upload
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PREVIEW_ALIAS: pr-${{ github.event.pull_request.number }}
+        run: |
+          set -o pipefail
+          npx wrangler versions upload --preview-alias "$PREVIEW_ALIAS" 2>&1 | tee "$RUNNER_TEMP/wrangler-preview.log"
+          deployment_url="$(grep -Eo 'https://[^[:space:]]+workers.dev[^[:space:]]*' "$RUNNER_TEMP/wrangler-preview.log" | tail -n 1)"
+          if [ -z "$deployment_url" ]; then
+            echo "No Cloudflare preview URL found in Wrangler output." >&2
+            exit 1
+          fi
+          echo "deployment-url=$deployment_url" >> "$GITHUB_OUTPUT"
 
       - name: Publish preview summary
         if: ${{ github.event_name == 'pull_request' && steps.preview.outputs.deployment-url != '' }}

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -14,6 +14,7 @@ function canonicalHref(path: string) {
 export default defineConfig({
   rootDir: '.',
   srcDir: '.',
+  renderStrategy: 'full-static',
   // The dead-link checker doesn't know about static assets shipped via
   // public/ (like our zip and brand SVGs), so downgrade to a warning rather
   // than failing the build.

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "centaur-docs",
   "compatibility_date": "2026-05-05",
+  "preview_urls": true,
   "routes": [
     {
       "pattern": "centaur.run",


### PR DESCRIPTION
## Summary
- switch Vocs docs to built-in full-static rendering so Cloudflare assets contain route HTML and RSC payloads
- enable Cloudflare preview URLs for the docs Worker
- publish PR preview URLs by parsing Wrangler preview-alias output

## Validation
- npm run build
- npx wrangler deploy --dry-run
- npx wrangler versions upload --preview-alias pr-35 --dry-run
- npx wrangler dev --local --port 8787, then curl /, /quickstart, and /RSC/R/quickstart.txt?query= all returned 200