### PR TITLE
fix: comment docs preview url

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ permissions:
   contents: read
   deployments: write
   issues: write
+  pull-requests: write
 
 jobs:
   build-and-deploy:
@@ -117,7 +118,7 @@ jobs:
           )"
           comment_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
             --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$marker\"))) | .id" \
-            | tail -n 1)"
+            2>/dev/null | tail -n 1 || true)"
           if [ -n "$comment_id" ]; then
             gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -f body="$body"
           else

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ concurrency:
 permissions:
   contents: read
   deployments: write
+  issues: write
 
 jobs:
   build-and-deploy:
@@ -98,3 +99,27 @@ jobs:
             echo
             echo "$DEPLOYMENT_URL"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish preview comment
+        if: ${{ github.event_name == 'pull_request' && steps.preview.outputs.deployment-url != '' }}
+        env:
+          DEPLOYMENT_URL: ${{ steps.preview.outputs.deployment-url }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          marker="<!-- centaur-docs-preview-url -->"
+          body="$(cat <<EOF
+          $marker
+          ### Cloudflare Workers docs preview
+
+          $DEPLOYMENT_URL
+          EOF
+          )"
+          comment_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$marker\"))) | .id" \
+            | tail -n 1)"
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -f body="$body"
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body"
+          fi


### PR DESCRIPTION
## Summary
- add `issues: write` permission for docs PR preview comments
- publish the Cloudflare Workers preview URL as a sticky PR comment
- update the existing preview comment on reruns instead of posting duplicates

## Validation
- workflow YAML inspected locally; PR Docs run will exercise the comment path