### PR TITLE
Fix landing header spacing

### DIFF
--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -436,7 +436,7 @@ body,
 
 .vocs_DocsLayout[data-layout="landing"] .vocs_DocsLayout_content,
 [data-layout="landing"] [data-v-main] {
-  min-height: calc(100dvh - var(--vocs-topNav_height));
+  min-height: calc(100dvh - var(--vocs-topNav_height, 64px));
 }
 
 .vocs_DocsLayout[data-layout="landing"] [data-v-main],
@@ -472,9 +472,9 @@ body,
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  min-height: calc(100dvh - var(--vocs-topNav_height));
+  min-height: calc(100dvh - var(--vocs-topNav_height, 64px));
   overflow: hidden;
-  padding: clamp(72px, 9dvh, 120px) 24px clamp(56px, 8dvh, 104px);
+  padding: calc(var(--vocs-topNav_height, 64px) + clamp(28px, 5dvh, 72px)) 24px clamp(56px, 8dvh, 104px);
   position: relative;
 }
 
@@ -1339,7 +1339,7 @@ a.home-lockup-link {
 @media (min-width: 761px) and (max-aspect-ratio: 4 / 3) {
   .centaur-home {
     justify-content: center;
-    padding: clamp(32px, 4dvh, 56px) 28px;
+    padding: calc(var(--vocs-topNav_height, 64px) + clamp(20px, 3dvh, 40px)) 28px clamp(32px, 4dvh, 56px);
   }
 
   .home-hero {
@@ -1347,7 +1347,7 @@ a.home-lockup-link {
     flex-direction: column;
     gap: clamp(28px, 4dvh, 44px);
     max-width: 980px;
-    min-height: calc(100dvh - var(--vocs-topNav_height) - clamp(64px, 8dvh, 112px));
+    min-height: calc(100dvh - var(--vocs-topNav_height, 64px) - clamp(64px, 8dvh, 112px));
     text-align: center;
   }
 
@@ -1413,7 +1413,7 @@ a.home-lockup-link {
 @media (max-width: 760px) {
   .centaur-home {
     min-height: calc(100dvh - 64px);
-    padding: 54px 20px 40px;
+    padding: calc(var(--vocs-topNav_height, 64px) + 24px) 20px 40px;
   }
 
   .home-hero {


### PR DESCRIPTION
## Summary\n- add explicit top-nav clearance to the Centaur landing page hero\n- add a 64px fallback for the Vocs top nav height variable so spacing does not collapse when the CSS var is absent\n\n## Validation\n- npx vocs build\n- Playwright screenshot at 2538x520 verified the hero starts below the header\n\nNote: npm run build is blocked in this container because scripts/build-brand-zip.sh requires the system zip binary, which is not installed.