### PR TITLE
[codex] refine docs homepage layout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,6 +72,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: ${{ matrix.worker.directory }}
+          command: deploy --config wrangler.ci.jsonc
 
       - name: Preview
         id: preview

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -602,6 +602,24 @@ a.home-lockup-link {
   margin-top: clamp(32px, 4dvh, 44px);
 }
 
+.home-media-grid {
+  display: grid;
+  gap: clamp(28px, 4vw, 56px);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: clamp(32px, 4dvh, 44px) auto 0;
+  max-width: 1440px;
+  width: 100%;
+}
+
+.home-media-grid .home-media-section {
+  margin: 0;
+  max-width: none;
+}
+
+.home-media-grid .home-overview-heading {
+  grid-template-columns: 1fr;
+}
+
 .home-overview-heading {
   display: grid;
   gap: 24px;
@@ -694,6 +712,8 @@ a.home-lockup-link {
 }
 
 .home-media-section .home-architecture-diagram {
+  margin-left: 0;
+  margin-right: auto;
   margin-top: 30px;
   padding-top: 0;
 }
@@ -1376,6 +1396,11 @@ a.home-lockup-link {
   }
 
   .home-overview {
+    max-width: 980px;
+  }
+
+  .home-media-grid {
+    grid-template-columns: 1fr;
     max-width: 980px;
   }
 

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -172,15 +172,6 @@
 }
 
 /*
- * Landing owns its own links in the hero. Hide Vocs's desktop and mobile
- * top navigation there so docs routes keep the normal navigation chrome.
- */
-.vocs_DocsLayout[data-layout="landing"] .vocs_DocsLayout_gutterTop,
-[data-layout="landing"] > div[class*="vocs:fixed"][class*="vocs:h-topNav"] {
-  display: none;
-}
-
-/*
  * Mirror Amp manual typography: serif docs body copy, Perfectly Nineties
  * headings, and explicit mono code.
  */

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -127,12 +127,6 @@
   font-display: swap;
 }
 
-/* Lockup is wider per em than the standalone mark — keep the topNav
- * tidy by dropping the rendered height a touch. */
-.vocs_NavLogo_logoImage {
-  height: 26px;
-}
-
 /*
  * Sidebar active state: Vocs bumps font-weight to medium on the active
  * item, which causes a horizontal layout shift in the link text (the

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -396,7 +396,7 @@ body,
   justify-content: flex-start;
   min-height: 100dvh;
   overflow: hidden;
-  padding: clamp(72px, 9dvh, 120px) 24px clamp(56px, 8dvh, 104px);
+  padding: clamp(176px, 24dvh, 420px) 24px clamp(56px, 8dvh, 104px);
   position: relative;
 }
 

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -620,6 +620,21 @@ a.home-lockup-link {
   grid-template-columns: 1fr;
 }
 
+.home-media-link {
+  color: inherit;
+  display: block;
+  text-decoration: none;
+}
+
+.home-media-link:focus-visible {
+  outline: 2px solid var(--centaur-accent);
+  outline-offset: 6px;
+}
+
+.home-media-link:hover .home-architecture-diagram img {
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
 .home-overview-heading {
   display: grid;
   gap: 24px;
@@ -652,25 +667,8 @@ a.home-lockup-link {
   padding: 0;
 }
 
-.home-overview-list li {
-  position: relative;
-}
-
 .home-overview-list li:nth-child(odd) {
   border-right: 0;
-}
-
-.home-overview-list li::before {
-  background: var(--centaur-accent);
-  border-radius: 50%;
-  content: "";
-  height: 7px;
-  left: 16px;
-  pointer-events: none;
-  position: absolute;
-  top: 32px;
-  width: 7px;
-  z-index: 1;
 }
 
 .home-overview-list a {
@@ -678,7 +676,7 @@ a.home-lockup-link {
   display: grid;
   gap: 8px;
   min-height: 100%;
-  padding: 22px 28px 24px 40px;
+  padding: 22px 28px 24px 0;
   text-decoration: none;
   transition: background 140ms ease;
 }
@@ -726,6 +724,7 @@ a.home-lockup-link {
   display: block;
   height: auto;
   object-fit: contain;
+  transition: border-color 140ms ease;
   width: 100%;
 }
 

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -288,9 +288,9 @@ body,
 }
 
 .centaur-home h1 {
-  font-family: var(--centaur-display);
-  font-weight: 400;
-  letter-spacing: 0.012em;
+  font-family: var(--centaur-manual-display);
+  font-weight: 500;
+  letter-spacing: 0;
 }
 
 :root,
@@ -393,10 +393,12 @@ body,
   color: #f7f7f2;
   display: flex;
   flex-direction: column;
+  font-family: var(--centaur-manual-display);
   justify-content: flex-start;
+  letter-spacing: 0;
   min-height: 100dvh;
   overflow: hidden;
-  padding: clamp(176px, 24dvh, 420px) 24px clamp(56px, 8dvh, 104px);
+  padding: clamp(86px, 12dvh, 156px) 24px clamp(56px, 8dvh, 104px);
   position: relative;
 }
 
@@ -406,24 +408,24 @@ body,
 
 .home-hero {
   align-items: center;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(54px, 6.5dvh, 84px);
+  display: grid;
+  gap: clamp(34px, 4vw, 72px);
+  grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
   margin: 0 auto;
-  max-width: 1320px;
+  max-width: 1440px;
   min-height: auto;
   position: relative;
-  text-align: center;
+  text-align: left;
   width: 100%;
   z-index: 1;
 }
 
 .home-copy {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   flex-direction: column;
-  margin: 0 auto;
-  max-width: 1160px;
+  margin: 0;
+  max-width: 600px;
   min-width: 0;
 }
 
@@ -447,21 +449,21 @@ a.home-lockup-link {
 
 .home-hero h1 {
   color: #f7f7f2;
-  font-size: 4.25rem;
+  font-size: 4rem;
   font-weight: 400;
-  letter-spacing: 0.012em;
+  letter-spacing: 0;
   line-height: 1.02;
   margin: 0;
-  max-width: 980px;
+  max-width: 600px;
+  text-wrap: balance;
 }
 
 .home-actions {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  font-family: var(--centaur-serif);
   gap: 12px;
-  justify-content: center;
+  justify-content: flex-start;
   letter-spacing: 0;
   margin-top: 34px;
 }
@@ -509,7 +511,7 @@ a.home-lockup-link {
   border-radius: 8px;
   color: #f7f7f2;
   display: inline-flex;
-  font-family: var(--centaur-serif);
+  font-family: inherit;
   font-size: 0.875rem;
   font-weight: 400;
   gap: 7px;
@@ -538,7 +540,7 @@ a.home-lockup-link {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
-  justify-content: center;
+  justify-content: flex-start;
   margin-top: 52px;
 }
 
@@ -556,7 +558,7 @@ a.home-lockup-link {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 18px;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .home-brand {
@@ -582,15 +584,16 @@ a.home-lockup-link {
 }
 
 .home-thread-demo {
-  margin: 0 auto;
-  max-width: 1280px;
+  justify-self: stretch;
+  margin: 0;
+  max-width: none;
   min-width: 0;
   width: 100%;
 }
 
 .home-overview {
   margin: clamp(36px, 4.5dvh, 56px) auto 0;
-  max-width: 1280px;
+  max-width: 1440px;
   text-align: left;
   width: 100%;
 }
@@ -607,9 +610,9 @@ a.home-lockup-link {
 
 .home-overview h2 {
   color: #f7f7f2;
-  font-family: var(--centaur-display);
+  font-family: var(--centaur-manual-display);
   font-size: 3rem;
-  font-weight: 400;
+  font-weight: 500;
   line-height: 1;
   margin: 0;
 }
@@ -632,9 +635,6 @@ a.home-lockup-link {
 }
 
 .home-overview-list li {
-  display: grid;
-  gap: 8px;
-  padding: 0 28px 0 40px;
   position: relative;
 }
 
@@ -648,27 +648,48 @@ a.home-lockup-link {
   content: "";
   height: 7px;
   left: 16px;
+  pointer-events: none;
   position: absolute;
   top: 32px;
   width: 7px;
+  z-index: 1;
+}
+
+.home-overview-list a {
+  color: inherit;
+  display: grid;
+  gap: 8px;
+  min-height: 100%;
+  padding: 22px 28px 24px 40px;
+  text-decoration: none;
+  transition: background 140ms ease;
+}
+
+.home-overview-list a:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.home-overview-list a:focus-visible {
+  outline: 2px solid var(--centaur-accent);
+  outline-offset: -2px;
 }
 
 .home-overview-list strong {
   color: #ffffff;
-  font-size: 1.06rem;
+  font-size: 1.28rem;
   font-weight: 650;
-  line-height: 1.25;
+  line-height: 1.18;
 }
 
 .home-overview-list span {
   color: #e0e0d8;
-  font-size: 1rem;
-  line-height: 1.5;
+  font-size: 1.14rem;
+  line-height: 1.42;
 }
 
 .home-architecture-diagram {
   margin: clamp(44px, 6dvh, 72px) auto 0;
-  max-width: 100%;
+  max-width: 75%;
   padding-top: clamp(28px, 4dvh, 44px);
 }
 
@@ -697,6 +718,41 @@ a.home-lockup-link {
   }
 }
 
+@media (max-width: 1120px) {
+  .centaur-home {
+    padding-top: clamp(54px, 8dvh, 96px);
+  }
+
+  .home-hero {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(36px, 5dvh, 56px);
+    max-width: 980px;
+    text-align: center;
+  }
+
+  .home-copy {
+    align-items: center;
+    margin: 0 auto;
+    max-width: 980px;
+  }
+
+  .home-hero h1 {
+    max-width: 780px;
+  }
+
+  .home-actions,
+  .home-built-with,
+  .home-logo-row {
+    justify-content: center;
+  }
+
+  .home-thread-demo {
+    margin: 0 auto;
+    max-width: 980px;
+  }
+}
+
 .thread-panel {
   --thread-panel: #101012;
   --thread-bg: #111114;
@@ -716,10 +772,17 @@ a.home-lockup-link {
   display: grid;
   font-family: Slack-Lato, Slack-Fractions, appleLogo, Lato, Arial, sans-serif;
   grid-template-columns: minmax(136px, 168px) minmax(0, 1fr);
-  height: min(760px, 74dvh);
-  min-height: 640px;
+  height: min(680px, 68dvh);
+  min-height: 560px;
   overflow: hidden;
   text-align: left;
+}
+
+@media (max-width: 1120px) {
+  .thread-panel {
+    height: clamp(480px, 64dvh, 620px);
+    min-height: 480px;
+  }
 }
 
 .thread-list {
@@ -1469,7 +1532,7 @@ a.home-lockup-link {
     padding-right: 12px;
   }
 
-  .home-overview-list li {
+  .home-overview-list a {
     padding-right: 0;
   }
 }

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -17,10 +17,7 @@ import ThreadPanel from '../components/ThreadPanel'
   <section className="home-hero" aria-labelledby="home-title">
     <div className="home-copy">
       <a className="home-lockup-link" href="https://github.com/paradigmxyz/centaur" target="_blank" rel="noopener noreferrer" aria-label="Centaur on GitHub">
-        <picture>
-          <source srcSet="/brand/lockup-white.svg" media="(prefers-color-scheme: dark)" />
-          <img className="home-lockup" src="/brand/lockup-black.svg" alt="Centaur" />
-        </picture>
+        <img className="home-lockup" src="/brand/lockup-white.svg" alt="Centaur" />
       </a>
       <h1 id="home-title">Multiplayer, self-hosted, secure agents for teams.</h1>
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -48,41 +48,32 @@ import ThreadPanel from '../components/ThreadPanel'
   <section className="home-overview" aria-labelledby="home-overview-title">
     <div className="home-overview-heading">
       <h2 id="home-overview-title">Overview</h2>
-      <p>Centaur is the shared control plane for agents that need real tools, durable state, and production-grade boundaries.</p>
     </div>
 
     <ul className="home-overview-list">
       <li>
-        <strong>Open source foundation.</strong>
-        <span>Built from open infrastructure and MIT-licensed project packages so teams can inspect, run, and extend the platform themselves.</span>
+        <a href="/architecture#tool-and-workflow-layer">
+          <strong>Shared tools, integrations, and workflows.</strong>
+          <span>Expose internal services as typed Python tools, run durable workflows, and collaborate natively through Slack threads.</span>
+        </a>
       </li>
       <li>
-        <strong>Self-hosted by design.</strong>
-        <span>Run Centaur in your own Kubernetes stack, connect enterprise systems, and keep repos, workflows, logs, and secrets inside your boundary.</span>
+        <a href="/security#credentials">
+          <strong>Zero-trust credentials.</strong>
+          <span>Agents never receive raw long-lived keys. They get placeholders, and credentials only get injected at the network edge.</span>
+        </a>
       </li>
       <li>
-        <strong>Zero-trust credentials.</strong>
-        <span>Agents never receive raw long-lived keys. Sandboxes get placeholders, and iron-proxy injects approved credentials only at the network edge.</span>
+        <a href="/architecture#execution-path">
+          <strong>Harness agnostic.</strong>
+          <span>Use Amp, Codex, Claude Code, pi-mono, or your own CLI harness with the same durable execution model.</span>
+        </a>
       </li>
       <li>
-        <strong>Harness agnostic.</strong>
-        <span>Use Amp, Codex, Claude Code, pi-mono, or your own CLI harness inside the same sandbox and durable execution model.</span>
-      </li>
-      <li>
-        <strong>Shared tools and integrations.</strong>
-        <span>Expose internal services, GitHub, Slack, databases, market data, calendars, or deployment APIs once as typed Python tools for every agent.</span>
-      </li>
-      <li>
-        <strong>Durable workflows.</strong>
-        <span>Run jobs that sleep, resume, branch, retry, wait for events, spawn child agents, and survive API or worker restarts.</span>
-      </li>
-      <li>
-        <strong>Personas and overlays.</strong>
-        <span>Layer organization-specific personas, skills, prompts, tools, workflows, and sandbox files without forking the base Centaur repo.</span>
-      </li>
-      <li>
-        <strong>Replayable team state.</strong>
-        <span>Messages, executions, streamed events, and final delivery state are stored so Slack and API clients can reconnect without losing the result.</span>
+        <a href="/deploying-in-production#production-shape">
+          <strong>Self-hosted and open source.</strong>
+          <span>Run Centaur in your own infrastructure to keep repos, workflows, logs, and secrets inside your boundary. Use our Kubernetes template or your own. MIT licensed.</span>
+        </a>
       </li>
     </ul>
 
@@ -91,7 +82,6 @@ import ThreadPanel from '../components/ThreadPanel'
   <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
     <div className="home-overview-heading">
       <h2 id="home-extensible-title">Extensible by default</h2>
-      <p>Layer team-specific skills, tools, workflows, personas, and app code over the open-source Centaur kernel without carrying a long-lived fork.</p>
     </div>
 
     <figure className="home-architecture-diagram">
@@ -102,7 +92,6 @@ import ThreadPanel from '../components/ThreadPanel'
   <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
     <div className="home-overview-heading">
       <h2 id="home-architecture-title">Architecture</h2>
-      <p>Self-host the control plane, isolate each harness in sandbox pods, persist every turn, and inject secrets only through controlled egress.</p>
     </div>
 
     <figure className="home-architecture-diagram">

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -79,23 +79,25 @@ import ThreadPanel from '../components/ThreadPanel'
 
   </section>
 
-  <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
-    <div className="home-overview-heading">
-      <h2 id="home-extensible-title">Extensible by default</h2>
-    </div>
+  <div className="home-media-grid">
+    <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
+      <div className="home-overview-heading">
+        <h2 id="home-extensible-title">Extensible by default</h2>
+      </div>
 
-    <figure className="home-architecture-diagram">
-      <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
-    </figure>
-  </section>
+      <figure className="home-architecture-diagram">
+        <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
+      </figure>
+    </section>
 
-  <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
-    <div className="home-overview-heading">
-      <h2 id="home-architecture-title">Architecture</h2>
-    </div>
+    <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
+      <div className="home-overview-heading">
+        <h2 id="home-architecture-title">Architecture</h2>
+      </div>
 
-    <figure className="home-architecture-diagram">
-      <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
-    </figure>
-  </section>
+      <figure className="home-architecture-diagram">
+        <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
+      </figure>
+    </section>
+  </div>
 </main>

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -81,23 +81,27 @@ import ThreadPanel from '../components/ThreadPanel'
 
   <div className="home-media-grid">
     <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
-      <div className="home-overview-heading">
-        <h2 id="home-extensible-title">Extensible by default</h2>
-      </div>
+      <a className="home-media-link" href="/extend/overlay" aria-labelledby="home-extensible-title">
+        <div className="home-overview-heading">
+          <h2 id="home-extensible-title">Extensible by default</h2>
+        </div>
 
-      <figure className="home-architecture-diagram">
-        <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
-      </figure>
+        <figure className="home-architecture-diagram">
+          <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
+        </figure>
+      </a>
     </section>
 
     <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
-      <div className="home-overview-heading">
-        <h2 id="home-architecture-title">Architecture</h2>
-      </div>
+      <a className="home-media-link" href="/architecture" aria-labelledby="home-architecture-title">
+        <div className="home-overview-heading">
+          <h2 id="home-architecture-title">Modular Architecture</h2>
+        </div>
 
-      <figure className="home-architecture-diagram">
-        <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
-      </figure>
+        <figure className="home-architecture-diagram">
+          <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
+        </figure>
+      </a>
     </section>
   </div>
 </main>

--- a/docs/public/md/index.md
+++ b/docs/public/md/index.md
@@ -17,10 +17,7 @@ import ThreadPanel from '../components/ThreadPanel'
   <section className="home-hero" aria-labelledby="home-title">
     <div className="home-copy">
       <a className="home-lockup-link" href="https://github.com/paradigmxyz/centaur" target="_blank" rel="noopener noreferrer" aria-label="Centaur on GitHub">
-        <picture>
-          <source srcSet="/brand/lockup-white.svg" media="(prefers-color-scheme: dark)" />
-          <img className="home-lockup" src="/brand/lockup-black.svg" alt="Centaur" />
-        </picture>
+        <img className="home-lockup" src="/brand/lockup-white.svg" alt="Centaur" />
       </a>
       <h1 id="home-title">Multiplayer, self-hosted, secure agents for teams.</h1>
 

--- a/docs/public/md/index.md
+++ b/docs/public/md/index.md
@@ -48,41 +48,32 @@ import ThreadPanel from '../components/ThreadPanel'
   <section className="home-overview" aria-labelledby="home-overview-title">
     <div className="home-overview-heading">
       <h2 id="home-overview-title">Overview</h2>
-      <p>Centaur is the shared control plane for agents that need real tools, durable state, and production-grade boundaries.</p>
     </div>
 
     <ul className="home-overview-list">
       <li>
-        <strong>Open source foundation.</strong>
-        <span>Built from open infrastructure and MIT-licensed project packages so teams can inspect, run, and extend the platform themselves.</span>
+        <a href="/architecture#tool-and-workflow-layer">
+          <strong>Shared tools, integrations, and workflows.</strong>
+          <span>Expose internal services as typed Python tools, run durable workflows, and collaborate natively through Slack threads.</span>
+        </a>
       </li>
       <li>
-        <strong>Self-hosted by design.</strong>
-        <span>Run Centaur in your own Kubernetes stack, connect enterprise systems, and keep repos, workflows, logs, and secrets inside your boundary.</span>
+        <a href="/security#credentials">
+          <strong>Zero-trust credentials.</strong>
+          <span>Agents never receive raw long-lived keys. They get placeholders, and credentials only get injected at the network edge.</span>
+        </a>
       </li>
       <li>
-        <strong>Zero-trust credentials.</strong>
-        <span>Agents never receive raw long-lived keys. Sandboxes get placeholders, and iron-proxy injects approved credentials only at the network edge.</span>
+        <a href="/architecture#execution-path">
+          <strong>Harness agnostic.</strong>
+          <span>Use Amp, Codex, Claude Code, pi-mono, or your own CLI harness with the same durable execution model.</span>
+        </a>
       </li>
       <li>
-        <strong>Harness agnostic.</strong>
-        <span>Use Amp, Codex, Claude Code, pi-mono, or your own CLI harness inside the same sandbox and durable execution model.</span>
-      </li>
-      <li>
-        <strong>Shared tools and integrations.</strong>
-        <span>Expose internal services, GitHub, Slack, databases, market data, calendars, or deployment APIs once as typed Python tools for every agent.</span>
-      </li>
-      <li>
-        <strong>Durable workflows.</strong>
-        <span>Run jobs that sleep, resume, branch, retry, wait for events, spawn child agents, and survive API or worker restarts.</span>
-      </li>
-      <li>
-        <strong>Personas and overlays.</strong>
-        <span>Layer organization-specific personas, skills, prompts, tools, workflows, and sandbox files without forking the base Centaur repo.</span>
-      </li>
-      <li>
-        <strong>Replayable team state.</strong>
-        <span>Messages, executions, streamed events, and final delivery state are stored so Slack and API clients can reconnect without losing the result.</span>
+        <a href="/deploying-in-production#production-shape">
+          <strong>Self-hosted and open source.</strong>
+          <span>Run Centaur in your own infrastructure to keep repos, workflows, logs, and secrets inside your boundary. Use our Kubernetes template or your own. MIT licensed.</span>
+        </a>
       </li>
     </ul>
 
@@ -91,7 +82,6 @@ import ThreadPanel from '../components/ThreadPanel'
   <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
     <div className="home-overview-heading">
       <h2 id="home-extensible-title">Extensible by default</h2>
-      <p>Layer team-specific skills, tools, workflows, personas, and app code over the open-source Centaur kernel without carrying a long-lived fork.</p>
     </div>
 
     <figure className="home-architecture-diagram">
@@ -102,7 +92,6 @@ import ThreadPanel from '../components/ThreadPanel'
   <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
     <div className="home-overview-heading">
       <h2 id="home-architecture-title">Architecture</h2>
-      <p>Self-host the control plane, isolate each harness in sandbox pods, persist every turn, and inject secrets only through controlled egress.</p>
     </div>
 
     <figure className="home-architecture-diagram">

--- a/docs/public/md/index.md
+++ b/docs/public/md/index.md
@@ -79,23 +79,25 @@ import ThreadPanel from '../components/ThreadPanel'
 
   </section>
 
-  <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
-    <div className="home-overview-heading">
-      <h2 id="home-extensible-title">Extensible by default</h2>
-    </div>
+  <div className="home-media-grid">
+    <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
+      <div className="home-overview-heading">
+        <h2 id="home-extensible-title">Extensible by default</h2>
+      </div>
 
-    <figure className="home-architecture-diagram">
-      <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
-    </figure>
-  </section>
+      <figure className="home-architecture-diagram">
+        <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
+      </figure>
+    </section>
 
-  <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
-    <div className="home-overview-heading">
-      <h2 id="home-architecture-title">Architecture</h2>
-    </div>
+    <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
+      <div className="home-overview-heading">
+        <h2 id="home-architecture-title">Architecture</h2>
+      </div>
 
-    <figure className="home-architecture-diagram">
-      <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
-    </figure>
-  </section>
+      <figure className="home-architecture-diagram">
+        <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
+      </figure>
+    </section>
+  </div>
 </main>

--- a/docs/public/md/index.md
+++ b/docs/public/md/index.md
@@ -81,23 +81,27 @@ import ThreadPanel from '../components/ThreadPanel'
 
   <div className="home-media-grid">
     <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
-      <div className="home-overview-heading">
-        <h2 id="home-extensible-title">Extensible by default</h2>
-      </div>
+      <a className="home-media-link" href="/extend/overlay" aria-labelledby="home-extensible-title">
+        <div className="home-overview-heading">
+          <h2 id="home-extensible-title">Extensible by default</h2>
+        </div>
 
-      <figure className="home-architecture-diagram">
-        <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
-      </figure>
+        <figure className="home-architecture-diagram">
+          <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
+        </figure>
+      </a>
     </section>
 
     <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
-      <div className="home-overview-heading">
-        <h2 id="home-architecture-title">Architecture</h2>
-      </div>
+      <a className="home-media-link" href="/architecture" aria-labelledby="home-architecture-title">
+        <div className="home-overview-heading">
+          <h2 id="home-architecture-title">Modular Architecture</h2>
+        </div>
 
-      <figure className="home-architecture-diagram">
-        <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
-      </figure>
+        <figure className="home-architecture-diagram">
+          <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
+        </figure>
+      </a>
     </section>
   </div>
 </main>

--- a/docs/wrangler.ci.jsonc
+++ b/docs/wrangler.ci.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "centaur-docs",
+  "compatibility_date": "2026-05-05",
+  "preview_urls": true,
+  "assets": {
+    "directory": "./dist/public",
+    "html_handling": "drop-trailing-slash",
+    "not_found_handling": "404-page"
+  },
+  "build": {
+    "command": "npm run build"
+  }
+}


### PR DESCRIPTION
## Summary

- moves the homepage demo beside the tagline on wide screens while preserving the mobile stack
- refreshes the Overview cards, links them into the docs, enlarges the card copy, and makes the lower homepage sections match the hero width
- keeps CTA and Built by typography on their original styles, uses docs heading typography for homepage headings, and scales homepage diagrams to 75% width on desktop

## Validation

- `npm run build` from `docs/`

Note: build still reports the existing Vocs warning about `/brand.mdx` linking `/centaur-brand-assets.zip`.
