### PR TITLE
fix docs open graph images

### DIFF
--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -57,25 +57,28 @@ export default defineConfig({
   // (ported from tempoxyz/mpp's /api/og handler) using the vendored brand
   // fonts. Map each known route to its card; new routes fall back to
   // _default.png until the next build picks them up.
-  ogImageUrl: {
-    '/': '/og/index.png',
-    '/what-is-centaur': '/og/what-is-centaur.png',
-    '/quickstart': '/og/quickstart.png',
-    '/deploying-in-production': '/og/deploying-in-production.png',
-    '/architecture': '/og/architecture.png',
-    '/operate/slack-etl': '/og/operate_slack-etl.png',
-    '/brand': '/og/brand.png',
-    '/extend/overlay': '/og/extend_overlay.png',
-    '/extend/apps': '/og/extend_apps.png',
-    '/extend/tools': '/og/extend_tools.png',
-    '/extend/workflows': '/og/extend_workflows.png',
-    '/extend/skills': '/og/extend_skills.png',
-    '/security': '/og/security.png',
-    '/secrets/onepassword': '/og/secrets_onepassword.png',
-    '/secrets/environment': '/og/secrets_environment.png',
-    '/secrets/aws-kms': '/og/secrets_aws-kms.png',
-    '/secrets/gcp-secret-manager': '/og/secrets_gcp-secret-manager.png',
-    '/secrets/advanced-permissioning': '/og/secrets_advanced-permissioning.png',
+  ogImageUrl: (path, { baseUrl }) => {
+    const images: Record<string, string> = {
+      '/': '/og/index.png',
+      '/what-is-centaur': '/og/what-is-centaur.png',
+      '/quickstart': '/og/quickstart.png',
+      '/deploying-in-production': '/og/deploying-in-production.png',
+      '/architecture': '/og/architecture.png',
+      '/operate/slack-etl': '/og/operate_slack-etl.png',
+      '/brand': '/og/brand.png',
+      '/extend/overlay': '/og/extend_overlay.png',
+      '/extend/apps': '/og/extend_apps.png',
+      '/extend/tools': '/og/extend_tools.png',
+      '/extend/workflows': '/og/extend_workflows.png',
+      '/extend/skills': '/og/extend_skills.png',
+      '/security': '/og/security.png',
+      '/secrets/onepassword': '/og/secrets_onepassword.png',
+      '/secrets/environment': '/og/secrets_environment.png',
+      '/secrets/aws-kms': '/og/secrets_aws-kms.png',
+      '/secrets/gcp-secret-manager': '/og/secrets_gcp-secret-manager.png',
+      '/secrets/advanced-permissioning': '/og/secrets_advanced-permissioning.png',
+    }
+    return `${baseUrl}${images[path] ?? '/og/_default.png'}`
   },
   ...(basePath ? { basePath } : {}),
   editLink: {


### PR DESCRIPTION
## Summary
- change Vocs ogImageUrl config from an unsupported object map to a route-aware function
- keep existing per-route OG image assets and fallback behavior

## Verification
- npx vocs build
- confirmed generated HTML includes og:image and twitter:image for / and /architecture

Root cause: the deployed assets existed, but this Vocs version only reads ogImageUrl as a string or function. The object map was silently ignored, so the built HTML had no image meta tags.