### PR TITLE
fix: force docs dark theme

### DIFF
--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -1,13 +1,14 @@
 :root {
+  color-scheme: dark;
   --centaur-accent: #00E100;
   --centaur-accent-hover: #35f335;
   --centaur-accent-soft: rgba(0, 225, 0, 0.14);
-  --centaur-bg: light-dark(#ffffff, #101012);
-  --centaur-code: light-dark(#f6f6f7, #0b0b0d);
-  --centaur-line: light-dark(rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.12));
-  --centaur-muted: light-dark(#727278, #9b9ba1);
-  --centaur-soft: light-dark(rgba(0, 0, 0, 0.035), rgba(255, 255, 255, 0.055));
-  --centaur-text: light-dark(#101012, #ffffff);
+  --centaur-bg: #101012;
+  --centaur-code: #0b0b0d;
+  --centaur-line: rgba(255, 255, 255, 0.12);
+  --centaur-muted: #9b9ba1;
+  --centaur-soft: rgba(255, 255, 255, 0.055);
+  --centaur-text: #ffffff;
   --centaur-sans: 'PolySans Var', system-ui, sans-serif;
   --centaur-serif: 'Iowan Old Style', 'Apple Garamond', Georgia, serif;
   --centaur-display: 'Sagittaire Display', var(--centaur-serif);
@@ -293,8 +294,7 @@ body,
   letter-spacing: 0;
 }
 
-:root,
-:root.dark {
+:root {
   --vocs-color_background: #050506;
   --vocs-color_background2: #0b0b0d;
   --vocs-color_background3: #111114;

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
   title: 'Centaur',
   titleTemplate: '%s - Centaur',
   description: 'The production control plane for shared AI agents, tools, workflows, and sandboxes.',
+  accentColor: '#00E100',
+  colorScheme: 'dark',
   // Browser-tab favicon: standalone centaur mark only (no background frame).
   // Vocs emits a per-scheme <link rel="icon"> pair so the tab shows the
   // black silhouette on light chrome and the white silhouette on dark.
@@ -126,26 +128,4 @@ export default defineConfig({
     },
   },
   sidebar,
-  theme: {
-    accentColor: {
-      light: '#00E100',
-      dark: '#00E100',
-    },
-    colorScheme: 'dark',
-    variables: {
-      color: {
-        background: {
-          light: '#ffffff',
-          dark: '#050505',
-        },
-        text: {
-          light: '#050505',
-          dark: '#f7f7f2',
-        },
-      },
-      content: {
-        width: '920px',
-      },
-    },
-  },
 })


### PR DESCRIPTION
## Summary\n- move Vocs accent and colorScheme to supported top-level config keys\n- remove ignored nested theme config\n- keep root docs color tokens dark instead of light-dark branches\n\n## Verification\n- npm run build\n- static mobile Chrome emulation at 390x844 with color_scheme=light: no visible white background nodes detected