### PR TITLE
Fix landing page load jitter

### DIFF
--- a/docs/components/ThreadPanel.tsx
+++ b/docs/components/ThreadPanel.tsx
@@ -644,7 +644,7 @@ function ThreadDetail({
     const element = scrollRef.current
     if (!element) return
     if (!stickToBottomRef.current) return
-    element.scrollTo({ top: element.scrollHeight, behavior: 'smooth' })
+    element.scrollTop = element.scrollHeight
   }, [phase, replyIdx, thread.id])
 
   const visible: Array<Reply & { i: number; isTyping: boolean; isStreaming: boolean }> = []

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -20,7 +20,7 @@
   src: url('/fonts/PolySans-variable.woff2') format('woff2-variations');
   font-style: normal;
   font-weight: 300 800;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -28,7 +28,7 @@
   src: url('/fonts/PolySansItalic-variable.woff2') format('woff2-variations');
   font-style: italic;
   font-weight: 300 800;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -36,7 +36,7 @@
   src: url('/fonts/SagittaireDisplay-Regular.woff2') format('woff2');
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -44,7 +44,7 @@
   src: url('/fonts/SagittaireDisplay-Extralight.woff2') format('woff2');
   font-style: normal;
   font-weight: 200;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -76,7 +76,7 @@
   src: url('/fonts/PerfectlyNineties-Regular.woff') format('woff');
   font-style: normal;
   font-weight: 500;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -84,7 +84,7 @@
   src: url('/fonts/PerfectlyNineties-Italic.woff') format('woff');
   font-style: italic;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -92,7 +92,7 @@
   src: url('/fonts/PerfectlyNineties-Semibold.woff') format('woff');
   font-style: normal;
   font-weight: 600;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -100,7 +100,7 @@
   src: url('/fonts/PerfectlyNineties-Bold.woff') format('woff');
   font-style: normal;
   font-weight: 700;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -108,7 +108,7 @@
   src: url('/fonts/slack/lato-latin-400-normal.woff2') format('woff2');
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -116,7 +116,7 @@
   src: url('/fonts/slack/lato-latin-700-normal.woff2') format('woff2');
   font-style: normal;
   font-weight: 700;
-  font-display: swap;
+  font-display: block;
 }
 
 @font-face {
@@ -124,7 +124,7 @@
   src: url('/fonts/slack/lato-latin-900-normal.woff2') format('woff2');
   font-style: normal;
   font-weight: 900;
-  font-display: swap;
+  font-display: block;
 }
 
 /*

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -77,6 +77,27 @@ export default defineConfig({
   head({ path }) {
     return createElement(Fragment, null,
       createElement('link', { rel: 'canonical', href: canonicalHref(path) }),
+      createElement('link', {
+        rel: 'preload',
+        href: '/fonts/PerfectlyNineties-Regular.woff',
+        as: 'font',
+        type: 'font/woff',
+        crossOrigin: '',
+      }),
+      createElement('link', {
+        rel: 'preload',
+        href: '/fonts/PolySans-variable.woff2',
+        as: 'font',
+        type: 'font/woff2',
+        crossOrigin: '',
+      }),
+      createElement('link', {
+        rel: 'preload',
+        href: '/fonts/slack/lato-latin-400-normal.woff2',
+        as: 'font',
+        type: 'font/woff2',
+        crossOrigin: '',
+      }),
       createElement('script', { src: '/centaur-brand-menu.js', defer: true }),
     )
   },


### PR DESCRIPTION
"## Summary\n- Preload the landing/docs fonts used above the fold.\n- Switch custom font faces from swap to block to prevent font metric swaps from moving the landing layout after paint.\n- Make the animated thread preview keep its internal scroll pinned immediately instead of smooth-scrolling during scripted message changes.\n\n## Verification\n- `npx vocs build`\n\nNote: `npm run build` is blocked in this sandbox because `scripts/build-brand-zip.sh` requires a missing system `zip` binary. The attached video download returned a 21-byte `Internal Server Error` body, so I verified from the source and production docs build instead.\n"