### PR TITLE
feat(api): add hmac_sign typed secret + bump iron-proxy to 0.37.0

### DIFF
--- a/services/api/api/proxy_config.py
+++ b/services/api/api/proxy_config.py
@@ -10,6 +10,8 @@ tool_manager (injection map). The API server owns iron-proxy's full config:
   ``oauth_token``; kept until tools migrate off the ``gcp_auth`` secret type.
 - ``oauth_token`` transform — one ``tokens`` entry per ``OAuthTokenSecret``,
   minting OAuth2 access tokens for the declared grant.
+- ``hmac_sign`` transforms — one per unique ``HmacSignSecret`` signing scheme,
+  HMAC-signing each request and injecting the configured headers.
 - top-level ``postgres:`` — one listener per ``PgDsnSecret`` on sequential ports
   starting at 5432, ordered by name.
 """
@@ -25,6 +27,7 @@ import yaml
 
 from api.tool_manager import (
     GcpAuthSecret,
+    HmacSignSecret,
     HttpSecret,
     OAuthFieldSource,
     OAuthTokenSecret,
@@ -48,7 +51,7 @@ GCP_AUTH_HOSTS: tuple[str, ...] = ("*.googleapis.com",)
 PG_LISTEN_PORT_BASE = 5432
 
 _MANAGED_TRANSFORMS: frozenset[str] = frozenset(
-    {"secrets", "gcp_auth", "oauth_token"}
+    {"secrets", "gcp_auth", "oauth_token", "hmac_sign"}
 )
 
 # Iron-proxy ``source`` schema for resolving secret values. ``env`` reads the
@@ -255,6 +258,77 @@ def _build_oauth_token_transform(
     return {"name": "oauth_token", "config": {"tokens": tokens}}
 
 
+def _build_hmac_sign_transforms(
+    secrets: list[SecretDef],
+) -> list[dict[str, Any]]:
+    """``hmac_sign`` transforms: one per unique signing config.
+
+    Each signing scheme (algorithm, encodings, message, timestamp format,
+    credentials, header layout) becomes its own transform. Two ``HmacSignSecret``
+    entries that differ only in ``hosts`` are merged — their host rules are
+    unioned so the same scheme covers every upstream that opted in.
+    """
+    by_scheme: dict[
+        tuple[
+            str,
+            str,
+            str,
+            str,
+            str,
+            bool,
+            tuple[tuple[str, OAuthFieldSource], ...],
+            tuple[tuple[str, str], ...],
+        ],
+        set[str],
+    ] = {}
+    for secret in secrets:
+        if not isinstance(secret, HmacSignSecret):
+            continue
+        key = (
+            secret.algorithm,
+            secret.key_encoding,
+            secret.output_encoding,
+            secret.message,
+            secret.timestamp_format,
+            secret.allow_chunked_body,
+            secret.credentials,
+            tuple((h.name, h.value) for h in secret.headers),
+        )
+        by_scheme.setdefault(key, set()).update(secret.hosts)
+
+    transforms: list[dict[str, Any]] = []
+    for key in sorted(by_scheme, key=lambda k: (k[0], k[3], tuple(n for n, _ in k[6]))):
+        (
+            algorithm,
+            key_encoding,
+            output_encoding,
+            message,
+            timestamp_format,
+            allow_chunked_body,
+            credentials,
+            headers,
+        ) = key
+        hosts = sorted(by_scheme[key])
+        config: dict[str, Any] = {
+            "timestamp": {"format": timestamp_format},
+            "signature": {
+                "algorithm": algorithm,
+                "key_encoding": key_encoding,
+                "output_encoding": output_encoding,
+                "message": message,
+            },
+            "credentials": {
+                name: _build_field_source(source) for name, source in credentials
+            },
+            "headers": [{"name": n, "value": v} for n, v in headers],
+            "rules": [{"host": h} for h in hosts],
+        }
+        if allow_chunked_body:
+            config["allow_chunked_body"] = True
+        transforms.append({"name": "hmac_sign", "config": config})
+    return transforms
+
+
 def _build_postgres_listeners(
     secrets: list[SecretDef],
     pg_listen_ports: dict[str, int],
@@ -318,6 +392,7 @@ def render_proxy_yaml(
     oauth_token = _build_oauth_token_transform(secrets)
     if oauth_token is not None:
         new_transforms.append(oauth_token)
+    new_transforms.extend(_build_hmac_sign_transforms(secrets))
     if new_transforms:
         for index, transform in enumerate(transforms):
             if (transform or {}).get("name") == "header_allowlist":

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -202,7 +202,54 @@ class OAuthTokenSecret:
     token_endpoint: str | None = None
 
 
-SecretDef = HttpSecret | GcpAuthSecret | PgDsnSecret | OAuthTokenSecret
+@dataclass(frozen=True)
+class HmacHeader:
+    """One header injected by iron-proxy's ``hmac_sign`` transform.
+
+    ``value`` is a Go template evaluated against the request's signing context;
+    the iron-proxy schema exposes ``.Timestamp``, ``.Signature``, and
+    ``.Credentials.<name>`` (where ``<name>`` is a key from the secret's
+    ``credentials`` map).
+    """
+
+    name: str
+    value: str
+
+
+@dataclass(frozen=True)
+class HmacSignSecret:
+    """Per-request HMAC signature minted by iron-proxy's ``hmac_sign`` transform.
+
+    iron-proxy resolves each entry in ``credentials`` from its own source,
+    composes the canonical ``message`` template, HMACs it with the credential
+    named ``secret`` (decoded per ``key_encoding``), encodes the digest per
+    ``output_encoding``, and writes ``headers`` onto the upstream request.
+    The credentials and signing key never reach the sandbox.
+
+    ``credentials`` is a map of name → source; the entry named ``secret`` is the
+    HMAC key and is required. Other keys are user-named and referenced from
+    ``headers[].value`` as ``{{.Credentials.<name>}}``.
+
+    ``allow_chunked_body`` opts in to signing requests with no Content-Length
+    (chunked bodies); iron-proxy refuses by default since the body cannot be
+    deterministically hashed in flight.
+    """
+
+    name: str
+    hosts: tuple[str, ...]
+    credentials: tuple[tuple[str, OAuthFieldSource], ...]
+    headers: tuple[HmacHeader, ...]
+    algorithm: str
+    key_encoding: str
+    output_encoding: str
+    message: str
+    timestamp_format: str
+    allow_chunked_body: bool = False
+
+
+SecretDef = (
+    HttpSecret | GcpAuthSecret | PgDsnSecret | OAuthTokenSecret | HmacSignSecret
+)
 
 # Per-grant credential fields: grant -> (required, optional). Field names are
 # the keys iron-proxy expects in each ``oauth_token`` token entry.
@@ -218,6 +265,19 @@ _OAUTH_GRANT_FIELDS: dict[str, tuple[frozenset[str], frozenset[str]]] = {
 }
 
 _OAUTH_GRANTS: frozenset[str] = frozenset(_OAUTH_GRANT_FIELDS)
+
+# Enums iron-proxy's ``hmac_sign`` transform accepts. Mirrors the upstream
+# schema; centralized here so parser errors list the same options the proxy
+# would.
+_HMAC_ALGORITHMS: frozenset[str] = frozenset({"sha256", "sha512", "sha1"})
+_HMAC_KEY_ENCODINGS: frozenset[str] = frozenset({"raw", "base64", "hex"})
+_HMAC_OUTPUT_ENCODINGS: frozenset[str] = frozenset({"base64", "hex"})
+_HMAC_TIMESTAMP_FORMATS: frozenset[str] = frozenset(
+    {"unix_seconds", "unix_millis", "unix_nanos", "rfc3339"}
+)
+# The HMAC key. Other ``credentials`` keys are user-named and only referenced
+# from ``headers[].value`` templates.
+_HMAC_REQUIRED_CREDENTIAL = "secret"
 
 
 def _parse_oauth_field_source(
@@ -278,6 +338,109 @@ def _parse_oauth_fields(
             f"fields {sorted(missing)}"
         )
     return tuple(sorted(parsed.items()))
+
+
+def _parse_hmac_credential_source(
+    secret_name: str, field_name: str, raw: Any
+) -> OAuthFieldSource:
+    """Parse one ``credentials`` entry for an ``hmac_sign`` secret.
+
+    Accepts a bare ``secret_ref`` string or a table with ``secret_ref`` and
+    optional ``json_key`` (for pulling a single key out of a JSON-encoded
+    secret). Mirrors ``_parse_oauth_field_source`` so the two typed secrets
+    that resolve named credential fields validate the same shape.
+    """
+    if isinstance(raw, str):
+        if not raw:
+            raise ValueError(
+                f"hmac_sign entry {secret_name!r} credential {field_name!r} "
+                f"'secret_ref' must be a non-empty string"
+            )
+        return OAuthFieldSource(secret_ref=raw)
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"hmac_sign entry {secret_name!r} credential {field_name!r} must be "
+            f"a string or table"
+        )
+    ref = raw.get("secret_ref")
+    if not isinstance(ref, str) or not ref:
+        raise ValueError(
+            f"hmac_sign entry {secret_name!r} credential {field_name!r} requires "
+            f"a non-empty 'secret_ref'"
+        )
+    json_key = raw.get("json_key")
+    if json_key is not None and (not isinstance(json_key, str) or not json_key):
+        raise ValueError(
+            f"hmac_sign entry {secret_name!r} credential {field_name!r} "
+            f"'json_key' must be a non-empty string"
+        )
+    return OAuthFieldSource(secret_ref=ref, json_key=json_key)
+
+
+def _parse_hmac_credentials(
+    secret_name: str, raw: Any
+) -> tuple[tuple[str, OAuthFieldSource], ...]:
+    """Parse ``credentials`` for an ``hmac_sign`` entry; require ``secret``."""
+    if not isinstance(raw, dict) or not raw:
+        raise ValueError(
+            f"hmac_sign entry {secret_name!r} 'credentials' must be a non-empty "
+            f"table"
+        )
+    parsed: dict[str, OAuthFieldSource] = {}
+    for field_name, value in raw.items():
+        if not isinstance(field_name, str) or not field_name:
+            raise ValueError(
+                f"hmac_sign entry {secret_name!r} credential names must be "
+                f"non-empty strings"
+            )
+        parsed[field_name] = _parse_hmac_credential_source(
+            secret_name, field_name, value
+        )
+    if _HMAC_REQUIRED_CREDENTIAL not in parsed:
+        raise ValueError(
+            f"hmac_sign entry {secret_name!r} 'credentials' must include "
+            f"{_HMAC_REQUIRED_CREDENTIAL!r} (the HMAC key)"
+        )
+    return tuple(sorted(parsed.items()))
+
+
+def _parse_hmac_headers(secret_name: str, raw: Any) -> tuple[HmacHeader, ...]:
+    """Parse the ordered ``headers`` list iron-proxy writes onto the request."""
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(
+            f"hmac_sign entry {secret_name!r} 'headers' must be a non-empty list"
+        )
+    headers: list[HmacHeader] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"hmac_sign entry {secret_name!r} header[{index}] must be a table"
+            )
+        name = entry.get("name")
+        value = entry.get("value")
+        if not isinstance(name, str) or not name:
+            raise ValueError(
+                f"hmac_sign entry {secret_name!r} header[{index}] requires a "
+                f"non-empty 'name'"
+            )
+        if not isinstance(value, str) or not value:
+            raise ValueError(
+                f"hmac_sign entry {secret_name!r} header[{index}] requires a "
+                f"non-empty 'value' template"
+            )
+        headers.append(HmacHeader(name=name, value=value))
+    return tuple(headers)
+
+
+def _parse_hmac_enum(
+    secret_name: str, key: str, value: Any, allowed: frozenset[str]
+) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        raise ValueError(
+            f"hmac_sign entry {secret_name!r} {key!r} must be one of "
+            f"{sorted(allowed)}, got {value!r}"
+        )
+    return value
 
 
 _INJECT_ONLY_KEYS: tuple[str, ...] = (
@@ -522,6 +685,60 @@ def _parse_secret(entry: Any, *, default_hosts: tuple[str, ...] = ()) -> SecretD
                 f"pg_dsn entry {name!r} requires a non-empty 'database' field"
             )
         return PgDsnSecret(name=name, secret_ref=secret_ref, database=database)
+    if secret_type == "hmac_sign":
+        hosts = entry.get("hosts", [])
+        if (
+            not isinstance(hosts, list)
+            or not hosts
+            or not all(isinstance(h, str) and h for h in hosts)
+        ):
+            raise ValueError(
+                f"hmac_sign entry {name!r} 'hosts' must be a non-empty array "
+                f"of non-empty strings"
+            )
+        credentials = _parse_hmac_credentials(name, entry.get("credentials"))
+        headers = _parse_hmac_headers(name, entry.get("headers"))
+        algorithm = _parse_hmac_enum(
+            name, "algorithm", entry.get("algorithm"), _HMAC_ALGORITHMS
+        )
+        key_encoding = _parse_hmac_enum(
+            name, "key_encoding", entry.get("key_encoding"), _HMAC_KEY_ENCODINGS
+        )
+        output_encoding = _parse_hmac_enum(
+            name,
+            "output_encoding",
+            entry.get("output_encoding"),
+            _HMAC_OUTPUT_ENCODINGS,
+        )
+        timestamp_format = _parse_hmac_enum(
+            name,
+            "timestamp_format",
+            entry.get("timestamp_format"),
+            _HMAC_TIMESTAMP_FORMATS,
+        )
+        message = entry.get("message")
+        if not isinstance(message, str) or not message:
+            raise ValueError(
+                f"hmac_sign entry {name!r} 'message' must be a non-empty "
+                f"Go-template string"
+            )
+        allow_chunked_body = entry.get("allow_chunked_body", False)
+        if not isinstance(allow_chunked_body, bool):
+            raise ValueError(
+                f"hmac_sign entry {name!r} 'allow_chunked_body' must be a boolean"
+            )
+        return HmacSignSecret(
+            name=name,
+            hosts=tuple(hosts),
+            credentials=credentials,
+            headers=headers,
+            algorithm=algorithm,
+            key_encoding=key_encoding,
+            output_encoding=output_encoding,
+            message=message,
+            timestamp_format=timestamp_format,
+            allow_chunked_body=allow_chunked_body,
+        )
     raise ValueError(f"unknown secret type {secret_type!r}")
 
 

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -11,6 +11,8 @@ from api.proxy_config import (
 from api.tool_manager import (
     DEFAULT_MATCH_HEADERS,
     GcpAuthSecret,
+    HmacHeader,
+    HmacSignSecret,
     HttpSecret,
     OAuthFieldSource,
     OAuthTokenSecret,
@@ -406,6 +408,114 @@ def test_parser_oauth_token_rejects_field_invalid_for_grant() -> None:
         )
 
 
+def _hmac_entry(**overrides: object) -> dict:
+    """Minimum valid ``hmac_sign`` entry, overridable per-test."""
+    entry: dict = {
+        "type": "hmac_sign",
+        "name": "FALCONX",
+        "hosts": ["api.falconx.io"],
+        "algorithm": "sha256",
+        "key_encoding": "base64",
+        "output_encoding": "base64",
+        "timestamp_format": "unix_seconds",
+        "message": "{{.Timestamp}}{{.Method}}{{.PathWithQuery}}{{.Body}}",
+        "credentials": {
+            "key": "FALCONX_API_KEY",
+            "secret": "FALCONX_SECRET",
+            "passphrase": "FALCONX_PASSPHRASE",
+        },
+        "headers": [
+            {"name": "FX-ACCESS-KEY", "value": "{{.Credentials.key}}"},
+            {"name": "FX-ACCESS-SIGN", "value": "{{.Signature}}"},
+            {"name": "FX-ACCESS-TIMESTAMP", "value": "{{.Timestamp}}"},
+            {
+                "name": "FX-ACCESS-PASSPHRASE",
+                "value": "{{.Credentials.passphrase}}",
+            },
+        ],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_parser_typed_hmac_sign_full_example() -> None:
+    secret = _parse_secret(_hmac_entry())
+    assert isinstance(secret, HmacSignSecret)
+    assert secret.hosts == ("api.falconx.io",)
+    assert secret.algorithm == "sha256"
+    assert secret.key_encoding == "base64"
+    assert secret.output_encoding == "base64"
+    assert secret.timestamp_format == "unix_seconds"
+    # credentials sort by name so the rendered config is deterministic
+    assert [name for name, _ in secret.credentials] == ["key", "passphrase", "secret"]
+    assert secret.headers[0] == HmacHeader(
+        "FX-ACCESS-KEY", "{{.Credentials.key}}"
+    )
+    assert secret.allow_chunked_body is False
+
+
+def test_parser_hmac_sign_requires_secret_credential() -> None:
+    with pytest.raises(ValueError, match="must include 'secret'"):
+        _parse_secret(_hmac_entry(credentials={"key": "FALCONX_API_KEY"}))
+
+
+def test_parser_hmac_sign_credential_supports_json_key() -> None:
+    secret = _parse_secret(
+        _hmac_entry(
+            credentials={
+                "secret": {"secret_ref": "FALCONX_BUNDLE", "json_key": "hmac_key"},
+            }
+        )
+    )
+    assert isinstance(secret, HmacSignSecret)
+    creds = dict(secret.credentials)
+    assert creds["secret"] == OAuthFieldSource("FALCONX_BUNDLE", "hmac_key")
+
+
+def test_parser_hmac_sign_rejects_unknown_algorithm() -> None:
+    with pytest.raises(ValueError, match="'algorithm' must be one of"):
+        _parse_secret(_hmac_entry(algorithm="md5"))
+
+
+def test_parser_hmac_sign_rejects_unknown_timestamp_format() -> None:
+    with pytest.raises(ValueError, match="'timestamp_format' must be one of"):
+        _parse_secret(_hmac_entry(timestamp_format="iso8601"))
+
+
+def test_parser_hmac_sign_rejects_unknown_key_encoding() -> None:
+    with pytest.raises(ValueError, match="'key_encoding' must be one of"):
+        _parse_secret(_hmac_entry(key_encoding="utf8"))
+
+
+def test_parser_hmac_sign_rejects_empty_headers() -> None:
+    with pytest.raises(ValueError, match="'headers' must be a non-empty list"):
+        _parse_secret(_hmac_entry(headers=[]))
+
+
+def test_parser_hmac_sign_requires_hosts() -> None:
+    entry = _hmac_entry()
+    entry.pop("hosts")
+    with pytest.raises(ValueError, match="'hosts' must be a non-empty array"):
+        _parse_secret(entry)
+
+
+def test_parser_hmac_sign_requires_message() -> None:
+    with pytest.raises(ValueError, match="'message' must be a non-empty"):
+        _parse_secret(_hmac_entry(message=""))
+
+
+def test_parser_hmac_sign_allow_chunked_body_must_be_bool() -> None:
+    with pytest.raises(ValueError, match="'allow_chunked_body' must be a boolean"):
+        _parse_secret(_hmac_entry(allow_chunked_body="yes"))
+
+
+def test_parser_hmac_sign_header_requires_name_and_value() -> None:
+    with pytest.raises(ValueError, match="header\\[0\\] requires a non-empty 'value'"):
+        _parse_secret(
+            _hmac_entry(headers=[{"name": "X-Sig", "value": ""}])
+        )
+
+
 # ── port allocation ─────────────────────────────────────────────────────────
 
 
@@ -720,6 +830,126 @@ def test_render_oauth_token_emits_token_endpoint_when_set() -> None:
         t for t in cfg["transforms"] if t["name"] == "oauth_token"
     )["config"]["tokens"]
     assert tokens[0]["token_endpoint"] == "https://login.example.com/oauth2/token"
+
+
+_RENDER_HMAC_CREDS: tuple[tuple[str, OAuthFieldSource], ...] = (
+    ("key", OAuthFieldSource("FALCONX_API_KEY")),
+    ("passphrase", OAuthFieldSource("FALCONX_PASSPHRASE")),
+    ("secret", OAuthFieldSource("FALCONX_SECRET")),
+)
+
+_RENDER_HMAC_HEADERS: tuple[HmacHeader, ...] = (
+    HmacHeader("FX-ACCESS-KEY", "{{.Credentials.key}}"),
+    HmacHeader("FX-ACCESS-SIGN", "{{.Signature}}"),
+    HmacHeader("FX-ACCESS-TIMESTAMP", "{{.Timestamp}}"),
+    HmacHeader("FX-ACCESS-PASSPHRASE", "{{.Credentials.passphrase}}"),
+)
+
+
+def _falconx_secret(
+    *, hosts: tuple[str, ...] = ("api.falconx.io",), **overrides: object
+) -> HmacSignSecret:
+    fields: dict[str, object] = {
+        "name": "FALCONX",
+        "hosts": hosts,
+        "credentials": _RENDER_HMAC_CREDS,
+        "headers": _RENDER_HMAC_HEADERS,
+        "algorithm": "sha256",
+        "key_encoding": "base64",
+        "output_encoding": "base64",
+        "message": "{{.Timestamp}}{{.Method}}{{.PathWithQuery}}{{.Body}}",
+        "timestamp_format": "unix_seconds",
+    }
+    fields.update(overrides)
+    return HmacSignSecret(**fields)  # type: ignore[arg-type]
+
+
+def test_render_hmac_sign_matches_iron_proxy_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    cfg = yaml.safe_load(render_proxy_yaml([_falconx_secret()]))
+    assert [t["name"] for t in cfg["transforms"]] == [
+        "allowlist",
+        "hmac_sign",
+        "header_allowlist",
+    ]
+    hmac = next(t for t in cfg["transforms"] if t["name"] == "hmac_sign")["config"]
+    assert hmac["timestamp"] == {"format": "unix_seconds"}
+    assert hmac["signature"] == {
+        "algorithm": "sha256",
+        "key_encoding": "base64",
+        "output_encoding": "base64",
+        "message": "{{.Timestamp}}{{.Method}}{{.PathWithQuery}}{{.Body}}",
+    }
+    assert hmac["credentials"] == {
+        "key": {"type": "env", "var": "FALCONX_API_KEY"},
+        "passphrase": {"type": "env", "var": "FALCONX_PASSPHRASE"},
+        "secret": {"type": "env", "var": "FALCONX_SECRET"},
+    }
+    # header order is preserved on the wire
+    assert hmac["headers"] == [
+        {"name": "FX-ACCESS-KEY", "value": "{{.Credentials.key}}"},
+        {"name": "FX-ACCESS-SIGN", "value": "{{.Signature}}"},
+        {"name": "FX-ACCESS-TIMESTAMP", "value": "{{.Timestamp}}"},
+        {"name": "FX-ACCESS-PASSPHRASE", "value": "{{.Credentials.passphrase}}"},
+    ]
+    assert hmac["rules"] == [{"host": "api.falconx.io"}]
+    # opt-in field is omitted at the safe default
+    assert "allow_chunked_body" not in hmac
+
+
+def test_render_hmac_sign_emits_allow_chunked_body_when_opted_in() -> None:
+    cfg = yaml.safe_load(
+        render_proxy_yaml([_falconx_secret(allow_chunked_body=True)])
+    )
+    hmac = next(t for t in cfg["transforms"] if t["name"] == "hmac_sign")["config"]
+    assert hmac["allow_chunked_body"] is True
+
+
+def test_render_hmac_sign_credential_supports_json_key() -> None:
+    secrets = [
+        _falconx_secret(
+            credentials=(
+                ("secret", OAuthFieldSource("FALCONX_BUNDLE", "hmac_key")),
+            )
+        )
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    hmac = next(t for t in cfg["transforms"] if t["name"] == "hmac_sign")["config"]
+    assert hmac["credentials"]["secret"] == {
+        "type": "env",
+        "var": "FALCONX_BUNDLE",
+        "json_key": "hmac_key",
+    }
+
+
+def test_render_hmac_sign_merges_entries_with_same_scheme_unioning_hosts() -> None:
+    secrets = [
+        _falconx_secret(hosts=("a.falconx.io",)),
+        _falconx_secret(hosts=("b.falconx.io",)),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    transforms = [t for t in cfg["transforms"] if t["name"] == "hmac_sign"]
+    assert len(transforms) == 1
+    assert transforms[0]["config"]["rules"] == [
+        {"host": "a.falconx.io"},
+        {"host": "b.falconx.io"},
+    ]
+
+
+def test_render_hmac_sign_separate_transforms_for_distinct_schemes() -> None:
+    secrets = [
+        _falconx_secret(),
+        _falconx_secret(algorithm="sha512", hosts=("v2.falconx.io",)),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    transforms = [t for t in cfg["transforms"] if t["name"] == "hmac_sign"]
+    assert len(transforms) == 2
+    assert {t["config"]["signature"]["algorithm"] for t in transforms} == {
+        "sha256",
+        "sha512",
+    }
 
 
 def test_render_omits_managed_transforms_when_no_matching_secrets() -> None:

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ironsh/iron-proxy:0.36.0@sha256:597856e32cc2f3256472922cd3610ad5415ec6ba91409501f0a64f5f0bc4fce9
+FROM ironsh/iron-proxy:0.37.0@sha256:f480a0f8233b8bb180e5837e24feeb71f214eaa10fdfa2439dd9aed7ecee62d6
 
 USER root
 RUN apk add --no-cache curl jq


### PR DESCRIPTION
Adds an `hmac_sign` typed secret that renders to iron-proxy's per-request HMAC signing transform — credentials are resolved at the proxy, the message is templated, and the configured headers are written onto the upstream request without exposing key material to the sandbox. Bumps iron-proxy to 0.37.0 so the transform is available.