### PR TITLE
[codex] add Slack chrome to landing demo

### DIFF
--- a/docs/components/ThreadPanel.tsx
+++ b/docs/components/ThreadPanel.tsx
@@ -571,6 +571,46 @@ function renderHumanText(text: string, botName: string) {
   )
 }
 
+function SlackChrome() {
+  return (
+    <div className="slack-chrome" aria-hidden="true">
+      <span className="slack-chrome-btn">
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="6" cy="6" r="2.6" />
+          <path d="M2 13.2c.5-2 2.2-3.2 4-3.2s3.5 1.2 4 3.2" />
+          <circle cx="11.5" cy="5.5" r="1.8" />
+          <path d="M11 9.6c1.6 0 2.7 1 3 2.4" />
+        </svg>
+        <span>21</span>
+      </span>
+      <span className="slack-chrome-btn slack-chrome-split">
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 9.5V7a5 5 0 1 1 10 0v2.5" />
+          <rect x="2" y="9" width="3" height="4" rx="1" />
+          <rect x="11" y="9" width="3" height="4" rx="1" />
+        </svg>
+        <svg viewBox="0 0 10 10" width="8" height="8" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M2 4l3 3 3-3" />
+        </svg>
+      </span>
+      <span className="slack-chrome-btn slack-chrome-bell">
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M4 11V7.5a4 4 0 0 1 8 0V11l1.2 1.5H2.8z" />
+          <path d="M6.5 13.5a1.5 1.5 0 0 0 3 0" />
+        </svg>
+        <span className="slack-chrome-dot" />
+      </span>
+      <span className="slack-chrome-btn">
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+          <circle cx="3.2" cy="8" r="1.3" />
+          <circle cx="8" cy="8" r="1.3" />
+          <circle cx="12.8" cy="8" r="1.3" />
+        </svg>
+      </span>
+    </div>
+  )
+}
+
 function ThreadDetail({
   accent,
   botGlyph,
@@ -681,6 +721,7 @@ function ThreadDetail({
             <span className="thread-panel-head-channel"># {thread.channel}</span>
           </div>
         </div>
+        <SlackChrome />
       </header>
 
       <div className="thread-panel-scroll" onScroll={handleScroll} ref={scrollRef}>

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -604,10 +604,10 @@ a.home-lockup-link {
 
 .home-media-grid {
   display: grid;
-  gap: clamp(28px, 4vw, 56px);
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin: clamp(32px, 4dvh, 44px) auto 0;
-  max-width: 1440px;
+  gap: clamp(48px, 6dvh, 84px);
+  grid-template-columns: 1fr;
+  margin: clamp(48px, 6dvh, 84px) auto 0;
+  max-width: 1280px;
   width: 100%;
 }
 
@@ -621,9 +621,20 @@ a.home-lockup-link {
 }
 
 .home-media-link {
+  align-items: center;
   color: inherit;
-  display: block;
+  display: grid;
+  gap: clamp(36px, 5vw, 80px);
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
   text-decoration: none;
+}
+
+.home-media-grid .home-media-section:nth-child(even) .home-media-link {
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+}
+
+.home-media-grid .home-media-section:nth-child(even) .home-architecture-diagram {
+  order: -1;
 }
 
 .home-media-link:focus-visible {
@@ -633,6 +644,12 @@ a.home-lockup-link {
 
 .home-media-link:hover .home-architecture-diagram img {
   border-color: rgba(255, 255, 255, 0.28);
+}
+
+.home-media-section .home-architecture-diagram {
+  margin: 0;
+  max-width: 100%;
+  padding-top: 0;
 }
 
 .home-overview-heading {
@@ -707,13 +724,6 @@ a.home-lockup-link {
   margin: clamp(44px, 6dvh, 72px) auto 0;
   max-width: 75%;
   padding-top: clamp(28px, 4dvh, 44px);
-}
-
-.home-media-section .home-architecture-diagram {
-  margin-left: 0;
-  margin-right: auto;
-  margin-top: 30px;
-  padding-top: 0;
 }
 
 .home-architecture-diagram img {
@@ -971,6 +981,61 @@ a.home-lockup-link {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.slack-chrome {
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  gap: 6px;
+  margin-left: auto;
+  pointer-events: none;
+}
+
+.slack-chrome-btn {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  color: var(--thread-ink-2);
+  cursor: default;
+  display: inline-flex;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  gap: 5px;
+  height: 28px;
+  letter-spacing: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  user-select: none;
+}
+
+.slack-chrome-split {
+  gap: 4px;
+  padding-right: 6px;
+}
+
+.slack-chrome-bell {
+  padding: 0 8px;
+  position: relative;
+}
+
+.slack-chrome-dot {
+  background: #f15a4a;
+  border: 1.5px solid var(--thread-panel);
+  border-radius: 50%;
+  height: 7px;
+  position: absolute;
+  right: 6px;
+  top: 4px;
+  width: 7px;
+}
+
+@media (max-width: 760px) {
+  .slack-chrome > .slack-chrome-btn:not(:last-child) {
+    display: none;
+  }
 }
 
 .thread-panel-scroll {
@@ -1399,8 +1464,24 @@ a.home-lockup-link {
   }
 
   .home-media-grid {
+    gap: 28px;
+    max-width: 720px;
+    text-align: center;
+  }
+
+  .home-media-link {
+    gap: 28px;
     grid-template-columns: 1fr;
-    max-width: 980px;
+  }
+
+  .home-media-grid .home-media-section:nth-child(even) .home-architecture-diagram {
+    order: 0;
+  }
+
+  .home-media-section .home-architecture-diagram {
+    margin-inline: auto;
+    max-width: 65vw;
+    width: 100%;
   }
 
   .home-overview-heading {

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -599,42 +599,20 @@ a.home-lockup-link {
 }
 
 .home-media-section {
-  margin-top: clamp(32px, 4dvh, 44px);
-}
-
-.home-media-grid {
-  display: grid;
-  gap: clamp(48px, 6dvh, 84px);
-  grid-template-columns: 1fr;
   margin: clamp(48px, 6dvh, 84px) auto 0;
   max-width: 1280px;
-  width: 100%;
+  text-align: center;
 }
 
-.home-media-grid .home-media-section {
-  margin: 0;
-  max-width: none;
-}
-
-.home-media-grid .home-overview-heading {
+.home-media-section .home-overview-heading {
   grid-template-columns: 1fr;
+  text-align: center;
 }
 
 .home-media-link {
-  align-items: center;
   color: inherit;
-  display: grid;
-  gap: clamp(36px, 5vw, 80px);
-  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  display: block;
   text-decoration: none;
-}
-
-.home-media-grid .home-media-section:nth-child(even) .home-media-link {
-  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-}
-
-.home-media-grid .home-media-section:nth-child(even) .home-architecture-diagram {
-  order: -1;
 }
 
 .home-media-link:focus-visible {
@@ -646,9 +624,10 @@ a.home-lockup-link {
   border-color: rgba(255, 255, 255, 0.28);
 }
 
-.home-media-section .home-architecture-diagram {
-  margin: 0;
-  max-width: 100%;
+.home-media-section .home-architecture-diagram,
+.home-overview-visual .home-architecture-diagram {
+  margin-left: auto;
+  margin-right: auto;
   padding-top: 0;
 }
 
@@ -1463,25 +1442,13 @@ a.home-lockup-link {
     max-width: 980px;
   }
 
-  .home-media-grid {
-    gap: 28px;
+  .home-media-section {
     max-width: 720px;
-    text-align: center;
   }
 
-  .home-media-link {
-    gap: 28px;
-    grid-template-columns: 1fr;
-  }
-
-  .home-media-grid .home-media-section:nth-child(even) .home-architecture-diagram {
-    order: 0;
-  }
-
-  .home-media-section .home-architecture-diagram {
-    margin-inline: auto;
+  .home-media-section .home-architecture-diagram,
+  .home-overview-visual .home-architecture-diagram {
     max-width: 65vw;
-    width: 100%;
   }
 
   .home-overview-heading {

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -19,7 +19,7 @@ import ThreadPanel from '../components/ThreadPanel'
       <a className="home-lockup-link" href="https://github.com/paradigmxyz/centaur" target="_blank" rel="noopener noreferrer" aria-label="Centaur on GitHub">
         <img className="home-lockup" src="/brand/lockup-white.svg" alt="Centaur" />
       </a>
-      <h1 id="home-title">Multiplayer, self-hosted, secure agents for teams.</h1>
+      <h1 id="home-title">Multiplayer, self-hosted, secure agents for Slack.</h1>
 
       <div className="home-actions" aria-label="Primary documentation links">
         <a className="home-button home-button-primary" href="/quickstart">Get Started</a>

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -46,10 +46,6 @@ import ThreadPanel from '../components/ThreadPanel'
   </section>
 
   <section className="home-overview" aria-labelledby="home-overview-title">
-    <div className="home-overview-heading">
-      <h2 id="home-overview-title">Overview</h2>
-    </div>
-
     <ul className="home-overview-list">
       <li>
         <a href="/architecture#tool-and-workflow-layer">
@@ -76,32 +72,5 @@ import ThreadPanel from '../components/ThreadPanel'
         </a>
       </li>
     </ul>
-
   </section>
-
-  <div className="home-media-grid">
-    <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
-      <a className="home-media-link" href="/extend/overlay" aria-labelledby="home-extensible-title">
-        <div className="home-overview-heading">
-          <h2 id="home-extensible-title">Extensible by default</h2>
-        </div>
-
-        <figure className="home-architecture-diagram">
-          <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
-        </figure>
-      </a>
-    </section>
-
-    <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
-      <a className="home-media-link" href="/architecture" aria-labelledby="home-architecture-title">
-        <div className="home-overview-heading">
-          <h2 id="home-architecture-title">Modular Architecture</h2>
-        </div>
-
-        <figure className="home-architecture-diagram">
-          <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
-        </figure>
-      </a>
-    </section>
-  </div>
 </main>

--- a/docs/public/md/index.md
+++ b/docs/public/md/index.md
@@ -19,7 +19,7 @@ import ThreadPanel from '../components/ThreadPanel'
       <a className="home-lockup-link" href="https://github.com/paradigmxyz/centaur" target="_blank" rel="noopener noreferrer" aria-label="Centaur on GitHub">
         <img className="home-lockup" src="/brand/lockup-white.svg" alt="Centaur" />
       </a>
-      <h1 id="home-title">Multiplayer, self-hosted, secure agents for teams.</h1>
+      <h1 id="home-title">Multiplayer, self-hosted, secure agents for Slack.</h1>
 
       <div className="home-actions" aria-label="Primary documentation links">
         <a className="home-button home-button-primary" href="/quickstart">Get Started</a>

--- a/docs/public/md/index.md
+++ b/docs/public/md/index.md
@@ -77,31 +77,23 @@ import ThreadPanel from '../components/ThreadPanel'
       </li>
     </ul>
 
+    <a className="home-media-link home-overview-visual" href="/extend/overlay" aria-label="Using an overlay">
+      <figure className="home-architecture-diagram">
+        <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
+      </figure>
+    </a>
+
   </section>
 
-  <div className="home-media-grid">
-    <section className="home-overview home-media-section" aria-labelledby="home-extensible-title">
-      <a className="home-media-link" href="/extend/overlay" aria-labelledby="home-extensible-title">
-        <div className="home-overview-heading">
-          <h2 id="home-extensible-title">Extensible by default</h2>
-        </div>
+  <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
+    <a className="home-media-link" href="/architecture" aria-labelledby="home-architecture-title">
+      <div className="home-overview-heading">
+        <h2 id="home-architecture-title">Modular Architecture</h2>
+      </div>
 
-        <figure className="home-architecture-diagram">
-          <img src="/brand/containers.svg" alt="Centaur deployment layout: the open-source kernel wrapped by an organization overlay and a per-app repository." />
-        </figure>
-      </a>
-    </section>
-
-    <section className="home-overview home-media-section" aria-labelledby="home-architecture-title">
-      <a className="home-media-link" href="/architecture" aria-labelledby="home-architecture-title">
-        <div className="home-overview-heading">
-          <h2 id="home-architecture-title">Modular Architecture</h2>
-        </div>
-
-        <figure className="home-architecture-diagram">
-          <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
-        </figure>
-      </a>
-    </section>
-  </div>
+      <figure className="home-architecture-diagram">
+        <img src="/brand/architecture.svg" alt="Centaur architecture: ingress, durable control plane, isolated execution, capabilities, secrets, and controlled egress." />
+      </figure>
+    </a>
+  </section>
 </main>

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -7,8 +7,9 @@ const basePath = process.env.VOCS_BASE_PATH || undefined
 const siteUrl = 'https://centaur.run'
 
 function canonicalHref(path: string) {
-  if (path === '/') return `${siteUrl}/`
-  return `${siteUrl}${path.replace(/\/+$/, '')}/`
+  const root = 'https://centaur.run'
+  if (path === '/') return `${root}/`
+  return `${root}${path.replace(/\/+$/, '')}/`
 }
 
 export default defineConfig({
@@ -64,7 +65,7 @@ export default defineConfig({
   ogImageUrl: (path: string, { baseUrl }: { baseUrl: string }) => {
     const key = path.replace(/\/$/, '') || '/'
     const slug = key === '/' ? 'index' : key.replace(/^\//, '').replace(/\//g, '_')
-    const root = baseUrl ?? siteUrl
+    const root = baseUrl ?? 'https://centaur.run'
     return `${root.replace(/\/$/, '')}/og/${slug}.png`
   },
   ...(basePath ? { basePath } : {}),


### PR DESCRIPTION
## Summary
- add inert Slack-style top-right chrome to the landing page thread demo
- keep the chrome hidden from assistive tech and non-interactive so it does not interfere with the demo

## Validation
- npm run build
- git diff --check

Note: docs build still emits the existing Vocs warning for /centaur-brand-assets.zip from brand.mdx.