### PR TITLE
Replace per-message footer with persona/engine header

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -194,6 +194,73 @@ def _agent_session_title(*, persona_id: str | None, engine: str | None, harness:
     return " · ".join(parts)
 
 
+# ── Per-message header (rendered italic at the top of every assistant message) ──
+
+_CLAUDE_MODEL_ALIASES: dict[str, str] = {
+    "opus": "claude-opus-4-7",
+    "sonnet": "claude-sonnet-4-6",
+    "haiku": "claude-haiku-4-5",
+}
+
+
+def _resolve_claude_model_label(model: str | None) -> str:
+    raw = (model or os.getenv("CLAUDE_MODEL") or "opus").strip().lower()
+    if raw.startswith("claude-"):
+        return raw
+    return _CLAUDE_MODEL_ALIASES.get(raw, raw or "claude-opus-4-7")
+
+
+def _resolve_codex_model_label(model: str | None) -> str:
+    raw = (model or os.getenv("CODEX_MODEL") or "").strip().lower()
+    if not raw:
+        return "codex"
+    if raw.startswith("codex-"):
+        return raw
+    return f"codex-{raw}"
+
+
+def _engine_model_label(
+    *,
+    engine: str | None,
+    harness: str | None,
+    model: str | None = None,
+) -> str:
+    """Return the `engine-model` segment for the per-message header.
+
+    Falls back to the engine identifier when no model is known, so the
+    header always renders something deterministic per (engine, persona) pair.
+    """
+    engine_name = (engine or harness or "").strip().lower()
+    explicit = (model or "").strip().lower()
+    if engine_name == "claude-code":
+        return _resolve_claude_model_label(explicit or None)
+    if engine_name == "codex":
+        return _resolve_codex_model_label(explicit or None)
+    if engine_name == "amp":
+        return f"amp-{explicit}" if explicit else "amp"
+    if explicit:
+        return explicit
+    return engine_name or "centaur"
+
+
+def _agent_session_header(
+    *,
+    persona_id: str | None,
+    engine: str | None,
+    harness: str | None,
+    model: str | None = None,
+) -> str:
+    """Return ``"<persona> · <engine-model>"`` for the per-message header line.
+
+    Persona is normalized to the literal ``"base"`` when no persona is
+    active so the header is always two segments. The slackbot wraps this
+    in italics; we do not add markdown styling here.
+    """
+    persona = (persona_id or "").strip() or "base"
+    engine_label = _engine_model_label(engine=engine, harness=harness, model=model)
+    return f"{persona} · {engine_label}"
+
+
 def flatten_event_parts(event: dict[str, Any]) -> list[dict[str, Any]]:
     message = event.get("message") if isinstance(event, dict) else None
     if not isinstance(message, dict):
@@ -1802,6 +1869,11 @@ async def _mark_execution_terminal(
         thread_key,
         canonical_json(decode_jsonb(row["delivery"], {}) if row else {}),
     )
+    session_header = _agent_session_header(
+        persona_id=persona_id,
+        engine=engine,
+        harness=harness,
+    )
     await pool.execute(
         "UPDATE agent_final_delivery_outbox SET state = 'pending', final_payload = $1::jsonb, "
         "next_attempt_at = $2, lease_owner = NULL, lease_expires_at = NULL, updated_at = NOW() "
@@ -1817,6 +1889,7 @@ async def _mark_execution_terminal(
                     engine=engine,
                     harness=harness,
                 ),
+                "session_header": session_header,
                 "result_text": result_text,
                 **({"error_text": error_text} if error_text else {}),
                 **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
@@ -1843,6 +1916,7 @@ async def _mark_execution_terminal(
                 engine=engine,
                 harness=harness,
             ),
+            "session_header": session_header,
             "result_text": result_text,
             **({"error_text": error_text} if error_text else {}),
             **({"repo_context": repo_context} if repo_context else {}),

--- a/services/api/api/slackbot_client.py
+++ b/services/api/api/slackbot_client.py
@@ -100,6 +100,7 @@ async def open_agent_session(
     metadata: dict[str, Any],
     thread_key: str,
     title: str = "Centaur execution",
+    header: str | None = None,
 ) -> str | None:
     if not enabled() or not is_slack_delivery(delivery):
         return None
@@ -107,16 +108,17 @@ async def open_agent_session(
     parent_ts = thread_ts(delivery)
     if not channel or not parent_ts:
         return None
-    result = await post(
-        "/api/slack/agent-sessions",
-        {
-            "channel": channel,
-            "parent_ts": parent_ts,
-            "recipient_team_id": recipient_team_id(delivery, thread_key),
-            "recipient_user_id": recipient_user_id(delivery, metadata),
-            "title": title,
-        },
-    )
+    body: dict[str, Any] = {
+        "channel": channel,
+        "parent_ts": parent_ts,
+        "recipient_team_id": recipient_team_id(delivery, thread_key),
+        "recipient_user_id": recipient_user_id(delivery, metadata),
+        "title": title,
+    }
+    header_text = (header or "").strip()
+    if header_text:
+        body["header"] = header_text
+    result = await post("/api/slack/agent-sessions", body)
     session_id = str((result or {}).get("session_id") or "").strip()
     return session_id or None
 

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -939,6 +939,39 @@ async def _compute_agent_session_title(
     return " · ".join(parts)
 
 
+async def _compute_agent_session_header(
+    pool,
+    thread_key: str,
+    selector: dict[str, str | None],
+) -> str:
+    """Build the per-message italic header (``"persona · engine-model"``).
+
+    Mirrors ``_compute_agent_session_title`` for the resolution path but emits
+    the persona/engine pair the slackbot renders italic at the top of every
+    assistant message. Persona defaults to the literal ``"base"`` when no
+    persona is active. The engine segment is upgraded to a concrete model
+    identifier (e.g. ``claude-opus-4-7``, ``codex-gpt-5``) when known.
+    """
+    from api.runtime_control import _agent_session_header  # local to avoid cycle
+
+    persona = selector.get("persona_id")
+    harness = selector.get("harness")
+    engine: str | None = None
+    if not persona or not harness:
+        active = await get_active_assignment(pool, thread_key)
+        if isinstance(active, dict):
+            persona = persona or _nonempty(active.get("persona_id"))
+            harness = harness or _nonempty(active.get("harness"))
+            engine = _nonempty(active.get("engine"))
+    if persona and not engine:
+        engine = _persona_default_engine(persona)
+    return _agent_session_header(
+        persona_id=persona,
+        engine=engine,
+        harness=harness,
+    )
+
+
 def _assignment_display_engine(active: dict[str, Any]) -> str | None:
     engine = _nonempty(active.get("engine"))
     if engine:
@@ -1131,11 +1164,15 @@ async def do_agent_turn(
         session_title = await _compute_agent_session_title(
             ctx._pool, effective_thread_key, selector,
         )
+        session_header = await _compute_agent_session_header(
+            ctx._pool, effective_thread_key, selector,
+        )
         slackbot_session_id = await slackbot_client.open_agent_session(
             delivery=effective_delivery,
             metadata=effective_metadata,
             thread_key=effective_thread_key,
             title=session_title,
+            header=session_header,
         )
         if slackbot_session_id:
             effective_metadata["slackbot_agent_session_id"] = slackbot_session_id

--- a/services/api/tests/test_workflow_engine_title.py
+++ b/services/api/tests/test_workflow_engine_title.py
@@ -132,3 +132,86 @@ async def test_title_handles_non_dict_active_assignment(monkeypatch):
         pool=object(), thread_key="slack:T:C:1.0", selector=selector,
     )
     assert title == "Centaur · amp"
+
+
+# ── Per-message header (rendered italic above every assistant message) ─────
+
+@pytest.mark.asyncio
+async def test_header_uses_base_when_no_persona_paradigm_claude(monkeypatch):
+    """Paradigm + no persona + claude-code → ``base · claude-opus-4-7``."""
+    get_active = AsyncMock(return_value={"persona_id": None, "harness": "claude-code", "engine": "claude-code"})
+    monkeypatch.setattr(workflow_engine, "get_active_assignment", get_active)
+    monkeypatch.delenv("CLAUDE_MODEL", raising=False)
+    monkeypatch.delenv("CODEX_MODEL", raising=False)
+    selector: dict[str, Any] = {"persona_id": None, "harness": None}
+    header = await workflow_engine._compute_agent_session_header(
+        pool=object(), thread_key="slack:T:C:1.0", selector=selector,
+    )
+    assert header == "base · claude-opus-4-7"
+
+
+@pytest.mark.asyncio
+async def test_header_uses_persona_segment_paradigm_legal_codex(monkeypatch):
+    """Paradigm + legal persona + codex → ``legal · codex-gpt-5``."""
+    get_active = AsyncMock(return_value={"persona_id": "legal", "harness": "legal", "engine": "codex"})
+    monkeypatch.setattr(workflow_engine, "get_active_assignment", get_active)
+    monkeypatch.setenv("CODEX_MODEL", "gpt-5")
+    selector: dict[str, Any] = {"persona_id": "legal", "harness": "codex"}
+    header = await workflow_engine._compute_agent_session_header(
+        pool=object(), thread_key="slack:T:C:1.0", selector=selector,
+    )
+    assert header == "legal · codex-gpt-5"
+
+
+@pytest.mark.asyncio
+async def test_header_uses_claude_sonnet_alias_for_tempo(monkeypatch):
+    """Tempo + no persona + claude-code with sonnet alias → ``base · claude-sonnet-4-6``."""
+    get_active = AsyncMock(return_value={"persona_id": None, "harness": "claude-code", "engine": "claude-code"})
+    monkeypatch.setattr(workflow_engine, "get_active_assignment", get_active)
+    monkeypatch.setenv("CLAUDE_MODEL", "sonnet")
+    selector: dict[str, Any] = {"persona_id": None, "harness": "claude-code"}
+    header = await workflow_engine._compute_agent_session_header(
+        pool=object(), thread_key="slack:T:C:1.0", selector=selector,
+    )
+    assert header == "base · claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
+async def test_header_uses_persona_default_engine_when_active_assignment_empty(monkeypatch):
+    """Fresh persona switch: no active assignment yet. Falls back to the persona's
+    declared default engine so the header is never ``base`` for a known persona."""
+    get_active = AsyncMock(return_value=None)
+    monkeypatch.setattr(workflow_engine, "get_active_assignment", get_active)
+    monkeypatch.setattr(workflow_engine, "_persona_default_engine", lambda persona_id: "codex")
+    monkeypatch.setenv("CODEX_MODEL", "gpt-5")
+    selector: dict[str, Any] = {"persona_id": "invest", "harness": None}
+    header = await workflow_engine._compute_agent_session_header(
+        pool=object(), thread_key="slack:T:C:1.0", selector=selector,
+    )
+    assert header == "invest · codex-gpt-5"
+
+
+@pytest.mark.asyncio
+async def test_header_passes_through_explicit_claude_model_id(monkeypatch):
+    """When CLAUDE_MODEL is already a full id like ``claude-haiku-4-5``,
+    pass it through verbatim instead of re-prefixing."""
+    get_active = AsyncMock(return_value={"persona_id": None, "harness": "claude-code", "engine": "claude-code"})
+    monkeypatch.setattr(workflow_engine, "get_active_assignment", get_active)
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-haiku-4-5")
+    selector: dict[str, Any] = {"persona_id": None, "harness": "claude-code"}
+    header = await workflow_engine._compute_agent_session_header(
+        pool=object(), thread_key="slack:T:C:1.0", selector=selector,
+    )
+    assert header == "base · claude-haiku-4-5"
+
+
+@pytest.mark.asyncio
+async def test_header_falls_back_to_engine_name_for_unknown_engine(monkeypatch):
+    """Unknown engines render with the engine name verbatim — no surprise output."""
+    get_active = AsyncMock(return_value=None)
+    monkeypatch.setattr(workflow_engine, "get_active_assignment", get_active)
+    selector: dict[str, Any] = {"persona_id": "experimental", "harness": "wasm-runner"}
+    header = await workflow_engine._compute_agent_session_header(
+        pool=object(), thread_key="slack:T:C:1.0", selector=selector,
+    )
+    assert header == "experimental · wasm-runner"

--- a/services/slackbot/examples/amp-full-stream.ts
+++ b/services/slackbot/examples/amp-full-stream.ts
@@ -50,7 +50,8 @@ const opened = await slackbot('POST', '/api/slack/agent-sessions', {
   parent_ts: parent.ts,
   recipient_team_id: recipientTeamId,
   recipient_user_id: recipientUserId,
-  title: 'Amp execution steps'
+  title: 'Amp execution steps',
+  header: 'base · amp'
 })
 agentSessionId = opened.session_id
 
@@ -199,7 +200,7 @@ async function streamAssistant(markdown) {
 
 async function stopAssistantStream() {
   await slackbot('POST', `/api/slack/agent-sessions/${agentSessionId}/done`, {
-    footer: `amp threads continue ${sessionId}`
+    thread_id: sessionId
   })
 }
 

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -2,7 +2,6 @@ import type { WebClient } from '@slack/web-api'
 import { centaurApiKey, type AppConfig } from '../config'
 import { logError } from '../logging'
 import { AgentSessionRenderer } from '../slack/agent-session'
-import { codexFooter } from '../slack/codex-session'
 import { withLaminarSpan } from './laminar'
 
 const CONSUMER_ID = `slackbot-${process.pid}`
@@ -70,10 +69,11 @@ async function deliver(client: WebClient, delivery: any): Promise<void> {
     parentTs: threadTs,
     recipientTeamId: String(meta.team_id ?? delivery.team_id ?? target.teamId ?? ''),
     recipientUserId: String(meta.recipient_user_id ?? meta.user_id ?? delivery.user_id ?? ''),
-    title: sessionTitle(payload)
+    title: sessionTitle(payload),
+    header: sessionHeader(payload)
   })
   await renderer.text(sessionId, extractText(payload))
-  await renderer.done(sessionId, deliveryFooter(payload))
+  await renderer.done(sessionId)
 }
 
 function sessionTitle(payload: any): string {
@@ -104,9 +104,9 @@ function firstNonEmpty(...values: unknown[]): string {
   return ''
 }
 
-function deliveryFooter(payload: any): string | undefined {
-  const threadId = String(payload?.agent_thread_id ?? '').trim()
-  return threadId ? codexFooter(threadId) : undefined
+function sessionHeader(payload: any): string | undefined {
+  const value = String(payload?.session_header ?? payload?.header ?? '').trim()
+  return value || undefined
 }
 
 function targetFromDelivery(delivery: any): {

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -10,7 +10,7 @@ import { loadConfig } from './config'
 import { logError, logWarn, sanitizeLogValue } from './logging'
 import { AgentSessionRenderer, withAgentSessionLock } from './slack/agent-session'
 import { authorizeSlackOrg } from './slack/authorization'
-import { CodexSessionRenderer, codexFooter, hasActiveCodexSession } from './slack/codex-session'
+import { CodexSessionRenderer, hasActiveCodexSession } from './slack/codex-session'
 import { EventDeduper, slackDedupKey } from './slack/dedup'
 import { duplicateSlackAlertText, type DuplicateSlackEventDetails } from './slack/duplicate-alert'
 import { EnvSlackInstallationStore, SlackClientResolver } from './slack/installations'
@@ -292,6 +292,7 @@ app.post('/api/slack/agent-sessions', apiKeyMiddleware, async c => {
     recipient_team_id: string
     recipient_user_id: string
     title?: string
+    header?: string
   }>()
   const { client } = await resolver.resolve({})
   try {
@@ -300,7 +301,8 @@ app.post('/api/slack/agent-sessions', apiKeyMiddleware, async c => {
       parentTs: body.parent_ts,
       recipientTeamId: body.recipient_team_id,
       recipientUserId: body.recipient_user_id,
-      title: body.title
+      title: body.title,
+      header: body.header
     })
     return c.json({ ok: true, session_id: result.sessionId })
   } catch (error) {
@@ -343,16 +345,15 @@ app.post('/api/slack/agent-sessions/:session_id/step', apiKeyMiddleware, async c
 })
 
 app.post('/api/slack/agent-sessions/:session_id/done', apiKeyMiddleware, async c => {
-  const body = await c.req.json<{ footer?: string; thread_id?: string }>()
+  const body = await c.req.json<{ thread_id?: string }>()
   const { client } = await resolver.resolve({})
   try {
     const sessionId = c.req.param('session_id')
     await withAgentSessionLock(sessionId, async () => {
-      const footer = body.footer ?? (body.thread_id ? codexFooter(body.thread_id) : undefined)
       if (hasActiveCodexSession(sessionId)) {
         await new CodexSessionRenderer(client).done(sessionId, body.thread_id)
       } else {
-        await new AgentSessionRenderer(client).done(sessionId, footer)
+        await new AgentSessionRenderer(client).done(sessionId)
       }
     })
     return c.json({ ok: true })

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -314,7 +314,7 @@ describe('AgentSessionRenderer', () => {
       },
       { flush: false }
     )
-    await renderer.done(sessionId, undefined, {
+    await renderer.done(sessionId, {
       answerMarkdown: 'Final answer stays visible.'
     })
 
@@ -371,7 +371,7 @@ describe('AgentSessionRenderer', () => {
       status: 'in_progress'
     })
     await renderer.text(sessionId, 'Live answer body.')
-    await renderer.done(sessionId, 'Codex thread `T-1`', {
+    await renderer.done(sessionId, {
       commentaryMarkdown: 'Planning the tool calls.',
       answerMarkdown: 'Live answer body.'
     })
@@ -380,8 +380,8 @@ describe('AgentSessionRenderer', () => {
     const blocks = stop?.params.blocks ?? []
     expect(blocks.some((block: any) => block.type === 'plan')).toBe(false)
     expect(blocks.some((block: any) => block.type === 'markdown')).toBe(false)
+    expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
-    expect(blocks.some((block: any) => block.type === 'context')).toBe(true)
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
   })
 
@@ -422,7 +422,7 @@ describe('AgentSessionRenderer', () => {
       title: 'Centaur execution'
     })
 
-    await renderer.done(sessionId, 'Codex thread `T-1`', {
+    await renderer.done(sessionId, {
       commentaryMarkdown: 'Planning the tool calls.',
       answerMarkdown: 'Done: five tools called.'
     })
@@ -493,7 +493,7 @@ describe('AgentSessionRenderer', () => {
 
     const longAnswer = 'A'.repeat(8_000)
     await renderer.text(sessionId, longAnswer)
-    await renderer.done(sessionId, 'Codex thread `T-1`')
+    await renderer.done(sessionId)
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
     const markdownBlocks = (stop?.params.blocks ?? []).filter(
@@ -564,6 +564,152 @@ describe('AgentSessionRenderer', () => {
 
     expect(renderer.done(sessionId)).resolves.toBeUndefined()
     expect(stopAttempts).toBe(2)
+  })
+
+  it('prepends the persona/engine header as the first streamed chunk and final block', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: { threads: { setStatus: async () => ({ ok: true }) } },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution',
+      header: 'legal · codex-gpt-5'
+    })
+
+    await renderer.text(sessionId, 'Hello world.')
+    await renderer.done(sessionId, { answerMarkdown: 'Hello world.' })
+
+    const start = calls.find(call => call.method === 'chat.startStream')
+    const firstChunk = start?.params.chunks?.[0]
+    expect(firstChunk?.type).toBe('markdown_text')
+    expect(String(firstChunk?.text ?? '')).toBe('_legal · codex-gpt-5_\n')
+
+    const allStreamedChunks = calls
+      .filter(call =>
+        call.method === 'chat.startStream' || call.method === 'chat.appendStream'
+      )
+      .flatMap(call => call.params.chunks ?? [])
+      .filter((chunk: any) => chunk?.type === 'markdown_text')
+      .map((chunk: any) => String(chunk.text ?? ''))
+    const headerOccurrences = allStreamedChunks.filter(text =>
+      text.includes('_legal · codex-gpt-5_')
+    ).length
+    expect(headerOccurrences).toBe(1)
+
+    const stop = calls.find(call => call.method === 'chat.stopStream')
+    const blocks = stop?.params.blocks ?? []
+    expect(blocks[0]).toEqual({ type: 'markdown', text: '_legal · codex-gpt-5_' })
+  })
+
+  it('omits the header block entirely when no header was supplied', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: { threads: { setStatus: async () => ({ ok: true }) } },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+
+    await renderer.text(sessionId, 'Hello world.')
+    await renderer.done(sessionId, { answerMarkdown: 'Hello world.' })
+
+    const start = calls.find(call => call.method === 'chat.startStream')
+    expect(start?.params.chunks?.[0]?.type).not.toBe('markdown_text')
+    const stop = calls.find(call => call.method === 'chat.stopStream')
+    const blocks = stop?.params.blocks ?? []
+    expect(blocks.some((block: any) => block.type === 'markdown' && /^_.*_$/.test(block.text)))
+      .toBe(false)
+  })
+
+  it('renders the header above streamed tasks when both are present', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: { threads: { setStatus: async () => ({ ok: true }) } },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution',
+      header: 'base · claude-opus-4-7'
+    })
+
+    await renderer.step(sessionId, {
+      id: 'cmd-1',
+      title: 'Run command',
+      status: 'in_progress',
+      details: '```bash\nls\n```'
+    })
+    await renderer.done(sessionId)
+
+    const start = calls.find(call => call.method === 'chat.startStream')
+    const chunks = start?.params.chunks ?? []
+    expect(chunks[0]).toEqual({
+      type: 'markdown_text',
+      text: '_base · claude-opus-4-7_\n'
+    })
+    const planUpdateIdx = chunks.findIndex((chunk: any) => chunk.type === 'plan_update')
+    expect(planUpdateIdx).toBeGreaterThan(0)
   })
 })
 

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -29,6 +29,7 @@ type Segment = {
   streamTs?: string
   streamStartPromise?: Promise<void>
   planStarted: boolean
+  headerEmitted: boolean
   pendingText: string
   pendingTextPlanPrefix: boolean
   streamedText: string
@@ -45,7 +46,7 @@ type AgentSessionState = {
   recipientTeamId: string
   recipientUserId: string
   title: string
-  footer?: string
+  header?: string
   finalCommentaryMarkdown?: string
   finalAnswerMarkdown?: string
   done: boolean
@@ -59,6 +60,9 @@ export type OpenAgentSessionInput = {
   recipientTeamId: string
   recipientUserId: string
   title?: string
+  /** Italic one-line identifier rendered at the top of every assistant message
+   *  (e.g. "base · claude-opus-4-7", "legal · codex-gpt-5"). */
+  header?: string
 }
 
 export type StepInput = {
@@ -87,6 +91,14 @@ export type DoneOptions = {
   answerMarkdown?: string
 }
 
+function headerMarkdown(header: string): string {
+  return `_${header.trim()}_`
+}
+
+function headerBlock(header: string): AnyBlock {
+  return { type: 'markdown', text: headerMarkdown(header) }
+}
+
 const sessions = new Map<string, AgentSessionState>()
 const sessionQueues = new Map<string, Promise<void>>()
 const THINKING_STATUS = 'Thinking...'
@@ -105,6 +117,7 @@ export class AgentSessionRenderer {
 
   async open(input: OpenAgentSessionInput): Promise<{ sessionId: string }> {
     const id = ulid()
+    const header = input.header?.trim() || undefined
     sessions.set(id, {
       id,
       channel: input.channel,
@@ -112,6 +125,7 @@ export class AgentSessionRenderer {
       recipientTeamId: input.recipientTeamId,
       recipientUserId: input.recipientUserId,
       title: input.title ?? 'Execution steps',
+      header,
       segments: [newSegment()],
       done: false,
       statusCleared: false
@@ -188,10 +202,9 @@ export class AgentSessionRenderer {
     await this.flushText(state, segment, { force: true })
   }
 
-  async done(sessionId: string, footer?: string, opts: DoneOptions = {}): Promise<void> {
+  async done(sessionId: string, opts: DoneOptions = {}): Promise<void> {
     const state = requireSession(sessionId)
     state.done = true
-    state.footer = footer
     state.finalCommentaryMarkdown = opts.commentaryMarkdown
     state.finalAnswerMarkdown = opts.answerMarkdown
     const streamFinalUpdates = opts.streamFinalUpdates ?? true
@@ -240,7 +253,6 @@ export class AgentSessionRenderer {
     if (!segment.streamTs && !segment.textParts.length && !segment.tasks.size && !hasFinalText) {
       return
     }
-    const footer = state.footer?.trim()
     await this.ensureStream(state, segment, [])
     if (!segment.streamTs) return
     const originalTasks = finalTaskSnapshot(segment)
@@ -253,22 +265,22 @@ export class AgentSessionRenderer {
     const showThinking =
       !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
     const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
+    const header = state.header?.trim()
     // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.
     // Only add blocks for content that was not streamed live; live task_update chunks carry
     // fenced details/output, so adding a final plan block would render a second plan step.
     const blocks = sanitizeFinalMessagePayload([
+      ...(header ? [headerBlock(header)] : []),
       ...(tasks.length && !segment.planStarted
         ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)]
         : []),
       ...(thinkingBlock ? [thinkingBlock] : []),
-      ...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : []),
-      ...(footer ? footerBlocks(footer) : [])
+      ...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
     ] as AnyBlock[])
     const fallbackText = buildFinalFallbackText({
       title: state.title,
       commentaryMarkdown: showThinking ? commentaryMarkdown : '',
-      answerMarkdown,
-      footer
+      answerMarkdown
     })
     const stopResponse = await this.client.chat.stopStream({
       channel: state.channel,
@@ -287,18 +299,19 @@ export class AgentSessionRenderer {
   ): Promise<void> {
     raiseStreamError(segment)
     if (!chunks.length || segment.closed) return
+    const effectiveChunks = this.withHeaderPrefix(state, segment, chunks)
     if (!segment.streamTs) {
-      const initialChunksUsed = await this.ensureStream(state, segment, chunks)
+      const initialChunksUsed = await this.ensureStream(state, segment, effectiveChunks)
       if (initialChunksUsed) return
     }
     if (!segment.streamTs) throw new Error('chat.startStream did not return a stream ts')
     const response = await this.client.chat.appendStream({
       channel: state.channel,
       ts: segment.streamTs,
-      chunks
+      chunks: effectiveChunks
     })
     if (!response.ok) throw new Error(response.error ?? 'chat.appendStream failed')
-    await this.clearStatusAfterVisibleOutput(state, chunks)
+    await this.clearStatusAfterVisibleOutput(state, effectiveChunks)
   }
 
   private async queueText(
@@ -454,6 +467,17 @@ export class AgentSessionRenderer {
     }
     return chunks
   }
+
+  private withHeaderPrefix(
+    state: AgentSessionState,
+    segment: Segment,
+    chunks: AnyChunk[]
+  ): AnyChunk[] {
+    const header = state.header?.trim()
+    if (!header || segment.headerEmitted) return chunks
+    segment.headerEmitted = true
+    return [markdownChunk(`${headerMarkdown(header)}\n`), ...chunks]
+  }
 }
 
 function finalizeOpenTasks(segment: Segment): StreamTask[] {
@@ -589,6 +613,7 @@ function newSegment(): Segment {
     textParts: [],
     tasks: new Map(),
     planStarted: false,
+    headerEmitted: false,
     pendingText: '',
     pendingTextPlanPrefix: true,
     streamedText: '',
@@ -709,10 +734,6 @@ function normalizeDeltaBoundary(previous: string, delta: string): string {
     return `\n${delta}`
   }
   return delta
-}
-
-function footerBlocks(footer: string): AnyBlock[] {
-  return [{ type: 'context', elements: [{ type: 'mrkdwn', text: footer }] }]
 }
 
 export async function withAgentSessionLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -204,15 +204,11 @@ export class CodexSessionRenderer {
     completeOpenTasks(state)
     await this.publishActivitySummary(agentSessionId, state, { final: true })
     await this.publishPendingAssistantText(agentSessionId, state, { force: true })
-    await this.renderer.done(
-      agentSessionId,
-      state.threadId ? codexFooter(state.threadId) : undefined,
-      {
-        streamFinalUpdates: false,
-        commentaryMarkdown: state.commentaryText,
-        answerMarkdown: state.answerText
-      }
-    )
+    await this.renderer.done(agentSessionId, {
+      streamFinalUpdates: false,
+      commentaryMarkdown: state.commentaryText,
+      answerMarkdown: state.answerText
+    })
     state.done = true
     states.delete(agentSessionId)
   }
@@ -302,10 +298,6 @@ export class CodexSessionRenderer {
     }
     await this.publishActivitySummary(agentSessionId, state)
   }
-}
-
-export function codexFooter(threadId: string): string {
-  return `Codex thread \`${threadId}\``
 }
 
 export function hasActiveCodexSession(agentSessionId: string): boolean {

--- a/services/slackbot/src/slack/final-message.test.ts
+++ b/services/slackbot/src/slack/final-message.test.ts
@@ -13,8 +13,7 @@ describe('buildFinalFallbackText', () => {
     const answer = 'x'.repeat(10_000)
     const text = buildFinalFallbackText({
       title: 'Centaur execution',
-      answerMarkdown: answer,
-      footer: 'Codex thread `T-1`'
+      answerMarkdown: answer
     })
     expect(text.length).toBeLessThanOrEqual(slackReplyLimits.text.maxFallbackChars)
     expect(text.startsWith('Centaur execution')).toBe(true)
@@ -25,8 +24,7 @@ describe('buildFinalFallbackText', () => {
   it('includes title and clipped answer without requiring a separate summary field', () => {
     const text = buildFinalFallbackText({
       title: 'Run',
-      answerMarkdown: 'Done.',
-      footer: undefined
+      answerMarkdown: 'Done.'
     })
     expect(text).toBe('Run\nDone.')
   })
@@ -54,7 +52,7 @@ describe('sanitizeFinalMessagePayload', () => {
     expect(total).toBeLessThanOrEqual(slackReplyLimits.stream.markdownChunkChars)
   })
 
-  it('shrinks oversized plan + markdown + footer compositions toward the byte budget', () => {
+  it('shrinks oversized plan + markdown + context compositions toward the byte budget', () => {
     const tasks = Array.from({ length: 12 }, (_, index) => ({
       id: `cmd-${index}`,
       title: `Run command ${index}`,
@@ -89,7 +87,7 @@ describe('sanitizeFinalMessagePayload', () => {
       { type: 'markdown', text: 'Final answer ' + 'w'.repeat(8_000) },
       {
         type: 'context',
-        elements: [{ type: 'mrkdwn', text: 'Codex thread `T-1`' }]
+        elements: [{ type: 'mrkdwn', text: 'Streamed thinking summary.' }]
       }
     ])
     expect(estimatePayloadBytes(blocks)).toBeLessThanOrEqual(

--- a/services/slackbot/src/slack/final-message.ts
+++ b/services/slackbot/src/slack/final-message.ts
@@ -10,13 +10,11 @@ export function buildFinalFallbackText(opts: {
   title: string
   answerMarkdown: string
   commentaryMarkdown?: string
-  footer?: string
 }): string {
   const parts = [
     opts.title.trim(),
     opts.commentaryMarkdown?.trim(),
-    opts.answerMarkdown.trim(),
-    opts.footer?.trim()
+    opts.answerMarkdown.trim()
   ].filter(Boolean)
   const text = parts.join('\n')
   if (!text) return opts.title.trim() || 'Centaur update'


### PR DESCRIPTION
## Summary

The previous behavior put a footer `Codex thread <id>` at the bottom of every assistant Slack message and hard-coded the engine name to "Codex" regardless of the actual engine. Replace it with an italic **header** rendered at the top of every assistant message:

```
_<persona> · <engine-model>_
```

- Persona is normalized to the literal `base` when none is active.
- Engine resolves to a concrete model id when known (`claude-opus-4-7`, `codex-gpt-5`, `claude-sonnet-4-6`, ...) via `CLAUDE_MODEL` / `CODEX_MODEL`, or falls back to the engine name verbatim (e.g. `amp`, unknown engines).
- No overlay segment — it's obvious to the org what's applied.
- The footer is gone; the header replaces it.

## Behavior across combos

| deployment | persona | engine | header |
|---|---|---|---|
| paradigm | none | claude-code | `_base · claude-opus-4-7_` |
| paradigm | legal | codex | `_legal · codex-gpt-5_` |
| tempo    | none | claude-code (sonnet) | `_base · claude-sonnet-4-6_` |
| paradigm | invest | claude-code | `_invest · claude-opus-4-7_` |

The header is recomputed per execution. When persona or engine changes mid-thread the next assistant reply naturally shows the new header (each turn opens a fresh agent-session).

## Implementation

**API (services/api/api)**
- runtime_control.py: new `_agent_session_header(persona_id, engine, harness, model)` + `_engine_model_label` / `_resolve_claude_model_label` / `_resolve_codex_model_label`. The final-delivery outbox payload and `final_delivery.ready` event now carry `session_header` alongside `session_title`.
- workflow_engine.py: new `_compute_agent_session_header(pool, thread_key, selector)` mirrors the title resolution path, and `do_agent_turn` passes the result to `slackbot_client.open_agent_session(header=...)`.
- slackbot_client.py: `open_agent_session` forwards a `header` field to the slackbot.

**Slackbot (services/slackbot/src)**
- slack/agent-session.ts: `OpenAgentSessionInput` gains `header?: string`. The renderer emits the header as the first streamed markdown chunk (`withHeaderPrefix`, guarded by `Segment.headerEmitted` so it can't duplicate on re-emission) and as `blocks[0]` in the composed final message inside `closeTextStream`. `done()` drops its `footer` parameter; `state.footer`, `footerBlocks`, and the corresponding rendering paths are removed.
- slack/codex-session.ts: `codexFooter` is deleted; the codex renderer's `done()` no longer passes a footer.
- slack/final-message.ts: `buildFinalFallbackText` drops the unused `footer` field.
- centaur/final-delivery.ts: reads `session_header` (or `header`) from the outbox payload and passes it to `renderer.open({ header })`. `deliveryFooter` / `codexFooter` import are gone.
- index.ts: `/api/slack/agent-sessions` POST accepts `header`. `/api/slack/agent-sessions/.../done` no longer reads `footer`.
- examples/amp-full-stream.ts: updated to use the new `header` / `thread_id` shape.

The diagnostic "Codex thread" string in slack/duplicate-alert.ts is unrelated to the user-facing assistant footer (it's an ops alert for duplicate Slack events) and is intentionally untouched.

## Test plan

- [x] `bun test` in services/slackbot — 54 tests pass, including new coverage for header rendering:
  - header emitted as the first streamed chunk
  - exactly one header occurrence across streaming (no duplication)
  - header omitted entirely when not supplied
  - header positioned above streamed tasks
  - `blocks[0]` is the header in the composed final message
- [x] `bun run check:types` — slackbot type-checks clean
- [x] `pytest tests/test_workflow_engine_title.py tests/test_agent_control_plane.py` — 19 pass, 53 skipped (DB-fixture skips unrelated). New header tests cover: paradigm+base+claude (default alias), paradigm+legal+codex (`CODEX_MODEL=gpt-5`), tempo-style base+sonnet alias, persona-default fallback when active assignment is empty, explicit full claude id passthrough, unknown-engine fallback.
- [x] Other pytest failures in this repo (`test_call_sh`, `test_db_schema_compatibility`, `test_health_readiness`, `test_tool_manager`) reproduce on main with my changes stashed — pre-existing, unrelated.

## Notes

- Backward compatible: `/api/slack/agent-sessions` extends additively; callers that don't send `header` get no header rendered (no footer either).
- Mid-thread engine/persona changes: each turn opens a new agent-session, so the next reply reflects the new state. No live-update plumbing needed.