### PR TITLE
fix(api): allow empty match_headers when other scan locations set

### DIFF
--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -312,6 +312,21 @@ def _parse_str_list(
     return tuple(raw)
 
 
+def _parse_match_headers(entry: dict, *, name: str) -> tuple[str, ...]:
+    """Validate ``match_headers``; empty/missing yields ``()`` so other scan locations can stand alone."""
+    raw = entry.get("match_headers")
+    if raw is None:
+        return ()
+    if not isinstance(raw, list) or not all(
+        isinstance(item, str) and item for item in raw
+    ):
+        raise ValueError(
+            f"HTTP secret {name!r} has invalid 'match_headers' "
+            f"(expected an array of header names): {raw!r}"
+        )
+    return tuple(raw)
+
+
 def _parse_bool(entry: dict, key: str, *, name: str) -> bool:
     value = entry.get(key, False)
     if not isinstance(value, bool):
@@ -337,9 +352,7 @@ def _parse_replace_secret(
 ) -> HttpSecret:
     """Parse a replace-mode HTTP secret: a placeholder plus scan locations."""
     _reject_foreign_keys(entry, _INJECT_ONLY_KEYS, name=name, mode="replace")
-    match_headers = (
-        _parse_str_list(entry, "match_headers", name=name, noun="header names") or ()
-    )
+    match_headers = _parse_match_headers(entry, name=name)
     match_path = _parse_bool(entry, "match_path", name=name)
     match_query = _parse_bool(entry, "match_query", name=name)
     if not match_headers and not match_path and not match_query:

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -82,9 +82,23 @@ def test_parser_replace_secret_requires_a_scan_location() -> None:
         _parse_secret({"type": "header", "name": "API_KEY"})
 
 
-def test_parser_typed_header_rejects_empty_match_headers() -> None:
+def test_parser_typed_header_rejects_non_string_match_headers() -> None:
     with pytest.raises(ValueError, match="invalid 'match_headers'"):
-        _parse_secret({"type": "header", "name": "API_KEY", "match_headers": []})
+        _parse_secret({"type": "header", "name": "API_KEY", "match_headers": [1]})
+
+
+def test_parser_typed_header_allows_empty_match_headers_with_match_query() -> None:
+    secret = _parse_secret(
+        {
+            "type": "header",
+            "name": "API_KEY",
+            "match_headers": [],
+            "match_query": True,
+        }
+    )
+    assert isinstance(secret, HttpSecret)
+    assert secret.match_headers == ()
+    assert secret.match_query is True
 
 
 def test_parser_replace_mode_rejects_inject_keys() -> None:


### PR DESCRIPTION
The HTTP secret parser rejected `match_headers: []` outright, even when `match_query` or `match_path` was set. Now an empty/missing `match_headers` is treated as no headers to scan, and the existing cross-field check still requires at least one scan location overall.