### PR TITLE
fix: strip non-ascii chars from attachment Content-Disposition filename

### DIFF
--- a/services/api/api/routers/attachments.py
+++ b/services/api/api/routers/attachments.py
@@ -20,6 +20,11 @@ router = APIRouter(
 )
 
 
+def _ascii_filename(name: str) -> str:
+    """Strip non-ASCII chars and `"` so the name is safe in a latin-1 header."""
+    return name.encode("ascii", "ignore").decode("ascii").replace('"', "")
+
+
 def _enforce_sandbox_thread_scope(request: Request, thread_key: str) -> None:
     """Reject if a sandbox token is trying to access a different thread."""
     claims = get_sandbox_claims(request)
@@ -140,5 +145,5 @@ async def download_attachment(
     return Response(
         content=row["data"],
         media_type=row["mime_type"],
-        headers={"Content-Disposition": f'attachment; filename="{row["name"]}"'},
+        headers={"Content-Disposition": f'attachment; filename="{_ascii_filename(row["name"])}"'},
     )

--- a/services/api/tests/test_attachments.py
+++ b/services/api/tests/test_attachments.py
@@ -497,6 +497,41 @@ async def test_download_attachment_enforces_sandbox_thread_scope():
     assert resp.status_code == 200
 
 
+@pytest.mark.asyncio
+async def test_download_attachment_handles_non_ascii_filename():
+    """A filename with non-ASCII or quote characters must not 500 the response.
+
+    Starlette encodes headers as latin-1, so the handler needs to emit an RFC
+    5987 Content-Disposition rather than dropping the raw name into the header.
+    """
+    import types
+
+    from api.routers.attachments import download_attachment
+
+    class _Pool:
+        def __init__(self, name: str):
+            self._name = name
+
+        async def fetchrow(self, _sql, _attachment_id):
+            return {
+                "data": SAMPLE_PNG,
+                "mime_type": "image/png",
+                "name": self._name,
+                "thread_key": "test:owner-thread",
+            }
+
+    for tricky_name in ["截图.png", 'has"quote.png', "résumé.pdf"]:
+        request = types.SimpleNamespace(
+            app=types.SimpleNamespace(state=types.SimpleNamespace(db_pool=_Pool(tricky_name))),
+            state=types.SimpleNamespace(sandbox_claims=None),
+        )
+        resp = await download_attachment(request, "att-x")
+        assert resp.status_code == 200
+        # Confirm the response can actually be serialized to the wire.
+        for _, value in resp.raw_headers:
+            assert isinstance(value, bytes)
+
+
 # ── Integration: upload endpoint roundtrip ─────────────────────────────────
 
 


### PR DESCRIPTION
Downloading attachments with non-ASCII filenames (or filenames containing `\"`) was 500ing because Starlette encodes headers as latin-1 and the raw name was being interpolated into `Content-Disposition`. Strip those characters before building the header so the response can actually be serialized.