### PR TITLE
fix: slack status failures

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -92,6 +92,51 @@ describe('AgentSessionRenderer', () => {
     expect(taskUpdates.at(-1)).toMatchObject({ id: 'sleep-1', status: 'complete' })
   })
 
+  it('continues streaming when assistant status is rejected', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async (params: any) => {
+            calls.push({ method: 'assistant.threads.setStatus', params })
+            return { ok: false, error: 'invalid_thread_ts' }
+          }
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+
+    await renderer.text(sessionId, 'Reply still streams.')
+    await renderer.done(sessionId)
+
+    expect(calls.map(call => call.method)).toContain('chat.startStream')
+    expect(calls.map(call => call.method)).toContain('chat.stopStream')
+    expect(calls.filter(call => call.method === 'assistant.threads.setStatus')).toHaveLength(3)
+  })
+
   it('streams task updates with accumulated details and output', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
@@ -553,7 +598,7 @@ describe('AgentSessionRenderer', () => {
     await renderer.text(sessionId, 'Finished reply')
     expect(renderer.done(sessionId)).rejects.toThrow('stream_already_closed')
 
-    expect(calls.at(-1)).toEqual({
+    expect(calls.filter(call => call.method === 'assistant.threads.setStatus').at(-1)).toEqual({
       method: 'assistant.threads.setStatus',
       params: {
         channel_id: 'C123',

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -2,6 +2,7 @@ import type { AnyBlock, AnyChunk } from '@slack/types'
 import type { WebClient } from '@slack/web-api'
 import { ulid } from '@std/ulid'
 import { slackReplyLimits } from '../constants'
+import { logWarn } from '../logging'
 import {
   markdownChunk,
   planBlock,
@@ -215,20 +216,31 @@ export class AgentSessionRenderer {
       }
       closed = true
     } finally {
-      await this.setStatus(sessionId, '')
+      if (!state.statusCleared) {
+        state.statusCleared = await this.setStatus(sessionId, '')
+      }
       if (closed) sessions.delete(sessionId)
     }
   }
 
-  private async setStatus(sessionId: string, status: string): Promise<void> {
+  private async setStatus(sessionId: string, status: string): Promise<boolean> {
     const state = requireSession(sessionId)
-    const response = await this.client.assistant.threads.setStatus({
-      channel_id: state.channel,
-      thread_ts: state.parentTs,
-      status,
-      ...(status ? { loading_messages: [status] } : {})
-    })
-    if (!response.ok) throw new Error(response.error ?? 'assistant.threads.setStatus failed')
+    try {
+      const response = await this.client.assistant.threads.setStatus({
+        channel_id: state.channel,
+        thread_ts: state.parentTs,
+        status,
+        ...(status ? { loading_messages: [status] } : {})
+      })
+      if (!response.ok) {
+        logStatusFailure(state, status, response.error ?? 'unknown_error')
+        return false
+      }
+      return true
+    } catch (error) {
+      logStatusFailure(state, status, error instanceof Error ? error.message : String(error))
+      return false
+    }
   }
 
   private async closeTextStream(state: AgentSessionState, segment: Segment): Promise<void> {
@@ -442,8 +454,7 @@ export class AgentSessionRenderer {
     chunks: AnyChunk[]
   ): Promise<void> {
     if (state.statusCleared || !hasVisibleStreamChunks(chunks)) return
-    await this.setStatus(state.id, '')
-    state.statusCleared = true
+    state.statusCleared = await this.setStatus(state.id, '')
   }
 
   private planPrefix(state: AgentSessionState, segment: Segment): AnyChunk[] {
@@ -454,6 +465,15 @@ export class AgentSessionRenderer {
     }
     return chunks
   }
+}
+
+function logStatusFailure(state: AgentSessionState, status: string, error: string): void {
+  logWarn('slack_assistant_status_failed', {
+    channel_id: state.channel,
+    thread_ts: state.parentTs,
+    status: status ? 'set' : 'clear',
+    error
+  })
 }
 
 function finalizeOpenTasks(segment: Segment): StreamTask[] {


### PR DESCRIPTION
## Summary

- Make Slack assistant status updates best-effort so `assistant.threads.setStatus` failures do not abort agent session creation or streaming.
- Fix the `invalid_thread_ts` path where `/api/slack/agent-sessions` stopped before reaching the actual `chat.startStream` response.
- Only mark assistant status as cleared after Slack accepts the clear call, allowing final cleanup to retry transient clear failures.

## Issue

Slack can reject `assistant.threads.setStatus` with `invalid_thread_ts` even when the bot can still use the normal streaming response APIs for that thread. Before this change, Centaur treated the status failure as fatal, so a failed “Thinking...” indicator prevented the agent from replying at all. Status is only a loading indicator; `chat.startStream` is the real response path.
