### PR TITLE
[codex] add Slack chrome to landing demo

### DIFF
--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -1008,6 +1008,23 @@ a.home-lockup-link {
   white-space: nowrap;
 }
 
+.thread-panel-head::after {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='178' height='32' viewBox='0 0 178 32'%3E%3Cg fill='%23ffffff' fill-opacity='.04' stroke='%23ffffff' stroke-opacity='.12'%3E%3Crect x='0.5' y='2.5' width='42' height='27' rx='6'/%3E%3Crect x='50.5' y='2.5' width='38' height='27' rx='6'/%3E%3Crect x='96.5' y='2.5' width='28' height='27' rx='6'/%3E%3Crect x='132.5' y='2.5' width='28' height='27' rx='6'/%3E%3C/g%3E%3Cg fill='none' stroke='%23d8d8d1' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.4'%3E%3Ccircle cx='14' cy='13' r='2.6'/%3E%3Cpath d='M10 22c.5-2 2.2-3.2 4-3.2s3.5 1.2 4 3.2'/%3E%3Ccircle cx='19.5' cy='12.5' r='1.8'/%3E%3Cpath d='M19 16.6c1.6 0 2.7 1 3 2.4'/%3E%3Cpath d='M61 18.5V16a5 5 0 0 1 10 0v2.5'/%3E%3Crect x='60' y='18' width='3' height='4' rx='1'/%3E%3Crect x='69' y='18' width='3' height='4' rx='1'/%3E%3Cpath d='M77 15l3 3 3-3'/%3E%3Cpath d='M105 19v-3.5a4 4 0 0 1 8 0V19l1.2 1.5h-10.4z'/%3E%3Cpath d='M107.5 22.5a1.5 1.5 0 0 0 3 0'/%3E%3C/g%3E%3Cg fill='%23d8d8d1'%3E%3Ctext x='27' y='20' font-family='Arial,sans-serif' font-size='12' font-weight='700'%3E21%3C/text%3E%3Ccircle cx='141.2' cy='16' r='1.3'/%3E%3Ccircle cx='146' cy='16' r='1.3'/%3E%3Ccircle cx='150.8' cy='16' r='1.3'/%3E%3C/g%3E%3Ccircle cx='116' cy='7' r='4' fill='%23f15a4a'/%3E%3C/svg%3E") center / contain no-repeat;
+  content: "";
+  flex: 0 0 auto;
+  height: 32px;
+  margin-left: auto;
+  pointer-events: none;
+  width: 178px;
+}
+
+@media (max-width: 760px) {
+  .thread-panel-head::after {
+    background-position: right center;
+    width: 32px;
+  }
+}
+
 .thread-panel-scroll {
   flex: 1;
   min-height: 0;

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -7,8 +7,9 @@ const basePath = process.env.VOCS_BASE_PATH || undefined
 const siteUrl = 'https://centaur.run'
 
 function canonicalHref(path: string) {
-  if (path === '/') return `${siteUrl}/`
-  return `${siteUrl}${path.replace(/\/+$/, '')}/`
+  const root = 'https://centaur.run'
+  if (path === '/') return `${root}/`
+  return `${root}${path.replace(/\/+$/, '')}/`
 }
 
 export default defineConfig({
@@ -64,7 +65,7 @@ export default defineConfig({
   ogImageUrl: (path: string, { baseUrl }: { baseUrl: string }) => {
     const key = path.replace(/\/$/, '') || '/'
     const slug = key === '/' ? 'index' : key.replace(/^\//, '').replace(/\//g, '_')
-    const root = baseUrl ?? siteUrl
+    const root = baseUrl ?? 'https://centaur.run'
     return `${root.replace(/\/$/, '')}/og/${slug}.png`
   },
   ...(basePath ? { basePath } : {}),


### PR DESCRIPTION
## Summary
- add inert Slack-style top-right chrome to the landing page thread demo
- keep the chrome hidden from assistive tech and non-interactive so it does not interfere with the demo

## Validation
- npm run build
- git diff --check

Note: docs build still emits the existing Vocs warning for /centaur-brand-assets.zip from brand.mdx.