### PR TITLE
Force docs to dark mode

### DIFF
--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -142,6 +142,7 @@ export default defineConfig({
       light: '#00E100',
       dark: '#00E100',
     },
+    colorScheme: 'dark',
     variables: {
       color: {
         background: {


### PR DESCRIPTION
## Summary
- restore Vocs colorScheme: 'dark' so docs stay dark regardless of system preference
- keep the theme-aware color cleanup from PR #62 intact

## Validation
- ./node_modules/.bin/vocs build

Note: build emitted the existing warning for /centaur-brand-assets.zip.