### PR TITLE
[codex] Fix thread status dot clipping

### DIFF
--- a/docs/components/ThreadPanel.tsx
+++ b/docs/components/ThreadPanel.tsx
@@ -799,7 +799,7 @@ export default function ThreadPanel({
               >
                 <div className="thread-list-channel-row">
                   <span className="thread-list-channel">
-                    # {thread.channel}
+                    <span className="thread-list-channel-label"># {thread.channel}</span>
                     {isActive && <span className="thread-list-live-dot" />}
                   </span>
                   <span className="thread-list-time">{thread.replies.at(-1)?.time}</span>

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -963,14 +963,20 @@ a.home-lockup-link {
   align-items: center;
   color: var(--thread-ink-3);
   display: inline-flex;
+  flex: 1 1 auto;
   font-size: 9.5px;
   font-weight: 650;
   gap: 6px;
   letter-spacing: 0.05em;
   min-width: 0;
+  text-transform: uppercase;
+}
+
+.thread-list-channel-label {
+  display: block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-transform: uppercase;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- move thread channel truncation into a nested label span
- keep the active status dot outside the clipped text box so its glow renders fully

## Testing
- npm run build
- checked local docs page at http://127.0.0.1:4173/