### PR TITLE
test: add Slack Emulate e2e coverage

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@typescript/native-preview':
         specifier: ^7.0.0-dev.20260512.1
         version: 7.0.0-dev.20260518.1
+      emulate:
+        specifier: ^0.5.0
+        version: 0.5.0(hono@4.12.19)
       oxfmt:
         specifier: ^0.49.0
         version: 0.49.0
@@ -258,6 +261,12 @@ packages:
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1206,6 +1215,10 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  emulate@0.5.0:
+    resolution: {integrity: sha512-2LrOE8sqa1ITQ1aRR3kZhAhOCNz8hu+Kea9oBKdG/jEK6I/RYlMgHbsvQmbTTtr+nx6+fOOWkL6wqvfLeF5vuA==}
+    hasBin: true
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -1976,6 +1989,10 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.6
       yargs: 17.7.2
+
+  '@hono/node-server@1.19.14(hono@4.12.19)':
+    dependencies:
+      hono: 4.12.19
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2912,6 +2929,15 @@ snapshots:
       gopd: 1.2.0
 
   emoji-regex@8.0.0: {}
+
+  emulate@0.5.0(hono@4.12.19):
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.19)
+      commander: 14.0.3
+      picocolors: 1.1.1
+      yaml: 2.8.4
+    transitivePeerDependencies:
+      - hono
 
   end-of-stream@1.4.5:
     dependencies:

--- a/services/slackbot/bun.lock
+++ b/services/slackbot/bun.lock
@@ -17,6 +17,7 @@
         "@types/bun": "^1.3.13",
         "@types/node": "^25.7.0",
         "@typescript/native-preview": "^7.0.0-dev.20260512.1",
+        "emulate": "^0.5.0",
         "oxfmt": "^0.49.0",
         "oxlint": "^1.64.0",
         "oxlint-tsgolint": "^0.22.1",
@@ -82,6 +83,8 @@
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
@@ -383,6 +386,8 @@
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "emulate": ["emulate@0.5.0", "", { "dependencies": { "@hono/node-server": "^1", "commander": "^14", "picocolors": "^1.1.1", "yaml": "^2" }, "bin": { "emulate": "dist/index.js" } }, "sha512-2LrOE8sqa1ITQ1aRR3kZhAhOCNz8hu+Kea9oBKdG/jEK6I/RYlMgHbsvQmbTTtr+nx6+fOOWkL6wqvfLeF5vuA=="],
+
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
@@ -492,6 +497,8 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "pino": ["pino@9.12.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "slow-redact": "^0.3.0", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw=="],
 

--- a/services/slackbot/package.json
+++ b/services/slackbot/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "bun --hot --watch src/index.ts",
     "test": "bun test src/*.test.ts src/**/*.test.ts",
+    "test:e2e:slack": "bun test test/emulate",
     "format": "oxfmt --config='oxfmt.config.ts' --write",
     "lint": "oxlint --config='oxlint.config.ts' --type-aware --type-check --fix-dangerously",
     "check": "bun format && bun lint",
@@ -28,6 +29,7 @@
     "@types/bun": "^1.3.13",
     "@types/node": "^25.7.0",
     "@typescript/native-preview": "^7.0.0-dev.20260512.1",
+    "emulate": "^0.5.0",
     "oxfmt": "^0.49.0",
     "oxlint": "^1.64.0",
     "oxlint-tsgolint": "^0.22.1",

--- a/services/slackbot/src/config.ts
+++ b/services/slackbot/src/config.ts
@@ -4,6 +4,7 @@ const EnvSchema = z.object({
   NODE_ENV: z.string().default('development'),
   PORT: z.coerce.number().int().positive().default(3001),
   SLACK_BOT_TOKEN: z.string().optional(),
+  SLACK_API_URL: z.string().url().optional(),
   SLACK_SIGNING_SECRET: z.string().optional(),
   SLACKBOT_API_KEY: z.string().optional(),
   CENTAUR_API_URL: z.string().url().default('http://localhost:8000'),

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -26,8 +26,10 @@ const config = loadConfig()
 const deploymentAlertChannel = config.RUNTIME_ERROR_ALERT_CHANNEL.trim()
 const resolver = new SlackClientResolver(
   new EnvSlackInstallationStore({
-    token: config.SLACK_BOT_TOKEN
-  })
+    token: config.SLACK_BOT_TOKEN,
+    slackApiUrl: config.SLACK_API_URL
+  }),
+  { slackApiUrl: config.SLACK_API_URL }
 )
 const handoff = new CentaurHandoff(config)
 const deduper = new EventDeduper(config.SLACK_EVENT_DEDUP_TTL_MS)

--- a/services/slackbot/src/slack/installations.ts
+++ b/services/slackbot/src/slack/installations.ts
@@ -1,5 +1,9 @@
 import { WebClient } from '@slack/web-api'
 
+export type SlackClientOptions = {
+  slackApiUrl?: string
+}
+
 export type SlackInstallation = {
   teamId?: string
   enterpriseId?: string
@@ -18,15 +22,19 @@ export interface SlackInstallationStore {
 
 export class EnvSlackInstallationStore implements SlackInstallationStore {
   readonly token?: string
+  private readonly slackApiUrl?: string
   private botUserId?: string
 
-  constructor(opts: { token?: string }) {
+  constructor(opts: { token?: string; slackApiUrl?: string }) {
     this.token = opts.token
+    this.slackApiUrl = opts.slackApiUrl
   }
 
   async findInstallation(key: SlackInstallationKey): Promise<SlackInstallation | null> {
     if (!this.token) return null
-    this.botUserId ??= await fetchBotUserId(this.token)
+    this.botUserId ??= await fetchBotUserId(this.token, {
+      slackApiUrl: this.slackApiUrl
+    })
     return {
       teamId: key.teamId,
       enterpriseId: key.enterpriseId,
@@ -36,16 +44,21 @@ export class EnvSlackInstallationStore implements SlackInstallationStore {
   }
 }
 
-async function fetchBotUserId(token: string): Promise<string | undefined> {
-  const auth = await new WebClient(token).auth.test()
+async function fetchBotUserId(
+  token: string,
+  opts: SlackClientOptions = {}
+): Promise<string | undefined> {
+  const auth = await createSlackWebClient(token, opts).auth.test()
   return typeof auth.user_id === 'string' ? auth.user_id : undefined
 }
 
 export class SlackClientResolver {
   readonly store: SlackInstallationStore
+  private readonly slackApiUrl?: string
 
-  constructor(store: SlackInstallationStore) {
+  constructor(store: SlackInstallationStore, opts: SlackClientOptions = {}) {
     this.store = store
+    this.slackApiUrl = opts.slackApiUrl
   }
 
   async resolve(
@@ -57,6 +70,26 @@ export class SlackClientResolver {
         `No Slack installation for team=${key.teamId ?? '-'} enterprise=${key.enterpriseId ?? '-'}`
       )
     }
-    return { installation, client: new WebClient(installation.botToken) }
+    return {
+      installation,
+      client: createSlackWebClient(installation.botToken, {
+        slackApiUrl: this.slackApiUrl
+      })
+    }
   }
+}
+
+export function createSlackWebClient(
+  token: string,
+  opts: SlackClientOptions = {}
+): WebClient {
+  return new WebClient(
+    token,
+    opts.slackApiUrl
+      ? {
+          slackApiUrl: opts.slackApiUrl,
+          allowAbsoluteUrls: false
+        }
+      : undefined
+  )
 }

--- a/services/slackbot/test/emulate/slack-e2e.test.ts
+++ b/services/slackbot/test/emulate/slack-e2e.test.ts
@@ -1,0 +1,520 @@
+import { createHmac } from 'node:crypto'
+import { connect } from 'node:net'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { createEmulator, type Emulator } from 'emulate'
+import { createSlackWebClient } from '../../src/slack/installations'
+import { pollFinalDeliveriesOnce } from '../../src/centaur/final-delivery'
+import { createPatchedSlackApi } from './slack-patches'
+
+const IMPLEMENTATION = 'custom-web-api-wrapper'
+const BOT_TOKEN = 'xoxb-centaur-emulate'
+const USER_TOKEN = 'xoxp-centaur-user'
+const API_KEY = 'aiv2_slackbot_emulate'
+const SIGNING_SECRET = 'emulate-signing-secret'
+const BOT_USER_ID = 'U000000001'
+const USER_ID = 'UEMULATEUSER'
+const TEAM_ID = 'T000000001'
+const CHANNEL_ID = 'C000000001'
+
+type WorkflowRunRequest = {
+  workflow_name: string
+  trigger_key: string
+  input: {
+    thread_key: string
+    parts: Array<{ type: string; text?: string }>
+    history_messages?: Array<{ role: string; parts: Array<{ type: string; text?: string }> }>
+    message_id: string
+    user_id: string
+    metadata: { is_mention?: boolean; slack?: Record<string, unknown> }
+    delivery: {
+      platform: string
+      channel: string
+      thread_ts: string
+      recipient_user_id: string
+      recipient_team_id: string
+    }
+  }
+}
+
+type FakeDelivery = {
+  execution_id: string
+  thread_key: string
+  delivery: Record<string, unknown>
+  final_payload: Record<string, unknown>
+}
+
+let emulator: Emulator
+let patchedSlack: Awaited<ReturnType<typeof createPatchedSlackApi>>
+let centaur: Awaited<ReturnType<typeof createFakeCentaur>>
+let app: Awaited<typeof import('../../src/index')>['app']
+let slack: ReturnType<typeof createSlackWebClient>
+let botSlack: ReturnType<typeof createSlackWebClient>
+
+beforeAll(async () => {
+  const slackPort = await preferredPort(4003)
+  emulator = await createEmulator({
+    service: 'slack',
+    port: slackPort,
+    seed: {
+      tokens: {
+        [BOT_TOKEN]: {
+          login: BOT_USER_ID,
+          scopes: ['chat:write', 'channels:read', 'users:read', 'reactions:write']
+        },
+        [USER_TOKEN]: {
+          login: USER_ID,
+          scopes: ['chat:write', 'channels:read', 'users:read', 'reactions:write']
+        }
+      },
+      slack: {
+        team: { name: 'Centaur E2E', domain: 'centaur-e2e' },
+        users: [{ name: 'tester', real_name: 'Test User', email: 'tester@example.com' }],
+        channels: [{ name: 'centaur-e2e', topic: 'Slackbot E2E tests' }],
+        bots: [{ name: 'centaur' }],
+        signing_secret: SIGNING_SECRET
+      }
+    }
+  })
+  patchedSlack = await createPatchedSlackApi(emulator)
+  centaur = await createFakeCentaur()
+  const slackApiUrl = `${patchedSlack.url}/api/`
+  slack = createSlackWebClient(USER_TOKEN, { slackApiUrl })
+  botSlack = createSlackWebClient(BOT_TOKEN, { slackApiUrl })
+
+  Object.assign(process.env, {
+    NODE_ENV: 'test',
+    SLACK_BOT_TOKEN: BOT_TOKEN,
+    SLACK_API_URL: slackApiUrl,
+    SLACK_SIGNING_SECRET: SIGNING_SECRET,
+    SLACKBOT_API_KEY: API_KEY,
+    CENTAUR_API_URL: centaur.url,
+    SLACK_EVENT_DEDUP_TTL_MS: '600000',
+    RUNTIME_ERROR_ALERT_CHANNEL: ''
+  })
+
+  ;({ app } = await import('../../src/index'))
+})
+
+beforeEach(async () => {
+  emulator.reset()
+  centaur.reset()
+})
+
+afterAll(async () => {
+  await patchedSlack?.close()
+  await emulator?.close()
+  await centaur?.close()
+})
+
+describe(`Slack Emulate E2E (${IMPLEMENTATION})`, () => {
+  it('dispatches an app_mention into a slack_thread_turn workflow with Slack metadata', async () => {
+    const parent = await postUserMessage(`<@${BOT_USER_ID}> summarize this incident`)
+    const waits: Promise<unknown>[] = []
+    const response = await app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-emulate-mention',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          ts: parent.ts,
+          text: `<@${BOT_USER_ID}> summarize this incident`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true })
+    await Promise.all(waits)
+
+    const run = onlyRun()
+    expect(run.workflow_name).toBe('slack_thread_turn')
+    expect(run.trigger_key).toBe(`slack:${TEAM_ID}:${CHANNEL_ID}:${parent.ts}`)
+    expect(run.input.thread_key).toBe(`slack:${TEAM_ID}:${CHANNEL_ID}:${parent.ts}`)
+    expect(run.input.message_id).toBe(`slack:${TEAM_ID}:${CHANNEL_ID}:${parent.ts}`)
+    expect(run.input.parts).toEqual([{ type: 'text', text: 'summarize this incident' }])
+    expect(run.input.user_id).toBe(USER_ID)
+    expect(run.input.metadata.is_mention).toBe(true)
+    expect(run.input.metadata.slack?.message_ts).toBe(parent.ts)
+    expect(run.input.delivery).toMatchObject({
+      platform: 'slack',
+      channel: CHANNEL_ID,
+      thread_ts: parent.ts,
+      recipient_user_id: USER_ID,
+      recipient_team_id: TEAM_ID
+    })
+  })
+
+  it('includes prior Slack thread replies as history for reply mentions', async () => {
+    const parent = await postUserMessage('Original request')
+    await postBotMessage('Earlier assistant context', parent.ts)
+    await postUserMessage('Prior user clarification', parent.ts)
+    const current = await postUserMessage(`<@${BOT_USER_ID}> retry`, parent.ts)
+    const waits: Promise<unknown>[] = []
+
+    await app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-emulate-thread-reply',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          ts: current.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> retry`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    await Promise.all(waits)
+
+    const history = onlyRun().input.history_messages ?? []
+    expect(history.map(item => item.role)).toEqual(['user', 'assistant', 'user'])
+    expect(history.flatMap(item => item.parts.map(part => part.text))).toContain('Original request')
+    expect(history.flatMap(item => item.parts.map(part => part.text))).toContain(
+      'Earlier assistant context'
+    )
+    expect(history.flatMap(item => item.parts.map(part => part.text))).toContain(
+      'Prior user clarification'
+    )
+  })
+
+  it('ignores bot-originated events and duplicate Slack event IDs', async () => {
+    const botMessage = await postBotMessage(`<@${BOT_USER_ID}> bot echo`)
+    const waits: Promise<unknown>[] = []
+    await app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-emulate-bot',
+        event: {
+          type: 'app_mention',
+          bot_id: 'BEMULATE',
+          user: BOT_USER_ID,
+          channel: CHANNEL_ID,
+          ts: botMessage.ts,
+          text: `<@${BOT_USER_ID}> bot echo`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    await Promise.all(waits)
+    expect(centaur.workflowRuns).toHaveLength(0)
+
+    const message = await postUserMessage(`<@${BOT_USER_ID}> once`)
+    const payload = signedSlackEvent({
+      event_id: 'Ev-emulate-duplicate',
+      event: {
+        type: 'app_mention',
+        user: USER_ID,
+        channel: CHANNEL_ID,
+        ts: message.ts,
+        text: `<@${BOT_USER_ID}> once`
+      }
+    })
+    const firstWaits: Promise<unknown>[] = []
+    const first = await app.request('/api/webhooks/slack', payload, {}, waitUntilContext(firstWaits))
+    await Promise.all(firstWaits)
+    const second = await app.request('/api/webhooks/slack', payload)
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect(await second.json()).toEqual({ ok: true, duplicate: true })
+    expect(centaur.workflowRuns).toHaveLength(1)
+  })
+
+  it('records reactions in Emulate without handing reaction events to Centaur', async () => {
+    const message = await postUserMessage('Please react to this')
+    const reaction = await slack.reactions.add({
+      channel: CHANNEL_ID,
+      timestamp: message.ts,
+      name: 'eyes'
+    })
+    expect(reaction.ok).toBe(true)
+
+    const response = await app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-emulate-reaction',
+        event: {
+          type: 'reaction_added',
+          user: USER_ID,
+          reaction: 'eyes',
+          item: { type: 'message', channel: CHANNEL_ID, ts: message.ts }
+        }
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(centaur.workflowRuns).toHaveLength(0)
+    const reactions = await slack.reactions.get({ channel: CHANNEL_ID, timestamp: message.ts })
+    expect(reactions.message?.reactions?.[0]).toMatchObject({ name: 'eyes', count: 1 })
+  })
+
+  it('posts, updates, deletes, and reads Slack messages through Slackbot API routes', async () => {
+    const post = await app.request('/api/slack/messages', {
+      method: 'POST',
+      headers: apiHeaders(),
+      body: JSON.stringify({ channel: CHANNEL_ID, text: 'route-created' })
+    })
+    expect(post.status).toBe(200)
+    const posted = (await post.json()) as { ts: string }
+
+    const update = await app.request('/api/slack/messages', {
+      method: 'PATCH',
+      headers: apiHeaders(),
+      body: JSON.stringify({ channel: CHANNEL_ID, ts: posted.ts, text: 'route-updated' })
+    })
+    expect(update.status).toBe(200)
+    expect(await channelText()).toContain('route-updated')
+
+    const replies = await app.request(
+      `/api/slack/conversations/replies?channel=${CHANNEL_ID}&ts=${posted.ts}`,
+      { headers: apiHeaders() }
+    )
+    expect(replies.status).toBe(200)
+    expect(((await replies.json()) as { messages: Array<{ text: string }> }).messages[0]?.text).toBe(
+      'route-updated'
+    )
+
+    const deleted = await app.request('/api/slack/messages', {
+      method: 'DELETE',
+      headers: apiHeaders(),
+      body: JSON.stringify({ channel: CHANNEL_ID, ts: posted.ts })
+    })
+    expect(deleted.status).toBe(200)
+    expect(await channelText()).not.toContain('route-updated')
+  })
+
+  it('renders agent sessions through patched Slack stream endpoints into Emulate history', async () => {
+    const parent = await postUserMessage('Start session here')
+    const opened = await app.request('/api/slack/agent-sessions', {
+      method: 'POST',
+      headers: apiHeaders(),
+      body: JSON.stringify({
+        channel: CHANNEL_ID,
+        parent_ts: parent.ts,
+        recipient_team_id: TEAM_ID,
+        recipient_user_id: USER_ID,
+        title: 'Centaur execution',
+        header: 'base · codex'
+      })
+    })
+    expect(opened.status).toBe(200)
+    const { session_id: sessionId } = (await opened.json()) as { session_id: string }
+
+    await app.request(`/api/slack/agent-sessions/${sessionId}/step`, {
+      method: 'POST',
+      headers: apiHeaders(),
+      body: JSON.stringify({
+        id: 'cmd-1',
+        title: 'Command execution',
+        status: 'in_progress',
+        details: 'call demo ping'
+      })
+    })
+    await app.request(`/api/slack/agent-sessions/${sessionId}/text`, {
+      method: 'POST',
+      headers: apiHeaders(),
+      body: JSON.stringify({ markdown: 'Final answer from stream.' })
+    })
+    const done = await app.request(`/api/slack/agent-sessions/${sessionId}/done`, {
+      method: 'POST',
+      headers: apiHeaders(),
+      body: JSON.stringify({})
+    })
+    expect(done.status).toBe(200)
+
+    const text = await threadText(parent.ts)
+    expect(text).toContain('Command execution')
+    expect(text).toContain('Final answer from stream.')
+  })
+
+  it('polls final-delivery fallback and posts the completed result into Slack', async () => {
+    const parent = await postUserMessage('Fallback target')
+    centaur.deliveries.push({
+      execution_id: 'exe-emulate-final',
+      thread_key: `slack:${TEAM_ID}:${CHANNEL_ID}:${parent.ts}`,
+      delivery: {
+        platform: 'slack',
+        channel: CHANNEL_ID,
+        thread_ts: parent.ts,
+        recipient_user_id: USER_ID,
+        team_id: TEAM_ID
+      },
+      final_payload: {
+        session_title: 'Recovered execution',
+        result_text: 'Fallback result delivered.'
+      }
+    })
+
+    await pollFinalDeliveriesOnce(
+      {
+        CENTAUR_API_URL: centaur.url,
+        SLACKBOT_API_KEY: API_KEY,
+        CENTAUR_API_KEY: undefined
+      } as any,
+      botSlack
+    )
+
+    expect(centaur.delivered).toContain('exe-emulate-final')
+    expect(await threadText(parent.ts)).toContain('Fallback result delivered.')
+  })
+})
+
+async function postUserMessage(text: string, threadTs?: string): Promise<{ ts: string }> {
+  const response = await slack.chat.postMessage({
+    channel: CHANNEL_ID,
+    thread_ts: threadTs,
+    text
+  })
+  expect(response.ok).toBe(true)
+  return { ts: String(response.ts) }
+}
+
+async function postBotMessage(text: string, threadTs?: string): Promise<{ ts: string }> {
+  const response = await botSlack.chat.postMessage({
+    channel: CHANNEL_ID,
+    thread_ts: threadTs,
+    text
+  })
+  expect(response.ok).toBe(true)
+  return { ts: String(response.ts) }
+}
+
+async function channelText(): Promise<string> {
+  const history = await slack.conversations.history({ channel: CHANNEL_ID, limit: 100 })
+  return (history.messages ?? []).map(message => message.text ?? '').join('\n')
+}
+
+async function threadText(threadTs: string): Promise<string> {
+  const replies = await slack.conversations.replies({
+    channel: CHANNEL_ID,
+    ts: threadTs,
+    limit: 100
+  })
+  return (replies.messages ?? []).map(message => message.text ?? '').join('\n')
+}
+
+function onlyRun(): WorkflowRunRequest {
+  expect(centaur.workflowRuns).toHaveLength(1)
+  return centaur.workflowRuns[0] as WorkflowRunRequest
+}
+
+function signedSlackEvent(input: {
+  event_id: string
+  event: Record<string, unknown>
+}): RequestInit {
+  const body = JSON.stringify({
+    type: 'event_callback',
+    team_id: TEAM_ID,
+    event_id: input.event_id,
+    event: input.event
+  })
+  const timestamp = Math.floor(Date.now() / 1000).toString()
+  const signature = `v0=${createHmac('sha256', SIGNING_SECRET)
+    .update(`v0:${timestamp}:${body}`)
+    .digest('hex')}`
+  return {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-slack-request-timestamp': timestamp,
+      'x-slack-signature': signature
+    },
+    body
+  }
+}
+
+function apiHeaders(): Record<string, string> {
+  return {
+    authorization: `Bearer ${API_KEY}`,
+    'content-type': 'application/json'
+  }
+}
+
+function waitUntilContext(waits: Promise<unknown>[]): any {
+  return {
+    waitUntil: (promise: Promise<unknown>) => waits.push(promise),
+    passThroughOnException: () => {},
+    props: {}
+  }
+}
+
+async function createFakeCentaur() {
+  const workflowRuns: WorkflowRunRequest[] = []
+  const deliveries: FakeDelivery[] = []
+  const delivered: string[] = []
+  const failed: string[] = []
+  const port = await preferredPort(4014)
+  const server = Bun.serve({
+    port,
+    async fetch(request: Request) {
+      const url = new URL(request.url)
+      if (url.pathname === '/workflows/runs') {
+        workflowRuns.push((await request.json()) as WorkflowRunRequest)
+        return Response.json({ ok: true, run_id: `wfr-${workflowRuns.length}` })
+      }
+      if (url.pathname === '/agent/final-deliveries/claim') {
+        return Response.json({ deliveries: deliveries.splice(0) })
+      }
+      const deliveredMatch = /^\/agent\/final-deliveries\/([^/]+)\/delivered$/.exec(url.pathname)
+      if (deliveredMatch) {
+        delivered.push(decodeURIComponent(deliveredMatch[1] ?? ''))
+        return Response.json({ ok: true })
+      }
+      const failedMatch = /^\/agent\/final-deliveries\/([^/]+)\/failed$/.exec(url.pathname)
+      if (failedMatch) {
+        failed.push(decodeURIComponent(failedMatch[1] ?? ''))
+        return Response.json({ ok: true })
+      }
+      return Response.json({ ok: false, error: 'not_found' }, { status: 404 })
+    }
+  })
+  return {
+    url: `http://localhost:${server.port}`,
+    workflowRuns,
+    deliveries,
+    delivered,
+    failed,
+    reset() {
+      workflowRuns.length = 0
+      deliveries.length = 0
+      delivered.length = 0
+      failed.length = 0
+    },
+    async close() {
+      await server.stop()
+    }
+  }
+}
+
+async function preferredPort(port: number): Promise<number> {
+  if (await isPortOpen(port)) {
+    for (let candidate = port + 1; candidate < port + 100; candidate++) {
+      if (!(await isPortOpen(candidate))) return candidate
+    }
+    throw new Error(`No available port near ${port}`)
+  }
+  return port
+}
+
+async function isPortOpen(port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const socket = connect(port, '127.0.0.1')
+    socket.once('connect', () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once('error', () => resolve(false))
+    socket.setTimeout(250, () => {
+      socket.destroy()
+      resolve(false)
+    })
+  })
+}

--- a/services/slackbot/test/emulate/slack-patches.ts
+++ b/services/slackbot/test/emulate/slack-patches.ts
@@ -1,0 +1,227 @@
+import type { Emulator } from 'emulate'
+
+type PatchedSlack = {
+  url: string
+  close(): Promise<void>
+}
+
+type StreamState = {
+  channel: string
+  ts: string
+  text: string
+}
+
+const STREAMS = new Map<string, StreamState>()
+
+export async function createPatchedSlackApi(emulator: Emulator): Promise<PatchedSlack> {
+  const port = await availablePort(4013)
+  const server = Bun.serve({
+    port,
+    async fetch(request: Request) {
+      const url = new URL(request.url)
+      const pathname = normalizeSlackPath(url.pathname)
+      if (pathname === '/api/assistant.threads.setStatus') {
+        // Emulate 0.5.0 does not implement Slack assistant.threads.setStatus.
+        // Remove this patch when https://emulate.dev/docs/slack lists the endpoint.
+        return slackOk()
+      }
+      if (pathname === '/api/assistant.threads.setTitle') {
+        // Emulate 0.5.0 does not implement Slack assistant.threads.setTitle.
+        // Remove this patch when https://emulate.dev/docs/slack lists the endpoint.
+        return slackOk()
+      }
+      if (pathname === '/api/chat.startStream') {
+        // Emulate 0.5.0 does not implement Slack chat.startStream.
+        // This maps streams onto chat.postMessage so E2E tests can still inspect state.
+        return startStream(emulator.url, request)
+      }
+      if (pathname === '/api/chat.appendStream') {
+        // Emulate 0.5.0 does not implement Slack chat.appendStream.
+        // This accumulates chunks into the message created by chat.startStream.
+        return appendStream(emulator.url, request)
+      }
+      if (pathname === '/api/chat.stopStream') {
+        // Emulate 0.5.0 does not implement Slack chat.stopStream.
+        // This finalizes the accumulated stream text through chat.update.
+        return stopStream(emulator.url, request)
+      }
+      return fetch(new URL(`${pathname}${url.search}`, emulator.url), {
+        method: request.method,
+        headers: request.headers,
+        body: request.body
+      })
+    }
+  })
+
+  return {
+    url: `http://localhost:${server.port}`,
+    close: async () => {
+      await server.stop()
+    }
+  }
+}
+
+function normalizeSlackPath(pathname: string): string {
+  return pathname.startsWith('/api/') ? pathname : `/api${pathname}`
+}
+
+async function availablePort(preferred: number): Promise<number> {
+  for (let port = preferred; port < preferred + 100; port++) {
+    if (!(await isPortOpen(port))) return port
+  }
+  throw new Error(`No available port near ${preferred}`)
+}
+
+async function isPortOpen(port: number): Promise<boolean> {
+  const { connect } = await import('node:net')
+  return new Promise(resolve => {
+    const socket = connect(port, '127.0.0.1')
+    socket.once('connect', () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once('error', () => resolve(false))
+    socket.setTimeout(250, () => {
+      socket.destroy()
+      resolve(false)
+    })
+  })
+}
+
+async function startStream(emulatorUrl: string, request: Request): Promise<Response> {
+  const body = await slackBody(request)
+  const channel = stringField(body.channel)
+  const threadTs = stringField(body.thread_ts)
+  const text = chunksText(body.chunks) || ' '
+  const posted = await slackFetch(emulatorUrl, request, '/api/chat.postMessage', {
+    channel,
+    thread_ts: threadTs || undefined,
+    text
+  })
+  if (!posted.ok) return Response.json(posted)
+  const ts = stringField(posted.ts)
+  STREAMS.set(streamKey(channel, ts), { channel, ts, text })
+  return Response.json({ ok: true, channel, ts })
+}
+
+async function appendStream(emulatorUrl: string, request: Request): Promise<Response> {
+  const body = await slackBody(request)
+  const channel = stringField(body.channel)
+  const ts = stringField(body.ts)
+  const key = streamKey(channel, ts)
+  const existing = STREAMS.get(key) ?? { channel, ts, text: '' }
+  existing.text += chunksText(body.chunks)
+  STREAMS.set(key, existing)
+  await slackFetch(emulatorUrl, request, '/api/chat.update', {
+    channel,
+    ts,
+    text: existing.text || ' '
+  })
+  return Response.json({ ok: true, channel, ts })
+}
+
+async function stopStream(emulatorUrl: string, request: Request): Promise<Response> {
+  const body = await slackBody(request)
+  const channel = stringField(body.channel)
+  const ts = stringField(body.ts)
+  const key = streamKey(channel, ts)
+  const existing = STREAMS.get(key) ?? { channel, ts, text: '' }
+  const finalText = [existing.text, blocksText(body.blocks), chunksText(body.chunks)]
+    .filter(text => text.trim())
+    .join('\n')
+  await slackFetch(emulatorUrl, request, '/api/chat.update', {
+    channel,
+    ts,
+    text: finalText || existing.text || ' '
+  })
+  STREAMS.delete(key)
+  return Response.json({ ok: true, channel, ts })
+}
+
+async function slackBody(request: Request): Promise<Record<string, unknown>> {
+  const contentType = request.headers.get('content-type') ?? ''
+  const text = await request.text()
+  if (contentType.includes('application/json')) {
+    return JSON.parse(text || '{}') as Record<string, unknown>
+  }
+  const params = new URLSearchParams(text)
+  return Object.fromEntries(
+    Array.from(params.entries()).map(([key, value]) => [key, parseMaybeJson(value)])
+  )
+}
+
+async function slackFetch(
+  emulatorUrl: string,
+  original: Request,
+  path: string,
+  body: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const response = await fetch(new URL(path, emulatorUrl), {
+    method: 'POST',
+    headers: {
+      authorization: original.headers.get('authorization') ?? '',
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+  return (await response.json()) as Record<string, unknown>
+}
+
+function slackOk(): Response {
+  return Response.json({ ok: true })
+}
+
+function streamKey(channel: string, ts: string): string {
+  return `${channel}:${ts}`
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function parseMaybeJson(value: string): unknown {
+  const trimmed = value.trim()
+  if (!trimmed || !['[', '{'].includes(trimmed[0] ?? '')) return value
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return value
+  }
+}
+
+function chunksText(value: unknown): string {
+  if (!Array.isArray(value)) return ''
+  return value
+    .map(chunk => {
+      if (!chunk || typeof chunk !== 'object') return ''
+      const item = chunk as Record<string, unknown>
+      if (typeof item.text === 'string') return item.text
+      if (typeof item.title === 'string') return item.title
+      if (typeof item.output === 'string') return item.output
+      if (typeof item.details === 'string') return item.details
+      return blocksText(item.blocks)
+    })
+    .filter(Boolean)
+    .join('\n')
+}
+
+function blocksText(value: unknown): string {
+  if (!Array.isArray(value)) return ''
+  return value.map(blockText).filter(Boolean).join('\n')
+}
+
+function blockText(block: unknown): string {
+  if (!block || typeof block !== 'object') return ''
+  const item = block as Record<string, unknown>
+  if (typeof item.text === 'string') return item.text
+  const text = item.text
+  if (
+    text &&
+    typeof text === 'object' &&
+    typeof (text as Record<string, unknown>).text === 'string'
+  ) {
+    return String((text as Record<string, unknown>).text)
+  }
+  if (Array.isArray(item.elements)) return item.elements.map(blockText).filter(Boolean).join('\n')
+  return ''
+}

--- a/services/slackbot/tsconfig.json
+++ b/services/slackbot/tsconfig.json
@@ -39,7 +39,8 @@
   },
   "include": [
     "src/**/*",
-    "examples/**/*"
+    "examples/**/*",
+    "test/**/*"
   ],
   "files": [
     "env.d.ts",


### PR DESCRIPTION
## Summary
- add SLACK_API_URL wiring for Slack WebClient construction
- add Emulate-backed Slack E2E tests for the current custom web-api wrapper
- keep unsupported Emulate Slack assistant/stream endpoint patches isolated and visible

## Validation
- bun test src/*.test.ts src/**/*.test.ts
- bun run test:e2e:slack
- bun run check:types
- bun oxlint --config=oxlint.config.ts test/emulate src/config.ts src/index.ts src/slack/installations.ts