### PR TITLE
feat: render slack thinking as plan tasks

### DIFF
--- a/services/slackbot/src/constants.ts
+++ b/services/slackbot/src/constants.ts
@@ -10,7 +10,8 @@ export const slackReplyLimits = {
     planTitleChars: 256,
     taskCount: 24,
     taskTitleChars: 128,
-    taskDetailsChars: 128,
+    /** Slack caps task_update chunk text at 256 chars; keep 10% headroom. */
+    taskDetailsChars: 230,
     taskOutputChars: 48
   },
   finalPlan: {

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -430,7 +430,7 @@ describe('AgentSessionRenderer', () => {
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
   })
 
-  it('renders thinking in a context block and the answer in markdown on finalize', async () => {
+  it('shows thinking text by default and renders the answer in markdown on finalize', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -478,7 +478,6 @@ describe('AgentSessionRenderer', () => {
       blocks.some(
         (block: any) =>
           block.type === 'context' &&
-          String(block.elements?.[0]?.text ?? '').includes('*Thinking*') &&
           String(block.elements?.[0]?.text ?? '').includes('Planning the tool calls.')
       )
     ).toBe(true)

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -274,8 +274,7 @@ export class AgentSessionRenderer {
       state.finalAnswerMarkdown?.trim() || segment.streamedText.trim() || segment.textParts.join('')
     const answerMarkdown = finalMarkdownForBlocks(answerSource, tasks)
     const streamedTextLive = Boolean(segment.streamedText.trim())
-    const showThinking =
-      !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
+    const showThinking = !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
     const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
     const header = state.header?.trim()
     // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -587,10 +587,9 @@ describe('CodexSessionRenderer', () => {
       chunk => chunk.type === 'markdown_text' && String(chunk.text).includes('Done.')
     )
     expect(firstTaskIndex).toBeGreaterThanOrEqual(0)
-    expect(thinkingIndex).toBeGreaterThan(firstTaskIndex)
+    expect(thinkingIndex).toBe(-1)
     expect(firstTextIndex).toBeGreaterThan(firstTaskIndex)
-    expect(firstTextIndex).toBeGreaterThan(thinkingIndex)
-    expect(thinkingBlockText(calls)).toContain('abcdefghijklmnop.')
+    expect(thinkingBlockText(calls)).toBe('')
 
     await renderer.event(sessionId, { type: 'turn.completed', result: 'Done.' })
 
@@ -600,7 +599,7 @@ describe('CodexSessionRenderer', () => {
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
   })
 
-  it('streams no-plan Thinking after the grace window when no task appears', async () => {
+  it('hides no-plan Thinking after the grace window when no task appears', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -653,10 +652,10 @@ describe('CodexSessionRenderer', () => {
     const chunks = calls.flatMap(call => call.params.chunks ?? [])
     expect(chunks.some(chunk => chunk.type === 'plan_update')).toBe(false)
     expect(chunks.some(chunk => chunk.type === 'task_update')).toBe(false)
-    expect(thinkingBlockText(calls)).toContain('Thinking before any task. More thinking.')
+    expect(thinkingBlockText(calls)).toBe('')
   })
 
-  it('does not split Thinking in the middle of a hyphenated phrase', async () => {
+  it('does not stream hidden Thinking for hyphenated commentary', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -711,9 +710,7 @@ describe('CodexSessionRenderer', () => {
       delta: '-parameter reasons.'
     })
 
-    const thinking = thinkingBlockText(calls)
-    expect(thinking).toContain('required-parameter reasons.')
-    expect(thinking).not.toContain('required\n-parameter')
+    expect(thinkingBlockText(calls)).toBe('')
   })
 
   it('inserts a blank line between consecutive commentary agent messages', async () => {
@@ -791,8 +788,7 @@ describe('CodexSessionRenderer', () => {
       .join('')
 
     expect(streamed).toContain('Done.')
-    expect(thinkingBlockText(calls)).toContain('First commentary paragraph.')
-    expect(thinkingBlockText(calls)).toContain('Second commentary paragraph.')
+    expect(thinkingBlockText(calls)).toBe('')
   })
 
   it('streams fenced task details in live task updates', async () => {
@@ -964,7 +960,7 @@ describe('CodexSessionRenderer', () => {
       .map(chunk => String(chunk.text))
       .join('')
     expect(streamed).toContain('Done: five tools called.')
-    expect(thinkingBlockText(calls)).toContain('Planning the tool calls.')
+    expect(thinkingBlockText(calls)).toBe('')
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
     const blocks = stop?.params.blocks ?? []

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -1,7 +1,6 @@
 import type { WebClient } from '@slack/web-api'
 import { slackReplyLimits } from '../constants'
 import { AgentSessionRenderer } from './agent-session'
-import { thinkingContextBlock } from './render'
 import {
   clipLines,
   preformatted as pre,
@@ -30,11 +29,11 @@ type CodexSessionState = {
   stepCounter: number
   nextCommandIndex: number
   commentaryText: string
+  commentaryByItemId: Map<string, string>
   answerText: string
   firstBufferedTextAt: number | null
   streamedCommentaryText: string
   streamedAnswerText: string
-  thinkingPublished: boolean
   agentMessagePhase: AgentMessagePhase | null
   planText: string
   taskByUseId: Map<string, HarnessTask>
@@ -164,8 +163,15 @@ export class CodexSessionRenderer {
       const delta = messageDelta(current, assistantMessage)
       if (delta) {
         if (buffer === 'answer') state.answerText += delta
-        else state.commentaryText += delta
+        else {
+          state.commentaryText += delta
+          trackCommentaryText(state, event, delta)
+        }
         await this.publishPendingAssistantText(agentSessionId, state)
+      }
+      if (buffer === 'commentary' && event?.type === 'item.completed') {
+        upsertThinkingTask(state, event)
+        await this.publishActivitySummary(agentSessionId, state)
       }
     }
 
@@ -173,7 +179,7 @@ export class CodexSessionRenderer {
     if (reasoningMessage) {
       const task: HarnessTask = {
         id: `reasoning-${++state.stepCounter}`,
-        title: 'Reasoning',
+        title: 'Thinking',
         status: 'complete',
         details: [section([text(reasoningMessage)])],
         output: []
@@ -201,6 +207,7 @@ export class CodexSessionRenderer {
     if (state.done) return
     if (threadId) state.threadId = threadId
     state.done = true
+    completeThinkingTasks(state)
     completeOpenTasks(state)
     await this.publishActivitySummary(agentSessionId, state, { final: true })
     await this.publishPendingAssistantText(agentSessionId, state, { force: true })
@@ -247,6 +254,7 @@ export class CodexSessionRenderer {
     ) {
       state.firstBufferedTextAt = Date.now()
     }
+    state.streamedCommentaryText = state.commentaryText
     const hasPlan = state.taskByUseId.size > 0
     const graceExpired =
       state.firstBufferedTextAt !== null &&
@@ -254,16 +262,6 @@ export class CodexSessionRenderer {
     const canStream = hasPlan || opts.force || graceExpired
     if (!canStream) return
 
-    const pendingCommentary = state.commentaryText.slice(state.streamedCommentaryText.length)
-    if (pendingCommentary && shouldFlushThinking(pendingCommentary, opts.force)) {
-      const delta = state.commentaryText.slice(state.streamedCommentaryText.length)
-      const thinkingBlock = thinkingContextBlock(delta, { heading: !state.thinkingPublished })
-      if (thinkingBlock) {
-        await this.renderer.blocks(agentSessionId, [thinkingBlock], { planPrefix: hasPlan })
-      }
-      state.streamedCommentaryText = state.commentaryText
-      state.thinkingPublished = true
-    }
     if (state.commentaryText.length > state.streamedCommentaryText.length) return
     if (state.answerText.length <= state.streamedAnswerText.length) return
     const delta = state.answerText.slice(state.streamedAnswerText.length)
@@ -313,11 +311,11 @@ function getState(agentSessionId: string): CodexSessionState {
       stepCounter: 0,
       nextCommandIndex: 0,
       commentaryText: '',
+      commentaryByItemId: new Map(),
       answerText: '',
       firstBufferedTextAt: null,
       streamedCommentaryText: '',
       streamedAnswerText: '',
-      thinkingPublished: false,
       agentMessagePhase: null,
       planText: '',
       taskByUseId: new Map(),
@@ -358,6 +356,38 @@ function ensureCommentarySegmentBreak(event: any, state: CodexSessionState): voi
   state.commentaryText = current.endsWith('\n') ? `${current}\n` : `${current}\n\n`
 }
 
+function commentaryItemId(event: any): string {
+  return String(event?.itemId ?? event?.item_id ?? event?.item?.id ?? '')
+}
+
+function trackCommentaryText(state: CodexSessionState, event: any, delta: string): void {
+  const id = commentaryItemId(event)
+  if (!id) return
+  state.commentaryByItemId.set(id, `${state.commentaryByItemId.get(id) ?? ''}${delta}`)
+}
+
+function upsertThinkingTask(state: CodexSessionState, event: any): void {
+  const id = commentaryItemId(event)
+  if (!id) return
+  const body = String(event?.item?.text ?? state.commentaryByItemId.get(id) ?? '').trim()
+  if (!body) return
+  const taskId = `thinking-${id}`
+  state.commentaryByItemId.set(id, body)
+  state.taskByUseId.set(taskId, {
+    id: taskId,
+    title: 'Thinking',
+    status: 'complete',
+    details: [section([text(body)])],
+    output: []
+  })
+}
+
+function completeThinkingTasks(state: CodexSessionState): void {
+  for (const [id, body] of state.commentaryByItemId) {
+    upsertThinkingTask(state, { item: { id, text: body } })
+  }
+}
+
 function activeAssistantBuffer(state: CodexSessionState, event: any): 'commentary' | 'answer' {
   if (event?.type === 'item.agentMessage.delta' || event?.type === 'item.completed') {
     return state.agentMessagePhase === 'final_answer' ? 'answer' : 'commentary'
@@ -396,11 +426,6 @@ function messageDelta(current: string, incoming: string): string {
 function reasoningText(event: any): string {
   if (event?.type !== 'reasoning') return ''
   return String(event.text ?? event.thinking ?? '')
-}
-
-function shouldFlushThinking(delta: string, force = false): boolean {
-  if (force) return true
-  return /(?:[.!?]\s*|\n\n)$/.test(delta)
 }
 
 function isTerminalTurnEvent(event: any): boolean {
@@ -539,7 +564,10 @@ function changedActivityTaskUpdates(
         state.emittedActivityRunByTaskId.add(task.id)
         details = activityRunBlock(task)
       }
-      if (!state.emittedActivityOutputByTaskId.has(task.id)) {
+      if (
+        (task.output.length || task.title !== 'Thinking') &&
+        !state.emittedActivityOutputByTaskId.has(task.id)
+      ) {
         state.emittedActivityOutputByTaskId.add(task.id)
         output = activityOutputBlock(task)
       }
@@ -550,6 +578,7 @@ function changedActivityTaskUpdates(
     if (
       !opts.final &&
       task.status === 'complete' &&
+      (task.output.length || task.title !== 'Thinking') &&
       !state.emittedActivityOutputByTaskId.has(task.id)
     ) {
       state.emittedActivityOutputByTaskId.add(task.id)
@@ -568,6 +597,9 @@ function changedActivityTaskUpdates(
 }
 
 function activityRunBlock(task: HarnessTask): StreamRichText {
+  if (task.title === 'Thinking' && task.details.length) {
+    return richText(task.details)
+  }
   const command = firstPreformattedBody(task.details)
   if (command) {
     return richText([pre(command, shellLanguage(firstPreformattedLanguage(task.details)))])


### PR DESCRIPTION
folded thinking commentaries into the same command executions plan step.

Flow:

```
Centaur · codex

# (plan step) 
Thinking

I’ll make five real tool calls and keep them low-impact: shell, goal state, plan state, live agent list, and a current-time lookup.

# (plan step) 
1. Command execution

Call shell tool

...

```