### PR TITLE
Remove duplicate Slack session footer

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -611,7 +611,7 @@ describe('AgentSessionRenderer', () => {
     expect(stopAttempts).toBe(2)
   })
 
-  it('prepends the persona/engine header as the first streamed chunk and final block', async () => {
+  it('prepends the persona/engine header as the first streamed chunk only', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: { threads: { setStatus: async () => ({ ok: true }) } },
@@ -651,9 +651,7 @@ describe('AgentSessionRenderer', () => {
     expect(String(firstChunk?.text ?? '')).toBe('_legal · codex-gpt-5_\n')
 
     const allStreamedChunks = calls
-      .filter(call =>
-        call.method === 'chat.startStream' || call.method === 'chat.appendStream'
-      )
+      .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
       .flatMap(call => call.params.chunks ?? [])
       .filter((chunk: any) => chunk?.type === 'markdown_text')
       .map((chunk: any) => String(chunk.text ?? ''))
@@ -664,7 +662,11 @@ describe('AgentSessionRenderer', () => {
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
     const blocks = stop?.params.blocks ?? []
-    expect(blocks[0]).toEqual({ type: 'markdown', text: '_legal · codex-gpt-5_' })
+    expect(
+      blocks.some(
+        (block: any) => block.type === 'markdown' && block.text === '_legal · codex-gpt-5_'
+      )
+    ).toBe(false)
   })
 
   it('omits the header block entirely when no header was supplied', async () => {
@@ -704,8 +706,9 @@ describe('AgentSessionRenderer', () => {
     expect(start?.params.chunks?.[0]?.type).not.toBe('markdown_text')
     const stop = calls.find(call => call.method === 'chat.stopStream')
     const blocks = stop?.params.blocks ?? []
-    expect(blocks.some((block: any) => block.type === 'markdown' && /^_.*_$/.test(block.text)))
-      .toBe(false)
+    expect(
+      blocks.some((block: any) => block.type === 'markdown' && /^_.*_$/.test(block.text))
+    ).toBe(false)
   })
 
   it('renders the header above streamed tasks when both are present', async () => {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -61,8 +61,10 @@ export type OpenAgentSessionInput = {
   recipientTeamId: string
   recipientUserId: string
   title?: string
-  /** Italic one-line identifier rendered at the top of every assistant message
-   *  (e.g. "base · claude-opus-4-7", "legal · codex-gpt-5"). */
+  /**
+   * Italic one-line identifier rendered at the top of every assistant message (e.g. "base ·
+   * claude-opus-4-7", "legal · codex-gpt-5").
+   */
   header?: string
 }
 
@@ -277,12 +279,10 @@ export class AgentSessionRenderer {
     const showThinking =
       !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
     const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
-    const header = state.header?.trim()
     // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.
     // Only add blocks for content that was not streamed live; live task_update chunks carry
-    // fenced details/output, so adding a final plan block would render a second plan step.
+    // fenced details/output, and the header has already been streamed as the first chunk.
     const blocks = sanitizeFinalMessagePayload([
-      ...(header ? [headerBlock(header)] : []),
       ...(tasks.length && !segment.planStarted
         ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)]
         : []),


### PR DESCRIPTION
## Summary
- keep the persona/engine label as the first streamed Slack chunk
- remove the duplicate final markdown header/footer block from stopStream payloads
- update Slackbot renderer tests for the single-label contract

## Tests
- bun test ./src/slack/agent-session.test.ts ./src/slack/final-message.test.ts
- bun run format && bun run check:types