### PR TITLE
fix: reduce slack plan task noise

### DIFF
--- a/services/slackbot/src/constants.ts
+++ b/services/slackbot/src/constants.ts
@@ -12,7 +12,7 @@ export const slackReplyLimits = {
     taskTitleChars: 128,
     /** Slack caps task_update chunk text at 256 chars; keep 10% headroom. */
     taskDetailsChars: 230,
-    taskOutputChars: 48
+    taskOutputChars: 230
   },
   finalPlan: {
     maxPayloadBytes: 240_000,

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -560,25 +560,22 @@ function changedActivityTaskUpdates(
     let details: StreamRichText | undefined
     let output: StreamRichText | undefined
     if (opts.final) {
-      if (!state.emittedActivityRunByTaskId.has(task.id)) {
+      if (task.details.length && !state.emittedActivityRunByTaskId.has(task.id)) {
         state.emittedActivityRunByTaskId.add(task.id)
         details = activityRunBlock(task)
       }
-      if (
-        (task.output.length || task.title !== 'Thinking') &&
-        !state.emittedActivityOutputByTaskId.has(task.id)
-      ) {
+      if (task.output.length && !state.emittedActivityOutputByTaskId.has(task.id)) {
         state.emittedActivityOutputByTaskId.add(task.id)
         output = activityOutputBlock(task)
       }
-    } else if (!state.emittedActivityRunByTaskId.has(task.id)) {
+    } else if (task.details.length && !state.emittedActivityRunByTaskId.has(task.id)) {
       state.emittedActivityRunByTaskId.add(task.id)
       details = activityRunBlock(task)
     }
     if (
       !opts.final &&
       task.status === 'complete' &&
-      (task.output.length || task.title !== 'Thinking') &&
+      task.output.length &&
       !state.emittedActivityOutputByTaskId.has(task.id)
     ) {
       state.emittedActivityOutputByTaskId.add(task.id)
@@ -604,14 +601,10 @@ function activityRunBlock(task: HarnessTask): StreamRichText {
   if (command) {
     return richText([pre(command, shellLanguage(firstPreformattedLanguage(task.details)))])
   }
-  const body = task.details.length ? elementsToPlainText(task.details) : task.title
-  return richText([pre(body, 'text')])
+  return richText(task.details)
 }
 
 function activityOutputBlock(task: HarnessTask): StreamRichText {
-  if (!task.output.length) {
-    return richText([pre('Done', 'text')])
-  }
   return richText([
     pre(elementsToPlainText(task.output), firstPreformattedLanguage(task.output) ?? 'text')
   ])
@@ -635,8 +628,7 @@ function shellLanguage(language: string | undefined): string {
 }
 
 function shellLanguageForCommand(command: string): string {
-  if (command.startsWith('call ')) return 'sh'
-  return languageFromContent(command)
+  return 'sh'
 }
 
 function commandOutputDelta(event: any): { id: string; delta: string } | null {


### PR DESCRIPTION
- omit empty Slack plan task details/output so duplicate title bodies and synthetic Done blocks do not render
- render command execution blocks as shell
- raise streamed task details/output caps to 230 chars

<img width="630" height="1179" alt="CleanShot 2026-05-19 at 15 31 22" src="https://github.com/user-attachments/assets/13fee7d4-3af7-4c4d-b9d7-1baac3046663" />
