### PR TITLE
Update docs Vocs configuration

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,12 +8,11 @@
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "vocs": "https://pkg.pr.new/vocs@e90555e",
+        "vocs": "https://pkg.pr.new/vocs@3f54829",
         "waku": "1.0.0-alpha.6"
       },
       "devDependencies": {
         "@resvg/resvg-wasm": "^2.6.2",
-        "fontverter": "^2.0.0",
         "gray-matter": "^4.0.3",
         "typescript": "5.9.3",
         "wrangler": "^4.14.0"
@@ -4612,17 +4611,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/fontverter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fontverter/-/fontverter-2.0.0.tgz",
-      "integrity": "sha512-DFVX5hvXuhi1Jven1tbpebYTCT9XYnvx6/Z+HFUPb7ZRMCW+pj2clU9VMhoTPgWKPhAs7JJDSk3CW1jNUvKCZQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "wawoff2": "^2.0.0",
-        "woff2sfnt-sfnt2woff": "^1.0.0"
-      }
-    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -6949,13 +6937,6 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9169,8 +9150,8 @@
     },
     "node_modules/vocs": {
       "version": "0.0.0",
-      "resolved": "https://pkg.pr.new/vocs@e90555e",
-      "integrity": "sha512-mBm5ixwBWQt6zZ4geQva71bmq1jyAzmGivw7pnIyyBxwdMmxcMZTvS7Qm4qqdEwpr40M3oVONyZoYV/KRsVmVA==",
+      "resolved": "https://pkg.pr.new/vocs@3f54829",
+      "integrity": "sha512-Fu6D8+4Z4gLRG0pZPouEzzoZfzqedzf/o69VF2GY0zNsTyYEgJ8ifTtp6ODmJrzzhK5OLaKp1XzofbZ43bXrgw==",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
@@ -9315,27 +9296,6 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/wawoff2": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/wawoff2/-/wawoff2-2.0.1.tgz",
-      "integrity": "sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "woff2_compress.js": "bin/woff2_compress.js",
-        "woff2_decompress.js": "bin/woff2_decompress.js"
-      }
-    },
-    "node_modules/wawoff2/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -9355,16 +9315,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/woff2sfnt-sfnt2woff": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/woff2sfnt-sfnt2woff/-/woff2sfnt-sfnt2woff-1.0.0.tgz",
-      "integrity": "sha512-edK4COc1c1EpRfMqCZO1xJOvdUtM5dbVb9iz97rScvnTevqEB3GllnLWCmMVp1MfQBdF1DFg/11I0rSyAdS4qQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^1.0.7"
       }
     },
     "node_modules/workerd": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "vocs": "https://pkg.pr.new/vocs@e90555e",
+    "vocs": "https://pkg.pr.new/vocs@3f54829",
     "waku": "1.0.0-alpha.6"
   },
   "devDependencies": {

--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -15,7 +15,8 @@
   --vocs-spacing-content: 920px;
 }
 
-:root.dark {
+:root[style*='color-scheme:dark'],
+:root[style*='color-scheme: dark'] {
   --centaur-bg: #101012;
   --centaur-code: #0b0b0d;
   --centaur-line: rgba(255, 255, 255, 0.12);
@@ -332,7 +333,8 @@ body,
   --vocs-color_title: #050505;
 }
 
-:root.dark {
+:root[style*='color-scheme:dark'],
+:root[style*='color-scheme: dark'] {
   --vocs-color_background: #050506;
   --vocs-color_background2: #0b0b0d;
   --vocs-color_background3: #111114;

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -15,6 +15,7 @@ function canonicalHref(path: string) {
 export default defineConfig({
   rootDir: '.',
   srcDir: '.',
+  colorScheme: 'dark',
   renderStrategy: 'full-static',
   // The dead-link checker doesn't know about static assets shipped via
   // public/ (like our zip and brand SVGs), so downgrade to a warning rather
@@ -143,7 +144,6 @@ export default defineConfig({
       light: '#00E100',
       dark: '#00E100',
     },
-    colorScheme: 'dark',
     variables: {
       color: {
         background: {


### PR DESCRIPTION
## Summary
- update docs Vocs dependency to pkg.pr.new/vocs@3f54829
- move the dark color scheme setting to the top-level Vocs config
- adjust dark-mode CSS selectors for inline color-scheme styles

## Validation
- npm install
- npx vocs build

Note: npm run build could not complete in this sandbox because the prebuild script requires the missing system zip binary.