### PR TITLE
fix: keep docs navigation on current origin

### DIFF
--- a/docs/public/md/index.md
+++ b/docs/public/md/index.md
@@ -19,7 +19,7 @@ import ThreadPanel from '../components/ThreadPanel'
       <a className="home-lockup-link" href="https://github.com/paradigmxyz/centaur" target="_blank" rel="noopener noreferrer" aria-label="Centaur on GitHub">
         <img className="home-lockup" src="/brand/lockup-white.svg" alt="Centaur" />
       </a>
-      <h1 id="home-title">Multiplayer, self-hosted, secure agents for teams.</h1>
+      <h1 id="home-title">Multiplayer, self-hosted, secure agents for Slack.</h1>
 
       <div className="home-actions" aria-label="Primary documentation links">
         <a className="home-button home-button-primary" href="/quickstart">Get Started</a>

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -7,9 +7,8 @@ const basePath = process.env.VOCS_BASE_PATH || undefined
 const siteUrl = 'https://centaur.run'
 
 function canonicalHref(path: string) {
-  const root = 'https://centaur.run'
-  if (path === '/') return `${root}/`
-  return `${root}${path.replace(/\/+$/, '')}/`
+  if (path === '/') return `${siteUrl}/`
+  return `${siteUrl}${path.replace(/\/+$/, '')}/`
 }
 
 export default defineConfig({
@@ -20,7 +19,6 @@ export default defineConfig({
   // public/ (like our zip and brand SVGs), so downgrade to a warning rather
   // than failing the build.
   checkDeadlinks: 'warn',
-  baseUrl: siteUrl,
   title: 'Centaur',
   titleTemplate: '%s - Centaur',
   description: 'The production control plane for shared AI agents, tools, workflows, and sandboxes.',


### PR DESCRIPTION
## Summary
- remove the hardcoded Vocs baseUrl so internal docs links stay on localhost and preview origins
- keep canonical and OG URLs pointing at the production docs host
- refresh generated markdown output from the docs build

## Testing
- npm run build
- verified generated HTML does not include a <base> tag
- verified generated internal docs hrefs stay root-relative