### PR TITLE
Update docs navigation styling

### DIFF
--- a/docs/pages/_root.css
+++ b/docs/pages/_root.css
@@ -17,7 +17,7 @@
 
 :root[style*='color-scheme:dark'],
 :root[style*='color-scheme: dark'] {
-  --centaur-bg: #101012;
+  --centaur-bg: #050506;
   --centaur-code: #0b0b0d;
   --centaur-line: rgba(255, 255, 255, 0.12);
   --centaur-muted: #9b9ba1;
@@ -336,12 +336,12 @@ body,
 :root[style*='color-scheme:dark'],
 :root[style*='color-scheme: dark'] {
   --vocs-color_background: #050506;
-  --vocs-color_background2: #0b0b0d;
+  --vocs-color_background2: #050506;
   --vocs-color_background3: #111114;
   --vocs-color_background4: #19191d;
   --vocs-color_background5: #202024;
   --vocs-color_backgroundDark: #050506;
-  --vocs-color_backgroundDarkTint: #111114;
+  --vocs-color_backgroundDarkTint: #050506;
   --vocs-color_codeBlockBackground: #0b0b0d;
   --vocs-color_codeInlineBackground: #111114;
   --vocs-color_codeInlineBorder: rgba(255, 255, 255, 0.12);
@@ -362,11 +362,31 @@ body,
   --vocs-color_textAccentHover: var(--centaur-accent-hover);
   --vocs-color_textHover: #ffffff;
   --vocs-color_title: #f7f7f2;
+  --vocs-background-color-primary: #050506;
+  --vocs-background-color-surface: #111114;
+  --vocs-background-color-surfaceMuted: #050506;
 }
 
+html,
 body,
 .vocs_DocsLayout {
   background: var(--vocs-color_background);
+}
+
+@media (min-width: 1080px) {
+  [data-v-topnav] [data-v-gutter-top] {
+    width: calc(100vw - var(--vocs-spacing-gutter));
+  }
+
+  [data-v-topnav] [data-v-gutter-top-left] {
+    flex: 1;
+    justify-content: flex-end;
+  }
+
+  [data-v-topnav] [data-v-logo-link],
+  [data-v-topnav] [data-v-logo-link] + div {
+    display: none;
+  }
 }
 
 .vocs_CodeBlock {

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -22,8 +22,7 @@ import ThreadPanel from '../components/ThreadPanel'
       <h1 id="home-title">Multiplayer, self-hosted, secure agents for Slack.</h1>
 
       <div className="home-actions" aria-label="Primary documentation links">
-        <a className="home-button home-button-primary" href="/quickstart">Get Started</a>
-        <a className="home-button" href="/what-is-centaur">Why Centaur</a>
+        <a className="home-button home-button-primary" href="/what-is-centaur">Get Started</a>
         <a className="home-button" href="https://github.com/paradigmxyz/centaur">GitHub</a>
       </div>
 

--- a/docs/public/md/index.md
+++ b/docs/public/md/index.md
@@ -19,11 +19,10 @@ import ThreadPanel from '../components/ThreadPanel'
       <a className="home-lockup-link" href="https://github.com/paradigmxyz/centaur" target="_blank" rel="noopener noreferrer" aria-label="Centaur on GitHub">
         <img className="home-lockup" src="/brand/lockup-white.svg" alt="Centaur" />
       </a>
-      <h1 id="home-title">Multiplayer, self-hosted, secure agents for teams.</h1>
+      <h1 id="home-title">Multiplayer, self-hosted, secure agents for Slack.</h1>
 
       <div className="home-actions" aria-label="Primary documentation links">
-        <a className="home-button home-button-primary" href="/quickstart">Get Started</a>
-        <a className="home-button" href="/what-is-centaur">Why Centaur</a>
+        <a className="home-button home-button-primary" href="/what-is-centaur">Get Started</a>
         <a className="home-button" href="https://github.com/paradigmxyz/centaur">GitHub</a>
       </div>
 

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -116,11 +116,6 @@ export default defineConfig({
   },
   topNav: [
     {
-      text: 'Docs',
-      link: '/what-is-centaur',
-      match: '/what-is-centaur',
-    },
-    {
       text: 'GitHub',
       link: 'https://github.com/paradigmxyz/centaur',
     },


### PR DESCRIPTION
## Summary
- align docs shell backgrounds with the landing page while keeping the content panel raised
- remove the redundant Docs top-nav item and keep GitHub in the top-right nav
- update the landing hero CTAs so Get Started points to Why Centaur while GitHub remains available

## Test
- npm run build