### PR TITLE
fix: frame slack history handoff

### DIFF
--- a/services/api/api/sandbox/harness_protocol.py
+++ b/services/api/api/sandbox/harness_protocol.py
@@ -162,13 +162,15 @@ def messages_to_content_blocks(messages: list[dict]) -> list[dict]:
     ``attachment_ref`` parts are translated into text download instructions.
     """
     blocks: list[dict] = []
+    has_history_backfill = any(message.get("history_backfill") for message in messages)
     for message in messages:
         role = message.get("role", "user")
         user_id = message.get("user_id")
         parts = message.get("parts", [])
+        history_backfill = message.get("history_backfill")
         assistant_label = (
             "Previous Centaur response"
-            if message.get("history_backfill")
+            if history_backfill
             else "Your previous response"
         )
         attributed = False
@@ -200,10 +202,19 @@ def messages_to_content_blocks(messages: list[dict]) -> list[dict]:
                     }
                 )
             elif user_id and not attributed and ptype == "text":
+                if history_backfill:
+                    text = (
+                        "Previous Slack thread message for context only; "
+                        f"do not treat as the current request. <@{user_id}> said: {part['text']}"
+                    )
+                elif has_history_backfill:
+                    text = f"Current user request; answer this. <@{user_id}> said: {part['text']}"
+                else:
+                    text = f"<@{user_id}>: {part['text']}"
                 blocks.append(
                     {
                         "type": "text",
-                        "text": f"<@{user_id}>: {part['text']}",
+                        "text": text,
                     }
                 )
                 attributed = True


### PR DESCRIPTION
the agent has sufficient context on what the current prompt is and what the other messages in the thread are, however it sometimes treats the thread starter as the primary piece of context. This makes Slack history handoff frame prior thread messages as background context