### PR TITLE
feat: handle `slackbot_live_delivery_failed` & `msg_too_long`

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -1795,11 +1795,10 @@ async def _mark_execution_terminal(
                 isinstance(steer_replacement, dict)
                 and steer_replacement.get("suppress_cancellation_delivery") is True
             )
-            suppress_legacy_delivery = _has_slackbot_live_delivery(metadata) and not metadata.get(
-                "slackbot_live_delivery_failed"
-            )
+            slackbot_live_delivery_failed = bool(metadata.get("slackbot_live_delivery_failed"))
+            suppress_legacy_delivery = _has_slackbot_live_delivery(metadata) and not slackbot_live_delivery_failed
             raw_streamed_answer_chars = metadata.get("slackbot_streamed_answer_chars")
-            if isinstance(raw_streamed_answer_chars, int):
+            if isinstance(raw_streamed_answer_chars, int) and not slackbot_live_delivery_failed:
                 slackbot_streamed_answer_chars = max(raw_streamed_answer_chars, 0)
         assignment_row = await pool.fetchrow(
             "SELECT harness, engine, persona_id, prompt_ref, effective_agents_md_sha256 "
@@ -2497,7 +2496,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         finalize_session_id = slackbot_session_id or str(
             execution_metadata.get("slackbot_agent_session_id") or ""
         )
-        if finalize_session_id and not slackbot_done:
+        if finalize_session_id and not slackbot_done and slackbot_forward_live:
             try:
                 if result_text.strip() and not slackbot_text_sent:
                     await slackbot_client.session_text(finalize_session_id, result_text)
@@ -2662,6 +2661,8 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                             "harness_event_failed",
                             streamed_answer_chars=slackbot_streamed_answer_chars,
                         )
+                        with contextlib.suppress(Exception):
+                            await slackbot_client.set_status(delivery, "")
                         slackbot_forward_live = False
                         break
                     if isinstance(harness_result, dict):

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -183,7 +183,9 @@ def prompt_identity(
     return prompt_ref, sha
 
 
-def _agent_session_title(*, persona_id: str | None, engine: str | None, harness: str | None) -> str:
+def _agent_session_title(
+    *, persona_id: str | None, engine: str | None, harness: str | None
+) -> str:
     parts = ["Centaur"]
     persona = (persona_id or "").strip()
     runtime = (engine or harness or "codex").strip()
@@ -932,7 +934,11 @@ def build_execution_state_payload(
 
 
 def _clip_slackbot(value: Any, max_chars: int = _MAX_SLACKBOT_STEP_CHARS) -> str:
-    text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False, default=str)
+    text = (
+        value
+        if isinstance(value, str)
+        else json.dumps(value, ensure_ascii=False, default=str)
+    )
     text = text.strip()
     return text if len(text) <= max_chars else f"{text[: max_chars - 1]}…"
 
@@ -944,29 +950,43 @@ def _has_slackbot_live_delivery(metadata: dict[str, Any]) -> bool:
     )
 
 
-async def _mark_slackbot_live_delivery_failed(pool, execution_id: str, reason: str) -> None:
+async def _mark_slackbot_live_delivery_failed(
+    pool,
+    execution_id: str,
+    reason: str,
+    *,
+    streamed_answer_chars: int | None = None,
+) -> None:
     await pool.execute(
         "UPDATE agent_execution_requests "
         "SET metadata = jsonb_set("
-        "  metadata, "
+        "  jsonb_set(metadata, "
         "  '{slackbot_live_delivery_failed}', "
         "  to_jsonb($2::text), "
+        "  true), "
+        "  '{slackbot_streamed_answer_chars}', "
+        "  to_jsonb($3::int), "
         "  true"
         "), updated_at = NOW() "
         "WHERE execution_id = $1",
         execution_id,
         reason,
+        max(streamed_answer_chars or 0, 0),
     )
 
 
 def _canonical_text_blocks(event: dict[str, Any]) -> list[str]:
     if event.get("type") == "assistant":
         message = event.get("message") if isinstance(event.get("message"), dict) else {}
-        content = message.get("content") if isinstance(message.get("content"), list) else []
+        content = (
+            message.get("content") if isinstance(message.get("content"), list) else []
+        )
         return [
             str(block.get("text") or "")
             for block in content
-            if isinstance(block, dict) and block.get("type") == "text" and str(block.get("text") or "").strip()
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and str(block.get("text") or "").strip()
         ]
     if event.get("type") == "result":
         text = str(event.get("result") or event.get("text") or "")
@@ -974,7 +994,9 @@ def _canonical_text_blocks(event: dict[str, Any]) -> list[str]:
     return []
 
 
-async def _send_slackbot_canonical_event(session_id: str, event: dict[str, Any]) -> bool:
+async def _send_slackbot_canonical_event(
+    session_id: str, event: dict[str, Any]
+) -> bool:
     sent_text = False
     for text in _canonical_text_blocks(event):
         await slackbot_client.session_text(
@@ -986,13 +1008,17 @@ async def _send_slackbot_canonical_event(session_id: str, event: dict[str, Any])
     event_type = str(event.get("type") or "")
     if event_type == "assistant":
         message = event.get("message") if isinstance(event.get("message"), dict) else {}
-        content = message.get("content") if isinstance(message.get("content"), list) else []
+        content = (
+            message.get("content") if isinstance(message.get("content"), list) else []
+        )
         for block in content:
             if not isinstance(block, dict) or block.get("type") != "tool_use":
                 continue
             tool_id = str(block.get("id") or uuid.uuid4())
             tool_name = str(block.get("name") or "Tool")
-            tool_input = block.get("input") if isinstance(block.get("input"), dict) else {}
+            tool_input = (
+                block.get("input") if isinstance(block.get("input"), dict) else {}
+            )
             await slackbot_client.session_step(
                 session_id,
                 step_id=tool_id,
@@ -1261,7 +1287,9 @@ async def enqueue_execution(
                 silence_deadline,
                 hard_deadline,
             )
-            if _delivery_platform(delivery) != "dev" and not _has_slackbot_live_delivery(metadata):
+            if _delivery_platform(
+                delivery
+            ) != "dev" and not _has_slackbot_live_delivery(metadata):
                 await conn.execute(
                     "INSERT INTO agent_final_delivery_outbox ("
                     "execution_id, thread_key, delivery, state"
@@ -1453,7 +1481,12 @@ async def steer_execution(
 
     Falls back to cancel_execution() if steering fails.
     """
-    from api.agent import _db_get_session, _flush_pending, _flushed_to_messages, _get_last_delivered_id
+    from api.agent import (
+        _db_get_session,
+        _flush_pending,
+        _flushed_to_messages,
+        _get_last_delivered_id,
+    )
     from api.sandbox.harness_protocol import messages_to_content_blocks
 
     row = await pool.fetchrow(
@@ -1567,7 +1600,9 @@ async def steer_execution(
             "ok": True,
             "execution_id": execution_id,
             "thread_key": thread_key,
-            "status": "cancel_requested" if current_status == "cancelled" else current_status,
+            "status": "cancel_requested"
+            if current_status == "cancelled"
+            else current_status,
         }
 
     if message_id and content_blocks:
@@ -1763,6 +1798,7 @@ async def _mark_execution_terminal(
     prompt_ref = None
     prompt_sha = None
     repo_context: dict[str, str] = {}
+    slackbot_streamed_answer_chars = 0
     suppress_final_delivery = False
     suppress_legacy_delivery = False
     raw_agent_thread_id = await pool.fetchval(
@@ -1784,9 +1820,12 @@ async def _mark_execution_terminal(
                 isinstance(steer_replacement, dict)
                 and steer_replacement.get("suppress_cancellation_delivery") is True
             )
-            suppress_legacy_delivery = _has_slackbot_live_delivery(metadata) and not metadata.get(
-                "slackbot_live_delivery_failed"
-            )
+            suppress_legacy_delivery = _has_slackbot_live_delivery(
+                metadata
+            ) and not metadata.get("slackbot_live_delivery_failed")
+            raw_streamed_answer_chars = metadata.get("slackbot_streamed_answer_chars")
+            if isinstance(raw_streamed_answer_chars, int):
+                slackbot_streamed_answer_chars = max(raw_streamed_answer_chars, 0)
         assignment_row = await pool.fetchrow(
             "SELECT harness, engine, persona_id, prompt_ref, effective_agents_md_sha256 "
             "FROM agent_runtime_assignments WHERE thread_key = $1 AND assignment_generation = $2",
@@ -1835,7 +1874,11 @@ async def _mark_execution_terminal(
             **({"error_text": error_text} if error_text else {}),
             **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
             **({"repo_context": repo_context} if repo_context else {}),
-            **({"suppress_final_delivery": True} if suppress_final_delivery_payload else {}),
+            **(
+                {"suppress_final_delivery": True}
+                if suppress_final_delivery_payload
+                else {}
+            ),
         },
     )
     delivery_platform = _delivery_platform(
@@ -1843,12 +1886,16 @@ async def _mark_execution_terminal(
     )
     if delivery_platform == "dev" or suppress_legacy_delivery:
         log.info(
-            "final_delivery_skipped" if suppress_legacy_delivery else "final_delivery_skipped_dev",
+            "final_delivery_skipped"
+            if suppress_legacy_delivery
+            else "final_delivery_skipped_dev",
             execution_id=execution_id,
             thread_key=thread_key,
             status=status,
             terminal_reason=terminal_reason,
-            reason="slackbot_live_delivery" if suppress_legacy_delivery else "dev_delivery",
+            reason="slackbot_live_delivery"
+            if suppress_legacy_delivery
+            else "dev_delivery",
         )
         try:
             from api.workflow_engine import notify_execution_terminal
@@ -1894,9 +1941,18 @@ async def _mark_execution_terminal(
                 "session_header": session_header,
                 "result_text": result_text,
                 **({"error_text": error_text} if error_text else {}),
+                **(
+                    {"slackbot_streamed_answer_chars": slackbot_streamed_answer_chars}
+                    if slackbot_streamed_answer_chars
+                    else {}
+                ),
                 **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
                 **({"repo_context": repo_context} if repo_context else {}),
-                **({"suppress_final_delivery": True} if suppress_final_delivery_payload else {}),
+                **(
+                    {"suppress_final_delivery": True}
+                    if suppress_final_delivery_payload
+                    else {}
+                ),
             }
         ),
         next_attempt_at,
@@ -1922,7 +1978,11 @@ async def _mark_execution_terminal(
             "result_text": result_text,
             **({"error_text": error_text} if error_text else {}),
             **({"repo_context": repo_context} if repo_context else {}),
-            **({"suppress_final_delivery": True} if suppress_final_delivery_payload else {}),
+            **(
+                {"suppress_final_delivery": True}
+                if suppress_final_delivery_payload
+                else {}
+            ),
         },
     )
     log.info(
@@ -2483,7 +2543,9 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 if result_text.strip() and not slackbot_text_sent:
                     await slackbot_client.session_text(finalize_session_id, result_text)
                     slackbot_text_sent = True
-                await slackbot_client.session_done(finalize_session_id, harness_thread_id or None)
+                await slackbot_client.session_done(
+                    finalize_session_id, harness_thread_id or None
+                )
                 slackbot_done = True
             except Exception:
                 log.warning(
@@ -2536,6 +2598,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
 
     turn_done_event: dict[str, Any] | None = None
     latest_terminal_result_text = ""
+    slackbot_streamed_answer_chars = 0
     pending_event: asyncio.Task | None = None
     stream = _stream_stdout(
         session,
@@ -2628,24 +2691,37 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 for slack_event in slack_events:
                     if harness_thread_id and isinstance(slack_event, dict):
                         slack_event.setdefault("session_id", harness_thread_id)
-                    harness_result = await slackbot_client.harness_event(slackbot_session_id, slack_event)
+                    harness_result = await slackbot_client.harness_event(
+                        slackbot_session_id, slack_event
+                    )
                     if harness_result is None:
                         log.warning(
                             "slackbot_live_delivery_failed",
                             execution_id=execution_id,
                             thread_key=thread_key,
-                            event_type=slack_event.get("type") if isinstance(slack_event, dict) else None,
+                            event_type=slack_event.get("type")
+                            if isinstance(slack_event, dict)
+                            else None,
                         )
                         await _mark_slackbot_live_delivery_failed(
                             pool,
                             execution_id,
                             "harness_event_failed",
+                            streamed_answer_chars=slackbot_streamed_answer_chars,
                         )
                         slackbot_forward_live = False
                         break
                     if isinstance(harness_result, dict):
-                        harness_thread_id = str(harness_result.get("threadId") or harness_thread_id)
+                        harness_thread_id = str(
+                            harness_result.get("threadId") or harness_thread_id
+                        )
                         slackbot_done = bool(harness_result.get("done"))
+                        streamed_chars = harness_result.get("streamedAnswerChars")
+                        if isinstance(streamed_chars, int):
+                            slackbot_streamed_answer_chars = max(
+                                slackbot_streamed_answer_chars,
+                                streamed_chars,
+                            )
                         if slack_event.get("type") in {
                             "assistant",
                             "item.agentMessage.delta",

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -1784,7 +1784,9 @@ async def _mark_execution_terminal(
                 isinstance(steer_replacement, dict)
                 and steer_replacement.get("suppress_cancellation_delivery") is True
             )
-            suppress_legacy_delivery = _has_slackbot_live_delivery(metadata)
+            suppress_legacy_delivery = _has_slackbot_live_delivery(metadata) and not metadata.get(
+                "slackbot_live_delivery_failed"
+            )
         assignment_row = await pool.fetchrow(
             "SELECT harness, engine, persona_id, prompt_ref, effective_agents_md_sha256 "
             "FROM agent_runtime_assignments WHERE thread_key = $1 AND assignment_generation = $2",

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -183,9 +183,7 @@ def prompt_identity(
     return prompt_ref, sha
 
 
-def _agent_session_title(
-    *, persona_id: str | None, engine: str | None, harness: str | None
-) -> str:
+def _agent_session_title(*, persona_id: str | None, engine: str | None, harness: str | None) -> str:
     parts = ["Centaur"]
     persona = (persona_id or "").strip()
     runtime = (engine or harness or "codex").strip()
@@ -934,11 +932,7 @@ def build_execution_state_payload(
 
 
 def _clip_slackbot(value: Any, max_chars: int = _MAX_SLACKBOT_STEP_CHARS) -> str:
-    text = (
-        value
-        if isinstance(value, str)
-        else json.dumps(value, ensure_ascii=False, default=str)
-    )
+    text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False, default=str)
     text = text.strip()
     return text if len(text) <= max_chars else f"{text[: max_chars - 1]}…"
 
@@ -978,15 +972,11 @@ async def _mark_slackbot_live_delivery_failed(
 def _canonical_text_blocks(event: dict[str, Any]) -> list[str]:
     if event.get("type") == "assistant":
         message = event.get("message") if isinstance(event.get("message"), dict) else {}
-        content = (
-            message.get("content") if isinstance(message.get("content"), list) else []
-        )
+        content = message.get("content") if isinstance(message.get("content"), list) else []
         return [
             str(block.get("text") or "")
             for block in content
-            if isinstance(block, dict)
-            and block.get("type") == "text"
-            and str(block.get("text") or "").strip()
+            if isinstance(block, dict) and block.get("type") == "text" and str(block.get("text") or "").strip()
         ]
     if event.get("type") == "result":
         text = str(event.get("result") or event.get("text") or "")
@@ -994,9 +984,7 @@ def _canonical_text_blocks(event: dict[str, Any]) -> list[str]:
     return []
 
 
-async def _send_slackbot_canonical_event(
-    session_id: str, event: dict[str, Any]
-) -> bool:
+async def _send_slackbot_canonical_event(session_id: str, event: dict[str, Any]) -> bool:
     sent_text = False
     for text in _canonical_text_blocks(event):
         await slackbot_client.session_text(
@@ -1008,17 +996,13 @@ async def _send_slackbot_canonical_event(
     event_type = str(event.get("type") or "")
     if event_type == "assistant":
         message = event.get("message") if isinstance(event.get("message"), dict) else {}
-        content = (
-            message.get("content") if isinstance(message.get("content"), list) else []
-        )
+        content = message.get("content") if isinstance(message.get("content"), list) else []
         for block in content:
             if not isinstance(block, dict) or block.get("type") != "tool_use":
                 continue
             tool_id = str(block.get("id") or uuid.uuid4())
             tool_name = str(block.get("name") or "Tool")
-            tool_input = (
-                block.get("input") if isinstance(block.get("input"), dict) else {}
-            )
+            tool_input = block.get("input") if isinstance(block.get("input"), dict) else {}
             await slackbot_client.session_step(
                 session_id,
                 step_id=tool_id,
@@ -1287,9 +1271,7 @@ async def enqueue_execution(
                 silence_deadline,
                 hard_deadline,
             )
-            if _delivery_platform(
-                delivery
-            ) != "dev" and not _has_slackbot_live_delivery(metadata):
+            if _delivery_platform(delivery) != "dev" and not _has_slackbot_live_delivery(metadata):
                 await conn.execute(
                     "INSERT INTO agent_final_delivery_outbox ("
                     "execution_id, thread_key, delivery, state"
@@ -1481,12 +1463,7 @@ async def steer_execution(
 
     Falls back to cancel_execution() if steering fails.
     """
-    from api.agent import (
-        _db_get_session,
-        _flush_pending,
-        _flushed_to_messages,
-        _get_last_delivered_id,
-    )
+    from api.agent import _db_get_session, _flush_pending, _flushed_to_messages, _get_last_delivered_id
     from api.sandbox.harness_protocol import messages_to_content_blocks
 
     row = await pool.fetchrow(
@@ -1600,9 +1577,7 @@ async def steer_execution(
             "ok": True,
             "execution_id": execution_id,
             "thread_key": thread_key,
-            "status": "cancel_requested"
-            if current_status == "cancelled"
-            else current_status,
+            "status": "cancel_requested" if current_status == "cancelled" else current_status,
         }
 
     if message_id and content_blocks:
@@ -1820,9 +1795,9 @@ async def _mark_execution_terminal(
                 isinstance(steer_replacement, dict)
                 and steer_replacement.get("suppress_cancellation_delivery") is True
             )
-            suppress_legacy_delivery = _has_slackbot_live_delivery(
-                metadata
-            ) and not metadata.get("slackbot_live_delivery_failed")
+            suppress_legacy_delivery = _has_slackbot_live_delivery(metadata) and not metadata.get(
+                "slackbot_live_delivery_failed"
+            )
             raw_streamed_answer_chars = metadata.get("slackbot_streamed_answer_chars")
             if isinstance(raw_streamed_answer_chars, int):
                 slackbot_streamed_answer_chars = max(raw_streamed_answer_chars, 0)
@@ -1874,11 +1849,7 @@ async def _mark_execution_terminal(
             **({"error_text": error_text} if error_text else {}),
             **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
             **({"repo_context": repo_context} if repo_context else {}),
-            **(
-                {"suppress_final_delivery": True}
-                if suppress_final_delivery_payload
-                else {}
-            ),
+            **({"suppress_final_delivery": True} if suppress_final_delivery_payload else {}),
         },
     )
     delivery_platform = _delivery_platform(
@@ -1886,16 +1857,12 @@ async def _mark_execution_terminal(
     )
     if delivery_platform == "dev" or suppress_legacy_delivery:
         log.info(
-            "final_delivery_skipped"
-            if suppress_legacy_delivery
-            else "final_delivery_skipped_dev",
+            "final_delivery_skipped" if suppress_legacy_delivery else "final_delivery_skipped_dev",
             execution_id=execution_id,
             thread_key=thread_key,
             status=status,
             terminal_reason=terminal_reason,
-            reason="slackbot_live_delivery"
-            if suppress_legacy_delivery
-            else "dev_delivery",
+            reason="slackbot_live_delivery" if suppress_legacy_delivery else "dev_delivery",
         )
         try:
             from api.workflow_engine import notify_execution_terminal
@@ -1948,11 +1915,7 @@ async def _mark_execution_terminal(
                 ),
                 **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
                 **({"repo_context": repo_context} if repo_context else {}),
-                **(
-                    {"suppress_final_delivery": True}
-                    if suppress_final_delivery_payload
-                    else {}
-                ),
+                **({"suppress_final_delivery": True} if suppress_final_delivery_payload else {}),
             }
         ),
         next_attempt_at,
@@ -1978,11 +1941,7 @@ async def _mark_execution_terminal(
             "result_text": result_text,
             **({"error_text": error_text} if error_text else {}),
             **({"repo_context": repo_context} if repo_context else {}),
-            **(
-                {"suppress_final_delivery": True}
-                if suppress_final_delivery_payload
-                else {}
-            ),
+            **({"suppress_final_delivery": True} if suppress_final_delivery_payload else {}),
         },
     )
     log.info(
@@ -2543,9 +2502,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 if result_text.strip() and not slackbot_text_sent:
                     await slackbot_client.session_text(finalize_session_id, result_text)
                     slackbot_text_sent = True
-                await slackbot_client.session_done(
-                    finalize_session_id, harness_thread_id or None
-                )
+                await slackbot_client.session_done(finalize_session_id, harness_thread_id or None)
                 slackbot_done = True
             except Exception:
                 log.warning(
@@ -2691,17 +2648,13 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 for slack_event in slack_events:
                     if harness_thread_id and isinstance(slack_event, dict):
                         slack_event.setdefault("session_id", harness_thread_id)
-                    harness_result = await slackbot_client.harness_event(
-                        slackbot_session_id, slack_event
-                    )
+                    harness_result = await slackbot_client.harness_event(slackbot_session_id, slack_event)
                     if harness_result is None:
                         log.warning(
                             "slackbot_live_delivery_failed",
                             execution_id=execution_id,
                             thread_key=thread_key,
-                            event_type=slack_event.get("type")
-                            if isinstance(slack_event, dict)
-                            else None,
+                            event_type=slack_event.get("type") if isinstance(slack_event, dict) else None,
                         )
                         await _mark_slackbot_live_delivery_failed(
                             pool,
@@ -2712,9 +2665,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                         slackbot_forward_live = False
                         break
                     if isinstance(harness_result, dict):
-                        harness_thread_id = str(
-                            harness_result.get("threadId") or harness_thread_id
-                        )
+                        harness_thread_id = str(harness_result.get("threadId") or harness_thread_id)
                         slackbot_done = bool(harness_result.get("done"))
                         streamed_chars = harness_result.get("streamedAnswerChars")
                         if isinstance(streamed_chars, int):

--- a/services/slackbot/scripts/slack-thread-logs.sh
+++ b/services/slackbot/scripts/slack-thread-logs.sh
@@ -25,4 +25,15 @@ echo "Searching ${namespace} logs for channel=${channel} ts=${ts_exact} since=${
   while IFS= read -r pod; do
     kubectl -n "$namespace" logs "$pod" --since="$since" --prefix=true || true
   done < <(kubectl -n "$namespace" get pod -o name | rg "sandbox-slack.*${channel_lc}" || true)
-} | rg "${channel}|${channel_lc}|${ts_exact}|${ts_prefix}" || true
+} | rg "${channel}|${channel_lc}|${ts_exact}|${ts_prefix}" | while IFS= read -r line; do
+  if [[ "$line" =~ ^(\[[^]]+\][[:space:]]+)(\{.*\})$ ]]; then
+    prefix="${BASH_REMATCH[1]}"
+    json="${BASH_REMATCH[2]}"
+    printf '%s\n' "${prefix}"
+    if ! jq . <<<"$json"; then
+      printf '%s\n' "$json"
+    fi
+  else
+    printf '%s\n' "$line"
+  fi
+done || true

--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -85,6 +85,10 @@ describe('final delivery polling', () => {
           slackCalls.push({ method: 'chat.appendStream', params })
           return { ok: true }
         },
+        postMessage: async (params: unknown) => {
+          slackCalls.push({ method: 'chat.postMessage', params })
+          return { ok: true }
+        },
         stopStream: async (params: unknown) => {
           slackCalls.push({ method: 'chat.stopStream', params })
           return { ok: true }
@@ -108,13 +112,10 @@ describe('final delivery polling', () => {
           call => call.path === '/agent/final-deliveries/exe-duplicate-guard/delivered'
         )
       ).toHaveLength(1)
-      expect(slackCalls.filter(call => call.method === 'chat.startStream')).toHaveLength(1)
-      const startStream = slackCalls.find(call => call.method === 'chat.startStream')
-      expect((startStream?.params as any)?.chunks[0]).toEqual({
-        type: 'plan_update',
-        title: 'Centaur · codex'
-      })
-      expect(slackCalls.filter(call => call.method === 'chat.stopStream')).toHaveLength(1)
+      expect(slackCalls.filter(call => call.method === 'chat.startStream')).toHaveLength(0)
+      expect(slackCalls.filter(call => call.method === 'chat.stopStream')).toHaveLength(0)
+      const postMessage = slackCalls.find(call => call.method === 'chat.postMessage')
+      expect((postMessage?.params as any)?.text).toBe('done once')
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -50,7 +50,7 @@ describe('final delivery polling', () => {
                     },
                     final_payload: {
                       session_title: 'Centaur · codex',
-                      result_text: 'done once'
+                      result_text: 'done [once](https://example.com) with **bold** text'
                     }
                   }
                 ]
@@ -115,7 +115,15 @@ describe('final delivery polling', () => {
       expect(slackCalls.filter(call => call.method === 'chat.startStream')).toHaveLength(0)
       expect(slackCalls.filter(call => call.method === 'chat.stopStream')).toHaveLength(0)
       const postMessage = slackCalls.find(call => call.method === 'chat.postMessage')
-      expect((postMessage?.params as any)?.text).toBe('done once')
+      expect((postMessage?.params as any)?.text).toBe(
+        'done [once](https://example.com) with **bold** text'
+      )
+      expect((postMessage?.params as any)?.blocks).toEqual([
+        {
+          type: 'markdown',
+          text: 'done [once](https://example.com) with **bold** text'
+        }
+      ])
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -1,10 +1,12 @@
 import type { WebClient } from '@slack/web-api'
 import { centaurApiKey, type AppConfig } from '../config'
+import { slackReplyLimits } from '../constants'
 import { logError } from '../logging'
 import { AgentSessionRenderer } from '../slack/agent-session'
 import { withLaminarSpan } from './laminar'
 
 const CONSUMER_ID = `slackbot-${process.pid}`
+const FINAL_DELIVERY_CHUNK_CHARS = slackReplyLimits.stream.maxLiveTextChars
 
 export function startFinalDeliveryPoller(config: AppConfig, client: WebClient): void {
   if (!centaurApiKey(config)) return
@@ -41,13 +43,16 @@ export async function pollFinalDeliveriesOnce(config: AppConfig, client: WebClie
           delivery
         )
       } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        const msgTooLong = errorMessage.includes('msg_too_long')
         await centaur(
           config,
           `/agent/final-deliveries/${executionId}/failed`,
           {
             consumer_id: CONSUMER_ID,
-            error: error instanceof Error ? error.message : String(error),
-            retry_after_seconds: 10
+            error: errorMessage,
+            retry_after_seconds: 10,
+            ...(msgTooLong ? { error_class: 'msg_too_long', non_retryable: true } : {})
           },
           delivery
         ).catch(failError => logError('final_delivery_mark_failed_failed', failError))
@@ -63,6 +68,12 @@ async function deliver(client: WebClient, delivery: any): Promise<void> {
   const channel = meta.channel_id ?? meta.channel ?? target.channel
   const threadTs = meta.thread_ts ?? target.threadTs
   if (!channel || !threadTs) throw new Error('missing_slack_delivery_target')
+  const text = extractText(payload)
+  const continuation = continuationText(payload, text)
+  if (continuation !== null) {
+    await postFollowups(client, channel, threadTs, splitFinalDeliveryText(continuation))
+    return
+  }
   const renderer = new AgentSessionRenderer(client)
   const { sessionId } = await renderer.open({
     channel,
@@ -72,8 +83,28 @@ async function deliver(client: WebClient, delivery: any): Promise<void> {
     title: sessionTitle(payload),
     header: sessionHeader(payload)
   })
-  await renderer.text(sessionId, extractText(payload))
+  const chunks = splitFinalDeliveryText(text)
+  await renderer.text(sessionId, chunks[0] ?? '')
   await renderer.done(sessionId)
+  await postFollowups(client, channel, threadTs, chunks.slice(1))
+}
+
+async function postFollowups(
+  client: WebClient,
+  channel: string,
+  threadTs: string,
+  chunks: string[]
+): Promise<void> {
+  for (const chunk of chunks) {
+    const response = await client.chat.postMessage({
+      channel,
+      thread_ts: threadTs,
+      text: chunk,
+      unfurl_links: false,
+      unfurl_media: false
+    })
+    if (!response.ok) throw new Error(response.error ?? 'chat.postMessage failed')
+  }
 }
 
 function sessionTitle(payload: any): string {
@@ -102,6 +133,33 @@ function firstNonEmpty(...values: unknown[]): string {
     if (text) return text
   }
   return ''
+}
+
+function continuationText(payload: any, text: string): string | null {
+  const rawOffset = Number(payload?.slackbot_streamed_answer_chars)
+  if (!Number.isFinite(rawOffset) || rawOffset <= 0) return null
+  return text.slice(Math.min(Math.floor(rawOffset), text.length)).trimStart()
+}
+
+function splitFinalDeliveryText(text: string): string[] {
+  const trimmed = text.trim()
+  if (!trimmed) return []
+  const chunks: string[] = []
+  let remaining = trimmed
+  while (remaining.length > FINAL_DELIVERY_CHUNK_CHARS) {
+    let cut = remaining.lastIndexOf('\n\n', FINAL_DELIVERY_CHUNK_CHARS)
+    if (cut <= FINAL_DELIVERY_CHUNK_CHARS * 0.3) {
+      cut = remaining.lastIndexOf('\n', FINAL_DELIVERY_CHUNK_CHARS)
+    }
+    if (cut <= FINAL_DELIVERY_CHUNK_CHARS * 0.3) {
+      cut = remaining.lastIndexOf(' ', FINAL_DELIVERY_CHUNK_CHARS)
+    }
+    if (cut <= FINAL_DELIVERY_CHUNK_CHARS * 0.3) cut = FINAL_DELIVERY_CHUNK_CHARS
+    chunks.push(remaining.slice(0, cut).trimEnd())
+    remaining = remaining.slice(cut).trimStart()
+  }
+  if (remaining) chunks.push(remaining)
+  return chunks
 }
 
 function sessionHeader(payload: any): string | undefined {

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -2,6 +2,7 @@ import type { WebClient } from '@slack/web-api'
 import { centaurApiKey, type AppConfig } from '../config'
 import { slackReplyLimits } from '../constants'
 import { logError } from '../logging'
+import { renderMarkdownBlocks } from '../slack/render'
 import { withLaminarSpan } from './laminar'
 
 const CONSUMER_ID = `slackbot-${process.pid}`
@@ -83,6 +84,7 @@ async function postFollowups(
       channel,
       thread_ts: threadTs,
       text: chunk,
+      blocks: renderMarkdownBlocks(chunk),
       unfurl_links: false,
       unfurl_media: false
     })

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -2,11 +2,10 @@ import type { WebClient } from '@slack/web-api'
 import { centaurApiKey, type AppConfig } from '../config'
 import { slackReplyLimits } from '../constants'
 import { logError } from '../logging'
-import { AgentSessionRenderer } from '../slack/agent-session'
 import { withLaminarSpan } from './laminar'
 
 const CONSUMER_ID = `slackbot-${process.pid}`
-const FINAL_DELIVERY_CHUNK_CHARS = slackReplyLimits.stream.maxLiveTextChars
+const FINAL_DELIVERY_CHUNK_CHARS = slackReplyLimits.text.maxFallbackChars
 
 export function startFinalDeliveryPoller(config: AppConfig, client: WebClient): void {
   if (!centaurApiKey(config)) return
@@ -69,24 +68,8 @@ async function deliver(client: WebClient, delivery: any): Promise<void> {
   const threadTs = meta.thread_ts ?? target.threadTs
   if (!channel || !threadTs) throw new Error('missing_slack_delivery_target')
   const text = extractText(payload)
-  const continuation = continuationText(payload, text)
-  if (continuation !== null) {
-    await postFollowups(client, channel, threadTs, splitFinalDeliveryText(continuation))
-    return
-  }
-  const renderer = new AgentSessionRenderer(client)
-  const { sessionId } = await renderer.open({
-    channel,
-    parentTs: threadTs,
-    recipientTeamId: String(meta.team_id ?? delivery.team_id ?? target.teamId ?? ''),
-    recipientUserId: String(meta.recipient_user_id ?? meta.user_id ?? delivery.user_id ?? ''),
-    title: sessionTitle(payload),
-    header: sessionHeader(payload)
-  })
-  const chunks = splitFinalDeliveryText(text)
-  await renderer.text(sessionId, chunks[0] ?? '')
-  await renderer.done(sessionId)
-  await postFollowups(client, channel, threadTs, chunks.slice(1))
+  const textToPost = continuationText(payload, text) ?? text
+  await postFollowups(client, channel, threadTs, splitFinalDeliveryText(textToPost))
 }
 
 async function postFollowups(
@@ -105,11 +88,6 @@ async function postFollowups(
     })
     if (!response.ok) throw new Error(response.error ?? 'chat.postMessage failed')
   }
-}
-
-function sessionTitle(payload: any): string {
-  const title = String(payload?.session_title ?? payload?.title ?? '').trim()
-  return title || 'Execution steps'
 }
 
 function extractText(payload: any): string {
@@ -138,7 +116,9 @@ function firstNonEmpty(...values: unknown[]): string {
 function continuationText(payload: any, text: string): string | null {
   const rawOffset = Number(payload?.slackbot_streamed_answer_chars)
   if (!Number.isFinite(rawOffset) || rawOffset <= 0) return null
-  return text.slice(Math.min(Math.floor(rawOffset), text.length)).trimStart()
+  const offset = Math.floor(rawOffset)
+  if (offset >= text.length) return null
+  return text.slice(offset).trimStart()
 }
 
 function splitFinalDeliveryText(text: string): string[] {
@@ -160,11 +140,6 @@ function splitFinalDeliveryText(text: string): string[] {
   }
   if (remaining) chunks.push(remaining)
   return chunks
-}
-
-function sessionHeader(payload: any): string | undefined {
-  const value = String(payload?.session_header ?? payload?.header ?? '').trim()
-  return value || undefined
 }
 
 function targetFromDelivery(delivery: any): {

--- a/services/slackbot/src/constants.ts
+++ b/services/slackbot/src/constants.ts
@@ -12,7 +12,9 @@ export const slackReplyLimits = {
     taskTitleChars: 128,
     /** Slack caps task_update chunk text at 256 chars; keep 10% headroom. */
     taskDetailsChars: 230,
-    taskOutputChars: 230
+    taskOutputChars: 230,
+    /** Keep live accumulated markdown below Slack message-size failures. */
+    maxLiveTextChars: 30_000
   },
   finalPlan: {
     maxPayloadBytes: 240_000,

--- a/services/slackbot/src/constants.ts
+++ b/services/slackbot/src/constants.ts
@@ -6,6 +6,7 @@ export const slackReplyLimits = {
     maxUntruncatedChars: 40_000
   },
   stream: {
+    /** {@link https://docs.slack.dev/reference/methods/chat.postMessage/} */
     markdownChunkChars: 12_000,
     planTitleChars: 256,
     taskCount: 24,

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -32,8 +32,10 @@ type Segment = {
   planStarted: boolean
   headerEmitted: boolean
   pendingText: string
+  pendingTextSourceChars: number
   pendingTextPlanPrefix: boolean
   streamedText: string
+  streamedTextSourceChars: number
   pendingTextTimer?: ReturnType<typeof setTimeout>
   pendingTextFlush?: Promise<void>
   streamError?: Error
@@ -164,6 +166,11 @@ export class AgentSessionRenderer {
     })
   }
 
+  streamedTextChars(sessionId: string): number {
+    const state = requireSession(sessionId)
+    return streamedTextSourceChars(state)
+  }
+
   async blocks(
     sessionId: string,
     blocks: AnyBlock[],
@@ -203,13 +210,14 @@ export class AgentSessionRenderer {
     await this.flushText(state, segment, { force: true })
   }
 
-  async done(sessionId: string, opts: DoneOptions = {}): Promise<void> {
+  async done(sessionId: string, opts: DoneOptions = {}): Promise<{ streamedTextChars: number }> {
     const state = requireSession(sessionId)
     state.done = true
     state.finalCommentaryMarkdown = opts.commentaryMarkdown
     state.finalAnswerMarkdown = opts.answerMarkdown
     const streamFinalUpdates = opts.streamFinalUpdates ?? true
     let closed = false
+    let streamedTextChars = 0
 
     try {
       for (const segment of state.segments) {
@@ -227,6 +235,7 @@ export class AgentSessionRenderer {
         }
         await this.closeTextStream(state, segment)
       }
+      streamedTextChars = streamedTextSourceChars(state)
       closed = true
     } finally {
       if (!state.statusCleared) {
@@ -234,6 +243,7 @@ export class AgentSessionRenderer {
       }
       if (closed) sessions.delete(sessionId)
     }
+    return { streamedTextChars }
   }
 
   private async setStatus(sessionId: string, status: string): Promise<boolean> {
@@ -339,8 +349,12 @@ export class AgentSessionRenderer {
     segment.pendingTextPlanPrefix = planPrefix
     const accepted = appendPendingTextWithinLiveLimit(segment, markdown)
     if (accepted <= 0) return 0
-    if (opts.force || segment.pendingText.length >= TEXT_FLUSH_CHARS) {
+    if (opts.force) {
       await this.flushText(state, segment, { force: true })
+      return accepted
+    }
+    if (segment.pendingText.length >= TEXT_FLUSH_CHARS) {
+      await this.flushText(state, segment, { force: false })
       return accepted
     }
     this.scheduleTextFlush(state, segment)
@@ -389,6 +403,7 @@ export class AgentSessionRenderer {
     if (!segment.pendingText) return
     const markdown = normalizeMarkdownChunk(segment.streamedText, segment.pendingText)
     segment.pendingText = ''
+    segment.pendingTextSourceChars = 0
     segment.streamedText += markdown
   }
 
@@ -411,12 +426,15 @@ export class AgentSessionRenderer {
     }
     const markdown = normalizeMarkdownChunk(segment.streamedText, segment.pendingText)
     if (!markdown) return
+    const pendingSourceChars = segment.pendingTextSourceChars
     segment.pendingText = ''
-    segment.streamedText += markdown
+    segment.pendingTextSourceChars = 0
     await this.streamChunks(state, segment, [
       ...(segment.pendingTextPlanPrefix ? this.planPrefix(state, segment) : []),
       ...markdownToStreamChunks(markdown)
     ])
+    segment.streamedText += markdown
+    segment.streamedTextSourceChars += pendingSourceChars
   }
 
   private async flushTask(
@@ -599,6 +617,10 @@ function currentSegment(state: AgentSessionState): Segment {
   return state.segments.at(-1) ?? newSegment()
 }
 
+function streamedTextSourceChars(state: AgentSessionState): number {
+  return state.segments.reduce((total, segment) => total + segment.streamedTextSourceChars, 0)
+}
+
 function newSegment(): Segment {
   return {
     id: ulid(),
@@ -607,8 +629,10 @@ function newSegment(): Segment {
     planStarted: false,
     headerEmitted: false,
     pendingText: '',
+    pendingTextSourceChars: 0,
     pendingTextPlanPrefix: true,
     streamedText: '',
+    streamedTextSourceChars: 0,
     closed: false
   }
 }
@@ -634,7 +658,6 @@ function hasVisibleStreamChunks(chunks: AnyChunk[]): boolean {
 
 function safeMarkdownFlush(markdown: string, pendingText: string, streamedText: string): boolean {
   if (hasOpenFence(markdown)) return false
-  if (pendingText.length >= TEXT_FLUSH_CHARS) return true
   if (!streamedText && pendingText.trim().length < FIRST_TEXT_FLUSH_CHARS) return false
   if (isBareListPrefix(pendingText)) return false
   return (
@@ -741,8 +764,10 @@ function appendPendingTextWithinLiveLimit(segment: Segment, markdown: string): n
   const remaining = MAX_LIVE_TEXT_CHARS - segment.streamedText.length - segment.pendingText.length
   if (remaining <= 0) return 0
   const acceptedNormalized = normalized.slice(0, remaining)
+  const acceptedSourceChars = Math.max(0, acceptedNormalized.length - prefixChars)
   segment.pendingText += acceptedNormalized
-  return Math.max(0, acceptedNormalized.length - prefixChars)
+  segment.pendingTextSourceChars += acceptedSourceChars
+  return acceptedSourceChars
 }
 
 export async function withAgentSessionLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -138,16 +138,16 @@ export class AgentSessionRenderer {
     return { sessionId: id }
   }
 
-  async text(sessionId: string, markdown: string): Promise<void> {
+  async text(sessionId: string, markdown: string): Promise<number> {
     const state = requireSession(sessionId)
     const segment = currentSegment(state)
 
     segment.textParts.push(markdown)
-    await this.queueText(state, segment, markdown)
+    return await this.queueText(state, segment, markdown)
   }
 
-  async textDelta(sessionId: string, markdownDelta: string, opts: TextOptions = {}): Promise<void> {
-    if (!markdownDelta) return
+  async textDelta(sessionId: string, markdownDelta: string, opts: TextOptions = {}): Promise<number> {
+    if (!markdownDelta) return 0
     const state = requireSession(sessionId)
     const segment = currentSegment(state)
 
@@ -155,13 +155,10 @@ export class AgentSessionRenderer {
     if (lastIndex >= 0) segment.textParts[lastIndex] += markdownDelta
     else segment.textParts.push(markdownDelta)
     if (opts.flush === false) {
-      segment.pendingText += normalizeDeltaBoundary(
-        segment.streamedText + segment.pendingText,
-        markdownDelta
-      )
-      return
+      const accepted = appendPendingTextWithinLiveLimit(segment, markdownDelta)
+      return accepted
     }
-    await this.queueText(state, segment, markdownDelta, {
+    return await this.queueText(state, segment, markdownDelta, {
       force: opts.force,
       planPrefix: opts.planPrefix
     })
@@ -333,22 +330,21 @@ export class AgentSessionRenderer {
     segment: Segment,
     markdown: string,
     opts: { force?: boolean; planPrefix?: boolean } = {}
-  ): Promise<void> {
+  ): Promise<number> {
     raiseStreamError(segment)
     const planPrefix = opts.planPrefix !== false
     if (segment.pendingText && segment.pendingTextPlanPrefix !== planPrefix) {
       await this.flushText(state, segment, { force: true })
     }
     segment.pendingTextPlanPrefix = planPrefix
-    const normalized = normalizeDeltaBoundary(segment.streamedText + segment.pendingText, markdown)
-    const remaining = MAX_LIVE_TEXT_CHARS - segment.streamedText.length - segment.pendingText.length
-    if (remaining <= 0) return
-    segment.pendingText += normalized.slice(0, remaining)
+    const accepted = appendPendingTextWithinLiveLimit(segment, markdown)
+    if (accepted <= 0) return 0
     if (opts.force || segment.pendingText.length >= TEXT_FLUSH_CHARS) {
       await this.flushText(state, segment, { force: true })
-      return
+      return accepted
     }
     this.scheduleTextFlush(state, segment)
+    return accepted
   }
 
   private scheduleTextFlush(state: AgentSessionState, segment: Segment): void {
@@ -415,7 +411,7 @@ export class AgentSessionRenderer {
     segment.streamedText += markdown
     await this.streamChunks(state, segment, [
       ...(segment.pendingTextPlanPrefix ? this.planPrefix(state, segment) : []),
-      markdownChunk(markdown)
+      ...markdownToStreamChunks(markdown)
     ])
   }
 
@@ -726,6 +722,17 @@ function normalizeDeltaBoundary(previous: string, delta: string): string {
     return `\n${delta}`
   }
   return delta
+}
+
+function appendPendingTextWithinLiveLimit(segment: Segment, markdown: string): number {
+  const previous = segment.streamedText + segment.pendingText
+  const normalized = normalizeDeltaBoundary(previous, markdown)
+  const prefixChars = normalized.length - markdown.length
+  const remaining = MAX_LIVE_TEXT_CHARS - segment.streamedText.length - segment.pendingText.length
+  if (remaining <= 0) return 0
+  const acceptedNormalized = normalized.slice(0, remaining)
+  segment.pendingText += acceptedNormalized
+  return Math.max(0, acceptedNormalized.length - prefixChars)
 }
 
 export async function withAgentSessionLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -400,7 +400,11 @@ export class AgentSessionRenderer {
     raiseStreamError(segment)
     if (
       !opts.force &&
-      !safeMarkdownFlush(segment.streamedText + segment.pendingText, segment.streamedText)
+      !safeMarkdownFlush(
+        segment.streamedText + segment.pendingText,
+        segment.pendingText,
+        segment.streamedText
+      )
     ) {
       this.scheduleTextFlush(state, segment)
       return
@@ -628,15 +632,21 @@ function hasVisibleStreamChunks(chunks: AnyChunk[]): boolean {
   })
 }
 
-function safeMarkdownFlush(markdown: string, streamedText: string): boolean {
+function safeMarkdownFlush(markdown: string, pendingText: string, streamedText: string): boolean {
   if (hasOpenFence(markdown)) return false
-  if (!streamedText && markdown.trim().length >= FIRST_TEXT_FLUSH_CHARS) return true
+  if (pendingText.length >= TEXT_FLUSH_CHARS) return true
+  if (!streamedText && pendingText.trim().length < FIRST_TEXT_FLUSH_CHARS) return false
+  if (isBareListPrefix(pendingText)) return false
   return (
-    markdown.endsWith('\n\n') ||
-    markdown.endsWith('```') ||
-    /[.!?](?:\s|$)$/.test(markdown) ||
-    markdown.length >= TEXT_FLUSH_CHARS
+    pendingText.endsWith('\n') ||
+    pendingText.endsWith('\n\n') ||
+    pendingText.endsWith('```') ||
+    /[.!?](?:\s|$)$/.test(pendingText)
   )
+}
+
+function isBareListPrefix(markdown: string): boolean {
+  return /^\s*\d+[.)]\s*$/.test(markdown)
 }
 
 function balancePendingMarkdown(segment: Segment): void {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -278,7 +278,8 @@ export class AgentSessionRenderer {
     const answerMarkdown = finalMarkdownForBlocks(answerSource)
     const streamedTextLive =
       Boolean(segment.streamedText.trim()) && segment.streamedText.length < MAX_LIVE_TEXT_CHARS
-    const showThinking = !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
+    const showThinking =
+      !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
     const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
     // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.
     // Only add blocks for content that was not streamed live; live task_update chunks carry
@@ -339,10 +340,7 @@ export class AgentSessionRenderer {
       await this.flushText(state, segment, { force: true })
     }
     segment.pendingTextPlanPrefix = planPrefix
-    const normalized = normalizeDeltaBoundary(
-      segment.streamedText + segment.pendingText,
-      markdown
-    )
+    const normalized = normalizeDeltaBoundary(segment.streamedText + segment.pendingText, markdown)
     const remaining = MAX_LIVE_TEXT_CHARS - segment.streamedText.length - segment.pendingText.length
     if (remaining <= 0) return
     segment.pendingText += normalized.slice(0, remaining)

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -114,6 +114,7 @@ const FINAL_PLAN_MAX_TASKS = slackReplyLimits.finalPlan.maxTasks
 const FINAL_PLAN_TITLE_CHARS = slackReplyLimits.finalPlan.taskTitleChars
 const FINAL_PLAN_DETAILS_LINES = slackReplyLimits.finalPlan.taskDetailsCodeBlockLines
 const FINAL_PLAN_OUTPUT_LINES = slackReplyLimits.finalPlan.taskOutputCodeBlockLines
+const MAX_LIVE_TEXT_CHARS = slackReplyLimits.stream.maxLiveTextChars
 
 export class AgentSessionRenderer {
   constructor(private readonly client: WebClient) {}
@@ -274,8 +275,9 @@ export class AgentSessionRenderer {
     const commentaryMarkdown = state.finalCommentaryMarkdown?.trim() ?? ''
     const answerSource =
       state.finalAnswerMarkdown?.trim() || segment.streamedText.trim() || segment.textParts.join('')
-    const answerMarkdown = finalMarkdownForBlocks(answerSource, tasks)
-    const streamedTextLive = Boolean(segment.streamedText.trim())
+    const answerMarkdown = finalMarkdownForBlocks(answerSource)
+    const streamedTextLive =
+      Boolean(segment.streamedText.trim()) && segment.streamedText.length < MAX_LIVE_TEXT_CHARS
     const showThinking = !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
     const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
     // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.
@@ -337,10 +339,13 @@ export class AgentSessionRenderer {
       await this.flushText(state, segment, { force: true })
     }
     segment.pendingTextPlanPrefix = planPrefix
-    segment.pendingText += normalizeDeltaBoundary(
+    const normalized = normalizeDeltaBoundary(
       segment.streamedText + segment.pendingText,
       markdown
     )
+    const remaining = MAX_LIVE_TEXT_CHARS - segment.streamedText.length - segment.pendingText.length
+    if (remaining <= 0) return
+    segment.pendingText += normalized.slice(0, remaining)
     if (opts.force || segment.pendingText.length >= TEXT_FLUSH_CHARS) {
       await this.flushText(state, segment, { force: true })
       return
@@ -582,38 +587,8 @@ function compactTaskBody(body: StreamTask['details'], maxLines: number): StreamT
   return richText([preformatted(clipLines(text, maxLines), language)])
 }
 
-function finalMarkdownForBlocks(markdown: string, tasks: StreamTask[]): string {
-  if (!tasks.length) return markdown
-  const remainingChars = slackReplyLimits.mixedBodyAndPlan.maxVisibleChars - taskVisibleChars(tasks)
-  if (remainingChars <= 0) return ''
-  return clipText(markdown, remainingChars)
-}
-
-function taskVisibleChars(tasks: StreamTask[]): number {
-  return tasks.reduce((total, task) => {
-    return (
-      total +
-      task.title.length +
-      taskBodyVisibleChars(task.details) +
-      taskBodyVisibleChars(task.output)
-    )
-  }, 0)
-}
-
-function taskBodyVisibleChars(body: StreamTask['details']): number {
-  if (!body) return 0
-  if (typeof body === 'string') return body.length
-  return body.elements.reduce((total, element) => {
-    return (
-      total +
-      element.elements.reduce((innerTotal, inline) => {
-        if ('text' in inline) return innerTotal + (inline.text ?? '').length
-        if ('url' in inline) return innerTotal + (inline.url ?? '').length
-        if ('user_id' in inline) return innerTotal + inline.user_id.length + 3
-        return innerTotal
-      }, 0)
-    )
-  }, 0)
+function finalMarkdownForBlocks(markdown: string): string {
+  return clipText(markdown, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
 }
 
 function clipText(value: string, maxChars: number): string {

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -891,6 +891,68 @@ describe('CodexSessionRenderer', () => {
     expect(String(detailUpdates[0]?.details ?? '')).toContain('```sh\ncall demo ping\n```')
   })
 
+  it('flushes the final buffered answer tail before stopping the stream', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async () => ({ ok: true })
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'call demo ping' }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.agentMessage.delta',
+      itemId: 'msg-1',
+      delta: 'Nulla facilisi.'
+    })
+    await renderer.event(sessionId, { type: 'turn.completed', result: 'Nulla facilisi.' })
+
+    const streamed = calls
+      .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
+      .flatMap(call => call.params.chunks ?? [])
+      .filter(chunk => chunk.type === 'markdown_text')
+      .map(chunk => String(chunk.text))
+      .join('')
+    expect(streamed).toContain('Nulla facilisi.')
+    expect(calls.some(call => call.method === 'chat.stopStream')).toBe(true)
+  })
+
   it('streams commentary and answer markdown live without duplicating them on stopStream', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -891,12 +891,15 @@ describe('CodexSessionRenderer', () => {
     expect(String(detailUpdates[0]?.details ?? '')).toContain('```sh\ncall demo ping\n```')
   })
 
-  it('flushes the final buffered answer tail before stopping the stream', async () => {
+  it('reports only Slack-visible streamed answer chars after live text is capped', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
         threads: {
-          setStatus: async () => ({ ok: true })
+          setStatus: async (params: any) => {
+            calls.push({ method: 'assistant.threads.setStatus', params })
+            return { ok: true }
+          }
         }
       },
       chat: {
@@ -927,11 +930,8 @@ describe('CodexSessionRenderer', () => {
       title: 'Centaur execution'
     })
     const renderer = new CodexSessionRenderer(client as any)
+    const longAnswer = 'x'.repeat(30_010)
 
-    await renderer.event(sessionId, {
-      type: 'item.started',
-      item: { id: 'cmd-1', type: 'commandExecution', command: 'call demo ping' }
-    })
     await renderer.event(sessionId, {
       type: 'item.started',
       item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
@@ -939,18 +939,18 @@ describe('CodexSessionRenderer', () => {
     await renderer.event(sessionId, {
       type: 'item.agentMessage.delta',
       itemId: 'msg-1',
-      delta: 'Nulla facilisi.'
+      delta: longAnswer
     })
-    await renderer.event(sessionId, { type: 'turn.completed', result: 'Nulla facilisi.' })
+    const result = await renderer.event(sessionId, { type: 'turn.done', result: longAnswer })
 
-    const streamed = calls
+    expect(result.streamedAnswerChars).toBe(30_000)
+    const visibleText = calls
       .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
       .flatMap(call => call.params.chunks ?? [])
-      .filter(chunk => chunk.type === 'markdown_text')
-      .map(chunk => String(chunk.text))
+      .filter((chunk: any) => chunk.type === 'markdown_text')
+      .map((chunk: any) => String(chunk.text ?? ''))
       .join('')
-    expect(streamed).toContain('Nulla facilisi.')
-    expect(calls.some(call => call.method === 'chat.stopStream')).toBe(true)
+    expect(visibleText.length).toBe(30_000)
   })
 
   it('streams commentary and answer markdown live without duplicating them on stopStream', async () => {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -271,12 +271,6 @@ export class CodexSessionRenderer {
     const canStream = hasPlan || opts.force || graceExpired
     if (!canStream) return
 
-    // Slack's stream markdown parser can silently corrupt rich_text_list output when
-    // list-shaped answer text is appended live. Fall back to authoritative final delivery.
-    if (containsMarkdownList(state.answerText)) {
-      throw new Error('slack_live_delivery_unsafe_markdown_list')
-    }
-
     if (state.commentaryText.length > state.streamedCommentaryText.length) return
     if (state.answerText.length <= state.streamedAnswerText.length) return
     const delta = state.answerText.slice(state.streamedAnswerText.length)
@@ -346,10 +340,6 @@ function getState(agentSessionId: string): CodexSessionState {
     states.set(agentSessionId, state)
   }
   return state
-}
-
-function containsMarkdownList(markdown: string): boolean {
-  return /^ {0,3}(?:\d{1,9}[.)]|[-*+])(?:\s|$)/m.test(markdown)
 }
 
 function content(event: any): any[] {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -34,6 +34,7 @@ type CodexSessionState = {
   firstBufferedTextAt: number | null
   streamedCommentaryText: string
   streamedAnswerText: string
+  deliveredAnswerChars: number
   agentMessagePhase: AgentMessagePhase | null
   planText: string
   taskByUseId: Map<string, HarnessTask>
@@ -205,7 +206,7 @@ export class CodexSessionRenderer {
     return {
       threadId: state.threadId || undefined,
       done: state.done,
-      streamedAnswerChars: state.streamedAnswerText.length
+      streamedAnswerChars: state.deliveredAnswerChars
     }
   }
 
@@ -218,11 +219,12 @@ export class CodexSessionRenderer {
     completeOpenTasks(state)
     await this.publishActivitySummary(agentSessionId, state, { final: true })
     await this.publishPendingAssistantText(agentSessionId, state, { force: true })
-    await this.renderer.done(agentSessionId, {
+    const { streamedTextChars } = await this.renderer.done(agentSessionId, {
       streamFinalUpdates: true,
       commentaryMarkdown: state.commentaryText,
       answerMarkdown: state.answerText
     })
+    state.deliveredAnswerChars = streamedTextChars
     state.done = true
     states.delete(agentSessionId)
   }
@@ -279,6 +281,7 @@ export class CodexSessionRenderer {
     })
     if (acceptedChars > 0) {
       state.streamedAnswerText += delta.slice(0, acceptedChars)
+      state.deliveredAnswerChars = this.renderer.streamedTextChars(agentSessionId)
     }
   }
 
@@ -325,6 +328,7 @@ function getState(agentSessionId: string): CodexSessionState {
       firstBufferedTextAt: null,
       streamedCommentaryText: '',
       streamedAnswerText: '',
+      deliveredAnswerChars: 0,
       agentMessagePhase: null,
       planText: '',
       taskByUseId: new Map(),

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -273,11 +273,13 @@ export class CodexSessionRenderer {
     if (state.answerText.length <= state.streamedAnswerText.length) return
     const delta = state.answerText.slice(state.streamedAnswerText.length)
     if (!delta) return
-    state.streamedAnswerText = state.answerText
-    await this.renderer.textDelta(agentSessionId, delta, {
+    const acceptedChars = await this.renderer.textDelta(agentSessionId, delta, {
       force: opts.force ?? false,
       planPrefix: hasPlan
     })
+    if (acceptedChars > 0) {
+      state.streamedAnswerText += delta.slice(0, acceptedChars)
+    }
   }
 
   private async publishStructuredPlan(

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -53,7 +53,10 @@ export class CodexSessionRenderer {
     this.renderer = new AgentSessionRenderer(client)
   }
 
-  async event(agentSessionId: string, event: any): Promise<{ threadId?: string; done: boolean }> {
+  async event(
+    agentSessionId: string,
+    event: any
+  ): Promise<{ threadId?: string; done: boolean; streamedAnswerChars: number }> {
     const state = getState(agentSessionId)
     if (event?.session_id) state.threadId = String(event.session_id)
     if (event?.thread_id) state.threadId = String(event.thread_id)
@@ -199,7 +202,11 @@ export class CodexSessionRenderer {
       await this.done(agentSessionId)
     }
 
-    return { threadId: state.threadId || undefined, done: state.done }
+    return {
+      threadId: state.threadId || undefined,
+      done: state.done,
+      streamedAnswerChars: state.streamedAnswerText.length
+    }
   }
 
   async done(agentSessionId: string, threadId?: string): Promise<void> {
@@ -212,7 +219,7 @@ export class CodexSessionRenderer {
     await this.publishActivitySummary(agentSessionId, state, { final: true })
     await this.publishPendingAssistantText(agentSessionId, state, { force: true })
     await this.renderer.done(agentSessionId, {
-      streamFinalUpdates: false,
+      streamFinalUpdates: true,
       commentaryMarkdown: state.commentaryText,
       answerMarkdown: state.answerText
     })
@@ -627,7 +634,7 @@ function shellLanguage(language: string | undefined): string {
   return language === 'bash' || !language ? 'sh' : language
 }
 
-function shellLanguageForCommand(command: string): string {
+function shellLanguageForCommand(_command: string): string {
   return 'sh'
 }
 

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -271,6 +271,12 @@ export class CodexSessionRenderer {
     const canStream = hasPlan || opts.force || graceExpired
     if (!canStream) return
 
+    // Slack's stream markdown parser can silently corrupt rich_text_list output when
+    // list-shaped answer text is appended live. Fall back to authoritative final delivery.
+    if (containsMarkdownList(state.answerText)) {
+      throw new Error('slack_live_delivery_unsafe_markdown_list')
+    }
+
     if (state.commentaryText.length > state.streamedCommentaryText.length) return
     if (state.answerText.length <= state.streamedAnswerText.length) return
     const delta = state.answerText.slice(state.streamedAnswerText.length)
@@ -340,6 +346,10 @@ function getState(agentSessionId: string): CodexSessionState {
     states.set(agentSessionId, state)
   }
   return state
+}
+
+function containsMarkdownList(markdown: string): boolean {
+  return /^ {0,3}(?:\d{1,9}[.)]|[-*+])(?:\s|$)/m.test(markdown)
 }
 
 function content(event: any): any[] {

--- a/services/slackbot/src/slack/final-message.ts
+++ b/services/slackbot/src/slack/final-message.ts
@@ -50,49 +50,13 @@ function capMarkdownBlocksCumulative(blocks: AnyBlock[], maxChars: number): AnyB
 
 function shrinkToPayloadByteBudget(blocks: AnyBlock[], maxBytes: number): AnyBlock[] {
   let sanitized = blocks
-  let bytes = estimatePayloadBytes(sanitized)
+  if (estimatePayloadBytes(sanitized) <= maxBytes) return sanitized
+
+  sanitized = trimPlanTasks(stripPlanTaskBodies(sanitized), 0)
+  const bytes = estimatePayloadBytes(sanitized)
   if (bytes <= maxBytes) return sanitized
 
-  sanitized = trimMarkdownFromEnd(sanitized, 0.25)
-  bytes = estimatePayloadBytes(sanitized)
-  if (bytes <= maxBytes) return sanitized
-
-  sanitized = dropTrailingMarkdownBlocks(sanitized)
-  bytes = estimatePayloadBytes(sanitized)
-  if (bytes <= maxBytes) return sanitized
-
-  sanitized = stripPlanTaskBodies(sanitized)
-  bytes = estimatePayloadBytes(sanitized)
-  if (bytes <= maxBytes) return sanitized
-
-  sanitized = trimPlanTasks(sanitized, slackReplyLimits.finalPlan.maxTasks)
-  return sanitized
-}
-
-function trimMarkdownFromEnd(blocks: AnyBlock[], fraction: number): AnyBlock[] {
-  const out = blocks.map(block => ({ ...block })) as AnyBlock[]
-  for (let index = out.length - 1; index >= 0; index -= 1) {
-    const block = out[index]
-    if (block?.type !== 'markdown') continue
-    const markdown = block as MarkdownBlock
-    const keep = Math.max(1, Math.floor(markdown.text.length * (1 - fraction)))
-    markdown.text = markdown.text.slice(0, keep).trimEnd() || ' '
-    if (estimatePayloadBytes(out) <= PAYLOAD_BYTE_BUDGET) break
-  }
-  return out
-}
-
-function dropTrailingMarkdownBlocks(blocks: AnyBlock[]): AnyBlock[] {
-  const out = [...blocks]
-  while (out.length > 0 && estimatePayloadBytes(out) > PAYLOAD_BYTE_BUDGET) {
-    const lastIndex = out.length - 1
-    if (out[lastIndex]?.type === 'markdown') {
-      out.pop()
-      continue
-    }
-    break
-  }
-  return out
+  return blocks.filter(block => block.type === 'markdown') as AnyBlock[]
 }
 
 function stripPlanTaskBodies(blocks: AnyBlock[]): AnyBlock[] {

--- a/services/slackbot/src/slack/installations.ts
+++ b/services/slackbot/src/slack/installations.ts
@@ -79,7 +79,10 @@ export class SlackClientResolver {
   }
 }
 
-export function createSlackWebClient(token: string, opts: SlackClientOptions = {}): WebClient {
+export function createSlackWebClient(
+  token: string,
+  opts: SlackClientOptions = {}
+): WebClient {
   return new WebClient(
     token,
     opts.slackApiUrl

--- a/services/slackbot/src/slack/installations.ts
+++ b/services/slackbot/src/slack/installations.ts
@@ -79,10 +79,7 @@ export class SlackClientResolver {
   }
 }
 
-export function createSlackWebClient(
-  token: string,
-  opts: SlackClientOptions = {}
-): WebClient {
+export function createSlackWebClient(token: string, opts: SlackClientOptions = {}): WebClient {
   return new WebClient(
     token,
     opts.slackApiUrl

--- a/services/slackbot/src/slack/render.ts
+++ b/services/slackbot/src/slack/render.ts
@@ -120,14 +120,14 @@ function splitText(input: string, maxChars: number): string[] {
   let remaining = input
   while (remaining.length > maxChars) {
     const hard = remaining.slice(0, maxChars)
-    const boundary = Math.max(
-      hard.lastIndexOf('\n\n'),
-      hard.lastIndexOf('\n'),
-      hard.lastIndexOf(' ')
-    )
-    const take = boundary > maxChars * 0.5 ? boundary : maxChars
+    const paragraphBoundary = hard.lastIndexOf('\n\n')
+    const lineBoundary = hard.lastIndexOf('\n')
+    const spaceBoundary = hard.lastIndexOf(' ')
+    const boundary = Math.max(paragraphBoundary, lineBoundary, spaceBoundary)
+    const delimiterLength = boundary === paragraphBoundary ? 2 : boundary >= 0 ? 1 : 0
+    const take = boundary > maxChars * 0.5 ? boundary + delimiterLength : maxChars
     chunks.push(remaining.slice(0, take))
-    remaining = remaining.slice(take).trimStart()
+    remaining = remaining.slice(take)
   }
   if (remaining) chunks.push(remaining)
   return chunks

--- a/services/slackbot/src/slack/render.ts
+++ b/services/slackbot/src/slack/render.ts
@@ -4,7 +4,7 @@ import { slackReplyLimits } from '../constants'
 const MAX_BLOCKS = slackReplyLimits.message.maxBlocks
 const MAX_MARKDOWN_CHARS = slackReplyLimits.stream.markdownChunkChars
 const MAX_FALLBACK_CHARS = slackReplyLimits.text.maxFallbackChars
-const MAX_STREAM_CHUNK_CHARS = 4_000
+const MAX_STREAM_CHUNK_CHARS = slackReplyLimits.stream.markdownChunkChars
 
 export type StatusMetadata = {
   title?: string


### PR DESCRIPTION
 - split oversized slack final-delivery text into follow-up replies
 - preserve already streamed answer offset when live slack delivery fails, so fallback delivery only posts the missing continuation