### PR TITLE
feat: add oauth_token password grant and token_endpoint_headers

### DIFF
--- a/docs/pages/extend/tools.mdx
+++ b/docs/pages/extend/tools.mdx
@@ -47,9 +47,11 @@ Each entry in `secrets` declares one credential the tool can request with
   `secret("...")`; iron-proxy swaps that placeholder for the real value at the
   network boundary.
 - `type = "oauth_token"` is for OAuth2 APIs. iron-proxy resolves the declared
-  `fields`, runs either a `refresh_token` or `client_credentials` exchange,
+  `fields`, runs a `refresh_token`, `client_credentials`, or `password` exchange,
   caches and refreshes the access token, then injects `Authorization: Bearer ...`
-  for the configured `hosts`.
+  for the configured `hosts`. Set `token_endpoint_headers` to send extra headers
+  on the token POST itself (for endpoints that require an API key alongside the
+  standard form-body client auth).
 - `type = "gcp_auth"` is for Google service-account JSON. iron-proxy resolves
   the keyfile, mints Google OAuth tokens for `scopes`, and injects them for the
   configured Google API `hosts`. If omitted, hosts default to

--- a/docs/public/md/extend/tools.md
+++ b/docs/public/md/extend/tools.md
@@ -47,9 +47,11 @@ Each entry in `secrets` declares one credential the tool can request with
   `secret("...")`; iron-proxy swaps that placeholder for the real value at the
   network boundary.
 - `type = "oauth_token"` is for OAuth2 APIs. iron-proxy resolves the declared
-  `fields`, runs either a `refresh_token` or `client_credentials` exchange,
+  `fields`, runs a `refresh_token`, `client_credentials`, or `password` exchange,
   caches and refreshes the access token, then injects `Authorization: Bearer ...`
-  for the configured `hosts`.
+  for the configured `hosts`. Set `token_endpoint_headers` to send extra headers
+  on the token POST itself (for endpoints that require an API key alongside the
+  standard form-body client auth).
 - `type = "gcp_auth"` is for Google service-account JSON. iron-proxy resolves
   the keyfile, mints Google OAuth tokens for `scopes`, and injects them for the
   configured Google API `hosts`. If omitted, hosts default to

--- a/services/api/api/proxy_config.py
+++ b/services/api/api/proxy_config.py
@@ -216,13 +216,23 @@ def _build_oauth_token_transform(
     fields are omitted when unset so the rendered config stays minimal.
     """
     by_token: dict[
-        tuple[str, tuple[tuple[str, OAuthFieldSource], ...], str | None],
+        tuple[
+            str,
+            tuple[tuple[str, OAuthFieldSource], ...],
+            str | None,
+            tuple[tuple[str, OAuthFieldSource], ...],
+        ],
         dict[str, set[str]],
     ] = {}
     for secret in secrets:
         if not isinstance(secret, OAuthTokenSecret):
             continue
-        key = (secret.grant, secret.fields, secret.token_endpoint)
+        key = (
+            secret.grant,
+            secret.fields,
+            secret.token_endpoint,
+            secret.token_endpoint_headers,
+        )
         agg = by_token.setdefault(key, {"hosts": set(), "scopes": set()})
         agg["hosts"].update(secret.hosts)
         agg["scopes"].update(secret.scopes)
@@ -231,20 +241,26 @@ def _build_oauth_token_transform(
         return None
 
     def _sort_key(
-        k: tuple[str, tuple[tuple[str, OAuthFieldSource], ...], str | None],
+        k: tuple[
+            str,
+            tuple[tuple[str, OAuthFieldSource], ...],
+            str | None,
+            tuple[tuple[str, OAuthFieldSource], ...],
+        ],
     ) -> tuple[str, ...]:
-        grant, fields, token_endpoint = k
+        grant, fields, token_endpoint, endpoint_headers = k
         # None sorts before any string; normalize None to "" so mixed
         # None/str keys stay comparable.
         return (
             grant,
             token_endpoint or "",
             tuple(name for name, _ in fields),
+            tuple(name for name, _ in endpoint_headers),
         )
 
     tokens: list[dict[str, Any]] = []
     for key in sorted(by_token, key=_sort_key):
-        grant, fields, token_endpoint = key
+        grant, fields, token_endpoint, endpoint_headers = key
         agg = by_token[key]
         entry: dict[str, Any] = {"grant": grant}
         for field_name, field_source in fields:
@@ -254,6 +270,11 @@ def _build_oauth_token_transform(
             entry["scopes"] = sorted(agg["scopes"])
         if token_endpoint is not None:
             entry["token_endpoint"] = token_endpoint
+        if endpoint_headers:
+            entry["token_endpoint_headers"] = {
+                header_name: _build_field_source(source)
+                for header_name, source in endpoint_headers
+            }
         tokens.append(entry)
     return {"name": "oauth_token", "config": {"tokens": tokens}}
 

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -185,13 +185,16 @@ class OAuthTokenSecret:
     credential fields nor the minted token ever reach the sandbox.
 
     ``grant`` is one of ``refresh_token`` (RFC 6749 — an authorized-user
-    credential) or ``client_credentials`` (RFC 6749 4.4 — a client id and
-    secret).
+    credential), ``client_credentials`` (RFC 6749 4.4 — a client id and
+    secret), or ``password`` (RFC 6749 4.3 — a resource-owner username and
+    password exchanged for a token).
 
     ``fields`` maps each grant's credential fields to a source; fields may be
     sourced from separate secrets or pulled from one JSON secret via
     ``json_key``. ``token_endpoint`` is the OAuth2 token endpoint to exchange
-    against.
+    against. ``token_endpoint_headers`` adds extra headers to the token POST
+    itself, each value resolved from its own source; use this when the token
+    endpoint requires an API key alongside the standard form-body client auth.
     """
 
     name: str
@@ -200,6 +203,7 @@ class OAuthTokenSecret:
     fields: tuple[tuple[str, OAuthFieldSource], ...]
     scopes: tuple[str, ...] = ()
     token_endpoint: str | None = None
+    token_endpoint_headers: tuple[tuple[str, OAuthFieldSource], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -261,6 +265,10 @@ _OAUTH_GRANT_FIELDS: dict[str, tuple[frozenset[str], frozenset[str]]] = {
     "client_credentials": (
         frozenset({"client_id", "client_secret"}),
         frozenset(),
+    ),
+    "password": (
+        frozenset({"username", "password", "client_id"}),
+        frozenset({"client_secret"}),
     ),
 }
 
@@ -336,6 +344,37 @@ def _parse_oauth_fields(
         raise ValueError(
             f"oauth_token entry {secret_name!r} grant {grant!r} requires "
             f"fields {sorted(missing)}"
+        )
+    return tuple(sorted(parsed.items()))
+
+
+def _parse_oauth_token_endpoint_headers(
+    secret_name: str, raw: Any
+) -> tuple[tuple[str, OAuthFieldSource], ...]:
+    """Parse the ``token_endpoint_headers`` table for an ``oauth_token`` entry.
+
+    Each entry maps a header name to a secret source. iron-proxy sends these
+    headers on the token POST itself, alongside the form-body client auth, so
+    each value is resolved like any other ``OAuthFieldSource``: a bare
+    ``secret_ref`` string or a table with ``secret_ref`` and optional
+    ``json_key``.
+    """
+    if raw is None:
+        return ()
+    if not isinstance(raw, dict) or not raw:
+        raise ValueError(
+            f"oauth_token entry {secret_name!r} 'token_endpoint_headers' must "
+            f"be a non-empty table"
+        )
+    parsed: dict[str, OAuthFieldSource] = {}
+    for header_name, value in raw.items():
+        if not isinstance(header_name, str) or not header_name:
+            raise ValueError(
+                f"oauth_token entry {secret_name!r} 'token_endpoint_headers' "
+                f"keys must be non-empty header names"
+            )
+        parsed[header_name] = _parse_oauth_field_source(
+            secret_name, f"token_endpoint_headers.{header_name}", value
         )
     return tuple(sorted(parsed.items()))
 
@@ -683,6 +722,9 @@ def _parse_secret(entry: Any, *, default_hosts: tuple[str, ...] = ()) -> SecretD
                 f"non-empty string"
             )
         fields = _parse_oauth_fields(name, grant, entry.get("fields"))
+        token_endpoint_headers = _parse_oauth_token_endpoint_headers(
+            name, entry.get("token_endpoint_headers")
+        )
         return OAuthTokenSecret(
             name=name,
             grant=grant,
@@ -690,6 +732,7 @@ def _parse_secret(entry: Any, *, default_hosts: tuple[str, ...] = ()) -> SecretD
             fields=fields,
             scopes=tuple(scopes),
             token_endpoint=token_endpoint,
+            token_endpoint_headers=token_endpoint_headers,
         )
     if secret_type == "pg_dsn":
         database = entry.get("database")

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -405,6 +405,146 @@ def test_parser_oauth_token_rejects_missing_required_field() -> None:
         )
 
 
+def test_parser_typed_oauth_token_password_grant() -> None:
+    secret = _parse_secret(
+        {
+            "type": "oauth_token",
+            "grant": "password",
+            "name": "VENDOR_OAUTH",
+            "hosts": ["api.example.com"],
+            "token_endpoint": "https://api.example.com/token",
+            "fields": {
+                "username": "API_USERNAME",
+                "password": "API_PASSWORD",
+                "client_id": "API_CLIENT_ID",
+                "client_secret": "API_CLIENT_SECRET",
+            },
+        }
+    )
+    assert isinstance(secret, OAuthTokenSecret)
+    assert secret.grant == "password"
+    assert secret.token_endpoint == "https://api.example.com/token"
+    fields = dict(secret.fields)
+    assert fields["username"] == OAuthFieldSource("API_USERNAME")
+    assert fields["password"] == OAuthFieldSource("API_PASSWORD")
+    assert fields["client_id"] == OAuthFieldSource("API_CLIENT_ID")
+    assert fields["client_secret"] == OAuthFieldSource("API_CLIENT_SECRET")
+
+
+def test_parser_oauth_token_password_grant_makes_client_secret_optional() -> None:
+    # Public clients (RFC 6749 4.3) authenticate with username/password and a
+    # client_id only — client_secret is optional.
+    secret = _parse_secret(
+        {
+            "type": "oauth_token",
+            "grant": "password",
+            "name": "VENDOR_OAUTH",
+            "hosts": ["api.example.com"],
+            "fields": {
+                "username": "API_USERNAME",
+                "password": "API_PASSWORD",
+                "client_id": "API_CLIENT_ID",
+            },
+        }
+    )
+    assert isinstance(secret, OAuthTokenSecret)
+    assert "client_secret" not in dict(secret.fields)
+
+
+def test_parser_oauth_token_password_grant_rejects_missing_username() -> None:
+    with pytest.raises(ValueError, match="requires fields \\['username'\\]"):
+        _parse_secret(
+            {
+                "type": "oauth_token",
+                "grant": "password",
+                "name": "X",
+                "hosts": ["h"],
+                "fields": {
+                    "password": "PW",
+                    "client_id": "CID",
+                },
+            }
+        )
+
+
+def test_parser_oauth_token_token_endpoint_headers_accepts_bare_string() -> None:
+    secret = _parse_secret(
+        {
+            "type": "oauth_token",
+            "grant": "client_credentials",
+            "name": "OAUTH_APP",
+            "hosts": ["api.example.com"],
+            "fields": {
+                "client_id": "OAUTH_CLIENT_ID",
+                "client_secret": "OAUTH_CLIENT_SECRET",
+            },
+            "token_endpoint_headers": {
+                "x-api-key": "API_KEY",
+            },
+        }
+    )
+    assert isinstance(secret, OAuthTokenSecret)
+    assert secret.token_endpoint_headers == (
+        ("x-api-key", OAuthFieldSource("API_KEY")),
+    )
+
+
+def test_parser_oauth_token_token_endpoint_headers_accepts_table_with_json_key() -> None:
+    secret = _parse_secret(
+        {
+            "type": "oauth_token",
+            "grant": "client_credentials",
+            "name": "OAUTH_APP",
+            "hosts": ["api.example.com"],
+            "fields": {
+                "client_id": "OAUTH_CLIENT_ID",
+                "client_secret": "OAUTH_CLIENT_SECRET",
+            },
+            "token_endpoint_headers": {
+                "x-api-key": {"secret_ref": "BUNDLE", "json_key": "api_key"},
+            },
+        }
+    )
+    assert secret.token_endpoint_headers == (
+        ("x-api-key", OAuthFieldSource("BUNDLE", "api_key")),
+    )
+
+
+def test_parser_oauth_token_token_endpoint_headers_rejects_empty_table() -> None:
+    with pytest.raises(
+        ValueError, match="'token_endpoint_headers' must be a non-empty table"
+    ):
+        _parse_secret(
+            {
+                "type": "oauth_token",
+                "grant": "client_credentials",
+                "name": "X",
+                "hosts": ["h"],
+                "fields": {
+                    "client_id": "CID",
+                    "client_secret": "CS",
+                },
+                "token_endpoint_headers": {},
+            }
+        )
+
+
+def test_parser_oauth_token_token_endpoint_headers_defaults_to_empty() -> None:
+    secret = _parse_secret(
+        {
+            "type": "oauth_token",
+            "grant": "client_credentials",
+            "name": "OAUTH_APP",
+            "hosts": ["api.example.com"],
+            "fields": {
+                "client_id": "OAUTH_CLIENT_ID",
+                "client_secret": "OAUTH_CLIENT_SECRET",
+            },
+        }
+    )
+    assert secret.token_endpoint_headers == ()
+
+
 def test_parser_oauth_token_rejects_field_invalid_for_grant() -> None:
     with pytest.raises(ValueError, match="is not valid for grant 'refresh_token'"):
         _parse_secret(
@@ -827,6 +967,128 @@ def test_render_oauth_token_separate_entries_for_distinct_fields() -> None:
         t for t in cfg["transforms"] if t["name"] == "oauth_token"
     )["config"]["tokens"]
     assert len(tokens) == 2
+
+
+_RENDER_PASSWORD_FIELDS = (
+    ("client_id", OAuthFieldSource("API_CLIENT_ID")),
+    ("client_secret", OAuthFieldSource("API_CLIENT_SECRET")),
+    ("password", OAuthFieldSource("API_PASSWORD")),
+    ("username", OAuthFieldSource("API_USERNAME")),
+)
+
+
+def test_render_oauth_token_password_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    secrets = [
+        OAuthTokenSecret(
+            name="VENDOR_OAUTH",
+            grant="password",
+            hosts=("api.example.com",),
+            fields=_RENDER_PASSWORD_FIELDS,
+            token_endpoint="https://api.example.com/token",
+        )
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    tokens = next(
+        t for t in cfg["transforms"] if t["name"] == "oauth_token"
+    )["config"]["tokens"]
+    assert tokens[0]["grant"] == "password"
+    assert tokens[0]["username"] == {"type": "env", "var": "API_USERNAME"}
+    assert tokens[0]["password"] == {"type": "env", "var": "API_PASSWORD"}
+    assert tokens[0]["client_id"] == {"type": "env", "var": "API_CLIENT_ID"}
+    assert tokens[0]["client_secret"] == {"type": "env", "var": "API_CLIENT_SECRET"}
+    assert tokens[0]["token_endpoint"] == "https://api.example.com/token"
+    assert tokens[0]["rules"] == [{"host": "api.example.com"}]
+
+
+def test_render_oauth_token_emits_token_endpoint_headers_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    secrets = [
+        OAuthTokenSecret(
+            name="OAUTH_APP",
+            grant="client_credentials",
+            hosts=("api.example.com",),
+            fields=_RENDER_CC_FIELDS,
+            token_endpoint="https://login.example.com/oauth2/token",
+            token_endpoint_headers=(
+                ("x-api-key", OAuthFieldSource("API_KEY")),
+            ),
+        )
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    tokens = next(
+        t for t in cfg["transforms"] if t["name"] == "oauth_token"
+    )["config"]["tokens"]
+    assert tokens[0]["token_endpoint_headers"] == {
+        "x-api-key": {"type": "env", "var": "API_KEY"},
+    }
+
+
+def test_render_oauth_token_omits_token_endpoint_headers_when_empty() -> None:
+    secrets = [
+        OAuthTokenSecret(
+            name="OAUTH_APP",
+            grant="client_credentials",
+            hosts=("api.example.com",),
+            fields=_RENDER_CC_FIELDS,
+        )
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    tokens = next(
+        t for t in cfg["transforms"] if t["name"] == "oauth_token"
+    )["config"]["tokens"]
+    assert "token_endpoint_headers" not in tokens[0]
+
+
+def test_render_oauth_token_separate_entries_for_distinct_endpoint_headers() -> None:
+    secrets = [
+        OAuthTokenSecret(
+            "A",
+            "client_credentials",
+            ("a.example.com",),
+            _RENDER_CC_FIELDS,
+            token_endpoint_headers=(("x-api-key", OAuthFieldSource("KEY_A")),),
+        ),
+        OAuthTokenSecret(
+            "B",
+            "client_credentials",
+            ("b.example.com",),
+            _RENDER_CC_FIELDS,
+            token_endpoint_headers=(("x-api-key", OAuthFieldSource("KEY_B")),),
+        ),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    tokens = next(
+        t for t in cfg["transforms"] if t["name"] == "oauth_token"
+    )["config"]["tokens"]
+    assert len(tokens) == 2
+
+
+def test_render_oauth_token_endpoint_headers_resolve_via_onepassword(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    monkeypatch.setenv("OP_VAULT", "ai-agents")
+    secrets = [
+        OAuthTokenSecret(
+            name="OAUTH_APP",
+            grant="client_credentials",
+            hosts=("api.example.com",),
+            fields=_RENDER_CC_FIELDS,
+            token_endpoint_headers=(("x-api-key", OAuthFieldSource("API_KEY")),),
+        )
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    tokens = next(
+        t for t in cfg["transforms"] if t["name"] == "oauth_token"
+    )["config"]["tokens"]
+    headers = tokens[0]["token_endpoint_headers"]
+    assert headers["x-api-key"]["type"] == "1password"
+    assert headers["x-api-key"]["secret_ref"] == "op://ai-agents/API_KEY/credential"
 
 
 def test_render_oauth_token_emits_token_endpoint_when_set() -> None:

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ironsh/iron-proxy:0.37.0@sha256:f480a0f8233b8bb180e5837e24feeb71f214eaa10fdfa2439dd9aed7ecee62d6
+FROM ironsh/iron-proxy:0.38.0@sha256:724c075e22e962e3452a95cd0680a195a42082033bb830b1eed0d4b7911b5626
 
 USER root
 RUN apk add --no-cache curl jq


### PR DESCRIPTION
Adds the RFC 6749 4.3 `password` grant to the `oauth_token` secret type (required fields: `username`, `password`, `client_id`; optional: `client_secret`). Adds a new `token_endpoint_headers` map on any `oauth_token` entry that sends extra headers on the token POST itself, each value resolved from its own secret source: useful when the token endpoint requires an API key alongside the standard form-body client auth. Bumps iron-proxy from 0.37.0 to 0.38.0.