### PR TITLE
fix: harden Slack delivery after live stream failures

### DIFF
--- a/services/api/api/final_delivery.py
+++ b/services/api/api/final_delivery.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
-NON_RETRYABLE_ERROR_CLASSES = frozenset({
-    "invalid_destination",
-    "restricted_destination",
-    "invalid_payload",
-    "duplicate_or_conflict",
-})
+# Slack-side classes cannot recover within a single delivery window, so the
+# outbox should dead-letter immediately rather than burn 50 retry attempts.
+NON_RETRYABLE_ERROR_CLASSES = frozenset(
+    {
+        "invalid_destination",
+        "restricted_destination",
+        "invalid_payload",
+        "duplicate_or_conflict",
+        "msg_too_long",
+        "user_not_found",
+        "channel_not_found",
+        "missing_slack_delivery_target",
+        "account_inactive",
+        "is_archived",
+        "restricted_action",
+        "not_in_channel",
+    }
+)
 
 
 def normalize_error_class(error_class: str | None) -> str | None:

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -183,7 +183,9 @@ def prompt_identity(
     return prompt_ref, sha
 
 
-def _agent_session_title(*, persona_id: str | None, engine: str | None, harness: str | None) -> str:
+def _agent_session_title(
+    *, persona_id: str | None, engine: str | None, harness: str | None
+) -> str:
     parts = ["Centaur"]
     persona = (persona_id or "").strip()
     runtime = (engine or harness or "codex").strip()
@@ -932,7 +934,11 @@ def build_execution_state_payload(
 
 
 def _clip_slackbot(value: Any, max_chars: int = _MAX_SLACKBOT_STEP_CHARS) -> str:
-    text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False, default=str)
+    text = (
+        value
+        if isinstance(value, str)
+        else json.dumps(value, ensure_ascii=False, default=str)
+    )
     text = text.strip()
     return text if len(text) <= max_chars else f"{text[: max_chars - 1]}…"
 
@@ -972,11 +978,15 @@ async def _mark_slackbot_live_delivery_failed(
 def _canonical_text_blocks(event: dict[str, Any]) -> list[str]:
     if event.get("type") == "assistant":
         message = event.get("message") if isinstance(event.get("message"), dict) else {}
-        content = message.get("content") if isinstance(message.get("content"), list) else []
+        content = (
+            message.get("content") if isinstance(message.get("content"), list) else []
+        )
         return [
             str(block.get("text") or "")
             for block in content
-            if isinstance(block, dict) and block.get("type") == "text" and str(block.get("text") or "").strip()
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and str(block.get("text") or "").strip()
         ]
     if event.get("type") == "result":
         text = str(event.get("result") or event.get("text") or "")
@@ -984,7 +994,9 @@ def _canonical_text_blocks(event: dict[str, Any]) -> list[str]:
     return []
 
 
-async def _send_slackbot_canonical_event(session_id: str, event: dict[str, Any]) -> bool:
+async def _send_slackbot_canonical_event(
+    session_id: str, event: dict[str, Any]
+) -> bool:
     sent_text = False
     for text in _canonical_text_blocks(event):
         await slackbot_client.session_text(
@@ -996,13 +1008,17 @@ async def _send_slackbot_canonical_event(session_id: str, event: dict[str, Any])
     event_type = str(event.get("type") or "")
     if event_type == "assistant":
         message = event.get("message") if isinstance(event.get("message"), dict) else {}
-        content = message.get("content") if isinstance(message.get("content"), list) else []
+        content = (
+            message.get("content") if isinstance(message.get("content"), list) else []
+        )
         for block in content:
             if not isinstance(block, dict) or block.get("type") != "tool_use":
                 continue
             tool_id = str(block.get("id") or uuid.uuid4())
             tool_name = str(block.get("name") or "Tool")
-            tool_input = block.get("input") if isinstance(block.get("input"), dict) else {}
+            tool_input = (
+                block.get("input") if isinstance(block.get("input"), dict) else {}
+            )
             await slackbot_client.session_step(
                 session_id,
                 step_id=tool_id,
@@ -1271,7 +1287,9 @@ async def enqueue_execution(
                 silence_deadline,
                 hard_deadline,
             )
-            if _delivery_platform(delivery) != "dev" and not _has_slackbot_live_delivery(metadata):
+            if _delivery_platform(
+                delivery
+            ) != "dev" and not _has_slackbot_live_delivery(metadata):
                 await conn.execute(
                     "INSERT INTO agent_final_delivery_outbox ("
                     "execution_id, thread_key, delivery, state"
@@ -1463,7 +1481,12 @@ async def steer_execution(
 
     Falls back to cancel_execution() if steering fails.
     """
-    from api.agent import _db_get_session, _flush_pending, _flushed_to_messages, _get_last_delivered_id
+    from api.agent import (
+        _db_get_session,
+        _flush_pending,
+        _flushed_to_messages,
+        _get_last_delivered_id,
+    )
     from api.sandbox.harness_protocol import messages_to_content_blocks
 
     row = await pool.fetchrow(
@@ -1577,7 +1600,9 @@ async def steer_execution(
             "ok": True,
             "execution_id": execution_id,
             "thread_key": thread_key,
-            "status": "cancel_requested" if current_status == "cancelled" else current_status,
+            "status": "cancel_requested"
+            if current_status == "cancelled"
+            else current_status,
         }
 
     if message_id and content_blocks:
@@ -1795,10 +1820,18 @@ async def _mark_execution_terminal(
                 isinstance(steer_replacement, dict)
                 and steer_replacement.get("suppress_cancellation_delivery") is True
             )
-            slackbot_live_delivery_failed = bool(metadata.get("slackbot_live_delivery_failed"))
-            suppress_legacy_delivery = _has_slackbot_live_delivery(metadata) and not slackbot_live_delivery_failed
+            slackbot_live_delivery_failed = bool(
+                metadata.get("slackbot_live_delivery_failed")
+            )
+            suppress_legacy_delivery = (
+                _has_slackbot_live_delivery(metadata)
+                and not slackbot_live_delivery_failed
+            )
             raw_streamed_answer_chars = metadata.get("slackbot_streamed_answer_chars")
-            if isinstance(raw_streamed_answer_chars, int) and not slackbot_live_delivery_failed:
+            if (
+                isinstance(raw_streamed_answer_chars, int)
+                and not slackbot_live_delivery_failed
+            ):
                 slackbot_streamed_answer_chars = max(raw_streamed_answer_chars, 0)
         assignment_row = await pool.fetchrow(
             "SELECT harness, engine, persona_id, prompt_ref, effective_agents_md_sha256 "
@@ -1848,7 +1881,11 @@ async def _mark_execution_terminal(
             **({"error_text": error_text} if error_text else {}),
             **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
             **({"repo_context": repo_context} if repo_context else {}),
-            **({"suppress_final_delivery": True} if suppress_final_delivery_payload else {}),
+            **(
+                {"suppress_final_delivery": True}
+                if suppress_final_delivery_payload
+                else {}
+            ),
         },
     )
     delivery_platform = _delivery_platform(
@@ -1856,12 +1893,16 @@ async def _mark_execution_terminal(
     )
     if delivery_platform == "dev" or suppress_legacy_delivery:
         log.info(
-            "final_delivery_skipped" if suppress_legacy_delivery else "final_delivery_skipped_dev",
+            "final_delivery_skipped"
+            if suppress_legacy_delivery
+            else "final_delivery_skipped_dev",
             execution_id=execution_id,
             thread_key=thread_key,
             status=status,
             terminal_reason=terminal_reason,
-            reason="slackbot_live_delivery" if suppress_legacy_delivery else "dev_delivery",
+            reason="slackbot_live_delivery"
+            if suppress_legacy_delivery
+            else "dev_delivery",
         )
         try:
             from api.workflow_engine import notify_execution_terminal
@@ -1914,7 +1955,11 @@ async def _mark_execution_terminal(
                 ),
                 **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
                 **({"repo_context": repo_context} if repo_context else {}),
-                **({"suppress_final_delivery": True} if suppress_final_delivery_payload else {}),
+                **(
+                    {"suppress_final_delivery": True}
+                    if suppress_final_delivery_payload
+                    else {}
+                ),
             }
         ),
         next_attempt_at,
@@ -1940,7 +1985,11 @@ async def _mark_execution_terminal(
             "result_text": result_text,
             **({"error_text": error_text} if error_text else {}),
             **({"repo_context": repo_context} if repo_context else {}),
-            **({"suppress_final_delivery": True} if suppress_final_delivery_payload else {}),
+            **(
+                {"suppress_final_delivery": True}
+                if suppress_final_delivery_payload
+                else {}
+            ),
         },
     )
     log.info(
@@ -2433,6 +2482,10 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
     slackbot_text_sent = False
     slackbot_done = False
     harness_thread_id = ""
+    # Tolerate up to 5 consecutive harness_event failures before falling back
+    # to the outbox path; the streak resets on the next success.
+    slackbot_live_failure_streak = 0
+    slackbot_live_failure_limit = 5
 
     async def _finalize_execution(
         *,
@@ -2501,7 +2554,9 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 if result_text.strip() and not slackbot_text_sent:
                     await slackbot_client.session_text(finalize_session_id, result_text)
                     slackbot_text_sent = True
-                await slackbot_client.session_done(finalize_session_id, harness_thread_id or None)
+                await slackbot_client.session_done(
+                    finalize_session_id, harness_thread_id or None
+                )
                 slackbot_done = True
             except Exception:
                 log.warning(
@@ -2647,26 +2702,43 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 for slack_event in slack_events:
                     if harness_thread_id and isinstance(slack_event, dict):
                         slack_event.setdefault("session_id", harness_thread_id)
-                    harness_result = await slackbot_client.harness_event(slackbot_session_id, slack_event)
+                    harness_result = await slackbot_client.harness_event(
+                        slackbot_session_id, slack_event
+                    )
                     if harness_result is None:
+                        slackbot_live_failure_streak += 1
                         log.warning(
                             "slackbot_live_delivery_failed",
                             execution_id=execution_id,
                             thread_key=thread_key,
-                            event_type=slack_event.get("type") if isinstance(slack_event, dict) else None,
+                            event_type=slack_event.get("type")
+                            if isinstance(slack_event, dict)
+                            else None,
+                            consecutive_failures=slackbot_live_failure_streak,
+                            failure_limit=slackbot_live_failure_limit,
                         )
-                        await _mark_slackbot_live_delivery_failed(
-                            pool,
-                            execution_id,
-                            "harness_event_failed",
-                            streamed_answer_chars=slackbot_streamed_answer_chars,
-                        )
-                        with contextlib.suppress(Exception):
-                            await slackbot_client.set_status(delivery, "")
-                        slackbot_forward_live = False
+                        if slackbot_live_failure_streak >= slackbot_live_failure_limit:
+                            log.error(
+                                "slackbot_live_delivery_disabled",
+                                execution_id=execution_id,
+                                thread_key=thread_key,
+                                consecutive_failures=slackbot_live_failure_streak,
+                            )
+                            await _mark_slackbot_live_delivery_failed(
+                                pool,
+                                execution_id,
+                                "harness_event_failed",
+                                streamed_answer_chars=slackbot_streamed_answer_chars,
+                            )
+                            with contextlib.suppress(Exception):
+                                await slackbot_client.set_status(delivery, "")
+                            slackbot_forward_live = False
                         break
                     if isinstance(harness_result, dict):
-                        harness_thread_id = str(harness_result.get("threadId") or harness_thread_id)
+                        slackbot_live_failure_streak = 0
+                        harness_thread_id = str(
+                            harness_result.get("threadId") or harness_thread_id
+                        )
                         slackbot_done = bool(harness_result.get("done"))
                         streamed_chars = harness_result.get("streamedAnswerChars")
                         if isinstance(streamed_chars, int):

--- a/services/api/api/slackbot_client.py
+++ b/services/api/api/slackbot_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Any
 
@@ -7,6 +8,11 @@ import httpx
 import structlog
 
 log = structlog.get_logger()
+
+# Other 4xx is permanent: the slackbot is telling us the call is malformed.
+_RETRYABLE_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+_RETRY_ATTEMPTS = 3
+_RETRY_BASE_DELAY_S = 0.25
 
 
 def _base_url() -> str:
@@ -32,32 +38,49 @@ async def post(
     if not base_url or not api_key:
         return None
     request_timeout = timeout or httpx.Timeout(8.0, connect=2.0)
-    try:
-        async with httpx.AsyncClient(timeout=request_timeout) as client:
-            response = await client.post(
-                f"{base_url}{path}",
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-                json=body,
-            )
-            text = response.text
-            if not response.is_success:
-                log.warning(
-                    "slackbot_call_failed",
-                    path=path,
-                    status=response.status_code,
-                    response=text[:500],
+    last_status: int | None = None
+    last_response: str | None = None
+    last_error: str | None = None
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            async with httpx.AsyncClient(timeout=request_timeout) as client:
+                response = await client.post(
+                    f"{base_url}{path}",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=body,
                 )
-                return None
-            if not text:
-                return {}
-            data = response.json()
-            return data if isinstance(data, dict) else {}
-    except Exception as exc:
-        log.warning("slackbot_call_error", path=path, error=str(exc))
-        return None
+                text = response.text
+                if response.is_success:
+                    if not text:
+                        return {}
+                    data = response.json()
+                    return data if isinstance(data, dict) else {}
+                last_status = response.status_code
+                last_response = text[:500]
+                if response.status_code not in _RETRYABLE_STATUS:
+                    log.warning(
+                        "slackbot_call_failed",
+                        path=path,
+                        status=response.status_code,
+                        response=last_response,
+                    )
+                    return None
+        except Exception as exc:
+            last_error = str(exc)
+        if attempt + 1 < _RETRY_ATTEMPTS:
+            await asyncio.sleep(_RETRY_BASE_DELAY_S * (2**attempt))
+    log.warning(
+        "slackbot_call_failed",
+        path=path,
+        status=last_status,
+        response=last_response,
+        error=last_error,
+        attempts=_RETRY_ATTEMPTS,
+    )
+    return None
 
 
 def is_slack_delivery(delivery: dict[str, Any] | None) -> bool:
@@ -157,7 +180,9 @@ async def session_done(session_id: str | None, thread_id: str | None = None) -> 
     await post(f"/api/slack/agent-sessions/{session_id}/done", body)
 
 
-async def harness_event(session_id: str | None, event: dict[str, Any]) -> dict[str, Any] | None:
+async def harness_event(
+    session_id: str | None, event: dict[str, Any]
+) -> dict[str, Any] | None:
     if not session_id:
         return None
     return await post(

--- a/services/api/tests/test_slackbot_client.py
+++ b/services/api/tests/test_slackbot_client.py
@@ -1,0 +1,101 @@
+"""Tests for slackbot_client transient-error retry behavior."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _slackbot_env(monkeypatch):
+    monkeypatch.setenv("SLACKBOT_URL", "http://slackbot.test")
+    monkeypatch.setenv("SLACKBOT_API_KEY", "test-key")
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    async def _instant(_s: float) -> None:
+        return None
+
+    monkeypatch.setattr("api.slackbot_client.asyncio.sleep", _instant)
+
+
+def _response(status: int, body: dict[str, Any] | None = None) -> httpx.Response:
+    text = json.dumps(body) if body is not None else ""
+    return httpx.Response(status_code=status, text=text)
+
+
+class _FakeClient:
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+    async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.calls.append({"url": url, **kwargs})
+        if not self._responses:
+            raise RuntimeError("no response programmed")
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_post_retries_on_5xx_then_returns_payload():
+    fake = _FakeClient([_response(502), _response(503), _response(200, {"ok": True})])
+    with patch("api.slackbot_client.httpx.AsyncClient", return_value=fake):
+        from api import slackbot_client
+
+        result = await slackbot_client.post(
+            "/api/slack/agent-sessions/sess/text", {"markdown": "x"}
+        )
+
+    assert result == {"ok": True}
+    assert len(fake.calls) == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [408, 429])
+async def test_post_retries_on_retryable_4xx(status: int):
+    fake = _FakeClient([_response(status), _response(200, {"ok": True})])
+    with patch("api.slackbot_client.httpx.AsyncClient", return_value=fake):
+        from api import slackbot_client
+
+        result = await slackbot_client.post("/api/slack/agent-sessions/sess/done", {})
+
+    assert result == {"ok": True}
+    assert len(fake.calls) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [400, 403, 404])
+async def test_post_does_not_retry_on_permanent_4xx(status: int):
+    fake = _FakeClient([_response(status, {"error": "bad"})])
+    with patch("api.slackbot_client.httpx.AsyncClient", return_value=fake):
+        from api import slackbot_client
+
+        result = await slackbot_client.post("/api/slack/agent-sessions/sess/done", {})
+
+    assert result is None
+    assert len(fake.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_returns_none_after_exhausting_retries():
+    fake = _FakeClient([_response(502), _response(502), _response(502)])
+    with patch("api.slackbot_client.httpx.AsyncClient", return_value=fake):
+        from api import slackbot_client
+
+        result = await slackbot_client.post(
+            "/api/slack/agent-sessions/sess/text", {"markdown": "x"}
+        )
+
+    assert result is None
+    assert len(fake.calls) == 3

--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -1,138 +1,308 @@
-import { afterEach, describe, expect, it, mock } from 'bun:test'
-import { pollFinalDeliveriesOnce } from './final-delivery'
-import type { AppConfig } from '../config'
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { pollFinalDeliveriesOnce } from "./final-delivery";
+import type { AppConfig } from "../config";
 
 const config: AppConfig = {
-  NODE_ENV: 'test',
+  NODE_ENV: "test",
   PORT: 3001,
-  CENTAUR_API_URL: 'http://centaur-api.test',
-  CENTAUR_API_KEY: 'centaur-test-key',
-  CENTAUR_SLACK_EVENTS_PATH: '/api/webhooks/slack',
-  RUNTIME_ERROR_ALERT_CHANNEL: '',
+  CENTAUR_API_URL: "http://centaur-api.test",
+  CENTAUR_API_KEY: "centaur-test-key",
+  CENTAUR_SLACK_EVENTS_PATH: "/api/webhooks/slack",
+  RUNTIME_ERROR_ALERT_CHANNEL: "",
   SLACK_EVENT_DEDUP_TTL_MS: 600000,
   SLACK_SIGNATURE_MAX_AGE_SECONDS: 300,
-  SLACK_FEEDBACK_COMMANDS: ['/website-feedback'],
-  SLACK_FEEDBACK_LINEAR_TEAM_ID: 'team-test',
-  SLACK_FEEDBACK_LINEAR_PROJECT_ID: 'project-test',
+  SLACK_FEEDBACK_COMMANDS: ["/website-feedback"],
+  SLACK_FEEDBACK_LINEAR_TEAM_ID: "team-test",
+  SLACK_FEEDBACK_LINEAR_PROJECT_ID: "project-test",
   SLACK_FEEDBACK_ALLOWED_CHANNELS: [],
-  SLACKBOT_EXTERNAL_ORG_ALLOWLIST: []
-}
+  SLACKBOT_EXTERNAL_ORG_ALLOWLIST: [],
+};
 
 afterEach(() => {
-  mock.restore()
-})
+  mock.restore();
+});
 
-describe('final delivery polling', () => {
-  it('posts a claimed delivery once and marks it delivered before the next poll', async () => {
-    const originalFetch = globalThis.fetch
-    const fetchCalls: Array<{ path: string; body: unknown }> = []
-    let claimCount = 0
-    const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = new URL(input instanceof Request ? input.url : input)
-      const body = init?.body ? JSON.parse(init.body as string) : undefined
-      fetchCalls.push({ path: url.pathname, body })
+describe("final delivery polling", () => {
+  it("posts a claimed delivery once and marks it delivered before the next poll", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchCalls: Array<{ path: string; body: unknown }> = [];
+    let claimCount = 0;
+    const fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        fetchCalls.push({ path: url.pathname, body });
 
-      if (url.pathname === '/agent/final-deliveries/claim') {
-        claimCount += 1
-        return jsonResponse({
-          deliveries:
-            claimCount === 1
-              ? [
-                  {
-                    execution_id: 'exe-duplicate-guard',
-                    thread_key: 'slack:T123:C123:1778883099.579529',
-                    delivery: {
-                      platform: 'slack',
-                      channel: 'C123',
-                      thread_ts: '1778883099.579529',
-                      recipient_team_id: 'T123',
-                      recipient_user_id: 'U123'
+        if (url.pathname === "/agent/final-deliveries/claim") {
+          claimCount += 1;
+          return jsonResponse({
+            deliveries:
+              claimCount === 1
+                ? [
+                    {
+                      execution_id: "exe-duplicate-guard",
+                      thread_key: "slack:T123:C123:1778883099.579529",
+                      delivery: {
+                        platform: "slack",
+                        channel: "C123",
+                        thread_ts: "1778883099.579529",
+                        recipient_team_id: "T123",
+                        recipient_user_id: "U123",
+                      },
+                      final_payload: {
+                        session_title: "Centaur · codex",
+                        result_text:
+                          "done [once](https://example.com) with **bold** text",
+                      },
                     },
-                    final_payload: {
-                      session_title: 'Centaur · codex',
-                      result_text: 'done [once](https://example.com) with **bold** text'
-                    }
-                  }
-                ]
-              : []
-        })
-      }
+                  ]
+                : [],
+          });
+        }
 
-      if (url.pathname === '/agent/final-deliveries/exe-duplicate-guard/delivered') {
-        return jsonResponse({ ok: true })
-      }
+        if (
+          url.pathname ===
+          "/agent/final-deliveries/exe-duplicate-guard/delivered"
+        ) {
+          return jsonResponse({ ok: true });
+        }
 
-      throw new Error(`unexpected request: ${url.pathname}`)
-    })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+        throw new Error(`unexpected request: ${url.pathname}`);
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const slackCalls: Array<{ method: string; params: unknown }> = []
+    const slackCalls: Array<{ method: string; params: unknown }> = [];
     const client = {
       assistant: {
         threads: {
           setStatus: async (params: unknown) => {
-            slackCalls.push({ method: 'assistant.threads.setStatus', params })
-            return { ok: true }
-          }
-        }
+            slackCalls.push({ method: "assistant.threads.setStatus", params });
+            return { ok: true };
+          },
+        },
       },
       chat: {
         startStream: async (params: any) => {
-          slackCalls.push({ method: 'chat.startStream', params })
-          return { ok: true, channel: params.channel, ts: '1778883100.000000' }
+          slackCalls.push({ method: "chat.startStream", params });
+          return { ok: true, channel: params.channel, ts: "1778883100.000000" };
         },
         appendStream: async (params: unknown) => {
-          slackCalls.push({ method: 'chat.appendStream', params })
-          return { ok: true }
+          slackCalls.push({ method: "chat.appendStream", params });
+          return { ok: true };
         },
         postMessage: async (params: unknown) => {
-          slackCalls.push({ method: 'chat.postMessage', params })
-          return { ok: true }
+          slackCalls.push({ method: "chat.postMessage", params });
+          return { ok: true };
         },
         stopStream: async (params: unknown) => {
-          slackCalls.push({ method: 'chat.stopStream', params })
-          return { ok: true }
+          slackCalls.push({ method: "chat.stopStream", params });
+          return { ok: true };
         },
         update: async (params: unknown) => {
-          slackCalls.push({ method: 'chat.update', params })
-          return { ok: true }
-        }
-      }
-    }
+          slackCalls.push({ method: "chat.update", params });
+          return { ok: true };
+        },
+      },
+      conversations: {
+        replies: async (params: unknown) => {
+          slackCalls.push({ method: "conversations.replies", params });
+          return { ok: true, messages: [] };
+        },
+      },
+    };
 
     try {
-      await pollFinalDeliveriesOnce(config, client as any)
-      await pollFinalDeliveriesOnce(config, client as any)
+      await pollFinalDeliveriesOnce(config, client as any);
+      await pollFinalDeliveriesOnce(config, client as any);
 
-      expect(fetchCalls.filter(call => call.path === '/agent/final-deliveries/claim')).toHaveLength(
-        2
-      )
       expect(
         fetchCalls.filter(
-          call => call.path === '/agent/final-deliveries/exe-duplicate-guard/delivered'
-        )
-      ).toHaveLength(1)
-      expect(slackCalls.filter(call => call.method === 'chat.startStream')).toHaveLength(0)
-      expect(slackCalls.filter(call => call.method === 'chat.stopStream')).toHaveLength(0)
-      const postMessage = slackCalls.find(call => call.method === 'chat.postMessage')
+          (call) => call.path === "/agent/final-deliveries/claim",
+        ),
+      ).toHaveLength(2);
+      expect(
+        fetchCalls.filter(
+          (call) =>
+            call.path ===
+            "/agent/final-deliveries/exe-duplicate-guard/delivered",
+        ),
+      ).toHaveLength(1);
+      expect(
+        slackCalls.filter((call) => call.method === "chat.startStream"),
+      ).toHaveLength(0);
+      expect(
+        slackCalls.filter((call) => call.method === "chat.stopStream"),
+      ).toHaveLength(0);
+      const postMessage = slackCalls.find(
+        (call) => call.method === "chat.postMessage",
+      );
       expect((postMessage?.params as any)?.text).toBe(
-        'done [once](https://example.com) with **bold** text'
-      )
+        "done [once](https://example.com) with **bold** text",
+      );
       expect((postMessage?.params as any)?.blocks).toEqual([
         {
-          type: 'markdown',
-          text: 'done [once](https://example.com) with **bold** text'
-        }
-      ])
+          type: "markdown",
+          text: "done [once](https://example.com) with **bold** text",
+        },
+      ]);
     } finally {
-      globalThis.fetch = originalFetch
+      globalThis.fetch = originalFetch;
     }
-  })
-})
+  });
+
+  it("does not repost already-delivered fallback chunks after a retry", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchCalls: Array<{ path: string; body: any }> = [];
+    const posted: any[] = [];
+    let claimCount = 0;
+    let postCount = 0;
+    const delivery = {
+      execution_id: "exe-chunk-retry",
+      thread_key: "slack:T123:C123:1778883099.579529",
+      delivery: {
+        platform: "slack",
+        channel: "C123",
+        thread_ts: "1778883099.579529",
+      },
+      final_payload: { result_text: `${"a".repeat(4100)} ${"b".repeat(100)}` },
+    };
+    const fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        fetchCalls.push({ path: url.pathname, body });
+        if (url.pathname === "/agent/final-deliveries/claim") {
+          claimCount += 1;
+          return jsonResponse({
+            deliveries: claimCount <= 2 ? [delivery] : [],
+          });
+        }
+        if (url.pathname === "/agent/final-deliveries/exe-chunk-retry/failed")
+          return jsonResponse({ ok: true });
+        if (
+          url.pathname === "/agent/final-deliveries/exe-chunk-retry/delivered"
+        )
+          return jsonResponse({ ok: true });
+        throw new Error(`unexpected request: ${url.pathname}`);
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const client = {
+      chat: {
+        postMessage: async (params: any) => {
+          posted.push(params);
+          postCount += 1;
+          if (postCount === 2)
+            return { ok: false, error: "service_unavailable" };
+          return { ok: true };
+        },
+      },
+      conversations: {
+        replies: async () => ({
+          ok: true,
+          messages:
+            claimCount <= 1
+              ? []
+              : [
+                  {
+                    metadata: {
+                      event_type: "centaur_final_delivery_chunk",
+                      event_payload: {
+                        execution_id: "exe-chunk-retry",
+                        chunk_index: 0,
+                        chunk_count: 2,
+                      },
+                    },
+                  },
+                ],
+        }),
+      },
+    };
+
+    try {
+      await pollFinalDeliveriesOnce(config, client as any);
+      await pollFinalDeliveriesOnce(config, client as any);
+
+      expect(fetchCalls.some((call) => call.path.endsWith("/failed"))).toBe(
+        true,
+      );
+      expect(fetchCalls.some((call) => call.path.endsWith("/delivered"))).toBe(
+        true,
+      );
+      expect(posted).toHaveLength(3);
+      expect(posted[0]?.metadata?.event_payload?.chunk_index).toBe(0);
+      expect(posted[1]?.metadata?.event_payload?.chunk_index).toBe(1);
+      expect(posted[2]?.metadata?.event_payload?.chunk_index).toBe(1);
+      expect(
+        posted.filter(
+          (message) => message.metadata?.event_payload?.chunk_index === 0,
+        ),
+      ).toHaveLength(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("marks permanent Slack post errors non-retryable", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchCalls: Array<{ path: string; body: any }> = [];
+    const fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        fetchCalls.push({ path: url.pathname, body });
+        if (url.pathname === "/agent/final-deliveries/claim") {
+          return jsonResponse({
+            deliveries: [
+              {
+                execution_id: "exe-channel-missing",
+                thread_key: "slack:T123:C123:1778883099.579529",
+                delivery: {
+                  platform: "slack",
+                  channel: "C123",
+                  thread_ts: "1778883099.579529",
+                },
+                final_payload: { result_text: "hello" },
+              },
+            ],
+          });
+        }
+        if (
+          url.pathname === "/agent/final-deliveries/exe-channel-missing/failed"
+        )
+          return jsonResponse({ ok: true });
+        throw new Error(`unexpected request: ${url.pathname}`);
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const client = {
+      chat: {
+        postMessage: async () => ({ ok: false, error: "channel_not_found" }),
+      },
+      conversations: { replies: async () => ({ ok: true, messages: [] }) },
+    };
+
+    try {
+      await pollFinalDeliveriesOnce(config, client as any);
+      const failed = fetchCalls.find((call) =>
+        call.path.endsWith("/final-deliveries/exe-channel-missing/failed"),
+      );
+      expect(failed?.body).toMatchObject({
+        error_class: "channel_not_found",
+        non_retryable: true,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
-    headers: { 'content-type': 'application/json' }
-  })
+    headers: { "content-type": "application/json" },
+  });
 }

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -1,95 +1,193 @@
-import type { WebClient } from '@slack/web-api'
-import { centaurApiKey, type AppConfig } from '../config'
-import { slackReplyLimits } from '../constants'
-import { logError } from '../logging'
-import { renderMarkdownBlocks } from '../slack/render'
-import { withLaminarSpan } from './laminar'
+import type { WebClient } from "@slack/web-api";
+import { centaurApiKey, type AppConfig } from "../config";
+import { slackReplyLimits } from "../constants";
+import { logError } from "../logging";
+import { renderMarkdownBlocks } from "../slack/render";
+import { withLaminarSpan } from "./laminar";
 
-const CONSUMER_ID = `slackbot-${process.pid}`
-const FINAL_DELIVERY_CHUNK_CHARS = slackReplyLimits.text.maxFallbackChars
+const CONSUMER_ID = `slackbot-${process.pid}`;
+const FINAL_DELIVERY_CHUNK_CHARS = slackReplyLimits.text.maxFallbackChars;
+const FINAL_DELIVERY_CHUNK_EVENT = "centaur_final_delivery_chunk";
+const NON_RETRYABLE_SLACK_ERRORS = new Set([
+  "msg_too_long",
+  "msg_blocks_too_long",
+  "channel_not_found",
+  "user_not_found",
+  "missing_slack_delivery_target",
+  "account_inactive",
+  "is_archived",
+  "restricted_action",
+  "not_in_channel",
+  "channel_type_not_supported",
+]);
 
-export function startFinalDeliveryPoller(config: AppConfig, client: WebClient): void {
-  if (!centaurApiKey(config)) return
+export function startFinalDeliveryPoller(
+  config: AppConfig,
+  client: WebClient,
+): void {
+  if (!centaurApiKey(config)) return;
   const tick = async () => {
     try {
-      await pollFinalDeliveriesOnce(config, client)
+      await pollFinalDeliveriesOnce(config, client);
     } catch (error) {
-      logError('final_delivery_poll_failed', error)
+      logError("final_delivery_poll_failed", error);
     }
-  }
-  setInterval(tick, 2_000).unref?.()
-  void tick()
+  };
+  setInterval(tick, 2_000).unref?.();
+  void tick();
 }
 
-export async function pollFinalDeliveriesOnce(config: AppConfig, client: WebClient): Promise<void> {
-  const claimed = await centaur(config, '/agent/final-deliveries/claim', {
+export async function pollFinalDeliveriesOnce(
+  config: AppConfig,
+  client: WebClient,
+): Promise<void> {
+  const claimed = await centaur(config, "/agent/final-deliveries/claim", {
     consumer_id: CONSUMER_ID,
-    platform: 'slack',
+    platform: "slack",
     limit: 5,
-    lease_seconds: 60
-  })
-  const deliveries = Array.isArray(claimed.deliveries) ? claimed.deliveries : []
+    lease_seconds: 60,
+  });
+  const deliveries = Array.isArray(claimed.deliveries)
+    ? claimed.deliveries
+    : [];
   for (const delivery of deliveries) {
-    await withLaminarSpan('centaur.slackbot.final_delivery', delivery, async () => {
-      const executionId = String(delivery.execution_id)
-      try {
-        await deliver(client, delivery)
-        await centaur(
-          config,
-          `/agent/final-deliveries/${executionId}/delivered`,
-          {
-            consumer_id: CONSUMER_ID
-          },
-          delivery
-        )
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error)
-        const msgTooLong = errorMessage.includes('msg_too_long')
-        await centaur(
-          config,
-          `/agent/final-deliveries/${executionId}/failed`,
-          {
-            consumer_id: CONSUMER_ID,
-            error: errorMessage,
-            retry_after_seconds: 10,
-            ...(msgTooLong ? { error_class: 'msg_too_long', non_retryable: true } : {})
-          },
-          delivery
-        ).catch(failError => logError('final_delivery_mark_failed_failed', failError))
-      }
-    })
+    await withLaminarSpan(
+      "centaur.slackbot.final_delivery",
+      delivery,
+      async () => {
+        const executionId = String(delivery.execution_id);
+        try {
+          await deliver(client, delivery);
+          await centaur(
+            config,
+            `/agent/final-deliveries/${executionId}/delivered`,
+            {
+              consumer_id: CONSUMER_ID,
+            },
+            delivery,
+          );
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          const errorClass = slackDeliveryErrorClass(errorMessage);
+          await centaur(
+            config,
+            `/agent/final-deliveries/${executionId}/failed`,
+            {
+              consumer_id: CONSUMER_ID,
+              error: errorMessage,
+              retry_after_seconds: 10,
+              ...(errorClass
+                ? { error_class: errorClass, non_retryable: true }
+                : {}),
+            },
+            delivery,
+          ).catch((failError) =>
+            logError("final_delivery_mark_failed_failed", failError),
+          );
+        }
+      },
+    );
   }
 }
 
 async function deliver(client: WebClient, delivery: any): Promise<void> {
-  const meta = delivery.delivery ?? {}
-  const payload = delivery.final_payload ?? {}
-  const target = targetFromDelivery(delivery)
-  const channel = meta.channel_id ?? meta.channel ?? target.channel
-  const threadTs = meta.thread_ts ?? target.threadTs
-  if (!channel || !threadTs) throw new Error('missing_slack_delivery_target')
-  const text = extractText(payload)
-  const textToPost = continuationText(payload, text) ?? text
-  await postFollowups(client, channel, threadTs, splitFinalDeliveryText(textToPost))
+  const meta = delivery.delivery ?? {};
+  const payload = delivery.final_payload ?? {};
+  const target = targetFromDelivery(delivery);
+  const channel = meta.channel_id ?? meta.channel ?? target.channel;
+  const threadTs = meta.thread_ts ?? target.threadTs;
+  if (!channel || !threadTs) throw new Error("missing_slack_delivery_target");
+  const text = extractText(payload);
+  const textToPost = continuationText(payload, text) ?? text;
+  await postFollowups(
+    client,
+    channel,
+    threadTs,
+    executionId(delivery),
+    splitFinalDeliveryText(textToPost),
+  );
+}
+
+function executionId(delivery: any): string {
+  return String(delivery?.execution_id ?? "");
 }
 
 async function postFollowups(
   client: WebClient,
   channel: string,
   threadTs: string,
-  chunks: string[]
+  executionId: string,
+  chunks: string[],
 ): Promise<void> {
-  for (const chunk of chunks) {
+  const posted = await postedChunkIndexes(
+    client,
+    channel,
+    threadTs,
+    executionId,
+  );
+  for (const [index, chunk] of chunks.entries()) {
+    if (posted.has(index)) continue;
     const response = await client.chat.postMessage({
       channel,
       thread_ts: threadTs,
       text: chunk,
       blocks: renderMarkdownBlocks(chunk),
       unfurl_links: false,
-      unfurl_media: false
-    })
-    if (!response.ok) throw new Error(response.error ?? 'chat.postMessage failed')
+      unfurl_media: false,
+      metadata: chunkMetadata(executionId, index, chunks.length),
+    });
+    if (!response.ok)
+      throw new Error(response.error ?? "chat.postMessage failed");
   }
+}
+
+async function postedChunkIndexes(
+  client: WebClient,
+  channel: string,
+  threadTs: string,
+  executionId: string,
+): Promise<Set<number>> {
+  if (!executionId) return new Set();
+  try {
+    const response = await client.conversations.replies({
+      channel,
+      ts: threadTs,
+      limit: 200,
+      inclusive: true,
+    });
+    if (!response.ok || !Array.isArray(response.messages)) return new Set();
+    const indexes = response.messages
+      .map((message: any) => message?.metadata)
+      .filter(
+        (metadata: any) => metadata?.event_type === FINAL_DELIVERY_CHUNK_EVENT,
+      )
+      .filter(
+        (metadata: any) =>
+          metadata?.event_payload?.execution_id === executionId,
+      )
+      .map((metadata: any) => Number(metadata.event_payload.chunk_index))
+      .filter((index: number) => Number.isInteger(index) && index >= 0);
+    return new Set(indexes);
+  } catch {
+    return new Set();
+  }
+}
+
+function chunkMetadata(
+  executionId: string,
+  chunkIndex: number,
+  chunkCount: number,
+): object | undefined {
+  if (!executionId) return undefined;
+  return {
+    event_type: FINAL_DELIVERY_CHUNK_EVENT,
+    event_payload: {
+      execution_id: executionId,
+      chunk_index: chunkIndex,
+      chunk_count: chunkCount,
+    },
+  };
 }
 
 function extractText(payload: any): string {
@@ -98,93 +196,115 @@ function extractText(payload: any): string {
     payload?.result,
     payload?.text,
     payload?.final_text,
-    payload?.message
-  )
-  if (value) return value
+    payload?.message,
+  );
+  if (value) return value;
 
-  const executionId = String(payload?.execution_id ?? '').trim()
-  const suffix = executionId ? ` Execution: \`${executionId}\`.` : ''
-  return `Execution completed, but no final text was captured.${suffix}`
+  const executionId = String(payload?.execution_id ?? "").trim();
+  const suffix = executionId ? ` Execution: \`${executionId}\`.` : "";
+  return `Execution completed, but no final text was captured.${suffix}`;
 }
 
 function firstNonEmpty(...values: unknown[]): string {
   for (const value of values) {
-    const text = value === undefined || value === null ? '' : String(value).trim()
-    if (text) return text
+    const text =
+      value === undefined || value === null ? "" : String(value).trim();
+    if (text) return text;
   }
-  return ''
+  return "";
 }
 
 function continuationText(payload: any, text: string): string | null {
-  const rawOffset = Number(payload?.slackbot_streamed_answer_chars)
-  if (!Number.isFinite(rawOffset) || rawOffset <= 0) return null
-  const offset = Math.floor(rawOffset)
-  if (offset >= text.length) return null
-  return text.slice(offset).trimStart()
+  const rawOffset = Number(payload?.slackbot_streamed_answer_chars);
+  if (!Number.isFinite(rawOffset) || rawOffset <= 0) return null;
+  const offset = Math.floor(rawOffset);
+  if (offset >= text.length) return null;
+  return text.slice(offset).trimStart();
 }
 
 function splitFinalDeliveryText(text: string): string[] {
-  const trimmed = text.trim()
-  if (!trimmed) return []
-  const chunks: string[] = []
-  let remaining = trimmed
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  const chunks: string[] = [];
+  let remaining = trimmed;
   while (remaining.length > FINAL_DELIVERY_CHUNK_CHARS) {
-    let cut = remaining.lastIndexOf('\n\n', FINAL_DELIVERY_CHUNK_CHARS)
+    let cut = remaining.lastIndexOf("\n\n", FINAL_DELIVERY_CHUNK_CHARS);
     if (cut <= FINAL_DELIVERY_CHUNK_CHARS * 0.3) {
-      cut = remaining.lastIndexOf('\n', FINAL_DELIVERY_CHUNK_CHARS)
+      cut = remaining.lastIndexOf("\n", FINAL_DELIVERY_CHUNK_CHARS);
     }
     if (cut <= FINAL_DELIVERY_CHUNK_CHARS * 0.3) {
-      cut = remaining.lastIndexOf(' ', FINAL_DELIVERY_CHUNK_CHARS)
+      cut = remaining.lastIndexOf(" ", FINAL_DELIVERY_CHUNK_CHARS);
     }
-    if (cut <= FINAL_DELIVERY_CHUNK_CHARS * 0.3) cut = FINAL_DELIVERY_CHUNK_CHARS
-    chunks.push(remaining.slice(0, cut).trimEnd())
-    remaining = remaining.slice(cut).trimStart()
+    if (cut <= FINAL_DELIVERY_CHUNK_CHARS * 0.3)
+      cut = FINAL_DELIVERY_CHUNK_CHARS;
+    chunks.push(remaining.slice(0, cut).trimEnd());
+    remaining = remaining.slice(cut).trimStart();
   }
-  if (remaining) chunks.push(remaining)
-  return chunks
+  if (remaining) chunks.push(remaining);
+  return chunks;
+}
+
+function slackDeliveryErrorClass(error: string): string | null {
+  const normalized = error.trim().toLowerCase();
+  for (const errorClass of NON_RETRYABLE_SLACK_ERRORS) {
+    if (normalized.includes(errorClass)) return errorClass;
+  }
+  return null;
 }
 
 function targetFromDelivery(delivery: any): {
-  teamId?: string
-  channel?: string
-  threadTs?: string
+  teamId?: string;
+  channel?: string;
+  threadTs?: string;
 } {
-  const threadKey = String(delivery.thread_key ?? '')
-  const parts = threadKey.split(':')
-  if (parts[0] === 'slack' && parts.length >= 4) {
-    return { teamId: parts[1], channel: parts[2], threadTs: parts.slice(3).join(':') }
+  const threadKey = String(delivery.thread_key ?? "");
+  const parts = threadKey.split(":");
+  if (parts[0] === "slack" && parts.length >= 4) {
+    return {
+      teamId: parts[1],
+      channel: parts[2],
+      threadTs: parts.slice(3).join(":"),
+    };
   }
-  return {}
+  return {};
 }
 
-async function centaur(config: AppConfig, path: string, body: unknown, trace?: any): Promise<any> {
-  const apiKey = centaurApiKey(config)
-  const traceHeaders = centaurTraceHeaders(trace)
+async function centaur(
+  config: AppConfig,
+  path: string,
+  body: unknown,
+  trace?: any,
+): Promise<any> {
+  const apiKey = centaurApiKey(config);
+  const traceHeaders = centaurTraceHeaders(trace);
   const response = await fetch(new URL(path, config.CENTAUR_API_URL), {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
       ...traceHeaders,
-      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
     },
-    body: JSON.stringify(body)
-  })
-  const text = await response.text()
-  const parsed: any = text ? JSON.parse(text) : {}
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  const parsed: any = text ? JSON.parse(text) : {};
   if (!response.ok)
     throw new Error(
-      parsed?.detail?.message ?? parsed?.detail ?? parsed?.error ?? response.statusText
-    )
-  return parsed
+      parsed?.detail?.message ??
+        parsed?.detail ??
+        parsed?.error ??
+        response.statusText,
+    );
+  return parsed;
 }
 
 function centaurTraceHeaders(trace: any): Record<string, string> {
-  const traceId = String(trace?.trace_id ?? '').trim()
-  const threadKey = String(trace?.thread_key ?? '').trim()
-  const traceparent = String(trace?.traceparent ?? '').trim()
+  const traceId = String(trace?.trace_id ?? "").trim();
+  const threadKey = String(trace?.thread_key ?? "").trim();
+  const traceparent = String(trace?.traceparent ?? "").trim();
   return {
-    ...(traceId ? { 'X-Trace-Id': traceId } : {}),
-    ...(threadKey ? { 'X-Centaur-Thread-Key': threadKey } : {}),
-    ...(traceparent ? { traceparent } : {})
-  }
+    ...(traceId ? { "X-Trace-Id": traceId } : {}),
+    ...(threadKey ? { "X-Centaur-Thread-Key": threadKey } : {}),
+    ...(traceparent ? { traceparent } : {}),
+  };
 }

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -606,7 +606,9 @@ describe('AgentSessionRenderer', () => {
       }
     })
 
-    expect(renderer.done(sessionId)).resolves.toBeUndefined()
+    await expect(renderer.done(sessionId)).resolves.toEqual({
+      streamedTextChars: expect.any(Number)
+    })
     expect(stopAttempts).toBe(2)
   })
 


### PR DESCRIPTION
## Summary
- Retry transient slackbot 408/429/5xx calls and only disable live delivery after repeated failures.
- Make final-delivery follow-up chunks idempotent so retries skip chunks already posted.
- Mark permanent Slack delivery errors non-retryable.

Follow-up to #88; keeps Omar's overflow work and adds the missing retry/idempotency/permanent-error handling.

## Test plan
- `bun test src/slack src/centaur`
- `uv run pytest tests/test_slackbot_client.py -q`

Co-authored-by: o-az <omaraziz.dev@proton.me>