### PR TITLE
feat: sanitize Slack egress plumbing leaks

### DIFF
--- a/services/api/api/slack_sanitize.py
+++ b/services/api/api/slack_sanitize.py
@@ -1,0 +1,76 @@
+"""Strip known plumbing-leak shapes from assistant text bound for Slack."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from typing import Any
+
+_THREAD_TRAILER_RE = re.compile(
+    r"(?:^|\s)(?:Agent|Codex|Amp|Claude\s+Code|Pi)\s+thread\s+`?[0-9a-f-]{8,}`?(?:,\s*with\s+interactive\s+elements)?(?=\s*$|[.!?]\s*$)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_EXECUTION_TRAILER_RE = re.compile(
+    r"\b(?:Execution|execution_id)\s*[:=]\s*`?exe_[0-9a-f]{16}`?",
+    re.IGNORECASE,
+)
+_CURL_EXIT_RE = re.compile(r"curl:?\s*\((\d+)\):?\s*[^\n]{0,200}", re.IGNORECASE)
+
+
+def _replace_matching_json_objects(
+    text: str,
+    predicate: Callable[[dict[str, Any]], bool],
+    replacement: str,
+) -> str:
+    decoder = json.JSONDecoder()
+    out: list[str] = []
+    index = 0
+    while index < len(text):
+        if text[index] != "{":
+            out.append(text[index])
+            index += 1
+            continue
+        try:
+            value, end = decoder.raw_decode(text[index:])
+        except ValueError:
+            out.append(text[index])
+            index += 1
+            continue
+        if isinstance(value, dict) and predicate(value):
+            out.append(replacement)
+            index += end
+            continue
+        out.append(text[index])
+        index += 1
+    return "".join(out)
+
+
+def _is_k8s_status(value: dict[str, Any]) -> bool:
+    return value.get("kind") == "Status" and any(
+        key in value for key in ("status", "reason", "code", "message")
+    )
+
+
+def _is_tool_error_envelope(value: dict[str, Any]) -> bool:
+    return "error_type" in value and any(
+        key in value for key in ("detail", "error", "status_code")
+    )
+
+
+def sanitize_for_slack(text: str | None) -> str:
+    """Strip known plumbing leaks from `text`. Idempotent; empty input -> ""."""
+    if not text:
+        return ""
+    sanitized = _replace_matching_json_objects(
+        text, _is_k8s_status, "[k8s status omitted]"
+    )
+    sanitized = _replace_matching_json_objects(
+        sanitized, _is_tool_error_envelope, "[tool error omitted]"
+    )
+    sanitized = _THREAD_TRAILER_RE.sub("", sanitized)
+    sanitized = _EXECUTION_TRAILER_RE.sub("[execution id omitted]", sanitized)
+    sanitized = _CURL_EXIT_RE.sub(r"transport_error(\1)", sanitized)
+    sanitized = re.sub(r"[ \t]+\n", "\n", sanitized)
+    sanitized = re.sub(r"\n{3,}", "\n\n", sanitized)
+    return sanitized.strip()

--- a/services/api/api/slackbot_client.py
+++ b/services/api/api/slackbot_client.py
@@ -6,6 +6,8 @@ from typing import Any
 import httpx
 import structlog
 
+from api.slack_sanitize import sanitize_for_slack
+
 log = structlog.get_logger()
 
 
@@ -124,9 +126,10 @@ async def open_agent_session(
 
 
 async def session_text(session_id: str | None, markdown: str) -> None:
-    if not session_id or not markdown.strip():
+    sanitized = sanitize_for_slack(markdown)
+    if not session_id or not sanitized.strip():
         return
-    await post(f"/api/slack/agent-sessions/{session_id}/text", {"markdown": markdown})
+    await post(f"/api/slack/agent-sessions/{session_id}/text", {"markdown": sanitized})
 
 
 async def session_step(
@@ -140,11 +143,15 @@ async def session_step(
 ) -> None:
     if not session_id or not step_id or not title:
         return
-    body: dict[str, Any] = {"id": step_id, "title": title, "status": status}
+    body: dict[str, Any] = {
+        "id": step_id,
+        "title": sanitize_for_slack(title),
+        "status": status,
+    }
     if details:
-        body["details"] = details
+        body["details"] = sanitize_for_slack(details)
     if output:
-        body["output"] = output
+        body["output"] = sanitize_for_slack(output)
     await post(f"/api/slack/agent-sessions/{session_id}/step", body)
 
 
@@ -157,12 +164,14 @@ async def session_done(session_id: str | None, thread_id: str | None = None) -> 
     await post(f"/api/slack/agent-sessions/{session_id}/done", body)
 
 
-async def harness_event(session_id: str | None, event: dict[str, Any]) -> dict[str, Any] | None:
+async def harness_event(
+    session_id: str | None, event: dict[str, Any]
+) -> dict[str, Any] | None:
     if not session_id:
         return None
     return await post(
         f"/api/slack/agent-sessions/{session_id}/harness-event",
-        {"event": event},
+        {"event": sanitize_slack_event(event)},
         timeout=httpx.Timeout(60.0, connect=2.0),
     )
 
@@ -178,3 +187,33 @@ async def set_status(delivery: dict[str, Any], status: str) -> None:
         "/api/slack/assistant/status",
         {"channel_id": channel, "thread_ts": ts, "status": status},
     )
+
+
+_TEXT_KEYS = {
+    "content",
+    "delta",
+    "details",
+    "error",
+    "message",
+    "output",
+    "result",
+    "summary",
+    "text",
+    "title",
+}
+
+
+def sanitize_slack_event(value: Any) -> Any:
+    if isinstance(value, str):
+        return sanitize_for_slack(value)
+    if isinstance(value, list):
+        return [sanitize_slack_event(item) for item in value]
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for key, item in value.items():
+            if isinstance(item, (dict, list)) or key in _TEXT_KEYS:
+                sanitized[key] = sanitize_slack_event(item)
+            else:
+                sanitized[key] = item
+        return sanitized
+    return value

--- a/services/api/tests/test_slack_sanitize.py
+++ b/services/api/tests/test_slack_sanitize.py
@@ -1,0 +1,111 @@
+"""Tests for sanitize_for_slack."""
+
+from __future__ import annotations
+
+import pytest
+
+from api.slack_sanitize import sanitize_for_slack
+
+
+def test_empty_input_returns_empty_string():
+    assert sanitize_for_slack(None) == ""
+    assert sanitize_for_slack("") == ""
+
+
+def test_passes_through_clean_prose_unchanged():
+    text = "Spock — Paradigm's investment agent. What are we looking at?"
+    assert sanitize_for_slack(text) == text
+
+
+def test_strips_k8s_status_block():
+    raw = (
+        "The sandbox spawn failed: "
+        '{"kind":"Status","apiVersion":"v1","status":"Failure",'
+        '"message":"pods already exists","reason":"AlreadyExists","code":409}'
+        " — retrying."
+    )
+    out = sanitize_for_slack(raw)
+    assert "[k8s status omitted]" in out
+    assert "AlreadyExists" not in out
+    assert "Status" not in out
+
+
+def test_strips_tool_error_envelope():
+    raw = (
+        "websearch failed: "
+        '{"detail":{"upstream":{"message":"bad gateway"}},"error_type":"InternalServerError",'
+        '"status_code":502}'
+        " — falling back to internal cache."
+    )
+    out = sanitize_for_slack(raw)
+    assert "[tool error omitted]" in out
+    assert "InternalServerError" not in out
+    assert "falling back" in out
+
+
+@pytest.mark.parametrize(
+    "label",
+    ["Codex", "Agent", "Amp", "Claude Code", "Pi", "claude code", "CODEX"],
+)
+def test_strips_thread_trailer_by_engine_label(label: str):
+    raw = f"All done. {label} thread `019e3c91-4030-7910-86c8-4c756f73bdc5`"
+    out = sanitize_for_slack(raw)
+    assert "thread" not in out.lower()
+    assert "019e" not in out
+    assert "All done." in out
+
+
+def test_strips_interactive_elements_suffix():
+    raw = "Reply body. Codex thread `019e3c91-4030-7910`, with interactive elements"
+    out = sanitize_for_slack(raw)
+    assert "interactive elements" not in out.lower()
+    assert "Reply body." in out
+
+
+def test_strips_execution_ids():
+    raw = "No final text was captured. Execution: `exe_e77594af2e0b4893`."
+    out = sanitize_for_slack(raw)
+    assert "exe_" not in out
+    assert "[execution id omitted]" in out
+
+
+def test_strips_curl_exit_code_blob():
+    raw = "Hit curl: (28) Operation timed out after 30000 milliseconds — retrying."
+    out = sanitize_for_slack(raw)
+    assert "Operation timed out" not in out
+    assert "transport_error(28)" in out
+
+
+def test_is_idempotent():
+    raw = (
+        'Done. {"kind":"Status","status":"Failure","reason":"x","code":409} '
+        "Codex thread `abc12345-9999-7910-86c8-4c756f73bdc5`, with interactive elements"
+    )
+    once = sanitize_for_slack(raw)
+    twice = sanitize_for_slack(once)
+    assert once == twice
+
+
+def test_does_not_strip_unrelated_json():
+    raw = 'Here is the schema: {"name":"alice","age":30} — looks fine.'
+    out = sanitize_for_slack(raw)
+    assert '"name":"alice"' in out
+
+
+def test_does_not_strip_normal_uuid_in_prose():
+    raw = "The migration uses uuid 019e3c91-4030-7910 and execution exe_e77594af2e0b4893 for tracking."
+    out = sanitize_for_slack(raw)
+    assert "019e3c91-4030-7910" in out
+    assert "exe_e77594af2e0b4893" in out
+
+
+def test_collapses_excess_blank_lines_left_by_strippers():
+    raw = (
+        "Top of message.\n\n"
+        '{"kind":"Status","status":"Failure","reason":"x"}\n\n\n\n'
+        "Bottom of message."
+    )
+    out = sanitize_for_slack(raw)
+    assert "\n\n\n" not in out
+    assert "Top of message." in out
+    assert "Bottom of message." in out

--- a/services/api/tests/test_slackbot_client_sanitize.py
+++ b/services/api/tests/test_slackbot_client_sanitize.py
@@ -1,0 +1,69 @@
+"""Tests for Slack egress sanitization in slackbot_client."""
+
+from __future__ import annotations
+
+import pytest
+
+from api import slackbot_client
+
+
+@pytest.fixture
+def posted(monkeypatch):
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_post(path: str, body: dict, **_kwargs):
+        calls.append((path, body))
+        return {"ok": True}
+
+    monkeypatch.setattr(slackbot_client, "post", fake_post)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_session_text_sanitizes_markdown(posted):
+    await slackbot_client.session_text(
+        "sess",
+        'Done. {"kind":"Status","status":"Failure","reason":"AlreadyExists"} Codex thread `019e3c91-4030-7910`',
+    )
+
+    body = posted[0][1]
+    assert body["markdown"] == "Done. [k8s status omitted]"
+
+
+@pytest.mark.asyncio
+async def test_session_step_sanitizes_visible_fields(posted):
+    await slackbot_client.session_step(
+        "sess",
+        step_id="s1",
+        title="Run command: curl (28): Operation timed out",
+        details='{"error_type":"InternalServerError","detail":"bad gateway"}',
+        output="Execution: `exe_e77594af2e0b4893`",
+    )
+
+    body = posted[0][1]
+    assert body["title"] == "Run command: transport_error(28)"
+    assert body["details"] == "[tool error omitted]"
+    assert body["output"] == "[execution id omitted]"
+
+
+@pytest.mark.asyncio
+async def test_harness_event_sanitizes_nested_text_fields(posted):
+    await slackbot_client.harness_event(
+        "sess",
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Body. Codex thread `019e3c91-4030-7910`, with interactive elements",
+                    }
+                ]
+            },
+            "metadata": {"thread_id": "019e3c91-4030-7910"},
+        },
+    )
+
+    event = posted[0][1]["event"]
+    assert event["message"]["content"][0]["text"] == "Body."
+    assert event["metadata"]["thread_id"] == "019e3c91-4030-7910"


### PR DESCRIPTION
## Summary
- Sanitize k8s status JSON, tool error envelopes, generated execution trailers, curl errors, and legacy engine-thread trailers at API → slackbot egress.
- Preserve raw durable execution results for API clients, workflows, replay, and debugging.

## Test plan
- `uv run pytest tests/test_slack_sanitize.py tests/test_slackbot_client_sanitize.py -q`
- `uv run ruff check api/slack_sanitize.py api/slackbot_client.py tests/test_slack_sanitize.py tests/test_slackbot_client_sanitize.py`