### PR TITLE
Install Nushell in sandbox image

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -49,6 +49,23 @@ RUN useradd -m -s /bin/bash -u 1001 agent \
 ARG CLAUDE_CODE_VERSION=2.1.143
 ARG CODEX_VERSION=0.130.0
 ARG PI_CODING_AGENT_VERSION=0.67.2
+ARG NUSHELL_VERSION=0.112.2
+
+# ── Nushell ─────────────────────────────────────────────────────────────────
+RUN set -eux; \
+    nu_arch="$(case "$(dpkg --print-architecture)" in \
+      amd64) echo x86_64 ;; \
+      arm64) echo aarch64 ;; \
+      *) echo unsupported-architecture >&2; exit 1 ;; \
+    esac)"; \
+    curl -fsSL \
+      "https://github.com/nushell/nushell/releases/download/${NUSHELL_VERSION}/nu-${NUSHELL_VERSION}-${nu_arch}-unknown-linux-gnu.tar.gz" \
+      -o /tmp/nu.tar.gz; \
+    mkdir -p /tmp/nu; \
+    tar -xzf /tmp/nu.tar.gz -C /tmp/nu --strip-components=1; \
+    install -m 0755 /tmp/nu/nu /usr/local/bin/nu; \
+    rm -rf /tmp/nu /tmp/nu.tar.gz; \
+    nu --version | grep -F "${NUSHELL_VERSION}"
 
 # ── Global npm CLIs (root) ──────────────────────────────────────────────────
 RUN npm install -g --prefer-online --force \

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -62,7 +62,7 @@
 
 [Environment]
 |repos: ~/github/{org}/{repo} (READ-ONLY mounts) | git pre-configured | gh authenticated
-|installed: Rust,Node24,Python3+uv,Foundry(forge/cast/anvil),rg,fd,jq,tmux,cmake,protobuf
+|installed: Rust,Node24,Python3+uv,Foundry(forge/cast/anvil),Nushell(nu),rg,fd,jq,tmux,cmake,protobuf
 |To modify a repo (commit, push, open PR): run `git-branch <org/repo>` → creates writable clone at ~/branches/<org>/<repo>
 |*NEVER run git commit/push inside* ~/github/ — it is read-only. Always use git-branch first.
 |Prefer `rg` (ripgrep) over `grep` for all codebase operations.


### PR DESCRIPTION
## Summary
- install Nushell 0.112.2 into the sandbox image as `nu`
- document Nushell in the sandbox system prompt installed tools list

## Verification
- verified the Nushell 0.112.2 Linux x86_64 release tarball contains the `nu` binary
- Docker build not run: this sandbox has no Docker daemon at `/var/run/docker.sock`