### PR TITLE
fix: expose Slack custom profile fields

### DIFF
--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1466,28 +1466,36 @@ class SlackClient:
             and custom_fields (dict of label -> value for non-empty custom fields)
         """
         try:
-            response = self._retry_on_ratelimit(
+            user_response = self._retry_on_ratelimit(
                 self._client.users_info,
                 user=user_id,
                 method_key="users.info",
             )
+            profile_response = self._retry_on_ratelimit(
+                self._client.users_profile_get,
+                user=user_id,
+                include_labels=True,
+                method_key="users.profile.get",
+            )
         except SlackApiError as e:
             self._raise_slack_api_error(
                 e,
-                slack_method="users.info",
+                slack_method="users.profile.get",
                 access_path="bot_token",
             )
 
-        user = response.get("user", {})
-        profile = user.get("profile", {})
+        user = user_response.get("user", {})
+        profile = profile_response.get("profile", {}) or user.get("profile", {})
 
         # Extract custom profile fields (Telegram, Skype, pronouns, etc.)
         custom_fields: dict[str, str] = {}
-        for _field_id, field_data in (profile.get("fields") or {}).items():
-            label = field_data.get("label", "")
-            value = field_data.get("value", "")
-            if label and value:
+        raw_custom_fields: dict[str, dict] = {}
+        for field_id, field_data in (profile.get("fields") or {}).items():
+            label = field_data.get("label") or field_id
+            value = field_data.get("value")
+            if value:
                 custom_fields[label] = value
+                raw_custom_fields[field_id] = dict(field_data)
 
         return {
             "id": user.get("id", ""),
@@ -1506,6 +1514,7 @@ class SlackClient:
             "is_bot": user.get("is_bot", False),
             "deleted": user.get("deleted", False),
             "custom_fields": custom_fields,
+            "raw_custom_fields": raw_custom_fields,
         }
 
     def _format_requester_attribution(self) -> str:

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -30,6 +30,9 @@ class _FakeWebClient:
         self.list_calls: list[dict] = []
         self.list_pages: list[dict] = []
         self.api_calls: list[tuple[str, dict]] = []
+        self.user_info_response: dict | None = None
+        self.user_profile_response: dict | None = None
+        self.user_profile_calls: list[dict] = []
         self.upload_exception: Exception | None = None
 
     def chat_postMessage(self, **kwargs):
@@ -47,6 +50,14 @@ class _FakeWebClient:
     def users_list(self, **kwargs):
         self.users_calls.append(kwargs)
         return self.users_pages.pop(0)
+
+    def users_info(self, **kwargs):
+        self.users_calls.append(kwargs)
+        return self.user_info_response or {"user": {}}
+
+    def users_profile_get(self, **kwargs):
+        self.user_profile_calls.append(kwargs)
+        return self.user_profile_response or {"profile": {}}
 
     def conversations_list(self, **kwargs):
         self.list_calls.append(kwargs)
@@ -248,6 +259,45 @@ def test_list_etl_channels_uses_user_token_client() -> None:
             "is_member": False,
         }
     ]
+
+
+def test_get_user_profile_reads_labeled_custom_fields() -> None:
+    client, fake_web_client = _make_client()
+    fake_web_client.user_info_response = {
+        "user": {
+            "id": "U123",
+            "name": "test-user",
+            "real_name": "Test User",
+            "tz": "Europe/London",
+            "tz_label": "British Summer Time",
+            "is_bot": False,
+            "deleted": False,
+        }
+    }
+    fake_web_client.user_profile_response = {
+        "profile": {
+            "display_name": "test-user",
+            "email": "test.user@example.com",
+            "fields": {
+                "Xf123": {
+                    "label": "Affiliations",
+                    "value": "GitHub: test-user",
+                    "alt": "",
+                }
+            },
+        }
+    }
+
+    profile = client.get_user_profile("U123")
+
+    assert fake_web_client.users_calls == [{"user": "U123"}]
+    assert fake_web_client.user_profile_calls == [
+        {"user": "U123", "include_labels": True}
+    ]
+    assert profile["custom_fields"] == {"Affiliations": "GitHub: test-user"}
+    assert profile["raw_custom_fields"] == {
+        "Xf123": {"label": "Affiliations", "value": "GitHub: test-user", "alt": ""}
+    }
 
 
 def test_get_etl_channel_history_page_uses_user_token_client_and_window() -> None:


### PR DESCRIPTION
Updates the Slack `get_user_profile` tool path to call `users.profile.get` with label support, so custom profile fields like `Github Username` are returned instead of being hidden behind empty `custom_fields` output.

The response now includes:
- `custom_fields`: labeled non-empty field values
- `raw_custom_fields`: Slack field IDs with raw field payloads

Prompted by: @DaniPopes

Validation:
- `PYTHONPATH=/home/agent/branches/paradigmxyz/centaur/tools/productivity:/home/agent/branches/paradigmxyz/centaur uv run --with pytest pytest tests/test_client.py -q` from `tools/productivity/slack` passed: 28 tests
- Test fixture uses fake user data for custom-field coverage
- `gh api orgs/tempoxyz/memberships/DaniPopes` verified the prompted-by handle is an active org member