### PR TITLE
fix(slackbot): preserve streamed token spacing

### DIFF
--- a/services/api/api/slack_sanitize.py
+++ b/services/api/api/slack_sanitize.py
@@ -58,7 +58,7 @@ def _is_tool_error_envelope(value: dict[str, Any]) -> bool:
     )
 
 
-def sanitize_for_slack(text: str | None) -> str:
+def sanitize_for_slack(text: str | None, *, preserve_edges: bool = False) -> str:
     """Strip known plumbing leaks from `text`. Idempotent; empty input -> ""."""
     if not text:
         return ""
@@ -73,4 +73,4 @@ def sanitize_for_slack(text: str | None) -> str:
     sanitized = _CURL_EXIT_RE.sub(r"transport_error(\1)", sanitized)
     sanitized = re.sub(r"[ \t]+\n", "\n", sanitized)
     sanitized = re.sub(r"\n{3,}", "\n\n", sanitized)
-    return sanitized.strip()
+    return sanitized if preserve_edges else sanitized.strip()

--- a/services/api/api/slackbot_client.py
+++ b/services/api/api/slackbot_client.py
@@ -228,7 +228,7 @@ _TEXT_KEYS = {
 
 def sanitize_slack_event(value: Any) -> Any:
     if isinstance(value, str):
-        return sanitize_for_slack(value)
+        return sanitize_for_slack(value, preserve_edges=True)
     if isinstance(value, list):
         return [sanitize_slack_event(item) for item in value]
     if isinstance(value, dict):


### PR DESCRIPTION
- preserve leading/trailing whitespace when sanitizing live Slack harness event strings
- keep direct Slack/status sanitization trimming behavior unchanged

- Reproduced the no-spaces regression locally by stashing this fix and redeploying.

repro:

```sh
OPENAI_API_KEY='sk-...' uv run --with openai python - <<'PY'
from openai import OpenAI

client = OpenAI()

stream = client.chat.completions.create(
    model="gpt-4o-mini",
    stream=True,
    messages=[
        {
            "role": "user",
            "content": "Reply exactly: I am on Centaur base persona with no overlay loaded.",
        }
    ],
    max_tokens=30,
)

parts = []
for event in stream:
    delta = event.choices[0].delta.content or ""
    if delta:
        parts.append(delta)
        print(repr(delta))

print("\njoined:")
print("".join(parts))

print("\njoined after stripping each delta:")
print("".join(part.strip() for part in parts))
PY
```