### PR TITLE
feat(slackbot): react with :ok_hand: instead of spawning for trivial thread acks

### DIFF
--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -17,8 +17,10 @@ import { EnvSlackInstallationStore, SlackClientResolver } from './slack/installa
 import { normalizeSlackEnvelope } from './slack/normalize'
 import { markdownToStreamChunks } from './slack/render'
 import { verifySlackSignature } from './slack/signature'
-import type { SlackEnvelope } from './slack/types'
+import { shouldAckWithReaction } from './slack/trivial-ack'
+import type { NormalizedSlackEvent, SlackEnvelope } from './slack/types'
 import type { AnyBlock, AnyChunk } from '@slack/types'
+import type { WebClient } from '@slack/web-api'
 
 const config = loadConfig()
 // This is the existing deployments/runtime alert channel wired by the Helm
@@ -514,6 +516,11 @@ async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {
   if (!normalized) return
   if (!normalized.is_mention) return
 
+  if (shouldAckWithReaction(normalized)) {
+    await ackWithReaction(client, normalized)
+    return
+  }
+
   const result = await handoff.emit(normalized)
   if (!result.ok) {
     if (result.status === 409) {
@@ -521,6 +528,24 @@ async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {
       return
     }
     throw new Error(`Centaur Slack handoff failed: ${result.status}`)
+  }
+}
+
+const TRIVIAL_ACK_REACTION = 'ok_hand'
+
+async function ackWithReaction(client: WebClient, event: NormalizedSlackEvent): Promise<void> {
+  try {
+    await client.reactions.add({
+      channel: event.channel_id,
+      timestamp: event.slack?.message_ts ?? event.thread_ts,
+      name: TRIVIAL_ACK_REACTION
+    })
+  } catch (error) {
+    logWarn('slack_trivial_ack_reaction_failed', {
+      channel_id: event.channel_id,
+      thread_ts: event.thread_ts,
+      error: error instanceof Error ? error.message : String(error)
+    })
   }
 }
 

--- a/services/slackbot/src/slack/trivial-ack.test.ts
+++ b/services/slackbot/src/slack/trivial-ack.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'bun:test'
+import { isTrivialAck, shouldAckWithReaction } from './trivial-ack'
+import type { NormalizedSlackEvent } from './types'
+
+describe('isTrivialAck', () => {
+  it('matches whitelisted ack phrases regardless of casing or trailing punctuation', () => {
+    expect(isTrivialAck('ok')).toBe(true)
+    expect(isTrivialAck('OK!')).toBe(true)
+    expect(isTrivialAck('Thanks!!')).toBe(true)
+    expect(isTrivialAck('ty.')).toBe(true)
+    expect(isTrivialAck('thank you')).toBe(true)
+    expect(isTrivialAck('thank you so much')).toBe(true)
+    expect(isTrivialAck('Got it.')).toBe(true)
+    expect(isTrivialAck('sgtm')).toBe(true)
+  })
+
+  it('matches pure ack-emoji messages', () => {
+    expect(isTrivialAck('👍')).toBe(true)
+    expect(isTrivialAck('🙏')).toBe(true)
+    expect(isTrivialAck('👌👍')).toBe(true)
+    expect(isTrivialAck(' ✨ ')).toBe(true)
+  })
+
+  it('does not treat bare single words like "you", "done", or "great" as acks', () => {
+    // These previously slipped through a permissive token set; without the
+    // surrounding phrase they're real asks ("@bot you?", "@bot done?").
+    expect(isTrivialAck('you')).toBe(false)
+    expect(isTrivialAck('it')).toBe(false)
+    expect(isTrivialAck('done')).toBe(false)
+    expect(isTrivialAck('great')).toBe(false)
+    expect(isTrivialAck('nice')).toBe(false)
+    expect(isTrivialAck('cool')).toBe(false)
+    expect(isTrivialAck('perfect')).toBe(false)
+  })
+
+  it('rejects messages that contain non-ack words even when short', () => {
+    expect(isTrivialAck('ok do the next one')).toBe(false)
+    expect(isTrivialAck('thanks, also can you')).toBe(false)
+    expect(isTrivialAck('this is a request')).toBe(false)
+    expect(isTrivialAck('cool, thanks!')).toBe(false)
+  })
+
+  it('rejects long messages even if they start with thanks', () => {
+    const longish = 'thanks for that, can you also pull last quarter and compare?'
+    expect(isTrivialAck(longish)).toBe(false)
+  })
+
+  it('returns false for empty or whitespace input', () => {
+    expect(isTrivialAck('')).toBe(false)
+    expect(isTrivialAck('   ')).toBe(false)
+  })
+})
+
+function baseEvent(overrides: Partial<NormalizedSlackEvent> = {}): NormalizedSlackEvent {
+  return {
+    thread_key: 'slack:T:C:1.0',
+    message_id: 'slack:T:C:2.0',
+    team_id: 'T',
+    recipient_team_id: 'T',
+    user_id: 'U1',
+    channel_id: 'C',
+    thread_ts: '1.0',
+    is_mention: true,
+    parts: [{ type: 'text', text: 'thanks!' }],
+    history_messages: [
+      {
+        message_id: 'slack:T:C:1.0',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Done.' }]
+      }
+    ],
+    slack: {
+      event_id: 'Ev1',
+      event_ts: '2.0',
+      message_ts: '2.0'
+    },
+    ...overrides
+  }
+}
+
+describe('shouldAckWithReaction', () => {
+  it('acks a trivial thanks reply inside a thread with prior assistant work', () => {
+    expect(shouldAckWithReaction(baseEvent())).toBe(true)
+  })
+
+  it('does not ack the first message in a brand-new thread', () => {
+    expect(
+      shouldAckWithReaction(
+        baseEvent({
+          slack: { event_id: 'Ev1', event_ts: '1.0', message_ts: '1.0' },
+          history_messages: []
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('does not ack when the thread has no prior assistant reply', () => {
+    expect(
+      shouldAckWithReaction(
+        baseEvent({
+          history_messages: [
+            {
+              message_id: 'slack:T:C:1.0',
+              role: 'user',
+              parts: [{ type: 'text', text: 'hi' }]
+            }
+          ]
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('does not ack when the message carries attachments', () => {
+    expect(
+      shouldAckWithReaction(
+        baseEvent({
+          parts: [
+            { type: 'text', text: 'thanks' },
+            {
+              type: 'image',
+              name: 'pic.png',
+              mime_type: 'image/png',
+              size: 100,
+              source: { type: 'base64', media_type: 'image/png', data: 'AA==' }
+            }
+          ]
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('does not ack a non-mention message', () => {
+    expect(shouldAckWithReaction(baseEvent({ is_mention: false }))).toBe(false)
+  })
+})

--- a/services/slackbot/src/slack/trivial-ack.ts
+++ b/services/slackbot/src/slack/trivial-ack.ts
@@ -1,0 +1,57 @@
+import type { NormalizedSlackEvent } from './types'
+
+const ACK_PHRASES = new Set([
+  'ok',
+  'okay',
+  'oki',
+  'okie',
+  'okies',
+  'k',
+  'kk',
+  'kkk',
+  'ty',
+  'tysm',
+  'thx',
+  'thanks',
+  'thank you',
+  'thank you so much',
+  'thanks so much',
+  'thanks man',
+  'thanks team',
+  'gotcha',
+  'got it',
+  'noted',
+  'understood',
+  'sgtm',
+  'lgtm',
+  'np'
+])
+
+const ACK_EMOJI_ONLY_RE = /^(?:\s|👍|👌|🙏|💯|🎉|✅|❤|🤝|🫡|🔥|🙌|💪|✨|❤️)+$/u
+const MAX_ACK_CHARS = 60
+
+export function isTrivialAck(text: string): boolean {
+  const trimmed = text.trim()
+  if (!trimmed || trimmed.length > MAX_ACK_CHARS) return false
+  if (ACK_EMOJI_ONLY_RE.test(trimmed)) return true
+
+  const normalized = trimmed
+    .toLowerCase()
+    .replace(/[!?.,…]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim()
+  return Boolean(normalized) && ACK_PHRASES.has(normalized)
+}
+
+// Mentions inside an existing thread that already has an assistant reply, with
+// a short whitelisted ack as the only part, get a reaction instead of a spawn.
+export function shouldAckWithReaction(event: NormalizedSlackEvent): boolean {
+  if (!event.is_mention) return false
+  if (event.parts.length !== 1) return false
+  const part = event.parts[0]
+  if (!part || part.type !== 'text') return false
+  if (!isTrivialAck(part.text)) return false
+  if (event.slack?.message_ts === event.thread_ts) return false
+  const history = event.history_messages ?? []
+  return history.some(message => message.role === 'assistant')
+}


### PR DESCRIPTION
## Summary
- Detect short follow-ups like "ok" / "thanks" / "thank you" / "got it" / pure ack-emoji and react with `:ok_hand:` instead of spawning a sandbox.
- Only fires on @-mentions inside threads with prior assistant participation; whitelisted phrases only (no bare `you`/`it`/`done`/`great`); attachments always fall through to the normal handoff.

## Test plan
- `bun --cwd services/slackbot test src/slack/trivial-ack.test.ts`