### PR TITLE
fix(api): eagerly close slackbot sessions when release cancels in-flight work

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -1632,6 +1632,34 @@ async def steer_execution(
     }
 
 
+def _collect_slackbot_session_ids(rows: list[Any]) -> list[str]:
+    seen: list[str] = []
+    for row in rows:
+        metadata = decode_jsonb(row["metadata"], {})
+        if not isinstance(metadata, dict):
+            continue
+        session_id = str(metadata.get("slackbot_agent_session_id") or "").strip()
+        if session_id and session_id not in seen:
+            seen.append(session_id)
+    return seen
+
+
+async def _close_slackbot_sessions_on_release(
+    *, thread_key: str, release_id: str, session_ids: list[str]
+) -> None:
+    for session_id in session_ids:
+        try:
+            await slackbot_client.session_done(session_id)
+        except Exception:
+            log.warning(
+                "slackbot_release_session_done_failed",
+                thread_key=thread_key,
+                release_id=release_id,
+                slackbot_agent_session_id=session_id,
+                exc_info=True,
+            )
+
+
 async def release_assignment(
     pool,
     *,
@@ -1649,6 +1677,7 @@ async def release_assignment(
     req_hash = request_hash(payload)
 
     response: dict[str, Any]
+    cancelled_session_ids: list[str] = []
     async with pool.acquire() as conn:
         async with conn.transaction():
             await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", thread_key)
@@ -1690,12 +1719,14 @@ async def release_assignment(
                     generation,
                 )
                 if cancel_inflight:
-                    await conn.execute(
+                    cancelled_rows = await conn.fetch(
                         "UPDATE agent_execution_requests SET status = 'cancelled', terminal_reason = 'released', "
                         "completed_at = NOW(), updated_at = NOW() "
-                        "WHERE thread_key = $1 AND status IN ('queued', 'running', 'cancel_requested', 'retry_wait')",
+                        "WHERE thread_key = $1 AND status IN ('queued', 'running', 'cancel_requested', 'retry_wait') "
+                        "RETURNING metadata",
                         thread_key,
                     )
+                    cancelled_session_ids = _collect_slackbot_session_ids(cancelled_rows)
                 response = {
                     "ok": True,
                     "thread_key": thread_key,
@@ -1712,6 +1743,12 @@ async def release_assignment(
                 req_hash,
                 canonical_json(response),
             )
+    if response.get("released") and cancelled_session_ids:
+        await _close_slackbot_sessions_on_release(
+            thread_key=thread_key,
+            release_id=release_id,
+            session_ids=cancelled_session_ids,
+        )
     if response.get("released") and stop_runtime:
         with contextlib.suppress(Exception):
             runtime_id = response.get("runtime_id")

--- a/services/api/tests/test_runtime_control_release_session_done.py
+++ b/services/api/tests/test_runtime_control_release_session_done.py
@@ -1,0 +1,61 @@
+"""Tests for the eager slackbot session_done dispatch on release_assignment."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _row(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    return {"metadata": json.dumps(metadata) if metadata is not None else None}
+
+
+def test_collect_slackbot_session_ids_dedupes_and_skips_blanks():
+    from api.runtime_control import _collect_slackbot_session_ids
+
+    rows = [
+        _row({"slackbot_agent_session_id": "sess_a"}),
+        _row({"slackbot_agent_session_id": "sess_a"}),
+        _row({"slackbot_agent_session_id": "sess_b"}),
+        _row({"slackbot_agent_session_id": "  "}),
+        _row({}),
+        _row(None),
+    ]
+
+    assert _collect_slackbot_session_ids(rows) == ["sess_a", "sess_b"]
+
+
+@pytest.mark.asyncio
+async def test_close_slackbot_sessions_on_release_calls_session_done(monkeypatch):
+    from api import runtime_control
+
+    session_done = AsyncMock(return_value=None)
+    monkeypatch.setattr(runtime_control.slackbot_client, "session_done", session_done)
+
+    await runtime_control._close_slackbot_sessions_on_release(
+        thread_key="slack:T:C:1.0",
+        release_id="rel-1",
+        session_ids=["sess_a", "sess_b"],
+    )
+
+    assert session_done.await_count == 2
+    assert [call.args[0] for call in session_done.await_args_list] == ["sess_a", "sess_b"]
+
+
+@pytest.mark.asyncio
+async def test_close_slackbot_sessions_on_release_swallows_errors(monkeypatch, caplog):
+    from api import runtime_control
+
+    async def _boom(_session_id: str) -> None:
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(runtime_control.slackbot_client, "session_done", _boom)
+
+    await runtime_control._close_slackbot_sessions_on_release(
+        thread_key="slack:T:C:1.0",
+        release_id="rel-1",
+        session_ids=["sess_a"],
+    )


### PR DESCRIPTION
## Summary
- `release_assignment(..., cancel_inflight=true)` now `RETURNING`s cancelled rows' metadata, collects distinct `slackbot_agent_session_id` values, and calls `slackbot_client.session_done` post-commit so the "Thinking" pill disappears within ~5s instead of hanging until the next message.
- Errors are logged but never block the release response.

## Test plan
- `uv run --project services/api pytest tests/test_runtime_control_release_session_done.py -q`