### PR TITLE
fix(sandbox): strip oversized binary blocks from codex stdin prompts

### DIFF
--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -227,3 +227,104 @@ def test_main_lazy_starts_app_server_after_input(monkeypatch) -> None:
     )
     assert {"type": "thread.started", "thread_id": "thread-123"} in emitted
     assert {"type": "turn.completed"} in emitted
+
+
+def test_text_from_blocks_strips_inline_binary_blobs() -> None:
+    wrapper = _load_wrapper()
+    big_pdf_b64 = "A" * 2_000_000
+    blocks = [
+        {"type": "text", "text": "Summarize this report:"},
+        {
+            "type": "document",
+            "name": "report.pdf",
+            "mime_type": "application/pdf",
+            "size": 1_400_000,
+            "source": {
+                "type": "base64",
+                "media_type": "application/pdf",
+                "data": big_pdf_b64,
+            },
+        },
+        {
+            "type": "image",
+            "name": "diagram.png",
+            "source": {"type": "base64", "media_type": "image/png", "data": "AAA"},
+        },
+        {
+            "type": "attachment_ref",
+            "attachment_id": "att_42",
+            "name": "deck.pdf",
+        },
+    ]
+    text = wrapper.text_from_blocks(blocks)
+    assert "Summarize this report" in text
+    assert big_pdf_b64 not in text
+    assert "report.pdf" in text
+    assert "diagram.png" in text
+    assert "att_42" in text
+    assert "/home/agent/uploads/" in text
+    assert len(text) < 4_000
+
+
+def test_text_from_blocks_keeps_small_unknown_blocks_intact() -> None:
+    wrapper = _load_wrapper()
+    blocks = [
+        {"type": "text", "text": "Use this tool result:"},
+        {"type": "tool_result", "tool_use_id": "tu_1", "content": "ok"},
+    ]
+    text = wrapper.text_from_blocks(blocks)
+    assert '"tool_use_id": "tu_1"' in text
+
+
+def test_text_from_blocks_collapses_oversize_non_binary_blocks_with_omitted_message() -> None:
+    wrapper = _load_wrapper()
+    huge = {"type": "tool_result", "content": "x" * 100_000}
+    text = wrapper.text_from_blocks([{"type": "text", "text": "go"}, huge])
+    assert "x" * 1000 not in text
+    # Oversize non-binary blocks should NOT say "binary data stripped"; that
+    # phrasing is reserved for image/document/file blocks.
+    assert "binary data stripped" not in text
+    assert "exceeds inline byte budget" in text
+
+
+def test_text_from_blocks_basenames_attachment_paths_for_path_safety() -> None:
+    wrapper = _load_wrapper()
+    blocks = [
+        {
+            "type": "image",
+            "name": "../../etc/passwd",
+            "source": {"type": "base64", "media_type": "image/png", "data": "AA=="},
+        },
+        {
+            "type": "attachment_ref",
+            "attachment_id": "att_99",
+            "name": "/etc/shadow",
+        },
+    ]
+    text = wrapper.text_from_blocks(blocks)
+    assert "../../etc/passwd" not in text
+    assert "/etc/shadow" not in text
+    assert "/home/agent/uploads/passwd" in text
+    assert "/home/agent/uploads/shadow" in text
+
+
+def test_text_from_blocks_prefers_attachment_id_over_stray_id() -> None:
+    wrapper = _load_wrapper()
+    blocks = [
+        {
+            "type": "attachment_ref",
+            "id": "msg_42",
+            "attachment_id": "att_42",
+            "name": "deck.pdf",
+        }
+    ]
+    text = wrapper.text_from_blocks(blocks)
+    assert "id=att_42" in text
+    assert "msg_42" not in text
+
+
+def test_text_from_blocks_ignores_non_dict_entries() -> None:
+    wrapper = _load_wrapper()
+    blocks = [{"type": "text", "text": "go"}, None, "stray", 7]
+    text = wrapper.text_from_blocks(blocks)
+    assert text == "go"

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -149,18 +149,66 @@ def api_stdin_reader() -> None:
     INPUTS.put(None)
 
 
+_BINARY_BLOCK_TYPES = frozenset({"image", "document", "file"})
+_INLINE_BLOCK_BYTE_BUDGET = 16_384
+
+
+def _safe_basename(name: str) -> str:
+    base = os.path.basename(name.strip()) if name else ""
+    return base if base not in ("", ".", "..") else ""
+
+
+def _describe_binary_block(block: dict[str, Any]) -> str:
+    btype = str(block.get("type") or "attachment")
+    name = _safe_basename(str(block.get("name") or block.get("filename") or ""))
+    media_type = str(block.get("mime_type") or "").strip()
+    if not media_type:
+        source = block.get("source") if isinstance(block.get("source"), dict) else {}
+        media_type = str(source.get("media_type") or "").strip()
+    size = block.get("size") or block.get("byte_size")
+    pieces: list[str] = [btype]
+    if name:
+        pieces.append(name)
+    if media_type:
+        pieces.append(media_type)
+    if isinstance(size, int) and size > 0:
+        pieces.append(f"{size}B")
+    descriptor = " · ".join(pieces)
+    hint = name or f"{btype}-attachment"
+    return (
+        f"[Attached {descriptor}; binary data stripped from prompt. "
+        f"If you need it, fetch it from /home/agent/uploads/{hint} or look it up in the attachments table.]"
+    )
+
+
+def _describe_oversize_block(block: dict[str, Any]) -> str:
+    btype = str(block.get("type") or "attachment")
+    return f"[{btype} block omitted from prompt: exceeds inline byte budget]"
+
+
 def text_from_blocks(blocks: list[dict[str, Any]]) -> str:
     parts: list[str] = []
     for block in blocks:
+        if not isinstance(block, dict):
+            continue
         btype = block.get("type")
         if btype == "text":
             parts.append(str(block.get("text") or ""))
-        elif btype == "image":
+        elif btype in _BINARY_BLOCK_TYPES:
+            parts.append(_describe_binary_block(block))
+        elif btype == "attachment_ref":
+            ref = block.get("attachment_id") or block.get("id") or "unknown"
+            name = _safe_basename(str(block.get("name") or block.get("filename") or "")) or "attachment"
             parts.append(
-                "[User sent an image attachment; if needed, ask them to upload it as a file reference.]"
+                f"[attachment_ref id={ref} name={name}; fetch via "
+                f"`curl http://api:8000/agent/attachments/{ref}/download -o /home/agent/uploads/{name}`]"
             )
         else:
-            parts.append(json.dumps(block, ensure_ascii=False))
+            encoded = json.dumps(block, ensure_ascii=False)
+            if len(encoded) > _INLINE_BLOCK_BYTE_BUDGET:
+                parts.append(_describe_oversize_block(block))
+            else:
+                parts.append(encoded)
     return "\n".join(p for p in parts if p).strip()
 
 


### PR DESCRIPTION
## Summary
- `text_from_blocks` replaces `image`/`document`/`file` blocks with a one-line descriptor pointing at `/home/agent/uploads/<basename>`, `attachment_ref` blocks with a curl recipe, and any other block over a 16KB inline budget with a distinct "exceeds inline byte budget" note (no more multi-MB base64 in codex stdin).
- `os.path.basename` on attachment names so path-traversal in `name` can't escape the uploads dir; non-dict block entries are skipped.

## Test plan
- `uv run --project services/api pytest tests/test_codex_app_wrapper.py -q`