### PR TITLE
Add Apache and MIT dual license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,8 @@
-The MIT License (MIT)
+Licensed under either of
 
-Copyright (c) 2022-2026 Centaur Contributors
+* Apache License, Version 2.0
+* MIT license
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+at your option.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+SPDX-License-Identifier: Apache-2.0 OR MIT

--- a/centaur_sdk/pyproject.toml
+++ b/centaur_sdk/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Lightweight SDK for building Centaur-compatible tools"
 requires-python = ">=3.11"
 readme = "README.md"
-license = "MIT"
+license = "Apache-2.0 OR MIT"
 dependencies = [
     "rich>=13.0",
 ]

--- a/services/slackbot/package.json
+++ b/services/slackbot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slackbot",
   "version": "0.0.0",
-  "license": "MIT",
+  "license": "Apache-2.0 OR MIT",
   "type": "module",
   "imports": {
     "#*": "./src/*",


### PR DESCRIPTION
## Summary
- Update repository licensing to Apache-2.0 OR MIT
- Update package metadata that declared MIT only

## Tests
- Not run; license-only change