### PR TITLE
Classify Slack final delivery API errors

### DIFF
--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -1783,6 +1783,17 @@ async def _insert_workflow_run(
         )
         if existing:
             if existing["request_hash"] != req_hash:
+                keys = ",".join(sorted(str(key) for key in run_input.keys()))
+                log.warning(
+                    "workflow_idempotency_payload_mismatch",
+                    workflow_name=workflow_name,
+                    trigger_key=trigger_key,
+                    thread_key=run_input.get("thread_key"),
+                    input_keys=keys,
+                    existing_request_hash_prefix=str(existing["request_hash"])[:12],
+                    request_hash_prefix=req_hash[:12],
+                    run_id=str(existing["run_id"]),
+                )
                 raise ControlPlaneError(
                     "IDEMPOTENCY_PAYLOAD_MISMATCH",
                     "trigger_key was already used with a different payload",

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -1226,6 +1226,13 @@ async def do_agent_turn(
                 if not history_parts:
                     skipped += 1
                     continue
+                if await _message_request_exists(
+                    ctx._pool,
+                    thread_key=effective_thread_key,
+                    message_id=history_message_id,
+                ):
+                    skipped += 1
+                    continue
                 history_role = str(item.get("role") or "user").strip().lower()
                 if history_role not in {"user", "assistant"}:
                     skipped += 1
@@ -1321,6 +1328,21 @@ async def do_agent_turn(
 
     # Not terminal yet — suspend and wait for notify_execution_terminal
     raise SuspendWorkflow(status="waiting")
+
+
+async def _message_request_exists(
+    pool,
+    *,
+    thread_key: str,
+    message_id: str,
+) -> bool:
+    row = await pool.fetchrow(
+        "SELECT 1 FROM agent_message_requests "
+        "WHERE thread_key = $1 AND message_id = $2",
+        thread_key,
+        message_id,
+    )
+    return row is not None
 
 
 # ── Handler discovery ─────────────────────────────────────────────────

--- a/services/api/tests/test_workflow_idempotency_unit.py
+++ b/services/api/tests/test_workflow_idempotency_unit.py
@@ -6,6 +6,20 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 
+class _FakeWorkflowContext:
+    def __init__(self, pool, run_id: str, run_input: dict):
+        self._pool = pool
+        self.run_id = run_id
+        self.run_input = run_input
+
+    def _peek_resolved_name(self, name: str) -> str:
+        return name
+
+    async def step(self, _name, fn, *, step_kind: str):
+        assert step_kind == "agent_turn"
+        return await fn()
+
+
 @pytest.mark.asyncio
 async def test_workflow_idempotency_mismatch_logs_safe_metadata():
     from api.runtime_control import ControlPlaneError
@@ -54,3 +68,56 @@ async def test_workflow_idempotency_mismatch_logs_safe_metadata():
     assert fields["run_id"] == "wfr_existing"
     assert fields["existing_request_hash_prefix"] == "different-ex"
     assert len(fields["request_hash_prefix"]) == 12
+
+
+@pytest.mark.asyncio
+async def test_agent_turn_skips_existing_history_message_before_append():
+    from api.workflow_engine import SuspendWorkflow, do_agent_turn
+
+    pool = AsyncMock()
+    ctx = _FakeWorkflowContext(
+        pool,
+        "wfr_test",
+        {
+            "thread_key": "slack:C:thread",
+            "history_messages": [
+                {
+                    "message_id": "slack:prior",
+                    "parts": [{"type": "text", "text": "already stored"}],
+                    "user_id": "U1",
+                }
+            ],
+        },
+    )
+
+    append_message = AsyncMock(return_value={"ok": True})
+    enqueue_execution = AsyncMock(return_value={
+        "execution_id": "exe_test",
+        "status": "queued",
+    })
+
+    with (
+        patch("api.workflow_engine._compute_agent_session_title", new=AsyncMock(return_value=None)),
+        patch("api.workflow_engine._compute_agent_session_header", new=AsyncMock(return_value=None)),
+        patch("api.workflow_engine.slackbot_client.open_agent_session", new=AsyncMock(return_value=None)),
+        patch("api.workflow_engine.spawn_assignment", new=AsyncMock(return_value={"assignment_generation": 1})),
+        patch("api.workflow_engine._message_request_exists", new=AsyncMock(return_value=True)) as exists,
+        patch("api.workflow_engine.append_message", new=append_message),
+        patch("api.workflow_engine.enqueue_execution", new=enqueue_execution),
+        patch("api.workflow_engine.get_execution", new=AsyncMock(return_value=None)),
+    ):
+        with pytest.raises(SuspendWorkflow):
+            await do_agent_turn(
+                ctx,
+                parts=[{"type": "text", "text": "current"}],
+                message_id="slack:current",
+            )
+
+    exists.assert_awaited_once_with(
+        pool,
+        thread_key="slack:C:thread",
+        message_id="slack:prior",
+    )
+    append_message.assert_awaited_once()
+    assert append_message.await_args.kwargs["message_id"] == "slack:current"
+    enqueue_execution.assert_awaited_once()

--- a/services/api/tests/test_workflow_idempotency_unit.py
+++ b/services/api/tests/test_workflow_idempotency_unit.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_workflow_idempotency_mismatch_logs_safe_metadata():
+    from api.runtime_control import ControlPlaneError
+    from api.workflow_engine import _insert_workflow_run
+
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}"
+    trigger_key = f"slack-turn:{uuid.uuid4().hex}"
+    run_input = {
+        "thread_key": thread_key,
+        "message_id": trigger_key,
+        "parts": [{"type": "text", "text": "changed"}],
+        "history_messages": [{"message_id": "slack:prior", "parts": []}],
+    }
+
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={
+        "run_id": "wfr_existing",
+        "request_hash": "different-existing-request-hash",
+    })
+
+    with (
+        patch("api.workflow_engine.get_workflow_handler", return_value=object()),
+        patch("api.workflow_engine.log.warning") as warning,
+    ):
+        with pytest.raises(ControlPlaneError) as exc:
+            await _insert_workflow_run(
+                conn,
+                workflow_name="slack_thread_turn",
+                run_input=run_input,
+                trigger_key=trigger_key,
+                workflow_version="test",
+                workflow_source_path=None,
+                parent_run_id=None,
+                root_run_id=None,
+            )
+
+    assert exc.value.code == "IDEMPOTENCY_PAYLOAD_MISMATCH"
+    warning.assert_called_once()
+    event_name = warning.call_args.args[0]
+    fields = warning.call_args.kwargs
+    assert event_name == "workflow_idempotency_payload_mismatch"
+    assert fields["workflow_name"] == "slack_thread_turn"
+    assert fields["trigger_key"] == trigger_key
+    assert fields["thread_key"] == thread_key
+    assert fields["input_keys"] == "history_messages,message_id,parts,thread_key"
+    assert fields["run_id"] == "wfr_existing"
+    assert fields["existing_request_hash_prefix"] == "different-ex"
+    assert len(fields["request_hash_prefix"]) == 12

--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -298,6 +298,66 @@ describe("final delivery polling", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("marks thrown Slack Web API block-size errors non-retryable", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchCalls: Array<{ path: string; body: any }> = [];
+    const fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        fetchCalls.push({ path: url.pathname, body });
+        if (url.pathname === "/agent/final-deliveries/claim") {
+          return jsonResponse({
+            deliveries: [
+              {
+                execution_id: "exe-blocks-too-long",
+                thread_key: "slack:T123:C123:1778883099.579529",
+                delivery: {
+                  platform: "slack",
+                  channel: "C123",
+                  thread_ts: "1778883099.579529",
+                },
+                final_payload: { result_text: "hello" },
+              },
+            ],
+          });
+        }
+        if (
+          url.pathname ===
+          "/agent/final-deliveries/exe-blocks-too-long/failed"
+        )
+          return jsonResponse({ ok: true });
+        throw new Error(`unexpected request: ${url.pathname}`);
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const client = {
+      chat: {
+        postMessage: async () => {
+          const error = new Error("An API error occurred");
+          (error as any).data = { ok: false, error: "msg_blocks_too_long" };
+          throw error;
+        },
+      },
+      conversations: { replies: async () => ({ ok: true, messages: [] }) },
+    };
+
+    try {
+      await pollFinalDeliveriesOnce(config, client as any);
+      const failed = fetchCalls.find((call) =>
+        call.path.endsWith("/final-deliveries/exe-blocks-too-long/failed"),
+      );
+      expect(failed?.body).toMatchObject({
+        error: "An API error occurred",
+        error_class: "msg_blocks_too_long",
+        non_retryable: true,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 function jsonResponse(body: unknown): Response {

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -67,9 +67,8 @@ export async function pollFinalDeliveriesOnce(
             delivery,
           );
         } catch (error) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          const errorClass = slackDeliveryErrorClass(errorMessage);
+          const errorMessage = slackDeliveryErrorMessage(error);
+          const errorClass = slackDeliveryErrorClass(error);
           await centaur(
             config,
             `/agent/final-deliveries/${executionId}/failed`,
@@ -244,12 +243,29 @@ function splitFinalDeliveryText(text: string): string[] {
   return chunks;
 }
 
-function slackDeliveryErrorClass(error: string): string | null {
-  const normalized = error.trim().toLowerCase();
+function slackDeliveryErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function slackDeliveryErrorClass(error: unknown): string | null {
+  const normalized = slackDeliveryErrorFingerprint(error).trim().toLowerCase();
   for (const errorClass of NON_RETRYABLE_SLACK_ERRORS) {
     if (normalized.includes(errorClass)) return errorClass;
   }
   return null;
+}
+
+function slackDeliveryErrorFingerprint(error: unknown): string {
+  const parts = [slackDeliveryErrorMessage(error)];
+  const data = (error as { data?: unknown })?.data;
+  if (data && typeof data === "object") {
+    const slackError = (data as { error?: unknown }).error;
+    if (slackError) parts.push(String(slackError));
+  }
+  const code = (error as { code?: unknown })?.code;
+  if (code) parts.push(String(code));
+  return parts.join(" ");
 }
 
 function targetFromDelivery(delivery: any): {


### PR DESCRIPTION
## Summary
- classify Slack final-delivery failures using thrown Web API `data.error` and `code`, not only `Error.message`
- add a regression test for thrown `msg_blocks_too_long` errors so they are marked non-retryable immediately

## Evidence
- vlogs showed `msg_blocks_too_long` final delivery failures retried 50 times with `error_class=unknown` before dead-lettering
- current Slack turn trace reached `execute_started` and `turn_first_output` cleanly; the API execution path was not the failing surface

## Tests
- `bun test src/centaur/final-delivery.test.ts`
- `bun test src/index.test.ts src/slack/dedup.test.ts`