### PR TITLE
fix: resolve Slack session header after spawn

### DIFF
--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -979,25 +979,6 @@ def _assignment_display_engine(active: dict[str, Any]) -> str | None:
     return _nonempty(active.get("harness"))
 
 
-def _display_harness_label(harness: str | None, persona: str | None) -> str | None:
-    """Best human-readable name for the runtime that ran.
-
-    Prefers an explicit ``harness`` override; falls back to the persona's
-    declared engine; finally returns ``None`` if nothing is known. Useful
-    for user-facing error messages where we don't want to hard-code a
-    specific engine name (e.g. ``"Failed to start the Codex runtime"`` is
-    wrong when the active engine is amp/claude-code/pi-mono).
-    """
-    label = _nonempty(harness)
-    if label:
-        return label
-    if persona:
-        engine = _persona_default_engine(persona)
-        if engine:
-            return engine
-    return None
-
-
 def _persona_default_engine(persona_id: str) -> str | None:
     try:
         from api.app import get_tool_manager
@@ -1160,6 +1141,42 @@ async def do_agent_turn(
             effective_delivery = dict(run_in.get("delivery") or {})
         effective_history = history_messages or run_in.get("history_messages") or []
         selector = {"persona_id": persona, "harness": harness}
+        slackbot_session_id: str | None = None
+
+        try:
+            spawn = await spawn_assignment(
+                ctx._pool,
+                thread_key=effective_thread_key,
+                spawn_id=f"{step_id}:spawn",
+                harness=harness,
+                engine=None,
+                persona_id=persona,
+                agents_md_override=agents_md_override,
+            )
+        except Exception as exc:
+            try:
+                failure_session_id = await slackbot_client.open_agent_session(
+                    delivery=effective_delivery,
+                    metadata=effective_metadata,
+                    thread_key=effective_thread_key,
+                    title="Centaur",
+                    header=None,
+                )
+                if failure_session_id:
+                    await slackbot_client.session_text(
+                        failure_session_id,
+                        f"Failed to start the runtime: {exc}",
+                    )
+                    await slackbot_client.session_done(failure_session_id)
+            except Exception:
+                log.warning(
+                    "workflow_spawn_failure_session_failed",
+                    workflow_run_id=ctx.run_id,
+                    thread_key=effective_thread_key,
+                    exc_info=True,
+                )
+            raise
+        ag = int(spawn["assignment_generation"])
 
         session_title = await _compute_agent_session_title(
             ctx._pool, effective_thread_key, selector,
@@ -1177,33 +1194,6 @@ async def do_agent_turn(
         if slackbot_session_id:
             effective_metadata["slackbot_agent_session_id"] = slackbot_session_id
             effective_metadata["slackbot_live_delivery"] = True
-
-        try:
-            spawn = await spawn_assignment(
-                ctx._pool,
-                thread_key=effective_thread_key,
-                spawn_id=f"{step_id}:spawn",
-                harness=harness,
-                engine=None,
-                persona_id=persona,
-                agents_md_override=agents_md_override,
-            )
-        except Exception as exc:
-            if slackbot_session_id:
-                # Surface the actual harness/engine name in the error instead of
-                # the hard-coded "Codex" — every harness path lands here, not
-                # just codex. Falls back to "agent" when no display name is
-                # available so the message stays readable.
-                runtime_label = (
-                    _display_harness_label(harness, persona) or "agent"
-                )
-                await slackbot_client.session_text(
-                    slackbot_session_id,
-                    f"Failed to start the {runtime_label} runtime: {exc}",
-                )
-                await slackbot_client.session_done(slackbot_session_id)
-            raise
-        ag = int(spawn["assignment_generation"])
 
         if isinstance(effective_history, list):
             backfilled = 0

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -1343,6 +1343,159 @@ async def test_agent_turn_idempotency_ids_follow_deduped_step_names(db_pool):
 
 
 @pytest.mark.asyncio
+async def test_agent_turn_opens_slack_session_after_spawn_with_resolved_header(
+    db_pool,
+    monkeypatch,
+):
+    from api.workflow_engine import SuspendWorkflow, WorkflowContext, do_agent_turn
+
+    monkeypatch.delenv("CODEX_MODEL", raising=False)
+    run_id = f"wfr_{uuid.uuid4().hex[:16]}"
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:session-after-spawn"
+    await db_pool.execute(
+        "INSERT INTO workflow_runs ("
+        "run_id, workflow_name, workflow_version, request_hash, root_run_id, "
+        "status, input_json, worker_id"
+        ") VALUES ($1, 'test', 'test-v1', 'hash', $1, 'running', '{}'::jsonb, 'w1')",
+        run_id,
+    )
+
+    ctx = WorkflowContext(
+        pool=db_pool,
+        run_id=run_id,
+        checkpoints={},
+        lease_s=30.0,
+        worker_id="w1",
+    )
+    order: list[str] = []
+
+    async def spawn_after_recording(*args, **kwargs):
+        order.append("spawn")
+        await db_pool.execute(
+            "INSERT INTO agent_runtime_assignments ("
+            "thread_key, assignment_generation, runtime_id, harness, engine, "
+            "persona_id, prompt_ref, effective_agents_md_sha256, state"
+            ") VALUES ($1, 1, 'rt-session-after-spawn', 'codex', 'codex', "
+            "NULL, 'harness:codex', 'sha', 'active')",
+            thread_key,
+        )
+        return {"assignment_generation": 1}
+
+    async def open_after_spawn(**kwargs):
+        order.append("open")
+        assert kwargs["title"] == "Centaur · codex"
+        assert kwargs["header"] == "base · codex"
+        return "sess-resolved"
+
+    append_message_mock = AsyncMock()
+    enqueue_execution_mock = AsyncMock(
+        return_value={"ok": True, "execution_id": "exe-resolved", "status": "queued"},
+    )
+
+    with (
+        patch(
+            "api.workflow_engine.spawn_assignment",
+            new=AsyncMock(side_effect=spawn_after_recording),
+        ),
+        patch(
+            "api.workflow_engine.slackbot_client.open_agent_session",
+            new=AsyncMock(side_effect=open_after_spawn),
+        ) as open_session_mock,
+        patch("api.workflow_engine.append_message", new=append_message_mock),
+        patch("api.workflow_engine.enqueue_execution", new=enqueue_execution_mock),
+    ):
+        with pytest.raises(SuspendWorkflow):
+            await do_agent_turn(
+                ctx,
+                prompt="hello",
+                thread_key=thread_key,
+                delivery={
+                    "platform": "slack",
+                    "channel": "C-test",
+                    "thread_ts": "1700000000.000100",
+                },
+            )
+
+    assert order == ["spawn", "open"]
+    open_session_mock.assert_awaited_once()
+    message_metadata = append_message_mock.await_args.kwargs["metadata"]
+    assert message_metadata["slackbot_agent_session_id"] == "sess-resolved"
+    assert message_metadata["slackbot_live_delivery"] is True
+    enqueue_metadata = enqueue_execution_mock.await_args.kwargs["metadata"]
+    assert enqueue_metadata["slackbot_agent_session_id"] == "sess-resolved"
+    assert enqueue_metadata["slackbot_live_delivery"] is True
+
+
+@pytest.mark.asyncio
+async def test_agent_turn_spawn_failure_opens_unresolved_failure_session(db_pool):
+    from api.workflow_engine import WorkflowContext, do_agent_turn
+
+    run_id = f"wfr_{uuid.uuid4().hex[:16]}"
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:spawn-failure-session"
+    await db_pool.execute(
+        "INSERT INTO workflow_runs ("
+        "run_id, workflow_name, workflow_version, request_hash, root_run_id, "
+        "status, input_json, worker_id"
+        ") VALUES ($1, 'test', 'test-v1', 'hash', $1, 'running', '{}'::jsonb, 'w1')",
+        run_id,
+    )
+
+    ctx = WorkflowContext(
+        pool=db_pool,
+        run_id=run_id,
+        checkpoints={},
+        lease_s=30.0,
+        worker_id="w1",
+    )
+    append_message_mock = AsyncMock()
+    enqueue_execution_mock = AsyncMock()
+
+    with (
+        patch(
+            "api.workflow_engine.spawn_assignment",
+            new=AsyncMock(side_effect=RuntimeError("spawn unavailable")),
+        ),
+        patch(
+            "api.workflow_engine.slackbot_client.open_agent_session",
+            new=AsyncMock(return_value="sess-failed"),
+        ) as open_session_mock,
+        patch(
+            "api.workflow_engine.slackbot_client.session_text",
+            new=AsyncMock(),
+        ) as session_text_mock,
+        patch(
+            "api.workflow_engine.slackbot_client.session_done",
+            new=AsyncMock(),
+        ) as session_done_mock,
+        patch("api.workflow_engine.append_message", new=append_message_mock),
+        patch("api.workflow_engine.enqueue_execution", new=enqueue_execution_mock),
+    ):
+        with pytest.raises(RuntimeError, match="spawn unavailable"):
+            await do_agent_turn(
+                ctx,
+                prompt="hello",
+                thread_key=thread_key,
+                delivery={
+                    "platform": "slack",
+                    "channel": "C-test",
+                    "thread_ts": "1700000000.000100",
+                },
+            )
+
+    open_session_mock.assert_awaited_once()
+    open_kwargs = open_session_mock.await_args.kwargs
+    assert open_kwargs["title"] == "Centaur"
+    assert open_kwargs["header"] is None
+    session_text_mock.assert_awaited_once_with(
+        "sess-failed",
+        "Failed to start the runtime: spawn unavailable",
+    )
+    session_done_mock.assert_awaited_once_with("sess-failed")
+    append_message_mock.assert_not_awaited()
+    enqueue_execution_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_step_only_auto_links_execution_ids_for_agent_turn_steps(db_pool):
     from api.workflow_engine import WorkflowContext
 


### PR DESCRIPTION
## Summary
- open Slack live sessions only after spawn assignment succeeds
- compute session title/header from the resolved active assignment
- add a minimal spawn-failure Slack session without inferred harness metadata
- cover resolved-session and spawn-failure paths in workflow tests

## Tests
- uv run --python 3.11 ruff check api/workflow_engine.py tests/test_workflows.py
- uv run --python 3.11 pytest tests/test_workflow_engine_title.py tests/test_workflows.py -k "agent_turn_opens_slack_session_after_spawn_with_resolved_header or agent_turn_spawn_failure_opens_unresolved_failure_session or agent_turn_idempotency_ids_follow_deduped_step_names or title or header"