### PR TITLE
fix(chart): pull mutable service images on restart

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.37
+version: 0.1.38
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -19,7 +19,7 @@ ironProxy:
   image:
     repository: centaur-iron-proxy
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   service:
     proxyPort: 8080
     managementPort: 9092
@@ -52,7 +52,7 @@ api:
   image:
     repository: centaur-api
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   executionWorkerEnabled: false
   workflowWorkerEnabled: true
   warmPoolEnabled: false
@@ -99,7 +99,7 @@ sandbox:
   image:
     repository: centaur-agent
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   runtimeClassName: ""
   reposPath: ""
   extraEnv: {}
@@ -135,7 +135,7 @@ slackbot:
   image:
     repository: centaur-slackbot
     tag: latest
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   runtimeErrorAlertChannel: ""
   extraEnv: {}
   resources: {}


### PR DESCRIPTION
## Summary
- set Centaur service image pull policies to `Always` for mutable `latest` tags
- bump chart version to 0.1.38

## Why
Runtime logs showed API pods alternating between old and new pod-template hashes after PR #110 image publish, and Slackbot remained on the old image. With `latest` + `IfNotPresent`, restarted pods can keep using stale node-local images, which blocks delivery-fix verification.

## Testing
- inspected live vlogs showing mixed API hashes `9b684c58c`/`6f6d7d9ccf` and Slackbot hash `66967fdd97` after publish
- chart version bumped to satisfy release-chart gate