### PR TITLE
chore(iron-proxy): allow x-as-user-email header

### DIFF
--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -74,6 +74,7 @@ transforms:
         - "x-cb-access-timestamp"
         - "addepar-firm"
         - "clientid"
+        - "x-as-user-email"
         - "/^x-[a-z0-9-]*(api-key|apikey|secret|token|auth|key)$/"
 
 log:


### PR DESCRIPTION
Adds `x-as-user-email` to the iron-proxy header allowlist so it passes through to upstream services.