### PR TITLE
Add www.centaur.run Cloudflare route

### DIFF
--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -7,6 +7,10 @@
     {
       "pattern": "centaur.run",
       "custom_domain": true
+    },
+    {
+      "pattern": "www.centaur.run",
+      "custom_domain": true
     }
   ],
   "assets": {


### PR DESCRIPTION
## Summary
- Add www.centaur.run as a custom-domain route for the Centaur docs Worker alongside centaur.run.

## Verification
- jq empty docs/wrangler.jsonc
- npm run build (blocked: sandbox is missing zip, required by docs/scripts/build-brand-zip.sh)
- npm exec wrangler -- deploy --dry-run --no-bundle --config wrangler.jsonc (blocked by same missing zip build dependency)