### PR TITLE
Revert "Add www.centaur.run Cloudflare route (#116)"

### DIFF
--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -7,10 +7,6 @@
     {
       "pattern": "centaur.run",
       "custom_domain": true
-    },
-    {
-      "pattern": "www.centaur.run",
-      "custom_domain": true
     }
   ],
   "assets": {


### PR DESCRIPTION
## Summary
- Reverts the Wrangler custom-domain route for `www.centaur.run`
- Leaves `centaur.run` as the only configured docs route

## Notes
- `www.centaur.run` currently returns DNS `NXDOMAIN`; making it work needs Cloudflare DNS plus a redirect rule, not just this Wrangler route.

## Testing
- Not run; revert only.