### PR TITLE
chore(api): allow x-as-user-email in iron-proxy base config

### DIFF
--- a/services/api/api/iron-proxy.base.yaml
+++ b/services/api/api/iron-proxy.base.yaml
@@ -74,6 +74,7 @@ transforms:
         - "x-cb-access-timestamp"
         - "addepar-firm"
         - "clientid"
+        - "x-as-user-email"
         - "/^x-[a-z0-9-]*(api-key|apikey|secret|token|auth|key)$/"
 
 log:


### PR DESCRIPTION
Adds x-as-user-email to the header allowlist in services/api's iron-proxy base config, matching the prior addition to services/iron-proxy in #115.