### PR TITLE
fix: summarize terminal execution failures

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -320,6 +320,52 @@ def _progress_silence_timeout_s(
     return float(EXECUTION_SILENCE_TIMEOUT_S)
 
 
+def _terminal_failure_result_text(
+    *,
+    terminal_reason: str,
+    error_text: str | None,
+    observations: ExecutionObservationAccumulator,
+    latest_command_event: dict[str, Any] | None = None,
+) -> str:
+    reason = terminal_reason.replace("_", " ")
+    lines = [f"I could not complete the turn because {reason}."]
+    details: list[str] = []
+    if observations.assistant_text_events:
+        details.append(
+            f"drafted {observations.assistant_text_events} assistant update(s)"
+        )
+    if observations.assistant_tool_use_events:
+        tool_names = ", ".join(
+            name for name, _count in observations.tools.most_common(3)
+        )
+        if tool_names:
+            details.append(
+                f"used {observations.assistant_tool_use_events} tool call(s): {tool_names}"
+            )
+        else:
+            details.append(
+                f"used {observations.assistant_tool_use_events} tool call(s)"
+            )
+    if observations.command_events:
+        details.append(f"observed {observations.command_events} command update(s)")
+    if observations.file_change_events:
+        details.append(f"observed {observations.file_change_events} file change event(s)")
+    if details:
+        lines.append("Progress before failure: " + "; ".join(details) + ".")
+    if latest_command_event:
+        command = str(latest_command_event.get("command") or "").strip()
+        status = str(latest_command_event.get("status") or "").strip()
+        if command:
+            command = command.replace("\n", " ")[:160]
+            suffix = f" ({status})" if status else ""
+            lines.append(f"Last command observed: `{command}`{suffix}.")
+    if error_text:
+        clipped_error = " ".join(str(error_text).strip().split())[:240]
+        if clipped_error:
+            lines.append(f"Error: {clipped_error}")
+    return "\n".join(lines)
+
+
 def _extract_repo_context(source: Any) -> dict[str, str]:
     payload = source if isinstance(source, dict) else {}
     repo_context: dict[str, str] = {}
@@ -2494,6 +2540,14 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         result_text: str,
         error_text: str | None,
     ) -> None:
+        nonlocal latest_command_event
+        if status != "completed" and not result_text.strip():
+            result_text = _terminal_failure_result_text(
+                terminal_reason=terminal_reason,
+                error_text=error_text,
+                observations=observations,
+                latest_command_event=latest_command_event,
+            )
         current_status = await pool.fetchval(
             "SELECT status FROM agent_execution_requests WHERE execution_id = $1",
             execution_id,
@@ -2609,6 +2663,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
 
     turn_done_event: dict[str, Any] | None = None
     latest_terminal_result_text = ""
+    latest_command_event: dict[str, Any] | None = None
     slackbot_streamed_answer_chars = 0
     pending_event: asyncio.Task | None = None
     stream = _stream_stdout(
@@ -2691,6 +2746,9 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
             if payload.get("session_id"):
                 harness_thread_id = str(payload.get("session_id") or "")
             canonical_events = normalize_harness_event(engine, payload)
+            for canonical_event in canonical_events:
+                if canonical_event.get("type") == "command_execution":
+                    latest_command_event = canonical_event
             for canonical_event in canonical_events:
                 if canonical_event.get("type") != "result":
                     continue

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -1164,6 +1164,127 @@ async def test_worker_marks_turn_done_error_as_failed_and_updates_runtime(db_poo
 
 
 @pytest.mark.asyncio
+async def test_worker_synthesizes_failure_result_from_observed_progress(db_pool):
+    from api.runtime_control import _process_execution
+
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}"
+    execution_id = f"exe-{uuid.uuid4().hex[:12]}"
+    runtime_id = f"rt-{uuid.uuid4().hex[:8]}"
+
+    await db_pool.execute(
+        "INSERT INTO agent_runtime_assignments ("
+        "thread_key, assignment_generation, runtime_id, harness, engine, "
+        "persona_id, prompt_ref, effective_agents_md_sha256, state"
+        ") VALUES ($1, 1, $2, 'codex', 'codex', NULL, 'harness:codex', 'sha', 'active')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, status, "
+        "delivery, metadata, hard_deadline_at"
+        ") VALUES ($1, $2, 1, 'exec-progress-error', 'hash-progress-error', "
+        "'running', '{}'::jsonb, '{}'::jsonb, NOW() + INTERVAL '10 minutes')",
+        execution_id,
+        thread_key,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_final_delivery_outbox (execution_id, thread_key, delivery, state) "
+        "VALUES ($1, $2, '{}'::jsonb, 'awaiting_terminal')",
+        execution_id,
+        thread_key,
+    )
+    row = {
+        "execution_id": execution_id,
+        "thread_key": thread_key,
+        "assignment_generation": 1,
+        "delivery": {},
+        "hard_deadline_at": dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=10),
+    }
+    session = SandboxSession(
+        sandbox_id=runtime_id,
+        thread_key=thread_key,
+        harness="codex",
+        engine="codex",
+    )
+
+    async def _progress_then_error_stream(*_args, **_kwargs):
+        yield {
+            "data": json.dumps(
+                {
+                    "type": "item.started",
+                    "item": {
+                        "id": "cmd-1",
+                        "type": "command_execution",
+                        "command": "gh run watch 123",
+                    },
+                }
+            )
+        }
+        yield {
+            "data": json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "id": "cmd-1",
+                        "type": "command_execution",
+                        "command": "gh run watch 123",
+                        "aggregated_output": "still waiting for CI",
+                        "status": "running",
+                    },
+                }
+            )
+        }
+        yield {
+            "data": json.dumps(
+                {
+                    "type": "turn.failed",
+                    "error": "command timed out waiting for CI",
+                }
+            )
+        }
+
+    backend = SimpleNamespace(attach=AsyncMock(), close_streams=AsyncMock())
+    with (
+        patch("api.runtime_control.get_or_spawn", new=AsyncMock(return_value=session)),
+        patch(
+            "api.runtime_control.inject_stdin",
+            new=AsyncMock(
+                return_value={"ok": True, "injected": True, "durable_turn_id": "turn-1"}
+            ),
+        ),
+        patch("api.runtime_control.get_backend", return_value=backend),
+        patch(
+            "api.runtime_control._get_runtime",
+            return_value=SimpleNamespace(turn_counter=1),
+        ),
+        patch("api.runtime_control._stream_stdout", _progress_then_error_stream),
+    ):
+        await _process_execution(db_pool, row)
+
+    execution = await db_pool.fetchrow(
+        "SELECT status, terminal_reason, result_text, error_text "
+        "FROM agent_execution_requests WHERE execution_id = $1",
+        execution_id,
+    )
+    assert execution is not None
+    assert execution["status"] == "failed_permanent"
+    assert execution["terminal_reason"] == "harness_error"
+    assert "could not complete the turn" in execution["result_text"]
+    assert "observed 1 command update" in execution["result_text"]
+    assert "gh run watch 123" in execution["result_text"]
+    assert "command timed out waiting for CI" in execution["error_text"]
+
+    outbox = await db_pool.fetchrow(
+        "SELECT final_payload FROM agent_final_delivery_outbox WHERE execution_id = $1",
+        execution_id,
+    )
+    assert outbox is not None
+    payload = json.loads(outbox["final_payload"])
+    assert payload["result_text"] == execution["result_text"]
+
+
+@pytest.mark.asyncio
 async def test_worker_requeues_raw_harness_auth_error_once_on_fresh_runtime(db_pool):
     from api.runtime_control import _claim_next_execution, _process_execution
 


### PR DESCRIPTION
## Summary
- synthesize a user-facing result_text when a non-completed execution terminates without a final answer
- include observed progress counts and the latest command in the final-delivery payload
- add regression coverage for a Codex command-progress flow that ends in turn.failed

Prompted by: @goksu

## Tests
- uv run ruff check api/runtime_control.py tests/test_agent_control_plane.py
- uv run python -m py_compile api/runtime_control.py tests/test_agent_control_plane.py
- uv run pytest tests/test_agent_control_plane.py -k "synthesizes_failure_result or marks_turn_done_error or silence_deadline_exceeded" (skipped locally: Postgres fixture unavailable)
