### PR TITLE
feat(api): support jwt_bearer oauth_token grant; bump iron-proxy to 0.39.0

### DIFF
--- a/docs/pages/extend/tools.mdx
+++ b/docs/pages/extend/tools.mdx
@@ -47,11 +47,14 @@ Each entry in `secrets` declares one credential the tool can request with
   `secret("...")`; iron-proxy swaps that placeholder for the real value at the
   network boundary.
 - `type = "oauth_token"` is for OAuth2 APIs. iron-proxy resolves the declared
-  `fields`, runs a `refresh_token`, `client_credentials`, or `password` exchange,
-  caches and refreshes the access token, then injects `Authorization: Bearer ...`
-  for the configured `hosts`. Set `token_endpoint_headers` to send extra headers
-  on the token POST itself (for endpoints that require an API key alongside the
-  standard form-body client auth).
+  `fields`, runs a `refresh_token`, `client_credentials`, `password`, or
+  `jwt_bearer` exchange, caches and refreshes the access token, then injects
+  `Authorization: Bearer ...` for the configured `hosts`. Set
+  `token_endpoint_headers` to send extra headers on the token POST itself (for
+  endpoints that require an API key alongside the standard form-body client
+  auth). For `jwt_bearer` (RFC 7523), supply `issuer`, `subject`, and
+  `private_key` (an RSA PEM) in `fields`, plus a top-level `audience`; an
+  optional `private_key_id` field is emitted as the JWT `kid` header.
 - `type = "gcp_auth"` is for Google service-account JSON. iron-proxy resolves
   the keyfile, mints Google OAuth tokens for `scopes`, and injects them for the
   configured Google API `hosts`. If omitted, hosts default to

--- a/services/api/api/proxy_config.py
+++ b/services/api/api/proxy_config.py
@@ -221,6 +221,7 @@ def _build_oauth_token_transform(
             tuple[tuple[str, OAuthFieldSource], ...],
             str | None,
             tuple[tuple[str, OAuthFieldSource], ...],
+            str | None,
         ],
         dict[str, set[str]],
     ] = {}
@@ -232,6 +233,7 @@ def _build_oauth_token_transform(
             secret.fields,
             secret.token_endpoint,
             secret.token_endpoint_headers,
+            secret.audience,
         )
         agg = by_token.setdefault(key, {"hosts": set(), "scopes": set()})
         agg["hosts"].update(secret.hosts)
@@ -246,21 +248,23 @@ def _build_oauth_token_transform(
             tuple[tuple[str, OAuthFieldSource], ...],
             str | None,
             tuple[tuple[str, OAuthFieldSource], ...],
+            str | None,
         ],
     ) -> tuple[str, ...]:
-        grant, fields, token_endpoint, endpoint_headers = k
+        grant, fields, token_endpoint, endpoint_headers, audience = k
         # None sorts before any string; normalize None to "" so mixed
         # None/str keys stay comparable.
         return (
             grant,
             token_endpoint or "",
+            audience or "",
             tuple(name for name, _ in fields),
             tuple(name for name, _ in endpoint_headers),
         )
 
     tokens: list[dict[str, Any]] = []
     for key in sorted(by_token, key=_sort_key):
-        grant, fields, token_endpoint, endpoint_headers = key
+        grant, fields, token_endpoint, endpoint_headers, audience = key
         agg = by_token[key]
         entry: dict[str, Any] = {"grant": grant}
         for field_name, field_source in fields:
@@ -270,6 +274,8 @@ def _build_oauth_token_transform(
             entry["scopes"] = sorted(agg["scopes"])
         if token_endpoint is not None:
             entry["token_endpoint"] = token_endpoint
+        if audience is not None:
+            entry["audience"] = audience
         if endpoint_headers:
             entry["token_endpoint_headers"] = {
                 header_name: _build_field_source(source)

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -186,8 +186,10 @@ class OAuthTokenSecret:
 
     ``grant`` is one of ``refresh_token`` (RFC 6749 — an authorized-user
     credential), ``client_credentials`` (RFC 6749 4.4 — a client id and
-    secret), or ``password`` (RFC 6749 4.3 — a resource-owner username and
-    password exchanged for a token).
+    secret), ``password`` (RFC 6749 4.3 — a resource-owner username and
+    password exchanged for a token), or ``jwt_bearer`` (RFC 7523 — a JWT
+    assertion signed by an RSA ``private_key`` and exchanged at the token
+    endpoint for a bearer token).
 
     ``fields`` maps each grant's credential fields to a source; fields may be
     sourced from separate secrets or pulled from one JSON secret via
@@ -195,6 +197,8 @@ class OAuthTokenSecret:
     against. ``token_endpoint_headers`` adds extra headers to the token POST
     itself, each value resolved from its own source; use this when the token
     endpoint requires an API key alongside the standard form-body client auth.
+    ``audience`` is the JWT ``aud`` claim — required for ``jwt_bearer``, unused
+    by the other grants.
     """
 
     name: str
@@ -204,6 +208,7 @@ class OAuthTokenSecret:
     scopes: tuple[str, ...] = ()
     token_endpoint: str | None = None
     token_endpoint_headers: tuple[tuple[str, OAuthFieldSource], ...] = ()
+    audience: str | None = None
 
 
 @dataclass(frozen=True)
@@ -269,6 +274,10 @@ _OAUTH_GRANT_FIELDS: dict[str, tuple[frozenset[str], frozenset[str]]] = {
     "password": (
         frozenset({"username", "password", "client_id"}),
         frozenset({"client_secret"}),
+    ),
+    "jwt_bearer": (
+        frozenset({"issuer", "subject", "private_key"}),
+        frozenset({"private_key_id"}),
     ),
 }
 
@@ -725,6 +734,18 @@ def _parse_secret(entry: Any, *, default_hosts: tuple[str, ...] = ()) -> SecretD
         token_endpoint_headers = _parse_oauth_token_endpoint_headers(
             name, entry.get("token_endpoint_headers")
         )
+        audience = entry.get("audience")
+        if grant == "jwt_bearer":
+            if not isinstance(audience, str) or not audience:
+                raise ValueError(
+                    f"oauth_token entry {name!r} grant 'jwt_bearer' requires a "
+                    f"non-empty 'audience'"
+                )
+        elif audience is not None:
+            raise ValueError(
+                f"oauth_token entry {name!r} 'audience' is only valid for grant "
+                f"'jwt_bearer', not {grant!r}"
+            )
         return OAuthTokenSecret(
             name=name,
             grant=grant,
@@ -733,6 +754,7 @@ def _parse_secret(entry: Any, *, default_hosts: tuple[str, ...] = ()) -> SecretD
             scopes=tuple(scopes),
             token_endpoint=token_endpoint,
             token_endpoint_headers=token_endpoint_headers,
+            audience=audience,
         )
     if secret_type == "pg_dsn":
         database = entry.get("database")

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -467,6 +467,111 @@ def test_parser_oauth_token_password_grant_rejects_missing_username() -> None:
         )
 
 
+def test_parser_typed_oauth_token_jwt_bearer() -> None:
+    secret = _parse_secret(
+        {
+            "type": "oauth_token",
+            "grant": "jwt_bearer",
+            "name": "DOCUSIGN_JWT",
+            "hosts": ["*.docusign.net"],
+            "audience": "account-d.docusign.com",
+            "token_endpoint": "https://account-d.docusign.com/oauth/token",
+            "scopes": ["signature", "impersonation"],
+            "fields": {
+                "issuer": "DOCUSIGN_INTEGRATION_KEY",
+                "subject": "DOCUSIGN_USER_GUID",
+                "private_key": {
+                    "secret_ref": "DOCUSIGN_BUNDLE",
+                    "json_key": "private_key",
+                },
+                "private_key_id": "DOCUSIGN_KEY_ID",
+            },
+        }
+    )
+    assert isinstance(secret, OAuthTokenSecret)
+    assert secret.grant == "jwt_bearer"
+    assert secret.audience == "account-d.docusign.com"
+    assert secret.token_endpoint == "https://account-d.docusign.com/oauth/token"
+    assert secret.scopes == ("signature", "impersonation")
+    fields = dict(secret.fields)
+    assert fields["issuer"] == OAuthFieldSource("DOCUSIGN_INTEGRATION_KEY")
+    assert fields["subject"] == OAuthFieldSource("DOCUSIGN_USER_GUID")
+    assert fields["private_key"] == OAuthFieldSource(
+        "DOCUSIGN_BUNDLE", "private_key"
+    )
+    assert fields["private_key_id"] == OAuthFieldSource("DOCUSIGN_KEY_ID")
+
+
+def test_parser_oauth_token_jwt_bearer_makes_private_key_id_optional() -> None:
+    secret = _parse_secret(
+        {
+            "type": "oauth_token",
+            "grant": "jwt_bearer",
+            "name": "VENDOR_JWT",
+            "hosts": ["api.vendor.com"],
+            "audience": "api.vendor.com",
+            "fields": {
+                "issuer": "INTEGRATION_KEY",
+                "subject": "USER_GUID",
+                "private_key": "PRIVATE_KEY_PEM",
+            },
+        }
+    )
+    assert isinstance(secret, OAuthTokenSecret)
+    assert "private_key_id" not in dict(secret.fields)
+
+
+def test_parser_oauth_token_jwt_bearer_requires_audience() -> None:
+    with pytest.raises(ValueError, match="requires a non-empty 'audience'"):
+        _parse_secret(
+            {
+                "type": "oauth_token",
+                "grant": "jwt_bearer",
+                "name": "X",
+                "hosts": ["h"],
+                "fields": {
+                    "issuer": "ISS",
+                    "subject": "SUB",
+                    "private_key": "PK",
+                },
+            }
+        )
+
+
+def test_parser_oauth_token_jwt_bearer_rejects_missing_private_key() -> None:
+    with pytest.raises(ValueError, match="requires fields \\['private_key'\\]"):
+        _parse_secret(
+            {
+                "type": "oauth_token",
+                "grant": "jwt_bearer",
+                "name": "X",
+                "hosts": ["h"],
+                "audience": "aud",
+                "fields": {
+                    "issuer": "ISS",
+                    "subject": "SUB",
+                },
+            }
+        )
+
+
+def test_parser_oauth_token_audience_rejected_for_non_jwt_bearer_grant() -> None:
+    with pytest.raises(ValueError, match="'audience' is only valid for grant"):
+        _parse_secret(
+            {
+                "type": "oauth_token",
+                "grant": "client_credentials",
+                "name": "X",
+                "hosts": ["h"],
+                "audience": "aud",
+                "fields": {
+                    "client_id": "CID",
+                    "client_secret": "CSEC",
+                },
+            }
+        )
+
+
 def test_parser_oauth_token_token_endpoint_headers_accepts_bare_string() -> None:
     secret = _parse_secret(
         {
@@ -1106,6 +1211,95 @@ def test_render_oauth_token_emits_token_endpoint_when_set() -> None:
         t for t in cfg["transforms"] if t["name"] == "oauth_token"
     )["config"]["tokens"]
     assert tokens[0]["token_endpoint"] == "https://login.example.com/oauth2/token"
+
+
+_RENDER_JWT_BEARER_FIELDS = (
+    ("issuer", OAuthFieldSource("DOCUSIGN_INTEGRATION_KEY")),
+    ("private_key", OAuthFieldSource("DOCUSIGN_BUNDLE", "private_key")),
+    ("private_key_id", OAuthFieldSource("DOCUSIGN_KEY_ID")),
+    ("subject", OAuthFieldSource("DOCUSIGN_USER_GUID")),
+)
+
+
+def test_render_oauth_token_jwt_bearer_emits_audience_and_field_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    secrets = [
+        OAuthTokenSecret(
+            name="DOCUSIGN_JWT",
+            grant="jwt_bearer",
+            hosts=("demo.docusign.net",),
+            fields=_RENDER_JWT_BEARER_FIELDS,
+            scopes=("signature", "impersonation"),
+            token_endpoint="https://account-d.docusign.com/oauth/token",
+            audience="account-d.docusign.com",
+        )
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    tokens = next(
+        t for t in cfg["transforms"] if t["name"] == "oauth_token"
+    )["config"]["tokens"]
+    assert tokens[0]["grant"] == "jwt_bearer"
+    assert tokens[0]["issuer"] == {
+        "type": "env",
+        "var": "DOCUSIGN_INTEGRATION_KEY",
+    }
+    assert tokens[0]["subject"] == {"type": "env", "var": "DOCUSIGN_USER_GUID"}
+    assert tokens[0]["private_key"] == {
+        "type": "env",
+        "var": "DOCUSIGN_BUNDLE",
+        "json_key": "private_key",
+    }
+    assert tokens[0]["private_key_id"] == {
+        "type": "env",
+        "var": "DOCUSIGN_KEY_ID",
+    }
+    assert tokens[0]["audience"] == "account-d.docusign.com"
+    assert tokens[0]["token_endpoint"] == "https://account-d.docusign.com/oauth/token"
+    assert tokens[0]["scopes"] == ["impersonation", "signature"]
+    assert tokens[0]["rules"] == [{"host": "demo.docusign.net"}]
+
+
+def test_render_oauth_token_omits_audience_when_unset() -> None:
+    secrets = [
+        OAuthTokenSecret(
+            name="OAUTH_APP",
+            grant="client_credentials",
+            hosts=("api.example.com",),
+            fields=_RENDER_CC_FIELDS,
+        )
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    tokens = next(
+        t for t in cfg["transforms"] if t["name"] == "oauth_token"
+    )["config"]["tokens"]
+    assert "audience" not in tokens[0]
+
+
+def test_render_oauth_token_separate_entries_for_distinct_audiences() -> None:
+    secrets = [
+        OAuthTokenSecret(
+            "A",
+            "jwt_bearer",
+            ("a.example.net",),
+            _RENDER_JWT_BEARER_FIELDS,
+            audience="a.example.com",
+        ),
+        OAuthTokenSecret(
+            "B",
+            "jwt_bearer",
+            ("b.example.net",),
+            _RENDER_JWT_BEARER_FIELDS,
+            audience="b.example.com",
+        ),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    tokens = next(
+        t for t in cfg["transforms"] if t["name"] == "oauth_token"
+    )["config"]["tokens"]
+    assert len(tokens) == 2
+    assert {t["audience"] for t in tokens} == {"a.example.com", "b.example.com"}
 
 
 _RENDER_HMAC_CREDS: tuple[tuple[str, OAuthFieldSource], ...] = (

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ironsh/iron-proxy:0.38.0@sha256:724c075e22e962e3452a95cd0680a195a42082033bb830b1eed0d4b7911b5626
+FROM ironsh/iron-proxy:0.39.0@sha256:a2e124f1266823f3d21ada5e3bd5611d85cdbb8ca8866047ff2b18ed122a274b
 
 USER root
 RUN apk add --no-cache curl jq


### PR DESCRIPTION
Bumps iron-proxy to 0.39.0 and wires up its new RFC 7523 `jwt_bearer` grant on the `oauth_token` secret type. Tools declare `issuer`, `subject`, `private_key` (plus optional `private_key_id`) under `fields`, and a top-level `audience`; iron-proxy mints the JWT assertion, exchanges it at `token_endpoint`, and injects the resulting bearer on requests to `hosts`. Enables clean DocuSign-style integrations where the tool no longer signs JWTs or hits `/oauth/token` itself.