### PR TITLE
fix: send final text when Slack live stream has zero answer chars

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -994,6 +994,14 @@ def _canonical_text_blocks(event: dict[str, Any]) -> list[str]:
     return []
 
 
+def _slackbot_streamed_answer_chars(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    return 0
+
+
 async def _send_slackbot_canonical_event(
     session_id: str, event: dict[str, Any]
 ) -> bool:
@@ -2551,7 +2559,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         )
         if finalize_session_id and not slackbot_done and slackbot_forward_live:
             try:
-                if result_text.strip() and not slackbot_text_sent:
+                if result_text.strip() and slackbot_streamed_answer_chars <= 0:
                     await slackbot_client.session_text(finalize_session_id, result_text)
                     slackbot_text_sent = True
                 await slackbot_client.session_done(
@@ -2741,17 +2749,24 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                         )
                         slackbot_done = bool(harness_result.get("done"))
                         streamed_chars = harness_result.get("streamedAnswerChars")
-                        if isinstance(streamed_chars, int):
+                        previous_streamed_answer_chars = slackbot_streamed_answer_chars
+                        streamed_chars = _slackbot_streamed_answer_chars(streamed_chars)
+                        if streamed_chars:
                             slackbot_streamed_answer_chars = max(
                                 slackbot_streamed_answer_chars,
                                 streamed_chars,
                             )
-                        if slack_event.get("type") in {
-                            "assistant",
-                            "item.agentMessage.delta",
-                            "result",
-                            "turn.done",
-                        }:
+                        if (
+                            slack_event.get("type")
+                            in {
+                                "assistant",
+                                "item.agentMessage.delta",
+                                "result",
+                                "turn.done",
+                            }
+                            and slackbot_streamed_answer_chars
+                            > previous_streamed_answer_chars
+                        ):
                             slackbot_text_sent = True
             observations.raw_event_count += 1
             # ``amp_raw_event`` is a HISTORICAL label preserved for API and

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -17,11 +17,25 @@ from api.sandbox.base import SandboxSession
 def test_agent_session_title_formats_base_and_persona_runs():
     from api.runtime_control import _agent_session_title
 
-    assert _agent_session_title(persona_id=None, engine=None, harness="codex") == "Centaur · codex"
+    assert (
+        _agent_session_title(persona_id=None, engine=None, harness="codex")
+        == "Centaur · codex"
+    )
     assert (
         _agent_session_title(persona_id="invest", engine="amp", harness="invest")
         == "Centaur · invest · amp"
     )
+
+
+def test_slackbot_streamed_answer_chars_requires_positive_integer_offset():
+    from api.runtime_control import _slackbot_streamed_answer_chars
+
+    assert _slackbot_streamed_answer_chars(0) == 0
+    assert _slackbot_streamed_answer_chars(None) == 0
+    assert _slackbot_streamed_answer_chars(True) == 0
+    assert _slackbot_streamed_answer_chars("25") == 0
+    assert _slackbot_streamed_answer_chars(-3) == 0
+    assert _slackbot_streamed_answer_chars(25) == 25
 
 
 def _auth(api_key: str) -> dict[str, str]:
@@ -89,13 +103,15 @@ async def test_spawn_assignment_treats_harness_persona_selector_as_persona(db_po
     )
     get_or_spawn = AsyncMock(return_value=session)
     tool_manager = SimpleNamespace(
-        get_persona=lambda name: SimpleNamespace(
-            name="legal",
-            engine="codex",
-            default_repo=None,
+        get_persona=lambda name: (
+            SimpleNamespace(
+                name="legal",
+                engine="codex",
+                default_repo=None,
+            )
+            if name == "legal"
+            else None
         )
-        if name == "legal"
-        else None
     )
 
     with (
@@ -112,7 +128,9 @@ async def test_spawn_assignment_treats_harness_persona_selector_as_persona(db_po
             agents_md_override=None,
         )
 
-    get_or_spawn.assert_awaited_once_with(thread_key, "codex", engine=None, persona="legal")
+    get_or_spawn.assert_awaited_once_with(
+        thread_key, "codex", engine=None, persona="legal"
+    )
     assert result["persona_id"] == "legal"
     assert result["prompt_ref"] == "persona:legal"
     assignment = await db_pool.fetchrow(
@@ -749,7 +767,9 @@ async def test_final_delivery_claim_and_mark_delivered(client, db_pool, api_key:
     assert deliveries[0]["execution_id"] == execution_id
     assert deliveries[0]["attempt_count"] == 1
     assert deliveries[0]["trace_id"] == str(trace_id)
-    assert deliveries[0]["traceparent"].startswith("00-00000000000040008000000000000123-")
+    assert deliveries[0]["traceparent"].startswith(
+        "00-00000000000040008000000000000123-"
+    )
 
     delivered = await client.post(
         f"/agent/final-deliveries/{execution_id}/delivered",
@@ -1161,6 +1181,145 @@ async def test_worker_marks_turn_done_error_as_failed_and_updates_runtime(db_poo
     assert assignment is not None
     assert assignment["runtime_id"] == resumed_runtime_id
     backend.close_streams.assert_awaited_once_with(session)
+
+
+@pytest.mark.asyncio
+async def test_worker_sends_final_result_when_live_slack_only_streamed_placeholder(
+    db_pool,
+):
+    from api.runtime_control import _process_execution
+
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:blank-live-placeholder"
+    execution_id = f"exe-{uuid.uuid4().hex[:12]}"
+    runtime_id = f"rt-{uuid.uuid4().hex[:8]}"
+    final_text = (
+        "Shortlist, ranked for meet in SF now.\n\n"
+        "| # | Person | Why them |\n"
+        "|---|---|---|\n"
+        "| 1 | Tim Rocktaschel | Recursive research automation |"
+    )
+
+    await db_pool.execute(
+        "INSERT INTO agent_runtime_assignments ("
+        "thread_key, assignment_generation, runtime_id, harness, engine, "
+        "persona_id, prompt_ref, effective_agents_md_sha256, state"
+        ") VALUES ($1, 1, $2, 'codex', 'codex', NULL, 'harness:codex', 'sha', 'active')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, status, "
+        "delivery, metadata, hard_deadline_at"
+        ") VALUES ($1, $2, 1, 'exec-blank-live', 'hash-blank-live', 'running', "
+        '\'{"platform":"slack","channel":"C-test","thread_ts":"1779333881.200699"}\'::jsonb, '
+        '\'{"slackbot_live_delivery":true,"slackbot_agent_session_id":"sess-blank"}\'::jsonb, '
+        "NOW() + INTERVAL '10 minutes')",
+        execution_id,
+        thread_key,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_final_delivery_outbox (execution_id, thread_key, delivery, state) "
+        "VALUES ($1, $2, '{}'::jsonb, 'awaiting_terminal')",
+        execution_id,
+        thread_key,
+    )
+
+    row = {
+        "execution_id": execution_id,
+        "thread_key": thread_key,
+        "assignment_generation": 1,
+        "delivery": {
+            "platform": "slack",
+            "channel": "C-test",
+            "thread_ts": "1779333881.200699",
+        },
+        "metadata": {
+            "slackbot_live_delivery": True,
+            "slackbot_agent_session_id": "sess-blank",
+        },
+        "hard_deadline_at": dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=10),
+    }
+    session = SandboxSession(
+        sandbox_id=runtime_id,
+        thread_key=thread_key,
+        harness="codex",
+        engine="codex",
+    )
+
+    async def _blank_placeholder_stream(*_args, **_kwargs):
+        yield {
+            "data": json.dumps(
+                {
+                    "type": "result",
+                    "result": final_text,
+                }
+            )
+        }
+        yield {
+            "data": json.dumps(
+                {
+                    "type": "turn.done",
+                    "result": final_text,
+                }
+            )
+        }
+
+    async def _live_delivery_ack_without_answer_text(*_args, **_kwargs):
+        return {
+            "done": False,
+            "threadId": "turn-059d374be813486b",
+            "streamedAnswerChars": 0,
+        }
+
+    session_text_mock = AsyncMock()
+    session_done_mock = AsyncMock()
+    backend = SimpleNamespace(attach=AsyncMock(), close_streams=AsyncMock())
+    with (
+        patch("api.runtime_control.get_or_spawn", new=AsyncMock(return_value=session)),
+        patch(
+            "api.runtime_control.inject_stdin",
+            new=AsyncMock(
+                return_value={"ok": True, "injected": True, "durable_turn_id": "turn-1"}
+            ),
+        ),
+        patch("api.runtime_control.get_backend", return_value=backend),
+        patch(
+            "api.runtime_control._get_runtime",
+            return_value=SimpleNamespace(turn_counter=1),
+        ),
+        patch("api.runtime_control._stream_stdout", _blank_placeholder_stream),
+        patch(
+            "api.runtime_control.slackbot_client.harness_event",
+            new=AsyncMock(side_effect=_live_delivery_ack_without_answer_text),
+        ),
+        patch(
+            "api.runtime_control.slackbot_client.session_text",
+            new=session_text_mock,
+        ),
+        patch(
+            "api.runtime_control.slackbot_client.session_done",
+            new=session_done_mock,
+        ),
+    ):
+        await _process_execution(db_pool, row)
+
+    session_text_mock.assert_awaited_once_with("sess-blank", final_text)
+    session_done_mock.assert_awaited_once_with("sess-blank", "turn-059d374be813486b")
+    execution = await db_pool.fetchrow(
+        "SELECT status, terminal_reason, result_text FROM agent_execution_requests WHERE execution_id = $1",
+        execution_id,
+    )
+    assert execution is not None
+    assert execution["status"] == "completed"
+    assert execution["terminal_reason"] == "completed"
+    assert execution["result_text"] == final_text
+    outbox = await db_pool.fetchrow(
+        "SELECT state, final_payload FROM agent_final_delivery_outbox WHERE execution_id = $1",
+        execution_id,
+    )
+    assert outbox is not None
+    assert outbox["state"] == "delivered"
 
 
 @pytest.mark.asyncio
@@ -1692,11 +1851,7 @@ async def test_worker_records_projected_observations_and_execution_summary(db_po
         # Claude Code/amp canonical terminal result events may arrive before
         # the synthesized turn.done. The durable worker must not finalize until
         # turn.done, or result_text can be lost.
-        yield {
-            "data": json.dumps(
-                {"type": "result", "text": "Here is the synthesis."}
-            )
-        }
+        yield {"data": json.dumps({"type": "result", "text": "Here is the synthesis."})}
         yield {
             "data": json.dumps(
                 {"type": "turn.done", "result": "Here is the synthesis."}


### PR DESCRIPTION
## Summary
- Treat Slack live delivery as having sent answer text only after Slackbot reports a positive streamed answer offset.
- On execution finalization, send captured result_text through the live Slack session when the live stream only produced a placeholder/header.
- Add a unit test for streamed-answer offset handling and a DB-backed fixture regression matching the observed blank-placeholder incident.

## Log-grounded regression
- Incident: slack:TGM4GKHA8:C0A82R7S80N:1779333881.200699 / execution exe_89575e7f5f3c4012 completed with result_text, but Slack reply 1779334363.746879 only showed the header/interactive placeholder.
- Existing related coverage checked: PR #110 has a log-grounded msg_blocks_too_long final-delivery test; final-delivery.test.ts still passes.

## Tests
- uv run --project services/api pytest services/api/tests/test_agent_control_plane.py -k 'slackbot_streamed_answer_chars or live_slack_only_streamed_placeholder' -q -rs
  - Result: 1 passed, 1 skipped locally because Docker Postgres is unavailable; the skipped test is the new DB-backed fixture.
- uv run --project services/api ruff check services/api/api/runtime_control.py services/api/tests/test_agent_control_plane.py
- uv run --project services/api ruff format --check services/api/api/runtime_control.py services/api/tests/test_agent_control_plane.py
- bun test ./src/centaur/final-delivery.test.ts