### PR TITLE
fix: preserve Slack final stream content

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -413,7 +413,7 @@ describe('AgentSessionRenderer', () => {
     expect(stop?.params.blocks?.length ?? 0).toBeLessThanOrEqual(50)
   })
 
-  it('does not duplicate live plan or streamed answer markdown on finalize', async () => {
+  it('keeps a durable final plan and answer after live streaming', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -460,8 +460,12 @@ describe('AgentSessionRenderer', () => {
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
     const blocks = stop?.params.blocks ?? []
-    expect(blocks.some((block: any) => block.type === 'plan')).toBe(false)
-    expect(blocks.some((block: any) => block.type === 'markdown')).toBe(false)
+    expect(blocks.some((block: any) => block.type === 'plan')).toBe(true)
+    expect(
+      blocks.some(
+        (block: any) => block.type === 'markdown' && block.text.includes('Live answer body.')
+      )
+    ).toBe(true)
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -150,7 +150,11 @@ export class AgentSessionRenderer {
     return await this.queueText(state, segment, markdown)
   }
 
-  async textDelta(sessionId: string, markdownDelta: string, opts: TextOptions = {}): Promise<number> {
+  async textDelta(
+    sessionId: string,
+    markdownDelta: string,
+    opts: TextOptions = {}
+  ): Promise<number> {
     if (!markdownDelta) return 0
     const state = requireSession(sessionId)
     const segment = currentSegment(state)
@@ -305,15 +309,15 @@ export class AgentSessionRenderer {
     const showThinking =
       !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
     const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
-    // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.
-    // Only add blocks for content that was not streamed live; live task_update chunks carry
-    // fenced details/output, and the header has already been streamed as the first chunk.
+    // Keep a durable final layout even when the live stream already showed
+    // tasks/text. Slack's streamed surface is not reliable enough to be the only
+    // persisted content.
     const blocks = sanitizeFinalMessagePayload([
-      ...(tasks.length && !segment.planStarted
+      ...(tasks.length
         ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)]
         : []),
       ...(thinkingBlock ? [thinkingBlock] : []),
-      ...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
+      ...(answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
     ] as AnyBlock[])
     const fallbackText = buildFinalFallbackText({
       title: state.title,

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -159,7 +159,7 @@ describe('CodexSessionRenderer', () => {
     expect(new Set(tasks.map(task => task.task_id ?? task.id))).toEqual(new Set(['cmd-1', 'cmd-2']))
     expect(planTaskDetailsText(calls, 'cmd-1')).toContain('call demo ping')
     expect(planTaskFromStop(calls, 'cmd-2')).toMatchObject({
-      id: 'cmd-2',
+      task_id: 'cmd-2',
       status: 'complete',
       title: '2. Command execution'
     })
@@ -1027,7 +1027,91 @@ describe('CodexSessionRenderer', () => {
     const stop = calls.find(call => call.method === 'chat.stopStream')
     const blocks = stop?.params.blocks ?? []
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
-    expect(blocks.some((block: any) => block.type === 'markdown')).toBe(false)
+    expect(
+      blocks.some(
+        (block: any) =>
+          block.type === 'markdown' && String(block.text).includes('Done: five tools called.')
+      )
+    ).toBe(true)
+  })
+
+  it('keeps durable visible content when finalizing a many-step streamed reply', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async () => ({ ok: true })
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    for (let index = 1; index <= 15; index += 1) {
+      await renderer.event(sessionId, {
+        type: 'item.started',
+        item: {
+          id: `cmd-${index}`,
+          type: 'commandExecution',
+          command: `call demo step ${index}`
+        }
+      })
+      await renderer.event(sessionId, {
+        type: 'item.completed',
+        item: {
+          id: `cmd-${index}`,
+          type: 'commandExecution',
+          command: `call demo step ${index}`,
+          exitCode: 0,
+          aggregated_output: `step ${index} ok`
+        }
+      })
+    }
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'msg-final', type: 'agentMessage', phase: 'final_answer' }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.agentMessage.delta',
+      itemId: 'msg-final',
+      delta: 'Found the bug.'
+    })
+    await renderer.event(sessionId, { type: 'turn.completed', result: 'Found the bug.' })
+
+    const stop = calls.find(call => call.method === 'chat.stopStream')
+    const finalBlocks = stop?.params.blocks ?? []
+    const finalChunkText = stopStreamFallbackText(stop?.params).trim()
+    const durableText = [
+      finalChunkText,
+      ...finalBlocks.map((block: any) => JSON.stringify(block))
+    ].join('\n')
+
+    expect(durableText).toContain('Found the bug.')
+    expect(
+      finalBlocks.some((block: any) => block.type === 'plan' && (block.tasks?.length ?? 0) >= 15)
+    ).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary
- keep Slack stopStream final blocks authoritative for streamed plans and answers
- add regression coverage for many-step streamed replies finalizing with visible durable content
- update renderer expectations for durable final plan/answer blocks

## Testing
- bun test src/*.test.ts src/**/*.test.ts
- bunx oxfmt --config='oxfmt.config.ts' --write src/slack/agent-session.ts src/slack/agent-session.test.ts src/slack/codex-session.test.ts
- bunx oxlint --config='oxlint.config.ts' src/slack/agent-session.ts src/slack/agent-session.test.ts src/slack/codex-session.test.ts (warnings only: pre-existing unused headerBlock and await-thenable in existing test)

## Not run
- bun run check:types: blocked by test/emulate imports failing to resolve emulate types locally
- just build-one slackbot: blocked by unavailable local Docker/OrbStack socket
