### PR TITLE
fix: finalize Slack streams as static messages

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -401,8 +401,9 @@ describe('AgentSessionRenderer', () => {
     })
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const plan = stop?.params.blocks?.find((block: any) => block.type === 'plan')
-    const body = stop?.params.blocks?.find((block: any) => block.type === 'markdown')
+    const blocks = finalBlocksFromCalls(calls)
+    const plan = blocks.find((block: any) => block.type === 'plan')
+    const body = blocks.find((block: any) => block.type === 'markdown')
     const outputText = plan?.tasks?.[0]?.output?.elements?.[0]?.elements?.[0]?.text ?? ''
 
     expect(outputText.split('\n')).toHaveLength(4)
@@ -410,7 +411,8 @@ describe('AgentSessionRenderer', () => {
     expect(body).toBeTruthy()
     expect(String(body?.text ?? '')).toContain('Final answer stays visible.')
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
-    expect(stop?.params.blocks?.length ?? 0).toBeLessThanOrEqual(50)
+    expect(stop?.params.blocks).toBeUndefined()
+    expect(blocks.length).toBeLessThanOrEqual(50)
   })
 
   it('keeps a durable final plan and answer after live streaming', async () => {
@@ -434,7 +436,10 @@ describe('AgentSessionRenderer', () => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
         },
-        update: async () => ({ ok: true })
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
       }
     }
 
@@ -459,7 +464,7 @@ describe('AgentSessionRenderer', () => {
     })
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const blocks = stop?.params.blocks ?? []
+    const blocks = finalBlocksFromCalls(calls)
     expect(blocks.some((block: any) => block.type === 'plan')).toBe(true)
     expect(
       blocks.some(
@@ -468,6 +473,7 @@ describe('AgentSessionRenderer', () => {
     ).toBe(true)
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
+    expect(stop?.params.blocks).toBeUndefined()
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
   })
 
@@ -513,8 +519,7 @@ describe('AgentSessionRenderer', () => {
       answerMarkdown: 'Done: five tools called.'
     })
 
-    const stop = calls.find(call => call.method === 'chat.stopStream')
-    const blocks = stop?.params.blocks ?? []
+    const blocks = finalBlocksFromCalls(calls)
     expect(
       blocks.some(
         (block: any) =>
@@ -581,7 +586,7 @@ describe('AgentSessionRenderer', () => {
     await renderer.done(sessionId)
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const markdownBlocks = (stop?.params.blocks ?? []).filter(
+    const markdownBlocks = finalBlocksFromCalls(calls).filter(
       (block: any) => block.type === 'markdown'
     )
     const displayedAnswer = markdownBlocks.map((block: any) => block.text).join('\n')
@@ -647,7 +652,8 @@ describe('AgentSessionRenderer', () => {
       }
     })
 
-    await expect(renderer.done(sessionId)).resolves.toEqual({
+    const doneResult = await renderer.done(sessionId)
+    expect(doneResult).toEqual({
       streamedTextChars: expect.any(Number)
     })
     expect(stopAttempts).toBe(2)
@@ -702,8 +708,7 @@ describe('AgentSessionRenderer', () => {
     ).length
     expect(headerOccurrences).toBe(1)
 
-    const stop = calls.find(call => call.method === 'chat.stopStream')
-    const blocks = stop?.params.blocks ?? []
+    const blocks = finalBlocksFromCalls(calls)
     expect(
       blocks.some(
         (block: any) => block.type === 'markdown' && block.text === '_legal · codex-gpt-5_'
@@ -746,8 +751,7 @@ describe('AgentSessionRenderer', () => {
 
     const start = calls.find(call => call.method === 'chat.startStream')
     expect(start?.params.chunks?.[0]?.type).not.toBe('markdown_text')
-    const stop = calls.find(call => call.method === 'chat.stopStream')
-    const blocks = stop?.params.blocks ?? []
+    const blocks = finalBlocksFromCalls(calls)
     expect(
       blocks.some((block: any) => block.type === 'markdown' && /^_.*_$/.test(block.text))
     ).toBe(false)
@@ -808,6 +812,13 @@ function stopStreamFallbackText(params: any): string {
     .filter((chunk: any) => chunk?.type === 'markdown_text')
     .map((chunk: any) => String(chunk.text ?? ''))
     .join('')
+}
+
+function finalBlocksFromCalls(calls: Array<{ method: string; params: any }>): any[] {
+  const update = calls.findLast(call => call.method === 'chat.update')
+  if (update?.params.blocks?.length) return update.params.blocks
+  const stop = calls.find(call => call.method === 'chat.stopStream')
+  return stop?.params.blocks ?? []
 }
 
 async function waitUntil(predicate: () => boolean): Promise<void> {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -101,10 +101,6 @@ function headerMarkdown(header: string): string {
   return `_${header.trim()}_`
 }
 
-function headerBlock(header: string): AnyBlock {
-  return { type: 'markdown', text: headerMarkdown(header) }
-}
-
 const sessions = new Map<string, AgentSessionState>()
 const sessionQueues = new Map<string, Promise<void>>()
 const THINKING_STATUS = 'Thinking...'
@@ -310,8 +306,9 @@ export class AgentSessionRenderer {
       !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
     const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
     // Keep a durable final layout even when the live stream already showed
-    // tasks/text. Slack's streamed surface is not reliable enough to be the only
-    // persisted content.
+    // tasks/text. Close the assistant stream first, then rewrite it as a normal
+    // message so Slack does not replay final blocks as fresh streaming content
+    // when users reopen the thread.
     const blocks = sanitizeFinalMessagePayload([
       ...(tasks.length
         ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)]
@@ -327,10 +324,18 @@ export class AgentSessionRenderer {
     const stopResponse = await this.client.chat.stopStream({
       channel: state.channel,
       ts: segment.streamTs,
-      chunks: markdownToStreamChunks(blocks.length || streamedTextLive ? ' ' : fallbackText),
-      ...(blocks.length ? { blocks } : {})
+      chunks: markdownToStreamChunks(blocks.length || streamedTextLive ? ' ' : fallbackText)
     })
     if (!stopResponse.ok) throw new Error(stopResponse.error ?? 'chat.stopStream failed')
+    if (blocks.length) {
+      const updateResponse = await this.client.chat.update({
+        channel: state.channel,
+        ts: segment.streamTs,
+        text: fallbackText || state.title,
+        blocks
+      })
+      if (!updateResponse.ok) throw new Error(updateResponse.error ?? 'chat.update failed')
+    }
     segment.closed = true
   }
 

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -88,7 +88,7 @@ describe('CodexSessionRenderer', () => {
     expect(richTextPlain(cmd?.output)).toContain('one\ntwo')
     expect(calls.filter(call => call.method === 'chat.startStream')).toHaveLength(1)
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
-    expect(calls.some(call => call.method === 'chat.update')).toBe(false)
+    expect(calls.some(call => call.method === 'chat.update')).toBe(true)
   })
 
   it('renders multiple command executions as one visible activity task', async () => {
@@ -453,7 +453,10 @@ describe('CodexSessionRenderer', () => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
         },
-        update: async () => ({ ok: true })
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
       }
     }
 
@@ -521,7 +524,10 @@ describe('CodexSessionRenderer', () => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
         },
-        update: async () => ({ ok: true })
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
       }
     }
 
@@ -594,8 +600,9 @@ describe('CodexSessionRenderer', () => {
     await renderer.event(sessionId, { type: 'turn.completed', result: 'Done.' })
 
     expect(streamedMarkdown()).toContain('Done.')
-    expect(calls.some(call => call.method === 'chat.update')).toBe(false)
+    expect(calls.some(call => call.method === 'chat.update')).toBe(true)
     const stop = calls.find(call => call.method === 'chat.stopStream')
+    expect(stop?.params.blocks).toBeUndefined()
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
   })
 
@@ -1025,8 +1032,9 @@ describe('CodexSessionRenderer', () => {
     expect(thinkingBlockText(calls)).toBe('')
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const blocks = stop?.params.blocks ?? []
+    const blocks = finalBlocksFromCalls(calls)
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
+    expect(stop?.params.blocks).toBeUndefined()
     expect(
       blocks.some(
         (block: any) =>
@@ -1056,7 +1064,10 @@ describe('CodexSessionRenderer', () => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
         },
-        update: async () => ({ ok: true })
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
       }
     }
 
@@ -1101,7 +1112,7 @@ describe('CodexSessionRenderer', () => {
     await renderer.event(sessionId, { type: 'turn.completed', result: 'Found the bug.' })
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const finalBlocks = stop?.params.blocks ?? []
+    const finalBlocks = finalBlocksFromCalls(calls)
     const finalChunkText = stopStreamFallbackText(stop?.params).trim()
     const durableText = [
       finalChunkText,
@@ -1116,8 +1127,7 @@ describe('CodexSessionRenderer', () => {
 })
 
 function planTasksFromCalls(calls: Array<{ method: string; params: any }>): any[] {
-  const stop = calls.find(call => call.method === 'chat.stopStream')
-  const plan = stop?.params.blocks?.find((block: any) => block.type === 'plan')
+  const plan = finalBlocksFromCalls(calls).find((block: any) => block.type === 'plan')
   if (plan?.tasks?.length) return plan.tasks
 
   const byId = new Map<string, any>()
@@ -1159,6 +1169,13 @@ function stopStreamFallbackText(params: any): string {
     .filter((chunk: any) => chunk?.type === 'markdown_text')
     .map((chunk: any) => String(chunk.text ?? ''))
     .join('')
+}
+
+function finalBlocksFromCalls(calls: Array<{ method: string; params: any }>): any[] {
+  const update = calls.findLast(call => call.method === 'chat.update')
+  if (update?.params.blocks?.length) return update.params.blocks
+  const stop = calls.find(call => call.method === 'chat.stopStream')
+  return stop?.params.blocks ?? []
 }
 
 function thinkingBlockText(calls: Array<{ method: string; params: any }>): string {


### PR DESCRIPTION
## Summary
- close Slack assistant streams without final blocks so Slack does not replay final-answer block animations on thread reopen
- immediately rewrite the stopped stream via chat.update with the durable final plan and answer blocks
- update Slackbot renderer tests to assert final blocks come from chat.update while stopStream stays minimal

## Testing
- bun test src/*.test.ts src/**/*.test.ts
- bunx oxfmt --config='oxfmt.config.ts' --write src/slack/agent-session.ts src/slack/agent-session.test.ts src/slack/codex-session.test.ts
- bunx oxlint --config='oxlint.config.ts' src/slack/agent-session.ts src/slack/agent-session.test.ts src/slack/codex-session.test.ts
- git diff --check

## Not run
- just build-one slackbot: local Docker/OrbStack socket was unavailable earlier in this thread
