### PR TITLE
revert: stop static Slack stream rewrite

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -401,9 +401,8 @@ describe('AgentSessionRenderer', () => {
     })
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const blocks = finalBlocksFromCalls(calls)
-    const plan = blocks.find((block: any) => block.type === 'plan')
-    const body = blocks.find((block: any) => block.type === 'markdown')
+    const plan = stop?.params.blocks?.find((block: any) => block.type === 'plan')
+    const body = stop?.params.blocks?.find((block: any) => block.type === 'markdown')
     const outputText = plan?.tasks?.[0]?.output?.elements?.[0]?.elements?.[0]?.text ?? ''
 
     expect(outputText.split('\n')).toHaveLength(4)
@@ -411,8 +410,7 @@ describe('AgentSessionRenderer', () => {
     expect(body).toBeTruthy()
     expect(String(body?.text ?? '')).toContain('Final answer stays visible.')
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
-    expect(stop?.params.blocks).toBeUndefined()
-    expect(blocks.length).toBeLessThanOrEqual(50)
+    expect(stop?.params.blocks?.length ?? 0).toBeLessThanOrEqual(50)
   })
 
   it('keeps a durable final plan and answer after live streaming', async () => {
@@ -436,10 +434,7 @@ describe('AgentSessionRenderer', () => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
         },
-        update: async (params: any) => {
-          calls.push({ method: 'chat.update', params })
-          return { ok: true }
-        }
+        update: async () => ({ ok: true })
       }
     }
 
@@ -464,7 +459,7 @@ describe('AgentSessionRenderer', () => {
     })
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const blocks = finalBlocksFromCalls(calls)
+    const blocks = stop?.params.blocks ?? []
     expect(blocks.some((block: any) => block.type === 'plan')).toBe(true)
     expect(
       blocks.some(
@@ -473,7 +468,6 @@ describe('AgentSessionRenderer', () => {
     ).toBe(true)
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
-    expect(stop?.params.blocks).toBeUndefined()
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
   })
 
@@ -519,7 +513,8 @@ describe('AgentSessionRenderer', () => {
       answerMarkdown: 'Done: five tools called.'
     })
 
-    const blocks = finalBlocksFromCalls(calls)
+    const stop = calls.find(call => call.method === 'chat.stopStream')
+    const blocks = stop?.params.blocks ?? []
     expect(
       blocks.some(
         (block: any) =>
@@ -586,7 +581,7 @@ describe('AgentSessionRenderer', () => {
     await renderer.done(sessionId)
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const markdownBlocks = finalBlocksFromCalls(calls).filter(
+    const markdownBlocks = (stop?.params.blocks ?? []).filter(
       (block: any) => block.type === 'markdown'
     )
     const displayedAnswer = markdownBlocks.map((block: any) => block.text).join('\n')
@@ -652,8 +647,7 @@ describe('AgentSessionRenderer', () => {
       }
     })
 
-    const doneResult = await renderer.done(sessionId)
-    expect(doneResult).toEqual({
+    await expect(renderer.done(sessionId)).resolves.toEqual({
       streamedTextChars: expect.any(Number)
     })
     expect(stopAttempts).toBe(2)
@@ -708,7 +702,8 @@ describe('AgentSessionRenderer', () => {
     ).length
     expect(headerOccurrences).toBe(1)
 
-    const blocks = finalBlocksFromCalls(calls)
+    const stop = calls.find(call => call.method === 'chat.stopStream')
+    const blocks = stop?.params.blocks ?? []
     expect(
       blocks.some(
         (block: any) => block.type === 'markdown' && block.text === '_legal · codex-gpt-5_'
@@ -751,7 +746,8 @@ describe('AgentSessionRenderer', () => {
 
     const start = calls.find(call => call.method === 'chat.startStream')
     expect(start?.params.chunks?.[0]?.type).not.toBe('markdown_text')
-    const blocks = finalBlocksFromCalls(calls)
+    const stop = calls.find(call => call.method === 'chat.stopStream')
+    const blocks = stop?.params.blocks ?? []
     expect(
       blocks.some((block: any) => block.type === 'markdown' && /^_.*_$/.test(block.text))
     ).toBe(false)
@@ -812,13 +808,6 @@ function stopStreamFallbackText(params: any): string {
     .filter((chunk: any) => chunk?.type === 'markdown_text')
     .map((chunk: any) => String(chunk.text ?? ''))
     .join('')
-}
-
-function finalBlocksFromCalls(calls: Array<{ method: string; params: any }>): any[] {
-  const update = calls.findLast(call => call.method === 'chat.update')
-  if (update?.params.blocks?.length) return update.params.blocks
-  const stop = calls.find(call => call.method === 'chat.stopStream')
-  return stop?.params.blocks ?? []
 }
 
 async function waitUntil(predicate: () => boolean): Promise<void> {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -101,6 +101,10 @@ function headerMarkdown(header: string): string {
   return `_${header.trim()}_`
 }
 
+function headerBlock(header: string): AnyBlock {
+  return { type: 'markdown', text: headerMarkdown(header) }
+}
+
 const sessions = new Map<string, AgentSessionState>()
 const sessionQueues = new Map<string, Promise<void>>()
 const THINKING_STATUS = 'Thinking...'
@@ -306,9 +310,8 @@ export class AgentSessionRenderer {
       !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
     const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
     // Keep a durable final layout even when the live stream already showed
-    // tasks/text. Close the assistant stream first, then rewrite it as a normal
-    // message so Slack does not replay final blocks as fresh streaming content
-    // when users reopen the thread.
+    // tasks/text. Slack's streamed surface is not reliable enough to be the only
+    // persisted content.
     const blocks = sanitizeFinalMessagePayload([
       ...(tasks.length
         ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)]
@@ -324,18 +327,10 @@ export class AgentSessionRenderer {
     const stopResponse = await this.client.chat.stopStream({
       channel: state.channel,
       ts: segment.streamTs,
-      chunks: markdownToStreamChunks(blocks.length || streamedTextLive ? ' ' : fallbackText)
+      chunks: markdownToStreamChunks(blocks.length || streamedTextLive ? ' ' : fallbackText),
+      ...(blocks.length ? { blocks } : {})
     })
     if (!stopResponse.ok) throw new Error(stopResponse.error ?? 'chat.stopStream failed')
-    if (blocks.length) {
-      const updateResponse = await this.client.chat.update({
-        channel: state.channel,
-        ts: segment.streamTs,
-        text: fallbackText || state.title,
-        blocks
-      })
-      if (!updateResponse.ok) throw new Error(updateResponse.error ?? 'chat.update failed')
-    }
     segment.closed = true
   }
 

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -88,7 +88,7 @@ describe('CodexSessionRenderer', () => {
     expect(richTextPlain(cmd?.output)).toContain('one\ntwo')
     expect(calls.filter(call => call.method === 'chat.startStream')).toHaveLength(1)
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
-    expect(calls.some(call => call.method === 'chat.update')).toBe(true)
+    expect(calls.some(call => call.method === 'chat.update')).toBe(false)
   })
 
   it('renders multiple command executions as one visible activity task', async () => {
@@ -453,10 +453,7 @@ describe('CodexSessionRenderer', () => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
         },
-        update: async (params: any) => {
-          calls.push({ method: 'chat.update', params })
-          return { ok: true }
-        }
+        update: async () => ({ ok: true })
       }
     }
 
@@ -524,10 +521,7 @@ describe('CodexSessionRenderer', () => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
         },
-        update: async (params: any) => {
-          calls.push({ method: 'chat.update', params })
-          return { ok: true }
-        }
+        update: async () => ({ ok: true })
       }
     }
 
@@ -600,9 +594,8 @@ describe('CodexSessionRenderer', () => {
     await renderer.event(sessionId, { type: 'turn.completed', result: 'Done.' })
 
     expect(streamedMarkdown()).toContain('Done.')
-    expect(calls.some(call => call.method === 'chat.update')).toBe(true)
+    expect(calls.some(call => call.method === 'chat.update')).toBe(false)
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    expect(stop?.params.blocks).toBeUndefined()
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
   })
 
@@ -1032,9 +1025,8 @@ describe('CodexSessionRenderer', () => {
     expect(thinkingBlockText(calls)).toBe('')
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const blocks = finalBlocksFromCalls(calls)
+    const blocks = stop?.params.blocks ?? []
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
-    expect(stop?.params.blocks).toBeUndefined()
     expect(
       blocks.some(
         (block: any) =>
@@ -1064,10 +1056,7 @@ describe('CodexSessionRenderer', () => {
           calls.push({ method: 'chat.stopStream', params })
           return { ok: true }
         },
-        update: async (params: any) => {
-          calls.push({ method: 'chat.update', params })
-          return { ok: true }
-        }
+        update: async () => ({ ok: true })
       }
     }
 
@@ -1112,7 +1101,7 @@ describe('CodexSessionRenderer', () => {
     await renderer.event(sessionId, { type: 'turn.completed', result: 'Found the bug.' })
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    const finalBlocks = finalBlocksFromCalls(calls)
+    const finalBlocks = stop?.params.blocks ?? []
     const finalChunkText = stopStreamFallbackText(stop?.params).trim()
     const durableText = [
       finalChunkText,
@@ -1127,7 +1116,8 @@ describe('CodexSessionRenderer', () => {
 })
 
 function planTasksFromCalls(calls: Array<{ method: string; params: any }>): any[] {
-  const plan = finalBlocksFromCalls(calls).find((block: any) => block.type === 'plan')
+  const stop = calls.find(call => call.method === 'chat.stopStream')
+  const plan = stop?.params.blocks?.find((block: any) => block.type === 'plan')
   if (plan?.tasks?.length) return plan.tasks
 
   const byId = new Map<string, any>()
@@ -1169,13 +1159,6 @@ function stopStreamFallbackText(params: any): string {
     .filter((chunk: any) => chunk?.type === 'markdown_text')
     .map((chunk: any) => String(chunk.text ?? ''))
     .join('')
-}
-
-function finalBlocksFromCalls(calls: Array<{ method: string; params: any }>): any[] {
-  const update = calls.findLast(call => call.method === 'chat.update')
-  if (update?.params.blocks?.length) return update.params.blocks
-  const stop = calls.find(call => call.method === 'chat.stopStream')
-  return stop?.params.blocks ?? []
 }
 
 function thinkingBlockText(calls: Array<{ method: string; params: any }>): string {


### PR DESCRIPTION
## Summary
- revert PR #124's post-stop `chat.update` rewrite
- return Slack stream finalization to the PR #122 behavior, which keeps durable final blocks on `chat.stopStream`
- avoid duplicating final answers when Slack retains the live streamed text and then receives an updated markdown block

## Testing
- `bun test src/*.test.ts src/**/*.test.ts`