### PR TITLE
revert: remove Slack duplicate-answer experiment

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -413,7 +413,7 @@ describe('AgentSessionRenderer', () => {
     expect(stop?.params.blocks?.length ?? 0).toBeLessThanOrEqual(50)
   })
 
-  it('does not duplicate a fully streamed final answer in final blocks', async () => {
+  it('keeps a durable final plan and answer after live streaming', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -465,65 +465,10 @@ describe('AgentSessionRenderer', () => {
       blocks.some(
         (block: any) => block.type === 'markdown' && block.text.includes('Live answer body.')
       )
-    ).toBe(false)
+    ).toBe(true)
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
-  })
-
-  it('keeps a durable final answer when it was not streamed live', async () => {
-    const calls: Array<{ method: string; params: any }> = []
-    const client = {
-      assistant: {
-        threads: {
-          setStatus: async () => ({ ok: true })
-        }
-      },
-      chat: {
-        startStream: async (params: any) => {
-          calls.push({ method: 'chat.startStream', params })
-          return { ok: true, ts: '1778866940.295499' }
-        },
-        appendStream: async (params: any) => {
-          calls.push({ method: 'chat.appendStream', params })
-          return { ok: true }
-        },
-        stopStream: async (params: any) => {
-          calls.push({ method: 'chat.stopStream', params })
-          return { ok: true }
-        },
-        update: async () => ({ ok: true })
-      }
-    }
-
-    const renderer = new AgentSessionRenderer(client as any)
-    const { sessionId } = await renderer.open({
-      channel: 'C123',
-      parentTs: '1778866921.505479',
-      recipientTeamId: 'T123',
-      recipientUserId: 'U123',
-      title: 'Centaur execution'
-    })
-
-    await renderer.step(sessionId, {
-      id: 'cmd-1',
-      title: '1. Command execution',
-      status: 'in_progress'
-    })
-    await renderer.done(sessionId, {
-      commentaryMarkdown: 'Planning the tool calls.',
-      answerMarkdown: 'Final answer body.'
-    })
-
-    const stop = calls.find(call => call.method === 'chat.stopStream')
-    const blocks = stop?.params.blocks ?? []
-    expect(blocks.some((block: any) => block.type === 'plan')).toBe(true)
-    expect(
-      blocks.some(
-        (block: any) => block.type === 'markdown' && block.text.includes('Final answer body.')
-      )
-    ).toBe(true)
-    expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
   })
 
   it('shows thinking text by default and renders the answer in markdown on finalize', async () => {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -303,13 +303,11 @@ export class AgentSessionRenderer {
     const commentaryMarkdown = state.finalCommentaryMarkdown?.trim() ?? ''
     const answerSource =
       state.finalAnswerMarkdown?.trim() || segment.streamedText.trim() || segment.textParts.join('')
-    const answerMarkdown = finalMarkdownForFinalBlocks(answerSource, segment)
+    const answerMarkdown = finalMarkdownForBlocks(answerSource)
     const streamedTextLive =
       Boolean(segment.streamedText.trim()) && segment.streamedText.length < MAX_LIVE_TEXT_CHARS
     const showThinking =
-      !tasks.length &&
-      !streamedTextLive &&
-      shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
+      !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
     const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
     // Keep a durable final layout even when the live stream already showed
     // tasks/text. Slack's streamed surface is not reliable enough to be the only
@@ -651,15 +649,8 @@ function compactTaskBody(body: StreamTask['details'], maxLines: number): StreamT
   return richText([preformatted(clipLines(text, maxLines), language)])
 }
 
-function finalMarkdownForFinalBlocks(markdown: string, segment: Segment): string {
-  const trimmed = markdown.trim()
-  if (!trimmed) return ''
-  if (!segment.streamedText.trim()) {
-    return clipText(trimmed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
-  }
-  const unstreamed = markdown.slice(segment.streamedTextSourceChars).trim()
-  if (!unstreamed) return ''
-  return clipText(unstreamed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
+function finalMarkdownForBlocks(markdown: string): string {
+  return clipText(markdown, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
 }
 
 function clipText(value: string, maxChars: number): string {

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -583,22 +583,19 @@ describe('CodexSessionRenderer', () => {
           String(block.elements?.[0]?.text ?? '').includes('*Thinking*')
         )
     )
+    const firstTextIndex = chunks.findIndex(
+      chunk => chunk.type === 'markdown_text' && String(chunk.text).includes('Done.')
+    )
     expect(firstTaskIndex).toBeGreaterThanOrEqual(0)
     expect(thinkingIndex).toBe(-1)
-    expect(
-      chunks.some(chunk => chunk.type === 'markdown_text' && String(chunk.text).includes('Done.'))
-    ).toBe(false)
+    expect(firstTextIndex).toBeGreaterThan(firstTaskIndex)
     expect(thinkingBlockText(calls)).toBe('')
 
     await renderer.event(sessionId, { type: 'turn.completed', result: 'Done.' })
 
+    expect(streamedMarkdown()).toContain('Done.')
     expect(calls.some(call => call.method === 'chat.update')).toBe(false)
     const stop = calls.find(call => call.method === 'chat.stopStream')
-    expect(
-      (stop?.params.blocks ?? []).some(
-        (block: any) => block.type === 'markdown' && String(block.text).includes('Done.')
-      )
-    ).toBe(true)
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
   })
 
@@ -790,13 +787,7 @@ describe('CodexSessionRenderer', () => {
       .map(chunk => String(chunk.text))
       .join('')
 
-    expect(streamed).not.toContain('Done.')
-    const stop = calls.find(call => call.method === 'chat.stopStream')
-    expect(
-      (stop?.params.blocks ?? []).some(
-        (block: any) => block.type === 'markdown' && String(block.text).includes('Done.')
-      )
-    ).toBe(true)
+    expect(streamed).toContain('Done.')
     expect(thinkingBlockText(calls)).toBe('')
   })
 
@@ -962,7 +953,7 @@ describe('CodexSessionRenderer', () => {
     expect(visibleText.length).toBe(30_000)
   })
 
-  it('buffers tool-run final answers and renders them once on stopStream', async () => {
+  it('streams commentary and answer markdown live without duplicating them on stopStream', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -1030,7 +1021,7 @@ describe('CodexSessionRenderer', () => {
       .filter(chunk => chunk.type === 'markdown_text')
       .map(chunk => String(chunk.text))
       .join('')
-    expect(streamed).not.toContain('Done: five tools called.')
+    expect(streamed).toContain('Done: five tools called.')
     expect(thinkingBlockText(calls)).toBe('')
 
     const stop = calls.find(call => call.method === 'chat.stopStream')

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -224,8 +224,7 @@ export class CodexSessionRenderer {
       commentaryMarkdown: state.commentaryText,
       answerMarkdown: state.answerText
     })
-    const finalBlockAnswerChars = state.taskByUseId.size > 0 ? state.answerText.trim().length : 0
-    state.deliveredAnswerChars = Math.max(streamedTextChars, finalBlockAnswerChars)
+    state.deliveredAnswerChars = streamedTextChars
     state.done = true
     states.delete(agentSessionId)
   }
@@ -274,7 +273,6 @@ export class CodexSessionRenderer {
 
     if (state.commentaryText.length > state.streamedCommentaryText.length) return
     if (state.answerText.length <= state.streamedAnswerText.length) return
-    if (hasPlan) return
     const delta = state.answerText.slice(state.streamedAnswerText.length)
     if (!delta) return
     const acceptedChars = await this.renderer.textDelta(agentSessionId, delta, {


### PR DESCRIPTION
## Summary
- revert #126, the remaining net Slackbot experiment after #122
- leave non-Slackbot commits after #122 intact, including docs and API/iron-proxy changes from other authors
- restores Slackbot code to the #122 behavior while preserving later unrelated main commits

## Verification
- `bun test src/slack/agent-session.test.ts src/slack/codex-session.test.ts`
- `git diff --check`
- verified `git diff 9bd07ccc..HEAD -- services/slackbot/src/slack` is empty after the revert