### PR TITLE
docs: remove MCP quickstart wording

### DIFF
--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -10,9 +10,8 @@ happy path is: point `kubectl` at a local cluster, bootstrap the required infra
 Secret, run `just up`, verify the API, then run one agent turn without Slack.
 
 If you want an agent to drive setup with you, point it at these docs: every page
-is available as Markdown through `/llms.txt`, `/llms-full.txt`, and `/md/...`,
-or add this site's Vocs MCP server at `/api/mcp` so the agent can search and
-read the docs directly.
+is available through `/llms.txt`, `/llms-full.txt`, and static Markdown files
+such as `/md/quickstart.md`.
 
 ## 1. Install prerequisites
 

--- a/docs/public/md/quickstart.md
+++ b/docs/public/md/quickstart.md
@@ -10,9 +10,8 @@ happy path is: point `kubectl` at a local cluster, bootstrap the required infra
 Secret, run `just up`, verify the API, then run one agent turn without Slack.
 
 If you want an agent to drive setup with you, point it at these docs: every page
-is available as Markdown through `/llms.txt`, `/llms-full.txt`, and `/md/...`,
-or add this site's Vocs MCP server at `/api/mcp` so the agent can search and
-read the docs directly.
+is available through `/llms.txt`, `/llms-full.txt`, and static Markdown files
+such as `/md/quickstart.md`.
 
 ## 1. Install prerequisites
 

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -1,5 +1,5 @@
 import { createElement, Fragment } from 'react'
-import { defineConfig, McpSource } from 'vocs/config'
+import { defineConfig } from 'vocs/config'
 
 import { sidebar } from './sidebar.js'
 
@@ -36,16 +36,6 @@ export default defineConfig({
   logoUrl: {
     light: '/brand/lockup-black.svg',
     dark: '/brand/lockup-white.svg',
-  },
-  mcp: {
-    enabled: true,
-    sources: [
-      McpSource.github({
-        name: 'centaur',
-        repo: 'paradigmxyz/centaur',
-        paths: ['docs', 'services', 'centaur_sdk', 'packages', 'tools', 'workflows'],
-      }),
-    ],
   },
   // Body copy uses Amp's PolySans via the pages/_root.css override. Docs headings
   // use Perfectly Nineties, while the landing hero uses Sagittaire Display.


### PR DESCRIPTION
## Summary
- remove the Quickstart reference to the Vocs MCP endpoint
- disable the Vocs MCP config that is not served by the static docs deployment
- keep the generated Markdown quickstart copy aligned

## Testing
- npm run build