### PR TITLE
fix: avoid repeating short streamed Slack answers

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -468,6 +468,61 @@ describe('AgentSessionRenderer', () => {
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
   })
 
+  it('keeps a durable final answer when the answer did not stream live', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async () => ({ ok: true })
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+
+    await renderer.step(sessionId, {
+      id: 'cmd-1',
+      title: '1. Command execution',
+      status: 'in_progress'
+    })
+    await renderer.done(sessionId, {
+      commentaryMarkdown: 'Planning the tool calls.',
+      answerMarkdown: 'Final answer body.'
+    })
+
+    const stop = calls.find(call => call.method === 'chat.stopStream')
+    const blocks = stop?.params.blocks ?? []
+    expect(blocks.some((block: any) => block.type === 'plan')).toBe(false)
+    expect(
+      blocks.some(
+        (block: any) => block.type === 'markdown' && block.text.includes('Final answer body.')
+      )
+    ).toBe(true)
+    expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
+  })
+
   it('shows thinking text by default and renders the answer in markdown on finalize', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -118,6 +118,7 @@ const FINAL_PLAN_TITLE_CHARS = slackReplyLimits.finalPlan.taskTitleChars
 const FINAL_PLAN_DETAILS_LINES = slackReplyLimits.finalPlan.taskDetailsCodeBlockLines
 const FINAL_PLAN_OUTPUT_LINES = slackReplyLimits.finalPlan.taskOutputCodeBlockLines
 const MAX_LIVE_TEXT_CHARS = slackReplyLimits.stream.maxLiveTextChars
+const DURABLE_STREAMED_ANSWER_TASK_THRESHOLD = 10
 
 export class AgentSessionRenderer {
   constructor(private readonly client: WebClient) {}
@@ -299,7 +300,9 @@ export class AgentSessionRenderer {
     const commentaryMarkdown = state.finalCommentaryMarkdown?.trim() ?? ''
     const answerSource =
       state.finalAnswerMarkdown?.trim() || segment.streamedText.trim() || segment.textParts.join('')
-    const answerMarkdown = finalMarkdownForBlocks(answerSource)
+    const answerMarkdown = finalMarkdownForFinalBlocks(answerSource, segment, {
+      includeStreamedText: originalTasks.length >= DURABLE_STREAMED_ANSWER_TASK_THRESHOLD
+    })
     const streamedTextLive =
       Boolean(segment.streamedText.trim()) && segment.streamedText.length < MAX_LIVE_TEXT_CHARS
     const showThinking =
@@ -647,8 +650,19 @@ function compactTaskBody(body: StreamTask['details'], maxLines: number): StreamT
   return richText([preformatted(clipLines(text, maxLines), language)])
 }
 
-function finalMarkdownForBlocks(markdown: string): string {
-  return clipText(markdown, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
+function finalMarkdownForFinalBlocks(
+  markdown: string,
+  segment: Segment,
+  opts: { includeStreamedText?: boolean } = {}
+): string {
+  const trimmed = markdown.trim()
+  if (!trimmed) return ''
+  if (opts.includeStreamedText || !segment.streamedText.trim()) {
+    return clipText(trimmed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
+  }
+  const unstreamed = markdown.slice(segment.streamedTextSourceChars).trim()
+  if (!unstreamed) return ''
+  return clipText(unstreamed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
 }
 
 function clipText(value: string, maxChars: number): string {


### PR DESCRIPTION
## Summary
- avoid adding already-live-streamed answer text again to final Slack markdown blocks for short tool runs
- preserve #122 durable final-answer behavior for task-heavy runs by keeping the final answer block at 10+ tasks
- keep Codex live answer streaming unchanged so the API zero-stream fallback is not reintroduced

## Testing
- `bun test src/slack/agent-session.test.ts src/slack/codex-session.test.ts`
- `bunx oxfmt --config='oxfmt.config.ts' --write src/slack/agent-session.ts src/slack/agent-session.test.ts src/slack/codex-session.test.ts`
- `bun test src/*.test.ts src/**/*.test.ts`
- `git diff --check`