### PR TITLE
fix: avoid noop Slack stop stream chunks

### DIFF
--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -279,7 +279,7 @@ app.post('/api/slack/streams/stop', apiKeyMiddleware, async c => {
     const response = await client.chat.stopStream({
       channel: body.channel,
       ts: body.ts,
-      chunks: body.chunks ?? markdownToStreamChunks(body.markdown ?? ' '),
+      chunks: body.chunks ?? (body.markdown ? markdownToStreamChunks(body.markdown) : undefined),
       blocks: body.blocks
     })
     if (!response.ok) return c.json(response, 502)

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -462,6 +462,7 @@ describe('AgentSessionRenderer', () => {
     const blocks = stop?.params.blocks ?? []
     expect(blocks.some((block: any) => block.type === 'plan')).toBe(false)
     expect(blocks.some((block: any) => block.type === 'markdown')).toBe(false)
+    expect(stop?.params.chunks).toBeUndefined()
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -320,10 +320,12 @@ export class AgentSessionRenderer {
       commentaryMarkdown: showThinking ? commentaryMarkdown : '',
       answerMarkdown
     })
+    const chunks =
+      blocks.length || streamedTextLive ? undefined : markdownToStreamChunks(fallbackText)
     const stopResponse = await this.client.chat.stopStream({
       channel: state.channel,
       ts: segment.streamTs,
-      chunks: markdownToStreamChunks(blocks.length || streamedTextLive ? ' ' : fallbackText),
+      ...(chunks ? { chunks } : {}),
       ...(blocks.length ? { blocks } : {})
     })
     if (!stopResponse.ok) throw new Error(stopResponse.error ?? 'chat.stopStream failed')

--- a/services/slackbot/src/slack/client.ts
+++ b/services/slackbot/src/slack/client.ts
@@ -115,7 +115,7 @@ export class SlackEdgeClient {
     const response = await this.client.chat.stopStream({
       channel: opts.channel,
       ts: opts.ts,
-      chunks: opts.chunks ?? markdownToStreamChunks(opts.markdown ?? ' '),
+      chunks: opts.chunks ?? (opts.markdown ? markdownToStreamChunks(opts.markdown) : undefined),
       blocks: opts.blocks ? enforceBlockLimits(opts.blocks) : undefined
     })
     return assertSlackOk('chat.stopStream', response)

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1026,6 +1026,7 @@ describe('CodexSessionRenderer', () => {
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
     const blocks = stop?.params.blocks ?? []
+    expect(stop?.params.chunks).toBeUndefined()
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(blocks.some((block: any) => block.type === 'markdown')).toBe(false)
   })


### PR DESCRIPTION
## Summary
- omit final chat.stopStream chunks when live text has already been streamed
- stop defaulting stopStream wrappers to a blank markdown chunk when no markdown is provided
- add regressions asserting streamed answers finalize without a trailing noop chunk or duplicate final blocks

## Why
Slack renders stopStream chunks as appended stream content. A blank markdown chunk was intended as a no-op finalizer, but it still mutates the finalized stream surface and appears to trigger duplicate rendering for short replies.

## Tested
- bun test src/slack/agent-session.test.ts src/slack/codex-session.test.ts
- bun run test

Note: bun run check:types is currently blocked by existing test/emulate missing emulate module resolution.