### PR TITLE
fix: classify unphased Codex final messages

### DIFF
--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1030,6 +1030,82 @@ describe('CodexSessionRenderer', () => {
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(blocks.some((block: any) => block.type === 'markdown')).toBe(false)
   })
+
+  it('treats an unphased terminal agent message after tool use as the final answer', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async () => ({ ok: true })
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'msg-thinking', type: 'agentMessage', phase: 'commentary' }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.agentMessage.delta',
+      itemId: 'msg-thinking',
+      delta: 'I’ll inspect the runtime metadata.'
+    })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: {
+        id: 'cmd-1',
+        type: 'commandExecution',
+        command: 'kubectl get pod',
+        aggregated_output: 'main-sha-df02d81',
+        exitCode: 0
+      }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: {
+        id: 'msg-final',
+        type: 'agentMessage',
+        text: 'Staging is running `main-sha-df02d81`.'
+      }
+    })
+    await renderer.event(sessionId, { type: 'turn.completed' })
+
+    const streamed = calls
+      .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
+      .flatMap(call => call.params.chunks ?? [])
+      .filter(chunk => chunk.type === 'markdown_text')
+      .map(chunk => String(chunk.text))
+      .join('')
+    expect(streamed).toContain('Staging is running `main-sha-df02d81`.')
+    expect(thinkingBlockText(calls)).not.toContain('Staging is running')
+  })
 })
 
 function planTasksFromCalls(calls: Array<{ method: string; params: any }>): any[] {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -36,6 +36,7 @@ type CodexSessionState = {
   streamedAnswerText: string
   deliveredAnswerChars: number
   agentMessagePhase: AgentMessagePhase | null
+  agentMessagePhaseByItemId: Map<string, AgentMessagePhase>
   planText: string
   taskByUseId: Map<string, HarnessTask>
   commandOutputById: Map<string, string>
@@ -330,6 +331,7 @@ function getState(agentSessionId: string): CodexSessionState {
       streamedAnswerText: '',
       deliveredAnswerChars: 0,
       agentMessagePhase: null,
+      agentMessagePhaseByItemId: new Map(),
       planText: '',
       taskByUseId: new Map(),
       commandOutputById: new Map(),
@@ -358,6 +360,12 @@ function trackAgentMessageLifecycle(event: any, state: CodexSessionState): void 
   const phase = agentMessageItemPhase(event?.item)
   if (!phase) return
   state.agentMessagePhase = phase
+  const id = agentMessageEventId(event)
+  if (id) state.agentMessagePhaseByItemId.set(id, phase)
+}
+
+function agentMessageEventId(event: any): string {
+  return String(event?.itemId ?? event?.item_id ?? event?.item?.id ?? '')
 }
 
 /** Codex may emit several commentary agentMessages in one turn; keep a blank line between them. */
@@ -403,6 +411,15 @@ function completeThinkingTasks(state: CodexSessionState): void {
 
 function activeAssistantBuffer(state: CodexSessionState, event: any): 'commentary' | 'answer' {
   if (event?.type === 'item.agentMessage.delta' || event?.type === 'item.completed') {
+    const itemPhase = state.agentMessagePhaseByItemId.get(agentMessageEventId(event))
+    if (itemPhase) return itemPhase === 'final_answer' ? 'answer' : 'commentary'
+    if (
+      event?.type === 'item.completed' &&
+      (event?.item?.type === 'agentMessage' || event?.item?.type === 'agent_message') &&
+      state.taskByUseId.size > 0
+    ) {
+      return 'answer'
+    }
     return state.agentMessagePhase === 'final_answer' ? 'answer' : 'commentary'
   }
   return 'answer'


### PR DESCRIPTION
## Summary
- track Codex agent-message phase per item id instead of relying only on a global current phase
- treat unphased completed agent messages after tool activity as final answers
- add a regression for the blank-after-tool-call case where the answer was previously classified as Thinking

## Tested
- bun run test