### PR TITLE
fix: stream Slack terminal result text

### DIFF
--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -13,6 +13,66 @@ describe('assistant message sections', () => {
 })
 
 describe('CodexSessionRenderer', () => {
+  it('streams canonical terminal result text before closing the session', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async (params: any) => {
+            calls.push({ method: 'assistant.threads.setStatus', params })
+            return { ok: true }
+          }
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    const result = await renderer.event(sessionId, {
+      type: 'result',
+      text: 'PONG'
+    })
+
+    const streamed = calls
+      .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
+      .flatMap(call => call.params.chunks ?? [])
+      .filter(chunk => chunk.type === 'markdown_text')
+      .map(chunk => String(chunk.text))
+      .join('')
+    expect(streamed).toContain('PONG')
+    expect(result.done).toBe(true)
+    expect(result.streamedAnswerChars).toBe(4)
+    expect(calls.some(call => call.method === 'chat.stopStream')).toBe(true)
+    expect(
+      stopStreamFallbackText(calls.find(call => call.method === 'chat.stopStream')?.params)
+    ).toBe('')
+  })
+
   it('accumulates command output deltas into the same task update', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -193,12 +193,10 @@ export class CodexSessionRenderer {
     }
 
     if (isTerminalTurnEvent(event)) {
-      if (typeof event.result === 'string' && !state.answerText.trim()) {
-        const resultText = event.result.trim()
-        if (resultText) {
-          state.answerText += resultText
-          await this.publishPendingAssistantText(agentSessionId, state, { force: true })
-        }
+      const resultText = terminalResultText(event)
+      if (resultText && !state.answerText.trim()) {
+        state.answerText += resultText
+        await this.publishPendingAssistantText(agentSessionId, state, { force: true })
       }
       await this.done(agentSessionId)
     }
@@ -443,6 +441,16 @@ function reasoningText(event: any): string {
 
 function isTerminalTurnEvent(event: any): boolean {
   return event?.type === 'result' || event?.type === 'turn.done' || event?.type === 'turn.completed'
+}
+
+function terminalResultText(event: any): string {
+  for (const key of ['result', 'result_text', 'text', 'final_text']) {
+    const value = event?.[key]
+    if (typeof value !== 'string') continue
+    const text = value.trim()
+    if (text) return text
+  }
+  return ''
 }
 
 function toolUses(event: any): any[] {


### PR DESCRIPTION
## Summary
- stream canonical terminal result text from Slackbot live sessions before closing
- cover normalized result events that carry text instead of result

## Tests
- bun test src/slack/codex-session.test.ts
- bun run check:types
- bun test src/*.test.ts src/**/*.test.ts