### PR TITLE
fix: log unphased Codex final messages

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -2710,6 +2710,12 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 for slack_event in slack_events:
                     if harness_thread_id and isinstance(slack_event, dict):
                         slack_event.setdefault("session_id", harness_thread_id)
+                    if isinstance(slack_event, dict):
+                        slack_event.setdefault("centaur_thread_key", thread_key)
+                        slack_event.setdefault("centaur_execution_id", execution_id)
+                        slack_event.setdefault(
+                            "centaur_assignment_generation", assignment_generation
+                        )
                     harness_result = await slackbot_client.harness_event(
                         slackbot_session_id, slack_event
                     )

--- a/services/slackbot/src/logging.ts
+++ b/services/slackbot/src/logging.ts
@@ -90,6 +90,10 @@ export function logWarn(event: string, ...values: unknown[]): void {
   console.warn(event, ...values.map(value => sanitizeLogValue(value)))
 }
 
+export function logInfo(event: string, ...values: unknown[]): void {
+  console.log(event, ...values.map(value => sanitizeLogValue(value)))
+}
+
 export function logError(event: string, ...values: unknown[]): void {
   console.error(event, ...values.map(value => sanitizeLogValue(value)))
 }

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1033,6 +1033,11 @@ describe('CodexSessionRenderer', () => {
 
   it('treats an unphased terminal agent message after tool use as the final answer', async () => {
     const calls: Array<{ method: string; params: any }> = []
+    const logCalls: unknown[][] = []
+    const originalLog = console.log
+    console.log = ((...args: unknown[]) => {
+      logCalls.push(args)
+    }) as typeof console.log
     const client = {
       assistant: {
         threads: {
@@ -1068,34 +1073,42 @@ describe('CodexSessionRenderer', () => {
     })
     const renderer = new CodexSessionRenderer(client as any)
 
-    await renderer.event(sessionId, {
-      type: 'item.started',
-      item: { id: 'msg-thinking', type: 'agentMessage', phase: 'commentary' }
-    })
-    await renderer.event(sessionId, {
-      type: 'item.agentMessage.delta',
-      itemId: 'msg-thinking',
-      delta: 'I’ll inspect the runtime metadata.'
-    })
-    await renderer.event(sessionId, {
-      type: 'item.completed',
-      item: {
-        id: 'cmd-1',
-        type: 'commandExecution',
-        command: 'kubectl get pod',
-        aggregated_output: 'main-sha-df02d81',
-        exitCode: 0
-      }
-    })
-    await renderer.event(sessionId, {
-      type: 'item.completed',
-      item: {
-        id: 'msg-final',
-        type: 'agentMessage',
-        text: 'Staging is running `main-sha-df02d81`.'
-      }
-    })
-    await renderer.event(sessionId, { type: 'turn.completed' })
+    try {
+      await renderer.event(sessionId, {
+        type: 'item.started',
+        item: { id: 'msg-thinking', type: 'agentMessage', phase: 'commentary' }
+      })
+      await renderer.event(sessionId, {
+        type: 'item.agentMessage.delta',
+        itemId: 'msg-thinking',
+        delta: 'I’ll inspect the runtime metadata.'
+      })
+      await renderer.event(sessionId, {
+        type: 'item.completed',
+        item: {
+          id: 'cmd-1',
+          type: 'commandExecution',
+          command: 'kubectl get pod',
+          aggregated_output: 'main-sha-df02d81',
+          exitCode: 0
+        }
+      })
+      await renderer.event(sessionId, {
+        type: 'item.completed',
+        centaur_thread_key: 'slack:C123:1778866921.505479',
+        centaur_execution_id: 'exe-test',
+        centaur_assignment_generation: 3,
+        session_id: 'codex-session-test',
+        item: {
+          id: 'msg-final',
+          type: 'agentMessage',
+          text: 'Staging is running `main-sha-df02d81`.'
+        }
+      })
+      await renderer.event(sessionId, { type: 'turn.completed' })
+    } finally {
+      console.log = originalLog
+    }
 
     const streamed = calls
       .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
@@ -1105,6 +1118,21 @@ describe('CodexSessionRenderer', () => {
       .join('')
     expect(streamed).toContain('Staging is running `main-sha-df02d81`.')
     expect(thinkingBlockText(calls)).not.toContain('Staging is running')
+    const fallbackLogs = logCalls.filter(
+      call => call[0] === 'slack_codex_unphased_final_agent_message_classified'
+    )
+    expect(fallbackLogs).toHaveLength(1)
+    expect(fallbackLogs[0]?.[1]).toMatchObject({
+      agent_session_id: sessionId,
+      centaur_thread_key: 'slack:C123:1778866921.505479',
+      execution_id: 'exe-test',
+      assignment_generation: 3,
+      codex_id: 'msg-final',
+      codex_item_id: 'msg-final',
+      codex_item_type: 'agentMessage',
+      codex_session_id: 'codex-session-test',
+      task_count: 1
+    })
   })
 })
 

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -1,5 +1,6 @@
 import type { WebClient } from '@slack/web-api'
 import { slackReplyLimits } from '../constants'
+import { logInfo } from '../logging'
 import { AgentSessionRenderer } from './agent-session'
 import {
   clipLines,
@@ -163,7 +164,7 @@ export class CodexSessionRenderer {
 
     const assistantMessage = assistantText(event)
     if (assistantMessage) {
-      const buffer = activeAssistantBuffer(state, event)
+      const buffer = activeAssistantBuffer(state, event, agentSessionId)
       const current = buffer === 'answer' ? state.answerText : state.commentaryText
       const delta = messageDelta(current, assistantMessage)
       if (delta) {
@@ -409,15 +410,34 @@ function completeThinkingTasks(state: CodexSessionState): void {
   }
 }
 
-function activeAssistantBuffer(state: CodexSessionState, event: any): 'commentary' | 'answer' {
+function activeAssistantBuffer(
+  state: CodexSessionState,
+  event: any,
+  agentSessionId: string
+): 'commentary' | 'answer' {
   if (event?.type === 'item.agentMessage.delta' || event?.type === 'item.completed') {
-    const itemPhase = state.agentMessagePhaseByItemId.get(agentMessageEventId(event))
+    const codexId = agentMessageEventId(event)
+    const itemPhase = state.agentMessagePhaseByItemId.get(codexId)
     if (itemPhase) return itemPhase === 'final_answer' ? 'answer' : 'commentary'
     if (
       event?.type === 'item.completed' &&
       (event?.item?.type === 'agentMessage' || event?.item?.type === 'agent_message') &&
       state.taskByUseId.size > 0
     ) {
+      logInfo('slack_codex_unphased_final_agent_message_classified', {
+        agent_session_id: agentSessionId,
+        centaur_thread_key: event?.centaur_thread_key,
+        execution_id: event?.centaur_execution_id,
+        assignment_generation: event?.centaur_assignment_generation,
+        codex_id: codexId,
+        codex_item_id: codexId,
+        codex_item_type: event?.item?.type,
+        codex_session_id: state.threadId || event?.session_id || event?.thread_id,
+        task_count: state.taskByUseId.size,
+        commentary_chars: state.commentaryText.length,
+        answer_chars: state.answerText.length,
+        item_text_chars: String(event?.item?.text ?? '').length
+      })
       return 'answer'
     }
     return state.agentMessagePhase === 'final_answer' ? 'answer' : 'commentary'


### PR DESCRIPTION
## Summary
- log only when the unphased Codex final-message fallback is triggered
- include the Codex item id plus Centaur thread/execution metadata for tying logs back to Slack threads
- forward durable thread/execution metadata from the API live harness events to Slackbot

## Test
- bun test services/slackbot/src/slack/codex-session.test.ts