### PR TITLE
fix: fall back when Slack live answer is missing

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -1767,6 +1767,7 @@ async def _mark_execution_terminal(
     terminal_reason: str,
     result_text: str,
     error_text: str | None,
+    slackbot_streamed_answer_chars_override: int | None = None,
 ) -> None:
     next_attempt_at = dt.datetime.now(dt.timezone.utc) + dt.timedelta(
         seconds=FINAL_DELIVERY_READY_GRACE_S,
@@ -1832,16 +1833,27 @@ async def _mark_execution_terminal(
             slackbot_live_delivery_failed = bool(
                 metadata.get("slackbot_live_delivery_failed")
             )
-            suppress_legacy_delivery = (
-                _has_slackbot_live_delivery(metadata)
-                and not slackbot_live_delivery_failed
-            )
             raw_streamed_answer_chars = metadata.get("slackbot_streamed_answer_chars")
             if (
                 isinstance(raw_streamed_answer_chars, int)
                 and not slackbot_live_delivery_failed
             ):
                 slackbot_streamed_answer_chars = max(raw_streamed_answer_chars, 0)
+            if (
+                slackbot_streamed_answer_chars_override is not None
+                and not slackbot_live_delivery_failed
+            ):
+                slackbot_streamed_answer_chars = max(
+                    slackbot_streamed_answer_chars,
+                    slackbot_streamed_answer_chars_override,
+                    0,
+                )
+            result_has_text = bool(result_text.strip())
+            suppress_legacy_delivery = (
+                _has_slackbot_live_delivery(metadata)
+                and not slackbot_live_delivery_failed
+                and (not result_has_text or slackbot_streamed_answer_chars > 0)
+            )
         assignment_row = await pool.fetchrow(
             "SELECT harness, engine, persona_id, prompt_ref, effective_agents_md_sha256 "
             "FROM agent_runtime_assignments WHERE thread_key = $1 AND assignment_generation = $2",
@@ -1903,11 +1915,7 @@ async def _mark_execution_terminal(
     if delivery_platform == "dev" or suppress_legacy_delivery:
         slackbot_agent_session_id = str(metadata.get("slackbot_agent_session_id") or "")
         result_size = payload_size_bytes(result_text)
-        if (
-            suppress_legacy_delivery
-            and result_size > 0
-            and slackbot_streamed_answer_chars <= 0
-        ):
+        if suppress_legacy_delivery and result_size > 0 and slackbot_streamed_answer_chars <= 0:
             log.warning(
                 "final_delivery_skipped_without_live_answer",
                 execution_id=execution_id,
@@ -2586,10 +2594,6 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         if finalize_session_id and not slackbot_done and slackbot_forward_live:
             try:
                 terminal_result_sent_to_slackbot = False
-                if result_text.strip() and slackbot_streamed_answer_chars <= 0:
-                    await slackbot_client.session_text(finalize_session_id, result_text)
-                    slackbot_text_sent = True
-                    terminal_result_sent_to_slackbot = True
                 await slackbot_client.session_done(
                     finalize_session_id, harness_thread_id or None
                 )
@@ -2626,6 +2630,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
             terminal_reason=terminal_reason,
             result_text=result_text,
             error_text=error_text,
+            slackbot_streamed_answer_chars_override=slackbot_streamed_answer_chars,
         )
 
     execution_started_payload = {

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -809,13 +809,31 @@ async def test_mark_execution_terminal_delays_outbox_claimability(db_pool):
     execution_id = f"exe-{uuid.uuid4().hex[:10]}"
     thread_key = f"slack:C-test:{uuid.uuid4().hex}"
     agent_thread_id = "T-terminal-thread"
+    runtime_id = f"rt-{uuid.uuid4().hex[:8]}"
     await db_pool.execute(
         "INSERT INTO sandbox_sessions ("
         "thread_key, sandbox_id, harness, engine, state, agent_thread_id"
         ") VALUES ($1, $2, 'amp', 'amp', 'idle', $3)",
         thread_key,
-        f"rt-{uuid.uuid4().hex[:8]}",
+        runtime_id,
         agent_thread_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_runtime_assignments ("
+        "thread_key, assignment_generation, runtime_id, harness, engine, "
+        "persona_id, prompt_ref, effective_agents_md_sha256, state"
+        ") VALUES ($1, 1, $2, 'amp', 'amp', NULL, 'harness:amp', 'sha', 'active')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, status, "
+        "delivery, metadata, started_at"
+        ") VALUES ($1, $2, 1, 'exec-terminal', 'hash-terminal', 'running', "
+        "'{\"platform\":\"slack\"}'::jsonb, '{}'::jsonb, NOW())",
+        execution_id,
+        thread_key,
     )
     await db_pool.execute(
         "INSERT INTO agent_final_delivery_outbox ("
@@ -863,6 +881,76 @@ async def test_mark_execution_terminal_delays_outbox_claimability(db_pool):
     if isinstance(event_json, str):
         event_json = json.loads(event_json)
     assert event_json["agent_thread_id"] == agent_thread_id
+
+
+@pytest.mark.asyncio
+async def test_mark_execution_terminal_skips_durable_delivery_after_live_answer(db_pool):
+    from api.runtime_control import _mark_execution_terminal
+
+    execution_id = f"exe-{uuid.uuid4().hex[:10]}"
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}"
+    runtime_id = f"rt-{uuid.uuid4().hex[:8]}"
+    await db_pool.execute(
+        "INSERT INTO sandbox_sessions (thread_key, sandbox_id, harness, engine, state) "
+        "VALUES ($1, $2, 'codex', 'codex', 'idle')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_runtime_assignments ("
+        "thread_key, assignment_generation, runtime_id, harness, engine, "
+        "persona_id, prompt_ref, effective_agents_md_sha256, state"
+        ") VALUES ($1, 1, $2, 'codex', 'codex', NULL, 'harness:codex', 'sha', 'active')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, status, "
+        "delivery, metadata, started_at"
+        ") VALUES ($1, $2, 1, 'exec-live-answer', 'hash-live-answer', 'running', "
+        "$3::jsonb, $4::jsonb, NOW())",
+        execution_id,
+        thread_key,
+        json.dumps({"platform": "slack", "channel": "C-test"}),
+        json.dumps(
+            {
+                "slackbot_live_delivery": True,
+                "slackbot_agent_session_id": "sess-live-answer",
+            }
+        ),
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_final_delivery_outbox (execution_id, thread_key, delivery, state) "
+        "VALUES ($1, $2, '{}'::jsonb, 'awaiting_terminal')",
+        execution_id,
+        thread_key,
+    )
+
+    await _mark_execution_terminal(
+        db_pool,
+        execution_id=execution_id,
+        thread_key=thread_key,
+        status="completed",
+        terminal_reason="completed",
+        result_text="already streamed",
+        error_text=None,
+        slackbot_streamed_answer_chars_override=15,
+    )
+
+    outbox = await db_pool.fetchrow(
+        "SELECT state, final_payload FROM agent_final_delivery_outbox WHERE execution_id = $1",
+        execution_id,
+    )
+    assert outbox is not None
+    assert outbox["state"] == "awaiting_terminal"
+    assert outbox["final_payload"] is None
+    ready_events = await db_pool.fetchval(
+        "SELECT COUNT(*) FROM agent_execution_events "
+        "WHERE execution_id = $1 AND event_kind = 'final_delivery_ready'",
+        execution_id,
+    )
+    assert int(ready_events or 0) == 0
 
 
 @pytest.mark.asyncio
@@ -1304,7 +1392,7 @@ async def test_worker_sends_final_result_when_live_slack_only_streamed_placehold
     ):
         await _process_execution(db_pool, row)
 
-    session_text_mock.assert_awaited_once_with("sess-blank", final_text)
+    session_text_mock.assert_not_awaited()
     session_done_mock.assert_awaited_once_with("sess-blank", "turn-059d374be813486b")
     execution = await db_pool.fetchrow(
         "SELECT status, terminal_reason, result_text FROM agent_execution_requests WHERE execution_id = $1",
@@ -1319,7 +1407,11 @@ async def test_worker_sends_final_result_when_live_slack_only_streamed_placehold
         execution_id,
     )
     assert outbox is not None
-    assert outbox["state"] == "delivered"
+    assert outbox["state"] == "pending"
+    final_payload = outbox["final_payload"]
+    if isinstance(final_payload, str):
+        final_payload = json.loads(final_payload)
+    assert final_payload["result_text"] == final_text
 
 
 @pytest.mark.asyncio

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -73,6 +73,113 @@ describe('CodexSessionRenderer', () => {
     ).toBe('')
   })
 
+  it('ignores duplicate terminal events after the session is already done', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async () => ({ ok: true })
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    const first = await renderer.event(sessionId, { type: 'result', result: 'PONG' })
+    const second = await renderer.event(sessionId, { type: 'turn.done', result: 'PONG' })
+
+    const streamed = calls
+      .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
+      .flatMap(call => call.params.chunks ?? [])
+      .filter(chunk => chunk.type === 'markdown_text')
+      .map(chunk => String(chunk.text))
+      .join('')
+    expect(streamed).toContain('PONG')
+    expect(streamed.match(/PONG/g)?.length).toBe(1)
+    expect(first.done).toBe(true)
+    expect(second.done).toBe(true)
+    expect(second.streamedAnswerChars).toBe(4)
+    expect(calls.filter(call => call.method === 'chat.stopStream')).toHaveLength(1)
+  })
+
+  it('waits for turn.done when a result event has no terminal text', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async () => ({ ok: true })
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    const emptyResult = await renderer.event(sessionId, { type: 'result' })
+    const done = await renderer.event(sessionId, { type: 'turn.done', result: 'PONG' })
+
+    const streamed = calls
+      .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
+      .flatMap(call => call.params.chunks ?? [])
+      .filter(chunk => chunk.type === 'markdown_text')
+      .map(chunk => String(chunk.text))
+      .join('')
+    expect(emptyResult.done).toBe(false)
+    expect(done.done).toBe(true)
+    expect(streamed).toContain('PONG')
+    expect(done.streamedAnswerChars).toBe(4)
+    expect(calls.filter(call => call.method === 'chat.stopStream')).toHaveLength(1)
+  })
+
   it('accumulates command output deltas into the same task update', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -46,8 +46,16 @@ type CodexSessionState = {
   done: boolean
 }
 
+type CompletedCodexSessionState = {
+  threadId: string
+  streamedAnswerChars: number
+  completedAt: number
+}
+
 const states = new Map<string, CodexSessionState>()
+const completedStates = new Map<string, CompletedCodexSessionState>()
 const PRE_STREAM_GRACE_MS = 500
+const COMPLETED_STATE_TTL_MS = 10 * 60 * 1000
 
 export class CodexSessionRenderer {
   private readonly renderer: AgentSessionRenderer
@@ -60,6 +68,17 @@ export class CodexSessionRenderer {
     agentSessionId: string,
     event: any
   ): Promise<{ threadId?: string; done: boolean; streamedAnswerChars: number }> {
+    const completed = completedState(agentSessionId)
+    if (completed) {
+      if (isTerminalTurnEvent(event)) {
+        logCodexTerminalEventIgnoredAfterDone(agentSessionId, event, completed)
+      }
+      return {
+        threadId: completed.threadId || undefined,
+        done: true,
+        streamedAnswerChars: completed.streamedAnswerChars
+      }
+    }
     const state = getState(agentSessionId)
     if (event?.session_id) state.threadId = String(event.session_id)
     if (event?.thread_id) state.threadId = String(event.thread_id)
@@ -196,11 +215,18 @@ export class CodexSessionRenderer {
 
     if (isTerminalTurnEvent(event)) {
       const resultText = terminalResultText(event)
+      const willClose = Boolean(resultText || event?.type !== 'result')
+      logCodexTerminalEventReceived(agentSessionId, event, state, {
+        resultText,
+        willClose
+      })
       if (resultText && !state.answerText.trim()) {
         state.answerText += resultText
         await this.publishPendingAssistantText(agentSessionId, state, { force: true })
       }
-      await this.done(agentSessionId)
+      if (willClose) {
+        await this.done(agentSessionId)
+      }
     }
 
     return {
@@ -226,6 +252,11 @@ export class CodexSessionRenderer {
     })
     state.deliveredAnswerChars = streamedTextChars
     state.done = true
+    completedStates.set(agentSessionId, {
+      threadId: state.threadId,
+      streamedAnswerChars: state.deliveredAnswerChars,
+      completedAt: Date.now()
+    })
     states.delete(agentSessionId)
   }
 
@@ -488,6 +519,58 @@ function terminalResultText(event: any): string {
     if (text) return text
   }
   return ''
+}
+
+function completedState(agentSessionId: string): CompletedCodexSessionState | undefined {
+  const completed = completedStates.get(agentSessionId)
+  if (!completed) return undefined
+  if (Date.now() - completed.completedAt > COMPLETED_STATE_TTL_MS) {
+    completedStates.delete(agentSessionId)
+    return undefined
+  }
+  return completed
+}
+
+function logCodexTerminalEventReceived(
+  agentSessionId: string,
+  event: any,
+  state: CodexSessionState,
+  opts: { resultText: string; willClose: boolean }
+): void {
+  logInfo('slack_codex_terminal_event_received', {
+    agent_session_id: agentSessionId,
+    centaur_thread_key: event?.centaur_thread_key,
+    execution_id: event?.centaur_execution_id,
+    assignment_generation: event?.centaur_assignment_generation,
+    event_type: event?.type,
+    codex_session_id: state.threadId || event?.session_id || event?.thread_id,
+    already_completed: false,
+    will_close: opts.willClose,
+    result_text_chars: opts.resultText.length,
+    answer_chars_before_event: state.answerText.length,
+    streamed_answer_chars_before_event: state.deliveredAnswerChars,
+    task_count: state.taskByUseId.size
+  })
+}
+
+function logCodexTerminalEventIgnoredAfterDone(
+  agentSessionId: string,
+  event: any,
+  completed: CompletedCodexSessionState
+): void {
+  logInfo('slack_codex_terminal_event_ignored_after_done', {
+    agent_session_id: agentSessionId,
+    centaur_thread_key: event?.centaur_thread_key,
+    execution_id: event?.centaur_execution_id,
+    assignment_generation: event?.centaur_assignment_generation,
+    event_type: event?.type,
+    codex_session_id: completed.threadId || event?.session_id || event?.thread_id,
+    already_completed: true,
+    will_close: false,
+    result_text_chars: terminalResultText(event).length,
+    streamed_answer_chars_at_completion: completed.streamedAnswerChars,
+    completed_age_ms: Date.now() - completed.completedAt
+  })
 }
 
 function toolUses(event: any): any[] {


### PR DESCRIPTION
## Summary
- require positive live answer evidence before suppressing durable Slack final delivery
- stop injecting terminal result text into the live Slack session when no answer chars were confirmed, so durable final delivery owns that fallback
- pass in-memory Slackbot streamed answer chars into terminal marking so successful live streams still avoid duplicate durable delivery
- tighten API regression coverage for zero-char fallback and positive-char suppression

## Testing
- uv run ruff check api/runtime_control.py tests/test_agent_control_plane.py
- python3 -m py_compile services/api/api/runtime_control.py
- uv run pytest tests/test_agent_control_plane.py::test_worker_sends_final_result_when_live_slack_only_streamed_placeholder tests/test_agent_control_plane.py::test_mark_execution_terminal_skips_durable_delivery_after_live_answer tests/test_agent_control_plane.py::test_mark_execution_terminal_delays_outbox_claimability tests/test_agent_control_plane.py::test_slackbot_streamed_answer_chars_requires_positive_integer_offset -q