### PR TITLE
fix: show Slack metadata once per thread

### DIFF
--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -973,6 +973,46 @@ async def _compute_agent_session_header(
     )
 
 
+def _history_has_assistant_message(history_messages: Any) -> bool:
+    if not isinstance(history_messages, list):
+        return False
+    return any(
+        isinstance(item, dict)
+        and str(item.get("role") or "").strip().lower() == "assistant"
+        for item in history_messages
+    )
+
+
+async def _thread_has_prior_slack_agent_reply(pool, thread_key: str) -> bool:
+    execution_row = await pool.fetchrow(
+        "SELECT 1 FROM agent_execution_requests "
+        "WHERE thread_key = $1 AND COALESCE(delivery->>'platform', '') = 'slack' "
+        "AND COALESCE(metadata->>'slackbot_agent_session_id', '') <> '' "
+        "LIMIT 1",
+        thread_key,
+    )
+    if execution_row is not None:
+        return True
+    message_row = await pool.fetchrow(
+        "SELECT 1 FROM agent_message_requests "
+        "WHERE thread_key = $1 AND event_json->>'type' = 'assistant' "
+        "LIMIT 1",
+        thread_key,
+    )
+    return message_row is not None
+
+
+async def _should_show_agent_session_header(
+    pool,
+    *,
+    thread_key: str,
+    history_messages: Any,
+) -> bool:
+    if _history_has_assistant_message(history_messages):
+        return False
+    return not await _thread_has_prior_slack_agent_reply(pool, thread_key)
+
+
 def _assignment_display_engine(active: dict[str, Any]) -> str | None:
     engine = _nonempty(active.get("engine"))
     if engine:
@@ -1182,8 +1222,18 @@ async def do_agent_turn(
         session_title = await _compute_agent_session_title(
             ctx._pool, effective_thread_key, selector,
         )
-        session_header = await _compute_agent_session_header(
-            ctx._pool, effective_thread_key, selector,
+        session_header = (
+            await _compute_agent_session_header(
+                ctx._pool,
+                effective_thread_key,
+                selector,
+            )
+            if await _should_show_agent_session_header(
+                ctx._pool,
+                thread_key=effective_thread_key,
+                history_messages=effective_history,
+            )
+            else None
         )
         slackbot_session_id = await slackbot_client.open_agent_session(
             delivery=effective_delivery,

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -984,22 +984,20 @@ def _history_has_assistant_message(history_messages: Any) -> bool:
 
 
 async def _thread_has_prior_slack_agent_reply(pool, thread_key: str) -> bool:
-    execution_row = await pool.fetchrow(
-        "SELECT 1 FROM agent_execution_requests "
+    if await pool.fetchval(
+        "SELECT EXISTS (SELECT 1 FROM agent_execution_requests "
         "WHERE thread_key = $1 AND COALESCE(delivery->>'platform', '') = 'slack' "
-        "AND COALESCE(metadata->>'slackbot_agent_session_id', '') <> '' "
-        "LIMIT 1",
+        "AND COALESCE(metadata->>'slackbot_agent_session_id', '') <> '')",
         thread_key,
-    )
-    if execution_row is not None:
+    ):
         return True
-    message_row = await pool.fetchrow(
-        "SELECT 1 FROM agent_message_requests "
-        "WHERE thread_key = $1 AND event_json->>'type' = 'assistant' "
-        "LIMIT 1",
-        thread_key,
+    return bool(
+        await pool.fetchval(
+            "SELECT EXISTS (SELECT 1 FROM agent_message_requests "
+            "WHERE thread_key = $1 AND event_json->>'type' = 'assistant')",
+            thread_key,
+        )
     )
-    return message_row is not None
 
 
 async def _should_show_agent_session_header(

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -1445,6 +1445,180 @@ async def test_agent_turn_opens_slack_session_after_spawn_with_resolved_header(
 
 
 @pytest.mark.asyncio
+async def test_agent_turn_omits_slack_session_header_after_prior_thread_execution(
+    db_pool,
+    monkeypatch,
+):
+    from api.workflow_engine import SuspendWorkflow, WorkflowContext, do_agent_turn
+
+    monkeypatch.delenv("CODEX_MODEL", raising=False)
+    run_id = f"wfr_{uuid.uuid4().hex[:16]}"
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:header-followup"
+    await db_pool.execute(
+        "INSERT INTO workflow_runs ("
+        "run_id, workflow_name, workflow_version, request_hash, root_run_id, "
+        "status, input_json, worker_id"
+        ") VALUES ($1, 'test', 'test-v1', 'hash', $1, 'running', '{}'::jsonb, 'w1')",
+        run_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, "
+        "status, delivery, metadata"
+        ") VALUES ($1, $2, 1, $3, 'prior-hash', 'completed', $4::jsonb, $5::jsonb)",
+        f"exe-prior-{uuid.uuid4().hex[:8]}",
+        thread_key,
+        f"prior-execute-{uuid.uuid4().hex[:8]}",
+        json.dumps({"platform": "slack"}),
+        json.dumps({"slackbot_agent_session_id": "sess-prior"}),
+    )
+
+    ctx = WorkflowContext(
+        pool=db_pool,
+        run_id=run_id,
+        checkpoints={},
+        lease_s=30.0,
+        worker_id="w1",
+    )
+
+    async def spawn_after_recording(*args, **kwargs):
+        await db_pool.execute(
+            "INSERT INTO agent_runtime_assignments ("
+            "thread_key, assignment_generation, runtime_id, harness, engine, "
+            "persona_id, prompt_ref, effective_agents_md_sha256, state"
+            ") VALUES ($1, 2, 'rt-header-followup', 'codex', 'codex', "
+            "NULL, 'harness:codex', 'sha', 'active')",
+            thread_key,
+        )
+        return {"assignment_generation": 2}
+
+    async def open_after_spawn(**kwargs):
+        assert kwargs["title"] == "Centaur · codex"
+        assert kwargs["header"] is None
+        return "sess-followup"
+
+    with (
+        patch(
+            "api.workflow_engine.spawn_assignment",
+            new=AsyncMock(side_effect=spawn_after_recording),
+        ),
+        patch(
+            "api.workflow_engine.slackbot_client.open_agent_session",
+            new=AsyncMock(side_effect=open_after_spawn),
+        ) as open_session_mock,
+        patch("api.workflow_engine.append_message", new=AsyncMock()),
+        patch(
+            "api.workflow_engine.enqueue_execution",
+            new=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "execution_id": "exe-followup",
+                    "status": "queued",
+                },
+            ),
+        ),
+    ):
+        with pytest.raises(SuspendWorkflow):
+            await do_agent_turn(
+                ctx,
+                prompt="follow up",
+                thread_key=thread_key,
+                delivery={
+                    "platform": "slack",
+                    "channel": "C-test",
+                    "thread_ts": "1700000000.000100",
+                },
+            )
+
+    open_session_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_agent_turn_omits_slack_session_header_when_history_has_assistant_message(
+    db_pool,
+    monkeypatch,
+):
+    from api.workflow_engine import SuspendWorkflow, WorkflowContext, do_agent_turn
+
+    monkeypatch.delenv("CODEX_MODEL", raising=False)
+    run_id = f"wfr_{uuid.uuid4().hex[:16]}"
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:header-history"
+    await db_pool.execute(
+        "INSERT INTO workflow_runs ("
+        "run_id, workflow_name, workflow_version, request_hash, root_run_id, "
+        "status, input_json, worker_id"
+        ") VALUES ($1, 'test', 'test-v1', 'hash', $1, 'running', '{}'::jsonb, 'w1')",
+        run_id,
+    )
+
+    ctx = WorkflowContext(
+        pool=db_pool,
+        run_id=run_id,
+        checkpoints={},
+        lease_s=30.0,
+        worker_id="w1",
+    )
+
+    async def spawn_after_recording(*args, **kwargs):
+        await db_pool.execute(
+            "INSERT INTO agent_runtime_assignments ("
+            "thread_key, assignment_generation, runtime_id, harness, engine, "
+            "persona_id, prompt_ref, effective_agents_md_sha256, state"
+            ") VALUES ($1, 1, 'rt-header-history', 'codex', 'codex', "
+            "NULL, 'harness:codex', 'sha', 'active')",
+            thread_key,
+        )
+        return {"assignment_generation": 1}
+
+    async def open_after_spawn(**kwargs):
+        assert kwargs["title"] == "Centaur · codex"
+        assert kwargs["header"] is None
+        return "sess-history"
+
+    with (
+        patch(
+            "api.workflow_engine.spawn_assignment",
+            new=AsyncMock(side_effect=spawn_after_recording),
+        ),
+        patch(
+            "api.workflow_engine.slackbot_client.open_agent_session",
+            new=AsyncMock(side_effect=open_after_spawn),
+        ) as open_session_mock,
+        patch("api.workflow_engine.append_message", new=AsyncMock()),
+        patch(
+            "api.workflow_engine.enqueue_execution",
+            new=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "execution_id": "exe-history",
+                    "status": "queued",
+                },
+            ),
+        ),
+    ):
+        with pytest.raises(SuspendWorkflow):
+            await do_agent_turn(
+                ctx,
+                prompt="follow up",
+                thread_key=thread_key,
+                history_messages=[
+                    {
+                        "message_id": f"slack:C-test:{uuid.uuid4().hex}",
+                        "role": "assistant",
+                        "parts": [{"type": "text", "text": "Earlier answer."}],
+                    },
+                ],
+                delivery={
+                    "platform": "slack",
+                    "channel": "C-test",
+                    "thread_ts": "1700000000.000100",
+                },
+            )
+
+    open_session_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_agent_turn_spawn_failure_opens_unresolved_failure_session(db_pool):
     from api.workflow_engine import WorkflowContext, do_agent_turn
 

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -291,7 +291,7 @@ async def test_slack_thread_turn_attachment_roundtrip_to_agent(
     )
     assert attachment is not None
     att_id = attachment["id"]
-    assert attachment["name"] == f"{att_id}.bin"
+    assert attachment["name"] == "customer-list.pdf"
     assert attachment["mime_type"] == "application/pdf"
     assert bytes(attachment["data"]) == raw_attachment
 
@@ -308,7 +308,7 @@ async def test_slack_thread_turn_attachment_roundtrip_to_agent(
     stored_part = event_json["message"]["content"][1]
     assert stored_part["type"] == "attachment_ref"
     assert stored_part["attachment_id"] == att_id
-    assert "name" not in stored_part
+    assert stored_part["name"] == "customer-list.pdf"
     assert "source" not in stored_part
 
     chat_row = await db_pool.fetchrow(
@@ -322,7 +322,7 @@ async def test_slack_thread_turn_attachment_roundtrip_to_agent(
     assert chat_parts[1] == {
         "type": "attachment_ref",
         "id": att_id,
-        "name": f"{att_id}.bin",
+        "name": "customer-list.pdf",
         "mime_type": "application/pdf",
     }
 
@@ -336,7 +336,7 @@ async def test_slack_thread_turn_attachment_roundtrip_to_agent(
         ]
     )
     assert blocks[0]["text"] == "<@U123>: please inspect this Slack file"
-    assert f"User attached file: {att_id}.bin (application/pdf)" in blocks[1]["text"]
+    assert "User attached file: customer-list.pdf (application/pdf)" in blocks[1]["text"]
     assert f"/agent/attachments/{att_id}/download" in blocks[1]["text"]
 
     sandbox_token = mint_sandbox_token(thread_key, "rt-test")


### PR DESCRIPTION
## Summary
- show Slack persona/model metadata only on the first live Slackbot reply in a thread
- suppress that metadata for follow-up turns when prior Slackbot session metadata or assistant history exists
- update stale workflow attachment assertions for preserved attachment names

## Tests
- `uv run --project services/api pytest services/api/tests/test_workflows.py -q`
- `uv run --project services/api ruff check services/api/api/workflow_engine.py services/api/tests/test_workflows.py`
- `git diff --check`

Closes #107