### PR TITLE
Avoid duplicating streamed Slack answers on finalize

### DIFF
--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -660,9 +660,30 @@ function finalMarkdownForFinalBlocks(
   if (opts.includeStreamedText || !segment.streamedText.trim()) {
     return clipText(trimmed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
   }
+  const streamedPrefix = unstreamedMarkdownAfterLivePrefix(markdown, segment.streamedText)
+  if (streamedPrefix !== null) {
+    return clipText(streamedPrefix, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
+  }
   const unstreamed = markdown.slice(segment.streamedTextSourceChars).trim()
   if (!unstreamed) return ''
   return clipText(unstreamed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
+}
+
+function unstreamedMarkdownAfterLivePrefix(markdown: string, streamedText: string): string | null {
+  if (!streamedText.trim()) return null
+  if (markdown.startsWith(streamedText)) return markdown.slice(streamedText.length).trim()
+
+  const normalizedMarkdown = normalizeFinalMarkdownPrefix(markdown)
+  const normalizedStreamed = normalizeFinalMarkdownPrefix(streamedText)
+  if (!normalizedMarkdown.startsWith(normalizedStreamed)) return null
+  return normalizedMarkdown.slice(normalizedStreamed.length).trim()
+}
+
+function normalizeFinalMarkdownPrefix(markdown: string): string {
+  return markdown
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+$/gm, '')
+    .trim()
 }
 
 function clipText(value: string, maxChars: number): string {


### PR DESCRIPTION
## Summary
- Avoid re-rendering final answer markdown during Slack stream finalization when it already matches the live streamed text.
- Normalize line endings/trailing whitespace before deciding whether the streamed answer is a prefix, so stale/misaligned source offsets do not append the same answer again.

## Context
Investigated Slack thread `slack:T092R71U6QY:C0AJ07U8Z1N:1779469609.338739`: logs showed one execution and `final_delivery_skipped` because Slack live delivery had already streamed content, but the stored Slack message contained the same answer twice. This patch makes finalization prefer content-prefix dedupe over relying only on streamed source char offsets.

## Test
- `bun test src/slack/agent-session.test.ts src/slack/codex-session.test.ts`

<@U0AANH5QHEF> please review.