### PR TITLE
fix: log suspicious Slack answer deltas

### DIFF
--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1126,6 +1126,150 @@ describe('CodexSessionRenderer', () => {
     expect(result.streamedAnswerChars).toBe(answerText.length)
   })
 
+  it('logs suspicious large answer snapshots without logging answer text', async () => {
+    const logCalls: unknown[][] = []
+    const originalLog = console.log
+    console.log = ((...args: unknown[]) => {
+      logCalls.push(args)
+    }) as typeof console.log
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async () => ({ ok: true })
+        }
+      },
+      chat: {
+        startStream: async () => ({ ok: true, ts: '1778866940.295499' }),
+        appendStream: async () => ({ ok: true }),
+        stopStream: async () => ({ ok: true }),
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+    const answer = 'first generated answer '.repeat(13)
+
+    try {
+      await renderer.event(sessionId, {
+        type: 'item.started',
+        item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
+      })
+      await renderer.event(sessionId, {
+        type: 'item.agentMessage.delta',
+        itemId: 'msg-1',
+        delta: answer
+      })
+      await renderer.event(sessionId, {
+        type: 'item.completed',
+        centaur_thread_key: 'slack:C123:1778866921.505479',
+        centaur_execution_id: 'exe-test',
+        centaur_assignment_generation: 3,
+        session_id: 'codex-session-test',
+        item: {
+          id: 'msg-1',
+          type: 'agentMessage',
+          phase: 'final_answer',
+          text: `${answer}\n${answer}`
+        }
+      })
+    } finally {
+      console.log = originalLog
+    }
+
+    const suspiciousLogs = logCalls.filter(
+      call => call[0] === 'slack_codex_suspicious_answer_delta'
+    )
+    expect(suspiciousLogs).toHaveLength(1)
+    expect(suspiciousLogs[0]?.[1]).toMatchObject({
+      agent_session_id: sessionId,
+      centaur_thread_key: 'slack:C123:1778866921.505479',
+      execution_id: 'exe-test',
+      assignment_generation: 3,
+      event_type: 'item.completed',
+      codex_id: 'msg-1',
+      codex_item_id: 'msg-1',
+      codex_item_type: 'agentMessage',
+      codex_item_phase: 'final_answer',
+      codex_session_id: 'codex-session-test',
+      current_answer_chars: answer.length,
+      incoming_chars: answer.length * 2 + 1,
+      delta_chars: answer.length + 1,
+      answer_chars_after: answer.length * 2 + 1,
+      current_contains_incoming_head: true,
+      incoming_contains_current_tail: true,
+      large_incoming_relative_to_current: true,
+      large_delta_relative_to_current: true
+    })
+    expect(suspiciousLogs[0]?.[1]).toEqual(
+      expect.objectContaining({
+        current_hash: expect.any(String),
+        incoming_hash: expect.any(String),
+        delta_hash: expect.any(String)
+      })
+    )
+    expect(JSON.stringify(suspiciousLogs)).not.toContain(answer.slice(0, 30))
+  })
+
+  it('does not log suspicious answer deltas for small incremental answer updates', async () => {
+    const logCalls: unknown[][] = []
+    const originalLog = console.log
+    console.log = ((...args: unknown[]) => {
+      logCalls.push(args)
+    }) as typeof console.log
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async () => ({ ok: true })
+        }
+      },
+      chat: {
+        startStream: async () => ({ ok: true, ts: '1778866940.295499' }),
+        appendStream: async () => ({ ok: true }),
+        stopStream: async () => ({ ok: true }),
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    try {
+      await renderer.event(sessionId, {
+        type: 'item.started',
+        item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
+      })
+      await renderer.event(sessionId, {
+        type: 'item.agentMessage.delta',
+        itemId: 'msg-1',
+        delta: 'ordinary answer text '.repeat(13)
+      })
+      await renderer.event(sessionId, {
+        type: 'item.agentMessage.delta',
+        itemId: 'msg-1',
+        delta: 'done'
+      })
+    } finally {
+      console.log = originalLog
+    }
+
+    expect(
+      logCalls.filter(call => call[0] === 'slack_codex_suspicious_answer_delta')
+    ).toHaveLength(0)
+  })
+
   it('reports only Slack-visible streamed answer chars after live text is capped', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import type { WebClient } from '@slack/web-api'
 import { slackReplyLimits } from '../constants'
 import { logInfo } from '../logging'
@@ -187,8 +188,14 @@ export class CodexSessionRenderer {
       const current = buffer === 'answer' ? state.answerText : state.commentaryText
       const delta = messageDelta(current, assistantMessage)
       if (delta) {
-        if (buffer === 'answer') state.answerText += delta
-        else {
+        if (buffer === 'answer') {
+          logSuspiciousAnswerDelta(agentSessionId, event, state, {
+            current,
+            incoming: assistantMessage,
+            delta
+          })
+          state.answerText += delta
+        } else {
           state.commentaryText += delta
           trackCommentaryText(state, event, delta)
         }
@@ -500,6 +507,61 @@ function messageDelta(current: string, incoming: string): string {
   if (incoming.startsWith(current)) return incoming.slice(current.length)
   if (current.endsWith(incoming)) return ''
   return incoming
+}
+
+function logSuspiciousAnswerDelta(
+  agentSessionId: string,
+  event: any,
+  state: CodexSessionState,
+  texts: { current: string; incoming: string; delta: string }
+): void {
+  const { current, incoming, delta } = texts
+  if (current.length <= 200 || incoming.length <= 200 || delta.length <= 200) return
+
+  const incomingHead = incoming.slice(0, 200)
+  const currentTail = current.slice(-200)
+  const currentContainsIncomingHead = current.includes(incomingHead)
+  const incomingContainsCurrentTail = incoming.includes(currentTail)
+  const largeIncomingRelativeToCurrent = incoming.length > current.length * 0.75
+  const largeDeltaRelativeToCurrent = delta.length > current.length * 0.5
+
+  if (
+    !currentContainsIncomingHead &&
+    !incomingContainsCurrentTail &&
+    !largeIncomingRelativeToCurrent &&
+    !largeDeltaRelativeToCurrent
+  ) {
+    return
+  }
+
+  logInfo('slack_codex_suspicious_answer_delta', {
+    agent_session_id: agentSessionId,
+    centaur_thread_key: event?.centaur_thread_key,
+    execution_id: event?.centaur_execution_id,
+    assignment_generation: event?.centaur_assignment_generation,
+    event_type: event?.type,
+    codex_id: agentMessageEventId(event),
+    codex_item_id: agentMessageEventId(event),
+    codex_item_type: event?.item?.type,
+    codex_item_phase: event?.item?.phase,
+    codex_session_id: state.threadId || event?.session_id || event?.thread_id,
+    current_answer_chars: current.length,
+    incoming_chars: incoming.length,
+    delta_chars: delta.length,
+    answer_chars_after: current.length + delta.length,
+    streamed_answer_chars: state.deliveredAnswerChars,
+    current_hash: textHash(current),
+    incoming_hash: textHash(incoming),
+    delta_hash: textHash(delta),
+    current_contains_incoming_head: currentContainsIncomingHead,
+    incoming_contains_current_tail: incomingContainsCurrentTail,
+    large_incoming_relative_to_current: largeIncomingRelativeToCurrent,
+    large_delta_relative_to_current: largeDeltaRelativeToCurrent
+  })
+}
+
+function textHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16)
 }
 
 function reasoningText(event: any): string {


### PR DESCRIPTION
## Summary
- add low-volume Slackbot logging for suspiciously large final-answer deltas
- include execution/session IDs, Codex item metadata, sizes, overlap flags, and hashes without logging message text
- cover the suspicious snapshot case and normal incremental answer updates in tests

## Test
- pnpm --filter slackbot test -- codex-session.test.ts
- git diff --check