### PR TITLE
fix: publish images under canonical GHCR path

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -26,6 +26,11 @@ permissions:
   contents: read
   packages: write
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: paradigmxyz/centaur
+  IMAGE_SOURCE: https://github.com/paradigmxyz/centaur
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -62,7 +67,7 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -70,7 +75,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
-          images: ghcr.io/paradigmxyz/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}
           flavor: |
             latest=false
           tags: |
@@ -83,6 +88,7 @@ jobs:
             type=sha
           labels: |
             org.opencontainers.image.title=${{ matrix.image }}
+            org.opencontainers.image.source=${{ env.IMAGE_SOURCE }}
         env:
           DOCKER_METADATA_PR_HEAD_SHA: true
 


### PR DESCRIPTION
## Summary
- publish Centaur images under ghcr.io/paradigmxyz/centaur/<image>
- pin image metadata source to the canonical paradigmxyz/centaur repo

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-images.yml")'
- git diff --check