### PR TITLE
Inject requester GitHub identity into agent context

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -18,6 +18,7 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 import time
 import uuid
 from collections.abc import AsyncIterator
@@ -39,6 +40,17 @@ from api.sandbox.registry import get_backend
 from api.trace_context import get_or_create_thread_trace_id
 
 log = structlog.get_logger()
+
+_GITHUB_HANDLE_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+_GITHUB_URL_RE = re.compile(
+    r"(?:https?://)?github\.com/([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)",
+    re.IGNORECASE,
+)
+_GITHUB_LABEL_RE = re.compile(r"\bgithub\b", re.IGNORECASE)
+_GITHUB_PREFIX_RE = re.compile(
+    r"\bgithub\b\s*(?:username|user|handle|profile)?\s*[:/@-]?\s*@?([A-Za-z0-9][A-Za-z0-9-]{0,38})",
+    re.IGNORECASE,
+)
 
 _VALID_STDOUT_EVENT_TYPES = frozenset(
     {
@@ -531,18 +543,160 @@ async def _get_last_delivered_id(thread_key: str) -> str | None:
     return row["last_delivered_id"] if row else None
 
 
-async def _insert_system_message(thread_key: str, platform: str) -> None:
+def _valid_github_handle(value: str) -> str | None:
+    candidate = value.strip().strip("@").strip()
+    candidate = candidate.rstrip("/").split("/", 1)[0]
+    return candidate if _GITHUB_HANDLE_RE.match(candidate) else None
+
+
+def _extract_github_handle_from_slack_profile(
+    profile: dict[str, Any],
+) -> tuple[str | None, str | None, str]:
+    """Return (handle, source, unavailable_reason) from Slack profile fields."""
+    custom_fields = profile.get("custom_fields")
+    if not isinstance(custom_fields, dict) or not custom_fields:
+        return None, None, "no GitHub custom field found on Slack profile"
+
+    saw_github_field = False
+    for label, raw_value in custom_fields.items():
+        label_text = str(label or "").strip()
+        value = str(raw_value or "").strip()
+        if not value:
+            continue
+
+        label_mentions_github = bool(_GITHUB_LABEL_RE.search(label_text))
+        value_mentions_github = bool(_GITHUB_LABEL_RE.search(value))
+        if not label_mentions_github and not value_mentions_github:
+            continue
+        saw_github_field = True
+
+        source = (
+            f'Slack profile custom field "{label_text}"'
+            if label_text
+            else "Slack profile custom field"
+        )
+        url_match = _GITHUB_URL_RE.search(value)
+        if url_match:
+            handle = _valid_github_handle(url_match.group(1))
+            if handle:
+                return f"@{handle}", source, ""
+
+        prefixed_match = _GITHUB_PREFIX_RE.search(value)
+        if prefixed_match:
+            handle = _valid_github_handle(prefixed_match.group(1))
+            if handle:
+                return f"@{handle}", source, ""
+
+        if label_mentions_github:
+            handle = _valid_github_handle(value)
+            if handle:
+                return f"@{handle}", source, ""
+
+    if saw_github_field:
+        return (
+            None,
+            None,
+            "GitHub profile field did not contain a valid GitHub handle",
+        )
+    return None, None, "no GitHub custom field found on Slack profile"
+
+
+async def _resolve_requester_identity(
+    *,
+    platform: str | None,
+    user_id: str | None,
+) -> dict[str, str | bool] | None:
+    if not user_id or (platform or "").lower() != "slack":
+        return None
+
+    identity: dict[str, str | bool] = {
+        "slack_user_id": user_id,
+        "slack_mention": f"<@{user_id}>",
+    }
+    try:
+        from api.app import get_tool_manager
+
+        profile = await get_tool_manager().call_tool_raw(
+            "slack", "get_user_profile", {"user_id": user_id}
+        )
+    except Exception as exc:
+        log.warning(
+            "requester_identity_lookup_failed",
+            platform=platform,
+            user_id=user_id,
+            error=str(exc),
+        )
+        identity.update(
+            {
+                "github_handle_verified": False,
+                "github_handle_unavailable_reason": "Slack profile could not be fetched",
+            }
+        )
+        return identity
+
+    if not isinstance(profile, dict) or profile.get("error"):
+        error = str(profile.get("error") or "Slack profile could not be fetched")
+        log.warning(
+            "requester_identity_lookup_failed",
+            platform=platform,
+            user_id=user_id,
+            error=error,
+        )
+        identity.update(
+            {
+                "github_handle_verified": False,
+                "github_handle_unavailable_reason": "Slack profile could not be fetched",
+            }
+        )
+        return identity
+
+    handle, source, reason = _extract_github_handle_from_slack_profile(profile)
+    if handle:
+        identity.update(
+            {
+                "github_handle": handle,
+                "github_handle_source": source or "Slack profile custom field",
+                "github_handle_verified": True,
+            }
+        )
+    else:
+        identity.update(
+            {
+                "github_handle_verified": False,
+                "github_handle_unavailable_reason": reason,
+            }
+        )
+    return identity
+
+
+async def _insert_system_message(
+    thread_key: str,
+    platform: str,
+    *,
+    user_id: str | None = None,
+) -> None:
     """Insert a static system message with platform formatting rules (idempotent)."""
     pool = _get_pool()
     msg_id = f"system-{thread_key}-{platform}"
-    context = _build_session_context(thread_key, platform=platform)
+    requester_identity = await _resolve_requester_identity(
+        platform=platform,
+        user_id=user_id,
+    )
+    context = _build_session_context(
+        thread_key,
+        platform=platform,
+        user_id=user_id,
+        requester_identity=requester_identity,
+    )
     await pool.execute(
         "INSERT INTO chat_messages (id, thread_key, role, parts, metadata) "
         "VALUES ($1, $2, 'system', $3::jsonb, '{}'::jsonb) "
-        "ON CONFLICT (id) DO NOTHING",
+        "ON CONFLICT (id) DO UPDATE SET parts = EXCLUDED.parts, created_at = NOW() "
+        "WHERE $4::boolean",
         msg_id,
         thread_key,
         json.dumps([{"type": "text", "text": context}]),
+        bool(user_id),
     )
 
 
@@ -755,6 +909,7 @@ def _build_session_context(
     *,
     platform: str | None = None,
     user_id: str | None = None,
+    requester_identity: dict[str, str | bool] | None = None,
 ) -> str:
     """Build session context to append to the system prompt.
 
@@ -772,6 +927,36 @@ def _build_session_context(
     ]
     if platform:
         lines.append(f"- **Platform**: {platform}")
+
+    if requester_identity:
+        lines.extend(
+            [
+                "",
+                "## Requester Identity",
+                "",
+                f"- Slack user ID: {requester_identity['slack_user_id']}",
+                f"- Slack mention: {requester_identity['slack_mention']}",
+            ]
+        )
+        if requester_identity.get("github_handle_verified"):
+            lines.extend(
+                [
+                    "- GitHub handle from Slack profile: "
+                    f"{requester_identity['github_handle']}",
+                    "- GitHub handle source: "
+                    f"{requester_identity['github_handle_source']}",
+                    "- GitHub handle verified: yes",
+                ]
+            )
+        else:
+            lines.extend(
+                [
+                    "- GitHub handle from Slack profile: unavailable",
+                    "- GitHub handle unavailable reason: "
+                    f"{requester_identity['github_handle_unavailable_reason']}",
+                    "- GitHub handle verified: no",
+                ]
+            )
 
     if platform and platform.lower() == "slack":
         lines.extend(
@@ -1025,6 +1210,7 @@ async def stream_connect(
     session: SandboxSession,
     *,
     platform: str | None = None,
+    user_id: str | None = None,
 ) -> AsyncIterator[dict]:
     """Attach to a sandbox's stdout and return a persistent SSE wire.
 
@@ -1035,7 +1221,7 @@ async def stream_connect(
     rt = _get_runtime(session.sandbox_id)
 
     if platform:
-        await _insert_system_message(session.thread_key, platform)
+        await _insert_system_message(session.thread_key, platform, user_id=user_id)
 
     backend = get_backend()
     await backend.attach(session)
@@ -1123,7 +1309,7 @@ async def inject_stdin(
     rt = _get_runtime(session.sandbox_id)
 
     if platform:
-        await _insert_system_message(session.thread_key, platform)
+        await _insert_system_message(session.thread_key, platform, user_id=user_id)
 
     last_delivered_id = await _get_last_delivered_id(session.thread_key)
     flushed = await _flush_pending(session.thread_key, last_delivered_id)

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -558,6 +558,69 @@ class TestBuildSessionContext:
         ctx = _build_session_context("test:1")
         assert "Date/Time" in ctx
 
+    def test_requester_identity_with_github_handle(self):
+        from api.agent import _build_session_context
+
+        ctx = _build_session_context(
+            "test:1",
+            platform="slack",
+            user_id="U123",
+            requester_identity={
+                "slack_user_id": "U123",
+                "slack_mention": "<@U123>",
+                "github_handle": "@alice",
+                "github_handle_source": 'Slack profile custom field "GitHub"',
+                "github_handle_verified": True,
+            },
+        )
+
+        assert "Requester Identity" in ctx
+        assert "GitHub handle from Slack profile: @alice" in ctx
+        assert "GitHub handle verified: yes" in ctx
+
+    def test_requester_identity_without_github_handle(self):
+        from api.agent import _build_session_context
+
+        ctx = _build_session_context(
+            "test:1",
+            platform="slack",
+            user_id="U123",
+            requester_identity={
+                "slack_user_id": "U123",
+                "slack_mention": "<@U123>",
+                "github_handle_verified": False,
+                "github_handle_unavailable_reason": (
+                    "no GitHub custom field found on Slack profile"
+                ),
+            },
+        )
+
+        assert "GitHub handle from Slack profile: unavailable" in ctx
+        assert "no GitHub custom field found on Slack profile" in ctx
+        assert "GitHub handle verified: no" in ctx
+
+    def test_extract_github_handle_from_slack_profile(self):
+        from api.agent import _extract_github_handle_from_slack_profile
+
+        handle, source, reason = _extract_github_handle_from_slack_profile(
+            {"custom_fields": {"Affiliations": "GitHub: test-user"}}
+        )
+
+        assert handle == "@test-user"
+        assert source == 'Slack profile custom field "Affiliations"'
+        assert reason == ""
+
+    def test_extract_github_handle_unavailable_reason(self):
+        from api.agent import _extract_github_handle_from_slack_profile
+
+        handle, source, reason = _extract_github_handle_from_slack_profile(
+            {"custom_fields": {"Telegram": "@alice"}}
+        )
+
+        assert handle is None
+        assert source is None
+        assert reason == "no GitHub custom field found on Slack profile"
+
 
 # ── Test 7: Status endpoint ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- resolve Slack requester identity through the loaded Slack profile tool when a Slack user id is available
- extract GitHub handles from Slack profile custom fields and inject explicit available/unavailable requester identity facts into session context
- pass requester user id through the existing system-context insertion path so the requester mention and GitHub facts are available to agents

## Validation
- uv run ruff check api/agent.py tests/test_integration.py
- uv run pytest tests/test_integration.py -k 'BuildSessionContext'
- uv run pytest tests/test_no_busy_guard.py tests/test_inflight_replay.py tests/test_stream_exec.py
- just build-one api
- local helm deploy of API image with api.image.pullPolicy=IfNotPresent
- kubectl exec -n centaur deploy/centaur-centaur-api -- curl -sS http://localhost:8000/health/ready
- kubectl exec -i -n centaur deploy/centaur-centaur-api -- /app/.venv/bin/python - <<'PY'
from api.agent import _build_session_context
ctx = _build_session_context(
    'slack:C123:456',
    platform='slack',
    user_id='U123',
    requester_identity={
        'slack_user_id': 'U123',
        'slack_mention': '<@U123>',
        'github_handle': '@alice',
        'github_handle_source': 'Slack profile custom field GitHub',
        'github_handle_verified': True,
    },
)
print('Requester Identity' in ctx)
print('GitHub handle from Slack profile: @alice' in ctx)
PY