### PR TITLE
Recover requester identity from thread messages

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -543,6 +543,25 @@ async def _get_last_delivered_id(thread_key: str) -> str | None:
     return row["last_delivered_id"] if row else None
 
 
+async def _get_latest_thread_user_id(thread_key: str) -> str | None:
+    """Return the most recent user id recorded for this thread."""
+    pool = _get_pool()
+    row = await pool.fetchrow(
+        "SELECT COALESCE(user_id, metadata->>'user_id') AS user_id "
+        "FROM chat_messages "
+        "WHERE thread_key = $1 "
+        "AND role = 'user' "
+        "AND COALESCE(user_id, metadata->>'user_id') IS NOT NULL "
+        "ORDER BY created_at DESC "
+        "LIMIT 1",
+        thread_key,
+    )
+    user_id = row["user_id"] if row else None
+    if not user_id:
+        return None
+    return str(user_id).strip() or None
+
+
 def _valid_github_handle(value: str) -> str | None:
     candidate = value.strip().strip("@").strip()
     candidate = candidate.rstrip("/").split("/", 1)[0]
@@ -678,14 +697,15 @@ async def _insert_system_message(
     """Insert a static system message with platform formatting rules (idempotent)."""
     pool = _get_pool()
     msg_id = f"system-{thread_key}-{platform}"
+    effective_user_id = user_id or await _get_latest_thread_user_id(thread_key)
     requester_identity = await _resolve_requester_identity(
         platform=platform,
-        user_id=user_id,
+        user_id=effective_user_id,
     )
     context = _build_session_context(
         thread_key,
         platform=platform,
-        user_id=user_id,
+        user_id=effective_user_id,
         requester_identity=requester_identity,
     )
     await pool.execute(
@@ -696,7 +716,7 @@ async def _insert_system_message(
         msg_id,
         thread_key,
         json.dumps([{"type": "text", "text": context}]),
-        bool(user_id),
+        bool(effective_user_id),
     )
 
 

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -14,6 +14,8 @@ Pure-function tests run without any infrastructure.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 
@@ -620,6 +622,66 @@ class TestBuildSessionContext:
         assert handle is None
         assert source is None
         assert reason == "no GitHub custom field found on Slack profile"
+
+    @pytest.mark.asyncio
+    async def test_latest_thread_user_id_reads_message_metadata(self, db_pool):
+        from api.agent import _get_latest_thread_user_id
+
+        thread_key = "test:requester-fallback"
+        await db_pool.execute(
+            "INSERT INTO chat_messages (id, thread_key, role, parts, metadata) "
+            "VALUES ($1, $2, 'user', '[]'::jsonb, $3::jsonb)",
+            "msg-requester-fallback",
+            thread_key,
+            '{"user_id": "U123"}',
+        )
+
+        assert await _get_latest_thread_user_id(thread_key) == "U123"
+
+    @pytest.mark.asyncio
+    async def test_insert_system_message_uses_thread_user_id_fallback(
+        self, db_pool, monkeypatch
+    ):
+        from api import agent
+
+        thread_key = "test:requester-context-fallback"
+        await db_pool.execute(
+            "INSERT INTO chat_messages (id, thread_key, role, parts, user_id, metadata) "
+            "VALUES ($1, $2, 'user', '[]'::jsonb, 'U123', '{}'::jsonb)",
+            "msg-requester-context-fallback",
+            thread_key,
+        )
+
+        async def fake_resolve_requester_identity(*, platform, user_id):
+            assert platform == "slack"
+            assert user_id == "U123"
+            return {
+                "slack_user_id": user_id,
+                "slack_mention": f"<@{user_id}>",
+                "github_handle": "@alice",
+                "github_handle_source": 'Slack profile custom field "GitHub"',
+                "github_handle_verified": True,
+            }
+
+        monkeypatch.setattr(
+            agent,
+            "_resolve_requester_identity",
+            fake_resolve_requester_identity,
+        )
+
+        await agent._insert_system_message(thread_key, "slack")
+
+        row = await db_pool.fetchrow(
+            "SELECT parts FROM chat_messages WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+        parts = row["parts"]
+        if isinstance(parts, str):
+            parts = json.loads(parts)
+        text = parts[0]["text"]
+        assert "Requester Identity" in text
+        assert "Slack user ID: U123" in text
+        assert "GitHub handle from Slack profile: @alice" in text
 
 
 # ── Test 7: Status endpoint ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fall back to the latest user id stored on thread messages when delivery metadata does not pass a requester id into system-context insertion
- use the recovered user id for the `Requester Identity` block and the existing Slack requester mention instruction
- add regression coverage for message-metadata fallback and system context insertion

## Validation
- `uv run ruff check api/agent.py tests/test_integration.py`
- `uv run pytest tests/test_integration.py -k 'BuildSessionContext'`
- `uv run pytest tests/test_no_busy_guard.py tests/test_inflight_replay.py tests/test_stream_exec.py`
- `just build-one api`
- local helm deploy with `api.image.pullPolicy=IfNotPresent`
- `kubectl rollout status -n centaur deploy/centaur-centaur-api --timeout=180s`
- `kubectl exec -n centaur deploy/centaur-centaur-api -- curl -sS http://localhost:8000/health/ready`
