### PR TITLE
Fix Slack requester identity context ordering

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -705,13 +705,12 @@ async def _insert_system_message(
     context = _build_session_context(
         thread_key,
         platform=platform,
-        user_id=effective_user_id,
         requester_identity=requester_identity,
     )
     await pool.execute(
         "INSERT INTO chat_messages (id, thread_key, role, parts, metadata) "
         "VALUES ($1, $2, 'system', $3::jsonb, '{}'::jsonb) "
-        "ON CONFLICT (id) DO UPDATE SET parts = EXCLUDED.parts, created_at = NOW() "
+        "ON CONFLICT (id) DO UPDATE SET parts = EXCLUDED.parts "
         "WHERE $4::boolean",
         msg_id,
         thread_key,
@@ -928,7 +927,6 @@ def _build_session_context(
     thread_key: str,
     *,
     platform: str | None = None,
-    user_id: str | None = None,
     requester_identity: dict[str, str | bool] | None = None,
 ) -> str:
     """Build session context to append to the system prompt.
@@ -993,9 +991,15 @@ def _build_session_context(
                 "- NEVER put links/URLs inside code blocks (``` ```) — they won't be clickable. Use markdown tables or plain text with `[text](url)` links instead",
             ]
         )
-        if user_id:
+        requester_slack_id = (
+            str(requester_identity.get("slack_user_id") or "").strip()
+            if requester_identity
+            else ""
+        )
+        if requester_slack_id:
             lines.append(
-                f"- After completing a long task, tag the requester with their real Slack mention: <@{user_id}>"
+                "- After completing a long task, tag the requester with their real Slack "
+                f"mention: <@{requester_slack_id}>"
             )
 
     lines.extend(["", "---", ""])

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -1195,6 +1195,22 @@ async def do_agent_turn(
             effective_metadata["slackbot_agent_session_id"] = slackbot_session_id
             effective_metadata["slackbot_live_delivery"] = True
 
+        if str(effective_delivery.get("platform") or "").lower() == "slack":
+            from api.agent import _insert_system_message
+
+            await _insert_system_message(
+                effective_thread_key,
+                "slack",
+                user_id=(
+                    str(
+                        effective_delivery.get("recipient_user_id")
+                        or effective_metadata.get("user_id")
+                        or "",
+                    ).strip()
+                    or None
+                ),
+            )
+
         if isinstance(effective_history, list):
             backfilled = 0
             skipped = 0

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -535,9 +535,9 @@ class TestBuildSessionContext:
     def test_slack_platform(self):
         from api.agent import _build_session_context
 
-        ctx = _build_session_context("test:1", platform="slack", user_id="U123")
+        ctx = _build_session_context("test:1", platform="slack")
         assert "Slack Formatting Rules" in ctx
-        assert "<@U123>" in ctx
+        assert "<@UXXXXXXX>" in ctx
         assert "test:1" in ctx
 
     def test_no_platform(self):
@@ -566,7 +566,6 @@ class TestBuildSessionContext:
         ctx = _build_session_context(
             "test:1",
             platform="slack",
-            user_id="U123",
             requester_identity={
                 "slack_user_id": "U123",
                 "slack_mention": "<@U123>",
@@ -586,7 +585,6 @@ class TestBuildSessionContext:
         ctx = _build_session_context(
             "test:1",
             platform="slack",
-            user_id="U123",
             requester_identity={
                 "slack_user_id": "U123",
                 "slack_mention": "<@U123>",
@@ -682,6 +680,54 @@ class TestBuildSessionContext:
         assert "Requester Identity" in text
         assert "Slack user ID: U123" in text
         assert "GitHub handle from Slack profile: @alice" in text
+
+    @pytest.mark.asyncio
+    async def test_insert_system_message_preserves_created_at_on_refresh(
+        self, db_pool, monkeypatch
+    ):
+        from api import agent
+
+        thread_key = "test:requester-context-order"
+
+        async def fake_resolve_requester_identity(*, platform, user_id):
+            return {
+                "slack_user_id": user_id,
+                "slack_mention": f"<@{user_id}>",
+                "github_handle": "@alice",
+                "github_handle_source": 'Slack profile custom field "GitHub"',
+                "github_handle_verified": True,
+            }
+
+        monkeypatch.setattr(
+            agent,
+            "_resolve_requester_identity",
+            fake_resolve_requester_identity,
+        )
+
+        await agent._insert_system_message(thread_key, "slack", user_id="U123")
+        first_created_at = await db_pool.fetchval(
+            "SELECT created_at FROM chat_messages WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+
+        await db_pool.execute(
+            "UPDATE chat_messages SET created_at = NOW() + INTERVAL '1 minute' "
+            "WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+        expected_created_at = await db_pool.fetchval(
+            "SELECT created_at FROM chat_messages WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+
+        await agent._insert_system_message(thread_key, "slack", user_id="U123")
+        refreshed_created_at = await db_pool.fetchval(
+            "SELECT created_at FROM chat_messages WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+
+        assert first_created_at is not None
+        assert refreshed_created_at == expected_created_at
 
 
 # ── Test 7: Status endpoint ──────────────────────────────────────────────────

--- a/services/api/tests/test_workflow_engine_unit.py
+++ b/services/api/tests/test_workflow_engine_unit.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class FakeWorkflowContext:
+    run_id = "wfr_unit"
+    run_input: dict = {}
+    _pool = object()
+
+    def _peek_resolved_name(self, name: str) -> str:
+        return name
+
+    async def step(self, _name, fn, **_kwargs):
+        return await fn()
+
+
+@pytest.mark.asyncio
+async def test_slack_agent_turn_inserts_requester_context_before_messages():
+    from api.workflow_engine import Delivery, SuspendWorkflow, do_agent_turn
+
+    calls: list[str] = []
+
+    async def fake_insert_system_message(thread_key, platform, *, user_id=None):
+        calls.append("system")
+        assert thread_key == "slack:T123:C123:1.23"
+        assert platform == "slack"
+        assert user_id == "U123"
+
+    async def fake_append_message(*_args, **_kwargs):
+        calls.append("message")
+        return {"ok": True, "message_id": "msg"}
+
+    with (
+        patch(
+            "api.workflow_engine.spawn_assignment",
+            new=AsyncMock(return_value={"assignment_generation": 1}),
+        ),
+        patch(
+            "api.workflow_engine._compute_agent_session_title",
+            new=AsyncMock(return_value="Centaur"),
+        ),
+        patch(
+            "api.workflow_engine._compute_agent_session_header",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "api.workflow_engine.slackbot_client.open_agent_session",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("api.workflow_engine.append_message", new=AsyncMock(side_effect=fake_append_message)),
+        patch(
+            "api.workflow_engine.enqueue_execution",
+            new=AsyncMock(return_value={"execution_id": "exe_unit", "status": "queued"}),
+        ),
+        patch("api.workflow_engine.get_execution", new=AsyncMock(return_value=None)),
+        patch("api.agent._insert_system_message", new=AsyncMock(side_effect=fake_insert_system_message)),
+    ):
+        with pytest.raises(SuspendWorkflow):
+            await do_agent_turn(
+                FakeWorkflowContext(),
+                thread_key="slack:T123:C123:1.23",
+                parts=[{"type": "text", "text": "hello"}],
+                message_id="slack:T123:C123:1.23",
+                user_id="U123",
+                delivery=Delivery.slack("C123", "1.23", user_id="U123"),
+            )
+
+    assert calls == ["system", "message"]

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -73,6 +73,19 @@ async def test_create_slack_thread_turn_workflow_eager_start(
             "status": "queued",
         },
     )
+    calls: list[str] = []
+
+    async def fake_insert_system_message(thread_key_arg, platform, *, user_id=None):
+        calls.append("system")
+        assert thread_key_arg == thread_key
+        assert platform == "slack"
+        assert user_id == "U123"
+
+    async def fake_append_message(*args, **kwargs):
+        calls.append("message")
+        return {"ok": True, "message_id": "wf-msg"}
+
+    append_message_mock.side_effect = fake_append_message
 
     with (
         patch(
@@ -86,6 +99,10 @@ async def test_create_slack_thread_turn_workflow_eager_start(
         patch(
             "api.workflow_engine.enqueue_execution",
             new=enqueue_execution_mock,
+        ),
+        patch(
+            "api.agent._insert_system_message",
+            new=AsyncMock(side_effect=fake_insert_system_message),
         ),
     ):
         response = await client.post(
@@ -118,6 +135,7 @@ async def test_create_slack_thread_turn_workflow_eager_start(
     assert append_message_mock.await_args_list[0].kwargs["message_id"] == "slack:prior"
     assert append_message_mock.await_args_list[0].kwargs["metadata"]["history_backfill"] is True
     assert append_message_mock.await_args_list[0].kwargs["event"]["message"]["role"] == "user"
+    assert calls[:2] == ["system", "message"]
     assert append_message_mock.await_args_list[1].kwargs["message_id"] == "slack:assistant-prior"
     assert append_message_mock.await_args_list[1].kwargs["event"]["message"]["role"] == "assistant"
     assert append_message_mock.await_args_list[2].kwargs["message_id"] == "slack:current"


### PR DESCRIPTION
## Summary
- Insert Slack session/requester context before workflow messages are appended so GitHub handle context can be flushed ahead of the user turn.
- Stop refreshing the synthetic system message created_at on updates, preserving cursor/order semantics.
- Remove the unused user_id parameter from _build_session_context and derive requester tagging from requester_identity.

## Tests
- uv run --project services/api ruff check services/api/api/agent.py services/api/api/workflow_engine.py services/api/tests/test_workflows.py services/api/tests/test_integration.py
- uv run --project services/api python -m py_compile services/api/api/agent.py services/api/api/workflow_engine.py
- uv run --project services/api pytest -rs services/api/tests/test_workflows.py::test_create_slack_thread_turn_workflow_eager_start services/api/tests/test_integration.py::TestBuildSessionContext::test_slack_platform services/api/tests/test_integration.py::TestBuildSessionContext::test_slack_no_user_id services/api/tests/test_integration.py::TestBuildSessionContext::test_requester_identity_with_github_handle services/api/tests/test_integration.py::TestBuildSessionContext::test_insert_system_message_preserves_created_at_on_refresh

Note: 3 tests passed; 2 DB-backed tests were skipped locally because Docker/Postgres is unavailable in this sandbox.