### PR TITLE
fix: harden requester identity context

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -544,15 +544,33 @@ async def _get_last_delivered_id(thread_key: str) -> str | None:
 
 
 async def _get_latest_thread_user_id(thread_key: str) -> str | None:
-    """Return the most recent user id recorded for this thread."""
+    """Return the most recent user id recorded for this thread.
+
+    Slack turns can surface the requester in several durable rows depending on
+    where execution is when prompt context is assembled. Prefer the newest row
+    across those sources so the session context does not depend on one caller
+    preserving one specific delivery field.
+    """
     pool = _get_pool()
     row = await pool.fetchrow(
-        "SELECT COALESCE(user_id, metadata->>'user_id') AS user_id "
-        "FROM chat_messages "
-        "WHERE thread_key = $1 "
-        "AND role = 'user' "
-        "AND COALESCE(user_id, metadata->>'user_id') IS NOT NULL "
-        "ORDER BY created_at DESC "
+        "WITH candidates AS ("
+        "  SELECT COALESCE(user_id, metadata->>'user_id') AS user_id, created_at, 1 AS source_rank "
+        "  FROM chat_messages "
+        "  WHERE thread_key = $1 AND role = 'user' "
+        "  UNION ALL "
+        "  SELECT COALESCE(metadata->>'user_id', delivery->>'recipient_user_id', delivery->>'user_id') "
+        "    AS user_id, created_at, 2 AS source_rank "
+        "  FROM agent_execution_requests "
+        "  WHERE thread_key = $1 "
+        "  UNION ALL "
+        "  SELECT COALESCE(input_json->>'user_id', input_json#>>'{delivery,recipient_user_id}', "
+        "    input_json#>>'{delivery,user_id}') AS user_id, created_at, 3 AS source_rank "
+        "  FROM workflow_runs "
+        "  WHERE thread_key = $1 AND workflow_name = 'slack_thread_turn' "
+        ") "
+        "SELECT user_id FROM candidates "
+        "WHERE user_id IS NOT NULL AND btrim(user_id) <> '' "
+        "ORDER BY created_at DESC, source_rank ASC "
         "LIMIT 1",
         thread_key,
     )
@@ -690,23 +708,35 @@ async def _resolve_requester_identity(
 
 async def _insert_system_message(
     thread_key: str,
-    platform: str,
+    platform: str | None,
     *,
     user_id: str | None = None,
 ) -> None:
     """Insert a static system message with platform formatting rules (idempotent)."""
     pool = _get_pool()
-    msg_id = f"system-{thread_key}-{platform}"
+    effective_platform = platform or ("slack" if thread_key.startswith("slack:") else None)
+    msg_id = f"system-{thread_key}-{effective_platform or 'generic'}"
     effective_user_id = user_id or await _get_latest_thread_user_id(thread_key)
     requester_identity = await _resolve_requester_identity(
-        platform=platform,
+        platform=effective_platform,
         user_id=effective_user_id,
     )
     context = _build_session_context(
         thread_key,
-        platform=platform,
+        platform=effective_platform,
         user_id=effective_user_id,
         requester_identity=requester_identity,
+    )
+    log.info(
+        "session_context_prepared",
+        thread_key=thread_key,
+        platform=effective_platform,
+        explicit_user_id=bool(user_id),
+        effective_user_id=bool(effective_user_id),
+        requester_identity=bool(requester_identity),
+        github_handle_verified=bool(
+            requester_identity and requester_identity.get("github_handle_verified")
+        ),
     )
     await pool.execute(
         "INSERT INTO chat_messages (id, thread_key, role, parts, metadata) "
@@ -1240,8 +1270,13 @@ async def stream_connect(
     """
     rt = _get_runtime(session.sandbox_id)
 
-    if platform:
-        await _insert_system_message(session.thread_key, platform, user_id=user_id)
+    effective_platform = platform or ("slack" if session.thread_key.startswith("slack:") else None)
+    if effective_platform:
+        await _insert_system_message(
+            session.thread_key,
+            effective_platform,
+            user_id=user_id,
+        )
 
     backend = get_backend()
     await backend.attach(session)
@@ -1328,8 +1363,13 @@ async def inject_stdin(
     """
     rt = _get_runtime(session.sandbox_id)
 
-    if platform:
-        await _insert_system_message(session.thread_key, platform, user_id=user_id)
+    effective_platform = platform or ("slack" if session.thread_key.startswith("slack:") else None)
+    if effective_platform:
+        await _insert_system_message(
+            session.thread_key,
+            effective_platform,
+            user_id=user_id,
+        )
 
     last_delivered_id = await _get_last_delivered_id(session.thread_key)
     flushed = await _flush_pending(session.thread_key, last_delivered_id)

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -2471,13 +2471,15 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         if silence_deadline <= dt.datetime.now(dt.timezone.utc):
             silence_deadline = await _touch_execution_progress(pool, execution_id)
     else:
+        requester_user_id = None
+        if isinstance(delivery, dict):
+            requester_user_id = delivery.get("recipient_user_id") or delivery.get("user_id")
+        requester_user_id = requester_user_id or execution_metadata.get("user_id")
         inject_result = await inject_stdin(
             session,
             "",
             platform=delivery.get("platform") if isinstance(delivery, dict) else None,
-            user_id=delivery.get("recipient_user_id")
-            if isinstance(delivery, dict)
-            else None,
+            user_id=requester_user_id,
         )
         durable_turn_id = str(inject_result.get("durable_turn_id") or "")
         await pool.execute(

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -639,6 +639,41 @@ class TestBuildSessionContext:
         assert await _get_latest_thread_user_id(thread_key) == "U123"
 
     @pytest.mark.asyncio
+    async def test_latest_thread_user_id_reads_execution_delivery(self, db_pool):
+        from api.agent import _get_latest_thread_user_id
+
+        thread_key = "test:requester-execution-fallback"
+        await db_pool.execute(
+            "INSERT INTO agent_execution_requests ("
+            "execution_id, thread_key, assignment_generation, execute_id, request_hash, "
+            "status, delivery, metadata"
+            ") VALUES ($1, $2, 1, $3, 'hash', 'queued', $4::jsonb, '{}'::jsonb)",
+            "exe-requester-fallback",
+            thread_key,
+            "exec-requester-fallback",
+            '{"platform": "slack", "recipient_user_id": "U456"}',
+        )
+
+        assert await _get_latest_thread_user_id(thread_key) == "U456"
+
+    @pytest.mark.asyncio
+    async def test_latest_thread_user_id_reads_slack_workflow_input(self, db_pool):
+        from api.agent import _get_latest_thread_user_id
+
+        thread_key = "test:requester-workflow-fallback"
+        await db_pool.execute(
+            "INSERT INTO workflow_runs ("
+            "run_id, workflow_name, workflow_version, request_hash, root_run_id, "
+            "thread_key, status, input_json"
+            ") VALUES ($1, 'slack_thread_turn', 'test', 'hash', $1, $2, 'queued', $3::jsonb)",
+            "wfr-requester-fallback",
+            thread_key,
+            '{"delivery": {"recipient_user_id": "U789"}}',
+        )
+
+        assert await _get_latest_thread_user_id(thread_key) == "U789"
+
+    @pytest.mark.asyncio
     async def test_insert_system_message_uses_thread_user_id_fallback(
         self, db_pool, monkeypatch
     ):
@@ -682,6 +717,48 @@ class TestBuildSessionContext:
         assert "Requester Identity" in text
         assert "Slack user ID: U123" in text
         assert "GitHub handle from Slack profile: @alice" in text
+
+    @pytest.mark.asyncio
+    async def test_insert_system_message_infers_slack_platform_from_thread_key(
+        self, db_pool, monkeypatch
+    ):
+        from api import agent
+
+        thread_key = "slack:C123:1712345678.000100"
+        await db_pool.execute(
+            "INSERT INTO chat_messages (id, thread_key, role, parts, user_id, metadata) "
+            "VALUES ($1, $2, 'user', '[]'::jsonb, 'U123', '{}'::jsonb)",
+            "msg-requester-context-infer-platform",
+            thread_key,
+        )
+
+        async def fake_resolve_requester_identity(*, platform, user_id):
+            assert platform == "slack"
+            assert user_id == "U123"
+            return {
+                "slack_user_id": user_id,
+                "slack_mention": f"<@{user_id}>",
+                "github_handle_verified": False,
+                "github_handle_unavailable_reason": "no GitHub custom field found",
+            }
+
+        monkeypatch.setattr(
+            agent,
+            "_resolve_requester_identity",
+            fake_resolve_requester_identity,
+        )
+
+        await agent._insert_system_message(thread_key, None)
+
+        row = await db_pool.fetchrow(
+            "SELECT parts FROM chat_messages WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+        parts = row["parts"]
+        if isinstance(parts, str):
+            parts = json.loads(parts)
+        assert "Requester Identity" in parts[0]["text"]
+        assert "Slack user ID: U123" in parts[0]["text"]
 
 
 # ── Test 7: Status endpoint ──────────────────────────────────────────────────


### PR DESCRIPTION
Broadens requester identity recovery for Slack session context.

Changes:
- Infer Slack platform from slack: thread keys when delivery platform is missing.
- Recover requester Slack user id from chat_messages, agent_execution_requests delivery/metadata, or slack_thread_turn workflow input.
- Pass execution metadata user_id into prompt context insertion if delivery drops recipient_user_id.
- Add session_context_prepared logging so the live path reports whether it found an effective user id and requester identity.

Validation:
- uv run ruff check api/agent.py api/runtime_control.py tests/test_integration.py
- uv run pytest tests/test_integration.py -k 'BuildSessionContext or latest_thread_user_id or insert_system_message'
- just build-one api

Note: a broader workflow regression run had one unrelated existing assertion failure in test_slack_thread_turn_attachment_roundtrip_to_agent expecting a generated attachment filename while current behavior preserves customer-list.pdf.