### PR TITLE
fix: order requester context before Slack turns

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -741,7 +741,7 @@ async def _insert_system_message(
     await pool.execute(
         "INSERT INTO chat_messages (id, thread_key, role, parts, metadata) "
         "VALUES ($1, $2, 'system', $3::jsonb, '{}'::jsonb) "
-        "ON CONFLICT (id) DO UPDATE SET parts = EXCLUDED.parts, created_at = NOW() "
+        "ON CONFLICT (id) DO UPDATE SET parts = EXCLUDED.parts "
         "WHERE $4::boolean",
         msg_id,
         thread_key,

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -32,6 +32,7 @@ from zoneinfo import ZoneInfo
 
 import structlog
 
+from api.agent import _insert_system_message
 from api import slackbot_client
 from api.runtime_control import (
     ControlPlaneError,
@@ -1194,6 +1195,23 @@ async def do_agent_turn(
         if slackbot_session_id:
             effective_metadata["slackbot_agent_session_id"] = slackbot_session_id
             effective_metadata["slackbot_live_delivery"] = True
+
+        effective_platform = str(effective_delivery.get("platform") or "").strip().lower()
+        if effective_platform == "slack" or effective_thread_key.startswith("slack:"):
+            requester_user_id = (
+                str(
+                    effective_delivery.get("recipient_user_id")
+                    or effective_delivery.get("user_id")
+                    or effective_metadata.get("user_id")
+                    or "",
+                ).strip()
+                or None
+            )
+            await _insert_system_message(
+                effective_thread_key,
+                effective_platform or "slack",
+                user_id=requester_user_id,
+            )
 
         if isinstance(effective_history, list):
             backfilled = 0

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -760,6 +760,54 @@ class TestBuildSessionContext:
         assert "Requester Identity" in parts[0]["text"]
         assert "Slack user ID: U123" in parts[0]["text"]
 
+    @pytest.mark.asyncio
+    async def test_insert_system_message_preserves_created_at_on_refresh(
+        self, db_pool, monkeypatch
+    ):
+        from api import agent
+
+        thread_key = "test:requester-context-order"
+
+        async def fake_resolve_requester_identity(*, platform, user_id):
+            return {
+                "slack_user_id": user_id,
+                "slack_mention": f"<@{user_id}>",
+                "github_handle": "@alice",
+                "github_handle_source": 'Slack profile custom field "GitHub"',
+                "github_handle_verified": True,
+            }
+
+        monkeypatch.setattr(
+            agent,
+            "_resolve_requester_identity",
+            fake_resolve_requester_identity,
+        )
+
+        await agent._insert_system_message(thread_key, "slack", user_id="U123")
+        first_created_at = await db_pool.fetchval(
+            "SELECT created_at FROM chat_messages WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+
+        await db_pool.execute(
+            "UPDATE chat_messages SET created_at = NOW() + INTERVAL '1 minute' "
+            "WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+        expected_created_at = await db_pool.fetchval(
+            "SELECT created_at FROM chat_messages WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+
+        await agent._insert_system_message(thread_key, "slack", user_id="U123")
+        refreshed_created_at = await db_pool.fetchval(
+            "SELECT created_at FROM chat_messages WHERE id = $1",
+            f"system-{thread_key}-slack",
+        )
+
+        assert first_created_at is not None
+        assert refreshed_created_at == expected_created_at
+
 
 # ── Test 7: Status endpoint ──────────────────────────────────────────────────
 

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -73,6 +73,19 @@ async def test_create_slack_thread_turn_workflow_eager_start(
             "status": "queued",
         },
     )
+    calls: list[str] = []
+
+    async def fake_insert_system_message(thread_key_arg, platform, *, user_id=None):
+        calls.append("system")
+        assert thread_key_arg == thread_key
+        assert platform == "slack"
+        assert user_id == "U123"
+
+    async def fake_append_message(*args, **kwargs):
+        calls.append("message")
+        return {"ok": True, "message_id": "wf-msg"}
+
+    append_message_mock.side_effect = fake_append_message
 
     with (
         patch(
@@ -86,6 +99,10 @@ async def test_create_slack_thread_turn_workflow_eager_start(
         patch(
             "api.workflow_engine.enqueue_execution",
             new=enqueue_execution_mock,
+        ),
+        patch(
+            "api.workflow_engine._insert_system_message",
+            new=AsyncMock(side_effect=fake_insert_system_message),
         ),
     ):
         response = await client.post(
@@ -118,6 +135,7 @@ async def test_create_slack_thread_turn_workflow_eager_start(
     assert append_message_mock.await_args_list[0].kwargs["message_id"] == "slack:prior"
     assert append_message_mock.await_args_list[0].kwargs["metadata"]["history_backfill"] is True
     assert append_message_mock.await_args_list[0].kwargs["event"]["message"]["role"] == "user"
+    assert calls[:2] == ["system", "message"]
     assert append_message_mock.await_args_list[1].kwargs["message_id"] == "slack:assistant-prior"
     assert append_message_mock.await_args_list[1].kwargs["event"]["message"]["role"] == "assistant"
     assert append_message_mock.await_args_list[2].kwargs["message_id"] == "slack:current"


### PR DESCRIPTION
Ports the behavioral fix from #149 on top of the requester identity hardening in #150.

Changes:
- Insert Slack requester/session context during workflow dispatch before history and current user messages are appended.
- Preserve the synthetic system message created_at on refresh so cursor/order semantics stay stable.
- Add regression coverage that the workflow writes system context before messages and that refresh does not move created_at.

Validation:
- uv run ruff check api/agent.py api/workflow_engine.py tests/test_workflows.py tests/test_integration.py
- uv run pytest tests/test_workflows.py::test_create_slack_thread_turn_workflow_eager_start tests/test_integration.py -k 'BuildSessionContext or latest_thread_user_id or insert_system_message'
- just build-one api