### PR TITLE
fix: put PR attribution in core context

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -989,13 +989,23 @@ def _build_session_context(
             ]
         )
         if requester_identity.get("github_handle_verified"):
+            github_handle = requester_identity["github_handle"]
+            github_login = github_handle.removeprefix("@")
             lines.extend(
                 [
                     "- GitHub handle from Slack profile: "
-                    f"{requester_identity['github_handle']}",
+                    f"{github_handle}",
                     "- GitHub handle source: "
                     f"{requester_identity['github_handle_source']}",
                     "- GitHub handle verified: yes",
+                    "",
+                    "## GitHub PR Attribution",
+                    "",
+                    "- If you create a GitHub PR for this Slack request, "
+                    f"the PR body MUST contain this standalone line: `Prompted by: {github_handle}`",
+                    "- This is a GitHub PR body requirement, not a Slack response mention rule.",
+                    "- Assign the PR to the requester when possible: "
+                    f"`{github_login}`",
                 ]
             )
         else:
@@ -1005,6 +1015,12 @@ def _build_session_context(
                     "- GitHub handle unavailable reason: "
                     f"{requester_identity['github_handle_unavailable_reason']}",
                     "- GitHub handle verified: no",
+                    "",
+                    "## GitHub PR Attribution",
+                    "",
+                    "- If you create a GitHub PR for this Slack request, do not infer a GitHub "
+                    "username from Slack display name, real name, or email.",
+                    "- Omit the `Prompted by` line unless a verified GitHub handle is present.",
                 ]
             )
 
@@ -1025,7 +1041,9 @@ def _build_session_context(
         )
         if user_id:
             lines.append(
-                f"- After completing a long task, tag the requester with their real Slack mention: <@{user_id}>"
+                "- For Slack replies after completing a long task, tag the requester with "
+                f"their real Slack mention: <@{user_id}>. This Slack reply rule does not "
+                "replace GitHub PR attribution requirements."
             )
 
     lines.extend(["", "---", ""])

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -579,6 +579,10 @@ class TestBuildSessionContext:
         assert "Requester Identity" in ctx
         assert "GitHub handle from Slack profile: @alice" in ctx
         assert "GitHub handle verified: yes" in ctx
+        assert "GitHub PR Attribution" in ctx
+        assert "Prompted by: @alice" in ctx
+        assert "Assign the PR to the requester when possible: `alice`" in ctx
+        assert "not a Slack response mention rule" in ctx
 
     def test_requester_identity_without_github_handle(self):
         from api.agent import _build_session_context
@@ -600,6 +604,9 @@ class TestBuildSessionContext:
         assert "GitHub handle from Slack profile: unavailable" in ctx
         assert "no GitHub custom field found on Slack profile" in ctx
         assert "GitHub handle verified: no" in ctx
+        assert "GitHub PR Attribution" in ctx
+        assert "do not infer a GitHub username" in ctx
+        assert "Omit the `Prompted by` line" in ctx
 
     def test_extract_github_handle_from_slack_profile(self):
         from api.agent import _extract_github_handle_from_slack_profile


### PR DESCRIPTION
## Summary
- add GitHub PR attribution instructions directly beside the core requester identity context
- clarify that Slack final-response tagging does not replace PR attribution
- cover verified and unavailable GitHub handle cases in session-context tests

## Testing
- uv run pytest tests/test_integration.py -k "BuildSessionContext" (from services/api)
- uv run ruff check api/agent.py tests/test_integration.py (from services/api)
- just build-one api

Note: I attempted a local deploy per the repo pre-push guidance, but this local stack uses imagePullPolicy Always for local latest images and hit ImagePullBackOff; I rolled the affected local deployments back to their prior healthy pods.