### PR TITLE
fix: refresh session context on every turn

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -711,7 +711,7 @@ async def _insert_system_message(
     platform: str | None,
     *,
     user_id: str | None = None,
-) -> None:
+) -> str:
     """Insert a static system message with platform formatting rules (idempotent)."""
     pool = _get_pool()
     effective_platform = platform or ("slack" if thread_key.startswith("slack:") else None)
@@ -748,6 +748,7 @@ async def _insert_system_message(
         json.dumps([{"type": "text", "text": context}]),
         bool(effective_user_id),
     )
+    return context
 
 
 # ── Harness / persona resolution ────────────────────────────────────────────
@@ -1382,8 +1383,9 @@ async def inject_stdin(
     rt = _get_runtime(session.sandbox_id)
 
     effective_platform = platform or ("slack" if session.thread_key.startswith("slack:") else None)
+    current_session_context: str | None = None
     if effective_platform:
-        await _insert_system_message(
+        current_session_context = await _insert_system_message(
             session.thread_key,
             effective_platform,
             user_id=user_id,
@@ -1391,6 +1393,14 @@ async def inject_stdin(
 
     last_delivered_id = await _get_last_delivered_id(session.thread_key)
     flushed = await _flush_pending(session.thread_key, last_delivered_id)
+    if current_session_context:
+        # The system context row is updated in place so its created_at stays at
+        # the top of the thread. Existing harness sessions may have already
+        # advanced their delivery cursor past that row, so prepend the freshly
+        # built context to every turn while removing any queued copy to avoid a
+        # duplicate on first delivery.
+        system_msg_id = f"system-{session.thread_key}-{effective_platform}"
+        flushed = [row for row in flushed if row.get("id") != system_msg_id]
 
     # Build harness-native input
     inline_blocks: list[dict] | None = None
@@ -1399,7 +1409,32 @@ async def inject_stdin(
     elif isinstance(message, str) and message:
         inline_blocks = [{"type": "text", "text": message}]
 
-    if flushed and inline_blocks:
+    context_blocks = (
+        [{"type": "text", "text": current_session_context}]
+        if current_session_context
+        else []
+    )
+
+    if context_blocks and flushed and inline_blocks:
+        msgs = _flushed_to_messages(flushed)
+        content_blocks = (
+            context_blocks + messages_to_content_blocks(msgs) + inline_blocks
+        )
+        turn_input = build_user_input(
+            content_blocks, thread_key=session.thread_key, trace_id=session.trace_id
+        )
+    elif context_blocks and flushed:
+        msgs = _flushed_to_messages(flushed)
+        content_blocks = context_blocks + messages_to_content_blocks(msgs)
+        turn_input = build_user_input(
+            content_blocks, thread_key=session.thread_key, trace_id=session.trace_id
+        )
+    elif context_blocks and inline_blocks:
+        content_blocks = context_blocks + inline_blocks
+        turn_input = build_user_input(
+            content_blocks, thread_key=session.thread_key, trace_id=session.trace_id
+        )
+    elif flushed and inline_blocks:
         msgs = _flushed_to_messages(flushed)
         content_blocks = messages_to_content_blocks(msgs) + inline_blocks
         turn_input = build_user_input(

--- a/services/api/tests/test_inflight_replay.py
+++ b/services/api/tests/test_inflight_replay.py
@@ -184,6 +184,122 @@ async def test_inject_stdin_persists_inflight_turn() -> None:
 
 
 @pytest.mark.asyncio
+async def test_inject_stdin_prepends_current_session_context_after_cursor() -> None:
+    session = SandboxSession(
+        sandbox_id="sbx-4",
+        thread_key="slack:C123:1712345678.000100",
+        harness="amp",
+        engine="amp",
+    )
+
+    backend = AsyncMock()
+    backend.refresh_token_by_id = AsyncMock()
+    backend.attach = AsyncMock()
+    backend.write_stdin = AsyncMock()
+
+    with (
+        patch(
+            "api.agent._insert_system_message",
+            new_callable=AsyncMock,
+            return_value=(
+                "# Session Context\n\n"
+                "## GitHub PR Attribution\n\n"
+                "- If you create a GitHub PR for this Slack request, "
+                "the PR body MUST contain this standalone line: `Prompted by: @alice`"
+            ),
+        ),
+        patch(
+            "api.agent._get_last_delivered_id",
+            new_callable=AsyncMock,
+            return_value="msg-after-system",
+        ),
+        patch("api.agent._flush_pending", new_callable=AsyncMock, return_value=[]),
+        patch("api.agent._db_set_inflight_turn", new_callable=AsyncMock),
+        patch("api.agent._db_update_state", new_callable=AsyncMock),
+        patch("api.agent._advance_cursor", new_callable=AsyncMock),
+        patch("api.agent.get_backend", return_value=backend),
+        patch("api.agent.mint_sandbox_token", return_value="sbx-token"),
+    ):
+        from api.agent import inject_stdin
+
+        result = await inject_stdin(
+            session,
+            "please make a PR",
+            platform="slack",
+            user_id="U123",
+        )
+
+    assert result["ok"] is True
+    payload = backend.write_stdin.await_args.args[1]
+    content = payload["message"]["content"]
+    assert "Prompted by: @alice" in content[0]["text"]
+    assert content[1] == {"type": "text", "text": "please make a PR"}
+
+
+@pytest.mark.asyncio
+async def test_inject_stdin_deduplicates_queued_session_context() -> None:
+    session = SandboxSession(
+        sandbox_id="sbx-5",
+        thread_key="slack:C123:1712345678.000200",
+        harness="amp",
+        engine="amp",
+    )
+
+    backend = AsyncMock()
+    backend.refresh_token_by_id = AsyncMock()
+    backend.attach = AsyncMock()
+    backend.write_stdin = AsyncMock()
+
+    system_id = f"system-{session.thread_key}-slack"
+    with (
+        patch(
+            "api.agent._insert_system_message",
+            new_callable=AsyncMock,
+            return_value="fresh session context with Prompted by: @alice",
+        ),
+        patch(
+            "api.agent._get_last_delivered_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "api.agent._flush_pending",
+            new_callable=AsyncMock,
+            return_value=[
+                {
+                    "id": system_id,
+                    "role": "system",
+                    "parts": [{"type": "text", "text": "stale session context"}],
+                    "metadata": {},
+                },
+                {
+                    "id": "msg-user",
+                    "role": "user",
+                    "parts": [{"type": "text", "text": "make a PR"}],
+                    "metadata": {},
+                },
+            ],
+        ),
+        patch("api.agent._db_set_inflight_turn", new_callable=AsyncMock),
+        patch("api.agent._db_update_state", new_callable=AsyncMock),
+        patch("api.agent._advance_cursor", new_callable=AsyncMock),
+        patch("api.agent.get_backend", return_value=backend),
+        patch("api.agent.mint_sandbox_token", return_value="sbx-token"),
+    ):
+        from api.agent import inject_stdin
+
+        result = await inject_stdin(session, "", platform="slack", user_id="U123")
+
+    assert result["ok"] is True
+    payload = backend.write_stdin.await_args.args[1]
+    texts = [part["text"] for part in payload["message"]["content"]]
+    assert texts == [
+        "fresh session context with Prompted by: @alice",
+        "make a PR",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_flush_pending_skips_assistant_messages(db_pool) -> None:
     thread_key = "test:thread-flush"
     user_one = "msg-1"


### PR DESCRIPTION
## Summary
- prepend the freshly generated Slack session context to each harness turn
- avoid relying on the persistent delivery cursor to resend updated requester identity / PR attribution rules
- dedupe the queued system context row so fresh threads do not receive stale or duplicate context

## Testing
- uv run pytest tests/test_inflight_replay.py -k "session_context or persists_inflight" (from services/api)
- uv run pytest tests/test_integration.py -k "BuildSessionContext or insert_system_message" (from services/api)
- uv run ruff check api/agent.py tests/test_inflight_replay.py (from services/api)