### PR TITLE
Add Postgres persistence subPath chart value

### DIFF
--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -73,6 +73,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+              {{- with .Values.postgres.persistence.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -132,6 +132,17 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "postgres": {
+      "type": "object",
+      "properties": {
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "subPath": { "type": "string" }
+          }
+        }
+      }
+    },
     "runnerAccess": {
       "type": "object",
       "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -159,6 +159,7 @@ postgres:
     enabled: true
     size: 20Gi
     storageClassName: ""
+    subPath: ""
   resources: {}
 
 laminar:


### PR DESCRIPTION
## Summary
- add postgres.persistence.subPath to chart values and schema
- render it onto the bundled Postgres data volumeMount when set
- keep the default empty value so existing installs render unchanged

Fixes #156

## Test plan
- helm lint contrib/chart
- helm template centaur contrib/chart
- helm template centaur contrib/chart --set postgres.persistence.subPath=data