### PR TITLE
Fix iron-proxy egress to 1Password Connect

### DIFF
--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -344,6 +344,15 @@ spec:
           port: 80
         - protocol: TCP
           port: 5432
+{{- if eq .Values.ironProxy.secretSource "onepassword-connect" }}
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ include "centaur.onepasswordConnectAppName" . | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ include "centaur.onepasswordConnectPort" . }}
+{{- end }}
 ---
 {{- if eq .Values.ironProxy.secretSource "onepassword-connect" }}
 # Targets the 1Password Connect subchart's pods, which carry

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -117,6 +117,21 @@ def _proxy_health_port() -> int:
     return _env_int("KUBERNETES_IRON_PROXY_HEALTH_PORT", 9090)
 
 
+def _op_connect_app_name() -> str:
+    return os.getenv("KUBERNETES_OP_CONNECT_APP_NAME", "onepassword-connect").strip()
+
+
+def _op_connect_port() -> int:
+    return _env_int("KUBERNETES_OP_CONNECT_PORT", 8080)
+
+
+def _uses_op_connect_secret_source() -> bool:
+    return (
+        os.getenv("KUBERNETES_FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+        == "onepassword-connect"
+    )
+
+
 def _proxy_image() -> str:
     return os.getenv("KUBERNETES_IRON_PROXY_IMAGE", "centaur-iron-proxy:latest")
 
@@ -164,10 +179,7 @@ def _proxy_iron_env(
             },
         }
     ]
-    if (
-        os.getenv("KUBERNETES_FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
-        == "onepassword-connect"
-    ):
+    if _uses_op_connect_secret_source():
         connect_host = os.getenv("KUBERNETES_OP_CONNECT_HOST", "").strip()
         if connect_host:
             env.append({"name": "OP_CONNECT_HOST", "value": connect_host})
@@ -668,6 +680,32 @@ class KubernetesExecutorBackend(SandboxBackend):
         for _, port in sorted(pg_listen_ports.items(), key=lambda item: item[1]):
             sandbox_to_proxy_ports.append({"protocol": "TCP", "port": port})
 
+        proxy_egress = [
+            {
+                "to": [{"podSelector": {"matchLabels": _api_pod_match_labels()}}],
+                "ports": [{"protocol": "TCP", "port": 8000}],
+            },
+            {
+                "ports": [{"protocol": "TCP", "port": 443}],
+            },
+            {
+                "ports": [{"protocol": "TCP", "port": 5432}],
+            },
+        ]
+        if _uses_op_connect_secret_source():
+            proxy_egress.append(
+                {
+                    "to": [
+                        {
+                            "podSelector": {
+                                "matchLabels": {"app": _op_connect_app_name()}
+                            }
+                        }
+                    ],
+                    "ports": [{"protocol": "TCP", "port": _op_connect_port()}],
+                }
+            )
+
         await self._networking_api().create_namespaced_network_policy(
             _namespace(),
             {
@@ -749,24 +787,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                             "ports": sandbox_to_proxy_ports,
                         }
                     ],
-                    "egress": [
-                        {
-                            "to": [
-                                {
-                                    "podSelector": {
-                                        "matchLabels": _api_pod_match_labels()
-                                    }
-                                }
-                            ],
-                            "ports": [{"protocol": "TCP", "port": 8000}],
-                        },
-                        {
-                            "ports": [{"protocol": "TCP", "port": 443}],
-                        },
-                        {
-                            "ports": [{"protocol": "TCP", "port": 5432}],
-                        },
-                    ],
+                    "egress": proxy_egress,
                 },
             },
         )

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -660,6 +660,14 @@ async def test_create_builds_per_sandbox_proxy_resources(
         "centaur.ai/iron-proxy": "true",
         "centaur.ai/sandbox-id": session.sandbox_id,
     }
+    assert not any(
+        egress.get("to", [{}])[0]
+        .get("podSelector", {})
+        .get("matchLabels", {})
+        .get("app")
+        == "onepassword-connect"
+        for egress in fake_networking.created_network_policies[1][1]["spec"]["egress"]
+    )
 
     replacement = await backend.create("slack:C123:123.456", "amp", "amp")
     assert replacement.sandbox_id != session.sandbox_id
@@ -690,6 +698,37 @@ async def test_per_sandbox_proxy_uses_bootstrap_secret_for_onepassword(
         {"secretRef": {"name": "centaur-infra-env"}},
         {"secretRef": {"name": "centaur-bootstrap"}},
     ]
+
+
+@pytest.mark.asyncio
+async def test_per_sandbox_proxy_allows_onepassword_connect_egress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = KubernetesExecutorBackend()
+    fake_networking = FakeNetworkingApi()
+    backend._networking = fake_networking
+    monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur-sandbox")
+    monkeypatch.setenv(
+        "KUBERNETES_FIREWALL_MANAGER_SECRET_SOURCE", "onepassword-connect"
+    )
+    monkeypatch.setenv("KUBERNETES_OP_CONNECT_APP_NAME", "custom-connect")
+    monkeypatch.setenv("KUBERNETES_OP_CONNECT_PORT", "8181")
+
+    await backend._create_proxy_network_policies("sandbox-pod", {})
+
+    proxy_policy = fake_networking.created_network_policies[1][1]
+    assert {
+        "to": [
+            {
+                "podSelector": {
+                    "matchLabels": {
+                        "app": "custom-connect",
+                    }
+                }
+            }
+        ],
+        "ports": [{"protocol": "TCP", "port": 8181}],
+    } in proxy_policy["spec"]["egress"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #157.

## Summary
- Allow the chart-managed API iron-proxy NetworkPolicy to egress to bundled 1Password Connect when `ironProxy.secretSource=onepassword-connect`.
- Apply the same 1Password Connect egress rule to runtime-created per-sandbox iron-proxy NetworkPolicies.
- Add regression coverage for the per-sandbox policy.

## Tests
- `uv run --project services/api pytest services/api/tests/test_sandbox_kubernetes_backend.py -q`
- `uv run --project services/api ruff check services/api/api/sandbox/kubernetes.py services/api/tests/test_sandbox_kubernetes_backend.py`
- `git diff --check`

## Notes
- `helm template` was not run locally because Helm is not installed in this sandbox.