### PR TITLE
fix(slackbot): de-duplicate Slack text from rich_text vs event.text

### DIFF
--- a/services/slackbot/src/slack/normalize.test.ts
+++ b/services/slackbot/src/slack/normalize.test.ts
@@ -268,6 +268,114 @@ describe('normalizeSlackEnvelope', () => {
     ])
   })
 
+  it('does not duplicate text when Slack sends both rich_text blocks and event.text', async () => {
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-rich-text-dup',
+        event: {
+          type: 'app_mention',
+          user: 'U123',
+          channel: 'C123',
+          channel_type: 'channel',
+          ts: '1778875070.942789',
+          text: '<@UBOT> how would we release this to pypi?',
+          blocks: [
+            {
+              type: 'rich_text',
+              elements: [
+                {
+                  type: 'rich_text_section',
+                  elements: [
+                    { type: 'user', user_id: 'UBOT' },
+                    { type: 'text', text: ' how would we release this to pypi?' }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      botUserId: 'UBOT',
+      client
+    })
+
+    expect(normalized?.parts).toEqual([
+      { type: 'text', text: 'how would we release this to pypi?' }
+    ])
+  })
+
+  it('does not duplicate history backfill text when blocks and text both present', async () => {
+    const replies = mock(async () => ({
+      ok: true,
+      messages: [
+        {
+          type: 'message',
+          user: 'U111',
+          channel: 'C123',
+          ts: '1778875060.000100',
+          text: 'https://example.com looks interesting',
+          blocks: [
+            {
+              type: 'rich_text',
+              elements: [
+                {
+                  type: 'rich_text_section',
+                  elements: [
+                    { type: 'link', url: 'https://example.com', text: 'https://example.com' },
+                    { type: 'text', text: ' looks interesting' }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          type: 'message',
+          user: 'U123',
+          channel: 'C123',
+          ts: '1778875070.942789',
+          text: '<@UBOT> investigate'
+        }
+      ]
+    }))
+
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-history-dup',
+        event: {
+          type: 'app_mention',
+          user: 'U123',
+          channel: 'C123',
+          channel_type: 'channel',
+          thread_ts: '1778875060.000100',
+          ts: '1778875070.942789',
+          text: '<@UBOT> investigate'
+        }
+      },
+      botUserId: 'UBOT',
+      client: {
+        token: 'xoxb-test-token',
+        conversations: { replies }
+      } as any
+    })
+
+    expect(normalized?.history_messages).toEqual([
+      {
+        message_id: 'slack:T123:C123:1778875060.000100',
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'https://example.com (https://example.com) looks interesting' }
+        ],
+        user_id: 'U111',
+        metadata: { platform: 'slack', history_backfill: true }
+      }
+    ])
+  })
+
   it('keeps mention handoff actionable when Slack thread history fetch fails', async () => {
     const replies = mock(async () => {
       throw new Error('ratelimited')

--- a/services/slackbot/src/slack/normalize.ts
+++ b/services/slackbot/src/slack/normalize.ts
@@ -49,10 +49,8 @@ export async function normalizeSlackEnvelope(opts: {
   if (!teamId) return null
 
   const threadTs = event.thread_ts ?? event.ts
-  const text = normalizeSlackText(event.text ?? '', opts.botUserId)
-  const richText = normalizeRichTextBlocks(event.blocks)
+  const textPart = preferRichText(event.text, event.blocks, opts.botUserId)
   const parts: NormalizedPart[] = []
-  const textPart = [richText, text].filter(Boolean).join('\n').trim()
   if (textPart) parts.push({ type: 'text', text: textPart })
 
   for (const file of event.files ?? []) {
@@ -176,10 +174,8 @@ async function partsFromSlackMessage(
   message: SlackThreadMessage,
   botUserId?: string
 ): Promise<NormalizedPart[]> {
-  const text = normalizeSlackText(message.text ?? '', botUserId)
-  const richText = normalizeRichTextBlocks(message.blocks)
+  const textPart = preferRichText(message.text, message.blocks, botUserId)
   const parts: NormalizedPart[] = []
-  const textPart = [richText, text].filter(Boolean).join('\n').trim()
   if (textPart) parts.push({ type: 'text', text: textPart })
 
   for (const file of message.files ?? []) {
@@ -187,6 +183,21 @@ async function partsFromSlackMessage(
     if (part) parts.push(part)
   }
   return parts
+}
+
+function preferRichText(
+  rawText: string | undefined,
+  blocks: unknown[] | undefined,
+  botUserId?: string
+): string {
+  const richText = normalizeRichTextBlocks(blocks)
+  if (richText) return stripBotMention(richText, botUserId)
+  return normalizeSlackText(rawText ?? '', botUserId)
+}
+
+function stripBotMention(text: string, botUserId?: string): string {
+  if (!botUserId) return text.trim()
+  return text.replaceAll(`@${botUserId}`, '').trim()
 }
 
 function compareSlackTs(a: string, b: string): number {


### PR DESCRIPTION
Slack delivers the same content in both `blocks.rich_text` and top-level `event.text`. The normalizer was concatenating both, so user messages reached the harness doubled. Prefer rich text when present, fall back to `event.text` otherwise. Adds regression tests on both live and history-backfill paths.