### PR TITLE
feat: guard Google Docs writes against concurrent edits

### DIFF
--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -1528,31 +1528,36 @@ def docs_get_text(document_id: str) -> str:
         return extract_text_from_content(content)
 
 
-def docs_append(document_id: str, text: str, tab_id: str | None = None) -> dict:
+def docs_append(
+    document_id: str,
+    text: str,
+    tab_id: str | None = None,
+    expected_revision_id: str | None = None,
+) -> dict:
     """Append text to a Google Doc.
 
     Args:
         document_id: The document ID
         text: Text to append
         tab_id: Optional tab ID to append to
+        expected_revision_id: Optional document revision that must still be current.
+            When set, the write is rejected by Google if the document changed since
+            this revision was observed, preventing accidental overwrites of
+            concurrent human edits.
 
     Returns:
         Dict with document ID
     """
-    service = get_docs_service()
-
     requests = [{"insertText": {"location": {"index": 1}, "text": text}}]
-
     if tab_id:
         requests[0]["insertText"]["location"]["tabId"] = tab_id
 
-    result = (
-        service.documents()
-        .batchUpdate(documentId=document_id, body={"requests": requests})
-        .execute()
+    result = docs_batch_update(
+        document_id,
+        requests,
+        required_revision_id=expected_revision_id,
     )
-
-    return {"document_id": result.get("documentId", "")}
+    return {"document_id": result.get("document_id", "")}
 
 
 def docs_insert_page_break(document_id: str, index: int = 1) -> dict:
@@ -1707,19 +1712,25 @@ def docs_bullets(
     return summary
 
 
-def docs_replace(document_id: str, old_text: str, new_text: str) -> dict:
+def docs_replace(
+    document_id: str,
+    old_text: str,
+    new_text: str,
+    expected_revision_id: str | None = None,
+) -> dict:
     """Find and replace text in a Google Doc.
 
     Args:
         document_id: The document ID
         old_text: Text to find
         new_text: Text to replace with
+        expected_revision_id: Optional document revision that must still be
+            current. When set, Google rejects the write if the document changed
+            since this revision was observed.
 
     Returns:
         Dict with document ID and occurrences replaced
     """
-    service = get_docs_service()
-
     requests = [
         {
             "replaceAllText": {
@@ -1729,10 +1740,10 @@ def docs_replace(document_id: str, old_text: str, new_text: str) -> dict:
         }
     ]
 
-    result = (
-        service.documents()
-        .batchUpdate(documentId=document_id, body={"requests": requests})
-        .execute()
+    result = docs_batch_update(
+        document_id,
+        requests,
+        required_revision_id=expected_revision_id,
     )
 
     occurrences = 0
@@ -1741,33 +1752,38 @@ def docs_replace(document_id: str, old_text: str, new_text: str) -> dict:
             occurrences = reply["replaceAllText"].get("occurrencesChanged", 0)
 
     return {
-        "document_id": result.get("documentId", ""),
+        "document_id": result.get("document_id", ""),
         "occurrences_replaced": occurrences,
     }
 
 
-def docs_insert(document_id: str, text: str, index: int) -> dict:
+def docs_insert(
+    document_id: str,
+    text: str,
+    index: int,
+    expected_revision_id: str | None = None,
+) -> dict:
     """Insert text at a specific position in a Google Doc.
 
     Args:
         document_id: The document ID
         text: Text to insert
         index: Position to insert at (1 = beginning)
+        expected_revision_id: Optional document revision that must still be
+            current. When set, Google rejects the write if the document changed
+            since this revision was observed.
 
     Returns:
         Dict with document ID
     """
-    service = get_docs_service()
-
     requests = [{"insertText": {"location": {"index": index}, "text": text}}]
 
-    result = (
-        service.documents()
-        .batchUpdate(documentId=document_id, body={"requests": requests})
-        .execute()
+    result = docs_batch_update(
+        document_id,
+        requests,
+        required_revision_id=expected_revision_id,
     )
-
-    return {"document_id": result.get("documentId", "")}
+    return {"document_id": result.get("document_id", "")}
 
 
 def docs_create(title: str, content: str | None = None) -> dict:
@@ -2910,18 +2926,32 @@ class GSuiteClient:
         """
         return docs_get_text(document_id)
 
-    def docs_append(self, document_id: str, text: str, tab_id: str | None = None) -> dict:
+    def docs_append(
+        self,
+        document_id: str,
+        text: str,
+        tab_id: str | None = None,
+        expected_revision_id: str | None = None,
+    ) -> dict:
         """Append text to a Google Doc.
 
         Args:
             document_id: The document ID
             text: Text to append
             tab_id: Optional tab ID to append to
+            expected_revision_id: Optional document revision that must still be
+                current. When set, Google rejects the write if the document
+                changed since this revision was observed.
 
         Returns:
             Dict with document ID
         """
-        return docs_append(document_id, text, tab_id=tab_id)
+        return docs_append(
+            document_id,
+            text,
+            tab_id=tab_id,
+            expected_revision_id=expected_revision_id,
+        )
 
     def docs_insert_page_break(self, document_id: str, index: int = 1) -> dict:
         """Insert a page break in a Google Doc.
@@ -2984,31 +3014,59 @@ class GSuiteClient:
             dry_run=dry_run,
         )
 
-    def docs_replace(self, document_id: str, old_text: str, new_text: str) -> dict:
+    def docs_replace(
+        self,
+        document_id: str,
+        old_text: str,
+        new_text: str,
+        expected_revision_id: str | None = None,
+    ) -> dict:
         """Find and replace text in a Google Doc.
 
         Args:
             document_id: The document ID
             old_text: Text to find
             new_text: Text to replace with
+            expected_revision_id: Optional document revision that must still be
+                current. When set, Google rejects the write if the document
+                changed since this revision was observed.
 
         Returns:
             Dict with document ID and occurrences replaced
         """
-        return docs_replace(document_id, old_text, new_text)
+        return docs_replace(
+            document_id,
+            old_text,
+            new_text,
+            expected_revision_id=expected_revision_id,
+        )
 
-    def docs_insert(self, document_id: str, text: str, index: int) -> dict:
+    def docs_insert(
+        self,
+        document_id: str,
+        text: str,
+        index: int,
+        expected_revision_id: str | None = None,
+    ) -> dict:
         """Insert text at a specific position in a Google Doc.
 
         Args:
             document_id: The document ID
             text: Text to insert
             index: Position to insert at (1 = beginning)
+            expected_revision_id: Optional document revision that must still be
+                current. When set, Google rejects the write if the document
+                changed since this revision was observed.
 
         Returns:
             Dict with document ID
         """
-        return docs_insert(document_id, text, index)
+        return docs_insert(
+            document_id,
+            text,
+            index,
+            expected_revision_id=expected_revision_id,
+        )
 
     def docs_create(self, title: str, content: str | None = None) -> dict:
         """Create a new Google Doc.

--- a/tools/productivity/gsuite/test_client.py
+++ b/tools/productivity/gsuite/test_client.py
@@ -533,3 +533,42 @@ def test_docs_bullets_requires_revision_for_writes(monkeypatch):
         client.docs_bullets("doc-123")
 
     assert fake_service.documents_api.batch_update_calls == []
+
+
+def test_docs_append_passes_expected_revision_id_through(monkeypatch):
+    fake_service = _FakeDocsService([])
+    monkeypatch.setattr(client, "get_docs_service", lambda: fake_service)
+
+    client.docs_append("doc-123", "hello")
+    client.docs_append("doc-123", "hello", expected_revision_id="rev-42")
+
+    calls = fake_service.documents_api.batch_update_calls
+    assert len(calls) == 2
+    assert "writeControl" not in calls[0]["body"]
+    assert calls[1]["body"]["writeControl"] == {"requiredRevisionId": "rev-42"}
+
+
+def test_docs_replace_passes_expected_revision_id_through(monkeypatch):
+    fake_service = _FakeDocsService([])
+    monkeypatch.setattr(client, "get_docs_service", lambda: fake_service)
+
+    client.docs_replace("doc-123", "old", "new")
+    client.docs_replace("doc-123", "old", "new", expected_revision_id="rev-7")
+
+    calls = fake_service.documents_api.batch_update_calls
+    assert len(calls) == 2
+    assert "writeControl" not in calls[0]["body"]
+    assert calls[1]["body"]["writeControl"] == {"requiredRevisionId": "rev-7"}
+
+
+def test_docs_insert_passes_expected_revision_id_through(monkeypatch):
+    fake_service = _FakeDocsService([])
+    monkeypatch.setattr(client, "get_docs_service", lambda: fake_service)
+
+    client.docs_insert("doc-123", "hello", 1)
+    client.docs_insert("doc-123", "hello", 1, expected_revision_id="rev-99")
+
+    calls = fake_service.documents_api.batch_update_calls
+    assert len(calls) == 2
+    assert "writeControl" not in calls[0]["body"]
+    assert calls[1]["body"]["writeControl"] == {"requiredRevisionId": "rev-99"}


### PR DESCRIPTION
Adds an optional `expected_revision_id` parameter to `docs_append`, `docs_replace`, and `docs_insert`. When set, Google rejects the write if the document changed since that revision. Default `None` preserves existing behavior.

Tests assert the parameter passes through as `writeControl.requiredRevisionId`.