### PR TITLE
Make default harness configurable

### DIFF
--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -207,6 +207,8 @@ spec:
               value: {{ printf "localhost,127.0.0.1,%s,%s,%s,%s%s,centaur-egress.svc.cluster.local,.centaur-egress.svc.cluster.local" (include "centaur.componentName" (dict "root" . "component" "postgres")) (include "centaur.componentName" (dict "root" . "component" "api")) (include "centaur.componentName" (dict "root" . "component" "slackbot")) (include "centaur.firewallNoProxyHosts" .) (include "centaur.laminarNoProxyHosts" .) | quote }}
             - name: CENTAUR_LOG_LEVEL
               value: info
+            - name: CENTAUR_DEFAULT_HARNESS
+              value: {{ .Values.api.defaultHarness | quote }}
             - name: TOOL_DIRS
 {{- if .Values.overlay.image.repository }}
               value: {{ printf "/app/tools:%s/tools" .Values.overlay.mountPath | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -54,6 +54,7 @@ api:
     tag: latest
     pullPolicy: Always
   executionWorkerEnabled: false
+  defaultHarness: codex
   workflowWorkerEnabled: true
   warmPoolEnabled: false
   slackEtlEnabled: false

--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -35,6 +35,7 @@ from api.sandbox.harness_protocol import (
     messages_to_content_blocks,
 )
 from api.deps import mint_sandbox_token
+from api.harness_config import default_harness
 from api.sandbox.normalize import normalize_harness_event
 from api.sandbox.registry import get_backend
 from api.trace_context import get_or_create_thread_trace_id
@@ -764,7 +765,7 @@ def _resolve_harness_profile(
     ``harness`` is the legacy caller-facing name for what is now treated as
     the sandbox engine. Precedence is:
     explicit ``engine_override`` > explicit differing ``harness`` >
-    persona-declared engine > ``codex`` default.
+    persona-declared engine > deployment default.
     """
     from api.app import get_tool_manager
 
@@ -804,7 +805,7 @@ def _resolve_harness_profile(
     elif normalized_harness:
         engine = normalized_harness
     else:
-        engine = "codex"
+        engine = default_harness()
 
     if persona_info:
         return engine, persona_info.name, persona_info.default_repo
@@ -816,7 +817,7 @@ def _resolve_harness_profile(
 
 async def get_or_spawn(
     thread_key: str,
-    harness: str = "codex",
+    harness: str | None = None,
     *,
     engine: str | None = None,
     persona: str | None = None,
@@ -866,9 +867,11 @@ async def get_or_spawn(
     pool = _get_pool()
     thread_trace_id = await get_or_create_thread_trace_id(pool, thread_key)
 
+    effective_harness = harness or default_harness()
+
     # Resolve harness profile (engine, persona, repo) once for both warm and cold paths
     resolved_engine, resolved_persona, repo = _resolve_harness_profile(
-        harness, persona=persona, engine_override=engine
+        effective_harness, persona=persona, engine_override=engine
     )
 
     # Try warm pool first
@@ -876,14 +879,14 @@ async def get_or_spawn(
         not engine
         and not old_agent_thread_id
         and not old_inflight_turn_id
-        and not (harness == "amp" and resolved_engine == "codex")
+        and not (effective_harness == "amp" and resolved_engine == "codex")
     )
     if should_try_warm:
         from api.warm_pool import claim_container
 
         trace_id = old_trace_id or thread_trace_id or str(uuid.uuid4())
         claimed = await claim_container(
-            thread_key, harness, persona=resolved_persona, repo=repo, trace_id=trace_id
+            thread_key, effective_harness, persona=resolved_persona, repo=repo, trace_id=trace_id
         )
         if claimed:
             if old_agent_thread_id:
@@ -905,14 +908,14 @@ async def get_or_spawn(
 
     # Cold spawn
     resolved_engine, resolved_persona, repo = _resolve_harness_profile(
-        harness, persona=persona, engine_override=engine
+        effective_harness, persona=persona, engine_override=engine
     )
     backend = get_backend()
     await _evict_idle_sessions_for_capacity(backend)
     trace_id = old_trace_id or thread_trace_id or str(uuid.uuid4())
     session = await backend.create(
         thread_key,
-        harness,
+        effective_harness,
         resolved_engine,
         persona=resolved_persona,
         repo=repo,

--- a/services/api/api/harness_config.py
+++ b/services/api/api/harness_config.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import os
+
+
+_DEFAULT_HARNESS_ALIASES: dict[str, str] = {
+    "amp": "amp",
+    "claude": "claude-code",
+    "claude-code": "claude-code",
+    "codex": "codex",
+    "pi": "pi-mono",
+    "pi-mono": "pi-mono",
+}
+
+
+def default_harness() -> str:
+    raw = (os.getenv("CENTAUR_DEFAULT_HARNESS") or "codex").strip().lower()
+    return _DEFAULT_HARNESS_ALIASES.get(raw, "codex")

--- a/services/api/api/models.py
+++ b/services/api/api/models.py
@@ -62,7 +62,7 @@ class BatchMessageRequest(BaseModel):
 
 class ExecuteRequest(BaseModel):
     thread_key: str
-    harness: str = "codex"
+    harness: str | None = None
     engine: str | None = None
     platform: str | None = None
     user_id: str | None = None

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -24,6 +24,7 @@ from api.agent import (
     stop_session,
 )
 from api import slackbot_client
+from api.harness_config import default_harness
 from api.observability import (
     ExecutionObservationAccumulator,
     extract_usage_metrics,
@@ -188,7 +189,7 @@ def _agent_session_title(
 ) -> str:
     parts = ["Centaur"]
     persona = (persona_id or "").strip()
-    runtime = (engine or harness or "codex").strip()
+    runtime = (engine or harness or default_harness()).strip()
     if persona:
         parts.append(persona)
     if runtime and runtime != persona:
@@ -459,19 +460,19 @@ async def spawn_assignment(
     )
 
     if active_assignment:
-        effective_harness = active_assignment.get("harness") or "codex"
+        effective_harness = active_assignment.get("harness") or default_harness()
         effective_engine = active_assignment.get("engine")
         effective_persona_id = active_assignment.get("persona_id")
         effective_agents_md_override = active_assignment.get("agents_md_override")
     else:
         # Explicit harness wins; otherwise inherit from the persona's declared
-        # engine; otherwise default to codex.
+        # engine; otherwise use the deployment default.
         if harness:
             effective_harness = harness
         elif persona_info is not None:
             effective_harness = persona_info.engine
         else:
-            effective_harness = "codex"
+            effective_harness = default_harness()
         effective_engine = engine
         effective_persona_id = persona_id
         effective_agents_md_override = agents_md_override
@@ -1316,7 +1317,7 @@ async def enqueue_execution(
 
     _worker_wake.set()
 
-    resolved_harness = str(active["harness"] or harness or "codex")
+    resolved_harness = str(active["harness"] or harness or default_harness())
     log.info(
         "execute_queued",
         thread_key=thread_key,

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -34,6 +34,7 @@ import structlog
 
 from api.agent import _insert_system_message
 from api import slackbot_client
+from api.harness_config import default_harness
 from api.runtime_control import (
     ControlPlaneError,
     append_message,
@@ -931,7 +932,7 @@ async def _compute_agent_session_title(
     if persona and (not harness or harness == persona):
         harness = _persona_default_engine(persona) or (None if harness == persona else harness)
     if not persona and not harness:
-        harness = "codex"
+        harness = default_harness()
     parts = ["Centaur"]
     if persona:
         parts.append(str(persona))

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -55,9 +55,10 @@ async def _insert_assignment(db_pool, thread_key: str, generation: int = 1) -> N
 
 
 @pytest.mark.asyncio
-async def test_spawn_assignment_defaults_to_codex_when_no_selector(db_pool):
+async def test_spawn_assignment_defaults_to_codex_when_no_selector(db_pool, monkeypatch):
     from api.runtime_control import spawn_assignment
 
+    monkeypatch.delenv("CENTAUR_DEFAULT_HARNESS", raising=False)
     thread_key = f"slack:C-test:{uuid.uuid4().hex}:default-codex"
     session = SandboxSession(
         sandbox_id=f"rt-{uuid.uuid4().hex[:8]}",
@@ -87,6 +88,42 @@ async def test_spawn_assignment_defaults_to_codex_when_no_selector(db_pool):
     assert assignment is not None
     assert assignment["harness"] == "codex"
     assert assignment["engine"] == "codex"
+    assert assignment["persona_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_spawn_assignment_uses_configured_default_harness(db_pool, monkeypatch):
+    from api.runtime_control import spawn_assignment
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:default-claude"
+    session = SandboxSession(
+        sandbox_id=f"rt-{uuid.uuid4().hex[:8]}",
+        thread_key=thread_key,
+        harness="claude-code",
+        engine="claude-code",
+    )
+    get_or_spawn = AsyncMock(return_value=session)
+
+    with patch("api.runtime_control.get_or_spawn", new=get_or_spawn):
+        await spawn_assignment(
+            db_pool,
+            thread_key=thread_key,
+            spawn_id="spawn-default-claude",
+            harness=None,
+            engine=None,
+            persona_id=None,
+            agents_md_override=None,
+        )
+
+    get_or_spawn.assert_awaited_once_with(thread_key, "claude-code", engine=None)
+    assignment = await db_pool.fetchrow(
+        "SELECT harness, engine, persona_id FROM agent_runtime_assignments WHERE thread_key = $1",
+        thread_key,
+    )
+    assert assignment is not None
+    assert assignment["harness"] == "claude-code"
+    assert assignment["engine"] == "claude-code"
     assert assignment["persona_id"] is None
 
 

--- a/services/api/tests/test_harness_config.py
+++ b/services/api/tests/test_harness_config.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+
+def test_default_harness_defaults_to_codex(monkeypatch):
+    from api.harness_config import default_harness
+
+    monkeypatch.delenv("CENTAUR_DEFAULT_HARNESS", raising=False)
+
+    assert default_harness() == "codex"
+
+
+def test_default_harness_supports_aliases(monkeypatch):
+    from api.harness_config import default_harness
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+    assert default_harness() == "claude-code"
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "pi")
+    assert default_harness() == "pi-mono"
+
+
+def test_default_harness_ignores_unknown_values(monkeypatch):
+    from api.harness_config import default_harness
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "unknown")
+
+    assert default_harness() == "codex"

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -443,7 +443,7 @@ class TestResolveHarnessProfile:
             1. engine_override
             2. harness (when DIFFERENT from persona's declared engine)
             3. persona.engine
-            4. system default ("codex")
+            4. deployment default (CENTAUR_DEFAULT_HARNESS, falling back to "codex")
 
         Regression-locked: the previous resolver hardcoded engine="codex"
         for harness=="amp" regardless of persona, silently dropping the
@@ -487,7 +487,10 @@ class TestResolveHarnessProfile:
         # Rule 4: no override, no persona → harness if given, else system default.
         assert resolve("amp", persona=None)[0] == "amp"
         assert resolve("claude-code", persona=None)[0] == "claude-code"
+        monkeypatch.delenv("CENTAUR_DEFAULT_HARNESS", raising=False)
         assert resolve(None, persona=None)[0] == "codex"
+        monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+        assert resolve(None, persona=None)[0] == "claude-code"
 
     def test_unknown_harness_or_persona_is_rejected(self, monkeypatch):
         import sys


### PR DESCRIPTION
## Summary
- add CENTAUR_DEFAULT_HARNESS resolver with existing harness aliases and codex fallback
- use the configured default in spawn/session/title fallback paths instead of hardcoded codex
- expose api.defaultHarness in the Helm chart and add focused tests

Fixes #166

## Tests
- uv run --project services/api ruff check services/api/api/harness_config.py services/api/api/runtime_control.py services/api/api/agent.py services/api/api/workflow_engine.py services/api/api/models.py services/api/tests/test_harness_config.py services/api/tests/test_agent_control_plane.py services/api/tests/test_integration.py
- uv run pytest tests/test_harness_config.py tests/test_agent_control_plane.py::test_spawn_assignment_defaults_to_codex_when_no_selector tests/test_agent_control_plane.py::test_spawn_assignment_uses_configured_default_harness tests/test_integration.py::TestResolveHarnessProfile::test_engine_resolution_precedence_matrix tests/test_workflow_engine_title.py::test_title_uses_default_harness_when_nothing_is_known

Note: Helm template verification was not run because helm is not installed in this sandbox.