### PR TITLE
Support Codex access-token auth through iron-proxy

### DIFF
--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -80,6 +80,7 @@ Store one secret per enabled harness credential:
 | Harness | API value | Slack selector | Credential to store | Upstream |
 |---------|-----------|----------------|---------------------|----------|
 | Codex default | `codex` | none or `--codex` | `OPENAI_API_KEY` | `api.openai.com` |
+| Codex account auth | `codex` | none or `--codex` | `CODEX_ACCESS_TOKEN` | `chatgpt.com/backend-api/codex` |
 | Amp | `amp` | `--amp` | `AMP_API_KEY` | `ampcode.com` |
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
@@ -91,7 +92,18 @@ headers the secret is bound to.
 
 When `ironProxy.secretSource` is `onepassword`, [iron-proxy](https://docs.iron.sh) resolves these values
 from `op://$OP_VAULT/<SECRET_NAME>/credential`. For example, store the default
-Codex credential in a 1Password item named `OPENAI_API_KEY`.
+Codex Platform credential in a 1Password item named `OPENAI_API_KEY`.
+
+Set `CODEX_AUTH_MODE=access_token` in the API environment to switch the Codex
+sandbox config to ChatGPT/Codex account auth. The sandbox receives only
+`CODEX_ACCESS_TOKEN=CODEX_ACCESS_TOKEN`; [iron-proxy](https://docs.iron.sh)
+resolves the real token from the configured secret source and injects
+`AgentAssertion` auth only for `chatgpt.com` requests under
+`/backend-api/codex/*`. This is ChatGPT/Codex account auth, not an OpenAI
+Platform API key path. `CODEX_AUTH_MODE` defaults to `api_key`. When
+`ironProxy.secretSource=env`, the API fails to start if the selected
+credential is missing from the shared API/proxy environment; 1Password modes
+resolve the selected credential from the vault instead.
 
 Whatever source you pick, the vault is shared across the whole deployment,
 so any thread can use any configured credential. Per-user and per-channel

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -73,8 +73,14 @@ placeholder values and [iron-proxy](https://docs.iron.sh) injects the real crede
 outbound requests.
 
 The default harness is `codex`, so `OPENAI_API_KEY` must exist in the configured
-secret source before Slack agent turns can complete. Use explicit harness
-selectors only when you want a non-default harness such as Amp or Claude Code.
+secret source before Slack agent turns can complete.
+
+To use ChatGPT/Codex account auth instead, set `CODEX_AUTH_MODE=access_token`
+and provide `CODEX_ACCESS_TOKEN` via the configured secret source. See
+[Deploying in production](/deploying-in-production) for the full rules.
+
+Use explicit harness selectors only when you want a non-default harness such as
+Amp or Claude Code.
 
 ## 3. Boot the stack
 

--- a/docs/pages/secrets/environment.mdx
+++ b/docs/pages/secrets/environment.mdx
@@ -44,6 +44,18 @@ kubectl create secret generic centaur-infra-env \
 For local development, `just bootstrap-secrets` creates the local Kubernetes
 Secret from your shell environment.
 
+`CODEX_AUTH_MODE` selects which Codex auth path the harness uses and defaults
+to `api_key`, which uses `OPENAI_API_KEY` when Codex runs. To switch to
+ChatGPT/Codex account auth instead, also include the two access-token keys:
+
+```bash
+kubectl patch secret centaur-infra-env -n centaur-system --type merge -p '
+data:
+  CODEX_AUTH_MODE: '"$(printf 'access_token' | base64)"'
+  CODEX_ACCESS_TOKEN: '"$(printf '...' | base64)"'
+'
+```
+
 ## How tool secrets resolve
 
 For:

--- a/docs/pages/secrets/onepassword.mdx
+++ b/docs/pages/secrets/onepassword.mdx
@@ -110,10 +110,15 @@ Store enabled harness credentials the same way:
 | Credential | Used for |
 |------------|----------|
 | `OPENAI_API_KEY` | Codex default |
+| `CODEX_ACCESS_TOKEN` | Optional ChatGPT/Codex account auth for Codex |
 | `AMP_API_KEY` | Amp |
 | `ANTHROPIC_API_KEY` | Claude Code and pi-mono |
 
 Each item should live in `OP_VAULT` with its value in `credential`.
+To use ChatGPT/Codex account auth instead of the default OpenAI Platform path,
+store `CODEX_ACCESS_TOKEN` in the vault and set `CODEX_AUTH_MODE=access_token`
+on the API environment. The API does not need the real `CODEX_ACCESS_TOKEN`
+value in its environment for 1Password-backed secret resolution.
 
 ## Verify
 

--- a/docs/pages/security.mdx
+++ b/docs/pages/security.mdx
@@ -108,6 +108,10 @@ Other typed variants extend the same boundary in different ways:
 - **`gcp_auth`** resolves a Google service-account keyfile, mints Google OAuth
   tokens for the configured scopes, and injects those bearer tokens for the
   configured Google API hosts.
+- **`codex_agent_identity`** resolves a ChatGPT/Codex Agent Identity token,
+  registers a Codex task, and injects per-request Agent Assertion auth for
+  `chatgpt.com/backend-api/codex` while the sandbox sees only the
+  `CODEX_ACCESS_TOKEN` placeholder.
 - **`pg_dsn`** resolves the real upstream Postgres DSN inside iron-proxy. The
   sandbox receives a local DSN that points at its per-sandbox proxy listener,
   so tool code can connect normally without receiving the real database URL.

--- a/harness/codex/access-token-provider.toml
+++ b/harness/codex/access-token-provider.toml
@@ -1,0 +1,19 @@
+# Codex CLI provider definition for ChatGPT/Codex account-auth mode.
+# entrypoint.sh composes this onto config.toml (and prepends a
+# `model_provider = "centaur_codex_access_token"` selector) when
+# CODEX_AUTH_MODE=access_token.
+
+[model_providers.centaur_codex_access_token]
+name = "OpenAI via Centaur Codex access token"
+base_url = "https://chatgpt.com/backend-api/codex"
+wire_api = "responses"
+supports_websockets = false
+
+[model_providers.centaur_codex_access_token.auth]
+command = "/usr/local/bin/centaur-codex-access-token"
+timeout_ms = 5000
+# 0 = re-invoke the helper on every request. The helper is a static
+# placeholder print, so per-request fork/exec cost is negligible and we
+# avoid any internal Codex-CLI auth cache that could outlast a token
+# rotation. If this becomes a latency hotspot, raise to e.g. 60_000.
+refresh_interval_ms = 0

--- a/services/api/api/app.py
+++ b/services/api/api/app.py
@@ -19,6 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from api.api_keys import bootstrap_service_api_keys
 from api.config import settings
 from api.db import close_pool, create_pool
+from api.sandbox.codex_auth import bootstrap_codex_auth_mode
 from api.laminar_tracing import (
     initialize_laminar,
     install_laminar_compat,
@@ -165,6 +166,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     global _shutting_down
 
     app.state.db_pool = await create_pool(settings.database_url)
+    bootstrap_codex_auth_mode()
     await bootstrap_service_api_keys(app.state.db_pool)
     execution_worker_enabled = os.getenv(
         "EXECUTION_WORKER_ENABLED", "1"

--- a/services/api/api/iron-proxy.base.yaml
+++ b/services/api/api/iron-proxy.base.yaml
@@ -34,6 +34,8 @@ transforms:
         - "anthropic-beta"
         - "openai-organization"
         - "openai-project"
+        - "chatgpt-account-id"
+        - "x-openai-fedramp"
         - "x-request-id"
         - "x-stainless-arch"
         - "x-stainless-os"

--- a/services/api/api/proxy_config.py
+++ b/services/api/api/proxy_config.py
@@ -12,6 +12,8 @@ tool_manager (injection map). The API server owns iron-proxy's full config:
   minting OAuth2 access tokens for the declared grant.
 - ``hmac_sign`` transforms — one per unique ``HmacSignSecret`` signing scheme,
   HMAC-signing each request and injecting the configured headers.
+- ``codex_agent_identity`` transform — resolves Codex Agent Identity JWTs,
+  registers agent tasks, and injects OpenAI ``AgentAssertion`` headers.
 - top-level ``postgres:`` — one listener per ``PgDsnSecret`` on sequential ports
   starting at 5432, ordered by name.
 """
@@ -26,6 +28,7 @@ from typing import Any
 import yaml
 
 from api.tool_manager import (
+    CodexAgentIdentitySecret,
     GcpAuthSecret,
     HmacSignSecret,
     HttpSecret,
@@ -51,7 +54,7 @@ GCP_AUTH_HOSTS: tuple[str, ...] = ("*.googleapis.com",)
 PG_LISTEN_PORT_BASE = 5432
 
 _MANAGED_TRANSFORMS: frozenset[str] = frozenset(
-    {"secrets", "gcp_auth", "oauth_token", "hmac_sign"}
+    {"secrets", "gcp_auth", "oauth_token", "hmac_sign", "codex_agent_identity"}
 )
 
 # Iron-proxy ``source`` schema for resolving secret values. ``env`` reads the
@@ -356,6 +359,37 @@ def _build_hmac_sign_transforms(
     return transforms
 
 
+def _build_codex_agent_identity_transform(
+    secrets: list[SecretDef],
+) -> dict[str, Any] | None:
+    """``codex_agent_identity`` transform for Codex access-token auth."""
+    identities: list[dict[str, Any]] = []
+    for secret in sorted(
+        (s for s in secrets if isinstance(s, CodexAgentIdentitySecret)),
+        key=lambda s: (s.name, s.secret_ref, s.hosts, s.paths, s.methods, s.header),
+    ):
+        rules: list[dict[str, Any]] = []
+        for host in sorted(secret.hosts):
+            rule: dict[str, Any] = {"host": host}
+            if secret.methods:
+                rule["methods"] = list(secret.methods)
+            if secret.paths:
+                rule["paths"] = list(secret.paths)
+            rules.append(rule)
+        entry: dict[str, Any] = {
+            "source": _build_source(secret.secret_ref),
+            "rules": rules,
+            "header": secret.header,
+            "placeholder": secret.placeholder,
+        }
+        if secret.authapi_base_url is not None:
+            entry["authapi_base_url"] = secret.authapi_base_url
+        identities.append(entry)
+    if not identities:
+        return None
+    return {"name": "codex_agent_identity", "config": {"identities": identities}}
+
+
 def _build_postgres_listeners(
     secrets: list[SecretDef],
     pg_listen_ports: dict[str, int],
@@ -399,9 +433,10 @@ def render_proxy_yaml(
 
     ``base_config`` is the seed config from ``services/iron-proxy/iron-proxy.yaml``
     (allowlist, header_allowlist, dns, proxy, management, tls, log). Managed
-    transforms (``secrets``, ``gcp_auth``, ``oauth_token``) are inserted before
-    ``header_allowlist``; existing managed entries are replaced. The top-level
-    ``postgres:`` list is overwritten.
+    transforms (``secrets``, ``gcp_auth``, ``oauth_token``, ``hmac_sign``,
+    ``codex_agent_identity``) are inserted before ``header_allowlist``;
+    existing managed entries are replaced. The top-level ``postgres:`` list
+    is overwritten.
     """
     if base_config is None:
         base_config = load_base_config()
@@ -420,6 +455,9 @@ def render_proxy_yaml(
     if oauth_token is not None:
         new_transforms.append(oauth_token)
     new_transforms.extend(_build_hmac_sign_transforms(secrets))
+    codex_agent_identity = _build_codex_agent_identity_transform(secrets)
+    if codex_agent_identity is not None:
+        new_transforms.append(codex_agent_identity)
     if new_transforms:
         for index, transform in enumerate(transforms):
             if (transform or {}).get("name") == "header_allowlist":

--- a/services/api/api/sandbox/codex_auth.py
+++ b/services/api/api/sandbox/codex_auth.py
@@ -1,0 +1,134 @@
+"""Codex auth-mode resolution for the sandbox harness.
+
+The API picks one of two Codex auth paths at startup based on the
+``CODEX_AUTH_MODE`` env var, freezes the choice for the process lifetime,
+and stamps a placeholder + selector pair into each sandbox's env. The
+sandbox-side ``entrypoint.sh`` cross-checks the selector before flipping
+Codex's provider config.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+
+import structlog
+
+log = structlog.get_logger()
+
+
+class CodexAuthMode(str, Enum):
+    """Which Codex auth path the harness uses.
+
+    ``api_key`` — Codex talks to ``api.openai.com`` with an
+    ``OPENAI_API_KEY`` placeholder that iron-proxy rewrites.
+    ``access_token`` — Codex talks to ``chatgpt.com/backend-api/codex`` with
+    a ``CODEX_ACCESS_TOKEN`` placeholder; iron-proxy mints and injects an
+    OpenAI ``AgentAssertion`` per request.
+    """
+
+    API_KEY = "api_key"
+    ACCESS_TOKEN = "access_token"
+
+
+class CodexAuthConfigError(RuntimeError):
+    """``CODEX_AUTH_MODE`` is invalid or names an unconfigured credential."""
+
+
+# Frozen by the API lifespan after resolve_codex_auth_mode() succeeds at
+# startup. None until then — tests reset this via the conftest autouse
+# fixture and rely on resolve_codex_auth_mode() being called live. Mirrors
+# the module-level state pattern in api.warm_pool.
+_active_mode: CodexAuthMode | None = None
+
+
+def resolve_codex_auth_mode() -> CodexAuthMode:
+    """Return the active Codex auth mode for this deployment.
+
+    Reads ``CODEX_AUTH_MODE`` from the API process env. Unset defaults to
+    :data:`CodexAuthMode.API_KEY`. The selected mode determines which
+    sandbox placeholder wiring is active:
+
+    * ``api_key`` — ``OPENAI_API_KEY`` placeholder path.
+    * ``access_token`` — ChatGPT/Codex account-auth placeholder path.
+
+    Credential presence is only validated when ``CODEX_AUTH_MODE`` is set
+    explicitly — the default does not require ``OPENAI_API_KEY`` because
+    many deployments use Claude or Amp and never touch Codex. An explicit
+    selector is treated as an opt-in to fail-fast on a misconfigured
+    credential. 1Password-backed proxy secret resolution skips the presence
+    check either way because real credentials don't live in the API process.
+
+    Raises :class:`CodexAuthConfigError` only when the selector is set to an
+    unknown value or when an explicit selector names a missing credential
+    under env-source proxy resolution.
+    """
+    raw = (os.getenv("CODEX_AUTH_MODE") or "").strip().lower()
+    if not raw:
+        return CodexAuthMode.API_KEY
+    try:
+        mode = CodexAuthMode(raw)
+    except ValueError:
+        raise CodexAuthConfigError(
+            f"CODEX_AUTH_MODE={raw!r} is invalid; expected "
+            f"'{CodexAuthMode.ACCESS_TOKEN.value}' or "
+            f"'{CodexAuthMode.API_KEY.value}'"
+        ) from None
+
+    secret_source = (
+        os.getenv("FIREWALL_MANAGER_SECRET_SOURCE") or "env"
+    ).strip().lower()
+    if secret_source == "env":
+        if mode is CodexAuthMode.ACCESS_TOKEN:
+            if not (os.getenv("CODEX_ACCESS_TOKEN") or "").strip():
+                raise CodexAuthConfigError(
+                    "CODEX_AUTH_MODE=access_token requires CODEX_ACCESS_TOKEN "
+                    "to be set when FIREWALL_MANAGER_SECRET_SOURCE=env"
+                )
+        elif not (os.getenv("OPENAI_API_KEY") or "").strip():
+            raise CodexAuthConfigError(
+                "CODEX_AUTH_MODE=api_key requires OPENAI_API_KEY to be set "
+                "when FIREWALL_MANAGER_SECRET_SOURCE=env"
+            )
+    return mode
+
+
+def codex_auth_mode() -> CodexAuthMode:
+    """Return the mode frozen at startup, else resolve once.
+
+    Per-spawn callers (``container_env``, warm pool) read through this so
+    transient env drift after startup can't raise
+    :class:`CodexAuthConfigError` into a request handler. Tests that haven't
+    set ``_active_mode`` fall through to live resolution.
+    """
+    if _active_mode is not None:
+        return _active_mode
+    return resolve_codex_auth_mode()
+
+
+def bootstrap_codex_auth_mode() -> CodexAuthMode:
+    """Resolve, freeze, and log the Codex auth mode for this process.
+
+    Call this once during application startup (FastAPI lifespan). Raises
+    :class:`CodexAuthConfigError` on invalid configuration, which aborts
+    startup before any other subsystem comes up.
+    """
+    global _active_mode
+    mode = resolve_codex_auth_mode()
+    _active_mode = mode
+    codex_access_token_present = bool((os.getenv("CODEX_ACCESS_TOKEN") or "").strip())
+    openai_api_key_present = bool((os.getenv("OPENAI_API_KEY") or "").strip())
+    log.info(
+        "codex_auth_mode_resolved",
+        mode=mode.value,
+        codex_access_token_present=codex_access_token_present,
+        openai_api_key_present=openai_api_key_present,
+        selector=(os.getenv("CODEX_AUTH_MODE") or "").strip().lower() or None,
+        api_key_ignored_for_codex=(
+            mode is CodexAuthMode.ACCESS_TOKEN and openai_api_key_present
+        ),
+        codex_access_token_ignored=(
+            mode is CodexAuthMode.API_KEY and codex_access_token_present
+        ),
+    )
+    return mode

--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -8,6 +8,7 @@ from urllib.parse import urlsplit
 
 from api.deps import mint_sandbox_token
 from api.sandbox.base import SandboxSession
+from api.sandbox.codex_auth import CodexAuthMode, codex_auth_mode
 
 
 def image() -> str:
@@ -138,6 +139,16 @@ def container_env(
     # before they reach the real upstream.
     for key in _HARNESS_STUB_KEYS:
         env.append(f"{key}={key}")
+    # Opt Codex into ChatGPT access-token auth only when the cached resolved
+    # mode (frozen at lifespan startup) selects it. Reading the cache avoids
+    # re-resolving per spawn — a stale env in a long-running process can't
+    # raise CodexAuthConfigError into a request handler or warm-pool tick.
+    # The sandbox-side entrypoint cross-checks CODEX_AUTH_MODE before
+    # actually flipping the Codex provider; placeholder presence alone
+    # doesn't switch modes.
+    if codex_auth_mode() is CodexAuthMode.ACCESS_TOKEN:
+        env.append("CODEX_ACCESS_TOKEN=CODEX_ACCESS_TOKEN")
+        env.append(f"CODEX_AUTH_MODE={CodexAuthMode.ACCESS_TOKEN.value}")
     for key in _SANDBOX_PASSTHROUGH_ENV_KEYS:
         value = (os.getenv(key) or "").strip()
         if value:

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -29,6 +29,7 @@ from toon_format import encode as toon_encode
 
 from api.api_keys import check_scope
 from api.laminar_tracing import set_span_attributes, start_span
+from api.sandbox.codex_auth import CodexAuthMode, codex_auth_mode
 from api.vm_metrics import record_tool_call
 from api.deps import get_key_info, get_sandbox_claims, verify_api_key
 from api import slackbot_client
@@ -256,8 +257,46 @@ class HmacSignSecret:
     allow_chunked_body: bool = False
 
 
+@dataclass(frozen=True)
+class CodexAgentIdentitySecret:
+    """Codex Agent Identity JWT resolved and signed by iron-proxy.
+
+    The sandbox sees ``placeholder`` in ``header``. iron-proxy resolves
+    ``secret_ref``, registers an agent task, and replaces the placeholder with
+    an OpenAI ``AgentAssertion`` header on matching ``hosts`` / ``paths``.
+
+    Wire contract with iron-proxy: Codex CLI's auth-command helper prints the
+    bare placeholder string (e.g. ``CODEX_ACCESS_TOKEN``), Codex constructs
+    ``Authorization: Bearer CODEX_ACCESS_TOKEN``, and the iron-proxy
+    ``codex_agent_identity`` transform substring-matches the placeholder
+    inside that header value before substituting in the real Agent Assertion.
+    The companion iron-proxy implementation MUST treat ``placeholder`` as a
+    substring match, not an exact match on the full header — keep this in
+    sync with the proxy side or both sides need to switch to ``"Bearer X"``
+    semantics together.
+    """
+
+    name: str
+    secret_ref: str
+    hosts: tuple[str, ...]
+    header: str = "Authorization"
+    placeholder: str = ""
+    authapi_base_url: str | None = None
+    paths: tuple[str, ...] = ()
+    methods: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.placeholder:
+            object.__setattr__(self, "placeholder", self.name)
+
+
 SecretDef = (
-    HttpSecret | GcpAuthSecret | PgDsnSecret | OAuthTokenSecret | HmacSignSecret
+    HttpSecret
+    | GcpAuthSecret
+    | PgDsnSecret
+    | OAuthTokenSecret
+    | HmacSignSecret
+    | CodexAgentIdentitySecret
 )
 
 # Per-grant credential fields: grant -> (required, optional). Field names are
@@ -842,10 +881,11 @@ async def _resolve_secrets(secrets: list[SecretDef]) -> dict[str, str]:
     ``ToolContext`` — the tool gets back the ``replacer`` token, which iron-proxy
     swaps for the real credential at the network boundary. Inject-mode HTTP
     secrets are applied entirely by iron-proxy and never reach the tool.
-    ``GcpAuthSecret``, ``OAuthTokenSecret`` and ``PgDsnSecret`` are likewise not
-    exposed via context: gcp_auth and oauth_token are minted and injected on the
-    wire by iron-proxy, and pg_dsn reaches the tool as an environment variable
-    set on the sandbox by the kubernetes backend.
+    ``GcpAuthSecret``, ``OAuthTokenSecret``, ``CodexAgentIdentitySecret`` and
+    ``PgDsnSecret`` are likewise not exposed via context: gcp_auth, oauth_token,
+    and codex_agent_identity are minted or signed on the wire by iron-proxy, and
+    pg_dsn reaches the tool as an environment variable set on the sandbox by the
+    kubernetes backend.
     """
     return {s.name: s.replacer for s in secrets if _is_replace_secret(s)}
 
@@ -1589,9 +1629,9 @@ class ToolManager:
         )
         return loaded
 
-    # Hardcoded infrastructure secrets for the injection map. Each ``HttpSecret``
+    # Hardcoded infrastructure secrets for the injection map. Each secret
     # carries the hosts iron-proxy attaches it to.
-    _INFRA_SECRETS: ClassVar[list[HttpSecret]] = [
+    _INFRA_SECRETS: ClassVar[list[SecretDef]] = [
         HttpSecret(
             name="ANTHROPIC_API_KEY",
             secret_ref="ANTHROPIC_API_KEY",
@@ -1603,6 +1643,16 @@ class ToolManager:
             secret_ref="OPENAI_API_KEY",
             hosts=("api.openai.com",),
             match_headers=("Authorization",),
+        ),
+        CodexAgentIdentitySecret(
+            name="CODEX_ACCESS_TOKEN",
+            secret_ref="CODEX_ACCESS_TOKEN",
+            hosts=("chatgpt.com",),
+            paths=("/backend-api/codex/*",),
+            # Intentionally no method restriction: future Codex CLI verbs
+            # (PUT/PATCH/DELETE/OPTIONS) must still get the AgentAssertion
+            # injection on this path. The path scope is the real boundary.
+            header="Authorization",
         ),
         HttpSecret(
             name="XAI_API_KEY",
@@ -1641,8 +1691,20 @@ class ToolManager:
 
         Every ``HttpSecret``, ``GcpAuthSecret`` and ``OAuthTokenSecret`` carries
         its own ``hosts``; ``PgDsnSecret`` is a TCP listener with no host.
+
+        ``CodexAgentIdentitySecret`` is filtered out unless the resolved
+        :func:`api.sandbox.codex_auth.codex_auth_mode` is ``access_token``: iron
+        proxy should only render the chatgpt.com transform when account-auth
+        is actually opted in, otherwise the transform sits dormant pointing
+        at an unresolvable ``CODEX_ACCESS_TOKEN`` env var.
         """
-        out: list[SecretDef] = list(self._INFRA_SECRETS)
+        active_mode = codex_auth_mode()
+        out: list[SecretDef] = [
+            s
+            for s in self._INFRA_SECRETS
+            if not isinstance(s, CodexAgentIdentitySecret)
+            or active_mode is CodexAuthMode.ACCESS_TOKEN
+        ]
         for lt in self.tools.values():
             out.extend(lt.all_secrets)
         return out

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -28,6 +28,20 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "sandbox: requires running sandbox container")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_codex_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Clear the Codex auth env so dev shells with these exported don't poison
+    # unrelated tests, and reset the module-level cache so the resolver
+    # re-reads env between tests. Tests that exercise the explicit-selector
+    # branches set the other env vars (OPENAI_API_KEY,
+    # FIREWALL_MANAGER_SECRET_SOURCE) themselves.
+    for key in ("CODEX_AUTH_MODE", "CODEX_ACCESS_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+    import api.sandbox.codex_auth as _codex_auth
+
+    _codex_auth._active_mode = None
+
+
 def _pick_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -138,6 +138,33 @@ def test_request_attaches_traceparent(monkeypatch) -> None:
     ]
 
 
+def test_codex_app_server_env_prefers_access_token_over_api_keys(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "access-token")
+    monkeypatch.setenv("CODEX_API_KEY", "codex-api-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-api-key")
+
+    env = wrapper._codex_app_server_env()
+
+    assert env["CODEX_ACCESS_TOKEN"] == "access-token"
+    assert "CODEX_API_KEY" not in env
+    assert "OPENAI_API_KEY" not in env
+
+
+def test_codex_app_server_env_preserves_api_keys_without_access_token(
+    monkeypatch,
+) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.delenv("CODEX_ACCESS_TOKEN", raising=False)
+    monkeypatch.setenv("CODEX_API_KEY", "codex-api-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-api-key")
+
+    env = wrapper._codex_app_server_env()
+
+    assert env["CODEX_API_KEY"] == "codex-api-key"
+    assert env["OPENAI_API_KEY"] == "openai-api-key"
+
+
 def test_main_lazy_starts_app_server_after_input(monkeypatch) -> None:
     wrapper = _load_wrapper()
     requests: list[tuple[str, dict]] = []

--- a/services/api/tests/test_codex_auth.py
+++ b/services/api/tests/test_codex_auth.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import pytest
+
+import api.sandbox.codex_auth as codex_auth_module
+from api.sandbox.codex_auth import (
+    CodexAuthConfigError,
+    CodexAuthMode,
+    bootstrap_codex_auth_mode,
+    codex_auth_mode,
+    resolve_codex_auth_mode,
+)
+
+
+def _clear_codex_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "CODEX_AUTH_MODE",
+        "CODEX_ACCESS_TOKEN",
+        "FIREWALL_MANAGER_SECRET_SOURCE",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_resolve_defaults_to_api_key_when_openai_api_key_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert resolve_codex_auth_mode() == CodexAuthMode.API_KEY
+
+
+def test_resolve_default_ignores_codex_access_token_presence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Presence of CODEX_ACCESS_TOKEN alone does NOT switch modes; the
+    # default is still api_key, which only checks OPENAI_API_KEY.
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+    assert resolve_codex_auth_mode() == CodexAuthMode.API_KEY
+
+
+def test_resolve_default_does_not_require_openai_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Non-Codex deployments (Claude-only, Amp-only) don't set OPENAI_API_KEY.
+    # The default api_key mode must NOT fail-fast for them — only an
+    # explicit CODEX_AUTH_MODE selector triggers credential enforcement.
+    _clear_codex_env(monkeypatch)
+    assert resolve_codex_auth_mode() == CodexAuthMode.API_KEY
+
+
+def test_resolve_default_does_not_require_anything_with_only_access_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Setting only CODEX_ACCESS_TOKEN does not enable access_token mode and
+    # does not raise; default remains api_key with no enforcement.
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+    assert resolve_codex_auth_mode() == CodexAuthMode.API_KEY
+
+
+def test_resolve_onepassword_default_does_not_require_openai_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+
+    assert resolve_codex_auth_mode() == CodexAuthMode.API_KEY
+
+
+def test_resolve_selector_picks_access_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "access_token")
+    assert resolve_codex_auth_mode() == CodexAuthMode.ACCESS_TOKEN
+
+
+def test_resolve_onepassword_access_token_does_not_require_token_in_api_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "access_token")
+
+    assert resolve_codex_auth_mode() == CodexAuthMode.ACCESS_TOKEN
+
+
+def test_resolve_selector_access_token_ignores_openai_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # access_token mode doesn't check OPENAI_API_KEY presence either way.
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "access_token")
+    assert resolve_codex_auth_mode() == CodexAuthMode.ACCESS_TOKEN
+
+
+def test_resolve_selector_picks_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "api_key")
+    assert resolve_codex_auth_mode() == CodexAuthMode.API_KEY
+
+
+def test_resolve_selector_is_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "Access_Token")
+    assert resolve_codex_auth_mode() == CodexAuthMode.ACCESS_TOKEN
+
+
+def test_resolve_raises_when_selector_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "platform")
+    with pytest.raises(CodexAuthConfigError) as exc:
+        resolve_codex_auth_mode()
+    assert "platform" in str(exc.value)
+
+
+def test_resolve_raises_when_selector_demands_missing_access_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "access_token")
+    with pytest.raises(CodexAuthConfigError) as exc:
+        resolve_codex_auth_mode()
+    assert "CODEX_ACCESS_TOKEN" in str(exc.value)
+
+
+def test_resolve_raises_when_selector_demands_missing_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "api_key")
+    with pytest.raises(CodexAuthConfigError) as exc:
+        resolve_codex_auth_mode()
+    assert "OPENAI_API_KEY" in str(exc.value)
+
+
+def test_container_env_omits_codex_placeholder_under_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Default mode is api_key. Even with CODEX_ACCESS_TOKEN set, the sandbox
+    # should not see the access-token placeholder.
+    from api.sandbox.config import container_env
+
+    _clear_codex_env(monkeypatch)
+    monkeypatch.delenv("AGENT_LOCAL_DEV", raising=False)
+    monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+    env = container_env("thread-key", "sandbox-id", "firewall.internal")
+
+    assert not any(item.startswith("CODEX_ACCESS_TOKEN=") for item in env)
+
+
+def test_container_env_includes_codex_placeholder_when_access_token_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.config import container_env
+
+    _clear_codex_env(monkeypatch)
+    monkeypatch.delenv("AGENT_LOCAL_DEV", raising=False)
+    monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "access_token")
+
+    env = container_env("thread-key", "sandbox-id", "firewall.internal")
+
+    assert "CODEX_ACCESS_TOKEN=CODEX_ACCESS_TOKEN" in env
+    # Sandbox-side entrypoint cross-checks CODEX_AUTH_MODE before flipping
+    # provider config, so we must propagate the selector too.
+    assert "CODEX_AUTH_MODE=access_token" in env
+
+
+def test_codex_auth_mode_uses_frozen_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After lifespan freezes the mode, subsequent env mutations don't
+    re-trigger the resolver (so warm-pool ticks / cold spawns can't raise)."""
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    codex_auth_module._active_mode = CodexAuthMode.API_KEY
+    try:
+        # Even if env drifts to an invalid selector, the cache wins.
+        monkeypatch.setenv("CODEX_AUTH_MODE", "bogus")
+        assert codex_auth_mode() is CodexAuthMode.API_KEY
+    finally:
+        codex_auth_module._active_mode = None
+
+
+def test_container_env_includes_codex_placeholder_with_onepassword_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.config import container_env
+
+    _clear_codex_env(monkeypatch)
+    monkeypatch.delenv("AGENT_LOCAL_DEV", raising=False)
+    monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "access_token")
+
+    env = container_env("thread-key", "sandbox-id", "firewall.internal")
+
+    assert "CODEX_ACCESS_TOKEN=CODEX_ACCESS_TOKEN" in env
+
+
+def test_codex_auth_startup_log_path_accepts_api_key_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_codex_env(monkeypatch)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/test")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    try:
+        assert bootstrap_codex_auth_mode() is CodexAuthMode.API_KEY
+        # The bootstrap freezes the cache for subsequent reads.
+        assert codex_auth_module._active_mode is CodexAuthMode.API_KEY
+    finally:
+        codex_auth_module._active_mode = None

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -401,6 +401,36 @@ class TestBuildHarnessCmd:
         assert "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1" not in env
         assert "CLAUDE_CODE_ENABLE_OPUS_4_7_FAST_MODE=1" not in env
 
+    def test_container_env_omits_codex_access_token_when_unconfigured(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from api.sandbox.config import container_env
+
+        monkeypatch.delenv("AGENT_LOCAL_DEV", raising=False)
+        monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+        monkeypatch.delenv("CODEX_ACCESS_TOKEN", raising=False)
+
+        env = container_env("thread-key", "sandbox-id", "firewall.internal")
+
+        assert not any(item.startswith("CODEX_ACCESS_TOKEN=") for item in env)
+
+    def test_container_env_passes_codex_access_token_placeholder_when_configured(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from api.sandbox.config import container_env
+
+        monkeypatch.delenv("AGENT_LOCAL_DEV", raising=False)
+        monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "actual-access-token")
+        monkeypatch.setenv("CODEX_AUTH_MODE", "access_token")
+
+        env = container_env("thread-key", "sandbox-id", "firewall.internal")
+
+        assert "CODEX_ACCESS_TOKEN=CODEX_ACCESS_TOKEN" in env
+        assert "CODEX_ACCESS_TOKEN=actual-access-token" not in env
+
 
 class TestResolveHarnessProfile:
     def test_persona_uses_declared_engine_unless_harness_overrides(self, monkeypatch):

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -9,6 +9,7 @@ from api.proxy_config import (
     render_proxy_yaml,
 )
 from api.tool_manager import (
+    CodexAgentIdentitySecret,
     DEFAULT_MATCH_HEADERS,
     GcpAuthSecret,
     HmacHeader,
@@ -1441,7 +1442,7 @@ def test_render_emits_postgres_listeners_with_env_refs(
     ]
     cfg = yaml.safe_load(render_proxy_yaml(secrets))
     listeners = cfg["postgres"]
-    assert [l["name"] for l in listeners] == ["analytics_pg", "database_url"]
+    assert [listener["name"] for listener in listeners] == ["analytics_pg", "database_url"]
     assert listeners[0]["listen"] == "0.0.0.0:5432"
     assert listeners[1]["listen"] == "0.0.0.0:5433"
     # upstream.dsn uses the secret_ref directly so iron-proxy can resolve it
@@ -1505,4 +1506,34 @@ def test_render_groups_header_secret_hosts_when_repeated() -> None:
         "github.com",
         "api.github.com",
         "uploads.github.com",
+    }
+
+
+def test_render_emits_codex_agent_identity_transform() -> None:
+    secrets = [
+        CodexAgentIdentitySecret(
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_ACCESS_TOKEN",
+            hosts=("chatgpt.com",),
+            paths=("/backend-api/codex/*",),
+            methods=("GET", "POST"),
+            header="Authorization",
+        )
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    names = [t["name"] for t in cfg["transforms"]]
+    assert names == ["allowlist", "codex_agent_identity", "header_allowlist"]
+    transform = next(t for t in cfg["transforms"] if t["name"] == "codex_agent_identity")
+    identity = transform["config"]["identities"][0]
+    assert identity == {
+        "source": {"type": "env", "var": "CODEX_ACCESS_TOKEN"},
+        "rules": [
+            {
+                "host": "chatgpt.com",
+                "methods": ["GET", "POST"],
+                "paths": ["/backend-api/codex/*"],
+            }
+        ],
+        "header": "Authorization",
+        "placeholder": "CODEX_ACCESS_TOKEN",
     }

--- a/services/api/tests/test_sandbox_entrypoint.py
+++ b/services/api/tests/test_sandbox_entrypoint.py
@@ -8,12 +8,43 @@ from pathlib import Path
 
 
 ENTRYPOINT_SH = Path(__file__).resolve().parents[2] / "sandbox" / "entrypoint.sh"
+CODEX_ACCESS_TOKEN_HELPER = (
+    Path(__file__).resolve().parents[2]
+    / "sandbox"
+    / "centaur-codex-access-token.sh"
+)
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HARNESS_CODEX_CONFIG = REPO_ROOT / "harness" / "codex" / "config.toml"
+
+
+def test_harness_codex_config_has_no_top_level_model_provider() -> None:
+    """entrypoint.sh's access-token setup blindly prepends
+    `model_provider = "centaur_codex_access_token"` to the harness config.
+    If the harness config ever gains a top-level `model_provider` of its
+    own, the file would end up with two and Codex would fail to parse it.
+    Pin the invariant here so any future commit that breaks it fails CI
+    instead of the sandbox at runtime."""
+    parsed = tomllib.loads(HARNESS_CODEX_CONFIG.read_text())
+    assert "model_provider" not in parsed, (
+        "harness/codex/config.toml must not declare a top-level "
+        "model_provider; entrypoint.sh prepends one in access-token mode."
+    )
+
+
+HARNESS_CODEX_ACCESS_TOKEN_PROVIDER = (
+    REPO_ROOT / "harness" / "codex" / "access-token-provider.toml"
+)
 
 
 def _write_codex_harness_config(home: Path) -> Path:
     harness_dir = home / "harness"
     codex_dir = harness_dir / "codex"
     codex_dir.mkdir(parents=True)
+    # Mirror the real harness layout: entrypoint expects the access-token
+    # provider snippet alongside config.toml in $CENTAUR_HARNESS_CONFIG_DIR.
+    (codex_dir / "access-token-provider.toml").write_text(
+        HARNESS_CODEX_ACCESS_TOKEN_PROVIDER.read_text()
+    )
     (codex_dir / "config.toml").write_text(
         "\n".join(
             [
@@ -54,6 +85,22 @@ def _write_codex_harness_config(home: Path) -> Path:
         )
     )
     return harness_dir
+
+
+def _write_fake_codex(bin_dir: Path) -> None:
+    bin_dir.mkdir(parents=True)
+    codex = bin_dir / "codex"
+    codex.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "printf '%s\\n' \"$*\" > \"$CODEX_LOGIN_ARGS_FILE\"",
+                "cat > \"$CODEX_LOGIN_STDIN_FILE\"",
+                "",
+            ]
+        )
+    )
+    codex.chmod(0o755)
 
 
 def test_sandbox_entrypoint_bootstraps_mock_google_adc(tmp_path: Path) -> None:
@@ -183,3 +230,213 @@ def test_sandbox_entrypoint_appends_codex_laminar_otel_config(tmp_path: Path) ->
     assert '"x-centaur-thread-key" = "slack:C123:1700000000.000100"' in result.stdout
     assert '"authorization" = "Bearer lmnr-key"' in result.stdout
     assert 'environment = "staging"' in result.stdout
+
+
+def test_sandbox_entrypoint_configures_codex_access_token_provider(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    harness_dir = _write_codex_harness_config(home)
+    fake_bin = tmp_path / "bin"
+    _write_fake_codex(fake_bin)
+    args_file = tmp_path / "codex-args"
+    stdin_file = tmp_path / "codex-stdin"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ENTRYPOINT_SH),
+            "sh",
+            "-lc",
+            'cat "$HOME/.codex/config.toml"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "CENTAUR_HARNESS_CONFIG_DIR": str(harness_dir),
+            # The API stamps the literal placeholder + the CODEX_AUTH_MODE
+            # signal. Entrypoint requires both to flip provider config.
+            "CODEX_ACCESS_TOKEN": "CODEX_ACCESS_TOKEN",
+            "CODEX_AUTH_MODE": "access_token",
+            "CODEX_API_KEY": "codex-api-key",
+            "OPENAI_API_KEY": "openai-api-key",
+            "CODEX_LOGIN_ARGS_FILE": str(args_file),
+            "CODEX_LOGIN_STDIN_FILE": str(stdin_file),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert not args_file.exists()
+    assert not stdin_file.exists()
+    parsed = tomllib.loads(result.stdout)
+    assert parsed["model_provider"] == "centaur_codex_access_token"
+    provider = parsed["model_providers"]["centaur_codex_access_token"]
+    assert provider["name"] == "OpenAI via Centaur Codex access token"
+    assert provider["base_url"] == "https://chatgpt.com/backend-api/codex"
+    assert provider["wire_api"] == "responses"
+    assert provider["supports_websockets"] is False
+    assert provider["auth"] == {
+        "command": "/usr/local/bin/centaur-codex-access-token",
+        "timeout_ms": 5000,
+        "refresh_interval_ms": 0,
+    }
+
+
+def test_sandbox_entrypoint_rejects_non_placeholder_access_token(
+    tmp_path: Path,
+) -> None:
+    """If something injects a real-looking CODEX_ACCESS_TOKEN into the sandbox
+    while CODEX_AUTH_MODE=access_token, the entrypoint must refuse to start —
+    the sandbox should only ever see the placeholder string."""
+    home = tmp_path / "home"
+    harness_dir = _write_codex_harness_config(home)
+    fake_bin = tmp_path / "bin"
+    _write_fake_codex(fake_bin)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ENTRYPOINT_SH),
+            "sh",
+            "-lc",
+            "true",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "CENTAUR_HARNESS_CONFIG_DIR": str(harness_dir),
+            "CODEX_ACCESS_TOKEN": "sk-real-leaked-token",
+            "CODEX_AUTH_MODE": "access_token",
+            "CODEX_LOGIN_ARGS_FILE": str(tmp_path / "codex-args"),
+            "CODEX_LOGIN_STDIN_FILE": str(tmp_path / "codex-stdin"),
+        },
+    )
+
+    assert result.returncode != 0
+    assert "sandbox placeholder" in result.stderr
+
+
+def test_sandbox_entrypoint_ignores_access_token_without_mode(
+    tmp_path: Path,
+) -> None:
+    """A CODEX_ACCESS_TOKEN leaked into the sandbox env without CODEX_AUTH_MODE
+    must NOT flip Codex to access-token mode. The legacy api-key path stays
+    active."""
+    home = tmp_path / "home"
+    harness_dir = _write_codex_harness_config(home)
+    fake_bin = tmp_path / "bin"
+    _write_fake_codex(fake_bin)
+    args_file = tmp_path / "codex-args"
+    stdin_file = tmp_path / "codex-stdin"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ENTRYPOINT_SH),
+            "sh",
+            "-lc",
+            'cat "$HOME/.codex/config.toml"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "CENTAUR_HARNESS_CONFIG_DIR": str(harness_dir),
+            "CODEX_ACCESS_TOKEN": "CODEX_ACCESS_TOKEN",
+            # No CODEX_AUTH_MODE set — entrypoint must NOT switch to access_token.
+            "OPENAI_API_KEY": "openai-api-key",
+            "CODEX_LOGIN_ARGS_FILE": str(args_file),
+            "CODEX_LOGIN_STDIN_FILE": str(stdin_file),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    parsed = tomllib.loads(result.stdout)
+    assert parsed.get("model_provider") != "centaur_codex_access_token"
+    # api-key login fallback still ran with the OPENAI_API_KEY value.
+    assert stdin_file.read_text() == "openai-api-key\n"
+
+
+def test_sandbox_entrypoint_falls_back_to_codex_api_key_login(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    harness_dir = _write_codex_harness_config(home)
+    fake_bin = tmp_path / "bin"
+    _write_fake_codex(fake_bin)
+    args_file = tmp_path / "codex-args"
+    stdin_file = tmp_path / "codex-stdin"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ENTRYPOINT_SH),
+            "sh",
+            "-lc",
+            "true",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "CENTAUR_HARNESS_CONFIG_DIR": str(harness_dir),
+            "CODEX_API_KEY": "codex-api-key",
+            "OPENAI_API_KEY": "openai-api-key",
+            "CODEX_LOGIN_ARGS_FILE": str(args_file),
+            "CODEX_LOGIN_STDIN_FILE": str(stdin_file),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert args_file.read_text().strip() == "login --with-api-key"
+    # Entrypoint sends the key newline-terminated to codex login.
+    assert stdin_file.read_text() == "codex-api-key\n"
+
+
+def test_codex_access_token_helper_prints_placeholder() -> None:
+    result = subprocess.run(
+        ["sh", str(CODEX_ACCESS_TOKEN_HELPER)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={"CODEX_ACCESS_TOKEN": "CODEX_ACCESS_TOKEN"},
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert result.stdout == "CODEX_ACCESS_TOKEN\n"
+
+
+def test_codex_access_token_helper_requires_token() -> None:
+    result = subprocess.run(
+        ["sh", str(CODEX_ACCESS_TOKEN_HELPER)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={},
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == "CODEX_ACCESS_TOKEN is not set\n"
+
+
+def test_codex_access_token_helper_rejects_raw_token() -> None:
+    result = subprocess.run(
+        ["sh", str(CODEX_ACCESS_TOKEN_HELPER)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={"CODEX_ACCESS_TOKEN": "real-token"},
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == "CODEX_ACCESS_TOKEN must be the sandbox placeholder\n"

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -189,6 +189,7 @@ def test_container_env_includes_firewall_host_for_secret_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.delenv("CODEX_ACCESS_TOKEN", raising=False)
 
     env = sandbox_container_env(
         "thread-key",
@@ -202,9 +203,27 @@ def test_container_env_includes_firewall_host_for_secret_bootstrap(
     # iron-proxy rewrites the placeholder mid-flight.
     assert env_map["AMP_API_KEY"] == "AMP_API_KEY"
     assert env_map["OPENAI_API_KEY"] == "OPENAI_API_KEY"
+    assert "CODEX_ACCESS_TOKEN" not in env_map
     assert env_map["CENTAUR_TRACE_ID"] == "00000000-0000-0000-0000-000000000123"
     assert env_map["NO_PROXY"] == "localhost,127.0.0.1,firewall.internal,api.internal"
     assert env_map["no_proxy"] == env_map["NO_PROXY"]
+
+
+def test_container_env_includes_codex_access_token_placeholder_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv("CODEX_ACCESS_TOKEN", "actual-access-token")
+    monkeypatch.setenv("CODEX_AUTH_MODE", "access_token")
+
+    env = sandbox_container_env(
+        "thread-key",
+        "sandbox-id",
+        "firewall.internal",
+    )
+    env_map = dict(item.split("=", 1) for item in env)
+
+    assert env_map["CODEX_ACCESS_TOKEN"] == "CODEX_ACCESS_TOKEN"
 
 
 def test_container_env_passes_laminar_otel_config(

--- a/services/api/tests/test_tool_manager.py
+++ b/services/api/tests/test_tool_manager.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from api.tool_manager import (  # noqa: E402
+    CodexAgentIdentitySecret,
     _LIFECYCLE_METHODS,
     _describe_method_docstring,
     _friendly_type_name,
@@ -22,6 +23,19 @@ from api.tool_manager import (  # noqa: E402
     ToolManager,
     ToolMethod,
 )
+
+
+def test_infra_codex_access_token_authenticates_chatgpt_codex_requests() -> None:
+    secret = next(s for s in ToolManager._INFRA_SECRETS if s.name == "CODEX_ACCESS_TOKEN")
+
+    assert isinstance(secret, CodexAgentIdentitySecret)
+    assert secret.hosts == ("chatgpt.com",)
+    assert secret.paths == ("/backend-api/codex/*",)
+    # No methods restriction — every HTTP verb to /backend-api/codex/* must
+    # get the AgentAssertion injection, including future Codex CLI verbs.
+    assert secret.methods == ()
+    assert secret.header == "Authorization"
+    assert secret.placeholder == "CODEX_ACCESS_TOKEN"
 
 
 class TestDescribeMethodDocstring:

--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -34,6 +34,8 @@ transforms:
         - "anthropic-beta"
         - "openai-organization"
         - "openai-project"
+        - "chatgpt-account-id"
+        - "x-openai-fedramp"
         - "x-request-id"
         - "x-stainless-arch"
         - "x-stainless-os"

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -168,6 +168,7 @@ COPY --link --chmod=755 services/sandbox/slack-upload.sh /usr/local/bin/slack-up
 COPY --link --chmod=755 services/sandbox/md2docx.py /usr/local/bin/md2docx
 COPY --link --chmod=755 services/sandbox/amp-wrapper.py /usr/local/bin/amp-wrapper
 COPY --link --chmod=755 services/sandbox/codex-app-wrapper.py /usr/local/bin/codex-app-wrapper
+COPY --link --chmod=755 services/sandbox/centaur-codex-access-token.sh /usr/local/bin/centaur-codex-access-token
 COPY --link --chmod=755 services/sandbox/claude-app-wrapper.py /usr/local/bin/claude-app-wrapper
 COPY --link --chmod=755 services/sandbox/harness_adapter.py /usr/local/bin/harness-adapter
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch

--- a/services/sandbox/centaur-codex-access-token.sh
+++ b/services/sandbox/centaur-codex-access-token.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+token="${CODEX_ACCESS_TOKEN:-}"
+if [ -z "$token" ]; then
+    echo "CODEX_ACCESS_TOKEN is not set" >&2
+    exit 1
+fi
+if [ "$token" != "CODEX_ACCESS_TOKEN" ]; then
+    echo "CODEX_ACCESS_TOKEN must be the sandbox placeholder" >&2
+    exit 1
+fi
+
+printf '%s\n' "$token"

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -90,6 +90,7 @@ def start_app_server() -> None:
         APP = None
         APP_INITIALIZED = False
 
+    env = _codex_app_server_env()
     APP = subprocess.Popen(
         [
             "codex",
@@ -103,6 +104,7 @@ def start_app_server() -> None:
         text=True,
         bufsize=1,
         cwd=os.getcwd(),
+        env=env,
     )
     threading.Thread(target=app_stdout_reader, daemon=True).start()
     request(
@@ -116,6 +118,14 @@ def start_app_server() -> None:
     notify("initialized")
     APP_INITIALIZED = True
     emit({"type": "system", "subtype": "wrapper_heartbeat", "phase": "app_server_started"})
+
+
+def _codex_app_server_env() -> dict[str, str]:
+    env = os.environ.copy()
+    if (env.get("CODEX_ACCESS_TOKEN") or "").strip():
+        env.pop("CODEX_API_KEY", None)
+        env.pop("OPENAI_API_KEY", None)
+    return env
 
 
 def app_stdout_reader() -> None:

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -70,11 +70,38 @@ toml_escape() {
 }
 
 HARNESS_CONFIG_DIR="${CENTAUR_HARNESS_CONFIG_DIR:-$HOME_DIR/harness}"
+CODEX_CONFIG_PATH="$HOME_DIR/.codex/config.toml"
 if [ -f "$HARNESS_CONFIG_DIR/codex/config.toml" ]; then
-    cp "$HARNESS_CONFIG_DIR/codex/config.toml" "$HOME_DIR/.codex/config.toml"
+    cp "$HARNESS_CONFIG_DIR/codex/config.toml" "$CODEX_CONFIG_PATH"
 else
     echo "missing Codex harness config: $HARNESS_CONFIG_DIR/codex/config.toml" >&2
     exit 1
+fi
+
+if [ "${CODEX_AUTH_MODE:-}" = "access_token" ]; then
+    if [ "${CODEX_ACCESS_TOKEN:-}" != "CODEX_ACCESS_TOKEN" ]; then
+        echo "CODEX_AUTH_MODE=access_token requires the CODEX_ACCESS_TOKEN sandbox placeholder; got an unexpected value" >&2
+        exit 1
+    fi
+    # Codex CLI exposes the upstream URL + wire API + auth command only via
+    # a [model_providers.<name>] TOML table, with the active provider chosen
+    # by a root-level `model_provider` key. We compose the harness base
+    # config with our provider snippet by exploiting TOML's "multiple
+    # section declarations add to the same parent table" semantics:
+    #   (1) prepend the `model_provider` selector,
+    #   (2) cat the base harness config (no top-level model_provider —
+    #       pinned by test_harness_codex_config_has_no_top_level_model_provider),
+    #   (3) cat the access-token provider snippet.
+    # The result is a single valid TOML config, no shell-side TOML edits.
+    tmp_codex_config="$(mktemp)"
+    trap 'rm -f "$tmp_codex_config"' EXIT
+    {
+        printf '%s\n' 'model_provider = "centaur_codex_access_token"'
+        cat "$CODEX_CONFIG_PATH"
+        cat "$HARNESS_CONFIG_DIR/codex/access-token-provider.toml"
+    } > "$tmp_codex_config"
+    mv "$tmp_codex_config" "$CODEX_CONFIG_PATH"
+    trap - EXIT
 fi
 
 codex_laminar_trace_endpoint="${CODEX_OTEL_LAMINAR_ENDPOINT:-}"
@@ -197,11 +224,15 @@ if [ -x "$HARNESS_ADAPTER" ]; then
     "$HARNESS_ADAPTER" "${1:-}" "$TARGET_PROMPT"
 fi
 
-# Codex reads its auth file when the app server starts. Complete this before
-# signaling readiness, otherwise warm pods can be claimed with no auth loaded.
+# Codex reads its auth file when the app server starts for API-key mode.
+# Access-token mode uses command-backed provider auth instead because the
+# placeholder token is resolved by iron-proxy only after Codex sends a request.
+# Keep the trailing newline — `codex login --with-api-key` reads stdin
+# line-by-line and dropping it has been observed to corrupt the stored key
+# on some Codex CLI versions.
 CODEX_KEY="${CODEX_API_KEY:-${OPENAI_API_KEY:-}}"
-if [ -n "$CODEX_KEY" ]; then
-    echo "$CODEX_KEY" | codex login --with-api-key 2>/dev/null || true
+if [ "${CODEX_AUTH_MODE:-}" != "access_token" ] && [ -n "$CODEX_KEY" ]; then
+    printf '%s\n' "$CODEX_KEY" | codex login --with-api-key 2>/dev/null || true
 fi
 
 # Signal readiness


### PR DESCRIPTION
## Problem

Centaur can run Codex inside sandbox pods, but the existing wiring assumes API-key style authentication. Codex account-auth traffic goes to `chatgpt.com/backend-api/codex` and requires Agent Identity request signing at the proxy boundary. Sandboxes should not receive the real account token, and the API/sandbox layers should not need to know how to sign Codex Agent Identity requests.

Without this integration, deployments cannot use Codex account-backed authentication through Centaur without either exposing the real token to the sandbox or carrying local-only proxy hacks.

Addresses issue #141. Requires the companion [iron-proxy transform PR](https://github.com/kkennis/iron-proxy/pull/1).

## Approach

A new `CODEX_AUTH_MODE` env var selects the Codex auth path. It defaults to `api_key` (the existing OpenAI Platform behavior). Setting `CODEX_AUTH_MODE=access_token`:

- Tells iron-proxy to render a `codex_agent_identity` transform that resolves `CODEX_ACCESS_TOKEN` and mints per-request `AgentAssertion` headers for `chatgpt.com/backend-api/codex/*`.
- Stamps `CODEX_ACCESS_TOKEN=CODEX_ACCESS_TOKEN` (placeholder) and `CODEX_AUTH_MODE=access_token` into sandbox pods; the real token never leaves iron-proxy.
- Switches the sandbox's Codex CLI to a `centaur_codex_access_token` provider that targets the ChatGPT backend with `wire_api = "responses"` and an `auth.command` helper.

The OpenAI Platform path is unchanged. Presence of `CODEX_ACCESS_TOKEN` alone does not switch modes.

## Commits

1. `feat(iron-proxy): allowlist Codex backend headers` — adds `chatgpt-account-id` and `x-openai-fedramp` to the iron-proxy header allowlist.
2. `feat(api): add CodexAuthMode resolver and startup bootstrap` — `CodexAuthMode` enum, `resolve_codex_auth_mode()`, cached `codex_auth_mode()` reader, and a `bootstrap_codex_auth_mode()` lifespan hook that fail-fasts on misconfiguration and logs `codex_auth_mode_resolved` with mode + credential presence + operator-supplied selector.
3. `feat(api): render codex_agent_identity iron-proxy transform` — `CodexAgentIdentitySecret` dataclass + renderer. The infra secret is filtered out of `collect_secrets` unless the resolved mode is access-token, so iron-proxy only gets the transform when account-auth is actually opted in.
4. `feat(api): stamp CODEX_ACCESS_TOKEN placeholder into sandbox env` — `container_env()` emits the placeholder and the `CODEX_AUTH_MODE` selector when the cached resolved mode is access-token.
5. `feat(sandbox): configure Codex CLI for access-token mode` — entrypoint composes the harness `config.toml` with `harness/codex/access-token-provider.toml` at start. New `centaur-codex-access-token` helper that the Codex `auth.command` invokes per request and that refuses anything other than the literal placeholder. `codex-app-wrapper.py` strips `OPENAI_API_KEY`/`CODEX_API_KEY` from the Codex subprocess env in access-token mode.
6. `docs: document Codex access-token mode` — quickstart, deploying-in-production, secrets/environment, secrets/onepassword, security.

## Validation

Run from `services/api/`:

```bash
UV_CACHE_DIR=/private/tmp/uv-cache uv run --python python3.11 pytest \
  tests/test_codex_auth.py \
  tests/test_proxy_config.py \
  tests/test_tool_manager.py \
  tests/test_codex_app_wrapper.py \
  tests/test_sandbox_entrypoint.py \
  tests/test_sandbox_kubernetes_backend.py \
  "tests/test_integration.py::TestBuildHarnessCmd"
```

- `just build-one api`
- `just build-one sandbox`
- Local durable smoke test through `spawn -> message -> execute` returned `PONG` end-to-end.

For the smoke test, the local kind cluster used images built from this branch plus a local `centaur-iron-proxy:latest` image built from the companion iron-proxy branch. Proxy logs confirmed `codex_agent_identity` injected `AgentAssertion` and `ChatGPT-Account-ID` for `/backend-api/codex/models` and `/backend-api/codex/responses`.