### PR TITLE
fix: gate plugin file watchers behind PLUGIN_WATCHER_ENABLED

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.38
+version: 0.1.39
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -249,6 +249,8 @@ spec:
               value: {{ ternary "1" "0" .Values.api.workflowWorkerEnabled | quote }}
             - name: WARM_POOL_ENABLED
               value: {{ ternary "1" "0" .Values.api.warmPoolEnabled | quote }}
+            - name: PLUGIN_WATCHER_ENABLED
+              value: {{ ternary "1" "0" .Values.api.pluginWatcherEnabled | quote }}
 {{- if not (hasKey $apiExtraEnv "SLACK_ETL_ENABLED") }}
             - name: SLACK_ETL_ENABLED
               value: {{ ternary "1" "0" .Values.api.slackEtlEnabled | quote }}

--- a/contrib/chart/values.dev.yaml
+++ b/contrib/chart/values.dev.yaml
@@ -17,6 +17,7 @@ slackbot:
 
 api:
   executionWorkerEnabled: true
+  pluginWatcherEnabled: true
   egressDiscovery:
     enabled: false
 

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -56,6 +56,7 @@ api:
   executionWorkerEnabled: false
   workflowWorkerEnabled: true
   warmPoolEnabled: false
+  pluginWatcherEnabled: false
   slackEtlEnabled: false
   slackSyncIntervalSeconds: 3600
   slackBackfillIntervalSeconds: 3600

--- a/services/api/api/app.py
+++ b/services/api/api/app.py
@@ -111,8 +111,19 @@ for _uvi_name in ("uvicorn.access",):
     logging.getLogger(_uvi_name).propagate = False
 
 
+def _plugin_watcher_enabled() -> bool:
+    return os.getenv("PLUGIN_WATCHER_ENABLED", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+    }
+
+
 async def _watch_tools(pm: ToolManager) -> None:
     """Watch all plugin directories and auto-reload when files change."""
+    if not _plugin_watcher_enabled():
+        log.info("tool_watcher_disabled", reason="plugin_watcher_disabled")
+        return
     from starlette.concurrency import run_in_threadpool
     from watchfiles import awatch
 
@@ -130,6 +141,9 @@ async def _watch_tools(pm: ToolManager) -> None:
 
 async def _watch_workflows() -> None:
     """Watch external workflow directories and auto-reload when files change."""
+    if not _plugin_watcher_enabled():
+        log.info("workflow_watcher_disabled", reason="plugin_watcher_disabled")
+        return
     from watchfiles import awatch
 
     watch_dirs = [d for d in get_workflow_dirs() if d.exists()]

--- a/services/api/tests/test_hot_reload_gate.py
+++ b/services/api/tests/test_hot_reload_gate.py
@@ -1,0 +1,69 @@
+"""Unit tests for the PLUGIN_WATCHER_ENABLED env gate."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+os.environ.setdefault("DATABASE_URL", "postgres://centaur:test@localhost:5432/test")
+
+from api.app import _plugin_watcher_enabled, _watch_tools, _watch_workflows  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_watch_tools_returns_immediately_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PLUGIN_WATCHER_ENABLED", "0")
+
+    pm = MagicMock()
+    pm.tools_dirs = [Path("/nonexistent")]
+
+    await asyncio.wait_for(_watch_tools(pm), timeout=0.5)
+
+    pm.reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_watch_workflows_returns_immediately_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PLUGIN_WATCHER_ENABLED", "0")
+
+    await asyncio.wait_for(_watch_workflows(), timeout=0.5)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("FALSE", False),
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("", True),
+    ],
+)
+def test_plugin_watcher_enabled_parses_truthy_values(
+    monkeypatch: pytest.MonkeyPatch, value: str, expected: bool
+) -> None:
+    monkeypatch.setenv("PLUGIN_WATCHER_ENABLED", value)
+
+    assert _plugin_watcher_enabled() is expected
+
+
+def test_plugin_watcher_enabled_defaults_to_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PLUGIN_WATCHER_ENABLED", raising=False)
+
+    assert _plugin_watcher_enabled() is True


### PR DESCRIPTION
The tool/workflow `awatch` loops hold inotify FDs per pod; rolling deploys exhaust the per-process limit and pods die with `WatchfilesRustInternalError: Too many open files`, killing in-flight executions.

Gate behind `PLUGIN_WATCHER_ENABLED` — default on locally, default off in the chart, override on for `just up` via `values.dev.yaml`. Naming matches the existing `EXECUTION_WORKER_ENABLED` / `WORKFLOW_WORKER_ENABLED` / `WARM_POOL_ENABLED` family.