### PR TITLE
feat(tools): add Composio integration for external service tools

### DIFF
--- a/tools/productivity/composio/client.py
+++ b/tools/productivity/composio/client.py
@@ -1,0 +1,103 @@
+"""Composio tool — execute actions from 1000+ services via Composio's cloud API."""
+
+from __future__ import annotations
+
+from centaur_sdk import secret
+
+# Composio user_id scopes connected accounts. "centaur" is the default for
+# shared/unscoped usage; callers should pass a real user_id when accounts
+# are per-user to avoid cross-tenant data leakage.
+_DEFAULT_USER_ID = "centaur"
+
+
+def _extract_tools(raw: list) -> list[dict]:
+    """Pull name + description from Composio's OpenAI-shaped tool dicts."""
+    tools = []
+    for t in raw:
+        if isinstance(t, dict):
+            fn = t.get("function", {})
+            tools.append({
+                "name": fn.get("name", ""),
+                "description": fn.get("description", ""),
+            })
+    return tools
+
+
+class ComposioClient:
+    """Bridge to Composio's tool execution platform."""
+
+    def __init__(self, api_key: str | None = None):
+        self._api_key = api_key or secret("COMPOSIO_API_KEY")
+        self._composio = None
+
+    def _get_client(self):
+        if self._composio is None:
+            from composio import Composio
+
+            self._composio = Composio(api_key=self._api_key)
+        return self._composio
+
+    def list_tools(self, toolkit: str, user_id: str = _DEFAULT_USER_ID) -> dict:
+        """List available tools for a toolkit (e.g. 'github', 'gmail', 'slack', 'notion')."""
+        c = self._get_client()
+        raw = c.tools.get(user_id, toolkits=[toolkit])
+        tools = _extract_tools(raw)
+        return {"toolkit": toolkit, "tools": tools, "count": len(tools)}
+
+    def search_tools(self, query: str, user_id: str = _DEFAULT_USER_ID) -> dict:
+        """Search for tools across all toolkits by description."""
+        c = self._get_client()
+        raw = c.tools.get(user_id, search=query)
+        tools = _extract_tools(raw[:20])
+        return {"query": query, "tools": tools, "count": len(tools)}
+
+    def execute(
+        self,
+        tool_slug: str,
+        arguments: dict | None = None,
+        user_id: str = _DEFAULT_USER_ID,
+    ) -> dict:
+        """Execute a Composio tool action.
+
+        tool_slug examples: GITHUB_LIST_REPOS_FOR_USER, HACKERNEWS_GET_TOP_STORIES.
+        Use get_tool_schema() to discover required arguments.
+        """
+        c = self._get_client()
+        # Version check requires per-toolkit version pinning which is impractical
+        # when the caller doesn't know the toolkit in advance.
+        result = c.tools.execute(
+            tool_slug,
+            user_id=user_id,
+            arguments=arguments or {},
+            dangerously_skip_version_check=True,
+        )
+        if isinstance(result, dict):
+            return {
+                "successful": result.get("successful", False),
+                "error": result.get("error"),
+                "data": result.get("data", {}),
+            }
+        return {
+            "successful": getattr(result, "successful", False),
+            "error": getattr(result, "error", None),
+            "data": getattr(result, "data", {}),
+        }
+
+    def get_tool_schema(self, tool_slug: str, user_id: str = _DEFAULT_USER_ID) -> dict:
+        """Get the input/output schema for a specific tool."""
+        c = self._get_client()
+        raw = c.tools.get(user_id, search=tool_slug)
+        for t in raw:
+            if isinstance(t, dict):
+                fn = t.get("function", {})
+                if fn.get("name") == tool_slug:
+                    return {
+                        "name": fn.get("name"),
+                        "description": fn.get("description", ""),
+                        "parameters": fn.get("parameters", {}),
+                    }
+        return {"error": f"Tool {tool_slug} not found"}
+
+
+def _client() -> ComposioClient:
+    return ComposioClient()

--- a/tools/productivity/composio/client.py
+++ b/tools/productivity/composio/client.py
@@ -2,24 +2,31 @@
 
 from __future__ import annotations
 
+import logging
+
 from centaur_sdk import secret
 
-# Composio user_id scopes connected accounts. "centaur" is the default for
-# shared/unscoped usage; callers should pass a real user_id when accounts
-# are per-user to avoid cross-tenant data leakage.
+log = logging.getLogger(__name__)
+
+# Composio user_id scopes connected accounts. Agents in a shared deployment
+# share this default scope; pass a distinct user_id when connected accounts
+# must be isolated per user or per thread.
 _DEFAULT_USER_ID = "centaur"
 
 
 def _extract_tools(raw: list) -> list[dict]:
-    """Pull name + description from Composio's OpenAI-shaped tool dicts."""
+    """Pull name, description, and required params from Composio tool dicts."""
     tools = []
     for t in raw:
-        if isinstance(t, dict):
-            fn = t.get("function", {})
-            tools.append({
-                "name": fn.get("name", ""),
-                "description": fn.get("description", ""),
-            })
+        if not isinstance(t, dict):
+            continue
+        fn = t.get("function", {})
+        params = fn.get("parameters", {})
+        tools.append({
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "required_params": params.get("required", []),
+        })
     return tools
 
 
@@ -39,17 +46,30 @@ class ComposioClient:
 
     def list_tools(self, toolkit: str, user_id: str = _DEFAULT_USER_ID) -> dict:
         """List available tools for a toolkit (e.g. 'github', 'gmail', 'slack', 'notion')."""
-        c = self._get_client()
-        raw = c.tools.get(user_id, toolkits=[toolkit])
-        tools = _extract_tools(raw)
-        return {"toolkit": toolkit, "tools": tools, "count": len(tools)}
+        if not toolkit or not toolkit.strip():
+            return {"error": "toolkit is required", "successful": False}
+        try:
+            c = self._get_client()
+            raw = c.tools.get(user_id, toolkits=[toolkit.strip()])
+            tools = _extract_tools(raw if isinstance(raw, list) else [])
+            return {"toolkit": toolkit, "tools": tools, "count": len(tools)}
+        except Exception as exc:
+            log.warning("composio list_tools failed", exc_info=True)
+            return {"error": str(exc), "successful": False}
 
     def search_tools(self, query: str, user_id: str = _DEFAULT_USER_ID) -> dict:
         """Search for tools across all toolkits by description."""
-        c = self._get_client()
-        raw = c.tools.get(user_id, search=query)
-        tools = _extract_tools(raw[:20])
-        return {"query": query, "tools": tools, "count": len(tools)}
+        if not query or not query.strip():
+            return {"error": "query is required", "successful": False}
+        try:
+            c = self._get_client()
+            raw = c.tools.get(user_id, search=query.strip())
+            items = raw[:20] if isinstance(raw, list) else []
+            tools = _extract_tools(items)
+            return {"query": query, "tools": tools, "count": len(tools)}
+        except Exception as exc:
+            log.warning("composio search_tools failed", exc_info=True)
+            return {"error": str(exc), "successful": False}
 
     def execute(
         self,
@@ -62,41 +82,55 @@ class ComposioClient:
         tool_slug examples: GITHUB_LIST_REPOS_FOR_USER, HACKERNEWS_GET_TOP_STORIES.
         Use get_tool_schema() to discover required arguments.
         """
-        c = self._get_client()
-        # Version check requires per-toolkit version pinning which is impractical
-        # when the caller doesn't know the toolkit in advance.
-        result = c.tools.execute(
-            tool_slug,
-            user_id=user_id,
-            arguments=arguments or {},
-            dangerously_skip_version_check=True,
-        )
-        if isinstance(result, dict):
+        if not tool_slug or not tool_slug.strip():
+            return {"error": "tool_slug is required", "successful": False}
+        try:
+            c = self._get_client()
+            # Version check requires per-toolkit version pinning which is
+            # impractical when the caller doesn't know the toolkit in advance.
+            result = c.tools.execute(
+                tool_slug.strip(),
+                user_id=user_id,
+                arguments=arguments or {},
+                dangerously_skip_version_check=True,
+            )
+            if isinstance(result, dict):
+                return {
+                    "successful": result.get("successful", False),
+                    "error": result.get("error"),
+                    "data": result.get("data", {}),
+                }
             return {
-                "successful": result.get("successful", False),
-                "error": result.get("error"),
-                "data": result.get("data", {}),
+                "successful": getattr(result, "successful", False),
+                "error": getattr(result, "error", None),
+                "data": getattr(result, "data", {}),
             }
-        return {
-            "successful": getattr(result, "successful", False),
-            "error": getattr(result, "error", None),
-            "data": getattr(result, "data", {}),
-        }
+        except Exception as exc:
+            log.warning("composio execute failed", exc_info=True)
+            return {"error": str(exc), "successful": False}
 
     def get_tool_schema(self, tool_slug: str, user_id: str = _DEFAULT_USER_ID) -> dict:
         """Get the input/output schema for a specific tool."""
-        c = self._get_client()
-        raw = c.tools.get(user_id, search=tool_slug)
-        for t in raw:
-            if isinstance(t, dict):
+        if not tool_slug or not tool_slug.strip():
+            return {"error": "tool_slug is required", "successful": False}
+        try:
+            c = self._get_client()
+            raw = c.tools.get(user_id, search=tool_slug.strip())
+            for t in raw if isinstance(raw, list) else []:
+                if not isinstance(t, dict):
+                    continue
                 fn = t.get("function", {})
-                if fn.get("name") == tool_slug:
+                if fn.get("name") == tool_slug.strip():
                     return {
+                        "successful": True,
                         "name": fn.get("name"),
                         "description": fn.get("description", ""),
                         "parameters": fn.get("parameters", {}),
                     }
-        return {"error": f"Tool {tool_slug} not found"}
+            return {"error": f"Tool {tool_slug} not found", "successful": False}
+        except Exception as exc:
+            log.warning("composio get_tool_schema failed", exc_info=True)
+            return {"error": str(exc), "successful": False}
 
 
 def _client() -> ComposioClient:

--- a/tools/productivity/composio/pyproject.toml
+++ b/tools/productivity/composio/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "composio"
+version = "0.1.0"
+description = "Execute tools from 1000+ services via Composio (GitHub, Gmail, Slack, Notion, etc.)"
+requires-python = ">=3.11"
+dependencies = [
+    "composio>=0.13.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.centaur]
+module = "client.py"
+secrets = [
+    {type = "http", name = "COMPOSIO_API_KEY", match_headers = ["x-api-key"], hosts = ["backend.composio.dev"]},
+]

--- a/tools/productivity/composio/pyproject.toml
+++ b/tools/productivity/composio/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "composio"
+name = "centaur-composio-tool"
 version = "0.1.0"
 description = "Execute tools from 1000+ services via Composio (GitHub, Gmail, Slack, Notion, etc.)"
 requires-python = ">=3.11"
@@ -10,6 +10,9 @@ dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
 
 [tool.centaur]
 module = "client.py"


### PR DESCRIPTION
## Summary

- Adds a Composio tool plugin (`tools/productivity/composio/`) that bridges Centaur agents to [Composio's](https://composio.dev) cloud-based tool execution platform
- Gives agents access to 1000+ external services (GitHub, Gmail, Slack, Notion, etc.) through four endpoints: `list_tools`, `search_tools`, `execute`, and `get_tool_schema`
- Credentials flow through iron-proxy via the standard `[tool.centaur]` secret declaration — sandboxes never see the raw Composio API key

## What it does

| Endpoint | Purpose |
|----------|---------|
| `list_tools(toolkit)` | List available actions for a toolkit (e.g. `github`, `gmail`) |
| `search_tools(query)` | Search across all toolkits by description |
| `execute(tool_slug, arguments)` | Run a Composio action (e.g. `HACKERNEWS_GET_TOP_STORIES`) |
| `get_tool_schema(tool_slug)` | Get input/output schema for an action |

## Test plan

- [x] Local Python smoke test: all 5 assertions pass (list, execute, schema, validation, error handling)
- [x] Centaur API test: all 4 endpoints respond correctly through `POST /tools/composio/*`
- [x] Full E2E: agent spawned in sandbox, used Composio tool, returned real Hacker News data
- [x] Codex code review completed — input validation, error handling, and response consistency addressed
- [ ] Reviewer verifies `COMPOSIO_API_KEY` iron-proxy injection works with the SDK's actual wire format

🤖 Generated with [Claude Code](https://claude.com/claude-code)