### PR TITLE
Add workflow catalog endpoint

### DIFF
--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -99,6 +99,28 @@ export interface WorkflowRunAccepted {
   idempotent?: boolean;
 }
 
+export interface WorkflowDefinition {
+  workflow_name: string;
+  version: string;
+  source_path: string;
+  schedule?: Record<string, unknown> | null;
+  input_type?: string | null;
+  input_fields: Array<{
+    name: string;
+    type: string;
+    required: boolean;
+  }>;
+  webhooks: Array<{
+    slug: string;
+    path: string;
+    provider?: string | null;
+    auth: Record<string, unknown>;
+    trigger_key?: Record<string, unknown> | string | null;
+    allowed_methods: string[];
+    allowed_content_types: string[];
+  }>;
+}
+
 export interface ThreadMessageRecord {
   id: string;
   role: string;
@@ -198,6 +220,16 @@ export class CentaurClient {
   async getWorkflowRun(runId: string): Promise<WorkflowRunAccepted> {
     const { data } = await this.http.get(`/workflows/runs/${encodeURIComponent(runId)}`);
     return data as WorkflowRunAccepted;
+  }
+
+  async listWorkflows(): Promise<{ ok: boolean; items: WorkflowDefinition[] }> {
+    const { data } = await this.http.get("/workflows");
+    return data as { ok: boolean; items: WorkflowDefinition[] };
+  }
+
+  async getWorkflow(workflowName: string): Promise<{ ok: boolean; item: WorkflowDefinition }> {
+    const { data } = await this.http.get(`/workflows/${encodeURIComponent(workflowName)}`);
+    return data as { ok: boolean; item: WorkflowDefinition };
   }
 
   async listWorkflowRuns(opts?: {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -5,6 +5,7 @@ export type {
   MessageOptions,
   InputContentBlock,
   ThreadMessageRecord,
+  WorkflowDefinition,
   WorkflowRunOptions,
   WorkflowRunAccepted,
 } from "./client";

--- a/services/api/api/app.py
+++ b/services/api/api/app.py
@@ -40,6 +40,7 @@ from api.routers import (
     attachments as attachments_mod,
     deprecated,
     health,
+    webhooks as webhooks_mod,
 )
 from api.routers import agent as agent_router_mod
 from api.routers import workflows as workflow_router_mod
@@ -398,6 +399,7 @@ async def instrument_requests(request, call_next):
 app.include_router(health.router)
 app.include_router(agent_router_mod.router)
 app.include_router(workflow_router_mod.router)
+app.include_router(webhooks_mod.router)
 app.include_router(attachments_mod.router)
 app.include_router(admin.router)
 app.include_router(deprecated.router)

--- a/services/api/api/routers/webhooks.py
+++ b/services/api/api/routers/webhooks.py
@@ -1,0 +1,229 @@
+"""Public workflow webhook routes."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from typing import Any
+from urllib.parse import parse_qs
+
+import structlog
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from api.runtime_control import ControlPlaneError
+from api.webhooks import HeaderTriggerKey, HmacAuth, WebhookSpec, get_webhook_spec
+from api.workflow_engine import create_workflow_run
+
+log = structlog.get_logger().bind(service="api", component="workflow_webhooks")
+
+router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
+
+_REDACTED_HEADERS = {
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "x-centaur-api-key",
+    "x-hub-signature",
+    "x-hub-signature-256",
+    "x-slack-signature",
+    "stripe-signature",
+}
+_MAX_WEBHOOK_BODY_BYTES = 1024 * 1024
+
+
+def _safe_headers(request: Request) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for key, value in request.headers.items():
+        normalized = key.lower()
+        if normalized in _REDACTED_HEADERS:
+            continue
+        headers[normalized] = value
+    return headers
+
+
+def _safe_headers_for_spec(request: Request, spec: WebhookSpec) -> dict[str, str]:
+    headers = _safe_headers(request)
+    if isinstance(spec.auth, HmacAuth):
+        headers.pop(spec.auth.signature_header.lower(), None)
+    return headers
+
+
+def _content_type(request: Request) -> str:
+    return request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+
+
+def _source_ip(request: Request) -> str | None:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        first = forwarded.split(",", 1)[0].strip()
+        if first:
+            return first
+    return request.client.host if request.client else None
+
+
+async def _parse_body(request: Request, raw_body: bytes) -> Any:
+    if not raw_body:
+        return {}
+    content_type = _content_type(request)
+    if content_type == "application/json":
+        try:
+            return json.loads(raw_body)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="invalid JSON webhook body") from exc
+    if content_type == "application/x-www-form-urlencoded":
+        parsed = parse_qs(raw_body.decode("utf-8", errors="replace"), keep_blank_values=True)
+        form = {
+            key: values[0] if len(values) == 1 else values
+            for key, values in parsed.items()
+        }
+        payload = form.get("payload")
+        if isinstance(payload, str):
+            try:
+                return json.loads(payload)
+            except json.JSONDecodeError:
+                return form
+        return form
+    return raw_body.decode("utf-8", errors="replace")
+
+
+def _extract_trigger_key(
+    *,
+    slug: str,
+    raw_body_sha256: str,
+    trigger_key_spec: HeaderTriggerKey | str | None,
+    request: Request,
+) -> str:
+    if isinstance(trigger_key_spec, HeaderTriggerKey):
+        header_value = request.headers.get(trigger_key_spec.header)
+        if header_value and header_value.strip():
+            return f"webhook:{slug}:{trigger_key_spec.header.lower()}:{header_value.strip()}"
+    if isinstance(trigger_key_spec, str) and trigger_key_spec.strip():
+        return f"webhook:{slug}:{trigger_key_spec.strip()}"
+    return f"webhook:{slug}:{raw_body_sha256}"
+
+
+def _expected_hmac_signature(auth: HmacAuth, secret: str, raw_body: bytes) -> str:
+    digest = hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).digest()
+    if auth.encoding == "hex":
+        encoded = digest.hex()
+    else:
+        encoded = base64.b64encode(digest).decode("ascii")
+    return f"{auth.signature_prefix}{encoded}"
+
+
+def _verify_webhook_auth(spec: WebhookSpec, request: Request, raw_body: bytes) -> None:
+    if spec.auth == "none":
+        return
+    if not isinstance(spec.auth, HmacAuth):
+        raise HTTPException(status_code=500, detail="unsupported webhook auth configuration")
+
+    signature = request.headers.get(spec.auth.signature_header)
+    if not signature:
+        log.warning(
+            "workflow_webhook_auth_failed",
+            slug=spec.slug,
+            reason="missing_signature",
+            signature_header=spec.auth.signature_header,
+        )
+        raise HTTPException(status_code=401, detail="missing webhook signature")
+
+    secret = os.getenv(spec.auth.secret_ref)
+    if not secret:
+        log.error(
+            "workflow_webhook_auth_config_error",
+            slug=spec.slug,
+            secret_ref=spec.auth.secret_ref,
+        )
+        raise HTTPException(status_code=500, detail="webhook auth secret is not configured")
+
+    expected = _expected_hmac_signature(spec.auth, secret, raw_body)
+    if not hmac.compare_digest(signature.strip(), expected):
+        log.warning(
+            "workflow_webhook_auth_failed",
+            slug=spec.slug,
+            reason="invalid_signature",
+            signature_header=spec.auth.signature_header,
+        )
+        raise HTTPException(status_code=401, detail="invalid webhook signature")
+
+
+@router.api_route("/{slug}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+async def invoke_workflow_webhook(slug: str, request: Request):
+    registered = get_webhook_spec(slug)
+    if registered is None:
+        raise HTTPException(status_code=404, detail="webhook not found")
+
+    spec = registered.spec
+    method = request.method.upper()
+    if method not in spec.allowed_methods:
+        raise HTTPException(status_code=405, detail="method not allowed for webhook")
+
+    content_type = _content_type(request)
+    if content_type and content_type not in spec.allowed_content_types:
+        raise HTTPException(status_code=400, detail="unsupported webhook content type")
+
+    raw_body = await request.body()
+    if len(raw_body) > _MAX_WEBHOOK_BODY_BYTES:
+        raise HTTPException(status_code=413, detail="webhook payload too large")
+    _verify_webhook_auth(spec, request, raw_body)
+
+    raw_body_sha256 = hashlib.sha256(raw_body).hexdigest()
+    body = await _parse_body(request, raw_body)
+    trigger_key = _extract_trigger_key(
+        slug=slug,
+        raw_body_sha256=raw_body_sha256,
+        trigger_key_spec=spec.trigger_key,
+        request=request,
+    )
+    run_input = {
+        "webhook": {
+            "slug": spec.slug,
+            "provider": spec.provider,
+            "method": method,
+            "path": request.url.path,
+            "headers": _safe_headers_for_spec(request, spec),
+            "query": dict(request.query_params),
+            "body": body,
+            "raw_body_sha256": raw_body_sha256,
+            "source_ip": _source_ip(request),
+        },
+    }
+
+    log.info(
+        "workflow_webhook_received",
+        slug=slug,
+        workflow_name=registered.workflow_name,
+        method=method,
+        raw_body_sha256=raw_body_sha256,
+        trigger_key=trigger_key,
+    )
+    try:
+        result = await create_workflow_run(
+            request.app.state.db_pool,
+            workflow_name=registered.workflow_name,
+            run_input=run_input,
+            trigger_key=trigger_key,
+            eager_start=False,
+        )
+    except ControlPlaneError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": exc.message},
+        ) from exc
+
+    status_code = 200 if result.get("idempotent") else 202
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "ok": True,
+            "run_id": result["run_id"],
+            "workflow_name": result["workflow_name"],
+            "status": result["status"],
+            "idempotent": result.get("idempotent", False),
+        },
+    )

--- a/services/api/api/routers/workflows.py
+++ b/services/api/api/routers/workflows.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+import dataclasses
+from typing import Any, get_args, get_origin
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
@@ -15,6 +16,7 @@ from api.workflow_engine import (
     create_workflow_run,
     get_workflow_checkpoints,
     get_workflow_run,
+    list_workflow_handlers,
     list_workflow_runs,
 )
 
@@ -71,6 +73,115 @@ class WorkflowRunCreateRequest(BaseModel):
     eager_start: bool = False
 
 
+def _has_broad_workflow_access(request: Request) -> bool:
+    info = get_key_info(request)
+    return (
+        check_scope(info, "agent:execute")
+        or check_scope(info, "admin")
+        or check_scope(info, "workflows", "")
+    )
+
+
+def _type_name(value: Any) -> str:
+    origin = get_origin(value)
+    if origin is not None:
+        args = ", ".join(_type_name(arg) for arg in get_args(value))
+        name = getattr(origin, "__name__", str(origin))
+        return f"{name}[{args}]" if args else name
+    return getattr(value, "__name__", str(value))
+
+
+def _input_fields(input_cls: type | None) -> list[dict[str, Any]]:
+    if input_cls is None or not dataclasses.is_dataclass(input_cls):
+        return []
+    fields: list[dict[str, Any]] = []
+    for field in dataclasses.fields(input_cls):
+        has_default = (
+            field.default is not dataclasses.MISSING
+            or field.default_factory is not dataclasses.MISSING
+        )
+        fields.append(
+            {
+                "name": field.name,
+                "type": _type_name(field.type),
+                "required": not has_default,
+            }
+        )
+    return fields
+
+
+def _webhook_trigger_key(value: Any) -> dict[str, Any] | str | None:
+    from api.webhooks import HeaderTriggerKey
+
+    if isinstance(value, HeaderTriggerKey):
+        return {"type": "header", "header": value.header}
+    return value
+
+
+def _webhook_auth(value: Any) -> dict[str, Any]:
+    from api.webhooks import HmacAuth
+
+    if isinstance(value, HmacAuth):
+        return {
+            "type": "hmac",
+            "algorithm": value.algorithm,
+            "signature_header": value.signature_header,
+            "signature_prefix": value.signature_prefix,
+            "encoding": value.encoding,
+        }
+    return {"type": value}
+
+
+def _webhooks_for_workflow(workflow_name: str) -> list[dict[str, Any]]:
+    from api.webhooks import list_webhook_specs
+
+    webhooks: list[dict[str, Any]] = []
+    for registered in list_webhook_specs().values():
+        if registered.workflow_name != workflow_name:
+            continue
+        spec = registered.spec
+        webhooks.append(
+            {
+                "slug": spec.slug,
+                "path": f"/api/webhooks/{spec.slug}",
+                "provider": spec.provider,
+                "auth": _webhook_auth(spec.auth),
+                "trigger_key": _webhook_trigger_key(spec.trigger_key),
+                "allowed_methods": spec.allowed_methods,
+                "allowed_content_types": spec.allowed_content_types,
+            }
+        )
+    return sorted(webhooks, key=lambda item: item["slug"])
+
+
+def _workflow_definition(workflow_name: str, handler: Any) -> dict[str, Any]:
+    input_cls = handler.input_cls
+    return {
+        "workflow_name": workflow_name,
+        "version": handler.version,
+        "source_path": handler.source_path,
+        "schedule": handler.schedule,
+        "input_type": getattr(input_cls, "__name__", None) if input_cls else None,
+        "input_fields": _input_fields(input_cls),
+        "webhooks": _webhooks_for_workflow(workflow_name),
+    }
+
+
+@router.get("")
+async def list_workflows(request: Request):
+    items = [
+        _workflow_definition(workflow_name, handler)
+        for workflow_name, handler in list_workflow_handlers().items()
+        if _key_authorized_for_workflow(request, workflow_name)
+    ]
+    if not items and not _has_broad_workflow_access(request):
+        raise HTTPException(
+            status_code=403,
+            detail="API key scope does not permit any registered workflow.",
+        )
+    return {"ok": True, "items": sorted(items, key=lambda item: item["workflow_name"])}
+
+
 @router.post("/runs")
 async def create_run(request: Request, body: WorkflowRunCreateRequest):
     _require_workflow_access(request, body.workflow_name)
@@ -98,13 +209,7 @@ async def list_runs(
     parent_run_id: str | None = None,
     limit: int = Query(default=50, ge=1, le=200),
 ):
-    info = get_key_info(request)
-    has_broad_access = (
-        check_scope(info, "agent:execute")
-        or check_scope(info, "admin")
-        or check_scope(info, "workflows", "")
-    )
-    if not has_broad_access:
+    if not _has_broad_workflow_access(request):
         # Narrow keys MUST filter to a workflow they're authorized for.
         if not workflow_name:
             raise HTTPException(
@@ -185,3 +290,12 @@ async def send_event(request: Request, body: SendEventRequest):
         correlation_id=body.correlation_id,
         payload=body.payload,
     )
+
+
+@router.get("/{workflow_name}")
+async def get_workflow(workflow_name: str, request: Request):
+    handler = list_workflow_handlers().get(workflow_name)
+    if handler is None:
+        raise HTTPException(status_code=404, detail="workflow not found")
+    _require_workflow_access(request, workflow_name)
+    return {"ok": True, "item": _workflow_definition(workflow_name, handler)}

--- a/services/api/api/webhooks.py
+++ b/services/api/api/webhooks.py
@@ -1,0 +1,197 @@
+"""Workflow webhook registration primitives."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger().bind(service="api", component="workflow_webhooks")
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+_RESERVED_SLUGS = {"slack"}
+
+
+@dataclass(frozen=True)
+class HeaderTriggerKey:
+    header: str
+
+
+@dataclass(frozen=True)
+class HmacAuth:
+    secret_ref: str
+    signature_header: str = "X-Webhook-Signature"
+    algorithm: str = "sha256"
+    signature_prefix: str = "sha256="
+    encoding: str = "hex"
+
+    @classmethod
+    def github(cls, *, secret_ref: str) -> HmacAuth:
+        return cls(
+            secret_ref=secret_ref,
+            signature_header="X-Hub-Signature-256",
+            signature_prefix="sha256=",
+        )
+
+
+@dataclass(frozen=True)
+class WebhookSpec:
+    slug: str
+    auth: str | HmacAuth = "none"
+    provider: str | None = None
+    trigger_key: HeaderTriggerKey | str | None = None
+    allowed_methods: list[str] = field(default_factory=lambda: ["POST"])
+    allowed_content_types: list[str] = field(default_factory=lambda: ["application/json"])
+
+
+@dataclass(frozen=True)
+class RegisteredWebhook:
+    spec: WebhookSpec
+    workflow_name: str
+    source_path: str
+
+
+_WEBHOOKS_BY_SLUG: dict[str, RegisteredWebhook] = {}
+
+
+def clear_webhook_specs() -> None:
+    _WEBHOOKS_BY_SLUG.clear()
+
+
+def list_webhook_specs() -> dict[str, RegisteredWebhook]:
+    return dict(_WEBHOOKS_BY_SLUG)
+
+
+def get_webhook_spec(slug: str) -> RegisteredWebhook | None:
+    return _WEBHOOKS_BY_SLUG.get(slug)
+
+
+def _coerce_trigger_key(value: Any) -> HeaderTriggerKey | str | None:
+    if value is None or isinstance(value, HeaderTriggerKey):
+        return value
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        kind = value.get("type", "header")
+        if kind == "header" and isinstance(value.get("header"), str):
+            return HeaderTriggerKey(value["header"])
+    raise ValueError("trigger_key must be a string, HeaderTriggerKey, or header trigger dict")
+
+
+def _coerce_auth(value: Any) -> str | HmacAuth:
+    if value is None:
+        return "none"
+    if isinstance(value, HmacAuth):
+        return value
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        kind = value.get("type", value.get("kind", "hmac"))
+        if kind == "none":
+            return "none"
+        if kind == "github":
+            secret_ref = value.get("secret_ref")
+            if not isinstance(secret_ref, str):
+                raise ValueError("github auth requires secret_ref")
+            return HmacAuth.github(secret_ref=secret_ref)
+        if kind == "hmac":
+            data = {k: v for k, v in value.items() if k not in {"type", "kind"}}
+            return HmacAuth(**data)
+    raise ValueError("auth must be 'none', HmacAuth, or an auth dict")
+
+
+def _coerce_spec(raw: Any) -> WebhookSpec:
+    if isinstance(raw, WebhookSpec):
+        return raw
+    if isinstance(raw, str):
+        return WebhookSpec(slug=raw)
+    if isinstance(raw, dict):
+        data = dict(raw)
+        data["trigger_key"] = _coerce_trigger_key(data.get("trigger_key"))
+        data["auth"] = _coerce_auth(data.get("auth"))
+        return WebhookSpec(**data)
+    raise ValueError("webhook spec must be a WebhookSpec, dict, or slug string")
+
+
+def _validate_spec(spec: WebhookSpec) -> None:
+    if not _SLUG_RE.match(spec.slug):
+        raise ValueError(
+            "webhook slug must be URL-safe lowercase text matching "
+            "[a-z0-9][a-z0-9._-]{0,127}",
+        )
+    if spec.slug in _RESERVED_SLUGS:
+        raise ValueError(f"webhook slug is reserved: {spec.slug}")
+    if isinstance(spec.auth, str):
+        if spec.auth != "none":
+            raise ValueError("unsupported webhook auth string")
+    elif isinstance(spec.auth, HmacAuth):
+        if spec.auth.algorithm != "sha256":
+            raise ValueError("only sha256 HMAC webhook auth is supported for now")
+        if spec.auth.encoding not in {"hex", "base64"}:
+            raise ValueError("HMAC encoding must be hex or base64")
+        if not spec.auth.secret_ref:
+            raise ValueError("HMAC auth requires secret_ref")
+        if not spec.auth.signature_header:
+            raise ValueError("HMAC auth requires signature_header")
+    else:
+        raise ValueError("unsupported webhook auth")
+    if not spec.allowed_methods:
+        raise ValueError("allowed_methods must not be empty")
+    normalized_methods = [method.upper() for method in spec.allowed_methods]
+    if any(not method.isalpha() for method in normalized_methods):
+        raise ValueError("allowed_methods must contain HTTP method names")
+    if not spec.allowed_content_types:
+        raise ValueError("allowed_content_types must not be empty")
+
+
+def register_workflow_webhooks(
+    workflow_name: str,
+    source_path: str,
+    raw_specs: Any,
+) -> None:
+    if raw_specs is None:
+        return
+    if isinstance(raw_specs, (WebhookSpec, str, dict)):
+        specs = [raw_specs]
+    elif isinstance(raw_specs, (list, tuple)):
+        specs = list(raw_specs)
+    else:
+        raise ValueError("WEBHOOKS must be a WebhookSpec, dict, slug string, or list")
+
+    for raw in specs:
+        spec = _coerce_spec(raw)
+        _validate_spec(spec)
+        existing = _WEBHOOKS_BY_SLUG.get(spec.slug)
+        if existing is not None:
+            raise ValueError(
+                "duplicate webhook slug "
+                f"{spec.slug!r} for workflows {existing.workflow_name!r} and {workflow_name!r}",
+            )
+        normalized_spec = WebhookSpec(
+            slug=spec.slug,
+            auth=spec.auth,
+            provider=spec.provider,
+            trigger_key=spec.trigger_key,
+            allowed_methods=[method.upper() for method in spec.allowed_methods],
+            allowed_content_types=[
+                content_type.lower() for content_type in spec.allowed_content_types
+            ],
+        )
+        _WEBHOOKS_BY_SLUG[normalized_spec.slug] = RegisteredWebhook(
+            spec=normalized_spec,
+            workflow_name=workflow_name,
+            source_path=source_path,
+        )
+        log.info(
+            "workflow_webhook_registered",
+            slug=normalized_spec.slug,
+            workflow_name=workflow_name,
+            auth=(
+                normalized_spec.auth
+                if isinstance(normalized_spec.auth, str)
+                else "hmac"
+            ),
+            provider=normalized_spec.provider,
+        )

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -51,6 +51,7 @@ from api.vm_metrics import (
     record_workflow_run_enqueued,
     record_workflow_run_terminal,
 )
+from api.webhooks import clear_webhook_specs, register_workflow_webhooks
 from api.laminar_tracing import set_trace_context, start_span
 from api.trace_context import get_or_create_thread_trace_id
 
@@ -1482,6 +1483,19 @@ def _load_workflow_file(
             schedule=schedule,
         )
         discovered[wf_name] = str(py_file)
+        try:
+            register_workflow_webhooks(
+                wf_name,
+                str(py_file),
+                getattr(mod, "WEBHOOKS", None),
+            )
+        except Exception:
+            log.warning(
+                "workflow_webhook_registration_failed",
+                workflow_name=wf_name,
+                file=str(py_file),
+                exc_info=True,
+            )
     except Exception:
         log.warning("workflow_handler_load_failed", file=str(py_file), exc_info=True)
 
@@ -1505,6 +1519,7 @@ def discover_workflow_handlers() -> dict[str, str]:
     """
     global _WORKFLOW_HANDLERS
     _WORKFLOW_HANDLERS.clear()
+    clear_webhook_specs()
     discovered: dict[str, str] = {}
 
     # 1. Built-in workflows (api.workflows package)

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -1553,6 +1553,11 @@ def get_workflow_handler(
     return _WORKFLOW_HANDLERS.get(workflow_name)
 
 
+def list_workflow_handlers() -> dict[str, _RegisteredHandler]:
+    """Return registered workflow handlers keyed by workflow name."""
+    return dict(_WORKFLOW_HANDLERS)
+
+
 # ── Schedule specs ────────────────────────────────────────────────────
 
 

--- a/services/api/tests/test_github_issue_triage_workflow.py
+++ b/services/api/tests/test_github_issue_triage_workflow.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from workflows.github_issue_triage import handler
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.agent_turn_calls = []
+
+    async def agent_turn(self, prompt, **kwargs):
+        self.agent_turn_calls.append((prompt, kwargs))
+        return {"result_text": "comment posted"}
+
+
+def _input(*, event: str = "issues", action: str = "opened") -> dict:
+    return {
+        "webhook": {
+            "headers": {
+                "x-github-event": event,
+                "x-github-delivery": f"delivery-{uuid.uuid4().hex}",
+            },
+            "body": {
+                "action": action,
+                "repository": {
+                    "full_name": "acme/widgets",
+                    "name": "widgets",
+                    "default_branch": "main",
+                    "owner": {"login": "acme"},
+                },
+                "issue": {
+                    "number": 42,
+                    "title": "Widget crashes on startup",
+                    "body": "The app exits immediately after launch.",
+                    "html_url": "https://github.com/acme/widgets/issues/42",
+                    "url": "https://api.github.com/repos/acme/widgets/issues/42",
+                    "user": {"login": "octo-user"},
+                    "labels": [{"name": "bug"}],
+                },
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_github_issue_triage_dispatches_agent_for_opened_issue():
+    ctx = FakeContext()
+
+    result = await handler(_input(), ctx)
+
+    assert result["triaged"] is True
+    assert result["repository"] == "acme/widgets"
+    assert result["issue_number"] == 42
+    assert len(ctx.agent_turn_calls) == 1
+    prompt, kwargs = ctx.agent_turn_calls[0]
+    assert "Widget crashes on startup" in prompt
+    assert "https://api.github.com/repos/acme/widgets/issues/42/comments" in prompt
+    assert kwargs["thread_key"] == "github:acme/widgets:42"
+    assert kwargs["metadata"]["github_repository"] == "acme/widgets"
+
+
+@pytest.mark.asyncio
+async def test_github_issue_triage_skips_non_issue_event():
+    ctx = FakeContext()
+
+    result = await handler(_input(event="ping"), ctx)
+
+    assert result == {
+        "skipped": True,
+        "reason": "unsupported_github_event",
+        "event_type": "ping",
+    }
+    assert ctx.agent_turn_calls == []
+
+
+@pytest.mark.asyncio
+async def test_github_issue_triage_skips_unsupported_issue_action():
+    ctx = FakeContext()
+
+    result = await handler(_input(action="edited"), ctx)
+
+    assert result == {
+        "skipped": True,
+        "reason": "unsupported_issue_action",
+        "action": "edited",
+    }
+    assert ctx.agent_turn_calls == []

--- a/services/api/tests/test_workflow_catalog.py
+++ b/services/api/tests/test_workflow_catalog.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+
+def _auth(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+@pytest.mark.asyncio
+async def test_list_workflows_returns_catalog_with_webhook_metadata(
+    client,
+    tmp_path,
+    monkeypatch,
+):
+    from api.workflow_engine import discover_workflow_handlers
+
+    workflow_name = f"catalog_{uuid.uuid4().hex}"
+    slug = f"catalog-{uuid.uuid4().hex}"
+    workflow_file = tmp_path / "catalog_workflow.py"
+    workflow_file.write_text(
+        "from dataclasses import dataclass\n"
+        "from api.webhooks import HmacAuth\n"
+        f"WORKFLOW_NAME = {workflow_name!r}\n"
+        "SCHEDULE = {'interval_seconds': 300, 'no_delivery': True}\n"
+        "WEBHOOKS = [{\n"
+        f"    'slug': {slug!r},\n"
+        "    'provider': 'test',\n"
+        "    'auth': HmacAuth.github(secret_ref='CATALOG_WEBHOOK_SECRET'),\n"
+        "    'trigger_key': {'type': 'header', 'header': 'X-Test-Delivery'},\n"
+        "}]\n"
+        "@dataclass\n"
+        "class Input:\n"
+        "    message: str\n"
+        "    count: int = 1\n"
+        "async def handler(inp, ctx):\n"
+        "    return {}\n",
+    )
+    monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
+    discover_workflow_handlers()
+
+    response = await client.get("/workflows")
+
+    assert response.status_code == 200
+    body = response.json()
+    item = next(item for item in body["items"] if item["workflow_name"] == workflow_name)
+    assert item["schedule"]["interval_seconds"] == 300
+    assert item["input_type"] == "Input"
+    assert item["input_fields"] == [
+        {"name": "message", "type": "str", "required": True},
+        {"name": "count", "type": "int", "required": False},
+    ]
+    assert item["webhooks"] == [
+        {
+            "slug": slug,
+            "path": f"/api/webhooks/{slug}",
+            "provider": "test",
+            "auth": {
+                "type": "hmac",
+                "algorithm": "sha256",
+                "signature_header": "X-Hub-Signature-256",
+                "signature_prefix": "sha256=",
+                "encoding": "hex",
+            },
+            "trigger_key": {"type": "header", "header": "X-Test-Delivery"},
+            "allowed_methods": ["POST"],
+            "allowed_content_types": ["application/json"],
+        }
+    ]
+    assert "CATALOG_WEBHOOK_SECRET" not in str(item)
+
+    detail_response = await client.get(f"/workflows/{workflow_name}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["item"]["workflow_name"] == workflow_name
+
+
+@pytest.mark.asyncio
+async def test_list_workflows_filters_to_key_scopes(
+    client,
+    managed_app,
+    api_key: str,
+):
+    create_response = await client.post(
+        "/admin/api-keys",
+        headers=_auth(api_key),
+        json={
+            "name": f"workflow-catalog-{uuid.uuid4().hex}",
+            "scopes": ["workflows:agent_turn"],
+            "created_by": "pytest",
+        },
+    )
+    assert create_response.status_code == 200
+    plaintext_key = create_response.json()["key"]
+
+    transport = httpx.ASGITransport(app=managed_app, client=("198.51.100.10", 49152))
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as external:
+        response = await external.get("/workflows", headers=_auth(plaintext_key))
+        assert response.status_code == 200
+        names = [item["workflow_name"] for item in response.json()["items"]]
+        assert names == ["agent_turn"]
+
+        allowed = await external.get("/workflows/agent_turn", headers=_auth(plaintext_key))
+        assert allowed.status_code == 200
+
+        forbidden = await external.get(
+            "/workflows/slack_thread_turn",
+            headers=_auth(plaintext_key),
+        )
+        assert forbidden.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_workflow_catalog_does_not_shadow_run_routes(client, api_key: str):
+    response = await client.get("/workflows/runs", headers=_auth(api_key))
+    assert response.status_code == 200
+    assert response.json()["ok"] is True

--- a/services/api/tests/test_workflow_webhooks.py
+++ b/services/api/tests/test_workflow_webhooks.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import uuid
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_workflow_webhook_tables(db_pool):
+    await db_pool.execute(
+        "TRUNCATE TABLE workflow_events, workflow_schedules, workflow_checkpoints, workflow_runs "
+        "CASCADE",
+    )
+    yield
+
+
+def _jsonb(value):
+    return json.loads(value) if isinstance(value, str) else value
+
+
+def _sha256_signature(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+@pytest_asyncio.fixture
+async def anonymous_client(managed_app):
+    transport = httpx.ASGITransport(app=managed_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_no_auth_workflow_webhook_enqueues_run(
+    anonymous_client,
+    db_pool,
+    monkeypatch,
+    tmp_path,
+):
+    from api.webhooks import get_webhook_spec
+    from api.workflow_engine import discover_workflow_handlers
+
+    workflow_name = f"webhook_echo_{uuid.uuid4().hex}"
+    slug = f"echo-{uuid.uuid4().hex}"
+    workflow_file = tmp_path / "webhook_echo.py"
+    workflow_file.write_text(
+        "WORKFLOW_NAME = " + repr(workflow_name) + "\n"
+        "WEBHOOKS = [{\n"
+        "    'slug': " + repr(slug) + ",\n"
+        "    'auth': 'none',\n"
+        "    'provider': 'test',\n"
+        "    'trigger_key': {'type': 'header', 'header': 'X-Test-Delivery'},\n"
+        "}]\n"
+        "async def handler(inp, ctx):\n"
+        "    return {'received': inp['webhook']['body']}\n",
+    )
+    monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
+    discover_workflow_handlers()
+
+    registered = get_webhook_spec(slug)
+    assert registered is not None
+    assert registered.workflow_name == workflow_name
+
+    response = await anonymous_client.post(
+        f"/api/webhooks/{slug}?source=unit",
+        headers={
+            "Cookie": "session=should-not-persist",
+            "X-Test-Delivery": "delivery-1",
+        },
+        json={"hello": "world"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["ok"] is True
+    assert body["workflow_name"] == workflow_name
+    assert body["status"] == "queued"
+    assert body["idempotent"] is False
+
+    run_row = await db_pool.fetchrow(
+        "SELECT workflow_name, trigger_key, input_json FROM workflow_runs WHERE run_id = $1",
+        body["run_id"],
+    )
+    assert run_row is not None
+    assert run_row["workflow_name"] == workflow_name
+    assert run_row["trigger_key"] == f"webhook:{slug}:x-test-delivery:delivery-1"
+
+    run_input = _jsonb(run_row["input_json"])
+    event = run_input["webhook"]
+    assert event["slug"] == slug
+    assert event["provider"] == "test"
+    assert event["method"] == "POST"
+    assert event["path"] == f"/api/webhooks/{slug}"
+    assert event["query"] == {"source": "unit"}
+    assert event["body"] == {"hello": "world"}
+    assert "raw_body_sha256" in event
+    assert "cookie" not in event["headers"]
+    assert event["headers"]["x-test-delivery"] == "delivery-1"
+
+    retry = await anonymous_client.post(
+        f"/api/webhooks/{slug}?source=unit",
+        headers={"X-Test-Delivery": "delivery-1"},
+        json={"hello": "world"},
+    )
+    assert retry.status_code == 200
+    assert retry.json()["run_id"] == body["run_id"]
+    assert retry.json()["idempotent"] is True
+
+
+@pytest.mark.asyncio
+async def test_hmac_workflow_webhook_enqueues_run_with_valid_signature(
+    anonymous_client,
+    db_pool,
+    monkeypatch,
+    tmp_path,
+):
+    from api.workflow_engine import discover_workflow_handlers
+
+    secret = "test-webhook-secret"
+    monkeypatch.setenv("TEST_WEBHOOK_SECRET", secret)
+    workflow_name = f"webhook_hmac_{uuid.uuid4().hex}"
+    slug = f"hmac-{uuid.uuid4().hex}"
+    workflow_file = tmp_path / "webhook_hmac.py"
+    workflow_file.write_text(
+        "WORKFLOW_NAME = " + repr(workflow_name) + "\n"
+        "WEBHOOKS = [{\n"
+        "    'slug': " + repr(slug) + ",\n"
+        "    'auth': {\n"
+        "        'type': 'hmac',\n"
+        "        'secret_ref': 'TEST_WEBHOOK_SECRET',\n"
+        "        'signature_header': 'X-Test-Signature',\n"
+        "        'signature_prefix': 'sha256=',\n"
+        "    },\n"
+        "}]\n"
+        "async def handler(inp, ctx):\n"
+        "    return {'received': inp['webhook']['body']}\n",
+    )
+    monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
+    discover_workflow_handlers()
+
+    raw_body = b'{"hello":"signed"}'
+    response = await anonymous_client.post(
+        f"/api/webhooks/{slug}",
+        content=raw_body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Test-Signature": _sha256_signature(secret, raw_body),
+        },
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["workflow_name"] == workflow_name
+
+    run_row = await db_pool.fetchrow(
+        "SELECT input_json FROM workflow_runs WHERE run_id = $1",
+        body["run_id"],
+    )
+    run_input = _jsonb(run_row["input_json"])
+    assert run_input["webhook"]["body"] == {"hello": "signed"}
+    assert "x-test-signature" not in run_input["webhook"]["headers"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_webhook_parses_form_payload_json(
+    anonymous_client,
+    db_pool,
+    monkeypatch,
+    tmp_path,
+):
+    from api.workflow_engine import discover_workflow_handlers
+
+    secret = "test-webhook-secret"
+    monkeypatch.setenv("TEST_WEBHOOK_SECRET", secret)
+    workflow_name = f"webhook_form_{uuid.uuid4().hex}"
+    slug = f"form-{uuid.uuid4().hex}"
+    workflow_file = tmp_path / "webhook_form.py"
+    workflow_file.write_text(
+        "WORKFLOW_NAME = " + repr(workflow_name) + "\n"
+        "WEBHOOKS = [{\n"
+        "    'slug': " + repr(slug) + ",\n"
+        "    'auth': {\n"
+        "        'type': 'hmac',\n"
+        "        'secret_ref': 'TEST_WEBHOOK_SECRET',\n"
+        "        'signature_header': 'X-Test-Signature',\n"
+        "        'signature_prefix': 'sha256=',\n"
+        "    },\n"
+        "    'allowed_content_types': [\n"
+        "        'application/json',\n"
+        "        'application/x-www-form-urlencoded',\n"
+        "    ],\n"
+        "}]\n"
+        "async def handler(inp, ctx):\n"
+        "    return {'received': inp['webhook']['body']}\n",
+    )
+    monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
+    discover_workflow_handlers()
+
+    raw_body = b'payload=%7B%22hello%22%3A%22form%22%7D'
+    response = await anonymous_client.post(
+        f"/api/webhooks/{slug}",
+        content=raw_body,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "X-Test-Signature": _sha256_signature(secret, raw_body),
+        },
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    run_row = await db_pool.fetchrow(
+        "SELECT input_json FROM workflow_runs WHERE run_id = $1",
+        body["run_id"],
+    )
+    run_input = _jsonb(run_row["input_json"])
+    assert run_input["webhook"]["body"] == {"hello": "form"}
+
+
+@pytest.mark.asyncio
+async def test_hmac_workflow_webhook_rejects_invalid_signature_without_run(
+    anonymous_client,
+    db_pool,
+    monkeypatch,
+    tmp_path,
+):
+    from api.workflow_engine import discover_workflow_handlers
+
+    monkeypatch.setenv("TEST_WEBHOOK_SECRET", "test-webhook-secret")
+    slug = f"hmac-reject-{uuid.uuid4().hex}"
+    workflow_file = tmp_path / "webhook_hmac_reject.py"
+    workflow_file.write_text(
+        "WORKFLOW_NAME = 'webhook_hmac_reject'\n"
+        "WEBHOOKS = [{\n"
+        f"    'slug': {slug!r},\n"
+        "    'auth': {'type': 'hmac', 'secret_ref': 'TEST_WEBHOOK_SECRET'},\n"
+        "}]\n"
+        "async def handler(inp, ctx):\n"
+        "    return {'ok': True}\n",
+    )
+    monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
+    discover_workflow_handlers()
+
+    response = await anonymous_client.post(
+        f"/api/webhooks/{slug}",
+        content=b'{"hello":"bad-signature"}',
+        headers={
+            "Content-Type": "application/json",
+            "X-Webhook-Signature": "sha256=bad",
+        },
+    )
+
+    assert response.status_code == 401
+    run_count = await db_pool.fetchval(
+        "SELECT COUNT(*)::int FROM workflow_runs WHERE workflow_name = 'webhook_hmac_reject'",
+    )
+    assert run_count == 0
+
+
+@pytest.mark.asyncio
+async def test_workflow_webhook_rejects_unregistered_slug(client):
+    response = await client.post("/api/webhooks/missing-webhook", json={"hello": "world"})
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_workflow_webhook_rejects_disallowed_method(client, monkeypatch, tmp_path):
+    from api.workflow_engine import discover_workflow_handlers
+
+    slug = f"post-only-{uuid.uuid4().hex}"
+    workflow_file = tmp_path / "webhook_post_only.py"
+    workflow_file.write_text(
+        "WORKFLOW_NAME = 'webhook_post_only'\n"
+        f"WEBHOOKS = [{{'slug': {slug!r}, 'auth': 'none'}}]\n"
+        "async def handler(inp, ctx):\n"
+        "    return {'ok': True}\n",
+    )
+    monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
+    discover_workflow_handlers()
+
+    response = await client.get(f"/api/webhooks/{slug}")
+    assert response.status_code == 405
+
+
+@pytest.mark.asyncio
+async def test_workflow_webhook_rejects_unsupported_content_type(
+    client,
+    monkeypatch,
+    tmp_path,
+):
+    from api.workflow_engine import discover_workflow_handlers
+
+    slug = f"json-only-{uuid.uuid4().hex}"
+    workflow_file = tmp_path / "webhook_json_only.py"
+    workflow_file.write_text(
+        "WORKFLOW_NAME = 'webhook_json_only'\n"
+        f"WEBHOOKS = [{{'slug': {slug!r}, 'auth': 'none'}}]\n"
+        "async def handler(inp, ctx):\n"
+        "    return {'ok': True}\n",
+    )
+    monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
+    discover_workflow_handlers()
+
+    response = await client.post(
+        f"/api/webhooks/{slug}",
+        content="hello",
+        headers={"Content-Type": "text/plain"},
+    )
+    assert response.status_code == 400

--- a/workflows/github_issue_triage.py
+++ b/workflows/github_issue_triage.py
@@ -1,0 +1,155 @@
+"""Example workflow: triage new GitHub issues from a webhook.
+
+Configure a GitHub repository webhook to POST issue events to:
+
+    /api/webhooks/github-issue-triage
+
+Required GitHub webhook settings:
+
+    Content type: application/json preferred; GitHub's default form payloads
+    are also accepted.
+    Secret: value stored as GITHUB_WEBHOOK_SECRET in the API environment
+    Events: Issues
+
+The workflow verifies GitHub's HMAC signature at the API edge, creates a
+durable workflow run, then asks an agent sandbox to post one comment on the
+issue with a concrete initial diagnosis and possible fix.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from api.workflow_engine import WorkflowContext
+
+WORKFLOW_NAME = "github_issue_triage"
+
+WEBHOOKS = [
+    {
+        "slug": "github-issue-triage",
+        "provider": "github",
+        "auth": {"type": "github", "secret_ref": "GITHUB_WEBHOOK_SECRET"},
+        "trigger_key": {"type": "header", "header": "X-GitHub-Delivery"},
+        "allowed_methods": ["POST"],
+        "allowed_content_types": ["application/json", "application/x-www-form-urlencoded"],
+    }
+]
+
+_SUPPORTED_ACTIONS = {"opened", "reopened"}
+
+
+def _webhook_payload(inp: dict[str, Any]) -> dict[str, Any]:
+    webhook = inp.get("webhook")
+    if not isinstance(webhook, dict):
+        return {}
+    body = webhook.get("body")
+    return body if isinstance(body, dict) else {}
+
+
+def _headers(inp: dict[str, Any]) -> dict[str, str]:
+    webhook = inp.get("webhook")
+    if not isinstance(webhook, dict):
+        return {}
+    headers = webhook.get("headers")
+    return headers if isinstance(headers, dict) else {}
+
+
+def _issue_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    issue = payload.get("issue") if isinstance(payload.get("issue"), dict) else {}
+    repo = payload.get("repository") if isinstance(payload.get("repository"), dict) else {}
+    owner = repo.get("owner") if isinstance(repo.get("owner"), dict) else {}
+    labels = issue.get("labels") if isinstance(issue.get("labels"), list) else []
+    return {
+        "repo_full_name": repo.get("full_name") or "",
+        "repo_default_branch": repo.get("default_branch") or "",
+        "repo_description": repo.get("description") or "",
+        "owner": owner.get("login") or "",
+        "repo": repo.get("name") or "",
+        "issue_number": issue.get("number"),
+        "issue_title": issue.get("title") or "",
+        "issue_body": issue.get("body") or "",
+        "issue_url": issue.get("html_url") or "",
+        "issue_api_url": issue.get("url") or "",
+        "author": (issue.get("user") or {}).get("login") if isinstance(issue.get("user"), dict) else "",
+        "labels": [
+            label.get("name")
+            for label in labels
+            if isinstance(label, dict) and label.get("name")
+        ],
+    }
+
+
+def _agent_prompt(summary: dict[str, Any]) -> str:
+    repo_full_name = summary["repo_full_name"]
+    issue_number = summary["issue_number"]
+    issue_json = json.dumps(summary, indent=2, sort_keys=True)
+    return f"""You are triaging a newly opened GitHub issue.
+
+Repository: {repo_full_name}
+Issue number: {issue_number}
+
+Issue payload summary:
+
+```json
+{issue_json}
+```
+
+Your task:
+1. Inspect the repository enough to form a plausible first diagnosis.
+2. Identify the most likely relevant files, commands, or code paths.
+3. Post exactly one GitHub issue comment with:
+   - a short acknowledgement
+   - the likely cause or first hypothesis
+   - concrete next steps or a possible fix
+   - any command or file references that would help a maintainer
+
+Constraints:
+- Do not close, label, assign, or edit the issue.
+- Do not post more than one comment.
+- Keep the comment concise and useful; avoid generic filler.
+- If you cannot access the repository or GitHub API, return a clear failure
+  explaining what blocked you.
+
+You may use `gh` or `curl` to post the comment to:
+https://api.github.com/repos/{repo_full_name}/issues/{issue_number}/comments
+"""
+
+
+async def handler(inp: dict[str, Any], ctx: WorkflowContext) -> dict[str, Any]:
+    headers = _headers(inp)
+    event_type = headers.get("x-github-event", "")
+    payload = _webhook_payload(inp)
+    action = str(payload.get("action") or "")
+    if event_type != "issues":
+        return {"skipped": True, "reason": "unsupported_github_event", "event_type": event_type}
+    if action not in _SUPPORTED_ACTIONS:
+        return {"skipped": True, "reason": "unsupported_issue_action", "action": action}
+
+    summary = _issue_summary(payload)
+    repo_full_name = str(summary.get("repo_full_name") or "")
+    issue_number = summary.get("issue_number")
+    if not repo_full_name or not issue_number:
+        return {"skipped": True, "reason": "missing_repository_or_issue"}
+
+    result = await ctx.agent_turn(
+        _agent_prompt(summary),
+        thread_key=f"github:{repo_full_name}:{issue_number}",
+        message_id=f"github:{repo_full_name}:{issue_number}:{headers.get('x-github-delivery', '')}",
+        metadata={
+            "source": "github_webhook",
+            "github_event": event_type,
+            "github_action": action,
+            "github_repository": repo_full_name,
+            "github_issue_number": issue_number,
+            "github_issue_url": summary.get("issue_url"),
+        },
+    )
+
+    return {
+        "triaged": True,
+        "repository": repo_full_name,
+        "issue_number": issue_number,
+        "issue_url": summary.get("issue_url"),
+        "agent_result": result,
+    }


### PR DESCRIPTION
## what

- adds `GET /workflows` to list registered workflow definitions available to the caller
- adds `GET /workflows/{workflow_name}` for a single workflow definition
- includes schedule metadata, input dataclass fields, and registered webhook entrypoints without exposing webhook secret refs
- adds API client helpers for listing/getting workflow definitions

## tested

- `cd services/api && uv run ruff check api/routers/workflows.py api/workflow_engine.py tests/test_workflow_catalog.py`
- `cd services/api && uv run pytest tests/test_workflow_catalog.py` (skipped in this sandbox because no Postgres test backend was available)
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @centaur/api-client exec tsc --noEmit`

Stacked on #161 because the catalog includes workflow webhook metadata.
