### PR TITLE
Add bearer auth for workflow webhooks

### DIFF
--- a/services/api/api/routers/webhooks.py
+++ b/services/api/api/routers/webhooks.py
@@ -15,7 +15,13 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from api.runtime_control import ControlPlaneError
-from api.webhooks import HeaderTriggerKey, HmacAuth, WebhookSpec, get_webhook_spec
+from api.webhooks import (
+    BearerAuth,
+    HeaderTriggerKey,
+    HmacAuth,
+    WebhookSpec,
+    get_webhook_spec,
+)
 from api.workflow_engine import create_workflow_run
 
 log = structlog.get_logger().bind(service="api", component="workflow_webhooks")
@@ -50,6 +56,8 @@ def _safe_headers_for_spec(request: Request, spec: WebhookSpec) -> dict[str, str
     headers = _safe_headers(request)
     if isinstance(spec.auth, HmacAuth):
         headers.pop(spec.auth.signature_header.lower(), None)
+    if isinstance(spec.auth, BearerAuth):
+        headers.pop(spec.auth.header.lower(), None)
     return headers
 
 
@@ -74,9 +82,13 @@ async def _parse_body(request: Request, raw_body: bytes) -> Any:
         try:
             return json.loads(raw_body)
         except Exception as exc:
-            raise HTTPException(status_code=400, detail="invalid JSON webhook body") from exc
+            raise HTTPException(
+                status_code=400, detail="invalid JSON webhook body"
+            ) from exc
     if content_type == "application/x-www-form-urlencoded":
-        parsed = parse_qs(raw_body.decode("utf-8", errors="replace"), keep_blank_values=True)
+        parsed = parse_qs(
+            raw_body.decode("utf-8", errors="replace"), keep_blank_values=True
+        )
         form = {
             key: values[0] if len(values) == 1 else values
             for key, values in parsed.items()
@@ -116,40 +128,99 @@ def _expected_hmac_signature(auth: HmacAuth, secret: str, raw_body: bytes) -> st
     return f"{auth.signature_prefix}{encoded}"
 
 
-def _verify_webhook_auth(spec: WebhookSpec, request: Request, raw_body: bytes) -> None:
-    if spec.auth == "none":
-        return
-    if not isinstance(spec.auth, HmacAuth):
-        raise HTTPException(status_code=500, detail="unsupported webhook auth configuration")
-
-    signature = request.headers.get(spec.auth.signature_header)
+def _verify_hmac_auth(
+    spec: WebhookSpec, auth: HmacAuth, request: Request, raw_body: bytes
+) -> None:
+    signature = request.headers.get(auth.signature_header)
     if not signature:
         log.warning(
             "workflow_webhook_auth_failed",
             slug=spec.slug,
             reason="missing_signature",
-            signature_header=spec.auth.signature_header,
+            signature_header=auth.signature_header,
         )
         raise HTTPException(status_code=401, detail="missing webhook signature")
 
-    secret = os.getenv(spec.auth.secret_ref)
+    secret = os.getenv(auth.secret_ref)
     if not secret:
         log.error(
             "workflow_webhook_auth_config_error",
             slug=spec.slug,
-            secret_ref=spec.auth.secret_ref,
+            secret_ref=auth.secret_ref,
         )
-        raise HTTPException(status_code=500, detail="webhook auth secret is not configured")
+        raise HTTPException(
+            status_code=500, detail="webhook auth secret is not configured"
+        )
 
-    expected = _expected_hmac_signature(spec.auth, secret, raw_body)
+    expected = _expected_hmac_signature(auth, secret, raw_body)
     if not hmac.compare_digest(signature.strip(), expected):
         log.warning(
             "workflow_webhook_auth_failed",
             slug=spec.slug,
             reason="invalid_signature",
-            signature_header=spec.auth.signature_header,
+            signature_header=auth.signature_header,
         )
         raise HTTPException(status_code=401, detail="invalid webhook signature")
+
+
+def _verify_bearer_auth(spec: WebhookSpec, auth: BearerAuth, request: Request) -> None:
+    authorization = request.headers.get(auth.header)
+    if not authorization:
+        log.warning(
+            "workflow_webhook_auth_failed",
+            slug=spec.slug,
+            reason="missing_authorization",
+            authorization_header=auth.header,
+        )
+        raise HTTPException(status_code=401, detail="missing webhook authorization")
+
+    secret = os.getenv(auth.secret_ref)
+    if not secret:
+        log.error(
+            "workflow_webhook_auth_config_error",
+            slug=spec.slug,
+            secret_ref=auth.secret_ref,
+        )
+        raise HTTPException(
+            status_code=500, detail="webhook auth secret is not configured"
+        )
+
+    value = authorization.strip()
+    prefix = f"{auth.scheme} "
+    if not value.lower().startswith(prefix.lower()):
+        log.warning(
+            "workflow_webhook_auth_failed",
+            slug=spec.slug,
+            reason="invalid_authorization_scheme",
+            authorization_header=auth.header,
+        )
+        raise HTTPException(status_code=401, detail="invalid webhook authorization")
+
+    token = value[len(prefix) :].strip()
+    if not token or not hmac.compare_digest(
+        token.encode("utf-8"), secret.encode("utf-8")
+    ):
+        log.warning(
+            "workflow_webhook_auth_failed",
+            slug=spec.slug,
+            reason="invalid_authorization_token",
+            authorization_header=auth.header,
+        )
+        raise HTTPException(status_code=401, detail="invalid webhook authorization")
+
+
+def _verify_webhook_auth(spec: WebhookSpec, request: Request, raw_body: bytes) -> None:
+    if spec.auth == "none":
+        return
+    if isinstance(spec.auth, HmacAuth):
+        _verify_hmac_auth(spec, spec.auth, request, raw_body)
+        return
+    if isinstance(spec.auth, BearerAuth):
+        _verify_bearer_auth(spec, spec.auth, request)
+        return
+    raise HTTPException(
+        status_code=500, detail="unsupported webhook auth configuration"
+    )
 
 
 @router.api_route("/{slug}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])

--- a/services/api/api/webhooks.py
+++ b/services/api/api/webhooks.py
@@ -37,13 +37,22 @@ class HmacAuth:
 
 
 @dataclass(frozen=True)
+class BearerAuth:
+    secret_ref: str
+    header: str = "Authorization"
+    scheme: str = "Bearer"
+
+
+@dataclass(frozen=True)
 class WebhookSpec:
     slug: str
-    auth: str | HmacAuth = "none"
+    auth: str | HmacAuth | BearerAuth = "none"
     provider: str | None = None
     trigger_key: HeaderTriggerKey | str | None = None
     allowed_methods: list[str] = field(default_factory=lambda: ["POST"])
-    allowed_content_types: list[str] = field(default_factory=lambda: ["application/json"])
+    allowed_content_types: list[str] = field(
+        default_factory=lambda: ["application/json"]
+    )
 
 
 @dataclass(frozen=True)
@@ -77,13 +86,15 @@ def _coerce_trigger_key(value: Any) -> HeaderTriggerKey | str | None:
         kind = value.get("type", "header")
         if kind == "header" and isinstance(value.get("header"), str):
             return HeaderTriggerKey(value["header"])
-    raise ValueError("trigger_key must be a string, HeaderTriggerKey, or header trigger dict")
+    raise ValueError(
+        "trigger_key must be a string, HeaderTriggerKey, or header trigger dict"
+    )
 
 
-def _coerce_auth(value: Any) -> str | HmacAuth:
+def _coerce_auth(value: Any) -> str | HmacAuth | BearerAuth:
     if value is None:
         return "none"
-    if isinstance(value, HmacAuth):
+    if isinstance(value, (HmacAuth, BearerAuth)):
         return value
     if isinstance(value, str):
         return value
@@ -99,7 +110,10 @@ def _coerce_auth(value: Any) -> str | HmacAuth:
         if kind == "hmac":
             data = {k: v for k, v in value.items() if k not in {"type", "kind"}}
             return HmacAuth(**data)
-    raise ValueError("auth must be 'none', HmacAuth, or an auth dict")
+        if kind == "bearer":
+            data = {k: v for k, v in value.items() if k not in {"type", "kind"}}
+            return BearerAuth(**data)
+    raise ValueError("auth must be 'none', HmacAuth, BearerAuth, or an auth dict")
 
 
 def _coerce_spec(raw: Any) -> WebhookSpec:
@@ -135,6 +149,17 @@ def _validate_spec(spec: WebhookSpec) -> None:
             raise ValueError("HMAC auth requires secret_ref")
         if not spec.auth.signature_header:
             raise ValueError("HMAC auth requires signature_header")
+    elif isinstance(spec.auth, BearerAuth):
+        if not spec.auth.secret_ref:
+            raise ValueError("bearer auth requires secret_ref")
+        if not spec.auth.header:
+            raise ValueError("bearer auth requires header")
+        if not spec.auth.scheme:
+            raise ValueError("bearer auth requires scheme")
+        if any(ch.isspace() for ch in spec.auth.header) or ":" in spec.auth.header:
+            raise ValueError("bearer auth header must be an HTTP header name")
+        if any(ch.isspace() for ch in spec.auth.scheme):
+            raise ValueError("bearer auth scheme must not contain whitespace")
     else:
         raise ValueError("unsupported webhook auth")
     if not spec.allowed_methods:
@@ -192,6 +217,8 @@ def register_workflow_webhooks(
                 normalized_spec.auth
                 if isinstance(normalized_spec.auth, str)
                 else "hmac"
+                if isinstance(normalized_spec.auth, HmacAuth)
+                else "bearer"
             ),
             provider=normalized_spec.provider,
         )

--- a/services/api/tests/test_workflow_webhooks.py
+++ b/services/api/tests/test_workflow_webhooks.py
@@ -167,6 +167,91 @@ async def test_hmac_workflow_webhook_enqueues_run_with_valid_signature(
 
 
 @pytest.mark.asyncio
+async def test_bearer_workflow_webhook_enqueues_run_with_valid_token(
+    anonymous_client,
+    db_pool,
+    monkeypatch,
+    tmp_path,
+):
+    from api.workflow_engine import discover_workflow_handlers
+
+    token = "test-webhook-token"
+    monkeypatch.setenv("TEST_WEBHOOK_TOKEN", token)
+    workflow_name = f"webhook_bearer_{uuid.uuid4().hex}"
+    slug = f"bearer-{uuid.uuid4().hex}"
+    workflow_file = tmp_path / "webhook_bearer.py"
+    workflow_file.write_text(
+        "WORKFLOW_NAME = " + repr(workflow_name) + "\n"
+        "WEBHOOKS = [{\n"
+        "    'slug': " + repr(slug) + ",\n"
+        "    'auth': {\n"
+        "        'type': 'bearer',\n"
+        "        'secret_ref': 'TEST_WEBHOOK_TOKEN',\n"
+        "    },\n"
+        "}]\n"
+        "async def handler(inp, ctx):\n"
+        "    return {'received': inp['webhook']['body']}\n",
+    )
+    monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
+    discover_workflow_handlers()
+
+    response = await anonymous_client.post(
+        f"/api/webhooks/{slug}",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"hello": "bearer"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["workflow_name"] == workflow_name
+
+    run_row = await db_pool.fetchrow(
+        "SELECT input_json FROM workflow_runs WHERE run_id = $1",
+        body["run_id"],
+    )
+    run_input = _jsonb(run_row["input_json"])
+    assert run_input["webhook"]["body"] == {"hello": "bearer"}
+    assert "authorization" not in run_input["webhook"]["headers"]
+
+
+@pytest.mark.asyncio
+async def test_bearer_workflow_webhook_rejects_invalid_token_without_run(
+    anonymous_client,
+    db_pool,
+    monkeypatch,
+    tmp_path,
+):
+    from api.workflow_engine import discover_workflow_handlers
+
+    monkeypatch.setenv("TEST_WEBHOOK_TOKEN", "test-webhook-token")
+    slug = f"bearer-reject-{uuid.uuid4().hex}"
+    workflow_file = tmp_path / "webhook_bearer_reject.py"
+    workflow_file.write_text(
+        "WORKFLOW_NAME = 'webhook_bearer_reject'\n"
+        "WEBHOOKS = [{\n"
+        f"    'slug': {slug!r},\n"
+        "    'auth': {'type': 'bearer', 'secret_ref': 'TEST_WEBHOOK_TOKEN'},\n"
+        "}]\n"
+        "async def handler(inp, ctx):\n"
+        "    return {'ok': True}\n",
+    )
+    monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
+    discover_workflow_handlers()
+
+    response = await anonymous_client.post(
+        f"/api/webhooks/{slug}",
+        headers={"Authorization": "Bearer wrong-token"},
+        json={"hello": "bad-token"},
+    )
+
+    assert response.status_code == 401
+    run_count = await db_pool.fetchval(
+        "SELECT COUNT(*)::int FROM workflow_runs WHERE workflow_name = 'webhook_bearer_reject'",
+    )
+    assert run_count == 0
+
+
+@pytest.mark.asyncio
 async def test_workflow_webhook_parses_form_payload_json(
     anonymous_client,
     db_pool,
@@ -201,7 +286,7 @@ async def test_workflow_webhook_parses_form_payload_json(
     monkeypatch.setenv("WORKFLOW_DIRS", str(tmp_path))
     discover_workflow_handlers()
 
-    raw_body = b'payload=%7B%22hello%22%3A%22form%22%7D'
+    raw_body = b"payload=%7B%22hello%22%3A%22form%22%7D"
     response = await anonymous_client.post(
         f"/api/webhooks/{slug}",
         content=raw_body,
@@ -263,12 +348,16 @@ async def test_hmac_workflow_webhook_rejects_invalid_signature_without_run(
 
 @pytest.mark.asyncio
 async def test_workflow_webhook_rejects_unregistered_slug(client):
-    response = await client.post("/api/webhooks/missing-webhook", json={"hello": "world"})
+    response = await client.post(
+        "/api/webhooks/missing-webhook", json={"hello": "world"}
+    )
     assert response.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_workflow_webhook_rejects_disallowed_method(client, monkeypatch, tmp_path):
+async def test_workflow_webhook_rejects_disallowed_method(
+    client, monkeypatch, tmp_path
+):
     from api.workflow_engine import discover_workflow_handlers
 
     slug = f"post-only-{uuid.uuid4().hex}"


### PR DESCRIPTION
## what

Adds a second workflow webhook auth mode alongside the existing `none` and HMAC modes:

- `BearerAuth` / `auth: {"type": "bearer", "secret_ref": "..."}` webhook specs
- validation of `Authorization: Bearer <token>` against the configured environment secret
- constant-time token comparison and auth-header redaction from the workflow input envelope
- request-path tests for accepted and rejected bearer-auth webhooks

## why

HMAC verification is the right default for providers like GitHub that can sign the exact request body. Alertmanager is different: its webhook receiver can post JSON payloads and can attach static HTTP auth from a Kubernetes Secret, but it does not naturally compute a Centaur-specific HMAC over the body.

For alert-triggered workflows, bearer auth gives us a clean path that does not require putting secrets in webhook URLs, exposing unauthenticated webhooks, or adding a separate signing bridge. The alert charts can configure Alertmanager's HTTP auth from a Secret, and Centaur can still keep workflow webhooks behind an explicit per-workflow auth contract.

This keeps #161's GitHub-style HMAC flow intact while making the same webhook entrypoint usable for Alertmanager/Prometheus-style integrations.

## tested

- `cd services/api && uv run ruff check api/webhooks.py api/routers/webhooks.py tests/test_workflow_webhooks.py`
- `cd services/api && uv run pytest tests/test_workflow_webhooks.py`
- `cd services/api && uv run pytest tests/test_github_issue_triage_workflow.py tests/test_workflows.py::test_handler_discovery`
