### PR TITLE
[codex] Auto-configure Hermes runtime in Centaur

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -45,15 +45,27 @@ build-one service:
 
 _build-api:
     docker build -t centaur-api:latest -f services/api/Dockerfile .
+    just _load-kind-image centaur-api:latest
 
 _build-iron-proxy:
     docker build -t centaur-iron-proxy:latest -f services/iron-proxy/Dockerfile .
+    just _load-kind-image centaur-iron-proxy:latest
 
 _build-slackbot:
     docker build -t centaur-slackbot:latest -f services/slackbot/Dockerfile .
+    just _load-kind-image centaur-slackbot:latest
 
 _build-agent:
     docker build --target sandbox -t centaur-agent:latest -f services/sandbox/Dockerfile .
+    just _load-kind-image centaur-agent:latest
+
+_load-kind-image image:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    context="$(kubectl config current-context 2>/dev/null || true)"
+    if [[ "$context" == kind-* ]] && command -v kind >/dev/null 2>&1; then
+      kind load docker-image "{{image}}" --name "${context#kind-}"
+    fi
 
 bootstrap-secrets *args:
     contrib/scripts/bootstrap-k8s-secrets.sh --namespace {{namespace}} {{args}}

--- a/contrib/chart/values.dev.yaml
+++ b/contrib/chart/values.dev.yaml
@@ -7,6 +7,24 @@ firewall:
   existingCaSecretName: centaur-firewall-ca
   existingCaKeySecretName: centaur-firewall-ca-key
 
+api:
+  image:
+    pullPolicy: IfNotPresent
+  executionWorkerEnabled: true
+  pluginWatcherEnabled: true
+  egressDiscovery:
+    enabled: false
+
+sandbox:
+  image:
+    pullPolicy: IfNotPresent
+
+ironProxy:
+  image:
+    pullPolicy: IfNotPresent
+  manager:
+    secretSource: onepassword
+
 postgres:
   auth:
     existingSecretName: centaur-infra-env
@@ -14,16 +32,8 @@ postgres:
 
 slackbot:
   enabled: true
-
-api:
-  executionWorkerEnabled: true
-  pluginWatcherEnabled: true
-  egressDiscovery:
-    enabled: false
+  image:
+    pullPolicy: IfNotPresent
 
 laminar:
   enabled: true
-
-ironProxy:
-  manager:
-    secretSource: onepassword

--- a/contrib/scripts/bootstrap-k8s-secrets.sh
+++ b/contrib/scripts/bootstrap-k8s-secrets.sh
@@ -11,6 +11,9 @@ Usage: scripts/bootstrap-k8s-secrets.sh [--namespace NAMESPACE] [--force]
 Creates the required local-dev Kubernetes infra Secrets consumed by the Helm chart.
 Requires OP_SERVICE_ACCOUNT_TOKEN, OP_VAULT, SLACK_BOT_TOKEN,
 SLACK_SIGNING_SECRET, and SLACKBOT_API_KEY in the shell environment.
+Optional provider/model envs such as ANTHROPIC_AUTH_TOKEN,
+ANTHROPIC_BASE_URL, ANTHROPIC_MODEL, HERMES_PROVIDER, and HERMES_MODEL are
+copied when present.
 
 Optional 1Password Connect bootstrap (when ironProxy.manager.secretSource is
 set to onepassword-connect in the Helm values):
@@ -80,6 +83,56 @@ require_env SLACK_BOT_TOKEN
 require_env SLACK_SIGNING_SECRET
 require_env SLACKBOT_API_KEY
 
+optional_secret_keys=(
+  LMNR_PROJECT_API_KEY
+  LMNR_BASE_URL
+  OP_CONNECT_TOKEN
+  HERMES_PROVIDER
+  HERMES_MODEL
+  HERMES_BASE_URL
+  HERMES_API_MODE
+  HERMES_INFERENCE_PROVIDER
+  HERMES_INFERENCE_MODEL
+  ANTHROPIC_API_KEY
+  ANTHROPIC_AUTH_TOKEN
+  ANTHROPIC_TOKEN
+  ANTHROPIC_BASE_URL
+  ANTHROPIC_MODEL
+  ANTHROPIC_DEFAULT_SONNET_MODEL
+  ANTHROPIC_DEFAULT_OPUS_MODEL
+  ANTHROPIC_DEFAULT_HAIKU_MODEL
+  API_TIMEOUT_MS
+)
+
+optional_secret_value() {
+  local name="$1"
+  if [[ "$name" == "ANTHROPIC_API_KEY" && -z "${ANTHROPIC_API_KEY:-}" && -n "${ANTHROPIC_AUTH_TOKEN:-}" ]]; then
+    printf '%s' "$ANTHROPIC_AUTH_TOKEN"
+    return
+  fi
+  printf '%s' "${!name:-}"
+}
+
+append_optional_literal_args() {
+  local value
+  for name in "${optional_secret_keys[@]}"; do
+    value="$(optional_secret_value "$name")"
+    if [[ -n "$value" ]]; then
+      secret_args+=(--from-literal="$name=$value")
+    fi
+  done
+}
+
+append_optional_patch_data() {
+  local value
+  for name in "${optional_secret_keys[@]}"; do
+    value="$(optional_secret_value "$name")"
+    if [[ -n "$value" ]]; then
+      patch_data+=("\"$name\":\"$(printf '%s' "$value" | base64 | tr -d '\n')\"")
+    fi
+  done
+}
+
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
 
 delete_if_forced centaur-infra-env
@@ -89,19 +142,11 @@ delete_if_forced centaur-onepassword-connect-credentials
 
 if secret_exists centaur-infra-env; then
   patch_data=()
-  if [[ -n "${LMNR_PROJECT_API_KEY:-}" ]]; then
-    patch_data+=("\"LMNR_PROJECT_API_KEY\":\"$(printf '%s' "$LMNR_PROJECT_API_KEY" | base64 | tr -d '\n')\"")
-  fi
-  if [[ -n "${LMNR_BASE_URL:-}" ]]; then
-    patch_data+=("\"LMNR_BASE_URL\":\"$(printf '%s' "$LMNR_BASE_URL" | base64 | tr -d '\n')\"")
-  fi
-  if [[ -n "${OP_CONNECT_TOKEN:-}" ]]; then
-    patch_data+=("\"OP_CONNECT_TOKEN\":\"$(printf '%s' "$OP_CONNECT_TOKEN" | base64 | tr -d '\n')\"")
-  fi
+  append_optional_patch_data
   if [[ "${#patch_data[@]}" -gt 0 ]]; then
     patch_json="{\"data\":{$(IFS=,; echo "${patch_data[*]}")}}"
     kubectl -n "$NAMESPACE" patch secret centaur-infra-env --type merge -p "$patch_json" >/dev/null
-    echo "Updated optional Laminar keys in Secret centaur-infra-env in namespace $NAMESPACE"
+    echo "Updated optional keys in Secret centaur-infra-env in namespace $NAMESPACE"
   fi
   echo "Secret centaur-infra-env already exists in namespace $NAMESPACE; leaving unchanged"
 else
@@ -119,15 +164,7 @@ else
     --from-literal=POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
     --from-literal=DATABASE_URL="$DATABASE_URL"
   )
-  if [[ -n "${LMNR_PROJECT_API_KEY:-}" ]]; then
-    secret_args+=(--from-literal=LMNR_PROJECT_API_KEY="$LMNR_PROJECT_API_KEY")
-  fi
-  if [[ -n "${LMNR_BASE_URL:-}" ]]; then
-    secret_args+=(--from-literal=LMNR_BASE_URL="$LMNR_BASE_URL")
-  fi
-  if [[ -n "${OP_CONNECT_TOKEN:-}" ]]; then
-    secret_args+=(--from-literal=OP_CONNECT_TOKEN="$OP_CONNECT_TOKEN")
-  fi
+  append_optional_literal_args
   kubectl "${secret_args[@]}" >/dev/null
   echo "Created Secret centaur-infra-env in namespace $NAMESPACE"
 fi

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -83,6 +83,17 @@ Store one secret per enabled harness credential:
 | Amp | `amp` | `--amp` | `AMP_API_KEY` | `ampcode.com` |
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
+| Hermes | `hermes` | `--hermes` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
+
+Hermes ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent))
+runs through its Agent Client Protocol (ACP) stdio server, bridged by
+`hermes-app-wrapper`. It defaults to the Anthropic provider + a Claude model so
+it reuses the same `ANTHROPIC_API_KEY` credential and iron-proxy path as Claude
+Code. To point Hermes at a different provider/model, set `HERMES_PROVIDER` and
+`HERMES_MODEL` in `KUBERNETES_SANDBOX_EXTRA_ENV` (the API also forwards a
+per-spawn model override). For a non-Anthropic provider — e.g. Hermes' native
+Nous models — also store that provider's key (e.g. `NOUS_API_KEY`) and add its
+upstream host to the iron-proxy allowlist.
 
 In normal sandbox mode, containers receive placeholder values such as
 `OPENAI_API_KEY=OPENAI_API_KEY`. [iron-proxy](https://docs.iron.sh) swaps the
@@ -233,7 +244,10 @@ reply with exactly PONG
 ```
 
 Slack messages without a harness flag use Codex. Use `--amp`, `--claude`,
-`--codex`, or `--pi` only when you want to select a specific harness.
+`--codex`, `--pi`, or `--hermes` only when you want to select a specific
+harness. API callers can pass the same selection as `"harness": "hermes"`
+(or `harness=hermes` in the message text) to `/agent/spawn` and
+`/agent/execute`.
 
 Inspect sandbox pods with the labels Centaur actually sets:
 

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -83,18 +83,15 @@ Store one secret per enabled harness credential:
 | Amp | `amp` | `--amp` | `AMP_API_KEY` | `ampcode.com` |
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
-| Hermes | `hermes` | `--hermes` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
+| Hermes | `hermes` | `--hermes` | provider-specific | provider-specific |
 
 Hermes ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent))
 is driven by `hermes-app-wrapper`, which runs Hermes' native agent loop in
-process and streams its events into Centaur. It defaults to the Anthropic
-provider + a Claude model so
-it reuses the same `ANTHROPIC_API_KEY` credential and iron-proxy path as Claude
-Code. To point Hermes at a different provider/model, set `HERMES_PROVIDER` and
-`HERMES_MODEL` in `KUBERNETES_SANDBOX_EXTRA_ENV` (the API also forwards a
-per-spawn model override). For a non-Anthropic provider — e.g. Hermes' native
-Nous models — also store that provider's key (e.g. `NOUS_API_KEY`) and add its
-upstream host to the iron-proxy allowlist.
+process and streams its events into Centaur. The sandbox writes Hermes'
+provider/model config from `HERMES_PROVIDER` and `HERMES_MODEL`, and the API can
+also forward a per-spawn model override. Configure the matching provider
+credential and upstream host in the iron-proxy injection map for the provider
+you deploy.
 
 In normal sandbox mode, containers receive placeholder values such as
 `OPENAI_API_KEY=OPENAI_API_KEY`. [iron-proxy](https://docs.iron.sh) swaps the

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -86,8 +86,9 @@ Store one secret per enabled harness credential:
 | Hermes | `hermes` | `--hermes` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 
 Hermes ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent))
-runs through its Agent Client Protocol (ACP) stdio server, bridged by
-`hermes-app-wrapper`. It defaults to the Anthropic provider + a Claude model so
+is driven by `hermes-app-wrapper`, which runs Hermes' native agent loop in
+process and streams its events into Centaur. It defaults to the Anthropic
+provider + a Claude model so
 it reuses the same `ANTHROPIC_API_KEY` credential and iron-proxy path as Claude
 Code. To point Hermes at a different provider/model, set `HERMES_PROVIDER` and
 `HERMES_MODEL` in `KUBERNETES_SANDBOX_EXTRA_ENV` (the API also forwards a

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -36,7 +36,9 @@ kubectl get nodes
 The `Justfile` builds local images named `centaur-api:latest`,
 `centaur-iron-proxy:latest`, `centaur-slackbot:latest`, and
 `centaur-agent:latest`, then deploys `contrib/chart` with
-`contrib/chart/values.dev.yaml`.
+`contrib/chart/values.dev.yaml`. When the current Kubernetes context is a
+`kind-*` cluster, the build recipes also load those images into the cluster
+before deployment.
 
 ## 2. Export bootstrap secrets
 

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -83,6 +83,17 @@ Store one secret per enabled harness credential:
 | Amp | `amp` | `--amp` | `AMP_API_KEY` | `ampcode.com` |
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
+| Hermes | `hermes` | `--hermes` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
+
+Hermes ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent))
+runs through its Agent Client Protocol (ACP) stdio server, bridged by
+`hermes-app-wrapper`. It defaults to the Anthropic provider + a Claude model so
+it reuses the same `ANTHROPIC_API_KEY` credential and iron-proxy path as Claude
+Code. To point Hermes at a different provider/model, set `HERMES_PROVIDER` and
+`HERMES_MODEL` in `KUBERNETES_SANDBOX_EXTRA_ENV` (the API also forwards a
+per-spawn model override). For a non-Anthropic provider — e.g. Hermes' native
+Nous models — also store that provider's key (e.g. `NOUS_API_KEY`) and add its
+upstream host to the iron-proxy allowlist.
 
 In normal sandbox mode, containers receive placeholder values such as
 `OPENAI_API_KEY=OPENAI_API_KEY`. [iron-proxy](https://docs.iron.sh) swaps the
@@ -233,7 +244,10 @@ reply with exactly PONG
 ```
 
 Slack messages without a harness flag use Codex. Use `--amp`, `--claude`,
-`--codex`, or `--pi` only when you want to select a specific harness.
+`--codex`, `--pi`, or `--hermes` only when you want to select a specific
+harness. API callers can pass the same selection as `"harness": "hermes"`
+(or `harness=hermes` in the message text) to `/agent/spawn` and
+`/agent/execute`.
 
 Inspect sandbox pods with the labels Centaur actually sets:
 

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -83,18 +83,15 @@ Store one secret per enabled harness credential:
 | Amp | `amp` | `--amp` | `AMP_API_KEY` | `ampcode.com` |
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
-| Hermes | `hermes` | `--hermes` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
+| Hermes | `hermes` | `--hermes` | provider-specific | provider-specific |
 
 Hermes ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent))
 is driven by `hermes-app-wrapper`, which runs Hermes' native agent loop in
-process and streams its events into Centaur. It defaults to the Anthropic
-provider + a Claude model so
-it reuses the same `ANTHROPIC_API_KEY` credential and iron-proxy path as Claude
-Code. To point Hermes at a different provider/model, set `HERMES_PROVIDER` and
-`HERMES_MODEL` in `KUBERNETES_SANDBOX_EXTRA_ENV` (the API also forwards a
-per-spawn model override). For a non-Anthropic provider — e.g. Hermes' native
-Nous models — also store that provider's key (e.g. `NOUS_API_KEY`) and add its
-upstream host to the iron-proxy allowlist.
+process and streams its events into Centaur. The sandbox writes Hermes'
+provider/model config from `HERMES_PROVIDER` and `HERMES_MODEL`, and the API can
+also forward a per-spawn model override. Configure the matching provider
+credential and upstream host in the iron-proxy injection map for the provider
+you deploy.
 
 In normal sandbox mode, containers receive placeholder values such as
 `OPENAI_API_KEY=OPENAI_API_KEY`. [iron-proxy](https://docs.iron.sh) swaps the

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -86,8 +86,9 @@ Store one secret per enabled harness credential:
 | Hermes | `hermes` | `--hermes` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 
 Hermes ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent))
-runs through its Agent Client Protocol (ACP) stdio server, bridged by
-`hermes-app-wrapper`. It defaults to the Anthropic provider + a Claude model so
+is driven by `hermes-app-wrapper`, which runs Hermes' native agent loop in
+process and streams its events into Centaur. It defaults to the Anthropic
+provider + a Claude model so
 it reuses the same `ANTHROPIC_API_KEY` credential and iron-proxy path as Claude
 Code. To point Hermes at a different provider/model, set `HERMES_PROVIDER` and
 `HERMES_MODEL` in `KUBERNETES_SANDBOX_EXTRA_ENV` (the API also forwards a

--- a/docs/public/md/quickstart.md
+++ b/docs/public/md/quickstart.md
@@ -36,7 +36,9 @@ kubectl get nodes
 The `Justfile` builds local images named `centaur-api:latest`,
 `centaur-iron-proxy:latest`, `centaur-slackbot:latest`, and
 `centaur-agent:latest`, then deploys `contrib/chart` with
-`contrib/chart/values.dev.yaml`.
+`contrib/chart/values.dev.yaml`. When the current Kubernetes context is a
+`kind-*` cluster, the build recipes also load those images into the cluster
+before deployment.
 
 ## 2. Export bootstrap secrets
 

--- a/packages/harness-events/package.json
+++ b/packages/harness-events/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^25.7.0",
     "typescript": "5.9.3"
   }
 }

--- a/packages/harness-events/src/normalize.ts
+++ b/packages/harness-events/src/normalize.ts
@@ -10,7 +10,7 @@
  */
 
 import { asString, asRecord } from './parse-utils'
-import type { CanonicalEvent, ContentBlock, SubagentActivity } from './types'
+import type { CanonicalEvent, SubagentActivity } from './types'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -639,19 +639,7 @@ function normalizeCodexEvent(event: Record<string, unknown>): CanonicalEvent[] {
   }
 
   if (eventType === 'assistant') {
-    const message = asRecord(event.message)
-    const content = asList(message.content)
-    if (!content.length) return []
-    return [
-      {
-        type: 'assistant',
-        message: {
-          content: content as ContentBlock[],
-          usage: asRecord(message.usage),
-          model: asString(message.model) || undefined
-        }
-      }
-    ]
+    return [event as CanonicalEvent]
   }
 
   if (eventType === 'error') {

--- a/packages/harness-events/src/normalize.ts
+++ b/packages/harness-events/src/normalize.ts
@@ -838,6 +838,66 @@ function normalizePiEvent(event: Record<string, unknown>): CanonicalEvent[] {
 }
 
 // ---------------------------------------------------------------------------
+// Hermes normalizer
+// ---------------------------------------------------------------------------
+
+function normalizeHermesEvent(event: Record<string, unknown>): CanonicalEvent[] {
+  const eventType = asString(event.type)
+
+  if (eventType === 'system') {
+    if (asString(event.subtype) === 'init') {
+      const sessionId = firstNonEmptyString(event.session_id)
+      return sessionId ? [{ type: 'system', subtype: 'init', session_id: sessionId }] : []
+    }
+    return []
+  }
+
+  if (eventType === 'agent_message_chunk') {
+    const text = asString(event.text)
+    return text ? [assistantTextEvent(text)] : []
+  }
+
+  if (eventType === 'agent_thought_chunk') {
+    const text = asString(event.text)
+    return text ? [{ type: 'reasoning', text }] : []
+  }
+
+  if (eventType === 'tool_call') {
+    const toolId = asString(event.tool_call_id)
+    const name = asString(event.name) || 'tool'
+    return [assistantToolUseEvent(toolId, name, event.input)]
+  }
+
+  if (eventType === 'tool_call_update') {
+    const status = asString(event.status)
+    if (status !== 'completed' && status !== 'failed') return []
+    const toolId = asString(event.tool_call_id)
+    if (!toolId) return []
+    return [toolResultEvent(toolId, event.output, Boolean(event.is_error))]
+  }
+
+  if (eventType === 'plan') {
+    return [{ type: 'turn.plan.updated', entries: asList(event.entries) }]
+  }
+
+  if (eventType === 'turn.completed') {
+    return attachUsageMetadata([], event, true)
+  }
+
+  if (eventType === 'turn.failed' || eventType === 'error') {
+    const errorValue = event.error
+    const message =
+      asString(errorValue) ||
+      asString(asRecord(errorValue).message) ||
+      asString(event.message) ||
+      'Unknown error'
+    return [{ type: 'error', error: message }]
+  }
+
+  return []
+}
+
+// ---------------------------------------------------------------------------
 // Main dispatcher
 // ---------------------------------------------------------------------------
 
@@ -867,6 +927,13 @@ export function normalizeHarnessEvent(
       eventType === 'tool_execution_end'
     ) {
       normalizedHarness = 'pi-mono'
+    } else if (
+      eventType === 'agent_message_chunk' ||
+      eventType === 'agent_thought_chunk' ||
+      eventType === 'tool_call' ||
+      eventType === 'tool_call_update'
+    ) {
+      normalizedHarness = 'hermes'
     } else {
       normalizedHarness = 'amp'
     }
@@ -877,6 +944,9 @@ export function normalizeHarnessEvent(
   }
   if (normalizedHarness === 'pi-mono') {
     return normalizePiEvent(event)
+  }
+  if (normalizedHarness === 'hermes') {
+    return normalizeHermesEvent(event)
   }
   // eng/legal use claude-code under the hood, same event format as amp/claude-code
   return normalizeAmpLikeEvent(event)

--- a/packages/harness-events/src/normalize.ts
+++ b/packages/harness-events/src/normalize.ts
@@ -10,7 +10,7 @@
  */
 
 import { asString, asRecord } from './parse-utils'
-import type { CanonicalEvent, SubagentActivity } from './types'
+import type { CanonicalEvent, ContentBlock, SubagentActivity } from './types'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -639,7 +639,19 @@ function normalizeCodexEvent(event: Record<string, unknown>): CanonicalEvent[] {
   }
 
   if (eventType === 'assistant') {
-    return [event]
+    const message = asRecord(event.message)
+    const content = asList(message.content)
+    if (!content.length) return []
+    return [
+      {
+        type: 'assistant',
+        message: {
+          content: content as ContentBlock[],
+          usage: asRecord(message.usage),
+          model: asString(message.model) || undefined
+        }
+      }
+    ]
   }
 
   if (eventType === 'error') {

--- a/packages/harness-events/tsconfig.json
+++ b/packages/harness-events/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "outDir": "dist"
   },
   "include": ["src"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   packages/harness-events:
     devDependencies:
+      '@types/node':
+        specifier: ^25.7.0
+        version: 25.9.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3

--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -56,6 +56,8 @@ _GITHUB_PREFIX_RE = re.compile(
 _VALID_STDOUT_EVENT_TYPES = frozenset(
     {
         "amp_raw_event",
+        "agent_message_chunk",
+        "agent_thought_chunk",
         "assistant",
         "command_execution",
         "content_block_delta",
@@ -85,6 +87,8 @@ _VALID_STDOUT_EVENT_TYPES = frozenset(
         "thread.goal.cleared",
         "thread.goal.updated",
         "thread.started",
+        "tool_call",
+        "tool_call_update",
         "tool",
         "tool_result",
         "tool_use",
@@ -715,7 +719,9 @@ async def _insert_system_message(
 ) -> None:
     """Insert a static system message with platform formatting rules (idempotent)."""
     pool = _get_pool()
-    effective_platform = platform or ("slack" if thread_key.startswith("slack:") else None)
+    effective_platform = platform or (
+        "slack" if thread_key.startswith("slack:") else None
+    )
     msg_id = f"system-{thread_key}-{effective_platform or 'generic'}"
     effective_user_id = user_id or await _get_latest_thread_user_id(thread_key)
     requester_identity = await _resolve_requester_identity(
@@ -780,9 +786,7 @@ def _resolve_harness_profile(
     if normalized_harness and normalized_harness not in _ENGINE_HARNESSES:
         raise ValueError(f"Unknown harness: {normalized_harness}")
 
-    persona_info = (
-        get_tool_manager().get_persona(persona) if persona else None
-    )
+    persona_info = get_tool_manager().get_persona(persona) if persona else None
     if persona and persona_info is None:
         raise ValueError(f"Unknown persona: {persona}")
 
@@ -886,7 +890,11 @@ async def get_or_spawn(
 
         trace_id = old_trace_id or thread_trace_id or str(uuid.uuid4())
         claimed = await claim_container(
-            thread_key, effective_harness, persona=resolved_persona, repo=repo, trace_id=trace_id
+            thread_key,
+            effective_harness,
+            persona=resolved_persona,
+            repo=repo,
+            trace_id=trace_id,
         )
         if claimed:
             if old_agent_thread_id:
@@ -996,8 +1004,7 @@ def _build_session_context(
             github_login = github_handle.removeprefix("@")
             lines.extend(
                 [
-                    "- GitHub handle from Slack profile: "
-                    f"{github_handle}",
+                    f"- GitHub handle from Slack profile: {github_handle}",
                     "- GitHub handle source: "
                     f"{requester_identity['github_handle_source']}",
                     "- GitHub handle verified: yes",
@@ -1007,8 +1014,7 @@ def _build_session_context(
                     "- If you create a GitHub PR for this Slack request, "
                     f"the PR body MUST contain this standalone line: `Prompted by: {github_handle}`",
                     "- This is a GitHub PR body requirement, not a Slack response mention rule.",
-                    "- Assign the PR to the requester when possible: "
-                    f"`{github_login}`",
+                    f"- Assign the PR to the requester when possible: `{github_login}`",
                 ]
             )
         else:
@@ -1292,7 +1298,9 @@ async def stream_connect(
     """
     rt = _get_runtime(session.sandbox_id)
 
-    effective_platform = platform or ("slack" if session.thread_key.startswith("slack:") else None)
+    effective_platform = platform or (
+        "slack" if session.thread_key.startswith("slack:") else None
+    )
     if effective_platform:
         await _insert_system_message(
             session.thread_key,
@@ -1385,7 +1393,9 @@ async def inject_stdin(
     """
     rt = _get_runtime(session.sandbox_id)
 
-    effective_platform = platform or ("slack" if session.thread_key.startswith("slack:") else None)
+    effective_platform = platform or (
+        "slack" if session.thread_key.startswith("slack:") else None
+    )
     if effective_platform:
         await _insert_system_message(
             session.thread_key,
@@ -1512,8 +1522,8 @@ async def steer_stdin(
     """Inject a steer message into a running sandbox's stdin.
 
     Unlike inject_stdin(), this does NOT start a new turn or reset turn counters.
-    The steer message tells Amp to cancel the current tool call and process
-    the new message instead, preserving conversation context.
+    The steer message tells interruptible harnesses to cancel the current tool
+    call and process the new message instead, preserving conversation context.
     """
     turn_input = build_user_input(
         content_blocks,
@@ -1523,18 +1533,28 @@ async def steer_stdin(
     )
     backend = get_backend()
 
-    is_amp = session.engine == "amp" or session.harness == "amp"
-    try:
-        if is_amp:
-            await backend.interrupt_by_id(session.sandbox_id)
-            await asyncio.sleep(0.05)
+    is_hermes = session.engine == "hermes" or session.harness == "hermes"
+    is_interruptible = session.engine in {"amp", "hermes"} or session.harness in {
+        "amp",
+        "hermes",
+    }
+
+    async def _write_with_reattach(payload: dict[str, Any]) -> None:
         try:
-            await backend.write_stdin(session, turn_input)
+            await backend.write_stdin(session, payload)
         except (BrokenPipeError, OSError, RuntimeError, AssertionError):
-            if not is_amp:
+            if not is_interruptible:
                 raise
             await backend.reattach_stdin(session)
-            await backend.write_stdin(session, turn_input)
+            await backend.write_stdin(session, payload)
+
+    try:
+        if is_interruptible:
+            await backend.interrupt_by_id(session.sandbox_id)
+            if is_hermes:
+                await _write_with_reattach({"type": "interrupt"})
+            await asyncio.sleep(0.05)
+        await _write_with_reattach(turn_input)
     except (BrokenPipeError, OSError, RuntimeError, AssertionError) as exc:
         log.warning(
             "steer_stdin_failed",

--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -98,7 +98,7 @@ _VALID_STDOUT_EVENT_TYPES = frozenset(
     }
 )
 
-_ENGINE_HARNESSES = {"amp", "claude-code", "codex", "pi-mono"}
+_ENGINE_HARNESSES = {"amp", "claude-code", "codex", "pi-mono", "hermes"}
 _REUSABLE_DB_STATES = {"running", "idle", "delivering", "error", "suspended"}
 
 IDLE_TTL_S = int(os.getenv("IDLE_TTL_S", "86400"))  # 24 hours

--- a/services/api/api/proxy_config.py
+++ b/services/api/api/proxy_config.py
@@ -64,7 +64,9 @@ _OP_REF_SOURCES: dict[str, str] = {
 }
 
 
-def _secret_source_kind() -> str:
+def _secret_source_kind(override: str = "") -> str:
+    if override:
+        return override.strip().lower()
     return os.environ.get("FIREWALL_MANAGER_SECRET_SOURCE", "env").strip().lower()
 
 
@@ -76,8 +78,8 @@ def _op_vault() -> str:
     return os.environ.get("OP_VAULT", "ai-agents").strip()
 
 
-def _build_source(secret_ref: str) -> dict[str, str]:
-    iron_proxy_type = _OP_REF_SOURCES.get(_secret_source_kind())
+def _build_source(secret_ref: str, *, source_kind: str = "") -> dict[str, str]:
+    iron_proxy_type = _OP_REF_SOURCES.get(_secret_source_kind(source_kind))
     if iron_proxy_type is not None:
         return {
             "type": iron_proxy_type,
@@ -148,7 +150,7 @@ def _build_secret_transform(
         action, block = _secret_action_block(secret)
         entries.append(
             {
-                "source": _build_source(secret.secret_ref),
+                "source": _build_source(secret.secret_ref, source_kind=secret.source_kind),
                 action: block,
                 "rules": [{"host": h} for h in sorted(host_set)],
             }

--- a/services/api/api/routers/agent.py
+++ b/services/api/api/routers/agent.py
@@ -81,6 +81,7 @@ _HARNESS_FLAGS: dict[str, str] = {
     "codex": "codex",
     "pi": "pi-mono",
     "pi-mono": "pi-mono",
+    "hermes": "hermes",
 }
 
 _KNOWN_FLAGS = {

--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -27,10 +27,21 @@ _SANDBOX_PASSTHROUGH_ENV_KEYS = (
     "CODEX_OTEL_LAMINAR_BASE_URL",
     "LMNR_BASE_URL",
     "LMNR_PROJECT_API_KEY",
-    # Hermes harness model selection. Defaults to Anthropic/Claude inside the
-    # wrapper; deployers can override the provider/model fleet-wide here.
+    # Hermes harness model selection. Explicit Hermes envs win, but the
+    # sandbox entrypoint can also derive Hermes config from Anthropic-compatible
+    # envs used by Claude-style deployments.
     "HERMES_PROVIDER",
     "HERMES_MODEL",
+    "HERMES_BASE_URL",
+    "HERMES_API_MODE",
+    "HERMES_INFERENCE_PROVIDER",
+    "HERMES_INFERENCE_MODEL",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "API_TIMEOUT_MS",
 )
 
 # Keep Claude Code deterministic in the pod while still allowing Centaur-owned
@@ -148,6 +159,10 @@ def container_env(
         value = (os.getenv(key) or "").strip()
         if value:
             env.append(f"{key}={value}")
+    if os.getenv("ANTHROPIC_AUTH_TOKEN") and not os.getenv("ANTHROPIC_TOKEN"):
+        env.append("ANTHROPIC_TOKEN=ANTHROPIC_API_KEY")
+    if os.getenv("ANTHROPIC_AUTH_TOKEN"):
+        env.append("ANTHROPIC_AUTH_TOKEN=ANTHROPIC_API_KEY")
     for key, value in _CLAUDE_HARDENING_ENV:
         env.append(f"{key}={value}")
     env.extend(

--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -27,6 +27,10 @@ _SANDBOX_PASSTHROUGH_ENV_KEYS = (
     "CODEX_OTEL_LAMINAR_BASE_URL",
     "LMNR_BASE_URL",
     "LMNR_PROJECT_API_KEY",
+    # Hermes harness model selection. Defaults to Anthropic/Claude inside the
+    # wrapper; deployers can override the provider/model fleet-wide here.
+    "HERMES_PROVIDER",
+    "HERMES_MODEL",
 )
 
 # Keep Claude Code deterministic in the pod while still allowing Centaur-owned
@@ -93,6 +97,8 @@ def build_harness_cmd(engine: str, model: str | None = None) -> list[str]:
         return ["codex-app-wrapper"]
     if engine == "claude-code":
         return ["claude-app-wrapper"]
+    if engine == "hermes":
+        return ["hermes-app-wrapper"]
     return ["sleep", "infinity"]
 
 

--- a/services/api/api/sandbox/harness_protocol.py
+++ b/services/api/api/sandbox/harness_protocol.py
@@ -60,6 +60,8 @@ def is_turn_done(engine: str, event: dict) -> bool:
         return False
     if engine == "codex":
         return t in ("turn.completed", "turn.failed")
+    if engine == "hermes":
+        return t in ("turn.completed", "turn.failed")
     return t == "agent_end"  # pi-mono
 
 
@@ -109,6 +111,9 @@ def extract_result(engine: str, event: dict) -> str | None:
             content = msg.get("content", [])
             if content:
                 return content[-1].get("text", "")
+    if engine == "hermes" and t == "turn.completed":
+        text = event.get("text")
+        return text if isinstance(text, str) and text else None
     return None
 
 
@@ -125,6 +130,9 @@ def extract_thread_id(engine: str, event: dict) -> str | None:
             return event.get("thread_id") or None
     elif engine == "pi-mono" and t == "session":
         return event.get("id") or None
+    elif engine == "hermes":
+        if t == "system" and event.get("subtype") == "init":
+            return event.get("session_id") or None
     return None
 
 

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -1079,6 +1079,10 @@ class KubernetesExecutorBackend(SandboxBackend):
             env.append(f"CLAUDE_MODEL={model}")
         if engine == "claude-code" and resume_thread_id:
             env.append(f"CLAUDE_CONTINUE_SESSION_ID={resume_thread_id}")
+        if engine == "hermes" and model:
+            env.append(f"HERMES_MODEL={model}")
+        if engine == "hermes" and resume_thread_id:
+            env.append(f"HERMES_CONTINUE_SESSION_ID={resume_thread_id}")
         if persona:
             env.append(f"AGENT_PERSONA={persona}")
         if repo:

--- a/services/api/api/sandbox/normalize.py
+++ b/services/api/api/sandbox/normalize.py
@@ -841,10 +841,77 @@ def _normalize_pi_event(event: dict) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Hermes normalizer
+# ---------------------------------------------------------------------------
+
+
+def _normalize_hermes_event(event: dict) -> list[dict]:
+    """Normalize Hermes ACP-bridge events (emitted by hermes-app-wrapper).
+
+    The wrapper flattens Hermes' ACP ``session/update`` notifications into a
+    small set of Centaur-shaped events; map those onto canonical events.
+    """
+    event_type = _as_str(event.get("type"))
+
+    if event_type == "system":
+        if _as_str(event.get("subtype")) == "init":
+            session_id = _first_non_empty(event.get("session_id"))
+            return (
+                [{"type": "system", "subtype": "init", "session_id": session_id}]
+                if session_id
+                else []
+            )
+        return []
+
+    if event_type == "agent_message_chunk":
+        text = _as_str(event.get("text"))
+        return [_assistant_text_event(text)] if text else []
+
+    if event_type == "agent_thought_chunk":
+        text = _as_str(event.get("text"))
+        return [{"type": "reasoning", "text": text}] if text else []
+
+    if event_type == "tool_call":
+        tool_id = _as_str(event.get("tool_call_id"))
+        name = _as_str(event.get("name")) or "tool"
+        return [_assistant_tool_use_event(tool_id, name, event.get("input"))]
+
+    if event_type == "tool_call_update":
+        if _as_str(event.get("status")) not in ("completed", "failed"):
+            return []
+        tool_id = _as_str(event.get("tool_call_id"))
+        if not tool_id:
+            return []
+        return [
+            _tool_result_event(
+                tool_id, event.get("output"), bool(event.get("is_error"))
+            )
+        ]
+
+    if event_type == "plan":
+        return [{"type": "turn.plan.updated", "entries": _as_list(event.get("entries"))}]
+
+    if event_type == "turn.completed":
+        return _attach_usage_metadata([], event, authoritative=True)
+
+    if event_type in ("turn.failed", "error"):
+        error_value = event.get("error")
+        message = (
+            _as_str(error_value)
+            or _as_str(_as_record(error_value).get("message"))
+            or _as_str(event.get("message"))
+            or "Unknown error"
+        )
+        return [{"type": "error", "error": message}]
+
+    return []
+
+
+# ---------------------------------------------------------------------------
 # Main dispatcher
 # ---------------------------------------------------------------------------
 
-_ENGINE_HARNESSES = {"amp", "claude-code", "codex", "pi-mono"}
+_ENGINE_HARNESSES = {"amp", "claude-code", "codex", "pi-mono", "hermes"}
 
 
 def normalize_harness_event(engine: str, event: dict) -> list[dict]:
@@ -885,6 +952,13 @@ def normalize_harness_event(engine: str, event: dict) -> list[dict]:
             "tool_execution_end",
         ):
             normalized = "pi-mono"
+        elif event_type in (
+            "agent_message_chunk",
+            "agent_thought_chunk",
+            "tool_call",
+            "tool_call_update",
+        ):
+            normalized = "hermes"
         else:
             normalized = "amp"
 
@@ -892,5 +966,7 @@ def normalize_harness_event(engine: str, event: dict) -> list[dict]:
         return _normalize_codex_event(event)
     if normalized == "pi-mono":
         return _normalize_pi_event(event)
+    if normalized == "hermes":
+        return _normalize_hermes_event(event)
     # Personas (legal, eng, etc.) use amp/claude-code format
     return _normalize_amp_like_event(event)

--- a/services/api/api/sandbox/normalize.py
+++ b/services/api/api/sandbox/normalize.py
@@ -846,10 +846,11 @@ def _normalize_pi_event(event: dict) -> list[dict]:
 
 
 def _normalize_hermes_event(event: dict) -> list[dict]:
-    """Normalize Hermes ACP-bridge events (emitted by hermes-app-wrapper).
+    """Normalize Hermes events (emitted by hermes-app-wrapper).
 
-    The wrapper flattens Hermes' ACP ``session/update`` notifications into a
-    small set of Centaur-shaped events; map those onto canonical events.
+    The wrapper drives Hermes' native ``AIAgent`` in process and flattens its
+    streaming callbacks into a small set of Centaur-shaped events; map those
+    onto canonical events.
     """
     event_type = _as_str(event.get("type"))
 

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -256,9 +256,7 @@ class HmacSignSecret:
     allow_chunked_body: bool = False
 
 
-SecretDef = (
-    HttpSecret | GcpAuthSecret | PgDsnSecret | OAuthTokenSecret | HmacSignSecret
-)
+SecretDef = HttpSecret | GcpAuthSecret | PgDsnSecret | OAuthTokenSecret | HmacSignSecret
 
 # Per-grant credential fields: grant -> (required, optional). Field names are
 # the keys iron-proxy expects in each ``oauth_token`` token entry.
@@ -345,9 +343,7 @@ def _parse_oauth_fields(
                 f"oauth_token entry {secret_name!r} field {field_name!r} is not "
                 f"valid for grant {grant!r}; allowed: {sorted(allowed)}"
             )
-        parsed[field_name] = _parse_oauth_field_source(
-            secret_name, field_name, raw
-        )
+        parsed[field_name] = _parse_oauth_field_source(secret_name, field_name, raw)
     missing = required - parsed.keys()
     if missing:
         raise ValueError(
@@ -431,8 +427,7 @@ def _parse_hmac_credentials(
     """Parse ``credentials`` for an ``hmac_sign`` entry; require ``secret``."""
     if not isinstance(raw, dict) or not raw:
         raise ValueError(
-            f"hmac_sign entry {secret_name!r} 'credentials' must be a non-empty "
-            f"table"
+            f"hmac_sign entry {secret_name!r} 'credentials' must be a non-empty table"
         )
     parsed: dict[str, OAuthFieldSource] = {}
     for field_name, value in raw.items():
@@ -663,7 +658,9 @@ def _parse_secret(entry: Any, *, default_hosts: tuple[str, ...] = ()) -> SecretD
             replacer=entry,
         )
     if not isinstance(entry, dict):
-        raise ValueError(f"secret entry must be a string or table, got {type(entry).__name__}")
+        raise ValueError(
+            f"secret entry must be a string or table, got {type(entry).__name__}"
+        )
     name = entry.get("name")
     if not isinstance(name, str) or not name:
         raise ValueError(f"secret entry missing 'name': {entry!r}")
@@ -927,7 +924,9 @@ async def _capture_live_slack_send(
         return None
     active_channel = parts[2]
     active_thread_ts = parts[3]
-    requested_channel = str(args.get("channel") or args.get("channel_id") or "").lstrip("#")
+    requested_channel = str(args.get("channel") or args.get("channel_id") or "").lstrip(
+        "#"
+    )
     requested_thread_ts = str(args.get("thread_ts") or "")
     channel_is_id = bool(re.match(r"^[CDG][A-Z0-9]+$", requested_channel))
     if channel_is_id and requested_channel != active_channel:

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -21,6 +21,7 @@ from dataclasses import asdict, dataclass, is_dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any, ClassVar
+from urllib.parse import urlsplit
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -102,6 +103,7 @@ class HttpSecret:
 
     name: str
     secret_ref: str
+    source_kind: str = ""
     mode: SecretMode = SecretMode.REPLACE
     hosts: tuple[str, ...] = ()
     # Replace mode — where iron-proxy scans for ``replacer``.
@@ -1635,6 +1637,36 @@ class ToolManager:
         ),
     ]
 
+    @staticmethod
+    def _anthropic_compatible_secret_ref() -> str:
+        for name in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_TOKEN"):
+            if os.getenv(name):
+                return name
+        return "ANTHROPIC_API_KEY"
+
+    @classmethod
+    def _dynamic_infra_secrets(cls) -> list[HttpSecret]:
+        hosts: set[str] = set()
+        for name in ("ANTHROPIC_BASE_URL", "HERMES_BASE_URL"):
+            raw = (os.getenv(name) or "").strip()
+            if not raw:
+                continue
+            host = urlsplit(raw).hostname
+            if host:
+                hosts.add(host)
+        if not hosts:
+            return []
+        secret_ref = cls._anthropic_compatible_secret_ref()
+        return [
+            HttpSecret(
+                name="ANTHROPIC_API_KEY",
+                secret_ref=secret_ref,
+                source_kind="env" if os.getenv(secret_ref) else "",
+                hosts=tuple(sorted(hosts)),
+                match_headers=("X-Api-Key", "Authorization"),
+            )
+        ]
+
     def collect_secrets(self) -> list[SecretDef]:
         """Return all secrets (infra + tool).
 
@@ -1642,6 +1674,7 @@ class ToolManager:
         its own ``hosts``; ``PgDsnSecret`` is a TCP listener with no host.
         """
         out: list[SecretDef] = list(self._INFRA_SECRETS)
+        out.extend(self._dynamic_infra_secrets())
         for lt in self.tools.values():
             out.extend(lt.all_secrets)
         return out

--- a/services/api/api/workflows/slack_thread_turn.py
+++ b/services/api/api/workflows/slack_thread_turn.py
@@ -12,7 +12,7 @@ from api.workflow_engine import Delivery, WorkflowContext
 
 WORKFLOW_NAME = "slack_thread_turn"
 
-_EXECUTION_HARNESSES = frozenset({"amp", "claude-code", "codex", "pi-mono"})
+_EXECUTION_HARNESSES = frozenset({"amp", "claude-code", "codex", "pi-mono", "hermes"})
 _PROMPT_FLAG_ALIASES = {
     "claude": "claude-code",
     "pi": "pi-mono",

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -51,6 +51,29 @@ def _have_local_pg_binaries() -> bool:
     return all(shutil.which(cmd) for cmd in ("initdb", "pg_ctl", "pg_isready"))
 
 
+def _local_pg_has_extension(extension: str) -> bool:
+    pg_config = shutil.which("pg_config")
+    if not pg_config:
+        return False
+    result = subprocess.run(
+        [pg_config, "--sharedir"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    sharedir = result.stdout.strip()
+    return (
+        bool(sharedir)
+        and (Path(sharedir) / "extension" / f"{extension}.control").exists()
+    )
+
+
+def _can_use_local_pg_for_tests() -> bool:
+    return _have_local_pg_binaries() and _local_pg_has_extension("pg_search")
+
+
 def _have_docker() -> bool:
     return shutil.which("docker") is not None
 
@@ -86,7 +109,9 @@ async def _wait_for_postgres(dsn: str, timeout_s: float = 30.0) -> None:
 async def _ensure_database(admin_dsn: str, database: str) -> None:
     conn = await asyncpg.connect(admin_dsn)
     try:
-        exists = await conn.fetchval("SELECT 1 FROM pg_database WHERE datname = $1", database)
+        exists = await conn.fetchval(
+            "SELECT 1 FROM pg_database WHERE datname = $1", database
+        )
         if not exists:
             safe_db = database.replace('"', '""')
             await conn.execute(f'CREATE DATABASE "{safe_db}"')
@@ -124,7 +149,7 @@ def pg():
         yield dsn
         return
 
-    if _have_local_pg_binaries():
+    if _can_use_local_pg_for_tests():
         tmpdir = tempfile.mkdtemp(prefix="centaur-test-pg-")
         port = _pick_free_port()
         admin_dsn = f"postgresql://localhost:{port}/postgres?host={tmpdir}"
@@ -138,8 +163,14 @@ def pg():
             )
             subprocess.run(
                 [
-                    "pg_ctl", "-D", tmpdir, "-o", f"-p {port} -k {tmpdir}",
-                    "-l", f"{tmpdir}/pg.log", "start",
+                    "pg_ctl",
+                    "-D",
+                    tmpdir,
+                    "-o",
+                    f"-p {port} -k {tmpdir} -c shared_preload_libraries=pg_search",
+                    "-l",
+                    f"{tmpdir}/pg.log",
+                    "start",
                 ],
                 check=True,
                 capture_output=True,

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -55,7 +55,9 @@ async def _insert_assignment(db_pool, thread_key: str, generation: int = 1) -> N
 
 
 @pytest.mark.asyncio
-async def test_spawn_assignment_defaults_to_codex_when_no_selector(db_pool, monkeypatch):
+async def test_spawn_assignment_defaults_to_codex_when_no_selector(
+    db_pool, monkeypatch
+):
     from api.runtime_control import spawn_assignment
 
     monkeypatch.delenv("CENTAUR_DEFAULT_HARNESS", raising=False)
@@ -1080,7 +1082,9 @@ async def test_mark_execution_terminal_delays_outbox_claimability(db_pool):
 
 
 @pytest.mark.asyncio
-async def test_mark_execution_terminal_skips_durable_delivery_after_live_answer(db_pool):
+async def test_mark_execution_terminal_skips_durable_delivery_after_live_answer(
+    db_pool,
+):
     from api.runtime_control import _mark_execution_terminal
 
     execution_id = f"exe-{uuid.uuid4().hex[:10]}"
@@ -2692,16 +2696,19 @@ async def test_steer_execution_reports_cancel_when_execution_finishes_during_inj
 
 
 @pytest.mark.asyncio
-async def test_steer_stdin_interrupts_amp_before_injecting(monkeypatch):
+@pytest.mark.parametrize("harness", ["amp", "hermes"])
+async def test_steer_stdin_interrupts_harness_before_injecting(monkeypatch, harness):
     from api.agent import steer_stdin
 
     calls: list[str] = []
+    payloads: list[dict] = []
 
     async def _interrupt_by_id(_sandbox_id: str) -> None:
         calls.append("interrupt")
 
-    async def _write_stdin(_session: SandboxSession, _payload: dict) -> None:
+    async def _write_stdin(_session: SandboxSession, payload: dict) -> None:
         calls.append("write")
+        payloads.append(payload)
 
     backend = SimpleNamespace(
         interrupt_by_id=AsyncMock(side_effect=_interrupt_by_id),
@@ -2713,28 +2720,40 @@ async def test_steer_stdin_interrupts_amp_before_injecting(monkeypatch):
     session = SandboxSession(
         sandbox_id=f"rt-{uuid.uuid4().hex[:8]}",
         thread_key=f"slack:C-test:{uuid.uuid4().hex}",
-        harness="amp",
-        engine="amp",
+        harness=harness,
+        engine=harness,
     )
 
     result = await steer_stdin(session, [{"type": "text", "text": "stop"}])
 
     assert result == {"ok": True, "steered": True}
-    assert calls == ["interrupt", "write"]
+    assert calls == (
+        ["interrupt", "write", "write"]
+        if harness == "hermes"
+        else ["interrupt", "write"]
+    )
+    if harness == "hermes":
+        assert payloads[0] == {"type": "interrupt"}
+        assert payloads[1]["type"] == "user"
+    else:
+        assert payloads[0]["type"] == "user"
     backend.interrupt_by_id.assert_awaited_once_with(session.sandbox_id)
 
 
 @pytest.mark.asyncio
-async def test_steer_stdin_reattaches_when_interrupt_closes_stdin(monkeypatch):
+@pytest.mark.parametrize("harness", ["amp", "hermes"])
+async def test_steer_stdin_reattaches_when_interrupt_closes_stdin(monkeypatch, harness):
     from api.agent import steer_stdin
 
     calls: list[str] = []
+    payloads: list[dict] = []
 
     async def _interrupt_by_id(_sandbox_id: str) -> None:
         calls.append("interrupt")
 
-    async def _write_stdin(_session: SandboxSession, _payload: dict) -> None:
+    async def _write_stdin(_session: SandboxSession, payload: dict) -> None:
         calls.append("write")
+        payloads.append(payload)
         if calls.count("write") == 1:
             raise RuntimeError("not attached (stdin)")
 
@@ -2752,14 +2771,25 @@ async def test_steer_stdin_reattaches_when_interrupt_closes_stdin(monkeypatch):
     session = SandboxSession(
         sandbox_id=f"rt-{uuid.uuid4().hex[:8]}",
         thread_key=f"slack:C-test:{uuid.uuid4().hex}",
-        harness="amp",
-        engine="amp",
+        harness=harness,
+        engine=harness,
     )
 
     result = await steer_stdin(session, [{"type": "text", "text": "stop"}])
 
     assert result == {"ok": True, "steered": True}
-    assert calls == ["interrupt", "write", "reattach", "write"]
+    assert calls == (
+        ["interrupt", "write", "reattach", "write", "write"]
+        if harness == "hermes"
+        else ["interrupt", "write", "reattach", "write"]
+    )
+    if harness == "hermes":
+        assert payloads[0] == {"type": "interrupt"}
+        assert payloads[1] == {"type": "interrupt"}
+        assert payloads[2]["type"] == "user"
+    else:
+        assert payloads[0]["type"] == "user"
+        assert payloads[1]["type"] == "user"
     backend.reattach_stdin.assert_awaited_once_with(session)
 
 

--- a/services/api/tests/test_harness_protocol.py
+++ b/services/api/tests/test_harness_protocol.py
@@ -442,3 +442,41 @@ class TestMessagesToContentBlocks:
             {"type": "text", "text": "first"},
             {"type": "text", "text": "second"},
         ]
+
+
+class TestHermesProtocol:
+    def test_is_turn_done_completed(self):
+        assert is_turn_done("hermes", {"type": "turn.completed"}) is True
+
+    def test_is_turn_done_failed(self):
+        assert is_turn_done("hermes", {"type": "turn.failed"}) is True
+
+    def test_is_turn_done_error(self):
+        assert is_turn_done("hermes", {"type": "error", "message": "boom"}) is True
+
+    def test_is_turn_done_chunk_not_done(self):
+        assert is_turn_done("hermes", {"type": "agent_message_chunk", "text": "x"}) is False
+        assert is_turn_done("hermes", {"type": "tool_call", "tool_call_id": "t"}) is False
+
+    def test_extract_result_from_turn_completed(self):
+        event = {"type": "turn.completed", "stop_reason": "end_turn", "text": "Final answer"}
+        assert extract_result("hermes", event) == "Final answer"
+
+    def test_extract_result_empty_text_none(self):
+        event = {"type": "turn.completed", "stop_reason": "end_turn", "text": ""}
+        assert extract_result("hermes", event) is None
+
+    def test_extract_result_chunk_is_none(self):
+        # Streamed deltas must not be treated as the final result.
+        assert extract_result("hermes", {"type": "agent_message_chunk", "text": "frag"}) is None
+
+    def test_extract_thread_id_from_init(self):
+        event = {"type": "system", "subtype": "init", "session_id": "sess-7"}
+        assert extract_thread_id("hermes", event) == "sess-7"
+
+    def test_extract_thread_id_empty_session(self):
+        event = {"type": "system", "subtype": "init", "session_id": ""}
+        assert extract_thread_id("hermes", event) is None
+
+    def test_extract_thread_id_unrelated(self):
+        assert extract_thread_id("hermes", {"type": "agent_message_chunk"}) is None

--- a/services/api/tests/test_hermes_app_wrapper.py
+++ b/services/api/tests/test_hermes_app_wrapper.py
@@ -1,21 +1,18 @@
-"""Tests for hermes-app-wrapper — command selection + ACP event translation.
+"""Tests for hermes-app-wrapper — command selection + AIAgent event translation.
 
-The wrapper imports ``acp`` lazily, so the module loads (and its pure helpers +
-``session_update`` translation are exercised) without the sandbox-only
-``agent-client-protocol`` package installed.
+The wrapper drives Hermes' native ``AIAgent`` in process and imports it lazily,
+so the module loads (and its pure helpers + ``TurnEmitter`` callback→event
+translation are exercised) without the sandbox-only ``hermes-agent`` package.
 """
 
 from __future__ import annotations
 
-import asyncio
 import importlib.util
 import io
 import json
 import sys
 from pathlib import Path
 from types import ModuleType
-
-import pytest
 
 from api.sandbox.config import build_harness_cmd
 
@@ -30,37 +27,15 @@ def _load_wrapper() -> ModuleType:
     return module
 
 
-class _FakeUpdate:
-    """Stands in for an ACP session-update pydantic model."""
-
-    def __init__(self, data: dict) -> None:
-        self._data = data
-
-    def model_dump(self, **_kwargs: object) -> dict:
-        return self._data
-
-
-class _Opt:
-    def __init__(self, kind: str, option_id: str) -> None:
-        self.kind = kind
-        self.option_id = option_id
-
-
-def _capture(coro_factory) -> list[dict]:
-    """Run an async client driver, capturing emitted NDJSON lines as dicts."""
-    wrapper = _load_wrapper()
+def _capture(fn) -> list[dict]:
+    """Run ``fn`` while capturing emitted NDJSON lines (emit falls back to stdout)."""
     buf = io.StringIO()
-    real_stdout = sys.stdout
-
-    async def driver() -> None:
-        client = wrapper.CentaurHermesClient()
-        sys.stdout = buf
-        try:
-            await coro_factory(client)
-        finally:
-            sys.stdout = real_stdout
-
-    asyncio.run(driver())
+    real = sys.stdout
+    sys.stdout = buf
+    try:
+        fn()
+    finally:
+        sys.stdout = real
     return [json.loads(line) for line in buf.getvalue().splitlines() if line]
 
 
@@ -71,32 +46,10 @@ def test_build_harness_cmd_selects_hermes_wrapper():
     assert build_harness_cmd("hermes") == ["hermes-app-wrapper"]
 
 
-def test_hermes_acp_cmd_prefers_console_script(monkeypatch):
+def test_module_loads_without_hermes_installed():
     wrapper = _load_wrapper()
-    monkeypatch.delenv("HERMES_ACP_COMMAND", raising=False)
-    monkeypatch.setattr(
-        wrapper, "_hermes_acp_cmd", wrapper._hermes_acp_cmd
-    )  # no-op, keep ref
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/" + name)
-    assert wrapper._hermes_acp_cmd() == ["hermes-acp"]
-
-
-def test_hermes_acp_cmd_env_override(monkeypatch):
-    wrapper = _load_wrapper()
-    monkeypatch.setenv("HERMES_ACP_COMMAND", "hermes acp --foo")
-    assert wrapper._hermes_acp_cmd() == ["hermes", "acp", "--foo"]
-
-
-def test_hermes_acp_cmd_module_fallback(monkeypatch):
-    wrapper = _load_wrapper()
-    monkeypatch.delenv("HERMES_ACP_COMMAND", raising=False)
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda name: None)
-    cmd = wrapper._hermes_acp_cmd()
-    assert cmd[1:] == ["-m", "acp_adapter.entry"]
+    assert hasattr(wrapper, "TurnEmitter")
+    assert "run_agent" not in sys.modules
 
 
 # ── pure helpers ───────────────────────────────────────────────────────────────
@@ -115,149 +68,121 @@ def test_prompt_text_empty_defaults_to_continue():
 
 def test_prompt_text_image_placeholder():
     wrapper = _load_wrapper()
-    turn = {"message": {"content": [{"type": "image"}]}}
-    assert "image attachment" in wrapper._prompt_text(turn)
+    assert "image attachment" in wrapper._prompt_text({"message": {"content": [{"type": "image"}]}})
 
 
-def test_tool_output_text_from_content_blocks():
+def test_stringify_passthrough_and_json():
     wrapper = _load_wrapper()
-    update = {"content": [{"type": "content", "content": {"type": "text", "text": "done"}}]}
-    assert wrapper._tool_output_text(update) == "done"
+    assert wrapper._stringify("plain") == "plain"
+    assert wrapper._stringify(None) == ""
+    assert wrapper._stringify({"x": 1}) == json.dumps({"x": 1})
 
 
-def test_tool_output_text_raw_output_fallback():
+def test_plan_entries_from_todo_with_trailing_hint():
     wrapper = _load_wrapper()
-    assert wrapper._tool_output_text({"rawOutput": {"x": 1}}) == json.dumps({"x": 1})
+    result = '{"todos":[{"content":"a","status":"in_progress"},{"content":"b","status":"cancelled"}]} (hint)'
+    entries = wrapper._plan_entries_from_todo(result)
+    assert entries == [
+        {"content": "a", "priority": "medium", "status": "in_progress"},
+        {"content": "[cancelled] b", "priority": "medium", "status": "completed"},
+    ]
 
 
-def test_pick_allow_option_prefers_allow_always():
+def test_plan_entries_from_todo_invalid_returns_none():
     wrapper = _load_wrapper()
-    options = [_Opt("reject_once", "r"), _Opt("allow_once", "a1"), _Opt("allow_always", "a2")]
-    assert wrapper._pick_allow_option(options) == "a2"
+    assert wrapper._plan_entries_from_todo("not json") is None
+    assert wrapper._plan_entries_from_todo("") is None
 
 
-def test_pick_allow_option_falls_back_to_allow_once():
+# ── TurnEmitter: AIAgent callbacks → Centaur NDJSON ─────────────────────────────
+
+
+def test_stream_delta_accumulates_and_emits():
     wrapper = _load_wrapper()
-    options = [_Opt("allow_once", "a1"), _Opt("reject_always", "r")]
-    assert wrapper._pick_allow_option(options) == "a1"
-
-
-def test_pick_allow_option_none_when_only_rejects():
-    wrapper = _load_wrapper()
-    options = [_Opt("reject_once", "r1"), _Opt("reject_always", "r2")]
-    assert wrapper._pick_allow_option(options) is None
-
-
-# ── session_update translation ─────────────────────────────────────────────────
-
-
-def test_session_update_message_chunk_accumulates_and_emits():
-    wrapper = _load_wrapper()
-    client = wrapper.CentaurHermesClient()
-    buf = io.StringIO()
-    real = sys.stdout
-
-    async def drive():
-        sys.stdout = buf
-        try:
-            await client.session_update(
-                "s", _FakeUpdate({"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "Hel"}})
-            )
-            await client.session_update(
-                "s", _FakeUpdate({"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "lo"}})
-            )
-        finally:
-            sys.stdout = real
-
-    asyncio.run(drive())
-    events = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+    em = wrapper.TurnEmitter()
+    events = _capture(lambda: (em.on_stream_delta("Hel"), em.on_stream_delta("lo")))
     assert events == [
         {"type": "agent_message_chunk", "text": "Hel"},
         {"type": "agent_message_chunk", "text": "lo"},
     ]
-    assert client.final_text == "Hello"
+    assert em.final_text == "Hello"
 
 
-def test_session_update_thought_chunk():
-    events = _capture(
-        lambda c: c.session_update(
-            "s", _FakeUpdate({"sessionUpdate": "agent_thought_chunk", "content": {"type": "text", "text": "hmm"}})
-        )
-    )
+def test_stream_delta_empty_dropped():
+    wrapper = _load_wrapper()
+    em = wrapper.TurnEmitter()
+    assert _capture(lambda: em.on_stream_delta("")) == []
+
+
+def test_reasoning_emits_thought_chunk():
+    wrapper = _load_wrapper()
+    em = wrapper.TurnEmitter()
+    events = _capture(lambda: em.on_reasoning("hmm"))
     assert events == [{"type": "agent_thought_chunk", "text": "hmm"}]
 
 
-def test_session_update_tool_call():
-    events = _capture(
-        lambda c: c.session_update(
-            "s",
-            _FakeUpdate(
-                {
-                    "sessionUpdate": "tool_call",
-                    "toolCallId": "t1",
-                    "title": "Read file",
-                    "kind": "read",
-                    "rawInput": {"path": "x"},
-                }
-            ),
-        )
-    )
-    assert events == [
-        {
-            "type": "tool_call",
-            "tool_call_id": "t1",
-            "name": "Read file",
-            "kind": "read",
-            "input": {"path": "x"},
-        }
-    ]
-
-
-def test_session_update_tool_call_update_completed():
-    events = _capture(
-        lambda c: c.session_update(
-            "s",
-            _FakeUpdate(
-                {
-                    "sessionUpdate": "tool_call_update",
-                    "toolCallId": "t1",
-                    "status": "completed",
-                    "content": [{"type": "content", "content": {"type": "text", "text": "BODY"}}],
-                }
-            ),
-        )
-    )
-    assert events == [
-        {
-            "type": "tool_call_update",
-            "tool_call_id": "t1",
-            "status": "completed",
-            "output": "BODY",
-            "is_error": False,
-        }
-    ]
-
-
-def test_session_update_tool_call_update_in_progress_suppressed():
-    events = _capture(
-        lambda c: c.session_update(
-            "s", _FakeUpdate({"sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "in_progress"})
-        )
-    )
+def test_tool_progress_only_started_emits():
+    wrapper = _load_wrapper()
+    em = wrapper.TurnEmitter()
+    events = _capture(lambda: em.on_tool_progress("tool.completed", "read", None, {}))
     assert events == []
 
 
-def test_session_update_plan():
-    entries = [{"content": "step", "priority": "medium", "status": "pending"}]
-    events = _capture(
-        lambda c: c.session_update("s", _FakeUpdate({"sessionUpdate": "plan", "entries": entries}))
-    )
-    assert events == [{"type": "plan", "entries": entries}]
+def test_tool_progress_parses_string_args():
+    wrapper = _load_wrapper()
+    em = wrapper.TurnEmitter()
+    events = _capture(lambda: em.on_tool_progress("tool.started", "read", None, '{"path":"x"}'))
+    assert events[0]["type"] == "tool_call"
+    assert events[0]["name"] == "read"
+    assert events[0]["input"] == {"path": "x"}
 
 
-def test_session_update_dict_fallback():
-    # A raw dict (no model_dump) is tolerated.
-    events = _capture(
-        lambda c: c.session_update("s", {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "x"}})
-    )
-    assert events == [{"type": "agent_message_chunk", "text": "x"}]
+def test_tool_start_complete_correlation_parallel_same_name():
+    wrapper = _load_wrapper()
+    em = wrapper.TurnEmitter()
+
+    def run():
+        em.on_tool_progress("tool.started", "read_file", None, {"path": "x"})
+        em.on_tool_progress("tool.started", "read_file", None, {"path": "y"})
+        em.on_step(1, [{"name": "read_file", "result": "BODY-x"}, {"name": "read_file", "result": "BODY-y"}])
+
+    events = _capture(run)
+    starts = [e for e in events if e["type"] == "tool_call"]
+    updates = [e for e in events if e["type"] == "tool_call_update"]
+    assert len(starts) == 2 and len(updates) == 2
+    # FIFO correlation: first start pairs with first completion.
+    assert starts[0]["tool_call_id"] == updates[0]["tool_call_id"]
+    assert starts[1]["tool_call_id"] == updates[1]["tool_call_id"]
+    assert updates[0]["output"] == "BODY-x" and updates[1]["output"] == "BODY-y"
+    assert all(u["status"] == "completed" and u["is_error"] is False for u in updates)
+
+
+def test_step_error_marks_failed():
+    wrapper = _load_wrapper()
+    em = wrapper.TurnEmitter()
+    events = _capture(lambda: em.on_step(1, [{"name": "web", "error": "timeout"}]))
+    assert events[0]["type"] == "tool_call_update"
+    assert events[0]["status"] == "failed"
+    assert events[0]["is_error"] is True
+
+
+def test_step_todo_emits_plan():
+    wrapper = _load_wrapper()
+    em = wrapper.TurnEmitter()
+    result = '{"todos":[{"content":"step1","status":"completed"}]}'
+    events = _capture(lambda: em.on_step(1, [{"name": "todo", "result": result}]))
+    assert {"type": "plan", "entries": [{"content": "step1", "priority": "medium", "status": "completed"}]} in events
+
+
+def test_step_ignores_non_list():
+    wrapper = _load_wrapper()
+    em = wrapper.TurnEmitter()
+    assert _capture(lambda: em.on_step(1, None)) == []
+
+
+def test_reset_clears_state():
+    wrapper = _load_wrapper()
+    em = wrapper.TurnEmitter()
+    em.on_stream_delta("x")
+    em.reset()
+    assert em.final_text == ""

--- a/services/api/tests/test_hermes_app_wrapper.py
+++ b/services/api/tests/test_hermes_app_wrapper.py
@@ -84,6 +84,24 @@ def test_stringify_passthrough_and_json():
     assert wrapper._stringify({"x": 1}) == json.dumps({"x": 1})
 
 
+def test_prompt_with_transcript_empty_returns_current_prompt():
+    wrapper = _load_wrapper()
+    assert wrapper._prompt_with_transcript("current", []) == "current"
+
+
+def test_prompt_with_transcript_includes_prior_turns():
+    wrapper = _load_wrapper()
+    prompt = wrapper._prompt_with_transcript(
+        "What nonce did I give you?",
+        [("Remember nonce HERMES_NONCE_7429.", "SAVED")],
+    )
+
+    assert "Previous conversation in this Hermes runtime" in prompt
+    assert "User:\nRemember nonce HERMES_NONCE_7429." in prompt
+    assert "Assistant:\nSAVED" in prompt
+    assert "Current user message:\nWhat nonce did I give you?" in prompt
+
+
 def test_plan_entries_from_todo_with_trailing_hint():
     wrapper = _load_wrapper()
     result = '{"todos":[{"content":"a","status":"in_progress"},{"content":"b","status":"cancelled"}]} (hint)'
@@ -302,4 +320,64 @@ def test_run_turn_uses_streamed_text_when_agent_returns_none():
     assert events == [
         {"type": "agent_message_chunk", "text": "PONG"},
         {"type": "turn.completed", "stop_reason": "end_turn", "text": "PONG"},
+    ]
+
+
+def test_run_turn_carries_prior_completed_turns_into_next_prompt():
+    wrapper = _load_wrapper()
+
+    class FakeAgent:
+        def __init__(self):
+            self.prompts: list[str] = []
+
+        def chat(self, prompt):
+            self.prompts.append(prompt)
+            if len(self.prompts) == 1:
+                return "SAVED"
+            return "HERMES_NONCE_7429"
+
+    agent = FakeAgent()
+    subject = wrapper.Wrapper()
+    subject.agent = agent
+
+    first = {
+        "type": "user",
+        "message": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Remember nonce HERMES_NONCE_7429. Reply exactly SAVED.",
+                }
+            ]
+        },
+    }
+    second = {
+        "type": "user",
+        "message": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "What nonce did I give you? Reply only with the nonce.",
+                }
+            ]
+        },
+    }
+
+    events = _capture(lambda: (subject._run_turn(first), subject._run_turn(second)))
+
+    assert agent.prompts[0] == "Remember nonce HERMES_NONCE_7429. Reply exactly SAVED."
+    assert "Previous conversation in this Hermes runtime" in agent.prompts[1]
+    assert "User:\nRemember nonce HERMES_NONCE_7429. Reply exactly SAVED." in agent.prompts[1]
+    assert "Assistant:\nSAVED" in agent.prompts[1]
+    assert (
+        "Current user message:\nWhat nonce did I give you? Reply only with the nonce."
+        in agent.prompts[1]
+    )
+    assert events == [
+        {"type": "turn.completed", "stop_reason": "end_turn", "text": "SAVED"},
+        {
+            "type": "turn.completed",
+            "stop_reason": "end_turn",
+            "text": "HERMES_NONCE_7429",
+        },
     ]

--- a/services/api/tests/test_hermes_app_wrapper.py
+++ b/services/api/tests/test_hermes_app_wrapper.py
@@ -57,7 +57,11 @@ def test_module_loads_without_hermes_installed():
 
 def test_prompt_text_joins_blocks():
     wrapper = _load_wrapper()
-    turn = {"message": {"content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]}}
+    turn = {
+        "message": {
+            "content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
+        }
+    }
     assert wrapper._prompt_text(turn) == "a\nb"
 
 
@@ -68,7 +72,9 @@ def test_prompt_text_empty_defaults_to_continue():
 
 def test_prompt_text_image_placeholder():
     wrapper = _load_wrapper()
-    assert "image attachment" in wrapper._prompt_text({"message": {"content": [{"type": "image"}]}})
+    assert "image attachment" in wrapper._prompt_text(
+        {"message": {"content": [{"type": "image"}]}}
+    )
 
 
 def test_stringify_passthrough_and_json():
@@ -131,7 +137,9 @@ def test_tool_progress_only_started_emits():
 def test_tool_progress_parses_string_args():
     wrapper = _load_wrapper()
     em = wrapper.TurnEmitter()
-    events = _capture(lambda: em.on_tool_progress("tool.started", "read", None, '{"path":"x"}'))
+    events = _capture(
+        lambda: em.on_tool_progress("tool.started", "read", None, '{"path":"x"}')
+    )
     assert events[0]["type"] == "tool_call"
     assert events[0]["name"] == "read"
     assert events[0]["input"] == {"path": "x"}
@@ -144,7 +152,13 @@ def test_tool_start_complete_correlation_parallel_same_name():
     def run():
         em.on_tool_progress("tool.started", "read_file", None, {"path": "x"})
         em.on_tool_progress("tool.started", "read_file", None, {"path": "y"})
-        em.on_step(1, [{"name": "read_file", "result": "BODY-x"}, {"name": "read_file", "result": "BODY-y"}])
+        em.on_step(
+            1,
+            [
+                {"name": "read_file", "result": "BODY-x"},
+                {"name": "read_file", "result": "BODY-y"},
+            ],
+        )
 
     events = _capture(run)
     starts = [e for e in events if e["type"] == "tool_call"]
@@ -171,7 +185,10 @@ def test_step_todo_emits_plan():
     em = wrapper.TurnEmitter()
     result = '{"todos":[{"content":"step1","status":"completed"}]}'
     events = _capture(lambda: em.on_step(1, [{"name": "todo", "result": result}]))
-    assert {"type": "plan", "entries": [{"content": "step1", "priority": "medium", "status": "completed"}]} in events
+    assert {
+        "type": "plan",
+        "entries": [{"content": "step1", "priority": "medium", "status": "completed"}],
+    } in events
 
 
 def test_step_ignores_non_list():
@@ -186,3 +203,103 @@ def test_reset_clears_state():
     em.on_stream_delta("x")
     em.reset()
     assert em.final_text == ""
+
+
+# ── Wrapper turn completion semantics ─────────────────────────────────────────
+
+
+def test_run_turn_fails_closed_when_agent_returns_no_text():
+    wrapper = _load_wrapper()
+
+    class FakeAgent:
+        def chat(self, _prompt):
+            return None
+
+    subject = wrapper.Wrapper()
+    subject.agent = FakeAgent()
+
+    events = _capture(
+        lambda: subject._run_turn(
+            {"type": "user", "message": {"content": [{"type": "text", "text": "hi"}]}}
+        )
+    )
+
+    assert events == [
+        {"type": "error", "message": "hermes returned no assistant output"},
+        {
+            "type": "turn.failed",
+            "error": {"message": "hermes returned no assistant output"},
+        },
+    ]
+
+
+def test_run_turn_suppresses_empty_failure_when_interrupted():
+    wrapper = _load_wrapper()
+    subject = wrapper.Wrapper()
+
+    class FakeAgent:
+        def interrupt(self):
+            return None
+
+        def chat(self, _prompt):
+            subject.request_interrupt()
+            return None
+
+    subject.agent = FakeAgent()
+
+    events = _capture(
+        lambda: subject._run_turn(
+            {"type": "user", "message": {"content": [{"type": "text", "text": "hi"}]}}
+        )
+    )
+
+    assert events == [{"type": "system", "subtype": "turn_interrupted"}]
+
+
+def test_run_turn_preserves_interrupt_received_before_turn_reset():
+    wrapper = _load_wrapper()
+    subject = wrapper.Wrapper()
+
+    class FakeAgent:
+        def interrupt(self):
+            return None
+
+        def chat(self, _prompt):
+            return None
+
+    subject.agent = FakeAgent()
+    subject.request_interrupt()
+
+    events = _capture(
+        lambda: subject._run_turn(
+            {"type": "user", "message": {"content": [{"type": "text", "text": "hi"}]}}
+        )
+    )
+
+    assert events == [{"type": "system", "subtype": "turn_interrupted"}]
+
+
+def test_run_turn_uses_streamed_text_when_agent_returns_none():
+    wrapper = _load_wrapper()
+
+    class FakeAgent:
+        def __init__(self, emitter):
+            self.emitter = emitter
+
+        def chat(self, _prompt):
+            self.emitter.on_stream_delta("PONG")
+            return None
+
+    subject = wrapper.Wrapper()
+    subject.agent = FakeAgent(subject.emitter)
+
+    events = _capture(
+        lambda: subject._run_turn(
+            {"type": "user", "message": {"content": [{"type": "text", "text": "hi"}]}}
+        )
+    )
+
+    assert events == [
+        {"type": "agent_message_chunk", "text": "PONG"},
+        {"type": "turn.completed", "stop_reason": "end_turn", "text": "PONG"},
+    ]

--- a/services/api/tests/test_hermes_app_wrapper.py
+++ b/services/api/tests/test_hermes_app_wrapper.py
@@ -1,0 +1,263 @@
+"""Tests for hermes-app-wrapper — command selection + ACP event translation.
+
+The wrapper imports ``acp`` lazily, so the module loads (and its pure helpers +
+``session_update`` translation are exercised) without the sandbox-only
+``agent-client-protocol`` package installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from api.sandbox.config import build_harness_cmd
+
+WRAPPER_PY = Path(__file__).resolve().parents[2] / "sandbox" / "hermes-app-wrapper.py"
+
+
+def _load_wrapper() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("hermes_app_wrapper", WRAPPER_PY)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeUpdate:
+    """Stands in for an ACP session-update pydantic model."""
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def model_dump(self, **_kwargs: object) -> dict:
+        return self._data
+
+
+class _Opt:
+    def __init__(self, kind: str, option_id: str) -> None:
+        self.kind = kind
+        self.option_id = option_id
+
+
+def _capture(coro_factory) -> list[dict]:
+    """Run an async client driver, capturing emitted NDJSON lines as dicts."""
+    wrapper = _load_wrapper()
+    buf = io.StringIO()
+    real_stdout = sys.stdout
+
+    async def driver() -> None:
+        client = wrapper.CentaurHermesClient()
+        sys.stdout = buf
+        try:
+            await coro_factory(client)
+        finally:
+            sys.stdout = real_stdout
+
+    asyncio.run(driver())
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line]
+
+
+# ── command selection ─────────────────────────────────────────────────────────
+
+
+def test_build_harness_cmd_selects_hermes_wrapper():
+    assert build_harness_cmd("hermes") == ["hermes-app-wrapper"]
+
+
+def test_hermes_acp_cmd_prefers_console_script(monkeypatch):
+    wrapper = _load_wrapper()
+    monkeypatch.delenv("HERMES_ACP_COMMAND", raising=False)
+    monkeypatch.setattr(
+        wrapper, "_hermes_acp_cmd", wrapper._hermes_acp_cmd
+    )  # no-op, keep ref
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/" + name)
+    assert wrapper._hermes_acp_cmd() == ["hermes-acp"]
+
+
+def test_hermes_acp_cmd_env_override(monkeypatch):
+    wrapper = _load_wrapper()
+    monkeypatch.setenv("HERMES_ACP_COMMAND", "hermes acp --foo")
+    assert wrapper._hermes_acp_cmd() == ["hermes", "acp", "--foo"]
+
+
+def test_hermes_acp_cmd_module_fallback(monkeypatch):
+    wrapper = _load_wrapper()
+    monkeypatch.delenv("HERMES_ACP_COMMAND", raising=False)
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    cmd = wrapper._hermes_acp_cmd()
+    assert cmd[1:] == ["-m", "acp_adapter.entry"]
+
+
+# ── pure helpers ───────────────────────────────────────────────────────────────
+
+
+def test_prompt_text_joins_blocks():
+    wrapper = _load_wrapper()
+    turn = {"message": {"content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]}}
+    assert wrapper._prompt_text(turn) == "a\nb"
+
+
+def test_prompt_text_empty_defaults_to_continue():
+    wrapper = _load_wrapper()
+    assert wrapper._prompt_text({}) == "continue"
+
+
+def test_prompt_text_image_placeholder():
+    wrapper = _load_wrapper()
+    turn = {"message": {"content": [{"type": "image"}]}}
+    assert "image attachment" in wrapper._prompt_text(turn)
+
+
+def test_tool_output_text_from_content_blocks():
+    wrapper = _load_wrapper()
+    update = {"content": [{"type": "content", "content": {"type": "text", "text": "done"}}]}
+    assert wrapper._tool_output_text(update) == "done"
+
+
+def test_tool_output_text_raw_output_fallback():
+    wrapper = _load_wrapper()
+    assert wrapper._tool_output_text({"rawOutput": {"x": 1}}) == json.dumps({"x": 1})
+
+
+def test_pick_allow_option_prefers_allow_always():
+    wrapper = _load_wrapper()
+    options = [_Opt("reject_once", "r"), _Opt("allow_once", "a1"), _Opt("allow_always", "a2")]
+    assert wrapper._pick_allow_option(options) == "a2"
+
+
+def test_pick_allow_option_falls_back_to_allow_once():
+    wrapper = _load_wrapper()
+    options = [_Opt("allow_once", "a1"), _Opt("reject_always", "r")]
+    assert wrapper._pick_allow_option(options) == "a1"
+
+
+def test_pick_allow_option_none_when_only_rejects():
+    wrapper = _load_wrapper()
+    options = [_Opt("reject_once", "r1"), _Opt("reject_always", "r2")]
+    assert wrapper._pick_allow_option(options) is None
+
+
+# ── session_update translation ─────────────────────────────────────────────────
+
+
+def test_session_update_message_chunk_accumulates_and_emits():
+    wrapper = _load_wrapper()
+    client = wrapper.CentaurHermesClient()
+    buf = io.StringIO()
+    real = sys.stdout
+
+    async def drive():
+        sys.stdout = buf
+        try:
+            await client.session_update(
+                "s", _FakeUpdate({"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "Hel"}})
+            )
+            await client.session_update(
+                "s", _FakeUpdate({"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "lo"}})
+            )
+        finally:
+            sys.stdout = real
+
+    asyncio.run(drive())
+    events = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+    assert events == [
+        {"type": "agent_message_chunk", "text": "Hel"},
+        {"type": "agent_message_chunk", "text": "lo"},
+    ]
+    assert client.final_text == "Hello"
+
+
+def test_session_update_thought_chunk():
+    events = _capture(
+        lambda c: c.session_update(
+            "s", _FakeUpdate({"sessionUpdate": "agent_thought_chunk", "content": {"type": "text", "text": "hmm"}})
+        )
+    )
+    assert events == [{"type": "agent_thought_chunk", "text": "hmm"}]
+
+
+def test_session_update_tool_call():
+    events = _capture(
+        lambda c: c.session_update(
+            "s",
+            _FakeUpdate(
+                {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "t1",
+                    "title": "Read file",
+                    "kind": "read",
+                    "rawInput": {"path": "x"},
+                }
+            ),
+        )
+    )
+    assert events == [
+        {
+            "type": "tool_call",
+            "tool_call_id": "t1",
+            "name": "Read file",
+            "kind": "read",
+            "input": {"path": "x"},
+        }
+    ]
+
+
+def test_session_update_tool_call_update_completed():
+    events = _capture(
+        lambda c: c.session_update(
+            "s",
+            _FakeUpdate(
+                {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "t1",
+                    "status": "completed",
+                    "content": [{"type": "content", "content": {"type": "text", "text": "BODY"}}],
+                }
+            ),
+        )
+    )
+    assert events == [
+        {
+            "type": "tool_call_update",
+            "tool_call_id": "t1",
+            "status": "completed",
+            "output": "BODY",
+            "is_error": False,
+        }
+    ]
+
+
+def test_session_update_tool_call_update_in_progress_suppressed():
+    events = _capture(
+        lambda c: c.session_update(
+            "s", _FakeUpdate({"sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "in_progress"})
+        )
+    )
+    assert events == []
+
+
+def test_session_update_plan():
+    entries = [{"content": "step", "priority": "medium", "status": "pending"}]
+    events = _capture(
+        lambda c: c.session_update("s", _FakeUpdate({"sessionUpdate": "plan", "entries": entries}))
+    )
+    assert events == [{"type": "plan", "entries": entries}]
+
+
+def test_session_update_dict_fallback():
+    # A raw dict (no model_dump) is tolerated.
+    events = _capture(
+        lambda c: c.session_update("s", {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "x"}})
+    )
+    assert events == [{"type": "agent_message_chunk", "text": "x"}]

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -250,7 +250,11 @@ class TestFlushedToMessages:
         from api.agent import _flushed_to_messages
 
         rows = [
-            {"role": "user", "parts": [{"type": "text", "text": "hi"}], "user_id": "U123"},
+            {
+                "role": "user",
+                "parts": [{"type": "text", "text": "hi"}],
+                "user_id": "U123",
+            },
         ]
         msgs = _flushed_to_messages(rows)
         assert len(msgs) == 1
@@ -263,7 +267,11 @@ class TestFlushedToMessages:
         from api.agent import _flushed_to_messages
 
         rows = [
-            {"role": "user", "parts": '[{"type": "text", "text": "world"}]', "user_id": None},
+            {
+                "role": "user",
+                "parts": '[{"type": "text", "text": "world"}]',
+                "user_id": None,
+            },
         ]
         msgs = _flushed_to_messages(rows)
         assert msgs[0]["parts"] == [{"type": "text", "text": "world"}]
@@ -274,8 +282,16 @@ class TestFlushedToMessages:
         from api.agent import _flushed_to_messages
 
         rows = [
-            {"role": "user", "parts": [{"type": "text", "text": "hi"}], "user_id": "U123"},
-            {"role": "user", "parts": '[{"type": "text", "text": "world"}]', "user_id": None},
+            {
+                "role": "user",
+                "parts": [{"type": "text", "text": "hi"}],
+                "user_id": "U123",
+            },
+            {
+                "role": "user",
+                "parts": '[{"type": "text", "text": "world"}]',
+                "user_id": None,
+            },
         ]
         msgs = _flushed_to_messages(rows)
         assert len(msgs) == 2
@@ -290,19 +306,21 @@ class TestMessagesToContentBlocksWithAttachmentRef:
         """DB message with attachment_ref → download instruction."""
         from api.sandbox.harness_protocol import messages_to_content_blocks
 
-        msgs = [{
-            "role": "user",
-            "parts": [
-                {"type": "text", "text": "check this"},
-                {
-                    "type": "attachment_ref",
-                    "id": "att-1",
-                    "name": "doc.pdf",
-                    "mime_type": "application/pdf",
-                },
-            ],
-            "user_id": "U999",
-        }]
+        msgs = [
+            {
+                "role": "user",
+                "parts": [
+                    {"type": "text", "text": "check this"},
+                    {
+                        "type": "attachment_ref",
+                        "id": "att-1",
+                        "name": "doc.pdf",
+                        "mime_type": "application/pdf",
+                    },
+                ],
+                "user_id": "U999",
+            }
+        ]
         blocks = messages_to_content_blocks(msgs)
         assert len(blocks) == 2
         assert blocks[0]["text"] == "<@U999>: check this"
@@ -467,7 +485,10 @@ class TestResolveHarnessProfile:
 
         # Rule 1: engine_override always wins.
         assert resolve("amp", persona="invest", engine_override="codex")[0] == "codex"
-        assert resolve(None, persona="invest", engine_override="claude-code")[0] == "claude-code"
+        assert (
+            resolve(None, persona="invest", engine_override="claude-code")[0]
+            == "claude-code"
+        )
         assert resolve("codex", persona=None, engine_override="amp")[0] == "amp"
 
         # Rule 2: explicit harness arg DIFFERENT from persona's engine wins

--- a/services/api/tests/test_normalize.py
+++ b/services/api/tests/test_normalize.py
@@ -221,3 +221,160 @@ class TestAutoDetect:
     def test_detect_amp_fallback(self):
         result = normalize_harness_event("", {"type": "result", "result": "ok"})
         assert result == [{"type": "result", "text": "ok"}]
+
+    def test_detect_hermes_message_chunk(self):
+        result = normalize_harness_event(
+            "", {"type": "agent_message_chunk", "text": "hi"}
+        )
+        assert result == [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}}
+        ]
+
+    def test_detect_hermes_tool_call(self):
+        result = normalize_harness_event(
+            "", {"type": "tool_call", "tool_call_id": "t1", "name": "Read", "input": {}}
+        )
+        assert result[0]["message"]["content"][0]["type"] == "tool_use"
+
+
+class TestHermes:
+    def test_init_session(self):
+        result = normalize_harness_event(
+            "hermes", {"type": "system", "subtype": "init", "session_id": "s9"}
+        )
+        assert result == [{"type": "system", "subtype": "init", "session_id": "s9"}]
+
+    def test_heartbeat_ignored(self):
+        result = normalize_harness_event(
+            "hermes",
+            {"type": "system", "subtype": "wrapper_heartbeat", "phase": "startup"},
+        )
+        assert result == []
+
+    def test_agent_message_chunk(self):
+        result = normalize_harness_event(
+            "hermes", {"type": "agent_message_chunk", "text": "Hello"}
+        )
+        assert result == [
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "Hello"}]},
+            }
+        ]
+
+    def test_empty_message_chunk_dropped(self):
+        assert (
+            normalize_harness_event("hermes", {"type": "agent_message_chunk", "text": ""})
+            == []
+        )
+
+    def test_thought_chunk(self):
+        result = normalize_harness_event(
+            "hermes", {"type": "agent_thought_chunk", "text": "thinking"}
+        )
+        assert result == [{"type": "reasoning", "text": "thinking"}]
+
+    def test_tool_call(self):
+        result = normalize_harness_event(
+            "hermes",
+            {
+                "type": "tool_call",
+                "tool_call_id": "t1",
+                "name": "Read file",
+                "input": {"path": "x"},
+            },
+        )
+        assert result == [
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "t1",
+                            "name": "Read file",
+                            "input": {"path": "x"},
+                        }
+                    ]
+                },
+            }
+        ]
+
+    def test_tool_call_update_completed(self):
+        result = normalize_harness_event(
+            "hermes",
+            {
+                "type": "tool_call_update",
+                "tool_call_id": "t1",
+                "status": "completed",
+                "output": "file body",
+                "is_error": False,
+            },
+        )
+        assert result == [
+            {
+                "type": "tool",
+                "content": [
+                    {"tool_use_id": "t1", "content": "file body", "is_error": False}
+                ],
+            }
+        ]
+
+    def test_tool_call_update_in_progress_dropped(self):
+        result = normalize_harness_event(
+            "hermes",
+            {"type": "tool_call_update", "tool_call_id": "t1", "status": "in_progress"},
+        )
+        assert result == []
+
+    def test_tool_call_update_failed_is_error(self):
+        result = normalize_harness_event(
+            "hermes",
+            {
+                "type": "tool_call_update",
+                "tool_call_id": "t1",
+                "status": "failed",
+                "output": "boom",
+                "is_error": True,
+            },
+        )
+        assert result[0]["content"][0]["is_error"] is True
+
+    def test_plan(self):
+        entries = [{"content": "step", "priority": "medium", "status": "pending"}]
+        result = normalize_harness_event("hermes", {"type": "plan", "entries": entries})
+        assert result == [{"type": "turn.plan.updated", "entries": entries}]
+
+    def test_turn_completed_usage(self):
+        result = normalize_harness_event(
+            "hermes",
+            {
+                "type": "turn.completed",
+                "stop_reason": "end_turn",
+                "text": "done",
+                "usage": {"input_tokens": 3, "output_tokens": 4},
+            },
+        )
+        assert result == [
+            {
+                "type": "usage",
+                "usage": {"input_tokens": 3, "output_tokens": 4},
+                "authoritative": True,
+            }
+        ]
+
+    def test_turn_completed_without_usage(self):
+        result = normalize_harness_event(
+            "hermes", {"type": "turn.completed", "stop_reason": "end_turn", "text": "done"}
+        )
+        assert result == []
+
+    def test_error(self):
+        result = normalize_harness_event("hermes", {"type": "error", "message": "boom"})
+        assert result == [{"type": "error", "error": "boom"}]
+
+    def test_turn_failed(self):
+        result = normalize_harness_event(
+            "hermes", {"type": "turn.failed", "error": {"message": "nope"}}
+        )
+        assert result == [{"type": "error", "error": "nope"}]

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -1441,7 +1441,10 @@ def test_render_emits_postgres_listeners_with_env_refs(
     ]
     cfg = yaml.safe_load(render_proxy_yaml(secrets))
     listeners = cfg["postgres"]
-    assert [l["name"] for l in listeners] == ["analytics_pg", "database_url"]
+    assert [listener["name"] for listener in listeners] == [
+        "analytics_pg",
+        "database_url",
+    ]
     assert listeners[0]["listen"] == "0.0.0.0:5432"
     assert listeners[1]["listen"] == "0.0.0.0:5433"
     # upstream.dsn uses the secret_ref directly so iron-proxy can resolve it
@@ -1479,6 +1482,28 @@ def test_render_with_onepassword_source_emits_op_ref(
         gcp["config"]["keyfile"]["secret_ref"]
         == "op://engineering/GCP_GCLOUD_CREDENTIAL/credential"
     )
+
+
+def test_render_http_secret_can_override_global_secret_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    secrets = [
+        HttpSecret(
+            name="ANTHROPIC_API_KEY",
+            secret_ref="ANTHROPIC_AUTH_TOKEN",
+            source_kind="env",
+            hosts=("api.minimax.io",),
+            match_headers=("X-Api-Key", "Authorization"),
+        )
+    ]
+
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    secret = next(t for t in cfg["transforms"] if t["name"] == "secrets")["config"][
+        "secrets"
+    ][0]
+
+    assert secret["source"] == {"type": "env", "var": "ANTHROPIC_AUTH_TOKEN"}
 
 
 def test_render_groups_header_secret_hosts_when_repeated() -> None:

--- a/services/api/tests/test_sandbox_entrypoint.py
+++ b/services/api/tests/test_sandbox_entrypoint.py
@@ -183,3 +183,38 @@ def test_sandbox_entrypoint_appends_codex_laminar_otel_config(tmp_path: Path) ->
     assert '"x-centaur-thread-key" = "slack:C123:1700000000.000100"' in result.stdout
     assert '"authorization" = "Bearer lmnr-key"' in result.stdout
     assert 'environment = "staging"' in result.stdout
+
+
+def test_sandbox_entrypoint_writes_hermes_config_from_anthropic_compatible_env(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    harness_dir = _write_codex_harness_config(home)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ENTRYPOINT_SH),
+            "sh",
+            "-lc",
+            'cat "$HOME/.hermes/config.yaml" && printf "\\nTOKEN=%s\\nAPI_KEY=%s\\n" "$ANTHROPIC_TOKEN" "$ANTHROPIC_API_KEY"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(home),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "CENTAUR_HARNESS_CONFIG_DIR": str(harness_dir),
+            "ANTHROPIC_AUTH_TOKEN": "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL": "https://llm.example.test/anthropic",
+            "ANTHROPIC_MODEL": "example-model",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert 'provider: "anthropic"' in result.stdout
+    assert 'default: "example-model"' in result.stdout
+    assert 'base_url: "https://llm.example.test/anthropic"' in result.stdout
+    assert "TOKEN=ANTHROPIC_API_KEY" in result.stdout
+    assert "API_KEY=ANTHROPIC_API_KEY" in result.stdout

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -228,6 +228,24 @@ def test_container_env_passes_laminar_otel_config(
     assert env_map["CODEX_OTEL_ENVIRONMENT"] == "staging"
 
 
+def test_container_env_passes_hermes_anthropic_compatible_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://llm.example.test/anthropic")
+    monkeypatch.setenv("ANTHROPIC_MODEL", "example-model")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "real-token-never-forwarded")
+
+    env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
+    env_map = dict(item.split("=", 1) for item in env)
+
+    assert env_map["ANTHROPIC_BASE_URL"] == "https://llm.example.test/anthropic"
+    assert env_map["ANTHROPIC_MODEL"] == "example-model"
+    assert env_map["ANTHROPIC_API_KEY"] == "ANTHROPIC_API_KEY"
+    assert env_map["ANTHROPIC_AUTH_TOKEN"] == "ANTHROPIC_API_KEY"
+    assert env_map["ANTHROPIC_TOKEN"] == "ANTHROPIC_API_KEY"
+    assert "real-token-never-forwarded" not in env
+
+
 def test_container_env_applies_kubernetes_sandbox_extra_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/api/tests/test_tool_manager.py
+++ b/services/api/tests/test_tool_manager.py
@@ -92,6 +92,26 @@ def test_infra_secrets_stay_provider_generic_for_harnesses() -> None:
     }
 
 
+def test_collect_secrets_scopes_anthropic_compatible_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "real-token")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://llm.example.test/anthropic")
+
+    manager = ToolManager(tmp_path)
+    secrets = [
+        secret
+        for secret in manager.collect_secrets()
+        if secret.name == "ANTHROPIC_API_KEY" and "llm.example.test" in secret.hosts
+    ]
+
+    assert len(secrets) == 1
+    assert secrets[0].secret_ref == "ANTHROPIC_AUTH_TOKEN"
+    assert secrets[0].source_kind == "env"
+    assert secrets[0].match_headers == ("X-Api-Key", "Authorization")
+
+
 # ---------------------------------------------------------------------------
 # _normalize_for_serialization
 # ---------------------------------------------------------------------------

--- a/services/api/tests/test_tool_manager.py
+++ b/services/api/tests/test_tool_manager.py
@@ -39,7 +39,10 @@ class TestDescribeMethodDocstring:
         assert _describe_method_docstring("   \n  \n") == ""
 
     def test_single_line_docstring_returned_verbatim(self):
-        assert _describe_method_docstring("Search Slack for messages.") == "Search Slack for messages."
+        assert (
+            _describe_method_docstring("Search Slack for messages.")
+            == "Search Slack for messages."
+        )
 
     def test_multi_paragraph_description_preserved(self):
         doc = """Hybrid research engine.
@@ -73,6 +76,20 @@ class TestDescribeMethodDocstring:
         out = _describe_method_docstring(doc)
         assert len(out) <= 1200
         assert out.endswith("\u2026")
+
+
+def test_infra_secrets_stay_provider_generic_for_harnesses() -> None:
+    names = {secret.name for secret in ToolManager._INFRA_SECRETS}
+
+    assert names == {
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "XAI_API_KEY",
+        "GEMINI_API_KEY",
+        "AMP_API_KEY",
+        "GITHUB_TOKEN",
+        "SLACK_BOT_TOKEN",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -657,6 +674,6 @@ async def test_tool_rest_router_lists_describes_and_invokes_tools(
         missing_response = await client.post("/tools/alpha/missing", json={})
         assert missing_response.status_code == 200
         assert missing_response.json()["result"] == (
-            '{"error": "Method \'missing\' not found in tool \'alpha\'", '
+            "{\"error\": \"Method 'missing' not found in tool 'alpha'\", "
             '"available_methods": ["async_echo", "secret_values", "sync_echo"]}'
         )

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -77,14 +77,15 @@ RUN npm install -g --prefer-online --force \
     && claude --version | grep -F "${CLAUDE_CODE_VERSION}" \
     && codex --version | grep -F "${CODEX_VERSION}"
 
-# ── Hermes Agent (NousResearch) + ACP stdio adapter (root, system-wide) ───────
-# Installs the `hermes` CLI and the `hermes-acp` console script that
-# hermes-app-wrapper drives over the Agent Client Protocol. `--check` verifies
-# the ACP dependency + adapter imports resolve at build time.
+# ── Hermes Agent (NousResearch), root system-wide ────────────────────────────
+# hermes-app-wrapper drives Hermes' native AIAgent Python API in process (no
+# ACP — that protocol is externally governed and an unstable seam to depend on),
+# so we install the base package only. The import check verifies the embedding
+# API (run_agent.AIAgent + supporting modules) resolves at build time.
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip3 install --break-system-packages \
-      "hermes-agent[acp]==${HERMES_AGENT_VERSION}" \
-    && hermes-acp --check
+      "hermes-agent==${HERMES_AGENT_VERSION}" \
+    && python3 -c "import run_agent, hermes_state, hermes_cli.runtime_provider, hermes_cli.tools_config"
 
 # ── agent-browser system deps (must run as root before USER agent) ───────────
 # Chrome for Testing doesn't provide Linux ARM64 builds; fall back to system chromium

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -80,12 +80,14 @@ RUN npm install -g --prefer-online --force \
 # ── Hermes Agent (NousResearch), root system-wide ────────────────────────────
 # hermes-app-wrapper drives Hermes' native AIAgent Python API in process (no
 # ACP — that protocol is externally governed and an unstable seam to depend on),
-# so we install the base package only. The import check verifies the embedding
-# API (run_agent.AIAgent + supporting modules) resolves at build time.
+# so we install the base package plus the provider SDK used by the default
+# sandbox config. The import check verifies the embedding API and provider
+# client resolve at build time.
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip3 install --break-system-packages \
       "hermes-agent==${HERMES_AGENT_VERSION}" \
-    && python3 -c "import run_agent, hermes_state, hermes_cli.runtime_provider, hermes_cli.tools_config"
+      "anthropic>=0.39.0" \
+    && python3 -c "import anthropic, run_agent, hermes_state, hermes_cli.runtime_provider, hermes_cli.tools_config"
 
 # ── agent-browser system deps (must run as root before USER agent) ───────────
 # Chrome for Testing doesn't provide Linux ARM64 builds; fall back to system chromium

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -49,6 +49,7 @@ RUN useradd -m -s /bin/bash -u 1001 agent \
 ARG CLAUDE_CODE_VERSION=2.1.143
 ARG CODEX_VERSION=0.130.0
 ARG PI_CODING_AGENT_VERSION=0.67.2
+ARG HERMES_AGENT_VERSION=0.14.0
 ARG NUSHELL_VERSION=0.112.2
 
 # ── Nushell ─────────────────────────────────────────────────────────────────
@@ -75,6 +76,15 @@ RUN npm install -g --prefer-online --force \
       agent-browser@0.26.0 \
     && claude --version | grep -F "${CLAUDE_CODE_VERSION}" \
     && codex --version | grep -F "${CODEX_VERSION}"
+
+# ── Hermes Agent (NousResearch) + ACP stdio adapter (root, system-wide) ───────
+# Installs the `hermes` CLI and the `hermes-acp` console script that
+# hermes-app-wrapper drives over the Agent Client Protocol. `--check` verifies
+# the ACP dependency + adapter imports resolve at build time.
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip3 install --break-system-packages \
+      "hermes-agent[acp]==${HERMES_AGENT_VERSION}" \
+    && hermes-acp --check
 
 # ── agent-browser system deps (must run as root before USER agent) ───────────
 # Chrome for Testing doesn't provide Linux ARM64 builds; fall back to system chromium
@@ -146,7 +156,7 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
 # ── Agent skills + workspace setup (rarely changes) ─────────────────────────
 RUN --mount=type=cache,target=/home/agent/.npm,uid=1001,gid=1001,sharing=locked \
     npx -y skills add vercel-labs/agent-browser
-RUN mkdir -p ~/.amp/bin ~/.config/amp ~/.codex ~/.pi/agent ~/github ~/workspace \
+RUN mkdir -p ~/.amp/bin ~/.config/amp ~/.codex ~/.pi/agent ~/.hermes ~/github ~/workspace \
     && git config --global init.defaultBranch main \
     && git config --global push.autoSetupRemote true \
     && git config --global --add safe.directory '*' \
@@ -169,6 +179,7 @@ COPY --link --chmod=755 services/sandbox/md2docx.py /usr/local/bin/md2docx
 COPY --link --chmod=755 services/sandbox/amp-wrapper.py /usr/local/bin/amp-wrapper
 COPY --link --chmod=755 services/sandbox/codex-app-wrapper.py /usr/local/bin/codex-app-wrapper
 COPY --link --chmod=755 services/sandbox/claude-app-wrapper.py /usr/local/bin/claude-app-wrapper
+COPY --link --chmod=755 services/sandbox/hermes-app-wrapper.py /usr/local/bin/hermes-app-wrapper
 COPY --link --chmod=755 services/sandbox/harness_adapter.py /usr/local/bin/harness-adapter
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
 COPY --link --chmod=755 services/sandbox/entrypoint.sh /entrypoint.sh

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -122,7 +122,7 @@ cat > "$HOME_DIR/.pi/agent/settings.json" <<EOF
 EOF
 
 # ── Hermes settings ──────────────────────────────────────────────────────────
-# Hermes (ACP harness) resolves its provider/model from ~/.hermes/config.yaml.
+# Hermes resolves its provider/model from ~/.hermes/config.yaml.
 # Default to Anthropic + Claude so it works out of the box through iron-proxy
 # using the stubbed ANTHROPIC_API_KEY; HERMES_PROVIDER/HERMES_MODEL override
 # fleet-wide or per-session (the model is set per spawn by the API).

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -121,6 +121,20 @@ cat > "$HOME_DIR/.pi/agent/settings.json" <<EOF
 }
 EOF
 
+# ── Hermes settings ──────────────────────────────────────────────────────────
+# Hermes (ACP harness) resolves its provider/model from ~/.hermes/config.yaml.
+# Default to Anthropic + Claude so it works out of the box through iron-proxy
+# using the stubbed ANTHROPIC_API_KEY; HERMES_PROVIDER/HERMES_MODEL override
+# fleet-wide or per-session (the model is set per spawn by the API).
+mkdir -p "$HOME_DIR/.hermes"
+HERMES_PROVIDER_VALUE="${HERMES_PROVIDER:-anthropic}"
+HERMES_MODEL_VALUE="${HERMES_MODEL:-claude-sonnet-4-20250514}"
+cat > "$HOME_DIR/.hermes/config.yaml" <<EOF
+model:
+  provider: "$(toml_escape "$HERMES_PROVIDER_VALUE")"
+  default: "$(toml_escape "$HERMES_MODEL_VALUE")"
+EOF
+
 # ── Per-session workspace clone (no shared worktree metadata) ────────────────
 WORKSPACE_DIR="$HOME_DIR/workspace"
 if [ -n "${AGENT_REPO:-}" ]; then

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -122,18 +122,36 @@ cat > "$HOME_DIR/.pi/agent/settings.json" <<EOF
 EOF
 
 # ── Hermes settings ──────────────────────────────────────────────────────────
-# Hermes resolves its provider/model from ~/.hermes/config.yaml.
-# Default to Anthropic + Claude so it works out of the box through iron-proxy
-# using the stubbed ANTHROPIC_API_KEY; HERMES_PROVIDER/HERMES_MODEL override
-# fleet-wide or per-session (the model is set per spawn by the API).
+# Hermes resolves its provider/model from ~/.hermes/config.yaml. Prefer explicit
+# Hermes envs, but also auto-configure from Anthropic-compatible deployment envs
+# so the same provider/model settings used by other harnesses work here.
 mkdir -p "$HOME_DIR/.hermes"
-HERMES_PROVIDER_VALUE="${HERMES_PROVIDER:-anthropic}"
-HERMES_MODEL_VALUE="${HERMES_MODEL:-claude-sonnet-4-20250514}"
-cat > "$HOME_DIR/.hermes/config.yaml" <<EOF
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+    export ANTHROPIC_API_KEY="$ANTHROPIC_AUTH_TOKEN"
+fi
+if [ -z "${ANTHROPIC_TOKEN:-}" ] && [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+    export ANTHROPIC_TOKEN="$ANTHROPIC_AUTH_TOKEN"
+fi
+HERMES_PROVIDER_VALUE="${HERMES_PROVIDER:-${HERMES_INFERENCE_PROVIDER:-}}"
+if [ -z "$HERMES_PROVIDER_VALUE" ]; then
+    HERMES_PROVIDER_VALUE="anthropic"
+fi
+HERMES_MODEL_VALUE="${HERMES_MODEL:-${HERMES_INFERENCE_MODEL:-${ANTHROPIC_MODEL:-${ANTHROPIC_DEFAULT_SONNET_MODEL:-claude-sonnet-4-20250514}}}}"
+HERMES_BASE_URL_VALUE="${HERMES_BASE_URL:-${ANTHROPIC_BASE_URL:-}}"
+HERMES_API_MODE_VALUE="${HERMES_API_MODE:-}"
+{
+cat <<EOF
 model:
   provider: "$(toml_escape "$HERMES_PROVIDER_VALUE")"
   default: "$(toml_escape "$HERMES_MODEL_VALUE")"
 EOF
+if [ -n "$HERMES_BASE_URL_VALUE" ]; then
+    printf '  base_url: "%s"\n' "$(toml_escape "$HERMES_BASE_URL_VALUE")"
+fi
+if [ -n "$HERMES_API_MODE_VALUE" ]; then
+    printf '  api_mode: "%s"\n' "$(toml_escape "$HERMES_API_MODE_VALUE")"
+fi
+} > "$HOME_DIR/.hermes/config.yaml"
 
 # ── Per-session workspace clone (no shared worktree metadata) ────────────────
 WORKSPACE_DIR="$HOME_DIR/workspace"

--- a/services/sandbox/hermes-app-wrapper.py
+++ b/services/sandbox/hermes-app-wrapper.py
@@ -57,6 +57,7 @@ from typing import Any
 # module's helpers stay importable + unit-testable without fd surgery.
 _OUT: Any = None
 _EMIT_LOCK = threading.Lock()
+_MAX_TRANSCRIPT_CHARS = 20_000
 
 
 def emit(payload: dict[str, Any]) -> None:
@@ -113,6 +114,37 @@ def _stringify(value: Any) -> str:
         return json.dumps(value, ensure_ascii=False, default=str)
     except (TypeError, ValueError):
         return str(value)
+
+
+def _transcript_chars(transcript: list[tuple[str, str]]) -> int:
+    return sum(
+        len(user_text) + len(assistant_text)
+        for user_text, assistant_text in transcript
+    )
+
+
+def _trim_transcript(transcript: list[tuple[str, str]]) -> None:
+    """Bound in-process Hermes context while preserving the newest turns."""
+    while len(transcript) > 1 and _transcript_chars(transcript) > _MAX_TRANSCRIPT_CHARS:
+        transcript.pop(0)
+
+
+def _prompt_with_transcript(
+    current_prompt: str,
+    transcript: list[tuple[str, str]],
+) -> str:
+    if not transcript:
+        return current_prompt
+    turns = [
+        f"User:\n{user_text}\n\nAssistant:\n{assistant_text}"
+        for user_text, assistant_text in transcript
+    ]
+    return (
+        "Previous conversation in this Hermes runtime:\n\n"
+        + "\n\n---\n\n".join(turns)
+        + "\n\nCurrent user message:\n"
+        + current_prompt
+    )
 
 
 _TODO_STATUS_MAP = {
@@ -351,6 +383,7 @@ class Wrapper:
         self.emitter = TurnEmitter()
         self.agent: Any = None
         self.inputs: queue.Queue[dict[str, Any] | None] = queue.Queue()
+        self.transcript: list[tuple[str, str]] = []
         self._interrupted = False
         self._pending_interrupt = False
 
@@ -386,7 +419,8 @@ class Wrapper:
         self.emitter.reset()
         self._interrupted = self._pending_interrupt
         self._pending_interrupt = False
-        prompt = _prompt_text(turn_input)
+        current_prompt = _prompt_text(turn_input)
+        prompt = _prompt_with_transcript(current_prompt, self.transcript)
 
         # Run the (blocking) turn on a worker thread so the stdin reader can
         # deliver an interrupt to AIAgent.interrupt() from another thread.
@@ -425,6 +459,8 @@ class Wrapper:
                 "text": text,
             }
         )
+        self.transcript.append((current_prompt, str(text)))
+        _trim_transcript(self.transcript)
 
     def run(self) -> None:
         _install_protocol_channel()

--- a/services/sandbox/hermes-app-wrapper.py
+++ b/services/sandbox/hermes-app-wrapper.py
@@ -1,111 +1,86 @@
 #!/usr/bin/env python3
-"""hermes-app-wrapper — Centaur NDJSON bridge for the Hermes Agent ACP server.
+"""hermes-app-wrapper — Centaur NDJSON bridge for the Hermes Agent.
 
-Hermes Agent (NousResearch/hermes-agent) speaks the Agent Client Protocol over
-stdio via ``hermes acp`` (entry point ``hermes-acp``). This wrapper acts as the
-ACP *client*: it keeps a single Hermes ACP session alive, translates each
-Centaur turn into an ACP ``session/prompt``, auto-approves tool permission
-requests, and re-emits Hermes' streaming ``session/update`` notifications as
-Centaur-shaped NDJSON for the API to normalize.
+Hermes Agent (NousResearch/hermes-agent) is integrated by driving its native
+``AIAgent`` Python API *in process* — the same class the interactive CLI and
+gateway use — with streaming callbacks wired to Centaur's event stream. We
+deliberately do NOT use Hermes' Agent Client Protocol (ACP) adapter: ACP is
+governed by an external committee and is an unstable seam to depend on. We also
+do not use the oneshot CLI (``hermes chat -q``), which nulls the streaming
+callbacks and only returns a final string. Driving ``AIAgent`` directly gives
+1:1 parity with the codex/claude/amp wrappers (streamed text, reasoning, tool
+start/complete, plan, interrupt, multi-turn) while coupling only to the
+``hermes-agent`` package we already install + version-pin.
 
-The stdin/stdout contract matches the other sandbox wrappers (codex/claude/amp):
+The stdin/stdout contract matches the other sandbox wrappers:
 
 * Read NDJSON turn envelopes from stdin:
-  ``{"type":"user","message":{"content":[blocks]}, "steer"?, "trace_id"?}`` and
+  ``{"type":"user","message":{"content":[blocks]}, ...}`` and
   ``{"type":"interrupt"}``.
-* Emit Hermes-native NDJSON events on stdout. The matching ``"hermes"`` engine
-  branch in ``api/sandbox/normalize.py`` + ``harness_protocol.py`` maps these to
-  canonical Centaur events:
+* Emit Hermes-native NDJSON events on stdout. The ``"hermes"`` engine branch in
+  ``api/sandbox/normalize.py`` + ``harness_protocol.py`` maps these to canonical
+  Centaur events:
     - ``{"type":"system","subtype":"init","session_id":...}``  (thread id)
     - ``{"type":"agent_message_chunk","text":...}``            (streamed answer)
     - ``{"type":"agent_thought_chunk","text":...}``            (reasoning)
     - ``{"type":"tool_call","tool_call_id":...,"name":...,"input":...}``
     - ``{"type":"tool_call_update","tool_call_id":...,"status":...,"output":...}``
     - ``{"type":"plan","entries":[...]}``                      (todo/plan panel)
-    - ``{"type":"turn.completed","stop_reason":...,"text":...,"usage":...}``
+    - ``{"type":"turn.completed","stop_reason":...,"text":...}``
     - ``{"type":"error","message":...}``
 
-Model/provider selection lives in ``~/.hermes/config.yaml`` (written by the
-sandbox entrypoint from ``HERMES_PROVIDER``/``HERMES_MODEL``), so this wrapper
-stays transport-only. Hermes inherits the firewall proxy + stubbed
-``ANTHROPIC_API_KEY`` from the container env, so its model traffic flows through
-iron-proxy like every other harness.
+Provider/model are resolved from ``~/.hermes/config.yaml`` (written by the
+sandbox entrypoint from ``HERMES_PROVIDER``/``HERMES_MODEL``), defaulting to the
+Anthropic provider + a Claude model so Hermes flows through iron-proxy using the
+stubbed ``ANTHROPIC_API_KEY`` like every other harness.
+
+Hermes runs in process, so its stray stdout would corrupt the NDJSON stream. We
+dup the real stdout to a private "protocol" channel for events and redirect the
+process's fd 1 to stderr, so any ``print`` from Hermes lands in pod logs.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
+import queue
 import signal
 import sys
 import threading
+import uuid
+from collections import defaultdict, deque
 from typing import Any
 
-# NOTE: ``acp`` (agent-client-protocol) is only present in the sandbox image, so
-# it is imported lazily inside the functions that need it. This keeps the module
-# importable — and its pure helpers unit-testable — in environments without it.
-
-# ── stdout (Centaur NDJSON) ──────────────────────────────────────────────────
-# ACP talks to the Hermes subprocess over its own pipes, so our stdout is free
-# for Centaur events. A lock keeps concurrent emits (loop callbacks + main)
-# from interleaving partial lines.
+# ── protocol channel ─────────────────────────────────────────────────────────
+# ``_OUT`` is the stream Centaur reads NDJSON from. Until the runtime installs
+# the dedicated channel (in ``main``), emit falls back to ``sys.stdout`` so the
+# module's helpers stay importable + unit-testable without fd surgery.
+_OUT: Any = None
 _EMIT_LOCK = threading.Lock()
 
 
 def emit(payload: dict[str, Any]) -> None:
+    out = _OUT if _OUT is not None else sys.stdout
     line = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
     with _EMIT_LOCK:
-        sys.stdout.write(line + "\n")
-        sys.stdout.flush()
+        out.write(line + "\n")
+        out.flush()
 
 
-def _hermes_acp_cmd() -> list[str]:
-    """Resolve the Hermes ACP server command.
+def _install_protocol_channel() -> None:
+    """Reserve real stdout for NDJSON; route everything else to stderr.
 
-    Prefer the installed ``hermes-acp`` console script; fall back to the module
-    entry point so the wrapper still works in editable/dev installs.
+    Hermes runs in this process and may print directly to fd 1. Dup fd 1 to a
+    private channel for events, then point fd 1 at stderr so stray output can't
+    corrupt the protocol stream.
     """
-    override = (os.environ.get("HERMES_ACP_COMMAND") or "").strip()
-    if override:
-        return override.split()
-    from shutil import which
-
-    if which("hermes-acp"):
-        return ["hermes-acp"]
-    if which("hermes"):
-        return ["hermes", "acp"]
-    return [sys.executable, "-m", "acp_adapter.entry"]
+    global _OUT
+    protocol_fd = os.dup(1)
+    os.dup2(2, 1)
+    _OUT = os.fdopen(protocol_fd, "w", encoding="utf-8", closefd=True)
 
 
 # ── content helpers ──────────────────────────────────────────────────────────
-
-def _content_block_text(content: Any) -> str:
-    """Extract text from an ACP content block (dict) or list of blocks."""
-    if isinstance(content, list):
-        return "".join(_content_block_text(c) for c in content)
-    if isinstance(content, dict):
-        if content.get("type") == "text":
-            return str(content.get("text") or "")
-        # tool-call ``content`` wrapper: {"type":"content","content":{...}}
-        inner = content.get("content")
-        if isinstance(inner, (dict, list)):
-            return _content_block_text(inner)
-    return ""
-
-
-def _tool_output_text(update: dict[str, Any]) -> str:
-    """Flatten a tool_call_update's content / rawOutput into a string."""
-    text = _content_block_text(update.get("content"))
-    if text:
-        return text
-    raw = update.get("rawOutput")
-    if isinstance(raw, str):
-        return raw
-    if raw is not None:
-        return json.dumps(raw, ensure_ascii=False)
-    return ""
-
 
 def _prompt_text(turn_input: dict[str, Any]) -> str:
     """Flatten a Centaur turn envelope's content blocks into prompt text."""
@@ -128,160 +103,253 @@ def _prompt_text(turn_input: dict[str, Any]) -> str:
     return "\n".join(p for p in parts if p).strip() or "continue"
 
 
-def _prompt_blocks(turn_input: dict[str, Any]) -> list[Any]:
-    """Build ACP prompt content blocks from a Centaur turn envelope."""
-    import acp
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ""
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(value)
 
-    return [acp.text_block(_prompt_text(turn_input))]
+
+_TODO_STATUS_MAP = {
+    "pending": "pending",
+    "in_progress": "in_progress",
+    "completed": "completed",
+    # Centaur plans only render pending/in_progress/completed; keep cancelled
+    # tasks visible as terminal entries instead of dropping them.
+    "cancelled": "completed",
+}
 
 
-# ── ACP client implementation ────────────────────────────────────────────────
+def _plan_entries_from_todo(result: Any) -> list[dict] | None:
+    """Translate Hermes' ``todo`` tool result into Centaur plan entries.
 
-class CentaurHermesClient:
-    """ACP client that re-emits Hermes session updates as Centaur NDJSON."""
+    The result is JSON shaped like ``{"todos": [{"content","status",...}]}``,
+    sometimes with a human hint appended after the JSON object.
+    """
+    if not isinstance(result, str) or not result.strip():
+        return None
+    text = result.strip()
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        try:
+            data, _ = json.JSONDecoder().raw_decode(text)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    if not isinstance(data, dict) or not isinstance(data.get("todos"), list):
+        return None
+    entries: list[dict] = []
+    for item in data["todos"]:
+        if not isinstance(item, dict):
+            continue
+        content = str(item.get("content") or item.get("id") or "").strip()
+        if not content:
+            continue
+        raw_status = str(item.get("status") or "pending").strip()
+        status = _TODO_STATUS_MAP.get(raw_status, "pending")
+        if raw_status == "cancelled":
+            content = f"[cancelled] {content}"
+        entries.append({"content": content, "priority": "medium", "status": status})
+    return entries
+
+
+# ── AIAgent streaming callbacks → Centaur NDJSON ─────────────────────────────
+
+class TurnEmitter:
+    """Translates ``AIAgent`` streaming callbacks into Centaur NDJSON events.
+
+    Tool starts and completions are correlated via a FIFO of generated ids per
+    tool name (Hermes' callbacks don't carry a shared id), matching how the ACP
+    adapter tracked parallel/duplicate same-name calls.
+    """
 
     def __init__(self) -> None:
-        # Accumulated agent message text for the in-flight turn, so the API's
-        # extract_result() gets the full final answer (streamed deltas only
-        # carry fragments).
+        self._tool_ids: dict[str, deque[str]] = defaultdict(deque)
         self.final_text_parts: list[str] = []
 
-    def reset_turn(self) -> None:
+    def reset(self) -> None:
         self.final_text_parts = []
+        self._tool_ids.clear()
 
     @property
     def final_text(self) -> str:
         return "".join(self.final_text_parts)
 
-    async def session_update(self, session_id: str, update: Any, **_kwargs: Any) -> None:
-        try:
-            data = update.model_dump(by_alias=True, exclude_none=True)
-        except AttributeError:
-            data = update if isinstance(update, dict) else {}
-        kind = data.get("sessionUpdate")
+    # AIAgent.stream_delta_callback(text)
+    def on_stream_delta(self, text: str) -> None:
+        if not text:
+            return
+        self.final_text_parts.append(text)
+        emit({"type": "agent_message_chunk", "text": text})
 
-        if kind == "agent_message_chunk":
-            text = _content_block_text(data.get("content"))
-            if text:
-                self.final_text_parts.append(text)
-                emit({"type": "agent_message_chunk", "text": text})
-        elif kind == "agent_thought_chunk":
-            text = _content_block_text(data.get("content"))
-            if text:
-                emit({"type": "agent_thought_chunk", "text": text})
-        elif kind == "tool_call":
-            emit(
-                {
-                    "type": "tool_call",
-                    "tool_call_id": data.get("toolCallId") or "",
-                    "name": data.get("title") or data.get("kind") or "tool",
-                    "kind": data.get("kind"),
-                    "input": data.get("rawInput") or {},
-                }
-            )
-        elif kind == "tool_call_update":
-            status = data.get("status")
-            # Only the terminal update carries the result Centaur renders.
-            if status in ("completed", "failed"):
-                emit(
-                    {
-                        "type": "tool_call_update",
-                        "tool_call_id": data.get("toolCallId") or "",
-                        "status": status,
-                        "output": _tool_output_text(data),
-                        "is_error": status == "failed",
-                    }
-                )
-        elif kind == "plan":
-            emit({"type": "plan", "entries": data.get("entries") or []})
-        # usage_update / available_commands_update / mode updates carry no
-        # Centaur-facing payload; usage is surfaced via turn.completed instead.
+    # AIAgent.reasoning_callback(text)
+    def on_reasoning(self, text: str) -> None:
+        if text:
+            emit({"type": "agent_thought_chunk", "text": text})
 
-    async def request_permission(
-        self, options: Any, session_id: str, tool_call: Any, **_kwargs: Any
-    ) -> Any:
-        """Auto-approve tool use (the sandbox is the trust boundary)."""
-        from acp.schema import (
-            AllowedOutcome,
-            DeniedOutcome,
-            RequestPermissionResponse,
+    # AIAgent.tool_progress_callback(event_type, name, preview, args, **kwargs)
+    def on_tool_progress(
+        self,
+        event_type: str,
+        name: str | None = None,
+        preview: str | None = None,
+        args: Any = None,
+        **_kwargs: Any,
+    ) -> None:
+        if event_type != "tool.started":
+            return
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except (json.JSONDecodeError, TypeError):
+                args = {"raw": args}
+        if not isinstance(args, dict):
+            args = {}
+        tool_name = name or "tool"
+        tc_id = "tool-" + uuid.uuid4().hex[:12]
+        self._tool_ids[tool_name].append(tc_id)
+        emit(
+            {
+                "type": "tool_call",
+                "tool_call_id": tc_id,
+                "name": tool_name,
+                "input": args,
+            }
         )
 
-        chosen = _pick_allow_option(options)
-        if chosen is not None:
-            return RequestPermissionResponse(
-                outcome=AllowedOutcome(outcome="selected", option_id=chosen)
+    # AIAgent.step_callback(api_call_count, prev_tools)
+    def on_step(self, api_call_count: int, prev_tools: Any = None) -> None:
+        if not isinstance(prev_tools, list):
+            return
+        for info in prev_tools:
+            if isinstance(info, dict):
+                name = info.get("name") or info.get("function_name") or "tool"
+                result = info.get("result")
+                if result is None:
+                    result = info.get("output")
+                is_error = bool(info.get("error") or info.get("is_error"))
+            elif isinstance(info, str):
+                name, result, is_error = info, None, False
+            else:
+                continue
+            queue_for_name = self._tool_ids.get(name)
+            tc_id = (
+                queue_for_name.popleft()
+                if queue_for_name
+                else "tool-" + uuid.uuid4().hex[:12]
             )
-        return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
-
-    # Minimal no-op extension hooks so the connection never errors on them.
-    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
-        return {}
-
-    async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
-        return None
-
-    def on_connect(self, conn: Any) -> None:
-        return None
-
-
-def _pick_allow_option(options: Any) -> str | None:
-    """Pick an 'allow' permission option id, preferring allow_always."""
-    fallback: str | None = None
-    for opt in options or []:
-        kind = getattr(opt, "kind", None)
-        option_id = getattr(opt, "option_id", None) or getattr(opt, "optionId", None)
-        if not option_id:
-            continue
-        if kind == "allow_always":
-            return option_id
-        if kind == "allow_once" and fallback is None:
-            fallback = option_id
-        if fallback is None and kind not in ("reject_once", "reject_always"):
-            fallback = option_id
-    return fallback
-
-
-# ── session lifecycle ────────────────────────────────────────────────────────
-
-async def _start_session(conn: acp.ClientSideConnection, cwd: str) -> str:
-    """Create or resume a Hermes ACP session; return its id."""
-    resume = (
-        os.environ.get("HERMES_CONTINUE_SESSION_ID")
-        or os.environ.get("AMP_CONTINUE_THREAD_ID")
-        or ""
-    ).strip()
-    if resume:
-        try:
-            result = await conn.load_session(cwd=cwd, session_id=resume)
-            if result is not None:
-                return resume
-        except Exception:
-            # Fall through to a fresh session if resume isn't supported / valid.
+            if queue_for_name is not None and not queue_for_name:
+                self._tool_ids.pop(name, None)
             emit(
                 {
-                    "type": "system",
-                    "subtype": "wrapper_heartbeat",
-                    "phase": "resume_failed",
+                    "type": "tool_call_update",
+                    "tool_call_id": tc_id,
+                    "status": "failed" if is_error else "completed",
+                    "output": _stringify(result),
+                    "is_error": is_error,
                 }
             )
-    result = await conn.new_session(cwd=cwd, mcp_servers=[])
-    return getattr(result, "session_id", None) or resume or ""
+            if name == "todo":
+                entries = _plan_entries_from_todo(result)
+                if entries is not None:
+                    emit({"type": "plan", "entries": entries})
+
+
+# ── agent construction (mirrors hermes_cli.oneshot._run_agent) ───────────────
+
+def _clarify_callback(question: str, choices: Any = None) -> str:
+    """Non-interactive clarify: instruct the agent to pick a sensible default.
+
+    There is no user at a terminal in the sandbox, so a clarify prompt would
+    otherwise stall the turn.
+    """
+    return (
+        "No interactive user is available. Choose the most reasonable default "
+        "and proceed without asking for clarification."
+    )
+
+
+def _build_agent(emitter: TurnEmitter) -> Any:
+    """Construct an ``AIAgent`` like a normal CLI chat turn, with callbacks wired."""
+    from hermes_cli.config import load_config
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from hermes_cli.tools_config import _get_platform_tools
+    from run_agent import AIAgent
+
+    try:
+        from hermes_state import SessionDB
+
+        session_db = SessionDB()
+    except Exception:
+        session_db = None
+
+    cfg = load_config()
+    model_cfg = cfg.get("model") or {}
+    if isinstance(model_cfg, str):
+        cfg_model = model_cfg
+    else:
+        cfg_model = model_cfg.get("default") or model_cfg.get("model") or ""
+
+    effective_model = (
+        (os.getenv("HERMES_MODEL") or "").strip()
+        or os.getenv("HERMES_INFERENCE_MODEL", "").strip()
+        or cfg_model
+    )
+    requested_provider = (os.getenv("HERMES_PROVIDER") or "").strip() or None
+    runtime = resolve_runtime_provider(
+        requested=requested_provider, target_model=effective_model or None
+    )
+
+    try:
+        toolsets = sorted(_get_platform_tools(cfg, "cli"))
+    except Exception:
+        toolsets = None
+
+    resume = (
+        os.getenv("HERMES_CONTINUE_SESSION_ID")
+        or os.getenv("AMP_CONTINUE_THREAD_ID")
+        or ""
+    ).strip() or None
+
+    agent = AIAgent(
+        api_key=runtime.get("api_key"),
+        base_url=runtime.get("base_url"),
+        provider=runtime.get("provider"),
+        api_mode=runtime.get("api_mode"),
+        model=effective_model,
+        enabled_toolsets=toolsets,
+        quiet_mode=True,
+        platform="cli",
+        session_db=session_db,
+        credential_pool=runtime.get("credential_pool"),
+        session_id=resume,
+        clarify_callback=_clarify_callback,
+    )
+    agent.suppress_status_output = True
+    # Local "kawaii" status updates are noise; route real provider reasoning
+    # deltas to the thought stream instead.
+    agent.thinking_callback = None
+    agent.reasoning_callback = emitter.on_reasoning
+    agent.stream_delta_callback = emitter.on_stream_delta
+    agent.tool_progress_callback = emitter.on_tool_progress
+    agent.step_callback = emitter.on_step
+    return agent
 
 
 # ── main driver ──────────────────────────────────────────────────────────────
 
 class Wrapper:
     def __init__(self) -> None:
-        self.loop: asyncio.AbstractEventLoop | None = None
-        self.conn: acp.ClientSideConnection | None = None
-        self.session_id: str = ""
-        self.inputs: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
-        self.client = CentaurHermesClient()
+        self.emitter = TurnEmitter()
+        self.agent: Any = None
+        self.inputs: queue.Queue[dict[str, Any] | None] = queue.Queue()
+        self._interrupted = False
 
-    # stdin runs in a background thread; it can't touch the loop directly.
     def _stdin_reader(self) -> None:
-        assert self.loop is not None
         for raw in sys.stdin:
             line = raw.strip()
             if not line:
@@ -296,118 +364,91 @@ class Wrapper:
             if msg.get("type") == "interrupt":
                 self.request_interrupt()
                 continue
-            self.loop.call_soon_threadsafe(self.inputs.put_nowait, msg)
-        self.loop.call_soon_threadsafe(self.inputs.put_nowait, None)
+            self.inputs.put(msg)
+        self.inputs.put(None)
 
     def request_interrupt(self, *_args: Any) -> None:
-        if self.loop is None or self.conn is None or not self.session_id:
-            return
-        self.loop.call_soon_threadsafe(
-            lambda: asyncio.ensure_future(self._cancel())
-        )
-
-    async def _cancel(self) -> None:
-        if self.conn is None or not self.session_id:
+        self._interrupted = True
+        if self.agent is None:
             return
         try:
-            await self.conn.cancel(session_id=self.session_id)
+            self.agent.interrupt()
         except Exception as exc:
             emit({"type": "error", "message": f"interrupt failed: {exc}"})
 
-    async def _run_turn(self, turn_input: dict[str, Any]) -> None:
-        assert self.conn is not None
-        self.client.reset_turn()
-        try:
-            resp = await self.conn.prompt(
-                prompt=_prompt_blocks(turn_input), session_id=self.session_id
-            )
-        except Exception as exc:
-            emit({"type": "error", "message": str(exc)})
-            return
-        stop_reason = getattr(resp, "stop_reason", None) or "end_turn"
-        usage = getattr(resp, "usage", None)
-        payload: dict[str, Any] = {
-            "type": "turn.completed",
-            "stop_reason": stop_reason,
-            "text": self.client.final_text,
-        }
-        if usage is not None:
+    def _run_turn(self, turn_input: dict[str, Any]) -> None:
+        self.emitter.reset()
+        self._interrupted = False
+        prompt = _prompt_text(turn_input)
+
+        # Run the (blocking) turn on a worker thread so the stdin reader can
+        # deliver an interrupt to AIAgent.interrupt() from another thread.
+        result: dict[str, Any] = {}
+
+        def _go() -> None:
             try:
-                payload["usage"] = usage.model_dump(by_alias=True, exclude_none=True)
-            except AttributeError:
-                payload["usage"] = usage
-        emit(payload)
+                result["text"] = self.agent.chat(prompt) or ""
+            except Exception as exc:  # pragma: no cover - provider/tool errors
+                result["error"] = str(exc)
 
-    async def run(self) -> None:
-        import acp
-        from acp.schema import (
-            ClientCapabilities,
-            FileSystemCapabilities,
-            Implementation,
+        worker = threading.Thread(target=_go)
+        worker.start()
+        worker.join()
+
+        if "error" in result:
+            emit({"type": "error", "message": result["error"]})
+            return
+        text = result.get("text") or self.emitter.final_text
+        emit(
+            {
+                "type": "turn.completed",
+                "stop_reason": "interrupted" if self._interrupted else "end_turn",
+                "text": text,
+            }
         )
 
-        self.loop = asyncio.get_running_loop()
-        cwd = os.getcwd()
-        env = dict(os.environ)
-        cmd, *args = _hermes_acp_cmd()
-
-        capabilities = ClientCapabilities(
-            fs=FileSystemCapabilities(read_text_file=False, write_text_file=False),
-            terminal=False,
-        )
-        client_info = Implementation(name="centaur", title="Centaur", version="0.1.0")
+    def run(self) -> None:
+        _install_protocol_channel()
+        # Non-interactive: auto-approve shell/tool/hook gates (the sandbox is the
+        # trust boundary, matching claude's --dangerously-skip-permissions).
+        os.environ.setdefault("HERMES_YOLO_MODE", "1")
+        os.environ.setdefault("HERMES_ACCEPT_HOOKS", "1")
 
         emit({"type": "system", "subtype": "wrapper_heartbeat", "phase": "startup"})
-        async with acp.spawn_agent_process(
-            self.client, cmd, *args, env=env, cwd=cwd, use_unstable_protocol=True
-        ) as (conn, _proc):
-            self.conn = conn
-            await conn.initialize(
-                acp.PROTOCOL_VERSION,
-                client_capabilities=capabilities,
-                client_info=client_info,
-            )
-            self.session_id = await _start_session(conn, cwd)
-            if self.session_id:
-                emit({"type": "system", "subtype": "init", "session_id": self.session_id})
-            emit(
-                {
-                    "type": "system",
-                    "subtype": "wrapper_heartbeat",
-                    "phase": "session_started",
-                }
-            )
+        try:
+            self.agent = _build_agent(self.emitter)
+        except Exception as exc:
+            emit({"type": "error", "message": f"failed to start hermes: {exc}"})
+            emit({"type": "turn.failed", "error": {"message": str(exc)}})
+            return
 
-            threading.Thread(target=self._stdin_reader, daemon=True).start()
+        session_id = getattr(self.agent, "session_id", None) or ""
+        if session_id:
+            emit({"type": "system", "subtype": "init", "session_id": session_id})
+        emit(
+            {"type": "system", "subtype": "wrapper_heartbeat", "phase": "session_started"}
+        )
 
-            while True:
-                item = await self.inputs.get()
-                if item is None:
-                    break
-                if item.get("type") != "user":
-                    continue
-                try:
-                    await self._run_turn(item)
-                except Exception as exc:  # pragma: no cover - defensive
-                    emit({"type": "error", "message": str(exc)})
+        threading.Thread(target=self._stdin_reader, daemon=True).start()
+
+        while True:
+            item = self.inputs.get()
+            if item is None:
+                break
+            if item.get("type") != "user":
+                continue
+            try:
+                self._run_turn(item)
+            except Exception as exc:  # pragma: no cover - defensive
+                emit({"type": "error", "message": str(exc)})
 
 
 def main() -> None:
     wrapper = Wrapper()
-
-    def _stop(*_args: Any) -> None:
-        # Best-effort: stop the loop so the spawn context manager tears the
-        # Hermes subprocess down.
-        if wrapper.loop is not None:
-            wrapper.loop.call_soon_threadsafe(wrapper.loop.stop)
-
-    signal.signal(signal.SIGTERM, _stop)
-    signal.signal(signal.SIGINT, _stop)
     signal.signal(signal.SIGUSR1, wrapper.request_interrupt)
-
     try:
-        asyncio.run(wrapper.run())
-    except (KeyboardInterrupt, RuntimeError):
+        wrapper.run()
+    except KeyboardInterrupt:
         pass
 
 

--- a/services/sandbox/hermes-app-wrapper.py
+++ b/services/sandbox/hermes-app-wrapper.py
@@ -82,6 +82,7 @@ def _install_protocol_channel() -> None:
 
 # ── content helpers ──────────────────────────────────────────────────────────
 
+
 def _prompt_text(turn_input: dict[str, Any]) -> str:
     """Flatten a Centaur turn envelope's content blocks into prompt text."""
     message = turn_input.get("message")
@@ -158,6 +159,7 @@ def _plan_entries_from_todo(result: Any) -> list[dict] | None:
 
 
 # ── AIAgent streaming callbacks → Centaur NDJSON ─────────────────────────────
+
 
 class TurnEmitter:
     """Translates ``AIAgent`` streaming callbacks into Centaur NDJSON events.
@@ -261,6 +263,7 @@ class TurnEmitter:
 
 # ── agent construction (mirrors hermes_cli.oneshot._run_agent) ───────────────
 
+
 def _clarify_callback(question: str, choices: Any = None) -> str:
     """Non-interactive clarify: instruct the agent to pick a sensible default.
 
@@ -342,12 +345,14 @@ def _build_agent(emitter: TurnEmitter) -> Any:
 
 # ── main driver ──────────────────────────────────────────────────────────────
 
+
 class Wrapper:
     def __init__(self) -> None:
         self.emitter = TurnEmitter()
         self.agent: Any = None
         self.inputs: queue.Queue[dict[str, Any] | None] = queue.Queue()
         self._interrupted = False
+        self._pending_interrupt = False
 
     def _stdin_reader(self) -> None:
         for raw in sys.stdin:
@@ -369,6 +374,7 @@ class Wrapper:
 
     def request_interrupt(self, *_args: Any) -> None:
         self._interrupted = True
+        self._pending_interrupt = True
         if self.agent is None:
             return
         try:
@@ -378,7 +384,8 @@ class Wrapper:
 
     def _run_turn(self, turn_input: dict[str, Any]) -> None:
         self.emitter.reset()
-        self._interrupted = False
+        self._interrupted = self._pending_interrupt
+        self._pending_interrupt = False
         prompt = _prompt_text(turn_input)
 
         # Run the (blocking) turn on a worker thread so the stdin reader can
@@ -387,7 +394,7 @@ class Wrapper:
 
         def _go() -> None:
             try:
-                result["text"] = self.agent.chat(prompt) or ""
+                result["text"] = self.agent.chat(prompt)
             except Exception as exc:  # pragma: no cover - provider/tool errors
                 result["error"] = str(exc)
 
@@ -396,9 +403,21 @@ class Wrapper:
         worker.join()
 
         if "error" in result:
+            if self._interrupted:
+                emit({"type": "system", "subtype": "turn_interrupted"})
+                return
             emit({"type": "error", "message": result["error"]})
+            emit({"type": "turn.failed", "error": {"message": result["error"]}})
             return
         text = result.get("text") or self.emitter.final_text
+        if not str(text or "").strip():
+            if self._interrupted:
+                emit({"type": "system", "subtype": "turn_interrupted"})
+                return
+            message = "hermes returned no assistant output"
+            emit({"type": "error", "message": message})
+            emit({"type": "turn.failed", "error": {"message": message}})
+            return
         emit(
             {
                 "type": "turn.completed",
@@ -426,7 +445,11 @@ class Wrapper:
         if session_id:
             emit({"type": "system", "subtype": "init", "session_id": session_id})
         emit(
-            {"type": "system", "subtype": "wrapper_heartbeat", "phase": "session_started"}
+            {
+                "type": "system",
+                "subtype": "wrapper_heartbeat",
+                "phase": "session_started",
+            }
         )
 
         threading.Thread(target=self._stdin_reader, daemon=True).start()

--- a/services/sandbox/hermes-app-wrapper.py
+++ b/services/sandbox/hermes-app-wrapper.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""hermes-app-wrapper — Centaur NDJSON bridge for the Hermes Agent ACP server.
+
+Hermes Agent (NousResearch/hermes-agent) speaks the Agent Client Protocol over
+stdio via ``hermes acp`` (entry point ``hermes-acp``). This wrapper acts as the
+ACP *client*: it keeps a single Hermes ACP session alive, translates each
+Centaur turn into an ACP ``session/prompt``, auto-approves tool permission
+requests, and re-emits Hermes' streaming ``session/update`` notifications as
+Centaur-shaped NDJSON for the API to normalize.
+
+The stdin/stdout contract matches the other sandbox wrappers (codex/claude/amp):
+
+* Read NDJSON turn envelopes from stdin:
+  ``{"type":"user","message":{"content":[blocks]}, "steer"?, "trace_id"?}`` and
+  ``{"type":"interrupt"}``.
+* Emit Hermes-native NDJSON events on stdout. The matching ``"hermes"`` engine
+  branch in ``api/sandbox/normalize.py`` + ``harness_protocol.py`` maps these to
+  canonical Centaur events:
+    - ``{"type":"system","subtype":"init","session_id":...}``  (thread id)
+    - ``{"type":"agent_message_chunk","text":...}``            (streamed answer)
+    - ``{"type":"agent_thought_chunk","text":...}``            (reasoning)
+    - ``{"type":"tool_call","tool_call_id":...,"name":...,"input":...}``
+    - ``{"type":"tool_call_update","tool_call_id":...,"status":...,"output":...}``
+    - ``{"type":"plan","entries":[...]}``                      (todo/plan panel)
+    - ``{"type":"turn.completed","stop_reason":...,"text":...,"usage":...}``
+    - ``{"type":"error","message":...}``
+
+Model/provider selection lives in ``~/.hermes/config.yaml`` (written by the
+sandbox entrypoint from ``HERMES_PROVIDER``/``HERMES_MODEL``), so this wrapper
+stays transport-only. Hermes inherits the firewall proxy + stubbed
+``ANTHROPIC_API_KEY`` from the container env, so its model traffic flows through
+iron-proxy like every other harness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import sys
+import threading
+from typing import Any
+
+# NOTE: ``acp`` (agent-client-protocol) is only present in the sandbox image, so
+# it is imported lazily inside the functions that need it. This keeps the module
+# importable — and its pure helpers unit-testable — in environments without it.
+
+# ── stdout (Centaur NDJSON) ──────────────────────────────────────────────────
+# ACP talks to the Hermes subprocess over its own pipes, so our stdout is free
+# for Centaur events. A lock keeps concurrent emits (loop callbacks + main)
+# from interleaving partial lines.
+_EMIT_LOCK = threading.Lock()
+
+
+def emit(payload: dict[str, Any]) -> None:
+    line = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    with _EMIT_LOCK:
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+
+def _hermes_acp_cmd() -> list[str]:
+    """Resolve the Hermes ACP server command.
+
+    Prefer the installed ``hermes-acp`` console script; fall back to the module
+    entry point so the wrapper still works in editable/dev installs.
+    """
+    override = (os.environ.get("HERMES_ACP_COMMAND") or "").strip()
+    if override:
+        return override.split()
+    from shutil import which
+
+    if which("hermes-acp"):
+        return ["hermes-acp"]
+    if which("hermes"):
+        return ["hermes", "acp"]
+    return [sys.executable, "-m", "acp_adapter.entry"]
+
+
+# ── content helpers ──────────────────────────────────────────────────────────
+
+def _content_block_text(content: Any) -> str:
+    """Extract text from an ACP content block (dict) or list of blocks."""
+    if isinstance(content, list):
+        return "".join(_content_block_text(c) for c in content)
+    if isinstance(content, dict):
+        if content.get("type") == "text":
+            return str(content.get("text") or "")
+        # tool-call ``content`` wrapper: {"type":"content","content":{...}}
+        inner = content.get("content")
+        if isinstance(inner, (dict, list)):
+            return _content_block_text(inner)
+    return ""
+
+
+def _tool_output_text(update: dict[str, Any]) -> str:
+    """Flatten a tool_call_update's content / rawOutput into a string."""
+    text = _content_block_text(update.get("content"))
+    if text:
+        return text
+    raw = update.get("rawOutput")
+    if isinstance(raw, str):
+        return raw
+    if raw is not None:
+        return json.dumps(raw, ensure_ascii=False)
+    return ""
+
+
+def _prompt_text(turn_input: dict[str, Any]) -> str:
+    """Flatten a Centaur turn envelope's content blocks into prompt text."""
+    message = turn_input.get("message")
+    blocks = message.get("content") if isinstance(message, dict) else None
+    parts: list[str] = []
+    for block in blocks or []:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "text":
+            parts.append(str(block.get("text") or ""))
+        elif btype == "image":
+            parts.append(
+                "[User sent an image attachment; ask them to upload it as a file "
+                "reference if you need it.]"
+            )
+        else:
+            parts.append(json.dumps(block, ensure_ascii=False))
+    return "\n".join(p for p in parts if p).strip() or "continue"
+
+
+def _prompt_blocks(turn_input: dict[str, Any]) -> list[Any]:
+    """Build ACP prompt content blocks from a Centaur turn envelope."""
+    import acp
+
+    return [acp.text_block(_prompt_text(turn_input))]
+
+
+# ── ACP client implementation ────────────────────────────────────────────────
+
+class CentaurHermesClient:
+    """ACP client that re-emits Hermes session updates as Centaur NDJSON."""
+
+    def __init__(self) -> None:
+        # Accumulated agent message text for the in-flight turn, so the API's
+        # extract_result() gets the full final answer (streamed deltas only
+        # carry fragments).
+        self.final_text_parts: list[str] = []
+
+    def reset_turn(self) -> None:
+        self.final_text_parts = []
+
+    @property
+    def final_text(self) -> str:
+        return "".join(self.final_text_parts)
+
+    async def session_update(self, session_id: str, update: Any, **_kwargs: Any) -> None:
+        try:
+            data = update.model_dump(by_alias=True, exclude_none=True)
+        except AttributeError:
+            data = update if isinstance(update, dict) else {}
+        kind = data.get("sessionUpdate")
+
+        if kind == "agent_message_chunk":
+            text = _content_block_text(data.get("content"))
+            if text:
+                self.final_text_parts.append(text)
+                emit({"type": "agent_message_chunk", "text": text})
+        elif kind == "agent_thought_chunk":
+            text = _content_block_text(data.get("content"))
+            if text:
+                emit({"type": "agent_thought_chunk", "text": text})
+        elif kind == "tool_call":
+            emit(
+                {
+                    "type": "tool_call",
+                    "tool_call_id": data.get("toolCallId") or "",
+                    "name": data.get("title") or data.get("kind") or "tool",
+                    "kind": data.get("kind"),
+                    "input": data.get("rawInput") or {},
+                }
+            )
+        elif kind == "tool_call_update":
+            status = data.get("status")
+            # Only the terminal update carries the result Centaur renders.
+            if status in ("completed", "failed"):
+                emit(
+                    {
+                        "type": "tool_call_update",
+                        "tool_call_id": data.get("toolCallId") or "",
+                        "status": status,
+                        "output": _tool_output_text(data),
+                        "is_error": status == "failed",
+                    }
+                )
+        elif kind == "plan":
+            emit({"type": "plan", "entries": data.get("entries") or []})
+        # usage_update / available_commands_update / mode updates carry no
+        # Centaur-facing payload; usage is surfaced via turn.completed instead.
+
+    async def request_permission(
+        self, options: Any, session_id: str, tool_call: Any, **_kwargs: Any
+    ) -> Any:
+        """Auto-approve tool use (the sandbox is the trust boundary)."""
+        from acp.schema import (
+            AllowedOutcome,
+            DeniedOutcome,
+            RequestPermissionResponse,
+        )
+
+        chosen = _pick_allow_option(options)
+        if chosen is not None:
+            return RequestPermissionResponse(
+                outcome=AllowedOutcome(outcome="selected", option_id=chosen)
+            )
+        return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
+
+    # Minimal no-op extension hooks so the connection never errors on them.
+    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
+        return None
+
+    def on_connect(self, conn: Any) -> None:
+        return None
+
+
+def _pick_allow_option(options: Any) -> str | None:
+    """Pick an 'allow' permission option id, preferring allow_always."""
+    fallback: str | None = None
+    for opt in options or []:
+        kind = getattr(opt, "kind", None)
+        option_id = getattr(opt, "option_id", None) or getattr(opt, "optionId", None)
+        if not option_id:
+            continue
+        if kind == "allow_always":
+            return option_id
+        if kind == "allow_once" and fallback is None:
+            fallback = option_id
+        if fallback is None and kind not in ("reject_once", "reject_always"):
+            fallback = option_id
+    return fallback
+
+
+# ── session lifecycle ────────────────────────────────────────────────────────
+
+async def _start_session(conn: acp.ClientSideConnection, cwd: str) -> str:
+    """Create or resume a Hermes ACP session; return its id."""
+    resume = (
+        os.environ.get("HERMES_CONTINUE_SESSION_ID")
+        or os.environ.get("AMP_CONTINUE_THREAD_ID")
+        or ""
+    ).strip()
+    if resume:
+        try:
+            result = await conn.load_session(cwd=cwd, session_id=resume)
+            if result is not None:
+                return resume
+        except Exception:
+            # Fall through to a fresh session if resume isn't supported / valid.
+            emit(
+                {
+                    "type": "system",
+                    "subtype": "wrapper_heartbeat",
+                    "phase": "resume_failed",
+                }
+            )
+    result = await conn.new_session(cwd=cwd, mcp_servers=[])
+    return getattr(result, "session_id", None) or resume or ""
+
+
+# ── main driver ──────────────────────────────────────────────────────────────
+
+class Wrapper:
+    def __init__(self) -> None:
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.conn: acp.ClientSideConnection | None = None
+        self.session_id: str = ""
+        self.inputs: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+        self.client = CentaurHermesClient()
+
+    # stdin runs in a background thread; it can't touch the loop directly.
+    def _stdin_reader(self) -> None:
+        assert self.loop is not None
+        for raw in sys.stdin:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                emit({"type": "error", "message": "invalid stdin JSON"})
+                continue
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("type") == "interrupt":
+                self.request_interrupt()
+                continue
+            self.loop.call_soon_threadsafe(self.inputs.put_nowait, msg)
+        self.loop.call_soon_threadsafe(self.inputs.put_nowait, None)
+
+    def request_interrupt(self, *_args: Any) -> None:
+        if self.loop is None or self.conn is None or not self.session_id:
+            return
+        self.loop.call_soon_threadsafe(
+            lambda: asyncio.ensure_future(self._cancel())
+        )
+
+    async def _cancel(self) -> None:
+        if self.conn is None or not self.session_id:
+            return
+        try:
+            await self.conn.cancel(session_id=self.session_id)
+        except Exception as exc:
+            emit({"type": "error", "message": f"interrupt failed: {exc}"})
+
+    async def _run_turn(self, turn_input: dict[str, Any]) -> None:
+        assert self.conn is not None
+        self.client.reset_turn()
+        try:
+            resp = await self.conn.prompt(
+                prompt=_prompt_blocks(turn_input), session_id=self.session_id
+            )
+        except Exception as exc:
+            emit({"type": "error", "message": str(exc)})
+            return
+        stop_reason = getattr(resp, "stop_reason", None) or "end_turn"
+        usage = getattr(resp, "usage", None)
+        payload: dict[str, Any] = {
+            "type": "turn.completed",
+            "stop_reason": stop_reason,
+            "text": self.client.final_text,
+        }
+        if usage is not None:
+            try:
+                payload["usage"] = usage.model_dump(by_alias=True, exclude_none=True)
+            except AttributeError:
+                payload["usage"] = usage
+        emit(payload)
+
+    async def run(self) -> None:
+        import acp
+        from acp.schema import (
+            ClientCapabilities,
+            FileSystemCapabilities,
+            Implementation,
+        )
+
+        self.loop = asyncio.get_running_loop()
+        cwd = os.getcwd()
+        env = dict(os.environ)
+        cmd, *args = _hermes_acp_cmd()
+
+        capabilities = ClientCapabilities(
+            fs=FileSystemCapabilities(read_text_file=False, write_text_file=False),
+            terminal=False,
+        )
+        client_info = Implementation(name="centaur", title="Centaur", version="0.1.0")
+
+        emit({"type": "system", "subtype": "wrapper_heartbeat", "phase": "startup"})
+        async with acp.spawn_agent_process(
+            self.client, cmd, *args, env=env, cwd=cwd, use_unstable_protocol=True
+        ) as (conn, _proc):
+            self.conn = conn
+            await conn.initialize(
+                acp.PROTOCOL_VERSION,
+                client_capabilities=capabilities,
+                client_info=client_info,
+            )
+            self.session_id = await _start_session(conn, cwd)
+            if self.session_id:
+                emit({"type": "system", "subtype": "init", "session_id": self.session_id})
+            emit(
+                {
+                    "type": "system",
+                    "subtype": "wrapper_heartbeat",
+                    "phase": "session_started",
+                }
+            )
+
+            threading.Thread(target=self._stdin_reader, daemon=True).start()
+
+            while True:
+                item = await self.inputs.get()
+                if item is None:
+                    break
+                if item.get("type") != "user":
+                    continue
+                try:
+                    await self._run_turn(item)
+                except Exception as exc:  # pragma: no cover - defensive
+                    emit({"type": "error", "message": str(exc)})
+
+
+def main() -> None:
+    wrapper = Wrapper()
+
+    def _stop(*_args: Any) -> None:
+        # Best-effort: stop the loop so the spawn context manager tears the
+        # Hermes subprocess down.
+        if wrapper.loop is not None:
+            wrapper.loop.call_soon_threadsafe(wrapper.loop.stop)
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+    signal.signal(signal.SIGUSR1, wrapper.request_interrupt)
+
+    try:
+        asyncio.run(wrapper.run())
+    except (KeyboardInterrupt, RuntimeError):
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Builds on the Hermes harness work from #142.
- Auto-configures Hermes sandboxes from existing provider/model/base URL environment.
- Propagates Anthropic-compatible provider env through sandbox specs and local bootstrap secrets.
- Adds dynamic proxy credential routing for Anthropic-compatible base URLs backed by local env secrets.
- Preserves Hermes multi-turn continuity inside a runtime with a bounded transcript.
- Loads locally built images into kind during `just build-one` for reliable local E2E.

## Validation
- `uv run --project services/api ruff check ...`
- `uv run --project services/api pytest ... -q` -> 33 passed
- `pnpm --filter @centaur/harness-events run typecheck`
- `git diff --check`
- Live local Kubernetes E2E: `/agent/spawn` with `harness=hermes`, message, execute, second message, execute. Results: `SAVED`, then `HERMES_NONCE_7429` via normal event stream.

## Notes
- This keeps Hermes at the harness/runtime layer; no Slack-specific Hermes path is added.
- The PR is draft so we can coordinate with #142 before marking ready.