### PR TITLE
Add Slack feedback transcript webhook

### DIFF
--- a/services/slackbot/src/config.ts
+++ b/services/slackbot/src/config.ts
@@ -33,6 +33,8 @@ const EnvSchema = z.object({
     ),
   SLACK_FEEDBACK_LINEAR_TEAM_ID: z.string().default('caf113f0-703b-454e-87fd-5772dfea62a5'),
   SLACK_FEEDBACK_LINEAR_PROJECT_ID: z.string().default('34e30cef-da96-4905-9814-1f8674e7f2ae'),
+  SLACK_FEEDBACK_WEBHOOK_URL: z.string().url().optional(),
+  SLACK_FEEDBACK_WEBHOOK_TOKEN: z.string().optional(),
   SLACK_FEEDBACK_ALLOWED_CHANNELS: z
     .string()
     .default('')

--- a/services/slackbot/src/index.test.ts
+++ b/services/slackbot/src/index.test.ts
@@ -1,5 +1,6 @@
 import { createHmac } from 'node:crypto'
 import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { buildSlackFeedbackWebhookPayload } from './slack/feedback'
 
 const originalEnv = { ...process.env }
 
@@ -44,7 +45,7 @@ describe('Slack event HTTP dedupe', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
 
     try {
-      const { app } = await import('./index')
+      const { app } = await import(`./index?feedback-webhook-${Date.now()}`)
       const body = new URLSearchParams({
         command: '/website-feedback',
         text: 'Button copy is confusing\nThe submit button should mention Linear.',
@@ -61,12 +62,49 @@ describe('Slack event HTTP dedupe', () => {
       expect(response.status).toBe(200)
       expect(await response.json()).toEqual({
         response_type: 'ephemeral',
-        text: 'Created DSGN-123: https://linear.app/paradigmxyz/issue/DSGN-123'
+        text: 'Feedback sent (DSGN-123: https://linear.app/paradigmxyz/issue/DSGN-123)'
       })
       expect(fetchMock).toHaveBeenCalledTimes(1)
     } finally {
       globalThis.fetch = originalFetch
     }
+  })
+
+  it('builds feedback webhook payloads with deployment metadata and thread transcript', () => {
+    const payload = buildSlackFeedbackWebhookPayload(
+      {
+        command: '/website-feedback',
+        user_id: 'U123',
+        team_id: 'T123',
+        team_domain: 'acme',
+        channel_id: 'C123',
+        channel_name: 'bot-debug',
+        thread_ts: '1779629014.647819'
+      },
+      'please fix this',
+      [
+        { ts: '1779629014.647819', user: 'U123', bot_id: null, text: 'please fix this' },
+        { ts: '1779629020.000000', user: null, bot_id: 'B123', text: 'I failed with error' }
+      ],
+      { CENTAUR_IMAGE_TAG: 'sha-abc123' }
+    )
+
+    expect(payload).toMatchObject({
+      type: 'centaur.slack_feedback',
+      version: 1,
+      feedback: { text: 'please fix this', submitted_by: '<@U123>' },
+      slack: {
+        team_id: 'T123',
+        channel_id: 'C123',
+        thread_ts: '1779629014.647819',
+        permalink: 'https://slack.com/archives/C123/p1779629014647819'
+      },
+      deployment: { image_tag: 'sha-abc123' },
+      transcript: [
+        { ts: '1779629014.647819', user: 'U123', bot_id: null, text: 'please fix this' },
+        { ts: '1779629020.000000', user: null, bot_id: 'B123', text: 'I failed with error' }
+      ]
+    })
   })
 
   it('acks duplicate Slack envelopes without scheduling duplicate processing', async () => {

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -13,6 +13,10 @@ import { authorizeSlackOrg } from './slack/authorization'
 import { CodexSessionRenderer, hasActiveCodexSession } from './slack/codex-session'
 import { EventDeduper, slackDedupKey } from './slack/dedup'
 import { duplicateSlackAlertText, type DuplicateSlackEventDetails } from './slack/duplicate-alert'
+import {
+  buildSlackFeedbackWebhookPayload,
+  type SlackFeedbackCommandPayload
+} from './slack/feedback'
 import { EnvSlackInstallationStore, SlackClientResolver } from './slack/installations'
 import { normalizeSlackEnvelope } from './slack/normalize'
 import { markdownToStreamChunks } from './slack/render'
@@ -561,14 +565,10 @@ function slackApiErrorResponse(c: Context, error: unknown) {
   )
 }
 
-type SlackCommandPayload = {
-  command?: string
-  text?: string
-  user_id?: string
-  user_name?: string
-  channel_id?: string
-  channel_name?: string
-  team_id?: string
+type SlackCommandPayload = SlackFeedbackCommandPayload & {
+  thread_ts?: string
+  response_url?: string
+  trigger_id?: string
 }
 
 async function slackCommandHandler(c: Context<{ Variables: Variables }>) {
@@ -587,10 +587,10 @@ async function slackCommandHandler(c: Context<{ Variables: Variables }>) {
       text: 'This feedback command is not enabled in this channel.'
     })
   }
-  if (!config.LINEAR_API_KEY) {
+  if (!config.LINEAR_API_KEY && !config.SLACK_FEEDBACK_WEBHOOK_URL) {
     return c.json({
       response_type: 'ephemeral',
-      text: 'Linear feedback is not configured: missing LINEAR_API_KEY.'
+      text: 'Feedback is not configured: missing LINEAR_API_KEY or SLACK_FEEDBACK_WEBHOOK_URL.'
     })
   }
 
@@ -603,20 +603,76 @@ async function slackCommandHandler(c: Context<{ Variables: Variables }>) {
   }
 
   try {
-    const issue = await createLinearFeedbackIssue(payload, text)
+    const [issue, webhook] = await Promise.all([
+      config.LINEAR_API_KEY ? createLinearFeedbackIssue(payload, text) : Promise.resolve(null),
+      config.SLACK_FEEDBACK_WEBHOOK_URL ? sendFeedbackWebhook(payload, text) : Promise.resolve(null)
+    ])
+    const destinations = [
+      issue ? `${issue.identifier}: ${issue.url}` : null,
+      webhook ? 'debug workflow notified' : null
+    ].filter(Boolean)
     return c.json({
       response_type: 'ephemeral',
-      text: `Created ${issue.identifier}: ${issue.url}`
+      text: `Feedback sent (${destinations.join('; ')})`
     })
   } catch (error) {
-    logError('linear_feedback_issue_create_failed', error)
+    logError('slack_feedback_dispatch_failed', error)
     return c.json(
       {
         response_type: 'ephemeral',
-        text: 'Could not create the Linear issue. The error was logged for follow-up.'
+        text: 'Could not send feedback. The error was logged for follow-up.'
       },
       200
     )
+  }
+}
+
+async function sendFeedbackWebhook(
+  payload: SlackCommandPayload,
+  text: string
+): Promise<{ ok: true }> {
+  if (!config.SLACK_FEEDBACK_WEBHOOK_URL)
+    throw new Error('SLACK_FEEDBACK_WEBHOOK_URL is not configured')
+  const transcript = await collectFeedbackTranscript(payload)
+  const response = await fetch(config.SLACK_FEEDBACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(config.SLACK_FEEDBACK_WEBHOOK_TOKEN
+        ? { Authorization: `Bearer ${config.SLACK_FEEDBACK_WEBHOOK_TOKEN}` }
+        : {})
+    },
+    body: JSON.stringify(buildSlackFeedbackWebhookPayload(payload, text, transcript))
+  })
+  if (!response.ok) throw new Error(`feedback webhook returned ${response.status}`)
+  return { ok: true }
+}
+
+async function collectFeedbackTranscript(
+  payload: SlackCommandPayload
+): Promise<Array<{ ts: string; user: string | null; bot_id: string | null; text: string }>> {
+  if (!payload.channel_id || !payload.thread_ts) return []
+  try {
+    const { client } = await resolver.resolve({ teamId: payload.team_id })
+    const response = await client.conversations.replies({
+      channel: payload.channel_id,
+      ts: payload.thread_ts,
+      limit: 100,
+      inclusive: true
+    })
+    return (response.messages ?? []).map(message => ({
+      ts: message.ts ?? '',
+      user: message.user ?? null,
+      bot_id: message.bot_id ?? null,
+      text: typeof message.text === 'string' ? message.text : ''
+    }))
+  } catch (error) {
+    logWarn('slack_feedback_transcript_fetch_failed', {
+      channel_id: payload.channel_id,
+      thread_ts: payload.thread_ts,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return []
   }
 }
 

--- a/services/slackbot/src/slack/feedback.ts
+++ b/services/slackbot/src/slack/feedback.ts
@@ -1,0 +1,58 @@
+export type SlackFeedbackCommandPayload = {
+  command?: string
+  text?: string
+  user_id?: string
+  user_name?: string
+  channel_id?: string
+  channel_name?: string
+  team_id?: string
+  team_domain?: string
+  thread_ts?: string
+}
+
+export type SlackFeedbackTranscriptMessage = {
+  ts: string
+  user: string | null
+  bot_id: string | null
+  text: string
+}
+
+export function buildSlackFeedbackWebhookPayload(
+  payload: SlackFeedbackCommandPayload,
+  text: string,
+  transcript: SlackFeedbackTranscriptMessage[],
+  env: Record<string, string | undefined> = process.env
+) {
+  return {
+    type: 'centaur.slack_feedback',
+    version: 1,
+    feedback: {
+      command: payload.command,
+      text,
+      submitted_by: payload.user_id ? `<@${payload.user_id}>` : (payload.user_name ?? null),
+      submitted_at: new Date().toISOString()
+    },
+    slack: {
+      team_id: payload.team_id ?? null,
+      team_domain: payload.team_domain ?? null,
+      channel_id: payload.channel_id ?? null,
+      channel_name: payload.channel_name ?? null,
+      thread_ts: payload.thread_ts ?? null,
+      permalink: feedbackPermalink(payload)
+    },
+    deployment: {
+      commit: env.COMMIT_SHA ?? null,
+      image: env.CENTAUR_IMAGE ?? env.IMAGE ?? null,
+      image_tag: env.CENTAUR_IMAGE_TAG ?? env.IMAGE_TAG ?? null,
+      release: env.CENTAUR_RELEASE ?? env.RELEASE_NAME ?? null,
+      namespace: env.CENTAUR_NAMESPACE ?? env.NAMESPACE ?? null,
+      hostname: env.HOSTNAME ?? null
+    },
+    transcript
+  }
+}
+
+export function feedbackPermalink(payload: SlackFeedbackCommandPayload): string | null {
+  if (!payload.channel_id || !payload.thread_ts) return null
+  return `https://slack.com/archives/${payload.channel_id}/p${payload.thread_ts.replace('.', '')}`
+}


### PR DESCRIPTION
## Summary
- add optional Slack feedback webhook delivery alongside Linear issue creation
- include Slack thread metadata, deployment/image metadata, and up to 100 thread transcript messages in the webhook payload
- keep Linear-only feedback behavior working and add payload contract test coverage

## Tests
- bun test services/slackbot/src/index.test.ts
- corepack pnpm --filter slackbot check:types *(fails on pre-existing src/slack/agent-session.ts block chunk type mismatch)*