### PR TITLE
docs: add workflow webhook guide

### DIFF
--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -89,9 +89,105 @@ curl -s "$CENTAUR_API_URL/workflows/runs/$RUN_ID" \
   -H "X-Api-Key: $CENTAUR_API_KEY" | jq
 ```
 
+## Expose a workflow as a webhook
+
+Workflows are private unless the workflow file explicitly exports `WEBHOOKS`.
+Each webhook is mounted at `POST /api/webhooks/{slug}` and creates a durable
+workflow run with a normalized webhook envelope. Use this for provider-driven
+entrypoints such as GitHub issue triage, billing events, or deploy callbacks.
+
+```python
+from typing import Any
+
+from api.webhooks import HeaderTriggerKey, HmacAuth, WebhookSpec
+from api.workflow_engine import WorkflowContext
+
+
+WORKFLOW_NAME = "github_issue_triage"
+
+WEBHOOKS = [
+    WebhookSpec(
+        slug="github-issue-triage",
+        provider="github",
+        auth=HmacAuth.github(secret_ref="GITHUB_WEBHOOK_SECRET"),
+        trigger_key=HeaderTriggerKey("X-GitHub-Delivery"),
+        allowed_methods=["POST"],
+        allowed_content_types=[
+            "application/json",
+            "application/x-www-form-urlencoded",
+        ],
+    )
+]
+
+
+async def handler(inp: dict[str, Any], ctx: WorkflowContext) -> dict[str, Any]:
+    webhook = inp["webhook"]
+    headers = webhook["headers"]
+    payload = webhook["body"]
+
+    if headers.get("x-github-event") != "issues":
+        return {"skipped": True, "reason": "unsupported_event"}
+
+    issue = payload["issue"]
+    repo = payload["repository"]["full_name"]
+    result = await ctx.agent_turn(
+        f"Triage GitHub issue {repo}#{issue['number']}: {issue['title']}",
+        thread_key=f"github:{repo}:{issue['number']}",
+    )
+    return {"triaged": True, "agent_result": result}
+```
+
+Configure the provider to call:
+
+```text
+https://<your-centaur-host>/api/webhooks/github-issue-triage
+```
+
+For GitHub, set the webhook secret to the same value as
+`GITHUB_WEBHOOK_SECRET` in the API deployment and select `application/json`.
+GitHub's default `application/x-www-form-urlencoded` payloads also work when
+that content type is listed in `allowed_content_types`.
+
+Webhook requests do not use Centaur API keys. The API verifies the provider
+signature before creating workflow state. `HmacAuth.github(...)` verifies
+`X-Hub-Signature-256`; a plain `HmacAuth(...)` can be used for other
+SHA-256 HMAC providers. During local development or for trusted internal
+routes, `auth="none"` is allowed.
+
+The workflow receives input in this shape:
+
+```json
+{
+  "webhook": {
+    "slug": "github-issue-triage",
+    "provider": "github",
+    "method": "POST",
+    "path": "/api/webhooks/github-issue-triage",
+    "headers": {
+      "x-github-event": "issues",
+      "x-github-delivery": "..."
+    },
+    "query": {},
+    "body": {},
+    "raw_body_sha256": "...",
+    "source_ip": "203.0.113.10"
+  }
+}
+```
+
+Sensitive headers such as signatures, cookies, authorization, and API keys are
+removed before the workflow input is persisted. `trigger_key` controls
+idempotency; prefer a provider delivery header like `X-GitHub-Delivery`. If no
+trigger key is configured, Centaur uses the raw body SHA-256 hash.
+
+The webhook endpoint returns `202` when it creates a new run and `200` when the
+same trigger key maps to an existing run.
+
 ## Verify
 
 After deploying an overlay, check API logs for workflow load events and create a
 small run with `eager_start: true`. If the workflow is missing, inspect
 `WORKFLOW_DIRS`, the overlay image contents, and whether the file exports
-`WORKFLOW_NAME`.
+`WORKFLOW_NAME`. For webhooks, also check for
+`workflow_webhook_registered` in the API logs and send a signed request to the
+public `/api/webhooks/{slug}` URL.

--- a/docs/public/md/extend/workflows.md
+++ b/docs/public/md/extend/workflows.md
@@ -89,9 +89,105 @@ curl -s "$CENTAUR_API_URL/workflows/runs/$RUN_ID" \
   -H "X-Api-Key: $CENTAUR_API_KEY" | jq
 ```
 
+## Expose a workflow as a webhook
+
+Workflows are private unless the workflow file explicitly exports `WEBHOOKS`.
+Each webhook is mounted at `POST /api/webhooks/{slug}` and creates a durable
+workflow run with a normalized webhook envelope. Use this for provider-driven
+entrypoints such as GitHub issue triage, billing events, or deploy callbacks.
+
+```python
+from typing import Any
+
+from api.webhooks import HeaderTriggerKey, HmacAuth, WebhookSpec
+from api.workflow_engine import WorkflowContext
+
+
+WORKFLOW_NAME = "github_issue_triage"
+
+WEBHOOKS = [
+    WebhookSpec(
+        slug="github-issue-triage",
+        provider="github",
+        auth=HmacAuth.github(secret_ref="GITHUB_WEBHOOK_SECRET"),
+        trigger_key=HeaderTriggerKey("X-GitHub-Delivery"),
+        allowed_methods=["POST"],
+        allowed_content_types=[
+            "application/json",
+            "application/x-www-form-urlencoded",
+        ],
+    )
+]
+
+
+async def handler(inp: dict[str, Any], ctx: WorkflowContext) -> dict[str, Any]:
+    webhook = inp["webhook"]
+    headers = webhook["headers"]
+    payload = webhook["body"]
+
+    if headers.get("x-github-event") != "issues":
+        return {"skipped": True, "reason": "unsupported_event"}
+
+    issue = payload["issue"]
+    repo = payload["repository"]["full_name"]
+    result = await ctx.agent_turn(
+        f"Triage GitHub issue {repo}#{issue['number']}: {issue['title']}",
+        thread_key=f"github:{repo}:{issue['number']}",
+    )
+    return {"triaged": True, "agent_result": result}
+```
+
+Configure the provider to call:
+
+```text
+https://<your-centaur-host>/api/webhooks/github-issue-triage
+```
+
+For GitHub, set the webhook secret to the same value as
+`GITHUB_WEBHOOK_SECRET` in the API deployment and select `application/json`.
+GitHub's default `application/x-www-form-urlencoded` payloads also work when
+that content type is listed in `allowed_content_types`.
+
+Webhook requests do not use Centaur API keys. The API verifies the provider
+signature before creating workflow state. `HmacAuth.github(...)` verifies
+`X-Hub-Signature-256`; a plain `HmacAuth(...)` can be used for other
+SHA-256 HMAC providers. During local development or for trusted internal
+routes, `auth="none"` is allowed.
+
+The workflow receives input in this shape:
+
+```json
+{
+  "webhook": {
+    "slug": "github-issue-triage",
+    "provider": "github",
+    "method": "POST",
+    "path": "/api/webhooks/github-issue-triage",
+    "headers": {
+      "x-github-event": "issues",
+      "x-github-delivery": "..."
+    },
+    "query": {},
+    "body": {},
+    "raw_body_sha256": "...",
+    "source_ip": "203.0.113.10"
+  }
+}
+```
+
+Sensitive headers such as signatures, cookies, authorization, and API keys are
+removed before the workflow input is persisted. `trigger_key` controls
+idempotency; prefer a provider delivery header like `X-GitHub-Delivery`. If no
+trigger key is configured, Centaur uses the raw body SHA-256 hash.
+
+The webhook endpoint returns `202` when it creates a new run and `200` when the
+same trigger key maps to an existing run.
+
 ## Verify
 
 After deploying an overlay, check API logs for workflow load events and create a
 small run with `eager_start: true`. If the workflow is missing, inspect
 `WORKFLOW_DIRS`, the overlay image contents, and whether the file exports
-`WORKFLOW_NAME`.
+`WORKFLOW_NAME`. For webhooks, also check for
+`workflow_webhook_registered` in the API logs and send a signed request to the
+public `/api/webhooks/{slug}` URL.


### PR DESCRIPTION
## what

Adds a Creating Workflows guide section for exposing workflows as public webhooks.

Covers:

- `WEBHOOKS` opt-in registration
- `WebhookSpec`, `HmacAuth`, and GitHub signature verification
- provider URL setup for `/api/webhooks/{slug}`
- normalized workflow input envelope
- idempotency via delivery headers
- webhook response statuses and verification logs

Also updates the generated `docs/public/md/extend/workflows.md` mirror.

## tested

- `cd docs && npm run build`
- `git diff --check -- docs/pages/extend/workflows.mdx docs/public/md/extend/workflows.md`

Note: `npm run build` still emits the existing Vocs warning about a dead link in `/brand.mdx` for `/centaur-brand-assets.zip`.