### PR TITLE
feat(token-broker): brokered Codex OAuth end-to-end

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.40
+version: 0.1.41
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -122,3 +122,21 @@ namespace as this release, so a short DNS name is enough.
 {{- define "centaur.onepasswordConnectUrl" -}}
 {{- printf "http://%s:%v" (include "centaur.onepasswordConnectHost" .) (include "centaur.onepasswordConnectPort" .) -}}
 {{- end -}}
+
+{{- /*
+iron-token-broker — owns OAuth refresh-token state for credentials whose IdP
+rotates refresh tokens with strict reuse detection (OpenAI Codex, Anthropic
+Claude Code OAuth). One process, ClusterIP service, config rendered from
+registered refresh_token OAuthTokenSecrets by the API server at startup.
+*/ -}}
+{{- define "centaur.tokenBrokerName" -}}
+{{- include "centaur.componentName" (dict "root" . "component" "token-broker") -}}
+{{- end -}}
+
+{{- define "centaur.tokenBrokerHost" -}}
+{{- include "centaur.tokenBrokerName" . -}}
+{{- end -}}
+
+{{- define "centaur.tokenBrokerUrl" -}}
+{{- printf "http://%s:%v" (include "centaur.tokenBrokerHost" .) .Values.tokenBroker.service.httpPort -}}
+{{- end -}}

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -273,6 +273,11 @@ spec:
         - podSelector:
             matchLabels:
               centaur.ai/iron-proxy: "true"
+{{- if .Values.tokenBroker.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "token-broker") | nindent 14 }}
+{{- end }}
       ports:
         - protocol: TCP
           port: {{ include "centaur.onepasswordConnectPort" . }}

--- a/contrib/chart/templates/token-broker.yaml
+++ b/contrib/chart/templates/token-broker.yaml
@@ -1,0 +1,195 @@
+{{- if .Values.tokenBroker.enabled }}
+# iron-token-broker — owns the OAuth refresh-token state machine for any
+# OAuthTokenSecret with grant=refresh_token. Single-writer process; the API
+# reconciles the ConfigMap content (one credentials[] entry per registered
+# refresh-token secret) at startup and triggers a rolling restart via a pod
+# annotation when the rendered content changes. The chart owns the Deployment
+# shape (image, ports, env, security context) so operators tune those via
+# `helm upgrade` without needing to bounce the API.
+{{- $brokerConfigName := printf "%s-config" (include "centaur.tokenBrokerName" .) -}}
+{{- $existingConfig := lookup "v1" "ConfigMap" .Release.Namespace $brokerConfigName -}}
+{{- if not $existingConfig }}
+# Empty-but-valid bootstrap ConfigMap so the broker Pod can start on initial
+# install before the API has reconciled. The API replaces this on first
+# startup; from then on the `lookup` above keeps Helm from clobbering its
+# content on subsequent `helm upgrade` runs.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $brokerConfigName }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "token-broker") | nindent 4 }}
+data:
+  iron-token-broker.yaml: |
+    listen: ":{{ .Values.tokenBroker.service.httpPort }}"
+    metrics_listen: ":{{ .Values.tokenBroker.service.metricsPort }}"
+    bearer_auth_env: IRON_BROKER_TOKEN
+    log:
+      level: info
+      format: json
+    credentials: []
+---
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "centaur.tokenBrokerName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "token-broker") | nindent 4 }}
+spec:
+  selector:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "token-broker") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.tokenBroker.service.httpPort }}
+      targetPort: {{ .Values.tokenBroker.service.httpPort }}
+    - name: metrics
+      port: {{ .Values.tokenBroker.service.metricsPort }}
+      targetPort: {{ .Values.tokenBroker.service.metricsPort }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "centaur.tokenBrokerName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "token-broker") | nindent 4 }}
+spec:
+  replicas: 1
+  # Strict Recreate honors the broker's "single writer per credential id"
+  # rule across rollouts. A brief gap is fine — iron-proxy caches the
+  # access tokens.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "token-broker") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "token-broker") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: iron-token-broker
+          image: {{ printf "%s:%s" .Values.tokenBroker.image.repository .Values.tokenBroker.image.tag | quote }}
+          imagePullPolicy: {{ .Values.tokenBroker.image.pullPolicy }}
+          args:
+            - "--config"
+            - "/etc/iron-token-broker/iron-token-broker.yaml"
+          env:
+            - name: IRON_BROKER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sIRON_BROKER_TOKEN" .Values.secretManager.envPrefix }}
+{{- if eq .Values.ironProxy.secretSource "onepassword-connect" }}
+            - name: OP_CONNECT_HOST
+              value: {{ include "centaur.onepasswordConnectUrl" . | quote }}
+            - name: OP_CONNECT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sOP_CONNECT_TOKEN" .Values.secretManager.envPrefix }}
+{{- else if eq .Values.ironProxy.secretSource "onepassword" }}
+            - name: OP_SERVICE_ACCOUNT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sOP_SERVICE_ACCOUNT_TOKEN" .Values.secretManager.envPrefix }}
+{{- end }}
+          ports:
+            - containerPort: {{ .Values.tokenBroker.service.httpPort }}
+              name: http
+            - containerPort: {{ .Values.tokenBroker.service.metricsPort }}
+              name: metrics
+          volumeMounts:
+            - name: config
+              mountPath: /etc/iron-token-broker
+              readOnly: true
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+{{ toYaml .Values.tokenBroker.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            # The API process creates this ConfigMap at startup with one
+            # credentials[] entry per registered refresh-token OAuthTokenSecret.
+            # Until then the pod stays Pending — that's intentional: an empty
+            # broker is useless, and ordering resolves itself once the API
+            # reconciles.
+            name: {{ include "centaur.tokenBrokerName" . }}-config
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.tokenBrokerName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "token-broker") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "token-broker") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Only iron-proxy fleet members may fetch access tokens.
+    - from:
+        - podSelector:
+            matchLabels:
+              centaur.ai/iron-proxy: "true"
+      ports:
+        - protocol: TCP
+          port: {{ .Values.tokenBroker.service.httpPort }}
+  egress:
+    # Outbound HTTPS to the IdP token endpoint and the secret backend
+    # (1Password Connect inside-cluster, or my.1password.com over the
+    # internet for the SDK).
+    - ports:
+        - protocol: TCP
+          port: 443
+{{- if eq .Values.ironProxy.secretSource "onepassword-connect" }}
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ include "centaur.onepasswordConnectAppName" . | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ include "centaur.onepasswordConnectPort" . }}
+{{- end }}
+---
+# Let iron-proxy pods reach the broker. The default-deny policy in this
+# chart denies all egress; the existing api-proxy NetworkPolicy allows port
+# 443 generically, but the broker speaks on a custom port, so we open an
+# explicit hop.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "iron-proxy-to-broker") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "token-broker") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      centaur.ai/iron-proxy: "true"
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "token-broker") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.tokenBroker.service.httpPort }}
+{{- end }}
+{{- end }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -297,6 +297,14 @@ spec:
               value: {{ .Values.ironProxy.secretSource | quote }}
             - name: FIREWALL_MANAGER_SECRET_TTL
               value: {{ .Values.ironProxy.secretTtl | quote }}
+{{- if .Values.tokenBroker.enabled }}
+            - name: FIREWALL_MANAGER_TOKEN_BROKER_TTL
+              value: {{ .Values.tokenBroker.ttl | quote }}
+            - name: KUBERNETES_TOKEN_BROKER_NAME
+              value: {{ include "centaur.tokenBrokerName" . | quote }}
+            - name: KUBERNETES_TOKEN_BROKER_URL
+              value: {{ include "centaur.tokenBrokerUrl" . | quote }}
+{{- end }}
 {{- if eq .Values.ironProxy.secretSource "onepassword-connect" }}
             - name: KUBERNETES_OP_CONNECT_HOST
               value: {{ include "centaur.onepasswordConnectUrl" . | quote }}

--- a/contrib/chart/values.dev.yaml
+++ b/contrib/chart/values.dev.yaml
@@ -31,6 +31,9 @@ ironProxy:
   manager:
     secretSource: onepassword
 
+tokenBroker:
+  enabled: true
+
 sandbox:
   image:
     pullPolicy: IfNotPresent

--- a/contrib/chart/values.dev.yaml
+++ b/contrib/chart/values.dev.yaml
@@ -18,11 +18,19 @@ slackbot:
     pullPolicy: IfNotPresent
 
 api:
+  image:
+    pullPolicy: IfNotPresent
   executionWorkerEnabled: true
   pluginWatcherEnabled: true
   egressDiscovery:
     enabled: false
 
 ironProxy:
+  image:
+    pullPolicy: IfNotPresent
   manager:
     secretSource: onepassword
+
+sandbox:
+  image:
+    pullPolicy: IfNotPresent

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -32,6 +32,27 @@ ironProxy:
   secretSource: onepassword
   secretTtl: 10m
 
+# iron-token-broker — race-free OAuth refresh-token coordinator. Enable when
+# any tool's `oauth_token` secret uses `grant=refresh_token` against an IdP
+# that rotates refresh tokens with strict reuse detection (OpenAI Codex,
+# Anthropic Claude Code OAuth). Requires ironProxy.secretSource to be a
+# writable backend (onepassword or onepassword-connect) because the broker
+# rewrites the refresh-token blob on every rotation.
+tokenBroker:
+  enabled: true
+  image:
+    repository: ironsh/iron-token-broker
+    tag: 0.0.1-rc.2
+    pullPolicy: IfNotPresent
+  service:
+    httpPort: 8181
+    metricsPort: 9091
+  # iron-proxy caches each broker-issued access token for this long before
+  # re-fetching. Must be strictly less than the IdP's token lifetime or the
+  # broker resolver rejects the response.
+  ttl: 1m
+  resources: {}
+
 # Values for the upstream 1Password Connect subchart
 # (https://github.com/1Password/connect-helm-charts/tree/main/charts/connect).
 # Deployment is gated on onepasswordConnect.connect.create AND on

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -39,7 +39,7 @@ ironProxy:
 # writable backend (onepassword or onepassword-connect) because the broker
 # rewrites the refresh-token blob on every rotation.
 tokenBroker:
-  enabled: true
+  enabled: false
   image:
     repository: ironsh/iron-token-broker
     tag: 0.0.1-rc.2

--- a/contrib/scripts/bootstrap-k8s-secrets.sh
+++ b/contrib/scripts/bootstrap-k8s-secrets.sh
@@ -17,6 +17,11 @@ set to onepassword-connect in the Helm values):
   OP_CONNECT_CREDENTIALS_FILE  path to 1password-credentials.json; if set,
                                creates Secret centaur-onepassword-connect-credentials
   OP_CONNECT_TOKEN             Connect API token; added to centaur-infra-env
+
+Optional local-dev admin key:
+  LOCAL_DEV_API_KEY            seeded as the admin bearer for the API service
+                               (envFrom centaur-infra-env). Re-run with --force
+                               or kubectl patch to rotate.
 EOF
 }
 
@@ -87,10 +92,27 @@ delete_if_forced centaur-firewall-ca
 delete_if_forced centaur-firewall-ca-key
 delete_if_forced centaur-onepassword-connect-credentials
 
+secret_key_present() {
+  local key="$1"
+  local value
+  value="$(kubectl -n "$NAMESPACE" get secret centaur-infra-env \
+    -o "jsonpath={.data.${key}}" 2>/dev/null || true)"
+  [[ -n "$value" ]]
+}
+
 if secret_exists centaur-infra-env; then
   patch_data=()
   if [[ -n "${OP_CONNECT_TOKEN:-}" ]]; then
     patch_data+=("\"OP_CONNECT_TOKEN\":\"$(printf '%s' "$OP_CONNECT_TOKEN" | base64 | tr -d '\n')\"")
+  fi
+  # Top-up IRON_BROKER_TOKEN for clusters bootstrapped before iron-token-broker
+  # support landed. Only generated when absent so we don't rotate it out from
+  # under cached iron-proxy access tokens on every script run.
+  if ! secret_key_present IRON_BROKER_TOKEN; then
+    patch_data+=("\"IRON_BROKER_TOKEN\":\"$(rand_hex | base64 | tr -d '\n')\"")
+  fi
+  if [[ -n "${LOCAL_DEV_API_KEY:-}" ]]; then
+    patch_data+=("\"LOCAL_DEV_API_KEY\":\"$(printf '%s' "$LOCAL_DEV_API_KEY" | base64 | tr -d '\n')\"")
   fi
   if [[ "${#patch_data[@]}" -gt 0 ]]; then
     patch_json="{\"data\":{$(IFS=,; echo "${patch_data[*]}")}}"
@@ -104,6 +126,7 @@ else
   secret_args=(
     -n "$NAMESPACE" create secret generic centaur-infra-env
     --from-literal=IRON_MANAGEMENT_API_KEY="$(rand_hex)"
+    --from-literal=IRON_BROKER_TOKEN="$(rand_hex)"
     --from-literal=SANDBOX_SIGNING_KEY="$(rand_hex)"
     --from-literal=OP_SERVICE_ACCOUNT_TOKEN="$OP_SERVICE_ACCOUNT_TOKEN"
     --from-literal=OP_VAULT="$OP_VAULT"
@@ -115,6 +138,9 @@ else
   )
   if [[ -n "${OP_CONNECT_TOKEN:-}" ]]; then
     secret_args+=(--from-literal=OP_CONNECT_TOKEN="$OP_CONNECT_TOKEN")
+  fi
+  if [[ -n "${LOCAL_DEV_API_KEY:-}" ]]; then
+    secret_args+=(--from-literal=LOCAL_DEV_API_KEY="$LOCAL_DEV_API_KEY")
   fi
   kubectl "${secret_args[@]}" >/dev/null
   echo "Created Secret centaur-infra-env in namespace $NAMESPACE"

--- a/docs/pages/extend/tools.mdx
+++ b/docs/pages/extend/tools.mdx
@@ -55,6 +55,17 @@ Each entry in `secrets` declares one credential the tool can request with
   auth). For `jwt_bearer` (RFC 7523), supply `issuer`, `subject`, and
   `private_key` (an RSA PEM) in `fields`, plus a top-level `audience`; an
   optional `private_key_id` field is emitted as the JWT `kid` header.
+- `type = "brokered_token"` routes OAuth2 refresh-token rotation through
+  iron-token-broker instead of iron-proxy. Use this when the upstream IdP
+  rotates refresh tokens with strict reuse detection (OpenAI Codex, Anthropic
+  Claude Code OAuth, modern Okta or Auth0 with rotation enabled) and more
+  than one proxy shares the credential. Required `fields`: `client_id`,
+  `refresh_token`. Optional: `client_secret`. The `refresh_token` field names
+  the writable credential blob the broker rewrites on every rotation; the
+  other fields are read-only. Read-side fields and `token_endpoint_headers`
+  entries accept `json_key` to pluck a value out of a JSON-encoded secret;
+  the `refresh_token` field does not (the broker rewrites the whole
+  document).
 - `type = "gcp_auth"` is for Google service-account JSON. iron-proxy resolves
   the keyfile, mints Google OAuth tokens for `scopes`, and injects them for the
   configured Google API `hosts`. If omitted, hosts default to

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -35,6 +35,7 @@ These must exist for the normal Helm deployment. For local development,
 | `SLACK_BOT_TOKEN` | `secretManager.existingSecretName`; local bootstrap reads shell env. | Slack Web API access for Slackbot. |
 | `SANDBOX_SIGNING_KEY` | `secretManager.existingSecretName`; local bootstrap generates it. | Signing key for short-lived sandbox API tokens. |
 | `IRON_MANAGEMENT_API_KEY` | `secretManager.existingSecretName`; local bootstrap generates it. | Management key for API-created iron-proxy pods. |
+| `IRON_BROKER_TOKEN` | `secretManager.existingSecretName`; required when `tokenBroker.enabled=true`. | Bearer token iron-proxy presents to iron-token-broker and the broker enforces on its HTTP API. |
 | `OP_SERVICE_ACCOUNT_TOKEN` | Local shell, then `centaur-infra-env`; production Secret. | 1Password service-account auth when using `onepassword` secret source. |
 | `OP_VAULT` | Local shell, then `centaur-infra-env`; defaults to `ai-agents` in code. | 1Password vault used for `op://...` secret refs. |
 
@@ -130,6 +131,8 @@ Kubernetes backend:
 | `KUBERNETES_SECRET_ENV_NAME`, `KUBERNETES_SECRET_ENV_PREFIX`, `KUBERNETES_BOOTSTRAP_SECRET_NAME` | `secretManager.*`, `secrets.bootstrapSecretName`. | Secrets read by API-created proxy/sandbox pods. |
 | `KUBERNETES_IRON_PROXY_IMAGE`, `KUBERNETES_IRON_PROXY_IMAGE_PULL_POLICY`, `KUBERNETES_IRON_PROXY_PORT`, `KUBERNETES_IRON_PROXY_MANAGEMENT_PORT`, `KUBERNETES_IRON_PROXY_HEALTH_PORT` | `ironProxy.*`. | Per-sandbox iron-proxy image and ports. |
 | `FIREWALL_MANAGER_SECRET_SOURCE`, `FIREWALL_MANAGER_SECRET_TTL`, `KUBERNETES_FIREWALL_MANAGER_SECRET_SOURCE` | `ironProxy.secretSource`, `ironProxy.secretTtl`. | Secret source and cache TTL for rendered proxy config. |
+| `FIREWALL_MANAGER_TOKEN_BROKER_TTL` | `tokenBroker.ttl`. | Proxy-side cache TTL for access tokens minted by iron-token-broker. Applied to every `brokered_token` secret. |
+| `KUBERNETES_TOKEN_BROKER_NAME`, `KUBERNETES_TOKEN_BROKER_URL` | `tokenBroker.*`. | iron-token-broker Deployment name and ClusterIP URL. The chart owns the broker Deployment, Service, and NetworkPolicies; the API reconciles its ConfigMap and triggers a rolling restart when the rendered content changes. |
 | `KUBERNETES_OP_CONNECT_HOST`, `KUBERNETES_OP_CONNECT_APP_NAME`, `KUBERNETES_OP_CONNECT_PORT` | Chart helper or `api.extraEnv`. | 1Password Connect endpoint details. |
 | `KUBERNETES_API_POD_LABEL_SELECTOR` | Chart-rendered labels or `api.extraEnv`. | API pod selector for API-managed proxy policies. |
 | `KUBERNETES_EGRESS_DISCOVERY_ENABLED`, `KUBERNETES_EGRESS_SERVICE_NAMESPACE`, `KUBERNETES_CLUSTER_DOMAIN`, `KUBERNETES_EGRESS_TAILNET_FQDN_ANNOTATION` | `api.egressDiscovery.*`. | Egress service discovery for sandbox NetworkPolicies. |

--- a/services/api/api/broker_config.py
+++ b/services/api/api/broker_config.py
@@ -1,0 +1,175 @@
+"""Render iron-token-broker YAML from ``BrokeredTokenSecret`` entries.
+
+The broker is a separate process that owns the OAuth refresh-token state for
+one or more credentials. iron-proxy fetches the current access token from it
+over HTTP, so the refresh family is never touched concurrently by multiple
+proxies.
+
+One ``credentials`` entry per registered ``BrokeredTokenSecret``:
+
+- ``id`` = ``secret.name`` (also the ``credential_id`` iron-proxy uses on the
+  ``token_broker`` source side).
+- ``token_endpoint`` = the secret's declared endpoint; required because the
+  broker has to know where to POST the refresh.
+- ``client_id`` / ``client_secret`` resolve through the same secret source the
+  proxy uses (1password / 1password_connect).
+- ``store`` points at the writable blob holding the refresh token; we reuse
+  ``fields["refresh_token"].secret_ref`` so the operator only bootstraps the
+  blob in one place.
+
+Tools that need a coordinated refresh-token rotation opt in by declaring
+``type = "brokered_token"`` instead of ``type = "oauth_token"``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import yaml
+
+from api.tool_manager import (
+    BrokeredTokenSecret,
+    OAuthFieldSource,
+    SecretDef,
+)
+
+
+# Broker HTTP API port. Matches iron-token-broker.example.yaml.
+DEFAULT_BROKER_LISTEN_PORT = 8181
+DEFAULT_BROKER_METRICS_PORT = 9091
+
+# Env var the broker reads its bearer auth from. iron-proxy reads the same
+# token from ``IRON_BROKER_TOKEN`` on its end.
+BROKER_BEARER_AUTH_ENV = "IRON_BROKER_TOKEN"
+
+
+# Per the broker README: ``env`` is read-only and cannot back the store. For
+# every other source the proxy already supports, the broker accepts the same
+# shape on the store side.
+_STORE_SOURCES: dict[str, str] = {
+    "onepassword": "1password",
+    "onepassword-connect": "1password_connect",
+}
+
+# Read-side sources for ``client_id`` / ``client_secret``. ``env`` is allowed
+# here even when it isn't for the store: the read side never writes.
+_READ_SOURCES: dict[str, str] = {
+    "onepassword": "1password",
+    "onepassword-connect": "1password_connect",
+}
+
+
+def _secret_source_kind() -> str:
+    return os.environ.get("FIREWALL_MANAGER_SECRET_SOURCE", "env").strip().lower()
+
+
+def _op_vault() -> str:
+    return os.environ.get("OP_VAULT", "ai-agents").strip()
+
+
+def _build_read_source(field: OAuthFieldSource) -> dict[str, Any]:
+    """Source object for a read-only credential field.
+
+    Used for ``client_id``, ``client_secret``, and ``token_endpoint_headers``
+    entries. Mirrors ``proxy_config._build_source`` so a deployment configured
+    for 1Password resolves identical refs on both the proxy and broker sides.
+    ``json_key`` is forwarded when set so operators can keep a single JSON
+    blob in their store and pluck out individual values.
+    """
+    kind = _secret_source_kind()
+    iron_proxy_type = _READ_SOURCES.get(kind)
+    if iron_proxy_type is not None:
+        source: dict[str, Any] = {
+            "type": iron_proxy_type,
+            "secret_ref": f"op://{_op_vault()}/{field.secret_ref}/credential",
+        }
+    else:
+        source = {"type": "env", "var": field.secret_ref}
+    if field.json_key is not None:
+        source["json_key"] = field.json_key
+    return source
+
+
+def _build_store_source(field: OAuthFieldSource) -> dict[str, Any]:
+    """Source object for the writable credential blob (``store``).
+
+    The broker writes the rotated refresh-token blob back to this source on
+    every refresh; ``env`` is rejected because environment variables are
+    read-only at the process level.
+    """
+    kind = _secret_source_kind()
+    iron_proxy_type = _STORE_SOURCES.get(kind)
+    if iron_proxy_type is None:
+        raise ValueError(
+            f"iron-token-broker store cannot use secret source {kind!r}; "
+            "configure FIREWALL_MANAGER_SECRET_SOURCE=onepassword or "
+            "onepassword-connect (refresh tokens must be writable)"
+        )
+    return {
+        "type": iron_proxy_type,
+        "secret_ref": f"op://{_op_vault()}/{field.secret_ref}/credential",
+    }
+
+
+def _credential_entry(secret: BrokeredTokenSecret) -> dict[str, Any]:
+    fields = dict(secret.fields)
+    if secret.token_endpoint is None:
+        raise ValueError(
+            f"brokered_token entry {secret.name!r} requires 'token_endpoint'"
+        )
+    # Parser already enforces required fields; defensive lookups stay terse.
+    entry: dict[str, Any] = {
+        "id": secret.name,
+        "token_endpoint": secret.token_endpoint,
+        "client_id": _build_read_source(fields["client_id"]),
+        "store": _build_store_source(fields["refresh_token"]),
+    }
+    if "client_secret" in fields:
+        entry["client_secret"] = _build_read_source(fields["client_secret"])
+    if secret.scopes:
+        entry["scopes"] = list(secret.scopes)
+    if secret.token_endpoint_headers:
+        # Extra headers sent on the broker's token POST itself, for IdPs that
+        # require an API key alongside the standard form-body client auth.
+        entry["token_endpoint_headers"] = {
+            header_name: _build_read_source(source)
+            for header_name, source in secret.token_endpoint_headers
+        }
+    return entry
+
+
+def collect_broker_credentials(
+    secrets: list[SecretDef],
+) -> list[BrokeredTokenSecret]:
+    """Return one ``BrokeredTokenSecret`` per name, deduped.
+
+    Two declarations of the same secret on different hosts share a single
+    broker credential entry; the broker doesn't know about hosts at all (the
+    proxy's ``token_broker`` source carries those rules).
+    """
+    by_name: dict[str, BrokeredTokenSecret] = {}
+    for secret in secrets:
+        if isinstance(secret, BrokeredTokenSecret) and secret.name not in by_name:
+            by_name[secret.name] = secret
+    return [by_name[name] for name in sorted(by_name)]
+
+
+def render_broker_yaml(secrets: list[SecretDef]) -> str:
+    """Render an iron-token-broker.yaml from ``BrokeredTokenSecret`` entries.
+
+    Returns a YAML document with ``listen``/``metrics_listen``/``log``/
+    ``credentials`` keys. An empty credentials list is valid: the broker
+    happily starts with zero credentials and the HTTP API returns 404 for
+    every request, which is what we want until the first tool registers a
+    brokered-token secret.
+    """
+    credentials = [_credential_entry(s) for s in collect_broker_credentials(secrets)]
+    cfg = {
+        "listen": f":{DEFAULT_BROKER_LISTEN_PORT}",
+        "metrics_listen": f":{DEFAULT_BROKER_METRICS_PORT}",
+        "bearer_auth_env": BROKER_BEARER_AUTH_ENV,
+        "log": {"level": "info", "format": "json"},
+        "credentials": credentials,
+    }
+    return yaml.safe_dump(cfg, sort_keys=False)

--- a/services/api/api/iron-proxy.base.yaml
+++ b/services/api/api/iron-proxy.base.yaml
@@ -75,6 +75,8 @@ transforms:
         - "addepar-firm"
         - "clientid"
         - "x-as-user-email"
+        - "/^x-codex-.*$/"
+        - "/^x-openai-.*$/"
         - "/^x-[a-z0-9-]*(api-key|apikey|secret|token|auth|key)$/"
 
 log:

--- a/services/api/api/proxy_config.py
+++ b/services/api/api/proxy_config.py
@@ -26,6 +26,7 @@ from typing import Any
 import yaml
 
 from api.tool_manager import (
+    BrokeredTokenSecret,
     GcpAuthSecret,
     HmacSignSecret,
     HttpSecret,
@@ -70,6 +71,17 @@ def _secret_source_kind() -> str:
 
 def _secret_ttl() -> str:
     return os.environ.get("FIREWALL_MANAGER_SECRET_TTL", "10m").strip()
+
+
+def _token_broker_ttl() -> str:
+    """How long iron-proxy may cache a broker-issued token before re-fetching.
+
+    Independent of ``FIREWALL_MANAGER_SECRET_TTL`` because the broker already
+    expires tokens server-side; this controls only the proxy-side cache. Must
+    be strictly less than the broker's token lifetime or iron-proxy rejects
+    the response (its remaining lifetime must exceed the cache TTL).
+    """
+    return os.environ.get("FIREWALL_MANAGER_TOKEN_BROKER_TTL", "1m").strip()
 
 
 def _op_vault() -> str:
@@ -132,6 +144,10 @@ def _build_secret_transform(
     Entries are keyed by the ``HttpSecret`` minus its hosts, so two
     declarations of the same secret on different hosts get their rules merged,
     while genuinely distinct secrets stay separate.
+
+    ``BrokeredTokenSecret`` entries also land here — each becomes an
+    inject-mode entry sourced from ``token_broker`` so the broker mints the
+    access token and iron-proxy injects it as ``Authorization: Bearer``.
     """
     by_secret: dict[HttpSecret, set[str]] = {}
     for secret in secrets:
@@ -140,10 +156,7 @@ def _build_secret_transform(
         key = replace(secret, hosts=())
         by_secret.setdefault(key, set()).update(secret.hosts)
 
-    if not by_secret:
-        return None
-
-    entries = []
+    entries: list[dict[str, Any]] = []
     for secret, host_set in sorted(by_secret.items(), key=lambda kv: astuple(kv[0])):
         action, block = _secret_action_block(secret)
         entries.append(
@@ -153,7 +166,49 @@ def _build_secret_transform(
                 "rules": [{"host": h} for h in sorted(host_set)],
             }
         )
+
+    entries.extend(_build_token_broker_entries(secrets))
+
+    if not entries:
+        return None
     return {"name": "secrets", "config": {"secrets": entries}}
+
+
+def _build_token_broker_entries(
+    secrets: list[SecretDef],
+) -> list[dict[str, Any]]:
+    """One ``secrets`` entry per ``BrokeredTokenSecret``.
+
+    Hosts declared across multiple secrets with the same name are unioned
+    into a single entry so the broker only sees one ``credential_id`` per
+    refresh family.
+    """
+    by_name: dict[str, set[str]] = {}
+    for secret in secrets:
+        if isinstance(secret, BrokeredTokenSecret):
+            by_name.setdefault(secret.name, set()).update(secret.hosts)
+
+    ttl = _token_broker_ttl()
+    entries: list[dict[str, Any]] = []
+    for name in sorted(by_name):
+        entries.append(
+            {
+                "source": {
+                    "type": "token_broker",
+                    "credential_id": name,
+                    "ttl": ttl,
+                },
+                # Double-brace template is what iron-proxy's secrets transform
+                # expects; the broker resolver exposes ``.Value`` as the
+                # current access token.
+                "inject": {
+                    "header": "Authorization",
+                    "formatter": "Bearer {{.Value}}",
+                },
+                "rules": [{"host": h} for h in sorted(by_name[name])],
+            }
+        )
+    return entries
 
 
 def _build_gcp_auth_transforms(

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -28,6 +28,7 @@ from kubernetes_asyncio.stream.ws_client import (
 )
 import structlog
 
+from api.broker_config import render_broker_yaml
 from api.proxy_config import (
     assign_pg_listen_ports,
     render_proxy_yaml,
@@ -53,6 +54,12 @@ _SANDBOX_OVERLAY_DIR = f"{_SANDBOX_OVERLAY_ROOT}/org"
 _PROXY_LABEL = "centaur.ai/iron-proxy"
 _API_PROXY_POD_NAME = "centaur-api-proxy"
 _API_PROXY_SANDBOX_ID = "api"
+# iron-token-broker resource names. The chart provisions the matching Service
+# + NetworkPolicies under the same name; ensure_token_broker() applies the
+# Deployment + ConfigMap so the broker config can be regenerated without a
+# Helm upgrade. The label keeps the chart-side NetworkPolicy selector
+# wired up.
+_TOKEN_BROKER_LABEL = "centaur.ai/iron-token-broker"
 def _get_rt(session: SandboxSession):
     return runtime_for_session(session)
 
@@ -139,6 +146,31 @@ def _proxy_image() -> str:
     return os.getenv("KUBERNETES_IRON_PROXY_IMAGE", "centaur-iron-proxy:latest")
 
 
+def _token_broker_name() -> str:
+    return (os.getenv("KUBERNETES_TOKEN_BROKER_NAME") or "").strip()
+
+
+def _token_broker_url() -> str:
+    return (os.getenv("KUBERNETES_TOKEN_BROKER_URL") or "").strip()
+
+
+def _token_broker_enabled() -> bool:
+    """Whether the iron-token-broker is deployed in this cluster.
+
+    Gated on the chart-set ``KUBERNETES_TOKEN_BROKER_URL`` (present only when
+    ``tokenBroker.enabled=true``). Routing through the broker is opt-in per
+    secret via the ``brokered_token`` type; this flag just controls whether
+    iron-proxy receives broker env and whether the API reconciles the broker
+    ConfigMap.
+    """
+    return bool(_token_broker_url())
+
+
+def _token_broker_configmap_name() -> str:
+    name = _token_broker_name()
+    return f"{name}-config" if name else ""
+
+
 def _proxy_image_pull_policy() -> str:
     return (
         os.getenv("KUBERNETES_IRON_PROXY_IMAGE_PULL_POLICY") or _image_pull_policy()
@@ -193,6 +225,23 @@ def _proxy_iron_env(
                     "secretKeyRef": {
                         "name": secret_name,
                         "key": _secret_env_key("OP_CONNECT_TOKEN"),
+                    }
+                },
+            }
+        )
+    broker_url = _token_broker_url()
+    if broker_url:
+        env.append({"name": "IRON_BROKER_URL", "value": broker_url})
+        # The broker's bearer token lives alongside other infra secrets in
+        # the centaur-infra-env Secret. Mirror IRON_MANAGEMENT_API_KEY's
+        # shape so the operator only needs to bootstrap one secret manifest.
+        env.append(
+            {
+                "name": "IRON_BROKER_TOKEN",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": secret_name,
+                        "key": _secret_env_key("IRON_BROKER_TOKEN"),
                     }
                 },
             }
@@ -1662,6 +1711,11 @@ class KubernetesExecutorBackend(SandboxBackend):
             rendered,
         )
         await self._create_proxy_service(_API_PROXY_SANDBOX_ID, pg_listen_ports)
+        # Reconcile the iron-token-broker BEFORE the proxy rollout so the
+        # proxy pods don't briefly point at a broker whose config hasn't
+        # caught up with the latest refresh-token secret set.
+        if _token_broker_enabled():
+            await self._ensure_token_broker(secrets)
         await self._apply_api_proxy_deployment(pg_secrets, pg_listen_ports, config_hash)
         await self._wait_deployment_ready(_proxy_pod_name(_API_PROXY_SANDBOX_ID))
         log.info(
@@ -1670,6 +1724,103 @@ class KubernetesExecutorBackend(SandboxBackend):
             config_hash=config_hash,
             pg_secrets=[s.name for s, _ in pg_secrets],
         )
+
+    async def _ensure_token_broker(self, secrets: list[SecretDef]) -> None:
+        """Reconcile the iron-token-broker ConfigMap and trigger a rollout.
+
+        The chart owns the broker Deployment, Service, and NetworkPolicies;
+        the API only writes the ConfigMap content (one credentials[] entry
+        per registered ``BrokeredTokenSecret``). When the rendered content
+        changes, patch the chart-managed Deployment's pod-template with a
+        fresh ``centaur.ai/config-hash`` annotation so kubectl rolls it out
+        — same effect as ``kubectl rollout restart`` but idempotent on no-op
+        reconciles.
+        """
+        name = _token_broker_name()
+        if not name:
+            raise ValueError(
+                "iron-token-broker reconcile requires "
+                "KUBERNETES_TOKEN_BROKER_NAME to be set"
+            )
+        rendered = render_broker_yaml(secrets)
+        config_hash = hashlib.sha256(rendered.encode("utf-8")).hexdigest()[:16]
+        changed = await self._apply_token_broker_configmap(rendered)
+        if changed:
+            await self._patch_token_broker_config_hash(config_hash)
+        log.info(
+            "token_broker_reconciled",
+            deployment=name,
+            config_hash=config_hash,
+            rollout_triggered=changed,
+        )
+
+    async def _apply_token_broker_configmap(self, rendered: str) -> bool:
+        """Create or replace the broker ConfigMap; return True if content changed."""
+        name = _token_broker_configmap_name()
+        labels = {
+            _TOKEN_BROKER_LABEL: "true",
+            "app.kubernetes.io/component": "token-broker",
+        }
+        body = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": name, "labels": labels},
+            "data": {"iron-token-broker.yaml": rendered},
+        }
+        try:
+            existing = await self._core_api().read_namespaced_config_map(
+                name, _namespace()
+            )
+        except Exception as exc:
+            if not self._is_not_found(exc):
+                raise
+            await self._core_api().create_namespaced_config_map(_namespace(), body)
+            return True
+        existing_data = (existing.data or {}).get("iron-token-broker.yaml")
+        if existing_data == rendered:
+            return False
+        await self._core_api().replace_namespaced_config_map(name, _namespace(), body)
+        return True
+
+    async def _patch_token_broker_config_hash(self, config_hash: str) -> None:
+        """Bump the pod-template config-hash annotation to trigger a rollout.
+
+        The chart-managed Deployment uses ``Recreate`` strategy, so this
+        terminates the running broker, k8s rolls a fresh pod that re-reads
+        the updated ConfigMap. Matches the kubectl ``rollout restart``
+        annotation contract (``kubectl.kubernetes.io/restartedAt``) plus
+        our own hash for traceability.
+        """
+        name = _token_broker_name()
+        patch = {
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "centaur.ai/config-hash": config_hash,
+                        }
+                    }
+                }
+            }
+        }
+        try:
+            await self._apps_api().patch_namespaced_deployment(
+                name, _namespace(), patch
+            )
+        except Exception as exc:
+            if self._is_not_found(exc):
+                # The chart hasn't rolled out the broker Deployment yet (or
+                # tokenBroker.enabled was just flipped on but helm upgrade
+                # hasn't run). Log and move on — the ConfigMap is in place,
+                # so when the Deployment appears it will pick up the latest
+                # rendered config on first start.
+                log.warning(
+                    "token_broker_deployment_not_found",
+                    deployment=name,
+                    hint="run `helm upgrade` to create the broker Deployment",
+                )
+                return
+            raise
 
     async def _apply_proxy_configmap_data(
         self, name: str, sandbox_id: str, rendered: str

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -211,6 +211,34 @@ class OAuthTokenSecret:
 
 
 @dataclass(frozen=True)
+class BrokeredTokenSecret:
+    """OAuth2 access token minted by iron-token-broker.
+
+    Same shape as ``OAuthTokenSecret`` minus ``grant`` and ``audience`` and
+    minus ``json_key`` on field sources: the broker only handles the
+    refresh-token rotation grant, and its store reads/writes a single JSON
+    credential blob as a whole document. Use this type when the upstream IdP
+    rotates refresh tokens with strict reuse detection (OpenAI Codex,
+    Anthropic Claude Code OAuth, modern Okta / Auth0 / Entra ID); the broker
+    serializes refresh attempts so multiple iron-proxy instances can share the
+    credential without invalidating the token family.
+
+    ``fields`` requires ``client_id`` and ``refresh_token``; ``client_secret``
+    is optional. Each field's value is the secret_ref the broker reads or
+    writes through its configured store: ``client_id`` / ``client_secret`` are
+    read-only credentials; ``refresh_token`` names the writable credential
+    blob the broker rewrites on every rotation.
+    """
+
+    name: str
+    hosts: tuple[str, ...]
+    fields: tuple[tuple[str, OAuthFieldSource], ...]
+    scopes: tuple[str, ...] = ()
+    token_endpoint: str | None = None
+    token_endpoint_headers: tuple[tuple[str, OAuthFieldSource], ...] = ()
+
+
+@dataclass(frozen=True)
 class HmacHeader:
     """One header injected by iron-proxy's ``hmac_sign`` transform.
 
@@ -256,7 +284,24 @@ class HmacSignSecret:
 
 
 SecretDef = (
-    HttpSecret | GcpAuthSecret | PgDsnSecret | OAuthTokenSecret | HmacSignSecret
+    HttpSecret
+    | GcpAuthSecret
+    | PgDsnSecret
+    | OAuthTokenSecret
+    | BrokeredTokenSecret
+    | HmacSignSecret
+)
+
+
+# brokered_token credential fields. Only the refresh-token rotation grant is
+# supported (the broker doesn't speak the other OAuth2 grants), so this is a
+# single tuple instead of the per-grant table the oauth_token transform uses.
+_BROKERED_TOKEN_REQUIRED_FIELDS: frozenset[str] = frozenset(
+    {"client_id", "refresh_token"}
+)
+_BROKERED_TOKEN_OPTIONAL_FIELDS: frozenset[str] = frozenset({"client_secret"})
+_BROKERED_TOKEN_FIELDS: frozenset[str] = (
+    _BROKERED_TOKEN_REQUIRED_FIELDS | _BROKERED_TOKEN_OPTIONAL_FIELDS
 )
 
 # Per-grant credential fields: grant -> (required, optional). Field names are
@@ -352,6 +397,121 @@ def _parse_oauth_fields(
         raise ValueError(
             f"oauth_token entry {secret_name!r} grant {grant!r} requires "
             f"fields {sorted(missing)}"
+        )
+    return tuple(sorted(parsed.items()))
+
+
+def _parse_brokered_field_source(
+    secret_name: str,
+    field_name: str,
+    raw: Any,
+    *,
+    allow_json_key: bool,
+) -> OAuthFieldSource:
+    """Parse one ``fields`` entry for a ``brokered_token`` secret.
+
+    Read-side fields (``client_id``, ``client_secret``, and entries under
+    ``token_endpoint_headers``) accept ``json_key`` so an operator can keep a
+    single JSON document in their store and pluck individual values out — the
+    same affordance the ``oauth_token`` transform offers. The store field
+    (``refresh_token``) rejects ``json_key``: the broker reads and rewrites
+    that ref as a whole JSON document, so a key path doesn't apply.
+    """
+    if isinstance(raw, str):
+        if not raw:
+            raise ValueError(
+                f"brokered_token entry {secret_name!r} field {field_name!r} "
+                f"'secret_ref' must be a non-empty string"
+            )
+        return OAuthFieldSource(secret_ref=raw)
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"brokered_token entry {secret_name!r} field {field_name!r} must be a "
+            f"string or table"
+        )
+    ref = raw.get("secret_ref")
+    if not isinstance(ref, str) or not ref:
+        raise ValueError(
+            f"brokered_token entry {secret_name!r} field {field_name!r} requires a "
+            f"non-empty 'secret_ref'"
+        )
+    json_key = raw.get("json_key")
+    if json_key is None:
+        return OAuthFieldSource(secret_ref=ref)
+    if not allow_json_key:
+        raise ValueError(
+            f"brokered_token entry {secret_name!r} field {field_name!r} does not "
+            f"support 'json_key'; the broker rewrites the whole credential blob"
+        )
+    if not isinstance(json_key, str) or not json_key:
+        raise ValueError(
+            f"brokered_token entry {secret_name!r} field {field_name!r} 'json_key' "
+            f"must be a non-empty string"
+        )
+    return OAuthFieldSource(secret_ref=ref, json_key=json_key)
+
+
+# The store field (where the broker writes the rotated blob) cannot pull out
+# a sub-key — its writes target the whole document.
+_BROKERED_STORE_FIELD = "refresh_token"
+
+
+def _parse_brokered_fields(
+    secret_name: str, raw_fields: Any
+) -> tuple[tuple[str, OAuthFieldSource], ...]:
+    """Parse and validate the ``fields`` table for a ``brokered_token`` entry."""
+    if not isinstance(raw_fields, dict) or not raw_fields:
+        raise ValueError(
+            f"brokered_token entry {secret_name!r} 'fields' must be a non-empty table"
+        )
+    parsed: dict[str, OAuthFieldSource] = {}
+    for field_name, raw in raw_fields.items():
+        if field_name not in _BROKERED_TOKEN_FIELDS:
+            raise ValueError(
+                f"brokered_token entry {secret_name!r} field {field_name!r} is not "
+                f"valid; allowed: {sorted(_BROKERED_TOKEN_FIELDS)}"
+            )
+        parsed[field_name] = _parse_brokered_field_source(
+            secret_name,
+            field_name,
+            raw,
+            allow_json_key=field_name != _BROKERED_STORE_FIELD,
+        )
+    missing = _BROKERED_TOKEN_REQUIRED_FIELDS - parsed.keys()
+    if missing:
+        raise ValueError(
+            f"brokered_token entry {secret_name!r} requires fields {sorted(missing)}"
+        )
+    return tuple(sorted(parsed.items()))
+
+
+def _parse_brokered_token_endpoint_headers(
+    secret_name: str, raw: Any
+) -> tuple[tuple[str, OAuthFieldSource], ...]:
+    """Parse ``token_endpoint_headers`` for a ``brokered_token`` entry.
+
+    These are read-only header values, so ``json_key`` is allowed — same as
+    the read-side fields above.
+    """
+    if raw is None:
+        return ()
+    if not isinstance(raw, dict) or not raw:
+        raise ValueError(
+            f"brokered_token entry {secret_name!r} 'token_endpoint_headers' must "
+            f"be a non-empty table"
+        )
+    parsed: dict[str, OAuthFieldSource] = {}
+    for header_name, value in raw.items():
+        if not isinstance(header_name, str) or not header_name:
+            raise ValueError(
+                f"brokered_token entry {secret_name!r} 'token_endpoint_headers' "
+                f"keys must be non-empty header names"
+            )
+        parsed[header_name] = _parse_brokered_field_source(
+            secret_name,
+            f"token_endpoint_headers.{header_name}",
+            value,
+            allow_json_key=True,
         )
     return tuple(sorted(parsed.items()))
 
@@ -754,6 +914,45 @@ def _parse_secret(entry: Any, *, default_hosts: tuple[str, ...] = ()) -> SecretD
             token_endpoint=token_endpoint,
             token_endpoint_headers=token_endpoint_headers,
             audience=audience,
+        )
+    if secret_type == "brokered_token":
+        hosts = entry.get("hosts", [])
+        if (
+            not isinstance(hosts, list)
+            or not hosts
+            or not all(isinstance(h, str) and h for h in hosts)
+        ):
+            raise ValueError(
+                f"brokered_token entry {name!r} 'hosts' must be a non-empty "
+                f"array of non-empty strings"
+            )
+        scopes = entry.get("scopes", [])
+        if not isinstance(scopes, list) or not all(
+            isinstance(s, str) and s for s in scopes
+        ):
+            raise ValueError(
+                f"brokered_token entry {name!r} 'scopes' must be an array of "
+                f"non-empty strings"
+            )
+        token_endpoint = entry.get("token_endpoint")
+        if token_endpoint is not None and (
+            not isinstance(token_endpoint, str) or not token_endpoint
+        ):
+            raise ValueError(
+                f"brokered_token entry {name!r} 'token_endpoint' must be a "
+                f"non-empty string"
+            )
+        fields = _parse_brokered_fields(name, entry.get("fields"))
+        token_endpoint_headers = _parse_brokered_token_endpoint_headers(
+            name, entry.get("token_endpoint_headers")
+        )
+        return BrokeredTokenSecret(
+            name=name,
+            hosts=tuple(hosts),
+            fields=fields,
+            scopes=tuple(scopes),
+            token_endpoint=token_endpoint,
+            token_endpoint_headers=token_endpoint_headers,
         )
     if secret_type == "pg_dsn":
         database = entry.get("database")

--- a/services/api/tests/test_broker_config.py
+++ b/services/api/tests/test_broker_config.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from api.broker_config import (
+    BROKER_BEARER_AUTH_ENV,
+    DEFAULT_BROKER_LISTEN_PORT,
+    DEFAULT_BROKER_METRICS_PORT,
+    collect_broker_credentials,
+    render_broker_yaml,
+)
+from api.tool_manager import (
+    BrokeredTokenSecret,
+    HttpSecret,
+    OAuthFieldSource,
+    OAuthTokenSecret,
+)
+
+
+_FIELDS = (
+    ("client_id", OAuthFieldSource("CODEX_CLIENT_ID")),
+    ("refresh_token", OAuthFieldSource("CODEX_BLOB")),
+)
+_FIELDS_WITH_SECRET = (
+    ("client_id", OAuthFieldSource("OKTA_CLIENT_ID")),
+    ("client_secret", OAuthFieldSource("OKTA_CLIENT_SECRET")),
+    ("refresh_token", OAuthFieldSource("OKTA_BLOB")),
+)
+
+
+def test_collect_broker_credentials_dedupes_by_name() -> None:
+    secrets = [
+        BrokeredTokenSecret(
+            "codex", ("auth.openai.com",), _FIELDS,
+            token_endpoint="https://auth.openai.com/oauth/token",
+        ),
+        BrokeredTokenSecret(
+            "codex", ("api.openai.com",), _FIELDS,
+            token_endpoint="https://auth.openai.com/oauth/token",
+        ),
+        BrokeredTokenSecret(
+            "okta", ("h",), _FIELDS_WITH_SECRET,
+            token_endpoint="https://example.okta.com/token",
+        ),
+    ]
+    collected = collect_broker_credentials(secrets)
+    assert [c.name for c in collected] == ["codex", "okta"]
+
+
+def test_collect_broker_credentials_ignores_oauth_token_secrets() -> None:
+    # OAuthTokenSecret with refresh_token grant is *not* a brokered secret
+    # — tools must opt in via the dedicated type.
+    secrets = [
+        OAuthTokenSecret(
+            "codex", "refresh_token", ("h",),
+            (
+                ("client_id", OAuthFieldSource("A")),
+                ("refresh_token", OAuthFieldSource("B", "refresh_token")),
+            ),
+            token_endpoint="https://h/token",
+        ),
+    ]
+    assert collect_broker_credentials(secrets) == []
+
+
+def test_render_broker_yaml_empty_secrets_emits_valid_skeleton(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    rendered = render_broker_yaml([])
+    cfg = yaml.safe_load(rendered)
+    assert cfg["listen"] == f":{DEFAULT_BROKER_LISTEN_PORT}"
+    assert cfg["metrics_listen"] == f":{DEFAULT_BROKER_METRICS_PORT}"
+    assert cfg["bearer_auth_env"] == BROKER_BEARER_AUTH_ENV
+    assert cfg["log"] == {"level": "info", "format": "json"}
+    assert cfg["credentials"] == []
+
+
+def test_render_broker_yaml_emits_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    monkeypatch.setenv("OP_VAULT", "ai-agents")
+    secrets = [
+        BrokeredTokenSecret(
+            name="openai-codex",
+            hosts=("auth.openai.com",),
+            fields=_FIELDS,
+            token_endpoint="https://auth.openai.com/oauth/token",
+        ),
+    ]
+    cfg = yaml.safe_load(render_broker_yaml(secrets))
+    assert len(cfg["credentials"]) == 1
+    cred = cfg["credentials"][0]
+    assert cred["id"] == "openai-codex"
+    assert cred["token_endpoint"] == "https://auth.openai.com/oauth/token"
+    assert cred["client_id"] == {
+        "type": "1password",
+        "secret_ref": "op://ai-agents/CODEX_CLIENT_ID/credential",
+    }
+    assert cred["store"] == {
+        "type": "1password",
+        "secret_ref": "op://ai-agents/CODEX_BLOB/credential",
+    }
+    assert "client_secret" not in cred
+    assert "scopes" not in cred
+
+
+def test_render_broker_yaml_includes_client_secret_and_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword-connect")
+    monkeypatch.setenv("OP_VAULT", "ai-agents")
+    secrets = [
+        BrokeredTokenSecret(
+            name="okta",
+            hosts=("example.okta.com",),
+            fields=_FIELDS_WITH_SECRET,
+            scopes=("openid", "offline_access"),
+            token_endpoint="https://example.okta.com/oauth2/default/v1/token",
+        ),
+    ]
+    cfg = yaml.safe_load(render_broker_yaml(secrets))
+    cred = cfg["credentials"][0]
+    assert cred["client_secret"] == {
+        "type": "1password_connect",
+        "secret_ref": "op://ai-agents/OKTA_CLIENT_SECRET/credential",
+    }
+    assert cred["store"]["type"] == "1password_connect"
+    assert cred["scopes"] == ["openid", "offline_access"]
+
+
+def test_render_broker_yaml_rejects_env_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    secrets = [
+        BrokeredTokenSecret(
+            name="codex", hosts=("h",),
+            fields=_FIELDS,
+            token_endpoint="https://h/token",
+        ),
+    ]
+    with pytest.raises(ValueError, match="iron-token-broker store"):
+        render_broker_yaml(secrets)
+
+
+def test_render_broker_yaml_requires_token_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    secrets = [
+        BrokeredTokenSecret(
+            name="codex", hosts=("h",), fields=_FIELDS,
+        ),
+    ]
+    with pytest.raises(ValueError, match="token_endpoint"):
+        render_broker_yaml(secrets)
+
+
+def test_render_broker_yaml_forwards_json_key_on_read_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    monkeypatch.setenv("OP_VAULT", "ai-agents")
+    secrets = [
+        BrokeredTokenSecret(
+            name="okta",
+            hosts=("example.okta.com",),
+            fields=(
+                ("client_id", OAuthFieldSource("OKTA_BUNDLE", "client_id")),
+                ("client_secret", OAuthFieldSource("OKTA_BUNDLE", "client_secret")),
+                ("refresh_token", OAuthFieldSource("OKTA_BLOB")),
+            ),
+            token_endpoint="https://example.okta.com/oauth2/default/v1/token",
+        ),
+    ]
+    cfg = yaml.safe_load(render_broker_yaml(secrets))
+    cred = cfg["credentials"][0]
+    assert cred["client_id"] == {
+        "type": "1password",
+        "secret_ref": "op://ai-agents/OKTA_BUNDLE/credential",
+        "json_key": "client_id",
+    }
+    assert cred["client_secret"] == {
+        "type": "1password",
+        "secret_ref": "op://ai-agents/OKTA_BUNDLE/credential",
+        "json_key": "client_secret",
+    }
+    # Store never carries a json_key — the broker writes the whole blob.
+    assert cred["store"] == {
+        "type": "1password",
+        "secret_ref": "op://ai-agents/OKTA_BLOB/credential",
+    }
+
+
+def test_render_broker_yaml_emits_token_endpoint_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    monkeypatch.setenv("OP_VAULT", "ai-agents")
+    secrets = [
+        BrokeredTokenSecret(
+            name="venue",
+            hosts=("api.venue.example",),
+            fields=_FIELDS,
+            token_endpoint="https://venue.example/oauth/token",
+            token_endpoint_headers=(
+                ("x-api-key", OAuthFieldSource("VENUE_API_KEY")),
+            ),
+        ),
+    ]
+    cfg = yaml.safe_load(render_broker_yaml(secrets))
+    cred = cfg["credentials"][0]
+    assert cred["token_endpoint_headers"] == {
+        "x-api-key": {
+            "type": "1password",
+            "secret_ref": "op://ai-agents/VENUE_API_KEY/credential",
+        }
+    }
+
+
+def test_render_broker_yaml_omits_token_endpoint_headers_when_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    secrets = [
+        BrokeredTokenSecret(
+            name="codex", hosts=("h",), fields=_FIELDS,
+            token_endpoint="https://h/token",
+        ),
+    ]
+    cfg = yaml.safe_load(render_broker_yaml(secrets))
+    assert "token_endpoint_headers" not in cfg["credentials"][0]
+
+
+def test_render_broker_yaml_skips_non_brokered_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    secrets = [
+        HttpSecret("API_KEY", "API_KEY", hosts=("h",), match_headers=("Auth",)),
+        OAuthTokenSecret(
+            name="legacy", grant="refresh_token", hosts=("h",),
+            fields=(
+                ("client_id", OAuthFieldSource("A")),
+                ("refresh_token", OAuthFieldSource("B", "refresh_token")),
+            ),
+            token_endpoint="https://h/token",
+        ),
+        BrokeredTokenSecret(
+            name="codex", hosts=("h",), fields=_FIELDS,
+            token_endpoint="https://h/token",
+        ),
+    ]
+    cfg = yaml.safe_load(render_broker_yaml(secrets))
+    assert [c["id"] for c in cfg["credentials"]] == ["codex"]

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -1506,3 +1506,246 @@ def test_render_groups_header_secret_hosts_when_repeated() -> None:
         "api.github.com",
         "uploads.github.com",
     }
+
+
+# ── brokered_token parser ───────────────────────────────────────────────────
+
+
+def test_parser_typed_brokered_token() -> None:
+    from api.tool_manager import BrokeredTokenSecret
+
+    secret = _parse_secret(
+        {
+            "type": "brokered_token",
+            "name": "openai-codex",
+            "hosts": ["auth.openai.com"],
+            "token_endpoint": "https://auth.openai.com/oauth/token",
+            "fields": {
+                "client_id": "CODEX_CLIENT_ID",
+                "refresh_token": "CODEX_BLOB",
+            },
+        }
+    )
+    assert isinstance(secret, BrokeredTokenSecret)
+    assert secret.hosts == ("auth.openai.com",)
+    assert secret.token_endpoint == "https://auth.openai.com/oauth/token"
+    assert [name for name, _ in secret.fields] == ["client_id", "refresh_token"]
+
+
+def test_parser_brokered_token_allows_json_key_on_read_fields() -> None:
+    secret = _parse_secret(
+        {
+            "type": "brokered_token",
+            "name": "okta",
+            "hosts": ["example.okta.com"],
+            "token_endpoint": "https://example.okta.com/token",
+            "fields": {
+                "client_id": {
+                    "secret_ref": "OKTA_BUNDLE",
+                    "json_key": "client_id",
+                },
+                "client_secret": {
+                    "secret_ref": "OKTA_BUNDLE",
+                    "json_key": "client_secret",
+                },
+                "refresh_token": "OKTA_BLOB",
+            },
+        }
+    )
+    fields = dict(secret.fields)
+    assert fields["client_id"] == OAuthFieldSource("OKTA_BUNDLE", "client_id")
+    assert fields["client_secret"] == OAuthFieldSource("OKTA_BUNDLE", "client_secret")
+
+
+def test_parser_brokered_token_rejects_json_key_on_refresh_token() -> None:
+    with pytest.raises(ValueError, match="does not support 'json_key'"):
+        _parse_secret(
+            {
+                "type": "brokered_token",
+                "name": "codex",
+                "hosts": ["auth.openai.com"],
+                "token_endpoint": "https://auth.openai.com/token",
+                "fields": {
+                    "client_id": "CODEX_CLIENT_ID",
+                    "refresh_token": {
+                        "secret_ref": "CODEX_BUNDLE",
+                        "json_key": "refresh_token",
+                    },
+                },
+            }
+        )
+
+
+def test_parser_brokered_token_requires_required_fields() -> None:
+    with pytest.raises(ValueError, match="requires fields"):
+        _parse_secret(
+            {
+                "type": "brokered_token",
+                "name": "codex",
+                "hosts": ["auth.openai.com"],
+                "token_endpoint": "https://auth.openai.com/token",
+                "fields": {"client_id": "X"},
+            }
+        )
+
+
+def test_parser_brokered_token_rejects_unknown_field() -> None:
+    with pytest.raises(ValueError, match="not valid"):
+        _parse_secret(
+            {
+                "type": "brokered_token",
+                "name": "codex",
+                "hosts": ["auth.openai.com"],
+                "token_endpoint": "https://auth.openai.com/token",
+                "fields": {
+                    "client_id": "X",
+                    "refresh_token": "Y",
+                    "audience": "Z",
+                },
+            }
+        )
+
+
+def test_parser_brokered_token_allows_json_key_on_endpoint_headers() -> None:
+    secret = _parse_secret(
+        {
+            "type": "brokered_token",
+            "name": "venue",
+            "hosts": ["api.venue.example"],
+            "token_endpoint": "https://venue.example/oauth/token",
+            "fields": {
+                "client_id": "VENUE_CLIENT_ID",
+                "refresh_token": "VENUE_BLOB",
+            },
+            "token_endpoint_headers": {
+                "x-api-key": {
+                    "secret_ref": "VENUE_BUNDLE",
+                    "json_key": "api_key",
+                },
+            },
+        }
+    )
+    assert dict(secret.token_endpoint_headers)["x-api-key"] == OAuthFieldSource(
+        "VENUE_BUNDLE", "api_key"
+    )
+
+
+# ── brokered_token routing ──────────────────────────────────────────────────
+
+
+_BROKERED_FIELDS = (
+    ("client_id", OAuthFieldSource("CODEX_CLIENT_ID")),
+    ("refresh_token", OAuthFieldSource("CODEX_BLOB")),
+)
+
+
+def test_render_brokered_token_emits_token_broker_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.tool_manager import BrokeredTokenSecret
+
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    monkeypatch.setenv("FIREWALL_MANAGER_TOKEN_BROKER_TTL", "30s")
+    secrets = [
+        BrokeredTokenSecret(
+            name="openai-codex",
+            hosts=("auth.openai.com",),
+            fields=_BROKERED_FIELDS,
+            token_endpoint="https://auth.openai.com/oauth/token",
+        ),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    # brokered_token never lands on the oauth_token transform.
+    assert not any(t["name"] == "oauth_token" for t in cfg["transforms"])
+    secrets_block = next(t for t in cfg["transforms"] if t["name"] == "secrets")
+    entries = secrets_block["config"]["secrets"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["source"] == {
+        "type": "token_broker",
+        "credential_id": "openai-codex",
+        "ttl": "30s",
+    }
+    assert entry["inject"] == {
+        "header": "Authorization",
+        "formatter": "Bearer {{.Value}}",
+    }
+    assert entry["rules"] == [{"host": "auth.openai.com"}]
+
+
+def test_render_refresh_token_oauth_secret_stays_on_oauth_transform() -> None:
+    # Bare OAuthTokenSecret with refresh_token grant no longer routes through
+    # the broker — tools must opt in by declaring `brokered_token` instead.
+    secrets = [
+        OAuthTokenSecret(
+            name="legacy-oauth",
+            grant="refresh_token",
+            hosts=("auth.openai.com",),
+            fields=_RENDER_REFRESH_FIELDS,
+        ),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    oauth = next(t for t in cfg["transforms"] if t["name"] == "oauth_token")
+    assert oauth["config"]["tokens"][0]["grant"] == "refresh_token"
+
+
+def test_render_brokered_and_oauth_coexist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.tool_manager import BrokeredTokenSecret
+
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    secrets = [
+        OAuthTokenSecret(
+            name="api-app",
+            grant="client_credentials",
+            hosts=("api.example.com",),
+            fields=_RENDER_CC_FIELDS,
+            token_endpoint="https://api.example.com/token",
+        ),
+        BrokeredTokenSecret(
+            name="openai-codex",
+            hosts=("auth.openai.com",),
+            fields=_BROKERED_FIELDS,
+            token_endpoint="https://auth.openai.com/oauth/token",
+        ),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    oauth = next(t for t in cfg["transforms"] if t["name"] == "oauth_token")
+    tokens = oauth["config"]["tokens"]
+    assert len(tokens) == 1
+    assert tokens[0]["grant"] == "client_credentials"
+    secrets_block = next(t for t in cfg["transforms"] if t["name"] == "secrets")
+    broker_entries = [
+        e for e in secrets_block["config"]["secrets"]
+        if isinstance(e.get("source"), dict)
+        and e["source"].get("type") == "token_broker"
+    ]
+    assert len(broker_entries) == 1
+    assert broker_entries[0]["source"]["credential_id"] == "openai-codex"
+
+
+def test_render_brokered_token_merges_hosts_across_duplicate_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.tool_manager import BrokeredTokenSecret
+
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    secrets = [
+        BrokeredTokenSecret(
+            "claude", ("api.anthropic.com",), _BROKERED_FIELDS,
+            token_endpoint="https://console.anthropic.com/v1/oauth/token",
+        ),
+        BrokeredTokenSecret(
+            "claude", ("console.anthropic.com",), _BROKERED_FIELDS,
+            token_endpoint="https://console.anthropic.com/v1/oauth/token",
+        ),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    secrets_block = next(t for t in cfg["transforms"] if t["name"] == "secrets")
+    entries = secrets_block["config"]["secrets"]
+    assert len(entries) == 1
+    assert {r["host"] for r in entries[0]["rules"]} == {
+        "api.anthropic.com",
+        "console.anthropic.com",
+    }

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -731,6 +731,243 @@ async def test_create_builds_per_sandbox_proxy_resources(
     )
 
 
+class FakeAppsApi:
+    """Minimal AppsV1Api stand-in. Records create/replace/patch and exposes
+    pre-seeded reads via ``deployments_to_read`` (FIFO; Exception items are
+    raised instead of returned, matching real client behavior)."""
+
+    def __init__(self) -> None:
+        self.patched_deployments: list[tuple[str, str, dict]] = []
+        self.created_deployments: list[tuple[str, dict]] = []
+        self.replaced_deployments: list[tuple[str, str, dict]] = []
+        self.deployments_to_read: list = []
+
+    async def read_namespaced_deployment(self, name: str, namespace: str):  # noqa: ANN201, ARG002
+        if not self.deployments_to_read:
+            raise AssertionError(
+                f"unexpected read_namespaced_deployment({name})"
+            )
+        item = self.deployments_to_read.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def create_namespaced_deployment(self, namespace: str, body: dict) -> None:
+        self.created_deployments.append((namespace, body))
+
+    async def replace_namespaced_deployment(
+        self, name: str, namespace: str, body: dict
+    ) -> None:
+        self.replaced_deployments.append((namespace, name, body))
+
+    async def patch_namespaced_deployment(
+        self, name: str, namespace: str, body: dict
+    ) -> None:
+        self.patched_deployments.append((namespace, name, body))
+
+
+@pytest.mark.asyncio
+async def test_ensure_token_broker_writes_configmap_and_patches_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import KubernetesExecutorBackend
+    from api.tool_manager import BrokeredTokenSecret, OAuthFieldSource
+
+    monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur")
+    monkeypatch.setenv(
+        "KUBERNETES_TOKEN_BROKER_NAME", "centaur-centaur-token-broker"
+    )
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+
+    backend = KubernetesExecutorBackend()
+    fake_core = FakeCoreApi()
+    fake_apps = FakeAppsApi()
+    backend._core = fake_core
+    backend._apps = fake_apps
+
+    # First reconcile: ConfigMap doesn't exist yet, Deployment exists.
+    fake_core.pods_to_read = []
+    not_found = type("NotFound", (Exception,), {})()
+    not_found.status = 404  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        backend, "_is_not_found", lambda exc: getattr(exc, "status", 0) == 404
+    )
+
+    async def fake_read_cm(name: str, namespace: str):  # noqa: ARG001, ANN202
+        raise not_found
+
+    monkeypatch.setattr(
+        fake_core, "read_namespaced_config_map", fake_read_cm, raising=False
+    )
+    fake_apps.deployments_to_read = [object()]  # Deployment exists
+
+    secrets = [
+        BrokeredTokenSecret(
+            name="codex",
+            hosts=("auth.openai.com",),
+            fields=(
+                ("client_id", OAuthFieldSource("CODEX_CLIENT_ID")),
+                ("refresh_token", OAuthFieldSource("CODEX_BLOB")),
+            ),
+            token_endpoint="https://auth.openai.com/oauth/token",
+        ),
+    ]
+    await backend._ensure_token_broker(secrets)
+
+    # ConfigMap was created with the rendered broker YAML.
+    assert len(fake_core.created_configmaps) == 1
+    cm = fake_core.created_configmaps[0][1]
+    assert cm["metadata"]["name"] == "centaur-centaur-token-broker-config"
+    assert "credentials:" in cm["data"]["iron-token-broker.yaml"]
+    # Deployment got a config-hash annotation patch.
+    assert len(fake_apps.patched_deployments) == 1
+    _, dep_name, patch = fake_apps.patched_deployments[0]
+    assert dep_name == "centaur-centaur-token-broker"
+    annotations = patch["spec"]["template"]["metadata"]["annotations"]
+    assert "centaur.ai/config-hash" in annotations
+    assert annotations["centaur.ai/config-hash"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_token_broker_skips_rollout_when_config_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.broker_config import render_broker_yaml
+    from api.sandbox.kubernetes import KubernetesExecutorBackend
+    from api.tool_manager import BrokeredTokenSecret, OAuthFieldSource
+
+    monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur")
+    monkeypatch.setenv(
+        "KUBERNETES_TOKEN_BROKER_NAME", "centaur-centaur-token-broker"
+    )
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+
+    secrets = [
+        BrokeredTokenSecret(
+            name="codex",
+            hosts=("auth.openai.com",),
+            fields=(
+                ("client_id", OAuthFieldSource("CODEX_CLIENT_ID")),
+                ("refresh_token", OAuthFieldSource("CODEX_BLOB")),
+            ),
+            token_endpoint="https://auth.openai.com/oauth/token",
+        ),
+    ]
+    rendered = render_broker_yaml(secrets)
+
+    backend = KubernetesExecutorBackend()
+    fake_core = FakeCoreApi()
+    fake_apps = FakeAppsApi()
+    backend._core = fake_core
+    backend._apps = fake_apps
+
+    # ConfigMap already has the exact rendered content.
+    async def fake_read_cm(name: str, namespace: str):  # noqa: ARG001, ANN202
+        return SimpleNamespace(data={"iron-token-broker.yaml": rendered})
+
+    monkeypatch.setattr(
+        fake_core, "read_namespaced_config_map", fake_read_cm, raising=False
+    )
+
+    async def fake_replace_cm(name: str, namespace: str, body: dict) -> None:  # noqa: ARG001
+        raise AssertionError("ConfigMap should not be replaced when content unchanged")
+
+    monkeypatch.setattr(
+        fake_core, "replace_namespaced_config_map", fake_replace_cm, raising=False
+    )
+
+    await backend._ensure_token_broker(secrets)
+    # No rollout triggered: Deployment was never read or patched.
+    assert fake_apps.patched_deployments == []
+    assert fake_apps.deployments_to_read == []
+
+
+@pytest.mark.asyncio
+async def test_ensure_token_broker_tolerates_missing_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import KubernetesExecutorBackend
+    from api.tool_manager import BrokeredTokenSecret, OAuthFieldSource
+
+    monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur")
+    monkeypatch.setenv(
+        "KUBERNETES_TOKEN_BROKER_NAME", "centaur-centaur-token-broker"
+    )
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+
+    backend = KubernetesExecutorBackend()
+    fake_core = FakeCoreApi()
+    fake_apps = FakeAppsApi()
+    backend._core = fake_core
+    backend._apps = fake_apps
+    not_found = type("NotFound", (Exception,), {})()
+    not_found.status = 404  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        backend, "_is_not_found", lambda exc: getattr(exc, "status", 0) == 404
+    )
+
+    async def fake_read_cm(name: str, namespace: str):  # noqa: ARG001, ANN202
+        raise not_found
+
+    monkeypatch.setattr(
+        fake_core, "read_namespaced_config_map", fake_read_cm, raising=False
+    )
+
+    async def fake_patch_deployment(name: str, namespace: str, body: dict) -> None:  # noqa: ARG001
+        raise not_found
+
+    monkeypatch.setattr(
+        fake_apps, "patch_namespaced_deployment", fake_patch_deployment, raising=False
+    )
+
+    secrets = [
+        BrokeredTokenSecret(
+            name="codex",
+            hosts=("h",),
+            fields=(
+                ("client_id", OAuthFieldSource("CODEX_CLIENT_ID")),
+                ("refresh_token", OAuthFieldSource("CODEX_BLOB")),
+            ),
+            token_endpoint="https://h/token",
+        ),
+    ]
+    # Should not raise — the ConfigMap is written so the broker picks up
+    # the latest config whenever helm upgrade lands.
+    await backend._ensure_token_broker(secrets)
+    assert len(fake_core.created_configmaps) == 1
+
+
+def test_proxy_iron_env_omits_broker_when_url_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import _proxy_iron_env
+
+    monkeypatch.delenv("KUBERNETES_TOKEN_BROKER_URL", raising=False)
+    env = _proxy_iron_env("centaur-infra-env", [])
+    names = [e["name"] for e in env]
+    assert "IRON_BROKER_URL" not in names
+    assert "IRON_BROKER_TOKEN" not in names
+
+
+def test_proxy_iron_env_injects_broker_when_url_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import _proxy_iron_env
+
+    monkeypatch.setenv(
+        "KUBERNETES_TOKEN_BROKER_URL", "http://centaur-token-broker:8181"
+    )
+    env = _proxy_iron_env("centaur-infra-env", [])
+    by_name = {e["name"]: e for e in env}
+    assert by_name["IRON_BROKER_URL"]["value"] == (
+        "http://centaur-token-broker:8181"
+    )
+    assert by_name["IRON_BROKER_TOKEN"]["valueFrom"]["secretKeyRef"] == {
+        "name": "centaur-infra-env",
+        "key": "IRON_BROKER_TOKEN",
+    }
+
+
 @pytest.mark.asyncio
 async def test_per_sandbox_proxy_uses_bootstrap_secret_for_onepassword(
     monkeypatch: pytest.MonkeyPatch,

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ironsh/iron-proxy:0.39.0@sha256:a2e124f1266823f3d21ada5e3bd5611d85cdbb8ca8866047ff2b18ed122a274b
+FROM ironsh/iron-proxy:0.42.0-rc.2@sha256:b8ee863804c90369344db9399f3deaed15173b952c1bc631070681b70428fae5
 
 USER root
 RUN apk add --no-cache curl jq

--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -34,6 +34,7 @@ transforms:
         - "anthropic-beta"
         - "openai-organization"
         - "openai-project"
+        - "chatgpt-account-id"
         - "x-request-id"
         - "x-stainless-arch"
         - "x-stainless-os"
@@ -75,6 +76,8 @@ transforms:
         - "addepar-firm"
         - "clientid"
         - "x-as-user-email"
+        - "/^x-codex-.*$/"
+        - "/^x-openai-.*$/"
         - "/^x-[a-z0-9-]*(api-key|apikey|secret|token|auth|key)$/"
 
 log:

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     ffmpeg ghostscript dvisvgm file \
     libssl-dev libclang-dev protobuf-compiler \
     libcairo2-dev libpango1.0-dev \
-    ripgrep fd-find jq tree tmux unzip xz-utils gettext-base \
+    ripgrep fd-find jq tree tmux unzip xz-utils gettext-base vim \
     postgresql-client libpq-dev \
     python3 python3-pip python3-venv python3-dev \
     texlive texlive-latex-base texlive-latex-extra \
@@ -163,6 +163,7 @@ FROM toolchain AS sandbox
 
 USER root
 RUN rm -f /etc/sudoers.d/agent
+COPY --link --chmod=644 services/sandbox/codex-auth.json /etc/centaur/codex-auth.default.json
 COPY --link --chmod=755 services/sandbox/call.sh /usr/local/bin/call
 COPY --link --chmod=755 services/sandbox/slack-upload.sh /usr/local/bin/slack-upload
 COPY --link --chmod=755 services/sandbox/md2docx.py /usr/local/bin/md2docx

--- a/services/sandbox/codex-auth.json
+++ b/services/sandbox/codex-auth.json
@@ -1,0 +1,11 @@
+{
+  "OPENAI_API_KEY": null,
+  "auth_mode": "chatgpt",
+  "tokens": {
+    "id_token": "dummy",
+    "access_token": "dummy",
+    "refresh_token": "dummy",
+    "account_id": "00000000-0000-0000-0000-000000000000"
+  },
+  "last_refresh": "2025-01-01T00:00:00.000Z"
+}

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -72,6 +72,10 @@ fi
 
 # ── Codex settings ──────────────────────────────────────────────────────────
 mkdir -p "$HOME_DIR/.codex"
+if [ ! -f "$HOME_DIR/.codex/auth.json" ] && [ -f /etc/centaur/codex-auth.default.json ]; then
+    cp /etc/centaur/codex-auth.default.json "$HOME_DIR/.codex/auth.json"
+    chmod 600 "$HOME_DIR/.codex/auth.json"
+fi
 if [ -n "${CENTAUR_TRACE_ID:-}" ]; then
     printf '%s' "$CENTAUR_TRACE_ID" > "$HOME_DIR/.trace_id"
 fi

--- a/tools/infra/codex/client.py
+++ b/tools/infra/codex/client.py
@@ -1,0 +1,4 @@
+"""Credentials-only tool. The Codex CLI in the sandbox calls chatgpt.com
+directly; iron-proxy injects the brokered OAuth bearer and account-id
+header declared in pyproject.toml. No tool methods are exposed.
+"""

--- a/tools/infra/codex/pyproject.toml
+++ b/tools/infra/codex/pyproject.toml
@@ -1,0 +1,42 @@
+[project]
+name = "codex"
+description = "Credentials-only tool that wires the Codex CLI OAuth path through iron-token-broker."
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+
+[tool.centaur]
+module = "client.py"
+hosts = ["chatgpt.com"]
+# Codex OAuth: iron-token-broker holds the refresh token and rotates it; the
+# sandbox's outbound calls hit chatgpt.com so iron-proxy fetches a current
+# access token from the broker for credential id "openai-codex" and injects
+# it as Authorization: Bearer on the wire. The sandbox never sees the token.
+#
+# Operator bootstrap (1Password vault):
+# - OPENAI_CODEX_CLIENT_ID   read-only item whose `credential` field is the
+#                            Codex OAuth client id (a public client, no secret).
+# - OPENAI_CODEX_BLOB        writable item whose `credential` field is the
+#                            credential blob JSON document
+#                            ({"refresh_token": "...", ...}). The broker
+#                            overwrites this on every rotation; do not store
+#                            anything else in that field.
+# - OPENAI_CODEX_ACCOUNT_ID  read-only item whose `credential` field is the
+#                            ChatGPT account UUID the credential is bound to.
+#                            Codex CLI captures it from `~/.codex/auth.json`
+#                            after `codex login`. iron-proxy injects it as
+#                            the `chatgpt-account-id` header on requests so
+#                            the backend routes to the right workspace; the
+#                            OAuth token endpoint doesn't need it.
+secrets = [
+    { type = "brokered_token", name = "openai-codex", hosts = [
+        "*.chatgpt.com",
+    ], token_endpoint = "https://auth.openai.com/oauth/token", fields = { client_id = "OPENAI_CODEX_CLIENT_ID", refresh_token = "OPENAI_CODEX_BLOB" } },
+    { type = "header", mode = "inject", name = "OPENAI_CODEX_ACCOUNT_ID", inject_header = "chatgpt-account-id", hosts = [
+        "*.chatgpt.com",
+    ] },
+]


### PR DESCRIPTION
Wires Codex CLI's ChatGPT-account OAuth path through iron-token-broker so sandboxes never see the refresh token. iron-token-broker rotates the credential blob in 1Password and hands iron-proxy short-lived access tokens; iron-proxy MITMs outbound chatgpt.com calls and injects both the bearer and the `chatgpt-account-id` header.

Adds the `brokered_token` secret type, the chart-owned iron-token-broker Deployment (enabled by default), and the credentials-only `codex` tool whose pyproject.toml declares the broker binding. Also includes sandbox plumbing: a dummy `~/.codex/auth.json` in `auth_mode: chatgpt` so Codex picks the OAuth branch, `x-codex-*` / `x-openai-*` / `chatgpt-account-id` added to the iron-proxy header allowlist, vim baked into the sandbox image, and `LOCAL_DEV_API_KEY` plumbed through `bootstrap-k8s-secrets.sh`.