### PR TITLE
feat(workflows): add sandbox reaper + cost report scheduled workflow

### DIFF
--- a/services/api/api/workflows/sandbox_reaper_report.py
+++ b/services/api/api/workflows/sandbox_reaper_report.py
@@ -1,0 +1,238 @@
+"""Workflow: daily sandbox reaper + cost report.
+
+A scheduled (cron) workflow that scans Centaur's ``sandbox_sessions`` table,
+summarizes the fleet (state + harness breakdown, age buckets, long-idle and
+terminal/"reapable" sessions, and a rough cost estimate), and posts a digest to
+a Slack channel. Read-only — it reports; the actual reaping is handled by the
+API's orphan reaper.
+
+Configuration (all optional, via env):
+
+- ``SANDBOX_REPORT_SLACK_CHANNEL`` — channel name/id to post to. The schedule is
+  skipped entirely when this is unset, so the workflow is inert until an
+  operator opts in.
+- ``SANDBOX_REPORT_CRON`` — cron expression (default ``0 16 * * *``, 16:00 UTC).
+- ``SANDBOX_REPORT_TZ`` — schedule timezone (default ``UTC``).
+- ``SANDBOX_REPORT_ENABLED`` — set falsy to disable.
+- ``SANDBOX_REPORT_IDLE_THRESHOLD_S`` — a non-terminal session whose
+  ``updated_at`` is older than this counts as "long-idle" (default 6h).
+- ``SANDBOX_POD_HOURLY_USD`` — per-pod hourly rate for the cost estimate
+  (default 0.05). The figure is a rough estimate, labelled as such.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from api.workflow_engine import Delivery, WorkflowContext
+
+WORKFLOW_NAME = "sandbox_reaper_report"
+
+# Terminal states linger in the table until reaped — surface them as cleanup
+# candidates. (Active states: creating/running/idle/delivering/suspended.)
+_TERMINAL_STATES = frozenset({"error", "stopped", "gone"})
+
+_IDLE_THRESHOLD_S = max(int(os.getenv("SANDBOX_REPORT_IDLE_THRESHOLD_S", str(6 * 3600))), 0)
+_POD_HOURLY_USD = max(float(os.getenv("SANDBOX_POD_HOURLY_USD", "0.05")), 0.0)
+_MAX_LISTED = max(int(os.getenv("SANDBOX_REPORT_MAX_LISTED", "10")), 1)
+
+SCHEDULE = {
+    "cron": os.getenv("SANDBOX_REPORT_CRON", "0 16 * * *"),
+    "timezone": os.getenv("SANDBOX_REPORT_TZ", "UTC"),
+    "enabled": os.getenv("SANDBOX_REPORT_ENABLED", "true"),
+    # When unset the schedule engine skips this workflow (no destination), so it
+    # stays inert until an operator configures a channel.
+    "slack_channel": os.getenv("SANDBOX_REPORT_SLACK_CHANNEL", ""),
+}
+
+
+@dataclass
+class Input:
+    delivery: Delivery = field(default_factory=Delivery)
+    slack_channel: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# ── pure helpers ─────────────────────────────────────────────────────────────
+
+
+def _age_seconds(value: Any, now: dt.datetime) -> float | None:
+    if not isinstance(value, dt.datetime):
+        return None
+    ts = value if value.tzinfo else value.replace(tzinfo=dt.timezone.utc)
+    return max((now - ts).total_seconds(), 0.0)
+
+
+def _bucket_for_age(age_s: float) -> str:
+    hours = age_s / 3600.0
+    if hours < 1:
+        return "<1h"
+    if hours < 6:
+        return "1-6h"
+    if hours < 24:
+        return "6-24h"
+    return ">24h"
+
+
+def _aggregate(rows: Sequence[Mapping[str, Any]], now: dt.datetime) -> dict[str, Any]:
+    """Summarize sandbox_sessions rows. Pure — no I/O."""
+    by_state: Counter[str] = Counter()
+    by_harness: Counter[str] = Counter()
+    age_buckets: Counter[str] = Counter()
+    est_cost = 0.0
+    terminal: list[dict[str, Any]] = []
+    long_idle: list[dict[str, Any]] = []
+
+    for row in rows:
+        state = str(row.get("state") or "unknown")
+        harness = str(row.get("harness") or "unknown")
+        by_state[state] += 1
+        by_harness[harness] += 1
+        is_terminal = state in _TERMINAL_STATES
+
+        age_s = _age_seconds(row.get("started_at"), now)
+        idle_s = _age_seconds(row.get("updated_at"), now)
+
+        entry = {
+            "sandbox_id": str(row.get("sandbox_id") or "")[:12],
+            "harness": harness,
+            "state": state,
+            "age_hours": round((age_s or 0) / 3600.0, 1),
+            "idle_hours": round((idle_s or 0) / 3600.0, 1),
+        }
+
+        if is_terminal:
+            terminal.append(entry)
+            continue
+
+        # Active session: count toward live fleet age/cost.
+        if age_s is not None:
+            age_buckets[_bucket_for_age(age_s)] += 1
+            est_cost += (age_s / 3600.0) * _POD_HOURLY_USD
+        if idle_s is not None and idle_s >= _IDLE_THRESHOLD_S:
+            long_idle.append(entry)
+
+    long_idle.sort(key=lambda e: e["idle_hours"], reverse=True)
+    terminal.sort(key=lambda e: e["age_hours"], reverse=True)
+
+    active_total = sum(v for s, v in by_state.items() if s not in _TERMINAL_STATES)
+    return {
+        "total": sum(by_state.values()),
+        "active_total": active_total,
+        "terminal_total": len(terminal),
+        "long_idle_total": len(long_idle),
+        "by_state": dict(by_state),
+        "by_harness": dict(by_harness),
+        "age_buckets": {k: age_buckets[k] for k in ("<1h", "1-6h", "6-24h", ">24h") if age_buckets[k]},
+        "est_cost_usd": round(est_cost, 2),
+        "idle_threshold_hours": round(_IDLE_THRESHOLD_S / 3600.0, 1),
+        "pod_hourly_usd": _POD_HOURLY_USD,
+        "long_idle": long_idle[:_MAX_LISTED],
+        "terminal": terminal[:_MAX_LISTED],
+        "generated_at": now.isoformat(),
+    }
+
+
+def _fmt_counter(counter: Mapping[str, int]) -> str:
+    if not counter:
+        return "none"
+    return ", ".join(f"{k}: {v}" for k, v in sorted(counter.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def _render_report(snapshot: Mapping[str, Any]) -> str:
+    lines = [
+        "*🧹 Sandbox fleet report*",
+        f"• Active sandboxes: *{snapshot['active_total']}*  "
+        f"(total rows incl. terminal: {snapshot['total']})",
+        f"• By state: {_fmt_counter(snapshot['by_state'])}",
+        f"• By harness: {_fmt_counter(snapshot['by_harness'])}",
+    ]
+    if snapshot["age_buckets"]:
+        lines.append(f"• Active age: {_fmt_counter(snapshot['age_buckets'])}")
+    lines.append(
+        f"• Estimated active spend so far: *~${snapshot['est_cost_usd']:.2f}* "
+        f"(@ ${snapshot['pod_hourly_usd']:.3f}/pod-hr, rough)"
+    )
+
+    long_idle = snapshot.get("long_idle") or []
+    if long_idle:
+        lines.append(
+            f"• ⏳ Long-idle (>{snapshot['idle_threshold_hours']:.0f}h idle): "
+            f"*{snapshot['long_idle_total']}*"
+        )
+        for e in long_idle:
+            lines.append(
+                f"    - `{e['sandbox_id']}` {e['harness']}/{e['state']} "
+                f"— idle {e['idle_hours']:.1f}h, age {e['age_hours']:.1f}h"
+            )
+
+    terminal = snapshot.get("terminal") or []
+    if terminal:
+        lines.append(f"• 🪦 Terminal/reapable rows: *{snapshot['terminal_total']}*")
+        for e in terminal:
+            lines.append(
+                f"    - `{e['sandbox_id']}` {e['harness']}/{e['state']} "
+                f"— age {e['age_hours']:.1f}h"
+            )
+
+    if not long_idle and not terminal:
+        lines.append("• ✅ No long-idle or terminal sandboxes — fleet looks clean.")
+
+    return "\n".join(lines)
+
+
+def _resolve_channel(inp: Input) -> str:
+    delivery_channel = inp.delivery.channel if isinstance(inp.delivery, Delivery) else None
+    return (
+        (delivery_channel or "")
+        or (inp.slack_channel or "")
+        or os.getenv("SANDBOX_REPORT_SLACK_CHANNEL", "")
+    ).strip().lstrip("#")
+
+
+# ── data source ──────────────────────────────────────────────────────────────
+
+
+async def _scan_sandboxes() -> dict[str, Any]:
+    """Snapshot + aggregate sandbox_sessions. Wrapped in a checkpointed step."""
+    from api.agent import _get_pool
+
+    pool = _get_pool()
+    rows = await pool.fetch(
+        "SELECT thread_key, sandbox_id, harness, engine, state, started_at, updated_at "
+        "FROM sandbox_sessions"
+    )
+    now = dt.datetime.now(dt.timezone.utc)
+    return _aggregate([dict(r) for r in rows], now)
+
+
+# ── handler ──────────────────────────────────────────────────────────────────
+
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    channel = _resolve_channel(inp)
+    if not channel:
+        ctx.log("sandbox_report_no_channel")
+        return {"posted": False, "reason": "no_channel"}
+
+    snapshot = await ctx.step("scan_sandboxes", _scan_sandboxes)
+    ctx.log(
+        "sandbox_report_snapshot",
+        active=snapshot["active_total"],
+        terminal=snapshot["terminal_total"],
+        long_idle=snapshot["long_idle_total"],
+        est_cost_usd=snapshot["est_cost_usd"],
+    )
+    await ctx.post_to_slack(channel, _render_report(snapshot))
+    return {
+        "posted": True,
+        "channel": channel,
+        "active_total": snapshot["active_total"],
+        "terminal_total": snapshot["terminal_total"],
+        "long_idle_total": snapshot["long_idle_total"],
+        "est_cost_usd": snapshot["est_cost_usd"],
+    }

--- a/services/api/tests/test_sandbox_reaper_report.py
+++ b/services/api/tests/test_sandbox_reaper_report.py
@@ -1,0 +1,141 @@
+"""Tests for the sandbox_reaper_report workflow — pure aggregation + render."""
+
+from __future__ import annotations
+
+import datetime as dt
+import inspect
+
+import pytest
+
+from api.workflow_engine import Delivery
+from api.workflows import sandbox_reaper_report as wf
+
+NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+
+def _row(state, harness, started_h_ago, updated_h_ago, sandbox_id="sbx-abcdef123456"):
+    return {
+        "thread_key": f"slack:T:C:{sandbox_id}",
+        "sandbox_id": sandbox_id,
+        "harness": harness,
+        "engine": harness,
+        "state": state,
+        "started_at": NOW - dt.timedelta(hours=started_h_ago),
+        "updated_at": NOW - dt.timedelta(hours=updated_h_ago),
+    }
+
+
+# ── registration ──────────────────────────────────────────────────────────────
+
+
+def test_workflow_exports():
+    assert wf.WORKFLOW_NAME == "sandbox_reaper_report"
+    assert isinstance(wf.SCHEDULE, dict)
+    assert wf.SCHEDULE.get("cron")
+    assert inspect.iscoroutinefunction(wf.handler)
+
+
+# ── bucketing ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "hours,bucket",
+    [(0.5, "<1h"), (1.0, "1-6h"), (5.9, "1-6h"), (6.0, "6-24h"), (23.9, "6-24h"), (24.0, ">24h"), (100, ">24h")],
+)
+def test_bucket_for_age(hours, bucket):
+    assert wf._bucket_for_age(hours * 3600) == bucket
+
+
+# ── aggregation ─────────────────────────────────────────────────────────────────
+
+
+def test_aggregate_mixed_fleet():
+    rows = [
+        _row("running", "codex", started_h_ago=2, updated_h_ago=0.1, sandbox_id="run-1"),
+        _row("idle", "hermes", started_h_ago=30, updated_h_ago=8, sandbox_id="idle-1"),
+        _row("running", "hermes", started_h_ago=0.4, updated_h_ago=0.05, sandbox_id="run-2"),
+        _row("error", "codex", started_h_ago=50, updated_h_ago=49, sandbox_id="err-1"),
+        _row("gone", "amp", started_h_ago=100, updated_h_ago=99, sandbox_id="gone-1"),
+    ]
+    snap = wf._aggregate(rows, NOW)
+
+    assert snap["total"] == 5
+    assert snap["active_total"] == 3  # running, idle, running
+    assert snap["terminal_total"] == 2  # error, gone
+    assert snap["long_idle_total"] == 1  # idle session updated 8h ago
+
+    assert snap["by_state"] == {"running": 2, "idle": 1, "error": 1, "gone": 1}
+    assert snap["by_harness"] == {"codex": 2, "hermes": 2, "amp": 1}
+
+    # Active-only age buckets: 2h→1-6h, 30h→>24h, 0.4h→<1h
+    assert snap["age_buckets"] == {"<1h": 1, "1-6h": 1, ">24h": 1}
+
+    # Cost = (2 + 30 + 0.4) * 0.05 = 1.62 (terminal sessions excluded)
+    assert snap["est_cost_usd"] == pytest.approx(1.62, abs=0.011)
+
+    # long-idle list carries the idle session, sorted by idle desc
+    assert [e["sandbox_id"] for e in snap["long_idle"]] == ["idle-1"]
+    assert snap["long_idle"][0]["state"] == "idle"
+    # terminal list carries the two terminal sessions, oldest first
+    assert {e["sandbox_id"] for e in snap["terminal"]} == {"err-1", "gone-1"}
+
+
+def test_aggregate_empty():
+    snap = wf._aggregate([], NOW)
+    assert snap["total"] == 0
+    assert snap["active_total"] == 0
+    assert snap["est_cost_usd"] == 0.0
+    assert snap["long_idle"] == [] and snap["terminal"] == []
+
+
+def test_aggregate_handles_missing_timestamps():
+    rows = [{"state": "running", "harness": "codex", "sandbox_id": "x", "started_at": None, "updated_at": None}]
+    snap = wf._aggregate(rows, NOW)
+    assert snap["active_total"] == 1
+    assert snap["age_buckets"] == {}  # no age → no bucket
+    assert snap["est_cost_usd"] == 0.0
+
+
+# ── rendering ───────────────────────────────────────────────────────────────────
+
+
+def test_render_report_contains_key_fields():
+    rows = [
+        _row("running", "codex", 2, 0.1, sandbox_id="run-1"),
+        _row("idle", "hermes", 30, 8, sandbox_id="idle-1"),
+        _row("error", "codex", 50, 49, sandbox_id="err-1"),
+    ]
+    text = wf._render_report(wf._aggregate(rows, NOW))
+    assert "Sandbox fleet report" in text
+    assert "Active sandboxes: *2*" in text
+    assert "Long-idle" in text and "idle-1" in text
+    assert "Terminal/reapable" in text and "err-1" in text
+    assert "Estimated active spend" in text
+
+
+def test_render_report_clean_fleet():
+    text = wf._render_report(wf._aggregate([_row("running", "codex", 1, 0.1)], NOW))
+    assert "fleet looks clean" in text
+
+
+# ── channel resolution ───────────────────────────────────────────────────────────
+
+
+def test_resolve_channel_from_delivery():
+    inp = wf.Input(delivery=Delivery(platform="slack", channel="#ops-sandboxes"))
+    assert wf._resolve_channel(inp) == "ops-sandboxes"
+
+
+def test_resolve_channel_from_slack_channel_field():
+    inp = wf.Input(slack_channel="team-infra")
+    assert wf._resolve_channel(inp) == "team-infra"
+
+
+def test_resolve_channel_from_env(monkeypatch):
+    monkeypatch.setenv("SANDBOX_REPORT_SLACK_CHANNEL", "#fallback")
+    assert wf._resolve_channel(wf.Input()) == "fallback"
+
+
+def test_resolve_channel_empty(monkeypatch):
+    monkeypatch.delenv("SANDBOX_REPORT_SLACK_CHANNEL", raising=False)
+    assert wf._resolve_channel(wf.Input()) == ""


### PR DESCRIPTION
A daily cron workflow that scans sandbox_sessions and posts a fleet digest to Slack: active count, breakdown by state and harness, active age buckets, long-idle sessions, terminal/reapable rows, and a rough cost estimate (active uptime x configurable pod-hour rate). Read-only — it reports; the API's orphan reaper does the reaping.

Auto-discovered as a built-in workflow. Inert by default: the schedule is skipped unless SANDBOX_REPORT_SLACK_CHANNEL is set. All knobs are env-tunable (SANDBOX_REPORT_CRON/_TZ/_IDLE_THRESHOLD_S, SANDBOX_POD_HOURLY_USD). Uses a checkpointed ctx.step snapshot and exactly-once ctx.post_to_slack delivery.

Tests cover aggregation, age bucketing, cost math, channel resolution, and rendering (pure logic, no DB).