### PR TITLE
fix: avoid Slack bot requester mentions

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -1074,7 +1074,7 @@ def _build_session_context(
                 "- For links to Slack threads or messages, always use the canonical `https://slack.com/archives/{CHANNEL_ID}/p{TS_WITHOUT_DOT}` form. Slack redirects this to the correct workspace. Do not invent or hardcode a `<workspace>.slack.com` subdomain.",
             ]
         )
-        if user_id:
+        if user_id and user_id.startswith(("U", "W")):
             lines.append(
                 "- For Slack replies after completing a long task, tag the requester with "
                 f"their real Slack mention: <@{user_id}>. This Slack reply rule does not "

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -557,6 +557,14 @@ class TestBuildSessionContext:
         assert "Slack Formatting Rules" in ctx
         assert "tag the requester" not in ctx
 
+    def test_slack_bot_user_id_not_mentioned(self):
+        from api.agent import _build_session_context
+
+        ctx = _build_session_context("test:1", platform="slack", user_id="B123")
+        assert "Slack Formatting Rules" in ctx
+        assert "<@B123>" not in ctx
+        assert "tag the requester" not in ctx
+
     def test_contains_timestamp(self):
         from api.agent import _build_session_context
 


### PR DESCRIPTION
## Summary
- Only inject the long-task requester mention instruction for Slack user IDs that look taggable (`U...` or `W...`).
- Avoid generating `<@B...>` requester mentions for bot IDs.
- Add session-context coverage for bot requester IDs.

## Validation
- `uv run --project services/api pytest services/api/tests/test_integration.py::TestBuildSessionContext`

Requester GitHub mapping unavailable; omitted `Prompted by`.