### PR TITLE
Make workflow starts non-blocking

### DIFF
--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -2198,10 +2198,7 @@ async def create_workflow_run(
             eager_start=eager_start,
         )
 
-    if eager_start and inserted:
-        await _execute_run(pool, run_id)
-    else:
-        _workflow_wake.set()
+    _workflow_wake.set()
 
     response = await get_workflow_run(pool, run_id)
     if response is None:
@@ -2326,7 +2323,7 @@ async def _load_checkpoints(
 
 
 async def _execute_run(pool, run_id: str) -> None:
-    """Claim a specific run by ID and execute it (for eager_start)."""
+    """Claim a specific run by ID and execute it."""
     worker_id = _new_worker_id()
     async with pool.acquire() as conn:
         async with conn.transaction():

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -25,7 +25,7 @@ async def _clear_workflow_tables(db_pool):
 
 
 @pytest.mark.asyncio
-async def test_create_slack_thread_turn_workflow_eager_start(
+async def test_create_slack_thread_turn_workflow_eager_start_returns_without_running(
     client, db_pool, api_key: str,
 ):
     thread_key = f"slack:C-test:{uuid.uuid4().hex}"
@@ -104,6 +104,7 @@ async def test_create_slack_thread_turn_workflow_eager_start(
             "api.workflow_engine._insert_system_message",
             new=AsyncMock(side_effect=fake_insert_system_message),
         ),
+        patch("api.workflow_engine._execute_run", new=AsyncMock()) as execute_run,
     ):
         response = await client.post(
             "/workflows/runs", headers=_auth(api_key), json=payload,
@@ -112,8 +113,8 @@ async def test_create_slack_thread_turn_workflow_eager_start(
     assert response.status_code == 200
     body = response.json()
     assert body["workflow_name"] == "slack_thread_turn"
-    assert body["status"] == "waiting"
-    assert body["execution_id"] == "exe-workflow-1"
+    assert body["status"] == "queued"
+    assert body["execution_id"] is None
 
     run_row = await db_pool.fetchrow(
         "SELECT workflow_name, status "
@@ -122,25 +123,18 @@ async def test_create_slack_thread_turn_workflow_eager_start(
     )
     assert run_row is not None
     assert run_row["workflow_name"] == "slack_thread_turn"
-    assert run_row["status"] == "waiting"
+    assert run_row["status"] == "queued"
 
     cp_row = await db_pool.fetchrow(
         "SELECT checkpoint_name, execution_id "
         "FROM workflow_checkpoints WHERE run_id = $1",
         body["run_id"],
     )
-    assert cp_row is not None
-    assert cp_row["execution_id"] == "exe-workflow-1"
-    assert append_message_mock.await_count == 3
-    assert append_message_mock.await_args_list[0].kwargs["message_id"] == "slack:prior"
-    assert append_message_mock.await_args_list[0].kwargs["metadata"]["history_backfill"] is True
-    assert append_message_mock.await_args_list[0].kwargs["event"]["message"]["role"] == "user"
-    assert calls[:2] == ["system", "message"]
-    assert append_message_mock.await_args_list[1].kwargs["message_id"] == "slack:assistant-prior"
-    assert append_message_mock.await_args_list[1].kwargs["event"]["message"]["role"] == "assistant"
-    assert append_message_mock.await_args_list[2].kwargs["message_id"] == "slack:current"
-    assert append_message_mock.await_args_list[2].kwargs["metadata"]["user_id"] == "U123"
-    assert enqueue_execution_mock.await_args.kwargs["metadata"]["user_id"] == "U123"
+    assert cp_row is None
+    append_message_mock.assert_not_awaited()
+    enqueue_execution_mock.assert_not_awaited()
+    execute_run.assert_not_awaited()
+    assert calls == []
 
 
 @pytest.mark.asyncio
@@ -282,7 +276,11 @@ async def test_slack_thread_turn_attachment_roundtrip_to_agent(
 
     assert response.status_code == 200
     body = response.json()
-    assert body["status"] == "waiting"
+    assert body["status"] == "queued"
+
+    from api.workflow_engine import _execute_run
+
+    await _execute_run(db_pool, body["run_id"])
 
     attachment = await db_pool.fetchrow(
         "SELECT id, message_id, name, mime_type, data "

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -25,7 +25,7 @@ async def _clear_workflow_tables(db_pool):
 
 
 @pytest.mark.asyncio
-async def test_create_slack_thread_turn_workflow_eager_start_returns_without_running(
+async def test_create_slack_thread_turn_workflow_eager_start(
     client, db_pool, api_key: str,
 ):
     thread_key = f"slack:C-test:{uuid.uuid4().hex}"

--- a/services/slackbot/src/centaur/handoff.ts
+++ b/services/slackbot/src/centaur/handoff.ts
@@ -24,7 +24,6 @@ export class CentaurHandoff {
       body: JSON.stringify({
         workflow_name: 'slack_thread_turn',
         trigger_key: event.message_id,
-        eager_start: true,
         input: {
           thread_key: event.thread_key,
           parts: event.parts,

--- a/services/slackbot/test/emulate/slack-e2e.test.ts
+++ b/services/slackbot/test/emulate/slack-e2e.test.ts
@@ -133,6 +133,7 @@ describe(`Slack Emulate E2E (${IMPLEMENTATION})`, () => {
 
     const run = onlyRun()
     expect(run.workflow_name).toBe('slack_thread_turn')
+    expect('eager_start' in run).toBe(false)
     expect(run.trigger_key).toBe(`slack:${TEAM_ID}:${CHANNEL_ID}:${parent.ts}`)
     expect(run.input.thread_key).toBe(`slack:${TEAM_ID}:${CHANNEL_ID}:${parent.ts}`)
     expect(run.input.message_id).toBe(`slack:${TEAM_ID}:${CHANNEL_ID}:${parent.ts}`)


### PR DESCRIPTION
## Summary
- make workflow run creation always enqueue and wake the worker instead of executing inline when `eager_start` is set
- stop Slackbot from sending `eager_start` for `slack_thread_turn` handoffs
- update focused tests to assert workflow creation returns before handler execution

## Testing
- `uv run --project services/api pytest services/api/tests/test_workflows.py -k 'eager_start or attachment_roundtrip'` (3 selected, all skipped by local fixtures)\n- `git diff --check`\n- `pnpm --filter slackbot test:e2e:slack` (not run: `pnpm` unavailable in sandbox)\n\nPrompted by: @kamsz