### PR TITLE
feat(iron-proxy): allow mcp-session-id and mcp-protocol-version headers

### DIFF
--- a/services/api/api/iron-proxy.base.yaml
+++ b/services/api/api/iron-proxy.base.yaml
@@ -57,6 +57,8 @@ transforms:
         - "range"
         - "cookie"
         - "notion-version"
+        - "mcp-session-id"
+        - "mcp-protocol-version"
         - "api-version"
         - "x-github-api-version"
         - "api-key"


### PR DESCRIPTION
## Summary
Two-line addition to the iron-proxy `header_allowlist`: `mcp-session-id` and `mcp-protocol-version`.

## Why
The MCP Streamable-HTTP transport ([spec](https://modelcontextprotocol.io)) requires clients to:

1. POST `initialize` → server returns an `Mcp-Session-Id` header
2. POST `notifications/initialized` with that session header
3. POST `tools/call` with the session header on every subsequent request

Without these two headers in the allowlist, iron-proxy strips `Mcp-Session-Id` on outbound requests, and the upstream server rejects every tool call with `Bad Request: No valid session ID provided`. The handshake itself returns 200 (no session header is sent on `initialize`), so the failure mode is "first call works, all subsequent calls 400/404" — confusing without proxy logs.

## Why now
Discovered while building a hosted-MCP tool (a separate PR will follow). The fix is generic — any future MCP Streamable-HTTP server (Anthropic-hosted, OpenAI-hosted, BrightData, Allium, etc.) needs it.

## Verification
Verified end-to-end through the API self-proxy against BrightData's hosted MCP: handshake completes, tool calls succeed, session reused across requests. Before the fix: 400/404 on every tool call. After: 200 with real payloads.

## Risk
- New entries are protocol-defined MCP headers; they carry no secret material.
- Allowing them is permissive only — iron-proxy still rejects anything outside the allowlist.
- No regression: existing tools that don't send these headers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)