### PR TITLE
feat: add API OTLP tracing

### DIFF
--- a/services/api/api/app.py
+++ b/services/api/api/app.py
@@ -20,6 +20,15 @@ from api.api_keys import bootstrap_service_api_keys
 from api.config import settings
 from api.db import close_pool, create_pool
 from api.logging_config import configure_structlog
+from api.otel import (
+    configure_otel,
+    context_from_headers,
+    current_traceparent,
+    mark_error,
+    record_exception,
+    set_span_attributes,
+    start_span,
+)
 from api.retention import start_retention_sweeper, stop_retention_sweeper
 from api.trace_context import get_or_create_thread_trace_id, traceparent_from_trace_id
 from api.vm_metrics import (
@@ -54,6 +63,7 @@ from api.workflow_engine import (
 from api.warm_pool import start_replenish_loop, stop_replenish_loop
 
 configure_structlog()
+configure_otel()
 
 log = structlog.get_logger().bind(service="api")
 
@@ -331,20 +341,47 @@ async def instrument_requests(request, call_next):
         except Exception:
             log.debug("thread_trace_lookup_failed", thread_key=thread_key, exc_info=True)
 
+    route = request.scope.get("route")
+    path = getattr(route, "path", None) or request.url.path
+    parent_context = context_from_headers(request.headers)
+
     start = time.perf_counter()
     status_code = 500
     HTTP_REQUESTS_IN_PROGRESS.inc()
     try:
-        route = request.scope.get("route")
-        path = getattr(route, "path", None) or request.url.path
-        response = await call_next(request)
-        status_code = response.status_code
-        if trace_id:
-            response.headers["X-Trace-Id"] = trace_id
-            traceparent = traceparent_from_trace_id(trace_id)
-            if traceparent:
-                response.headers["traceparent"] = traceparent
-        return response
+        with start_span(
+            "centaur.api.http_request",
+            parent_context=parent_context,
+            attributes={
+                "http.request.method": request.method,
+                "url.path": path,
+                "centaur.thread_key": thread_key,
+                "centaur.trace_id": trace_id,
+                "client.address": request.client.host if request.client else None,
+            },
+        ) as span:
+            try:
+                response = await call_next(request)
+            except Exception as exc:
+                record_exception(span, exc)
+                raise
+            status_code = response.status_code
+            set_span_attributes(
+                span,
+                {
+                    "http.response.status_code": status_code,
+                    "centaur.thread_key": thread_key,
+                    "centaur.trace_id": trace_id,
+                },
+            )
+            if status_code >= 500:
+                mark_error(span, f"HTTP {status_code}")
+            if trace_id:
+                response.headers["X-Trace-Id"] = trace_id
+                traceparent = current_traceparent(span) or traceparent_from_trace_id(trace_id)
+                if traceparent:
+                    response.headers["traceparent"] = traceparent
+            return response
     finally:
         HTTP_REQUESTS_IN_PROGRESS.dec()
         route = request.scope.get("route")

--- a/services/api/api/otel.py
+++ b/services/api/api/otel.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from contextlib import contextmanager
+from typing import Any
+
+import structlog
+from opentelemetry import propagate, trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.trace import (
+    NonRecordingSpan,
+    Span,
+    SpanContext,
+    SpanKind,
+    Status,
+    StatusCode,
+    TraceFlags,
+    TraceState,
+)
+
+log = structlog.get_logger()
+
+_TRACER_NAME = "centaur.api"
+_configured = False
+_instrumented = False
+
+
+def configure_otel() -> None:
+    """Configure first-party OpenTelemetry tracing for the API process.
+
+    Export is opt-in: set OTEL_EXPORTER_OTLP_ENDPOINT or
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT for OTLP/HTTP, or set
+    OTEL_TRACES_EXPORTER=console for local debugging.
+    """
+    global _configured, _instrumented
+    if _configured:
+        return
+    _configured = True
+
+    exporter = (os.getenv("OTEL_TRACES_EXPORTER") or "").strip().lower()
+    endpoint = (
+        os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+        or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+        or ""
+    ).strip()
+    if exporter in {"none", "false", "0", "off"}:
+        log.info("otel_tracing_disabled", reason="OTEL_TRACES_EXPORTER")
+        return
+    if not endpoint and exporter != "console":
+        log.info("otel_tracing_disabled", reason="missing_otlp_endpoint")
+        return
+
+    resource = Resource.create(
+        {
+            "service.name": os.getenv("OTEL_SERVICE_NAME", "centaur-api"),
+            "service.namespace": "centaur",
+            "deployment.environment": (
+                os.getenv("CENTAUR_ENVIRONMENT")
+                or os.getenv("DEPLOY_ENV")
+                or os.getenv("ENVIRONMENT")
+                or "local"
+            ),
+        }
+    )
+    provider = TracerProvider(resource=resource)
+    if exporter == "console":
+        provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    else:
+        provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+    log.info(
+        "otel_tracing_configured",
+        exporter=exporter or "otlp",
+        endpoint=endpoint or None,
+    )
+
+    if not _instrumented:
+        _instrumented = True
+        try:
+            from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+            if _db_auto_instrumentation_enabled():
+                from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
+
+                AsyncPGInstrumentor().instrument()
+            HTTPXClientInstrumentor().instrument()
+        except Exception:
+            log.warning("otel_auto_instrumentation_failed", exc_info=True)
+
+
+def _db_auto_instrumentation_enabled() -> bool:
+    return (os.getenv("OTEL_INSTRUMENT_ASYNCPG") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def tracer():
+    return trace.get_tracer(_TRACER_NAME)
+
+
+def _clean_attr_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, bool, int, float)):
+        if isinstance(value, str) and len(value) > 512:
+            return value[:509] + "..."
+        return value
+    if isinstance(value, (list, tuple)):
+        cleaned = [_clean_attr_value(item) for item in value]
+        return [item for item in cleaned if isinstance(item, (str, bool, int, float))]
+    return str(value)[:512]
+
+
+def clean_attributes(attributes: Mapping[str, Any] | None) -> dict[str, Any]:
+    cleaned: dict[str, Any] = {}
+    for key, value in (attributes or {}).items():
+        cleaned_value = _clean_attr_value(value)
+        if cleaned_value is not None:
+            cleaned[str(key)] = cleaned_value
+    return cleaned
+
+
+@contextmanager
+def start_span(
+    name: str,
+    *,
+    attributes: Mapping[str, Any] | None = None,
+    parent_context=None,
+    kind: SpanKind = SpanKind.INTERNAL,
+):
+    if parent_context is not None:
+        current_ctx = trace.get_current_span().get_span_context()
+        parent_ctx = trace.get_current_span(parent_context).get_span_context()
+        if current_ctx.is_valid and parent_ctx.is_valid and current_ctx.trace_id == parent_ctx.trace_id:
+            parent_context = None
+
+    with tracer().start_as_current_span(
+        name,
+        context=parent_context,
+        kind=kind,
+        attributes=clean_attributes(attributes),
+    ) as span:
+        yield span
+
+
+def set_span_attributes(span: Span, attributes: Mapping[str, Any] | None) -> None:
+    for key, value in clean_attributes(attributes).items():
+        span.set_attribute(key, value)
+
+
+def add_span_event(
+    name: str,
+    attributes: Mapping[str, Any] | None = None,
+    *,
+    span: Span | None = None,
+) -> None:
+    target = span or trace.get_current_span()
+    if not target:
+        return
+    target.add_event(name, clean_attributes(attributes))
+
+
+def record_exception(span: Span, exc: BaseException) -> None:
+    span.record_exception(exc)
+    span.set_status(Status(StatusCode.ERROR, str(exc)[:512]))
+
+
+def mark_error(span: Span, message: str) -> None:
+    span.set_status(Status(StatusCode.ERROR, message[:512]))
+
+
+def span_context_to_dict(span: Span | None = None) -> dict[str, Any] | None:
+    target = span or trace.get_current_span()
+    span_context = target.get_span_context() if target else None
+    if not span_context or not span_context.is_valid:
+        return None
+    return {
+        "trace_id": f"{span_context.trace_id:032x}",
+        "span_id": f"{span_context.span_id:016x}",
+        "trace_flags": int(span_context.trace_flags),
+        "trace_state": list(span_context.trace_state.items()),
+    }
+
+
+def context_from_serialized(value: Any):
+    if not isinstance(value, dict):
+        return None
+    try:
+        trace_id = int(str(value.get("trace_id") or ""), 16)
+        span_id = int(str(value.get("span_id") or ""), 16)
+    except ValueError:
+        return None
+    if trace_id <= 0 or span_id <= 0:
+        return None
+    trace_state_entries = value.get("trace_state")
+    trace_state = TraceState(
+        trace_state_entries if isinstance(trace_state_entries, list) else []
+    )
+    span_context = SpanContext(
+        trace_id=trace_id,
+        span_id=span_id,
+        is_remote=True,
+        trace_flags=TraceFlags(int(value.get("trace_flags") or TraceFlags.SAMPLED)),
+        trace_state=trace_state,
+    )
+    if not span_context.is_valid:
+        return None
+    return trace.set_span_in_context(NonRecordingSpan(span_context))
+
+
+def context_from_headers(headers: Mapping[str, str]):
+    return propagate.extract(headers)
+
+
+def current_traceparent(span: Span | None = None) -> str | None:
+    span_context = (span or trace.get_current_span()).get_span_context()
+    if not span_context or not span_context.is_valid:
+        return None
+    return (
+        f"00-{span_context.trace_id:032x}-"
+        f"{span_context.span_id:016x}-{int(span_context.trace_flags):02x}"
+    )

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -14,6 +14,7 @@ import uuid
 from typing import Any
 
 import structlog
+from opentelemetry import trace
 
 from api.agent import (
     _get_runtime,
@@ -25,6 +26,15 @@ from api.agent import (
 )
 from api import slackbot_client
 from api.harness_config import default_harness
+from api.otel import (
+    add_span_event,
+    context_from_serialized,
+    mark_error,
+    record_exception,
+    set_span_attributes,
+    span_context_to_dict,
+    start_span,
+)
 from api.observability import (
     ExecutionObservationAccumulator,
     extract_usage_metrics,
@@ -116,6 +126,8 @@ _RAW_HARNESS_AUTH_SAFE_FAILURE_MESSAGE = (
     "The agent hit a temporary runtime startup issue and could not complete the turn. "
     "Please retry in a moment."
 )
+_OTEL_METADATA_KEY = "_otel"
+_OTEL_EXECUTION_SPAN_CONTEXT_KEY = "execution_span_context"
 
 
 class ControlPlaneError(RuntimeError):
@@ -504,12 +516,34 @@ async def spawn_assignment(
             )
         return decode_jsonb(existing_idem["response_json"], {})
 
-    session = await get_or_spawn(
-        thread_key,
-        effective_harness,
-        engine=effective_engine,
-        persona=effective_persona_id,
-    )
+    with start_span(
+        "centaur.agent.spawn",
+        attributes={
+            "centaur.thread_key": thread_key,
+            "centaur.harness": effective_harness,
+            "centaur.engine": effective_engine,
+            "centaur.persona_id": effective_persona_id,
+            "centaur.spawn_id": spawn_id,
+            "centaur.assignment.attach_active": attach_active_assignment,
+        },
+    ) as span:
+        spawn_kwargs: dict[str, Any] = {"engine": effective_engine}
+        if effective_persona_id is not None:
+            spawn_kwargs["persona"] = effective_persona_id
+        session = await get_or_spawn(
+            thread_key,
+            effective_harness,
+            **spawn_kwargs,
+        )
+        set_span_attributes(
+            span,
+            {
+                "centaur.runtime_id": session.sandbox_id,
+                "centaur.trace_id": session.trace_id,
+                "centaur.engine": session.engine,
+                "centaur.harness": session.harness,
+            },
+        )
     if effective_agents_md_override is not None:
         await _write_agents_override(session.sandbox_id, effective_agents_md_override)
 
@@ -1152,6 +1186,63 @@ async def get_execution_terminal_snapshot(
 
 
 async def enqueue_execution(
+    pool,
+    *,
+    thread_key: str,
+    assignment_generation: int,
+    execute_id: str,
+    harness: str | None,
+    delivery: dict[str, Any],
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    with start_span(
+        "centaur.agent.enqueue",
+        attributes={
+            "centaur.thread_key": thread_key,
+            "centaur.assignment_generation": assignment_generation,
+            "centaur.execute_id": execute_id,
+            "centaur.harness": harness,
+            "centaur.delivery.platform": _delivery_platform(delivery),
+        },
+    ) as span:
+        span_context = span_context_to_dict(span)
+        if span_context:
+            metadata = {
+                **metadata,
+                _OTEL_METADATA_KEY: {
+                    **decode_jsonb(metadata.get(_OTEL_METADATA_KEY), {}),
+                    _OTEL_EXECUTION_SPAN_CONTEXT_KEY: span_context,
+                },
+            }
+        try:
+            result = await _enqueue_execution_impl(
+                pool,
+                thread_key=thread_key,
+                assignment_generation=assignment_generation,
+                execute_id=execute_id,
+                harness=harness,
+                delivery=delivery,
+                metadata=metadata,
+            )
+        except ControlPlaneError as exc:
+            set_span_attributes(span, {"centaur.error.code": exc.code})
+            mark_error(span, exc.message)
+            raise
+        except Exception as exc:
+            record_exception(span, exc)
+            raise
+        set_span_attributes(
+            span,
+            {
+                "centaur.execution_id": result.get("execution_id"),
+                "centaur.idempotent": bool(result.get("idempotent")),
+                "centaur.execution.status": result.get("status"),
+            },
+        )
+        return result
+
+
+async def _enqueue_execution_impl(
     pool,
     *,
     thread_key: str,
@@ -1887,6 +1978,20 @@ async def _mark_execution_terminal(
         result_size_bytes=payload_size_bytes(result_text),
         error_size_bytes=payload_size_bytes(error_text) if error_text else 0,
     )
+    add_span_event(
+        "centaur.agent.execution_completed",
+        {
+            "centaur.execution_id": execution_id,
+            "centaur.thread_key": thread_key,
+            "centaur.execution.status": status,
+            "centaur.terminal_reason": terminal_reason,
+            "centaur.execution.duration_s": round(duration_s, 3),
+            "centaur.result_size_bytes": payload_size_bytes(result_text),
+            "centaur.error_size_bytes": payload_size_bytes(error_text)
+            if error_text
+            else 0,
+        },
+    )
     record_agent_execution(harness, status, duration_s)
     record_execution_terminal(harness or "unknown", status, terminal_reason)
     suppress_final_delivery_payload = (
@@ -1962,54 +2067,64 @@ async def _mark_execution_terminal(
             )
         return
 
-    await pool.execute(
-        "INSERT INTO agent_final_delivery_outbox (execution_id, thread_key, delivery, state) "
-        "VALUES ($1, $2, $3::jsonb, 'awaiting_terminal') "
-        "ON CONFLICT (execution_id) DO NOTHING",
-        execution_id,
-        thread_key,
-        canonical_json(decode_jsonb(row["delivery"], {}) if row else {}),
-    )
-    session_header = _agent_session_header(
-        persona_id=persona_id,
-        engine=engine,
-        harness=harness,
-    )
-    await pool.execute(
-        "UPDATE agent_final_delivery_outbox SET state = 'pending', final_payload = $1::jsonb, "
-        "next_attempt_at = $2, lease_owner = NULL, lease_expires_at = NULL, updated_at = NOW() "
-        "WHERE execution_id = $3",
-        canonical_json(
-            {
-                "execution_id": execution_id,
-                "thread_key": thread_key,
-                "status": status,
-                "terminal_reason": terminal_reason,
-                "session_title": _agent_session_title(
-                    persona_id=persona_id,
-                    engine=engine,
-                    harness=harness,
-                ),
-                "session_header": session_header,
-                "result_text": result_text,
-                **({"error_text": error_text} if error_text else {}),
-                **(
-                    {"slackbot_streamed_answer_chars": slackbot_streamed_answer_chars}
-                    if slackbot_streamed_answer_chars
-                    else {}
-                ),
-                **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
-                **({"repo_context": repo_context} if repo_context else {}),
-                **(
-                    {"suppress_final_delivery": True}
-                    if suppress_final_delivery_payload
-                    else {}
-                ),
-            }
-        ),
-        next_attempt_at,
-        execution_id,
-    )
+    with start_span(
+        "centaur.final_delivery.ready",
+        attributes={
+            "centaur.execution_id": execution_id,
+            "centaur.thread_key": thread_key,
+            "centaur.delivery.platform": delivery_platform,
+            "centaur.execution.status": status,
+            "centaur.terminal_reason": terminal_reason,
+        },
+    ):
+        await pool.execute(
+            "INSERT INTO agent_final_delivery_outbox (execution_id, thread_key, delivery, state) "
+            "VALUES ($1, $2, $3::jsonb, 'awaiting_terminal') "
+            "ON CONFLICT (execution_id) DO NOTHING",
+            execution_id,
+            thread_key,
+            canonical_json(decode_jsonb(row["delivery"], {}) if row else {}),
+        )
+        session_header = _agent_session_header(
+            persona_id=persona_id,
+            engine=engine,
+            harness=harness,
+        )
+        await pool.execute(
+            "UPDATE agent_final_delivery_outbox SET state = 'pending', final_payload = $1::jsonb, "
+            "next_attempt_at = $2, lease_owner = NULL, lease_expires_at = NULL, updated_at = NOW() "
+            "WHERE execution_id = $3",
+            canonical_json(
+                {
+                    "execution_id": execution_id,
+                    "thread_key": thread_key,
+                    "status": status,
+                    "terminal_reason": terminal_reason,
+                    "session_title": _agent_session_title(
+                        persona_id=persona_id,
+                        engine=engine,
+                        harness=harness,
+                    ),
+                    "session_header": session_header,
+                    "result_text": result_text,
+                    **({"error_text": error_text} if error_text else {}),
+                    **(
+                        {"slackbot_streamed_answer_chars": slackbot_streamed_answer_chars}
+                        if slackbot_streamed_answer_chars
+                        else {}
+                    ),
+                    **({"agent_thread_id": agent_thread_id} if agent_thread_id else {}),
+                    **({"repo_context": repo_context} if repo_context else {}),
+                    **(
+                        {"suppress_final_delivery": True}
+                        if suppress_final_delivery_payload
+                        else {}
+                    ),
+                }
+            ),
+            next_attempt_at,
+            execution_id,
+        )
     await append_execution_event(
         pool,
         thread_key=thread_key,
@@ -2292,7 +2407,90 @@ async def _claim_next_execution(pool) -> dict[str, Any] | None:
 
 
 async def _process_execution(pool, row: dict[str, Any]) -> None:
-    await _process_execution_impl(pool, row)
+    execution_id = str(row["execution_id"])
+    thread_key = str(row["thread_key"])
+    assignment_generation = int(row["assignment_generation"])
+    delivery = decode_jsonb(row.get("delivery"), {})
+    metadata = decode_jsonb(row.get("metadata"), {})
+    with start_span(
+        "centaur.agent.execution",
+        parent_context=execution_span_context_from_metadata(metadata),
+        attributes={
+            "centaur.thread_key": thread_key,
+            "centaur.execution_id": execution_id,
+            "centaur.assignment_generation": assignment_generation,
+            "centaur.delivery.platform": _delivery_platform(delivery),
+            "centaur.worker_id": WORKER_INSTANCE_ID,
+            "centaur.execute_id": row.get("execute_id"),
+        },
+    ) as span:
+        span_context = span_context_to_dict(span)
+        if span_context:
+            try:
+                await _store_execution_span_context(pool, execution_id, span_context)
+            except Exception:
+                log.warning(
+                    "execution_span_context_store_failed",
+                    execution_id=execution_id,
+                    thread_key=thread_key,
+                    exc_info=True,
+                )
+        if isinstance(metadata, dict):
+            set_span_attributes(
+                span,
+                {
+                    "centaur.user_id": metadata.get("user_id"),
+                    "centaur.slackbot.live_delivery": bool(
+                        _has_slackbot_live_delivery(metadata)
+                    ),
+                },
+            )
+        try:
+            await _process_execution_impl(pool, row)
+        except Exception as exc:
+            record_exception(span, exc)
+            raise
+        finally:
+            terminal = await pool.fetchrow(
+                "SELECT status, terminal_reason, error_text FROM agent_execution_requests "
+                "WHERE execution_id = $1",
+                execution_id,
+            )
+            if terminal:
+                status = str(terminal["status"] or "")
+                terminal_reason = terminal["terminal_reason"]
+                set_span_attributes(
+                    span,
+                    {
+                        "centaur.execution.status": status,
+                        "centaur.terminal_reason": terminal_reason,
+                    },
+                )
+                if status in {"failed_permanent", "cancelled"}:
+                    mark_error(span, str(terminal_reason or terminal["error_text"] or status))
+
+
+async def _store_execution_span_context(
+    pool,
+    execution_id: str,
+    span_context: dict[str, Any],
+) -> None:
+    await pool.execute(
+        "UPDATE agent_execution_requests "
+        "SET metadata = metadata || $1::jsonb, updated_at = NOW() "
+        "WHERE execution_id = $2",
+        canonical_json({_OTEL_METADATA_KEY: {_OTEL_EXECUTION_SPAN_CONTEXT_KEY: span_context}}),
+        execution_id,
+    )
+
+
+def execution_span_context_from_metadata(metadata: dict[str, Any] | None):
+    if not isinstance(metadata, dict):
+        return None
+    otel = decode_jsonb(metadata.get(_OTEL_METADATA_KEY), {})
+    if not isinstance(otel, dict):
+        return None
+    return context_from_serialized(otel.get(_OTEL_EXECUTION_SPAN_CONTEXT_KEY))
 
 
 async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
@@ -2445,12 +2643,31 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         if isinstance(delivery, dict):
             requester_user_id = delivery.get("recipient_user_id") or delivery.get("user_id")
         requester_user_id = requester_user_id or execution_metadata.get("user_id")
-        inject_result = await inject_stdin(
-            session,
-            "",
-            platform=delivery.get("platform") if isinstance(delivery, dict) else None,
-            user_id=requester_user_id,
-        )
+        with start_span(
+            "centaur.sandbox.inject",
+            attributes={
+                "centaur.execution_id": execution_id,
+                "centaur.thread_key": thread_key,
+                "centaur.runtime_id": session.sandbox_id,
+                "centaur.delivery.platform": delivery.get("platform")
+                if isinstance(delivery, dict)
+                else None,
+                "centaur.user_id": requester_user_id,
+            },
+        ) as span:
+            inject_result = await inject_stdin(
+                session,
+                "",
+                platform=delivery.get("platform") if isinstance(delivery, dict) else None,
+                user_id=requester_user_id,
+            )
+            set_span_attributes(
+                span,
+                {
+                    "centaur.durable_turn_id": inject_result.get("durable_turn_id"),
+                    "centaur.sandbox.injected": bool(inject_result.get("injected")),
+                },
+            )
         durable_turn_id = str(inject_result.get("durable_turn_id") or "")
         await pool.execute(
             "UPDATE agent_execution_requests SET durable_turn_id = $1, updated_at = NOW() "
@@ -2628,6 +2845,20 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         event_kind="execution_started",
         event_json=execution_started_payload,
     )
+    set_span_attributes(
+        trace.get_current_span(),
+        {
+            "centaur.harness": harness,
+            "centaur.engine": engine,
+            "centaur.persona_id": persona_id,
+            "centaur.runtime_id": session.sandbox_id,
+            "centaur.prompt_ref": prompt_ref,
+            "centaur.prompt_sha": prompt_sha,
+            "centaur.execution_sequence": execution_sequence,
+            "centaur.user_id": user_id,
+        },
+    )
+    add_span_event("centaur.agent.execution_started", execution_started_payload)
     log.info("execute_started", **execution_started_payload)
     await _touch_execution_progress(pool, execution_id)
 
@@ -2714,6 +2945,14 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 continue
             if payload.get("session_id"):
                 harness_thread_id = str(payload.get("session_id") or "")
+                add_span_event(
+                    "centaur.harness.session",
+                    {
+                        "centaur.execution_id": execution_id,
+                        "centaur.thread_key": thread_key,
+                        "centaur.harness_thread_id": harness_thread_id,
+                    },
+                )
             canonical_events = normalize_harness_event(engine, payload)
             for canonical_event in canonical_events:
                 if canonical_event.get("type") != "result":
@@ -2829,6 +3068,19 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                         event_json=observation_payload,
                     )
                     log.info(event_kind, **observation_payload)
+                    add_span_event(
+                        f"centaur.observation.{event_kind}",
+                        {
+                            "centaur.execution_id": execution_id,
+                            "centaur.thread_key": thread_key,
+                            "centaur.event_kind": event_kind,
+                            "centaur.tool.name": observation_payload.get("tool_name"),
+                            "centaur.model": observation_payload.get("model"),
+                            "centaur.error_category": observation_payload.get(
+                                "error_category"
+                            ),
+                        },
+                    )
                     was_first_token = not observations.first_token_seen
                     observations.observe(event_kind, observation_payload)
                     if was_first_token and observations.first_token_seen:

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -28,6 +28,13 @@ from fastapi.responses import PlainTextResponse
 from toon_format import encode as toon_encode
 
 from api.api_keys import check_scope
+from api.otel import (
+    context_from_serialized,
+    mark_error,
+    record_exception,
+    set_span_attributes,
+    start_span,
+)
 from api.vm_metrics import record_tool_call
 from api.deps import get_key_info, get_sandbox_claims, verify_api_key
 from api import slackbot_client
@@ -905,6 +912,48 @@ def _resolve_timeout_s(tool_conf: dict[str, Any], *, tool: str) -> float | None:
 
 def _timeout_label(timeout_s: float | None) -> str:
     return "no timeout" if timeout_s is None else f"{timeout_s:g}s"
+
+
+def _decode_jsonb(value: Any, fallback: Any) -> Any:
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return fallback
+    return fallback
+
+
+async def _active_execution_parent_context(
+    request: Request | None,
+    sandbox_claims: dict[str, Any] | None,
+):
+    if request is None or not sandbox_claims:
+        return None
+    thread_key = str(sandbox_claims.get("thread_key") or "")
+    if not thread_key:
+        return None
+    pool = getattr(getattr(request, "app", None), "state", None)
+    pool = getattr(pool, "db_pool", None) if pool else None
+    if pool is None:
+        return None
+    row = await pool.fetchrow(
+        "SELECT metadata FROM agent_execution_requests "
+        "WHERE thread_key = $1 AND status IN ('running', 'cancel_requested', 'retry_wait') "
+        "ORDER BY started_at DESC NULLS LAST, claimed_at DESC NULLS LAST, created_at DESC "
+        "LIMIT 1",
+        thread_key,
+    )
+    if not row:
+        return None
+    metadata = _decode_jsonb(row["metadata"], {})
+    if not isinstance(metadata, dict):
+        return None
+    otel = _decode_jsonb(metadata.get("_otel"), {})
+    if not isinstance(otel, dict):
+        return None
+    return context_from_serialized(otel.get("execution_span_context"))
 
 
 async def _capture_live_slack_send(
@@ -1995,63 +2044,95 @@ class ToolManager:
                 else {}
             ),
         }
-        t0 = time.monotonic()
-        log.info("tool_call_started", **call_fields)
-        captured_slack_send = await _capture_live_slack_send(
-            request=request,
-            sandbox_claims=sandbox_claims,
-            tool_name=tool_name,
-            method_name=method_name,
-            args=args,
-        )
-        if captured_slack_send is not None:
-            duration_ms = round((time.monotonic() - t0) * 1000)
-            log.info(
-                "tool_call_completed",
-                duration_ms=duration_ms,
-                success=True,
-                result_size_bytes=_payload_size_bytes(captured_slack_send),
-                captured=True,
-                **call_fields,
+        parent_context = await _active_execution_parent_context(request, sandbox_claims)
+        with start_span(
+            "centaur.tool.call",
+            parent_context=parent_context,
+            attributes={
+                "centaur.tool.name": tool_name,
+                "centaur.tool.method": method_name,
+                "centaur.thread_key": call_fields.get("thread_key"),
+                "centaur.sandbox_container_id": call_fields.get("sandbox_container_id"),
+                "centaur.tool.arg_keys": call_fields["arg_keys"],
+                "centaur.tool.arg_size_bytes": call_fields["arg_size_bytes"],
+            },
+        ) as span:
+            t0 = time.monotonic()
+            log.info("tool_call_started", **call_fields)
+            captured_slack_send = await _capture_live_slack_send(
+                request=request,
+                sandbox_claims=sandbox_claims,
+                tool_name=tool_name,
+                method_name=method_name,
+                args=args,
             )
-            record_tool_call(tool_name, method_name, True, duration_ms / 1000)
-            if format == "toon":
-                return _to_toon(captured_slack_send)
-            return _normalize_for_serialization(captured_slack_send)
-        validation_error = _tool_arg_validation_error(method, args)
-        if validation_error is not None:
-            log.warning(
-                "tool_argument_validation_failed",
-                error=validation_error["message"],
-                **call_fields,
-            )
-            return json.dumps(validation_error)
-
-        # Resolve placeholder secrets for tools that declare them. Required
-        # secrets gate availability elsewhere; optional secrets should still be
-        # present in ToolContext when declared so tool code can choose to use
-        # them.
-        ctx = lt.ctx
-        all_secrets = lt.all_secrets
-        if all_secrets:
-            resolved = await _resolve_secrets(all_secrets)
-            log.info(
-                "tool_secrets_resolved",
-                tool=tool_name,
-                keys=list(resolved.keys()),
-                declared=[s.name for s in all_secrets],
-            )
-            if resolved:
-                ctx = ToolContext(
-                    name=lt.name,
-                    secrets={**lt.ctx.secrets, **resolved},
-                    thread_key=sandbox_claims.get("thread_key")
-                    if sandbox_claims
-                    else None,
-                    container_id=sandbox_claims.get("container_id")
-                    if sandbox_claims
-                    else None,
+            if captured_slack_send is not None:
+                duration_ms = round((time.monotonic() - t0) * 1000)
+                set_span_attributes(
+                    span,
+                    {
+                        "centaur.tool.duration_ms": duration_ms,
+                        "centaur.tool.success": True,
+                        "centaur.tool.captured": True,
+                        "centaur.tool.result_size_bytes": _payload_size_bytes(
+                            captured_slack_send
+                        ),
+                    },
                 )
+                log.info(
+                    "tool_call_completed",
+                    duration_ms=duration_ms,
+                    success=True,
+                    result_size_bytes=_payload_size_bytes(captured_slack_send),
+                    captured=True,
+                    **call_fields,
+                )
+                record_tool_call(tool_name, method_name, True, duration_ms / 1000)
+                if format == "toon":
+                    return _to_toon(captured_slack_send)
+                return _normalize_for_serialization(captured_slack_send)
+            validation_error = _tool_arg_validation_error(method, args)
+            if validation_error is not None:
+                mark_error(span, validation_error["message"])
+                log.warning(
+                    "tool_argument_validation_failed",
+                    error=validation_error["message"],
+                    **call_fields,
+                )
+                return json.dumps(validation_error)
+
+            # Resolve placeholder secrets for tools that declare them. Required
+            # secrets gate availability elsewhere; optional secrets should still be
+            # present in ToolContext when declared so tool code can choose to use
+            # them.
+            ctx = lt.ctx
+            all_secrets = lt.all_secrets
+            if all_secrets:
+                resolved = await _resolve_secrets(all_secrets)
+                log.info(
+                    "tool_secrets_resolved",
+                    tool=tool_name,
+                    keys=list(resolved.keys()),
+                    declared=[s.name for s in all_secrets],
+                )
+                if resolved:
+                    ctx = ToolContext(
+                        name=lt.name,
+                        secrets={**lt.ctx.secrets, **resolved},
+                        thread_key=sandbox_claims.get("thread_key")
+                        if sandbox_claims
+                        else None,
+                        container_id=sandbox_claims.get("container_id")
+                        if sandbox_claims
+                        else None,
+                    )
+                elif sandbox_claims:
+                    ctx = ToolContext(
+                        name=lt.name,
+                        secrets=dict(lt.ctx.secrets),
+                        thread_key=sandbox_claims.get("thread_key"),
+                        container_id=sandbox_claims.get("container_id"),
+                    )
             elif sandbox_claims:
                 ctx = ToolContext(
                     name=lt.name,
@@ -2059,65 +2140,76 @@ class ToolManager:
                     thread_key=sandbox_claims.get("thread_key"),
                     container_id=sandbox_claims.get("container_id"),
                 )
-        elif sandbox_claims:
-            ctx = ToolContext(
-                name=lt.name,
-                secrets=dict(lt.ctx.secrets),
-                thread_key=sandbox_claims.get("thread_key"),
-                container_id=sandbox_claims.get("container_id"),
-            )
 
-        token = set_tool_context(ctx)
-        try:
-            if inspect.iscoroutinefunction(method.fn):
-                coro = method.fn(**args)
-            else:
-                coro = asyncio.to_thread(method.fn, **args)
-            result = await asyncio.wait_for(coro, timeout=lt.timeout_s)
-            duration_ms = round((time.monotonic() - t0) * 1000)
-            log.info(
-                "tool_call_completed",
-                duration_ms=duration_ms,
-                success=True,
-                result_size_bytes=_payload_size_bytes(result),
-                **call_fields,
-            )
-            record_tool_call(tool_name, method_name, True, duration_ms / 1000)
-            if isinstance(result, dict):
-                thread_key = (
-                    sandbox_claims.get("thread_key") if sandbox_claims else None
+            token = set_tool_context(ctx)
+            try:
+                if inspect.iscoroutinefunction(method.fn):
+                    coro = method.fn(**args)
+                else:
+                    coro = asyncio.to_thread(method.fn, **args)
+                result = await asyncio.wait_for(coro, timeout=lt.timeout_s)
+                duration_ms = round((time.monotonic() - t0) * 1000)
+                result_size_bytes = _payload_size_bytes(result)
+                set_span_attributes(
+                    span,
+                    {
+                        "centaur.tool.duration_ms": duration_ms,
+                        "centaur.tool.success": True,
+                        "centaur.tool.result_size_bytes": result_size_bytes,
+                    },
                 )
-                result = await _extract_tool_attachment(
-                    result,
-                    request=request,
-                    thread_key=thread_key,
-                    tool_name=tool_name,
+                log.info(
+                    "tool_call_completed",
+                    duration_ms=duration_ms,
+                    success=True,
+                    result_size_bytes=result_size_bytes,
+                    **call_fields,
                 )
-            if format == "toon":
-                return result if isinstance(result, str) else _to_toon(result)
-            return _normalize_for_serialization(result)
-        except (SystemExit, Exception) as e:
-            duration_ms = round((time.monotonic() - t0) * 1000)
-            if isinstance(e, asyncio.TimeoutError):
-                error_msg = f"Tool call timed out after {_timeout_label(lt.timeout_s)}"
-            elif isinstance(e, SystemExit):
-                error_msg = f"sys.exit({e.code})"
-            else:
-                error_msg = str(e)
-            log.warning(
-                "tool_call_completed",
-                duration_ms=duration_ms,
-                success=False,
-                error=error_msg,
-                error_type=type(e).__name__,
-                **call_fields,
-            )
-            record_tool_call(tool_name, method_name, False, duration_ms / 1000)
-            return json.dumps(
-                {"error": error_msg, "tool": tool_name, "method": method_name}
-            )
-        finally:
-            reset_tool_context(token)
+                record_tool_call(tool_name, method_name, True, duration_ms / 1000)
+                if isinstance(result, dict):
+                    thread_key = (
+                        sandbox_claims.get("thread_key") if sandbox_claims else None
+                    )
+                    result = await _extract_tool_attachment(
+                        result,
+                        request=request,
+                        thread_key=thread_key,
+                        tool_name=tool_name,
+                    )
+                if format == "toon":
+                    return result if isinstance(result, str) else _to_toon(result)
+                return _normalize_for_serialization(result)
+            except (SystemExit, Exception) as e:
+                duration_ms = round((time.monotonic() - t0) * 1000)
+                if isinstance(e, asyncio.TimeoutError):
+                    error_msg = f"Tool call timed out after {_timeout_label(lt.timeout_s)}"
+                elif isinstance(e, SystemExit):
+                    error_msg = f"sys.exit({e.code})"
+                else:
+                    error_msg = str(e)
+                set_span_attributes(
+                    span,
+                    {
+                        "centaur.tool.duration_ms": duration_ms,
+                        "centaur.tool.success": False,
+                        "error.type": type(e).__name__,
+                    },
+                )
+                record_exception(span, e)
+                log.warning(
+                    "tool_call_completed",
+                    duration_ms=duration_ms,
+                    success=False,
+                    error=error_msg,
+                    error_type=type(e).__name__,
+                    **call_fields,
+                )
+                record_tool_call(tool_name, method_name, False, duration_ms / 1000)
+                return json.dumps(
+                    {"error": error_msg, "tool": tool_name, "method": method_name}
+                )
+            finally:
+                reset_tool_context(token)
 
     def create_rest_router(self) -> APIRouter:
         """Create a stable FastAPI router that dispatches to tools via live lookup.

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -35,6 +35,13 @@ import structlog
 from api.agent import _insert_system_message
 from api import slackbot_client
 from api.harness_config import default_harness
+from api.otel import (
+    add_span_event,
+    mark_error,
+    record_exception,
+    set_span_attributes,
+    start_span,
+)
 from api.runtime_control import (
     ControlPlaneError,
     append_message,
@@ -352,6 +359,14 @@ class WorkflowContext:
         checkpoint_name = self._resolve_name(name)
         if checkpoint_name in self._checkpoints:
             cached = self._checkpoints[checkpoint_name]
+            add_span_event(
+                "centaur.workflow.step_replayed",
+                {
+                    "centaur.workflow.run_id": self.run_id,
+                    "centaur.workflow.step": checkpoint_name,
+                    "centaur.workflow.step_kind": step_kind,
+                },
+            )
             return cached  # type: ignore[return-value]
 
         self._in_replay = False
@@ -359,42 +374,63 @@ class WorkflowContext:
         max_attempts = 1 + (retry.limit if retry else 0)
         last_err: Exception | None = None
 
-        for attempt in range(max_attempts):
-            try:
-                if timeout is not None:
-                    result = await asyncio.wait_for(
-                        self._call_step_fn(fn), timeout.total_seconds(),
+        with start_span(
+            "centaur.workflow.step",
+            attributes={
+                "centaur.workflow.run_id": self.run_id,
+                "centaur.workflow.step": checkpoint_name,
+                "centaur.workflow.step_kind": step_kind,
+                "centaur.workflow.replay": False,
+                "centaur.workflow.retry_limit": retry.limit if retry else 0,
+            },
+        ) as span:
+            for attempt in range(max_attempts):
+                set_span_attributes(span, {"centaur.workflow.step_attempt": attempt + 1})
+                try:
+                    if timeout is not None:
+                        result = await asyncio.wait_for(
+                            self._call_step_fn(fn), timeout.total_seconds(),
+                        )
+                    else:
+                        result = await self._call_step_fn(fn)
+
+                    eid = execution_id
+                    cid = child_run_id
+                    if eid is None and step_kind == "agent_turn" and isinstance(result, dict):
+                        eid = result.get("execution_id")
+                    if cid is None and step_kind == "child_workflow_start" and isinstance(result, dict):
+                        cid = result.get("run_id")
+
+                    await self._persist_checkpoint(
+                        checkpoint_name, result, step_kind=step_kind,
+                        execution_id=eid,
+                        child_run_id=cid,
                     )
-                else:
-                    result = await self._call_step_fn(fn)
+                    set_span_attributes(
+                        span,
+                        {
+                            "centaur.execution_id": eid,
+                            "centaur.workflow.child_run_id": cid,
+                            "centaur.workflow.step.success": True,
+                        },
+                    )
+                    return result  # type: ignore[return-value]
 
-                eid = execution_id
-                cid = child_run_id
-                if eid is None and step_kind == "agent_turn" and isinstance(result, dict):
-                    eid = result.get("execution_id")
-                if cid is None and step_kind == "child_workflow_start" and isinstance(result, dict):
-                    cid = result.get("run_id")
-
-                await self._persist_checkpoint(
-                    checkpoint_name, result, step_kind=step_kind,
-                    execution_id=eid,
-                    child_run_id=cid,
-                )
-                return result  # type: ignore[return-value]
-
-            except NonRetryableError:
-                raise
-            except CancelledWorkflow:
-                raise
-            except SuspendWorkflow:
-                raise
-            except Exception as err:
-                last_err = err
-                if attempt + 1 >= max_attempts:
-                    break
-                delay = retry.delay_for_attempt(attempt) if retry else 0.0
-                if delay > 0:
-                    await asyncio.sleep(delay)
+                except NonRetryableError as err:
+                    record_exception(span, err)
+                    raise
+                except CancelledWorkflow:
+                    raise
+                except SuspendWorkflow:
+                    raise
+                except Exception as err:
+                    last_err = err
+                    if attempt + 1 >= max_attempts:
+                        record_exception(span, err)
+                        break
+                    delay = retry.delay_for_attempt(attempt) if retry else 0.0
+                    if delay > 0:
+                        await asyncio.sleep(delay)
 
         raise last_err  # type: ignore[misc]
 
@@ -2418,6 +2454,17 @@ async def _run_handler(pool, run_row: dict[str, Any]) -> None:
         ),
         name=f"workflow-lease-{run_id}",
     )
+    span_cm = start_span(
+        "centaur.workflow.run",
+        attributes={
+            "centaur.workflow.run_id": run_id,
+            "centaur.workflow.name": workflow_name,
+            "centaur.workflow.worker_id": worker_id,
+            "centaur.workflow.queue_delay_s": round(queue_delay, 3),
+            "centaur.thread_key": run_input.get("thread_key"),
+        },
+    )
+    span = span_cm.__enter__()
 
     try:
         result = await registered.handler(params, ctx)
@@ -2444,6 +2491,13 @@ async def _run_handler(pool, run_row: dict[str, Any]) -> None:
             )
             return
         _duration = time.monotonic() - _start
+        set_span_attributes(
+            span,
+            {
+                "centaur.workflow.status": "completed",
+                "centaur.workflow.duration_s": _duration,
+            },
+        )
         record_workflow_run_terminal(workflow_name, "completed", _duration)
         await notify_workflow_run_terminal(pool, run_id)
         log.info(
@@ -2491,6 +2545,13 @@ async def _run_handler(pool, run_row: dict[str, Any]) -> None:
                 state=exc.status,
             )
             return
+        set_span_attributes(
+            span,
+            {
+                "centaur.workflow.status": exc.status,
+                "centaur.workflow.available_at": available_at.isoformat(),
+            },
+        )
         log.info(
             "workflow_run_suspended",
             run_id=run_id,
@@ -2520,6 +2581,14 @@ async def _run_handler(pool, run_row: dict[str, Any]) -> None:
             )
             return
         _duration = time.monotonic() - _start
+        set_span_attributes(
+            span,
+            {
+                "centaur.workflow.status": "cancelled",
+                "centaur.workflow.duration_s": _duration,
+            },
+        )
+        mark_error(span, "workflow cancelled")
         record_workflow_run_terminal(workflow_name, "cancelled", _duration)
         await notify_workflow_run_terminal(pool, run_id)
         log.info(
@@ -2546,6 +2615,15 @@ async def _run_handler(pool, run_row: dict[str, Any]) -> None:
         )
         if _command_updated(updated):
             _duration = time.monotonic() - _start
+            set_span_attributes(
+                span,
+                {
+                    "centaur.workflow.status": "failed",
+                    "centaur.workflow.duration_s": _duration,
+                    "centaur.error.code": exc.code,
+                },
+            )
+            mark_error(span, exc.message)
             record_workflow_run_terminal(workflow_name, "failed", _duration)
             await notify_workflow_run_terminal(pool, run_id)
             log.warning(
@@ -2564,6 +2642,7 @@ async def _run_handler(pool, run_row: dict[str, Any]) -> None:
             )
 
     except Exception as exc:
+        record_exception(span, exc)
         log.warning(
             "workflow_run_failed",
             run_id=run_id,
@@ -2585,6 +2664,13 @@ async def _run_handler(pool, run_row: dict[str, Any]) -> None:
         )
         if _command_updated(updated):
             _duration = time.monotonic() - _start
+            set_span_attributes(
+                span,
+                {
+                    "centaur.workflow.status": "failed",
+                    "centaur.workflow.duration_s": _duration,
+                },
+            )
             record_workflow_run_terminal(workflow_name, "failed", _duration)
             await notify_workflow_run_terminal(pool, run_id)
         else:
@@ -2599,6 +2685,7 @@ async def _run_handler(pool, run_row: dict[str, Any]) -> None:
         heartbeat_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await heartbeat_task
+        span_cm.__exit__(None, None, None)
 
 
 # ── Scheduler ─────────────────────────────────────────────────────────

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -24,6 +24,12 @@ dependencies = [
     "sse-starlette>=3.2.0",
     "croniter>=6.2.2",
     "feedparser>=6.0.0",
+    "opentelemetry-api>=1.42.1",
+    "opentelemetry-sdk>=1.42.1",
+    "opentelemetry-exporter-otlp-proto-http>=1.42.1",
+    "opentelemetry-instrumentation-fastapi>=0.63b1",
+    "opentelemetry-instrumentation-httpx>=0.63b1",
+    "opentelemetry-instrumentation-asyncpg>=0.63b1",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary

Adds opt-in OTLP tracing for the Centaur API and instruments the main control-plane surfaces:

- HTTP request middleware with thread trace correlation
- spawn/message/execute runtime-control spans
- execution worker spans, including sandbox injection and terminal status
- tool call spans parented to the active execution
- workflow run and step spans

Also keeps asyncpg auto-instrumentation disabled by default so traces are not dominated by low-value `SELECT` / `UPDATE` / transaction spans. DB spans can be enabled explicitly with `OTEL_INSTRUMENT_ASYNCPG=1` for deep debugging.

## Notes

The implementation avoids manufacturing non-exported parent spans from `thread_traces.trace_id`; that produced exported traces with missing roots and empty tree views. Background execution now uses the stored enqueue span context as its parent.

## Verification

- `uv run ruff check services/api/api/app.py services/api/api/runtime_control.py services/api/api/tool_manager.py services/api/api/workflow_engine.py services/api/api/otel.py`
- `just build-one api`
- Local Helm deploy with OTLP env pointed at a local collector
- Full local smoke test: `spawn -> message -> execute -> completed`, result `PONG`
- Verified exported smoke traces in the trace store had valid roots and `missing_parents = 0`
