### PR TITLE
feat: export Codex OTLP traces

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -1409,6 +1409,8 @@ async def inject_stdin(
     *,
     platform: str | None = None,
     user_id: str | None = None,
+    trace_id: str | None = None,
+    traceparent: str | None = None,
 ) -> dict:
     """Flush pending messages + write to stdin. Does not touch stdout.
 
@@ -1438,17 +1440,26 @@ async def inject_stdin(
         msgs = _flushed_to_messages(flushed)
         content_blocks = messages_to_content_blocks(msgs) + inline_blocks
         turn_input = build_user_input(
-            content_blocks, thread_key=session.thread_key, trace_id=session.trace_id
+            content_blocks,
+            thread_key=session.thread_key,
+            trace_id=trace_id or session.trace_id,
+            traceparent=traceparent,
         )
     elif flushed:
         msgs = _flushed_to_messages(flushed)
         content_blocks = messages_to_content_blocks(msgs)
         turn_input = build_user_input(
-            content_blocks, thread_key=session.thread_key, trace_id=session.trace_id
+            content_blocks,
+            thread_key=session.thread_key,
+            trace_id=trace_id or session.trace_id,
+            traceparent=traceparent,
         )
     elif inline_blocks:
         turn_input = build_user_input(
-            inline_blocks, thread_key=session.thread_key, trace_id=session.trace_id
+            inline_blocks,
+            thread_key=session.thread_key,
+            trace_id=trace_id or session.trace_id,
+            traceparent=traceparent,
         )
     else:
         return {"ok": True, "injected": False}

--- a/services/api/api/app.py
+++ b/services/api/api/app.py
@@ -22,15 +22,16 @@ from api.db import close_pool, create_pool
 from api.logging_config import configure_structlog
 from api.otel import (
     configure_otel,
+    context_from_serialized,
     context_from_headers,
     current_traceparent,
     mark_error,
     record_exception,
     set_span_attributes,
+    span_context_to_dict,
     start_span,
 )
 from api.retention import start_retention_sweeper, stop_retention_sweeper
-from api.trace_context import get_or_create_thread_trace_id, traceparent_from_trace_id
 from api.vm_metrics import (
     HTTP_REQUESTS_IN_PROGRESS,
     observe_http_request,
@@ -333,10 +334,17 @@ async def instrument_requests(request, call_next):
         except Exception:
             pass
 
+    thread_trace_root_span_id = None
     if not trace_id and thread_key:
         try:
-            trace_id = await get_or_create_thread_trace_id(request.app.state.db_pool, thread_key)
-            if trace_id:
+            row = await request.app.state.db_pool.fetchrow(
+                "SELECT trace_id::text AS trace_id, root_span_id FROM thread_traces "
+                "WHERE thread_key = $1",
+                thread_key,
+            )
+            if row:
+                trace_id = row["trace_id"]
+                thread_trace_root_span_id = row["root_span_id"]
                 structlog.contextvars.bind_contextvars(trace_id=trace_id)
         except Exception:
             log.debug("thread_trace_lookup_failed", thread_key=thread_key, exc_info=True)
@@ -344,6 +352,15 @@ async def instrument_requests(request, call_next):
     route = request.scope.get("route")
     path = getattr(route, "path", None) or request.url.path
     parent_context = context_from_headers(request.headers)
+    incoming_traceparent = request.headers.get("traceparent")
+    if trace_id and thread_trace_root_span_id and not incoming_traceparent:
+        parent_context = context_from_serialized(
+            {
+                "trace_id": trace_id.replace("-", ""),
+                "span_id": thread_trace_root_span_id,
+                "trace_flags": 1,
+            }
+        )
 
     start = time.perf_counter()
     status_code = 500
@@ -360,6 +377,29 @@ async def instrument_requests(request, call_next):
                 "client.address": request.client.host if request.client else None,
             },
         ) as span:
+            span_context = span_context_to_dict(span)
+            if thread_key and span_context and not thread_trace_root_span_id:
+                trace_id = span_context["trace_id"]
+                try:
+                    await request.app.state.db_pool.execute(
+                        "INSERT INTO thread_traces (thread_key, trace_id, root_span_id) "
+                        "VALUES ($1, $2, $3) "
+                        "ON CONFLICT (thread_key) DO UPDATE SET "
+                        "trace_id = EXCLUDED.trace_id, "
+                        "root_span_id = COALESCE(thread_traces.root_span_id, EXCLUDED.root_span_id), "
+                        "updated_at = NOW()",
+                        thread_key,
+                        trace_id,
+                        span_context["span_id"],
+                    )
+                    thread_trace_root_span_id = span_context["span_id"]
+                    structlog.contextvars.bind_contextvars(trace_id=trace_id)
+                except Exception:
+                    log.debug(
+                        "thread_trace_root_store_failed",
+                        thread_key=thread_key,
+                        exc_info=True,
+                    )
             try:
                 response = await call_next(request)
             except Exception as exc:
@@ -378,7 +418,7 @@ async def instrument_requests(request, call_next):
                 mark_error(span, f"HTTP {status_code}")
             if trace_id:
                 response.headers["X-Trace-Id"] = trace_id
-                traceparent = current_traceparent(span) or traceparent_from_trace_id(trace_id)
+                traceparent = current_traceparent(span)
                 if traceparent:
                     response.headers["traceparent"] = traceparent
             return response

--- a/services/api/api/otel.py
+++ b/services/api/api/otel.py
@@ -225,5 +225,5 @@ def current_traceparent(span: Span | None = None) -> str | None:
         return None
     return (
         f"00-{span_context.trace_id:032x}-"
-        f"{span_context.span_id:016x}-{int(span_context.trace_flags):02x}"
+        f"{span_context.span_id:016x}-{int(span_context.trace_flags) & 0x01:02x}"
     )

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -29,6 +29,7 @@ from api.harness_config import default_harness
 from api.otel import (
     add_span_event,
     context_from_serialized,
+    current_traceparent,
     mark_error,
     record_exception,
     set_span_attributes,
@@ -2458,6 +2459,17 @@ async def _process_execution(pool, row: dict[str, Any]) -> None:
                     ),
                 },
             )
+        input_text = await _execution_input_text(
+            pool, execution_id, thread_key, assignment_generation
+        )
+        if input_text:
+            clipped_input = _clip_slackbot(input_text)
+            set_span_attributes(
+                span,
+                {
+                    "centaur.llm.input": clipped_input,
+                },
+            )
         try:
             await _process_execution_impl(pool, row)
         except Exception as exc:
@@ -2465,7 +2477,7 @@ async def _process_execution(pool, row: dict[str, Any]) -> None:
             raise
         finally:
             terminal = await pool.fetchrow(
-                "SELECT status, terminal_reason, error_text FROM agent_execution_requests "
+                "SELECT status, terminal_reason, result_text, error_text FROM agent_execution_requests "
                 "WHERE execution_id = $1",
                 execution_id,
             )
@@ -2479,8 +2491,47 @@ async def _process_execution(pool, row: dict[str, Any]) -> None:
                         "centaur.terminal_reason": terminal_reason,
                     },
                 )
+                result_text = terminal["result_text"]
+                if result_text:
+                    clipped_output = _clip_slackbot(result_text)
+                    set_span_attributes(
+                        span,
+                        {
+                            "centaur.llm.output": clipped_output,
+                        },
+                    )
                 if status in {"failed_permanent", "cancelled"}:
                     mark_error(span, str(terminal_reason or terminal["error_text"] or status))
+
+
+async def _execution_input_text(
+    pool,
+    execution_id: str,
+    thread_key: str,
+    assignment_generation: int,
+) -> str:
+    rows = await pool.fetch(
+        "SELECT event_json FROM agent_message_requests "
+        "WHERE delivered_execution_id = $1 "
+        "OR (thread_key = $2 AND assignment_generation = $3 AND delivered_execution_id IS NULL) "
+        "ORDER BY created_at, message_id",
+        execution_id,
+        thread_key,
+        assignment_generation,
+    )
+    texts: list[str] = []
+    for row in rows:
+        event = decode_jsonb(row["event_json"], {})
+        message = event.get("message") if isinstance(event, dict) else None
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = str(block.get("text") or "").strip()
+                if text:
+                    texts.append(text)
+    return "\n\n".join(texts)
 
 
 async def _store_execution_span_context(
@@ -2668,11 +2719,14 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 "centaur.user_id": requester_user_id,
             },
         ) as span:
+            inject_span_context = span_context_to_dict(span) or {}
             inject_result = await inject_stdin(
                 session,
                 "",
                 platform=delivery.get("platform") if isinstance(delivery, dict) else None,
                 user_id=requester_user_id,
+                trace_id=inject_span_context.get("trace_id"),
+                traceparent=current_traceparent(span),
             )
             set_span_attributes(
                 span,

--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -22,7 +22,15 @@ _HARNESS_STUB_KEYS = (
 )
 
 _SANDBOX_PASSTHROUGH_ENV_KEYS = (
+    "CODEX_OTEL_AUTHORIZATION",
     "CODEX_OTEL_ENVIRONMENT",
+    "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
+    "CODEX_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "CODEX_OTEL_LAMINAR_BASE_URL",
+    "CODEX_OTEL_LAMINAR_ENDPOINT",
+    "CODEX_OTEL_SPAN_PREFIX",
+    "LMNR_BASE_URL",
+    "LMNR_PROJECT_API_KEY",
 )
 
 # Keep Claude Code deterministic in the pod while still allowing Centaur-owned
@@ -72,6 +80,23 @@ def _sandbox_extra_env() -> list[tuple[str, str]]:
     return extra
 
 
+def _sandbox_otel_endpoint_hosts(extra_env: list[tuple[str, str]]) -> list[str]:
+    extra = dict(extra_env)
+    hosts: list[str] = []
+    for key in (
+        "CODEX_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
+        "CODEX_OTEL_LAMINAR_ENDPOINT",
+        "CODEX_OTEL_LAMINAR_BASE_URL",
+        "LMNR_BASE_URL",
+    ):
+        value = (os.getenv(key) or extra.get(key) or "").strip()
+        host = urlsplit(value).hostname
+        if host:
+            hosts.append(host)
+    return hosts
+
+
 def amp_mode() -> str:
     return (os.getenv("AMP_MODE") or "deep").strip() or "deep"
 
@@ -110,6 +135,7 @@ def container_env(
     """
     api_key = mint_sandbox_token(thread_key, container_name)
     api_url = os.getenv("AGENT_API_URL", "http://api:8000")
+    extra_env = _sandbox_extra_env()
 
     env = [
         f"CENTAUR_API_URL={api_url}",
@@ -128,6 +154,7 @@ def container_env(
     api_host = urlsplit(api_url).hostname
     if api_host:
         no_proxy_hosts.append(api_host)
+    no_proxy_hosts.extend(_sandbox_otel_endpoint_hosts(extra_env))
     no_proxy = ",".join(dict.fromkeys(no_proxy_hosts))
     # Placeholder values for harness infra secrets. iron-proxy MITMs the
     # outbound TLS connection and rewrites these strings in auth headers
@@ -160,7 +187,7 @@ def container_env(
         for name, dsn in pg_dsns.items():
             env.append(f"{name}={dsn}")
 
-    for name, value in _sandbox_extra_env():
+    for name, value in extra_env:
         _set_env(env, name, value)
 
     return env

--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -22,11 +22,10 @@ _HARNESS_STUB_KEYS = (
 )
 
 _SANDBOX_PASSTHROUGH_ENV_KEYS = (
-    "CODEX_OTEL_AUTHORIZATION",
-    "CODEX_OTEL_ENVIRONMENT",
-    "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
-    "CODEX_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-    "CODEX_OTEL_SPAN_PREFIX",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_RESOURCE_ATTRIBUTES",
 )
 
 # Keep Claude Code deterministic in the pod while still allowing Centaur-owned
@@ -80,8 +79,8 @@ def _sandbox_otel_endpoint_hosts(extra_env: list[tuple[str, str]]) -> list[str]:
     extra = dict(extra_env)
     hosts: list[str] = []
     for key in (
-        "CODEX_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-        "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
     ):
         value = (os.getenv(key) or extra.get(key) or "").strip()
         host = urlsplit(value).hostname

--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -26,11 +26,7 @@ _SANDBOX_PASSTHROUGH_ENV_KEYS = (
     "CODEX_OTEL_ENVIRONMENT",
     "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
     "CODEX_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-    "CODEX_OTEL_LAMINAR_BASE_URL",
-    "CODEX_OTEL_LAMINAR_ENDPOINT",
     "CODEX_OTEL_SPAN_PREFIX",
-    "LMNR_BASE_URL",
-    "LMNR_PROJECT_API_KEY",
 )
 
 # Keep Claude Code deterministic in the pod while still allowing Centaur-owned
@@ -86,9 +82,6 @@ def _sandbox_otel_endpoint_hosts(extra_env: list[tuple[str, str]]) -> list[str]:
     for key in (
         "CODEX_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
         "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
-        "CODEX_OTEL_LAMINAR_ENDPOINT",
-        "CODEX_OTEL_LAMINAR_BASE_URL",
-        "LMNR_BASE_URL",
     ):
         value = (os.getenv(key) or extra.get(key) or "").strip()
         host = urlsplit(value).hostname

--- a/services/api/api/sandbox/harness_protocol.py
+++ b/services/api/api/sandbox/harness_protocol.py
@@ -134,6 +134,7 @@ def build_user_input(
     steer: bool = False,
     thread_key: str | None = None,
     trace_id: str | None = None,
+    traceparent: str | None = None,
 ) -> dict:
     """Build a harness-native user input envelope from content blocks."""
     envelope = {
@@ -149,6 +150,8 @@ def build_user_input(
         envelope["thread_key"] = thread_key
     if trace_id:
         envelope["trace_id"] = trace_id
+    if traceparent:
+        envelope["traceparent"] = traceparent
     return envelope
 
 

--- a/services/api/db/migrations/037_add_thread_trace_root_span.sql
+++ b/services/api/db/migrations/037_add_thread_trace_root_span.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE thread_traces
+    ADD COLUMN IF NOT EXISTS root_span_id TEXT;
+
+-- migrate:down
+ALTER TABLE thread_traces
+    DROP COLUMN IF EXISTS root_span_id;

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -118,9 +118,9 @@ def test_configure_codex_otel_writes_startup_config(monkeypatch, tmp_path) -> No
         )
     )
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
-    monkeypatch.setenv("CODEX_OTEL_EXPORTER_OTLP_ENDPOINT", "http://otlp-collector:4318")
-    monkeypatch.setenv("CODEX_OTEL_AUTHORIZATION", "otlp-key")
-    monkeypatch.setenv("CODEX_OTEL_ENVIRONMENT", "staging")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otlp-collector:4318")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "authorization=Bearer%20otlp-key")
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=staging")
     monkeypatch.setattr(
         wrapper,
         "start_codex_otel_prefix_proxy",
@@ -157,13 +157,13 @@ def test_configure_codex_otel_writes_startup_config(monkeypatch, tmp_path) -> No
     assert proxy_calls == [("http://otlp-collector:4318/v1/traces", "codex.")]
 
 
-def test_configure_codex_otel_ignores_generic_collector_endpoint(monkeypatch, tmp_path) -> None:
+def test_configure_codex_otel_ignores_unrelated_collector_endpoint(monkeypatch, tmp_path) -> None:
     wrapper = _load_wrapper()
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
     monkeypatch.setenv("OTLP_BASE_URL", "http://otlp-collector:4318")
-    monkeypatch.setenv("CODEX_OTEL_AUTHORIZATION", "otlp-key")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "authorization=Bearer%20otlp-key")
     monkeypatch.setattr(
         wrapper,
         "start_codex_otel_prefix_proxy",

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -118,8 +118,8 @@ def test_configure_codex_otel_writes_startup_config(monkeypatch, tmp_path) -> No
         )
     )
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
-    monkeypatch.setenv("LMNR_BASE_URL", "http://laminar:8000")
-    monkeypatch.setenv("LMNR_PROJECT_API_KEY", "lmnr-key")
+    monkeypatch.setenv("CODEX_OTEL_EXPORTER_OTLP_ENDPOINT", "http://otlp-collector:4318")
+    monkeypatch.setenv("CODEX_OTEL_AUTHORIZATION", "otlp-key")
     monkeypatch.setenv("CODEX_OTEL_ENVIRONMENT", "staging")
     monkeypatch.setattr(
         wrapper,
@@ -151,10 +151,32 @@ def test_configure_codex_otel_writes_startup_config(monkeypatch, tmp_path) -> No
     assert parsed["otel"]["trace_exporter"]["otlp-http"]["headers"] == {
         "x-trace-id": "00000000-0000-4000-8000-000000000123",
         "x-centaur-thread-key": "slack:C123:1700000000.000100",
-        "authorization": "Bearer lmnr-key",
+        "authorization": "Bearer otlp-key",
     }
     assert config.count("[otel]") == 1
-    assert proxy_calls == [("http://laminar:8000/v1/traces", "codex.")]
+    assert proxy_calls == [("http://otlp-collector:4318/v1/traces", "codex.")]
+
+
+def test_configure_codex_otel_ignores_generic_collector_endpoint(monkeypatch, tmp_path) -> None:
+    wrapper = _load_wrapper()
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("OTLP_BASE_URL", "http://otlp-collector:4318")
+    monkeypatch.setenv("CODEX_OTEL_AUTHORIZATION", "otlp-key")
+    monkeypatch.setattr(
+        wrapper,
+        "start_codex_otel_prefix_proxy",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("otel should stay disabled")),
+    )
+
+    wrapper.CONFIGURED_OTEL_TRACE_ID = None
+    wrapper.configure_codex_otel_for_startup(
+        "00000000-0000-4000-8000-000000000123",
+        "slack:C123:1700000000.000100",
+    )
+
+    assert not (codex_home / "config.toml").exists()
 
 
 def test_prefix_otlp_span_names_prefixes_codex_spans() -> None:
@@ -177,7 +199,7 @@ def test_prefix_otlp_span_names_prefixes_codex_spans() -> None:
     assert names == ["codex.session_task.turn", "codex.initialize"]
 
 
-def test_prefix_otlp_span_names_normalizes_codex_turn_as_laminar_llm_span() -> None:
+def test_prefix_otlp_span_names_normalizes_codex_turn_as_gen_ai_span() -> None:
     wrapper = _load_wrapper()
     request = ExportTraceServiceRequest()
     span = request.resource_spans.add().scope_spans.add().spans.add(name="session_task.turn")
@@ -215,14 +237,14 @@ def test_prefix_otlp_span_names_normalizes_codex_turn_as_laminar_llm_span() -> N
     }
 
     assert rewritten_span.name == "codex.session_task.turn"
-    assert attributes["lmnr.span.type"].string_value == "LLM"
+    assert attributes["gen_ai.operation.name"].string_value == "chat"
     assert attributes["gen_ai.system"].string_value == "openai"
     assert attributes["gen_ai.request.model"].string_value == "gpt-5.5"
     assert attributes["gen_ai.response.model"].string_value == "gpt-5.5"
-    assert attributes["lmnr.span.input"].string_value == (
+    assert attributes["input.value"].string_value == (
         "Reply with exactly PONG and nothing else."
     )
-    assert attributes["lmnr.span.output"].string_value == "PONG"
+    assert attributes["output.value"].string_value == "PONG"
     assert attributes["gen_ai.usage.input_tokens"].int_value == 20448
     assert attributes["gen_ai.usage.output_tokens"].int_value == 11
     assert attributes["gen_ai.usage.cache_read_input_tokens"].int_value == 20352

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import tomllib
 from types import ModuleType
 import uuid
+
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
 
 
 WRAPPER_PY = Path(__file__).resolve().parents[2] / "sandbox" / "codex-app-wrapper.py"
@@ -52,6 +57,18 @@ def test_configure_trace_context_ignores_invalid_trace_id(monkeypatch) -> None:
     assert "TRACEPARENT" not in wrapper.os.environ
 
 
+def test_configure_traceparent_uses_exact_parent_context(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    traceparent = "00-00000000000040008000000000000123-1111111122223333-01"
+    monkeypatch.delenv("TRACEPARENT", raising=False)
+
+    wrapper.CURRENT_TRACEPARENT = None
+    wrapper.configure_traceparent(traceparent)
+
+    assert wrapper.CURRENT_TRACEPARENT == traceparent
+    assert wrapper.os.environ["TRACEPARENT"] == traceparent
+
+
 def test_request_attaches_traceparent(monkeypatch) -> None:
     wrapper = _load_wrapper()
     sent: list[dict] = []
@@ -79,6 +96,163 @@ def test_request_attaches_traceparent(monkeypatch) -> None:
             },
         }
     ]
+
+
+def test_configure_codex_otel_writes_startup_config(monkeypatch, tmp_path) -> None:
+    wrapper = _load_wrapper()
+    proxy_calls: list[tuple[str, str]] = []
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        "\n".join(
+            [
+                'model = "gpt-5.5"',
+                "",
+                "[otel]",
+                'environment = "old"',
+                "",
+                "[otel.trace_exporter.otlp-http]",
+                'endpoint = "http://old/v1/traces"',
+                "",
+            ]
+        )
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("LMNR_BASE_URL", "http://laminar:8000")
+    monkeypatch.setenv("LMNR_PROJECT_API_KEY", "lmnr-key")
+    monkeypatch.setenv("CODEX_OTEL_ENVIRONMENT", "staging")
+    monkeypatch.setattr(
+        wrapper,
+        "start_codex_otel_prefix_proxy",
+        lambda endpoint, span_prefix: proxy_calls.append((endpoint, span_prefix))
+        or "http://127.0.0.1:4319/v1/traces",
+    )
+
+    wrapper.CONFIGURED_OTEL_TRACE_ID = None
+    wrapper.configure_codex_otel_for_startup(
+        "00000000-0000-4000-8000-000000000123",
+        "slack:C123:1700000000.000100",
+    )
+
+    config = (codex_home / "config.toml").read_text()
+    parsed = tomllib.loads(config)
+    assert parsed["model"] == "gpt-5.5"
+    assert parsed["otel"]["environment"] == "staging"
+    assert parsed["otel"]["log_user_prompt"] is True
+    assert parsed["otel"]["span_attributes"] == {
+        "service.name": "codex",
+        "centaur.span_prefix": "codex.",
+    }
+    assert (
+        parsed["otel"]["trace_exporter"]["otlp-http"]["endpoint"]
+        == "http://127.0.0.1:4319/v1/traces"
+    )
+    assert parsed["otel"]["trace_exporter"]["otlp-http"]["protocol"] == "binary"
+    assert parsed["otel"]["trace_exporter"]["otlp-http"]["headers"] == {
+        "x-trace-id": "00000000-0000-4000-8000-000000000123",
+        "x-centaur-thread-key": "slack:C123:1700000000.000100",
+        "authorization": "Bearer lmnr-key",
+    }
+    assert config.count("[otel]") == 1
+    assert proxy_calls == [("http://laminar:8000/v1/traces", "codex.")]
+
+
+def test_prefix_otlp_span_names_prefixes_codex_spans() -> None:
+    wrapper = _load_wrapper()
+    request = ExportTraceServiceRequest()
+    scope_spans = request.resource_spans.add().scope_spans.add()
+    scope_spans.spans.add(name="session_task.turn")
+    scope_spans.spans.add(name="codex.initialize")
+
+    rewritten = wrapper._prefix_otlp_span_names(request.SerializeToString(), "codex.")
+    parsed = ExportTraceServiceRequest()
+    parsed.ParseFromString(rewritten)
+
+    names = [
+        span.name
+        for resource_span in parsed.resource_spans
+        for scope_span in resource_span.scope_spans
+        for span in scope_span.spans
+    ]
+    assert names == ["codex.session_task.turn", "codex.initialize"]
+
+
+def test_prefix_otlp_span_names_normalizes_codex_turn_as_laminar_llm_span() -> None:
+    wrapper = _load_wrapper()
+    request = ExportTraceServiceRequest()
+    span = request.resource_spans.add().scope_spans.add().spans.add(name="session_task.turn")
+
+    def set_string(key: str, value: str) -> None:
+        attribute = span.attributes.add()
+        attribute.key = key
+        attribute.value.string_value = value
+
+    def set_int(key: str, value: int) -> None:
+        attribute = span.attributes.add()
+        attribute.key = key
+        attribute.value.int_value = value
+
+    set_string("model", "gpt-5.5")
+    set_string("turn.id", "turn-123")
+    set_int("codex.turn.token_usage.input_tokens", 20448)
+    set_int("codex.turn.token_usage.output_tokens", 11)
+    set_int("codex.turn.token_usage.cached_input_tokens", 20352)
+    set_int("codex.turn.token_usage.reasoning_output_tokens", 0)
+    wrapper.CURRENT_LLM_INPUT_TEXT = "stale input"
+    wrapper.CURRENT_LLM_OUTPUT_TEXT = "stale output"
+    wrapper.LLM_INPUTS_BY_TURN_ID = {
+        "turn-123": "Reply with exactly PONG and nothing else."
+    }
+    wrapper.LLM_OUTPUTS_BY_TURN_ID = {"turn-123": "PONG"}
+
+    rewritten = wrapper._prefix_otlp_span_names(request.SerializeToString(), "codex.")
+    parsed = ExportTraceServiceRequest()
+    parsed.ParseFromString(rewritten)
+    rewritten_span = parsed.resource_spans[0].scope_spans[0].spans[0]
+    attributes = {
+        attribute.key: attribute.value
+        for attribute in rewritten_span.attributes
+    }
+
+    assert rewritten_span.name == "codex.session_task.turn"
+    assert attributes["lmnr.span.type"].string_value == "LLM"
+    assert attributes["gen_ai.system"].string_value == "openai"
+    assert attributes["gen_ai.request.model"].string_value == "gpt-5.5"
+    assert attributes["gen_ai.response.model"].string_value == "gpt-5.5"
+    assert attributes["lmnr.span.input"].string_value == (
+        "Reply with exactly PONG and nothing else."
+    )
+    assert attributes["lmnr.span.output"].string_value == "PONG"
+    assert attributes["gen_ai.usage.input_tokens"].int_value == 20448
+    assert attributes["gen_ai.usage.output_tokens"].int_value == 11
+    assert attributes["gen_ai.usage.cache_read_input_tokens"].int_value == 20352
+    assert attributes["gen_ai.usage.reasoning_tokens"].int_value == 0
+
+
+def test_emit_notification_collects_agent_message_delta_output(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    emitted: list[dict] = []
+    monkeypatch.setattr(wrapper, "emit", emitted.append)
+
+    wrapper.CURRENT_LLM_OUTPUT_TEXT = ""
+    wrapper.LLM_OUTPUTS_BY_TURN_ID = {}
+    done = wrapper.emit_notification(
+        {
+            "method": "item/agentMessage/delta",
+            "params": {"delta": "PO", "itemId": "msg-1", "turnId": "turn-123"},
+        }
+    )
+    wrapper.emit_notification(
+        {
+            "method": "item/agentMessage/delta",
+            "params": {"delta": "NG", "itemId": "msg-1", "turnId": "turn-123"},
+        }
+    )
+
+    assert done is False
+    assert wrapper.CURRENT_LLM_OUTPUT_TEXT == "PONG"
+    assert wrapper.LLM_OUTPUTS_BY_TURN_ID == {"turn-123": "PONG"}
+    assert emitted[0]["type"] == "item.agentMessage.delta"
 
 
 def test_main_lazy_starts_app_server_after_input(monkeypatch) -> None:

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -23,7 +23,9 @@ def _load_wrapper() -> ModuleType:
     return module
 
 
-def test_configure_trace_context_for_startup_sets_w3c_trace_context(monkeypatch, tmp_path) -> None:
+def test_configure_trace_context_for_startup_sets_w3c_trace_context(
+    monkeypatch, tmp_path
+) -> None:
     wrapper = _load_wrapper()
     codex_home = tmp_path / ".codex"
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
@@ -43,6 +45,36 @@ def test_configure_trace_context_for_startup_sets_w3c_trace_context(monkeypatch,
     assert (
         wrapper.os.environ["TRACEPARENT"]
         == "00-00000000000040008000000000000123-1111111122223333-01"
+    )
+    assert wrapper.CONFIGURED_TRACE_CONTEXT_ID == "00000000-0000-4000-8000-000000000123"
+    assert wrapper.CONFIGURED_OTEL_TRACE_ID is None
+
+
+def test_trace_context_startup_does_not_skip_codex_otel_config(
+    monkeypatch, tmp_path
+) -> None:
+    wrapper = _load_wrapper()
+    codex_home = tmp_path / ".codex"
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otlp-collector:4318")
+    monkeypatch.setattr(
+        wrapper,
+        "start_codex_otel_prefix_proxy",
+        lambda _endpoint, _span_prefix: "http://127.0.0.1:4319/v1/traces",
+    )
+
+    wrapper.CONFIGURED_TRACE_CONTEXT_ID = None
+    wrapper.CONFIGURED_OTEL_TRACE_ID = None
+    wrapper.configure_trace_context_for_startup("00000000-0000-4000-8000-000000000123")
+    wrapper.configure_codex_otel_for_startup(
+        "00000000-0000-4000-8000-000000000123",
+        "slack:C123:1700000000.000100",
+    )
+
+    parsed = tomllib.loads((codex_home / "config.toml").read_text())
+    assert (
+        parsed["otel"]["trace_exporter"]["otlp-http"]["endpoint"]
+        == "http://127.0.0.1:4319/v1/traces"
     )
 
 
@@ -124,8 +156,10 @@ def test_configure_codex_otel_writes_startup_config(monkeypatch, tmp_path) -> No
     monkeypatch.setattr(
         wrapper,
         "start_codex_otel_prefix_proxy",
-        lambda endpoint, span_prefix: proxy_calls.append((endpoint, span_prefix))
-        or "http://127.0.0.1:4319/v1/traces",
+        lambda endpoint, span_prefix: (
+            proxy_calls.append((endpoint, span_prefix))
+            or "http://127.0.0.1:4319/v1/traces"
+        ),
     )
 
     wrapper.CONFIGURED_OTEL_TRACE_ID = None
@@ -157,7 +191,9 @@ def test_configure_codex_otel_writes_startup_config(monkeypatch, tmp_path) -> No
     assert proxy_calls == [("http://otlp-collector:4318/v1/traces", "codex.")]
 
 
-def test_configure_codex_otel_ignores_unrelated_collector_endpoint(monkeypatch, tmp_path) -> None:
+def test_configure_codex_otel_ignores_unrelated_collector_endpoint(
+    monkeypatch, tmp_path
+) -> None:
     wrapper = _load_wrapper()
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()
@@ -167,7 +203,9 @@ def test_configure_codex_otel_ignores_unrelated_collector_endpoint(monkeypatch, 
     monkeypatch.setattr(
         wrapper,
         "start_codex_otel_prefix_proxy",
-        lambda *_args: (_ for _ in ()).throw(AssertionError("otel should stay disabled")),
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("otel should stay disabled")
+        ),
     )
 
     wrapper.CONFIGURED_OTEL_TRACE_ID = None
@@ -202,7 +240,11 @@ def test_prefix_otlp_span_names_prefixes_codex_spans() -> None:
 def test_prefix_otlp_span_names_normalizes_codex_turn_as_gen_ai_span() -> None:
     wrapper = _load_wrapper()
     request = ExportTraceServiceRequest()
-    span = request.resource_spans.add().scope_spans.add().spans.add(name="session_task.turn")
+    span = (
+        request.resource_spans.add()
+        .scope_spans.add()
+        .spans.add(name="session_task.turn")
+    )
 
     def set_string(key: str, value: str) -> None:
         attribute = span.attributes.add()
@@ -232,8 +274,7 @@ def test_prefix_otlp_span_names_normalizes_codex_turn_as_gen_ai_span() -> None:
     parsed.ParseFromString(rewritten)
     rewritten_span = parsed.resource_spans[0].scope_spans[0].spans[0]
     attributes = {
-        attribute.key: attribute.value
-        for attribute in rewritten_span.attributes
+        attribute.key: attribute.value for attribute in rewritten_span.attributes
     }
 
     assert rewritten_span.name == "codex.session_task.turn"
@@ -245,6 +286,12 @@ def test_prefix_otlp_span_names_normalizes_codex_turn_as_gen_ai_span() -> None:
         "Reply with exactly PONG and nothing else."
     )
     assert attributes["output.value"].string_value == "PONG"
+    assert attributes["gen_ai.input.messages"].string_value == (
+        '[{"role":"user","content":"Reply with exactly PONG and nothing else."}]'
+    )
+    assert attributes["gen_ai.output.messages"].string_value == (
+        '[{"role":"assistant","content":"PONG"}]'
+    )
     assert attributes["gen_ai.usage.input_tokens"].int_value == 20448
     assert attributes["gen_ai.usage.output_tokens"].int_value == 11
     assert attributes["gen_ai.usage.cache_read_input_tokens"].int_value == 20352
@@ -308,7 +355,9 @@ def test_main_lazy_starts_app_server_after_input(monkeypatch) -> None:
                         "type": "user",
                         "trace_id": "00000000-0000-0000-0000-000000000123",
                         "thread_key": "slack:C123:1700000000.000100",
-                        "message": {"content": [{"type": "text", "text": "/goal ship"}]},
+                        "message": {
+                            "content": [{"type": "text", "text": "/goal ship"}]
+                        },
                     }
                 )
                 wrapper.INPUTS.put(None)

--- a/services/api/tests/test_harness_protocol.py
+++ b/services/api/tests/test_harness_protocol.py
@@ -272,6 +272,12 @@ class TestBuildUserInput:
         )
         assert result["trace_id"] == "00000000-0000-0000-0000-000000000123"
 
+    def test_traceparent_is_included_when_provided(self):
+        blocks = [{"type": "text", "text": "hi"}]
+        traceparent = "00-00000000000040008000000000000123-1111111122223333-01"
+        result = build_user_input(blocks, traceparent=traceparent)
+        assert result["traceparent"] == traceparent
+
 
 class TestMessagesToContentBlocks:
     def test_simple_text_message(self):

--- a/services/api/tests/test_otel.py
+++ b/services/api/tests/test_otel.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+from api.otel import current_traceparent
+
+
+def test_current_traceparent_masks_trace_flags_to_w3c_sampled_bit() -> None:
+    span = NonRecordingSpan(
+        SpanContext(
+            trace_id=int("00000000000040008000000000000123", 16),
+            span_id=int("1111111122223333", 16),
+            is_remote=False,
+            trace_flags=TraceFlags(0x03),
+            trace_state=[],
+        )
+    )
+
+    assert (
+        current_traceparent(span)
+        == "00-00000000000040008000000000000123-1111111122223333-01"
+    )

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -281,19 +281,17 @@ def test_container_env_passes_allowed_otel_config(
 ) -> None:
     monkeypatch.setenv("CODEX_OTEL_AUTHORIZATION", "Bearer local-key")
     monkeypatch.setenv("CODEX_OTEL_ENVIRONMENT", "staging")
-    monkeypatch.setenv("CODEX_OTEL_EXPORTER_OTLP_ENDPOINT", "http://laminar:8000")
+    monkeypatch.setenv("CODEX_OTEL_EXPORTER_OTLP_ENDPOINT", "http://otlp-collector:4318")
     monkeypatch.setenv("CODEX_OTEL_SPAN_PREFIX", "codex.")
-    monkeypatch.setenv("LMNR_PROJECT_API_KEY", "lmnr-key")
 
     env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
     env_map = dict(item.split("=", 1) for item in env)
 
     assert env_map["CODEX_OTEL_AUTHORIZATION"] == "Bearer local-key"
     assert env_map["CODEX_OTEL_ENVIRONMENT"] == "staging"
-    assert env_map["CODEX_OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://laminar:8000"
+    assert env_map["CODEX_OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://otlp-collector:4318"
     assert env_map["CODEX_OTEL_SPAN_PREFIX"] == "codex."
-    assert env_map["LMNR_PROJECT_API_KEY"] == "lmnr-key"
-    assert "laminar" in env_map["NO_PROXY"].split(",")
+    assert "otlp-collector" in env_map["NO_PROXY"].split(",")
 
 
 def test_container_env_applies_kubernetes_sandbox_extra_env(

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -279,18 +279,16 @@ def test_container_env_includes_firewall_host_for_secret_bootstrap(
 def test_container_env_passes_allowed_otel_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("CODEX_OTEL_AUTHORIZATION", "Bearer local-key")
-    monkeypatch.setenv("CODEX_OTEL_ENVIRONMENT", "staging")
-    monkeypatch.setenv("CODEX_OTEL_EXPORTER_OTLP_ENDPOINT", "http://otlp-collector:4318")
-    monkeypatch.setenv("CODEX_OTEL_SPAN_PREFIX", "codex.")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "authorization=Bearer%20local-key")
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=staging")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otlp-collector:4318")
 
     env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
     env_map = dict(item.split("=", 1) for item in env)
 
-    assert env_map["CODEX_OTEL_AUTHORIZATION"] == "Bearer local-key"
-    assert env_map["CODEX_OTEL_ENVIRONMENT"] == "staging"
-    assert env_map["CODEX_OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://otlp-collector:4318"
-    assert env_map["CODEX_OTEL_SPAN_PREFIX"] == "codex."
+    assert env_map["OTEL_EXPORTER_OTLP_HEADERS"] == "authorization=Bearer%20local-key"
+    assert env_map["OTEL_RESOURCE_ATTRIBUTES"] == "deployment.environment=staging"
+    assert env_map["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://otlp-collector:4318"
     assert "otlp-collector" in env_map["NO_PROXY"].split(",")
 
 
@@ -311,7 +309,7 @@ def test_container_env_applies_kubernetes_sandbox_extra_env(
                     "value": "localhost,127.0.0.1,api.internal,metrics.internal",
                 },
                 {
-                    "name": "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
+                    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
                     "value": "http://host.orb.internal:8000",
                 },
             ]
@@ -323,7 +321,7 @@ def test_container_env_applies_kubernetes_sandbox_extra_env(
 
     assert env_map["NO_PROXY"] == "localhost,127.0.0.1,api.internal,metrics.internal"
     assert env_map["no_proxy"] == "localhost,127.0.0.1,api.internal,metrics.internal"
-    assert env_map["CODEX_OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://host.orb.internal:8000"
+    assert env_map["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://host.orb.internal:8000"
     assert len([item for item in env if item.startswith("NO_PROXY=")]) == 1
     assert len([item for item in env if item.startswith("no_proxy=")]) == 1
 
@@ -336,7 +334,7 @@ def test_container_env_adds_extra_otel_endpoint_host_to_no_proxy(
         json.dumps(
             [
                 {
-                    "name": "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
+                    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
                     "value": "http://host.orb.internal:8000",
                 },
             ]

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -279,12 +279,21 @@ def test_container_env_includes_firewall_host_for_secret_bootstrap(
 def test_container_env_passes_allowed_otel_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("CODEX_OTEL_AUTHORIZATION", "Bearer local-key")
     monkeypatch.setenv("CODEX_OTEL_ENVIRONMENT", "staging")
+    monkeypatch.setenv("CODEX_OTEL_EXPORTER_OTLP_ENDPOINT", "http://laminar:8000")
+    monkeypatch.setenv("CODEX_OTEL_SPAN_PREFIX", "codex.")
+    monkeypatch.setenv("LMNR_PROJECT_API_KEY", "lmnr-key")
 
     env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
     env_map = dict(item.split("=", 1) for item in env)
 
+    assert env_map["CODEX_OTEL_AUTHORIZATION"] == "Bearer local-key"
     assert env_map["CODEX_OTEL_ENVIRONMENT"] == "staging"
+    assert env_map["CODEX_OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://laminar:8000"
+    assert env_map["CODEX_OTEL_SPAN_PREFIX"] == "codex."
+    assert env_map["LMNR_PROJECT_API_KEY"] == "lmnr-key"
+    assert "laminar" in env_map["NO_PROXY"].split(",")
 
 
 def test_container_env_applies_kubernetes_sandbox_extra_env(
@@ -303,6 +312,10 @@ def test_container_env_applies_kubernetes_sandbox_extra_env(
                     "name": "no_proxy",
                     "value": "localhost,127.0.0.1,api.internal,metrics.internal",
                 },
+                {
+                    "name": "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
+                    "value": "http://host.orb.internal:8000",
+                },
             ]
         ),
     )
@@ -312,8 +325,30 @@ def test_container_env_applies_kubernetes_sandbox_extra_env(
 
     assert env_map["NO_PROXY"] == "localhost,127.0.0.1,api.internal,metrics.internal"
     assert env_map["no_proxy"] == "localhost,127.0.0.1,api.internal,metrics.internal"
+    assert env_map["CODEX_OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://host.orb.internal:8000"
     assert len([item for item in env if item.startswith("NO_PROXY=")]) == 1
     assert len([item for item in env if item.startswith("no_proxy=")]) == 1
+
+
+def test_container_env_adds_extra_otel_endpoint_host_to_no_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "KUBERNETES_SANDBOX_EXTRA_ENV",
+        json.dumps(
+            [
+                {
+                    "name": "CODEX_OTEL_EXPORTER_OTLP_ENDPOINT",
+                    "value": "http://host.orb.internal:8000",
+                },
+            ]
+        ),
+    )
+
+    env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
+    env_map = dict(item.split("=", 1) for item in env)
+
+    assert "host.orb.internal" in env_map["NO_PROXY"].split(",")
 
 
 def test_prompt_bundle_includes_live_capability_inventory_guidance(

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -26,7 +26,8 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     python-docx==1.2.0 lxml==6.0.2 docx-revisions==0.1.4 \
     matplotlib==3.10.8 numpy==2.4.4 pandas==3.0.2 \
     python-pptx==1.0.2 openpyxl==3.1.5 PyMuPDF==1.27.2 mammoth==1.12.0 \
-    faster-whisper
+    faster-whisper \
+    opentelemetry-proto==1.42.1
 
 # ── GitHub CLI + Node.js 24 (LTS) + Docker CLI (single layer, cached) ─────────────
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 import queue
 import signal
 import subprocess
@@ -18,7 +19,15 @@ import sys
 import threading
 import time
 import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+from urllib import request as urllib_request
+from urllib.error import HTTPError, URLError
+
+from opentelemetry.proto.common.v1.common_pb2 import KeyValue
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
 
 APP: subprocess.Popen[str] | None = None
 WRITE_LOCK = threading.Lock()
@@ -32,6 +41,13 @@ SHUTTING_DOWN = False
 CONFIGURED_OTEL_TRACE_ID: str | None = None
 APP_INITIALIZED = False
 CURRENT_TRACEPARENT: str | None = None
+OTEL_PROXY: ThreadingHTTPServer | None = None
+OTEL_PROXY_TARGET_ENDPOINT: str | None = None
+OTEL_PROXY_SPAN_PREFIX = "codex."
+CURRENT_LLM_INPUT_TEXT = ""
+CURRENT_LLM_OUTPUT_TEXT = ""
+LLM_INPUTS_BY_TURN_ID: dict[str, str] = {}
+LLM_OUTPUTS_BY_TURN_ID: dict[str, str] = {}
 
 
 def emit(payload: dict[str, Any]) -> None:
@@ -181,6 +197,311 @@ def split_goal(items: list[dict[str, Any]]) -> tuple[str | None, list[dict[str, 
     return goal or None, []
 
 
+def _codex_otel_endpoint() -> str:
+    endpoint = (
+        os.environ.get("CODEX_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+        or os.environ.get("CODEX_OTEL_LAMINAR_ENDPOINT")
+        or ""
+    ).strip()
+    if endpoint:
+        return endpoint
+    base = (
+        os.environ.get("CODEX_OTEL_EXPORTER_OTLP_ENDPOINT")
+        or os.environ.get("CODEX_OTEL_LAMINAR_BASE_URL")
+        or os.environ.get("LMNR_BASE_URL")
+        or ""
+    ).strip()
+    if not base:
+        return ""
+    base = base.rstrip("/")
+    if base.endswith("/v1/traces"):
+        return base
+    return f"{base}/v1/traces"
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _strip_otel_toml_sections(contents: str) -> str:
+    kept: list[str] = []
+    skipping = False
+    for line in contents.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped.strip("[]").strip()
+            skipping = section == "otel" or section.startswith("otel.")
+        if not skipping:
+            kept.append(line)
+    return "\n".join(kept).rstrip()
+
+
+def _write_codex_otel_config(
+    *, endpoint: str, trace_id: str, thread_key: str, api_key: str, environment: str
+) -> None:
+    config_path = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex") / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    base = _strip_otel_toml_sections(config_path.read_text() if config_path.exists() else "")
+    headers = [
+        f"x-trace-id = {_toml_string(trace_id)}",
+    ]
+    if thread_key:
+        headers.append(f"x-centaur-thread-key = {_toml_string(thread_key)}")
+    if api_key:
+        headers.append(f"authorization = {_toml_string(f'Bearer {api_key}')}")
+
+    span_prefix = (os.environ.get("CODEX_OTEL_SPAN_PREFIX") or "codex.").strip() or "codex."
+    span_attributes = [
+        f'"service.name" = {_toml_string("codex")}',
+        f'"centaur.span_prefix" = {_toml_string(span_prefix)}',
+    ]
+
+    trace_exporter = (
+        f'trace_exporter = {{ otlp-http = {{ endpoint = {_toml_string(endpoint)}, '
+        f'protocol = "binary", headers = {{ {", ".join(headers)} }} }} }}'
+    )
+    otel_block = "\n".join(
+        [
+            "[otel]",
+            f"environment = {_toml_string(environment)}",
+            "log_user_prompt = true",
+            f"span_attributes = {{ {', '.join(span_attributes)} }}",
+            trace_exporter,
+        ]
+    )
+    next_contents = f"{base}\n\n{otel_block}\n" if base else f"{otel_block}\n"
+    config_path.write_text(next_contents)
+
+
+def _span_prefix() -> str:
+    return (os.environ.get("CODEX_OTEL_SPAN_PREFIX") or "codex.").strip() or "codex."
+
+
+def _attribute(span: Any, key: str) -> KeyValue | None:
+    return next((attribute for attribute in span.attributes if attribute.key == key), None)
+
+
+def _attribute_string(span: Any, key: str) -> str:
+    attribute = _attribute(span, key)
+    if attribute is None:
+        return ""
+    value_type = attribute.value.WhichOneof("value")
+    if value_type == "string_value":
+        return attribute.value.string_value
+    if value_type == "int_value":
+        return str(attribute.value.int_value)
+    if value_type == "double_value":
+        return str(attribute.value.double_value)
+    if value_type == "bool_value":
+        return "true" if attribute.value.bool_value else "false"
+    return ""
+
+
+def _attribute_int(span: Any, key: str) -> int | None:
+    attribute = _attribute(span, key)
+    if attribute is None:
+        return None
+    value_type = attribute.value.WhichOneof("value")
+    if value_type == "int_value":
+        return int(attribute.value.int_value)
+    if value_type == "double_value":
+        return int(attribute.value.double_value)
+    if value_type == "string_value":
+        try:
+            return int(attribute.value.string_value)
+        except ValueError:
+            return None
+    return None
+
+
+def _set_attribute_string(span: Any, key: str, value: str) -> None:
+    if value == "":
+        return
+    attribute = _attribute(span, key)
+    if attribute is None:
+        attribute = span.attributes.add()
+        attribute.key = key
+    attribute.value.string_value = value
+
+
+def _append_current_llm_output(text: Any) -> None:
+    global CURRENT_LLM_OUTPUT_TEXT
+    if isinstance(text, str) and text:
+        CURRENT_LLM_OUTPUT_TEXT += text
+
+
+def _append_llm_output_for_turn(turn_id: Any, text: Any) -> None:
+    if not isinstance(turn_id, str) or not turn_id or not isinstance(text, str) or not text:
+        return
+    LLM_OUTPUTS_BY_TURN_ID[turn_id] = LLM_OUTPUTS_BY_TURN_ID.get(turn_id, "") + text
+
+
+def _set_attribute_int(span: Any, key: str, value: int | None) -> None:
+    if value is None:
+        return
+    attribute = _attribute(span, key)
+    if attribute is None:
+        attribute = span.attributes.add()
+        attribute.key = key
+    attribute.value.int_value = value
+
+
+def _normalize_codex_llm_span(span: Any, prefix: str) -> None:
+    if span.name != f"{prefix}session_task.turn":
+        return
+
+    model = _attribute_string(span, "model")
+    turn_id = _attribute_string(span, "turn.id")
+    _set_attribute_string(span, "lmnr.span.type", "LLM")
+    _set_attribute_string(span, "gen_ai.system", "openai")
+    _set_attribute_string(span, "gen_ai.request.model", model)
+    _set_attribute_string(span, "gen_ai.response.model", model)
+    _set_attribute_string(
+        span, "lmnr.span.input", LLM_INPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_INPUT_TEXT)
+    )
+    _set_attribute_string(
+        span, "lmnr.span.output", LLM_OUTPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_OUTPUT_TEXT)
+    )
+    _set_attribute_int(
+        span,
+        "gen_ai.usage.input_tokens",
+        _attribute_int(span, "codex.turn.token_usage.input_tokens"),
+    )
+    _set_attribute_int(
+        span,
+        "gen_ai.usage.output_tokens",
+        _attribute_int(span, "codex.turn.token_usage.output_tokens"),
+    )
+    _set_attribute_int(
+        span,
+        "gen_ai.usage.cache_read_input_tokens",
+        _attribute_int(span, "codex.turn.token_usage.cached_input_tokens"),
+    )
+    _set_attribute_int(
+        span,
+        "gen_ai.usage.reasoning_tokens",
+        _attribute_int(span, "codex.turn.token_usage.reasoning_output_tokens"),
+    )
+
+
+def _prefix_otlp_span_names(payload: bytes, prefix: str) -> bytes:
+    request = ExportTraceServiceRequest()
+    request.ParseFromString(payload)
+    for resource_span in request.resource_spans:
+        for scope_span in resource_span.scope_spans:
+            for span in scope_span.spans:
+                if span.name and not span.name.startswith(prefix):
+                    span.name = f"{prefix}{span.name}"
+                _normalize_codex_llm_span(span, prefix)
+    return request.SerializeToString()
+
+
+class CodexOtelPrefixProxyHandler(BaseHTTPRequestHandler):
+    server_version = "CodexOtelPrefixProxy/1.0"
+
+    def do_POST(self) -> None:
+        if self.path != "/v1/traces":
+            self.send_error(404)
+            return
+        endpoint = OTEL_PROXY_TARGET_ENDPOINT
+        if not endpoint:
+            self.send_error(503, "OTLP target endpoint not configured")
+            return
+        try:
+            length = int(self.headers.get("content-length") or "0")
+            body = self.rfile.read(length)
+            rewritten = _prefix_otlp_span_names(body, OTEL_PROXY_SPAN_PREFIX)
+            headers = {
+                key: value
+                for key, value in self.headers.items()
+                if key.lower()
+                not in {
+                    "host",
+                    "content-length",
+                    "content-encoding",
+                    "accept-encoding",
+                    "connection",
+                }
+            }
+            headers["content-type"] = "application/x-protobuf"
+            request = urllib_request.Request(
+                endpoint,
+                data=rewritten,
+                headers=headers,
+                method="POST",
+            )
+            with urllib_request.urlopen(request, timeout=10) as response:
+                response_body = response.read()
+                self.send_response(response.status)
+                for key, value in response.headers.items():
+                    if key.lower() not in {"content-length", "connection"}:
+                        self.send_header(key, value)
+                self.send_header("content-length", str(len(response_body)))
+                self.end_headers()
+                if response_body:
+                    self.wfile.write(response_body)
+        except HTTPError as exc:
+            body = exc.read()
+            self.send_response(exc.code)
+            for key, value in exc.headers.items():
+                if key.lower() not in {"content-length", "connection"}:
+                    self.send_header(key, value)
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            if body:
+                self.wfile.write(body)
+        except (OSError, URLError, ValueError) as exc:
+            self.send_error(502, str(exc))
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+def start_codex_otel_prefix_proxy(endpoint: str, span_prefix: str) -> str:
+    global OTEL_PROXY, OTEL_PROXY_SPAN_PREFIX, OTEL_PROXY_TARGET_ENDPOINT
+    OTEL_PROXY_TARGET_ENDPOINT = endpoint
+    OTEL_PROXY_SPAN_PREFIX = span_prefix
+    if OTEL_PROXY is None:
+        OTEL_PROXY = ThreadingHTTPServer(("127.0.0.1", 0), CodexOtelPrefixProxyHandler)
+        threading.Thread(target=OTEL_PROXY.serve_forever, daemon=True).start()
+    host, port = OTEL_PROXY.server_address
+    return f"http://{host}:{port}/v1/traces"
+
+
+def configure_codex_otel_for_startup(
+    trace_id: str | None, thread_key: str | None
+) -> None:
+    global CONFIGURED_OTEL_TRACE_ID
+    trace_id = (trace_id or os.environ.get("CENTAUR_TRACE_ID") or "").strip()
+    endpoint = _codex_otel_endpoint()
+    if not trace_id or not endpoint or CONFIGURED_OTEL_TRACE_ID == trace_id:
+        return
+    span_prefix = _span_prefix()
+    export_endpoint = start_codex_otel_prefix_proxy(endpoint, span_prefix)
+
+    api_key = (
+        os.environ.get("CODEX_OTEL_AUTHORIZATION")
+        or os.environ.get("LMNR_PROJECT_API_KEY")
+        or ""
+    ).strip()
+    if api_key.lower().startswith("bearer "):
+        api_key = api_key[7:].strip()
+    environment = (
+        os.environ.get("CODEX_OTEL_ENVIRONMENT")
+        or os.environ.get("DEPLOY_ENV")
+        or os.environ.get("ENVIRONMENT")
+        or "dev"
+    ).strip() or "dev"
+    _write_codex_otel_config(
+        endpoint=export_endpoint,
+        trace_id=trace_id,
+        thread_key=(thread_key or os.environ.get("CENTAUR_THREAD_KEY") or "").strip(),
+        api_key=api_key,
+        environment=environment,
+    )
+    CONFIGURED_OTEL_TRACE_ID = trace_id
+
+
 def _trace_id_to_w3c_hex(trace_id: str | None) -> str | None:
     raw = (trace_id or "").strip()
     if not raw:
@@ -213,6 +534,32 @@ def configure_trace_context(trace_id: str | None) -> None:
         return
     CURRENT_TRACEPARENT = traceparent
     os.environ["TRACEPARENT"] = traceparent
+
+
+def configure_traceparent(traceparent: str | None) -> None:
+    global CURRENT_TRACEPARENT
+    value = (traceparent or "").strip()
+    parts = value.split("-")
+    if (
+        len(parts) == 4
+        and parts[0] == "00"
+        and len(parts[1]) == 32
+        and len(parts[2]) == 16
+        and all(char in "0123456789abcdef" for char in parts[1].lower())
+        and all(char in "0123456789abcdef" for char in parts[2].lower())
+    ):
+        CURRENT_TRACEPARENT = value
+        os.environ["TRACEPARENT"] = value
+
+
+def _trace_id_from_traceparent(traceparent: str | None) -> str | None:
+    parts = (traceparent or "").strip().split("-")
+    if len(parts) != 4 or len(parts[1]) != 32:
+        return None
+    try:
+        return str(uuid.UUID(hex=parts[1]))
+    except ValueError:
+        return None
 
 
 def configure_trace_context_for_startup(trace_id: str | None) -> None:
@@ -266,10 +613,6 @@ def emit_notification(msg: dict[str, Any]) -> bool:
         emit({"type": "turn.started", "turn_id": ACTIVE_TURN_ID or ""})
         return False
 
-    if method in {"item/started", "item/updated", "item/completed"}:
-        emit({"type": method.replace("/", "."), "item": params.get("item") or params})
-        return False
-
     if method in {
         "item/commandExecution/outputDelta",
         "item/fileChange/outputDelta",
@@ -286,10 +629,23 @@ def emit_notification(msg: dict[str, Any]) -> bool:
         return False
 
     if method == "item/agentMessage/delta":
+        _append_current_llm_output(params.get("delta"))
+        _append_llm_output_for_turn(params.get("turnId"), params.get("delta"))
         payload = {"type": method.replace("/", "."), **params}
         if THREAD_ID and "session_id" not in payload and "thread_id" not in payload:
             payload["session_id"] = THREAD_ID
         emit(payload)
+        return False
+
+    if method == "item/completed":
+        item = params.get("item") if isinstance(params.get("item"), dict) else {}
+        if item.get("type") == "agentMessage" and not CURRENT_LLM_OUTPUT_TEXT:
+            _append_current_llm_output(item.get("text"))
+        emit({"type": method.replace("/", "."), "item": item or params})
+        return False
+
+    if method in {"item/started", "item/updated"}:
+        emit({"type": method.replace("/", "."), "item": params.get("item") or params})
         return False
 
     if method == "turn/completed":
@@ -336,7 +692,7 @@ def drain_until_turn_done() -> None:
 
 
 def handle_input(turn_input: dict[str, Any]) -> None:
-    global ACTIVE_TURN_ID
+    global ACTIVE_TURN_ID, CURRENT_LLM_INPUT_TEXT, CURRENT_LLM_OUTPUT_TEXT
     if turn_input.get("type") == "interrupt":
         interrupt_active_turn()
         return
@@ -344,9 +700,18 @@ def handle_input(turn_input: dict[str, Any]) -> None:
         return
 
     configure_trace_context_for_startup(turn_input.get("trace_id"))
+    configure_traceparent(turn_input.get("traceparent"))
+    configure_codex_otel_for_startup(
+        _trace_id_from_traceparent(turn_input.get("traceparent")) or turn_input.get("trace_id"),
+        turn_input.get("thread_key"),
+    )
     start_app_server()
     thread_id = start_or_resume_thread()
     items = input_items(turn_input)
+    CURRENT_LLM_INPUT_TEXT = "\n".join(
+        str(item.get("text") or "") for item in items if item.get("type") == "text"
+    ).strip()
+    CURRENT_LLM_OUTPUT_TEXT = ""
     goal, items = split_goal(items)
     if goal is not None:
         request(
@@ -382,6 +747,8 @@ def handle_input(turn_input: dict[str, Any]) -> None:
     result = request("turn/start", params, timeout=60)
     turn = result.get("turn") or {}
     ACTIVE_TURN_ID = str(turn.get("id") or result.get("turnId") or "") or None
+    if ACTIVE_TURN_ID and CURRENT_LLM_INPUT_TEXT:
+        LLM_INPUTS_BY_TURN_ID[ACTIVE_TURN_ID] = CURRENT_LLM_INPUT_TEXT
     drain_until_turn_done()
 
 

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -200,15 +200,12 @@ def split_goal(items: list[dict[str, Any]]) -> tuple[str | None, list[dict[str, 
 def _codex_otel_endpoint() -> str:
     endpoint = (
         os.environ.get("CODEX_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
-        or os.environ.get("CODEX_OTEL_LAMINAR_ENDPOINT")
         or ""
     ).strip()
     if endpoint:
         return endpoint
     base = (
         os.environ.get("CODEX_OTEL_EXPORTER_OTLP_ENDPOINT")
-        or os.environ.get("CODEX_OTEL_LAMINAR_BASE_URL")
-        or os.environ.get("LMNR_BASE_URL")
         or ""
     ).strip()
     if not base:
@@ -352,15 +349,15 @@ def _normalize_codex_llm_span(span: Any, prefix: str) -> None:
 
     model = _attribute_string(span, "model")
     turn_id = _attribute_string(span, "turn.id")
-    _set_attribute_string(span, "lmnr.span.type", "LLM")
+    _set_attribute_string(span, "gen_ai.operation.name", "chat")
     _set_attribute_string(span, "gen_ai.system", "openai")
     _set_attribute_string(span, "gen_ai.request.model", model)
     _set_attribute_string(span, "gen_ai.response.model", model)
     _set_attribute_string(
-        span, "lmnr.span.input", LLM_INPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_INPUT_TEXT)
+        span, "input.value", LLM_INPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_INPUT_TEXT)
     )
     _set_attribute_string(
-        span, "lmnr.span.output", LLM_OUTPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_OUTPUT_TEXT)
+        span, "output.value", LLM_OUTPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_OUTPUT_TEXT)
     )
     _set_attribute_int(
         span,
@@ -479,11 +476,7 @@ def configure_codex_otel_for_startup(
     span_prefix = _span_prefix()
     export_endpoint = start_codex_otel_prefix_proxy(endpoint, span_prefix)
 
-    api_key = (
-        os.environ.get("CODEX_OTEL_AUTHORIZATION")
-        or os.environ.get("LMNR_PROJECT_API_KEY")
-        or ""
-    ).strip()
+    api_key = (os.environ.get("CODEX_OTEL_AUTHORIZATION") or "").strip()
     if api_key.lower().startswith("bearer "):
         api_key = api_key[7:].strip()
     environment = (

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -23,6 +23,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib import request as urllib_request
 from urllib.error import HTTPError, URLError
+from urllib.parse import unquote
 
 from opentelemetry.proto.common.v1.common_pb2 import KeyValue
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
@@ -199,13 +200,13 @@ def split_goal(items: list[dict[str, Any]]) -> tuple[str | None, list[dict[str, 
 
 def _codex_otel_endpoint() -> str:
     endpoint = (
-        os.environ.get("CODEX_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+        os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
         or ""
     ).strip()
     if endpoint:
         return endpoint
     base = (
-        os.environ.get("CODEX_OTEL_EXPORTER_OTLP_ENDPOINT")
+        os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
         or ""
     ).strip()
     if not base:
@@ -247,10 +248,9 @@ def _write_codex_otel_config(
     if api_key:
         headers.append(f"authorization = {_toml_string(f'Bearer {api_key}')}")
 
-    span_prefix = (os.environ.get("CODEX_OTEL_SPAN_PREFIX") or "codex.").strip() or "codex."
     span_attributes = [
         f'"service.name" = {_toml_string("codex")}',
-        f'"centaur.span_prefix" = {_toml_string(span_prefix)}',
+        f'"centaur.span_prefix" = {_toml_string("codex.")}',
     ]
 
     trace_exporter = (
@@ -271,7 +271,46 @@ def _write_codex_otel_config(
 
 
 def _span_prefix() -> str:
-    return (os.environ.get("CODEX_OTEL_SPAN_PREFIX") or "codex.").strip() or "codex."
+    return "codex."
+
+
+def _otel_headers() -> dict[str, str]:
+    headers: dict[str, str] = {}
+    raw = (os.environ.get("OTEL_EXPORTER_OTLP_HEADERS") or "").strip()
+    if not raw:
+        return headers
+    for item in raw.split(","):
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        key = key.strip().lower()
+        if key:
+            headers[key] = unquote(value.strip())
+    return headers
+
+
+def _otel_authorization_token() -> str:
+    authorization = _otel_headers().get("authorization", "").strip()
+    if authorization.lower().startswith("bearer "):
+        return authorization[7:].strip()
+    return authorization
+
+
+def _otel_environment() -> str:
+    raw = os.environ.get("OTEL_RESOURCE_ATTRIBUTES") or ""
+    for item in raw.split(","):
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        if key.strip() == "deployment.environment":
+            environment = value.strip()
+            if environment:
+                return environment
+    return (
+        os.environ.get("DEPLOY_ENV")
+        or os.environ.get("ENVIRONMENT")
+        or "dev"
+    ).strip() or "dev"
 
 
 def _attribute(span: Any, key: str) -> KeyValue | None:
@@ -476,15 +515,8 @@ def configure_codex_otel_for_startup(
     span_prefix = _span_prefix()
     export_endpoint = start_codex_otel_prefix_proxy(endpoint, span_prefix)
 
-    api_key = (os.environ.get("CODEX_OTEL_AUTHORIZATION") or "").strip()
-    if api_key.lower().startswith("bearer "):
-        api_key = api_key[7:].strip()
-    environment = (
-        os.environ.get("CODEX_OTEL_ENVIRONMENT")
-        or os.environ.get("DEPLOY_ENV")
-        or os.environ.get("ENVIRONMENT")
-        or "dev"
-    ).strip() or "dev"
+    api_key = _otel_authorization_token()
+    environment = _otel_environment()
     _write_codex_otel_config(
         endpoint=export_endpoint,
         trace_id=trace_id,

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -40,6 +40,7 @@ THREAD_ID: str | None = None
 ACTIVE_TURN_ID: str | None = None
 SHUTTING_DOWN = False
 CONFIGURED_OTEL_TRACE_ID: str | None = None
+CONFIGURED_TRACE_CONTEXT_ID: str | None = None
 APP_INITIALIZED = False
 CURRENT_TRACEPARENT: str | None = None
 OTEL_PROXY: ThreadingHTTPServer | None = None
@@ -131,7 +132,13 @@ def start_app_server() -> None:
     )
     notify("initialized")
     APP_INITIALIZED = True
-    emit({"type": "system", "subtype": "wrapper_heartbeat", "phase": "app_server_started"})
+    emit(
+        {
+            "type": "system",
+            "subtype": "wrapper_heartbeat",
+            "phase": "app_server_started",
+        }
+    )
 
 
 def app_stdout_reader() -> None:
@@ -199,16 +206,10 @@ def split_goal(items: list[dict[str, Any]]) -> tuple[str | None, list[dict[str, 
 
 
 def _codex_otel_endpoint() -> str:
-    endpoint = (
-        os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
-        or ""
-    ).strip()
+    endpoint = (os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") or "").strip()
     if endpoint:
         return endpoint
-    base = (
-        os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
-        or ""
-    ).strip()
+    base = (os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or "").strip()
     if not base:
         return ""
     base = base.rstrip("/")
@@ -237,9 +238,13 @@ def _strip_otel_toml_sections(contents: str) -> str:
 def _write_codex_otel_config(
     *, endpoint: str, trace_id: str, thread_key: str, api_key: str, environment: str
 ) -> None:
-    config_path = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex") / "config.toml"
+    config_path = (
+        Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex") / "config.toml"
+    )
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    base = _strip_otel_toml_sections(config_path.read_text() if config_path.exists() else "")
+    base = _strip_otel_toml_sections(
+        config_path.read_text() if config_path.exists() else ""
+    )
     headers = [
         f"x-trace-id = {_toml_string(trace_id)}",
     ]
@@ -254,7 +259,7 @@ def _write_codex_otel_config(
     ]
 
     trace_exporter = (
-        f'trace_exporter = {{ otlp-http = {{ endpoint = {_toml_string(endpoint)}, '
+        f"trace_exporter = {{ otlp-http = {{ endpoint = {_toml_string(endpoint)}, "
         f'protocol = "binary", headers = {{ {", ".join(headers)} }} }} }}'
     )
     otel_block = "\n".join(
@@ -307,14 +312,14 @@ def _otel_environment() -> str:
             if environment:
                 return environment
     return (
-        os.environ.get("DEPLOY_ENV")
-        or os.environ.get("ENVIRONMENT")
-        or "dev"
+        os.environ.get("DEPLOY_ENV") or os.environ.get("ENVIRONMENT") or "dev"
     ).strip() or "dev"
 
 
 def _attribute(span: Any, key: str) -> KeyValue | None:
-    return next((attribute for attribute in span.attributes if attribute.key == key), None)
+    return next(
+        (attribute for attribute in span.attributes if attribute.key == key), None
+    )
 
 
 def _attribute_string(span: Any, key: str) -> str:
@@ -367,7 +372,12 @@ def _append_current_llm_output(text: Any) -> None:
 
 
 def _append_llm_output_for_turn(turn_id: Any, text: Any) -> None:
-    if not isinstance(turn_id, str) or not turn_id or not isinstance(text, str) or not text:
+    if (
+        not isinstance(turn_id, str)
+        or not turn_id
+        or not isinstance(text, str)
+        or not text
+    ):
         return
     LLM_OUTPUTS_BY_TURN_ID[turn_id] = LLM_OUTPUTS_BY_TURN_ID.get(turn_id, "") + text
 
@@ -382,21 +392,35 @@ def _set_attribute_int(span: Any, key: str, value: int | None) -> None:
     attribute.value.int_value = value
 
 
+def _chat_messages_attribute(role: str, text: str) -> str:
+    return json.dumps(
+        [{"role": role, "content": text}],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
 def _normalize_codex_llm_span(span: Any, prefix: str) -> None:
     if span.name != f"{prefix}session_task.turn":
         return
 
     model = _attribute_string(span, "model")
     turn_id = _attribute_string(span, "turn.id")
+    input_text = LLM_INPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_INPUT_TEXT)
+    output_text = LLM_OUTPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_OUTPUT_TEXT)
     _set_attribute_string(span, "gen_ai.operation.name", "chat")
     _set_attribute_string(span, "gen_ai.system", "openai")
     _set_attribute_string(span, "gen_ai.request.model", model)
     _set_attribute_string(span, "gen_ai.response.model", model)
+    _set_attribute_string(span, "input.value", input_text)
+    _set_attribute_string(span, "output.value", output_text)
     _set_attribute_string(
-        span, "input.value", LLM_INPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_INPUT_TEXT)
+        span, "gen_ai.input.messages", _chat_messages_attribute("user", input_text)
     )
     _set_attribute_string(
-        span, "output.value", LLM_OUTPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_OUTPUT_TEXT)
+        span,
+        "gen_ai.output.messages",
+        _chat_messages_attribute("assistant", output_text),
     )
     _set_attribute_int(
         span,
@@ -588,12 +612,12 @@ def _trace_id_from_traceparent(traceparent: str | None) -> str | None:
 
 
 def configure_trace_context_for_startup(trace_id: str | None) -> None:
-    global CONFIGURED_OTEL_TRACE_ID
+    global CONFIGURED_TRACE_CONTEXT_ID
     trace_id = (trace_id or os.environ.get("CENTAUR_TRACE_ID") or "").strip()
     configure_trace_context(trace_id)
-    if not trace_id or CONFIGURED_OTEL_TRACE_ID == trace_id:
+    if not trace_id or CONFIGURED_TRACE_CONTEXT_ID == trace_id:
         return
-    CONFIGURED_OTEL_TRACE_ID = trace_id
+    CONFIGURED_TRACE_CONTEXT_ID = trace_id
 
 
 def start_or_resume_thread() -> str:
@@ -727,7 +751,8 @@ def handle_input(turn_input: dict[str, Any]) -> None:
     configure_trace_context_for_startup(turn_input.get("trace_id"))
     configure_traceparent(turn_input.get("traceparent"))
     configure_codex_otel_for_startup(
-        _trace_id_from_traceparent(turn_input.get("traceparent")) or turn_input.get("trace_id"),
+        _trace_id_from_traceparent(turn_input.get("traceparent"))
+        or turn_input.get("trace_id"),
         turn_input.get("thread_key"),
     )
     start_app_server()


### PR DESCRIPTION
## Summary

- propagate W3C `traceparent` from the API execution/inject span into sandbox harness input
- write Codex OTLP startup config before the lazy `codex app-server` starts
- route Codex OTLP exports through a sandbox-local prefix proxy that rewrites span names to `codex.*` before forwarding to the configured collector
- add sandbox OTLP endpoint hosts to `NO_PROXY` so local HTTP OTLP exports do not go through iron-proxy
- configure sandbox OTLP with generic `OTEL_*` env vars; Codex hardcodes its internal `codex.` span prefix when that harness is used
- attach prompt/output details using generalized OTLP/gen-ai attributes (`gen_ai.*`, `input.value`, `output.value`), plus Centaur-specific attributes for filtering

## Verification

- `cd services/api && uv run --python 3.11 pytest tests/test_codex_app_wrapper.py tests/test_otel.py tests/test_harness_protocol.py tests/test_sandbox_kubernetes_backend.py -q`
  - `92 passed, 1 warning`
- `cd services/api && uv run pytest tests/test_codex_app_wrapper.py tests/test_sandbox_kubernetes_backend.py -q`
  - `43 passed, 1 warning`
- `uv run ruff check services/sandbox/codex-app-wrapper.py services/api/api/sandbox/config.py services/api/tests/test_codex_app_wrapper.py services/api/tests/test_sandbox_kubernetes_backend.py`
  - `All checks passed!`
- local stack build/deploy:
  - `just build-one api`
  - `just build-one sandbox`
  - `helm upgrade --install ...` with generic sandbox `OTEL_*` env
  - rollout completed for `deploy/centaur-centaur-api`
- real API smoke, API-key authenticated, with sandbox spin-up:
  - thread: `orbstack-generic-otlp-smoke-1779821914`
  - runtime: `centaur-centaur-sandbox-orbstack-generic-otlp-smoke-af085aa1ba`
  - execution: `exe_2a2030ae366d4af1`
  - result: `ORBSTACK_GENERIC_OTLP_OK`
  - generated Codex config contains `centaur.span_prefix = "codex."` without any span-prefix env var
- code search confirms no backend-specific OTLP naming remains in the OTLP code stack
