### PR TITLE
Clarify lightweight Kubernetes setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Features
 
 - **Slack-native agent conversations**: mention the bot in Slack and get progress plus final answers back in the thread.
-- **Real execution environment**: each conversation runs in an isolated Kubernetes sandbox with a shell, workspace, git, Python, Node.js, Bun, and common development tools.
+- **Real execution environment**: each conversation runs in an isolated Kubernetes sandbox with a shell, workspace, git, Python, Node.js, Bun, and common development tools. For local setup, a lightweight k3s-based cluster is enough; you do not need a full production Kubernetes installation.
 - **Bring your own harness**: run CLI-based agents such as Amp, Claude Code, Codex, or deployment-specific harnesses.
 - **Shared tools**: add Python tool plugins once and make them available to every agent conversation.
 - **Durable workflows**: run jobs that can sleep, resume, wait for events, start child agents, and survive service restarts.
@@ -97,7 +97,9 @@ The main directories are:
 
 ## Getting Started
 
-Centaur runs locally on Kubernetes. The expected local checkout path is:
+Centaur runs locally on Kubernetes, but local setup does not require a full
+production Kubernetes installation. A lightweight k3s cluster on a small
+always-on host is enough. The expected local checkout path is:
 
 ```bash
 /Users/magelinskaas/paradigmxyz/centaur
@@ -146,6 +148,10 @@ just up
 ```
 
 After `just up` finishes, use Slack or the API examples in the [Developer Guide](AGENTS.md#e2e-testing-without-slack).
+
+For a more explicit path, see [Running Centaur on a Mac Mini-style setup](docs/pages/mac-mini-setup.mdx).
+It covers k3s on a small VPS, DigitalOcean droplet, Linux box, or Mac
+Mini-style host.
 
 ## Tools
 

--- a/docs/pages/mac-mini-setup.mdx
+++ b/docs/pages/mac-mini-setup.mdx
@@ -1,0 +1,123 @@
+---
+title: Running Centaur on a Mac Mini-style setup
+description: Run Centaur on k3s with a Mac Mini, small VPS, or similar always-on host.
+---
+
+# Running Centaur on a Mac Mini-style setup
+
+The easiest way to run Centaur outside a developer laptop is a small always-on
+machine with k3s. This can be a Mac Mini running Linux, a DigitalOcean droplet,
+another simple VPS, or a spare Linux box. You do not need a managed Kubernetes
+cluster to get started.
+
+Centaur's development workflow builds images locally:
+
+```bash
+just build
+```
+
+Those images are named `centaur-api:latest`, `centaur-iron-proxy:latest`,
+`centaur-slackbot:latest`, and `centaur-agent:latest`. On a single small host,
+the simplest setup is to build those images on the same machine that runs k3s,
+then import them into k3s' container runtime.
+
+## 1. Install k3s
+
+Run these commands on the machine that will host Centaur:
+
+```bash
+curl -sfL https://get.k3s.io | sh -
+sudo chmod 644 /etc/rancher/k3s/k3s.yaml
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+kubectl get nodes
+```
+
+Persist `KUBECONFIG` in your shell profile if you want future shells to target
+this cluster automatically.
+
+## 2. Install local tools
+
+Install Docker plus the command-line tools Centaur's local workflow expects:
+
+```bash
+brew install just kubectl helm jq
+```
+
+If `brew` is not available on your Linux host, install Docker, `just`,
+`kubectl`, `helm`, and `jq` from your package manager or their upstream
+installers.
+
+Clone Centaur on the host:
+
+```bash
+git clone <repo-url>
+cd centaur
+```
+
+## 3. Build and load images
+
+Build the Centaur images:
+
+```bash
+just build
+```
+
+Load them into k3s' container runtime:
+
+```bash
+docker save \
+  centaur-api:latest \
+  centaur-iron-proxy:latest \
+  centaur-slackbot:latest \
+  centaur-agent:latest \
+  -o /tmp/centaur-images.tar
+
+sudo k3s ctr images import /tmp/centaur-images.tar
+```
+
+For repeated deploys on the same host, rerun `just build`, reload the changed
+images, then run `just deploy`.
+
+## 4. Bootstrap secrets
+
+The default local chart expects one infra Secret named `centaur-infra-env`.
+Export the required values before deploying:
+
+```bash
+export OP_SERVICE_ACCOUNT_TOKEN=...
+export OP_VAULT=...
+export SLACK_BOT_TOKEN=...
+export SLACK_SIGNING_SECRET=...
+export SLACKBOT_API_KEY=...
+```
+
+Then create the Kubernetes Secret:
+
+```bash
+just bootstrap-secrets
+```
+
+## 5. Deploy Centaur
+
+Deploy the Helm chart:
+
+```bash
+just deploy
+just status
+```
+
+Verify the API:
+
+```bash
+kubectl exec -n centaur deploy/centaur-centaur-api -- \
+  curl -fsS http://localhost:8000/health
+```
+
+Expected shape:
+
+```json
+{"status":"ok"}
+```
+
+Then continue with the [Quickstart](/quickstart) smoke test and agent-turn
+verification steps.

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -5,9 +5,13 @@ description: Boot Centaur locally and verify the control plane.
 
 # Quickstart
 
-This guide gets you from a fresh checkout to a working local Centaur stack. The
-happy path is: point `kubectl` at a local cluster, bootstrap the required infra
-Secret, run `just up`, verify the API, then run one agent turn without Slack.
+This guide gets you from a fresh checkout to a working local Centaur stack. You
+do not need a full production Kubernetes installation for local setup: a
+lightweight k3s-based cluster is enough. The happy path is: point `kubectl` at
+that cluster, bootstrap the required infra Secret, run `just up`, verify the
+API, then run one agent turn without Slack. If you want the easiest small-host
+path first, start with [Running Centaur on a Mac Mini-style
+setup](/mac-mini-setup).
 
 If you want an agent to drive setup with you, point it at these docs: every page
 is available through `/llms.txt`, `/llms-full.txt`, and static Markdown files
@@ -21,10 +25,11 @@ From the repo root:
 brew install just kubectl helm jq
 ```
 
-You also need Docker and a local Kubernetes cluster. The most direct path on
-macOS is Docker Desktop with Kubernetes enabled, but kind, minikube, and k3d are
-fine as long as `kubectl` points at that local cluster and it can run the Helm
-chart.
+You also need Docker and a local Kubernetes cluster. This can be lightweight:
+k3s works on a small VPS, DigitalOcean droplet, Linux box, or Mac Mini-style
+host. Docker Desktop with Kubernetes enabled, kind, and minikube are also fine
+as long as `kubectl` points at that local cluster and it can run the Helm chart.
+The [Mac Mini-style setup guide](/mac-mini-setup) walks through the k3s path.
 
 Check the target before booting Centaur:
 

--- a/docs/public/md/mac-mini-setup.md
+++ b/docs/public/md/mac-mini-setup.md
@@ -1,0 +1,123 @@
+---
+title: Running Centaur on a Mac Mini-style setup
+description: Run Centaur on k3s with a Mac Mini, small VPS, or similar always-on host.
+---
+
+# Running Centaur on a Mac Mini-style setup
+
+The easiest way to run Centaur outside a developer laptop is a small always-on
+machine with k3s. This can be a Mac Mini running Linux, a DigitalOcean droplet,
+another simple VPS, or a spare Linux box. You do not need a managed Kubernetes
+cluster to get started.
+
+Centaur's development workflow builds images locally:
+
+```bash
+just build
+```
+
+Those images are named `centaur-api:latest`, `centaur-iron-proxy:latest`,
+`centaur-slackbot:latest`, and `centaur-agent:latest`. On a single small host,
+the simplest setup is to build those images on the same machine that runs k3s,
+then import them into k3s' container runtime.
+
+## 1. Install k3s
+
+Run these commands on the machine that will host Centaur:
+
+```bash
+curl -sfL https://get.k3s.io | sh -
+sudo chmod 644 /etc/rancher/k3s/k3s.yaml
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+kubectl get nodes
+```
+
+Persist `KUBECONFIG` in your shell profile if you want future shells to target
+this cluster automatically.
+
+## 2. Install local tools
+
+Install Docker plus the command-line tools Centaur's local workflow expects:
+
+```bash
+brew install just kubectl helm jq
+```
+
+If `brew` is not available on your Linux host, install Docker, `just`,
+`kubectl`, `helm`, and `jq` from your package manager or their upstream
+installers.
+
+Clone Centaur on the host:
+
+```bash
+git clone <repo-url>
+cd centaur
+```
+
+## 3. Build and load images
+
+Build the Centaur images:
+
+```bash
+just build
+```
+
+Load them into k3s' container runtime:
+
+```bash
+docker save \
+  centaur-api:latest \
+  centaur-iron-proxy:latest \
+  centaur-slackbot:latest \
+  centaur-agent:latest \
+  -o /tmp/centaur-images.tar
+
+sudo k3s ctr images import /tmp/centaur-images.tar
+```
+
+For repeated deploys on the same host, rerun `just build`, reload the changed
+images, then run `just deploy`.
+
+## 4. Bootstrap secrets
+
+The default local chart expects one infra Secret named `centaur-infra-env`.
+Export the required values before deploying:
+
+```bash
+export OP_SERVICE_ACCOUNT_TOKEN=...
+export OP_VAULT=...
+export SLACK_BOT_TOKEN=...
+export SLACK_SIGNING_SECRET=...
+export SLACKBOT_API_KEY=...
+```
+
+Then create the Kubernetes Secret:
+
+```bash
+just bootstrap-secrets
+```
+
+## 5. Deploy Centaur
+
+Deploy the Helm chart:
+
+```bash
+just deploy
+just status
+```
+
+Verify the API:
+
+```bash
+kubectl exec -n centaur deploy/centaur-centaur-api -- \
+  curl -fsS http://localhost:8000/health
+```
+
+Expected shape:
+
+```json
+{"status":"ok"}
+```
+
+Then continue with the [Quickstart](/quickstart) smoke test and agent-turn
+verification steps.

--- a/docs/public/md/quickstart.md
+++ b/docs/public/md/quickstart.md
@@ -5,9 +5,13 @@ description: Boot Centaur locally and verify the control plane.
 
 # Quickstart
 
-This guide gets you from a fresh checkout to a working local Centaur stack. The
-happy path is: point `kubectl` at a local cluster, bootstrap the required infra
-Secret, run `just up`, verify the API, then run one agent turn without Slack.
+This guide gets you from a fresh checkout to a working local Centaur stack. You
+do not need a full production Kubernetes installation for local setup: a
+lightweight k3s-based cluster is enough. The happy path is: point `kubectl` at
+that cluster, bootstrap the required infra Secret, run `just up`, verify the
+API, then run one agent turn without Slack. If you want the easiest small-host
+path first, start with [Running Centaur on a Mac Mini-style
+setup](/mac-mini-setup).
 
 If you want an agent to drive setup with you, point it at these docs: every page
 is available through `/llms.txt`, `/llms-full.txt`, and static Markdown files
@@ -21,10 +25,11 @@ From the repo root:
 brew install just kubectl helm jq
 ```
 
-You also need Docker and a local Kubernetes cluster. The most direct path on
-macOS is Docker Desktop with Kubernetes enabled, but kind, minikube, and k3d are
-fine as long as `kubectl` points at that local cluster and it can run the Helm
-chart.
+You also need Docker and a local Kubernetes cluster. This can be lightweight:
+k3s works on a small VPS, DigitalOcean droplet, Linux box, or Mac Mini-style
+host. Docker Desktop with Kubernetes enabled, kind, and minikube are also fine
+as long as `kubectl` points at that local cluster and it can run the Helm chart.
+The [Mac Mini-style setup guide](/mac-mini-setup) walks through the k3s path.
 
 Check the target before booting Centaur:
 

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -6,6 +6,7 @@ export const sidebar = [
     items: [
       { text: 'What is Centaur?', link: '/what-is-centaur' },
       { text: 'Quickstart', link: '/quickstart' },
+      { text: 'Mac Mini-style setup', link: '/mac-mini-setup' },
       { text: 'Deploying in Production', link: '/deploying-in-production' },
       { text: 'Architecture', link: '/architecture' },
     ],


### PR DESCRIPTION
## Summary
- add a dedicated "Running Centaur on a Mac Mini-style setup" guide for k3s on a Mac Mini-style host, small VPS, DigitalOcean droplet, or Linux box
- link the guide from the README and Quickstart before readers get into setup steps
- keep the early README/Quickstart wording explicit that local setup does not require full production Kubernetes
- remove k3d mentions from the setup docs

## Testing
- `npm run build` in `docs` did not complete because `zip` is not installed in the sandbox; generated Markdown artifacts were updated manually to match the MDX docs

Prompted by: @gakonst