### PR TITLE
fix(slackbot): replace completed Codex message snapshots

### DIFF
--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
 import { describe, expect, it } from 'bun:test'
 import { shouldShowThinkingBlock } from './render'
 import { AgentSessionRenderer } from './agent-session'
@@ -1126,26 +1128,16 @@ describe('CodexSessionRenderer', () => {
     expect(result.streamedAnswerChars).toBe(answerText.length)
   })
 
-  it('logs suspicious large answer snapshots without logging answer text', async () => {
+  it('replaces the per-item buffer with item.completed canonical text and emits a correction log', async () => {
+    // The May 23 2026 prod duplicate-reply bug: codex's item.completed sometimes carries
+    // an item.text that differs by one interior character from the sum of streamed
+    // deltas. The pre-fix delta-diff heuristic appended the entire canonical text on
+    // top of the accumulated deltas, doubling the visible body.
     const logCalls: unknown[][] = []
     const originalLog = console.log
-    console.log = ((...args: unknown[]) => {
-      logCalls.push(args)
-    }) as typeof console.log
-    const client = {
-      assistant: {
-        threads: {
-          setStatus: async () => ({ ok: true })
-        }
-      },
-      chat: {
-        startStream: async () => ({ ok: true, ts: '1778866940.295499' }),
-        appendStream: async () => ({ ok: true }),
-        stopStream: async () => ({ ok: true }),
-        update: async () => ({ ok: true })
-      }
-    }
-
+    console.log = ((...args: unknown[]) => logCalls.push(args)) as typeof console.log
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
     const { sessionId } = await new AgentSessionRenderer(client as any).open({
       channel: 'C123',
       parentTs: '1778866921.505479',
@@ -1154,7 +1146,9 @@ describe('CodexSessionRenderer', () => {
       title: 'Centaur execution'
     })
     const renderer = new CodexSessionRenderer(client as any)
-    const answer = 'first generated answer '.repeat(13)
+
+    const deltaSum = 'X'.repeat(500) + ' middle delta ' + 'Y'.repeat(500)
+    const canonical = deltaSum.replace('middle delta', 'middle_delta')
 
     try {
       await renderer.event(sessionId, {
@@ -1164,7 +1158,7 @@ describe('CodexSessionRenderer', () => {
       await renderer.event(sessionId, {
         type: 'item.agentMessage.delta',
         itemId: 'msg-1',
-        delta: answer
+        delta: deltaSum
       })
       await renderer.event(sessionId, {
         type: 'item.completed',
@@ -1172,22 +1166,22 @@ describe('CodexSessionRenderer', () => {
         centaur_execution_id: 'exe-test',
         centaur_assignment_generation: 3,
         session_id: 'codex-session-test',
-        item: {
-          id: 'msg-1',
-          type: 'agentMessage',
-          phase: 'final_answer',
-          text: `${answer}\n${answer}`
-        }
+        item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: canonical }
       })
+      await renderer.event(sessionId, { type: 'turn.done', result: canonical })
     } finally {
       console.log = originalLog
     }
 
-    const suspiciousLogs = logCalls.filter(
-      call => call[0] === 'slack_codex_suspicious_answer_delta'
+    const visible = visibleMarkdown(calls)
+    expect(countOccurrences(visible, 'X'.repeat(500))).toBe(1)
+    expect(countOccurrences(visible, 'Y'.repeat(500))).toBe(1)
+
+    const correctionLogs = logCalls.filter(
+      call => call[0] === 'slack_codex_canonical_answer_correction'
     )
-    expect(suspiciousLogs).toHaveLength(1)
-    expect(suspiciousLogs[0]?.[1]).toMatchObject({
+    expect(correctionLogs).toHaveLength(1)
+    expect(correctionLogs[0]?.[1]).toMatchObject({
       agent_session_id: sessionId,
       centaur_thread_key: 'slack:C123:1778866921.505479',
       execution_id: 'exe-test',
@@ -1198,45 +1192,304 @@ describe('CodexSessionRenderer', () => {
       codex_item_type: 'agentMessage',
       codex_item_phase: 'final_answer',
       codex_session_id: 'codex-session-test',
-      current_answer_chars: answer.length,
-      incoming_chars: answer.length * 2 + 1,
-      delta_chars: answer.length + 1,
-      answer_chars_after: answer.length * 2 + 1,
-      current_contains_incoming_head: true,
-      incoming_contains_current_tail: true,
-      large_incoming_relative_to_current: true,
-      large_delta_relative_to_current: true
+      delta_total_chars: deltaSum.length,
+      canonical_text_chars: canonical.length,
+      chars_diff: 0,
+      delta_hash: expect.any(String),
+      canonical_hash: expect.any(String)
     })
-    expect(suspiciousLogs[0]?.[1]).toEqual(
-      expect.objectContaining({
-        current_hash: expect.any(String),
-        incoming_hash: expect.any(String),
-        delta_hash: expect.any(String)
-      })
-    )
-    expect(JSON.stringify(suspiciousLogs)).not.toContain(answer.slice(0, 30))
+    expect(JSON.stringify(correctionLogs)).not.toContain(deltaSum.slice(0, 20))
   })
 
-  it('does not log suspicious answer deltas for small incremental answer updates', async () => {
+  it('replaces a typo-corrected final snapshot instead of appending both copies', async () => {
     const logCalls: unknown[][] = []
     const originalLog = console.log
-    console.log = ((...args: unknown[]) => {
-      logCalls.push(args)
-    }) as typeof console.log
-    const client = {
-      assistant: {
-        threads: {
-          setStatus: async () => ({ ok: true })
+    console.log = ((...args: unknown[]) => logCalls.push(args)) as typeof console.log
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    const streamedDraft =
+      '@alex The archive discount keeps the same 42,000 records exported, but bills eligible report jobs at a lower storage tier. For example, this looks like a single CSV export, so the metered rate should be 12 cents per thousand rows instead of 20 cents, with the difference credited after the run. This is low-risk because it changes billing, not data processing.\n\n' +
+      '2) export fast path means: reduce actual work by special-casing the common “CSV export to the defaut bucket” path. Today the job does normal pre-validation, writes rows, then post-proceses checksums, touching report metadata and audit state. A fast path would skip or merge some of that when the route is trivial, for example same destination bucket, no CDN purge, pure CSV export, no mixed formats. That attacks the 17,500 extra operations directly, but it is higher-risk because it changes execution/accounting.'
+    const canonical =
+      '@alex The archive discount keeps the same 42,000 records exported, but bills eligible report jobs at a lower storage tier. For example, this looks like a single CSV export, so the metered rate should be 12 cents per thousand rows instead of 20 cents, with the difference credited after the run. This is low-risk because it changes billing, not data processing.\n\n' +
+      '2) export fast path means: reduce actual work by special-casing the common “CSV export to the default bucket” path. Today the job does normal pre-validation, writes rows, then post-processes checksums, touching report metadata and audit state. A fast path would skip or merge some of that when the route is trivial, for example same destination bucket, no CDN purge, pure CSV export, no mixed formats. That attacks the 17,500 extra operations directly, but it is higher-risk because it changes execution/accounting.'
+
+    try {
+      await renderer.event(sessionId, {
+        type: 'item.started',
+        item: { id: 'msg-typo-case', type: 'agentMessage', phase: 'final_answer' }
+      })
+      await renderer.event(sessionId, {
+        type: 'item.agentMessage.delta',
+        itemId: 'msg-typo-case',
+        delta: streamedDraft
+      })
+      await renderer.event(sessionId, {
+        type: 'item.completed',
+        centaur_thread_key: 'slack:C123:1778866921.505479',
+        centaur_execution_id: 'exe-typo-case',
+        centaur_assignment_generation: 7,
+        session_id: 'codex-session-typo-case',
+        item: {
+          id: 'msg-typo-case',
+          type: 'agentMessage',
+          phase: 'final_answer',
+          text: canonical
         }
-      },
-      chat: {
-        startStream: async () => ({ ok: true, ts: '1778866940.295499' }),
-        appendStream: async () => ({ ok: true }),
-        stopStream: async () => ({ ok: true }),
-        update: async () => ({ ok: true })
-      }
+      })
+      await renderer.event(sessionId, { type: 'turn.done', result: canonical })
+    } finally {
+      console.log = originalLog
     }
 
+    const visible = visibleMarkdown(calls)
+    expect(countOccurrences(visible, '@alex The archive discount')).toBe(1)
+    expect(visible).toContain('default bucket')
+    expect(visible).toContain('post-processes checksums')
+    expect(visible).not.toContain('defaut bucket')
+    expect(visible).not.toContain('post-proceses checksums')
+
+    const correctionLogs = logCalls.filter(
+      call => call[0] === 'slack_codex_canonical_answer_correction'
+    )
+    expect(correctionLogs).toHaveLength(1)
+    expect(correctionLogs[0]?.[1]).toMatchObject({
+      agent_session_id: sessionId,
+      centaur_thread_key: 'slack:C123:1778866921.505479',
+      execution_id: 'exe-typo-case',
+      assignment_generation: 7,
+      event_type: 'item.completed',
+      codex_id: 'msg-typo-case',
+      delta_total_chars: streamedDraft.length,
+      canonical_text_chars: canonical.length,
+      chars_diff: canonical.length - streamedDraft.length,
+      delta_hash: expect.any(String),
+      canonical_hash: expect.any(String)
+    })
+  })
+
+  it('replays the exact prod event stream from exe_a89da7f248bb4724 without doubling the reply', async () => {
+    // Real captured event stream from the May 23 2026 prod duplicate-reply incident.
+    // Pre-fix, this exact sequence produced a Slack message that contained the entire
+    // 1540-char final answer twice (visible body ~3079 chars). With the per-item
+    // canonical-replace contract, the final answer appears exactly once.
+    const fixturePath = join(
+      __dirname,
+      '..',
+      '..',
+      'test-fixtures',
+      'codex',
+      'exe_a89da7f248bb4724-min.json'
+    )
+    const fixture = JSON.parse(readFileSync(fixturePath, 'utf8')) as {
+      events: Array<Record<string, unknown>>
+    }
+    const finalEvent = fixture.events.find(
+      (event: any) =>
+        event.type === 'item.completed' &&
+        event?.item?.type === 'agentMessage' &&
+        event?.item?.phase === 'final_answer'
+    ) as { item: { text: string } } | undefined
+    expect(finalEvent).toBeTruthy()
+    const canonicalAnswer = finalEvent!.item.text
+    expect(canonicalAnswer.length).toBeGreaterThan(1000)
+
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    for (const event of fixture.events) {
+      await renderer.event(sessionId, event)
+    }
+
+    const visible = visibleMarkdown(calls)
+    const openingPhrase = canonicalAnswer.slice(0, 80)
+    expect(countOccurrences(canonicalAnswer, openingPhrase)).toBe(1)
+    expect(countOccurrences(visible, openingPhrase)).toBe(1)
+    const closingPhrase = canonicalAnswer.slice(-80)
+    expect(countOccurrences(canonicalAnswer, closingPhrase)).toBe(1)
+    expect(countOccurrences(visible, closingPhrase)).toBe(1)
+  })
+
+  it('concatenates two final_answer agentMessages in the same turn exactly once each', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    for (const id of ['msg-a', 'msg-b']) {
+      await renderer.event(sessionId, {
+        type: 'item.started',
+        item: { id, type: 'agentMessage', phase: 'final_answer' }
+      })
+      await renderer.event(sessionId, {
+        type: 'item.agentMessage.delta',
+        itemId: id,
+        delta: `Half ${id}.`
+      })
+      await renderer.event(sessionId, {
+        type: 'item.completed',
+        item: { id, type: 'agentMessage', phase: 'final_answer', text: `Half ${id}.` }
+      })
+    }
+    await renderer.event(sessionId, { type: 'turn.done', result: 'Half msg-a.Half msg-b.' })
+
+    const visible = visibleMarkdown(calls)
+    expect(countOccurrences(visible, 'Half msg-a.')).toBe(1)
+    expect(countOccurrences(visible, 'Half msg-b.')).toBe(1)
+  })
+
+  it('ignores deltas that arrive after the same item has already been completed', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'msg-late', type: 'agentMessage', phase: 'final_answer' }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.agentMessage.delta',
+      itemId: 'msg-late',
+      delta: 'Final canonical reply.'
+    })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: {
+        id: 'msg-late',
+        type: 'agentMessage',
+        phase: 'final_answer',
+        text: 'Final canonical reply.'
+      }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.agentMessage.delta',
+      itemId: 'msg-late',
+      delta: ' INJECTED-LATE-CHUNK'
+    })
+    await renderer.event(sessionId, { type: 'turn.done', result: 'Final canonical reply.' })
+
+    const visible = visibleMarkdown(calls)
+    expect(visible).not.toContain('INJECTED-LATE-CHUNK')
+    expect(countOccurrences(visible, 'Final canonical reply.')).toBe(1)
+  })
+
+  it('drops item.completed without an item id and emits a missing-id log', async () => {
+    const logCalls: unknown[][] = []
+    const originalLog = console.log
+    console.log = ((...args: unknown[]) => logCalls.push(args)) as typeof console.log
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    try {
+      await renderer.event(sessionId, {
+        type: 'item.started',
+        item: { id: 'msg-pre', type: 'agentMessage', phase: 'final_answer' }
+      })
+      await renderer.event(sessionId, {
+        type: 'item.agentMessage.delta',
+        itemId: 'msg-pre',
+        delta: 'Streamed reply.'
+      })
+      await renderer.event(sessionId, {
+        type: 'item.completed',
+        centaur_thread_key: 'slack:C123:1778866921.505479',
+        centaur_execution_id: 'exe-noid',
+        item: { type: 'agentMessage', phase: 'final_answer', text: 'Malformed canonical body.' }
+      })
+      await renderer.event(sessionId, { type: 'turn.done', result: 'Streamed reply.' })
+    } finally {
+      console.log = originalLog
+    }
+
+    const visible = visibleMarkdown(calls)
+    expect(visible).toContain('Streamed reply.')
+    expect(visible).not.toContain('Malformed canonical body.')
+
+    const missingIdLogs = logCalls.filter(
+      call => call[0] === 'slack_codex_item_completed_missing_id'
+    )
+    expect(missingIdLogs).toHaveLength(1)
+    expect(missingIdLogs[0]?.[1]).toMatchObject({
+      agent_session_id: sessionId,
+      centaur_thread_key: 'slack:C123:1778866921.505479',
+      execution_id: 'exe-noid',
+      canonical_text_chars: 'Malformed canonical body.'.length,
+      canonical_hash: expect.any(String)
+    })
+  })
+
+  it('streams cumulative amp/claude assistant text without duplication', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    await renderer.event(sessionId, {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'Hello.' }] }
+    })
+    await renderer.event(sessionId, {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'Hello. World.' }] }
+    })
+    await renderer.event(sessionId, { type: 'result', result: 'Hello. World.' })
+
+    const visible = visibleMarkdown(calls)
+    expect(countOccurrences(visible, 'Hello. World.')).toBe(1)
+    expect(countOccurrences(visible, 'Hello.')).toBe(1)
+  })
+
+  it('does not log a canonical correction for plain delta streams without item.completed', async () => {
+    const logCalls: unknown[][] = []
+    const originalLog = console.log
+    console.log = ((...args: unknown[]) => logCalls.push(args)) as typeof console.log
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
     const { sessionId } = await new AgentSessionRenderer(client as any).open({
       channel: 'C123',
       parentTs: '1778866921.505479',
@@ -1266,7 +1519,7 @@ describe('CodexSessionRenderer', () => {
     }
 
     expect(
-      logCalls.filter(call => call[0] === 'slack_codex_suspicious_answer_delta')
+      logCalls.filter(call => call[0] === 'slack_codex_canonical_answer_correction')
     ).toHaveLength(0)
   })
 
@@ -1585,4 +1838,64 @@ function richTextPlain(value: any): string {
         .join('')
     )
     .join('\n')
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0
+  let count = 0
+  let index = 0
+  while (true) {
+    const at = haystack.indexOf(needle, index)
+    if (at === -1) return count
+    count += 1
+    index = at + needle.length
+  }
+}
+
+function visibleMarkdown(calls: Array<{ method: string; params: any }>): string {
+  const streamed = calls
+    .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
+    .flatMap(call => call.params.chunks ?? [])
+    .filter((chunk: any) => chunk.type === 'markdown_text')
+    .map((chunk: any) => String(chunk.text ?? ''))
+    .join('')
+  const stopBlocks = calls.find(call => call.method === 'chat.stopStream')?.params.blocks ?? []
+  const stopMarkdown = stopBlocks
+    .filter((block: any) => block.type === 'markdown')
+    .map((block: any) => String(block.text ?? ''))
+    .join('')
+  return streamed + stopMarkdown
+}
+
+function makeFakeSlackClient(
+  calls: Array<{ method: string; params: any }>
+): Record<string, unknown> {
+  return {
+    assistant: {
+      threads: {
+        setStatus: async (params: any) => {
+          calls.push({ method: 'assistant.threads.setStatus', params })
+          return { ok: true }
+        }
+      }
+    },
+    chat: {
+      startStream: async (params: any) => {
+        calls.push({ method: 'chat.startStream', params })
+        return { ok: true, ts: '1778866940.295499' }
+      },
+      appendStream: async (params: any) => {
+        calls.push({ method: 'chat.appendStream', params })
+        return { ok: true }
+      },
+      stopStream: async (params: any) => {
+        calls.push({ method: 'chat.stopStream', params })
+        return { ok: true }
+      },
+      update: async (params: any) => {
+        calls.push({ method: 'chat.update', params })
+        return { ok: true }
+      }
+    }
+  }
 }

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -30,9 +30,13 @@ type CodexSessionState = {
   threadId: string
   stepCounter: number
   nextCommandIndex: number
-  commentaryText: string
-  commentaryByItemId: Map<string, string>
+  answerByItemId: Map<string, string>
+  harnessAnswerText: string
   answerText: string
+  commentaryByItemId: Map<string, string>
+  harnessCommentaryText: string
+  commentaryText: string
+  completedItemIds: Set<string>
   firstBufferedTextAt: number | null
   streamedCommentaryText: string
   streamedAnswerText: string
@@ -182,24 +186,14 @@ export class CodexSessionRenderer {
       await this.publishActivitySummary(agentSessionId, state)
     }
 
-    const assistantMessage = assistantText(event)
-    if (assistantMessage) {
+    if (eventCarriesAgentMessageText(event)) {
       const buffer = activeAssistantBuffer(state, event, agentSessionId)
-      const current = buffer === 'answer' ? state.answerText : state.commentaryText
-      const delta = messageDelta(current, assistantMessage)
-      if (delta) {
-        if (buffer === 'answer') {
-          logSuspiciousAnswerDelta(agentSessionId, event, state, {
-            current,
-            incoming: assistantMessage,
-            delta
-          })
-          state.answerText += delta
-        } else {
-          state.commentaryText += delta
-          trackCommentaryText(state, event, delta)
-        }
+      const update = applyAgentMessageUpdate(state, event, buffer, agentSessionId)
+      if (update.bufferChanged) {
         await this.publishPendingAssistantText(agentSessionId, state)
+      }
+      if (update.correction) {
+        logCanonicalCorrection(agentSessionId, event, state, update.correction)
       }
       if (buffer === 'commentary' && event?.type === 'item.completed') {
         upsertThinkingTask(state, event)
@@ -228,7 +222,8 @@ export class CodexSessionRenderer {
         willClose
       })
       if (resultText && !state.answerText.trim()) {
-        state.answerText += resultText
+        state.harnessAnswerText += resultText
+        recomposeBuffers(state)
         await this.publishPendingAssistantText(agentSessionId, state, { force: true })
       }
       if (willClose) {
@@ -360,9 +355,13 @@ function getState(agentSessionId: string): CodexSessionState {
       threadId: '',
       stepCounter: 0,
       nextCommandIndex: 0,
-      commentaryText: '',
-      commentaryByItemId: new Map(),
+      answerByItemId: new Map(),
+      harnessAnswerText: '',
       answerText: '',
+      commentaryByItemId: new Map(),
+      harnessCommentaryText: '',
+      commentaryText: '',
+      completedItemIds: new Set(),
       firstBufferedTextAt: null,
       streamedCommentaryText: '',
       streamedAnswerText: '',
@@ -409,19 +408,30 @@ function agentMessageEventId(event: any): string {
 function ensureCommentarySegmentBreak(event: any, state: CodexSessionState): void {
   if (event?.type !== 'item.started') return
   if (agentMessageItemPhase(event?.item) !== 'commentary') return
-  const current = state.commentaryText
-  if (!current.trim() || current.endsWith('\n\n')) return
-  state.commentaryText = current.endsWith('\n') ? `${current}\n` : `${current}\n\n`
+  const lastId = lastInsertedKey(state.commentaryByItemId)
+  if (lastId) {
+    const prior = state.commentaryByItemId.get(lastId) ?? ''
+    if (prior.trim() && !prior.endsWith('\n\n')) {
+      state.commentaryByItemId.set(lastId, prior.endsWith('\n') ? `${prior}\n` : `${prior}\n\n`)
+    }
+  } else if (state.harnessCommentaryText.trim() && !state.harnessCommentaryText.endsWith('\n\n')) {
+    state.harnessCommentaryText = state.harnessCommentaryText.endsWith('\n')
+      ? `${state.harnessCommentaryText}\n`
+      : `${state.harnessCommentaryText}\n\n`
+  } else {
+    return
+  }
+  recomposeBuffers(state)
+}
+
+function lastInsertedKey<K>(map: Map<K, unknown>): K | undefined {
+  let last: K | undefined
+  for (const key of map.keys()) last = key
+  return last
 }
 
 function commentaryItemId(event: any): string {
   return String(event?.itemId ?? event?.item_id ?? event?.item?.id ?? '')
-}
-
-function trackCommentaryText(state: CodexSessionState, event: any, delta: string): void {
-  const id = commentaryItemId(event)
-  if (!id) return
-  state.commentaryByItemId.set(id, `${state.commentaryByItemId.get(id) ?? ''}${delta}`)
 }
 
 function upsertThinkingTask(state: CodexSessionState, event: any): void {
@@ -429,10 +439,12 @@ function upsertThinkingTask(state: CodexSessionState, event: any): void {
   if (!id) return
   const body = String(event?.item?.text ?? state.commentaryByItemId.get(id) ?? '').trim()
   if (!body) return
-  const taskId = `thinking-${id}`
-  state.commentaryByItemId.set(id, body)
-  state.taskByUseId.set(taskId, {
-    id: taskId,
+  if (state.commentaryByItemId.get(id) !== body) {
+    state.commentaryByItemId.set(id, body)
+    recomposeBuffers(state)
+  }
+  state.taskByUseId.set(`thinking-${id}`, {
+    id: `thinking-${id}`,
     title: 'Thinking',
     status: 'complete',
     details: [section([text(body)])],
@@ -481,60 +493,120 @@ function activeAssistantBuffer(
   return 'answer'
 }
 
-function assistantText(event: any): string {
+function eventCarriesAgentMessageText(event: any): boolean {
+  if (event?.type === 'item.agentMessage.delta') return Boolean(extractDeltaText(event))
+  if (event?.type === 'assistant') return Boolean(assistantTextFromAssistantEvent(event))
+  if (event?.type === 'item.completed') {
+    const itemType = event?.item?.type
+    if (itemType !== 'agentMessage' && itemType !== 'agent_message') return false
+    return Boolean(String(event?.item?.text ?? ''))
+  }
+  return false
+}
+
+type AgentMessageUpdateResult = {
+  bufferChanged: boolean
+  correction?: { previous: string; canonical: string }
+}
+
+function applyAgentMessageUpdate(
+  state: CodexSessionState,
+  event: any,
+  buffer: 'answer' | 'commentary',
+  agentSessionId: string
+): AgentMessageUpdateResult {
+  const itemId = agentMessageEventId(event)
+
   if (event?.type === 'item.agentMessage.delta') {
-    const delta = event.delta ?? event.text ?? event.content ?? ''
-    if (delta && typeof delta === 'object') {
-      return String(delta.text ?? delta.content ?? '')
+    if (!itemId || state.completedItemIds.has(itemId)) return { bufferChanged: false }
+    const delta = extractDeltaText(event)
+    if (!delta) return { bufferChanged: false }
+    const byId = buffer === 'answer' ? state.answerByItemId : state.commentaryByItemId
+    byId.set(itemId, (byId.get(itemId) ?? '') + delta)
+    recomposeBuffers(state)
+    return { bufferChanged: true }
+  }
+
+  if (event?.type === 'item.completed') {
+    const canonical = String(event?.item?.text ?? '')
+    if (!canonical) return { bufferChanged: false }
+    if (!itemId) {
+      // Without an item id we cannot map this canonical text to the per-item buffer it
+      // was meant to replace. Falling back to a flat append would re-introduce the
+      // pre-fix duplication, so we drop and log instead. Codex always emits an id in
+      // observed prod streams; this branch defends against malformed events.
+      logInfo('slack_codex_item_completed_missing_id', {
+        agent_session_id: agentSessionId,
+        centaur_thread_key: event?.centaur_thread_key,
+        execution_id: event?.centaur_execution_id,
+        canonical_text_chars: canonical.length,
+        canonical_hash: textHash(canonical)
+      })
+      return { bufferChanged: false }
     }
-    return String(delta)
+    const byId = buffer === 'answer' ? state.answerByItemId : state.commentaryByItemId
+    const previous = byId.get(itemId) ?? ''
+    state.completedItemIds.add(itemId)
+    if (canonical === previous) return { bufferChanged: false }
+    byId.set(itemId, canonical)
+    recomposeBuffers(state)
+    return {
+      bufferChanged: true,
+      correction: previous ? { previous, canonical } : undefined
+    }
   }
-  if (
-    event?.type === 'item.completed' &&
-    (event?.item?.type === 'agentMessage' || event?.item?.type === 'agent_message')
-  ) {
-    return String(event.item.text ?? '')
+
+  if (event?.type === 'assistant') {
+    const cumulative = assistantTextFromAssistantEvent(event)
+    if (!cumulative) return { bufferChanged: false }
+    const key = buffer === 'answer' ? 'harnessAnswerText' : 'harnessCommentaryText'
+    const before = state[key]
+    if (cumulative === before || before.endsWith(cumulative)) return { bufferChanged: false }
+    state[key] = cumulative.startsWith(before)
+      ? cumulative
+      : before
+        ? `${before}\n${cumulative}`
+        : cumulative
+    recomposeBuffers(state)
+    return { bufferChanged: true }
   }
-  if (event?.type !== 'assistant') return ''
+
+  return { bufferChanged: false }
+}
+
+function recomposeBuffers(state: CodexSessionState): void {
+  state.answerText = compose(state.answerByItemId, state.harnessAnswerText)
+  state.commentaryText = compose(state.commentaryByItemId, state.harnessCommentaryText)
+}
+
+function compose(byItemId: Map<string, string>, trailing: string): string {
+  let out = ''
+  for (const value of byItemId.values()) out += value
+  return trailing ? out + trailing : out
+}
+
+function extractDeltaText(event: any): string {
+  const delta = event?.delta ?? event?.text ?? event?.content ?? ''
+  if (delta && typeof delta === 'object') return String(delta.text ?? delta.content ?? '')
+  return String(delta)
+}
+
+function assistantTextFromAssistantEvent(event: any): string {
   return content(event)
     .map(part => (part?.type === 'text' ? (part.text ?? '') : ''))
     .filter(Boolean)
     .join('')
 }
 
-function messageDelta(current: string, incoming: string): string {
-  if (!current) return incoming
-  if (incoming.startsWith(current)) return incoming.slice(current.length)
-  if (current.endsWith(incoming)) return ''
-  return incoming
-}
-
-function logSuspiciousAnswerDelta(
+function logCanonicalCorrection(
   agentSessionId: string,
   event: any,
   state: CodexSessionState,
-  texts: { current: string; incoming: string; delta: string }
+  correction: { previous: string; canonical: string }
 ): void {
-  const { current, incoming, delta } = texts
-  if (current.length <= 200 || incoming.length <= 200 || delta.length <= 200) return
-
-  const incomingHead = incoming.slice(0, 200)
-  const currentTail = current.slice(-200)
-  const currentContainsIncomingHead = current.includes(incomingHead)
-  const incomingContainsCurrentTail = incoming.includes(currentTail)
-  const largeIncomingRelativeToCurrent = incoming.length > current.length * 0.75
-  const largeDeltaRelativeToCurrent = delta.length > current.length * 0.5
-
-  if (
-    !currentContainsIncomingHead &&
-    !incomingContainsCurrentTail &&
-    !largeIncomingRelativeToCurrent &&
-    !largeDeltaRelativeToCurrent
-  ) {
-    return
-  }
-
-  logInfo('slack_codex_suspicious_answer_delta', {
+  const { previous, canonical } = correction
+  const charsDiff = canonical.length - previous.length
+  logInfo('slack_codex_canonical_answer_correction', {
     agent_session_id: agentSessionId,
     centaur_thread_key: event?.centaur_thread_key,
     execution_id: event?.centaur_execution_id,
@@ -545,18 +617,12 @@ function logSuspiciousAnswerDelta(
     codex_item_type: event?.item?.type,
     codex_item_phase: event?.item?.phase,
     codex_session_id: state.threadId || event?.session_id || event?.thread_id,
-    current_answer_chars: current.length,
-    incoming_chars: incoming.length,
-    delta_chars: delta.length,
-    answer_chars_after: current.length + delta.length,
-    streamed_answer_chars: state.deliveredAnswerChars,
-    current_hash: textHash(current),
-    incoming_hash: textHash(incoming),
-    delta_hash: textHash(delta),
-    current_contains_incoming_head: currentContainsIncomingHead,
-    incoming_contains_current_tail: incomingContainsCurrentTail,
-    large_incoming_relative_to_current: largeIncomingRelativeToCurrent,
-    large_delta_relative_to_current: largeDeltaRelativeToCurrent
+    delta_total_chars: previous.length,
+    canonical_text_chars: canonical.length,
+    chars_diff: charsDiff,
+    delta_hash: textHash(previous),
+    canonical_hash: textHash(canonical),
+    streamed_answer_chars: state.deliveredAnswerChars
   })
 }
 

--- a/services/slackbot/test-fixtures/codex/exe_a89da7f248bb4724-min.json
+++ b/services/slackbot/test-fixtures/codex/exe_a89da7f248bb4724-min.json
@@ -1,0 +1,672 @@
+{
+  "events": [
+    {
+      "item": {
+        "id": "e57c10eb-e8a2-40f9-b60b-35c8a2ed3d51",
+        "type": "userMessage",
+        "content": [
+          {
+            "text": "[Previous Centaur response]: base · codex\nPlan: estimate this as a triangulated range, not a single “true” number, because token demand is fragmented across closed APIs, routers, self-hosted open models, consumer apps, and embedded product use.\n\n\n- Define the buckets\n- Frontier: top closed frontier and near-frontier models by capability/pricing, e.g. GPT-5-class, Claude Opus/Sonnet-class, Gemini Pro/Ultra-class.\n- Cheaper models: small/proprietary budget models, open-weight hosted models, self-hosted models, routing/free tiers.\n- Decide whether to measure by tokens, revenue, or inference compute. Tokens will overweight cheap/high-volume workloads; revenue will overweight frontier.\n- Build a provider-level token model\n- Pull public/partner data from OpenRouter, Together, Fireworks, Replicate, Groq, Bedrock, Azure/OpenAI, Anthropic, Google, and major app platforms where available.\n- OpenRouter is useful because it publishes token-level market-share signals, though it is router-biased. Recent third-party analyses suggest token share is moving heavily toward cheaper/open models, while revenue remains concentrated in closed frontier models. (fdq.ai (https://www.fdq.ai/state-of-ai?utm_source=openai))\n- Use pricing as an inverse demand signal\n- Estimate implied token volume from provider/model revenue:\ntokens = model revenue / blended price per token\n- This is especially important because frontier models can have much higher revenue share than token share. Public research using OpenRouter-like data has found closed models around 80% of usage but roughly 96% of revenue, showing how different the two denominators can be. (itpro.com (https://www.itpro.com/software/open-source/open-source-ai-performance-cost-savings-proprietary-models-linux-foundation?utm_source=openai))\n- Segment by workload\n- Coding agents, chat, search/RAG, customer support, batch extraction, evals, synthetic data, and consumer companion/chat all have very different model mixes.\n- Agentic coding deserves a separate adjustment because it can consume orders of magnitude more tokens than ordinary chat, and token usage varies sharply by model and task. (arxiv.org (https://arxiv.org/abs/2604.22750?utm_source=openai))\n- Triangulate with infrastructure constraints\n- Frontier demand should roughly reconcile with hyperscaler GPU allocation, inference capacity, reported API revenue, and known enterprise deployments.\n- Cheap model demand should reconcile with open-model hosting revenue, router traffic, self-hosted inference clusters, and enterprise substitution behavior.\n- Output ranges\n- Produce three estimates:\n- Token share: frontier vs cheaper models.\n- Revenue share: frontier vs cheaper models.\n- Compute share: frontier vs cheaper models.\n- My prior: frontier likely remains much higher in revenue share than token share; cheaper models likely take a growing majority of raw token volume in production/batch workloads as price-performance improves. Price studies show inference prices have fallen massively, which accelerates this substitution. (arxiv.org (https://arxiv.org/abs/2603.28576?utm_source=openai))\n<@U0FIXTURE0>: let's try to estimate",
+            "type": "text",
+            "text_elements": []
+          }
+        ]
+      },
+      "type": "item.started"
+    },
+    {
+      "item": {
+        "id": "e57c10eb-e8a2-40f9-b60b-35c8a2ed3d51",
+        "type": "userMessage",
+        "content": [
+          {
+            "text": "[Previous Centaur response]: base · codex\nPlan: estimate this as a triangulated range, not a single “true” number, because token demand is fragmented across closed APIs, routers, self-hosted open models, consumer apps, and embedded product use.\n\n\n- Define the buckets\n- Frontier: top closed frontier and near-frontier models by capability/pricing, e.g. GPT-5-class, Claude Opus/Sonnet-class, Gemini Pro/Ultra-class.\n- Cheaper models: small/proprietary budget models, open-weight hosted models, self-hosted models, routing/free tiers.\n- Decide whether to measure by tokens, revenue, or inference compute. Tokens will overweight cheap/high-volume workloads; revenue will overweight frontier.\n- Build a provider-level token model\n- Pull public/partner data from OpenRouter, Together, Fireworks, Replicate, Groq, Bedrock, Azure/OpenAI, Anthropic, Google, and major app platforms where available.\n- OpenRouter is useful because it publishes token-level market-share signals, though it is router-biased. Recent third-party analyses suggest token share is moving heavily toward cheaper/open models, while revenue remains concentrated in closed frontier models. (fdq.ai (https://www.fdq.ai/state-of-ai?utm_source=openai))\n- Use pricing as an inverse demand signal\n- Estimate implied token volume from provider/model revenue:\ntokens = model revenue / blended price per token\n- This is especially important because frontier models can have much higher revenue share than token share. Public research using OpenRouter-like data has found closed models around 80% of usage but roughly 96% of revenue, showing how different the two denominators can be. (itpro.com (https://www.itpro.com/software/open-source/open-source-ai-performance-cost-savings-proprietary-models-linux-foundation?utm_source=openai))\n- Segment by workload\n- Coding agents, chat, search/RAG, customer support, batch extraction, evals, synthetic data, and consumer companion/chat all have very different model mixes.\n- Agentic coding deserves a separate adjustment because it can consume orders of magnitude more tokens than ordinary chat, and token usage varies sharply by model and task. (arxiv.org (https://arxiv.org/abs/2604.22750?utm_source=openai))\n- Triangulate with infrastructure constraints\n- Frontier demand should roughly reconcile with hyperscaler GPU allocation, inference capacity, reported API revenue, and known enterprise deployments.\n- Cheap model demand should reconcile with open-model hosting revenue, router traffic, self-hosted inference clusters, and enterprise substitution behavior.\n- Output ranges\n- Produce three estimates:\n- Token share: frontier vs cheaper models.\n- Revenue share: frontier vs cheaper models.\n- Compute share: frontier vs cheaper models.\n- My prior: frontier likely remains much higher in revenue share than token share; cheaper models likely take a growing majority of raw token volume in production/batch workloads as price-performance improves. Price studies show inference prices have fallen massively, which accelerates this substitution. (arxiv.org (https://arxiv.org/abs/2603.28576?utm_source=openai))\n<@U0FIXTURE0>: let's try to estimate",
+            "type": "text",
+            "text_elements": []
+          }
+        ]
+      },
+      "type": "item.completed"
+    },
+    {
+      "item": {
+        "id": "rs_085ada0ef3939f0a016a123f521f4c81978a9104b73856e86f",
+        "type": "reasoning",
+        "content": [],
+        "summary": []
+      },
+      "type": "item.started"
+    },
+    {
+      "item": {
+        "id": "rs_085ada0ef3939f0a016a123f521f4c81978a9104b73856e86f",
+        "type": "reasoning",
+        "content": [],
+        "summary": []
+      },
+      "type": "item.completed"
+    },
+    {
+      "item": {
+        "id": "msg_085ada0ef3939f0a016a123f52893c819796e4c991ff6969ed",
+        "text": "",
+        "type": "agentMessage",
+        "phase": "commentary",
+        "memoryCitation": null
+      },
+      "type": "item.started"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "I’ll use the AI ecosystem brief skill because this is",
+      "itemId": "msg_085ada0ef3939f0a016a123f52893c819796e4c991ff6969ed"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " a frontier-model demand sizing",
+      "itemId": "msg_085ada0ef3939f0a016a123f52893c819796e4c991ff6969ed"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " question, then I’ll turn",
+      "itemId": "msg_085ada0ef3939f0a016a123f52893c819796e4c991ff6969ed"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " it into a concrete rough",
+      "itemId": "msg_085ada0ef3939f0a016a123f52893c819796e4c991ff6969ed"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " estimate instead of another process plan.",
+      "itemId": "msg_085ada0ef3939f0a016a123f52893c819796e4c991ff6969ed"
+    },
+    {
+      "item": {
+        "id": "msg_085ada0ef3939f0a016a123f52893c819796e4c991ff6969ed",
+        "text": "I’ll use the AI ecosystem brief skill because this is a frontier-model demand sizing question, then I’ll turn it into a concrete rough estimate instead of another process plan.",
+        "type": "agentMessage",
+        "phase": "commentary",
+        "memoryCitation": null
+      },
+      "type": "item.completed"
+    },
+    {
+      "item": {
+        "id": "call_RxLNtCAYwsy3S6YDTh0p4sSI",
+        "cwd": "/home/agent/workspace",
+        "type": "commandExecution",
+        "source": "unifiedExecStartup",
+        "status": "inProgress",
+        "command": "/bin/bash -lc \"sed -n '1,220p' /home/agent/workspace/.agents/skills/ai-ecosystem-brief/SKILL.md\"",
+        "exitCode": null,
+        "processId": "46048",
+        "durationMs": null,
+        "commandActions": [
+          {
+            "name": "SKILL.md",
+            "path": "/home/agent/workspace/.agents/skills/ai-ecosystem-brief/SKILL.md",
+            "type": "read",
+            "command": "sed -n '1,220p' /home/agent/workspace/.agents/skills/ai-ecosystem-brief/SKILL.md"
+          }
+        ],
+        "aggregatedOutput": null
+      },
+      "type": "item.started"
+    },
+    {
+      "item": {
+        "id": "call_RxLNtCAYwsy3S6YDTh0p4sSI",
+        "cwd": "/home/agent/workspace",
+        "type": "commandExecution",
+        "source": "unifiedExecStartup",
+        "status": "completed",
+        "command": "/bin/bash -lc \"sed -n '1,220p' /home/agent/workspace/.agents/skills/ai-ecosystem-brief/SKILL.md\"",
+        "exitCode": 0,
+        "processId": "46048",
+        "durationMs": 0,
+        "commandActions": [
+          {
+            "name": "SKILL.md",
+            "path": "/home/agent/workspace/.agents/skills/ai-ecosystem-brief/SKILL.md",
+            "type": "read",
+            "command": "sed -n '1,220p' /home/agent/workspace/.agents/skills/ai-ecosystem-brief/SKILL.md"
+          }
+        ],
+        "aggregatedOutput": "---\nname: ai-ecosystem-brief\ndescription: \"Builds a repeatable competitive brief for frontier-AI agents, model families, and repos. Use when asked to explain what an AI product is, how it works, how it handles memory, compare repo stars or OpenRouter usage, build a model family table, benchmark one agent against peers, or reason about value accrual. Triggers on: tldr X agent, compare repo stars, model family table, how does X solve memory, benchmark X vs Y, OpenRouter usage, AI ecosystem brief.\"\n---\n\n# AI Ecosystem Competitive Brief\n\nTurn a frontier-AI product, model family, repo set, or architecture question into a consistent competitive brief.\n\n## Use This Skill For\n\n- AI agent product briefs where the user wants both product understanding and market position\n- Model family comparison tables\n- Repo-set comparisons such as `compare repo stars`\n- Architecture questions such as `how does X solve memory`\n- Competitive benchmarking across agents, frameworks, or model vendors\n- Value-accrual questions such as who captures revenue, margin, or distribution power\n\n## Do Not Use This Skill For\n\n- Generic company or meeting briefs where the main goal is financing, team, or recent news. Use `tldr` instead.\n- Internal relationship mapping, CRM coverage, or meeting follow-up work. Use `gtm` instead.\n- Requests that are only asking for a chart. Use `charting` directly.\n- Requests to build or debug the product itself. That is normal engineering work, not ecosystem briefing.\n\n## Working Rules\n\n1. Start with official sources: product docs, repo README, launch posts, pricing pages, benchmark pages, and source code.\n2. Use external commentary only after you understand the first-party story.\n3. Separate observed facts from inference. If a claim is a judgment, label it as a judgment.\n4. Compare like with like. Do not compare a closed hosted assistant to an open framework without saying what differs in distribution, business model, and scope.\n5. Use public traction proxies instead of invented market-share numbers.\n6. When the user asks about `memory`, answer the implementation question directly: state model context, retrieval, persistence, summarization, scratchpads, or external state.\n7. When the user asks for `repo stars`, treat stars as one proxy, not the whole story. Pair them with freshness, forks, release cadence, and distribution where possible.\n\n## Trigger Patterns\n\nStrong triggers include:\n\n- `tldr <agent name>`\n- `compare repo stars for <repo set>`\n- `model family table for <models>`\n- `how does <product> solve memory`\n- `benchmark <agent> vs <agent>`\n- `what is the value accrual for <AI product>`\n- `compare <AI product> to Claude Code / OpenHands / Manus / Copilot`\n\nIf the request is ambiguous between a general company brief and an AI ecosystem brief, ask one short clarifying question.\n\n## Workflow\n\n### 1. Classify The Request\n\nPut the request into one of these buckets before researching:\n\n- `single_product_brief`: one agent, product, or framework\n- `pairwise_benchmark`: X vs Y or X vs peer set\n- `model_family_table`: model lineups, variants, and positioning\n- `architecture_deep_dive`: memory, tool use, planning, or execution loop\n- `ecosystem_slice`: a category such as coding agents, browser agents, or memory layers\n\n### 2. Resolve The Entity Set\n\n- Confirm the exact product, org, model family, or repo names.\n- If repo stats are requested, resolve the repo slug before comparing.\n- If the user mixes products and repos, keep both surfaces but label them separately.\n\n### 3. Research In Parallel\n\nBefore using any Centaur API tool, inspect it once with `call discover <tool>`.\n\nUse the smallest set of sources that can answer the question, but cover these lanes when relevant:\n\n#### Official product and documentation lane\n\n- `call discover websearch`\n- `call websearch search '{\"query\":\"<product> official docs product overview architecture memory pricing\",\"num_results\":5,\"synthesize\":true}'`\n- Read the official site, docs, launch blog, and pricing pages first.\n\n#### Open-source repo lane\n\nUse `gh` for authoritative GitHub metadata when a repo exists.\n\n```bash\ngh repo view <owner/repo> --json name,description,url,homepageUrl,licenseInfo,primaryLanguage,stargazerCount,forkCount,updatedAt\n```\n\nWhen useful, also inspect release and contributor freshness:\n\n```bash\ngh release list --repo <owner/repo> --limit 5\ngh api repos/<owner>/<repo>/contributors?per_page=5\n```\n\n#### Architecture and memory lane\n\n- Search for technical writeups, docs, or code paths that explain tool use, memory, retrieval, or planning.\n- For code-heavy repos or multi-repo systems, use `librarian` to understand implementation details from source.\n- Answer memory questions with concrete mechanisms: context window, retrieval index, episodic memory, long-term store, summaries, or user profiles.\n\n#### Traction-proxy lane\n\nChoose only the public proxies that fit the surface:\n\n- GitHub stars, forks, recency, release cadence\n- Product web traffic or rank if there is a public site\n- Public distribution surfaces such as app directories, package registries, or social followings\n- OpenRouter presence or rankings when the product or model is distributed there\n- Benchmark references or leaderboard mentions when they are public and current\n\nUse `call websearch search` to locate public proxy pages quickly. Do not imply private revenue or usage data unless it is explicitly public.\n\n#### Independent context lane\n\n- `call websearch search '{\"query\":\"<product> reviews benchmark comparison 2026\",\"num_results\":5,\"synthesize\":true}'`\n- Use this lane to pressure-test the first-party story, not to replace it.\n\n### 4. Synthesize By Surface\n\nAlways adapt the evidence to the user's actual question:\n\n- If the user asked `how does X solve memory`, lead with architecture and keep market context short.\n- If the user asked `compare repo stars`, lead with the comparison table and then explain what the star counts do and do not mean.\n- If the user asked for a `model family table`, normalize model names, sizes, open vs closed status, context window, reasoning/tooling support, and distribution surface.\n- If the user asked for `value accrual`, explicitly map product value to who captures it: model provider, app layer, infra layer, open-source maintainer, enterprise distribution, or hosted service.\n\n## Standard Output Shape\n\nUse this section order unless the user asks for a different artifact.\n\nStart with one sentence of bottom-line synthesis.\n\nThen render the brief in a plain code block with these sections:\n\n```\nBOTTOM LINE\n<1-3 sentences>\n\nPRODUCT SUMMARY\n- What it is\n- Primary user / buyer\n- Core workflow or job-to-be-done\n- Why it matters now\n\nARCHITECTURE\n- Core loop\n- Model dependency\n- Memory / retrieval / persistence design\n- Tooling / integration surface\n\nCOMPETITIVE SET\n<compact comparison table or bullets>\n\nTRACTION PROXIES\n<table of public signals with source and date>\n\nVALUE ACCRUAL\n- Where value is created\n- Who captures it today\n- What could commoditize it\n- What would strengthen capture\n\nCHART HANDOFF\n<only when a chart would materially improve the answer>\n\nSOURCES\n- <domain 1>\n- <domain 2>\n- <domain 3>\n```\n\n### Comparison Table Defaults\n\nFor agent or product comparisons, prefer a compact code-block table with these columns when data exists:\n\n```text\nname | type | memory approach | distribution | repo stars | public usage proxy | edge\n```\n\nFor model-family comparisons, prefer:\n\n```text\nfamily | variants | open/closed | context | tool/reasoning support | distribution | notes\n```\n\nIf a column is unknown, omit it instead of padding the table with `N/A` in every row.\n\n## Value Accrual Rubric\n\nWhen reasoning about value capture, explicitly answer these questions:\n\n1. Is the moat in the base model, the product UX, the workflow integration, proprietary data, or distribution?\n2. Does the product depend on a third-party model vendor in a way that compresses margin?\n3. Is the open-source repo mainly a demand-generation surface for a hosted product?\n4. Are users locked in by memory, integrations, evals, deployment workflow, or team adoption?\n5. What is the strongest commoditization risk over the next 12 months?\n\nDo not confuse adoption with capture. A repo can have strong stars and weak monetization.\n\n## Chart Handoff Contract\n\nIf the answer hinges on a ranking, trend, distribution, or concentration pattern, hand off to `charting` instead of forcing a prose-only answer.\n\nGood chart handoff cases:\n\n- repo-star ranking across 3+ repos\n- traffic or usage trend over time\n- model pricing or context-window comparison\n- benchmark win-rate comparison across agents or model families\n\nWhen you decide a chart is warranted, emit a short YAML brief that `charting` can use directly:\n\n```yaml\nquestion: \"How do the leading coding-agent repos compare on GitHub adoption?\"\nchart_type: horizontal_bar\nprotagonist: \"Target repo or category leader\"\ntakeaway_title: \"Open-source coding-agent attention is concentrated in a small leader set\"\nsubtitle: \"GitHub stars, captured on <date>\"\nsource: \"GitHub repo metadata\"\n```\n"
+      },
+      "type": "item.completed"
+    },
+    {
+      "item": {
+        "id": "rs_085ada0ef3939f0a016a123f5420cc819783b86122076fe748",
+        "type": "reasoning",
+        "content": [],
+        "summary": []
+      },
+      "type": "item.started"
+    },
+    {
+      "item": {
+        "id": "rs_085ada0ef3939f0a016a123f5420cc819783b86122076fe748",
+        "type": "reasoning",
+        "content": [],
+        "summary": []
+      },
+      "type": "item.completed"
+    },
+    {
+      "item": {
+        "id": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730",
+        "text": "",
+        "type": "agentMessage",
+        "phase": "commentary",
+        "memoryCitation": null
+      },
+      "type": "item.started"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "I’m going to use",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " public token",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "-share proxies first (OpenRouter",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "-like data and model",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "-pricing studies), then",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " make explicit assumptions for",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " the missing",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " pieces: direct closed",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "-provider APIs,",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " hyperscaler channels, and self-hosted inference.",
+      "itemId": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730"
+    },
+    {
+      "item": {
+        "id": "msg_085ada0ef3939f0a016a123f547d488197b9890aa366f1c730",
+        "text": "I’m going to use public token-share proxies first (OpenRouter-like data and model-pricing studies), then make explicit assumptions for the missing pieces: direct closed-provider APIs, hyperscaler channels, and self-hosted inference.",
+        "type": "agentMessage",
+        "phase": "commentary",
+        "memoryCitation": null
+      },
+      "type": "item.completed"
+    },
+    {
+      "item": {
+        "id": "call_9dovziUyYHr0dW37KtE3DEvu",
+        "cwd": "/home/agent/workspace",
+        "type": "commandExecution",
+        "source": "unifiedExecStartup",
+        "status": "inProgress",
+        "command": "/bin/bash -lc 'call discover websearch'",
+        "exitCode": null,
+        "processId": "46245",
+        "durationMs": null,
+        "commandActions": [
+          {
+            "type": "unknown",
+            "command": "call discover websearch"
+          }
+        ],
+        "aggregatedOutput": null
+      },
+      "type": "item.started"
+    },
+    {
+      "item": {
+        "id": "call_9dovziUyYHr0dW37KtE3DEvu",
+        "cwd": "/home/agent/workspace",
+        "type": "commandExecution",
+        "source": "unifiedExecStartup",
+        "status": "completed",
+        "command": "/bin/bash -lc 'call discover websearch'",
+        "exitCode": 0,
+        "processId": "46245",
+        "durationMs": 0,
+        "commandActions": [
+          {
+            "type": "unknown",
+            "command": "call discover websearch"
+          }
+        ],
+        "aggregatedOutput": "{\"tool\":\"websearch\",\"description\":\"Web search and deep research via Exa and Claude\",\"methods\":[{\"name\":\"answer\",\"description\":\"One-shot cited answer via Exa /answer.\\n\\nUse as a sub-primitive inside the research fanout for bounded fact\\nlookups. Cost: $0.005 flat. Latency: 3-13s without streaming.\",\"parameters\":{\"query\":{\"type\":\"str\",\"required\":true},\"output_schema\":{\"type\":\"dict[str, Any] | None\",\"default\":null},\"text\":{\"type\":\"bool\",\"default\":false},\"timeout_seconds\":{\"type\":\"float\",\"default\":30.0}}},{\"name\":\"contents\",\"description\":\"Hydrate known URLs through Exa Contents.\\n\\nUse this after search has identified high-value URLs. On the `/contents`\\nendpoint, text/highlights/summary are top-level parameters, unlike\\n`/search` where they live under `contents`.\",\"parameters\":{\"urls\":{\"type\":\"list[str]\",\"required\":true},\"highlights_query\":{\"type\":\"str | None\",\"default\":null},\"text_chars\":{\"type\":\"int | None\",\"default\":null},\"summary_query\":{\"type\":\"str | None\",\"default\":null},\"summary_schema\":{\"type\":\"dict[str, Any] | None\",\"default\":null},\"subpages\":{\"type\":\"int\",\"default\":0},\"subpage_target\":{\"type\":\"str | list[str] | None\",\"default\":null},\"max_age_hours\":{\"type\":\"int | None\",\"default\":null},\"livecrawl_timeout_ms\":{\"type\":\"int\",\"default\":12000},\"links\":{\"type\":\"int\",\"default\":0},\"timeout_seconds\":{\"type\":\"float\",\"default\":60.0}}},{\"name\":\"deep_research\",\"description\":\"Run iterative deep research with citation validation.\",\"parameters\":{\"question\":{\"type\":\"str\",\"required\":true},\"max_iterations\":{\"type\":\"int\",\"default\":1},\"num_queries_per_iteration\":{\"type\":\"int\",\"default\":4},\"num_results_per_query\":{\"type\":\"int\",\"default\":5},\"thread_context\":{\"type\":\"list[str] | None\",\"default\":null},\"max_report_chars\":{\"type\":\"int\",\"default\":50000},\"timeout_seconds\":{\"type\":\"float\",\"default\":300.0}}},{\"name\":\"deep_search\",\"description\":\"Agentic deep search via /search with type=deep / deep-reasoning.\\n\\nThis is the canonical primitive for ``map a space``,\\n``compare X vs Y``, ``what are the buyers/sellers/regulators in\\nthis market`` workloads when the caller wants Exa to do the\\nmulti-step planning + structured output internally.\\n\\nCost: ``deep`` $0.012 (~9s); ``deep-reasoning`` $0.015 (~12-43s).\",\"parameters\":{\"query\":{\"type\":\"str\",\"required\":true},\"output_schema\":{\"type\":\"dict[str, Any] | None\",\"default\":null},\"system_prompt\":{\"type\":\"str | None\",\"default\":null},\"search_type\":{\"type\":\"str\",\"default\":\"deep-reasoning\"},\"num_results\":{\"type\":\"int\",\"default\":10},\"category\":{\"type\":\"str | None\",\"default\":null},\"include_domains\":{\"type\":\"list[str] | None\",\"default\":null},\"exclude_domains\":{\"type\":\"list[str] | None\",\"default\":null},\"include_text\":{\"type\":\"list[str] | str | None\",\"default\":null},\"exclude_text\":{\"type\":\"list[str] | str | None\",\"default\":null},\"max_age_hours\":{\"type\":\"int | None\",\"default\":null},\"user_location\":{\"type\":\"str | None\",\"default\":null},\"additional_queries\":{\"type\":\"list[str] | None\",\"default\":null},\"summary_query\":{\"type\":\"str | None\",\"default\":null},\"summary_schema\":{\"type\":\"dict[str, Any] | None\",\"default\":null},\"timeout_seconds\":{\"type\":\"float\",\"default\":90.0}}},{\"name\":\"find_similar\",\"description\":\"Find pages similar to a known URL via Exa.\",\"parameters\":{\"url\":{\"type\":\"str\",\"required\":true},\"num_results\":{\"type\":\"int\",\"default\":10},\"category\":{\"type\":\"str | None\",\"default\":null},\"exclude_source_domain\":{\"type\":\"bool\",\"default\":true},\"timeout_seconds\":{\"type\":\"float\",\"default\":30.0},\"highlights_query\":{\"type\":\"str | None\",\"default\":null},\"text_chars\":{\"type\":\"int | None\",\"default\":null}}},{\"name\":\"search\",\"description\":\"Search the web via Exa and optionally synthesize a cited answer.\",\"parameters\":{\"query\":{\"type\":\"str\",\"required\":true},\"num_results\":{\"type\":\"int\",\"default\":10},\"search_type\":{\"type\":\"str\",\"default\":\"auto\"},\"category\":{\"type\":\"str | None\",\"default\":null},\"additional_queries\":{\"type\":\"list[str] | None\",\"default\":null},\"system_prompt\":{\"type\":\"str | None\",\"default\":null},\"output_schema\":{\"type\":\"dict[str, Any] | None\",\"default\":null},\"summary_query\":{\"type\":\"str | None\",\"default\":null},\"summary_schema\":{\"type\":\"dict[str, Any] | None\",\"default\":null},\"text_chars\":{\"type\":\"int | None\",\"default\":null},\"highlights_chars\":{\"type\":\"int | None\",\"default\":2000},\"subpages\":{\"type\":\"int\",\"default\":0},\"subpage_target\":{\"type\":\"str | list[str] | None\",\"default\":null},\"livecrawl\":{\"type\":\"str | None\",\"default\":null},\"livecrawl_timeout_ms\":{\"type\":\"int | None\",\"default\":null},\"links\":{\"type\":\"int\",\"default\":0},\"image_links\":{\"type\":\"int\",\"default\":0},\"include_domains\":{\"type\":\"list[str] | None\",\"default\":null},\"exclude_domains\":{\"type\":\"list[str] | None\",\"default\":null},\"include_text\":{\"type\":\"list[str] | None\",\"default\":null},\"exclude_text\":{\"type\":\"list[str] | None\",\"default\":null},\"user_location\":{\"type\":\"str | None\",\"default\":null},\"max_age_hours\":{\"type\":\"int | None\",\"default\":null},\"start_published_date\":{\"type\":\"str | None\",\"default\":null},\"end_published_date\":{\"type\":\"str | None\",\"default\":null},\"start_crawl_date\":{\"type\":\"str | None\",\"default\":null},\"end_crawl_date\":{\"type\":\"str | None\",\"default\":null},\"timeout_seconds\":{\"type\":\"float\",\"default\":30.0},\"synthesize\":{\"type\":\"bool\",\"default\":true},\"thread_context\":{\"type\":\"list[str] | None\",\"default\":null},\"max_report_chars\":{\"type\":\"int\",\"default\":12000}}}]}\n"
+      },
+      "type": "item.completed"
+    },
+    {
+      "item": {
+        "id": "call_tvkwicB5JHrocLMPKlYXyv7U",
+        "cwd": "/home/agent/workspace",
+        "type": "commandExecution",
+        "source": "unifiedExecStartup",
+        "status": "inProgress",
+        "command": "/bin/bash -lc \"call websearch search '{\\\"query\\\":\\\"AI inference token demand revenue share closed models open models 2025 2026 OpenRouter\\\", \\\"num_results\\\": 5, \\\"synthesize\\\": true}'\"",
+        "exitCode": null,
+        "processId": "68015",
+        "durationMs": null,
+        "commandActions": [
+          {
+            "type": "unknown",
+            "command": "call websearch search '{\"query\":\"AI inference token demand revenue share closed models open models 2025 2026 OpenRouter\", \"num_results\": 5, \"synthesize\": true}'"
+          }
+        ],
+        "aggregatedOutput": null
+      },
+      "type": "item.started"
+    },
+    {
+      "item": {
+        "id": "call_YGfEad9xZlAj2LamGo4ykLDX",
+        "cwd": "/home/agent/workspace",
+        "type": "commandExecution",
+        "source": "unifiedExecStartup",
+        "status": "inProgress",
+        "command": "/bin/bash -lc \"call websearch search '{\\\"query\\\":\\\"2026 OpenRouter token usage by model share frontier cheap open models\\\", \\\"num_results\\\": 5, \\\"synthesize\\\": true}'\"",
+        "exitCode": null,
+        "processId": "25846",
+        "durationMs": null,
+        "commandActions": [
+          {
+            "type": "unknown",
+            "command": "call websearch search '{\"query\":\"2026 OpenRouter token usage by model share frontier cheap open models\", \"num_results\": 5, \"synthesize\": true}'"
+          }
+        ],
+        "aggregatedOutput": null
+      },
+      "type": "item.started"
+    },
+    {
+      "item": {
+        "id": "rs_085ada0ef3939f0a016a123f7074d88197875677a61f0501d9",
+        "type": "reasoning",
+        "content": [],
+        "summary": []
+      },
+      "type": "item.started"
+    },
+    {
+      "item": {
+        "id": "rs_085ada0ef3939f0a016a123f7074d88197875677a61f0501d9",
+        "type": "reasoning",
+        "content": [],
+        "summary": []
+      },
+      "type": "item.completed"
+    },
+    {
+      "item": {
+        "id": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527",
+        "text": "",
+        "type": "agentMessage",
+        "phase": "final_answer",
+        "memoryCitation": null
+      },
+      "type": "item.started"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "<@U0FIXTURE0>",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " My rough estimate: **frontier models are",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " ~25-40% of token demand, but ~",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "70-90% of inference revenue",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "**.\n\n```",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "text\n2026 token-demand",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " estimate\n\nSegment                      ",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " Token share  ",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " Frontier share within segment  ",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " Frontier token",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " contribution\nConsumer",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " chat apps             ",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "25-35%        60-80%",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "                         15-",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "28%\nEnterprise/API",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " apps            25-35%        ",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "35-55%                         ",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "9-19%\n",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "Coding/agent workloads         15-25%        25-",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "45%                         4-",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "11%\nBatch/RAG/extraction",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "/support   20-30%        ",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "5-20%                          1-6%\nSelf-hosted/open",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " infra         5-15%",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "         ~0-",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "10%                         0-2%\n\n",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "Implied frontier total: ~",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "25-40% of",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " tokens\nImplied cheaper-model total: ~60",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "-75% of tokens\n```\n\nWhy",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": ": public",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " router data is biased but",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " points toward huge",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " cheap/open-model",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " token volume; OpenRouter",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "-linked reporting",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " showed non-frontier",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " Chinese/open models",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " taking leading token",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " ranks in 2026,",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " including MiniMax M2.5 at ~",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "4.55T tokens in",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " one month via",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " OpenRouter. ",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " Separately,",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " public analyses",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " suggest open/cheap models can",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " take much more",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " token share than revenue share; one cited working-paper",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " summary found closed models around **80% of usage",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " and 96% of revenue**, which implies frontier/closed",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " demand monetizes",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " far above its token",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " share. ",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "\n\nI’d",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " use **~",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": "1/3 frontier tokens, ~2/3 cheaper tokens**",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " as the base case, with the caveat that",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " “frontier” share is",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " materially higher if we include consumer",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " ChatGPT/Claude/Gemini",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " app usage and lower if we focus",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "type": "item.agentMessage.delta",
+      "delta": " only on production API workloads.",
+      "itemId": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527"
+    },
+    {
+      "item": {
+        "id": "msg_085ada0ef3939f0a016a123f7116188197b5d08f5cde6b8527",
+        "text": "<@U0FIXTURE0> My rough estimate: **frontier models are ~25-40% of token demand, but ~70-90% of inference revenue**.\n\n```text\n2026 token-demand estimate\n\nSegment                       Token share   Frontier share within segment   Frontier token contribution\nConsumer chat apps             25-35%        60-80%                         15-28%\nEnterprise/API apps            25-35%        35-55%                         9-19%\nCoding/agent workloads         15-25%        25-45%                         4-11%\nBatch/RAG/extraction/support   20-30%        5-20%                          1-6%\nSelf-hosted/open infra         5-15%         ~0-10%                         0-2%\n\nImplied frontier total: ~25-40% of tokens\nImplied cheaper-model total: ~60-75% of tokens\n```\n\nWhy: publXc router data is biased but points toward huge cheap/open-model token volume; OpenRouter-linked reporting showed non-frontier Chinese/open models taking leading token ranks in 2026, including MiniMax M2.5 at ~4.55T tokens in one month via OpenRouter.  Separately, public analyses suggest open/cheap models can take much more token share than revenue share; one cited working-paper summary found closed models around **80% of usage and 96% of revenue**, which implies frontier/closed demand monetizes far above its token share. \n\nI’d use **~1/3 frontier tokens, ~2/3 cheaper tokens** as the base case, with the caveat that “frontier” share is materially higher if we include consumer ChatGPT/Claude/Gemini app usage and lower if we focus only on production API workloads.",
+        "type": "agentMessage",
+        "phase": "final_answer",
+        "memoryCitation": null
+      },
+      "type": "item.completed"
+    },
+    {
+      "type": "turn.done",
+      "result": "<@U0FIXTURE0> My rough estimate: **frontier models are ~25-40% of token demand, but ~70-90% of inference revenue**.\n\n```text\n2026 token-demand estimate\n\nSegment                       Token share   Frontier share within segment   Frontier token contribution\nConsumer chat apps             25-35%        60-80%                         15-28%\nEnterprise/API apps            25-35%        35-55%                         9-19%\nCoding/agent workloads         15-25%        25-45%                         4-11%\nBatch/RAG/extraction/support   20-30%        5-20%                          1-6%\nSelf-hosted/open infra         5-15%         ~0-10%                         0-2%\n\nImplied frontier total: ~25-40% of tokens\nImplied cheaper-model total: ~60-75% of tokens\n```\n\nWhy: public router data is biased but points toward huge cheap/open-model token volume; OpenRouter-linked reporting showed non-frontier Chinese/open models taking leading token ranks in 2026, including MiniMax M2.5 at ~4.55T tokens in one month via OpenRouter.  Separately, public analyses suggest open/cheap models can take much more token share than revenue share; one cited working-paper summary found closed models around **80% of usage and 96% of revenue**, which implies frontier/closed demand monetizes far above its token share. \n\nI’d use **~1/3 frontier tokens, ~2/3 cheaper tokens** as the base case, with the caveat that “frontier” share is materially higher if we include consumer ChatGPT/Claude/Gemini app usage and lower if we focus only on production API workloads.",
+      "turn_id": 2,
+      "agent_thread_id": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Track Codex final-answer and commentary text by agentMessage item id.
- Replace each item buffer with item.completed canonical text instead of appending it as a new delta.
- Add regressions for the captured prod fixture and a neutral typo-correction snapshot case.

## Tests
- bun test src/slack/codex-session.test.ts

Relates AT-7
Closes paradigmxyz/centaur#179