### PR TITLE
Add Centaur onboarding CLI wizard

### DIFF
--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -15,6 +15,18 @@ such as `/md/quickstart.md`.
 
 ## 1. Install prerequisites
 
+For guided setup, install the onboarding CLI from this checkout and let it
+generate the overlay, Slack manifest, secret checklist, and deployment plan:
+
+```bash
+uv run --project packages/centaur-cli centaur init
+uv run --project packages/centaur-cli centaur doctor --deep
+uv run --project packages/centaur-cli centaur deploy kind
+```
+
+The wizard is resumable through `centaur init --resume` and writes local state
+under `~/.centaur`.
+
 From the repo root:
 
 ```bash

--- a/docs/public/md/quickstart.md
+++ b/docs/public/md/quickstart.md
@@ -15,6 +15,18 @@ such as `/md/quickstart.md`.
 
 ## 1. Install prerequisites
 
+For guided setup, install the onboarding CLI from this checkout and let it
+generate the overlay, Slack manifest, secret checklist, and deployment plan:
+
+```bash
+uv run --project packages/centaur-cli centaur init
+uv run --project packages/centaur-cli centaur doctor --deep
+uv run --project packages/centaur-cli centaur deploy kind
+```
+
+The wizard is resumable through `centaur init --resume` and writes local state
+under `~/.centaur`.
+
 From the repo root:
 
 ```bash

--- a/packages/centaur-cli/README.md
+++ b/packages/centaur-cli/README.md
@@ -1,0 +1,12 @@
+# Centaur CLI
+
+`centaur` is the guided setup CLI for Centaur. It scaffolds an overlay, records resumable onboarding state, generates integration templates, validates local prerequisites, and prints exact repair steps for Slack, model, GitHub, secrets, and deployment setup.
+
+```bash
+uv run centaur init --non-interactive --org acme --assistant-name centaur --domain centaur.acme.com
+uv run centaur doctor --deep
+uv run centaur integrations slack-manifest --domain centaur.acme.com
+uv run centaur deploy kind
+```
+
+The wizard is safe by default. It writes local files and templates, but does not create remote Slack apps, GitHub apps, password-manager entries, or Kubernetes resources unless a later deploy command is run explicitly.

--- a/packages/centaur-cli/centaur_cli/__init__.py
+++ b/packages/centaur-cli/centaur_cli/__init__.py
@@ -1,0 +1,5 @@
+"""Centaur onboarding CLI."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/packages/centaur-cli/centaur_cli/checks.py
+++ b/packages/centaur-cli/centaur_cli/checks.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+    repair: str = ""
+
+
+REQUIRED_BINARIES = ["git", "jq", "openssl"]
+DEPLOY_BINARIES = ["kubectl", "helm"]
+OPTIONAL_BINARIES = ["gh", "docker", "kind", "ssh", "op", "sops", "age", "argocd"]
+
+
+def binary_checks(include_deploy: bool = False, include_ssh: bool = False) -> list[CheckResult]:
+    names = REQUIRED_BINARIES + OPTIONAL_BINARIES
+    if include_deploy:
+        names += DEPLOY_BINARIES
+    results: list[CheckResult] = []
+    for name in names:
+        path = shutil.which(name)
+        required = name in REQUIRED_BINARIES or (include_deploy and name in DEPLOY_BINARIES) or (include_ssh and name == "ssh")
+        detail = path or ("missing optional" if not required else "not installed")
+        results.append(
+            CheckResult(
+                name=f"binary:{name}",
+                ok=path is not None or not required,
+                detail=detail,
+                repair=f"Install {name} and rerun centaur doctor" if required and not path else "",
+            )
+        )
+    return results
+
+
+def docker_daemon_check() -> CheckResult:
+    if not shutil.which("docker"):
+        return CheckResult("docker:daemon", False, "docker not installed", "Install Docker or use an existing Kubernetes cluster.")
+    return command_check("docker:daemon", ["docker", "info", "--format", "{{.ServerVersion}}"], "Start Docker Desktop or the Docker daemon.")
+
+
+def env_checks() -> list[CheckResult]:
+    checks = {
+        "SLACK_BOT_TOKEN": "Create a Slack app and store the bot token.",
+        "SLACK_SIGNING_SECRET": "Copy the Slack signing secret into your secret backend.",
+        "OPENAI_API_KEY or ANTHROPIC_API_KEY": "Configure at least one model provider key.",
+        "GITHUB_APP_ID or GITHUB_TOKEN": "Configure a GitHub App or PAT.",
+    }
+    results: list[CheckResult] = []
+    for name, repair in checks.items():
+        if " or " in name:
+            keys = name.split(" or ")
+            ok = any(os.getenv(key) for key in keys)
+        else:
+            ok = bool(os.getenv(name))
+        results.append(CheckResult(name=f"env:{name}", ok=ok, detail="set" if ok else "missing", repair=repair if not ok else ""))
+    return results
+
+
+def command_check(name: str, cmd: list[str], repair: str) -> CheckResult:
+    try:
+        proc = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=15)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return CheckResult(name=name, ok=False, detail=str(exc), repair=repair)
+    detail = (proc.stdout or proc.stderr).strip().splitlines()
+    return CheckResult(name=name, ok=proc.returncode == 0, detail=detail[0] if detail else f"exit {proc.returncode}", repair="" if proc.returncode == 0 else repair)
+
+
+def overlay_checks(path: Path) -> list[CheckResult]:
+    required = ["AGENTS.md", "secrets.example.env", "values.centaur.yaml"]
+    return [
+        CheckResult(
+            name=f"overlay:{rel}",
+            ok=(path / rel).exists(),
+            detail=str(path / rel),
+            repair="" if (path / rel).exists() else f"Run centaur overlay init --path {path}",
+        )
+        for rel in required
+    ]

--- a/packages/centaur-cli/centaur_cli/main.py
+++ b/packages/centaur-cli/centaur_cli/main.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from .checks import binary_checks, command_check, docker_daemon_check, env_checks, overlay_checks
+from .state import DEFAULT_HOME, OnboardingState, load_state, save_state
+from .templates import SLACK_SCOPES, write_overlay, write_slack_manifest
+
+app = typer.Typer(name="centaur", help="Centaur onboarding and operations CLI")
+overlay_app = typer.Typer(help="Create and validate Centaur overlays")
+integrations_app = typer.Typer(help="Generate and verify integration setup")
+deploy_app = typer.Typer(help="Prepare Centaur deployments")
+secrets_app = typer.Typer(help="Validate secret backend setup")
+app.add_typer(overlay_app, name="overlay")
+app.add_typer(integrations_app, name="integrations")
+app.add_typer(deploy_app, name="deploy")
+app.add_typer(secrets_app, name="secrets")
+
+console = Console()
+
+
+def _ask(prompt: str, default: str, non_interactive: bool) -> str:
+    if non_interactive:
+        return default
+    return typer.prompt(prompt, default=default)
+
+
+def _render_results(results) -> bool:
+    table = Table("Check", "Status", "Detail", "Repair")
+    all_ok = True
+    for result in results:
+        all_ok = all_ok and result.ok
+        table.add_row(result.name, "ok" if result.ok else "fail", result.detail, result.repair)
+    console.print(table)
+    return all_ok
+
+
+@app.command()
+def init(
+    org: str = typer.Option("", help="Organization name"),
+    assistant_name: str = typer.Option("centaur", help="Assistant display name"),
+    domain: str = typer.Option("", help="Public deployment domain"),
+    admin_email: str = typer.Option("", help="Admin email"),
+    install_mode: str = typer.Option("local", help="local, k8s, or ssh"),
+    secret_backend: str = typer.Option("local-env", help="local-env, onepassword, doppler, vault, sops, or kubernetes"),
+    overlay_path: Path = typer.Option(Path("org"), help="Overlay directory to create or validate"),
+    home: Path = typer.Option(DEFAULT_HOME, help="Centaur config directory"),
+    resume: bool = typer.Option(False, help="Resume from existing onboarding state"),
+    non_interactive: bool = typer.Option(False, "--non-interactive", help="Use provided/default values without prompts"),
+) -> None:
+    """Run the guided Centaur onboarding wizard."""
+    state = load_state(home) if resume else OnboardingState()
+    console.print(Panel("Centaur will set up an overlay, secrets plan, Slack, model, GitHub, and deployment checklist."))
+
+    state.org = _ask("Organization name", org or state.org or "acme", non_interactive)
+    state.assistant_name = _ask("Assistant name", assistant_name or state.assistant_name, non_interactive)
+    state.domain = _ask("Public domain", domain or state.domain or "centaur.example.com", non_interactive)
+    state.admin_email = _ask("Admin email", admin_email or state.admin_email or "admin@example.com", non_interactive)
+    state.install_mode = _ask("Install mode (local/k8s/ssh)", install_mode or state.install_mode, non_interactive)
+    state.secret_backend = _ask("Secret backend", secret_backend or state.secret_backend, non_interactive)
+    state.overlay_path = str(overlay_path)
+
+    written = write_overlay(overlay_path, state.org, state.assistant_name, state.domain)
+    write_slack_manifest(overlay_path / "slack-app-manifest.json", state.assistant_name, state.domain, socket_mode=state.install_mode == "local")
+    for step in ["local-state", "overlay", "slack-manifest", "secrets-plan", "deployment-plan"]:
+        state.mark_done(step)
+    save_state(state, home)
+
+    console.print(f"Wrote onboarding state to {home / 'onboarding-state.json'}")
+    console.print(f"Overlay path: {overlay_path}")
+    if written:
+        console.print("Created:")
+        for path in written:
+            console.print(f"  - {path}")
+    console.print("\nNext checks:")
+    _render_results(binary_checks(include_deploy=state.install_mode in {"k8s", "ssh"}, include_ssh=state.install_mode == "ssh") + overlay_checks(overlay_path))
+    console.print("\nRun `centaur integrations slack-manifest --domain %s` to print the Slack app manifest." % state.domain)
+
+
+@app.command()
+def doctor(
+    deep: bool = typer.Option(False, help="Include deploy and environment checks"),
+    overlay_path: Path = typer.Option(Path("org"), help="Overlay path"),
+) -> None:
+    """Check local prerequisites and generated Centaur setup files."""
+    results = binary_checks(include_deploy=deep) + overlay_checks(overlay_path)
+    if deep:
+        results += env_checks()
+        results.append(docker_daemon_check())
+        if any(result.name == "binary:kubectl" and result.ok for result in results):
+            results.append(command_check("kubectl:cluster", ["kubectl", "cluster-info"], "Select a working Kubernetes context or use centaur deploy kind."))
+        if any(result.name == "binary:helm" and result.ok for result in results):
+            results.append(command_check("helm:version", ["helm", "version", "--short"], "Install Helm before deploying to Kubernetes."))
+    ok = _render_results(results)
+    raise typer.Exit(0 if ok else 1)
+
+
+@app.command()
+def status(home: Path = typer.Option(DEFAULT_HOME, help="Centaur config directory")) -> None:
+    """Show resumable onboarding state."""
+    state = load_state(home)
+    console.print_json(json.dumps(state.__dict__, default=str))
+
+
+@app.command("smoke-test")
+def smoke_test(namespace: str = "centaur", release: str = "centaur") -> None:
+    """Print the exact commands for an end-to-end Centaur smoke test."""
+    console.print("Run this after deployment:")
+    console.print(f"just namespace={namespace} release={release} smoke")
+
+
+@overlay_app.command("init")
+def overlay_init(
+    path: Path = typer.Option(Path("org"), help="Overlay directory"),
+    org: str = typer.Option("acme", help="Organization name"),
+    assistant_name: str = typer.Option("centaur", help="Assistant name"),
+    domain: str = typer.Option("centaur.example.com", help="Deployment domain"),
+) -> None:
+    """Scaffold a Centaur overlay repo."""
+    written = write_overlay(path, org, assistant_name, domain)
+    write_slack_manifest(path / "slack-app-manifest.json", assistant_name, domain, socket_mode=False)
+    console.print(f"Overlay ready at {path}")
+    for item in written:
+        console.print(f"  - {item}")
+
+
+@overlay_app.command("validate")
+def overlay_validate(path: Path = typer.Option(Path("org"), help="Overlay directory")) -> None:
+    """Validate required overlay files."""
+    ok = _render_results(overlay_checks(path))
+    raise typer.Exit(0 if ok else 1)
+
+
+@integrations_app.command("slack-manifest")
+def slack_manifest_cmd(
+    domain: str = typer.Option("centaur.example.com", help="Public Centaur domain"),
+    app_name: str = typer.Option("centaur", help="Slack app name"),
+    socket_mode: bool = typer.Option(False, help="Use Socket Mode instead of public request URLs"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Write manifest to a file"),
+) -> None:
+    """Generate the Slack app manifest with scopes, events, commands, and interactivity."""
+    path = output or Path("/tmp/centaur-slack-app-manifest.json")
+    write_slack_manifest(path, app_name, domain, socket_mode)
+    text = path.read_text()
+    if output:
+        console.print(f"Wrote Slack manifest to {output}")
+    else:
+        console.print(text)
+    console.print("Required bot scopes: " + ", ".join(SLACK_SCOPES))
+    console.print("After installing the app, store SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, and optionally SLACK_APP_TOKEN.")
+
+
+@integrations_app.command("setup")
+def integrations_setup() -> None:
+    """Print the baseline manual setup checklist for Slack, models, and GitHub."""
+    console.print(
+        """Baseline setup:
+1. Slack: create app from `centaur integrations slack-manifest`, install it, copy bot token/signing secret/app token.
+2. Models: add OPENAI_API_KEY, ANTHROPIC_API_KEY, or OPENROUTER_API_KEY to your secret backend.
+3. GitHub: create a GitHub App with contents/pull-requests/issues/actions permissions, then store app id/private key/installation id.
+4. Verify with `centaur doctor --deep` after secrets are exported or synced into Kubernetes."""
+    )
+
+
+@secrets_app.command("doctor")
+def secrets_doctor(backend: str = typer.Option("local-env", help="local-env, onepassword, sops, doppler, vault, or kubernetes")) -> None:
+    """Validate the selected secret backend enough to continue onboarding."""
+    results = []
+    if backend == "onepassword":
+        results.append(command_check("1password:op", ["op", "vault", "list"], "Set OP_SERVICE_ACCOUNT_TOKEN and run `op vault list`."))
+    elif backend == "sops":
+        results.append(command_check("sops:version", ["sops", "--version"], "Install sops."))
+        results.append(command_check("age:version", ["age", "--version"], "Install age and generate a key."))
+    elif backend == "kubernetes":
+        results.append(command_check("kubectl:secrets", ["kubectl", "get", "secret", "-A"], "Create Kubernetes secrets or configure cluster access."))
+    else:
+        results += env_checks()
+    ok = _render_results(results)
+    raise typer.Exit(0 if ok else 1)
+
+
+@deploy_app.command("k8s")
+def deploy_k8s(namespace: str = "centaur", release: str = "centaur", values: Path = Path("org/values.centaur.yaml")) -> None:
+    """Print the existing-cluster deployment command."""
+    console.print("Existing Kubernetes deployment:")
+    console.print(f"kubectl create namespace {namespace} --dry-run=client -o yaml | kubectl apply -f -")
+    console.print(f"helm upgrade --install {release} contrib/chart -n {namespace} -f {values}")
+
+
+@deploy_app.command("kind")
+def deploy_kind(
+    cluster_name: str = typer.Option("centaur", help="kind cluster name"),
+    namespace: str = typer.Option("centaur", help="Kubernetes namespace"),
+    release: str = typer.Option("centaur", help="Helm release name"),
+    values: Path = typer.Option(Path("org/values.centaur.yaml"), help="Helm values file"),
+    apply: bool = typer.Option(False, "--apply", help="Run the commands instead of printing them"),
+) -> None:
+    """Create a local kind cluster and deploy Centaur into it."""
+    commands = [
+        ["kind", "create", "cluster", "--name", cluster_name],
+        ["kubectl", "cluster-info", "--context", f"kind-{cluster_name}"],
+        ["kubectl", "create", "namespace", namespace, "--dry-run=client", "-o", "yaml"],
+        ["helm", "dependency", "update", "contrib/chart"],
+        ["helm", "upgrade", "--install", release, "contrib/chart", "-n", namespace, "-f", str(values)],
+    ]
+    if not apply:
+        console.print("Local kind deployment:")
+        console.print(f"kind create cluster --name {cluster_name}")
+        console.print(f"kubectl cluster-info --context kind-{cluster_name}")
+        console.print(f"kubectl create namespace {namespace} --dry-run=client -o yaml | kubectl apply -f -")
+        console.print("helm dependency update contrib/chart")
+        console.print(f"helm upgrade --install {release} contrib/chart -n {namespace} -f {values}")
+        console.print("Add `--apply` to run these commands.")
+        return
+
+    import subprocess
+
+    for command in commands[:2]:
+        subprocess.run(command, check=True)
+    namespace_yaml = subprocess.run(commands[2], check=True, capture_output=True)
+    subprocess.run(["kubectl", "apply", "-f", "-"], input=namespace_yaml.stdout, check=True)
+    for command in commands[3:]:
+        subprocess.run(command, check=True)
+
+
+@deploy_app.command("ssh")
+def deploy_ssh(host: str, domain: str = typer.Option(..., help="Public domain for this host")) -> None:
+    """Print the SSH/k3s bootstrap plan for a new server."""
+    console.print(f"SSH deployment plan for {host}:")
+    console.print("1. ssh into host and install k3s")
+    console.print("2. copy kubeconfig locally")
+    console.print("3. install ingress-nginx, cert-manager, and ArgoCD")
+    console.print(f"4. point DNS for {domain} at the host")
+    console.print("5. run `centaur deploy k8s` once the kube context works")
+
+
+@app.command()
+def logs(component: str = "api", namespace: str = "centaur", release: str = "centaur") -> None:
+    """Print the kubectl log command for a Centaur component."""
+    console.print(f"kubectl logs -n {namespace} deploy/{release}-centaur-{component} --tail=200 -f")
+
+
+@app.command()
+def repair(step: str) -> None:
+    """Print focused repair instructions for one onboarding area."""
+    repairs = {
+        "slack": "Regenerate the manifest, update Slack request URLs, reinstall the app, then rerun auth.test and a test mention.",
+        "github": "Check GitHub App permissions, installation id, private key formatting, and webhook delivery status.",
+        "secrets": "Run `centaur secrets doctor --backend <backend>` and sync missing keys into the selected backend.",
+        "deploy": "Run `centaur doctor --deep`, fix cluster/helm failures, then rerun `centaur deploy k8s`.",
+    }
+    console.print(repairs.get(step, "Known repair steps: slack, github, secrets, deploy"))
+
+
+if __name__ == "__main__":
+    app()

--- a/packages/centaur-cli/centaur_cli/state.py
+++ b/packages/centaur-cli/centaur_cli/state.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_HOME = Path.home() / ".centaur"
+
+
+@dataclass
+class OnboardingState:
+    org: str = ""
+    assistant_name: str = "centaur"
+    domain: str = ""
+    admin_email: str = ""
+    install_mode: str = "local"
+    secret_backend: str = "local-env"
+    overlay_path: str = ""
+    completed_steps: list[str] = field(default_factory=list)
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def mark_done(self, step: str) -> None:
+        if step not in self.completed_steps:
+            self.completed_steps.append(step)
+
+
+def state_path(home: Path = DEFAULT_HOME) -> Path:
+    return home / "onboarding-state.json"
+
+
+def config_path(home: Path = DEFAULT_HOME) -> Path:
+    return home / "config.json"
+
+
+def load_state(home: Path = DEFAULT_HOME) -> OnboardingState:
+    path = state_path(home)
+    if not path.exists():
+        return OnboardingState()
+    raw = json.loads(path.read_text())
+    return OnboardingState(**raw)
+
+
+def save_state(state: OnboardingState, home: Path = DEFAULT_HOME) -> Path:
+    home.mkdir(parents=True, exist_ok=True)
+    path = state_path(home)
+    path.write_text(json.dumps(asdict(state), indent=2, sort_keys=True) + "\n")
+    config_path(home).write_text(json.dumps(asdict(state), indent=2, sort_keys=True) + "\n")
+    (home / "logs").mkdir(exist_ok=True)
+    return path

--- a/packages/centaur-cli/centaur_cli/templates.py
+++ b/packages/centaur-cli/centaur_cli/templates.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SLACK_SCOPES = [
+    "app_mentions:read",
+    "channels:history",
+    "channels:read",
+    "chat:write",
+    "files:read",
+    "files:write",
+    "groups:history",
+    "groups:read",
+    "im:history",
+    "im:read",
+    "users:read",
+]
+
+
+def slack_manifest(app_name: str, domain: str, socket_mode: bool) -> dict:
+    base_url = f"https://{domain}".rstrip("/")
+    manifest = {
+        "display_information": {"name": app_name},
+        "features": {
+            "bot_user": {"display_name": app_name, "always_online": True},
+            "slash_commands": [
+                {
+                    "command": "/centaur",
+                    "description": "Send a command to Centaur",
+                    "url": f"{base_url}/slack/commands",
+                    "should_escape": False,
+                }
+            ],
+        },
+        "oauth_config": {"scopes": {"bot": SLACK_SCOPES}},
+        "settings": {
+            "interactivity": {
+                "is_enabled": True,
+                "request_url": f"{base_url}/slack/interactivity",
+            },
+            "event_subscriptions": {
+                "request_url": f"{base_url}/slack/events",
+                "bot_events": ["app_mention", "message.im", "file_shared"],
+            },
+            "org_deploy_enabled": False,
+            "socket_mode_enabled": socket_mode,
+            "token_rotation_enabled": False,
+        },
+    }
+    if socket_mode:
+        manifest["settings"]["event_subscriptions"].pop("request_url", None)
+        manifest["settings"]["interactivity"].pop("request_url", None)
+    return manifest
+
+
+def write_overlay(path: Path, org: str, assistant_name: str, domain: str) -> list[Path]:
+    path.mkdir(parents=True, exist_ok=True)
+    files = {
+        "AGENTS.md": f"""# {assistant_name}
+
+You are {assistant_name}, the AI assistant for {org}.
+
+## Operating Rules
+
+- Be direct and concrete.
+- Verify external writes before claiming success.
+- Ask before taking destructive actions.
+- Use the configured Centaur tools before ad hoc external calls.
+
+## Deployment
+
+- Domain: {domain or "unset"}
+- Overlay owner: {org}
+""",
+        "secrets.example.env": """# Slack
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_SIGNING_SECRET=...
+SLACK_APP_TOKEN=xapp-...
+SLACK_CLIENT_ID=...
+SLACK_CLIENT_SECRET=...
+
+# Models
+OPENAI_API_KEY=...
+ANTHROPIC_API_KEY=...
+OPENROUTER_API_KEY=...
+
+# GitHub
+GITHUB_APP_ID=...
+GITHUB_APP_PRIVATE_KEY=...
+GITHUB_INSTALLATION_ID=...
+
+# Centaur
+SLACKBOT_API_KEY=...
+DATABASE_URL=postgres://...
+""",
+        "values.centaur.yaml": f"""global:
+  domain: {domain or "centaur.example.com"}
+  overlay:
+    enabled: true
+    mountPath: /overlay/org
+
+slackbot:
+  enabled: true
+
+api:
+  ingress:
+    enabled: true
+""",
+        "personas/base.md": f"""You are {assistant_name}. Follow the overlay instructions in AGENTS.md.""",
+        "skills/README.md": "# Skills\n\nAdd organization-specific Centaur skills here.\n",
+        "tools/README.md": "# Tools\n\nAdd organization-specific tool wrappers here.\n",
+        "workflows/README.md": "# Workflows\n\nAdd durable workflow definitions here.\n",
+    }
+    written: list[Path] = []
+    for rel, content in files.items():
+        target = path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not target.exists():
+            target.write_text(content)
+            written.append(target)
+    return written
+
+
+def write_slack_manifest(path: Path, app_name: str, domain: str, socket_mode: bool) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(slack_manifest(app_name, domain, socket_mode), indent=2) + "\n")
+    return path

--- a/packages/centaur-cli/pyproject.toml
+++ b/packages/centaur-cli/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "centaur-cli"
+version = "0.1.0"
+description = "Interactive onboarding CLI for Centaur deployments"
+requires-python = ">=3.11"
+readme = "README.md"
+license = "Apache-2.0 OR MIT"
+dependencies = [
+    "rich>=13.0",
+    "typer>=0.12.0",
+]
+
+[project.scripts]
+centaur = "centaur_cli.main:app"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["centaur_cli"]

--- a/packages/centaur-cli/tests/test_cli.py
+++ b/packages/centaur-cli/tests/test_cli.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from centaur_cli.main import app
+from centaur_cli.templates import slack_manifest
+
+runner = CliRunner()
+
+
+def test_slack_manifest_uses_public_urls() -> None:
+    manifest = slack_manifest("centaur", "centaur.example.com", socket_mode=False)
+
+    assert manifest["settings"]["event_subscriptions"]["request_url"] == "https://centaur.example.com/slack/events"
+    assert manifest["settings"]["interactivity"]["request_url"] == "https://centaur.example.com/slack/interactivity"
+    assert "chat:write" in manifest["oauth_config"]["scopes"]["bot"]
+
+
+def test_slack_manifest_socket_mode_removes_request_urls() -> None:
+    manifest = slack_manifest("centaur", "centaur.example.com", socket_mode=True)
+
+    assert manifest["settings"]["socket_mode_enabled"] is True
+    assert "request_url" not in manifest["settings"]["event_subscriptions"]
+    assert "request_url" not in manifest["settings"]["interactivity"]
+
+
+def test_init_non_interactive_scaffolds_overlay(tmp_path) -> None:
+    overlay = tmp_path / "org"
+    home = tmp_path / "home"
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--non-interactive",
+            "--org",
+            "acme",
+            "--assistant-name",
+            "centaur",
+            "--domain",
+            "centaur.acme.com",
+            "--overlay-path",
+            str(overlay),
+            "--home",
+            str(home),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (overlay / "AGENTS.md").exists()
+    assert (overlay / "slack-app-manifest.json").exists()
+    state = json.loads((home / "onboarding-state.json").read_text())
+    assert state["org"] == "acme"
+    assert "slack-manifest" in state["completed_steps"]
+
+
+def test_deploy_kind_prints_local_cluster_commands() -> None:
+    result = runner.invoke(app, ["deploy", "kind", "--cluster-name", "dogfood"])
+
+    assert result.exit_code == 0
+    assert "kind create cluster --name dogfood" in result.stdout
+    assert "helm upgrade --install centaur contrib/chart" in result.stdout


### PR DESCRIPTION
## Summary
- add a standalone Python/Typer `centaur` CLI package with `init`, `doctor`, `status`, `overlay`, `integrations`, `secrets`, `deploy`, `smoke-test`, `logs`, and `repair` commands
- scaffold overlay files, Slack app manifest, secret templates, local onboarding state, and deployment checklists
- document the guided CLI path in the quickstart

## Test Plan
- `UV_PROJECT_ENVIRONMENT=/tmp/centaur-cli-venv uv run --project packages/centaur-cli pytest packages/centaur-cli/tests`
- `uvx ruff check packages/centaur-cli`
- `UV_PROJECT_ENVIRONMENT=/tmp/centaur-cli-venv uv run --project packages/centaur-cli centaur integrations slack-manifest --domain centaur.example.com`