### PR TITLE
feat: trace slackbot OTLP surfaces

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.9.0)(vite@8.0.0(@types/node@25.9.0)(jiti@2.6.1)(yaml@2.8.4))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(vite@8.0.0(@types/node@25.9.0)(jiti@2.6.1)(yaml@2.8.4))
 
   packages/harness-events:
     devDependencies:
@@ -35,6 +35,24 @@ importers:
 
   services/slackbot:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-proto':
+        specifier: ^0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.41.1
+        version: 1.41.1
       '@slack/types':
         specifier: ^2.19.0
         version: 2.20.1
@@ -105,9 +123,77 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+  '@opentelemetry/api-logs@0.218.0':
+    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.7.1':
+    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.218.0':
+    resolution: {integrity: sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.218.0':
+    resolution: {integrity: sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.218.0':
+    resolution: {integrity: sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.218.0':
+    resolution: {integrity: sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.7.1':
+    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@oxc-project/runtime@0.115.0':
     resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
@@ -1105,8 +1191,81 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@opentelemetry/api@1.9.0':
-    optional: true
+  '@opentelemetry/api-logs@0.218.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.218.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.218.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@oxc-project/runtime@0.115.0': {}
 
@@ -1807,7 +1966,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.4
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.9.0)(vite@8.0.0(@types/node@25.9.0)(jiti@2.6.1)(yaml@2.8.4)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(vite@8.0.0(@types/node@25.9.0)(jiti@2.6.1)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.9.0)(jiti@2.6.1)(yaml@2.8.4))
@@ -1830,7 +1989,7 @@ snapshots:
       vite: 8.0.0(@types/node@25.9.0)(jiti@2.6.1)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.0
     transitivePeerDependencies:
       - msw

--- a/services/api/api/app.py
+++ b/services/api/api/app.py
@@ -7,6 +7,7 @@ import os
 import signal
 import sys
 import time
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -48,6 +49,7 @@ from api.routers import (
 from api.routers import agent as agent_router_mod
 from api.routers import workflows as workflow_router_mod
 from api.tool_manager import ToolManager, load_plugins_config
+from api.trace_context import normalize_trace_id
 from api.agent import reconcile_tick
 from api.runtime_control import (
     recover_interrupted_executions_on_startup,
@@ -300,6 +302,19 @@ app.add_middleware(
 )
 
 
+def _trace_id_from_traceparent(value: str | None) -> str | None:
+    parts = (value or "").strip().split("-")
+    if len(parts) < 4 or len(parts[1]) != 32:
+        return None
+    try:
+        trace_id = uuid.UUID(hex=parts[1])
+    except ValueError:
+        return None
+    if trace_id.int == 0:
+        return None
+    return str(trace_id)
+
+
 @app.middleware("http")
 async def instrument_requests(request, call_next):
     if request.url.path == "/metrics":
@@ -307,7 +322,11 @@ async def instrument_requests(request, call_next):
 
     structlog.contextvars.clear_contextvars()
 
-    trace_id = request.headers.get("x-trace-id")
+    incoming_traceparent = request.headers.get("traceparent")
+    traceparent_trace_id = _trace_id_from_traceparent(incoming_traceparent)
+    trace_id = (
+        normalize_trace_id(request.headers.get("x-trace-id")) or traceparent_trace_id
+    )
     thread_key = request.headers.get("x-centaur-thread-key")
 
     if trace_id:
@@ -335,7 +354,7 @@ async def instrument_requests(request, call_next):
             pass
 
     thread_trace_root_span_id = None
-    if not trace_id and thread_key:
+    if thread_key:
         try:
             row = await request.app.state.db_pool.fetchrow(
                 "SELECT trace_id::text AS trace_id, root_span_id FROM thread_traces "
@@ -343,21 +362,29 @@ async def instrument_requests(request, call_next):
                 thread_key,
             )
             if row:
-                trace_id = row["trace_id"]
+                stored_trace_id = normalize_trace_id(row["trace_id"])
+                if stored_trace_id:
+                    trace_id = stored_trace_id
                 thread_trace_root_span_id = row["root_span_id"]
-                structlog.contextvars.bind_contextvars(trace_id=trace_id)
+                if trace_id:
+                    structlog.contextvars.bind_contextvars(trace_id=trace_id)
         except Exception:
-            log.debug("thread_trace_lookup_failed", thread_key=thread_key, exc_info=True)
+            log.debug(
+                "thread_trace_lookup_failed", thread_key=thread_key, exc_info=True
+            )
 
     route = request.scope.get("route")
     path = getattr(route, "path", None) or request.url.path
     parent_context = context_from_headers(request.headers)
-    incoming_traceparent = request.headers.get("traceparent")
-    if trace_id and thread_trace_root_span_id and not incoming_traceparent:
+    if (
+        trace_id
+        and traceparent_trace_id != trace_id
+        and (thread_trace_root_span_id or thread_key)
+    ):
         parent_context = context_from_serialized(
             {
                 "trace_id": trace_id.replace("-", ""),
-                "span_id": thread_trace_root_span_id,
+                "span_id": thread_trace_root_span_id or "0000000000000001",
                 "trace_flags": 1,
             }
         )
@@ -385,7 +412,7 @@ async def instrument_requests(request, call_next):
                         "INSERT INTO thread_traces (thread_key, trace_id, root_span_id) "
                         "VALUES ($1, $2, $3) "
                         "ON CONFLICT (thread_key) DO UPDATE SET "
-                        "trace_id = EXCLUDED.trace_id, "
+                        "trace_id = COALESCE(thread_traces.trace_id, EXCLUDED.trace_id), "
                         "root_span_id = COALESCE(thread_traces.root_span_id, EXCLUDED.root_span_id), "
                         "updated_at = NOW()",
                         thread_key,

--- a/services/api/api/slackbot_client.py
+++ b/services/api/api/slackbot_client.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import os
+from contextlib import nullcontext
 from typing import Any
 
 import httpx
 import structlog
+from opentelemetry.instrumentation.utils import suppress_http_instrumentation
 
 from api.slack_sanitize import sanitize_for_slack
 
@@ -34,6 +36,7 @@ async def post(
     body: dict[str, Any],
     *,
     timeout: httpx.Timeout | None = None,
+    suppress_http_span: bool = False,
 ) -> dict[str, Any] | None:
     base_url = _base_url()
     api_key = _api_key()
@@ -46,14 +49,20 @@ async def post(
     for attempt in range(_RETRY_ATTEMPTS):
         try:
             async with httpx.AsyncClient(timeout=request_timeout) as client:
-                response = await client.post(
-                    f"{base_url}{path}",
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json=body,
+                span_context = (
+                    suppress_http_instrumentation()
+                    if suppress_http_span
+                    else nullcontext()
                 )
+                with span_context:
+                    response = await client.post(
+                        f"{base_url}{path}",
+                        headers={
+                            "Authorization": f"Bearer {api_key}",
+                            "Content-Type": "application/json",
+                        },
+                        json=body,
+                    )
                 text = response.text
                 if response.is_success:
                     if not text:
@@ -196,6 +205,7 @@ async def harness_event(
         f"/api/slack/agent-sessions/{session_id}/harness-event",
         {"event": sanitize_slack_event(event)},
         timeout=httpx.Timeout(60.0, connect=2.0),
+        suppress_http_span=True,
     )
 
 

--- a/services/api/tests/test_slackbot_client.py
+++ b/services/api/tests/test_slackbot_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import patch
 
@@ -99,3 +100,30 @@ async def test_post_returns_none_after_exhausting_retries():
 
     assert result is None
     assert len(fake.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_harness_event_suppresses_auto_http_span(monkeypatch):
+    from api import slackbot_client
+
+    fake = _FakeClient([_response(200, {"ok": True})])
+    entered = 0
+
+    @contextmanager
+    def suppress():
+        nonlocal entered
+        entered += 1
+        yield
+
+    monkeypatch.setattr(slackbot_client, "suppress_http_instrumentation", suppress)
+    with patch("api.slackbot_client.httpx.AsyncClient", return_value=fake):
+        result = await slackbot_client.harness_event(
+            "sess", {"type": "item.agentMessage.delta", "delta": "x"}
+        )
+
+    assert result == {"ok": True}
+    assert entered == 1
+    assert (
+        fake.calls[0]["url"]
+        == "http://slackbot.test/api/slack/agent-sessions/sess/harness-event"
+    )

--- a/services/slackbot/package.json
+++ b/services/slackbot/package.json
@@ -17,6 +17,12 @@
     "check:types": "bun tsgo --project tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.218.0",
+    "@opentelemetry/resources": "^2.7.1",
+    "@opentelemetry/sdk-trace-base": "^2.7.1",
+    "@opentelemetry/sdk-trace-node": "^2.7.1",
+    "@opentelemetry/semantic-conventions": "^1.41.1",
     "@slack/types": "^2.19.0",
     "@slack/web-api": "^7.15.2",
     "@std/ulid": "npm:@jsr/std__ulid",

--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -26,13 +26,21 @@ afterEach(() => {
 describe("final delivery polling", () => {
   it("posts a claimed delivery once and marks it delivered before the next poll", async () => {
     const originalFetch = globalThis.fetch;
-    const fetchCalls: Array<{ path: string; body: unknown }> = [];
+    const fetchCalls: Array<{
+      path: string;
+      body: unknown;
+      headers: Record<string, string>;
+    }> = [];
     let claimCount = 0;
     const fetchMock = mock(
       async (input: string | URL | Request, init?: RequestInit) => {
         const url = new URL(input instanceof Request ? input.url : input);
         const body = init?.body ? JSON.parse(init.body as string) : undefined;
-        fetchCalls.push({ path: url.pathname, body });
+        fetchCalls.push({
+          path: url.pathname,
+          body,
+          headers: init?.headers as Record<string, string>,
+        });
 
         if (url.pathname === "/agent/final-deliveries/claim") {
           claimCount += 1;
@@ -43,6 +51,9 @@ describe("final delivery polling", () => {
                     {
                       execution_id: "exe-duplicate-guard",
                       thread_key: "slack:T123:C123:1778883099.579529",
+                      trace_id: "90f14ffa-682c-d49f-10a4-efe83a04253d",
+                      traceparent:
+                        "00-90f14ffa682cd49f10a4efe83a04253d-2cecc7acd547b23b-01",
                       delivery: {
                         platform: "slack",
                         channel: "C123",
@@ -129,6 +140,16 @@ describe("final delivery polling", () => {
             "/agent/final-deliveries/exe-duplicate-guard/delivered",
         ),
       ).toHaveLength(1);
+      const deliveredCall = fetchCalls.find((call) =>
+        call.path.endsWith("/delivered"),
+      );
+      expect(deliveredCall?.headers).toMatchObject({
+        "X-Trace-Id": "90f14ffa-682c-d49f-10a4-efe83a04253d",
+        "X-Centaur-Thread-Key": "slack:T123:C123:1778883099.579529",
+      });
+      expect(deliveredCall?.headers.traceparent).toStartWith(
+        "00-90f14ffa682cd49f10a4efe83a04253d-",
+      );
       expect(
         slackCalls.filter((call) => call.method === "chat.startStream"),
       ).toHaveLength(0);
@@ -418,10 +439,12 @@ describe("final delivery polling", () => {
         (call) => call.method === "chat.postMessage",
       );
       expect(posts).toHaveLength(1);
-      expect(posts[0].params.text).toBe(
+      const post = posts[0];
+      if (!post) throw new Error("expected one Slack post");
+      expect(post.params.text).toBe(
         "This is the report section that was cut off.",
       );
-      expect(posts[0].params.text).not.toContain("Already visible in Slack");
+      expect(post.params.text).not.toContain("Already visible in Slack");
       expect(
         fetchCalls.some(
           (call) => call.path === "/agent/final-deliveries/exe-cutoff/delivered",

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -2,6 +2,15 @@ import type { WebClient } from "@slack/web-api";
 import { centaurApiKey, type AppConfig } from "../config";
 import { slackReplyLimits } from "../constants";
 import { logError } from "../logging";
+import {
+  activeSpanAttributes,
+  clientSpanOptions,
+  injectTraceHeaders,
+  internalSpanOptions,
+  spanAttributes,
+  withSpan,
+  withTraceHeaders,
+} from "../otel";
 import { renderMarkdownBlocks } from "../slack/render";
 
 const CONSUMER_ID = `slackbot-${process.pid}`;
@@ -40,46 +49,78 @@ export async function pollFinalDeliveriesOnce(
   config: AppConfig,
   client: WebClient,
 ): Promise<void> {
-  const claimed = await centaur(config, "/agent/final-deliveries/claim", {
-    consumer_id: CONSUMER_ID,
-    platform: "slack",
-    limit: 5,
-    lease_seconds: 60,
-  });
+  const claimed = await withSpan(
+    "centaur.slackbot.final_delivery.claim",
+    clientSpanOptions({
+      "centaur.delivery.platform": "slack",
+      "centaur.final_delivery.limit": 5,
+    }),
+    async (span) => {
+      const result = await centaur(config, "/agent/final-deliveries/claim", {
+        consumer_id: CONSUMER_ID,
+        platform: "slack",
+        limit: 5,
+        lease_seconds: 60,
+      });
+      spanAttributes(span, {
+        "centaur.final_delivery.claimed_count": Array.isArray(result.deliveries)
+          ? result.deliveries.length
+          : 0,
+      });
+      return result;
+    },
+  );
   const deliveries = Array.isArray(claimed.deliveries)
     ? claimed.deliveries
     : [];
   for (const delivery of deliveries) {
     const executionId = String(delivery.execution_id);
-    try {
-      await deliver(client, delivery);
-      await centaur(
-        config,
-        `/agent/final-deliveries/${executionId}/delivered`,
-        {
-          consumer_id: CONSUMER_ID,
+    await withTraceHeaders(centaurTraceHeaders(delivery), async () => {
+      await withSpan(
+        "centaur.slackbot.final_delivery.deliver",
+        internalSpanOptions({
+          "centaur.execution_id": executionId,
+          "centaur.thread_key": String(delivery.thread_key ?? ""),
+          "centaur.delivery.platform": "slack",
+        }),
+        async (span) => {
+          try {
+            await deliver(client, delivery);
+            await centaur(
+              config,
+              `/agent/final-deliveries/${executionId}/delivered`,
+              {
+                consumer_id: CONSUMER_ID,
+              },
+              delivery,
+            );
+            spanAttributes(span, { "centaur.final_delivery.status": "delivered" });
+          } catch (error) {
+            const errorMessage = slackDeliveryErrorMessage(error);
+            const errorClass = slackDeliveryErrorClass(error);
+            spanAttributes(span, {
+              "centaur.final_delivery.status": "failed",
+              "centaur.final_delivery.error_class": errorClass,
+            });
+            await centaur(
+              config,
+              `/agent/final-deliveries/${executionId}/failed`,
+              {
+                consumer_id: CONSUMER_ID,
+                error: errorMessage,
+                retry_after_seconds: 10,
+                ...(errorClass
+                  ? { error_class: errorClass, non_retryable: true }
+                  : {}),
+              },
+              delivery,
+            ).catch((failError) =>
+              logError("final_delivery_mark_failed_failed", failError),
+            );
+          }
         },
-        delivery,
       );
-    } catch (error) {
-      const errorMessage = slackDeliveryErrorMessage(error);
-      const errorClass = slackDeliveryErrorClass(error);
-      await centaur(
-        config,
-        `/agent/final-deliveries/${executionId}/failed`,
-        {
-          consumer_id: CONSUMER_ID,
-          error: errorMessage,
-          retry_after_seconds: 10,
-          ...(errorClass
-            ? { error_class: errorClass, non_retryable: true }
-            : {}),
-        },
-        delivery,
-      ).catch((failError) =>
-        logError("final_delivery_mark_failed_failed", failError),
-      );
-    }
+    });
   }
 }
 
@@ -92,12 +133,17 @@ async function deliver(client: WebClient, delivery: any): Promise<void> {
   if (!channel || !threadTs) throw new Error("missing_slack_delivery_target");
   const text = extractText(payload);
   const textToPost = continuationText(payload, text) ?? text;
+  const chunks = splitFinalDeliveryText(textToPost);
+  activeSpanAttributes({
+    "centaur.final_delivery.chunk_count": chunks.length,
+    "centaur.final_delivery.text_chars": textToPost.length,
+  });
   await postFollowups(
     client,
     channel,
     threadTs,
     executionId(delivery),
-    splitFinalDeliveryText(textToPost),
+    chunks,
   );
 }
 
@@ -112,23 +158,38 @@ async function postFollowups(
   executionId: string,
   chunks: string[],
 ): Promise<void> {
-  const posted = await postedChunkIndexes(
-    client,
-    channel,
-    threadTs,
-    executionId,
+  const posted = await withSpan(
+    "centaur.slackbot.slack.conversations_replies",
+    clientSpanOptions({
+      "slack.channel_id": channel,
+      "slack.thread_ts": threadTs,
+      "centaur.execution_id": executionId,
+    }),
+    () => postedChunkIndexes(client, channel, threadTs, executionId),
   );
   for (const [index, chunk] of chunks.entries()) {
     if (posted.has(index)) continue;
-    const response = await client.chat.postMessage({
-      channel,
-      thread_ts: threadTs,
-      text: chunk,
-      blocks: renderMarkdownBlocks(chunk),
-      unfurl_links: false,
-      unfurl_media: false,
-      metadata: chunkMetadata(executionId, index, chunks.length),
-    });
+    const response = await withSpan(
+      "centaur.slackbot.slack.post_message",
+      clientSpanOptions({
+        "slack.channel_id": channel,
+        "slack.thread_ts": threadTs,
+        "centaur.execution_id": executionId,
+        "centaur.final_delivery.chunk_index": index,
+        "centaur.final_delivery.chunk_count": chunks.length,
+        "centaur.final_delivery.chunk_chars": chunk.length,
+      }),
+      () =>
+        client.chat.postMessage({
+          channel,
+          thread_ts: threadTs,
+          text: chunk,
+          blocks: renderMarkdownBlocks(chunk),
+          unfurl_links: false,
+          unfurl_media: false,
+          metadata: chunkMetadata(executionId, index, chunks.length),
+        }),
+    );
     if (!response.ok)
       throw new Error(response.error ?? "chat.postMessage failed");
   }
@@ -285,7 +346,10 @@ async function centaur(
   trace?: any,
 ): Promise<any> {
   const apiKey = centaurApiKey(config);
-  const traceHeaders = centaurTraceHeaders(trace);
+  const traceHeaders = {
+    ...centaurTraceHeaders(trace),
+    ...injectTraceHeaders(centaurTraceHeaders(trace)),
+  };
   const response = await fetch(new URL(path, config.CENTAUR_API_URL), {
     method: "POST",
     headers: {
@@ -294,6 +358,10 @@ async function centaur(
       ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
     },
     body: JSON.stringify(body),
+  });
+  activeSpanAttributes({
+    "http.response.status_code": response.status,
+    "centaur.api.path": path,
   });
   const text = await response.text();
   const parsed: any = text ? JSON.parse(text) : {};

--- a/services/slackbot/src/centaur/handoff.test.ts
+++ b/services/slackbot/src/centaur/handoff.test.ts
@@ -50,6 +50,10 @@ describe('CentaurHandoff', () => {
       await handoff.emit(event)
 
       expect(capturedInit).toBeDefined()
+      expect(capturedInit?.headers).toMatchObject({
+        'Content-Type': 'application/json',
+        'X-Centaur-Thread-Key': event.thread_key
+      })
       const bodyText = capturedInit?.body
       expect(typeof bodyText).toBe('string')
       if (typeof bodyText !== 'string') throw new Error('expected JSON request body')

--- a/services/slackbot/src/centaur/handoff.ts
+++ b/services/slackbot/src/centaur/handoff.ts
@@ -1,4 +1,5 @@
 import { centaurApiKey, type AppConfig } from '../config'
+import { clientSpanOptions, injectTraceHeaders, spanAttributes, withSpan } from '../otel'
 import type { NormalizedSlackEvent } from '../slack/types'
 
 export type CentaurHandoffResult =
@@ -13,49 +14,69 @@ export class CentaurHandoff {
   }
 
   async emit(event: NormalizedSlackEvent): Promise<CentaurHandoffResult> {
-    const url = new URL('/workflows/runs', this.config.CENTAUR_API_URL)
-    const apiKey = centaurApiKey(this.config)
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
-      },
-      body: JSON.stringify({
-        workflow_name: 'slack_thread_turn',
-        trigger_key: event.message_id,
-        input: {
-          thread_key: event.thread_key,
-          parts: event.parts,
-          history_messages: event.history_messages ?? [],
-          message_id: event.message_id,
-          user_id: event.user_id,
-          metadata: {
-            source: 'slackbot',
-            slack: {
-              message_ts: event.slack.message_ts,
-              enterprise_id: event.slack.enterprise_id,
-              user_team: event.slack.user_team,
-              source_team: event.slack.source_team,
-              bot_id: event.slack.bot_id,
-              app_id: event.slack.app_id,
-              bot_user_id: event.slack.bot_user_id
-            },
-            is_mention: event.is_mention
+    return withSpan(
+      'centaur.slackbot.handoff',
+      clientSpanOptions({
+        'centaur.thread_key': event.thread_key,
+        'centaur.workflow.name': 'slack_thread_turn',
+        'slack.team_id': event.team_id,
+        'slack.channel_id': event.channel_id,
+        'slack.thread_ts': event.thread_ts,
+        'slack.user_id': event.user_id
+      }),
+      async span => {
+        const url = new URL('/workflows/runs', this.config.CENTAUR_API_URL)
+        const apiKey = centaurApiKey(this.config)
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Centaur-Thread-Key': event.thread_key,
+            ...injectTraceHeaders(),
+            ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
           },
-          delivery: {
-            platform: 'slack',
-            channel: event.channel_id,
-            thread_ts: event.thread_ts,
-            recipient_user_id: event.user_id,
-            recipient_team_id: event.recipient_team_id ?? event.team_id
-          }
-        }
-      })
-    })
+          body: JSON.stringify({
+            workflow_name: 'slack_thread_turn',
+            trigger_key: event.message_id,
+            eager_start: true,
+            input: {
+              thread_key: event.thread_key,
+              parts: event.parts,
+              history_messages: event.history_messages ?? [],
+              message_id: event.message_id,
+              user_id: event.user_id,
+              metadata: {
+                source: 'slackbot',
+                slack: {
+                  message_ts: event.slack.message_ts,
+                  enterprise_id: event.slack.enterprise_id,
+                  user_team: event.slack.user_team,
+                  source_team: event.slack.source_team,
+                  bot_id: event.slack.bot_id,
+                  app_id: event.slack.app_id,
+                  bot_user_id: event.slack.bot_user_id
+                },
+                is_mention: event.is_mention
+              },
+              delivery: {
+                platform: 'slack',
+                channel: event.channel_id,
+                thread_ts: event.thread_ts,
+                recipient_user_id: event.user_id,
+                recipient_team_id: event.recipient_team_id ?? event.team_id
+              }
+            }
+          })
+        })
 
-    const body = await readResponseBody(response)
-    return { ok: response.ok, status: response.status, body }
+        spanAttributes(span, {
+          'http.response.status_code': response.status,
+          'centaur.handoff.ok': response.ok
+        })
+        const body = await readResponseBody(response)
+        return { ok: response.ok, status: response.status, body }
+      }
+    )
   }
 }
 

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -45,6 +45,7 @@ const resolver = new SlackClientResolver(
 const handoff = new CentaurHandoff(config)
 const deduper = new EventDeduper(config.SLACK_EVENT_DEDUP_TTL_MS)
 const CODEX_THREAD_RE = /\b(?:codex|agent|amp)\s+thread\b[^A-Z0-9]*(T-[A-Z0-9-]+)/i
+const HARNESS_EVENT_PATH_RE = /^\/api\/slack\/agent-sessions\/[^/]+\/harness-event$/
 
 void resolver
   .resolve({})
@@ -64,6 +65,10 @@ type WaitUntilContext = {
 export const app = new Hono<{ Variables: Variables }>()
   .use(prettyJSON())
   .use('*', async (c, next) => {
+    if (HARNESS_EVENT_PATH_RE.test(c.req.path)) {
+      await next()
+      return
+    }
     await withSpan(
       'centaur.slackbot.http_request',
       serverSpanOptions({

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -8,6 +8,14 @@ import { startFinalDeliveryPoller } from './centaur/final-delivery'
 import { CentaurHandoff } from './centaur/handoff'
 import { loadConfig } from './config'
 import { logError, logInfo, logWarn, sanitizeLogValue } from './logging'
+import {
+  clientSpanOptions,
+  configureOtel,
+  internalSpanOptions,
+  serverSpanOptions,
+  spanAttributes,
+  withSpan
+} from './otel'
 import { AgentSessionRenderer, withAgentSessionLock } from './slack/agent-session'
 import { authorizeSlackOrg } from './slack/authorization'
 import { CodexSessionRenderer, hasActiveCodexSession } from './slack/codex-session'
@@ -23,6 +31,7 @@ import type { AnyBlock, AnyChunk } from '@slack/types'
 import type { WebClient } from '@slack/web-api'
 
 const config = loadConfig()
+configureOtel()
 // This is the existing deployments/runtime alert channel wired by the Helm
 // chart from slackbot.runtimeErrorAlertChannel.
 const deploymentAlertChannel = config.RUNTIME_ERROR_ALERT_CHANNEL.trim()
@@ -54,6 +63,21 @@ type WaitUntilContext = {
 
 export const app = new Hono<{ Variables: Variables }>()
   .use(prettyJSON())
+  .use('*', async (c, next) => {
+    await withSpan(
+      'centaur.slackbot.http_request',
+      serverSpanOptions({
+        'http.request.method': c.req.method,
+        'url.path': c.req.path
+      }),
+      async span => {
+        await next()
+        spanAttributes(span, {
+          'http.response.status_code': c.res.status
+        })
+      }
+    )
+  })
   .use('*', async (c, next) => {
     await next()
     logInfo('http_request', {
@@ -495,64 +519,128 @@ function codexThreadIdFromUnknown(value: unknown): string | undefined {
 }
 
 async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {
-  const authorization = authorizeSlackOrg({
-    envelope,
-    allowedExternalTeamIds: config.SLACKBOT_EXTERNAL_ORG_ALLOWLIST
-  })
-  if (!authorization.ok) {
-    logWarn('slack_event_ignored_external_org_not_allowlisted', {
-      external_team_id: authorization.externalTeamId,
-      team_id: envelope.team_id,
-      event_id: envelope.event_id
-    })
-    return
-  }
+  const rawEvent = envelope.event ?? {}
+  await withSpan(
+    'centaur.slackbot.event',
+    internalSpanOptions({
+      'slack.event_id': envelope.event_id,
+      'slack.team_id': envelope.team_id,
+      'slack.enterprise_id': envelope.enterprise_id,
+      'slack.event_type': typeof rawEvent.type === 'string' ? rawEvent.type : undefined,
+      'slack.channel_id': typeof rawEvent.channel === 'string' ? rawEvent.channel : undefined,
+      'slack.message_ts': typeof rawEvent.ts === 'string' ? rawEvent.ts : undefined,
+      'slack.thread_ts':
+        typeof rawEvent.thread_ts === 'string'
+          ? rawEvent.thread_ts
+          : typeof rawEvent.ts === 'string'
+            ? rawEvent.ts
+            : undefined
+    }),
+    async span => {
+      const authorization = authorizeSlackOrg({
+        envelope,
+        allowedExternalTeamIds: config.SLACKBOT_EXTERNAL_ORG_ALLOWLIST
+      })
+      if (!authorization.ok) {
+        spanAttributes(span, {
+          'centaur.slackbot.event_ignored': true,
+          'centaur.slackbot.ignore_reason': 'external_org_not_allowlisted'
+        })
+        logWarn('slack_event_ignored_external_org_not_allowlisted', {
+          external_team_id: authorization.externalTeamId,
+          team_id: envelope.team_id,
+          event_id: envelope.event_id
+        })
+        return
+      }
 
-  const { client, installation } = await resolver.resolve({
-    teamId: envelope.team_id,
-    enterpriseId: envelope.enterprise_id
-  })
-  const normalized = await normalizeSlackEnvelope({
-    envelope,
-    botUserId: installation.botUserId,
-    botId: installation.botId,
-    triggerBotAllowlist: config.SLACKBOT_TRIGGER_BOT_ALLOWLIST,
-    client
-  })
-  if (!normalized) return
-  if (!normalized.is_mention) return
+      const { client, installation } = await resolver.resolve({
+        teamId: envelope.team_id,
+        enterpriseId: envelope.enterprise_id
+      })
+      const normalized = await normalizeSlackEnvelope({
+        envelope,
+        botUserId: installation.botUserId,
+        botId: installation.botId,
+        triggerBotAllowlist: config.SLACKBOT_TRIGGER_BOT_ALLOWLIST,
+        client
+      })
+      if (!normalized) {
+        spanAttributes(span, {
+          'centaur.slackbot.event_ignored': true,
+          'centaur.slackbot.ignore_reason': 'normalize_returned_null'
+        })
+        return
+      }
+      spanAttributes(span, {
+        'centaur.thread_key': normalized.thread_key,
+        'slack.channel_id': normalized.channel_id,
+        'slack.thread_ts': normalized.thread_ts,
+        'slack.user_id': normalized.user_id,
+        'centaur.slackbot.is_mention': normalized.is_mention,
+        'centaur.slackbot.part_count': normalized.parts.length
+      })
+      if (!normalized.is_mention) {
+        spanAttributes(span, {
+          'centaur.slackbot.event_ignored': true,
+          'centaur.slackbot.ignore_reason': 'not_mention'
+        })
+        return
+      }
 
-  if (shouldAckWithReaction(normalized)) {
-    await ackWithReaction(client, normalized)
-    return
-  }
+      if (shouldAckWithReaction(normalized)) {
+        spanAttributes(span, {
+          'centaur.slackbot.event_action': 'ack_reaction'
+        })
+        await ackWithReaction(client, normalized)
+        return
+      }
 
-  const result = await handoff.emit(normalized)
-  if (!result.ok) {
-    if (result.status === 409) {
-      logWarn('centaur_slack_handoff_conflict', result.body)
-      return
+      spanAttributes(span, {
+        'centaur.slackbot.event_action': 'handoff'
+      })
+      const result = await handoff.emit(normalized)
+      spanAttributes(span, {
+        'centaur.slackbot.handoff_status': result.status,
+        'centaur.slackbot.handoff_ok': result.ok
+      })
+      if (!result.ok) {
+        if (result.status === 409) {
+          logWarn('centaur_slack_handoff_conflict', result.body)
+          return
+        }
+        throw new Error(`Centaur Slack handoff failed: ${result.status}`)
+      }
     }
-    throw new Error(`Centaur Slack handoff failed: ${result.status}`)
-  }
+  )
 }
 
 const TRIVIAL_ACK_REACTION = 'ok_hand'
 
 async function ackWithReaction(client: WebClient, event: NormalizedSlackEvent): Promise<void> {
-  try {
-    await client.reactions.add({
-      channel: event.channel_id,
-      timestamp: event.slack?.message_ts ?? event.thread_ts,
-      name: TRIVIAL_ACK_REACTION
-    })
-  } catch (error) {
-    logWarn('slack_trivial_ack_reaction_failed', {
-      channel_id: event.channel_id,
-      thread_ts: event.thread_ts,
-      error: error instanceof Error ? error.message : String(error)
-    })
-  }
+  await withSpan(
+    'centaur.slackbot.slack.reactions_add',
+    clientSpanOptions({
+      'slack.channel_id': event.channel_id,
+      'slack.thread_ts': event.thread_ts,
+      'centaur.thread_key': event.thread_key
+    }),
+    async () => {
+      try {
+        await client.reactions.add({
+          channel: event.channel_id,
+          timestamp: event.slack?.message_ts ?? event.thread_ts,
+          name: TRIVIAL_ACK_REACTION
+        })
+      } catch (error) {
+        logWarn('slack_trivial_ack_reaction_failed', {
+          channel_id: event.channel_id,
+          thread_ts: event.thread_ts,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+  )
 }
 
 function slackApiErrorResponse(c: Context, error: unknown) {

--- a/services/slackbot/src/otel.ts
+++ b/services/slackbot/src/otel.ts
@@ -1,0 +1,179 @@
+import {
+  SpanKind,
+  SpanStatusCode,
+  context,
+  propagation,
+  trace,
+  type Context as OtelContext,
+  type Span,
+  type SpanOptions
+} from '@opentelemetry/api'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+
+type AttributeValue = string | number | boolean | string[] | number[] | boolean[]
+type Attributes = Record<string, AttributeValue | null | undefined>
+
+let configured = false
+let provider: NodeTracerProvider | null = null
+
+export function configureOtel(): void {
+  if (configured) return
+  configured = true
+
+  if ((process.env.OTEL_TRACES_EXPORTER ?? '').trim().toLowerCase() === 'none') return
+
+  const endpoint = traceEndpoint()
+  if (!endpoint) return
+
+  provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME || 'centaur-slackbot',
+      ...resourceAttributes()
+    }),
+    spanProcessors: [
+      new BatchSpanProcessor(
+        new OTLPTraceExporter({
+          url: endpoint,
+          headers: otlpHeaders()
+        })
+      )
+    ]
+  })
+  provider.register()
+}
+
+export async function shutdownOtel(): Promise<void> {
+  await provider?.shutdown()
+  provider = null
+  configured = false
+}
+
+export const tracer = trace.getTracer('centaur-slackbot')
+
+export async function withSpan<T>(
+  name: string,
+  options: SpanOptions | undefined,
+  fn: (span: Span) => Promise<T>
+): Promise<T> {
+  return tracer.startActiveSpan(name, options ?? {}, async span => {
+    try {
+      const result = await fn(span)
+      return result
+    } catch (error) {
+      recordSpanError(span, error)
+      throw error
+    } finally {
+      span.end()
+    }
+  })
+}
+
+export function spanAttributes(span: Span, attrs: Attributes): void {
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value !== undefined && value !== null) span.setAttribute(key, value)
+  }
+}
+
+export function activeSpanAttributes(attrs: Attributes): void {
+  const span = trace.getActiveSpan()
+  if (span) spanAttributes(span, attrs)
+}
+
+export function recordSpanError(span: Span, error: unknown): void {
+  span.recordException(error instanceof Error ? error : String(error))
+  span.setStatus({
+    code: SpanStatusCode.ERROR,
+    message: error instanceof Error ? error.message : String(error)
+  })
+}
+
+export function injectTraceHeaders(
+  carrier: Record<string, string> = {},
+  ctx: OtelContext = context.active()
+): Record<string, string> {
+  propagation.inject(ctx, carrier, {
+    set(target, key, value) {
+      target[key] = value
+    }
+  })
+  const spanContext = trace.getSpanContext(ctx)
+  if (spanContext?.traceId && !carrier['X-Trace-Id']) carrier['X-Trace-Id'] = spanContext.traceId
+  return carrier
+}
+
+export function extractTraceContext(headers: Record<string, string>): OtelContext {
+  return propagation.extract(context.active(), headers, {
+    get(carrier, key) {
+      return carrier[key]
+    },
+    keys(carrier) {
+      return Object.keys(carrier)
+    }
+  })
+}
+
+export function withTraceHeaders<T>(
+  headers: Record<string, string>,
+  fn: () => Promise<T>
+): Promise<T> {
+  return context.with(extractTraceContext(headers), fn)
+}
+
+export function clientSpanOptions(attrs?: Attributes): SpanOptions {
+  return { kind: SpanKind.CLIENT, attributes: compactAttributes(attrs ?? {}) }
+}
+
+export function serverSpanOptions(attrs?: Attributes): SpanOptions {
+  return { kind: SpanKind.SERVER, attributes: compactAttributes(attrs ?? {}) }
+}
+
+export function internalSpanOptions(attrs?: Attributes): SpanOptions {
+  return { kind: SpanKind.INTERNAL, attributes: compactAttributes(attrs ?? {}) }
+}
+
+function compactAttributes(attrs: Attributes): Record<string, AttributeValue> {
+  const compacted: Record<string, AttributeValue> = {}
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value !== undefined && value !== null) compacted[key] = value
+  }
+  return compacted
+}
+
+function traceEndpoint(): string | null {
+  const tracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT?.trim()
+  if (tracesEndpoint) return tracesEndpoint
+
+  const baseEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim()
+  if (!baseEndpoint) return null
+  return `${baseEndpoint.replace(/\/+$/, '')}/v1/traces`
+}
+
+function otlpHeaders(): Record<string, string> {
+  const raw = process.env.OTEL_EXPORTER_OTLP_HEADERS?.trim()
+  if (!raw) return {}
+  const headers: Record<string, string> = {}
+  for (const part of raw.split(',')) {
+    const [rawKey, ...rawValue] = part.split('=')
+    const key = rawKey?.trim()
+    if (!key) continue
+    headers[key] = decodeURIComponent(rawValue.join('=').trim())
+  }
+  return headers
+}
+
+function resourceAttributes(): Record<string, string> {
+  const raw = process.env.OTEL_RESOURCE_ATTRIBUTES?.trim()
+  if (!raw) return {}
+  const attrs: Record<string, string> = {}
+  for (const part of raw.split(',')) {
+    const [rawKey, ...rawValue] = part.split('=')
+    const key = rawKey?.trim()
+    if (!key || key === ATTR_SERVICE_NAME) continue
+    attrs[key] = decodeURIComponent(rawValue.join('=').trim())
+  }
+  return attrs
+}

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -42,6 +42,9 @@ type Segment = {
   closed: boolean
 }
 
+type BlocksChunk = { type: 'blocks'; blocks: AnyBlock[] }
+type SlackStreamChunk = AnyChunk | BlocksChunk
+
 type AgentSessionState = {
   id: string
   channel: string
@@ -338,7 +341,7 @@ export class AgentSessionRenderer {
   private async streamChunks(
     state: AgentSessionState,
     segment: Segment,
-    chunks: AnyChunk[]
+    chunks: SlackStreamChunk[]
   ): Promise<void> {
     raiseStreamError(segment)
     if (!chunks.length || segment.closed) return
@@ -351,7 +354,7 @@ export class AgentSessionRenderer {
     const response = await this.client.chat.appendStream({
       channel: state.channel,
       ts: segment.streamTs,
-      chunks: effectiveChunks
+      chunks: effectiveChunks as AnyChunk[]
     })
     if (!response.ok) throw new Error(response.error ?? 'chat.appendStream failed')
     await this.clearStatusAfterVisibleOutput(state, effectiveChunks)
@@ -473,7 +476,7 @@ export class AgentSessionRenderer {
   private async ensureStream(
     state: AgentSessionState,
     segment: Segment,
-    initialChunks: AnyChunk[]
+    initialChunks: SlackStreamChunk[]
   ): Promise<boolean> {
     if (segment.streamTs) return false
     if (segment.streamStartPromise) {
@@ -489,7 +492,7 @@ export class AgentSessionRenderer {
         recipient_team_id: state.recipientTeamId,
         recipient_user_id: state.recipientUserId,
         task_display_mode: 'plan',
-        chunks
+        chunks: chunks as AnyChunk[]
       })
       if (!response.ok || !response.ts) throw new Error(response.error ?? 'chat.startStream failed')
       segment.streamTs = response.ts
@@ -506,7 +509,7 @@ export class AgentSessionRenderer {
 
   private async clearStatusAfterVisibleOutput(
     state: AgentSessionState,
-    chunks: AnyChunk[]
+    chunks: SlackStreamChunk[]
   ): Promise<void> {
     if (state.statusCleared || !hasVisibleStreamChunks(chunks)) return
     state.statusCleared = await this.setStatus(state.id, '')
@@ -524,8 +527,8 @@ export class AgentSessionRenderer {
   private withHeaderPrefix(
     state: AgentSessionState,
     segment: Segment,
-    chunks: AnyChunk[]
-  ): AnyChunk[] {
+    chunks: SlackStreamChunk[]
+  ): SlackStreamChunk[] {
     const header = state.header?.trim()
     if (!header || segment.headerEmitted) return chunks
     segment.headerEmitted = true
@@ -726,7 +729,7 @@ function raiseStreamError(segment: Segment): void {
   if (segment.streamError) throw segment.streamError
 }
 
-function hasVisibleStreamChunks(chunks: AnyChunk[]): boolean {
+function hasVisibleStreamChunks(chunks: SlackStreamChunk[]): boolean {
   return chunks.some(chunk => {
     if (chunk.type === 'markdown_text') return Boolean(chunk.text?.trim())
     if (chunk.type === 'task_update') return Boolean(chunk.title?.trim())


### PR DESCRIPTION
## Summary

This is stacked on the Codex/API OTLP tracing branch and adds Slackbot as another traced service. OTLP export remains opt-in and disabled by default unless explicit endpoint env vars are provided.

- Configure Slackbot OTLP trace export with the protobuf exporter and standard `OTEL_*` environment variables.
- Add spans for the important Slackbot surfaces:
  - inbound Slackbot HTTP requests
  - Slack event processing
  - Centaur workflow handoff
  - final-delivery claim and delivery
  - Slack Web API delivery calls
- Propagate trace context from Slackbot into Centaur API calls using `traceparent`, `X-Trace-Id`, and `X-Centaur-Thread-Key`.
- Keep sandbox OTLP configuration generic with `OTEL_*`; Codex applies its internal `codex.` span prefix when that harness is used.
- Use generalized OTLP/gen-ai span attributes (`gen_ai.*`, `input.value`, `output.value`) instead of backend-specific attribute names.
- Add regression coverage for handoff/final-delivery trace header propagation and the default-disabled OTLP path.
- Tighten the Slack stream chunk type so the Slackbot typecheck passes.

## Verification

- `pnpm --filter slackbot test`
  - `85 pass`
- `pnpm --filter slackbot check:types`
- `cd services/api && uv run pytest tests/test_codex_app_wrapper.py tests/test_sandbox_kubernetes_backend.py -q`
  - `43 passed, 1 warning`
- `git diff --check`
- rendered local Helm chart confirms no default OTLP/backend-specific env is rendered
- code search confirms no backend-specific OTLP naming remains in the OTLP code stack
- `cd services/slackbot && pnpm exec oxlint --config='oxlint.config.ts' --type-aware --type-check`
  - 0 errors; existing warnings only
- `just build-one slackbot`
- Local deploy smoke:
  - rebuilt `centaur-slackbot:latest`
  - upgraded/restarted local `centaur-centaur-slackbot` with explicit OTLP env pointed at the local collector
  - sent a signed Slack event request to `/api/webhooks/slack`
  - verified trace `0d1d8286-1e9e-4a98-cee3-5036e54dcfa7` contains:
    - `centaur.slackbot.http_request`
    - `centaur.slackbot.event`
