### PR TITLE
fix: deliver cut off Slack replies

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -1005,6 +1005,13 @@ def _slackbot_streamed_answer_chars(value: Any) -> int:
     return 0
 
 
+def _slackbot_live_delivery_covers_result(result_text: str, streamed_chars: int) -> bool:
+    text = result_text.strip()
+    if not text:
+        return True
+    return streamed_chars >= len(text)
+
+
 async def _send_slackbot_canonical_event(
     session_id: str, event: dict[str, Any]
 ) -> bool:
@@ -1855,7 +1862,13 @@ async def _mark_execution_terminal(
             suppress_legacy_delivery = (
                 _has_slackbot_live_delivery(metadata)
                 and not slackbot_live_delivery_failed
-                and (not result_has_text or slackbot_streamed_answer_chars > 0)
+                and (
+                    not result_has_text
+                    or _slackbot_live_delivery_covers_result(
+                        result_text,
+                        slackbot_streamed_answer_chars,
+                    )
+                )
             )
         assignment_row = await pool.fetchrow(
             "SELECT harness, engine, persona_id, prompt_ref, effective_agents_md_sha256 "

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -28,7 +28,10 @@ def test_agent_session_title_formats_base_and_persona_runs():
 
 
 def test_slackbot_streamed_answer_chars_requires_positive_integer_offset():
-    from api.runtime_control import _slackbot_streamed_answer_chars
+    from api.runtime_control import (
+        _slackbot_live_delivery_covers_result,
+        _slackbot_streamed_answer_chars,
+    )
 
     assert _slackbot_streamed_answer_chars(0) == 0
     assert _slackbot_streamed_answer_chars(None) == 0
@@ -36,6 +39,9 @@ def test_slackbot_streamed_answer_chars_requires_positive_integer_offset():
     assert _slackbot_streamed_answer_chars("25") == 0
     assert _slackbot_streamed_answer_chars(-3) == 0
     assert _slackbot_streamed_answer_chars(25) == 25
+    assert _slackbot_live_delivery_covers_result("", 0) is True
+    assert _slackbot_live_delivery_covers_result("already streamed", 16) is True
+    assert _slackbot_live_delivery_covers_result("cut off report", 6) is False
 
 
 def _auth(api_key: str) -> dict[str, str]:
@@ -1131,7 +1137,7 @@ async def test_mark_execution_terminal_skips_durable_delivery_after_live_answer(
         terminal_reason="completed",
         result_text="already streamed",
         error_text=None,
-        slackbot_streamed_answer_chars_override=15,
+        slackbot_streamed_answer_chars_override=len("already streamed"),
     )
 
     outbox = await db_pool.fetchrow(
@@ -1147,6 +1153,89 @@ async def test_mark_execution_terminal_skips_durable_delivery_after_live_answer(
         execution_id,
     )
     assert int(ready_events or 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_mark_execution_terminal_falls_back_after_cut_off_live_answer(db_pool):
+    from api.runtime_control import _mark_execution_terminal
+
+    execution_id = f"exe-{uuid.uuid4().hex[:10]}"
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}"
+    runtime_id = f"rt-{uuid.uuid4().hex[:8]}"
+    streamed_prefix = "Partial Slack prefix.\n\n"
+    remaining_report = "Full report remainder with the details Slack never received."
+    result_text = streamed_prefix + remaining_report
+    await db_pool.execute(
+        "INSERT INTO sandbox_sessions (thread_key, sandbox_id, harness, engine, state) "
+        "VALUES ($1, $2, 'codex', 'codex', 'idle')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_runtime_assignments ("
+        "thread_key, assignment_generation, runtime_id, harness, engine, "
+        "persona_id, prompt_ref, effective_agents_md_sha256, state"
+        ") VALUES ($1, 1, $2, 'codex', 'codex', NULL, 'harness:codex', 'sha', 'active')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, status, "
+        "delivery, metadata, started_at"
+        ") VALUES ($1, $2, 1, 'exec-cutoff-live', 'hash-cutoff-live', 'running', "
+        "$3::jsonb, $4::jsonb, NOW())",
+        execution_id,
+        thread_key,
+        json.dumps(
+            {
+                "platform": "slack",
+                "channel": "C-test",
+                "thread_ts": "1779333881.200699",
+            }
+        ),
+        json.dumps(
+            {
+                "slackbot_live_delivery": True,
+                "slackbot_agent_session_id": "sess-cutoff-live",
+                "slackbot_streamed_answer_chars": len(streamed_prefix),
+            }
+        ),
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_final_delivery_outbox (execution_id, thread_key, delivery, state) "
+        "VALUES ($1, $2, '{}'::jsonb, 'awaiting_terminal')",
+        execution_id,
+        thread_key,
+    )
+
+    await _mark_execution_terminal(
+        db_pool,
+        execution_id=execution_id,
+        thread_key=thread_key,
+        status="completed",
+        terminal_reason="completed",
+        result_text=result_text,
+        error_text=None,
+    )
+
+    outbox = await db_pool.fetchrow(
+        "SELECT state, final_payload FROM agent_final_delivery_outbox WHERE execution_id = $1",
+        execution_id,
+    )
+    assert outbox is not None
+    assert outbox["state"] == "pending"
+    final_payload = outbox["final_payload"]
+    if isinstance(final_payload, str):
+        final_payload = json.loads(final_payload)
+    assert final_payload["result_text"] == result_text
+    assert final_payload["slackbot_streamed_answer_chars"] == len(streamed_prefix)
+    ready_events = await db_pool.fetchval(
+        "SELECT COUNT(*) FROM agent_execution_events "
+        "WHERE execution_id = $1 AND event_kind = 'final_delivery_ready'",
+        execution_id,
+    )
+    assert int(ready_events or 0) == 1
 
 
 @pytest.mark.asyncio

--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -359,6 +359,78 @@ describe("final delivery polling", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("posts only the missing suffix when live delivery was cut off", async () => {
+    const originalFetch = globalThis.fetch;
+    const resultText =
+      "Already visible in Slack.\n\nThis is the report section that was cut off.";
+    const streamedPrefix = "Already visible in Slack.\n\n";
+    const fetchCalls: Array<{ path: string; body: unknown }> = [];
+    const fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        fetchCalls.push({ path: url.pathname, body });
+        if (url.pathname === "/agent/final-deliveries/claim") {
+          return jsonResponse({
+            deliveries: [
+              {
+                execution_id: "exe-cutoff",
+                thread_key: "slack:T123:C123:1778883099.579529",
+                delivery: {
+                  platform: "slack",
+                  channel: "C123",
+                  thread_ts: "1778883099.579529",
+                },
+                final_payload: {
+                  result_text: resultText,
+                  slackbot_streamed_answer_chars: streamedPrefix.length,
+                },
+              },
+            ],
+          });
+        }
+        if (url.pathname === "/agent/final-deliveries/exe-cutoff/delivered") {
+          return jsonResponse({ ok: true });
+        }
+        throw new Error(`unexpected request: ${url.pathname}`);
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const slackCalls: Array<{ method: string; params: any }> = [];
+    const client = {
+      chat: {
+        postMessage: async (params: any) => {
+          slackCalls.push({ method: "chat.postMessage", params });
+          return { ok: true };
+        },
+      },
+      conversations: {
+        replies: async () => ({ ok: true, messages: [] }),
+      },
+    };
+
+    try {
+      await pollFinalDeliveriesOnce(config, client as any);
+
+      const posts = slackCalls.filter(
+        (call) => call.method === "chat.postMessage",
+      );
+      expect(posts).toHaveLength(1);
+      expect(posts[0].params.text).toBe(
+        "This is the report section that was cut off.",
+      );
+      expect(posts[0].params.text).not.toContain("Already visible in Slack");
+      expect(
+        fetchCalls.some(
+          (call) => call.path === "/agent/final-deliveries/exe-cutoff/delivered",
+        ),
+      ).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 function jsonResponse(body: unknown): Response {

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1277,6 +1277,47 @@ describe('CodexSessionRenderer', () => {
     })
   })
 
+  it('reports canonical completed snapshot chars after filling missing live text', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    const streamedDraft = 'The report starts here.'
+    const canonical = `${streamedDraft} This sentence only appears in item.completed.`
+
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'msg-missing-live-text', type: 'agentMessage', phase: 'final_answer' }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.agentMessage.delta',
+      itemId: 'msg-missing-live-text',
+      delta: streamedDraft
+    })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: {
+        id: 'msg-missing-live-text',
+        type: 'agentMessage',
+        phase: 'final_answer',
+        text: canonical
+      }
+    })
+    const result = await renderer.event(sessionId, { type: 'turn.done', result: canonical })
+
+    const visible = visibleMarkdown(calls)
+    expect(countOccurrences(visible, streamedDraft)).toBe(1)
+    expect(visible).toContain('This sentence only appears in item.completed.')
+    expect(result.streamedAnswerChars).toBe(canonical.length)
+  })
+
   it('replays the exact prod event stream from exe_a89da7f248bb4724 without doubling the reply', async () => {
     // Real captured event stream from the May 23 2026 prod duplicate-reply incident.
     // Pre-fix, this exact sequence produced a Slack message that contained the entire


### PR DESCRIPTION
## Summary
- keep durable final delivery active when Slack live delivery only streamed a prefix
- preserve suffix-only fallback delivery so cut-off Slack replies get completed without duplicating visible text
- add regression coverage for cut-offs, duplicate completed snapshots, and missing completed text

## Tests
- uv run pytest tests/test_agent_control_plane.py -k 'slackbot_streamed_answer_chars or skips_durable_delivery_after_live_answer or cut_off_live_answer or worker_sends_final_result_when_live_slack_only_streamed_placeholder'\n- bun test services/slackbot/src/centaur/final-delivery.test.ts services/slackbot/src/slack/codex-session.test.ts\n- uv run ruff check api/runtime_control.py tests/test_agent_control_plane.py\n\nRelates AT-6\nRelates AT-11