### PR TITLE
docs: use GHCR images in Mac mini setup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,7 @@ set dotenv-load := true
 
 namespace := env_var_or_default("CENTAUR_NAMESPACE", "centaur")
 release := env_var_or_default("CENTAUR_RELEASE", "centaur")
+source := env_var_or_default("CENTAUR_IMAGE_SOURCE", "local")
 chart := "contrib/chart"
 dev_values := "contrib/chart/values.dev.yaml"
 
@@ -63,6 +64,18 @@ deploy:
     set -euo pipefail
     helm dependency update {{chart}} >/dev/null
     extra_args=()
+    case "{{source}}" in
+      local) ;;
+      ghcr)
+        extra_args+=(
+          --set api.image.repository=ghcr.io/paradigmxyz/centaur-api
+          --set ironProxy.image.repository=ghcr.io/paradigmxyz/centaur-iron-proxy
+          --set slackbot.image.repository=ghcr.io/paradigmxyz/centaur-slackbot
+          --set sandbox.image.repository=ghcr.io/paradigmxyz/centaur-agent
+        )
+        ;;
+      *) echo "unknown source: {{source}} (expected local or ghcr)" >&2; exit 2 ;;
+    esac
     if [[ -n "${OP_CONNECT_CREDENTIALS_FILE:-}" ]]; then
       extra_args+=(
         --set ironProxy.secretSource=onepassword-connect
@@ -72,9 +85,15 @@ deploy:
     helm upgrade --install {{release}} {{chart}} -n {{namespace}} --create-namespace -f {{dev_values}} ${extra_args[@]+"${extra_args[@]}"}
 
 up:
+    #!/usr/bin/env bash
+    set -euo pipefail
     just bootstrap-secrets
-    just build
-    just deploy
+    case "{{source}}" in
+      local) just build ;;
+      ghcr) ;;
+      *) echo "unknown source: {{source}} (expected local or ghcr)" >&2; exit 2 ;;
+    esac
+    just source={{source}} deploy
 
 down:
     kubectl delete namespace {{namespace}} --ignore-not-found --wait

--- a/docs/pages/mac-mini-setup.mdx
+++ b/docs/pages/mac-mini-setup.mdx
@@ -10,16 +10,9 @@ machine with k3s. This can be a Mac Mini running Linux, a DigitalOcean droplet,
 another simple VPS, or a spare Linux box. You do not need a managed Kubernetes
 cluster to get started.
 
-Centaur's development workflow builds images locally:
-
-```bash
-just build
-```
-
-Those images are named `centaur-api:latest`, `centaur-iron-proxy:latest`,
-`centaur-slackbot:latest`, and `centaur-agent:latest`. On a single small host,
-the simplest setup is to build those images on the same machine that runs k3s,
-then import them into k3s' container runtime.
+Centaur publishes development images to GHCR. On a single small host, the
+simplest setup is to point the local chart at those images instead of building
+and importing images into k3s' container runtime.
 
 ## 1. Install k3s
 
@@ -54,29 +47,15 @@ git clone <repo-url>
 cd centaur
 ```
 
-## 3. Build and load images
+## 3. Use GHCR images
 
-Build the Centaur images:
+Use `source=ghcr` with the local Just recipes to point the chart at the
+published `ghcr.io/paradigmxyz/centaur-*` images instead of local image names.
+This keeps the chart's default `latest` tags and `IfNotPresent` pull policy
+from `contrib/chart/values.dev.yaml`.
 
-```bash
-just build
-```
-
-Load them into k3s' container runtime:
-
-```bash
-docker save \
-  centaur-api:latest \
-  centaur-iron-proxy:latest \
-  centaur-slackbot:latest \
-  centaur-agent:latest \
-  -o /tmp/centaur-images.tar
-
-sudo k3s ctr images import /tmp/centaur-images.tar
-```
-
-For repeated deploys on the same host, rerun `just build`, reload the changed
-images, then run `just deploy`.
+If GHCR access for the repository is private, create an image pull Secret and
+add it to the chart with `global.imagePullSecrets`.
 
 ## 4. Bootstrap secrets
 
@@ -99,10 +78,10 @@ just bootstrap-secrets
 
 ## 5. Deploy Centaur
 
-Deploy the Helm chart:
+Deploy the Helm chart with the GHCR image values:
 
 ```bash
-just deploy
+just source=ghcr deploy
 just status
 ```
 

--- a/docs/public/md/mac-mini-setup.md
+++ b/docs/public/md/mac-mini-setup.md
@@ -10,16 +10,9 @@ machine with k3s. This can be a Mac Mini running Linux, a DigitalOcean droplet,
 another simple VPS, or a spare Linux box. You do not need a managed Kubernetes
 cluster to get started.
 
-Centaur's development workflow builds images locally:
-
-```bash
-just build
-```
-
-Those images are named `centaur-api:latest`, `centaur-iron-proxy:latest`,
-`centaur-slackbot:latest`, and `centaur-agent:latest`. On a single small host,
-the simplest setup is to build those images on the same machine that runs k3s,
-then import them into k3s' container runtime.
+Centaur publishes development images to GHCR. On a single small host, the
+simplest setup is to point the local chart at those images instead of building
+and importing images into k3s' container runtime.
 
 ## 1. Install k3s
 
@@ -54,29 +47,15 @@ git clone <repo-url>
 cd centaur
 ```
 
-## 3. Build and load images
+## 3. Use GHCR images
 
-Build the Centaur images:
+Use `source=ghcr` with the local Just recipes to point the chart at the
+published `ghcr.io/paradigmxyz/centaur-*` images instead of local image names.
+This keeps the chart's default `latest` tags and `IfNotPresent` pull policy
+from `contrib/chart/values.dev.yaml`.
 
-```bash
-just build
-```
-
-Load them into k3s' container runtime:
-
-```bash
-docker save \
-  centaur-api:latest \
-  centaur-iron-proxy:latest \
-  centaur-slackbot:latest \
-  centaur-agent:latest \
-  -o /tmp/centaur-images.tar
-
-sudo k3s ctr images import /tmp/centaur-images.tar
-```
-
-For repeated deploys on the same host, rerun `just build`, reload the changed
-images, then run `just deploy`.
+If GHCR access for the repository is private, create an image pull Secret and
+add it to the chart with `global.imagePullSecrets`.
 
 ## 4. Bootstrap secrets
 
@@ -99,10 +78,10 @@ just bootstrap-secrets
 
 ## 5. Deploy Centaur
 
-Deploy the Helm chart:
+Deploy the Helm chart with the GHCR image values:
 
 ```bash
-just deploy
+just source=ghcr deploy
 just status
 ```
 


### PR DESCRIPTION
Adds `source=ghcr` support to the local Just recipes so `just source=ghcr deploy` uses published `ghcr.io/paradigmxyz/centaur-*` images instead of local image names. `just source=ghcr up` also skips the local image build step.

Updates the Mac Mini-style setup guide and generated static Markdown copy to use the new Justfile flag instead of raw Helm overrides.

Prompted by: @Zygimantass