### PR TITLE
Add kubectl to sandbox image

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -50,6 +50,20 @@ ARG CLAUDE_CODE_VERSION=2.1.143
 ARG CODEX_VERSION=0.130.0
 ARG PI_CODING_AGENT_VERSION=0.67.2
 ARG NUSHELL_VERSION=0.112.2
+ARG KUBECTL_VERSION=v1.34.2
+
+# ── kubectl ──────────────────────────────────────────────────────────────────
+RUN set -eux; \
+    kubectl_arch="$(case "$(dpkg --print-architecture)" in \
+      amd64) echo amd64 ;; \
+      arm64) echo arm64 ;; \
+      *) echo unsupported-architecture >&2; exit 1 ;; \
+    esac)"; \
+    curl -fsSL \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${kubectl_arch}/kubectl" \
+      -o /usr/local/bin/kubectl; \
+    chmod +x /usr/local/bin/kubectl; \
+    kubectl version --client=true | grep -F "${KUBECTL_VERSION#v}"
 
 # ── Nushell ─────────────────────────────────────────────────────────────────
 RUN set -eux; \


### PR DESCRIPTION
## Summary
- install pinned kubectl in the sandbox toolchain image
- support both linux/amd64 and linux/arm64 downloads
- verify the client binary during image build

## Testing
- Verified v1.34.2 amd64 release checksum is available from dl.k8s.io
- Unable to run docker build locally because the sandbox has no Docker daemon socket

Prompted by: @gakonst