### PR TITLE
fix: include log version UUID in logs

### DIFF
--- a/services/api/api/logging_config.py
+++ b/services/api/api/logging_config.py
@@ -24,6 +24,9 @@ _SECRET_FIELD_NAMES = {"apikey", "authorization", "clientsecret", "accesstoken",
 _EMAIL_FIELD_NAMES = {"email", "useremail", "authoremail"}
 _PHONE_FIELD_NAMES = {"phone", "phonenumber", "userphone"}
 _SSN_FIELD_NAMES = {"ssn", "socialsecuritynumber"}
+# This can drift over time, but it is less disruptive than reading image refs
+# through Helm chart changes while we need a quick production log marker.
+_LOG_VERSION_UUID = "7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14"
 
 
 def _normalize_field_name(field_name: str | None) -> str:
@@ -83,6 +86,12 @@ def _add_default_service(logger, method_name, event_dict):
     return event_dict
 
 
+def _add_log_version(logger, method_name, event_dict):
+    """Attach a manually rotated log version marker to every structured log line."""
+    event_dict.setdefault("log_version_uuid", _LOG_VERSION_UUID)
+    return event_dict
+
+
 def _scrub_sensitive_fields(logger, method_name, event_dict):
     """Redact obvious PII and secrets before any renderer emits the log line."""
     return {k: _sanitize_log_value(v, field_name=str(k)) for k, v in event_dict.items()}
@@ -106,6 +115,7 @@ def configure_structlog() -> int:
     processors = [
         structlog.contextvars.merge_contextvars,
         _add_default_service,
+        _add_log_version,
         _scrub_sensitive_fields,
         structlog.processors.add_log_level,
         structlog.processors.TimeStamper(fmt="iso", key="timestamp"),

--- a/services/api/tests/test_logging_config.py
+++ b/services/api/tests/test_logging_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from api.logging_config import _scrub_sensitive_fields
+from api.logging_config import _add_log_version, _scrub_sensitive_fields
 
 
 def test_scrub_sensitive_fields_redacts_nested_pii_and_secrets():
@@ -44,3 +44,10 @@ def test_scrub_sensitive_fields_keeps_non_sensitive_values_readable():
     redacted = _scrub_sensitive_fields(None, "info", payload)
 
     assert redacted == payload
+
+
+def test_add_log_version_includes_static_uuid():
+    enriched = _add_log_version(None, "info", {"event": "execute_completed"})
+
+    assert enriched["event"] == "execute_completed"
+    assert enriched["log_version_uuid"] == "7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14"

--- a/services/slackbot/src/index.test.ts
+++ b/services/slackbot/src/index.test.ts
@@ -122,17 +122,21 @@ describe('Slack event HTTP dedupe', () => {
       expect(await first.json()).toEqual({ ok: true })
       expect(second.status).toBe(200)
       expect(await second.json()).toEqual({ ok: true, duplicate: true })
-      expect(console.warn).toHaveBeenCalledWith('slack_duplicate_event_skipped', {
-        dedupe_key: 'event:Ev-duplicate',
-        event_id: 'Ev-duplicate',
-        team_id: 'T123',
-        channel_id: 'C123',
-        message_ts: '1778883099.579529',
-        thread_ts: '1778883099.579529',
-        event_type: 'app_mention',
-        codex_thread_id: undefined,
-        alert_channel_id: undefined
-      })
+      expect(console.warn).toHaveBeenCalledWith(
+        'slack_duplicate_event_skipped',
+        expect.objectContaining({
+          dedupe_key: 'event:Ev-duplicate',
+          event_id: 'Ev-duplicate',
+          team_id: 'T123',
+          channel_id: 'C123',
+          message_ts: '1778883099.579529',
+          thread_ts: '1778883099.579529',
+          event_type: 'app_mention',
+          codex_thread_id: undefined,
+          alert_channel_id: undefined,
+          log_version_uuid: '7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14'
+        })
+      )
       expect(waits).toHaveLength(1)
       await Promise.allSettled(waits)
     } finally {
@@ -190,17 +194,21 @@ describe('Slack event HTTP dedupe', () => {
 
       expect(second.status).toBe(200)
       expect(await second.json()).toEqual({ ok: true, duplicate: true })
-      expect(console.warn).toHaveBeenCalledWith('slack_duplicate_message_skipped', {
-        dedupe_key: 'message:T123:C123:1778883099.579530',
-        event_id: undefined,
-        team_id: 'T123',
-        channel_id: 'C123',
-        message_ts: '1778883099.579530',
-        thread_ts: '1778883099.579530',
-        event_type: 'message',
-        codex_thread_id: 'T-019e28c1-08bb-777d-9a2e-74a393296b28',
-        alert_channel_id: undefined
-      })
+      expect(console.warn).toHaveBeenCalledWith(
+        'slack_duplicate_message_skipped',
+        expect.objectContaining({
+          dedupe_key: 'message:T123:C123:1778883099.579530',
+          event_id: undefined,
+          team_id: 'T123',
+          channel_id: 'C123',
+          message_ts: '1778883099.579530',
+          thread_ts: '1778883099.579530',
+          event_type: 'message',
+          codex_thread_id: 'T-019e28c1-08bb-777d-9a2e-74a393296b28',
+          alert_channel_id: undefined,
+          log_version_uuid: '7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14'
+        })
+      )
       expect(waits).toHaveLength(1)
       await Promise.allSettled(waits)
     } finally {

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -7,7 +7,7 @@ import { prettyJSON } from 'hono/pretty-json'
 import { startFinalDeliveryPoller } from './centaur/final-delivery'
 import { CentaurHandoff } from './centaur/handoff'
 import { loadConfig } from './config'
-import { logError, logWarn, sanitizeLogValue } from './logging'
+import { logError, logInfo, logWarn, sanitizeLogValue } from './logging'
 import { AgentSessionRenderer, withAgentSessionLock } from './slack/agent-session'
 import { authorizeSlackOrg } from './slack/authorization'
 import { CodexSessionRenderer, hasActiveCodexSession } from './slack/codex-session'
@@ -56,7 +56,11 @@ export const app = new Hono<{ Variables: Variables }>()
   .use(prettyJSON())
   .use('*', async (c, next) => {
     await next()
-    console.log('http_request', c.req.method, c.req.path, c.res.status)
+    logInfo('http_request', {
+      method: c.req.method,
+      path: c.req.path,
+      status: c.res.status
+    })
   })
   .use('*', timeout(5_000))
   .use(
@@ -496,7 +500,7 @@ async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {
     allowedExternalTeamIds: config.SLACKBOT_EXTERNAL_ORG_ALLOWLIST
   })
   if (!authorization.ok) {
-    console.warn('slack_event_ignored_external_org_not_allowlisted', {
+    logWarn('slack_event_ignored_external_org_not_allowlisted', {
       external_team_id: authorization.externalTeamId,
       team_id: envelope.team_id,
       event_id: envelope.event_id

--- a/services/slackbot/src/logging.test.ts
+++ b/services/slackbot/src/logging.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'bun:test'
-import { sanitizeLogString, sanitizeLogValue } from './logging'
+import { describe, expect, it, mock } from 'bun:test'
+import { logInfo, sanitizeLogString, sanitizeLogValue } from './logging'
 
 describe('Slackbot log sanitization', () => {
   it('redacts nested PII and secrets', () => {
@@ -40,5 +40,20 @@ describe('Slackbot log sanitization', () => {
     expect(sanitizeLogString('Processed channel C123 at 2026-05-15T10:00:00Z')).toBe(
       'Processed channel C123 at 2026-05-15T10:00:00Z'
     )
+  })
+
+  it('adds log version metadata to structured log helper calls', () => {
+    const originalLog = console.log
+    console.log = mock(() => {}) as typeof console.log
+    try {
+      logInfo('slack_test_event', { thread_key: 'slack:C123:1' })
+
+      expect(console.log).toHaveBeenCalledWith('slack_test_event', {
+        log_version_uuid: '7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14',
+        thread_key: 'slack:C123:1'
+      })
+    } finally {
+      console.log = originalLog
+    }
   })
 })

--- a/services/slackbot/src/logging.ts
+++ b/services/slackbot/src/logging.ts
@@ -15,6 +15,13 @@ const SECRET_FIELD_NAMES = new Set([
 const EMAIL_FIELD_NAMES = new Set(['email', 'useremail', 'authoremail'])
 const PHONE_FIELD_NAMES = new Set(['phone', 'phonenumber', 'userphone'])
 const SSN_FIELD_NAMES = new Set(['ssn', 'socialsecuritynumber'])
+const LOG_VERSION_UUID = '7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14'
+
+function logVersionFields(): Record<string, string> {
+  return {
+    log_version_uuid: LOG_VERSION_UUID
+  }
+}
 
 function normalizeFieldName(fieldName: string | undefined): string {
   return (fieldName ?? '').toLowerCase().replace(/[^a-z0-9]/g, '')
@@ -86,14 +93,30 @@ export function sanitizeLogValue(
   )
 }
 
+function withLogVersionMetadata(values: unknown[]): unknown[] {
+  const metadata = logVersionFields()
+  if (values.length === 0) return [metadata]
+  const [first, ...rest] = values
+  if (
+    first &&
+    typeof first === 'object' &&
+    !Array.isArray(first) &&
+    !(first instanceof Error) &&
+    !(first instanceof Date)
+  ) {
+    return [{ ...metadata, ...(sanitizeLogValue(first) as Record<string, unknown>) }, ...rest]
+  }
+  return [metadata, ...values.map(value => sanitizeLogValue(value))]
+}
+
 export function logWarn(event: string, ...values: unknown[]): void {
-  console.warn(event, ...values.map(value => sanitizeLogValue(value)))
+  console.warn(event, ...withLogVersionMetadata(values))
 }
 
 export function logInfo(event: string, ...values: unknown[]): void {
-  console.log(event, ...values.map(value => sanitizeLogValue(value)))
+  console.log(event, ...withLogVersionMetadata(values))
 }
 
 export function logError(event: string, ...values: unknown[]): void {
-  console.error(event, ...values.map(value => sanitizeLogValue(value)))
+  console.error(event, ...withLogVersionMetadata(values))
 }

--- a/services/slackbot/src/slack/normalize.ts
+++ b/services/slackbot/src/slack/normalize.ts
@@ -1,4 +1,5 @@
 import type { WebClient } from '@slack/web-api'
+import { logWarn } from '../logging'
 import type { NormalizedPart, NormalizedSlackEvent, SlackEnvelope, SlackMessageFile } from './types'
 
 type SlackMessageEvent = {
@@ -156,7 +157,7 @@ async function collectThreadHistorySafely(opts: {
   try {
     return await collectThreadHistory(opts)
   } catch (error) {
-    console.warn('slack_thread_history_collect_failed', {
+    logWarn('slack_thread_history_collect_failed', {
       channel: opts.channel,
       thread_ts: opts.threadTs,
       error: error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
## Summary
- add a static log_version_uuid marker to API structlog output
- add the same log_version_uuid marker to Slackbot log helper output
- route remaining direct Slackbot log sites through the helpers
- leave Helm chart templates unchanged

## Tests
- bun test services/slackbot/src/index.test.ts services/slackbot/src/logging.test.ts services/slackbot/src/slack/codex-session.test.ts
- uv run pytest tests/test_logging_config.py
- uv run ruff check api/logging_config.py tests/test_logging_config.py