### PR TITLE
feat: support descriptive sandbox branches

### DIFF
--- a/services/api/tests/test_git_branch_helper.py
+++ b/services/api/tests/test_git_branch_helper.py
@@ -1,0 +1,76 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GIT_BRANCH = REPO_ROOT / "services" / "sandbox" / "git-branch.sh"
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def _create_source_repo(home: Path, repo: str) -> Path:
+    src = home / "github" / repo
+    src.mkdir(parents=True)
+    _run(["git", "init", "-q"], cwd=src)
+    (src / "README.md").write_text("# test\n")
+    _run(["git", "add", "README.md"], cwd=src)
+    _run(
+        [
+            "git",
+            "-c",
+            "user.name=Test User",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-q",
+            "-m",
+            "initial commit",
+        ],
+        cwd=src,
+    )
+    return src
+
+
+def test_git_branch_uses_slug_with_timestamp_suffix(tmp_path: Path) -> None:
+    repo = "owner/project"
+    _create_source_repo(tmp_path, repo)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+
+    dest = Path(
+        _run(
+            ["bash", str(GIT_BRANCH), repo, "fix-flaky-slack-reply-delivery"],
+            env=env,
+        )
+    )
+
+    branch = _run(["git", "branch", "--show-current"], cwd=dest)
+    assert branch.startswith("centaur/fix-flaky-slack-reply-delivery-")
+    assert branch.rsplit("-", 1)[-1].isdigit()
+
+
+def test_git_branch_falls_back_to_centaur_random_branch(tmp_path: Path) -> None:
+    repo = "owner/project"
+    _create_source_repo(tmp_path, repo)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+
+    dest = Path(_run(["bash", str(GIT_BRANCH), repo], env=env))
+
+    branch = _run(["git", "branch", "--show-current"], cwd=dest)
+    assert branch.startswith("centaur/")
+    assert not branch.startswith("agent-")

--- a/services/sandbox/git-branch.sh
+++ b/services/sandbox/git-branch.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # git-branch — create a writable working copy from a read-only mounted repo.
 #
-# Usage:  git-branch <org/repo>
-# Example: git-branch owner/centaur
+# Usage:  git-branch <org/repo> [branch slug]
+# Example: git-branch owner/centaur fix-flaky-slack-delivery
 #
 # Creates ~/branches/<org>/<repo> as a --shared clone from ~/github/<org>/<repo>
 # with a unique agent branch checked out. The resulting directory is fully writable
@@ -10,12 +10,13 @@
 
 set -euo pipefail
 
-if [ $# -ne 1 ]; then
-    echo "Usage: git-branch <org/repo>" >&2
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+    echo "Usage: git-branch <org/repo> [branch slug]" >&2
     exit 1
 fi
 
 REPO="$1"
+SLUG="${2:-}"
 SRC="$HOME/github/$REPO"
 DEST="$HOME/branches/$REPO"
 
@@ -45,7 +46,11 @@ if [ -n "$UPSTREAM_URL" ]; then
     git -C "$DEST" remote set-url origin "$UPSTREAM_URL"
 fi
 
-BRANCH="agent-$(date +%s)-${RANDOM}-${RANDOM}"
+if [ -n "$SLUG" ]; then
+    BRANCH="centaur/$SLUG-$(date +%s)"
+else
+    BRANCH="centaur/$(date +%s)-${RANDOM}-${RANDOM}"
+fi
 git -C "$DEST" checkout -q -b "$BRANCH"
 
 echo "$DEST"


### PR DESCRIPTION
## Summary
- allow git-branch to accept an optional branch slug
- create centaur/<slug>-<timestamp> branches when a slug is provided
- fall back to centaur/<timestamp>-<random>-<random> when omitted

## Tests
- uv run pytest tests/test_git_branch_helper.py
- uv run ruff check tests/test_git_branch_helper.py