### PR TITLE
feat: support ChatGPT-login auth mode for Codex sandboxes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -82,6 +82,11 @@ deploy:
         --set onepasswordConnect.connect.create=true
       )
     fi
+    if [[ -n "${CODEX_AUTH_MODE:-}" ]]; then
+      extra_args+=(
+        --set sandbox.extraEnv.CODEX_AUTH_MODE=${CODEX_AUTH_MODE}
+      )
+    fi
     helm upgrade --install {{release}} {{chart}} -n {{namespace}} --create-namespace -f {{dev_values}} ${extra_args[@]+"${extra_args[@]}"}
 
 up:

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -98,6 +98,36 @@ so any thread can use any configured credential. Per-user and per-channel
 scoping is on the roadmap; until then, scope tool and harness access
 accordingly. See [Security](/security) for the full threat model.
 
+### Codex Auth Modes
+
+Codex supports two authentication modes, selected per deployment with the
+`CODEX_AUTH_MODE` env var on the sandbox (set it via `sandbox.extraEnv`):
+
+| Mode | Upstream | Secrets required |
+|------|----------|------------------|
+| `api_key` (default) | `api.openai.com` | `OPENAI_API_KEY` |
+| `access_token` | `chatgpt.com` | `OPENAI_CODEX_CLIENT_ID`, `OPENAI_CODEX_BLOB`, `OPENAI_CODEX_ACCOUNT_ID` |
+
+`access_token` mode routes Codex through a ChatGPT account rather than a raw
+API key. [iron-token-broker](https://docs.iron.sh) holds the refresh token
+and mints short-lived access tokens, which iron-proxy injects on outbound
+requests so the sandbox never sees them.
+
+Store these three items in your secrets backend (1Password vault, Kubernetes
+Secret, etc.) when running in `access_token` mode:
+
+- `OPENAI_CODEX_CLIENT_ID`: Codex CLI's public OAuth client id. Read-only.
+- `OPENAI_CODEX_BLOB`: a JSON document `{"refresh_token": "..."}`. The
+  broker rotates this in place on every refresh, so the backing item must
+  be writable.
+- `OPENAI_CODEX_ACCOUNT_ID`: the ChatGPT account UUID the credential is
+  bound to. It is static, but iron-proxy injects it as the
+  `chatgpt-account-id` header so the backend can route to the right
+  workspace. Store it alongside the other two, not in code.
+
+To bootstrap, run `codex login` locally, then copy the values from
+`~/.codex/auth.json` into the three secret items.
+
 ## 4. Configure Slack
 
 Create the Slackbot app at [api.slack.com/apps](https://api.slack.com/apps).

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -146,6 +146,7 @@ Sandbox entrypoint and wrappers:
 | `AGENT_REPO`, `AGENT_PERSONA` | Runtime assignment metadata. | Workspace repo clone and persona prompt. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Sandbox entrypoint or `sandbox.extraEnv`. | Google ADC path; entrypoint creates a local stub when unset. |
 | `CODEX_API_KEY`, `CODEX_HOME`, `CODEX_CONTINUE_THREAD_ID` | `sandbox.extraEnv` or runtime resume. | Codex auth/config/resume behavior. |
+| `CODEX_AUTH_MODE` | `sandbox.extraEnv`. | Codex auth flow: `api_key` (default, hits `api.openai.com`) or `access_token` (hits `chatgpt.com` via the brokered ChatGPT login). See [Codex Auth Modes](/deploying-in-production#codex-auth-modes). |
 | `CLAUDE_MODEL`, `CLAUDE_CONTINUE_SESSION_ID` | `sandbox.extraEnv` or runtime resume. | Claude model and resume behavior. |
 | `DEPLOY_ENV`, `ENVIRONMENT`, `TRACEPARENT` | Deployment env or wrapper-generated. | Runtime environment and trace context. |
 | `CALL_TIMEOUT_SECONDS` | Sandbox env before running `call`. | Curl watchdog for API tool calls. |

--- a/services/api/api/iron-proxy.base.yaml
+++ b/services/api/api/iron-proxy.base.yaml
@@ -34,6 +34,7 @@ transforms:
         - "anthropic-beta"
         - "openai-organization"
         - "openai-project"
+        - "chatgpt-account-id"
         - "x-request-id"
         - "x-stainless-arch"
         - "x-stainless-os"

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -178,6 +178,10 @@ FROM toolchain AS sandbox
 
 USER root
 RUN rm -f /etc/sudoers.d/agent
+# BuildKit's COPY --link creates parent directories without an explicit mode,
+# which can leave /etc/centaur without the execute bit for non-root users.
+# Pre-create it as 0755 so the agent user can traverse into it at runtime.
+RUN install -d -m 0755 /etc/centaur
 COPY --link --chmod=644 services/sandbox/codex-auth.json /etc/centaur/codex-auth.default.json
 COPY --link --chmod=755 services/sandbox/call.sh /usr/local/bin/call
 COPY --link --chmod=755 services/sandbox/slack-upload.sh /usr/local/bin/slack-upload

--- a/services/sandbox/codex-auth.json
+++ b/services/sandbox/codex-auth.json
@@ -2,9 +2,9 @@
   "OPENAI_API_KEY": null,
   "auth_mode": "chatgpt",
   "tokens": {
-    "id_token": "dummy",
-    "access_token": "dummy",
-    "refresh_token": "dummy",
+    "id_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImR1bW15In0.eyJzdWIiOiJhdXRoMHxkdW1teSIsImVtYWlsIjoiZHVtbXlAZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6Ly9hdXRoLm9wZW5haS5jb20vIiwiYXVkIjoiaHR0cHM6Ly9hcGkub3BlbmFpLmNvbS92MSIsImlhdCI6MTcwMDAwMDAwMCwiZXhwIjo0MTAyNDQ0ODAwLCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsidXNlcl9pZCI6InVzZXItZHVtbXkiLCJjaGF0Z3B0X2FjY291bnRfaWQiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJjaGF0Z3B0X3BsYW5fdHlwZSI6InBsdXMifSwiaHR0cHM6Ly9hcGkub3BlbmFpLmNvbS9wcm9maWxlIjp7ImVtYWlsIjoiZHVtbXlAZXhhbXBsZS5jb20ifX0.ZHVtbXktc2lnbmF0dXJlLWJ5dGVzLW5vdC1yZWFs",
+    "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImR1bW15In0.eyJzdWIiOiJhdXRoMHxkdW1teSIsImlzcyI6Imh0dHBzOi8vYXV0aC5vcGVuYWkuY29tLyIsImF1ZCI6WyJodHRwczovL2FwaS5vcGVuYWkuY29tL3YxIiwiaHR0cHM6Ly9jaGF0Z3B0LmNvbS9iYWNrZW5kLWFwaSJdLCJhenAiOiJjb2RleC1jbGkiLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6NDEwMjQ0NDgwMCwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBvZmZsaW5lX2FjY2VzcyJ9.ZHVtbXktc2lnbmF0dXJlLWJ5dGVzLW5vdC1yZWFs",
+    "refresh_token": "dummy-refresh-token-replaced-by-iron-proxy-broker",
     "account_id": "00000000-0000-0000-0000-000000000000"
   },
   "last_refresh": "2025-01-01T00:00:00.000Z"

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -71,8 +71,20 @@ PYEOF
 fi
 
 # ── Codex settings ──────────────────────────────────────────────────────────
+# CODEX_AUTH_MODE selects how codex authenticates with the upstream:
+#   - api_key (default): codex uses an OPENAI_API_KEY against api.openai.com.
+#     The entrypoint runs `codex login --with-api-key` below, which overwrites
+#     auth.json.
+#   - access_token: codex uses a ChatGPT-style access token against
+#     chatgpt.com. The default auth.json (auth_mode: chatgpt) is always
+#     installed and the api-key login step is skipped so iron-proxy can
+#     inject the brokered Bearer + chatgpt-account-id headers.
+CODEX_AUTH_MODE="${CODEX_AUTH_MODE:-api_key}"
 mkdir -p "$HOME_DIR/.codex"
-if [ ! -f "$HOME_DIR/.codex/auth.json" ] && [ -f /etc/centaur/codex-auth.default.json ]; then
+if [ "$CODEX_AUTH_MODE" = "access_token" ] && [ -f /etc/centaur/codex-auth.default.json ]; then
+    cp /etc/centaur/codex-auth.default.json "$HOME_DIR/.codex/auth.json"
+    chmod 600 "$HOME_DIR/.codex/auth.json"
+elif [ ! -f "$HOME_DIR/.codex/auth.json" ] && [ -f /etc/centaur/codex-auth.default.json ]; then
     cp /etc/centaur/codex-auth.default.json "$HOME_DIR/.codex/auth.json"
     chmod 600 "$HOME_DIR/.codex/auth.json"
 fi
@@ -189,9 +201,13 @@ fi
 
 # Codex reads its auth file when the app server starts. Complete this before
 # signaling readiness, otherwise warm pods can be claimed with no auth loaded.
-CODEX_KEY="${CODEX_API_KEY:-${OPENAI_API_KEY:-}}"
-if [ -n "$CODEX_KEY" ]; then
-    echo "$CODEX_KEY" | codex login --with-api-key 2>/dev/null || true
+# Skipped under access_token mode — that path relies on the chatgpt auth.json
+# installed above plus iron-proxy injecting the real Bearer at request time.
+if [ "$CODEX_AUTH_MODE" != "access_token" ]; then
+    CODEX_KEY="${CODEX_API_KEY:-${OPENAI_API_KEY:-}}"
+    if [ -n "$CODEX_KEY" ]; then
+        echo "$CODEX_KEY" | codex login --with-api-key 2>/dev/null || true
+    fi
 fi
 
 # Signal readiness

--- a/tools/infra/codex/pyproject.toml
+++ b/tools/infra/codex/pyproject.toml
@@ -34,9 +34,9 @@ hosts = ["chatgpt.com"]
 #                            OAuth token endpoint doesn't need it.
 secrets = [
     { type = "brokered_token", name = "openai-codex", hosts = [
-        "*.chatgpt.com",
+        "chatgpt.com",
     ], token_endpoint = "https://auth.openai.com/oauth/token", fields = { client_id = "OPENAI_CODEX_CLIENT_ID", refresh_token = "OPENAI_CODEX_BLOB" } },
     { type = "header", mode = "inject", name = "OPENAI_CODEX_ACCOUNT_ID", inject_header = "chatgpt-account-id", hosts = [
-        "*.chatgpt.com",
+        "chatgpt.com",
     ] },
 ]


### PR DESCRIPTION
Introduces `CODEX_AUTH_MODE` (default `api_key`) so a sandbox can be flipped to a ChatGPT-style access-token flow against `chatgpt.com`. In `access_token` mode the entrypoint always installs the chatgpt `auth.json` template and skips `codex login --with-api-key`, letting iron-proxy's brokered-token transform inject the real Bearer plus `chatgpt-account-id` at request time.

Also: header_allowlist now keeps `chatgpt-account-id`, `/etc/centaur` is pre-created `0755` so the agent user can traverse it, the bundled `codex-auth.json` template uses JWT-shaped dummy tokens, Codex tool secrets are scoped to apex `chatgpt.com` (no wildcard), and `just up` forwards `CODEX_AUTH_MODE` from `.env` into `sandbox.extraEnv`.