### PR TITLE
docs: note OPENAI_CODEX_CLIENT_ID is a fixed public constant

### DIFF
--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -116,7 +116,11 @@ requests so the sandbox never sees them.
 Store these three items in your secrets backend (1Password vault, Kubernetes
 Secret, etc.) when running in `access_token` mode:
 
-- `OPENAI_CODEX_CLIENT_ID`: Codex CLI's public OAuth client id. Read-only.
+- `OPENAI_CODEX_CLIENT_ID`: the Codex CLI's OAuth client id. This is a
+  fixed, publicly known constant: `app_EMoamEEZ73f0CkXaXp7hrann`. It is
+  the same for every Codex install and never rotates, but the broker
+  still resolves it through your secrets backend, so store the literal
+  value as-is.
 - `OPENAI_CODEX_BLOB`: a JSON document `{"refresh_token": "..."}`. The
   broker rotates this in place on every refresh, so the backing item must
   be writable.
@@ -125,8 +129,9 @@ Secret, etc.) when running in `access_token` mode:
   `chatgpt-account-id` header so the backend can route to the right
   workspace. Store it alongside the other two, not in code.
 
-To bootstrap, run `codex login` locally, then copy the values from
-`~/.codex/auth.json` into the three secret items.
+To bootstrap, run `codex login` locally, then copy the refresh token and
+account id from `~/.codex/auth.json` into the matching secret items. Use
+the constant above for `OPENAI_CODEX_CLIENT_ID`.
 
 ## 4. Configure Slack
 


### PR DESCRIPTION
Clarifies in the production deployment guide that the Codex CLI OAuth client id stored as `OPENAI_CODEX_CLIENT_ID` is a fixed, publicly known constant (`app_EMoamEEZ73f0CkXaXp7hrann`) that is identical for every Codex install. Operators still need to put it in their secrets backend, but they no longer have to pull it out of `~/.codex/auth.json` to do so.