### PR TITLE
fix: stop Slack requester mentions

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -1072,14 +1072,9 @@ def _build_session_context(
                 "- Markdown tables are allowed and may render as native Slack tables when the structure is clean",
                 "- NEVER put links/URLs inside code blocks (``` ```) — they won't be clickable. Use markdown tables or plain text with `[text](url)` links instead",
                 "- For links to Slack threads or messages, always use the canonical `https://slack.com/archives/{CHANNEL_ID}/p{TS_WITHOUT_DOT}` form. Slack redirects this to the correct workspace. Do not invent or hardcode a `<workspace>.slack.com` subdomain.",
+                "- Do not @-mention or tag the requester when replying; reply naturally in the thread.",
             ]
         )
-        if user_id and user_id.startswith(("U", "W")):
-            lines.append(
-                "- For Slack replies after completing a long task, tag the requester with "
-                f"their real Slack mention: <@{user_id}>. This Slack reply rule does not "
-                "replace GitHub PR attribution requirements."
-            )
 
     lines.extend(["", "---", ""])
     return "\n".join(lines)

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -540,7 +540,8 @@ class TestBuildSessionContext:
 
         ctx = _build_session_context("test:1", platform="slack", user_id="U123")
         assert "Slack Formatting Rules" in ctx
-        assert "<@U123>" in ctx
+        assert "<@U123>" not in ctx
+        assert "Do not @-mention or tag the requester" in ctx
         assert "test:1" in ctx
 
     def test_no_platform(self):
@@ -555,7 +556,8 @@ class TestBuildSessionContext:
 
         ctx = _build_session_context("test:1", platform="slack")
         assert "Slack Formatting Rules" in ctx
-        assert "tag the requester" not in ctx
+        assert "their real Slack mention" not in ctx
+        assert "Do not @-mention or tag the requester" in ctx
 
     def test_slack_bot_user_id_not_mentioned(self):
         from api.agent import _build_session_context
@@ -563,7 +565,7 @@ class TestBuildSessionContext:
         ctx = _build_session_context("test:1", platform="slack", user_id="B123")
         assert "Slack Formatting Rules" in ctx
         assert "<@B123>" not in ctx
-        assert "tag the requester" not in ctx
+        assert "Do not @-mention or tag the requester" in ctx
 
     def test_contains_timestamp(self):
         from api.agent import _build_session_context


### PR DESCRIPTION
## Summary
- remove the generated Slack instruction that told agents to tag the requester
- add an explicit Slack formatting rule to reply naturally without requester @-mentions
- update session-context tests for human and bot Slack user IDs

## Why 695aa06 was not sufficient
- that commit only suppressed bot IDs (`B...`) in the old positive mention rule
- human Slack requester IDs (`U...`/`W...`) still generated `tag the requester with <@...>`, so multiplayer threads could still address the wrong participant

## Tests
- `uv run pytest tests/test_integration.py::TestBuildSessionContext`

Prompted by: @goksu
