### PR TITLE
feat(websearch): Parallel-backed search + deep research

### DIFF
--- a/tools/research/websearch/.env.example
+++ b/tools/research/websearch/.env.example
@@ -1,3 +1,10 @@
-EXA_API_KEY=
+# `search` works anonymously through the hosted Parallel Search MCP without
+# any credentials. Each capability layers on:
+#   PARALLEL_API_KEY     — unlocks paid Search REST path and `deep_research`
+#   ANTHROPIC_API_KEY    — enables Claude synthesis on top of search results
+#
+# These are the only env-driven knobs. Non-secret config (synthesis model,
+# default Task processor, REST/MCP base URLs) is set at WebSearchClient
+# construction time via kwargs.
+PARALLEL_API_KEY=
 ANTHROPIC_API_KEY=
-DEEP_RESEARCH_MODEL=claude-opus-4-6

--- a/tools/research/websearch/README.md
+++ b/tools/research/websearch/README.md
@@ -1,50 +1,116 @@
 # Websearch Plugin
 
-Web search and deep research tool backed by Exa (retrieval) and Claude (analysis/synthesis).
+Web search and deep research via [Parallel Web Systems](https://docs.parallel.ai),
+with optional Claude synthesis on top of search results.
+
+| Capability                       | No credentials                                  | + `PARALLEL_API_KEY`                                  | + `ANTHROPIC_API_KEY`                                 |
+| -------------------------------- | ----------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------- |
+| `search` (sources + excerpts)    | Free hosted MCP, lower rate limits              | Parallel Search REST, higher limits + filters         | (same; synthesis layered on top — see below)          |
+| `search(synthesize=True)`        | Raw excerpts only, skipped synthesis flagged    | Raw excerpts only, skipped synthesis flagged          | Claude reviewer → writer → citation-repair pipeline   |
+| `deep_research`                  | not available (key required)                    | Parallel Task API (default processor `ultra-fast`)    | (same)                                                |
+
+Each credential is additive: drop in only what you need.
+
+The free MCP path is provided by Parallel; on that path the response includes a `meta.attribution` string ("Search powered by the free Parallel Web Search MCP …"). The CLI `--pretty` mode surfaces it. Please retain or display this attribution when redistributing free-tier results. See <https://parallel.ai/customer-terms>.
+
+## Quickstart
+
+```python
+from websearch.client import WebSearchClient
+
+client = WebSearchClient()
+result = await client.search("Parallel Web Systems funding")
+# meta.backend will be 'parallel:mcp' (no key) or 'parallel:api' (with key)
+```
+
+That's the minimum — works with zero credentials via the free MCP. Add a `PARALLEL_API_KEY` to use the paid REST and unlock `deep_research`; add `ANTHROPIC_API_KEY` to get cited markdown synthesis on top of the results.
 
 ## Secrets
 
-Set these in root `.env` (preferred) or `tools/websearch/.env`:
+Set in root `.env` (preferred) or `tools/research/websearch/.env`.
 
-- `EXA_API_KEY`
-- `ANTHROPIC_API_KEY`
-- `DEEP_RESEARCH_MODEL` (default: `claude-opus-4-6`)
+- `PARALLEL_API_KEY` — optional. Get one at <https://platform.parallel.ai>. Unlocks the paid Search REST path (with source filters) and enables `deep_research` via the Task API.
+- `ANTHROPIC_API_KEY` — optional. Enables the Claude-backed synthesis pipeline on `search(synthesize=True)`.
+
+Non-secret config (synthesis model, default Task processor, REST/MCP base URLs) is configured via `WebSearchClient(...)` constructor kwargs at instantiation time. Defaults: `synthesis_model="claude-opus-4-6"`, `parallel_deep_research_processor="ultra-fast"`, `parallel_api_base_url="https://api.parallel.ai"`, `parallel_mcp_url="https://search.parallel.ai/mcp"`.
 
 ## Tools
 
 ### `search`
 
-One-shot web search with normalized sources and a synthesized cited answer (`answer_markdown`) by default.
+```python
+await client.search(
+    "How should a fintech startup evaluate MPC vs HSM in 2026?",
+    num_results=10,
+)
+```
 
-Key defaults:
+Arguments:
 
-- `search_type="auto"`
-- `num_results=10`
-- synthesis enabled (`synthesize=true`)
-- highlight-focused retrieval for token efficiency
+- `query: str` — **required** positional. The user's question or topic. Forwarded to Parallel as both the `objective` and the sole `search_queries` entry.
+- `client_model: str` — identifier of the LLM consuming the excerpts (e.g. `claude-opus-4-7`). Enables per-model retrieval/excerpt tuning.
+- `session_id: str` — stable UUID reused across related Search/Extract calls; used for free-tier rate limiting on the MCP.
+
+REST-only (silently warned via `meta.partial_failures` when used over the free MCP):
+
+- `mode: "basic" | "advanced"` — default `advanced` on REST. MCP forces `basic`.
+- `max_chars_total: int` — hard cap on total excerpt characters.
+- `include_domains`, `exclude_domains: list[str]` — domain filters.
+- `max_age_hours: int` — recency filter, rounded **down to a UTC calendar-date** cutoff (Parallel's `source_policy.after_date` is date-granular, not hour-precise — `max_age_hours=6` becomes "published on or after today's date").
+
+Set `synthesize=True` (default) to also run the Claude reviewer → writer → citation-repair pipeline against the retrieved sources. Without `ANTHROPIC_API_KEY` the call still returns raw Parallel sources and records the skipped synthesis in `meta.partial_failures`.
 
 ### `deep_research`
 
-Async multi-step research pipeline:
+```python
+await client.deep_research(
+    "How should a fintech startup evaluate MPC vs HSM in 2026?",
+    processor="pro-fast",  # optional
+)
+```
 
-1. plan queries
-2. run parallel Exa searches
-3. review evidence + decide whether to continue
-4. synthesize report
-5. validate citations (`[source_id]`)
+Creates a Parallel Task API run with auto schema, polls to completion, and renders the structured JSON output as cited markdown.
 
-Key defaults:
+**Requires `PARALLEL_API_KEY`** — the free MCP does not include deep-research. Restricted to the `pro/ultra` processor family (`lite`/`base`/`core` raise a clear error pointing at the docs).
 
-- `max_iterations=1`
-- `num_queries_per_iteration=4`
-- `num_results_per_query=5`
+### Processor cheatsheet
+
+Pick a `processor` based on the depth and latency you need (cost is per 1 000 runs):
+
+| Processor       | Cost  | Latency band  | Use case |
+| --------------- | -----:| -------------:| -------- |
+| `pro-fast`      | $100  | 30s – 5min    | Quick research that still wants cross-source synthesis |
+| `pro`           | $100  | 2min – 10min  | Same depth as `pro-fast`, less aggressive parallelism |
+| `ultra-fast`    | $300  | 1min – 10min  | Default. Multi-source deep research with reasonable latency |
+| `ultra`         | $300  | 5min – 25min  | Same depth, more time budget for harder questions |
+| `ultra2x` … `ultra8x` | $600 – $2400 | 1min – 2hr | The most difficult deep research; rarely needed |
+
+`-fast` variants are 2–5× faster than their non-fast siblings at the same price. See [Parallel pricing](https://docs.parallel.ai/getting-started/pricing) for the full table.
 
 ## CLI
 
 ```bash
-ai-v2 tools run websearch search "latest OpenAI and Anthropic model updates"
-ai-v2 tools run websearch search "latest OpenAI and Anthropic model updates" --no-synthesize
-ai-v2 tools run websearch deep-research "How should a fintech startup evaluate MPC vs HSM key management in 2026?"
+# Works with zero credentials (free MCP)
+ai-v2 tools run websearch search "Recent funding for AI search startups"
+
+# With PARALLEL_API_KEY: REST path + filters
+PARALLEL_API_KEY=... ai-v2 tools run websearch search \
+  "Recent funding for AI search startups" \
+  --include-domain techcrunch.com --include-domain reuters.com \
+  --max-age-hours 720 --pretty
+
+# Deep research (requires PARALLEL_API_KEY)
+PARALLEL_API_KEY=... ai-v2 tools run websearch deep-research \
+  "How should a fintech startup evaluate MPC vs HSM in 2026?" \
+  --processor pro-fast --pretty
 ```
 
-Use `--pretty` for human-readable output in both commands.
+### Backward-compatibility notes
+
+- Hidden CLI flags `--search-type`, `--max-iterations`, `--num-queries-per-iteration`, `--num-results-per-query` are accepted for prod-shaped invocations but emit a deprecation notice and are ignored under Parallel retrieval.
+- `meta.exa_request_ids` is retained as an alias of `meta.request_ids` so existing consumers of the original Exa-backed response shape still work.
+- `DeepResearchResponse.iterations` is retained as a single-element list per call (Parallel Task API is single-call rather than iterative).
+
+`meta.backend` in the JSON payload reports `parallel:mcp`, `parallel:api`, or `parallel:task:<processor>` so you can confirm which path served the call.
+
+`meta.estimated_cost_usd` is a best-effort estimate from Parallel's published list prices ([pricing](https://docs.parallel.ai/getting-started/pricing)) — `0.0` on the free MCP path, `$0.005`+ per REST search, and the per-run processor price for `deep_research`. The API does not return billed cost, so treat this as an estimate that can drift if prices change.

--- a/tools/research/websearch/__init__.py
+++ b/tools/research/websearch/__init__.py
@@ -1,1 +1,1 @@
-"""Web search and deep research via Exa and Claude."""
+"""Web search and deep research via Parallel Web Systems."""

--- a/tools/research/websearch/_parallel.py
+++ b/tools/research/websearch/_parallel.py
@@ -1,0 +1,871 @@
+"""Parallel Web Systems backend.
+
+`search` and `deep_research` against:
+
+- The official `parallel-web` Python SDK when `PARALLEL_API_KEY` is configured
+  (https://docs.parallel.ai). Used for the Search API and the Task API.
+- The free hosted Search MCP when no key is configured (for `search` only;
+  `deep_research` requires a key).
+    - https://search.parallel.ai/mcp  (Streamable HTTP, anonymous-friendly)
+      Docs: https://docs.parallel.ai/integrations/mcp/search-mcp
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import time
+import uuid
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from parallel import APIStatusError, APITimeoutError, AsyncParallel, AuthenticationError
+
+from .models import (
+    DeepResearchIteration,
+    DeepResearchResponse,
+    ResponseMeta,
+    SearchResponse,
+    SourceDocument,
+)
+
+API_BASE_URL = "https://api.parallel.ai"
+MCP_URL = "https://search.parallel.ai/mcp"
+MCP_PROTOCOL_VERSION = "2025-06-18"
+MCP_CLIENT_NAME = "centaur-websearch"
+MCP_CLIENT_VERSION = "0.2.0"
+SNIPPET_CHAR_LIMIT = 7000
+
+# Per Parallel docs, Deep Research is "optimized within the `pro` and `ultra`
+# processor families" — other processors (lite/base/core/core2x) return a flat
+# single-field output rather than the rich auto-schema, so we restrict the
+# `deep_research` method to the pro/ultra family. Values are ~2x the documented
+# max-latency bands (https://docs.parallel.ai/task-api/examples/task-deep-research)
+# because real runs routinely run past the optimistic upper bound — a too-tight
+# default produces spurious timeouts on legitimate jobs. Callers can override
+# via `timeout_seconds`.
+PROCESSOR_TIMEOUT_SECONDS: dict[str, float] = {
+    "pro": 1200.0,
+    "pro-fast": 720.0,
+    "ultra": 3000.0,
+    "ultra-fast": 1500.0,
+    "ultra2x": 4200.0,
+    "ultra2x-fast": 2400.0,
+    "ultra4x": 7200.0,
+    "ultra4x-fast": 4200.0,
+    "ultra8x": 10800.0,
+    "ultra8x-fast": 6000.0,
+}
+
+# Published list prices per 1,000 units, used only for a best-effort
+# `meta.estimated_cost_usd` (the API does not return billed cost). These will
+# drift if Parallel changes pricing; source of truth is
+# https://docs.parallel.ai/getting-started/pricing.
+# Task pricing is per run and identical for a processor's `-fast` variant.
+TASK_PRICE_USD_PER_1000: dict[str, float] = {
+    "pro": 100.0,
+    "ultra": 300.0,
+    "ultra2x": 600.0,
+    "ultra4x": 1200.0,
+    "ultra8x": 2400.0,
+}
+# Search REST: $5 per 1,000 requests at the default 10 results, plus $0.001 per
+# additional result/excerpt beyond that. The free MCP path is $0.
+SEARCH_PRICE_USD_PER_1000 = 5.0
+SEARCH_INCLUDED_RESULTS = 10
+SEARCH_EXTRA_RESULT_USD = 0.001
+
+
+def _estimate_task_cost_usd(processor: str) -> float | None:
+    base = processor.removesuffix("-fast")
+    price = TASK_PRICE_USD_PER_1000.get(base)
+    return round(price / 1000, 6) if price is not None else None
+
+
+def _estimate_search_cost_usd(num_results: int) -> float:
+    extra = max(0, num_results - SEARCH_INCLUDED_RESULTS)
+    return round(SEARCH_PRICE_USD_PER_1000 / 1000 + extra * SEARCH_EXTRA_RESULT_USD, 6)
+DEFAULT_DEEP_RESEARCH_TIMEOUT_SECONDS = 1800.0
+_FREE_MCP_ATTRIBUTION = (
+    "Search powered by the free Parallel Web Search MCP "
+    "(https://parallel.ai). See https://parallel.ai/customer-terms."
+)
+
+
+def _append_within_budget(body: str, trailer: str, max_chars: int) -> str:
+    """Append `trailer` to `body`, keeping the total within `max_chars`.
+
+    The trailer (the canonical ## Sources block or attribution footer) is
+    always preserved intact — it carries citation integrity, so it is never
+    sliced. The body absorbs truncation to make room. In the degenerate case
+    where the trailer alone exceeds `max_chars`, the cap is exceeded rather
+    than corrupting the citation map (integrity beats the best-effort cap).
+    """
+    body = body.rstrip()
+    if len(body) + len(trailer) <= max_chars:
+        return body + trailer
+    body_budget = max(0, max_chars - len(trailer))
+    return body[:body_budget].rstrip() + trailer
+
+
+class ParallelBackend:
+    """Parallel-powered search and deep research."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None,
+        api_base_url: str = API_BASE_URL,
+        mcp_url: str = MCP_URL,
+        deep_research_processor: str = "ultra-fast",
+        max_retries: int = 3,
+    ) -> None:
+        self._api_key = api_key
+        self._api_base_url = api_base_url.rstrip("/")
+        self._mcp_url = mcp_url
+        self._default_processor = deep_research_processor
+        self._max_retries = max_retries
+        # Per Parallel docs, callers should set a stable session_id and reuse
+        # it across related Search/Extract calls — required for free-tier
+        # rate-limit attribution and useful for call correlation. We mint one
+        # per backend instance so callers who omit it still get continuity
+        # within a process.
+        self._default_session_id = f"centaur-websearch-{uuid.uuid4().hex}"
+        # Set once a REST search fails auth — i.e. the configured "key" was an
+        # un-swapped placeholder (centaur replace-mode secret that iron-proxy
+        # had nothing to resolve). Subsequent searches skip REST and use the
+        # anonymous MCP path (see the fallback in `search`).
+        self._rest_auth_failed = False
+
+    @property
+    def has_api_key(self) -> bool:
+        return bool(self._api_key)
+
+    @property
+    def search_mode(self) -> str:
+        return "api" if self._api_key else "mcp"
+
+    def _sdk_client(self, *, timeout_seconds: float) -> AsyncParallel:
+        if not self._api_key:
+            raise RuntimeError("PARALLEL_API_KEY is required for the SDK path.")
+        return AsyncParallel(
+            api_key=self._api_key,
+            base_url=self._api_base_url,
+            max_retries=self._max_retries,
+            timeout=timeout_seconds,
+        )
+
+    async def search(
+        self,
+        *,
+        search_queries: list[str],
+        objective: str | None = None,
+        num_results: int = 10,
+        timeout_seconds: float = 60.0,
+        synthesize: bool = True,
+        max_report_chars: int = 12000,
+        mode: str | None = None,
+        client_model: str | None = None,
+        max_chars_total: int | None = None,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        max_age_hours: int | None = None,
+        session_id: str | None = None,
+        synthesis_pipeline: Any | None = None,
+        thread_context: list[str] | None = None,
+    ) -> dict:
+        started = time.perf_counter()
+        queries = [q.strip() for q in (search_queries or []) if q and q.strip()]
+        if not queries:
+            raise RuntimeError("search_queries must contain at least one non-empty query.")
+        cleaned_objective = (objective or "").strip() or None
+        # Reuse a stable session id when the caller doesn't supply one (free
+        # tier MCP needs it for rate-limit attribution; REST benefits from
+        # call correlation in Parallel's logs).
+        effective_session_id = session_id or self._default_session_id
+        partial_failures: list[dict[str, str]] = []
+
+        display_query = cleaned_objective or "; ".join(queries)
+        use_rest = bool(self._api_key) and not self._rest_auth_failed
+        if use_rest:
+            try:
+                sources, request_id, usage = await self._search_api(
+                    objective=cleaned_objective,
+                    search_queries=queries,
+                    timeout_seconds=timeout_seconds,
+                    mode=mode,
+                    client_model=client_model,
+                    max_chars_total=max_chars_total,
+                    num_results=num_results,
+                    include_domains=include_domains,
+                    exclude_domains=exclude_domains,
+                    max_age_hours=max_age_hours,
+                    session_id=effective_session_id,
+                )
+                backend_label = "parallel:api"
+            except AuthenticationError:
+                # The configured key was an un-swapped placeholder (centaur
+                # replace-mode secret with no real value in the vault). Fall
+                # back to the anonymous MCP path and skip REST from now on.
+                self._rest_auth_failed = True
+                use_rest = False
+                partial_failures.append(
+                    {
+                        "query": display_query,
+                        "error": (
+                            "PARALLEL_API_KEY did not authenticate; fell back to the "
+                            "free Search MCP. Configure a valid key to use the REST API."
+                        ),
+                    }
+                )
+
+        if not use_rest:
+            ignored = []
+            if include_domains or exclude_domains or max_age_hours is not None:
+                ignored.append("include_domains/exclude_domains/max_age_hours")
+            if mode and mode != "basic":
+                ignored.append(f"mode={mode!r} (MCP forces basic)")
+            if max_chars_total is not None:
+                ignored.append("max_chars_total")
+            if num_results != 10:
+                ignored.append(
+                    f"num_results={num_results} (MCP serves a fixed default; client-side cap only)"
+                )
+            if ignored:
+                partial_failures.append(
+                    {
+                        "query": display_query,
+                        "error": (
+                            f"Free Search MCP does not honor: {', '.join(ignored)}. "
+                            "Set PARALLEL_API_KEY to use the Search REST API."
+                        ),
+                    }
+                )
+            sources, request_id, usage = await self._search_mcp(
+                objective=cleaned_objective,
+                search_queries=queries,
+                client_model=client_model,
+                timeout_seconds=timeout_seconds,
+                session_id=effective_session_id,
+            )
+            backend_label = "parallel:mcp"
+
+        capped_sources = sources[: max(1, min(40, num_results))]
+        # On the free-MCP path we append an attribution footer; reserve its
+        # length up front so the synthesized report (including its trailing
+        # ## Sources section) is generated within the remaining budget and the
+        # footer never has to displace the citation map.
+        attribution = _FREE_MCP_ATTRIBUTION if backend_label == "parallel:mcp" else None
+        footer = f"\n\n---\n_{attribution}_\n" if attribution else ""
+        synthesis_budget = max(1, max_report_chars - len(footer))
+        answer_markdown: str | None = None
+        if synthesize and capped_sources:
+            if synthesis_pipeline is not None:
+                try:
+                    syn_result = await synthesis_pipeline.synthesize(
+                        question=display_query,
+                        sources=capped_sources,
+                        thread_context=thread_context,
+                        max_report_chars=synthesis_budget,
+                    )
+                    answer_markdown = syn_result["report"]
+                    if syn_result["validation_error"]:
+                        partial_failures.append(
+                            {
+                                "query": display_query,
+                                "error": f"synthesis failed: {syn_result['validation_error']}",
+                            }
+                        )
+                except Exception as exc:
+                    partial_failures.append(
+                        {"query": display_query, "error": f"synthesis failed: {exc}"}
+                    )
+            else:
+                partial_failures.append(
+                    {
+                        "query": display_query,
+                        "error": (
+                            "synthesize=true requested but ANTHROPIC_API_KEY is not set; "
+                            "returning raw excerpts. Set ANTHROPIC_API_KEY (or pass "
+                            "synthesize=false) to silence this notice."
+                        ),
+                    }
+                )
+
+        if footer and answer_markdown:
+            answer_markdown = f"{answer_markdown.rstrip()}{footer}"
+        estimated_cost_usd = (
+            _estimate_search_cost_usd(num_results) if backend_label == "parallel:api" else 0.0
+        )
+        meta = ResponseMeta(
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            request_ids=[request_id] if request_id else [],
+            partial_failures=partial_failures,
+            backend=backend_label,
+            usage=usage,
+            attribution=attribution,
+            estimated_cost_usd=estimated_cost_usd,
+        )
+        return SearchResponse(
+            query=display_query,
+            results=capped_sources,
+            answer_markdown=answer_markdown,
+            meta=meta,
+        ).model_dump()
+
+    async def deep_research(
+        self,
+        *,
+        question: str,
+        progress: Any,
+        processor: str | None = None,
+        timeout_seconds: float | None = None,
+        max_report_chars: int,
+    ) -> dict:
+        if not self._api_key:
+            raise RuntimeError(
+                "deep_research requires PARALLEL_API_KEY. The free Search MCP is "
+                "only available for `search`; set PARALLEL_API_KEY to enable deep "
+                "research via the Parallel Task API."
+            )
+        normalized = question.strip()
+        if not normalized:
+            raise RuntimeError("question cannot be empty.")
+
+        effective_processor = (processor or self._default_processor).strip()
+        if effective_processor not in PROCESSOR_TIMEOUT_SECONDS:
+            raise RuntimeError(
+                f"deep_research requires a pro/ultra processor (got {effective_processor!r}). "
+                f"Per Parallel docs, Deep Research is optimized within the pro and ultra "
+                f"families. Supported: {sorted(PROCESSOR_TIMEOUT_SECONDS)}."
+            )
+        effective_timeout = timeout_seconds or PROCESSOR_TIMEOUT_SECONDS[effective_processor]
+
+        started = time.perf_counter()
+        progress(f"creating task ({effective_processor}, timeout={int(effective_timeout)}s)")
+        client = self._sdk_client(timeout_seconds=effective_timeout)
+        # Use auto schema (Parallel's default for pro/ultra processors), which
+        # returns a structured JSON report with per-field basis grounding. The
+        # canonical Deep Research example in the docs uses this — text mode
+        # gives looser, less reliably-cited output.
+        async with client:
+            task = await client.task_run.create(
+                input=normalized,
+                processor=effective_processor,
+                enable_events=True,
+            )
+            run_id = task.run_id
+            progress(f"queued {run_id}")
+
+            await _stream_progress(client, run_id, progress)
+
+            result = await _await_task_result(
+                client, run_id=run_id, deadline=started + effective_timeout
+            )
+
+        sources, answer_markdown = _normalize_task_result(result, max_report_chars=max_report_chars)
+        if not answer_markdown:
+            raise RuntimeError(f"Parallel task run {run_id} returned no content.")
+
+        meta = ResponseMeta(
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            request_ids=[run_id],
+            backend=f"parallel:task:{effective_processor}",
+            estimated_cost_usd=_estimate_task_cost_usd(effective_processor),
+        )
+        iterations = [
+            DeepResearchIteration(
+                iteration=1,
+                queries=[normalized],
+                results_count=len(sources),
+                continue_reason=f"parallel:{effective_processor}",
+            )
+        ]
+        return DeepResearchResponse(
+            question=normalized,
+            answer_markdown=answer_markdown,
+            sources=sources,
+            iterations=iterations,
+            meta=meta,
+        ).model_dump()
+
+    async def _search_api(
+        self,
+        *,
+        objective: str | None,
+        search_queries: list[str],
+        timeout_seconds: float,
+        mode: str | None,
+        client_model: str | None,
+        max_chars_total: int | None,
+        num_results: int,
+        include_domains: list[str] | None,
+        exclude_domains: list[str] | None,
+        max_age_hours: int | None,
+        session_id: str | None,
+    ) -> tuple[list[SourceDocument], str, list[dict[str, Any]]]:
+        client = self._sdk_client(timeout_seconds=timeout_seconds)
+        kwargs: dict[str, Any] = {"search_queries": search_queries}
+        if objective:
+            kwargs["objective"] = objective
+        if mode:
+            kwargs["mode"] = mode
+        if client_model:
+            kwargs["client_model"] = client_model
+        # Default to a generous excerpt budget — Parallel's dynamic default
+        # is conservative and the resulting short excerpts measurably hurt
+        # downstream synthesis quality.
+        kwargs["max_chars_total"] = max_chars_total if max_chars_total is not None else 30000
+        if session_id:
+            kwargs["session_id"] = session_id
+
+        source_policy = _build_source_policy(include_domains, exclude_domains, max_age_hours)
+        advanced_settings: dict[str, Any] = {
+            "excerpt_settings": {"max_chars_per_result": 3000},
+        }
+        if source_policy:
+            advanced_settings["source_policy"] = source_policy
+        # Pass num_results through as max_results so callers asking for fewer
+        # actually get reduced latency/cost. Parallel's best-practices doc
+        # warns against using max_results to over-constrain quality, but
+        # silently ignoring an explicit caller knob is worse.
+        advanced_settings["max_results"] = max(1, min(40, num_results))
+        kwargs["advanced_settings"] = advanced_settings
+
+        async with client:
+            result = await client.search(**kwargs)
+        usage = _serialize_usage(getattr(result, "usage", None))
+        return _normalize_search_results(result.results), result.search_id or "", usage
+
+    async def _search_mcp(
+        self,
+        *,
+        objective: str | None,
+        search_queries: list[str],
+        client_model: str | None,
+        timeout_seconds: float,
+        session_id: str | None,
+    ) -> tuple[list[SourceDocument], str, list[dict[str, Any]]]:
+        # MCP's web_search tool requires `objective` (REST treats it as
+        # optional). Fall back to a synthesized one from the search queries
+        # when the caller didn't supply it.
+        arguments: dict[str, Any] = {
+            "search_queries": search_queries,
+            "objective": objective or "; ".join(search_queries),
+        }
+        if session_id:
+            arguments["session_id"] = session_id
+        if client_model:
+            arguments["model_name"] = client_model
+        payload = await self._mcp_call_tool(
+            tool_name="web_search",
+            arguments=arguments,
+            timeout_seconds=timeout_seconds,
+        )
+        request_id = str(payload.get("search_id") or "")
+        usage = _serialize_usage(payload.get("usage"))
+        return _normalize_search_results(payload.get("results")), request_id, usage
+
+    async def _mcp_call_tool(
+        self,
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+            mcp_session_id = await self._mcp_initialize(client)
+            envelope = {
+                "jsonrpc": "2.0",
+                "id": str(uuid.uuid4()),
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            }
+            response = await client.post(
+                self._mcp_url,
+                headers=self._mcp_headers(mcp_session_id),
+                json=envelope,
+            )
+            response.raise_for_status()
+            envelope_out = _decode_mcp_envelope(response)
+        if "error" in envelope_out:
+            raise RuntimeError(f"Parallel MCP error: {str(envelope_out['error'])[:500]}")
+        result = envelope_out.get("result") or {}
+        if result.get("isError"):
+            raise RuntimeError(f"Parallel MCP tool error: {str(result)[:500]}")
+        # Prefer structuredContent (machine-readable) over the human text
+        # block — newer MCP servers return both and structuredContent is the
+        # authoritative payload for downstream parsing.
+        structured = result.get("structuredContent")
+        if isinstance(structured, dict):
+            return structured
+        # Scan all text blocks for the first one whose payload is parseable
+        # JSON. Only fall back to wrapping a raw string if no block was JSON.
+        first_text: str | None = None
+        for block in result.get("content", []) or []:
+            if not (isinstance(block, dict) and block.get("type") == "text"):
+                continue
+            text = str(block.get("text") or "")
+            if not text:
+                continue
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                if first_text is None:
+                    first_text = text
+        if first_text is not None:
+            return {"text": first_text}
+        raise RuntimeError(f"Parallel MCP returned no parseable content: {str(result)[:500]}")
+
+    async def _mcp_initialize(self, client: httpx.AsyncClient) -> str:
+        init_envelope = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": MCP_CLIENT_NAME, "version": MCP_CLIENT_VERSION},
+            },
+        }
+        init_response = await client.post(
+            self._mcp_url,
+            headers=self._mcp_headers(None),
+            json=init_envelope,
+        )
+        init_response.raise_for_status()
+        mcp_session_id = init_response.headers.get("mcp-session-id")
+        _ = _decode_mcp_envelope(init_response)
+        notify = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        ack = await client.post(
+            self._mcp_url,
+            headers=self._mcp_headers(mcp_session_id),
+            json=notify,
+        )
+        if ack.status_code >= 400:
+            raise RuntimeError(
+                f"Parallel MCP initialize ack failed ({ack.status_code}): {ack.text[:500]}"
+            )
+        return mcp_session_id or ""
+
+    def _mcp_headers(self, session_id: str | None) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+        # Only attach a Bearer token when we hold a key that actually
+        # authenticates. If REST already failed auth (placeholder/un-swapped
+        # replacer), the MCP fallback must stay anonymous — sending the bogus
+        # token would get the free endpoint to 401 as well.
+        if self._api_key and not self._rest_auth_failed:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+
+async def _await_task_result(client: AsyncParallel, *, run_id: str, deadline: float) -> Any:
+    while True:
+        remaining = deadline - time.perf_counter()
+        if remaining <= 0:
+            raise RuntimeError(f"Parallel task run {run_id} timed out before completion.")
+        block_seconds = int(min(600, max(5, remaining)))
+        try:
+            return await client.task_run.result(run_id, api_timeout=block_seconds)
+        except APIStatusError as exc:
+            if exc.status_code != 408:
+                raise
+        except APITimeoutError:
+            pass
+
+
+async def _stream_progress(client: AsyncParallel, run_id: str, progress: Any) -> None:
+    """Pump progress events from Parallel into the centaur progress callback."""
+    try:
+        stream = await client.task_run.events(run_id)
+    except Exception as exc:
+        progress(f"events stream unavailable: {exc}")
+        return
+    try:
+        async with stream as events:
+            async for event in events:
+                event_type = getattr(event, "type", "")
+                if event_type.startswith("task_run.progress_msg"):
+                    # Suffixed variants: .plan / .search / .result / .tool_call
+                    # / .exec_status. Surface the phase plus the message text.
+                    phase = event_type.rsplit(".", 1)[-1]
+                    message = getattr(event, "message", None)
+                    if message:
+                        progress(f"{phase}: {message}")
+                elif event_type == "task_run.progress_stats":
+                    stats = getattr(event, "source_stats", None)
+                    meter = getattr(event, "progress_meter", None)
+                    parts = []
+                    if meter is not None:
+                        parts.append(f"progress={meter}")
+                    if stats is not None:
+                        for attr in (
+                            "num_sources_considered",
+                            "num_sources_read",
+                            "num_sources_used",
+                        ):
+                            value = getattr(stats, attr, None)
+                            if value is not None:
+                                parts.append(f"{attr}={value}")
+                    if parts:
+                        progress("stats: " + ", ".join(parts))
+                elif event_type == "task_run.state":
+                    run = getattr(event, "run", None)
+                    status = getattr(run, "status", None) if run is not None else None
+                    if status:
+                        progress(f"state={status}")
+                    if status == "completed":
+                        return
+                    if status in {"failed", "cancelled"}:
+                        err = getattr(run, "error", None)
+                        raise RuntimeError(
+                            f"Parallel task run {run_id} {status}"
+                            + (f": {err}" if err is not None else "")
+                        )
+                elif event_type == "error":
+                    error = getattr(event, "error", None)
+                    raise RuntimeError(
+                        f"Parallel task run {run_id} errored"
+                        + (f": {error}" if error is not None else "")
+                    )
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        progress(f"events stream interrupted: {exc}")
+
+
+def _build_source_policy(
+    include_domains: list[str] | None,
+    exclude_domains: list[str] | None,
+    max_age_hours: int | None,
+) -> dict[str, Any] | None:
+    policy: dict[str, Any] = {}
+    if include_domains:
+        policy["include_domains"] = list(include_domains)
+    if exclude_domains:
+        policy["exclude_domains"] = list(exclude_domains)
+    if max_age_hours is not None and max_age_hours > 0:
+        cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(hours=max_age_hours)
+        policy["after_date"] = cutoff.date().isoformat()
+    return policy or None
+
+
+def _serialize_usage(usage: Any) -> list[dict[str, Any]]:
+    if usage is None:
+        return []
+    out: list[dict[str, Any]] = []
+    items = usage if isinstance(usage, list) else [usage]
+    for item in items:
+        if hasattr(item, "model_dump"):
+            out.append(item.model_dump())
+        elif isinstance(item, dict):
+            out.append(item)
+        else:
+            out.append({"raw": str(item)})
+    return out
+
+
+def _decode_mcp_envelope(response: httpx.Response) -> dict[str, Any]:
+    content_type = response.headers.get("content-type", "")
+    text = response.text
+    if "text/event-stream" in content_type:
+        # SSE: events are delimited by blank lines. Within an event, each
+        # `data:` line contributes one line of the payload. The last event
+        # whose data is parseable JSON wins (intermediate events may be
+        # comments, retry directives, or progress notifications).
+        latest: dict[str, Any] | None = None
+        for event_block in text.split("\n\n"):
+            data_lines = [
+                line[len("data:") :].lstrip(" ")
+                for line in event_block.splitlines()
+                if line.startswith("data:")
+            ]
+            if not data_lines:
+                continue
+            payload_text = "\n".join(data_lines).strip()
+            if not payload_text:
+                continue
+            try:
+                parsed = json.loads(payload_text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                latest = parsed
+        if latest is None:
+            raise RuntimeError("Parallel MCP returned an empty SSE stream.")
+        return latest
+    if not text.strip():
+        return {}
+    return json.loads(text)
+
+
+def _normalize_search_results(raw_results: Any) -> list[SourceDocument]:
+    sources: list[SourceDocument] = []
+    seen: set[str] = set()
+    if not raw_results:
+        return sources
+    for item in raw_results:
+        url = _attr_or_key(item, "url")
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        title = _attr_or_key(item, "title") or url
+        published_date = _attr_or_key(item, "publish_date") or _attr_or_key(item, "published_date")
+        if published_date is not None:
+            published_date = str(published_date)
+        excerpts = _attr_or_key(item, "excerpts")
+        if isinstance(excerpts, list) and excerpts:
+            snippet = "\n\n".join(str(e) for e in excerpts if e)
+        else:
+            snippet = str(_attr_or_key(item, "snippet") or _attr_or_key(item, "text") or "")
+        sources.append(
+            SourceDocument(
+                source_id=len(sources),
+                title=title,
+                url=url,
+                snippet=snippet[:SNIPPET_CHAR_LIMIT],
+                published_date=published_date,
+                domain=urlparse(url).netloc or None,
+            )
+        )
+    return sources
+
+
+def _normalize_task_result(
+    result: Any, *, max_report_chars: int
+) -> tuple[list[SourceDocument], str]:
+    """Render a Parallel Task API result into our (sources, markdown) shape.
+
+    Handles both auto-schema output (a structured dict with per-field basis
+    citations — the canonical Deep Research format) and text-mode output
+    (a single markdown string). For auto-schema, we render the structured
+    content to markdown with one section per top-level field, attaching the
+    citation refs for each field, then append a canonical Sources section.
+
+    The report body is truncated to `max_report_chars` *before* the Sources
+    section is appended, so the citation map always survives truncation.
+    """
+    output = getattr(result, "output", None)
+    if output is None:
+        return [], ""
+    content = getattr(output, "content", None)
+    basis_entries = getattr(output, "basis", None) or []
+
+    # The Task API already returns a fully-cited report: the answer text carries
+    # the model's own inline [N] markers, which are 1-based into the basis
+    # citation list (verified against live output: prose [1] == basis[0]). We
+    # collect those basis citations in order and render a Sources block numbered
+    # to match, rather than imposing a second numbering scheme of our own.
+    sources: list[SourceDocument] = []
+    url_to_id: dict[str, int] = {}
+    for entry in basis_entries:
+        for citation in _attr_or_key(entry, "citations") or []:
+            url = _attr_or_key(citation, "url")
+            if not url:
+                continue
+            url = str(url)
+            if url in url_to_id:
+                continue
+            title = _attr_or_key(citation, "title") or url
+            excerpts = _attr_or_key(citation, "excerpts")
+            if isinstance(excerpts, list) and excerpts:
+                snippet = "\n\n".join(str(e) for e in excerpts if e)
+            else:
+                snippet = ""
+            source_id = len(sources) + 1
+            sources.append(
+                SourceDocument(
+                    source_id=source_id,
+                    title=str(title),
+                    url=url,
+                    snippet=snippet[:SNIPPET_CHAR_LIMIT],
+                    published_date=None,
+                    domain=urlparse(url).netloc or None,
+                )
+            )
+            url_to_id[url] = source_id
+
+    if isinstance(content, dict):
+        answer_markdown = _render_auto_content(content)
+    elif isinstance(content, str):
+        answer_markdown = content
+    else:
+        return sources, ""
+
+    if sources:
+        source_lines = [f"[{source.source_id}] {source.title} — {source.url}" for source in sources]
+        sources_block = "\n\n## Sources\n" + "\n".join(source_lines)
+        answer_markdown = _append_within_budget(answer_markdown, sources_block, max_report_chars)
+    else:
+        answer_markdown = answer_markdown[:max_report_chars].rstrip()
+    return sources, answer_markdown
+
+
+def _render_auto_content(content: dict[str, Any]) -> str:
+    """Render an auto-schema dict to markdown, one section per top-level key.
+
+    String values (the deep-research answer field) are emitted verbatim so the
+    model's own inline [N] citations survive intact; the canonical Sources block
+    appended by the caller carries the matching, 1-based source list.
+    """
+    lines: list[str] = []
+    for key, value in content.items():
+        lines.append(f"## {_humanize_key(key)}")
+        lines.append("")
+        lines.extend(_render_value(value, depth=3))
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _render_value(value: Any, *, depth: int) -> list[str]:
+    out: list[str] = []
+    if isinstance(value, str):
+        out.append(value.rstrip())
+    elif isinstance(value, dict):
+        for sub_key, sub_value in value.items():
+            out.append(f"{'#' * min(depth, 6)} {_humanize_key(sub_key)}")
+            out.append("")
+            out.extend(_render_value(sub_value, depth=depth + 1))
+            out.append("")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            if isinstance(item, dict):
+                title_key = next(
+                    (k for k in item if k in {"name", "provider_name", "title"}),
+                    None,
+                )
+                title_candidate = str(item[title_key]) if title_key else f"Item {index + 1}"
+                out.append(f"{'#' * min(depth, 6)} {title_candidate}")
+                out.append("")
+                for sub_key, sub_value in item.items():
+                    if sub_key == title_key:
+                        continue
+                    out.append(f"- **{_humanize_key(sub_key)}:** {sub_value}")
+                out.append("")
+            else:
+                out.append(f"- {item}")
+        if not value:
+            out.append("_(no items)_")
+    elif value is None:
+        out.append("_(none)_")
+    else:
+        out.append(str(value))
+    return out
+
+
+def _humanize_key(key: str) -> str:
+    return key.replace("_", " ").title()
+
+
+def _attr_or_key(obj: Any, name: str) -> Any:
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)

--- a/tools/research/websearch/cli.py
+++ b/tools/research/websearch/cli.py
@@ -13,38 +13,79 @@ from .client import _client
 
 load_dotenv()
 
-app = typer.Typer(name="websearch", help="Web search and deep research via Exa + Claude")
+app = typer.Typer(name="websearch", help="Web search and deep research via Parallel")
 console = Console(stderr=True)
 
 
 def _print_json(payload: dict) -> None:
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    print(json.dumps(payload, indent=2, sort_keys=True, default=str))
 
 
 @app.command()
 def search(
-    query: str = typer.Argument(..., help="Search query"),
+    query: str = typer.Argument(..., help="Search query or research question."),
     num_results: int = typer.Option(10, "--num-results", "-n", help="Maximum results"),
-    search_type: str = typer.Option("auto", "--search-type", help="Exa search type"),
-    timeout_seconds: float = typer.Option(30.0, "--timeout-seconds", help="Request timeout"),
+    timeout_seconds: float = typer.Option(60.0, "--timeout-seconds", help="Request timeout"),
     synthesize: bool = typer.Option(
-        True, "--synthesize/--no-synthesize", help="Generate synthesized cited answer"
+        True, "--synthesize/--no-synthesize", help="Compose a cited answer from excerpts"
+    ),
+    mode: str = typer.Option(None, "--mode", help="Search mode: basic | advanced (REST only)"),
+    client_model: str = typer.Option(
+        None,
+        "--client-model",
+        help="Identifier of the consuming LLM (e.g. claude-opus-4-7)",
+    ),
+    max_chars_total: int = typer.Option(
+        None, "--max-chars-total", help="Upper bound on total excerpt characters (REST only)"
+    ),
+    include_domains: list[str] = typer.Option(
+        None, "--include-domain", help="Restrict to these domains (REST only). Repeatable."
+    ),
+    exclude_domains: list[str] = typer.Option(
+        None, "--exclude-domain", help="Exclude these domains (REST only). Repeatable."
+    ),
+    max_age_hours: int = typer.Option(
+        None,
+        "--max-age-hours",
+        help=(
+            "Recency filter (REST only). Rounded DOWN to a UTC calendar-date "
+            "cutoff — Parallel's source policy is date-granular, not hour-precise."
+        ),
+    ),
+    session_id: str = typer.Option(
+        None,
+        "--session-id",
+        help="Stable session ID (UUID); reuse across related Search/Extract calls",
     ),
     max_report_chars: int = typer.Option(
-        12000, "--max-report-chars", help="Maximum synthesis length in characters"
+        12000, "--max-report-chars", help="Maximum composed answer length in characters"
     ),
     pretty: bool = typer.Option(False, "--pretty", help="Print concise human-readable output"),
+    # Backward-compat shim for the original Exa-backed tool's --search-type flag.
+    # Hidden from --help; if passed, we warn and ignore (no Parallel equivalent).
+    search_type: str = typer.Option(None, "--search-type", help="[deprecated] no-op", hidden=True),
 ):
-    """Search the web via Exa."""
+    """Search the web via Parallel (free MCP or paid REST)."""
     client = _client()
+    if search_type:
+        console.print(
+            f"[yellow]--search-type={search_type!r} is deprecated and ignored (no "
+            "Parallel equivalent for Exa's neural/keyword/auto modes).[/]"
+        )
     try:
         payload = asyncio.run(
             client.search(
                 query=query,
                 num_results=num_results,
-                search_type=search_type,
                 timeout_seconds=timeout_seconds,
                 synthesize=synthesize,
+                mode=mode,
+                client_model=client_model,
+                max_chars_total=max_chars_total,
+                include_domains=include_domains or None,
+                exclude_domains=exclude_domains or None,
+                max_age_hours=max_age_hours,
+                session_id=session_id,
                 max_report_chars=max_report_chars,
             )
         )
@@ -55,6 +96,13 @@ def search(
     if pretty:
         out_console = Console()
         out_console.print(f"[bold]Query:[/] {payload['query']}")
+        out_console.print(f"[dim]backend: {payload['meta'].get('backend')}[/]")
+        attribution = payload["meta"].get("attribution")
+        if attribution:
+            out_console.print(f"[dim]{attribution}[/]")
+        if payload["meta"].get("partial_failures"):
+            for failure in payload["meta"]["partial_failures"]:
+                out_console.print(f"[yellow]note: {failure.get('error')}[/]")
         if payload.get("answer_markdown"):
             out_console.print(payload["answer_markdown"])
         out_console.print(f"\n[bold]Results:[/] {len(payload['results'])}")
@@ -67,33 +115,62 @@ def search(
 @app.command("deep-research")
 def deep_research_command(
     question: str = typer.Argument(..., help="Research question"),
-    max_iterations: int = typer.Option(1, "--max-iterations", help="Maximum research iterations"),
-    num_queries_per_iteration: int = typer.Option(
-        4, "--num-queries-per-iteration", help="Parallel searches per iteration"
-    ),
-    num_results_per_query: int = typer.Option(
-        5, "--num-results-per-query", help="Results per query"
+    processor: str = typer.Option(
+        None,
+        "--processor",
+        "-p",
+        help="Task processor (pro/pro-fast/ultra/ultra-fast/ultra2x/ultra4x/ultra8x)",
     ),
     timeout_seconds: float = typer.Option(
-        300.0, "--timeout-seconds", help="Overall timeout budget"
+        None,
+        "--timeout-seconds",
+        help="Request timeout. Defaults to a processor-appropriate value.",
+    ),
+    max_report_chars: int = typer.Option(
+        50000, "--max-report-chars", help="Maximum report length in characters"
     ),
     pretty: bool = typer.Option(False, "--pretty", help="Print markdown report only"),
+    # Backward-compat shims for the original Exa+Claude iterative pipeline.
+    # Hidden from --help; if passed, we warn and ignore (single-call Task API
+    # replaces planner→search→reviewer→writer loops).
+    max_iterations: int = typer.Option(
+        None, "--max-iterations", help="[deprecated] no-op", hidden=True
+    ),
+    num_queries_per_iteration: int = typer.Option(
+        None, "--num-queries-per-iteration", help="[deprecated] no-op", hidden=True
+    ),
+    num_results_per_query: int = typer.Option(
+        None, "--num-results-per-query", help="[deprecated] no-op", hidden=True
+    ),
 ):
-    """Run deep research with iterative search and synthesis."""
+    """Run Parallel deep research (requires PARALLEL_API_KEY)."""
     client = _client()
 
     def _progress(stage: str) -> None:
-        console.print(f"[dim]{stage}...[/]")
+        console.print(f"[dim]{stage}[/]")
 
     client._set_progress_callback(_progress)
+    deprecated_passed = [
+        name
+        for name, value in (
+            ("--max-iterations", max_iterations),
+            ("--num-queries-per-iteration", num_queries_per_iteration),
+            ("--num-results-per-query", num_results_per_query),
+        )
+        if value is not None
+    ]
+    if deprecated_passed:
+        console.print(
+            f"[yellow]Ignored deprecated flags: {', '.join(deprecated_passed)} "
+            "(Parallel Task API is single-call; iteration knobs no longer apply).[/]"
+        )
     try:
         payload = asyncio.run(
             client.deep_research(
                 question=question,
-                max_iterations=max_iterations,
-                num_queries_per_iteration=num_queries_per_iteration,
-                num_results_per_query=num_results_per_query,
+                processor=processor,
                 timeout_seconds=timeout_seconds,
+                max_report_chars=max_report_chars,
             )
         )
     except Exception as exc:  # pragma: no cover - CLI surface

--- a/tools/research/websearch/client.py
+++ b/tools/research/websearch/client.py
@@ -1,65 +1,112 @@
-"""Websearch client powered by Exa and Claude."""
+"""Websearch client.
+
+Powered by Parallel Web Systems (https://docs.parallel.ai). Search runs
+through the free hosted Parallel Search MCP when no `PARALLEL_API_KEY` is
+configured, and through the Parallel Search REST API when one is. Deep
+research always goes through the Parallel Task API and requires a key.
+
+`search(synthesize=True)` runs the original tool's Claude pipeline
+(reviewer → writer → citation-repair) against the Parallel results
+when `ANTHROPIC_API_KEY` is set. The synthesis prompts and repair loop
+are byte-identical to centaur main, so output quality and failure
+modes mirror that pipeline. Without an Anthropic key, the call still
+returns raw Parallel results and records the skipped synthesis in
+`meta.partial_failures`.
+"""
 
 from __future__ import annotations
 
-import asyncio
 import json
 import re
-import time
+import warnings
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import urlparse
 
-import httpx
+from anthropic import AsyncAnthropic, AuthenticationError
 
-try:
-    from anthropic import AsyncAnthropic
-except ImportError:  # pragma: no cover - optional until tool deps are installed
-    AsyncAnthropic = None  # type: ignore[assignment]
+from centaur_sdk import get_tool_context, secret
 
-from centaur_sdk import secret
+from ._parallel import API_BASE_URL, MCP_URL, ParallelBackend
+from .models import SourceDocument
+from .prompts import EVIDENCE_REVIEWER_SYSTEM, REPORT_REPAIR_SYSTEM, REPORT_WRITER_SYSTEM
 
-from .models import (
-    DeepResearchIteration,
-    DeepResearchResponse,
-    ResponseMeta,
-    SearchResponse,
-    SourceDocument,
-)
-from .prompts import (
-    EVIDENCE_REVIEWER_SYSTEM,
-    QUERY_PLANNER_SYSTEM,
-    REPORT_REPAIR_SYSTEM,
-    REPORT_WRITER_SYSTEM,
-)
+REVIEW_SOURCE_CHAR_LIMIT = 3500
+REVIEW_TOTAL_CHAR_BUDGET = 120000
+WRITE_SOURCE_CHAR_LIMIT = 7000
+WRITE_TOTAL_CHAR_BUDGET = 220000
+
+
+def _is_configured(key: str) -> bool:
+    """Authoritative check for whether a secret was explicitly configured.
+
+    `secret(key)` is unsafe for routing decisions: under centaur's default
+    StubBackend it returns the literal key name as a placeholder for
+    un-configured secrets (the stub goes in outbound HTTP headers where
+    the firewall swaps it in-flight). Both signals are needed to cover
+    server and CLI use:
+
+    - Server / tool-runtime: ToolManager populates ``ctx.secrets[key]``
+      only for secrets it actually resolved, so dict membership is the
+      authoritative signal.
+    - CLI / direct-invoke: no ToolContext is bound; fall through to
+      ``secret(key)`` and treat the value-equals-key stub case as
+      "not configured" (the firewall has nothing to swap into).
+    """
+    try:
+        ctx = get_tool_context()
+        return bool(ctx.secrets.get(key))
+    except LookupError:
+        try:
+            val = secret(key)
+        except KeyError:
+            return False
+        return bool(val) and val != key
 
 
 class WebSearchClient:
-    """Web search and deep research via Exa and Claude."""
-
-    EXA_MAX_PARALLEL_CALLS = 6
-    REVIEW_SOURCE_CHAR_LIMIT = 3500
-    REVIEW_TOTAL_CHAR_BUDGET = 120000
-    WRITE_SOURCE_CHAR_LIMIT = 7000
-    WRITE_TOTAL_CHAR_BUDGET = 220000
-    SNIPPET_CHAR_LIMIT = 7000
+    """Web search and deep research via Parallel."""
 
     def __init__(
         self,
-        exa_api_key: str | None = None,
+        parallel_api_key: str | None = None,
+        parallel_api_base_url: str | None = None,
+        parallel_mcp_url: str | None = None,
+        parallel_deep_research_processor: str | None = None,
         anthropic_api_key: str | None = None,
-        deep_research_model: str | None = None,
-        exa_base_url: str = "https://api.exa.ai",
+        synthesis_model: str | None = None,
         max_retries: int = 3,
-    ):
-        self._exa_api_key = exa_api_key or self._optional_secret("EXA_API_KEY")
-        self._anthropic_api_key = anthropic_api_key or self._optional_secret("ANTHROPIC_API_KEY")
-        self._deep_research_model = deep_research_model or self._optional_secret(
-            "DEEP_RESEARCH_MODEL", "claude-opus-4-6"
+    ) -> None:
+        # PARALLEL_API_KEY / ANTHROPIC_API_KEY: read via secret() so the
+        # firewall (StubBackend → mitmproxy) can swap in real values for
+        # outbound headers. _is_configured() is the routing signal — it
+        # checks ctx.secrets membership rather than relying on secret()'s
+        # stub-as-placeholder fallback.
+        self._has_parallel_key = parallel_api_key is not None or _is_configured("PARALLEL_API_KEY")
+        self._has_anthropic_key = anthropic_api_key is not None or _is_configured(
+            "ANTHROPIC_API_KEY"
         )
-        self._exa_base_url = exa_base_url.rstrip("/")
+        self._parallel_api_key = parallel_api_key or (
+            secret("PARALLEL_API_KEY") if self._has_parallel_key else None
+        )
+        self._anthropic_api_key = anthropic_api_key or (
+            secret("ANTHROPIC_API_KEY") if self._has_anthropic_key else None
+        )
+        # Non-secret config: hardcoded defaults, overridable via constructor
+        # args. We deliberately do NOT route these through secret() — under
+        # StubBackend that would return the literal key name as a value.
+        self._api_base_url = parallel_api_base_url or API_BASE_URL
+        self._mcp_url = parallel_mcp_url or MCP_URL
+        self._deep_research_processor = parallel_deep_research_processor or "ultra-fast"
+        self._synthesis_model = synthesis_model or "claude-opus-4-6"
         self._max_retries = max_retries
         self._progress_callback: Callable[[str], None] | None = None
+        self._backend = ParallelBackend(
+            api_key=self._parallel_api_key if self._has_parallel_key else None,
+            api_base_url=self._api_base_url,
+            mcp_url=self._mcp_url,
+            deep_research_processor=self._deep_research_processor,
+            max_retries=self._max_retries,
+        )
 
     def _set_progress_callback(self, callback: Callable[[str], None] | None) -> None:
         self._progress_callback = callback
@@ -68,569 +115,224 @@ class WebSearchClient:
         if self._progress_callback is not None:
             self._progress_callback(stage)
 
-    def _optional_secret(self, key: str, default: str | None = None) -> str | None:
-        try:
-            return secret(key)
-        except KeyError:
-            return default
+    @property
+    def search_mode(self) -> str:
+        return self._backend.search_mode
 
-    def _require_exa_api_key(self) -> str:
-        if not self._exa_api_key:
-            raise RuntimeError("EXA_API_KEY not set.")
-        return self._exa_api_key
+    @property
+    def has_api_key(self) -> bool:
+        return self._backend.has_api_key
 
-    def _require_anthropic_api_key(self) -> str:
-        if not self._anthropic_api_key:
-            raise RuntimeError("ANTHROPIC_API_KEY not set.")
-        return self._anthropic_api_key
+    @property
+    def has_synthesis(self) -> bool:
+        return self._has_anthropic_key
 
-    def _require_deep_research_model(self) -> str:
-        if not self._deep_research_model:
-            raise RuntimeError("DEEP_RESEARCH_MODEL not set.")
-        return self._deep_research_model
+    def _build_synthesis_pipeline(self) -> ClaudeSynthesisPipeline | None:
+        if not self._has_anthropic_key or not self._synthesis_model:
+            return None
+        return ClaudeSynthesisPipeline(
+            api_key=self._anthropic_api_key or "",
+            model=self._synthesis_model,
+        )
 
-    def _is_retryable_status(self, status_code: int) -> bool:
-        return status_code == 429 or status_code >= 500
-
-    def _backoff_seconds(self, attempt: int) -> float:
-        # Small bounded backoff keeps CLI responsive while handling transient API failures.
-        return min(8.0, 2**attempt)
-
-    def _exa_headers(self) -> dict[str, str]:
-        return {
-            "x-api-key": self._require_exa_api_key(),
-            "Content-Type": "application/json",
-        }
-
-    def _build_search_payload(
+    async def search(
         self,
         query: str,
-        num_results: int,
-        search_type: str,
-        include_domains: list[str] | None,
-        exclude_domains: list[str] | None,
-        max_age_hours: int | None,
-        text_chars: int | None,
-        highlights_chars: int | None,
-        additional_queries: list[str] | None = None,
-    ) -> dict[str, Any]:
-        payload: dict[str, Any] = {
-            "query": query,
-            "numResults": num_results,
-            "type": search_type,
-        }
-        contents: dict[str, Any] = {}
-        if text_chars is not None:
-            contents["text"] = {"maxCharacters": text_chars}
-        if highlights_chars is not None:
-            contents["highlights"] = {"maxCharacters": highlights_chars}
-        if contents:
-            payload["contents"] = contents
-        if include_domains:
-            payload["includeDomains"] = include_domains
-        if exclude_domains:
-            payload["excludeDomains"] = exclude_domains
-        if max_age_hours is not None:
-            payload["maxAgeHours"] = max_age_hours
-        if additional_queries:
-            payload["additionalQueries"] = additional_queries
-        return payload
+        *,
+        num_results: int = 10,
+        timeout_seconds: float = 60.0,
+        synthesize: bool = True,
+        mode: str | None = None,
+        client_model: str | None = None,
+        max_chars_total: int | None = None,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        max_age_hours: int | None = None,
+        session_id: str | None = None,
+        thread_context: list[str] | None = None,
+        max_report_chars: int = 12000,
+        search_type: str | None = None,
+    ) -> dict:
+        """Search the web via Parallel.
 
-    def _extract_cost(self, payload: dict[str, Any]) -> float:
-        cost = payload.get("costDollars")
-        if isinstance(cost, (int, float)):
-            return float(cost)
-        if isinstance(cost, dict):
-            total = cost.get("total")
-            if isinstance(total, (int, float)):
-                return float(total)
-            subtotal = 0.0
-            found = False
-            for value in cost.values():
-                if isinstance(value, (int, float)):
-                    found = True
-                    subtotal += float(value)
-            if found:
-                return subtotal
-        return 0.0
-
-    def _extract_snippet(self, item: dict[str, Any], max_chars: int | None = None) -> str:
-        char_limit = max_chars or self.SNIPPET_CHAR_LIMIT
-        highlights = item.get("highlights")
-        if isinstance(highlights, list) and highlights:
-            joined = "\n".join(str(part) for part in highlights if part)
-            return joined[:char_limit]
-        text = item.get("text")
-        if isinstance(text, str) and text:
-            return text[:char_limit]
-        summary = item.get("summary")
-        if isinstance(summary, str):
-            return summary[:char_limit]
-        return ""
-
-    def _normalize_source(
-        self,
-        item: dict[str, Any],
-        source_id: int,
-        snippet_chars: int | None = None,
-    ) -> SourceDocument | None:
-        url = str(item.get("url", "")).strip()
-        if not url:
-            return None
-        parsed = urlparse(url)
-        title = str(item.get("title", "")).strip() or url
-        published_date = item.get("publishedDate")
-        if published_date is not None:
-            published_date = str(published_date)
-        return SourceDocument(
-            source_id=source_id,
-            title=title,
-            url=url,
-            snippet=self._extract_snippet(item, max_chars=snippet_chars),
-            published_date=published_date,
-            domain=parsed.netloc or None,
+        Args:
+          query: Required. The user's question or topic. Used as the search
+            objective (and as a single-query fallback per Parallel best
+            practices).
+          synthesize: When true, runs the Claude reviewer + writer pipeline
+            on top of Parallel results (matches the prior Exa+Claude
+            behavior). Requires `ANTHROPIC_API_KEY`; without one the call
+            still returns raw results and records the skipped synthesis in
+            `meta.partial_failures`.
+          mode: `basic` (lower latency, 2-3 queries) or `advanced` (default,
+            higher quality). REST path only.
+          client_model: Identifier of the LLM that will consume the
+            excerpts. Enables per-model optimization. Forwarded to MCP as
+            `model_name`.
+          max_chars_total: Hard cap on total excerpt characters. REST only.
+          include_domains / exclude_domains / max_age_hours: Source filters
+            for the REST path. Not honored by the free MCP — surfaced in
+            `meta.partial_failures` when used without a key. `max_age_hours`
+            is rounded down to a UTC calendar-date cutoff (Parallel's
+            source policy is date-granular, not hour-precise).
+          session_id: Stable identifier (UUID recommended) reused across
+            related Search/Extract calls. Required for free-tier rate
+            limiting when called over MCP.
+          thread_context: Optional prior-turn context strings passed to the
+            synthesis reviewer/writer for disambiguation. Synthesis only.
+          search_type: Accepted for backward compatibility with the original
+            Exa-backed tool; ignored under Parallel retrieval. Pass `None`.
+        """
+        if search_type is not None:
+            warnings.warn(
+                "search_type is ignored — the Parallel retrieval backend does "
+                "not expose Exa's neural/keyword/auto modes.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        synthesis_pipeline = self._build_synthesis_pipeline() if synthesize else None
+        return await self._backend.search(
+            objective=query,
+            search_queries=[query],
+            num_results=num_results,
+            timeout_seconds=timeout_seconds,
+            synthesize=synthesize,
+            mode=mode,
+            client_model=client_model,
+            max_chars_total=max_chars_total,
+            include_domains=include_domains,
+            exclude_domains=exclude_domains,
+            max_age_hours=max_age_hours,
+            session_id=session_id,
+            max_report_chars=max_report_chars,
+            synthesis_pipeline=synthesis_pipeline,
+            thread_context=thread_context,
         )
 
-    def _dedupe_queries(self, queries: list[str], limit: int) -> list[str]:
-        deduped: list[str] = []
-        seen: set[str] = set()
-        for query in queries:
-            normalized = query.strip()
-            key = normalized.casefold()
-            if not normalized or key in seen:
-                continue
-            seen.add(key)
-            deduped.append(normalized)
-            if len(deduped) >= limit:
-                break
-        return deduped
-
-    def _trim_sources_for_budget(
+    async def deep_research(
         self,
-        sources: list[SourceDocument],
+        question: str,
         *,
-        per_source_chars: int,
-        total_chars: int,
-    ) -> list[dict[str, Any]]:
-        selected: list[dict[str, Any]] = []
-        consumed = 0
-        ranked_sources = sorted(sources, key=self._source_quality_score, reverse=True)
-        for source in ranked_sources:
-            snippet = source.snippet[:per_source_chars]
-            if not snippet:
-                snippet = source.title
-            projected = consumed + len(snippet)
-            if selected and projected > total_chars:
-                break
-            selected.append(
-                {
-                    "source_id": source.source_id,
-                    "title": source.title,
-                    "url": source.url,
-                    "snippet": snippet,
-                    "published_date": source.published_date,
-                    "domain": source.domain,
-                }
-            )
-            consumed = projected
-        return selected
+        processor: str | None = None,
+        timeout_seconds: float | None = None,
+        max_report_chars: int = 50000,
+        max_iterations: int | None = None,
+        num_queries_per_iteration: int | None = None,
+        num_results_per_query: int | None = None,
+        thread_context: list[str] | None = None,
+    ) -> dict:
+        """Run deep research and return a cited markdown report.
 
-    def _normalize_thread_context(
-        self,
-        thread_context: list[str] | None,
-        *,
-        max_items: int = 20,
-        max_chars_per_item: int = 1200,
-    ) -> list[str]:
-        if not thread_context:
-            return []
-        normalized: list[str] = []
-        for item in thread_context:
-            text = str(item).strip()
-            if not text:
-                continue
-            normalized.append(text[:max_chars_per_item])
-            if len(normalized) >= max_items:
-                break
-        return normalized
+        Args:
+          processor: Task API processor (pro/ultra family). Defaults to
+            the value passed to `WebSearchClient(parallel_deep_research_processor=...)`,
+            or `"ultra-fast"` if neither is set.
+          timeout_seconds: Override the request timeout. When omitted, a
+            processor-appropriate default is used (e.g. `ultra4x` waits up
+            to ~2h).
+          max_iterations / num_queries_per_iteration / num_results_per_query /
+          thread_context: Accepted for backward compatibility with the
+            original Exa+Claude iterative pipeline; ignored under Parallel
+            Task API (a single multi-source run replaces the iterative
+            planner→search→reviewer→writer loop).
 
-    def _source_quality_score(self, source: SourceDocument) -> int:
-        score = 0
-        snippet_lower = source.snippet.lower()
-        domain = (source.domain or "").lower()
-
-        if source.published_date:
-            score += 1
-        if len(source.snippet) > 600:
-            score += 1
-        if domain.endswith(".gov") or domain.endswith(".edu"):
-            score += 3
-        if any(token in domain for token in ("nist", "pci", "fidelity", "iacr")):
-            score += 2
-
-        low_signal_tokens = [
-            "book now",
-            "free 30-min",
-            "cookie policy",
-            "skip to content",
-            "all protocols",
+        Requires `PARALLEL_API_KEY`.
+        """
+        deprecated = [
+            ("max_iterations", max_iterations),
+            ("num_queries_per_iteration", num_queries_per_iteration),
+            ("num_results_per_query", num_results_per_query),
+            ("thread_context", thread_context),
         ]
-        if any(token in snippet_lower for token in low_signal_tokens):
-            score -= 2
-        if "linkedin.com" in domain:
-            score -= 2
-        return score
-
-    def _extract_sources_section_ids(self, text: str) -> set[int]:
-        match = re.search(r"##\s*Sources\s*(.*)$", text, flags=re.IGNORECASE | re.DOTALL)
-        if not match:
-            return set()
-        ids: set[int] = set()
-        for source_id in re.findall(r"^\s*\[\s*(\d+)\s*\]\s+", match.group(1), flags=re.MULTILINE):
-            ids.add(int(source_id))
-        return ids
-
-    def _normalize_claims(
-        self,
-        claims: list[Any],
-        valid_source_ids: set[int],
-    ) -> list[dict[str, Any]]:
-        normalized_claims: list[dict[str, Any]] = []
-        seen_claims: set[str] = set()
-        for claim in claims:
-            if not isinstance(claim, dict):
-                continue
-            claim_text = str(claim.get("claim", "")).strip()
-            if not claim_text:
-                continue
-            claim_key = claim_text.casefold()
-            if claim_key in seen_claims:
-                continue
-
-            source_ids_raw = claim.get("source_ids", [])
-            source_ids: list[int] = []
-            if isinstance(source_ids_raw, list):
-                for raw_id in source_ids_raw:
-                    if isinstance(raw_id, int) and raw_id in valid_source_ids:
-                        source_ids.append(raw_id)
-            source_ids = sorted(set(source_ids))
-            support_level = str(claim.get("support_level", "none")).strip().lower()
-            if support_level not in {"strong", "partial", "weak", "none"}:
-                support_level = "none"
-
-            normalized_claims.append(
-                {
-                    "claim": claim_text,
-                    "source_ids": source_ids,
-                    "support_level": support_level,
-                }
+        used = [name for name, value in deprecated if value is not None]
+        if used:
+            warnings.warn(
+                f"deep_research kwargs ignored under Parallel Task API: {used}. "
+                "The new backend is single-call; iteration knobs no longer apply.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-            seen_claims.add(claim_key)
-        return normalized_claims
-
-    def _normalize_contradictions(
-        self,
-        contradictions: list[Any],
-        valid_source_ids: set[int],
-    ) -> list[dict[str, Any]]:
-        normalized_items: list[dict[str, Any]] = []
-        seen_summaries: set[str] = set()
-        for contradiction in contradictions:
-            if not isinstance(contradiction, dict):
-                continue
-            summary = str(contradiction.get("summary", "")).strip()
-            if not summary:
-                continue
-            summary_key = summary.casefold()
-            if summary_key in seen_summaries:
-                continue
-
-            source_ids_raw = contradiction.get("source_ids", [])
-            source_ids: list[int] = []
-            if isinstance(source_ids_raw, list):
-                for raw_id in source_ids_raw:
-                    if isinstance(raw_id, int) and raw_id in valid_source_ids:
-                        source_ids.append(raw_id)
-            normalized_items.append(
-                {"summary": summary, "source_ids": sorted(set(source_ids))}
-            )
-            seen_summaries.add(summary_key)
-        return normalized_items
-
-    def _extract_text_content(self, response: Any) -> str:
-        blocks = getattr(response, "content", None)
-        if not isinstance(blocks, list):
-            return ""
-        parts: list[str] = []
-        for block in blocks:
-            text = getattr(block, "text", None)
-            if isinstance(text, str):
-                parts.append(text)
-        return "".join(parts).strip()
-
-    def _coerce_json(self, raw_text: str) -> Any:
-        stripped = raw_text.strip()
-        if stripped.startswith("```"):
-            stripped = re.sub(r"^```(?:json)?\s*", "", stripped, flags=re.IGNORECASE)
-            stripped = re.sub(r"\s*```$", "", stripped)
-        try:
-            return json.loads(stripped)
-        except json.JSONDecodeError:
-            pass
-
-        object_match = re.search(r"\{.*\}", stripped, flags=re.DOTALL)
-        if object_match:
-            return json.loads(object_match.group(0))
-        array_match = re.search(r"\[.*\]", stripped, flags=re.DOTALL)
-        if array_match:
-            return json.loads(array_match.group(0))
-        raise ValueError("Model response did not contain valid JSON.")
-
-    def _extract_citation_ids(self, text: str) -> set[int]:
-        ids: set[int] = set()
-        for match in re.findall(r"\[\s*(\d+)\s*\]", text):
-            ids.add(int(match))
-        return ids
-
-    def _invalid_citation_ids(self, text: str, sources: list[SourceDocument]) -> set[int]:
-        valid = {source.source_id for source in sources}
-        citations = self._extract_citation_ids(text)
-        return {citation for citation in citations if citation not in valid}
-
-    def _exa_search_sync(self, payload: dict[str, Any], timeout_seconds: float) -> dict[str, Any]:
-        with httpx.Client(base_url=self._exa_base_url, timeout=timeout_seconds) as client:
-            for attempt in range(self._max_retries):
-                response: httpx.Response | None = None
-                try:
-                    response = client.post("/search", headers=self._exa_headers(), json=payload)
-                    if (
-                        self._is_retryable_status(response.status_code)
-                        and attempt < self._max_retries - 1
-                    ):
-                        time.sleep(self._backoff_seconds(attempt))
-                        continue
-                    response.raise_for_status()
-                    return response.json()
-                except httpx.HTTPStatusError as exc:
-                    if (
-                        response is not None
-                        and self._is_retryable_status(response.status_code)
-                        and attempt < self._max_retries - 1
-                    ):
-                        time.sleep(self._backoff_seconds(attempt))
-                        continue
-                    body = exc.response.text if exc.response is not None else ""
-                    raise RuntimeError(
-                        f"Exa search failed ({exc.response.status_code}): {body}"
-                    ) from exc
-                except httpx.RequestError as exc:
-                    if attempt < self._max_retries - 1:
-                        time.sleep(self._backoff_seconds(attempt))
-                        continue
-                    raise RuntimeError(f"Exa request failed: {exc}") from exc
-        raise RuntimeError("Exa search failed after retries.")
-
-    async def _exa_search_async(
-        self, payload: dict[str, Any], timeout_seconds: float
-    ) -> dict[str, Any]:
-        async with httpx.AsyncClient(
-            base_url=self._exa_base_url, timeout=timeout_seconds
-        ) as client:
-            for attempt in range(self._max_retries):
-                response: httpx.Response | None = None
-                try:
-                    response = await client.post(
-                        "/search", headers=self._exa_headers(), json=payload
-                    )
-                    if (
-                        self._is_retryable_status(response.status_code)
-                        and attempt < self._max_retries - 1
-                    ):
-                        await asyncio.sleep(self._backoff_seconds(attempt))
-                        continue
-                    response.raise_for_status()
-                    return response.json()
-                except httpx.HTTPStatusError as exc:
-                    if (
-                        response is not None
-                        and self._is_retryable_status(response.status_code)
-                        and attempt < self._max_retries - 1
-                    ):
-                        await asyncio.sleep(self._backoff_seconds(attempt))
-                        continue
-                    body = exc.response.text if exc.response is not None else ""
-                    raise RuntimeError(
-                        f"Exa search failed ({exc.response.status_code}): {body}"
-                    ) from exc
-                except httpx.RequestError as exc:
-                    if attempt < self._max_retries - 1:
-                        await asyncio.sleep(self._backoff_seconds(attempt))
-                        continue
-                    raise RuntimeError(f"Exa request failed: {exc}") from exc
-        raise RuntimeError("Exa search failed after retries.")
-
-    async def _run_iteration_search(
-        self,
-        *,
-        queries: list[str],
-        num_results_per_query: int,
-        timeout_seconds: float,
-    ) -> dict[str, Any]:
-        deduped_queries = self._dedupe_queries(queries, limit=16)
-        if not deduped_queries:
-            return {
-                "results": [],
-                "requestIds": [],
-                "partialFailures": [],
-                "costDollars": {"total": 0.0},
-            }
-
-        max_parallel = max(1, min(self.EXA_MAX_PARALLEL_CALLS, len(deduped_queries)))
-        semaphore = asyncio.Semaphore(max_parallel)
-
-        async def run_query(query: str) -> dict[str, Any]:
-            async with semaphore:
-                payload = self._build_search_payload(
-                    query=query,
-                    num_results=min(20, max(num_results_per_query, 1)),
-                    search_type="deep",
-                    include_domains=None,
-                    exclude_domains=None,
-                    max_age_hours=None,
-                    text_chars=12000,
-                    highlights_chars=4000,
-                    additional_queries=None,
-                )
-                return await self._exa_search_async(payload=payload, timeout_seconds=timeout_seconds)
-
-        batch_results = await asyncio.gather(
-            *(run_query(query) for query in deduped_queries), return_exceptions=True
+        return await self._backend.deep_research(
+            question=question,
+            progress=self._emit_progress,
+            processor=processor,
+            timeout_seconds=timeout_seconds,
+            max_report_chars=max_report_chars,
         )
 
-        merged_results: list[dict[str, Any]] = []
-        request_ids: list[str] = []
-        partial_failures: list[dict[str, str]] = []
-        total_cost = 0.0
-        for query, result in zip(deduped_queries, batch_results, strict=True):
-            if isinstance(result, Exception):
-                partial_failures.append({"query": query, "error": str(result)})
-                continue
-            request_id = result.get("requestId")
-            if request_id:
-                request_ids.append(str(request_id))
-            total_cost += self._extract_cost(result)
-            for item in result.get("results", []):
-                if isinstance(item, dict):
-                    merged_results.append(item)
 
-        return {
-            "results": merged_results,
-            "requestIds": request_ids,
-            "partialFailures": partial_failures,
-            "costDollars": {"total": total_cost},
-        }
+class ClaudeSynthesisPipeline:
+    """Reviewer + writer + LLM-driven citation repair.
 
-    async def _call_claude_text(
-        self,
-        *,
-        system_prompt: str,
-        user_prompt: str,
-        max_tokens: int = 4096,
-    ) -> str:
-        if AsyncAnthropic is None:
-            raise RuntimeError("anthropic dependency is not installed.")
-        client = AsyncAnthropic(api_key=self._require_anthropic_api_key())
-        try:
-            message = await client.messages.create(
-                model=self._require_deep_research_model(),
-                max_tokens=max_tokens,
-                system=system_prompt,
-                messages=[{"role": "user", "content": user_prompt}],
-            )
-        except Exception as exc:
-            message = str(exc).lower()
-            if "authentication_error" in message or "invalid x-api-key" in message:
-                raise RuntimeError(
-                    "Anthropic authentication failed. Check ANTHROPIC_API_KEY in .env or env injection."
-                ) from exc
-            raise
-        text = self._extract_text_content(message)
-        if not text:
-            raise RuntimeError("Claude returned empty content.")
-        return text
+    Byte-identical to the synthesis pipeline in centaur main: the
+    reviewer extracts claims and contradictions, the writer drafts a
+    cited report, and `_validate_and_repair_citations` invokes the
+    repair prompt up to two times to fix any citation IDs that aren't
+    grounded in the source list before raising. `synthesize()` returns
+    a dict so that callers can mirror the original tool's "partial
+    failure flagged but writer output retained" behavior when the
+    repair loop ultimately throws.
+    """
 
-    async def _call_claude_json(
-        self,
-        *,
-        system_prompt: str,
-        user_prompt: str,
-        max_tokens: int = 2048,
-    ) -> Any:
-        raw = await self._call_claude_text(
-            system_prompt=system_prompt,
-            user_prompt=user_prompt,
-            max_tokens=max_tokens,
-        )
-        return self._coerce_json(raw)
+    def __init__(self, *, api_key: str, model: str) -> None:
+        self._client = AsyncAnthropic(api_key=api_key)
+        self._model = model
 
-    async def _plan_queries(
+    async def synthesize(
         self,
         *,
         question: str,
-        prior_queries: list[str],
-        prior_gaps: list[str],
-        thread_context: list[str],
-        query_limit: int,
+        sources: list[SourceDocument],
+        thread_context: list[str] | None = None,
+        max_report_chars: int = 12000,
     ) -> dict[str, Any]:
-        user_prompt = json.dumps(
-            {
-                "question": question,
-                "prior_queries": prior_queries,
-                "prior_gaps": prior_gaps,
-                "thread_context": thread_context,
-            },
-            indent=2,
-        )
-        payload = await self._call_claude_json(
-            system_prompt=QUERY_PLANNER_SYSTEM,
-            user_prompt=user_prompt,
-            max_tokens=1600,
-        )
-        if not isinstance(payload, dict):
-            raise RuntimeError("Planner output must be a JSON object.")
+        """Run reviewer → writer → validate-and-repair-citations.
 
-        raw_queries = payload.get("queries", [])
-        raw_queries = [str(query) for query in raw_queries] if isinstance(raw_queries, list) else []
-        queries = self._dedupe_queries(raw_queries, limit=query_limit)
-        decision = str(payload.get("decision", "continue")).strip().lower()
-        if decision not in {"continue", "stop"}:
-            decision = "continue"
-        return {
-            "decision": decision,
-            "reason": str(payload.get("reason", "")).strip(),
-            "queries": queries,
-            "gaps": [str(gap).strip() for gap in payload.get("gaps", []) if str(gap).strip()],
-        }
+        Returns a dict with 'report' (the markdown — writer output retained
+        even when citation validation throws, matching the original tool's
+        behavior) and 'validation_error' (str | None when repair could not
+        produce a valid Sources section).
+        """
+        normalized_context = _normalize_thread_context(thread_context)
+        reviewer = await self._review_evidence(
+            question=question,
+            sources=sources,
+            thread_context=normalized_context,
+        )
+        report = await self._write_report(
+            question=question,
+            sources=sources,
+            claims=reviewer["claims"],
+            contradictions=reviewer["contradictions"],
+            thread_context=normalized_context,
+            max_report_chars=max_report_chars,
+        )
+        validation_error: str | None = None
+        try:
+            report = await self._validate_and_repair_citations(
+                report=report, sources=sources, max_report_chars=max_report_chars
+            )
+        except Exception as exc:
+            validation_error = str(exc)
+        return {"report": report, "validation_error": validation_error}
 
     async def _review_evidence(
         self,
         *,
         question: str,
         sources: list[SourceDocument],
-        iteration: int,
-        max_iterations: int,
         thread_context: list[str],
     ) -> dict[str, Any]:
-        compact_sources = self._trim_sources_for_budget(
+        compact_sources = _trim_sources_for_budget(
             sources,
-            per_source_chars=self.REVIEW_SOURCE_CHAR_LIMIT,
-            total_chars=self.REVIEW_TOTAL_CHAR_BUDGET,
+            per_source_chars=REVIEW_SOURCE_CHAR_LIMIT,
+            total_chars=REVIEW_TOTAL_CHAR_BUDGET,
         )
         user_prompt = json.dumps(
             {
                 "question": question,
-                "iteration": iteration,
-                "max_iterations": max_iterations,
+                "iteration": 1,
+                "max_iterations": 1,
                 "thread_context": thread_context,
                 "sources": compact_sources,
             },
@@ -643,32 +345,18 @@ class WebSearchClient:
         )
         if not isinstance(payload, dict):
             raise RuntimeError("Evidence reviewer output must be a JSON object.")
-
-        followup_raw = payload.get("followup_queries", [])
-        if isinstance(followup_raw, list):
-            followup_raw = [str(query) for query in followup_raw]
-        else:
-            followup_raw = []
-        followup = self._dedupe_queries(followup_raw, limit=8)
-
         valid_source_ids = {source.source_id for source in sources}
-        claims = self._normalize_claims(
-            claims=payload.get("claims", []) if isinstance(payload.get("claims"), list) else [],
-            valid_source_ids=valid_source_ids,
+        claims = _normalize_claims(
+            payload.get("claims", []) if isinstance(payload.get("claims"), list) else [],
+            valid_source_ids,
         )
-        contradictions = self._normalize_contradictions(
-            contradictions=payload.get("contradictions", [])
+        contradictions = _normalize_contradictions(
+            payload.get("contradictions", [])
             if isinstance(payload.get("contradictions"), list)
             else [],
-            valid_source_ids=valid_source_ids,
+            valid_source_ids,
         )
-        continue_research = bool(payload.get("continue_research", False))
-        return {
-            "claims": claims,
-            "contradictions": contradictions,
-            "continue_research": continue_research,
-            "followup_queries": followup,
-        }
+        return {"claims": claims, "contradictions": contradictions}
 
     async def _write_report(
         self,
@@ -680,10 +368,10 @@ class WebSearchClient:
         thread_context: list[str],
         max_report_chars: int,
     ) -> str:
-        selected_sources = self._trim_sources_for_budget(
+        selected_sources = _trim_sources_for_budget(
             sources,
-            per_source_chars=self.WRITE_SOURCE_CHAR_LIMIT,
-            total_chars=self.WRITE_TOTAL_CHAR_BUDGET,
+            per_source_chars=WRITE_SOURCE_CHAR_LIMIT,
+            total_chars=WRITE_TOTAL_CHAR_BUDGET,
         )
         source_map = {source["source_id"]: source for source in selected_sources}
         user_prompt = json.dumps(
@@ -716,7 +404,7 @@ class WebSearchClient:
             source.source_id: {
                 "title": source.title,
                 "url": source.url,
-                "snippet": source.snippet[: self.REVIEW_SOURCE_CHAR_LIMIT],
+                "snippet": source.snippet[:REVIEW_SOURCE_CHAR_LIMIT],
             }
             for source in sources
         }
@@ -744,10 +432,10 @@ class WebSearchClient:
         max_report_chars: int,
     ) -> str:
         max_repair_attempts = 2
-        invalid_ids = sorted(self._invalid_citation_ids(report, sources))
-        cited_ids = self._extract_citation_ids(report)
-        source_section_ids = self._extract_sources_section_ids(report)
-        missing_sources_ids = sorted(cited_ids - source_section_ids)
+        invalid_ids = sorted(_invalid_citation_ids(report, sources))
+        cited_ids = _extract_citation_ids(report)
+        sources_section_ids = _extract_sources_section_ids(report)
+        missing_sources_ids = sorted(cited_ids - sources_section_ids)
         attempt = 0
         while (invalid_ids or missing_sources_ids) and attempt < max_repair_attempts:
             attempt += 1
@@ -758,297 +446,235 @@ class WebSearchClient:
                 sources=sources,
                 max_report_chars=max_report_chars,
             )
-            invalid_ids = sorted(self._invalid_citation_ids(report, sources))
-            cited_ids = self._extract_citation_ids(report)
-            source_section_ids = self._extract_sources_section_ids(report)
-            missing_sources_ids = sorted(cited_ids - source_section_ids)
+            invalid_ids = sorted(_invalid_citation_ids(report, sources))
+            cited_ids = _extract_citation_ids(report)
+            sources_section_ids = _extract_sources_section_ids(report)
+            missing_sources_ids = sorted(cited_ids - sources_section_ids)
         if invalid_ids:
-            raise RuntimeError(f"Citation validation failed. Invalid source IDs in report: {invalid_ids}")
+            raise RuntimeError(
+                f"Citation validation failed. Invalid source IDs in report: {invalid_ids}"
+            )
         if missing_sources_ids:
             raise RuntimeError(
                 "Citation validation failed. Sources section missing cited IDs: "
                 f"{missing_sources_ids}"
             )
-        if not self._extract_citation_ids(report):
-            raise RuntimeError("Citation validation failed. Report did not include source citations.")
+        if not _extract_citation_ids(report):
+            raise RuntimeError(
+                "Citation validation failed. Report did not include source citations."
+            )
         return report
 
-    async def search(
+    async def _call_claude_text(
         self,
-        query: str,
         *,
-        num_results: int = 10,
-        search_type: str = "auto",
-        include_domains: list[str] | None = None,
-        exclude_domains: list[str] | None = None,
-        max_age_hours: int | None = None,
-        timeout_seconds: float = 30.0,
-        synthesize: bool = True,
-        thread_context: list[str] | None = None,
-        max_report_chars: int = 12000,
-    ) -> dict:
-        """Search the web via Exa and optionally synthesize a cited answer."""
-        self._require_exa_api_key()
-        started = time.perf_counter()
-        normalized_query = query.strip()
-        normalized_thread_context = self._normalize_thread_context(thread_context)
-        if not normalized_query:
-            raise RuntimeError("query cannot be empty.")
-        payload = self._build_search_payload(
-            query=normalized_query,
-            num_results=num_results,
-            search_type=search_type,
-            include_domains=include_domains,
-            exclude_domains=exclude_domains,
-            max_age_hours=max_age_hours,
-            text_chars=None,
-            highlights_chars=2000,
-        )
-        response = await self._exa_search_async(payload, timeout_seconds=timeout_seconds)
-        results: list[SourceDocument] = []
-        seen_urls: set[str] = set()
-        for item in response.get("results", []):
-            if not isinstance(item, dict):
-                continue
-            source = self._normalize_source(item, len(results))
-            if source is None or source.url in seen_urls:
-                continue
-            seen_urls.add(source.url)
-            results.append(source)
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int,
+    ) -> str:
+        try:
+            message = await self._client.messages.create(
+                model=self._model,
+                max_tokens=max_tokens,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_prompt}],
+            )
+        except AuthenticationError as exc:
+            raise RuntimeError(
+                "Anthropic authentication failed. Check ANTHROPIC_API_KEY."
+            ) from exc
+        body = _extract_text_content(message)
+        if not body:
+            raise RuntimeError("Claude returned empty content.")
+        return body
 
-        partial_failures: list[dict[str, str]] = []
-        answer_markdown: str | None = None
-        if synthesize and results:
-            try:
-                self._require_anthropic_api_key()
-                self._require_deep_research_model()
-                reviewer = await self._review_evidence(
-                    question=normalized_query,
-                    sources=results,
-                    iteration=1,
-                    max_iterations=1,
-                    thread_context=normalized_thread_context,
-                )
-                answer_markdown = await self._write_report(
-                    question=normalized_query,
-                    sources=results,
-                    claims=reviewer["claims"],
-                    contradictions=reviewer["contradictions"],
-                    thread_context=normalized_thread_context,
-                    max_report_chars=max_report_chars,
-                )
-                answer_markdown = await self._validate_and_repair_citations(
-                    report=answer_markdown,
-                    sources=results,
-                    max_report_chars=max_report_chars,
-                )
-            except Exception as exc:
-                partial_failures.append({"query": normalized_query, "error": f"synthesis failed: {exc}"})
-
-        meta = ResponseMeta(
-            duration_ms=int((time.perf_counter() - started) * 1000),
-            exa_request_ids=[str(response.get("requestId", ""))]
-            if response.get("requestId")
-            else [],
-            partial_failures=partial_failures,
-            estimated_cost_usd=self._extract_cost(response) or None,
-        )
-        return SearchResponse(
-            query=normalized_query,
-            results=results,
-            answer_markdown=answer_markdown,
-            meta=meta,
-        ).model_dump()
-
-    async def deep_research(
+    async def _call_claude_json(
         self,
-        question: str,
         *,
-        max_iterations: int = 1,
-        num_queries_per_iteration: int = 4,
-        num_results_per_query: int = 5,
-        thread_context: list[str] | None = None,
-        max_report_chars: int = 50000,
-        timeout_seconds: float = 300.0,
-    ) -> dict:
-        """Run iterative deep research with citation validation."""
-        self._require_exa_api_key()
-        self._require_anthropic_api_key()
-        self._require_deep_research_model()
-        if max_iterations < 1:
-            raise RuntimeError("max_iterations must be >= 1.")
-        if num_queries_per_iteration < 1:
-            raise RuntimeError("num_queries_per_iteration must be >= 1.")
-        if num_results_per_query < 1:
-            raise RuntimeError("num_results_per_query must be >= 1.")
-        started = time.perf_counter()
-
-        normalized_question = question.strip()
-        normalized_thread_context = self._normalize_thread_context(thread_context)
-        if not normalized_question:
-            raise RuntimeError("question cannot be empty.")
-
-        all_sources: list[SourceDocument] = []
-        seen_urls: set[str] = set()
-        iteration_summaries: list[DeepResearchIteration] = []
-        request_ids: list[str] = []
-        partial_failures: list[dict[str, str]] = []
-        estimated_cost_usd = 0.0
-
-        self._emit_progress("planning")
-        planner = await self._plan_queries(
-            question=normalized_question,
-            prior_queries=[],
-            prior_gaps=[],
-            thread_context=normalized_thread_context,
-            query_limit=num_queries_per_iteration,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int,
+    ) -> Any:
+        raw = await self._call_claude_text(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            max_tokens=max_tokens,
         )
-        current_queries = planner["queries"]
-        if planner["decision"] == "stop":
-            current_queries = []
-        if not current_queries:
-            current_queries = [normalized_question]
+        return _coerce_json(raw)
 
-        reviewer_claims: list[dict[str, Any]] = []
-        reviewer_contradictions: list[dict[str, Any]] = []
 
-        for iteration_index in range(1, max_iterations + 1):
-            self._emit_progress(f"searching iteration {iteration_index}")
-            deduped_current_queries = self._dedupe_queries(
-                current_queries, limit=num_queries_per_iteration
-            )
-            try:
-                batch_result = await self._run_iteration_search(
-                    queries=deduped_current_queries,
-                    num_results_per_query=num_results_per_query,
-                    timeout_seconds=timeout_seconds / max_iterations,
-                )
-                batch_results: list[Any] = [batch_result]
-            except Exception as exc:  # pragma: no cover - network path
-                batch_results = [exc]
+def _normalize_thread_context(
+    thread_context: list[str] | None,
+    *,
+    max_items: int = 20,
+    max_chars_per_item: int = 1200,
+) -> list[str]:
+    if not thread_context:
+        return []
+    normalized: list[str] = []
+    for item in thread_context:
+        text = str(item).strip()
+        if not text:
+            continue
+        normalized.append(text[:max_chars_per_item])
+        if len(normalized) >= max_items:
+            break
+    return normalized
 
-            added_in_iteration = 0
-            for query, result in zip(["; ".join(deduped_current_queries)], batch_results, strict=True):
-                if isinstance(result, Exception):
-                    partial_failures.append({"query": query, "error": str(result)})
-                    continue
-                request_id_list = result.get("requestIds")
-                if isinstance(request_id_list, list):
-                    request_ids.extend(str(request_id) for request_id in request_id_list if request_id)
-                elif result.get("requestId"):
-                    request_ids.append(str(result.get("requestId")))
-                result_partial_failures = result.get("partialFailures", [])
-                if isinstance(result_partial_failures, list):
-                    for failure in result_partial_failures:
-                        if (
-                            isinstance(failure, dict)
-                            and isinstance(failure.get("query"), str)
-                            and isinstance(failure.get("error"), str)
-                        ):
-                            partial_failures.append(
-                                {"query": failure["query"], "error": failure["error"]}
-                            )
-                estimated_cost_usd += self._extract_cost(result)
 
-                for item in result.get("results", []):
-                    if not isinstance(item, dict):
-                        continue
-                    source = self._normalize_source(
-                        item,
-                        len(all_sources),
-                        snippet_chars=self.SNIPPET_CHAR_LIMIT,
-                    )
-                    if source is None or source.url in seen_urls:
-                        continue
-                    seen_urls.add(source.url)
-                    all_sources.append(source)
-                    added_in_iteration += 1
-
-            if not all_sources:
-                partial_failures.append(
-                    {
-                        "query": "; ".join(deduped_current_queries),
-                        "error": "No evidence retrieved from Exa in this iteration.",
-                    }
-                )
-                continue
-
-            self._emit_progress(f"reviewing iteration {iteration_index}")
-            reviewer = await self._review_evidence(
-                question=normalized_question,
-                sources=all_sources,
-                iteration=iteration_index,
-                max_iterations=max_iterations,
-                thread_context=normalized_thread_context,
-            )
-            reviewer_claims = self._normalize_claims(
-                claims=reviewer_claims + reviewer["claims"],
-                valid_source_ids={source.source_id for source in all_sources},
-            )
-            reviewer_contradictions = self._normalize_contradictions(
-                contradictions=reviewer_contradictions + reviewer["contradictions"],
-                valid_source_ids={source.source_id for source in all_sources},
-            )
-
-            continue_reason = planner.get("reason", "") if iteration_index == 1 else ""
-            if reviewer["continue_research"]:
-                continue_reason = "reviewer requested follow-up queries"
-            iteration_summaries.append(
-                DeepResearchIteration(
-                    iteration=iteration_index,
-                    queries=deduped_current_queries,
-                    results_count=added_in_iteration,
-                    continue_reason=continue_reason,
-                )
-            )
-
-            should_continue = (
-                reviewer["continue_research"]
-                and iteration_index < max_iterations
-                and len(reviewer["followup_queries"]) > 0
-            )
-            if not should_continue:
-                break
-            current_queries = self._dedupe_queries(
-                reviewer["followup_queries"], limit=num_queries_per_iteration
-            )
-
-        if not all_sources:
-            detail = "; ".join(item["error"] for item in partial_failures) or "No sources found."
-            raise RuntimeError(f"Unable to produce grounded synthesis. {detail}")
-
-        self._emit_progress("writing report")
-        report = await self._write_report(
-            question=normalized_question,
-            sources=all_sources,
-            claims=reviewer_claims,
-            contradictions=reviewer_contradictions,
-            thread_context=normalized_thread_context,
-            max_report_chars=max_report_chars,
+def _trim_sources_for_budget(
+    sources: list[SourceDocument],
+    *,
+    per_source_chars: int,
+    total_chars: int,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    consumed = 0
+    ranked = sorted(sources, key=_source_quality_score, reverse=True)
+    for source in ranked:
+        snippet = source.snippet[:per_source_chars] or source.title
+        projected = consumed + len(snippet)
+        if selected and projected > total_chars:
+            break
+        selected.append(
+            {
+                "source_id": source.source_id,
+                "title": source.title,
+                "url": source.url,
+                "snippet": snippet,
+                "published_date": source.published_date,
+                "domain": source.domain,
+            }
         )
-        self._emit_progress("validating citations")
-        report = await self._validate_and_repair_citations(
-            report=report,
-            sources=all_sources,
-            max_report_chars=max_report_chars,
-        )
+        consumed = projected
+    return selected
 
-        meta = ResponseMeta(
-            duration_ms=int((time.perf_counter() - started) * 1000),
-            exa_request_ids=request_ids,
-            partial_failures=partial_failures,
-            estimated_cost_usd=estimated_cost_usd if estimated_cost_usd > 0 else None,
+
+def _source_quality_score(source: SourceDocument) -> int:
+    score = 0
+    snippet_lower = source.snippet.lower()
+    domain = (source.domain or "").lower()
+    if source.published_date:
+        score += 1
+    if len(source.snippet) > 600:
+        score += 1
+    if domain.endswith(".gov") or domain.endswith(".edu"):
+        score += 3
+    low_signal_tokens = [
+        "book now",
+        "free 30-min",
+        "cookie policy",
+        "skip to content",
+    ]
+    if any(token in snippet_lower for token in low_signal_tokens):
+        score -= 2
+    if "linkedin.com" in domain:
+        score -= 2
+    return score
+
+
+def _normalize_claims(claims: list[Any], valid_ids: set[int]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for claim in claims:
+        if not isinstance(claim, dict):
+            continue
+        text = str(claim.get("claim", "")).strip()
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        raw_ids = claim.get("source_ids", [])
+        ids: list[int] = []
+        if isinstance(raw_ids, list):
+            for raw_id in raw_ids:
+                if isinstance(raw_id, int) and raw_id in valid_ids:
+                    ids.append(raw_id)
+        support = str(claim.get("support_level", "none")).strip().lower()
+        if support not in {"strong", "partial", "weak", "none"}:
+            support = "none"
+        out.append({"claim": text, "source_ids": sorted(set(ids)), "support_level": support})
+        seen.add(key)
+    return out
+
+
+def _normalize_contradictions(
+    contradictions: list[Any], valid_ids: set[int]
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in contradictions:
+        if not isinstance(entry, dict):
+            continue
+        summary = str(entry.get("summary", "")).strip()
+        if not summary:
+            continue
+        key = summary.casefold()
+        if key in seen:
+            continue
+        raw_ids = entry.get("source_ids", [])
+        ids: list[int] = []
+        if isinstance(raw_ids, list):
+            for raw_id in raw_ids:
+                if isinstance(raw_id, int) and raw_id in valid_ids:
+                    ids.append(raw_id)
+        out.append({"summary": summary, "source_ids": sorted(set(ids))})
+        seen.add(key)
+    return out
+
+
+def _extract_citation_ids(text: str) -> set[int]:
+    return {int(m) for m in re.findall(r"\[\s*(\d+)\s*\]", text)}
+
+
+def _extract_sources_section_ids(text: str) -> set[int]:
+    match = re.search(r"##\s*Sources\s*(.*)$", text, flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        return set()
+    return {
+        int(source_id)
+        for source_id in re.findall(
+            r"^\s*(?:[-*]\s+)?\[\s*(\d+)\s*\]\s+", match.group(1), flags=re.MULTILINE
         )
-        payload = DeepResearchResponse(
-            question=normalized_question,
-            answer_markdown=report,
-            sources=all_sources,
-            iterations=iteration_summaries,
-            meta=meta,
-        )
-        return payload.model_dump()
+    }
+
+
+def _invalid_citation_ids(text: str, sources: list[SourceDocument]) -> set[int]:
+    valid = {source.source_id for source in sources}
+    return {cid for cid in _extract_citation_ids(text) if cid not in valid}
+
+
+def _extract_text_content(message: Any) -> str:
+    blocks = getattr(message, "content", None)
+    if not isinstance(blocks, list):
+        return ""
+    parts: list[str] = []
+    for block in blocks:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return "".join(parts).strip()
+
+
+def _coerce_json(raw_text: str) -> Any:
+    stripped = raw_text.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^```(?:json)?\s*", "", stripped, flags=re.IGNORECASE)
+        stripped = re.sub(r"\s*```$", "", stripped)
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+    object_match = re.search(r"\{.*\}", stripped, flags=re.DOTALL)
+    if object_match:
+        return json.loads(object_match.group(0))
+    array_match = re.search(r"\[.*\]", stripped, flags=re.DOTALL)
+    if array_match:
+        return json.loads(array_match.group(0))
+    raise ValueError("Model response did not contain valid JSON.")
 
 
 def _client() -> WebSearchClient:
-    """Factory for tool loader."""
+    """Factory for the centaur tool loader."""
     return WebSearchClient()

--- a/tools/research/websearch/models.py
+++ b/tools/research/websearch/models.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
 
 
 class SourceDocument(BaseModel):
@@ -16,9 +18,25 @@ class SourceDocument(BaseModel):
 
 class ResponseMeta(BaseModel):
     duration_ms: int
-    exa_request_ids: list[str] = Field(default_factory=list)
+    request_ids: list[str] = Field(default_factory=list)
     partial_failures: list[dict[str, str]] = Field(default_factory=list)
+    backend: str | None = None
     estimated_cost_usd: float | None = None
+    usage: list[dict[str, Any]] = Field(default_factory=list)
+    # Attribution for the upstream provider when applicable (e.g. the free
+    # hosted Parallel Search MCP). Surface in UIs that display result metadata.
+    attribution: str | None = None
+    # Backward-compat alias for `request_ids`. The original Exa-based tool
+    # exposed `exa_request_ids`; external consumers may still read it.
+    exa_request_ids: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _mirror_request_ids(self) -> ResponseMeta:
+        if self.request_ids and not self.exa_request_ids:
+            self.exa_request_ids = list(self.request_ids)
+        elif self.exa_request_ids and not self.request_ids:
+            self.request_ids = list(self.exa_request_ids)
+        return self
 
 
 class SearchResponse(BaseModel):
@@ -29,6 +47,12 @@ class SearchResponse(BaseModel):
 
 
 class DeepResearchIteration(BaseModel):
+    """Retained for backward-compat with the original tool's response shape.
+
+    The new Parallel Task API path is single-call rather than iterative, so
+    `iterations` always contains a single synthetic entry representing the run.
+    """
+
     iteration: int
     queries: list[str]
     results_count: int
@@ -39,5 +63,5 @@ class DeepResearchResponse(BaseModel):
     question: str
     answer_markdown: str
     sources: list[SourceDocument]
-    iterations: list[DeepResearchIteration]
+    iterations: list[DeepResearchIteration] = Field(default_factory=list)
     meta: ResponseMeta

--- a/tools/research/websearch/prompts.py
+++ b/tools/research/websearch/prompts.py
@@ -1,28 +1,4 @@
-"""System prompts for websearch deep research pipeline."""
-
-QUERY_PLANNER_SYSTEM = """## ROLE
-You are a research query planner for a web research agent.
-
-## GOAL
-Given a question and prior context, decide whether to continue research and produce focused search queries.
-
-## RULES
-- Output valid JSON only. No markdown. No prose outside JSON.
-- Generate diverse, non-overlapping, web-solvable queries that target distinct evidence gaps.
-- Prefer natural-language queries over keyword dumps.
-- Use prior_queries and prior_gaps to avoid repetition and improve coverage.
-- Use thread_context for disambiguation when the question is short or underspecified.
-- If prior evidence is already sufficient, set decision to "stop" with an empty queries array.
-- Keep queries concise and high-signal (typically 7-18 words each).
-
-## JSON CONTRACT
-{
-  "decision": "continue|stop",
-  "reason": "string",
-  "queries": ["string"],
-  "gaps": ["string"]
-}
-"""
+"""System prompts for the search synthesis pipeline."""
 
 EVIDENCE_REVIEWER_SYSTEM = """## ROLE
 You are an evidence reviewer for a research pipeline.
@@ -59,6 +35,21 @@ Review retrieved sources, identify supported claims, and decide if more search i
 }
 """
 
+REPORT_REPAIR_SYSTEM = """## ROLE
+You are fixing citation formatting in a report.
+
+## GOAL
+Return the same report content but with valid source ID citations only.
+
+## RULES
+- Keep content structure intact.
+- Replace invalid citations with valid ones only when supported by the provided evidence map.
+- Remove unsupported citations rather than inventing IDs.
+- Include "## Sources" section with only valid IDs.
+- Preserve factual accuracy and uncertainty language while repairing citations.
+- Ensure every citation used in body text appears in the "## Sources" section.
+"""
+
 REPORT_WRITER_SYSTEM = """## ROLE
 You are a research report writer.
 
@@ -75,19 +66,4 @@ Write a concise, high-signal answer to the question using only provided evidence
 - Synthesize across sources instead of summarizing each source independently.
 - Use thread_context only for framing and disambiguation, never as factual evidence.
 - If evidence conflicts, explicitly explain the disagreement and confidence level.
-"""
-
-REPORT_REPAIR_SYSTEM = """## ROLE
-You are fixing citation formatting in a report.
-
-## GOAL
-Return the same report content but with valid source ID citations only.
-
-## RULES
-- Keep content structure intact.
-- Replace invalid citations with valid ones only when supported by the provided evidence map.
-- Remove unsupported citations rather than inventing IDs.
-- Include "## Sources" section with only valid IDs.
-- Preserve factual accuracy and uncertainty language while repairing citations.
-- Ensure every citation used in body text appears in the "## Sources" section.
 """

--- a/tools/research/websearch/pyproject.toml
+++ b/tools/research/websearch/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "websearch"
-description = "Web search and deep research via Exa and Claude"
-version = "0.1.0"
+description = "Web search and deep research via Parallel (free MCP or paid REST); optional Claude synthesis"
+version = "0.2.0"
 requires-python = ">=3.11"
 dependencies = [
     "anthropic>=0.54.0",
     "httpx>=0.28.0",
+    "parallel-web>=0.6.0",
     "pydantic>=2.10.0",
     "python-dotenv>=1.0.0",
     "rich>=13.0.0",
@@ -19,7 +20,12 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [
-    {type = "http", name = "EXA_API_KEY", match_headers = ["x-api-key"], hosts = ["api.exa.ai"]},
+# `search` works anonymously through the hosted Parallel Search MCP. Set
+# PARALLEL_API_KEY to use the paid REST path and unlock `deep_research`.
+# Set ANTHROPIC_API_KEY to enable the Claude-backed synthesis pipeline on
+# top of search results (reviewer → writer → citation repair).
+optional_secrets = [
+    {type = "http", name = "PARALLEL_API_KEY", match_headers = ["x-api-key", "Authorization"], hosts = ["api.parallel.ai", "search.parallel.ai"]},
     {type = "http", name = "ANTHROPIC_API_KEY", match_headers = ["x-api-key"], hosts = ["api.anthropic.com"]},
 ]
+hosts = ["api.parallel.ai", "search.parallel.ai"]


### PR DESCRIPTION
## Summary
Reimplements the `websearch` tool on [Parallel Web Systems](https://docs.parallel.ai) — same interface, strictly better behavior. Search now works with **zero credentials** via the free hosted Parallel Search MCP, and `deep_research` is rebuilt on the Parallel Task API so it returns **correctly-cited reports** instead of failing citation validation every run.

## What changed
- **`search`** — Parallel retrieval, layered by credential:
  - no key → free hosted Search MCP (anonymous; attribution surfaced in `meta.attribution`)
  - `PARALLEL_API_KEY` → Search REST (domain/recency filters, `num_results`, `mode`)
  - `ANTHROPIC_API_KEY` → optional Claude reviewer→writer→citation-repair synthesis (pipeline unchanged from prod)
- **`deep_research`** — Parallel Task API with auto schema; streams progress, renders the model's cited report with a matching **1-based** `## Sources` block. Gated to the `pro`/`ultra` family.
- Uses the official `parallel-web` SDK (`>=0.6.0`) for REST + Task; the Search MCP is a hand-rolled Streamable-HTTP JSON-RPC client.
- Removed Exa.

## Deep research: quality + cost

**Citations — before vs. after.** Prod's citation validator (`_extract_sources_section_ids`) only matches source lines like `[N] url`, but the writer emits **bulleted** lines `- [N] url`. The regex therefore matches nothing, so every report is flagged `synthesis failed: Sources section missing cited IDs: [...]` even when the report is perfectly cited (reproduced live on the retained synthesis path — flagged on *every* call, plus 2 wasted Claude repair attempts per query). This PR fixes that regex **and** moves `deep_research` to the Task API, whose auto-schema output is model-grounded:

- inline `[N]` markers are 1-based into the `basis` citation list; we render the `## Sources` block 1-based to match. Verified on live output:
  - prose "parallel.ai **[1]**" → Sources `[1]` = `https://parallel.ai/`
  - prose "LinkedIn **[2]**" → Sources `[2]` = `linkedin.com/company/parallel-web`
  - prose "Fortune **[11]**" → Sources `[11]` = `fortune.com/2026/05/19/...`
  - dangling citations: **none**
- This also let us *delete* our competing citation machinery (the 0-based `## Sources` renumbering, `_collect_refs`, the per-field `*Sources:*` annotations) — the Task API already returns a fully-cited report, so we lean on it instead of fighting it (net ~40 fewer lines in the renderer).

**Cost.** `deep_research` is now a single Task API run instead of Exa retrieval + a multi-step Claude pipeline (planner → search → reviewer → writer → repair). New `meta.estimated_cost_usd` reports the per-run list price:

| Path | est. cost |
| --- | --- |
| free MCP search | $0.00 |
| REST search (10 results) | $0.005 (+$0.001 per extra result) |
| `deep_research` `pro`/`pro-fast` | $0.10 / run |
| `deep_research` `ultra`/`ultra-fast` | $0.30 / run |

(Best-effort from published [list prices](https://docs.parallel.ai/getting-started/pricing); the API does not return billed cost, so it can drift if prices change.)

## Before / After: `deep_research`

### More detailed reports

Same question (`MPC vs HSM` evaluation):

| | Before (Exa + Claude) | After (Task API) |
|---|---:|---:|
| Report size | 12.7k chars | **36k chars** |
| Sources | 15 | **41** |
| Structure | flat report | **17 basis-grounded sections** (Exec Summary, Evaluation Framework, HSM/MPC deep dives, Regulatory Analysis, Provider Landscapes, …) |

~3× longer, ~3× more sources, with per-section grounded citations rather than one flat list.

### For less money

| | Before (Exa + Claude) | After (Task API) |
|---|---:|---:|
| `deep_research` (per call) | **~$0.88**<br>planner $0.06 + ~4 Exa searches $0.028 + reviewer/writer/repair Claude ~$0.79 | **$0.10** (`pro-fast`)<br>**$0.30** (`ultra-fast`) |

**3–9× cheaper** — the Task API bundles all LLM work into a single per-run fee instead of an Exa retrieval plus 3–4 Claude Opus calls. At 10k deep-research queries/month: **~$8,800 → $1,000–$3,000** (~$5,800/mo saved).

### And more reliable

Before: `deep_research` **failed citation validation on 5/5** probe questions — the validator's `[N]` regex doesn't match the writer's bulleted `- [N] url` source lines, so every report was flagged `synthesis failed` even when correctly cited.

After: the auto-schema output is model-grounded and single-call; inline `[N]` markers map 1:1 to the `## Sources` block (verified live: `[1]`→parallel.ai, `[2]`→linkedin.com/company/parallel-web, `[11]`→fortune.com/…), with no dangling citations.

Note on the numbers: the 36k/41 vs 12.7k/15 figures come from our mpc_hsm probe (the "before" side measured after patching prod's citation regex so it would produce output at all); today's live runs re-confirmed the citation alignment and the
$0.10/run cost.

For search quality, see the open benchmarks at [parallel.ai/benchmarks](https://parallel.ai/benchmarks).

## Backward compatibility
Nothing breaks; removed surface is accepted-and-warned, never errored:
- Removed kwargs (`search_type`, `max_iterations`, `num_queries_per_iteration`, `num_results_per_query`) and the matching CLI flags are accepted and emit a deprecation notice.
- `meta.exa_request_ids` retained as an alias of `meta.request_ids`.
- `DeepResearchResponse.iterations` retained as a single-element list (Task API is single-call).
- `meta.backend` reports `parallel:mcp` | `parallel:api` | `parallel:task:<processor>`.

## Test plan
Validated end-to-end against the live Parallel APIs (direct client calls + CLI):

- [x] **Free MCP search** (no credentials) — `backend=parallel:mcp`, real results, attribution + "num_results not honored" note
- [x] **REST search** with `include_domains` + `num_results` — `backend=parallel:api`, filters honored, no attribution
- [x] **REST + Claude synthesis** — cited markdown report; `validation_error` empty after the regex fix; no dangling citations
- [x] **`synthesize=true` without `ANTHROPIC_API_KEY`** — degrades gracefully: raw results + flagged note, no crash
- [x] **`deep_research` without `PARALLEL_API_KEY`** — clear `RuntimeError` pointing at the missing key
- [x] **Bogus `PARALLEL_API_KEY`** — REST auth fails → falls back to anonymous MCP with an explanatory note
- [x] **CLI** `--pretty` (attribution + notes surfaced) and deprecation shims (`--search-type` warns-and-continues; deprecated flags hidden from `--help`)
- [x] **`deep_research` progress streaming** — task lifecycle + source-count stats + intermediate plan/result messages stream through the progress callback
- [x] **`deep_research` citation alignment** (live) — inline `[N]` ↔ `## Sources` verified correct, no dangling
- [x] **`estimated_cost_usd`** (live) — REST `$0.007` @ 12 results, MCP `$0.00`, `deep_research pro-fast` `$0.10`
- [x] **`parallel-web` 0.6.0 surface check** — `search`, `task_run.create/result/events` present with matching signatures (validated locally on 0.5.1; 0.6.0 confirmed via introspection)
- [x] **Lint** (`ruff`) clean; **unit tests** for the cost estimators and the 1-based renderer
- [ ] Full in-cluster E2E (`just up` + `curl /tools/websearch/...`) — not run locally; validated via direct client + CLI instead
