### PR TITLE
Recover reclaimed executions from persisted session result

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -1193,6 +1193,37 @@ async def get_execution_terminal_snapshot(
     }
 
 
+async def _completed_session_result_for_reclaimed_turn(
+    pool,
+    *,
+    thread_key: str,
+    durable_turn_id: str,
+) -> str | None:
+    """Return the persisted result for a reclaimed turn that already completed.
+
+    A worker can die after the sandbox stream persists turn completion in
+    ``sandbox_sessions`` but before runtime control records the execution as
+    terminal.  Reclaimed executions with an existing durable turn id must not
+    wait only for a fresh live ``turn.done`` event; that event may already have
+    been consumed by the dead worker.
+    """
+    if not durable_turn_id:
+        return None
+    row = await pool.fetchrow(
+        "SELECT inflight_turn_id, last_result FROM sandbox_sessions "
+        "WHERE thread_key = $1",
+        thread_key,
+    )
+    if row is None:
+        return None
+    if row["inflight_turn_id"]:
+        return None
+    last_result = row["last_result"]
+    if last_result is None:
+        return None
+    return str(last_result)
+
+
 async def enqueue_execution(
     pool,
     *,
@@ -2700,6 +2731,29 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
 
     if durable_turn_id:
         await _heartbeat_execution_lease(pool, execution_id)
+        completed_result = await _completed_session_result_for_reclaimed_turn(
+            pool,
+            thread_key=thread_key,
+            durable_turn_id=durable_turn_id,
+        )
+        if completed_result is not None:
+            log.info(
+                "execution_reclaimed_completed_session_result",
+                execution_id=execution_id,
+                thread_key=thread_key,
+                durable_turn_id=durable_turn_id,
+                result_size_bytes=payload_size_bytes(completed_result),
+            )
+            await _mark_execution_terminal(
+                pool,
+                execution_id=execution_id,
+                thread_key=thread_key,
+                status="completed",
+                terminal_reason="completed_reclaimed_session_result",
+                result_text=completed_result,
+                error_text=None,
+            )
+            return
         if silence_deadline <= dt.datetime.now(dt.timezone.utc):
             silence_deadline = await _touch_execution_progress(pool, execution_id)
     else:
@@ -3255,6 +3309,26 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
             await backend.close_streams(session)
 
     if turn_done_event is None:
+        completed_result = await _completed_session_result_for_reclaimed_turn(
+            pool,
+            thread_key=thread_key,
+            durable_turn_id=durable_turn_id,
+        )
+        if completed_result is not None:
+            log.info(
+                "execution_stream_recovered_completed_session_result",
+                execution_id=execution_id,
+                thread_key=thread_key,
+                durable_turn_id=durable_turn_id,
+                result_size_bytes=payload_size_bytes(completed_result),
+            )
+            await _finalize_execution(
+                status="completed",
+                terminal_reason="completed_reclaimed_session_result",
+                result_text=completed_result,
+                error_text=None,
+            )
+            return
         status_row = await pool.fetchrow(
             "SELECT status FROM agent_execution_requests WHERE execution_id = $1",
             execution_id,

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -1890,6 +1890,84 @@ async def test_worker_requeues_raw_harness_auth_error_once_on_fresh_runtime(db_p
 
 
 @pytest.mark.asyncio
+async def test_worker_finalizes_reclaimed_execution_from_completed_session_result(db_pool):
+    from api.runtime_control import _process_execution
+
+    thread_key = f"slack:C-reclaim:{uuid.uuid4().hex}"
+    execution_id = f"exe-{uuid.uuid4().hex[:12]}"
+    runtime_id = f"rt-reclaim-{uuid.uuid4().hex[:8]}"
+    durable_turn_id = f"turn-{uuid.uuid4().hex[:12]}"
+
+    await db_pool.execute(
+        "INSERT INTO sandbox_sessions ("
+        "thread_key, sandbox_id, harness, engine, state, started_at, updated_at, "
+        "inflight_turn_id, last_result"
+        ") VALUES ($1, $2, 'codex', 'codex', 'idle', NOW(), NOW(), NULL, $3)",
+        thread_key,
+        runtime_id,
+        "recovered answer",
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_runtime_assignments ("
+        "thread_key, assignment_generation, runtime_id, harness, engine, "
+        "persona_id, prompt_ref, effective_agents_md_sha256, state"
+        ") VALUES ($1, 1, $2, 'codex', 'codex', NULL, 'harness:codex', 'sha', 'active')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, status, "
+        "delivery, metadata, durable_turn_id, started_at, claimed_at, hard_deadline_at"
+        ") VALUES ($1, $2, 1, 'exec-reclaim', 'hash-reclaim', 'running', "
+        "'{\"platform\":\"dev\"}'::jsonb, '{}'::jsonb, $3, NOW() - INTERVAL '2 minutes', "
+        "NOW() - INTERVAL '2 minutes', NOW() + INTERVAL '10 minutes')",
+        execution_id,
+        thread_key,
+        durable_turn_id,
+    )
+
+    row = {
+        "execution_id": execution_id,
+        "thread_key": thread_key,
+        "assignment_generation": 1,
+        "status": "running",
+        "delivery": {"platform": "dev"},
+        "metadata": {},
+        "durable_turn_id": durable_turn_id,
+        "hard_deadline_at": dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=10),
+        "silence_deadline_at": dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=10),
+        "created_at": dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=2),
+        "claimed_at": dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=2),
+    }
+    session = SandboxSession(
+        sandbox_id=runtime_id,
+        thread_key=thread_key,
+        harness="codex",
+        engine="codex",
+    )
+    stream_mock = AsyncMock()
+
+    with (
+        patch("api.runtime_control.get_or_spawn", new=AsyncMock(return_value=session)),
+        patch("api.runtime_control._stream_stdout", stream_mock),
+    ):
+        await _process_execution(db_pool, row)
+
+    execution = await db_pool.fetchrow(
+        "SELECT status, terminal_reason, result_text, error_text "
+        "FROM agent_execution_requests WHERE execution_id = $1",
+        execution_id,
+    )
+    assert execution is not None
+    assert execution["status"] == "completed"
+    assert execution["terminal_reason"] == "completed_reclaimed_session_result"
+    assert execution["result_text"] == "recovered answer"
+    assert execution["error_text"] is None
+    stream_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_worker_sanitizes_raw_harness_auth_failure_after_retry(db_pool):
     from api.runtime_control import _process_execution
 


### PR DESCRIPTION
## Summary
- finalize reclaimed executions from sandbox_sessions.last_result when the durable turn already completed
- add a fallback after stream EOF to recover a persisted completed result
- add regression coverage for the reclaimed completed-session case

## Testing
- uv run --project services/api python -m py_compile services/api/api/runtime_control.py services/api/tests/test_agent_control_plane.py
- uv run --project services/api pytest services/api/tests/test_agent_control_plane.py::test_worker_finalizes_reclaimed_execution_from_completed_session_result -q (skipped: DB fixture unavailable in sandbox)
