### PR TITLE
[codex] dispatch generic Argo debug from Slack

### DIFF
--- a/services/api/api/workflows/slack_thread_turn.py
+++ b/services/api/api/workflows/slack_thread_turn.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 import json
 import re
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 from api.runtime_control import ControlPlaneError
 from api.workflow_engine import Delivery, WorkflowContext
@@ -59,6 +60,11 @@ _RECOVERY_COMMANDS = frozenset(
 _RECOVERY_NORMALIZE_RE = re.compile(r"[^a-z0-9\s]+")
 _SLACK_ID_MENTION_RE = re.compile(r"^<@[WU][A-Z0-9]+>\s*[:,;-]?\s*(.*)$", re.IGNORECASE)
 _RECOVERY_CONTEXT_PREFIX = "Previous unresolved user request from this thread:\n"
+_GENERIC_ARGO_DEBUG_WORKFLOW = "generic_debug_argo_workflow"
+_ARGO_WORKFLOW_URL_RE = re.compile(
+    r"https?://[^\s<>()`|]*tempo-workflows-ui[^\s<>()`|]*",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -336,6 +342,190 @@ def _is_recovery_turn(parts: list[dict[str, Any]]) -> bool:
     return _normalize_recovery_command(text) in _RECOVERY_COMMANDS
 
 
+def _is_generic_argo_debug_request(parts: list[dict[str, Any]]) -> bool:
+    text = (_extract_text_parts(parts) or "").lower()
+    return (
+        _GENERIC_ARGO_DEBUG_WORKFLOW in text
+        and "argo" in text
+        and ("failure" in text or "failed" in text)
+    )
+
+
+def _clip_text(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars].rstrip()}..."
+
+
+def _slack_target_from_thread_key(thread_key: str) -> tuple[str | None, str | None]:
+    parts = thread_key.split(":")
+    if len(parts) >= 4 and parts[0] == "slack":
+        return parts[2] or None, ":".join(parts[3:]) or None
+    return None, None
+
+
+def _delivery_channel_and_thread(inp: Input) -> tuple[str | None, str | None]:
+    channel = inp.delivery.channel if isinstance(inp.delivery, Delivery) else None
+    thread_ts = inp.delivery.thread_ts if isinstance(inp.delivery, Delivery) else None
+    fallback_channel, fallback_thread_ts = _slack_target_from_thread_key(inp.thread_key)
+    return channel or fallback_channel, thread_ts or fallback_thread_ts
+
+
+def _thread_context_text(inp: Input, parts: list[dict[str, Any]]) -> str:
+    snippets: list[str] = []
+    for item in inp.history_messages:
+        if not isinstance(item, dict):
+            continue
+        text = _extract_text_parts(item.get("parts"))
+        if text:
+            snippets.append(text)
+    current = _extract_text_parts(parts)
+    if current:
+        snippets.append(current)
+    return "\n\n".join(snippets)
+
+
+def _first_argo_workflow_url(text: str) -> str:
+    for match in _ARGO_WORKFLOW_URL_RE.finditer(text):
+        return match.group(0).rstrip(".,")
+    return ""
+
+
+def _parse_argo_workflow_url(url: str) -> tuple[str, str]:
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+    namespace = (query.get("ns") or query.get("namespace") or [""])[0]
+    workflow_name = (query.get("wf") or query.get("workflow") or [""])[0]
+    if not workflow_name:
+        match = re.search(r"/workflows/([^/?#]+)/([^/?#]+)", parsed.path)
+        if match:
+            namespace = namespace or match.group(1)
+            workflow_name = match.group(2)
+    return namespace, workflow_name
+
+
+def _clean_alert_value(value: str) -> str:
+    cleaned = value.strip().strip("`* ")
+    slack_link = re.match(r"<https?://[^>|]+\|([^>]+)>", cleaned)
+    if slack_link:
+        cleaned = slack_link.group(1)
+    cleaned = re.sub(r"\s+\(https?://.*\)\s*$", "", cleaned).strip()
+    return cleaned.strip("`* ")
+
+
+def _extract_alert_field(text: str, label: str) -> str:
+    match = re.search(
+        rf"(?im)^\s*(?:[-*]\s*)?\*?{re.escape(label)}:\*?\s*(.+?)\s*$",
+        text,
+    )
+    return _clean_alert_value(match.group(1)) if match else ""
+
+
+def _extract_primary_failed_node(text: str) -> str:
+    marker = re.search(r"(?im)^\s*\*?(?:What failed|Failed steps):\*?\s*$", text)
+    if not marker:
+        return ""
+    for line in text[marker.end() :].splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if re.match(r"^\*?(?:Error|Info|Workflow|Namespace|Branch|Duration|Trigger):", stripped):
+            break
+        candidate = stripped.lstrip("- ").strip()
+        candidate = re.split(r"\s*[:(]\s*", candidate, maxsplit=1)[0]
+        return _clean_alert_value(candidate)
+    return ""
+
+
+def _parse_argo_alert_context(text: str) -> dict[str, str]:
+    workflow_url = _first_argo_workflow_url(text)
+    namespace, workflow_name = _parse_argo_workflow_url(workflow_url) if workflow_url else ("", "")
+    workflow_name = workflow_name or _extract_alert_field(text, "Workflow")
+    namespace = namespace or _extract_alert_field(text, "Namespace")
+    return {
+        "workflow_url": workflow_url,
+        "workflow_name": workflow_name,
+        "namespace": namespace,
+        "branch": _extract_alert_field(text, "Branch"),
+        "trigger": _extract_alert_field(text, "Trigger"),
+        "primary_failed_node": _extract_primary_failed_node(text),
+    }
+
+
+def _generic_argo_debug_workflow_input(
+    inp: Input,
+    parts: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if not _is_generic_argo_debug_request(parts):
+        return None
+
+    context_text = _thread_context_text(inp, parts)
+    alert = _parse_argo_alert_context(context_text)
+    if not (alert["workflow_name"] or alert["workflow_url"]):
+        return None
+
+    channel, thread_ts = _delivery_channel_and_thread(inp)
+    context_parts = ["triggered_from=slack_argo_alert"]
+    if alert["trigger"]:
+        context_parts.append(f"trigger={alert['trigger']}")
+    if alert["primary_failed_node"]:
+        context_parts.append(f"primary_failed_node={alert['primary_failed_node']}")
+
+    run_input: dict[str, Any] = {
+        "source": "argo-slack-alert",
+        "workflow_name": alert["workflow_name"],
+        "namespace": alert["namespace"],
+        "workflow_url": alert["workflow_url"],
+        "state": "Failed",
+        "context": "; ".join(context_parts),
+        "alert_context": _clip_text(context_text, 8000),
+        "source_thread_key": inp.thread_key.strip(),
+    }
+    if thread_ts:
+        run_input["source_thread_ts"] = thread_ts
+    if channel:
+        run_input["slack_channel"] = channel
+    if alert["branch"]:
+        run_input["branch"] = alert["branch"]
+    return run_input
+
+
+async def _start_generic_argo_debug_workflow(
+    ctx: WorkflowContext,
+    *,
+    inp: Input,
+    run_input: dict[str, Any],
+) -> dict[str, Any]:
+    child = await ctx.start_workflow(
+        "generic-argo-debug",
+        workflow_name=_GENERIC_ARGO_DEBUG_WORKFLOW,
+        run_input=run_input,
+        trigger_key=f"{inp.message_id or inp.thread_key}:generic-argo-debug",
+        eager_start=True,
+    )
+    run_id = str(child.get("run_id") or "")
+    channel = str(run_input.get("slack_channel") or "")
+    thread_ts = str(run_input.get("source_thread_ts") or "")
+    workflow_name = str(run_input.get("workflow_name") or "this Argo failure")
+    if channel and thread_ts:
+        suffix = f" Run: `{run_id}`." if run_id else ""
+        await ctx.post_to_slack(
+            channel,
+            (
+                f"Started `{_GENERIC_ARGO_DEBUG_WORKFLOW}` for `{workflow_name}`."
+                f"{suffix} I will post the investigation here."
+            ),
+            thread_ts=thread_ts,
+        )
+    return {
+        "ok": True,
+        "action": "started_workflow",
+        "workflow_name": _GENERIC_ARGO_DEBUG_WORKFLOW,
+        "child_run_id": run_id or None,
+        "input": run_input,
+    }
+
+
 def _lookup_last_unresolved_ask_from_history(
     history_messages: list[dict[str, Any]],
     *,
@@ -500,6 +690,14 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         switched=selection_changed,
         history_messages=inp.history_messages,
     )
+    generic_argo_debug_input = _generic_argo_debug_workflow_input(inp, parts)
+    if generic_argo_debug_input is not None:
+        return await _start_generic_argo_debug_workflow(
+            ctx,
+            inp=inp,
+            run_input=generic_argo_debug_input,
+        )
+
     history_messages = (
         inp.history_messages
         if await _should_backfill_history(

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -395,6 +395,158 @@ def test_recovery_command_paraphrases_are_recognized():
         )
 
 
+def test_generic_argo_debug_request_builds_workflow_input_from_thread_history():
+    from api.workflow_engine import Delivery
+    from api.workflows.slack_thread_turn import (
+        Input,
+        _generic_argo_debug_workflow_input,
+    )
+
+    inp = Input(
+        thread_key="slack:T123:C456:1779876103.796029",
+        parts=[
+            {
+                "type": "text",
+                "text": "debug this Argo failure with `generic_debug_argo_workflow`.",
+            },
+        ],
+        history_messages=[
+            {
+                "message_id": "slack:T123:C456:1779876103.796029",
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": (
+                            ":rotating_light: txgen failing - main\n\n"
+                            "*Workflow:* txgen-coverage-1779881400 "
+                            "(https://dev-eu-tempo-workflows-ui.tail388b2e.ts.net/"
+                            "?ns=tempo-devnet-stable&wf=txgen-coverage-1779881400)\n"
+                            "*Namespace:* `tempo-devnet-stable`\n"
+                            "*Branch:* `main`\n"
+                            "*Trigger:* Cron\n\n"
+                            "*What failed:*\n"
+                            "`generate-and-send`: Failed\n\n"
+                            "*Error:* pod failed"
+                        ),
+                    },
+                ],
+            },
+        ],
+        delivery=Delivery.slack("C456", "1779876103.796029", user_id="U123"),
+    )
+
+    run_input = _generic_argo_debug_workflow_input(inp, inp.effective_parts)
+
+    assert run_input is not None
+    assert run_input["source"] == "argo-slack-alert"
+    assert run_input["workflow_name"] == "txgen-coverage-1779881400"
+    assert run_input["namespace"] == "tempo-devnet-stable"
+    assert run_input["branch"] == "main"
+    assert run_input["source_thread_key"] == "slack:T123:C456:1779876103.796029"
+    assert run_input["source_thread_ts"] == "1779876103.796029"
+    assert run_input["slack_channel"] == "C456"
+    assert "primary_failed_node=generate-and-send" in run_input["context"]
+    assert "pod failed" in run_input["alert_context"]
+
+
+@pytest.mark.asyncio
+async def test_slack_thread_turn_dispatches_generic_argo_debug_without_agent():
+    from api.workflow_engine import Delivery
+    from api.workflows.slack_thread_turn import Input, handler
+
+    class StubContext:
+        run_id = "wfr_parent"
+
+        def __init__(self):
+            self.started = []
+            self.posts = []
+
+        async def start_workflow(self, name, **kwargs):
+            self.started.append((name, kwargs))
+            return {"run_id": "wfr_child"}
+
+        async def post_to_slack(self, channel, text, *, thread_ts=None):
+            self.posts.append((channel, text, thread_ts))
+            return {"ok": True, "ts": "1779876122.661759"}
+
+    ctx = StubContext()
+    inp = Input(
+        thread_key="slack:T123:C456:1779876103.796029",
+        message_id="slack:T123:C456:1779876122.661759",
+        parts=[
+            {
+                "type": "text",
+                "text": "debug this Argo failure with `generic_debug_argo_workflow`.",
+            },
+        ],
+        history_messages=[
+            {
+                "parts": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "*Workflow:* repro-verify-1779876000 "
+                            "(https://dev-eu-tempo-workflows-ui.tail388b2e.ts.net/"
+                            "?ns=repro-verifier&wf=repro-verify-1779876000)"
+                        ),
+                    },
+                ],
+            },
+        ],
+        delivery=Delivery.slack("C456", "1779876103.796029", user_id="U123"),
+    )
+    do_agent_turn_mock = AsyncMock(return_value={"ok": False})
+
+    with patch("api.workflow_engine.do_agent_turn", new=do_agent_turn_mock):
+        result = await handler(inp, ctx)  # type: ignore[arg-type]
+
+    assert result["ok"] is True
+    assert result["action"] == "started_workflow"
+    assert result["child_run_id"] == "wfr_child"
+    do_agent_turn_mock.assert_not_awaited()
+    assert ctx.started == [
+        (
+            "generic-argo-debug",
+            {
+                "workflow_name": "generic_debug_argo_workflow",
+                "run_input": {
+                    "source": "argo-slack-alert",
+                    "workflow_name": "repro-verify-1779876000",
+                    "namespace": "repro-verifier",
+                    "workflow_url": (
+                        "https://dev-eu-tempo-workflows-ui.tail388b2e.ts.net/"
+                        "?ns=repro-verifier&wf=repro-verify-1779876000"
+                    ),
+                    "state": "Failed",
+                    "context": "triggered_from=slack_argo_alert",
+                    "alert_context": (
+                        "*Workflow:* repro-verify-1779876000 "
+                        "(https://dev-eu-tempo-workflows-ui.tail388b2e.ts.net/"
+                        "?ns=repro-verifier&wf=repro-verify-1779876000)\n\n"
+                        "debug this Argo failure with `generic_debug_argo_workflow`."
+                    ),
+                    "source_thread_key": "slack:T123:C456:1779876103.796029",
+                    "source_thread_ts": "1779876103.796029",
+                    "slack_channel": "C456",
+                },
+                "trigger_key": "slack:T123:C456:1779876122.661759:generic-argo-debug",
+                "eager_start": True,
+            },
+        ),
+    ]
+    assert ctx.posts == [
+        (
+            "C456",
+            (
+                "Started `generic_debug_argo_workflow` for "
+                "`repro-verify-1779876000`. Run: `wfr_child`. "
+                "I will post the investigation here."
+            ),
+            "1779876103.796029",
+        ),
+    ]
+
+
 @pytest.mark.parametrize(
     ("text", "harness", "persona", "cleaned"),
     [


### PR DESCRIPTION
## Summary
- Recognize the compact Slack request to run `generic_debug_argo_workflow` for Argo failures.
- Parse workflow URL, namespace, branch, trigger, failed node, and alert context from Slack thread history instead of relying on visible JSON.
- Start the generic debug workflow directly with the real Slack thread key/channel/thread timestamp, and post a short acknowledgement before the final report lands in-thread.

Pairs with tempoxyz/workflows#541.

## Validation
- `uv run --project services/api pytest services/api/tests/test_workflows.py -k 'generic_argo_debug'`\n- `uv run --project services/api ruff check services/api/api/workflows/slack_thread_turn.py services/api/tests/test_workflows.py`\n- `python3 -m py_compile services/api/api/workflows/slack_thread_turn.py`