### PR TITLE
fix: load secret env in slackbot

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.41
+version: 0.1.42
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -506,6 +506,9 @@ spec:
             - name: {{ $name }}
               value: {{ $value | quote }}
 {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "centaur.secretEnvName" . }}
           ports:
             - containerPort: 3001
               name: http


### PR DESCRIPTION
## Summary
- load the shared Centaur secret env into the Slackbot deployment via envFrom
- lets Slackbot receive OTEL_EXPORTER_OTLP_HEADERS without putting OTLP credentials in Helm values

## Validation
- helm template centaur contrib/chart -f /Users/magelinskaas/tempoxyz/prd-centaur-infra/clusters/centaur-na/argocd/values/centaur.yaml
- helm template centaur contrib/chart -f /Users/magelinskaas/tempoxyz/prd-centaur-infra/clusters/centaur-na/argocd/values/centaur-staging.yaml