### PR TITLE
feat: add Laminar trace metadata

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -1411,6 +1411,7 @@ async def inject_stdin(
     user_id: str | None = None,
     trace_id: str | None = None,
     traceparent: str | None = None,
+    trace_metadata: dict | None = None,
 ) -> dict:
     """Flush pending messages + write to stdin. Does not touch stdout.
 
@@ -1444,6 +1445,7 @@ async def inject_stdin(
             thread_key=session.thread_key,
             trace_id=trace_id or session.trace_id,
             traceparent=traceparent,
+            trace_metadata=trace_metadata,
         )
     elif flushed:
         msgs = _flushed_to_messages(flushed)
@@ -1453,6 +1455,7 @@ async def inject_stdin(
             thread_key=session.thread_key,
             trace_id=trace_id or session.trace_id,
             traceparent=traceparent,
+            trace_metadata=trace_metadata,
         )
     elif inline_blocks:
         turn_input = build_user_input(
@@ -1460,6 +1463,7 @@ async def inject_stdin(
             thread_key=session.thread_key,
             trace_id=trace_id or session.trace_id,
             traceparent=traceparent,
+            trace_metadata=trace_metadata,
         )
     else:
         return {"ok": True, "injected": False}

--- a/services/api/api/otel.py
+++ b/services/api/api/otel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -25,6 +26,7 @@ from opentelemetry.trace import (
 log = structlog.get_logger()
 
 _TRACER_NAME = "centaur.api"
+_LAMINAR_METADATA_PREFIX = "lmnr.association.properties.metadata."
 _configured = False
 _instrumented = False
 
@@ -127,6 +129,39 @@ def clean_attributes(attributes: Mapping[str, Any] | None) -> dict[str, Any]:
     return cleaned
 
 
+def _laminar_metadata_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, bool, int, float)):
+        return value
+    if isinstance(value, (list, tuple)) and all(
+        isinstance(item, (str, bool, int, float)) for item in value
+    ):
+        return list(value)
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    except TypeError:
+        return str(value)
+
+
+def laminar_trace_metadata_attributes(
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    attributes: dict[str, Any] = {}
+    for key, value in (metadata or {}).items():
+        metadata_key = str(key).strip()
+        if not metadata_key:
+            continue
+        cleaned_value = _laminar_metadata_value(value)
+        if cleaned_value is not None:
+            attributes[f"{_LAMINAR_METADATA_PREFIX}{metadata_key}"] = cleaned_value
+    return attributes
+
+
+def set_laminar_trace_metadata(span: Span, metadata: Mapping[str, Any] | None) -> None:
+    set_span_attributes(span, laminar_trace_metadata_attributes(metadata))
+
+
 @contextmanager
 def start_span(
     name: str,
@@ -138,7 +173,11 @@ def start_span(
     if parent_context is not None:
         current_ctx = trace.get_current_span().get_span_context()
         parent_ctx = trace.get_current_span(parent_context).get_span_context()
-        if current_ctx.is_valid and parent_ctx.is_valid and current_ctx.trace_id == parent_ctx.trace_id:
+        if (
+            current_ctx.is_valid
+            and parent_ctx.is_valid
+            and current_ctx.trace_id == parent_ctx.trace_id
+        ):
             parent_context = None
 
     with tracer().start_as_current_span(

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -30,8 +30,10 @@ from api.otel import (
     add_span_event,
     context_from_serialized,
     current_traceparent,
+    laminar_trace_metadata_attributes,
     mark_error,
     record_exception,
+    set_laminar_trace_metadata,
     set_span_attributes,
     span_context_to_dict,
     start_span,
@@ -396,6 +398,74 @@ def _metadata_platform(metadata: dict[str, Any]) -> str | None:
 def _delivery_platform(delivery: dict[str, Any]) -> str | None:
     platform = delivery.get("platform") if isinstance(delivery, dict) else None
     return platform if isinstance(platform, str) and platform else None
+
+
+def _deployment_environment() -> str:
+    return (
+        os.getenv("CENTAUR_ENVIRONMENT")
+        or os.getenv("DEPLOY_ENV")
+        or os.getenv("ENVIRONMENT")
+        or "local"
+    ).strip() or "local"
+
+
+def _slack_thread_metadata(thread_key: str) -> dict[str, str]:
+    parts = thread_key.split(":", 2)
+    if len(parts) != 3 or parts[0] != "slack":
+        return {}
+    return {
+        "slack_channel_id": parts[1],
+        "slack_thread_ts": parts[2],
+    }
+
+
+def _execution_laminar_metadata(
+    *,
+    thread_key: str,
+    execution_id: str,
+    execute_id: Any = None,
+    assignment_generation: int | None = None,
+    delivery: dict[str, Any] | None = None,
+    execution_metadata: dict[str, Any] | None = None,
+    harness: Any = None,
+    engine: Any = None,
+    persona_id: Any = None,
+    prompt_ref: Any = None,
+    runtime_id: Any = None,
+    user_id: Any = None,
+) -> dict[str, Any]:
+    delivery = delivery if isinstance(delivery, dict) else {}
+    execution_metadata = (
+        execution_metadata if isinstance(execution_metadata, dict) else {}
+    )
+    effective_user_id = (
+        user_id
+        or delivery.get("recipient_user_id")
+        or delivery.get("user_id")
+        or execution_metadata.get("user_id")
+    )
+    metadata: dict[str, Any] = {
+        "app": "centaur",
+        "environment": _deployment_environment(),
+        "thread_key": thread_key,
+        "execution_id": execution_id,
+        "execute_id": execute_id,
+        "assignment_generation": assignment_generation,
+        "platform": _delivery_platform(delivery),
+        "harness": harness,
+        "engine": engine,
+        "persona_id": persona_id,
+        "prompt_ref": prompt_ref,
+        "runtime_id": runtime_id,
+        "user_id": effective_user_id,
+    }
+    metadata.update(_slack_thread_metadata(thread_key))
+    channel = (
+        delivery.get("channel") if isinstance(delivery.get("channel"), str) else None
+    )
+    if channel and not metadata.get("slack_channel_id"):
+        metadata["slack_channel_id"] = channel
+    return metadata
 
 
 async def _write_agents_override(runtime_id: str, agents_md_override: str) -> None:
@@ -2450,6 +2520,17 @@ async def _process_execution(pool, row: dict[str, Any]) -> None:
                     exc_info=True,
                 )
         if isinstance(metadata, dict):
+            set_laminar_trace_metadata(
+                span,
+                _execution_laminar_metadata(
+                    thread_key=thread_key,
+                    execution_id=execution_id,
+                    execute_id=row.get("execute_id"),
+                    assignment_generation=assignment_generation,
+                    delivery=delivery,
+                    execution_metadata=metadata,
+                ),
+            )
             set_span_attributes(
                 span,
                 {
@@ -2707,6 +2788,20 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         if isinstance(delivery, dict):
             requester_user_id = delivery.get("recipient_user_id") or delivery.get("user_id")
         requester_user_id = requester_user_id or execution_metadata.get("user_id")
+        trace_metadata = _execution_laminar_metadata(
+            thread_key=thread_key,
+            execution_id=execution_id,
+            execute_id=row.get("execute_id"),
+            assignment_generation=assignment_generation,
+            delivery=delivery,
+            execution_metadata=execution_metadata,
+            harness=harness,
+            engine=engine,
+            persona_id=persona_id,
+            prompt_ref=prompt_ref,
+            runtime_id=session.sandbox_id,
+            user_id=requester_user_id,
+        )
         with start_span(
             "centaur.sandbox.inject",
             attributes={
@@ -2717,6 +2812,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 if isinstance(delivery, dict)
                 else None,
                 "centaur.user_id": requester_user_id,
+                **laminar_trace_metadata_attributes(trace_metadata),
             },
         ) as span:
             inject_span_context = span_context_to_dict(span) or {}
@@ -2727,6 +2823,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 user_id=requester_user_id,
                 trace_id=inject_span_context.get("trace_id"),
                 traceparent=current_traceparent(span),
+                trace_metadata=trace_metadata,
             )
             set_span_attributes(
                 span,
@@ -2912,6 +3009,20 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         event_kind="execution_started",
         event_json=execution_started_payload,
     )
+    execution_trace_metadata = _execution_laminar_metadata(
+        thread_key=thread_key,
+        execution_id=execution_id,
+        execute_id=row.get("execute_id"),
+        assignment_generation=assignment_generation,
+        delivery=delivery,
+        execution_metadata=execution_metadata,
+        harness=harness,
+        engine=engine,
+        persona_id=persona_id,
+        prompt_ref=prompt_ref,
+        runtime_id=session.sandbox_id,
+        user_id=user_id,
+    )
     set_span_attributes(
         trace.get_current_span(),
         {
@@ -2923,6 +3034,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
             "centaur.prompt_sha": prompt_sha,
             "centaur.execution_sequence": execution_sequence,
             "centaur.user_id": user_id,
+            **laminar_trace_metadata_attributes(execution_trace_metadata),
         },
     )
     add_span_event("centaur.agent.execution_started", execution_started_payload)

--- a/services/api/api/sandbox/harness_protocol.py
+++ b/services/api/api/sandbox/harness_protocol.py
@@ -135,6 +135,7 @@ def build_user_input(
     thread_key: str | None = None,
     trace_id: str | None = None,
     traceparent: str | None = None,
+    trace_metadata: dict | None = None,
 ) -> dict:
     """Build a harness-native user input envelope from content blocks."""
     envelope = {
@@ -152,6 +153,8 @@ def build_user_input(
         envelope["trace_id"] = trace_id
     if traceparent:
         envelope["traceparent"] = traceparent
+    if trace_metadata:
+        envelope["trace_metadata"] = trace_metadata
     return envelope
 
 

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -268,6 +268,14 @@ def test_prefix_otlp_span_names_normalizes_codex_turn_as_gen_ai_span() -> None:
         "turn-123": "Reply with exactly PONG and nothing else."
     }
     wrapper.LLM_OUTPUTS_BY_TURN_ID = {"turn-123": "PONG"}
+    wrapper.CURRENT_TRACE_METADATA = {"environment": "stale"}
+    wrapper.TRACE_METADATA_BY_TURN_ID = {
+        "turn-123": {
+            "environment": "local",
+            "thread_key": "slack:C123:1700000000.000100",
+            "execution_id": "exe_123",
+        }
+    }
 
     rewritten = wrapper._prefix_otlp_span_names(request.SerializeToString(), "codex.")
     parsed = ExportTraceServiceRequest()
@@ -296,6 +304,18 @@ def test_prefix_otlp_span_names_normalizes_codex_turn_as_gen_ai_span() -> None:
     assert attributes["gen_ai.usage.output_tokens"].int_value == 11
     assert attributes["gen_ai.usage.cache_read_input_tokens"].int_value == 20352
     assert attributes["gen_ai.usage.reasoning_tokens"].int_value == 0
+    assert (
+        attributes["lmnr.association.properties.metadata.environment"].string_value
+        == "local"
+    )
+    assert (
+        attributes["lmnr.association.properties.metadata.thread_key"].string_value
+        == "slack:C123:1700000000.000100"
+    )
+    assert (
+        attributes["lmnr.association.properties.metadata.execution_id"].string_value
+        == "exe_123"
+    )
 
 
 def test_emit_notification_collects_agent_message_delta_output(monkeypatch) -> None:

--- a/services/api/tests/test_harness_protocol.py
+++ b/services/api/tests/test_harness_protocol.py
@@ -278,6 +278,15 @@ class TestBuildUserInput:
         result = build_user_input(blocks, traceparent=traceparent)
         assert result["traceparent"] == traceparent
 
+    def test_trace_metadata_is_included_when_provided(self):
+        blocks = [{"type": "text", "text": "hi"}]
+        metadata = {
+            "environment": "local",
+            "thread_key": "slack:C123:1700000000.000100",
+        }
+        result = build_user_input(blocks, trace_metadata=metadata)
+        assert result["trace_metadata"] == metadata
+
 
 class TestMessagesToContentBlocks:
     def test_simple_text_message(self):

--- a/services/api/tests/test_otel.py
+++ b/services/api/tests/test_otel.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 
-from api.otel import current_traceparent
+from api.otel import current_traceparent, laminar_trace_metadata_attributes
 
 
 def test_current_traceparent_masks_trace_flags_to_w3c_sampled_bit() -> None:
@@ -20,3 +20,18 @@ def test_current_traceparent_masks_trace_flags_to_w3c_sampled_bit() -> None:
         current_traceparent(span)
         == "00-00000000000040008000000000000123-1111111122223333-01"
     )
+
+
+def test_laminar_trace_metadata_attributes_use_wire_format() -> None:
+    assert laminar_trace_metadata_attributes(
+        {
+            "environment": "local",
+            "execution_id": "exe_123",
+            "payload": {"a": 1},
+            "none": None,
+        }
+    ) == {
+        "lmnr.association.properties.metadata.environment": "local",
+        "lmnr.association.properties.metadata.execution_id": "exe_123",
+        "lmnr.association.properties.metadata.payload": '{"a":1}',
+    }

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -50,6 +50,10 @@ CURRENT_LLM_INPUT_TEXT = ""
 CURRENT_LLM_OUTPUT_TEXT = ""
 LLM_INPUTS_BY_TURN_ID: dict[str, str] = {}
 LLM_OUTPUTS_BY_TURN_ID: dict[str, str] = {}
+CURRENT_TRACE_METADATA: dict[str, Any] = {}
+TRACE_METADATA_BY_TURN_ID: dict[str, dict[str, Any]] = {}
+
+LAMINAR_METADATA_PREFIX = "lmnr.association.properties.metadata."
 
 
 def emit(payload: dict[str, Any]) -> None:
@@ -193,6 +197,11 @@ def input_items(turn_input: dict[str, Any]) -> list[dict[str, Any]]:
         blocks = []
     text = text_from_blocks(blocks)
     return [{"type": "text", "text": text or "continue"}]
+
+
+def trace_metadata_from_input(turn_input: dict[str, Any]) -> dict[str, Any]:
+    metadata = turn_input.get("trace_metadata")
+    return dict(metadata) if isinstance(metadata, dict) else {}
 
 
 def split_goal(items: list[dict[str, Any]]) -> tuple[str | None, list[dict[str, Any]]]:
@@ -365,6 +374,46 @@ def _set_attribute_string(span: Any, key: str, value: str) -> None:
     attribute.value.string_value = value
 
 
+def _set_attribute_value(span: Any, key: str, value: Any) -> None:
+    if value is None:
+        return
+    attribute = _attribute(span, key)
+    if attribute is None:
+        attribute = span.attributes.add()
+        attribute.key = key
+    if isinstance(value, bool):
+        attribute.value.bool_value = value
+    elif isinstance(value, int) and not isinstance(value, bool):
+        attribute.value.int_value = value
+    elif isinstance(value, float):
+        attribute.value.double_value = value
+    elif isinstance(value, str):
+        attribute.value.string_value = value
+    elif isinstance(value, (list, tuple)) and all(
+        isinstance(item, (str, bool, int, float)) for item in value
+    ):
+        attribute.value.string_value = json.dumps(
+            list(value), ensure_ascii=False, separators=(",", ":")
+        )
+    else:
+        attribute.value.string_value = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+
+
+def _set_laminar_trace_metadata(span: Any, metadata: dict[str, Any]) -> None:
+    for key, value in metadata.items():
+        metadata_key = str(key).strip()
+        if metadata_key:
+            _set_attribute_value(
+                span, f"{LAMINAR_METADATA_PREFIX}{metadata_key}", value
+            )
+
+
 def _append_current_llm_output(text: Any) -> None:
     global CURRENT_LLM_OUTPUT_TEXT
     if isinstance(text, str) and text:
@@ -408,6 +457,8 @@ def _normalize_codex_llm_span(span: Any, prefix: str) -> None:
     turn_id = _attribute_string(span, "turn.id")
     input_text = LLM_INPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_INPUT_TEXT)
     output_text = LLM_OUTPUTS_BY_TURN_ID.get(turn_id, CURRENT_LLM_OUTPUT_TEXT)
+    trace_metadata = TRACE_METADATA_BY_TURN_ID.get(turn_id, CURRENT_TRACE_METADATA)
+    _set_laminar_trace_metadata(span, trace_metadata)
     _set_attribute_string(span, "gen_ai.operation.name", "chat")
     _set_attribute_string(span, "gen_ai.system", "openai")
     _set_attribute_string(span, "gen_ai.request.model", model)
@@ -742,6 +793,7 @@ def drain_until_turn_done() -> None:
 
 def handle_input(turn_input: dict[str, Any]) -> None:
     global ACTIVE_TURN_ID, CURRENT_LLM_INPUT_TEXT, CURRENT_LLM_OUTPUT_TEXT
+    global CURRENT_TRACE_METADATA
     if turn_input.get("type") == "interrupt":
         interrupt_active_turn()
         return
@@ -755,6 +807,7 @@ def handle_input(turn_input: dict[str, Any]) -> None:
         or turn_input.get("trace_id"),
         turn_input.get("thread_key"),
     )
+    CURRENT_TRACE_METADATA = trace_metadata_from_input(turn_input)
     start_app_server()
     thread_id = start_or_resume_thread()
     items = input_items(turn_input)
@@ -791,6 +844,8 @@ def handle_input(turn_input: dict[str, Any]) -> None:
                 )
                 or None
             )
+            if ACTIVE_TURN_ID and CURRENT_TRACE_METADATA:
+                TRACE_METADATA_BY_TURN_ID[ACTIVE_TURN_ID] = dict(CURRENT_TRACE_METADATA)
             return
         except Exception:
             interrupt_active_turn()
@@ -799,6 +854,8 @@ def handle_input(turn_input: dict[str, Any]) -> None:
     ACTIVE_TURN_ID = str(turn.get("id") or result.get("turnId") or "") or None
     if ACTIVE_TURN_ID and CURRENT_LLM_INPUT_TEXT:
         LLM_INPUTS_BY_TURN_ID[ACTIVE_TURN_ID] = CURRENT_LLM_INPUT_TEXT
+    if ACTIVE_TURN_ID and CURRENT_TRACE_METADATA:
+        TRACE_METADATA_BY_TURN_ID[ACTIVE_TURN_ID] = dict(CURRENT_TRACE_METADATA)
     drain_until_turn_done()
 
 


### PR DESCRIPTION
## Summary
- add Laminar metadata helpers for dashboard-filterable trace attributes
- propagate execution, runtime, harness, persona, platform, and Slack identifiers into sandbox turn envelopes
- stamp Laminar metadata onto Codex model-call spans

## Tests
- uv run --project services/api ruff check services/api/api/otel.py services/api/api/runtime_control.py services/api/api/agent.py services/api/api/sandbox/harness_protocol.py services/sandbox/codex-app-wrapper.py services/api/tests/test_otel.py services/api/tests/test_harness_protocol.py services/api/tests/test_codex_app_wrapper.py
- uv run --project services/api pytest services/api/tests/test_otel.py services/api/tests/test_harness_protocol.py services/api/tests/test_codex_app_wrapper.py
- just build-one api
- just build-one sandbox
- just deploy
- just smoke (stopped per request; exited with Missing API key before completion)