### PR TITLE
fix: stop rendering Slack context blocks

### DIFF
--- a/services/api/api/logging_config.py
+++ b/services/api/api/logging_config.py
@@ -26,7 +26,7 @@ _PHONE_FIELD_NAMES = {"phone", "phonenumber", "userphone"}
 _SSN_FIELD_NAMES = {"ssn", "socialsecuritynumber"}
 # This can drift over time, but it is less disruptive than reading image refs
 # through Helm chart changes while we need a quick production log marker.
-_LOG_VERSION_UUID = "7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14"
+_LOG_VERSION_UUID = "013ca634-6a30-4047-8511-8e5483f313ea"
 
 
 def _normalize_field_name(field_name: str | None) -> str:

--- a/services/api/tests/test_logging_config.py
+++ b/services/api/tests/test_logging_config.py
@@ -50,4 +50,4 @@ def test_add_log_version_includes_static_uuid():
     enriched = _add_log_version(None, "info", {"event": "execute_completed"})
 
     assert enriched["event"] == "execute_completed"
-    assert enriched["log_version_uuid"] == "7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14"
+    assert enriched["log_version_uuid"] == "013ca634-6a30-4047-8511-8e5483f313ea"

--- a/services/slackbot/src/constants.ts
+++ b/services/slackbot/src/constants.ts
@@ -34,8 +34,6 @@ export const slackReplyLimits = {
     maxVisibleChars: 6_250
   },
   message: {
-    maxBlocks: 50,
-    /** Max mrkdwn chars for the thinking context block on finalized replies. */
-    thinkingContextChars: 2_800
+    maxBlocks: 50
   }
 } as const

--- a/services/slackbot/src/index.test.ts
+++ b/services/slackbot/src/index.test.ts
@@ -134,7 +134,7 @@ describe('Slack event HTTP dedupe', () => {
           event_type: 'app_mention',
           codex_thread_id: undefined,
           alert_channel_id: undefined,
-          log_version_uuid: '7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14'
+          log_version_uuid: '013ca634-6a30-4047-8511-8e5483f313ea'
         })
       )
       expect(waits).toHaveLength(1)
@@ -206,7 +206,7 @@ describe('Slack event HTTP dedupe', () => {
           event_type: 'message',
           codex_thread_id: 'T-019e28c1-08bb-777d-9a2e-74a393296b28',
           alert_channel_id: undefined,
-          log_version_uuid: '7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14'
+          log_version_uuid: '013ca634-6a30-4047-8511-8e5483f313ea'
         })
       )
       expect(waits).toHaveLength(1)

--- a/services/slackbot/src/logging.test.ts
+++ b/services/slackbot/src/logging.test.ts
@@ -49,7 +49,7 @@ describe('Slackbot log sanitization', () => {
       logInfo('slack_test_event', { thread_key: 'slack:C123:1' })
 
       expect(console.log).toHaveBeenCalledWith('slack_test_event', {
-        log_version_uuid: '7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14',
+        log_version_uuid: '013ca634-6a30-4047-8511-8e5483f313ea',
         thread_key: 'slack:C123:1'
       })
     } finally {

--- a/services/slackbot/src/logging.ts
+++ b/services/slackbot/src/logging.ts
@@ -15,7 +15,7 @@ const SECRET_FIELD_NAMES = new Set([
 const EMAIL_FIELD_NAMES = new Set(['email', 'useremail', 'authoremail'])
 const PHONE_FIELD_NAMES = new Set(['phone', 'phonenumber', 'userphone'])
 const SSN_FIELD_NAMES = new Set(['ssn', 'socialsecuritynumber'])
-const LOG_VERSION_UUID = '7f3b4a2e-9d7c-4f2a-8b91-3e6d2c0a5f14'
+const LOG_VERSION_UUID = '013ca634-6a30-4047-8511-8e5483f313ea'
 
 function logVersionFields(): Record<string, string> {
   return {

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -174,6 +174,58 @@ describe('AgentSessionRenderer', () => {
     expect(calls.filter(call => call.method === 'assistant.threads.setStatus')).toHaveLength(3)
   })
 
+  it('strips context blocks from streamed block chunks', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async () => ({ ok: true })
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+
+    await renderer.blocks(
+      sessionId,
+      [
+        { type: 'context', elements: [{ type: 'mrkdwn', text: 'Hidden context' }] },
+        { type: 'markdown', text: 'Visible body' }
+      ] as any,
+      { planPrefix: false }
+    )
+    await renderer.done(sessionId)
+
+    const chunks = calls.flatMap(call => call.params.chunks ?? [])
+    const blocks = chunks
+      .filter((chunk: any) => chunk.type === 'blocks')
+      .flatMap((chunk: any) => chunk.blocks ?? [])
+    expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
+    expect(blocks.some((block: any) => block.type === 'markdown')).toBe(true)
+  })
+
   it('streams task updates with accumulated details and output', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
@@ -454,7 +506,6 @@ describe('AgentSessionRenderer', () => {
     })
     await renderer.text(sessionId, 'Live answer body.')
     await renderer.done(sessionId, {
-      commentaryMarkdown: 'Planning the tool calls.',
       answerMarkdown: 'Live answer body.'
     })
 
@@ -508,7 +559,6 @@ describe('AgentSessionRenderer', () => {
       status: 'in_progress'
     })
     await renderer.done(sessionId, {
-      commentaryMarkdown: 'Planning the tool calls.',
       answerMarkdown: 'Final answer body.'
     })
 
@@ -523,7 +573,7 @@ describe('AgentSessionRenderer', () => {
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
   })
 
-  it('shows thinking text by default and renders the answer in markdown on finalize', async () => {
+  it('does not render a context block on finalize', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -561,19 +611,12 @@ describe('AgentSessionRenderer', () => {
     })
 
     await renderer.done(sessionId, {
-      commentaryMarkdown: 'Planning the tool calls.',
       answerMarkdown: 'Done: five tools called.'
     })
 
     const stop = calls.find(call => call.method === 'chat.stopStream')
     const blocks = stop?.params.blocks ?? []
-    expect(
-      blocks.some(
-        (block: any) =>
-          block.type === 'context' &&
-          String(block.elements?.[0]?.text ?? '').includes('Planning the tool calls.')
-      )
-    ).toBe(true)
+    expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(
       blocks.some(
         (block: any) =>

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -174,58 +174,6 @@ describe('AgentSessionRenderer', () => {
     expect(calls.filter(call => call.method === 'assistant.threads.setStatus')).toHaveLength(3)
   })
 
-  it('strips context blocks from streamed block chunks', async () => {
-    const calls: Array<{ method: string; params: any }> = []
-    const client = {
-      assistant: {
-        threads: {
-          setStatus: async () => ({ ok: true })
-        }
-      },
-      chat: {
-        startStream: async (params: any) => {
-          calls.push({ method: 'chat.startStream', params })
-          return { ok: true, ts: '1778866940.295499' }
-        },
-        appendStream: async (params: any) => {
-          calls.push({ method: 'chat.appendStream', params })
-          return { ok: true }
-        },
-        stopStream: async (params: any) => {
-          calls.push({ method: 'chat.stopStream', params })
-          return { ok: true }
-        },
-        update: async () => ({ ok: true })
-      }
-    }
-
-    const renderer = new AgentSessionRenderer(client as any)
-    const { sessionId } = await renderer.open({
-      channel: 'C123',
-      parentTs: '1778866921.505479',
-      recipientTeamId: 'T123',
-      recipientUserId: 'U123',
-      title: 'Centaur execution'
-    })
-
-    await renderer.blocks(
-      sessionId,
-      [
-        { type: 'context', elements: [{ type: 'mrkdwn', text: 'Hidden context' }] },
-        { type: 'markdown', text: 'Visible body' }
-      ] as any,
-      { planPrefix: false }
-    )
-    await renderer.done(sessionId)
-
-    const chunks = calls.flatMap(call => call.params.chunks ?? [])
-    const blocks = chunks
-      .filter((chunk: any) => chunk.type === 'blocks')
-      .flatMap((chunk: any) => chunk.blocks ?? [])
-    expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
-    expect(blocks.some((block: any) => block.type === 'markdown')).toBe(true)
-  })
-
   it('streams task updates with accumulated details and output', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -18,8 +18,7 @@ import { buildFinalFallbackText, sanitizeFinalMessagePayload } from './final-mes
 import {
   markdownToStreamChunks,
   renderMarkdownBlocks,
-  shouldShowThinkingBlock,
-  thinkingContextBlock
+  stripContextBlocks
 } from './render'
 import { clipLines } from './streaming'
 
@@ -53,7 +52,6 @@ type AgentSessionState = {
   recipientUserId: string
   title: string
   header?: string
-  finalCommentaryMarkdown?: string
   finalAnswerMarkdown?: string
   done: boolean
   statusCleared: boolean
@@ -96,7 +94,6 @@ export type TextOptions = {
 
 export type DoneOptions = {
   streamFinalUpdates?: boolean
-  commentaryMarkdown?: string
   answerMarkdown?: string
 }
 
@@ -182,12 +179,13 @@ export class AgentSessionRenderer {
     blocks: AnyBlock[],
     opts: { planPrefix?: boolean } = {}
   ): Promise<void> {
-    if (!blocks.length) return
+    const visibleBlocks = stripContextBlocks(blocks)
+    if (!visibleBlocks.length) return
     const state = requireSession(sessionId)
     const segment = currentSegment(state)
     await this.streamChunks(state, segment, [
       ...(opts.planPrefix === false ? [] : this.planPrefix(state, segment)),
-      { type: 'blocks', blocks }
+      { type: 'blocks', blocks: visibleBlocks }
     ])
   }
 
@@ -219,7 +217,6 @@ export class AgentSessionRenderer {
   async done(sessionId: string, opts: DoneOptions = {}): Promise<{ streamedTextChars: number }> {
     const state = requireSession(sessionId)
     state.done = true
-    state.finalCommentaryMarkdown = opts.commentaryMarkdown
     state.finalAnswerMarkdown = opts.answerMarkdown
     const streamFinalUpdates = opts.streamFinalUpdates ?? true
     let closed = false
@@ -290,9 +287,7 @@ export class AgentSessionRenderer {
   private async closeTextStream(state: AgentSessionState, segment: Segment): Promise<void> {
     raiseStreamError(segment)
     if (segment.closed) return
-    const hasFinalText = Boolean(
-      state.finalCommentaryMarkdown?.trim() || state.finalAnswerMarkdown?.trim()
-    )
+    const hasFinalText = Boolean(state.finalAnswerMarkdown?.trim())
     if (!segment.streamTs && !segment.textParts.length && !segment.tasks.size && !hasFinalText) {
       return
     }
@@ -300,7 +295,6 @@ export class AgentSessionRenderer {
     if (!segment.streamTs) return
     const originalTasks = finalTaskSnapshot(segment)
     const tasks = compactFinalTasks(originalTasks)
-    const commentaryMarkdown = state.finalCommentaryMarkdown?.trim() ?? ''
     const answerSource =
       state.finalAnswerMarkdown?.trim() || segment.streamedText.trim() || segment.textParts.join('')
     const answerMarkdown = finalMarkdownForFinalBlocks(answerSource, segment, {
@@ -308,9 +302,6 @@ export class AgentSessionRenderer {
     })
     const streamedTextLive =
       Boolean(segment.streamedText.trim()) && segment.streamedText.length < MAX_LIVE_TEXT_CHARS
-    const showThinking =
-      !streamedTextLive && shouldShowThinkingBlock(commentaryMarkdown, answerMarkdown)
-    const thinkingBlock = showThinking ? thinkingContextBlock(commentaryMarkdown) : null
     // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.
     // Only add blocks for content that was not streamed live; live task_update chunks carry
     // fenced details/output, and the header has already been streamed as the first chunk.
@@ -318,12 +309,10 @@ export class AgentSessionRenderer {
       ...(tasks.length && !segment.planStarted
         ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)]
         : []),
-      ...(thinkingBlock ? [thinkingBlock] : []),
       ...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
     ] as AnyBlock[])
     const fallbackText = buildFinalFallbackText({
       title: state.title,
-      commentaryMarkdown: showThinking ? commentaryMarkdown : '',
       answerMarkdown
     })
     const chunks =
@@ -344,8 +333,9 @@ export class AgentSessionRenderer {
     chunks: SlackStreamChunk[]
   ): Promise<void> {
     raiseStreamError(segment)
-    if (!chunks.length || segment.closed) return
-    const effectiveChunks = this.withHeaderPrefix(state, segment, chunks)
+    const visibleChunks = stripContextBlockChunks(chunks)
+    if (!visibleChunks.length || segment.closed) return
+    const effectiveChunks = this.withHeaderPrefix(state, segment, visibleChunks)
     if (!segment.streamTs) {
       const initialChunksUsed = await this.ensureStream(state, segment, effectiveChunks)
       if (initialChunksUsed) return
@@ -727,6 +717,19 @@ function requireSession(id: string): AgentSessionState {
 
 function raiseStreamError(segment: Segment): void {
   if (segment.streamError) throw segment.streamError
+}
+
+function stripContextBlockChunks(chunks: SlackStreamChunk[]): SlackStreamChunk[] {
+  const visibleChunks: SlackStreamChunk[] = []
+  for (const chunk of chunks) {
+    if (chunk.type !== 'blocks') {
+      visibleChunks.push(chunk)
+      continue
+    }
+    const blocks = stripContextBlocks((chunk as BlocksChunk).blocks)
+    if (blocks.length) visibleChunks.push({ type: 'blocks', blocks })
+  }
+  return visibleChunks
 }
 
 function hasVisibleStreamChunks(chunks: SlackStreamChunk[]): boolean {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -17,8 +17,7 @@ import {
 import { buildFinalFallbackText, sanitizeFinalMessagePayload } from './final-message'
 import {
   markdownToStreamChunks,
-  renderMarkdownBlocks,
-  stripContextBlocks
+  renderMarkdownBlocks
 } from './render'
 import { clipLines } from './streaming'
 
@@ -179,13 +178,12 @@ export class AgentSessionRenderer {
     blocks: AnyBlock[],
     opts: { planPrefix?: boolean } = {}
   ): Promise<void> {
-    const visibleBlocks = stripContextBlocks(blocks)
-    if (!visibleBlocks.length) return
+    if (!blocks.length) return
     const state = requireSession(sessionId)
     const segment = currentSegment(state)
     await this.streamChunks(state, segment, [
       ...(opts.planPrefix === false ? [] : this.planPrefix(state, segment)),
-      { type: 'blocks', blocks: visibleBlocks }
+      { type: 'blocks', blocks }
     ])
   }
 
@@ -333,9 +331,8 @@ export class AgentSessionRenderer {
     chunks: SlackStreamChunk[]
   ): Promise<void> {
     raiseStreamError(segment)
-    const visibleChunks = stripContextBlockChunks(chunks)
-    if (!visibleChunks.length || segment.closed) return
-    const effectiveChunks = this.withHeaderPrefix(state, segment, visibleChunks)
+    if (!chunks.length || segment.closed) return
+    const effectiveChunks = this.withHeaderPrefix(state, segment, chunks)
     if (!segment.streamTs) {
       const initialChunksUsed = await this.ensureStream(state, segment, effectiveChunks)
       if (initialChunksUsed) return
@@ -717,19 +714,6 @@ function requireSession(id: string): AgentSessionState {
 
 function raiseStreamError(segment: Segment): void {
   if (segment.streamError) throw segment.streamError
-}
-
-function stripContextBlockChunks(chunks: SlackStreamChunk[]): SlackStreamChunk[] {
-  const visibleChunks: SlackStreamChunk[] = []
-  for (const chunk of chunks) {
-    if (chunk.type !== 'blocks') {
-      visibleChunks.push(chunk)
-      continue
-    }
-    const blocks = stripContextBlocks((chunk as BlocksChunk).blocks)
-    if (blocks.length) visibleChunks.push({ type: 'blocks', blocks })
-  }
-  return visibleChunks
 }
 
 function hasVisibleStreamChunks(chunks: SlackStreamChunk[]): boolean {

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1,18 +1,8 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { describe, expect, it } from 'bun:test'
-import { shouldShowThinkingBlock } from './render'
 import { AgentSessionRenderer } from './agent-session'
 import { CodexSessionRenderer } from './codex-session'
-
-describe('assistant message sections', () => {
-  it('skips Thinking when commentary is duplicated in the answer', () => {
-    const prose = 'I will call five tools and report results.'
-    expect(shouldShowThinkingBlock(prose, prose)).toBe(false)
-    expect(shouldShowThinkingBlock(prose, `${prose}\n\nTool results follow.`)).toBe(false)
-    expect(shouldShowThinkingBlock('Planning only.', 'Final answer only.')).toBe(true)
-  })
-})
 
 describe('CodexSessionRenderer', () => {
   it('streams canonical terminal result text before closing the session', async () => {
@@ -669,7 +659,7 @@ describe('CodexSessionRenderer', () => {
     expect(toolTask?.title).not.toContain('failed')
   })
 
-  it('streams small Thinking context before the answer after the first plan task', async () => {
+  it('does not stream Thinking context before the answer after the first plan task', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -745,7 +735,7 @@ describe('CodexSessionRenderer', () => {
 
     const chunks = calls.flatMap(call => call.params.chunks ?? [])
     const firstTaskIndex = chunks.findIndex(chunk => chunk.type === 'task_update')
-    const thinkingIndex = chunks.findIndex(
+    const contextBlockIndex = chunks.findIndex(
       chunk =>
         chunk.type === 'blocks' &&
         chunk.blocks?.some((block: any) =>
@@ -756,7 +746,7 @@ describe('CodexSessionRenderer', () => {
       chunk => chunk.type === 'markdown_text' && String(chunk.text).includes('Done.')
     )
     expect(firstTaskIndex).toBeGreaterThanOrEqual(0)
-    expect(thinkingIndex).toBe(-1)
+    expect(contextBlockIndex).toBe(-1)
     expect(firstTextIndex).toBeGreaterThan(firstTaskIndex)
     expect(thinkingBlockText(calls)).toBe('')
 

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -249,7 +249,6 @@ export class CodexSessionRenderer {
     await this.publishPendingAssistantText(agentSessionId, state, { force: true })
     const { streamedTextChars } = await this.renderer.done(agentSessionId, {
       streamFinalUpdates: true,
-      commentaryMarkdown: state.commentaryText,
       answerMarkdown: state.answerText
     })
     state.deliveredAnswerChars = streamedTextChars

--- a/services/slackbot/src/slack/final-message.test.ts
+++ b/services/slackbot/src/slack/final-message.test.ts
@@ -52,7 +52,7 @@ describe('sanitizeFinalMessagePayload', () => {
     expect(total).toBeLessThanOrEqual(slackReplyLimits.stream.markdownChunkChars)
   })
 
-  it('shrinks oversized plan + markdown + context compositions toward the byte budget', () => {
+  it('shrinks oversized plan + markdown compositions and drops context blocks', () => {
     const tasks = Array.from({ length: 12 }, (_, index) => ({
       id: `cmd-${index}`,
       title: `Run command ${index}`,
@@ -94,5 +94,6 @@ describe('sanitizeFinalMessagePayload', () => {
       slackReplyLimits.mixedBodyAndPlan.maxPayloadBytes
     )
     expect(blocks.length).toBeLessThanOrEqual(slackReplyLimits.message.maxBlocks)
+    expect(blocks.some(block => block.type === 'context')).toBe(false)
   })
 })

--- a/services/slackbot/src/slack/final-message.test.ts
+++ b/services/slackbot/src/slack/final-message.test.ts
@@ -52,7 +52,7 @@ describe('sanitizeFinalMessagePayload', () => {
     expect(total).toBeLessThanOrEqual(slackReplyLimits.stream.markdownChunkChars)
   })
 
-  it('shrinks oversized plan + markdown compositions and drops context blocks', () => {
+  it('shrinks oversized plan + markdown compositions toward the byte budget', () => {
     const tasks = Array.from({ length: 12 }, (_, index) => ({
       id: `cmd-${index}`,
       title: `Run command ${index}`,
@@ -84,16 +84,11 @@ describe('sanitizeFinalMessagePayload', () => {
     }))
     const blocks = sanitizeFinalMessagePayload([
       planBlock('Centaur execution', tasks, 'plan-1') as AnyBlock,
-      { type: 'markdown', text: 'Final answer ' + 'w'.repeat(8_000) },
-      {
-        type: 'context',
-        elements: [{ type: 'mrkdwn', text: 'Streamed thinking summary.' }]
-      }
+      { type: 'markdown', text: 'Final answer ' + 'w'.repeat(8_000) }
     ])
     expect(estimatePayloadBytes(blocks)).toBeLessThanOrEqual(
       slackReplyLimits.mixedBodyAndPlan.maxPayloadBytes
     )
     expect(blocks.length).toBeLessThanOrEqual(slackReplyLimits.message.maxBlocks)
-    expect(blocks.some(block => block.type === 'context')).toBe(false)
   })
 })

--- a/services/slackbot/src/slack/final-message.ts
+++ b/services/slackbot/src/slack/final-message.ts
@@ -9,13 +9,8 @@ const MAX_FALLBACK_CHARS = slackReplyLimits.text.maxFallbackChars
 export function buildFinalFallbackText(opts: {
   title: string
   answerMarkdown: string
-  commentaryMarkdown?: string
 }): string {
-  const parts = [
-    opts.title.trim(),
-    opts.commentaryMarkdown?.trim(),
-    opts.answerMarkdown.trim()
-  ].filter(Boolean)
+  const parts = [opts.title.trim(), opts.answerMarkdown.trim()].filter(Boolean)
   const text = parts.join('\n')
   if (!text) return opts.title.trim() || 'Centaur update'
   if (text.length <= MAX_FALLBACK_CHARS) return text

--- a/services/slackbot/src/slack/render.ts
+++ b/services/slackbot/src/slack/render.ts
@@ -60,11 +60,7 @@ export function renderStatusBlock(metadata: StatusMetadata): RichTextBlock | nul
 }
 
 export function enforceBlockLimits(blocks: AnyBlock[]): AnyBlock[] {
-  return stripContextBlocks(blocks).slice(0, MAX_BLOCKS)
-}
-
-export function stripContextBlocks(blocks: AnyBlock[]): AnyBlock[] {
-  return blocks.filter(block => block.type !== 'context')
+  return blocks.slice(0, MAX_BLOCKS)
 }
 
 export function fallbackText(input: {

--- a/services/slackbot/src/slack/render.ts
+++ b/services/slackbot/src/slack/render.ts
@@ -1,4 +1,4 @@
-import type { AnyBlock, AnyChunk, ContextBlock, MarkdownBlock, RichTextBlock } from '@slack/types'
+import type { AnyBlock, AnyChunk, MarkdownBlock, RichTextBlock } from '@slack/types'
 import { slackReplyLimits } from '../constants'
 
 const MAX_BLOCKS = slackReplyLimits.message.maxBlocks
@@ -17,32 +17,6 @@ export function blockquoteMarkdown(text: string): string {
     .split('\n')
     .map(line => `> ${line}`)
     .join('\n')
-}
-
-/** Skip Thinking when Codex repeated the same prose in commentary and final_answer. */
-export function shouldShowThinkingBlock(commentary: string, answer: string): boolean {
-  const trimmedCommentary = commentary.trim()
-  const trimmedAnswer = answer.trim()
-  if (!trimmedCommentary) return false
-  if (!trimmedAnswer) return true
-  if (trimmedCommentary === trimmedAnswer) return false
-  if (trimmedAnswer.includes(trimmedCommentary)) return false
-  return true
-}
-
-export function thinkingContextBlock(
-  commentary: string,
-  opts: { heading?: boolean } = {}
-): ContextBlock | null {
-  const trimmed = commentary.trim()
-  if (!trimmed) return null
-  const maxChars = slackReplyLimits.message.thinkingContextChars
-  const body =
-    trimmed.length > maxChars ? `${trimmed.slice(0, maxChars - 13)}\n// truncated` : trimmed
-  return {
-    type: 'context',
-    elements: [{ type: 'mrkdwn', text: opts.heading === false ? body : `*Thinking*\n${body}` }]
-  }
 }
 
 export function renderMarkdownBlocks(markdown: string): MarkdownBlock[] {
@@ -86,7 +60,11 @@ export function renderStatusBlock(metadata: StatusMetadata): RichTextBlock | nul
 }
 
 export function enforceBlockLimits(blocks: AnyBlock[]): AnyBlock[] {
-  return blocks.slice(0, MAX_BLOCKS)
+  return stripContextBlocks(blocks).slice(0, MAX_BLOCKS)
+}
+
+export function stripContextBlocks(blocks: AnyBlock[]): AnyBlock[] {
+  return blocks.filter(block => block.type !== 'context')
 }
 
 export function fallbackText(input: {


### PR DESCRIPTION
## Summary
- remove Slack final-rendering paths that turn commentary into context blocks
- strip context blocks from final payloads and streamed block chunks
- keep final fallback text scoped to title plus answer content

## Tests
- bun test src/slack/agent-session.test.ts src/slack/codex-session.test.ts src/slack/final-message.test.ts
- bun run check:types
- git diff --check