### PR TITLE
Remove SimilarWeb credits endpoint

### DIFF
--- a/tools/research/similarweb/cli.py
+++ b/tools/research/similarweb/cli.py
@@ -465,37 +465,6 @@ def app_ranking(
 
 
 @app.command()
-def credits(
-    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
-):
-    """Check remaining API credits."""
-    client = get_client()
-
-    try:
-        data = client.get_credits()
-    except RuntimeError as e:
-        console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
-
-    if json_output:
-        print(json.dumps(data, indent=2))
-        return
-
-    remaining = data.get("remaining_credits", data.get("credits", "N/A"))
-    total = data.get("total_credits", "")
-
-    console.print(
-        f"\n[bold]API Credits:[/] {remaining:,}"
-        if isinstance(remaining, int)
-        else f"\n[bold]API Credits:[/] {remaining}"
-    )
-    if total:
-        console.print(
-            f"[dim]Total: {total:,}[/]" if isinstance(total, int) else f"[dim]Total: {total}[/]"
-        )
-
-
-@app.command()
 def raw(
     endpoint: str = typer.Argument(
         ..., help="API endpoint (e.g., /v1/website/google.com/global-rank/global-rank)"

--- a/tools/research/similarweb/client.py
+++ b/tools/research/similarweb/client.py
@@ -374,10 +374,6 @@ class SimilarWebClient:
         params = {"term": query}
         return self._request(f"/v1/app/{store}/search", params=params)
 
-    def get_credits(self) -> dict:
-        """Get remaining API credits."""
-        return self._request("/v3/batch/credits")
-
     def get_categories(self) -> dict:
         """Get list of available industry categories."""
         return self._request("/v1/TopSites/categories")


### PR DESCRIPTION
## Summary
- remove SimilarWeb get_credits from the tool client so Batch credits are no longer exposed
- remove the matching SimilarWeb CLI credits command

## Test
- rg -n "get_credits|/v3/batch/credits|remaining API credits|API Credits|def credits" tools/research/similarweb
- uv run --with httpx --with typer --with rich --with python-dotenv python -c "import ast; from pathlib import Path; [ast.parse(p.read_text()) for p in [Path(\"tools/research/similarweb/client.py\"), Path(\"tools/research/similarweb/cli.py\")]]; text = Path(\"tools/research/similarweb/client.py\").read_text(); assert \"def get_credits\" not in text; assert \"/v3/batch/credits\" not in text; print(\"similarweb syntax and credits removal ok\")"

Note: `uv run --project tools/research/similarweb ...` still fails on the pre-existing Hatch file-selection/package-layout issue.
