### PR TITLE
fix: resolve internal attachment API URL

### DIFF
--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import logging
 import mimetypes
+import os
 import urllib.request
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -101,7 +102,7 @@ def save_attachment(
     thread_key = current_thread_key()
     safe_name = Path(name).name or "attachment"
     resolved_mime = mime_type or mimetypes.guess_type(safe_name)[0] or "application/octet-stream"
-    base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
+    base_url = (os.environ.get("CENTAUR_API_URL") or "http://api:8000").rstrip("/")
     payload = json.dumps(
         {
             "thread_key": thread_key,

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -739,7 +739,7 @@ def _download_attachment_bytes(
     if not path:
         raise ValueError("attachment_id or attachment_url is required")
 
-    base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
+    base_url = (os.environ.get("CENTAUR_API_URL") or "http://api:8000").rstrip("/")
     base_parts = urlparse(base_url)
     if path.startswith(("http://", "https://")):
         url_parts = urlparse(path)

--- a/tools/productivity/gsuite/test_client.py
+++ b/tools/productivity/gsuite/test_client.py
@@ -1,7 +1,9 @@
 import base64
+import urllib.request
 
 import pytest
 
+from centaur_sdk.tool_sdk import ToolContext, reset_tool_context, set_tool_context
 from gsuite import client
 
 
@@ -214,6 +216,45 @@ def test_drive_upload_accepts_attachment_id(monkeypatch):
     assert create_call["media_body"]["content"] == b"from-attachment"
     assert create_call["media_body"]["mimetype"] == "text/csv"
     assert result["id"] == "file-123"
+
+
+class _FakeHTTPResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_download_attachment_bytes_uses_default_api_url_when_env_missing(monkeypatch):
+    monkeypatch.delenv("CENTAUR_API_URL", raising=False)
+    seen_urls: list[str] = []
+
+    def fake_urlopen(req, *args, **kwargs):
+        seen_urls.append(req.full_url)
+        if req.full_url == (
+            "http://api:8000/agent/attachments/att-xyz/download"
+            "?thread_key=slack%3AC1%3A1.2"
+        ):
+            return _FakeHTTPResponse(b"attachment-bytes")
+        raise AssertionError(f"unexpected url {req.full_url}")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    token = set_tool_context(ToolContext(name="gsuite", thread_key="slack:C1:1.2"))
+    try:
+        body = client._download_attachment_bytes(attachment_id="att-xyz")
+    finally:
+        reset_tool_context(token)
+
+    assert body == b"attachment-bytes"
+    assert "CENTAUR_API_URL/agent/attachments" not in seen_urls
 
 
 def test_drive_create_folder_uses_folder_mime_type(monkeypatch):

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1655,7 +1655,7 @@ class SlackClient:
             path = f"/agent/attachments/{attachment_id}/download"
         if not path:
             raise ValueError("attachment_id or attachment_url is required")
-        base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
+        base_url = (os.environ.get("CENTAUR_API_URL") or "http://api:8000").rstrip("/")
         base_parts = urlparse(base_url)
         if path.startswith(("http://", "https://")):
             url_parts = urlparse(path)

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -620,6 +620,39 @@ def test_download_file_stores_attachment(monkeypatch: pytest.MonkeyPatch) -> Non
     assert base64.b64decode(posted["body"]["data"]) == b"%PDF-1.4 report"
 
 
+def test_download_file_uses_default_api_url_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.request
+
+    client, _ = _make_client()
+    client.token = "SLACK_BOT_TOKEN"
+    monkeypatch.delenv("CENTAUR_API_URL", raising=False)
+    seen_urls: list[str] = []
+
+    def fake_urlopen(req, *args, **kwargs):
+        seen_urls.append(req.full_url)
+        if "files.slack.com" in req.full_url:
+            return _FakeHTTPResponse(b"report", "application/pdf")
+        if req.full_url == "http://api:8000/agent/attachments/upload":
+            return _FakeHTTPResponse(
+                json.dumps({"id": "att-default"}).encode(),
+                "application/json",
+            )
+        raise AssertionError(f"unexpected url {req.full_url}")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    token = set_tool_context(ToolContext(name="slack", thread_key="slack:C1:1.2"))
+    try:
+        result = client.download_file("https://files.slack.com/files-pri/T1-F1/report.pdf")
+    finally:
+        reset_tool_context(token)
+
+    assert result["attachment_id"] == "att-default"
+    assert "CENTAUR_API_URL/agent/attachments/upload" not in seen_urls
+
+
 def test_download_file_requires_thread_context(monkeypatch: pytest.MonkeyPatch) -> None:
     import urllib.request
 


### PR DESCRIPTION
Fixes Slack file recovery into Centaur attachments by using the process env/default API URL for internal attachment API calls instead of the secret-stub resolver. The secret backend can return literal key names in server mode, which produced URLs like CENTAUR_API_URL/agent/attachments/upload.

Validation:
- PYTHONPATH=/home/agent/branches/paradigmxyz/centaur/tools/productivity:/home/agent/branches/paradigmxyz/centaur uv run --with pytest pytest tests/test_client.py -k 'download_file'\n\nPrompted by: @horsefacts