### PR TITLE
fix(slackbot): validate Slack Block Kit payloads

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^1.41.1
         version: 1.41.1
       '@slack/types':
-        specifier: ^2.19.0
-        version: 2.20.1
+        specifier: ^2.21.1
+        version: 2.21.1
       '@slack/web-api':
         specifier: ^7.15.2
         version: 7.16.0

--- a/services/slackbot/package.json
+++ b/services/slackbot/package.json
@@ -23,7 +23,7 @@
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@opentelemetry/semantic-conventions": "^1.41.1",
-    "@slack/types": "^2.19.0",
+    "@slack/types": "^2.21.1",
     "@slack/web-api": "^7.15.2",
     "@std/ulid": "npm:@jsr/std__ulid",
     "hono": "^4.12.18",

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -27,7 +27,15 @@ import { markdownToStreamChunks } from './slack/render'
 import { verifySlackSignature } from './slack/signature'
 import { shouldAckWithReaction } from './slack/trivial-ack'
 import type { NormalizedSlackEvent, SlackEnvelope } from './slack/types'
-import type { AnyBlock, AnyChunk } from '@slack/types'
+import {
+  BlockKitValidationError,
+  parseOptionalSlackBlocks,
+  parseOptionalSlackStreamChunks,
+  slackStreamChunksForApi,
+  type SlackBlock,
+  type SlackStreamChunk,
+  type SlackTaskDisplayMode
+} from './slack/block-kit'
 import type { WebClient } from '@slack/web-api'
 
 const config = loadConfig()
@@ -181,14 +189,20 @@ app.post('/api/slack/messages', apiKeyMiddleware, async c => {
     channel: string
     thread_ts?: string
     text: string
-    blocks?: AnyBlock[]
+    blocks?: unknown
   }>()
+  let blocks: SlackBlock[] | undefined
+  try {
+    blocks = parseOptionalSlackBlocks(body.blocks)
+  } catch (error) {
+    return blockKitErrorResponse(c, error)
+  }
   const { client } = await resolver.resolve({})
   const response = await client.chat.postMessage({
     channel: body.channel,
     thread_ts: body.thread_ts,
     text: body.text,
-    blocks: body.blocks
+    blocks
   })
   if (!response.ok) return c.json(response, 502)
   return c.json({ ok: true, channel: response.channel, ts: response.ts })
@@ -199,15 +213,21 @@ app.patch('/api/slack/messages', apiKeyMiddleware, async c => {
     channel: string
     ts: string
     text: string
-    blocks?: AnyBlock[]
+    blocks?: unknown
   }>()
+  let blocks: SlackBlock[] | undefined
+  try {
+    blocks = parseOptionalSlackBlocks(body.blocks)
+  } catch (error) {
+    return blockKitErrorResponse(c, error)
+  }
   const { client } = await resolver.resolve({})
   try {
     const response = await client.chat.update({
       channel: body.channel,
       ts: body.ts,
       text: body.text,
-      blocks: body.blocks
+      blocks
     })
     if (!response.ok) return c.json(response, 502)
     return c.json({ ok: true, channel: response.channel, ts: response.ts })
@@ -256,17 +276,24 @@ app.post('/api/slack/streams/start', apiKeyMiddleware, async c => {
     channel: string
     thread_ts: string
     markdown?: string
-    chunks?: AnyChunk[]
+    chunks?: unknown
     recipient_team_id?: string
     recipient_user_id?: string
-    task_display_mode?: 'plan' | 'timeline'
+    task_display_mode?: SlackTaskDisplayMode
   }>()
+  let chunks: SlackStreamChunk[]
+  try {
+    chunks =
+      parseOptionalSlackStreamChunks(body.chunks) ?? markdownToStreamChunks(body.markdown ?? ' ')
+  } catch (error) {
+    return blockKitErrorResponse(c, error)
+  }
   const { client } = await resolver.resolve({})
   try {
     const response = await client.chat.startStream({
       channel: body.channel,
       thread_ts: body.thread_ts,
-      chunks: body.chunks ?? markdownToStreamChunks(body.markdown ?? ' '),
+      chunks: slackStreamChunksForApi(chunks),
       recipient_team_id: body.recipient_team_id,
       recipient_user_id: body.recipient_user_id,
       task_display_mode: body.task_display_mode
@@ -283,14 +310,21 @@ app.post('/api/slack/streams/append', apiKeyMiddleware, async c => {
     channel: string
     ts: string
     markdown?: string
-    chunks?: AnyChunk[]
+    chunks?: unknown
   }>()
+  let chunks: SlackStreamChunk[]
+  try {
+    chunks =
+      parseOptionalSlackStreamChunks(body.chunks) ?? markdownToStreamChunks(body.markdown ?? ' ')
+  } catch (error) {
+    return blockKitErrorResponse(c, error)
+  }
   const { client } = await resolver.resolve({})
   try {
     const response = await client.chat.appendStream({
       channel: body.channel,
       ts: body.ts,
-      chunks: body.chunks ?? markdownToStreamChunks(body.markdown ?? ' ')
+      chunks: slackStreamChunksForApi(chunks)
     })
     if (!response.ok) return c.json(response, 502)
     return c.json({ ok: true, channel: response.channel, ts: response.ts })
@@ -304,16 +338,26 @@ app.post('/api/slack/streams/stop', apiKeyMiddleware, async c => {
     channel: string
     ts: string
     markdown?: string
-    chunks?: AnyChunk[]
-    blocks?: AnyBlock[]
+    chunks?: unknown
+    blocks?: unknown
   }>()
+  let chunks: SlackStreamChunk[] | undefined
+  let blocks: SlackBlock[] | undefined
+  try {
+    chunks =
+      parseOptionalSlackStreamChunks(body.chunks) ??
+      (body.markdown ? markdownToStreamChunks(body.markdown) : undefined)
+    blocks = parseOptionalSlackBlocks(body.blocks)
+  } catch (error) {
+    return blockKitErrorResponse(c, error)
+  }
   const { client } = await resolver.resolve({})
   try {
     const response = await client.chat.stopStream({
       channel: body.channel,
       ts: body.ts,
-      chunks: body.chunks ?? (body.markdown ? markdownToStreamChunks(body.markdown) : undefined),
-      blocks: body.blocks
+      chunks: chunks ? slackStreamChunksForApi(chunks) : undefined,
+      blocks
     })
     if (!response.ok) return c.json(response, 502)
     return c.json({ ok: true, channel: response.channel, ts: response.ts })
@@ -658,6 +702,13 @@ function slackApiErrorResponse(c: Context, error: unknown) {
     },
     502
   )
+}
+
+function blockKitErrorResponse(c: Context, error: unknown) {
+  if (error instanceof BlockKitValidationError) {
+    return c.json({ ok: false, error: error.code, message: error.message }, 400)
+  }
+  throw error
 }
 
 type SlackCommandPayload = {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -1,8 +1,14 @@
-import type { AnyBlock, AnyChunk } from '@slack/types'
+import type { AnyChunk } from '@slack/types'
 import type { WebClient } from '@slack/web-api'
 import { ulid } from '@std/ulid'
 import { slackReplyLimits } from '../constants'
 import { logWarn } from '../logging'
+import {
+  blocksChunk,
+  slackStreamChunksForApi,
+  type SlackBlock,
+  type SlackStreamChunk
+} from './block-kit'
 import {
   markdownChunk,
   planBlock,
@@ -15,10 +21,7 @@ import {
   type StreamTaskStatus
 } from './streaming'
 import { buildFinalFallbackText, sanitizeFinalMessagePayload } from './final-message'
-import {
-  markdownToStreamChunks,
-  renderMarkdownBlocks
-} from './render'
+import { markdownToStreamChunks, renderMarkdownBlocks } from './render'
 import { clipLines } from './streaming'
 
 type Segment = {
@@ -39,9 +42,6 @@ type Segment = {
   streamError?: Error
   closed: boolean
 }
-
-type BlocksChunk = { type: 'blocks'; blocks: AnyBlock[] }
-type SlackStreamChunk = AnyChunk | BlocksChunk
 
 type AgentSessionState = {
   id: string
@@ -100,17 +100,12 @@ function headerMarkdown(header: string): string {
   return `_${header.trim()}_`
 }
 
-function headerBlock(header: string): AnyBlock {
-  return { type: 'markdown', text: headerMarkdown(header) }
-}
-
 const sessions = new Map<string, AgentSessionState>()
 const sessionQueues = new Map<string, Promise<void>>()
 const THINKING_STATUS = 'Thinking...'
 const TEXT_FLUSH_INTERVAL_MS = 250
 const TEXT_FLUSH_CHARS = 1000
 const FIRST_TEXT_FLUSH_CHARS = 1
-const EXECUTION_PLAN_ID = 'codex-execution-timeline'
 const LIVE_PLAN_MAX_TASKS = slackReplyLimits.stream.taskCount
 const FINAL_PLAN_MAX_TASKS = slackReplyLimits.finalPlan.maxTasks
 const FINAL_PLAN_TITLE_CHARS = slackReplyLimits.finalPlan.taskTitleChars
@@ -150,7 +145,11 @@ export class AgentSessionRenderer {
     return await this.queueText(state, segment, markdown)
   }
 
-  async textDelta(sessionId: string, markdownDelta: string, opts: TextOptions = {}): Promise<number> {
+  async textDelta(
+    sessionId: string,
+    markdownDelta: string,
+    opts: TextOptions = {}
+  ): Promise<number> {
     if (!markdownDelta) return 0
     const state = requireSession(sessionId)
     const segment = currentSegment(state)
@@ -175,7 +174,7 @@ export class AgentSessionRenderer {
 
   async blocks(
     sessionId: string,
-    blocks: AnyBlock[],
+    blocks: SlackBlock[],
     opts: { planPrefix?: boolean } = {}
   ): Promise<void> {
     if (!blocks.length) return
@@ -183,7 +182,7 @@ export class AgentSessionRenderer {
     const segment = currentSegment(state)
     await this.streamChunks(state, segment, [
       ...(opts.planPrefix === false ? [] : this.planPrefix(state, segment)),
-      { type: 'blocks', blocks }
+      blocksChunk(blocks)
     ])
   }
 
@@ -305,10 +304,10 @@ export class AgentSessionRenderer {
     // fenced details/output, and the header has already been streamed as the first chunk.
     const blocks = sanitizeFinalMessagePayload([
       ...(tasks.length && !segment.planStarted
-        ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)]
+        ? [planBlock(planTitle(state.title, originalTasks), tasks)]
         : []),
       ...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
-    ] as AnyBlock[])
+    ] as SlackBlock[])
     const fallbackText = buildFinalFallbackText({
       title: state.title,
       answerMarkdown
@@ -341,7 +340,7 @@ export class AgentSessionRenderer {
     const response = await this.client.chat.appendStream({
       channel: state.channel,
       ts: segment.streamTs,
-      chunks: effectiveChunks as AnyChunk[]
+      chunks: slackStreamChunksForApi(effectiveChunks)
     })
     if (!response.ok) throw new Error(response.error ?? 'chat.appendStream failed')
     await this.clearStatusAfterVisibleOutput(state, effectiveChunks)
@@ -479,7 +478,7 @@ export class AgentSessionRenderer {
         recipient_team_id: state.recipientTeamId,
         recipient_user_id: state.recipientUserId,
         task_display_mode: 'plan',
-        chunks: chunks as AnyChunk[]
+        chunks: slackStreamChunksForApi(chunks)
       })
       if (!response.ok || !response.ts) throw new Error(response.error ?? 'chat.startStream failed')
       segment.streamTs = response.ts

--- a/services/slackbot/src/slack/block-kit.test.ts
+++ b/services/slackbot/src/slack/block-kit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  BlockKitValidationError,
+  blocksChunk,
+  parseSlackBlocks,
+  parseSlackStreamChunks
+} from './block-kit'
+
+describe('Block Kit validation', () => {
+  it('accepts documented markdown, context, rich text, and plan blocks', () => {
+    const blocks = parseSlackBlocks([
+      { type: 'markdown', text: '**Done**' },
+      {
+        type: 'context',
+        elements: [{ type: 'mrkdwn', text: '*Thinking*\\nChecked local tests.' }]
+      },
+      {
+        type: 'plan',
+        title: 'Execution complete',
+        tasks: [
+          {
+            task_id: 'cmd-1',
+            title: 'Ran unit tests',
+            status: 'complete',
+            output: {
+              type: 'rich_text',
+              elements: [
+                {
+                  type: 'rich_text_section',
+                  elements: [{ type: 'text', text: 'All tests passed' }]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ])
+
+    expect(blocks).toHaveLength(3)
+  })
+
+  it('rejects blocks that violate documented required fields and limits', () => {
+    expect(() => parseSlackBlocks([{ type: 'section' }])).toThrow(BlockKitValidationError)
+    expect(() => parseSlackBlocks([{ type: 'markdown', text: 'x'.repeat(12_001) }])).toThrow(
+      'markdown blocks exceed'
+    )
+    expect(() =>
+      parseSlackBlocks([
+        {
+          type: 'context',
+          elements: Array.from({ length: 11 }, () => ({ type: 'mrkdwn', text: 'x' }))
+        }
+      ])
+    ).toThrow('must contain 1 to 10 items')
+  })
+
+  it('accepts Slack stream blocks chunks in addition to typed stream chunks', () => {
+    const chunks = parseSlackStreamChunks([
+      { type: 'plan_update', title: 'Execution' },
+      { type: 'task_update', id: 'task-1', title: 'Run command', status: 'in_progress' },
+      blocksChunk([{ type: 'section', text: { type: 'mrkdwn', text: 'Section text' } }])
+    ])
+
+    expect(chunks.map(chunk => chunk.type)).toEqual(['plan_update', 'task_update', 'blocks'])
+  })
+})

--- a/services/slackbot/src/slack/block-kit.ts
+++ b/services/slackbot/src/slack/block-kit.ts
@@ -8,6 +8,17 @@ export type SlackTaskDisplayMode = 'timeline' | 'plan' | 'dense'
 
 const MAX_BLOCKS = slackReplyLimits.message.maxBlocks
 const MAX_MARKDOWN_CHARS = slackReplyLimits.stream.markdownChunkChars
+
+// These mirror Slack's published Block Kit limits. Keep the values explicit
+// near the validator because this module guards JSON supplied to internal
+// Slackbot endpoints before it reaches Slack as chat.postMessage/chat.update
+// or chat.*Stream payloads.
+//
+// Reference:
+// - Section block: https://docs.slack.dev/reference/block-kit/blocks/section-block/
+// - Context block: https://docs.slack.dev/reference/block-kit/blocks/context-block/
+// - Markdown block: https://docs.slack.dev/reference/block-kit/blocks/markdown-block/
+// - Common block_id fields are capped at 255 chars across Block Kit blocks.
 const MAX_SECTION_TEXT_CHARS = 3_000
 const MAX_SECTION_FIELD_CHARS = 2_000
 const MAX_TEXT_OBJECT_CHARS = 3_000

--- a/services/slackbot/src/slack/block-kit.ts
+++ b/services/slackbot/src/slack/block-kit.ts
@@ -1,0 +1,365 @@
+import type { AnyBlock, AnyChunk, BlocksChunk } from '@slack/types'
+import { slackReplyLimits } from '../constants'
+
+export type SlackBlock = AnyBlock
+export type SlackBlocksChunk = BlocksChunk
+export type SlackStreamChunk = AnyChunk | SlackBlocksChunk
+export type SlackTaskDisplayMode = 'timeline' | 'plan' | 'dense'
+
+const MAX_BLOCKS = slackReplyLimits.message.maxBlocks
+const MAX_MARKDOWN_CHARS = slackReplyLimits.stream.markdownChunkChars
+const MAX_SECTION_TEXT_CHARS = 3_000
+const MAX_SECTION_FIELD_CHARS = 2_000
+const MAX_TEXT_OBJECT_CHARS = 3_000
+const MAX_BLOCK_ID_CHARS = 255
+const MAX_CONTEXT_ELEMENTS = 10
+const MAX_SECTION_FIELDS = 10
+const TASK_STATUSES = new Set(['pending', 'in_progress', 'complete', 'error'])
+
+export class BlockKitValidationError extends Error {
+  readonly code: 'invalid_blocks' | 'invalid_chunks'
+
+  constructor(code: 'invalid_blocks' | 'invalid_chunks', message: string) {
+    super(message)
+    this.name = 'BlockKitValidationError'
+    this.code = code
+  }
+}
+
+export function parseSlackBlocks(value: unknown, field = 'blocks'): SlackBlock[] {
+  if (!Array.isArray(value)) {
+    throw new BlockKitValidationError('invalid_blocks', `${field} must be an array`)
+  }
+  if (value.length > MAX_BLOCKS) {
+    throw new BlockKitValidationError(
+      'invalid_blocks',
+      `${field} must contain ${MAX_BLOCKS} blocks or fewer`
+    )
+  }
+
+  let markdownChars = 0
+  for (const [index, block] of value.entries()) {
+    assertPlainObject(block, `${field}[${index}]`, 'invalid_blocks')
+    const type = assertString(block.type, `${field}[${index}].type`, 'invalid_blocks')
+    assertBlockId(block, `${field}[${index}]`)
+    if (type === 'markdown') {
+      const text = assertString(block.text, `${field}[${index}].text`, 'invalid_blocks')
+      assertNonEmpty(text, `${field}[${index}].text`, 'invalid_blocks')
+      markdownChars += text.length
+      continue
+    }
+    validateKnownBlock(block, type, `${field}[${index}]`)
+  }
+  if (markdownChars > MAX_MARKDOWN_CHARS) {
+    throw new BlockKitValidationError(
+      'invalid_blocks',
+      `${field} markdown blocks exceed the ${MAX_MARKDOWN_CHARS} character cumulative limit`
+    )
+  }
+  return value as SlackBlock[]
+}
+
+export function parseOptionalSlackBlocks(
+  value: unknown,
+  field = 'blocks'
+): SlackBlock[] | undefined {
+  if (value === undefined || value === null) return undefined
+  return parseSlackBlocks(value, field)
+}
+
+export function parseSlackStreamChunks(value: unknown, field = 'chunks'): SlackStreamChunk[] {
+  if (!Array.isArray(value)) {
+    throw new BlockKitValidationError('invalid_chunks', `${field} must be an array`)
+  }
+  return value.map((chunk, index) => {
+    assertPlainObject(chunk, `${field}[${index}]`, 'invalid_chunks')
+    const type = assertString(chunk.type, `${field}[${index}].type`, 'invalid_chunks')
+    if (type === 'markdown_text') {
+      const text = assertString(chunk.text, `${field}[${index}].text`, 'invalid_chunks')
+      assertNonEmpty(text, `${field}[${index}].text`, 'invalid_chunks')
+      assertMaxChars(text, MAX_MARKDOWN_CHARS, `${field}[${index}].text`, 'invalid_chunks')
+    } else if (type === 'plan_update') {
+      assertNonEmpty(
+        assertString(chunk.title, `${field}[${index}].title`, 'invalid_chunks'),
+        `${field}[${index}].title`,
+        'invalid_chunks'
+      )
+    } else if (type === 'task_update') {
+      assertNonEmpty(
+        assertString(chunk.id, `${field}[${index}].id`, 'invalid_chunks'),
+        `${field}[${index}].id`,
+        'invalid_chunks'
+      )
+      assertNonEmpty(
+        assertString(chunk.title, `${field}[${index}].title`, 'invalid_chunks'),
+        `${field}[${index}].title`,
+        'invalid_chunks'
+      )
+      validateTaskStatus(chunk.status, `${field}[${index}].status`, 'invalid_chunks')
+      assertOptionalString(chunk.details, `${field}[${index}].details`, 'invalid_chunks')
+      assertOptionalString(chunk.output, `${field}[${index}].output`, 'invalid_chunks')
+    } else if (type === 'blocks') {
+      parseSlackBlocks(chunk.blocks, `${field}[${index}].blocks`)
+    } else {
+      throw new BlockKitValidationError(
+        'invalid_chunks',
+        `${field}[${index}].type must be markdown_text, plan_update, task_update, or blocks`
+      )
+    }
+    return chunk as unknown as SlackStreamChunk
+  })
+}
+
+export function parseOptionalSlackStreamChunks(
+  value: unknown,
+  field = 'chunks'
+): SlackStreamChunk[] | undefined {
+  if (value === undefined || value === null) return undefined
+  return parseSlackStreamChunks(value, field)
+}
+
+export function blocksChunk(blocks: SlackBlock[]): SlackBlocksChunk {
+  return { type: 'blocks', blocks: parseSlackBlocks(blocks) }
+}
+
+export function slackStreamChunksForApi(chunks: SlackStreamChunk[]): AnyChunk[] {
+  // Slack documents blocks chunks for chat.*Stream, but @slack/types still omits them
+  // from AnyChunk, so the SDK call boundary needs this validated cast.
+  return chunks as AnyChunk[]
+}
+
+function validateKnownBlock(block: Record<string, unknown>, type: string, path: string): void {
+  if (type === 'section') {
+    const hasText = block.text !== undefined
+    const hasFields = block.fields !== undefined
+    if (!hasText && !hasFields) {
+      throw new BlockKitValidationError('invalid_blocks', `${path} must include text or fields`)
+    }
+    if (hasText) {
+      validateTextObject(block.text, `${path}.text`, MAX_SECTION_TEXT_CHARS)
+    }
+    if (hasFields) {
+      validateTextObjectArray(
+        block.fields,
+        `${path}.fields`,
+        MAX_SECTION_FIELDS,
+        MAX_SECTION_FIELD_CHARS
+      )
+    }
+    assertOptionalBoolean(block.expand, `${path}.expand`, 'invalid_blocks')
+  } else if (type === 'context') {
+    assertArray(block.elements, `${path}.elements`, 'invalid_blocks')
+    if (!block.elements.length || block.elements.length > MAX_CONTEXT_ELEMENTS) {
+      throw new BlockKitValidationError(
+        'invalid_blocks',
+        `${path}.elements must contain 1 to ${MAX_CONTEXT_ELEMENTS} items`
+      )
+    }
+    for (const [index, element] of block.elements.entries()) {
+      validateContextElement(element, `${path}.elements[${index}]`)
+    }
+  } else if (type === 'rich_text') {
+    assertArray(block.elements, `${path}.elements`, 'invalid_blocks')
+  } else if (type === 'plan') {
+    assertNonEmpty(
+      assertString(block.title, `${path}.title`, 'invalid_blocks'),
+      `${path}.title`,
+      'invalid_blocks'
+    )
+    if (block.tasks !== undefined) {
+      assertArray(block.tasks, `${path}.tasks`, 'invalid_blocks')
+      for (const [index, task] of block.tasks.entries()) {
+        validateTaskCard(task, `${path}.tasks[${index}]`, { nested: true })
+      }
+    }
+  } else if (type === 'task_card') {
+    validateTaskCard(block, path, { nested: false })
+  } else if (type === 'header') {
+    validateTextObject(block.text, `${path}.text`, 150, { plainTextOnly: true })
+  } else if (type === 'divider') {
+    return
+  }
+}
+
+function validateTaskCard(value: unknown, path: string, opts: { nested: boolean }): void {
+  assertPlainObject(value, path, 'invalid_blocks')
+  if (!opts.nested) {
+    const type = assertString(value.type, `${path}.type`, 'invalid_blocks')
+    if (type !== 'task_card') {
+      throw new BlockKitValidationError('invalid_blocks', `${path}.type must be task_card`)
+    }
+  }
+  assertNonEmpty(
+    assertString(value.task_id, `${path}.task_id`, 'invalid_blocks'),
+    `${path}.task_id`,
+    'invalid_blocks'
+  )
+  assertNonEmpty(
+    assertString(value.title, `${path}.title`, 'invalid_blocks'),
+    `${path}.title`,
+    'invalid_blocks'
+  )
+  if (value.status !== undefined) {
+    validateTaskStatus(value.status, `${path}.status`, 'invalid_blocks')
+  }
+  if (value.details !== undefined) {
+    validateRichTextBlock(value.details, `${path}.details`)
+  }
+  if (value.output !== undefined) {
+    validateRichTextBlock(value.output, `${path}.output`)
+  }
+  if (value.sources !== undefined) {
+    assertArray(value.sources, `${path}.sources`, 'invalid_blocks')
+  }
+}
+
+function validateRichTextBlock(value: unknown, path: string): void {
+  assertPlainObject(value, path, 'invalid_blocks')
+  const type = assertString(value.type, `${path}.type`, 'invalid_blocks')
+  if (type !== 'rich_text') {
+    throw new BlockKitValidationError('invalid_blocks', `${path}.type must be rich_text`)
+  }
+  assertArray(value.elements, `${path}.elements`, 'invalid_blocks')
+}
+
+function validateContextElement(value: unknown, path: string): void {
+  assertPlainObject(value, path, 'invalid_blocks')
+  const type = assertString(value.type, `${path}.type`, 'invalid_blocks')
+  if (type === 'image') {
+    assertNonEmpty(
+      assertString(value.image_url, `${path}.image_url`, 'invalid_blocks'),
+      `${path}.image_url`,
+      'invalid_blocks'
+    )
+    assertNonEmpty(
+      assertString(value.alt_text, `${path}.alt_text`, 'invalid_blocks'),
+      `${path}.alt_text`,
+      'invalid_blocks'
+    )
+    return
+  }
+  validateTextObject(value, path, MAX_TEXT_OBJECT_CHARS)
+}
+
+function validateTextObject(
+  value: unknown,
+  path: string,
+  maxChars = MAX_TEXT_OBJECT_CHARS,
+  opts: { plainTextOnly?: boolean } = {}
+): void {
+  assertPlainObject(value, path, 'invalid_blocks')
+  const type = assertString(value.type, `${path}.type`, 'invalid_blocks')
+  if (opts.plainTextOnly && type !== 'plain_text') {
+    throw new BlockKitValidationError('invalid_blocks', `${path}.type must be plain_text`)
+  }
+  if (type !== 'plain_text' && type !== 'mrkdwn') {
+    throw new BlockKitValidationError('invalid_blocks', `${path}.type must be plain_text or mrkdwn`)
+  }
+  const text = assertString(value.text, `${path}.text`, 'invalid_blocks')
+  assertNonEmpty(text, `${path}.text`, 'invalid_blocks')
+  assertMaxChars(text, maxChars, `${path}.text`, 'invalid_blocks')
+}
+
+function validateTextObjectArray(
+  value: unknown,
+  path: string,
+  maxItems: number,
+  maxChars: number
+): void {
+  assertArray(value, path, 'invalid_blocks')
+  if (!value.length || value.length > maxItems) {
+    throw new BlockKitValidationError(
+      'invalid_blocks',
+      `${path} must contain 1 to ${maxItems} items`
+    )
+  }
+  for (const [index, item] of value.entries()) {
+    validateTextObject(item, `${path}[${index}]`, maxChars)
+  }
+}
+
+function validateTaskStatus(
+  value: unknown,
+  path: string,
+  code: BlockKitValidationError['code']
+): void {
+  const status = assertString(value, path, code)
+  if (!TASK_STATUSES.has(status)) {
+    throw new BlockKitValidationError(
+      code,
+      `${path} must be pending, in_progress, complete, or error`
+    )
+  }
+}
+
+function assertBlockId(block: Record<string, unknown>, path: string): void {
+  if (block.block_id === undefined) return
+  assertMaxChars(
+    assertString(block.block_id, `${path}.block_id`, 'invalid_blocks'),
+    MAX_BLOCK_ID_CHARS,
+    `${path}.block_id`,
+    'invalid_blocks'
+  )
+}
+
+function assertPlainObject(
+  value: unknown,
+  path: string,
+  code: BlockKitValidationError['code']
+): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new BlockKitValidationError(code, `${path} must be an object`)
+  }
+}
+
+function assertArray(
+  value: unknown,
+  path: string,
+  code: BlockKitValidationError['code']
+): asserts value is unknown[] {
+  if (!Array.isArray(value)) {
+    throw new BlockKitValidationError(code, `${path} must be an array`)
+  }
+}
+
+function assertString(value: unknown, path: string, code: BlockKitValidationError['code']): string {
+  if (typeof value !== 'string') {
+    throw new BlockKitValidationError(code, `${path} must be a string`)
+  }
+  return value
+}
+
+function assertOptionalString(
+  value: unknown,
+  path: string,
+  code: BlockKitValidationError['code']
+): void {
+  if (value === undefined) return
+  assertString(value, path, code)
+}
+
+function assertOptionalBoolean(
+  value: unknown,
+  path: string,
+  code: BlockKitValidationError['code']
+): void {
+  if (value === undefined || typeof value === 'boolean') return
+  throw new BlockKitValidationError(code, `${path} must be a boolean`)
+}
+
+function assertNonEmpty(value: string, path: string, code: BlockKitValidationError['code']): void {
+  if (!value.length) {
+    throw new BlockKitValidationError(code, `${path} must not be empty`)
+  }
+}
+
+function assertMaxChars(
+  value: string,
+  maxChars: number,
+  path: string,
+  code: BlockKitValidationError['code']
+): void {
+  if (value.length > maxChars) {
+    throw new BlockKitValidationError(code, `${path} must be ${maxChars} characters or fewer`)
+  }
+}

--- a/services/slackbot/src/slack/client.ts
+++ b/services/slackbot/src/slack/client.ts
@@ -1,4 +1,3 @@
-import type { AnyBlock, AnyChunk } from '@slack/types'
 import type {
   ChatAppendStreamResponse,
   ChatPostMessageResponse,
@@ -9,6 +8,12 @@ import type {
   WebAPICallResult
 } from '@slack/web-api'
 import { WebClient } from '@slack/web-api'
+import {
+  slackStreamChunksForApi,
+  type SlackBlock,
+  type SlackStreamChunk,
+  type SlackTaskDisplayMode
+} from './block-kit'
 import {
   enforceBlockLimits,
   fallbackText,
@@ -75,18 +80,19 @@ export class SlackEdgeClient {
     channel: string
     threadTs: string
     markdown?: string
-    chunks?: AnyChunk[]
+    chunks?: SlackStreamChunk[]
     recipientTeamId?: string
     recipientUserId?: string
-    taskDisplayMode?: 'plan' | 'timeline' | 'dense'
+    taskDisplayMode?: SlackTaskDisplayMode
   }): Promise<ChatStartStreamResponse> {
+    const chunks = opts.chunks ?? markdownToStreamChunks(opts.markdown ?? ' ')
     const response = await this.client.chat.startStream({
       channel: opts.channel,
       thread_ts: opts.threadTs,
       recipient_team_id: opts.recipientTeamId,
       recipient_user_id: opts.recipientUserId,
       task_display_mode: opts.taskDisplayMode,
-      chunks: opts.chunks ?? markdownToStreamChunks(opts.markdown ?? ' ')
+      chunks: slackStreamChunksForApi(chunks)
     })
     return assertSlackOk('chat.startStream', response)
   }
@@ -95,12 +101,13 @@ export class SlackEdgeClient {
     channel: string
     ts: string
     markdown?: string
-    chunks?: AnyChunk[]
+    chunks?: SlackStreamChunk[]
   }): Promise<ChatAppendStreamResponse> {
+    const chunks = opts.chunks ?? markdownToStreamChunks(opts.markdown ?? ' ')
     const response = await this.client.chat.appendStream({
       channel: opts.channel,
       ts: opts.ts,
-      chunks: opts.chunks ?? markdownToStreamChunks(opts.markdown ?? ' ')
+      chunks: slackStreamChunksForApi(chunks)
     })
     return assertSlackOk('chat.appendStream', response)
   }
@@ -109,13 +116,15 @@ export class SlackEdgeClient {
     channel: string
     ts: string
     markdown?: string
-    chunks?: AnyChunk[]
-    blocks?: AnyBlock[]
+    chunks?: SlackStreamChunk[]
+    blocks?: SlackBlock[]
   }): Promise<ChatStopStreamResponse> {
+    const chunks =
+      opts.chunks ?? (opts.markdown ? markdownToStreamChunks(opts.markdown) : undefined)
     const response = await this.client.chat.stopStream({
       channel: opts.channel,
       ts: opts.ts,
-      chunks: opts.chunks ?? (opts.markdown ? markdownToStreamChunks(opts.markdown) : undefined),
+      chunks: chunks ? slackStreamChunksForApi(chunks) : undefined,
       blocks: opts.blocks ? enforceBlockLimits(opts.blocks) : undefined
     })
     return assertSlackOk('chat.stopStream', response)
@@ -156,7 +165,7 @@ export class SlackEdgeClient {
     bytes: Uint8Array
     title?: string
     altText?: string
-    blocks?: AnyBlock[]
+    blocks?: SlackBlock[]
   }): Promise<FilesCompleteUploadExternalResponse> {
     const upload = await this.client.files.getUploadURLExternal({
       filename: opts.filename,
@@ -189,8 +198,8 @@ export class SlackEdgeClient {
     return assertSlackOk('files.completeUploadExternal', complete)
   }
 
-  private renderBlocks(markdown: string, metadata?: StatusMetadata): AnyBlock[] {
-    const blocks: AnyBlock[] = [...renderMarkdownBlocks(markdown)]
+  private renderBlocks(markdown: string, metadata?: StatusMetadata): SlackBlock[] {
+    const blocks: SlackBlock[] = [...renderMarkdownBlocks(markdown)]
     const status = metadata ? renderStatusBlock(metadata) : null
     if (status) blocks.push(status)
     return enforceBlockLimits(blocks)

--- a/services/slackbot/src/slack/final-message.test.ts
+++ b/services/slackbot/src/slack/final-message.test.ts
@@ -83,7 +83,7 @@ describe('sanitizeFinalMessagePayload', () => {
       }
     }))
     const blocks = sanitizeFinalMessagePayload([
-      planBlock('Centaur execution', tasks, 'plan-1') as AnyBlock,
+      planBlock('Centaur execution', tasks) as AnyBlock,
       { type: 'markdown', text: 'Final answer ' + 'w'.repeat(8_000) }
     ])
     expect(estimatePayloadBytes(blocks)).toBeLessThanOrEqual(

--- a/services/slackbot/src/slack/final-message.ts
+++ b/services/slackbot/src/slack/final-message.ts
@@ -1,15 +1,13 @@
-import type { AnyBlock, MarkdownBlock } from '@slack/types'
+import type { MarkdownBlock } from '@slack/types'
 import { slackReplyLimits } from '../constants'
+import type { SlackBlock } from './block-kit'
 import { enforceBlockLimits } from './render'
 
 const MARKDOWN_CUMULATIVE_CHARS = slackReplyLimits.stream.markdownChunkChars
 const PAYLOAD_BYTE_BUDGET = slackReplyLimits.mixedBodyAndPlan.maxPayloadBytes
 const MAX_FALLBACK_CHARS = slackReplyLimits.text.maxFallbackChars
 
-export function buildFinalFallbackText(opts: {
-  title: string
-  answerMarkdown: string
-}): string {
+export function buildFinalFallbackText(opts: { title: string; answerMarkdown: string }): string {
   const parts = [opts.title.trim(), opts.answerMarkdown.trim()].filter(Boolean)
   const text = parts.join('\n')
   if (!text) return opts.title.trim() || 'Centaur update'
@@ -18,18 +16,18 @@ export function buildFinalFallbackText(opts: {
 }
 
 /** Enforce Slack limits on the composed chat.update payload (plan + markdown + footer). */
-export function sanitizeFinalMessagePayload(blocks: AnyBlock[]): AnyBlock[] {
+export function sanitizeFinalMessagePayload(blocks: SlackBlock[]): SlackBlock[] {
   let sanitized = enforceBlockLimits(blocks)
   sanitized = capMarkdownBlocksCumulative(sanitized, MARKDOWN_CUMULATIVE_CHARS)
   sanitized = shrinkToPayloadByteBudget(sanitized, PAYLOAD_BYTE_BUDGET)
   return sanitized
 }
 
-function capMarkdownBlocksCumulative(blocks: AnyBlock[], maxChars: number): AnyBlock[] {
+function capMarkdownBlocksCumulative(blocks: SlackBlock[], maxChars: number): SlackBlock[] {
   let total = markdownCharsUsed(blocks)
   if (total <= maxChars) return blocks
 
-  const out = blocks.map(block => ({ ...block })) as AnyBlock[]
+  const out = blocks.map(block => ({ ...block })) as SlackBlock[]
   for (let index = out.length - 1; index >= 0 && total > maxChars; index -= 1) {
     const block = out[index]
     if (block?.type !== 'markdown') continue
@@ -43,7 +41,7 @@ function capMarkdownBlocksCumulative(blocks: AnyBlock[], maxChars: number): AnyB
   return out
 }
 
-function shrinkToPayloadByteBudget(blocks: AnyBlock[], maxBytes: number): AnyBlock[] {
+function shrinkToPayloadByteBudget(blocks: SlackBlock[], maxBytes: number): SlackBlock[] {
   let sanitized = blocks
   if (estimatePayloadBytes(sanitized) <= maxBytes) return sanitized
 
@@ -51,10 +49,10 @@ function shrinkToPayloadByteBudget(blocks: AnyBlock[], maxBytes: number): AnyBlo
   const bytes = estimatePayloadBytes(sanitized)
   if (bytes <= maxBytes) return sanitized
 
-  return blocks.filter(block => block.type === 'markdown') as AnyBlock[]
+  return blocks.filter(block => block.type === 'markdown') as SlackBlock[]
 }
 
-function stripPlanTaskBodies(blocks: AnyBlock[]): AnyBlock[] {
+function stripPlanTaskBodies(blocks: SlackBlock[]): SlackBlock[] {
   return blocks.map(block => {
     if (block.type !== 'plan' || !('tasks' in block) || !Array.isArray(block.tasks)) {
       return block
@@ -70,7 +68,7 @@ function stripPlanTaskBodies(blocks: AnyBlock[]): AnyBlock[] {
   })
 }
 
-function trimPlanTasks(blocks: AnyBlock[], maxTasks: number): AnyBlock[] {
+function trimPlanTasks(blocks: SlackBlock[], maxTasks: number): SlackBlock[] {
   return blocks.map(block => {
     if (block.type !== 'plan' || !('tasks' in block) || !Array.isArray(block.tasks)) {
       return block
@@ -79,16 +77,16 @@ function trimPlanTasks(blocks: AnyBlock[], maxTasks: number): AnyBlock[] {
       ...block,
       tasks: block.tasks.slice(0, maxTasks)
     }
-  }) as AnyBlock[]
+  }) as SlackBlock[]
 }
 
-function markdownCharsUsed(blocks: AnyBlock[]): number {
+function markdownCharsUsed(blocks: SlackBlock[]): number {
   return blocks.reduce((total, block) => {
     if (block.type !== 'markdown') return total
     return total + (block as MarkdownBlock).text.length
   }, 0)
 }
 
-export function estimatePayloadBytes(blocks: AnyBlock[]): number {
+export function estimatePayloadBytes(blocks: SlackBlock[]): number {
   return Buffer.byteLength(JSON.stringify(blocks), 'utf8')
 }

--- a/services/slackbot/src/slack/render.ts
+++ b/services/slackbot/src/slack/render.ts
@@ -1,5 +1,6 @@
-import type { AnyBlock, AnyChunk, MarkdownBlock, RichTextBlock } from '@slack/types'
+import type { AnyChunk, MarkdownBlock, RichTextBlock } from '@slack/types'
 import { slackReplyLimits } from '../constants'
+import type { SlackBlock } from './block-kit'
 
 const MAX_BLOCKS = slackReplyLimits.message.maxBlocks
 const MAX_MARKDOWN_CHARS = slackReplyLimits.stream.markdownChunkChars
@@ -59,7 +60,7 @@ export function renderStatusBlock(metadata: StatusMetadata): RichTextBlock | nul
   }
 }
 
-export function enforceBlockLimits(blocks: AnyBlock[]): AnyBlock[] {
+export function enforceBlockLimits(blocks: SlackBlock[]): SlackBlock[] {
   return blocks.slice(0, MAX_BLOCKS)
 }
 

--- a/services/slackbot/src/slack/streaming.ts
+++ b/services/slackbot/src/slack/streaming.ts
@@ -1,5 +1,6 @@
-import type { AnyChunk, RichTextBlock } from '@slack/types'
+import type { AnyChunk, PlanBlock, RichTextBlock } from '@slack/types'
 import { slackReplyLimits } from '../constants'
+import type { SlackStreamChunk } from './block-kit'
 
 export type StreamTaskStatus = 'pending' | 'in_progress' | 'complete' | 'error'
 
@@ -40,7 +41,7 @@ export type StreamTask = {
   sources?: Array<{ type: 'url'; text: string; url: string }>
 }
 
-export type StreamChunk = AnyChunk
+export type StreamChunk = SlackStreamChunk
 
 export const SLACK_STREAM_MARKDOWN_TEXT_LIMIT = slackReplyLimits.stream.markdownChunkChars
 export const SLACK_STREAM_TASK_UPDATE_FIELD_LIMIT = slackReplyLimits.stream.taskDetailsChars
@@ -70,10 +71,9 @@ export function taskUpdateChunk(task: StreamTask): StreamChunk {
   }
 }
 
-export function planBlock(title: string, tasks: StreamTask[], planId?: string): object {
+export function planBlock(title: string, tasks: StreamTask[]): PlanBlock {
   return {
     type: 'plan',
-    ...(planId ? { plan_id: planId } : {}),
     title,
     tasks: tasks.map(task => ({
       task_id: task.id,
@@ -87,7 +87,7 @@ export function planBlock(title: string, tasks: StreamTask[], planId?: string): 
         : {}),
       ...(task.sources ? { sources: task.sources } : {})
     }))
-  }
+  } satisfies PlanBlock
 }
 
 export function plainRichText(value: string, blockId?: string): StreamRichText {

--- a/services/slackbot/src/slack/types.ts
+++ b/services/slackbot/src/slack/types.ts
@@ -1,4 +1,5 @@
-import type { AnyBlock, AnyChunk, MarkdownBlock, RichTextBlock } from '@slack/types'
+import type { MarkdownBlock, RichTextBlock } from '@slack/types'
+import type { SlackBlock, SlackStreamChunk } from './block-kit'
 
 export type NormalizedTextPart = {
   type: 'text'
@@ -74,6 +75,6 @@ export type SlackMessageFile = {
 
 export type SlackRenderableBlock = MarkdownBlock | RichTextBlock
 
-export type SlackBlocks = SlackRenderableBlock[] | AnyBlock[]
+export type SlackBlocks = SlackRenderableBlock[] | SlackBlock[]
 
-export type SlackStreamChunk = AnyChunk
+export type { SlackStreamChunk }


### PR DESCRIPTION
## Summary
- add a Slack Block Kit validation boundary for message blocks and stream chunks
- route Slack write APIs through typed SlackBlock and SlackStreamChunk helpers
- update @slack/types and remove the undocumented plan_id field from generated plan blocks

## Tests
- bun run check:types
- bun test src/*.test.ts src/**/*.test.ts
- git diff --check