### PR TITLE
fix: ignore quoted Slack bot mentions

### DIFF
--- a/services/slackbot/src/slack/normalize.test.ts
+++ b/services/slackbot/src/slack/normalize.test.ts
@@ -193,6 +193,44 @@ describe('normalizeSlackEnvelope', () => {
     expect(normalized?.slack.user_team).toBe('TEXTERNAL')
   })
 
+  it('does not treat a mention inside quoted rich text as an actionable mention', async () => {
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-quoted-mention',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'C123',
+          channel_type: 'channel',
+          ts: '1778875070.942789',
+          text: 'Following up',
+          blocks: [
+            {
+              type: 'rich_text',
+              elements: [
+                {
+                  type: 'rich_text_quote',
+                  elements: [{ type: 'user', user_id: 'UBOT' }, { type: 'text', text: ' help' }]
+                },
+                {
+                  type: 'rich_text_section',
+                  elements: [{ type: 'text', text: 'Following up' }]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      botUserId: 'UBOT',
+      client
+    })
+
+    expect(normalized?.is_mention).toBe(false)
+    expect(normalized?.parts).toEqual([{ type: 'text', text: 'help\nFollowing up' }])
+  })
+
   it('keeps non-self bot-authored alert mentions actionable', async () => {
     const normalized = await normalizeSlackEnvelope({
       envelope: {

--- a/services/slackbot/src/slack/normalize.ts
+++ b/services/slackbot/src/slack/normalize.ts
@@ -246,14 +246,10 @@ function slackMessageText(
 }
 
 function messageMentionsBot(
-  message: Pick<SlackMessageEvent, 'text' | 'blocks' | 'attachments'>,
+  message: Pick<SlackMessageEvent, 'text'>,
   botUserId: string
 ): boolean {
-  return uniqueNonEmpty([
-    normalizeSlackText(message.text ?? ''),
-    normalizeRichTextBlocks(message.blocks),
-    normalizeSlackAttachments(message.attachments)
-  ]).some(text => text.includes(`@${botUserId}`))
+  return typeof message.text === 'string' && message.text.includes(`<@${botUserId}>`)
 }
 
 function slackActorId(


### PR DESCRIPTION
## Summary
- ignore rich-text quote blocks when deciding whether a Slack message mentions the bot
- keep quoted text in normalized message content
- add regression coverage for quoted bot mentions

## Test
- bun test services/slackbot/src/slack/normalize.test.ts