### PR TITLE
fix: avoid cold-resuming agent threads across sandboxes

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -944,18 +944,23 @@ async def get_or_spawn(
     backend = get_backend()
     await _evict_idle_sessions_for_capacity(backend)
     trace_id = old_trace_id or thread_trace_id or str(uuid.uuid4())
+    if old_agent_thread_id:
+        log.info(
+            "cold_spawn_resume_skipped",
+            thread_key=thread_key,
+            engine=resolved_engine,
+            reason="agent_thread_state_belongs_to_previous_sandbox",
+        )
     session = await backend.create(
         thread_key,
         effective_harness,
         resolved_engine,
         persona=resolved_persona,
         repo=repo,
-        resume_thread_id=old_agent_thread_id or None,
+        resume_thread_id=None,
         trace_id=trace_id,
     )
     session.trace_id = trace_id
-    if old_agent_thread_id:
-        session.agent_thread_id = old_agent_thread_id
     _get_runtime(session.sandbox_id)
     log.info(
         "pipe_session_spawned", thread_key=thread_key, sandbox=session.sandbox_id[:12]
@@ -966,7 +971,7 @@ async def get_or_spawn(
         session,
         harness=session.harness,
         engine=session.engine,
-        agent_thread_id=old_agent_thread_id,
+        agent_thread_id="",
         last_delivered_id=old_last_delivered_id,
         inflight_turn_id=old_inflight_turn_id,
         inflight_turn_input=old_inflight_turn_input,

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -61,6 +61,70 @@ async def _insert_assignment(db_pool, thread_key: str, generation: int = 1) -> N
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("engine", "stale_agent_thread_id"),
+    [
+        ("codex", "019e69c0-05c3-7841-9340-2cafeec83972"),
+        ("amp", "T-123"),
+        ("claude-code", "session-123"),
+    ],
+)
+async def test_get_or_spawn_does_not_resume_agent_thread_on_cold_spawn(
+    engine: str,
+    stale_agent_thread_id: str,
+):
+    from api.agent import get_or_spawn
+
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:{engine}-cold-spawn"
+    prior_runtime_id = f"rt-old-{uuid.uuid4().hex[:8]}"
+    fresh_runtime_id = f"rt-new-{uuid.uuid4().hex[:8]}"
+    prior = SandboxSession(
+        sandbox_id=prior_runtime_id,
+        thread_key=thread_key,
+        harness=engine,
+        engine=engine,
+        db_state="stopped",
+        agent_thread_id=stale_agent_thread_id,
+        last_delivered_id="msg-prev",
+        trace_id="trace-prev",
+    )
+    created = SandboxSession(
+        sandbox_id=fresh_runtime_id,
+        thread_key=thread_key,
+        harness=engine,
+        engine=engine,
+    )
+    backend = SimpleNamespace(create=AsyncMock(return_value=created))
+    db_insert = AsyncMock(return_value=True)
+
+    with (
+        patch("api.agent._get_pool", return_value=SimpleNamespace()),
+        patch("api.agent._db_get_session", new=AsyncMock(return_value=prior)),
+        patch("api.agent._db_delete_session", new=AsyncMock()),
+        patch("api.agent._db_insert_session", new=db_insert),
+        patch("api.agent._drop_runtime"),
+        patch("api.agent._get_runtime", return_value=SimpleNamespace()),
+        patch(
+            "api.agent.get_or_create_thread_trace_id",
+            new=AsyncMock(return_value="trace-new"),
+        ),
+        patch(
+            "api.agent._resolve_harness_profile",
+            return_value=(engine, None, None),
+        ),
+        patch("api.agent._evict_idle_sessions_for_capacity", new=AsyncMock()),
+        patch("api.agent.get_backend", return_value=backend),
+    ):
+        session = await get_or_spawn(thread_key, engine)
+
+    assert session.sandbox_id == fresh_runtime_id
+    assert session.agent_thread_id == ""
+    assert backend.create.await_args.kwargs["resume_thread_id"] is None
+    assert db_insert.await_args.kwargs["agent_thread_id"] == ""
+    assert db_insert.await_args.kwargs["last_delivered_id"] == "msg-prev"
+
+
+@pytest.mark.asyncio
 async def test_spawn_assignment_defaults_to_codex_when_no_selector(db_pool, monkeypatch):
     from api.runtime_control import spawn_assignment
 


### PR DESCRIPTION
## Summary
- do not pass prior `agent_thread_id` values into any cold-spawned sandbox
- keep Centaur delivery state such as `last_delivered_id` while clearing sandbox-local agent thread state
- add focused regression coverage across Codex, Amp, and Claude Code cold-spawn paths

## Context
We hit a Slack runtime failure after a stale sandbox was cleared and Centaur cold-spawned a fresh sandbox while still passing the previous `agent_thread_id` as `resume_thread_id`. For Codex this surfaced as `no rollout found for thread id ...`, but the underlying lifecycle rule is not Codex-specific: an `agent_thread_id` belongs to the sandbox/runtime that produced it. Once Centaur cold-spawns a replacement sandbox, the durable source of context should be Centaur chat/message state, not harness-private thread state from the prior sandbox.

This is related to #211, but distinct: #211 covers suspended bare-pod resume failing before a new sandbox is spawned. This PR covers the later cold-spawn path where a fresh sandbox is created but receives stale local runtime state from a deleted/stopped sandbox. PR #84 is auth transport only; PR #85 handles explicit Slack stop/cancel state, not implicit cold-spawn after stale runtime cleanup.

## Verification
- `uv run --project services/api ruff check services/api/api/agent.py services/api/tests/test_agent_control_plane.py`
- `uv run --project services/api pytest services/api/tests/test_agent_control_plane.py::test_get_or_spawn_does_not_resume_agent_thread_on_cold_spawn -q`