### PR TITLE
fix(slackbot): deliver the final answer when it never streamed live

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -453,6 +453,13 @@ describe('AgentSessionRenderer', () => {
       status: 'in_progress'
     })
     await renderer.text(sessionId, 'Live answer body.')
+    // Completing the step force-flushes the pending text, so the answer is durably streamed
+    // live during the turn — the case where deduping it out of the final blocks is correct.
+    await renderer.step(sessionId, {
+      id: 'cmd-1',
+      title: '1. Command execution',
+      status: 'complete'
+    })
     await renderer.done(sessionId, {
       answerMarkdown: 'Live answer body.'
     })
@@ -465,6 +472,72 @@ describe('AgentSessionRenderer', () => {
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
+  })
+
+  it('delivers a durable final answer when the answer was queued but never streamed live', async () => {
+    // Regression: on fast turns the whole answer can arrive in one burst and sit queued in
+    // pendingText without crossing a flush threshold, so nothing reaches Slack live. The
+    // finalize-time appendStream then races chat.stopStream and is dropped, leaving the thread
+    // ending after the last tool output. The answer must instead be composed into the durable
+    // stopStream blocks, and counted as delivered so the control plane skips its fallback.
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: { threads: { setStatus: async () => ({ ok: true }) } },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+
+    const answer = 'Relay does not support it; the fix is a non-Relay exact-address fallback.'
+    // Tool call streams (and persists) live during the turn.
+    await renderer.step(sessionId, {
+      id: 'cmd-1',
+      title: '1. call relay currencies',
+      status: 'complete',
+      details: '```\ncurl https://api.relay.link/currencies/v2\n```',
+      output: '```\n[]\n```'
+    })
+    // Answer arrives after the tool calls and is only queued, never durably flushed.
+    await renderer.textDelta(sessionId, answer, { flush: false })
+    const result = await renderer.done(sessionId, { answerMarkdown: answer })
+
+    const stop = calls.find(call => call.method === 'chat.stopStream')
+    const blocks = stop?.params.blocks ?? []
+    // The answer is delivered as a durable block, not left to the racing finalize appendStream.
+    expect(
+      blocks.some((block: any) => block.type === 'markdown' && String(block.text).includes(answer))
+    ).toBe(true)
+    // ...and it is not also pushed as a live markdown_text chunk, so there is no duplicate.
+    const liveAnswerText = calls
+      .filter(call => call.method === 'chat.appendStream')
+      .flatMap(call => call.params.chunks ?? [])
+      .filter((chunk: any) => chunk?.type === 'markdown_text')
+      .map((chunk: any) => String(chunk.text ?? ''))
+      .join('')
+    expect(liveAnswerText).not.toContain(answer)
+    // Delivered-char count covers the answer so services/api won't post a duplicate fallback.
+    expect(result.streamedTextChars).toBeGreaterThanOrEqual(answer.length)
   })
 
   it('keeps a durable final answer when the answer did not stream live', async () => {
@@ -679,7 +752,7 @@ describe('AgentSessionRenderer', () => {
     })
 
     await renderer.text(sessionId, 'Finished reply')
-    expect(renderer.done(sessionId)).rejects.toThrow('stream_already_closed')
+    await expect(renderer.done(sessionId)).rejects.toThrow('stream_already_closed')
 
     expect(calls.filter(call => call.method === 'assistant.threads.setStatus').at(-1)).toEqual({
       method: 'assistant.threads.setStatus',

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -150,7 +150,11 @@ export class AgentSessionRenderer {
     return await this.queueText(state, segment, markdown)
   }
 
-  async textDelta(sessionId: string, markdownDelta: string, opts: TextOptions = {}): Promise<number> {
+  async textDelta(
+    sessionId: string,
+    markdownDelta: string,
+    opts: TextOptions = {}
+  ): Promise<number> {
     if (!markdownDelta) return 0
     const state = requireSession(sessionId)
     const segment = currentSegment(state)
@@ -222,8 +226,17 @@ export class AgentSessionRenderer {
 
     try {
       for (const segment of state.segments) {
+        // When a segment also carries a live task plan and the answer never reached Slack as a
+        // durable live chunk before finalize (e.g. a fast turn whose whole answer arrived in one
+        // burst, after the tool calls, without crossing a flush threshold), a finalize-time
+        // appendStream races chat.stopStream's composed layout and is dropped — the thread ends
+        // after the last tool output. Fold the answer into the durable stopStream blocks instead
+        // of relying on that racing live chunk. Text-only turns keep streaming live as before.
+        const answerStreamedLive = segment.streamedTextSourceChars > 0
+        const foldAnswerIntoBlocks = !answerStreamedLive && segment.tasks.size > 0
         balancePendingMarkdown(segment)
-        if (streamFinalUpdates) {
+        const flushedAnswerLive = streamFinalUpdates && !foldAnswerIntoBlocks
+        if (flushedAnswerLive) {
           await this.flushText(state, segment, { force: true })
         } else {
           await this.absorbPendingText(segment)
@@ -234,7 +247,7 @@ export class AgentSessionRenderer {
             await this.flushTask(state, segment, task)
           }
         }
-        await this.closeTextStream(state, segment)
+        await this.closeTextStream(state, segment, { answerInLiveStream: flushedAnswerLive })
       }
       streamedTextChars = streamedTextSourceChars(state)
       closed = true
@@ -282,7 +295,11 @@ export class AgentSessionRenderer {
     }
   }
 
-  private async closeTextStream(state: AgentSessionState, segment: Segment): Promise<void> {
+  private async closeTextStream(
+    state: AgentSessionState,
+    segment: Segment,
+    opts: { answerInLiveStream?: boolean } = {}
+  ): Promise<void> {
     raiseStreamError(segment)
     if (segment.closed) return
     const hasFinalText = Boolean(state.finalAnswerMarkdown?.trim())
@@ -295,11 +312,18 @@ export class AgentSessionRenderer {
     const tasks = compactFinalTasks(originalTasks)
     const answerSource =
       state.finalAnswerMarkdown?.trim() || segment.streamedText.trim() || segment.textParts.join('')
+    // When the answer is not in the live stream (it was folded in at finalize), its live copy
+    // can't be relied on, so it must be composed into the final blocks in full rather than
+    // deduped against the streamed prefix.
+    const answerInLiveStream = opts.answerInLiveStream ?? Boolean(segment.streamedText.trim())
     const answerMarkdown = finalMarkdownForFinalBlocks(answerSource, segment, {
-      includeStreamedText: originalTasks.length >= DURABLE_STREAMED_ANSWER_TASK_THRESHOLD
+      includeStreamedText:
+        !answerInLiveStream || originalTasks.length >= DURABLE_STREAMED_ANSWER_TASK_THRESHOLD
     })
     const streamedTextLive =
-      Boolean(segment.streamedText.trim()) && segment.streamedText.length < MAX_LIVE_TEXT_CHARS
+      answerInLiveStream &&
+      Boolean(segment.streamedText.trim()) &&
+      segment.streamedText.length < MAX_LIVE_TEXT_CHARS
     // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.
     // Only add blocks for content that was not streamed live; live task_update chunks carry
     // fenced details/output, and the header has already been streamed as the first chunk.
@@ -414,9 +438,14 @@ export class AgentSessionRenderer {
     if (segment.pendingTextFlush) await segment.pendingTextFlush
     if (!segment.pendingText) return
     const markdown = normalizeMarkdownChunk(segment.streamedText, segment.pendingText)
+    const absorbedSourceChars = segment.pendingTextSourceChars
     segment.pendingText = ''
     segment.pendingTextSourceChars = 0
     segment.streamedText += markdown
+    // Folded text is delivered via the final stopStream blocks, so count it as delivered. The
+    // control plane reads this back as `slackbot_streamed_answer_chars`; under-counting here
+    // makes services/api treat the answer as cut off and post a duplicate fallback copy.
+    segment.streamedTextSourceChars += absorbedSourceChars
   }
 
   private async flushTextNow(


### PR DESCRIPTION
We had an issue where a small, fast API response (this time it was the agent fetching from Relay's unauthed API endpoint) and the resulting agent response caused a race condition that made the session think it had returned everything but it hadn't. This meant that the Slackbot just cut off entirely:
<img width="437" height="586" alt="Screenshot 2026-05-27 at 3 44 37 PM" src="https://github.com/user-attachments/assets/1f93d3f9-87fb-4691-8b81-bf864a53ea60" />

The control plane's `slackbot_live_delivery` check counted those undelivered characters resulting in it treating the message as delivered and skipped fallback reposts. The answer _was_ in logs and I was able to fish it out, but just never posted.

This change should fix that all.