### PR TITLE
fix: disable Codex fanout as it is experimental and potentially inferring with renderers

### DIFF
--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -12,7 +12,7 @@ goals = true
 fast_mode = true
 memories = true
 hooks = true
-enable_fanout = true
+enable_fanout = false
 runtime_metrics = true
 
 [features.multi_agent_v2]


### PR DESCRIPTION
## Summary
- disable the experimental Codex fanout flag in `harness/codex/config.toml`
- leave Slackbot renderer behavior unchanged for now

## Context
Codex source truth showed fanout can produce more than one root
`final_answer` `agentMessage` item in a single turn. Centaur currently
expects one assistant answer per execution, so this PR uses the simpler
temporary mitigation and disables fanout at the Codex harness config.

A follow-up can add first-class fanout response selection without
changing the harness config again.

## Validation
- `git diff origin/main --check`
- `uv run python -c 'import tomllib; tomllib.load(open("harness/codex/config.toml", "rb"))'`