### PR TITLE
fix: exempt Slackbot internal delivery from short timeout

### DIFF
--- a/services/slackbot/src/index.test.ts
+++ b/services/slackbot/src/index.test.ts
@@ -1,5 +1,6 @@
 import { createHmac } from 'node:crypto'
 import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { usesShortRequestTimeout } from './request-timeout'
 
 const originalEnv = { ...process.env }
 
@@ -11,6 +12,17 @@ afterEach(() => {
 })
 
 describe('Slack event HTTP dedupe', () => {
+  it('keeps short timeouts off internal delivery endpoints', () => {
+    expect(usesShortRequestTimeout('/api/webhooks/slack')).toBe(true)
+    expect(usesShortRequestTimeout('/api/slack/commands')).toBe(true)
+    expect(usesShortRequestTimeout('/api/slack/agent-sessions')).toBe(false)
+    expect(usesShortRequestTimeout('/api/slack/agent-sessions/session-123/harness-event')).toBe(
+      false
+    )
+    expect(usesShortRequestTimeout('/api/slack/agent-sessions/session-123/done')).toBe(false)
+    expect(usesShortRequestTimeout('/api/slack/assistant/status')).toBe(false)
+  })
+
   it('creates Linear issues from configured feedback slash commands', async () => {
     process.env.SLACK_SIGNING_SECRET = 'test-signing-secret'
     process.env.LINEAR_API_KEY = 'lin-test-key'

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -29,6 +29,7 @@ import { shouldAckWithReaction } from './slack/trivial-ack'
 import type { NormalizedSlackEvent, SlackEnvelope } from './slack/types'
 import type { AnyBlock, AnyChunk } from '@slack/types'
 import type { WebClient } from '@slack/web-api'
+import { usesShortRequestTimeout } from './request-timeout'
 
 const config = loadConfig()
 configureOtel()
@@ -46,6 +47,7 @@ const handoff = new CentaurHandoff(config)
 const deduper = new EventDeduper(config.SLACK_EVENT_DEDUP_TTL_MS)
 const CODEX_THREAD_RE = /\b(?:codex|agent|amp)\s+thread\b[^A-Z0-9]*(T-[A-Z0-9-]+)/i
 const HARNESS_EVENT_PATH_RE = /^\/api\/slack\/agent-sessions\/[^/]+\/harness-event$/
+const slackFacingRequestTimeout = timeout(5_000)
 
 void resolver
   .resolve({})
@@ -91,7 +93,10 @@ export const app = new Hono<{ Variables: Variables }>()
       status: c.res.status
     })
   })
-  .use('*', timeout(5_000))
+  .use('*', (c, next) => {
+    if (!usesShortRequestTimeout(c.req.path)) return next()
+    return slackFacingRequestTimeout(c, next)
+  })
   .use(
     requestId({
       headerName: 'X-Slackbot-Request-ID',

--- a/services/slackbot/src/request-timeout.ts
+++ b/services/slackbot/src/request-timeout.ts
@@ -1,0 +1,6 @@
+const INTERNAL_DELIVERY_PATH_RE =
+  /^\/api\/slack\/(?:agent-sessions(?:\/|$)|assistant\/(?:status|title)$)/
+
+export function usesShortRequestTimeout(path: string): boolean {
+  return !INTERNAL_DELIVERY_PATH_RE.test(path)
+}


### PR DESCRIPTION
## Summary
- keep the 5s timeout for Slack-facing webhook/command requests
- exempt internal Slackbot delivery endpoints from that short timeout so harness-event streaming can survive slower Slack API calls
- add coverage for the timeout routing rules

## Test plan
- pnpm --filter slackbot test

## Production note
- Hotfixed the Latitude deployment by rebuilding/importing `centaur-slackbot:latest` and restarting only the Slackbot deployment.