### PR TITLE
feat(sentry): read-only issue perusal tool

### DIFF
--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -66,6 +66,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `profslice` | Extract Firefox Profiler data for analysis | None |
 | `reth` | Reth execution timing and performance metrics | None |
 | `reth-log-analyzer` | Parse Reth logs and generate performance graphs | None |
+| `sentry` | Browse Sentry issues, issue details, events, stacktraces, and tag values (read-only) | `SENTRY_AUTH_TOKEN` |
 | `vlogs` | VictoriaLogs queries, fields, streams, and log analytics | None |
 | `vmetrics` | VictoriaMetrics PromQL/MetricsQL queries and metric discovery | None |
 

--- a/tools/infra/sentry/.env.example
+++ b/tools/infra/sentry/.env.example
@@ -1,0 +1,7 @@
+# Sentry user auth token. Create at: Settings -> Account -> Auth Tokens (or an
+# Organization/Internal Integration token). Read-only scopes are sufficient:
+# org:read, project:read, event:read.
+SENTRY_AUTH_TOKEN=your-sentry-user-auth-token-here
+
+# Optional: override the base URL for self-hosted Sentry. Defaults to https://sentry.io.
+# SENTRY_URL=https://sentry.example.com

--- a/tools/infra/sentry/client.py
+++ b/tools/infra/sentry/client.py
@@ -1,0 +1,193 @@
+"""Sentry HTTP API client for read-only issue perusal.
+
+Wraps the parts of the Sentry REST API needed to browse issues without any of the
+AI-powered search/Seer tooling: list/search issues with Sentry's native query syntax,
+read issue details, list an issue's events, and pull a single event's full
+stacktrace and breadcrumbs.
+"""
+
+import os
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from centaur_sdk import secret
+
+
+class SentryClient:
+    """Client for the Sentry REST API (SaaS by default).
+
+    Authenticates with a Sentry user auth token via ``Authorization: Bearer``.
+    Reads the token from ``SENTRY_AUTH_TOKEN``; the base URL defaults to
+    ``https://sentry.io`` and can be overridden with ``SENTRY_URL`` for self-hosted.
+    """
+
+    def __init__(
+        self,
+        url: str | None = None,
+        auth_token: str | None = None,
+        timeout: float = 30.0,
+    ):
+        self._url = url
+        self._auth_token = auth_token
+        self.timeout = timeout
+        self._client: httpx.Client | None = None
+
+    @property
+    def base_url(self) -> str:
+        url = (self._url or os.getenv("SENTRY_URL", "https://sentry.io")).rstrip("/")  # noqa: TID251
+        if url and not url.startswith(("http://", "https://")):
+            url = f"https://{url}"
+        return f"{url}/api/0"
+
+    def _auth_headers(self) -> dict[str, str]:
+        token = self._auth_token or secret("SENTRY_AUTH_TOKEN", "")
+        return {"Authorization": f"Bearer {token}"} if token else {}
+
+    @property
+    def client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self.base_url,
+                headers=self._auth_headers(),
+                timeout=self.timeout,
+                follow_redirects=True,
+            )
+        return self._client
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict | None = None,
+    ) -> Any:
+        clean = {k: v for k, v in (params or {}).items() if v is not None}
+        resp = self.client.request(method, path, params=clean)
+        if resp.status_code >= 400:
+            raise RuntimeError(f"Sentry API error ({resp.status_code}): {resp.text}")
+        return resp.json()
+
+    # -- Navigation ----------------------------------------------------------
+
+    def list_organizations(self) -> list[dict]:
+        """List Sentry organizations the auth token can access."""
+        return self._request("GET", "/organizations/")
+
+    def list_projects(self, organization_slug: str) -> list[dict]:
+        """List projects in an organization. Use to find project slugs for list_issues."""
+        return self._request("GET", f"/organizations/{organization_slug}/projects/")
+
+    # -- Issues --------------------------------------------------------------
+
+    def list_issues(
+        self,
+        organization_slug: str,
+        project_slug: str | None = None,
+        query: str = "is:unresolved",
+        sort: str = "date",
+        stats_period: str = "14d",
+        limit: int = 25,
+    ) -> list[dict]:
+        """List/search issues using Sentry's native search syntax (no AI translation).
+
+        Args:
+            organization_slug: Org slug (see list_organizations).
+            project_slug: Restrict to one project (see list_projects). Omit to search all
+                projects the token can access.
+            query: Raw Sentry issue search, e.g. 'is:unresolved level:error environment:prod'.
+            sort: 'date' (last seen), 'new', 'freq', 'user', or 'priority'.
+            stats_period: Relative window, e.g. '24h', '14d', '90d'.
+            limit: Max issues to return (per_page; cursor pagination not exposed).
+        """
+        params: dict[str, Any] = {
+            "query": query,
+            "sort": sort,
+            "statsPeriod": stats_period,
+            "limit": limit,
+        }
+        if project_slug:
+            path = f"/projects/{organization_slug}/{project_slug}/issues/"
+        else:
+            path = f"/organizations/{organization_slug}/issues/"
+            params["project"] = -1
+        return self._request("GET", path, params=params)
+
+    def get_issue(self, organization_slug: str, issue_id: str) -> dict:
+        """Get full details for a single issue.
+
+        Args:
+            organization_slug: Org slug.
+            issue_id: Numeric id or short id (e.g. 'PROJECT-1A').
+        """
+        return self._request(
+            "GET", f"/organizations/{organization_slug}/issues/{issue_id}/"
+        )
+
+    def list_issue_events(
+        self,
+        organization_slug: str,
+        issue_id: str,
+        full: bool = False,
+        limit: int = 25,
+    ) -> list[dict]:
+        """List events (individual occurrences) for an issue.
+
+        Args:
+            organization_slug: Org slug.
+            issue_id: Numeric or short issue id.
+            full: Include the full event payload for each occurrence.
+            limit: Max events (per_page; cursor pagination not exposed).
+        """
+        return self._request(
+            "GET",
+            f"/organizations/{organization_slug}/issues/{issue_id}/events/",
+            params={"full": "true" if full else "false", "per_page": limit},
+        )
+
+    def get_event(
+        self,
+        organization_slug: str,
+        issue_id: str,
+        event_id: str = "latest",
+    ) -> dict:
+        """Get one event for an issue with full stacktrace and breadcrumbs.
+
+        Args:
+            organization_slug: Org slug.
+            issue_id: Numeric or short issue id.
+            event_id: A specific event id, or 'latest'/'oldest'. Defaults to 'latest'.
+        """
+        return self._request(
+            "GET",
+            f"/organizations/{organization_slug}/issues/{issue_id}/events/{event_id}/",
+        )
+
+    def get_issue_tag_values(
+        self,
+        organization_slug: str,
+        issue_id: str,
+        tag_key: str,
+    ) -> dict:
+        """Get the value distribution for a tag on an issue (e.g. 'release', 'browser')."""
+        return self._request(
+            "GET",
+            f"/organizations/{organization_slug}/issues/{issue_id}/tags/{quote(tag_key)}/",
+        )
+
+    # -- Lifecycle -----------------------------------------------------------
+
+    def close(self):
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def _client() -> SentryClient:
+    return SentryClient()

--- a/tools/infra/sentry/pyproject.toml
+++ b/tools/infra/sentry/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "sentry"
+description = "Sentry issues — list/search issues, issue details, events, stacktraces, and tag values (read-only)"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+
+[tool.centaur]
+module = "client.py"
+hosts = ["sentry.io", "*.sentry.io"]
+secrets = [
+    {type = "http", name = "SENTRY_AUTH_TOKEN", match_headers = ["Authorization"], hosts = ["sentry.io", "*.sentry.io"]},
+]

--- a/tools/infra/sentry/test_client.py
+++ b/tools/infra/sentry/test_client.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+spec = importlib.util.spec_from_file_location("sentry_client", Path(__file__).with_name("client.py"))
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+SentryClient = module.SentryClient
+
+
+class RecordingSentryClient(SentryClient):
+    """Captures requests instead of hitting the network."""
+
+    def __init__(self) -> None:
+        super().__init__(url="https://sentry.io", auth_token="t")
+        self.calls: list[dict[str, Any]] = []
+        self.response: Any = []
+
+    def _request(self, method: str, path: str, params: dict | None = None) -> Any:
+        clean = {k: v for k, v in (params or {}).items() if v is not None}
+        self.calls.append({"method": method, "path": path, "params": clean})
+        return self.response
+
+    @property
+    def last(self) -> dict[str, Any]:
+        return self.calls[-1]
+
+
+def test_base_url_appends_api_prefix() -> None:
+    assert SentryClient(url="https://sentry.io").base_url == "https://sentry.io/api/0"
+    assert SentryClient(url="sentry.example.com").base_url == "https://sentry.example.com/api/0"
+
+
+def test_list_issues_project_scoped() -> None:
+    client = RecordingSentryClient()
+
+    client.list_issues("acme", project_slug="web", query="is:unresolved level:error")
+
+    assert client.last["path"] == "/projects/acme/web/issues/"
+    assert client.last["params"] == {
+        "query": "is:unresolved level:error",
+        "sort": "date",
+        "statsPeriod": "14d",
+        "limit": 25,
+    }
+    assert "project" not in client.last["params"]
+
+
+def test_list_issues_org_scoped_sets_all_projects() -> None:
+    client = RecordingSentryClient()
+
+    client.list_issues("acme", sort="freq", stats_period="24h", limit=10)
+
+    assert client.last["path"] == "/organizations/acme/issues/"
+    assert client.last["params"] == {
+        "query": "is:unresolved",
+        "sort": "freq",
+        "statsPeriod": "24h",
+        "limit": 10,
+        "project": -1,
+    }
+
+
+def test_get_event_defaults_to_latest() -> None:
+    client = RecordingSentryClient()
+
+    client.get_event("acme", "ISSUE-1")
+
+    assert client.last["path"] == "/organizations/acme/issues/ISSUE-1/events/latest/"
+
+
+def test_get_event_accepts_specific_id() -> None:
+    client = RecordingSentryClient()
+
+    client.get_event("acme", "ISSUE-1", event_id="deadbeef")
+
+    assert client.last["path"] == "/organizations/acme/issues/ISSUE-1/events/deadbeef/"
+
+
+def test_list_issue_events_serializes_full_flag() -> None:
+    client = RecordingSentryClient()
+
+    client.list_issue_events("acme", "ISSUE-1", full=True, limit=5)
+
+    assert client.last["path"] == "/organizations/acme/issues/ISSUE-1/events/"
+    assert client.last["params"] == {"full": "true", "per_page": 5}
+
+
+def test_get_issue_tag_values_url_encodes_tag() -> None:
+    client = RecordingSentryClient()
+
+    client.get_issue_tag_values("acme", "ISSUE-1", "server name")
+
+    assert client.last["path"] == "/organizations/acme/issues/ISSUE-1/tags/server%20name/"


### PR DESCRIPTION
Mirrors the non-AI subset of the Sentry MCP: list/search issues with native Sentry query syntax, read issue details, list an issue's events, pull a single event's full stacktrace/breadcrumbs, and read issue tag value distributions. Auth is a Sentry user auth token (Bearer) declared as an iron-proxy HTTP secret; defaults to SaaS sentry.io with an optional SENTRY_URL override.

successfully tested on my instance