### PR TITLE
fix(tool-server): run the sandbox sidecar without a Postgres pool

### DIFF
--- a/services/api/api/deps.py
+++ b/services/api/api/deps.py
@@ -140,8 +140,12 @@ async def verify_api_key(
         )
         raise HTTPException(status_code=401, detail="Invalid or expired sandbox token")
 
-    # DB key lookup — all external callers use DB-backed aiv2_* keys
+    # DB key lookup — all external callers use DB-backed aiv2_* keys. The
+    # tool-server sidecar runs without a DB pool (sandbox tokens only), so a
+    # non-sandbox key reaching it is simply unauthenticated rather than a crash.
     pool = request.app.state.db_pool
+    if pool is None:
+        raise HTTPException(status_code=401, detail="Invalid API key")
     key_info = await lookup_key(pool, token)
     if key_info is not None:
         request.state.api_key_info = key_info

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -436,6 +436,9 @@ def _build_tool_server_container(
         {"name": "CENTAUR_API_URL", "value": api_url},
         {"name": "TOOL_DIRS", "value": _tool_server_tool_dirs()},
         {"name": "PLUGIN_WATCHER_ENABLED", "value": "0"},
+        # Sidecar auths HMAC sandbox tokens only and has no Postgres egress,
+        # so it runs without a DB pool. See tool_server_app._skip_db.
+        {"name": "TOOL_SERVER_SKIP_DB", "value": "1"},
     ]
 
     volume_mounts: list[dict[str, Any]] = [

--- a/services/api/api/tool_server_app.py
+++ b/services/api/api/tool_server_app.py
@@ -38,6 +38,21 @@ def _plugin_watcher_enabled() -> bool:
     }
 
 
+def _skip_db() -> bool:
+    """Run without a Postgres pool (sandbox-sidecar mode).
+
+    As a per-sandbox sidecar the tool-server only ever authenticates HMAC
+    sandbox tokens, which need no DB, and the sandbox NetworkPolicy denies it
+    Postgres egress anyway. The shared tool-server Deployment leaves this unset
+    and keeps its pool for aiv2_* key auth.
+    """
+    return (os.getenv("TOOL_SERVER_SKIP_DB") or "0").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+    }
+
+
 async def _watch_tools(pm: ToolManager) -> None:
     if not _plugin_watcher_enabled():
         log.info("tool_watcher_disabled")
@@ -75,7 +90,11 @@ def _resolve_tool_dirs() -> list[Path]:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    app.state.db_pool = await create_pool(settings.database_url)
+    if _skip_db():
+        app.state.db_pool = None
+        log.info("tool_server_db_skipped")
+    else:
+        app.state.db_pool = await create_pool(settings.database_url)
     watcher_task = asyncio.create_task(_watch_tools(app.state.tool_manager))
     try:
         yield
@@ -83,7 +102,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         watcher_task.cancel()
         with suppress(asyncio.CancelledError):
             await watcher_task
-        await close_pool(app.state.db_pool)
+        if app.state.db_pool is not None:
+            await close_pool(app.state.db_pool)
 
 
 app = FastAPI(


### PR DESCRIPTION
The per-sandbox tool-server sidecar (#216) only ever authenticates HMAC sandbox tokens (sbx1.*), which need no database, and the chart's NetworkPolicy denies sandbox pods Postgres egress ("only the API process connects to the postgres listeners"). But tool_server_app.lifespan unconditionally opened an asyncpg pool and ran migrations, so on any NetworkPolicy-enforcing cluster (e.g. k3s) the sidecar crashed at startup with `dbmate ... connect: connection refused` and every agent tool call failed with a transport error. It only worked on kind, which does not enforce NetworkPolicy.

Gate the pool + migrations behind TOOL_SERVER_SKIP_DB, which _build_tool_server_container sets on the sidecar. verify_api_key now returns 401 when the pool is absent — DB-backed aiv2_* keys never reach the sidecar, so this only affects a misdirected non-sandbox request. The shared tool-server Deployment leaves the flag unset and keeps its pool.