### PR TITLE
Fix GHCR image paths in Justfile deploy

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -68,10 +68,10 @@ deploy:
       local) ;;
       ghcr)
         extra_args+=(
-          --set api.image.repository=ghcr.io/paradigmxyz/centaur-api
-          --set ironProxy.image.repository=ghcr.io/paradigmxyz/centaur-iron-proxy
-          --set slackbot.image.repository=ghcr.io/paradigmxyz/centaur-slackbot
-          --set sandbox.image.repository=ghcr.io/paradigmxyz/centaur-agent
+          --set api.image.repository=ghcr.io/paradigmxyz/centaur/centaur-api
+          --set ironProxy.image.repository=ghcr.io/paradigmxyz/centaur/centaur-iron-proxy
+          --set slackbot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-slackbot
+          --set sandbox.image.repository=ghcr.io/paradigmxyz/centaur/centaur-agent
         )
         ;;
       *) echo "unknown source: {{source}} (expected local or ghcr)" >&2; exit 2 ;;


### PR DESCRIPTION
## Summary
- update `CENTAUR_IMAGE_SOURCE=ghcr` deploy overrides to use the published `ghcr.io/paradigmxyz/centaur/centaur-*` image paths

Fixes #237

Prompted by: @Zygimantass

## Testing
- Not run: `just --summary` (`just` is not installed in this sandbox)