### PR TITLE
Fix sandbox tool routing

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.43
+version: 0.1.44
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -39,7 +39,7 @@ ironProxy:
 # sidecar — currently the API still serves /tools so this is a no-op
 # until the API drops its router (Phase 5).
 toolServer:
-  enabled: false
+  enabled: true
   port: 8001
 
 # iron-token-broker — race-free OAuth refresh-token coordinator. Enable when

--- a/services/api/tests/test_call_sh.py
+++ b/services/api/tests/test_call_sh.py
@@ -265,3 +265,30 @@ def test_call_uses_trace_id_header_and_separate_thread_key_header():
     headers = _AgentHandler.headers_seen[0]
     assert headers["X-Trace-Id"] == "00000000-0000-0000-0000-000000000123"
     assert headers["X-Centaur-Thread-Key"] == "slack:C123:1700000000.000100"
+
+
+def test_call_bypasses_proxy_for_centaur_internal_hosts():
+    _AgentHandler.requests = []
+    _AgentHandler.headers_seen = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _AgentHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        result = _run_call_args(
+            ["agent", "runtime", "?key=task:legal-review-123"],
+            server,
+            extra_env={
+                "http_proxy": "http://127.0.0.1:9",
+                "https_proxy": "http://127.0.0.1:9",
+            },
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert [(method, path) for method, path, _ in _AgentHandler.requests] == [
+        ("GET", "/agent/runtime?key=task:legal-review-123"),
+    ]

--- a/services/sandbox/call.sh
+++ b/services/sandbox/call.sh
@@ -10,13 +10,27 @@ U="${CENTAUR_API_URL:-http://api:8000}"
 TU="${CENTAUR_TOOLS_URL:-$U}"
 T="Accept: text/plain"
 J="Content-Type: application/json"
+
+_host_from_url() {
+  printf '%s\n' "$1" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://([^/:]+).*#\1#'
+}
+
+_append_no_proxy() {
+  local additions="$1"
+  export no_proxy="${no_proxy:+$no_proxy,}${additions}"
+  export NO_PROXY="${NO_PROXY:+$NO_PROXY,}${additions}"
+}
+
+_api_host="$(_host_from_url "$U")"
+_tools_host="$(_host_from_url "$TU")"
+_append_no_proxy "localhost,127.0.0.1,api,centaur-api,centaur-centaur-api,centaur-api-proxy,.centaur.svc.cluster.local,${_api_host},${_tools_host}"
 # Prefer refreshed token (written on warm-pool claim) over original env var
 _KEY="${CENTAUR_API_KEY:-}"
 if [ -f /home/agent/.api_key ]; then
   _KEY="$(cat /home/agent/.api_key)"
 fi
 _TRACE_ID="${CENTAUR_TRACE_ID:-}"
-if [ -f /home/agent/.trace_id ]; then
+if [ -z "${_TRACE_ID:-}" ] && [ -f /home/agent/.trace_id ]; then
   _TRACE_ID="$(cat /home/agent/.trace_id)"
 fi
 A="Authorization: Bearer ${_KEY}"


### PR DESCRIPTION
## Summary
- enable the sandbox tool-server sidecar by default now that the API no longer mounts /tools
- make call.sh bypass sandbox HTTP proxy for internal Centaur service hosts
- prefer explicit CENTAUR_TRACE_ID over a stale trace file

## Test
- uv run --with pytest pytest services/api/tests/test_call_sh.py