### PR TITLE
fix: bridge workflow executor db pool

### DIFF
--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -2358,6 +2358,22 @@ async def _load_checkpoints(
     }
 
 
+def _bind_app_db_pool(pool) -> None:
+    """Expose the workflow worker pool to shared API helpers.
+
+    The out-of-process workflow executor does not run FastAPI lifespan, so
+    ``api.app.state.db_pool`` is otherwise missing for workflow handlers that
+    call shared API helpers.
+    """
+    try:
+        from api.app import app as api_app
+    except Exception:
+        log.debug("workflow_app_db_pool_bind_skipped", exc_info=True)
+        return
+    if not hasattr(api_app.state, "db_pool"):
+        api_app.state.db_pool = pool
+
+
 async def _execute_run(pool, run_id: str) -> None:
     """Claim a specific run by ID and execute it."""
     worker_id = _new_worker_id()
@@ -2475,6 +2491,7 @@ async def _mark_run_failed_on_sandbox_crash(pool, run_id: str, pod_name: str) ->
 
 async def _run_handler(pool, run_row: dict[str, Any]) -> None:
     """Execute the handler for a claimed run."""
+    _bind_app_db_pool(pool)
     _start = time.monotonic()
     run_id = str(run_row["run_id"])
     workflow_name = str(run_row["workflow_name"])

--- a/services/api/tests/test_workflow_engine_title.py
+++ b/services/api/tests/test_workflow_engine_title.py
@@ -2,12 +2,39 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 
 from api import workflow_engine
+
+
+def test_bind_app_db_pool_sets_missing_app_state(monkeypatch):
+    pool = object()
+    fake_app_module = types.ModuleType("api.app")
+    fake_app_module.app = types.SimpleNamespace(state=types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "api.app", fake_app_module)
+
+    workflow_engine._bind_app_db_pool(pool)
+
+    assert fake_app_module.app.state.db_pool is pool
+
+
+def test_bind_app_db_pool_preserves_existing_app_state(monkeypatch):
+    pool = object()
+    existing_pool = object()
+    fake_app_module = types.ModuleType("api.app")
+    fake_app_module.app = types.SimpleNamespace(
+        state=types.SimpleNamespace(db_pool=existing_pool),
+    )
+    monkeypatch.setitem(sys.modules, "api.app", fake_app_module)
+
+    workflow_engine._bind_app_db_pool(pool)
+
+    assert fake_app_module.app.state.db_pool is existing_pool
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expose the workflow worker pool on `api.app.state.db_pool` before workflow handlers run
- preserve an existing FastAPI lifespan-provided pool when present
- add regression coverage for the bridge behavior

## Context
Fixes #245. The one-shot workflow executor does not run FastAPI lifespan, but shared handler code can call helpers that expect `api.app.state.db_pool`. That crashes Slack workflow turns after Slack ingress returns 200.

## Tests
- `uv run --project services/api pytest services/api/tests/test_workflow_engine_title.py -q`
- `uv run --project services/api ruff check services/api/api/workflow_engine.py services/api/tests/test_workflow_engine_title.py`