### PR TITLE
fix: run sandbox tool server without database

### DIFF
--- a/services/api/api/deps.py
+++ b/services/api/api/deps.py
@@ -140,8 +140,13 @@ async def verify_api_key(
         )
         raise HTTPException(status_code=401, detail="Invalid or expired sandbox token")
 
-    # DB key lookup — all external callers use DB-backed aiv2_* keys
-    pool = request.app.state.db_pool
+    # DB key lookup — all external callers use DB-backed aiv2_* keys. Some
+    # sandbox-local apps only accept sbx1 tokens and deliberately do not keep a
+    # DB pool.
+    pool = getattr(request.app.state, "db_pool", None)
+    if pool is None:
+        log.warning("db_api_key_lookup_unavailable", path=str(request.url.path))
+        raise HTTPException(status_code=401, detail="Invalid API key")
     key_info = await lookup_key(pool, token)
     if key_info is not None:
         request.state.api_key_info = key_info

--- a/services/api/api/tool_server_app.py
+++ b/services/api/api/tool_server_app.py
@@ -21,8 +21,6 @@ from pathlib import Path
 import structlog
 from fastapi import FastAPI
 
-from api.config import settings
-from api.db import close_pool, create_pool
 from api.logging_config import configure_structlog
 from api.tool_manager import ToolManager, load_plugins_config
 
@@ -75,7 +73,11 @@ def _resolve_tool_dirs() -> list[Path]:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    app.state.db_pool = await create_pool(settings.database_url)
+    # Sandbox-local tool servers authenticate with HMAC sandbox tokens and do
+    # not need direct database access. Keeping them DB-free avoids giving every
+    # sandbox pod Postgres network reachability just to serve /tools.
+    app.state.db_pool = None
+    log.info("tool_server_db_disabled")
     watcher_task = asyncio.create_task(_watch_tools(app.state.tool_manager))
     try:
         yield
@@ -83,7 +85,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         watcher_task.cancel()
         with suppress(asyncio.CancelledError):
             await watcher_task
-        await close_pool(app.state.db_pool)
 
 
 app = FastAPI(

--- a/services/api/tests/test_sandbox_tokens.py
+++ b/services/api/tests/test_sandbox_tokens.py
@@ -2,12 +2,19 @@
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pytest
+from fastapi import HTTPException
 
-from api.deps import mint_sandbox_token, sandbox_thread_in_scope, verify_sandbox_token
+from api.deps import (
+    mint_sandbox_token,
+    sandbox_thread_in_scope,
+    verify_api_key,
+    verify_sandbox_token,
+)
 
 _TEST_SECRET = "test-secret-key-for-unit-tests"
 
@@ -97,3 +104,34 @@ class TestSandboxThreadScope:
         assert sandbox_thread_in_scope("thread:1", "thread:1")
         assert not sandbox_thread_in_scope("thread:1", "thread:2")
         assert not sandbox_thread_in_scope("thread:1", "thread:1:child")
+
+
+class TestVerifyApiKeyWithoutDbPool:
+    @pytest.mark.asyncio
+    async def test_sandbox_token_does_not_require_db_pool(self):
+        token = mint_sandbox_token("thread:1", "ctr-abc")
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(db_pool=None)),
+            client=SimpleNamespace(host="127.0.0.1"),
+            headers={"authorization": f"Bearer {token}"},
+            state=SimpleNamespace(),
+            url=SimpleNamespace(path="/tools/demo/ping"),
+        )
+
+        assert await verify_api_key(request) == "sandbox:ctr-abc"
+        assert request.state.sandbox_claims["thread_key"] == "thread:1"
+
+    @pytest.mark.asyncio
+    async def test_db_key_fails_closed_without_db_pool(self):
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(db_pool=None)),
+            client=SimpleNamespace(host="127.0.0.1"),
+            headers={"authorization": "Bearer aiv2_test"},
+            state=SimpleNamespace(),
+            url=SimpleNamespace(path="/tools/demo/ping"),
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await verify_api_key(request)
+
+        assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary
- keep sandbox-local tool-server startup DB-free so it does not run migrations or require Postgres network access
- fail closed for DB-backed API keys when an app has no DB pool; sandbox sbx1 tokens still authenticate normally
- add coverage for sandbox-token auth without a DB pool

## Production context
After deploying main-sha-2d7932f to prd-centaur-na on 2026-05-28, new sandbox pods failed because the tool-server sidecar tried to run dbmate against Postgres from inside sandbox network policy. A temporary NetworkPolicy unblock was applied live to restore centaur-system and stg-centaur-system; this PR removes the need for that unblock.

## Verification
- uv run pytest tests/test_sandbox_tokens.py
- uv run ruff check api/deps.py api/tool_server_app.py tests/test_sandbox_tokens.py
- just build-one api
- prd-centaur-na centaur-system debug execution exe_72acf104af25427d completed after live mitigation