### PR TITLE
fix: pass workflow db pool to system message insert

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -544,7 +544,7 @@ async def _get_last_delivered_id(thread_key: str) -> str | None:
     return row["last_delivered_id"] if row else None
 
 
-async def _get_latest_thread_user_id(thread_key: str) -> str | None:
+async def _get_latest_thread_user_id(thread_key: str, *, pool=None) -> str | None:
     """Return the most recent user id recorded for this thread.
 
     Slack turns can surface the requester in several durable rows depending on
@@ -552,7 +552,7 @@ async def _get_latest_thread_user_id(thread_key: str) -> str | None:
     across those sources so the session context does not depend on one caller
     preserving one specific delivery field.
     """
-    pool = _get_pool()
+    pool = pool or _get_pool()
     row = await pool.fetchrow(
         "WITH candidates AS ("
         "  SELECT COALESCE(user_id, metadata->>'user_id') AS user_id, created_at, 1 AS source_rank "
@@ -712,12 +712,13 @@ async def _insert_system_message(
     platform: str | None,
     *,
     user_id: str | None = None,
+    pool=None,
 ) -> None:
     """Insert a static system message with platform formatting rules (idempotent)."""
-    pool = _get_pool()
+    pool = pool or _get_pool()
     effective_platform = platform or ("slack" if thread_key.startswith("slack:") else None)
     msg_id = f"system-{thread_key}-{effective_platform or 'generic'}"
-    effective_user_id = user_id or await _get_latest_thread_user_id(thread_key)
+    effective_user_id = user_id or await _get_latest_thread_user_id(thread_key, pool=pool)
     requester_identity = await _resolve_requester_identity(
         platform=effective_platform,
         user_id=effective_user_id,

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -1295,6 +1295,7 @@ async def do_agent_turn(
                 effective_thread_key,
                 effective_platform or "slack",
                 user_id=requester_user_id,
+                pool=ctx._pool,
             )
 
         if isinstance(effective_history, list):

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -75,11 +75,12 @@ async def test_create_slack_thread_turn_workflow_eager_start(
     )
     calls: list[str] = []
 
-    async def fake_insert_system_message(thread_key_arg, platform, *, user_id=None):
+    async def fake_insert_system_message(thread_key_arg, platform, *, user_id=None, pool=None):
         calls.append("system")
         assert thread_key_arg == thread_key
         assert platform == "slack"
         assert user_id == "U123"
+        assert pool is db_pool
 
     async def fake_append_message(*args, **kwargs):
         calls.append("message")


### PR DESCRIPTION
## Summary
- pass the workflow executor DB pool into Slack system-message insertion
- avoid reaching for `api.app.state.db_pool` from one-shot workflow executor pods
- assert the Slack workflow path supplies the pool

## Verification
- `uv run ruff check api/agent.py api/workflow_engine.py tests/test_workflows.py`
- `uv run pytest tests/test_workflows.py::test_create_slack_thread_turn_workflow_eager_start tests/test_integration.py::TestBuildSessionContext::test_insert_system_message_uses_thread_user_id_fallback tests/test_integration.py::TestBuildSessionContext::test_insert_system_message_infers_slack_platform_from_thread_key tests/test_integration.py::TestBuildSessionContext::test_insert_system_message_preserves_created_at_on_refresh tests/test_integration.py::TestBuildSessionContext::test_latest_thread_user_id_reads_slack_workflow_input`
- `just build-one api`