### PR TITLE
fix: hydrate workflow executor app db pool

### DIFF
--- a/services/api/api/workflow_executor.py
+++ b/services/api/api/workflow_executor.py
@@ -21,6 +21,7 @@ import sys
 
 import structlog
 
+from api.app import app
 from api.config import settings
 from api.db import close_pool, create_pool
 from api.logging_config import configure_structlog
@@ -36,6 +37,9 @@ log = structlog.get_logger().bind(service="workflow-executor")
 async def _run(run_id: str) -> int:
     pool = await create_pool(settings.database_url)
     try:
+        # Workflow executor pods do not run the FastAPI lifespan, but some
+        # legacy agent helpers still read the pool from app.state.
+        app.state.db_pool = pool
         discover_workflow_handlers()
         row = await pool.fetchrow(
             "SELECT run_id, workflow_name, input_json, status, "

--- a/services/api/tests/test_workflow_executor.py
+++ b/services/api/tests/test_workflow_executor.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+class _FakePool:
+    async def fetchrow(self, *_args, **_kwargs):
+        return {
+            "run_id": "wfr_test",
+            "workflow_name": "slack_thread_turn",
+            "input_json": {},
+            "status": "running",
+            "created_at": None,
+            "worker_id": "worker-test",
+        }
+
+
+@pytest.mark.asyncio
+async def test_workflow_executor_sets_app_state_db_pool(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example.invalid/centaur")
+    sys.modules.pop("api.workflow_executor", None)
+
+    workflow_executor = importlib.import_module("api.workflow_executor")
+    pool = _FakePool()
+
+    async def fake_create_pool(_database_url):
+        return pool
+
+    async def fake_close_pool(_pool):
+        assert _pool is pool
+
+    async def fake_run_handler(handler_pool, run_row):
+        assert handler_pool is pool
+        assert run_row["run_id"] == "wfr_test"
+        assert workflow_executor.app.state.db_pool is pool
+
+    monkeypatch.setattr(workflow_executor, "create_pool", fake_create_pool)
+    monkeypatch.setattr(workflow_executor, "close_pool", fake_close_pool)
+    monkeypatch.setattr(workflow_executor, "discover_workflow_handlers", lambda: {})
+    monkeypatch.setattr(workflow_executor, "_run_handler", fake_run_handler)
+
+    assert await workflow_executor._run("wfr_test") == 0


### PR DESCRIPTION
## Summary
- set `api.app.app.state.db_pool` from the one-shot workflow executor pool
- keep legacy agent helpers that read app state working in workflow executor pods
- add a regression test for executor pool hydration

## Verification
- `uv run ruff check api/workflow_executor.py tests/test_workflow_executor.py`
- `uv run pytest tests/test_workflow_executor.py`
- `just build-one api`