### PR TITLE
fix(slackbot): stop reposting the answer tail after a durable final delivery

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -1940,6 +1940,7 @@ async def _mark_execution_terminal(
     result_text: str,
     error_text: str | None,
     slackbot_streamed_answer_chars_override: int | None = None,
+    slackbot_final_answer_durably_delivered: bool = False,
 ) -> None:
     next_attempt_at = dt.datetime.now(dt.timezone.utc) + dt.timedelta(
         seconds=FINAL_DELIVERY_READY_GRACE_S,
@@ -2026,6 +2027,11 @@ async def _mark_execution_terminal(
                 and not slackbot_live_delivery_failed
                 and (
                     not result_has_text
+                    # The slackbot rendered the complete final answer into durable Slack blocks,
+                    # so the live delivery covers the result regardless of the streamed-char
+                    # tally — skip the fallback so its continuation does not repost the answer's
+                    # trailing characters as a separate thread message.
+                    or slackbot_final_answer_durably_delivered
                     or _slackbot_live_delivery_covers_result(
                         result_text,
                         slackbot_streamed_answer_chars,
@@ -2984,6 +2990,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
             result_text=result_text,
             error_text=error_text,
             slackbot_streamed_answer_chars_override=slackbot_streamed_answer_chars,
+            slackbot_final_answer_durably_delivered=slackbot_final_answer_durably_delivered,
         )
 
     execution_started_payload = {
@@ -3044,6 +3051,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
     turn_done_event: dict[str, Any] | None = None
     latest_terminal_result_text = ""
     slackbot_streamed_answer_chars = 0
+    slackbot_final_answer_durably_delivered = False
     pending_event: asyncio.Task | None = None
     stream = _stream_stdout(
         session,
@@ -3188,6 +3196,12 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                             harness_result.get("threadId") or harness_thread_id
                         )
                         slackbot_done = bool(harness_result.get("done"))
+                        if harness_result.get("finalAnswerDurablyDelivered"):
+                            # The slackbot composed the complete final answer into durable
+                            # chat.stopStream blocks (never dropped by Slack), so the live
+                            # delivery already covers the result and the fallback continuation
+                            # must not repost the answer's tail in the thread.
+                            slackbot_final_answer_durably_delivered = True
                         streamed_chars = harness_result.get("streamedAnswerChars")
                         previous_streamed_answer_chars = slackbot_streamed_answer_chars
                         streamed_chars = _slackbot_streamed_answer_chars(streamed_chars)

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -1239,6 +1239,92 @@ async def test_mark_execution_terminal_falls_back_after_cut_off_live_answer(db_p
 
 
 @pytest.mark.asyncio
+async def test_mark_execution_terminal_skips_fallback_when_answer_durably_delivered(db_pool):
+    # Regression for the #249 duplicate-tail bug: when the slackbot folded the complete answer
+    # into durable blocks, the streamed-char tally can still be a few chars short of result_text.
+    # Without the durable-delivery signal the fallback would repost result_text[streamed_chars:]
+    # (the answer's tail) even though it is already shown. The signal must suppress that fallback.
+    from api.runtime_control import _mark_execution_terminal
+
+    execution_id = f"exe-{uuid.uuid4().hex[:10]}"
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}"
+    runtime_id = f"rt-{uuid.uuid4().hex[:8]}"
+    result_text = "Done. The migration is safe to run now"
+    streamed_chars = len("Done. The migration is safe to run")  # short of result_text
+    assert streamed_chars < len(result_text.strip())
+    await db_pool.execute(
+        "INSERT INTO sandbox_sessions (thread_key, sandbox_id, harness, engine, state) "
+        "VALUES ($1, $2, 'codex', 'codex', 'idle')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_runtime_assignments ("
+        "thread_key, assignment_generation, runtime_id, harness, engine, "
+        "persona_id, prompt_ref, effective_agents_md_sha256, state"
+        ") VALUES ($1, 1, $2, 'codex', 'codex', NULL, 'harness:codex', 'sha', 'active')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, status, "
+        "delivery, metadata, started_at"
+        ") VALUES ($1, $2, 1, 'exec-durable', 'hash-durable', 'running', "
+        "$3::jsonb, $4::jsonb, NOW())",
+        execution_id,
+        thread_key,
+        json.dumps(
+            {
+                "platform": "slack",
+                "channel": "C-test",
+                "thread_ts": "1779333881.200699",
+            }
+        ),
+        json.dumps(
+            {
+                "slackbot_live_delivery": True,
+                "slackbot_agent_session_id": "sess-durable",
+                "slackbot_streamed_answer_chars": streamed_chars,
+            }
+        ),
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_final_delivery_outbox (execution_id, thread_key, delivery, state) "
+        "VALUES ($1, $2, '{}'::jsonb, 'awaiting_terminal')",
+        execution_id,
+        thread_key,
+    )
+
+    await _mark_execution_terminal(
+        db_pool,
+        execution_id=execution_id,
+        thread_key=thread_key,
+        status="completed",
+        terminal_reason="completed",
+        result_text=result_text,
+        error_text=None,
+        slackbot_streamed_answer_chars_override=streamed_chars,
+        slackbot_final_answer_durably_delivered=True,
+    )
+
+    outbox = await db_pool.fetchrow(
+        "SELECT state, final_payload FROM agent_final_delivery_outbox WHERE execution_id = $1",
+        execution_id,
+    )
+    assert outbox is not None
+    # The durable block already carries the full answer, so no fallback delivery is enqueued.
+    assert outbox["state"] == "awaiting_terminal"
+    assert outbox["final_payload"] is None
+    ready_events = await db_pool.fetchval(
+        "SELECT COUNT(*) FROM agent_execution_events "
+        "WHERE execution_id = $1 AND event_kind = 'final_delivery_ready'",
+        execution_id,
+    )
+    assert int(ready_events or 0) == 0
+
+
+@pytest.mark.asyncio
 async def test_final_delivery_claim_filters_platform(client, db_pool, api_key: str):
     slack_execution_id = f"exe-{uuid.uuid4().hex[:10]}"
     web_execution_id = f"exe-{uuid.uuid4().hex[:10]}"

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -764,7 +764,8 @@ describe('AgentSessionRenderer', () => {
     })
 
     await expect(renderer.done(sessionId)).resolves.toEqual({
-      streamedTextChars: expect.any(Number)
+      streamedTextChars: expect.any(Number),
+      finalAnswerDurablyDelivered: expect.any(Boolean)
     })
     expect(stopAttempts).toBe(2)
   })

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -216,13 +216,20 @@ export class AgentSessionRenderer {
     await this.flushText(state, segment, { force: true })
   }
 
-  async done(sessionId: string, opts: DoneOptions = {}): Promise<{ streamedTextChars: number }> {
+  async done(
+    sessionId: string,
+    opts: DoneOptions = {}
+  ): Promise<{ streamedTextChars: number; finalAnswerDurablyDelivered: boolean }> {
     const state = requireSession(sessionId)
     state.done = true
     state.finalAnswerMarkdown = opts.answerMarkdown
     const streamFinalUpdates = opts.streamFinalUpdates ?? true
     let closed = false
     let streamedTextChars = 0
+    // True once the complete final answer has been composed into the durable chat.stopStream
+    // blocks. Durable blocks are never dropped by Slack, so the control plane can safely skip
+    // its live-delivery coverage fallback and avoid reposting the answer's tail in the thread.
+    let finalAnswerDurablyDelivered = false
 
     try {
       for (const segment of state.segments) {
@@ -247,7 +254,10 @@ export class AgentSessionRenderer {
             await this.flushTask(state, segment, task)
           }
         }
-        await this.closeTextStream(state, segment, { answerInLiveStream: flushedAnswerLive })
+        const { answerDeliveredInBlocks } = await this.closeTextStream(state, segment, {
+          answerInLiveStream: flushedAnswerLive
+        })
+        if (answerDeliveredInBlocks) finalAnswerDurablyDelivered = true
       }
       streamedTextChars = streamedTextSourceChars(state)
       closed = true
@@ -257,7 +267,7 @@ export class AgentSessionRenderer {
       }
       if (closed) sessions.delete(sessionId)
     }
-    return { streamedTextChars }
+    return { streamedTextChars, finalAnswerDurablyDelivered }
   }
 
   private async setStatus(sessionId: string, status: string): Promise<boolean> {
@@ -299,15 +309,15 @@ export class AgentSessionRenderer {
     state: AgentSessionState,
     segment: Segment,
     opts: { answerInLiveStream?: boolean } = {}
-  ): Promise<void> {
+  ): Promise<{ answerDeliveredInBlocks: boolean }> {
     raiseStreamError(segment)
-    if (segment.closed) return
+    if (segment.closed) return { answerDeliveredInBlocks: false }
     const hasFinalText = Boolean(state.finalAnswerMarkdown?.trim())
     if (!segment.streamTs && !segment.textParts.length && !segment.tasks.size && !hasFinalText) {
-      return
+      return { answerDeliveredInBlocks: false }
     }
     await this.ensureStream(state, segment, [])
-    if (!segment.streamTs) return
+    if (!segment.streamTs) return { answerDeliveredInBlocks: false }
     const originalTasks = finalTaskSnapshot(segment)
     const tasks = compactFinalTasks(originalTasks)
     const answerSource =
@@ -333,6 +343,11 @@ export class AgentSessionRenderer {
         : []),
       ...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
     ] as AnyBlock[])
+    // The complete answer was composed into a durable block (not just streamed live) only when
+    // it was rendered in full — a clipped/truncated block still relies on a separate delivery
+    // for the remainder, so coverage must not be treated as complete in that case.
+    const answerDeliveredInBlocks =
+      !streamedTextLive && Boolean(answerMarkdown) && !answerMarkdown.endsWith('// truncated')
     const fallbackText = buildFinalFallbackText({
       title: state.title,
       answerMarkdown
@@ -347,6 +362,7 @@ export class AgentSessionRenderer {
     })
     if (!stopResponse.ok) throw new Error(stopResponse.error ?? 'chat.stopStream failed')
     segment.closed = true
+    return { answerDeliveredInBlocks }
   }
 
   private async streamChunks(

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -326,10 +326,14 @@ export class AgentSessionRenderer {
     // can't be relied on, so it must be composed into the final blocks in full rather than
     // deduped against the streamed prefix.
     const answerInLiveStream = opts.answerInLiveStream ?? Boolean(segment.streamedText.trim())
-    const answerMarkdown = finalMarkdownForFinalBlocks(answerSource, segment, {
-      includeStreamedText:
-        !answerInLiveStream || originalTasks.length >= DURABLE_STREAMED_ANSWER_TASK_THRESHOLD
-    })
+    const { markdown: answerMarkdown, truncated: answerTruncated } = finalMarkdownForFinalBlocks(
+      answerSource,
+      segment,
+      {
+        includeStreamedText:
+          !answerInLiveStream || originalTasks.length >= DURABLE_STREAMED_ANSWER_TASK_THRESHOLD
+      }
+    )
     const streamedTextLive =
       answerInLiveStream &&
       Boolean(segment.streamedText.trim()) &&
@@ -343,11 +347,13 @@ export class AgentSessionRenderer {
         : []),
       ...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
     ] as AnyBlock[])
-    // The complete answer was composed into a durable block (not just streamed live) only when
-    // it was rendered in full — a clipped/truncated block still relies on a separate delivery
-    // for the remainder, so coverage must not be treated as complete in that case.
+    // The complete answer was composed into a durable block (not just streamed live) only when it
+    // was rendered in full. answerTruncated reflects whether clipText dropped characters. The
+    // pre-sanitize answerMarkdown is trustworthy because maxVisibleChars (6_250) stays under every
+    // sanitize cap (markdownChunkChars is 12_000) and shrinkToPayloadByteBudget only sheds the plan
+    // block, never the answer text — so the sanitized blocks still carry the answer in full.
     const answerDeliveredInBlocks =
-      !streamedTextLive && Boolean(answerMarkdown) && !answerMarkdown.endsWith('// truncated')
+      !streamedTextLive && Boolean(answerMarkdown) && !answerTruncated
     const fallbackText = buildFinalFallbackText({
       title: state.title,
       answerMarkdown
@@ -689,19 +695,23 @@ function finalMarkdownForFinalBlocks(
   markdown: string,
   segment: Segment,
   opts: { includeStreamedText?: boolean } = {}
-): string {
+): { markdown: string; truncated: boolean } {
+  const maxVisibleChars = slackReplyLimits.mixedBodyAndPlan.maxVisibleChars
   const trimmed = markdown.trim()
-  if (!trimmed) return ''
+  if (!trimmed) return { markdown: '', truncated: false }
   if (opts.includeStreamedText || !segment.streamedText.trim()) {
-    return clipText(trimmed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
+    const { text, truncated } = clipTextWithFlag(trimmed, maxVisibleChars)
+    return { markdown: text, truncated }
   }
   const streamedPrefix = unstreamedMarkdownAfterLivePrefix(markdown, segment.streamedText)
   if (streamedPrefix !== null) {
-    return clipText(streamedPrefix, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
+    const { text, truncated } = clipTextWithFlag(streamedPrefix, maxVisibleChars)
+    return { markdown: text, truncated }
   }
   const unstreamed = markdown.slice(segment.streamedTextSourceChars).trim()
-  if (!unstreamed) return ''
-  return clipText(unstreamed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
+  if (!unstreamed) return { markdown: '', truncated: false }
+  const { text, truncated } = clipTextWithFlag(unstreamed, maxVisibleChars)
+  return { markdown: text, truncated }
 }
 
 function unstreamedMarkdownAfterLivePrefix(markdown: string, streamedText: string): string | null {
@@ -722,9 +732,22 @@ function normalizeFinalMarkdownPrefix(markdown: string): string {
 }
 
 function clipText(value: string, maxChars: number): string {
-  if (maxChars <= 0) return ''
-  if (maxChars <= 13) return value.length > maxChars ? value.slice(0, maxChars) : value
-  return value.length > maxChars ? `${value.slice(0, maxChars - 13)}\n// truncated` : value
+  return clipTextWithFlag(value, maxChars).text
+}
+
+// Returns the clipped text alongside whether clipping actually dropped characters, so callers can
+// signal "the complete value was rendered" without sniffing the `// truncated` sentinel (which a
+// real answer could legitimately end with, and which is easy to drift away from at a distance).
+function clipTextWithFlag(value: string, maxChars: number): { text: string; truncated: boolean } {
+  if (maxChars <= 0) return { text: '', truncated: value.length > 0 }
+  if (maxChars <= 13) {
+    return value.length > maxChars
+      ? { text: value.slice(0, maxChars), truncated: true }
+      : { text: value, truncated: false }
+  }
+  return value.length > maxChars
+    ? { text: `${value.slice(0, maxChars - 13)}\n// truncated`, truncated: true }
+    : { text: value, truncated: false }
 }
 
 function currentSegment(state: AgentSessionState): Segment {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -41,6 +41,7 @@ type CodexSessionState = {
   streamedCommentaryText: string
   streamedAnswerText: string
   deliveredAnswerChars: number
+  finalAnswerDurablyDelivered: boolean
   agentMessagePhase: AgentMessagePhase | null
   agentMessagePhaseByItemId: Map<string, AgentMessagePhase>
   planText: string
@@ -54,6 +55,7 @@ type CodexSessionState = {
 type CompletedCodexSessionState = {
   threadId: string
   streamedAnswerChars: number
+  finalAnswerDurablyDelivered: boolean
   completedAt: number
 }
 
@@ -72,7 +74,12 @@ export class CodexSessionRenderer {
   async event(
     agentSessionId: string,
     event: any
-  ): Promise<{ threadId?: string; done: boolean; streamedAnswerChars: number }> {
+  ): Promise<{
+    threadId?: string
+    done: boolean
+    streamedAnswerChars: number
+    finalAnswerDurablyDelivered: boolean
+  }> {
     const completed = completedState(agentSessionId)
     if (completed) {
       if (isTerminalTurnEvent(event)) {
@@ -81,7 +88,8 @@ export class CodexSessionRenderer {
       return {
         threadId: completed.threadId || undefined,
         done: true,
-        streamedAnswerChars: completed.streamedAnswerChars
+        streamedAnswerChars: completed.streamedAnswerChars,
+        finalAnswerDurablyDelivered: completed.finalAnswerDurablyDelivered
       }
     }
     const state = getState(agentSessionId)
@@ -234,7 +242,8 @@ export class CodexSessionRenderer {
     return {
       threadId: state.threadId || undefined,
       done: state.done,
-      streamedAnswerChars: state.deliveredAnswerChars
+      streamedAnswerChars: state.deliveredAnswerChars,
+      finalAnswerDurablyDelivered: state.finalAnswerDurablyDelivered
     }
   }
 
@@ -247,15 +256,20 @@ export class CodexSessionRenderer {
     completeOpenTasks(state)
     await this.publishActivitySummary(agentSessionId, state, { final: true })
     await this.publishPendingAssistantText(agentSessionId, state, { force: true })
-    const { streamedTextChars } = await this.renderer.done(agentSessionId, {
-      streamFinalUpdates: true,
-      answerMarkdown: state.answerText
-    })
+    const { streamedTextChars, finalAnswerDurablyDelivered } = await this.renderer.done(
+      agentSessionId,
+      {
+        streamFinalUpdates: true,
+        answerMarkdown: state.answerText
+      }
+    )
     state.deliveredAnswerChars = streamedTextChars
+    state.finalAnswerDurablyDelivered = finalAnswerDurablyDelivered
     state.done = true
     completedStates.set(agentSessionId, {
       threadId: state.threadId,
       streamedAnswerChars: state.deliveredAnswerChars,
+      finalAnswerDurablyDelivered: state.finalAnswerDurablyDelivered,
       completedAt: Date.now()
     })
     states.delete(agentSessionId)
@@ -365,6 +379,7 @@ function getState(agentSessionId: string): CodexSessionState {
       streamedCommentaryText: '',
       streamedAnswerText: '',
       deliveredAnswerChars: 0,
+      finalAnswerDurablyDelivered: false,
       agentMessagePhase: null,
       agentMessagePhaseByItemId: new Map(),
       planText: '',

--- a/services/slackbot/src/slack/durable-final-answer.test.ts
+++ b/services/slackbot/src/slack/durable-final-answer.test.ts
@@ -75,6 +75,32 @@ describe('#249 duplicate-tail regression: durable-delivery signal', () => {
     expect(durableBlockText(calls)).toContain(answer)
   })
 
+  it('does NOT report durable delivery when a folded answer is clipped by the visible-char cap', async () => {
+    const { client } = makeClient()
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778883099.579529',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    await renderer.step(sessionId, {
+      id: 'cmd-1',
+      title: '1. run migration check',
+      status: 'complete',
+      details: '```\nmake db:check\n```',
+      output: '```\nok\n```'
+    })
+    // An answer past mixedBodyAndPlan.maxVisibleChars (6250) is folded but clipped, so its tail is
+    // not in the durable block. The signal must stay false so the coverage fallback delivers it.
+    const answer = 'A'.repeat(7000)
+    await renderer.textDelta(sessionId, answer, { flush: false })
+    const result = await renderer.done(sessionId, { answerMarkdown: answer })
+
+    expect(result.finalAnswerDurablyDelivered).toBe(false)
+  })
+
   it('does NOT report durable delivery when the answer streamed live', async () => {
     const { client, calls } = makeClient()
     const renderer = new AgentSessionRenderer(client as any)

--- a/services/slackbot/src/slack/durable-final-answer.test.ts
+++ b/services/slackbot/src/slack/durable-final-answer.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'bun:test'
+import { AgentSessionRenderer } from './agent-session'
+import { CodexSessionRenderer } from './codex-session'
+
+// Regression coverage for the duplicate-tail bug reported against #249
+// (a285db16 "fix(slackbot): deliver the final answer when it never streamed live").
+//
+// Symptom: "the last 2-3 characters of the main reply get posted again in the thread."
+//
+// Root cause: on a fast turn the answer is queued and never flushed live, so done() folds the
+// FULL answer into the durable chat.stopStream blocks but credits coverage as the count of
+// live-streamed delta source chars. When the control plane's result_text carries a few trailing
+// characters beyond that count, _slackbot_live_delivery_covers_result() returns False and the
+// fallback reposts result_text.slice(streamed_chars) — the answer's tail — even though it is
+// already present in the durable block.
+//
+// Fix: the renderer reports finalAnswerDurablyDelivered when the complete answer was composed
+// into the durable blocks. The control plane treats that as full coverage and skips the fallback
+// continuation. These tests pin the slackbot side of that contract.
+
+function makeClient() {
+  const calls: Array<{ method: string; params: any }> = []
+  const client = {
+    assistant: { threads: { setStatus: async () => ({ ok: true }) } },
+    chat: {
+      startStream: async () => ({ ok: true, ts: '1778866940.295499' }),
+      appendStream: async (params: any) => {
+        calls.push({ method: 'chat.appendStream', params })
+        return { ok: true }
+      },
+      stopStream: async (params: any) => {
+        calls.push({ method: 'chat.stopStream', params })
+        return { ok: true }
+      },
+      update: async () => ({ ok: true })
+    }
+  }
+  return { client, calls }
+}
+
+function durableBlockText(calls: Array<{ method: string; params: any }>): string {
+  const stop = calls.find(c => c.method === 'chat.stopStream')
+  return (stop?.params.blocks ?? [])
+    .filter((b: any) => b.type === 'markdown')
+    .map((b: any) => String(b.text ?? ''))
+    .join('\n')
+}
+
+describe('#249 duplicate-tail regression: durable-delivery signal', () => {
+  it('reports finalAnswerDurablyDelivered when a fast-turn answer is folded into durable blocks', async () => {
+    const { client, calls } = makeClient()
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778883099.579529',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    // A tool ran -> the segment carries a live plan (fold requires tasks.size > 0).
+    await renderer.step(sessionId, {
+      id: 'cmd-1',
+      title: '1. run migration check',
+      status: 'complete',
+      details: '```\nmake db:check\n```',
+      output: '```\nok\n```'
+    })
+    // Whole answer arrives in one burst and is only queued (never flushed live).
+    const answer = 'Done. The migration is safe to run now'
+    await renderer.textDelta(sessionId, answer, { flush: false })
+    const result = await renderer.done(sessionId, { answerMarkdown: answer })
+
+    // The complete answer is durably delivered, so the control plane must skip the fallback.
+    expect(result.finalAnswerDurablyDelivered).toBe(true)
+    expect(durableBlockText(calls)).toContain(answer)
+  })
+
+  it('does NOT report durable delivery when the answer streamed live', async () => {
+    const { client, calls } = makeClient()
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778883099.579529',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    await renderer.step(sessionId, {
+      id: 'cmd-1',
+      title: '1. Command execution',
+      status: 'in_progress'
+    })
+    await renderer.text(sessionId, 'Live answer body.')
+    // Completing the step force-flushes the pending text, so the answer streams live.
+    await renderer.step(sessionId, {
+      id: 'cmd-1',
+      title: '1. Command execution',
+      status: 'complete'
+    })
+    const result = await renderer.done(sessionId, { answerMarkdown: 'Live answer body.' })
+
+    // Streamed-live answers keep the existing coverage fallback as a safety net.
+    expect(result.finalAnswerDurablyDelivered).toBe(false)
+    expect(durableBlockText(calls)).not.toContain('Live answer body.')
+  })
+
+  it('propagates the durable-delivery signal through the codex harness-event response', async () => {
+    const { client } = makeClient()
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778883099.579529',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+    // No tools, no live plan -> a text-only turn streams live, not folded.
+    const terminal = await renderer.event(sessionId, { type: 'result', text: 'PONG' })
+    expect(terminal.done).toBe(true)
+    expect(typeof terminal.finalAnswerDurablyDelivered).toBe('boolean')
+    expect(terminal.finalAnswerDurablyDelivered).toBe(false)
+  })
+})


### PR DESCRIPTION
#249 fixed fast-turn answer loss by folding the whole answer into the durable chat.stopStream blocks instead of a finalize-time appendStream that Slack drops. But the control plane still gauges live-delivery coverage by comparing its result_text length against the slackbot's streamed-char tally, and that tally counts only the live-streamed delta source chars. When result_text carries a few trailing characters the live deltas did not, coverage reads as incomplete and the fallback reposts result_text.slice(streamed_chars) — the answer's last 2-3 characters — as a separate thread message, duplicating text the durable block already shows.

Have the renderer report finalAnswerDurablyDelivered when the complete answer is composed into the durable blocks (durable blocks are never dropped by Slack), thread it through the codex harness-event response, and treat it as full coverage in _mark_execution_terminal so the fallback continuation is skipped. Streamed-live answers keep the existing coverage fallback as the cut-off safety net.