### PR TITLE
fix: support Claude Opus 4.8 rendering

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -216,8 +216,10 @@ def _agent_session_title(
 
 # ── Per-message header (rendered italic at the top of every assistant message) ──
 
+_DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
+
 _CLAUDE_MODEL_ALIASES: dict[str, str] = {
-    "opus": "claude-opus-4-7",
+    "opus": _DEFAULT_CLAUDE_MODEL,
     "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5",
 }
@@ -227,7 +229,7 @@ def _resolve_claude_model_label(model: str | None) -> str:
     raw = (model or os.getenv("CLAUDE_MODEL") or "opus").strip().lower()
     if raw.startswith("claude-"):
         return raw
-    return _CLAUDE_MODEL_ALIASES.get(raw, raw or "claude-opus-4-7")
+    return _CLAUDE_MODEL_ALIASES.get(raw, raw or _DEFAULT_CLAUDE_MODEL)
 
 
 def _resolve_codex_model_label(model: str | None) -> str:

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -987,7 +987,7 @@ async def _compute_agent_session_header(
     the persona/engine pair the slackbot renders italic at the top of every
     assistant message. Persona defaults to the literal ``"base"`` when no
     persona is active. The engine segment is upgraded to a concrete model
-    identifier (e.g. ``claude-opus-4-7``, ``codex-gpt-5``) when known.
+    identifier (e.g. ``claude-opus-4-8``, ``codex-gpt-5``) when known.
     """
     from api.runtime_control import _agent_session_header  # local to avoid cycle
 

--- a/services/api/tests/test_claude_app_wrapper.py
+++ b/services/api/tests/test_claude_app_wrapper.py
@@ -40,7 +40,7 @@ def test_build_claude_cmd_defaults(monkeypatch) -> None:
     assert "--include-hook-events" not in cmd
     assert "--append-system-prompt-file" not in cmd
     assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "opus"
+    assert cmd[cmd.index("--model") + 1] == "claude-opus-4-8"
     assert "--resume" not in cmd
 
 
@@ -57,14 +57,14 @@ def test_build_claude_cmd_appends_agents_prompt(monkeypatch, tmp_path) -> None:
 
 def test_build_claude_cmd_model_and_resume(monkeypatch) -> None:
     wrapper = _load_wrapper()
-    monkeypatch.setenv("CLAUDE_MODEL", "claude-opus-4-7")
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-opus-4-8")
     monkeypatch.setenv("CLAUDE_CONTINUE_SESSION_ID", "abc-123")
 
     cmd = wrapper._build_claude_cmd()
 
     assert "--model" in cmd
     model_idx = cmd.index("--model")
-    assert cmd[model_idx + 1] == "claude-opus-4-7"
+    assert cmd[model_idx + 1] == "claude-opus-4-8"
     assert "--resume" in cmd
     resume_idx = cmd.index("--resume")
     assert cmd[resume_idx + 1] == "abc-123"

--- a/services/api/tests/test_workflow_engine_title.py
+++ b/services/api/tests/test_workflow_engine_title.py
@@ -138,7 +138,7 @@ async def test_title_handles_non_dict_active_assignment(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_header_uses_base_when_no_persona_paradigm_claude(monkeypatch):
-    """Paradigm + no persona + claude-code → ``base · claude-opus-4-7``."""
+    """Paradigm + no persona + claude-code → ``base · claude-opus-4-8``."""
     get_active = AsyncMock(return_value={"persona_id": None, "harness": "claude-code", "engine": "claude-code"})
     monkeypatch.setattr(workflow_engine, "get_active_assignment", get_active)
     monkeypatch.delenv("CLAUDE_MODEL", raising=False)
@@ -147,7 +147,7 @@ async def test_header_uses_base_when_no_persona_paradigm_claude(monkeypatch):
     header = await workflow_engine._compute_agent_session_header(
         pool=object(), thread_key="slack:T:C:1.0", selector=selector,
     )
-    assert header == "base · claude-opus-4-7"
+    assert header == "base · claude-opus-4-8"
 
 
 @pytest.mark.asyncio

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN useradd -m -s /bin/bash -u 1001 agent \
     && echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/agent
 
-ARG CLAUDE_CODE_VERSION=2.1.143
+ARG CLAUDE_CODE_VERSION=2.1.154
 ARG CODEX_VERSION=0.130.0
 ARG PI_CODING_AGENT_VERSION=0.67.2
 ARG NUSHELL_VERSION=0.112.2

--- a/services/sandbox/claude-app-wrapper.py
+++ b/services/sandbox/claude-app-wrapper.py
@@ -27,6 +27,8 @@ import sys
 import threading
 from typing import Any
 
+DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
+
 APP: subprocess.Popen[str] | None = None
 WRITE_LOCK = threading.Lock()
 SHUTTING_DOWN = False
@@ -203,7 +205,8 @@ def _build_claude_cmd() -> list[str]:
     ]
     if os.path.isfile("AGENTS.md"):
         cmd.extend(["--append-system-prompt-file", "AGENTS.md"])
-    model = (os.environ.get("CLAUDE_MODEL") or "opus").strip() or "opus"
+    model = (os.environ.get("CLAUDE_MODEL") or DEFAULT_CLAUDE_MODEL).strip()
+    model = model or DEFAULT_CLAUDE_MODEL
     cmd.extend(["--model", model])
     resume = _resume_session_id()
     if resume:

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -824,7 +824,7 @@ describe('AgentSessionRenderer', () => {
       recipientTeamId: 'T123',
       recipientUserId: 'U123',
       title: 'Centaur execution',
-      header: 'base · claude-opus-4-7'
+      header: 'base · claude-opus-4-8'
     })
 
     await renderer.step(sessionId, {
@@ -839,7 +839,7 @@ describe('AgentSessionRenderer', () => {
     const chunks = start?.params.chunks ?? []
     expect(chunks[0]).toEqual({
       type: 'markdown_text',
-      text: '_base · claude-opus-4-7_\n'
+      text: '_base · claude-opus-4-8_\n'
     })
     const planUpdateIdx = chunks.findIndex((chunk: any) => chunk.type === 'plan_update')
     expect(planUpdateIdx).toBeGreaterThan(0)

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -66,7 +66,7 @@ export type OpenAgentSessionInput = {
   title?: string
   /**
    * Italic one-line identifier rendered at the top of every assistant message (e.g. "base ·
-   * claude-opus-4-7", "legal · codex-gpt-5").
+   * claude-opus-4-8", "legal · codex-gpt-5").
    */
   header?: string
 }

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1515,6 +1515,49 @@ describe('CodexSessionRenderer', () => {
     expect(countOccurrences(visible, 'Hello.')).toBe(1)
   })
 
+  it('streams claude-code delta assistant text and ignores the canonical duplicate', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+    const finalText = "I'm centaur, Tempo's AI assistant. I help with engineering and ops."
+
+    await renderer.event(sessionId, {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: "I'm" }] }
+    })
+    await renderer.event(sessionId, {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: " centaur, Tempo's AI assistant." }] }
+    })
+    await renderer.event(sessionId, {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: ' I help with engineering and ops.' }] }
+    })
+    await renderer.event(sessionId, {
+      type: 'assistant',
+      uuid: 'msg-uuid',
+      request_id: 'req-123',
+      session_id: 'claude-session',
+      message: {
+        id: 'msg_123',
+        model: 'claude-opus-4-8',
+        content: [{ type: 'text', text: finalText }]
+      }
+    })
+    await renderer.event(sessionId, { type: 'result', result: finalText })
+
+    const visible = visibleMarkdown(calls)
+    expect(countOccurrences(visible, finalText)).toBe(1)
+    expect(visible).not.toContain("I'm\n centaur")
+  })
+
   it('does not log a canonical correction for plain delta streams without item.completed', async () => {
     const logCalls: unknown[][] = []
     const originalLog = console.log

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -556,16 +556,18 @@ function applyAgentMessageUpdate(
   }
 
   if (event?.type === 'assistant') {
-    const cumulative = assistantTextFromAssistantEvent(event)
-    if (!cumulative) return { bufferChanged: false }
+    const text = assistantTextFromAssistantEvent(event)
+    if (!text) return { bufferChanged: false }
     const key = buffer === 'answer' ? 'harnessAnswerText' : 'harnessCommentaryText'
     const before = state[key]
-    if (cumulative === before || before.endsWith(cumulative)) return { bufferChanged: false }
-    state[key] = cumulative.startsWith(before)
-      ? cumulative
-      : before
-        ? `${before}\n${cumulative}`
-        : cumulative
+    if (text === before || before.endsWith(text)) return { bufferChanged: false }
+    if (assistantEventLooksCanonical(event)) {
+      state[key] = text
+    } else if (text.startsWith(before)) {
+      state[key] = text
+    } else {
+      state[key] = before + text
+    }
     recomposeBuffers(state)
     return { bufferChanged: true }
   }
@@ -595,6 +597,18 @@ function assistantTextFromAssistantEvent(event: any): string {
     .map(part => (part?.type === 'text' ? (part.text ?? '') : ''))
     .filter(Boolean)
     .join('')
+}
+
+function assistantEventLooksCanonical(event: any): boolean {
+  const message = event?.message
+  return Boolean(
+    event?.uuid ||
+    event?.request_id ||
+    event?.session_id ||
+    message?.id ||
+    message?.model ||
+    message?.usage
+  )
 }
 
 function logCanonicalCorrection(


### PR DESCRIPTION
## What changed

- Update Claude defaults from Opus 4.7 to `claude-opus-4-8` in runtime labels and the Claude Code wrapper.
- Bump the sandbox Claude Code package to `2.1.154`.
- Fix Slack live rendering for Claude Code streams that emit text deltas followed by a canonical full assistant message.
- Add a regression test for the Claude Code delta-plus-canonical event shape that previously caused duplicated/scrambled Slack output.

## Why

Claude Code 2.1.154 with Opus 4.8 emits plain `assistant` text chunks as deltas, then emits a full canonical assistant message. Slackbot previously treated plain `assistant` events as cumulative text, which inserted extra line breaks and then appended the complete final answer again.

## Validation

- `uv run --directory services/api pytest tests/test_claude_app_wrapper.py tests/test_workflow_engine_title.py`
- `uv run --directory services/api ruff check api/runtime_control.py ../sandbox/claude-app-wrapper.py tests/test_claude_app_wrapper.py tests/test_workflow_engine_title.py`
- `pnpm --dir services/slackbot exec bun test src/slack/codex-session.test.ts src/slack/agent-session.test.ts`
- `pnpm --dir services/slackbot exec oxfmt --config='oxfmt.config.ts' --write src/slack/codex-session.ts src/slack/codex-session.test.ts`
- `pnpm --dir services/slackbot exec oxlint --config='oxlint.config.ts' --type-aware --type-check src/slack/codex-session.ts src/slack/codex-session.test.ts`
- `pnpm --dir services/slackbot exec bun tsgo --project tsconfig.json --noEmit`
- Local cluster E2E with exact render-test prompt via `claude-code`: completed successfully, `result_len=1492`, event stream contained `model: claude-opus-4-8`.
