### PR TITLE
Support CORS origin regex

### DIFF
--- a/services/api/api/app.py
+++ b/services/api/api/app.py
@@ -296,6 +296,7 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
+    allow_origin_regex=settings.cors_allow_origin_regex,
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/api/api/config.py
+++ b/services/api/api/config.py
@@ -9,6 +9,13 @@ class Settings(BaseSettings):
 
     database_url: str = Field(alias="DATABASE_URL")
     cors_origins: list[str] = []
+    cors_origin_regex: str | None = None
+
+    @property
+    def cors_allow_origin_regex(self) -> str | None:
+        if self.cors_origin_regex == "*":
+            return ".*"
+        return self.cors_origin_regex
 
 
 settings = Settings()

--- a/services/api/tests/test_cors_config.py
+++ b/services/api/tests/test_cors_config.py
@@ -1,0 +1,35 @@
+import importlib
+import uuid
+
+import pytest
+
+
+def test_settings_reads_cors_origin_regex_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql://centaur:centaur@localhost:5432/centaur"
+    )
+    origin_regex = rf"^https://{uuid.uuid4().hex}\.example\.invalid$"
+    monkeypatch.setenv("CORS_ORIGIN_REGEX", origin_regex)
+
+    config = importlib.import_module("api.config")
+    settings = config.Settings()
+
+    assert settings.cors_origin_regex == origin_regex
+    assert settings.cors_allow_origin_regex == origin_regex
+
+
+def test_settings_normalizes_wildcard_cors_origin_regex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql://centaur:centaur@localhost:5432/centaur"
+    )
+    monkeypatch.setenv("CORS_ORIGIN_REGEX", "*")
+
+    config = importlib.import_module("api.config")
+    settings = config.Settings()
+
+    assert settings.cors_origin_regex == "*"
+    assert settings.cors_allow_origin_regex == ".*"


### PR DESCRIPTION
## Summary
- add CORS_ORIGIN_REGEX support to the API settings
- pass the regex through to FastAPI CORSMiddleware
- cover env parsing with a focused test

## Validation
- uv run pytest tests/test_cors_config.py
- git diff --check