### PR TITLE
fix(slackbot): allow home users in external channels

### DIFF
--- a/services/slackbot/src/slack/authorization.test.ts
+++ b/services/slackbot/src/slack/authorization.test.ts
@@ -45,6 +45,24 @@ describe('authorizeSlackOrg', () => {
     ).toEqual({ ok: true, externalTeamId: 'TEXTERNAL' })
   })
 
+  it('allows home-workspace users in external Slack Connect channels', () => {
+    expect(
+      authorizeSlackOrg({
+        envelope: {
+          type: 'event_callback',
+          team_id: 'THOME',
+          event: {
+            type: 'app_mention',
+            team: 'THOME',
+            user_team: 'THOME',
+            source_team: 'TEXTERNAL'
+          }
+        },
+        allowedExternalTeamIds: []
+      })
+    ).toEqual({ ok: true })
+  })
+
   it('falls back to source_team when user_team is absent', () => {
     expect(
       authorizeSlackOrg({

--- a/services/slackbot/src/slack/authorization.ts
+++ b/services/slackbot/src/slack/authorization.ts
@@ -34,7 +34,11 @@ function externalSlackTeamId(envelope: SlackEnvelope): string | undefined {
   if (!homeTeamId || !isRecord(envelope.event)) return undefined
 
   const event = envelope.event as SlackEventWithTeam
-  const candidates = [event.user_team, event.source_team, event.team]
+  if (typeof event.user_team === 'string' && event.user_team) {
+    return event.user_team === homeTeamId ? undefined : event.user_team
+  }
+
+  const candidates = [event.source_team, event.team]
   for (const candidate of candidates) {
     if (typeof candidate === 'string' && candidate && candidate !== homeTeamId) {
       return candidate


### PR DESCRIPTION
## Summary
- allow installed-workspace users to invoke Slackbot from Slack Connect channels even when source_team is external
- keep external users blocked unless their team is explicitly allowlisted
- add focused authorization coverage for home users in external channels

## Tests
- bun test services/slackbot/src/slack/authorization.test.ts

Prompted by: @letstokenize