### PR TITLE
fix: complete no-input wakeup executions

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -2106,7 +2106,8 @@ async def _mark_execution_terminal(
     delivery_platform = _delivery_platform(
         decode_jsonb(row["delivery"], {}) if row else {}
     )
-    if delivery_platform == "dev" or suppress_legacy_delivery:
+    suppress_no_input_delivery = terminal_reason == "no_input"
+    if delivery_platform == "dev" or suppress_legacy_delivery or suppress_no_input_delivery:
         slackbot_agent_session_id = str(metadata.get("slackbot_agent_session_id") or "")
         result_size = payload_size_bytes(result_text)
         if suppress_legacy_delivery and result_size > 0 and slackbot_streamed_answer_chars <= 0:
@@ -2124,17 +2125,21 @@ async def _mark_execution_terminal(
                     metadata.get("slackbot_live_delivery_failed")
                 ),
             )
+        if suppress_no_input_delivery:
+            reason = "no_input"
+        elif suppress_legacy_delivery:
+            reason = "slackbot_live_delivery"
+        else:
+            reason = "dev_delivery"
         log.info(
             "final_delivery_skipped"
-            if suppress_legacy_delivery
+            if suppress_legacy_delivery or suppress_no_input_delivery
             else "final_delivery_skipped_dev",
             execution_id=execution_id,
             thread_key=thread_key,
             status=status,
             terminal_reason=terminal_reason,
-            reason="slackbot_live_delivery"
-            if suppress_legacy_delivery
-            else "dev_delivery",
+            reason=reason,
             agent_thread_id=agent_thread_id or None,
             slackbot_agent_session_id=slackbot_agent_session_id or None,
             slackbot_streamed_answer_chars=slackbot_streamed_answer_chars,
@@ -2782,6 +2787,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         await _write_agents_override(session.sandbox_id, str(assignment_override))
 
     if durable_turn_id:
+        injected_for_execution = True
         await _heartbeat_execution_lease(pool, execution_id)
         if silence_deadline <= dt.datetime.now(dt.timezone.utc):
             silence_deadline = await _touch_execution_progress(pool, execution_id)
@@ -2835,6 +2841,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
                 },
             )
         durable_turn_id = str(inject_result.get("durable_turn_id") or "")
+        injected_for_execution = bool(inject_result.get("injected"))
         await pool.execute(
             "UPDATE agent_execution_requests SET durable_turn_id = $1, updated_at = NOW() "
             "WHERE execution_id = $2",
@@ -2868,9 +2875,6 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
     )
     user_id: str | None = str(user_id_row) if user_id_row else None
 
-    backend = get_backend()
-    await backend.attach(session)
-    rt = _get_runtime(session.sandbox_id)
     observations = ExecutionObservationAccumulator()
     started_at = claimed_at or row.get("created_at")
     first_token_at: dt.datetime | None = None
@@ -2883,6 +2887,8 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
     # to the outbox path; the streak resets on the next success.
     slackbot_live_failure_streak = 0
     slackbot_live_failure_limit = 5
+    latest_terminal_result_text = ""
+    slackbot_streamed_answer_chars = 0
 
     async def _finalize_execution(
         *,
@@ -2988,6 +2994,42 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
             slackbot_streamed_answer_chars_override=slackbot_streamed_answer_chars,
         )
 
+    if not injected_for_execution:
+        log.info(
+            "execution_no_input_skipped",
+            execution_id=execution_id,
+            thread_key=thread_key,
+            assignment_generation=assignment_generation,
+            runtime_id=session.sandbox_id,
+            queue_delay_s=round(queue_delay_s, 3),
+        )
+        add_span_event(
+            "centaur.agent.execution_no_input",
+            {
+                "execution_id": execution_id,
+                "thread_key": thread_key,
+                "assignment_generation": assignment_generation,
+                "runtime_id": session.sandbox_id,
+            },
+        )
+        set_span_attributes(
+            trace.get_current_span(),
+            {
+                "centaur.execution.no_input": True,
+            },
+        )
+        await _finalize_execution(
+            status="completed",
+            terminal_reason="no_input",
+            result_text="",
+            error_text=None,
+        )
+        return
+
+    backend = get_backend()
+    await backend.attach(session)
+    rt = _get_runtime(session.sandbox_id)
+
     execution_started_payload = {
         "type": "obs.execution_started",
         "execution_id": execution_id,
@@ -3044,8 +3086,6 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
     await _touch_execution_progress(pool, execution_id)
 
     turn_done_event: dict[str, Any] | None = None
-    latest_terminal_result_text = ""
-    slackbot_streamed_answer_chars = 0
     pending_event: asyncio.Task | None = None
     stream = _stream_stdout(
         session,

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import uuid
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -3132,6 +3132,95 @@ async def test_worker_marks_silence_deadline_exceeded_and_stops_session(db_pool)
     assert execution["terminal_reason"] == "silence_deadline_exceeded"
     assert "no progress" in (execution["error_text"] or "")
     stop_session_mock.assert_awaited_once_with(thread_key)
+
+
+@pytest.mark.asyncio
+async def test_worker_completes_no_input_wakeup_without_starting_stdout(db_pool):
+    from api.runtime_control import _process_execution
+
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}"
+    execution_id = f"exe-{uuid.uuid4().hex[:12]}"
+    runtime_id = f"rt-{uuid.uuid4().hex[:8]}"
+
+    await db_pool.execute(
+        "INSERT INTO agent_runtime_assignments ("
+        "thread_key, assignment_generation, runtime_id, harness, engine, "
+        "persona_id, prompt_ref, effective_agents_md_sha256, state"
+        ") VALUES ($1, 1, $2, 'amp', 'amp', NULL, 'harness:amp', 'sha', 'active')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, status, "
+        "delivery, metadata, hard_deadline_at"
+        ") VALUES ($1, $2, 1, 'exec-idem', 'hash', 'running', '{}'::jsonb, '{}'::jsonb, NOW() + INTERVAL '10 minutes')",
+        execution_id,
+        thread_key,
+    )
+
+    row = {
+        "execution_id": execution_id,
+        "thread_key": thread_key,
+        "assignment_generation": 1,
+        "delivery": {},
+        "metadata": {},
+        "hard_deadline_at": dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=10),
+        "created_at": dt.datetime.now(dt.timezone.utc),
+        "claimed_at": dt.datetime.now(dt.timezone.utc),
+    }
+    session = SandboxSession(
+        sandbox_id=runtime_id,
+        thread_key=thread_key,
+        harness="amp",
+        engine="amp",
+    )
+
+    get_backend_mock = Mock()
+    stream_mock = Mock()
+    stop_session_mock = AsyncMock()
+    with (
+        patch("api.runtime_control.get_or_spawn", new=AsyncMock(return_value=session)),
+        patch(
+            "api.runtime_control.inject_stdin",
+            new=AsyncMock(return_value={"ok": True, "injected": False}),
+        ),
+        patch("api.runtime_control.get_backend", get_backend_mock),
+        patch("api.runtime_control._stream_stdout", stream_mock),
+        patch("api.runtime_control.stop_session", stop_session_mock),
+    ):
+        await _process_execution(db_pool, row)
+
+    execution = await db_pool.fetchrow(
+        "SELECT status, terminal_reason, durable_turn_id, error_text "
+        "FROM agent_execution_requests WHERE execution_id = $1",
+        execution_id,
+    )
+    assert execution is not None
+    assert execution["status"] == "completed"
+    assert execution["terminal_reason"] == "no_input"
+    assert execution["durable_turn_id"] is None
+    assert execution["error_text"] is None
+    get_backend_mock.assert_not_called()
+    stream_mock.assert_not_called()
+    stop_session_mock.assert_not_awaited()
+
+    summary = await db_pool.fetchrow(
+        "SELECT event_json FROM agent_execution_events "
+        "WHERE execution_id = $1 AND event_kind = 'execution_summary'",
+        execution_id,
+    )
+    assert summary is not None
+    payload = json.loads(summary["event_json"])
+    assert payload["status"] == "completed"
+    assert payload["terminal_reason"] == "no_input"
+    assert payload["raw_event_count"] == 0
+
+    outbox = await db_pool.fetchrow(
+        "SELECT 1 FROM agent_final_delivery_outbox WHERE execution_id = $1",
+        execution_id,
+    )
+    assert outbox is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Treat queued agent executions as wakeups when cursor-based flushing has already consumed their input.

If an execution reaches the worker and `inject_stdin()` returns `injected=false`, the worker now:

- records the execution as `completed` with `terminal_reason=no_input`
- skips backend attach/stdout streaming
- avoids the silence watchdog path
- avoids stopping the sandbox/session
- suppresses empty final-delivery outbox payloads

This preserves cursor-based coalescing: rapid follow-up mentions can still be folded into the next active turn, and any later redundant wakeup becomes a benign no-op.

## Why this catches the issue

The regression test models the failure mode directly: a queued wakeup is claimed after another turn has already advanced the cursor, so `inject_stdin()` reports `injected=false`. Before this change, that execution would still enter stdout streaming, produce no harness events, eventually hit the silence deadline, and stop the session. With this change, the same condition completes immediately as `no_input` and leaves the live session alone.

## Tests

- `uv run --project services/api pytest services/api/tests/test_agent_control_plane.py::test_worker_completes_no_input_wakeup_without_starting_stdout services/api/tests/test_agent_control_plane.py::test_worker_marks_silence_deadline_exceeded_and_stops_session -q`
- `uv run --project services/api ruff check services/api/api/runtime_control.py services/api/tests/test_agent_control_plane.py`
