### PR TITLE
feat: support pvc-backed repo cache

### DIFF
--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -63,6 +63,14 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 {{- end -}}
 
+{{- define "centaur.repoCachePvcName" -}}
+{{- if .Values.repoCache.persistence.existingClaim -}}
+{{- .Values.repoCache.persistence.existingClaim | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "centaur.componentName" (dict "root" . "component" "repo-cache") -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "centaur.httpRouteName" -}}
 {{- $suffix := default (printf "route-%v" .index) .route.name -}}
 {{- printf "%s-%s" (include "centaur.fullname" .root) $suffix | trunc 63 | trimSuffix "-" -}}

--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -5,13 +5,34 @@
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
 {{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
 {{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
+{{- if and .Values.repoCache.persistence.enabled (not .Values.repoCache.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "centaur.repoCachePvcName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
+spec:
+  accessModes:
+{{ toYaml .Values.repoCache.persistence.accessModes | nindent 4 }}
+  {{- with .Values.repoCache.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.repoCache.persistence.size }}
+---
+{{- end }}
 apiVersion: apps/v1
-kind: DaemonSet
+kind: {{ ternary "Deployment" "DaemonSet" .Values.repoCache.persistence.enabled }}
 metadata:
   name: {{ include "centaur.componentName" (dict "root" . "component" "repo-cache") }}
   labels:
 {{ include "centaur.componentLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
 spec:
+{{- if .Values.repoCache.persistence.enabled }}
+  replicas: 1
+{{- end }}
   selector:
     matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 6 }}
@@ -139,9 +160,14 @@ spec:
               readOnly: true
       volumes:
         - name: repo-cache
+{{- if .Values.repoCache.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "centaur.repoCachePvcName" . }}
+{{- else }}
           hostPath:
             path: {{ .Values.repoCache.hostPath | quote }}
             type: DirectoryOrCreate
+{{- end }}
         - name: github-token
           secret:
             secretName: {{ include "centaur.repoCacheGithubTokenSecretName" . }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -1,6 +1,12 @@
 {{- $reposPath := .Values.sandbox.reposPath -}}
+{{- $reposPvcClaimName := "" -}}
 {{- $apiExtraEnv := .Values.api.extraEnv | default dict -}}
-{{- if and .Values.repoCache.enabled (not $reposPath) -}}
+{{- if and .Values.repoCache.enabled .Values.repoCache.persistence.enabled -}}
+{{- if $reposPath -}}
+{{- fail "sandbox.reposPath cannot be set when repoCache.persistence.enabled=true" -}}
+{{- end -}}
+{{- $reposPvcClaimName = include "centaur.repoCachePvcName" . -}}
+{{- else if and .Values.repoCache.enabled (not $reposPath) -}}
 {{- $reposPath = .Values.repoCache.hostPath -}}
 {{- end -}}
 {{- if .Values.postgres.enabled }}
@@ -365,6 +371,10 @@ spec:
 {{- if $reposPath }}
             - name: REPOS_PATH
               value: {{ $reposPath | quote }}
+{{- end }}
+{{- if $reposPvcClaimName }}
+            - name: REPOS_PVC_CLAIM_NAME
+              value: {{ $reposPvcClaimName | quote }}
 {{- end }}
 {{- with .Values.sandbox.extraEnv }}
 {{- $envList := list }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -102,6 +102,19 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "hostPath": { "type": "string" },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingClaim": { "type": "string" },
+            "size": { "type": "string" },
+            "storageClassName": { "type": "string" },
+            "accessModes": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
         "repositories": {
           "type": "array",
           "items": { "type": "string" }

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -151,7 +151,16 @@ sandbox:
 
 repoCache:
   enabled: false
+  # hostPath is kept for local/dev clusters. Production clusters should prefer
+  # persistence.enabled so sandboxes mount a PVC instead of a node filesystem path.
   hostPath: /var/lib/centaur/repos
+  persistence:
+    enabled: false
+    existingClaim: ""
+    size: 20Gi
+    storageClassName: ""
+    accessModes:
+      - ReadWriteOnce
   repositories: []
   syncIntervalSeconds: 300
   image:

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -341,6 +341,35 @@ def _repos_path() -> str | None:
     return value or None
 
 
+def _repos_pvc_claim_name() -> str | None:
+    value = (os.getenv("REPOS_PVC_CLAIM_NAME") or "").strip()
+    return value or None
+
+
+def _repos_volume() -> dict[str, Any] | None:
+    repos_path = _repos_path()
+    repos_pvc_claim_name = _repos_pvc_claim_name()
+    if repos_path and repos_pvc_claim_name:
+        raise ValueError("Only one of REPOS_PATH or REPOS_PVC_CLAIM_NAME may be set")
+    if repos_pvc_claim_name:
+        return {
+            "name": "repos",
+            "persistentVolumeClaim": {
+                "claimName": repos_pvc_claim_name,
+                "readOnly": True,
+            },
+        }
+    if repos_path:
+        return {
+            "name": "repos",
+            "hostPath": {
+                "path": repos_path,
+                "type": "Directory",
+            },
+        }
+    return None
+
+
 def _overlay_image() -> str | None:
     value = (os.getenv("CENTAUR_OVERLAY_IMAGE") or "").strip()
     return value or None
@@ -1299,8 +1328,8 @@ class KubernetesExecutorBackend(SandboxBackend):
         _ensure_kubernetes_env()
         await self._ensure_clients()
 
-        repos_path = _repos_path()
-        if repo and not repos_path:
+        repos_volume = _repos_volume()
+        if repo and not repos_volume:
             raise ValueError("REPOS_PATH is required when AGENT_REPO is set")
 
         runtime_key = f"{thread_key}:{uuid.uuid4().hex[:8]}"
@@ -1421,7 +1450,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                 }
             )
 
-        if repos_path:
+        if repos_volume:
             volume_mounts.append(
                 {
                     "name": "repos",
@@ -1429,15 +1458,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                     "readOnly": True,
                 }
             )
-            volumes.append(
-                {
-                    "name": "repos",
-                    "hostPath": {
-                        "path": repos_path,
-                        "type": "Directory",
-                    },
-                }
-            )
+            volumes.append(repos_volume)
 
         self._configure_workload_volumes(volume_mounts, volumes)
 

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -1309,6 +1309,101 @@ async def test_create_mounts_repo_cache_host_path(
 
 
 @pytest.mark.asyncio
+async def test_create_mounts_repo_cache_pvc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = KubernetesExecutorBackend()
+    fake_core = FakeCoreApi()
+    fake_networking = FakeNetworkingApi()
+    backend._core = fake_core
+    backend._networking = fake_networking
+
+    monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv("FIREWALL_HOST", "firewall.internal")
+    monkeypatch.setenv("KUBERNETES_FIREWALL_CA_SECRET_NAME", "firewall-ca")
+    monkeypatch.setenv("REPOS_PVC_CLAIM_NAME", "centaur-repo-cache")
+    monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur-sandbox")
+    monkeypatch.setattr(
+        "api.sandbox.kubernetes._prompt_bundle",
+        lambda persona: f"prompt:{persona}",
+    )
+    monkeypatch.setattr(
+        "api.sandbox.kubernetes.container_env",
+        lambda *_args, **_kwargs: [
+            "CENTAUR_API_URL=http://api.internal:8000",
+            "CENTAUR_API_KEY=sandbox-token",
+        ],
+    )
+
+    monkeypatch.setattr(
+        "api.sandbox.kubernetes.build_harness_cmd", lambda *_args: ["amp-wrapper"]
+    )
+    monkeypatch.setattr("api.sandbox.kubernetes.image", lambda: "centaur-agent:test")
+
+    async def fake_ensure_clients() -> None:
+        return None
+
+    async def fake_wait_ready(_pod_name: str) -> float:
+        return 0.01
+
+    monkeypatch.setattr(backend, "_ensure_clients", fake_ensure_clients)
+    monkeypatch.setattr(backend, "_wait_pod_ready", fake_wait_ready)
+    monkeypatch.setattr(backend, "_wait_ready", fake_wait_ready)
+
+    await backend.create(
+        "slack:C123:123.456",
+        "amp",
+        "amp",
+        repo="paradigmxyz/centaur",
+    )
+
+    pod_body = fake_core.created_pods[1][1]
+    container = pod_body["spec"]["containers"][0]
+
+    assert any(
+        mount["name"] == "repos"
+        and mount["mountPath"] == "/home/agent/github"
+        and mount["readOnly"] is True
+        for mount in container["volumeMounts"]
+    )
+    assert {
+        "name": "repos",
+        "persistentVolumeClaim": {
+            "claimName": "centaur-repo-cache",
+            "readOnly": True,
+        },
+    } in pod_body["spec"]["volumes"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_multiple_repo_cache_volume_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = KubernetesExecutorBackend()
+
+    monkeypatch.setenv("AGENT_API_URL", "http://api:8000")
+    monkeypatch.setenv("FIREWALL_HOST", "firewall")
+    monkeypatch.setenv("KUBERNETES_FIREWALL_CA_SECRET_NAME", "firewall-ca")
+    monkeypatch.setenv("REPOS_PATH", "/var/lib/centaur/repos")
+    monkeypatch.setenv("REPOS_PVC_CLAIM_NAME", "centaur-repo-cache")
+
+    async def fake_ensure_clients() -> None:
+        return None
+
+    monkeypatch.setattr(backend, "_ensure_clients", fake_ensure_clients)
+
+    with pytest.raises(
+        ValueError, match="Only one of REPOS_PATH or REPOS_PVC_CLAIM_NAME"
+    ):
+        await backend.create(
+            "slack:C123:123.456",
+            "amp",
+            "amp",
+            repo="paradigmxyz/centaur",
+        )
+
+
+@pytest.mark.asyncio
 async def test_create_can_use_agent_sandbox_with_state_volume(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add API support for mounting sandbox repo caches from a PVC via REPOS_PVC_CLAIM_NAME
- keep existing REPOS_PATH hostPath behavior for local/dev compatibility
- add Helm repoCache.persistence settings that create/use a PVC and switch repo-cache from a DaemonSet to a single Deployment in PVC mode
- add tests for hostPath, PVC, and conflicting repo volume sources

## Why
Managed Kubernetes clusters commonly reject sandbox hostPath mounts. PVC-backed repo caches keep the fast shared-clone workflow without granting sandboxes node filesystem access.

## Validation
- uv run pytest tests/test_sandbox_kubernetes_backend.py -k 'repo_cache or builds_pod_and_prompt_secret'
- uv run ruff check api/sandbox/kubernetes.py tests/test_sandbox_kubernetes_backend.py
- git diff --check
- helm template PVC mode with repoCache.persistence.enabled=true
- helm template legacy mode with repoCache.persistence.enabled=false