### PR TITLE
fix(sandbox): harden proxy env against extraEnv override

### DIFF
--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -6,8 +6,12 @@ import os
 import json
 from urllib.parse import urlsplit
 
+import structlog
+
 from api.deps import mint_sandbox_token
 from api.sandbox.base import SandboxSession
+
+log = structlog.get_logger()
 
 
 def image() -> str:
@@ -41,6 +45,27 @@ _CLAUDE_HARDENING_ENV = (
     ("DISABLE_UPDATES", "1"),
 )
 
+# Env vars that wire the sandbox to its per-sandbox iron-proxy. A stray
+# ``sandbox.extraEnv`` entry overriding one of these silently breaks all
+# sandbox egress, so they are pinned: operator extraEnv cannot replace them.
+# ``NO_PROXY``/``no_proxy`` are handled separately (merged, not pinned) so
+# operators can still add bypass hosts without dropping the firewall/API host.
+_PINNED_PROXY_ENV_KEYS = frozenset(
+    {
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "FIREWALL_HOST",
+        "NODE_EXTRA_CA_CERTS",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "GIT_SSL_CAINFO",
+    }
+)
+
+_NO_PROXY_ENV_KEYS = frozenset({"NO_PROXY", "no_proxy"})
+
 
 def _set_env(env: list[str], name: str, value: str) -> None:
     prefix = f"{name}="
@@ -50,6 +75,20 @@ def _set_env(env: list[str], name: str, value: str) -> None:
             env[index] = entry
             return
     env.append(entry)
+
+
+def _merge_no_proxy(computed: str, operator_supplied: str) -> str:
+    """Union the computed no_proxy hosts with operator-supplied extras.
+
+    Operators may *add* bypass hosts via ``sandbox.extraEnv`` but must never
+    drop the ones the sandbox needs to reach directly (the firewall proxy and
+    the Centaur API host); dropping those routes that traffic through iron-proxy,
+    which rejects the plain-HTTP forward with a 405. Computed hosts come first so
+    they are always present; duplicates are removed while preserving order.
+    """
+    hosts = [h.strip() for h in computed.split(",") if h.strip()]
+    hosts.extend(h.strip() for h in operator_supplied.split(",") if h.strip())
+    return ",".join(dict.fromkeys(hosts))
 
 
 def _sandbox_extra_env() -> list[tuple[str, str]]:
@@ -197,6 +236,14 @@ def container_env(
             env.append(f"{name}={dsn}")
 
     for name, value in extra_env:
+        if name in _PINNED_PROXY_ENV_KEYS:
+            # Operator extraEnv must not break the sandbox's egress wiring.
+            log.warning("sandbox_extra_env_ignored_pinned_proxy_var", key=name)
+            continue
+        if name in _NO_PROXY_ENV_KEYS:
+            # Merge rather than replace so the firewall/API host always survive.
+            _set_env(env, name, _merge_no_proxy(no_proxy, value))
+            continue
         _set_env(env, name, value)
 
     return env

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -302,11 +302,11 @@ def test_container_env_applies_kubernetes_sandbox_extra_env(
             [
                 {
                     "name": "NO_PROXY",
-                    "value": "localhost,127.0.0.1,api.internal,metrics.internal",
+                    "value": "localhost,127.0.0.1,metrics.internal",
                 },
                 {
                     "name": "no_proxy",
-                    "value": "localhost,127.0.0.1,api.internal,metrics.internal",
+                    "value": "localhost,127.0.0.1,metrics.internal",
                 },
                 {
                     "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -319,11 +319,66 @@ def test_container_env_applies_kubernetes_sandbox_extra_env(
     env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
     env_map = dict(item.split("=", 1) for item in env)
 
-    assert env_map["NO_PROXY"] == "localhost,127.0.0.1,api.internal,metrics.internal"
-    assert env_map["no_proxy"] == "localhost,127.0.0.1,api.internal,metrics.internal"
+    # The operator's extra host is added, but the critical computed hosts (the
+    # firewall proxy and the API host) are retained — extraEnv merges, never
+    # replaces, so it can't break sandbox egress.
+    no_proxy_hosts = env_map["NO_PROXY"].split(",")
+    assert "firewall.internal" in no_proxy_hosts
+    assert "api.internal" in no_proxy_hosts
+    assert "metrics.internal" in no_proxy_hosts
+    assert env_map["no_proxy"] == env_map["NO_PROXY"]
     assert env_map["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://host.orb.internal:8000"
     assert len([item for item in env if item.startswith("NO_PROXY=")]) == 1
     assert len([item for item in env if item.startswith("no_proxy=")]) == 1
+
+
+def test_container_env_extra_env_cannot_drop_critical_no_proxy_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression: an operator NO_PROXY override that omits the API host used to
+    # clobber the computed value, routing API calls through iron-proxy (405).
+    monkeypatch.setenv("AGENT_API_URL", "http://centaur-centaur-api:8000")
+    monkeypatch.setenv(
+        "KUBERNETES_SANDBOX_EXTRA_ENV",
+        json.dumps(
+            [
+                {"name": "NO_PROXY", "value": "localhost,127.0.0.1,centaur-api"},
+                {"name": "no_proxy", "value": "localhost,127.0.0.1,centaur-api"},
+            ]
+        ),
+    )
+
+    env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
+    env_map = dict(item.split("=", 1) for item in env)
+
+    no_proxy_hosts = env_map["NO_PROXY"].split(",")
+    assert "centaur-centaur-api" in no_proxy_hosts  # real API host survives
+    assert "firewall.internal" in no_proxy_hosts
+    assert "centaur-api" in no_proxy_hosts  # operator's extra is still honored
+
+
+def test_container_env_extra_env_cannot_override_pinned_proxy_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "KUBERNETES_SANDBOX_EXTRA_ENV",
+        json.dumps(
+            [
+                {"name": "HTTPS_PROXY", "value": "http://evil:9999"},
+                {"name": "http_proxy", "value": "http://evil:9999"},
+                {"name": "REQUESTS_CA_BUNDLE", "value": "/tmp/attacker.pem"},
+                {"name": "FIREWALL_HOST", "value": "elsewhere"},
+            ]
+        ),
+    )
+
+    env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
+    env_map = dict(item.split("=", 1) for item in env)
+
+    assert env_map["HTTPS_PROXY"] == "http://firewall.internal:8080"
+    assert env_map["http_proxy"] == "http://firewall.internal:8080"
+    assert env_map["REQUESTS_CA_BUNDLE"] == "/firewall-certs/ca-cert.pem"
+    assert env_map["FIREWALL_HOST"] == "firewall.internal"
 
 
 def test_container_env_adds_extra_otel_endpoint_host_to_no_proxy(


### PR DESCRIPTION
Operator-supplied `sandbox.extraEnv` is applied last via `_set_env`, which replaces any computed env entry of the same name. A `NO_PROXY`/`no_proxy` override that omitted the API host clobbered the computed value, so sandbox-to-API traffic (e.g. attachment downloads at `/agent/attachments/{id}/download`) got routed through iron-proxy, which returns 405 for the plain-HTTP forward and produced empty downloads.

This pins the proxy and CA wiring vars (`HTTP(S)_PROXY`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `GIT_SSL_CAINFO`, `FIREWALL_HOST`) so extraEnv cannot replace them, and merges `NO_PROXY`/`no_proxy` instead of replacing it so operators can still add bypass hosts without dropping the firewall and API hosts the sandbox must reach directly.