### PR TITLE
Merge sandbox NO_PROXY extras with generated hosts

### DIFF
--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -52,6 +52,19 @@ def _set_env(env: list[str], name: str, value: str) -> None:
     env.append(entry)
 
 
+def _merge_env_csv(env: list[str], name: str, value: str) -> None:
+    prefix = f"{name}="
+    additions = [item.strip() for item in value.split(",") if item.strip()]
+    for index, existing in enumerate(env):
+        if existing.startswith(prefix):
+            current = existing[len(prefix) :]
+            hosts = [item.strip() for item in current.split(",") if item.strip()]
+            merged = ",".join(dict.fromkeys([*hosts, *additions]))
+            env[index] = f"{name}={merged}"
+            return
+    env.append(f"{name}={','.join(dict.fromkeys(additions))}")
+
+
 def _sandbox_extra_env() -> list[tuple[str, str]]:
     raw = (os.getenv("KUBERNETES_SANDBOX_EXTRA_ENV") or "").strip()
     if not raw:
@@ -197,7 +210,10 @@ def container_env(
             env.append(f"{name}={dsn}")
 
     for name, value in extra_env:
-        _set_env(env, name, value)
+        if name in {"NO_PROXY", "no_proxy"}:
+            _merge_env_csv(env, name, value)
+        else:
+            _set_env(env, name, value)
 
     return env
 

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -258,6 +258,8 @@ def test_container_env_includes_firewall_host_for_secret_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
 
     env = sandbox_container_env(
         "thread-key",
@@ -296,6 +298,8 @@ def test_container_env_applies_kubernetes_sandbox_extra_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
     monkeypatch.setenv(
         "KUBERNETES_SANDBOX_EXTRA_ENV",
         json.dumps(
@@ -319,8 +323,14 @@ def test_container_env_applies_kubernetes_sandbox_extra_env(
     env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
     env_map = dict(item.split("=", 1) for item in env)
 
-    assert env_map["NO_PROXY"] == "localhost,127.0.0.1,api.internal,metrics.internal"
-    assert env_map["no_proxy"] == "localhost,127.0.0.1,api.internal,metrics.internal"
+    assert env_map["NO_PROXY"] == (
+        "localhost,127.0.0.1,firewall.internal,api.internal,host.orb.internal,"
+        "metrics.internal"
+    )
+    assert env_map["no_proxy"] == (
+        "localhost,127.0.0.1,firewall.internal,api.internal,host.orb.internal,"
+        "metrics.internal"
+    )
     assert env_map["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://host.orb.internal:8000"
     assert len([item for item in env if item.startswith("NO_PROXY=")]) == 1
     assert len([item for item in env if item.startswith("no_proxy=")]) == 1


### PR DESCRIPTION
## Summary
- merge chart-provided sandbox NO_PROXY/no_proxy hosts with generated sandbox hosts instead of replacing them
- keep normal override behavior for other sandbox.extraEnv keys
- update sandbox env regression coverage to preserve API/firewall/OTEL hosts

## Tests
- uv run pytest tests/test_sandbox_kubernetes_backend.py -k 'container_env'
- uv run ruff check api/sandbox/config.py tests/test_sandbox_kubernetes_backend.py