### PR TITLE
fix(tool-server): route the sandbox sidecar's DB pool through the iron-proxy

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,9 @@ release := env_var_or_default("CENTAUR_RELEASE", "centaur")
 source := env_var_or_default("CENTAUR_IMAGE_SOURCE", "local")
 chart := "contrib/chart"
 dev_values := "contrib/chart/values.dev.yaml"
+# Command used to import images into k3s's containerd. Override for rootless or
+# remote setups, e.g. CENTAUR_K3S_CTR="k3s ctr" or "ssh host sudo k3s ctr".
+k3s_ctr := env_var_or_default("CENTAUR_K3S_CTR", "sudo k3s ctr")
 
 default:
     just --list
@@ -56,6 +59,17 @@ _build-slackbot:
 _build-agent:
     docker build --target sandbox -t centaur-agent:latest -f services/sandbox/Dockerfile .
 
+# Import locally-built images into k3s's containerd. k3s uses containerd, not
+# the Docker daemon, so `docker build` images are otherwise invisible to it
+# (pods ImagePullBackOff on the :latest tags). Used by `just up k3s`.
+_import-k3s:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for img in centaur-api centaur-iron-proxy centaur-slackbot centaur-agent; do
+      echo "importing ${img}:latest into k3s containerd..."
+      docker save "${img}:latest" | {{k3s_ctr}} images import -
+    done
+
 bootstrap-secrets *args:
     contrib/scripts/bootstrap-k8s-secrets.sh --namespace {{namespace}} {{args}}
 
@@ -94,12 +108,21 @@ deploy:
     fi
     helm upgrade --install {{release}} {{chart}} -n {{namespace}} --create-namespace -f {{dev_values}} ${extra_args[@]+"${extra_args[@]}"}
 
-up:
+# Bring up the dev stack; pass `k3s` (just up k3s) to import local images into k3s's containerd.
+up import="":
     #!/usr/bin/env bash
     set -euo pipefail
+    if [[ -n "{{import}}" && "{{import}}" != "k3s" ]]; then
+      echo "unknown argument: {{import}} (expected nothing or 'k3s')" >&2; exit 2
+    fi
     just bootstrap-secrets
     case "{{source}}" in
-      local) just build ;;
+      local)
+        just build
+        if [[ "{{import}}" == "k3s" ]]; then
+          just _import-k3s
+        fi
+        ;;
       ghcr) ;;
       *) echo "unknown source: {{source}} (expected local or ghcr)" >&2; exit 2 ;;
     esac

--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.45
+version: 0.1.46
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -138,6 +138,12 @@ spec:
     - ports:
         - protocol: TCP
           port: 443
+    # API server egress. The kubernetes.default ClusterIP (:443) is DNAT'd to
+    # the real endpoint port (6443 on k3s/kubeadm); enforcing CNIs match egress
+    # post-DNAT, so allow that port or the API can't manage sandboxes.
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.apiServerPort }}
 ---
 {{- if .Values.slackbot.enabled }}
 apiVersion: networking.k8s.io/v1

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -59,6 +59,12 @@ spec:
         - podSelector:
             matchLabels:
               centaur.ai/component: workflow-run
+        # iron-proxy pods forward the tool-server sidecar's pool to Postgres
+        # (the sidecar reaches the core DB through the per-sandbox proxy, not
+        # directly), so the proxy must be allowed to connect.
+        - podSelector:
+            matchLabels:
+              centaur.ai/iron-proxy: "true"
       ports:
         - protocol: TCP
           port: 5432

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -239,6 +239,12 @@ networkPolicy:
   apiIngressSourceNamespaces: []
   ingressControllerNamespaces:
     - kube-system
+  # Port the kubernetes.default ClusterIP forwards to for the API server. The
+  # API needs egress to the control plane to manage sandboxes/proxies; under an
+  # enforcing CNI the ClusterIP (:443) is DNAT'd to this real endpoint port, so
+  # the egress rule must allow it. Defaults to 6443 (k3s, kubeadm). Set to 443
+  # on clusters whose API server endpoint already listens on 443.
+  apiServerPort: 6443
 
 podSecurityContext:
   fsGroupChangePolicy: OnRootMismatch

--- a/services/api/api/db.py
+++ b/services/api/api/db.py
@@ -96,8 +96,12 @@ def _dbmate_url(database_url: str) -> str:
     return f"{database_url}{sep}sslmode=disable"
 
 
-async def create_pool(database_url: str) -> asyncpg.Pool:
-    run_migrations(database_url)
+async def create_pool(database_url: str, *, apply_migrations: bool = True) -> asyncpg.Pool:
+    # The sandbox tool-server sidecar reaches the DB through the per-sandbox
+    # iron-proxy and is not a schema owner, so it opens a pool with
+    # apply_migrations=False. The API (and shared tool-server) own migrations.
+    if apply_migrations:
+        run_migrations(database_url)
     pool = await asyncpg.create_pool(
         database_url,
         min_size=2,

--- a/services/api/api/proxy_config.py
+++ b/services/api/api/proxy_config.py
@@ -99,6 +99,30 @@ def _build_source(secret_ref: str) -> dict[str, str]:
     return {"type": "env", "var": secret_ref}
 
 
+# Per-sandbox listener that lets a co-located tool-server sidecar reach the
+# core Centaur DB through the proxy (sandboxes are denied direct Postgres
+# egress). Unlike tool ``pg_dsn`` listeners, its upstream is always resolved
+# from an env var: the proxy already has the core DSN via ``envFrom`` the infra
+# secret, so this is robust regardless of the configured secret source.
+CENTAUR_CORE_PG_LISTENER = "centaur_core"
+
+
+def core_pg_listen_port(pg_listen_ports: dict[str, int]) -> int:
+    """Port for the core-DB listener: just past the tool ``pg_dsn`` listeners."""
+    return PG_LISTEN_PORT_BASE + len(pg_listen_ports)
+
+
+def _build_core_pg_listener(
+    *, port: int, dsn_env_var: str, password_env: str
+) -> dict[str, Any]:
+    return {
+        "name": CENTAUR_CORE_PG_LISTENER,
+        "listen": f"0.0.0.0:{port}",
+        "upstream": {"dsn": {"type": "env", "var": dsn_env_var}},
+        "client": {"user": "app_user", "password_env": password_env},
+    }
+
+
 def assign_pg_listen_ports(secrets: list[SecretDef]) -> dict[str, int]:
     """Allocate listen ports for ``PgDsnSecret`` entries.
 
@@ -449,6 +473,7 @@ def render_proxy_yaml(
     base_config: str | None = None,
     *,
     pg_listen_ports: dict[str, int] | None = None,
+    core_pg: dict[str, Any] | None = None,
 ) -> str:
     """Splice managed transforms + postgres listeners into ``base_config`` YAML.
 
@@ -485,6 +510,8 @@ def render_proxy_yaml(
     cfg["transforms"] = transforms
 
     listeners = _build_postgres_listeners(secrets, pg_listen_ports)
+    if core_pg is not None:
+        listeners.append(_build_core_pg_listener(**core_pg))
     if listeners:
         cfg["postgres"] = listeners
     else:

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -31,6 +31,7 @@ import structlog
 from api.broker_config import render_broker_yaml
 from api.proxy_config import (
     assign_pg_listen_ports,
+    core_pg_listen_port,
     render_proxy_yaml,
 )
 from api.sandbox.base import SandboxBackend, SandboxSession
@@ -244,6 +245,7 @@ def _secret_env_key(name: str) -> str:
 def _proxy_iron_env(
     secret_name: str,
     pg_secrets: list[tuple[PgDsnSecret, str]],
+    core: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Env block for the iron-proxy container.
 
@@ -299,6 +301,8 @@ def _proxy_iron_env(
         env.append(
             {"name": f"PG_PROXY_PASSWORD_{secret.name}", "value": proxy_password}
         )
+    if core is not None:
+        env.append({"name": core["password_env"], "value": core["password"]})
     return env
 
 
@@ -311,6 +315,42 @@ def _build_proxied_pg_url(host: str, port: int, password: str, database: str) ->
     """
     netloc = f"app_user:{password}@{host}:{port}"
     return urlunsplit(("postgresql", netloc, f"/{database}", "", ""))
+
+
+_CORE_PG_PASSWORD_ENV = "PG_PROXY_PASSWORD_CENTAUR_CORE"
+
+
+def _core_db_name() -> str:
+    """Database name of the core Centaur DB, parsed from the API's own DSN.
+
+    iron-proxy forwards the client's startup-packet database to the upstream,
+    so the sidecar's proxied DSN must declare the same dbname.
+    """
+    from api.config import settings
+
+    return urlsplit(settings.database_url).path.lstrip("/") or "centaur"
+
+
+def _build_core_pg(
+    firewall_host: str, pg_listen_ports: dict[str, int]
+) -> dict[str, Any]:
+    """Wiring for the per-sandbox proxy's core-DB listener (sidecar use only).
+
+    The tool-server sidecar reaches the core DB through the proxy because the
+    sandbox is denied direct Postgres egress. Returns the fields needed to
+    render the listener, inject the proxy-side password, open the sidecar's
+    pool, and allow egress to the listener port. Never injected into the agent
+    container, so no DB credential lives in the sandbox.
+    """
+    port = core_pg_listen_port(pg_listen_ports)
+    password = _secrets.token_urlsafe(24)
+    return {
+        "port": port,
+        "password": password,
+        "password_env": _CORE_PG_PASSWORD_ENV,
+        "dsn_env_var": _secret_env_key("DATABASE_URL"),
+        "dsn": _build_proxied_pg_url(firewall_host, port, password, _core_db_name()),
+    }
 
 
 def _api_pod_match_labels() -> dict[str, str]:
@@ -386,12 +426,16 @@ def _build_tool_server_container(
     firewall_host: str,
     api_url: str,
     overlay_mount: str | None,
+    database_url: str,
 ) -> dict[str, Any]:
     """Build the tool-server sidecar container spec.
 
     The sidecar listens on loopback inside the sandbox Pod and routes its own
-    HTTP egress through the per-sandbox iron-proxy. Caller is responsible for
-    only invoking this when ``_tool_server_image()`` is set.
+    HTTP egress through the per-sandbox iron-proxy. ``database_url`` points at
+    the proxy's core-DB listener (not the raw DSN) so the pool respects the
+    sandbox's NetworkPolicy; the real credentials stay in the proxy pod.
+    Caller is responsible for only invoking this when ``_tool_server_image()``
+    is set.
     """
     image_ref = _tool_server_image()
     if not image_ref:
@@ -406,15 +450,7 @@ def _build_tool_server_container(
     no_proxy = ",".join(dict.fromkeys(no_proxy_hosts))
 
     env: list[dict[str, Any]] = [
-        {
-            "name": "DATABASE_URL",
-            "valueFrom": {
-                "secretKeyRef": {
-                    "name": secret_name,
-                    "key": _secret_env_key("DATABASE_URL"),
-                }
-            },
-        },
+        {"name": "DATABASE_URL", "value": database_url},
         {
             "name": "SANDBOX_SIGNING_KEY",
             "valueFrom": {
@@ -827,9 +863,18 @@ class KubernetesExecutorBackend(SandboxBackend):
         sandbox_id: str,
         secrets: list[SecretDef],
         pg_listen_ports: dict[str, int],
+        core: dict[str, Any] | None = None,
     ) -> None:
+        core_pg = (
+            {k: core[k] for k in ("port", "dsn_env_var", "password_env")}
+            if core is not None
+            else None
+        )
         rendered = render_proxy_yaml(
-            secrets, base_config=None, pg_listen_ports=pg_listen_ports
+            secrets,
+            base_config=None,
+            pg_listen_ports=pg_listen_ports,
+            core_pg=core_pg,
         )
         name = _proxy_configmap_name(sandbox_id)
         await self._delete_configmap(name)
@@ -872,7 +917,10 @@ class KubernetesExecutorBackend(SandboxBackend):
         )
 
     async def _create_proxy_service(
-        self, sandbox_id: str, pg_listen_ports: dict[str, int]
+        self,
+        sandbox_id: str,
+        pg_listen_ports: dict[str, int],
+        core: dict[str, Any] | None = None,
     ) -> None:
         service_name = _proxy_service_name(sandbox_id)
         await self._delete_service(service_name)
@@ -890,6 +938,15 @@ class KubernetesExecutorBackend(SandboxBackend):
                     "name": f"pg-{name[:11].lower().replace('_', '-')}",
                     "port": port,
                     "targetPort": port,
+                    "protocol": "TCP",
+                }
+            )
+        if core is not None:
+            ports.append(
+                {
+                    "name": "pg-core",
+                    "port": core["port"],
+                    "targetPort": core["port"],
                     "protocol": "TCP",
                 }
             )
@@ -916,7 +973,10 @@ class KubernetesExecutorBackend(SandboxBackend):
         )
 
     async def _create_proxy_network_policies(
-        self, sandbox_id: str, pg_listen_ports: dict[str, int]
+        self,
+        sandbox_id: str,
+        pg_listen_ports: dict[str, int],
+        core_port: int | None = None,
     ) -> None:
         await self._delete_network_policy(_sandbox_egress_policy_name(sandbox_id))
         await self._delete_network_policy(_proxy_policy_name(sandbox_id))
@@ -924,6 +984,9 @@ class KubernetesExecutorBackend(SandboxBackend):
         sandbox_to_proxy_ports = [{"protocol": "TCP", "port": _proxy_port()}]
         for _, port in sorted(pg_listen_ports.items(), key=lambda item: item[1]):
             sandbox_to_proxy_ports.append({"protocol": "TCP", "port": port})
+        if core_port is not None:
+            # Lets the tool-server sidecar reach the proxy's core-DB listener.
+            sandbox_to_proxy_ports.append({"protocol": "TCP", "port": core_port})
 
         proxy_egress = [
             {
@@ -1044,6 +1107,7 @@ class KubernetesExecutorBackend(SandboxBackend):
         pg_listen_ports: dict[str, int],
         *,
         restart_policy: str,
+        core: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Return the pod.spec dict shared by the sandbox bare Pod and the api-self Deployment."""
         configmap_name = _proxy_configmap_name(sandbox_id)
@@ -1068,6 +1132,8 @@ class KubernetesExecutorBackend(SandboxBackend):
                     "name": f"pg-{name[:11].lower().replace('_', '-')}",
                 }
             )
+        if core is not None:
+            proxy_ports.append({"containerPort": core["port"], "name": "pg-core"})
         return {
             "automountServiceAccountToken": False,
             "restartPolicy": restart_policy,
@@ -1077,7 +1143,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                     "name": "iron-proxy",
                     "image": _proxy_image(),
                     "imagePullPolicy": _proxy_image_pull_policy(),
-                    "env": _proxy_iron_env(secret_name, pg_secrets),
+                    "env": _proxy_iron_env(secret_name, pg_secrets, core=core),
                     "envFrom": env_from,
                     "ports": proxy_ports,
                     "readinessProbe": {
@@ -1145,10 +1211,11 @@ class KubernetesExecutorBackend(SandboxBackend):
         sandbox_id: str,
         pg_secrets: list[tuple[PgDsnSecret, str]],
         pg_listen_ports: dict[str, int],
+        core: dict[str, Any] | None = None,
     ) -> str:
         proxy_pod_name = _new_proxy_pod_name(sandbox_id)
         spec = self._build_proxy_pod_spec(
-            sandbox_id, pg_secrets, pg_listen_ports, restart_policy="Never"
+            sandbox_id, pg_secrets, pg_listen_ports, restart_policy="Never", core=core
         )
         await self._core_api().create_namespaced_pod(
             _namespace(),
@@ -1320,6 +1387,13 @@ class KubernetesExecutorBackend(SandboxBackend):
             )
             for secret, proxy_password in pg_secrets
         }
+        # Core-DB listener for the tool-server sidecar (sidecar-only; never put
+        # into sandbox_pg_dsns / the agent env). None when no sidecar runs.
+        core_pg = (
+            _build_core_pg(firewall_host, pg_listen_ports)
+            if _tool_server_image()
+            else None
+        )
 
         env = container_env(
             thread_key,
@@ -1472,6 +1546,7 @@ class KubernetesExecutorBackend(SandboxBackend):
             }
         ]
         if _tool_server_image():
+            assert core_pg is not None  # set under the same guard above
             containers.append(
                 _build_tool_server_container(
                     firewall_host=firewall_host,
@@ -1479,6 +1554,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                     overlay_mount=(
                         _SANDBOX_OVERLAY_ROOT if overlay_image else None
                     ),
+                    database_url=core_pg["dsn"],
                 )
             )
 
@@ -1517,11 +1593,17 @@ class KubernetesExecutorBackend(SandboxBackend):
         await self._delete_proxy_resources(pod_name)
         try:
             await self._create_prompt_secret(secret_name, persona)
-            await self._create_proxy_configmap(pod_name, secrets, pg_listen_ports)
-            await self._create_proxy_service(pod_name, pg_listen_ports)
-            await self._create_proxy_network_policies(pod_name, pg_listen_ports)
+            await self._create_proxy_configmap(
+                pod_name, secrets, pg_listen_ports, core=core_pg
+            )
+            await self._create_proxy_service(pod_name, pg_listen_ports, core=core_pg)
+            await self._create_proxy_network_policies(
+                pod_name,
+                pg_listen_ports,
+                core_port=core_pg["port"] if core_pg else None,
+            )
             proxy_pod_name = await self._create_proxy_pod(
-                pod_name, pg_secrets, pg_listen_ports
+                pod_name, pg_secrets, pg_listen_ports, core=core_pg
             )
             await self._wait_pod_ready(proxy_pod_name)
             await self._create_workload(pod_spec)

--- a/services/api/api/tool_server_app.py
+++ b/services/api/api/tool_server_app.py
@@ -75,7 +75,11 @@ def _resolve_tool_dirs() -> list[Path]:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    app.state.db_pool = await create_pool(settings.database_url)
+    # The tool-server is never a schema owner: the per-sandbox sidecar reaches
+    # the core DB through the iron-proxy (DATABASE_URL points at the proxy's
+    # core listener) and the shared tool-server Deployment runs alongside the
+    # API. Open the pool without running migrations; the API owns migrations.
+    app.state.db_pool = await create_pool(settings.database_url, apply_migrations=False)
     watcher_task = asyncio.create_task(_watch_tools(app.state.tool_manager))
     try:
         yield

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -4,8 +4,10 @@ import pytest
 import yaml
 
 from api.proxy_config import (
+    CENTAUR_CORE_PG_LISTENER,
     PG_LISTEN_PORT_BASE,
     assign_pg_listen_ports,
+    core_pg_listen_port,
     render_proxy_yaml,
 )
 from api.tool_manager import (
@@ -790,6 +792,57 @@ def test_pg_listen_ports_are_sequential_and_sorted_by_name() -> None:
         "MIKE": PG_LISTEN_PORT_BASE + 1,
         "ZEBRA": PG_LISTEN_PORT_BASE + 2,
     }
+
+
+def test_core_pg_listen_port_is_after_tool_listeners() -> None:
+    ports = {"ALPHA": PG_LISTEN_PORT_BASE, "ZEBRA": PG_LISTEN_PORT_BASE + 1}
+    assert core_pg_listen_port(ports) == PG_LISTEN_PORT_BASE + 2
+    assert core_pg_listen_port({}) == PG_LISTEN_PORT_BASE
+
+
+def test_render_core_listener_uses_forced_env_upstream() -> None:
+    # No tool pg_dsn secrets; core listener still rendered when core_pg given.
+    core_pg = {
+        "port": PG_LISTEN_PORT_BASE,
+        "dsn_env_var": "CENTAUR_DATABASE_URL",
+        "password_env": "PG_PROXY_PASSWORD_CENTAUR_CORE",
+    }
+    cfg = yaml.safe_load(render_proxy_yaml([], core_pg=core_pg))
+    listeners = cfg["postgres"]
+    assert len(listeners) == 1
+    core = listeners[0]
+    assert core["name"] == CENTAUR_CORE_PG_LISTENER
+    assert core["listen"] == f"0.0.0.0:{PG_LISTEN_PORT_BASE}"
+    # forced env source (not 1Password) since the proxy always has the DSN env
+    assert core["upstream"]["dsn"] == {"type": "env", "var": "CENTAUR_DATABASE_URL"}
+    assert core["client"] == {
+        "user": "app_user",
+        "password_env": "PG_PROXY_PASSWORD_CENTAUR_CORE",
+    }
+
+
+def test_render_core_listener_appended_after_tool_listeners() -> None:
+    secrets = [PgDsnSecret("TOOLDB", "TOOLDB", "tooldb")]
+    pg_listen_ports = assign_pg_listen_ports(secrets)
+    core_pg = {
+        "port": core_pg_listen_port(pg_listen_ports),
+        "dsn_env_var": "CENTAUR_DATABASE_URL",
+        "password_env": "PG_PROXY_PASSWORD_CENTAUR_CORE",
+    }
+    cfg = yaml.safe_load(
+        render_proxy_yaml(secrets, pg_listen_ports=pg_listen_ports, core_pg=core_pg)
+    )
+    names = [listener["name"] for listener in cfg["postgres"]]
+    assert names == ["tooldb", CENTAUR_CORE_PG_LISTENER]
+    # core port does not collide with the tool listener's port
+    ports = {listener["name"]: listener["listen"] for listener in cfg["postgres"]}
+    assert ports["tooldb"] == f"0.0.0.0:{PG_LISTEN_PORT_BASE}"
+    assert ports[CENTAUR_CORE_PG_LISTENER] == f"0.0.0.0:{PG_LISTEN_PORT_BASE + 1}"
+
+
+def test_render_without_core_pg_emits_no_core_listener() -> None:
+    cfg = yaml.safe_load(render_proxy_yaml([]))
+    assert "postgres" not in cfg
 
 
 def test_pg_listen_ports_deduplicates() -> None:

--- a/services/api/tests/test_tool_server_core_pg.py
+++ b/services/api/tests/test_tool_server_core_pg.py
@@ -1,0 +1,85 @@
+"""Option B: tool-server sidecar reaches the core DB through the iron-proxy."""
+
+from __future__ import annotations
+
+import pytest
+
+from api.proxy_config import PG_LISTEN_PORT_BASE
+from api.sandbox.kubernetes import (
+    _CORE_PG_PASSWORD_ENV,
+    _build_core_pg,
+    _build_tool_server_container,
+    _proxy_iron_env,
+)
+
+
+def test_build_core_pg_points_at_proxy_listener(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@db:5432/ai_v2")
+    monkeypatch.delenv("KUBERNETES_SECRET_ENV_PREFIX", raising=False)
+
+    core = _build_core_pg("proxy-host", {"TOOLDB": PG_LISTEN_PORT_BASE})
+
+    assert core["port"] == PG_LISTEN_PORT_BASE + 1  # after the one tool listener
+    assert core["password_env"] == _CORE_PG_PASSWORD_ENV
+    assert core["dsn_env_var"] == "DATABASE_URL"
+    assert core["password"]  # generated, non-empty
+    # proxied DSN points at the proxy listener as app_user, dbname from the API DSN
+    assert (
+        core["dsn"]
+        == f"postgresql://app_user:{core['password']}@proxy-host:{PG_LISTEN_PORT_BASE + 1}/ai_v2"
+    )
+
+
+def test_build_core_pg_respects_secret_env_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@db:5432/ai_v2")
+    monkeypatch.setenv("KUBERNETES_SECRET_ENV_PREFIX", "CENTAUR_")
+
+    core = _build_core_pg("proxy-host", {})
+
+    assert core["dsn_env_var"] == "CENTAUR_DATABASE_URL"
+    assert core["port"] == PG_LISTEN_PORT_BASE  # no tool listeners
+
+
+def test_tool_server_container_uses_proxied_dsn_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_IMAGE", "centaur-api:latest")
+    monkeypatch.setenv("KUBERNETES_SECRET_ENV_NAME", "centaur-infra-env")
+
+    dsn = "postgresql://app_user:pw@proxy-host:5433/ai_v2"
+    container = _build_tool_server_container(
+        firewall_host="proxy-host",
+        api_url="http://api:8000",
+        overlay_mount=None,
+        database_url=dsn,
+    )
+
+    env = {e["name"]: e for e in container["env"]}
+    # DATABASE_URL is the literal proxied value, not a secretKeyRef
+    assert env["DATABASE_URL"] == {"name": "DATABASE_URL", "value": dsn}
+    # the signing key still comes from the secret
+    assert "valueFrom" in env["SANDBOX_SIGNING_KEY"]
+
+
+def test_proxy_iron_env_includes_core_password_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KUBERNETES_SECRET_ENV_NAME", "centaur-infra-env")
+    core = {"password_env": _CORE_PG_PASSWORD_ENV, "password": "sekret"}
+
+    env = _proxy_iron_env("centaur-infra-env", [], core=core)
+
+    values = {e["name"]: e.get("value") for e in env}
+    assert values[_CORE_PG_PASSWORD_ENV] == "sekret"
+
+
+def test_proxy_iron_env_omits_core_password_when_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KUBERNETES_SECRET_ENV_NAME", "centaur-infra-env")
+
+    env = _proxy_iron_env("centaur-infra-env", [], core=None)
+
+    assert _CORE_PG_PASSWORD_ENV not in [e["name"] for e in env]


### PR DESCRIPTION
Makes the per-sandbox tool-server work under an **enforced** NetworkPolicy (paradigm does not currently enforce it; clusters that do — e.g. default k3s — hit these bugs).

**Sidecar DB pool via iron-proxy.** The sidecar opened an asyncpg pool and ran dbmate migrations against the core DB directly, which the sandbox NetworkPolicy denies, so it crashed at startup and every agent tool call failed. It now reaches the core DB through the per-sandbox iron-proxy: a core-DB listener is added to the proxy and the sidecar `DATABASE_URL` points at it. Real DB creds stay in the proxy pod; the sandbox only holds an `app_user` proxied DSN, injected into the tool-server container only (never the agent container). The sidecar opens its pool with `apply_migrations=False` (the API owns migrations).

**API egress to the k8s API server.** The chart default-deny egress only allowed `:443`, but the `kubernetes.default` ClusterIP is DNAT'd to the real endpoint port (6443 on k3s/kubeadm) and enforcing CNIs match egress post-DNAT, so the API could not reach the control plane and no iron-proxy came up. Adds an egress rule for the API-server port, configurable via `networkPolicy.apiServerPort` (default 6443).

**Dev tooling.** `just up k3s` imports locally-built images into k3s containerd.

Supersedes the skip-DB approach in #260 by @0xdiid, whose report identified the original bug.
