### PR TITLE
feat(api): let sandbox tokens read any thread, and fix attachment downloads

### DIFF
--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -83,6 +83,7 @@ Execution tuning:
 | `THREAD_FAILURE_LOOP_WINDOW_S`, `THREAD_FAILURE_LOOP_THRESHOLD` | `api.extraEnv`. | Repeated thread failure detection. |
 | `IDLE_TTL_S`, `SUSPENDED_RETENTION_S`, `MAX_ACTIVE_SANDBOX_SESSIONS` | `api.extraEnv`. | Sandbox cleanup limits. |
 | `STREAM_EOF_REATTACH_MAX`, `STREAM_EOF_REATTACH_BACKOFF_S` | `api.extraEnv`. | Stream reattach retry behavior. |
+| `SANDBOX_CROSS_THREAD_READS` | `api.extraEnv`. | Lets a sandbox token read any thread it has the key for (messages, status, attachments). Defaults to enabled. Set to `0` to confine reads to the token's own thread. Writes are always confined regardless. |
 
 ## Slackbot
 

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -82,6 +82,7 @@ Execution tuning:
 | `THREAD_FAILURE_LOOP_WINDOW_S`, `THREAD_FAILURE_LOOP_THRESHOLD` | `api.extraEnv`. | Repeated thread failure detection. |
 | `IDLE_TTL_S`, `SUSPENDED_RETENTION_S`, `MAX_ACTIVE_SANDBOX_SESSIONS` | `api.extraEnv`. | Sandbox cleanup limits. |
 | `STREAM_EOF_REATTACH_MAX`, `STREAM_EOF_REATTACH_BACKOFF_S` | `api.extraEnv`. | Stream reattach retry behavior. |
+| `SANDBOX_CROSS_THREAD_READS` | `api.extraEnv`. | Lets a sandbox token read any thread it has the key for (messages, status, attachments). Defaults to enabled. Set to `0` to confine reads to the token's own thread. Writes are always confined regardless. |
 
 ## Slackbot
 

--- a/services/api/api/deps.py
+++ b/services/api/api/deps.py
@@ -181,6 +181,37 @@ def sandbox_thread_in_scope(allowed_thread_key: str | None, requested_thread_key
     return False
 
 
+def sandbox_cross_thread_reads_allowed() -> bool:
+    """Whether a sandbox token may READ threads other than the one it is scoped to.
+
+    Reads are relaxed by default so that anyone holding a thread link can view
+    its contents and attachments. Writes are always confined to the token's own
+    thread regardless of this setting. Set ``SANDBOX_CROSS_THREAD_READS`` to a
+    falsey value (``0``/``false``/``no``/``off``) to lock reads back down.
+    """
+    val = os.environ.get("SANDBOX_CROSS_THREAD_READS", "1").strip().lower()
+    return val not in ("0", "false", "no", "off")
+
+
+def enforce_sandbox_thread_scope(request: Request, thread_key: str, *, write: bool) -> None:
+    """Reject if a sandbox token is accessing a thread it is not allowed to.
+
+    Non-sandbox callers (service keys) are never restricted here. For sandbox
+    tokens, writes are always confined to the token's own thread; reads are
+    allowed across threads when ``sandbox_cross_thread_reads_allowed`` is true
+    (the default).
+    """
+    claims = get_sandbox_claims(request)
+    if claims is None:
+        return
+    allowed = claims.get("thread_key")
+    if sandbox_thread_in_scope(allowed, thread_key):
+        return
+    if not write and sandbox_cross_thread_reads_allowed():
+        return
+    raise HTTPException(status_code=403, detail="Sandbox token is scoped to a different thread")
+
+
 def require_scope(scope: str) -> Callable:
     """Return a FastAPI dependency that checks the caller has the given scope.
 

--- a/services/api/api/routers/agent.py
+++ b/services/api/api/routers/agent.py
@@ -22,9 +22,9 @@ from api.agent import (
     stop_session,
 )
 from api.deps import (
+    enforce_sandbox_thread_scope,
     get_sandbox_claims,
     require_scope,
-    sandbox_thread_in_scope,
     verify_api_key,
 )
 from api.final_delivery import (
@@ -59,16 +59,6 @@ router = APIRouter(
     tags=["agent"],
     dependencies=[Depends(verify_api_key)],
 )
-
-
-def _enforce_sandbox_thread_scope(request: Request, thread_key: str) -> None:
-    """Reject if a sandbox token is trying to access a different thread."""
-    claims = get_sandbox_claims(request)
-    if claims is None:
-        return
-    allowed = claims.get("thread_key")
-    if not sandbox_thread_in_scope(allowed, thread_key):
-        raise HTTPException(status_code=403, detail="Sandbox token is scoped to a different thread")
 
 
 # ── Known harness flags ─────────────────────────────────────────────────────
@@ -250,7 +240,7 @@ def _overlay_runtime_payload() -> dict[str, Any]:
 @router.post("/execute", dependencies=[Depends(require_scope("agent:execute"))])
 async def execute(request: Request):
     body = ExecuteRequest.model_validate(await request.json())
-    _enforce_sandbox_thread_scope(request, body.thread_key)
+    enforce_sandbox_thread_scope(request, body.thread_key, write=True)
     pool = request.app.state.db_pool
 
     # Auto-orchestrate spawn → message → execute when assignment_generation
@@ -359,7 +349,7 @@ async def _auto_execute(pool, body: ExecuteRequest) -> JSONResponse:
 
 @router.post("/spawn", dependencies=[Depends(require_scope("agent:execute"))])
 async def spawn(req: SpawnRequest, request: Request):
-    _enforce_sandbox_thread_scope(request, req.thread_key)
+    enforce_sandbox_thread_scope(request, req.thread_key, write=True)
     pool = request.app.state.db_pool
     spawn_id = req.spawn_id or f"spawn-{uuid.uuid4().hex[:16]}"
     try:
@@ -379,7 +369,7 @@ async def spawn(req: SpawnRequest, request: Request):
 @router.post("/message", dependencies=[Depends(require_scope("agent:execute"))])
 async def post_message(request: Request):
     body = MessageRequest.model_validate(await request.json())
-    _enforce_sandbox_thread_scope(request, body.thread_key)
+    enforce_sandbox_thread_scope(request, body.thread_key, write=True)
     event, metadata = _normalize_message_event(body.model_dump(exclude_none=True))
     message_id = body.message_id or f"msg-{uuid.uuid4().hex[:16]}"
     pool = request.app.state.db_pool
@@ -447,7 +437,7 @@ async def post_messages(request: Request):
 @router.get("/messages", dependencies=[Depends(require_scope("agent:execute"))])
 async def get_messages(request: Request, thread_key: str, cursor: str | None = None, limit: int = 50):
     """Paginated chat_messages for a thread."""
-    _enforce_sandbox_thread_scope(request, thread_key)
+    enforce_sandbox_thread_scope(request, thread_key, write=False)
     pool = request.app.state.db_pool
     limit = min(limit, 200)
 
@@ -506,7 +496,7 @@ class StopRequest(BaseModel):
 
 @router.post("/stop", dependencies=[Depends(require_scope("agent:stop"))])
 async def stop(req: StopRequest, request: Request):
-    _enforce_sandbox_thread_scope(request, req.thread_key)
+    enforce_sandbox_thread_scope(request, req.thread_key, write=True)
     ok = await stop_session(req.thread_key)
     return {"ok": ok}
 
@@ -518,7 +508,7 @@ class TitleRequest(BaseModel):
 
 @router.post("/title", dependencies=[Depends(require_scope("agent:execute"))])
 async def set_title(req: TitleRequest, request: Request):
-    _enforce_sandbox_thread_scope(request, req.thread_key)
+    enforce_sandbox_thread_scope(request, req.thread_key, write=True)
     pool = request.app.state.db_pool
     await pool.execute(
         "UPDATE sandbox_sessions SET thread_name = $1, updated_at = NOW() WHERE thread_key = $2",
@@ -530,7 +520,7 @@ async def set_title(req: TitleRequest, request: Request):
 
 @router.get("/status", dependencies=[Depends(require_scope("agent:status"))])
 async def status(request: Request, key: str):
-    _enforce_sandbox_thread_scope(request, key)
+    enforce_sandbox_thread_scope(request, key, write=False)
     result = await get_status(key)
     # Add pending message count
     try:
@@ -578,7 +568,7 @@ async def status(request: Request, key: str):
 
 @router.get("/runtime", dependencies=[Depends(require_scope("agent:status"))])
 async def runtime(request: Request, key: str):
-    _enforce_sandbox_thread_scope(request, key)
+    enforce_sandbox_thread_scope(request, key, write=False)
     active = await get_active_assignment(request.app.state.db_pool, key)
     persona_id = active["persona_id"] if active else None
     return {
@@ -600,13 +590,13 @@ async def execution_status(request: Request, execution_id: str):
     result = await get_execution(pool, execution_id)
     if not result:
         raise HTTPException(status_code=404, detail="execution not found")
-    _enforce_sandbox_thread_scope(request, result["thread_key"])
+    enforce_sandbox_thread_scope(request, result["thread_key"], write=False)
     return result
 
 
 @router.get("/threads/{thread_key}/executions", dependencies=[Depends(require_scope("agent:execute"))])
 async def thread_executions(request: Request, thread_key: str, limit: int = 20):
-    _enforce_sandbox_thread_scope(request, thread_key)
+    enforce_sandbox_thread_scope(request, thread_key, write=False)
     pool = request.app.state.db_pool
     return {
         "thread_key": thread_key,
@@ -622,7 +612,7 @@ async def thread_events(
     execution_id: str | None = None,
     poll_ms: int = 500,
 ):
-    _enforce_sandbox_thread_scope(request, thread_key)
+    enforce_sandbox_thread_scope(request, thread_key, write=False)
     pool = request.app.state.db_pool
     poll_s = max(0.05, min(poll_ms / 1000.0, 5.0))
 
@@ -697,7 +687,7 @@ class ReleaseRequest(BaseModel):
 
 @router.post("/threads/{thread_key}/release", dependencies=[Depends(require_scope("agent:execute"))])
 async def release_thread(request: Request, thread_key: str, body: ReleaseRequest):
-    _enforce_sandbox_thread_scope(request, thread_key)
+    enforce_sandbox_thread_scope(request, thread_key, write=True)
     pool = request.app.state.db_pool
     release_id = body.release_id or f"rel-{uuid.uuid4().hex[:16]}"
     try:
@@ -719,7 +709,7 @@ async def execution_cancel(request: Request, execution_id: str):
     existing = await get_execution(pool, execution_id)
     if not existing:
         raise HTTPException(status_code=404, detail="execution not found")
-    _enforce_sandbox_thread_scope(request, existing["thread_key"])
+    enforce_sandbox_thread_scope(request, existing["thread_key"], write=True)
     result = await cancel_execution(pool, execution_id)
     if not result:
         raise HTTPException(status_code=404, detail="execution not found")
@@ -746,7 +736,7 @@ async def steer_execution_endpoint(execution_id: str, request: Request):
     existing = await get_execution(pool, execution_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Execution not found")
-    _enforce_sandbox_thread_scope(request, existing["thread_key"])
+    enforce_sandbox_thread_scope(request, existing["thread_key"], write=True)
     raw_bytes = await request.body()
     raw_body = _json.loads(raw_bytes) if raw_bytes else {}
     body = SteerExecutionRequest.model_validate(raw_body)
@@ -1125,7 +1115,7 @@ async def list_threads(request: Request, limit: int = 200):
 @router.get("/threads/detail", dependencies=[Depends(require_scope("agent:status"))])
 async def thread_detail(request: Request, key: str):
     """Get detailed info for a single thread."""
-    _enforce_sandbox_thread_scope(request, key)
+    enforce_sandbox_thread_scope(request, key, write=False)
     pool = request.app.state.db_pool
 
     rows = await pool.fetch(

--- a/services/api/api/routers/attachments.py
+++ b/services/api/api/routers/attachments.py
@@ -9,7 +9,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
 
-from api.deps import get_sandbox_claims, sandbox_thread_in_scope, verify_api_key
+from api.deps import enforce_sandbox_thread_scope, verify_api_key
 
 log = structlog.get_logger()
 
@@ -25,20 +25,10 @@ def _ascii_filename(name: str) -> str:
     return name.encode("ascii", "ignore").decode("ascii").replace('"', "")
 
 
-def _enforce_sandbox_thread_scope(request: Request, thread_key: str) -> None:
-    """Reject if a sandbox token is trying to access a different thread."""
-    claims = get_sandbox_claims(request)
-    if claims is None:
-        return
-    allowed = claims.get("thread_key")
-    if not sandbox_thread_in_scope(allowed, thread_key):
-        raise HTTPException(status_code=403, detail="Sandbox token is scoped to a different thread")
-
-
 @router.get("")
 async def list_attachments(request: Request, thread_key: str):
     """List attachment metadata for a thread."""
-    _enforce_sandbox_thread_scope(request, thread_key)
+    enforce_sandbox_thread_scope(request, thread_key, write=False)
     pool = request.app.state.db_pool
     rows = await pool.fetch(
         "SELECT id, thread_key, message_id, name, mime_type, created_at "
@@ -82,7 +72,7 @@ async def upload_attachment(request: Request):
             detail="thread_key, name, mime_type, and data are required",
         )
 
-    _enforce_sandbox_thread_scope(request, thread_key)
+    enforce_sandbox_thread_scope(request, thread_key, write=True)
 
     try:
         raw_bytes = base64.b64decode(data_b64)
@@ -134,8 +124,10 @@ async def download_attachment(
     )
     if not row:
         raise HTTPException(status_code=404, detail="Attachment not found")
-    # Reject a sandbox token reading an attachment from another thread.
-    _enforce_sandbox_thread_scope(request, row["thread_key"])
+    # Reject a sandbox token reading an attachment from another thread, unless
+    # cross-thread reads are enabled (the default) — a thread link is the
+    # capability to view its attachments.
+    enforce_sandbox_thread_scope(request, row["thread_key"], write=False)
     # An explicit thread_key constrains the read to that thread, for callers
     # whose key is not a sandbox token (so the check above does not apply).
     if thread_key is not None and row["thread_key"] != thread_key:

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -412,13 +412,23 @@ def _deployment_environment() -> str:
 
 
 def _slack_thread_metadata(thread_key: str) -> dict[str, str]:
-    parts = thread_key.split(":", 2)
-    if len(parts) != 3 or parts[0] != "slack":
+    # Slack thread keys are slack:<team>:<channel>:<thread_ts>; the older
+    # slack:<channel>:<thread_ts> form is still accepted for compatibility.
+    parts = thread_key.split(":")
+    if parts[0] != "slack":
         return {}
-    return {
-        "slack_channel_id": parts[1],
-        "slack_thread_ts": parts[2],
-    }
+    if len(parts) == 4:
+        return {
+            "slack_team_id": parts[1],
+            "slack_channel_id": parts[2],
+            "slack_thread_ts": parts[3],
+        }
+    if len(parts) == 3:
+        return {
+            "slack_channel_id": parts[1],
+            "slack_thread_ts": parts[2],
+        }
+    return {}
 
 
 def _execution_laminar_metadata(

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -29,6 +29,7 @@ from kubernetes_asyncio.stream.ws_client import (
 import structlog
 
 from api.broker_config import render_broker_yaml
+from api.deps import mint_sandbox_token
 from api.proxy_config import (
     assign_pg_listen_ports,
     core_pg_listen_port,
@@ -423,6 +424,8 @@ def _firewall_ca_key_secret_name() -> str:
 
 def _build_tool_server_container(
     *,
+    thread_key: str,
+    container_name: str,
     firewall_host: str,
     api_url: str,
     overlay_mount: str | None,
@@ -436,6 +439,12 @@ def _build_tool_server_container(
     sandbox's NetworkPolicy; the real credentials stay in the proxy pod.
     Caller is responsible for only invoking this when ``_tool_server_image()``
     is set.
+
+    The sidecar runs tool code that calls back into the API (e.g. the slack
+    tool offloading a downloaded file to ``/agent/attachments/upload``), so it
+    needs its own ``CENTAUR_API_KEY``. Mint a sandbox token scoped to this
+    thread, mirroring the agent container; without it the callback is
+    unauthenticated and the API rejects it with 401.
     """
     image_ref = _tool_server_image()
     if not image_ref:
@@ -470,6 +479,7 @@ def _build_tool_server_container(
         {"name": "SSL_CERT_FILE", "value": "/firewall-certs/ca-cert.pem"},
         {"name": "NODE_EXTRA_CA_CERTS", "value": "/firewall-certs/ca-cert.pem"},
         {"name": "CENTAUR_API_URL", "value": api_url},
+        {"name": "CENTAUR_API_KEY", "value": mint_sandbox_token(thread_key, container_name)},
         {"name": "TOOL_DIRS", "value": _tool_server_tool_dirs()},
         {"name": "PLUGIN_WATCHER_ENABLED", "value": "0"},
     ]
@@ -1549,6 +1559,8 @@ class KubernetesExecutorBackend(SandboxBackend):
             assert core_pg is not None  # set under the same guard above
             containers.append(
                 _build_tool_server_container(
+                    thread_key=thread_key,
+                    container_name=pod_name,
                     firewall_host=firewall_host,
                     api_url=os.getenv("AGENT_API_URL", "http://api:8000"),
                     overlay_mount=(

--- a/services/api/tests/test_attachments.py
+++ b/services/api/tests/test_attachments.py
@@ -660,18 +660,80 @@ async def test_nonexistent_attachment_404(client, api_key):
 
 
 @pytest.mark.asyncio
-async def test_download_attachment_enforces_sandbox_thread_scope():
-    """download_attachment refuses a sandbox token scoped to another thread.
+async def test_download_attachment_allows_cross_thread_reads_by_default(monkeypatch):
+    """A sandbox token may download another thread's attachment by default.
 
-    Exercises the handler directly: the HTTP path can't be used because
-    verify_api_key bypasses auth for loopback clients, so a test client never
-    carries sandbox claims.
+    Cross-thread reads are relaxed so anyone holding a thread link can view its
+    attachments. Exercises the handler directly: the HTTP path can't be used
+    because a test client never carries sandbox claims.
     """
     import types
 
     from fastapi import HTTPException
 
     from api.routers.attachments import download_attachment
+
+    monkeypatch.delenv("SANDBOX_CROSS_THREAD_READS", raising=False)
+
+    row = {
+        "data": SAMPLE_PNG,
+        "mime_type": "image/png",
+        "name": "secret.png",
+        "thread_key": "test:owner-thread",
+    }
+
+    class _Pool:
+        async def fetchrow(self, _sql, _attachment_id):
+            return row
+
+    def _request(sandbox_claims):
+        return types.SimpleNamespace(
+            app=types.SimpleNamespace(state=types.SimpleNamespace(db_pool=_Pool())),
+            state=types.SimpleNamespace(sandbox_claims=sandbox_claims),
+        )
+
+    # Sandbox token scoped to a different thread → still serves the bytes
+    resp = await download_attachment(
+        _request({"thread_key": "test:other-thread"}), "att-x"
+    )
+    assert resp.status_code == 200
+    assert resp.body == SAMPLE_PNG
+
+    # Sandbox token scoped to the owning thread → serves the bytes
+    resp = await download_attachment(
+        _request({"thread_key": "test:owner-thread"}), "att-x"
+    )
+    assert resp.status_code == 200
+    assert resp.body == SAMPLE_PNG
+
+    # Non-sandbox caller (no claims) → unaffected
+    resp = await download_attachment(_request(None), "att-x")
+    assert resp.status_code == 200
+
+    # Explicit thread_key must match the attachment's thread, regardless of
+    # token type (used by privileged callers acting for an agent).
+    with pytest.raises(HTTPException) as excinfo:
+        await download_attachment(
+            _request(None), "att-x", thread_key="test:other-thread"
+        )
+    assert excinfo.value.status_code == 403
+
+    resp = await download_attachment(
+        _request(None), "att-x", thread_key="test:owner-thread"
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_download_attachment_enforces_thread_scope_when_reads_locked(monkeypatch):
+    """With SANDBOX_CROSS_THREAD_READS disabled, a sandbox token is confined."""
+    import types
+
+    from fastapi import HTTPException
+
+    from api.routers.attachments import download_attachment
+
+    monkeypatch.setenv("SANDBOX_CROSS_THREAD_READS", "0")
 
     row = {
         "data": SAMPLE_PNG,
@@ -703,23 +765,6 @@ async def test_download_attachment_enforces_sandbox_thread_scope():
     )
     assert resp.status_code == 200
     assert resp.body == SAMPLE_PNG
-
-    # Non-sandbox caller (no claims) → unaffected
-    resp = await download_attachment(_request(None), "att-x")
-    assert resp.status_code == 200
-
-    # Explicit thread_key must match the attachment's thread, regardless of
-    # token type (used by privileged callers acting for an agent).
-    with pytest.raises(HTTPException) as excinfo:
-        await download_attachment(
-            _request(None), "att-x", thread_key="test:other-thread"
-        )
-    assert excinfo.value.status_code == 403
-
-    resp = await download_attachment(
-        _request(None), "att-x", thread_key="test:owner-thread"
-    )
-    assert resp.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -14,6 +14,7 @@ from api.sandbox.config import container_env as sandbox_container_env
 from api.sandbox.kubernetes import (
     KubernetesExecutorBackend,
     STDOUT_CHANNEL,
+    _build_tool_server_container,
 )
 from api.sandbox.kubernetes_agent_sandbox import KubernetesAgentSandboxBackend
 from api.sandbox.registry import auto_configure
@@ -563,6 +564,33 @@ async def test_create_requires_repo_cache_volume_for_repo(
             "amp",
             repo="paradigmxyz/centaur",
         )
+
+
+def test_tool_server_container_has_verifiable_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sidecar runs tool code that calls back into the API (e.g. the slack
+    tool offloading a download to /agent/attachments/upload), so it must carry
+    a CENTAUR_API_KEY the API accepts — otherwise the callback 401s."""
+    from api.deps import verify_sandbox_token
+
+    monkeypatch.setenv("SANDBOX_SIGNING_KEY", "test-signing-key")
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_IMAGE", "centaur-tools:test")
+
+    container = _build_tool_server_container(
+        thread_key="slack:C123:123.456",
+        container_name="centaur-sandbox-pod-abc",
+        firewall_host="firewall.internal",
+        api_url="http://api.internal:8000",
+        overlay_mount=None,
+        database_url="postgres://app_user@firewall.internal:5433/centaur",
+    )
+
+    env = {item["name"]: item.get("value") for item in container["env"]}
+    claims = verify_sandbox_token(env["CENTAUR_API_KEY"])
+    assert claims is not None
+    assert claims["thread_key"] == "slack:C123:123.456"
+    assert claims["container_id"] == "centaur-sandbox-pod-abc"
 
 
 @pytest.mark.asyncio

--- a/services/api/tests/test_sandbox_tokens.py
+++ b/services/api/tests/test_sandbox_tokens.py
@@ -7,7 +7,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pytest
 
-from api.deps import mint_sandbox_token, sandbox_thread_in_scope, verify_sandbox_token
+import types
+
+from fastapi import HTTPException
+
+from api.deps import (
+    enforce_sandbox_thread_scope,
+    mint_sandbox_token,
+    sandbox_thread_in_scope,
+    verify_sandbox_token,
+)
 
 _TEST_SECRET = "test-secret-key-for-unit-tests"
 
@@ -97,3 +106,41 @@ class TestSandboxThreadScope:
         assert sandbox_thread_in_scope("thread:1", "thread:1")
         assert not sandbox_thread_in_scope("thread:1", "thread:2")
         assert not sandbox_thread_in_scope("thread:1", "thread:1:child")
+
+
+def _request(sandbox_claims):
+    return types.SimpleNamespace(
+        state=types.SimpleNamespace(sandbox_claims=sandbox_claims)
+    )
+
+
+class TestEnforceSandboxThreadScope:
+    def test_non_sandbox_caller_is_never_restricted(self):
+        # No claims → service key; reads and writes to any thread are allowed.
+        enforce_sandbox_thread_scope(_request(None), "thread:other", write=True)
+        enforce_sandbox_thread_scope(_request(None), "thread:other", write=False)
+
+    def test_own_thread_allowed_for_reads_and_writes(self):
+        req = _request({"thread_key": "thread:1"})
+        enforce_sandbox_thread_scope(req, "thread:1", write=True)
+        enforce_sandbox_thread_scope(req, "thread:1", write=False)
+
+    def test_cross_thread_write_always_rejected(self, monkeypatch):
+        # Even with reads relaxed, writes stay confined to the token's thread.
+        monkeypatch.setenv("SANDBOX_CROSS_THREAD_READS", "1")
+        req = _request({"thread_key": "thread:1"})
+        with pytest.raises(HTTPException) as excinfo:
+            enforce_sandbox_thread_scope(req, "thread:2", write=True)
+        assert excinfo.value.status_code == 403
+
+    def test_cross_thread_read_allowed_by_default(self, monkeypatch):
+        monkeypatch.delenv("SANDBOX_CROSS_THREAD_READS", raising=False)
+        req = _request({"thread_key": "thread:1"})
+        enforce_sandbox_thread_scope(req, "thread:2", write=False)
+
+    def test_cross_thread_read_rejected_when_locked(self, monkeypatch):
+        monkeypatch.setenv("SANDBOX_CROSS_THREAD_READS", "0")
+        req = _request({"thread_key": "thread:1"})
+        with pytest.raises(HTTPException) as excinfo:
+            enforce_sandbox_thread_scope(req, "thread:2", write=False)
+        assert excinfo.value.status_code == 403

--- a/services/api/tests/test_slack_thread_metadata.py
+++ b/services/api/tests/test_slack_thread_metadata.py
@@ -1,0 +1,27 @@
+"""Unit tests for slack thread_key parsing in runtime_control metadata."""
+
+from __future__ import annotations
+
+from api.runtime_control import _slack_thread_metadata
+
+
+def test_team_scoped_thread_key() -> None:
+    # slack:<team>:<channel>:<thread_ts> — the format the slackbot emits.
+    assert _slack_thread_metadata(
+        "slack:T0AQQ46PL4C:C0B0XS7BLA3:1780035646.228899"
+    ) == {
+        "slack_team_id": "T0AQQ46PL4C",
+        "slack_channel_id": "C0B0XS7BLA3",
+        "slack_thread_ts": "1780035646.228899",
+    }
+
+
+def test_legacy_thread_key_without_team() -> None:
+    assert _slack_thread_metadata("slack:C0B0XS7BLA3:1780035646.228899") == {
+        "slack_channel_id": "C0B0XS7BLA3",
+        "slack_thread_ts": "1780035646.228899",
+    }
+
+
+def test_non_slack_thread_key() -> None:
+    assert _slack_thread_metadata("task:do-something-123") == {}

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ironsh/iron-proxy:0.42.0-rc.2@sha256:b8ee863804c90369344db9399f3deaed15173b952c1bc631070681b70428fae5
+FROM ironsh/iron-proxy:0.42.0-rc.3@sha256:d62792cbc1121e0277cb6bf76df53bf6d1050748cbe625a9ac3039dff1cee88f
 
 USER root
 RUN apk add --no-cache curl jq

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -255,7 +255,7 @@
 |Files attached to the current user message should be at /home/agent/uploads/.
 |When you see [Attached image: ...], use the look_at tool to view the image.
 |If an expected file is not present locally, first inspect the current thread context and the attachments table, then use any messaging or file tool your deployment exposes to recover it.
-|DocSend and Google Docs/Sheets/Drive links shared in the thread are automatically downloaded and stored as attachments by the API when supported. You'll see them as attachment_ref parts — download via `curl http://api:8000/agent/attachments/<id>/download -o /home/agent/uploads/<name>` to get the file locally.
+|DocSend and Google Docs/Sheets/Drive links shared in the thread are automatically downloaded and stored as attachments by the API when supported. You'll see them as attachment_ref parts — download via `curl "$CENTAUR_API_URL/agent/attachments/<id>/download" -o /home/agent/uploads/<name>` to get the file locally.
 |Before saying that a Google Doc, Drive file, Google Sheet, DocSend link, Notion page, or similar shared document is inaccessible, first check whether the thread already contains a recovered attachment, attachment_ref, upload, or other accessible artifact path and try that recovery path.
 |Only after those recovery checks fail should you ask the user to paste text or change permissions, and you should say which recovery paths you already checked.
 |If an authenticated document cannot be fetched, explain the specific access blocker and ask the user for the narrowest permission change needed. Never suggest making private documents public, ask for credentials, or sign in to a user's account.

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1587,14 +1587,27 @@ class SlackClient:
             raise RuntimeError(f"Slack API error: {e.response['error']}") from e
 
     def _current_slack_destination(self) -> tuple[str | None, str | None]:
-        """Return the active Slack channel/thread from the tool context, if any."""
+        """Return the active Slack channel/thread from the tool context, if any.
+
+        Slack thread keys are ``slack:<team>:<channel>:<thread_ts>`` (the format
+        the slackbot emits). The older ``slack:<channel>:<thread_ts>`` form is
+        still accepted for backwards compatibility.
+        """
         try:
             thread_key = get_tool_context().thread_key or ""
         except LookupError:
             return None, None
         parts = thread_key.split(":")
-        if len(parts) == 3 and parts[0] == "slack" and parts[1] and parts[2]:
-            return parts[1], parts[2]
+        if parts[0] != "slack":
+            return None, None
+        if len(parts) == 4:
+            channel, thread_ts = parts[2], parts[3]
+        elif len(parts) == 3:
+            channel, thread_ts = parts[1], parts[2]
+        else:
+            return None, None
+        if channel and thread_ts:
+            return channel, thread_ts
         return None, None
 
     @staticmethod

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -499,6 +499,28 @@ def test_upload_file_infers_slack_thread_from_tool_context() -> None:
     assert fake_web_client.last_kwargs["initial_comment"] == "Uploaded `chart.png`."
 
 
+def test_upload_file_infers_destination_from_team_scoped_thread_key() -> None:
+    """The slackbot emits slack:<team>:<channel>:<thread_ts>; upload_file must
+    infer the channel and thread from that 4-part key, not just the legacy
+    3-part form. Otherwise an agent that omits channel/thread_ts gets a
+    'channel is required' error and files never land in the thread."""
+    client, fake_web_client = _make_client()
+    token = set_tool_context(
+        ToolContext(
+            name="slack",
+            thread_key="slack:T0AQQ46PL4C:C0B0XS7BLA3:1780035646.228899",
+        ),
+    )
+    try:
+        client.upload_file(content_base64="dGVzdA==", filename="random_data.csv")
+    finally:
+        reset_tool_context(token)
+
+    assert fake_web_client.last_kwargs is not None
+    assert fake_web_client.last_kwargs["channel"] == "C123"
+    assert fake_web_client.last_kwargs["thread_ts"] == "1780035646.228899"
+
+
 def test_upload_file_rejects_local_path_argument() -> None:
     """upload_file must not accept a local path: it runs server-side, so a
     caller path would read the API host's filesystem."""


### PR DESCRIPTION
Relaxes sandbox-token thread scoping so an agent holding a thread key can read that thread's messages, status, and attachments, while writes stay confined to the token's own thread. The policy is centralized in `deps.enforce_sandbox_thread_scope` (read vs write) and gated by `SANDBOX_CROSS_THREAD_READS` (default on).

Fixing the slack `download_file` 401s surfaced two more breaks in the sandbox attachment path, also fixed here: the tool-server sidecar had no `CENTAUR_API_KEY` so its `/agent/attachments/upload` callbacks were unauthenticated (now minted a thread-scoped sandbox token, like the agent container), and the system prompt told the agent to download attachments from a hardcoded `http://api:8000` instead of `$CENTAUR_API_URL`, which bypassed `NO_PROXY` and routed the request through iron-proxy. Also bumps iron-proxy to 0.42.0-rc.3.

Note: the system prompt change requires a sandbox-image rebuild to take effect.