### PR TITLE
fix(tool-server): make the proxied DB pool's connection reset single-statement

### DIFF
--- a/services/api/api/db.py
+++ b/services/api/api/db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 import subprocess
@@ -10,6 +11,35 @@ import asyncpg
 import structlog
 
 log = structlog.get_logger()
+
+
+class ProxySafeConnection(asyncpg.Connection):
+    """asyncpg connection whose pool-reset never sends a multi-statement query.
+
+    The per-sandbox iron-proxy rejects multi-statement queries, which is not
+    configurable on the proxy. asyncpg's default connection reset — run on every
+    release back to the pool — joins several reset commands
+    (``SELECT pg_advisory_unlock_all();``, ``CLOSE ALL;``, ``UNLISTEN *;``,
+    ``RESET ALL;``) into a single simple-query string. The proxy refuses it, so
+    the failure surfaces from the *next* pool operation (e.g. ``pool.fetchrow``)
+    even though that query itself is fine.
+
+    Run each reset statement as its own single-statement query instead.
+    """
+
+    async def reset(self, *, timeout: float | None = None) -> None:
+        async def _do_reset() -> None:
+            await self._reset()
+            reset_query = self.get_reset_query()
+            for statement in reset_query.split("\n"):
+                statement = statement.strip()
+                if statement:
+                    await self.execute(statement)
+
+        if timeout is None:
+            await _do_reset()
+        else:
+            await asyncio.wait_for(_do_reset(), timeout)
 
 BASE_MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "db" / "migrations"
 BASE_MIGRATIONS_TABLE = "schema_migrations"
@@ -96,17 +126,26 @@ def _dbmate_url(database_url: str) -> str:
     return f"{database_url}{sep}sslmode=disable"
 
 
-async def create_pool(database_url: str, *, apply_migrations: bool = True) -> asyncpg.Pool:
+async def create_pool(
+    database_url: str,
+    *,
+    apply_migrations: bool = True,
+    via_proxy: bool = False,
+) -> asyncpg.Pool:
     # The sandbox tool-server sidecar reaches the DB through the per-sandbox
     # iron-proxy and is not a schema owner, so it opens a pool with
     # apply_migrations=False. The API (and shared tool-server) own migrations.
     if apply_migrations:
         run_migrations(database_url)
+    # Connections that traverse the iron-proxy need the multi-statement-safe
+    # reset; direct connections keep asyncpg's default (one round-trip) reset.
+    connection_class = ProxySafeConnection if via_proxy else asyncpg.Connection
     pool = await asyncpg.create_pool(
         database_url,
         min_size=2,
         max_size=10,
         command_timeout=60,
+        connection_class=connection_class,
     )
     assert pool is not None
     return pool

--- a/services/api/api/tool_server_app.py
+++ b/services/api/api/tool_server_app.py
@@ -79,7 +79,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # the core DB through the iron-proxy (DATABASE_URL points at the proxy's
     # core listener) and the shared tool-server Deployment runs alongside the
     # API. Open the pool without running migrations; the API owns migrations.
-    app.state.db_pool = await create_pool(settings.database_url, apply_migrations=False)
+    # via_proxy=True: the per-sandbox sidecar's DATABASE_URL points at the
+    # iron-proxy core listener, which rejects multi-statement queries. The
+    # proxy-safe connection runs asyncpg's reset one statement at a time. It is
+    # also correct (just slightly slower on release) for the shared tool-server
+    # Deployment that reaches Postgres directly.
+    app.state.db_pool = await create_pool(
+        settings.database_url, apply_migrations=False, via_proxy=True
+    )
     watcher_task = asyncio.create_task(_watch_tools(app.state.tool_manager))
     try:
         yield

--- a/services/api/tests/test_proxy_safe_connection.py
+++ b/services/api/tests/test_proxy_safe_connection.py
@@ -1,0 +1,91 @@
+"""Unit tests for ProxySafeConnection's multi-statement-free reset.
+
+The per-sandbox iron-proxy rejects multi-statement queries. asyncpg's default
+connection reset joins several statements into one simple-query string, so the
+tool-server's proxied pool must run each reset statement on its own. These tests
+exercise the reset logic via a duck-typed self (asyncpg.Connection uses
+``__slots__``, so a real subclass instance can't be hand-constructed in a test).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+
+from api.db import ProxySafeConnection
+
+# The reset commands asyncpg joins with newlines for a fully-capable server.
+_DEFAULT_RESET = (
+    "SELECT pg_advisory_unlock_all();\n"
+    "CLOSE ALL;\n"
+    "UNLISTEN *;\n"
+    "RESET ALL;"
+)
+
+
+class _StubConnection:
+    """Provides the three members ProxySafeConnection.reset depends on."""
+
+    def __init__(self, reset_query: str):
+        self._reset_query = reset_query
+        self.reset_called = False
+        self.executed: list[str] = []
+
+    async def _reset(self) -> None:
+        self.reset_called = True
+
+    def get_reset_query(self) -> str:
+        return self._reset_query
+
+    async def execute(self, query: str, *args, **kwargs) -> None:
+        self.executed.append(query)
+
+
+async def _run_reset(stub: _StubConnection, *, timeout: float | None = None) -> None:
+    # Bind the unbound coroutine to the duck-typed stub.
+    await ProxySafeConnection.reset(stub, timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_reset_runs_each_statement_individually():
+    stub = _StubConnection(_DEFAULT_RESET)
+    await _run_reset(stub)
+
+    assert stub.reset_called
+    assert stub.executed == [
+        "SELECT pg_advisory_unlock_all();",
+        "CLOSE ALL;",
+        "UNLISTEN *;",
+        "RESET ALL;",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reset_never_emits_a_multi_statement_query():
+    stub = _StubConnection(_DEFAULT_RESET)
+    await _run_reset(stub)
+
+    for query in stub.executed:
+        assert "\n" not in query
+        # A single statement carries at most its own trailing semicolon.
+        assert query.count(";") <= 1
+
+
+@pytest.mark.asyncio
+async def test_reset_with_empty_query_executes_nothing():
+    stub = _StubConnection("")
+    await _run_reset(stub)
+
+    assert stub.reset_called
+    assert stub.executed == []
+
+
+@pytest.mark.asyncio
+async def test_reset_honors_timeout_path():
+    # Exercises the asyncio.wait_for branch; the work completes well under it.
+    stub = _StubConnection(_DEFAULT_RESET)
+    await _run_reset(stub, timeout=5.0)
+
+    assert len(stub.executed) == 4


### PR DESCRIPTION
The per-sandbox tool-server sidecar reaches the core DB through the iron-proxy (#286), which rejects multi-statement queries and is not configurable. asyncpg runs a connection reset on every release back to the pool, joining `SELECT pg_advisory_unlock_all();`, `CLOSE ALL;`, `UNLISTEN *;` and `RESET ALL;` into one simple-query string. The proxy refuses it, so the failure surfaced from the *next* pool operation (e.g. `pool.fetchrow` in `_active_execution_parent_context`) even though that query was fine: every tool call that touches the DB failed.

Adds `ProxySafeConnection`, which runs each reset statement on its own, and opens the tool-server pool with `via_proxy=True`. The main API pool keeps asyncpg's default single round-trip reset since it reaches Postgres directly.