### PR TITLE
fix(tool-server): split sandbox pool reset into single statements

### DIFF
--- a/services/api/api/db.py
+++ b/services/api/api/db.py
@@ -96,18 +96,56 @@ def _dbmate_url(database_url: str) -> str:
     return f"{database_url}{sep}sslmode=disable"
 
 
+class _SingleStmtResetConnection(asyncpg.Connection):
+    """Connection that runs the pool-release reset as single-statement queries.
+
+    asyncpg's default ``Connection.reset`` joins ``SELECT
+    pg_advisory_unlock_all()``, ``CLOSE ALL``, ``UNLISTEN *`` and
+    ``RESET ALL`` into a single multi-statement query. The per-sandbox
+    iron-proxy added in #286 blocks multi-statement SQL by policy, so every
+    ``pool.release()`` from the tool-server sidecar raises
+    ``asyncpg.exceptions.PostgresSyntaxError: blocked by iron-proxy policy:
+    multi-statement queries not permitted`` and the sidecar returns HTTP 500
+    on every tool call.
+
+    This subclass keeps asyncpg's reset semantics (rollback open txn, clear
+    listeners, then run the reset query) but executes each reset statement
+    individually so iron-proxy accepts them.
+    """
+
+    async def reset(self, *, timeout=None):
+        # Defer the asyncpg.compat import to avoid touching internals at module
+        # load time; this is the same import the upstream method uses.
+        from asyncpg import compat  # type: ignore[attr-defined]
+
+        async with compat.timeout(timeout):
+            await self._reset()  # rollback open txn + drop listener callbacks
+            reset_query = self.get_reset_query()
+            if not reset_query:
+                return
+            for stmt in (s.strip() for s in reset_query.split("\n")):
+                if stmt:
+                    await self.execute(stmt)
+
+
 async def create_pool(database_url: str, *, apply_migrations: bool = True) -> asyncpg.Pool:
     # The sandbox tool-server sidecar reaches the DB through the per-sandbox
     # iron-proxy and is not a schema owner, so it opens a pool with
     # apply_migrations=False. The API (and shared tool-server) own migrations.
     if apply_migrations:
         run_migrations(database_url)
-    pool = await asyncpg.create_pool(
-        database_url,
-        min_size=2,
-        max_size=10,
-        command_timeout=60,
-    )
+    pool_kwargs: dict[str, object] = {
+        "min_size": 2,
+        "max_size": 10,
+        "command_timeout": 60,
+    }
+    if not apply_migrations:
+        # Sandbox tool-server path: the pool talks to Postgres through the
+        # per-sandbox iron-proxy, which forbids multi-statement SQL. Override
+        # the connection class so the pool's release-time reset is split into
+        # single statements.
+        pool_kwargs["connection_class"] = _SingleStmtResetConnection
+    pool = await asyncpg.create_pool(database_url, **pool_kwargs)
     assert pool is not None
     return pool
 

--- a/services/api/tests/test_db_pool_reset.py
+++ b/services/api/tests/test_db_pool_reset.py
@@ -1,0 +1,121 @@
+"""Unit tests for ``_SingleStmtResetConnection`` used by the sandbox pool.
+
+The sandbox tool-server sidecar's pool runs ``Connection.reset()`` on every
+``pool.release()``. asyncpg's default reset joins several cleanup statements
+into one multi-statement query, which the per-sandbox iron-proxy refuses.
+This regression test pins the override so reset stays split per-statement.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api.db import _SingleStmtResetConnection
+
+
+class _StubConnection(_SingleStmtResetConnection):
+    """Bypass ``asyncpg.Connection.__init__`` so we can drive ``reset()`` in tests."""
+
+    def __init__(self) -> None:  # noqa: D401 — minimal stub
+        self.executed: list[str] = []
+        self._inner_reset_called = 0
+
+    async def _reset(self) -> None:
+        self._inner_reset_called += 1
+
+    def get_reset_query(self) -> str:
+        return (
+            "SELECT pg_advisory_unlock_all();\n"
+            "CLOSE ALL;\n"
+            "UNLISTEN *;\n"
+            "RESET ALL;"
+        )
+
+    async def execute(self, query: str, *args: object, **kwargs: object) -> str:  # type: ignore[override]
+        self.executed.append(query)
+        return "OK"
+
+
+@pytest.mark.asyncio
+async def test_reset_runs_statements_individually() -> None:
+    """Each cleanup statement is executed in its own ``execute()`` call.
+
+    Guards against regression to the multi-statement reset, which iron-proxy
+    blocks with ``PostgresSyntaxError: blocked by iron-proxy policy:
+    multi-statement queries not permitted``.
+    """
+    conn = _StubConnection()
+
+    await conn.reset()
+
+    assert conn._inner_reset_called == 1
+    assert conn.executed == [
+        "SELECT pg_advisory_unlock_all();",
+        "CLOSE ALL;",
+        "UNLISTEN *;",
+        "RESET ALL;",
+    ]
+    # Sanity-check: no element ever contains a newline (i.e. concatenated stmts).
+    assert all("\n" not in stmt for stmt in conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_reset_noop_when_query_empty() -> None:
+    conn = _StubConnection()
+    conn.get_reset_query = lambda: ""  # type: ignore[assignment]
+
+    await conn.reset()
+
+    assert conn._inner_reset_called == 1
+    assert conn.executed == []
+
+
+@pytest.mark.asyncio
+async def test_reset_skips_blank_lines() -> None:
+    conn = _StubConnection()
+    conn.get_reset_query = lambda: "\nCLOSE ALL;\n\nRESET ALL;\n"  # type: ignore[assignment]
+
+    await conn.reset()
+
+    assert conn.executed == ["CLOSE ALL;", "RESET ALL;"]
+
+
+@pytest.mark.asyncio
+async def test_create_pool_uses_override_for_sandbox_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``apply_migrations=False`` must wire the no-multi-stmt connection class."""
+    import api.db as db_mod
+
+    captured: dict[str, object] = {}
+
+    async def fake_create_pool(_url: str, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return AsyncMock()
+
+    monkeypatch.setattr(db_mod.asyncpg, "create_pool", fake_create_pool)
+
+    await db_mod.create_pool("postgresql://x/y", apply_migrations=False)
+
+    assert captured.get("connection_class") is _SingleStmtResetConnection
+
+
+@pytest.mark.asyncio
+async def test_create_pool_default_path_keeps_stock_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``apply_migrations=True`` (API + shared tool-server) keeps asyncpg's default."""
+    import api.db as db_mod
+
+    captured: dict[str, object] = {}
+
+    async def fake_create_pool(_url: str, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return AsyncMock()
+
+    monkeypatch.setattr(db_mod.asyncpg, "create_pool", fake_create_pool)
+    monkeypatch.setattr(db_mod, "run_migrations", lambda _url: None)
+
+    await db_mod.create_pool("postgresql://x/y", apply_migrations=True)
+
+    assert "connection_class" not in captured


### PR DESCRIPTION
## Problem

After #286 the sandbox tool-server sidecar reaches Postgres through the
per-sandbox iron-proxy. iron-proxy 0.42+ blocks multi-statement SQL by
policy. asyncpg's default `Connection.reset()` concatenates several
cleanup statements (`SELECT pg_advisory_unlock_all(); CLOSE ALL; UNLISTEN *; RESET ALL;`)
into one query and sends them on every `pool.release()`.

Result: every `pool.release()` — and therefore every `fetchrow` via
`async with pool.acquire()` — raises

```
asyncpg.exceptions.PostgresSyntaxError: blocked by iron-proxy policy:
multi-statement queries not permitted
```

and the sidecar returns HTTP 500 on every tool call (slack,
company_context, wrike, etc.).

### Traceback

```
File "/app/api/tool_manager.py", line 2338, in call_tool
    parent_context = await _active_execution_parent_context(request, sandbox_claims)
File "/app/api/tool_manager.py", line 1140, in _active_execution_parent_context
    row = await pool.fetchrow(...)
File "asyncpg/pool.py", line 239, in release
    await self._con.reset(timeout=budget)
File "asyncpg/connection.py", line 1571, in reset
    await self.execute(reset_query)
asyncpg.exceptions.PostgresSyntaxError: blocked by iron-proxy policy:
    multi-statement queries not permitted
```

The bug is silent on clusters without iron-proxy on the DB path, which
is why #286's tests don't catch it.

## Fix

Override the connection class for the sandbox pool only
(`apply_migrations=False`) with one that runs the reset query as one
`asyncpg.execute()` per statement. Semantics are preserved; iron-proxy
accepts each statement individually.

The API and shared tool-server keep asyncpg's default connection class
since they don't sit behind a multi-stmt-blocking proxy.

## Reproduction

Any sandbox-agent tool call on a cluster running iron-proxy 0.42.0-rc.2
(the centaur 0.1.46 chart's default) after #286. Spin up a sandbox via
the slack mention path and call any tool — the sidecar's tool-server
returns 500 with the traceback above in its logs.

## Tests

`services/api/tests/test_db_pool_reset.py`:

- Pin that `reset()` executes each cleanup statement individually
  (regression guard against re-introducing a multi-statement reset).
- Pin that empty / blank-line reset queries are no-ops / skipped.
- Pin that `create_pool(apply_migrations=False)` wires the override and
  `apply_migrations=True` does not (the API/shared tool-server path
  stays on stock asyncpg).

## Refs

- Introduced by: #286 (07c03fb)
- iron-proxy version: 0.42.0-rc.2 (the policy enforcing the block)