### PR TITLE
docs(tool-directory): reflect Parallel-backed websearch

### DIFF
--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -33,7 +33,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `notion` | Search and update Notion pages, databases, blocks, and comments | `NOTION_API_KEY` |
 | `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
-| `websearch` | Web search and deep research via Parallel; free with no credentials, with optional REST and synthesis paths | None; optional: `PARALLEL_API_KEY`, `ANTHROPIC_API_KEY` |
+| `websearch` | Free web search via Parallel; `deep_research` and REST search need `PARALLEL_API_KEY`; cited synthesis needs `ANTHROPIC_API_KEY` | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for synthesis |
 | `company_context` | Search indexed company history across internal sources | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
@@ -104,7 +104,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `plural` | State legislation, legislators, committees, events, and jurisdictions | `PLURAL_API_KEY` |
 | `sensortower` | Mobile app analytics, publisher data, charts, and sales estimates | `SENSOR_TOWER_AUTH_TOKEN` |
 | `similarweb` | Web traffic, rankings, referrals, keywords, geography, and app data | `SIMILARWEB_API_KEY` |
-| `websearch` | Web search and deep research via Parallel; free with no credentials, with optional REST and synthesis paths | None; optional: `PARALLEL_API_KEY`, `ANTHROPIC_API_KEY` |
+| `websearch` | Free web search via Parallel; `deep_research` and REST search need `PARALLEL_API_KEY`; cited synthesis needs `ANTHROPIC_API_KEY` | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for synthesis |
 | `youtube` | YouTube video, channel, transcript, and search data | `YOUTUBE_API_KEY`, `GOOGLE_API_KEY` |
 
 ## Media

--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -33,7 +33,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `notion` | Search and update Notion pages, databases, blocks, and comments | `NOTION_API_KEY` |
 | `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
-| `websearch` | Run web search and deeper research | `EXA_API_KEY`, `ANTHROPIC_API_KEY` |
+| `websearch` | Web search and deep research via Parallel; free with no credentials, with optional REST and synthesis paths | None; optional: `PARALLEL_API_KEY`, `ANTHROPIC_API_KEY` |
 | `company_context` | Search indexed company history across internal sources | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
@@ -104,7 +104,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `plural` | State legislation, legislators, committees, events, and jurisdictions | `PLURAL_API_KEY` |
 | `sensortower` | Mobile app analytics, publisher data, charts, and sales estimates | `SENSOR_TOWER_AUTH_TOKEN` |
 | `similarweb` | Web traffic, rankings, referrals, keywords, geography, and app data | `SIMILARWEB_API_KEY` |
-| `websearch` | Web search and deep research | `EXA_API_KEY`, `ANTHROPIC_API_KEY` |
+| `websearch` | Web search and deep research via Parallel; free with no credentials, with optional REST and synthesis paths | None; optional: `PARALLEL_API_KEY`, `ANTHROPIC_API_KEY` |
 | `youtube` | YouTube video, channel, transcript, and search data | `YOUTUBE_API_KEY`, `GOOGLE_API_KEY` |
 
 ## Media

--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -33,7 +33,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `notion` | Search and update Notion pages, databases, blocks, and comments | `NOTION_API_KEY` |
 | `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
-| `websearch` | Free web search via Parallel; `deep_research` and REST search need `PARALLEL_API_KEY`; cited synthesis needs `ANTHROPIC_API_KEY` | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for synthesis |
+| `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `company_context` | Search indexed company history across internal sources | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
@@ -104,7 +104,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `plural` | State legislation, legislators, committees, events, and jurisdictions | `PLURAL_API_KEY` |
 | `sensortower` | Mobile app analytics, publisher data, charts, and sales estimates | `SENSOR_TOWER_AUTH_TOKEN` |
 | `similarweb` | Web traffic, rankings, referrals, keywords, geography, and app data | `SIMILARWEB_API_KEY` |
-| `websearch` | Free web search via Parallel; `deep_research` and REST search need `PARALLEL_API_KEY`; cited synthesis needs `ANTHROPIC_API_KEY` | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for synthesis |
+| `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `youtube` | YouTube video, channel, transcript, and search data | `YOUTUBE_API_KEY`, `GOOGLE_API_KEY` |
 
 ## Media


### PR DESCRIPTION
## Summary
Updates the two `websearch` rows in the tool directory to reflect the rewrite in #228. The tool now works credential-free via the free hosted Parallel Search MCP; `PARALLEL_API_KEY` and `ANTHROPIC_API_KEY` are optional unlocks (REST path + `deep_research`, and cited synthesis, respectively).

## Diff
```diff
- | `websearch` | Run web search and deeper research | `EXA_API_KEY`, `ANTHROPIC_API_KEY` |
+ | `websearch` | Web search and deep research via Parallel; free with no credentials, with optional REST and synthesis paths | None; optional: `PARALLEL_API_KEY`, `ANTHROPIC_API_KEY` |
```

Both occurrences (common-out-of-box tools section and Research section) updated identically.

## Test plan
- [x] `grep EXA_API_KEY docs/pages/reference/tool-directory.mdx` → no matches
- [x] Diff inspected: two-row change, identical update, no other content touched