### PR TITLE
feat: add network repo cache

### DIFF
--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -63,6 +63,14 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 {{- end -}}
 
+{{- define "centaur.repoCachePvcName" -}}
+{{- if .Values.repoCache.persistence.existingClaim -}}
+{{- .Values.repoCache.persistence.existingClaim | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "centaur.componentName" (dict "root" . "component" "repo-cache") -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "centaur.httpRouteName" -}}
 {{- $suffix := default (printf "route-%v" .index) .route.name -}}
 {{- printf "%s-%s" (include "centaur.fullname" .root) $suffix | trunc 63 | trimSuffix "-" -}}

--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -55,6 +55,10 @@ app.kubernetes.io/component: {{ .component }}
 {{- printf "%s-api" (include "centaur.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "centaur.repoCacheMode" -}}
+{{- default "hostPath" .Values.repoCache.mode -}}
+{{- end -}}
+
 {{- define "centaur.repoCacheGithubTokenSecretName" -}}
 {{- if .Values.repoCache.githubToken.existingSecretName -}}
 {{- .Values.repoCache.githubToken.existingSecretName | trunc 63 | trimSuffix "-" -}}

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -309,12 +309,36 @@ spec:
     matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 6 }}
   policyTypes:
+{{- if .Values.repoCache.persistence.enabled }}
+    - Ingress
+{{- end }}
     - Egress
+{{- if .Values.repoCache.persistence.enabled }}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              centaur.ai/managed: "true"
+      ports:
+        - protocol: TCP
+          port: {{ .Values.repoCache.service.port }}
+{{- end }}
   egress:
+{{- if .Values.repoCache.persistence.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              centaur.ai/iron-proxy: "true"
+              centaur.ai/sandbox-id: api
+      ports:
+        - protocol: TCP
+          port: {{ .Values.ironProxy.service.proxyPort }}
+{{- else }}
 {{- range .Values.repoCache.egressPorts }}
     - ports:
         - protocol: TCP
           port: {{ . }}
+{{- end }}
 {{- end }}
 ---
 {{- end }}
@@ -389,4 +413,13 @@ spec:
       ports:
         - protocol: TCP
           port: 8000
+{{- if and .Values.repoCache.enabled .Values.repoCache.persistence.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.repoCache.service.port }}
+{{- end }}
 {{- end }}

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $ingressSourceNamespaces := default .Values.networkPolicy.ingressControllerNamespaces .Values.networkPolicy.ingressSourceNamespaces }}
+{{- $repoCacheMode := include "centaur.repoCacheMode" . }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -309,11 +310,11 @@ spec:
     matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 6 }}
   policyTypes:
-{{- if .Values.repoCache.persistence.enabled }}
+{{- if eq $repoCacheMode "gitMirror" }}
     - Ingress
 {{- end }}
     - Egress
-{{- if .Values.repoCache.persistence.enabled }}
+{{- if eq $repoCacheMode "gitMirror" }}
   ingress:
     - from:
         - podSelector:
@@ -324,7 +325,7 @@ spec:
           port: {{ .Values.repoCache.service.port }}
 {{- end }}
   egress:
-{{- if .Values.repoCache.persistence.enabled }}
+{{- if eq $repoCacheMode "gitMirror" }}
     - to:
         - podSelector:
             matchLabels:
@@ -413,7 +414,7 @@ spec:
       ports:
         - protocol: TCP
           port: 8000
-{{- if and .Values.repoCache.enabled .Values.repoCache.persistence.enabled }}
+{{- if and .Values.repoCache.enabled (eq $repoCacheMode "gitMirror") }}
     - to:
         - podSelector:
             matchLabels:

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -299,6 +299,7 @@ spec:
 ---
 {{- end }}
 {{- if .Values.repoCache.enabled }}
+# Repo-cache traffic differs by mode: mirror accepts sandbox HTTP; hostPath only syncs out.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -310,11 +311,11 @@ spec:
     matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 6 }}
   policyTypes:
-{{- if eq $repoCacheMode "gitMirror" }}
+{{- if eq $repoCacheMode "mirror" }}
     - Ingress
 {{- end }}
     - Egress
-{{- if eq $repoCacheMode "gitMirror" }}
+{{- if eq $repoCacheMode "mirror" }}
   ingress:
     - from:
         - podSelector:
@@ -325,7 +326,7 @@ spec:
           port: {{ .Values.repoCache.service.port }}
 {{- end }}
   egress:
-{{- if eq $repoCacheMode "gitMirror" }}
+{{- if eq $repoCacheMode "mirror" }}
     - to:
         - podSelector:
             matchLabels:
@@ -414,7 +415,8 @@ spec:
       ports:
         - protocol: TCP
           port: 8000
-{{- if and .Values.repoCache.enabled (eq $repoCacheMode "gitMirror") }}
+{{- if and .Values.repoCache.enabled (eq $repoCacheMode "mirror") }}
+    # Sandboxes only need repo-cache access in mirror mode; hostPath mounts no service.
     - to:
         - podSelector:
             matchLabels:

--- a/contrib/chart/templates/repo-cache-git-mirror.yaml
+++ b/contrib/chart/templates/repo-cache-git-mirror.yaml
@@ -1,11 +1,9 @@
-{{- if .Values.repoCache.enabled }}
-{{- if and (not .Values.repoCache.persistence.enabled) (not .Values.repoCache.repositories) }}
-{{- fail "repoCache.repositories must contain at least one owner/repo entry when repoCache.enabled=true without persistence" }}
-{{- end }}
+{{- $repoCacheMode := include "centaur.repoCacheMode" . -}}
+{{- if and .Values.repoCache.enabled (eq $repoCacheMode "gitMirror") }}
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
 {{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
 {{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
-{{- if and .Values.repoCache.persistence.enabled (not .Values.repoCache.persistence.existingClaim) }}
+{{- if not .Values.repoCache.persistence.existingClaim }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -23,7 +21,6 @@ spec:
       storage: {{ .Values.repoCache.persistence.size }}
 ---
 {{- end }}
-{{- if .Values.repoCache.persistence.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -38,17 +35,14 @@ spec:
       port: {{ .Values.repoCache.service.port }}
       targetPort: git-http
 ---
-{{- end }}
 apiVersion: apps/v1
-kind: {{ ternary "Deployment" "DaemonSet" .Values.repoCache.persistence.enabled }}
+kind: Deployment
 metadata:
   name: {{ include "centaur.componentName" (dict "root" . "component" "repo-cache") }}
   labels:
 {{ include "centaur.componentLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
 spec:
-{{- if .Values.repoCache.persistence.enabled }}
   replicas: 1
-{{- end }}
   selector:
     matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 6 }}
@@ -78,77 +72,11 @@ spec:
         - name: repo-cache
           image: {{ printf "%s:%s" $repoCacheImageRepository $repoCacheImageTag | quote }}
           imagePullPolicy: {{ $repoCacheImagePullPolicy }}
-{{- if .Values.repoCache.persistence.enabled }}
           ports:
             - name: git-http
               containerPort: {{ .Values.repoCache.service.port }}
-{{- end }}
-{{- if .Values.repoCache.persistence.enabled }}
           command:
             - /usr/local/bin/repo-cache-server
-{{- else }}
-          command:
-            - /bin/bash
-            - -ec
-            - |
-              set -o pipefail
-              token_file=/github-token/token
-              if [ ! -s "$token_file" ]; then
-                echo "GitHub token file is missing or empty: $token_file" >&2
-                exit 1
-              fi
-
-              cat > /tmp/git-askpass <<'EOF'
-              #!/bin/sh
-              case "$1" in
-                *Username*) printf '%s\n' x-access-token ;;
-                *Password*) cat /github-token/token ;;
-                *) printf '\n' ;;
-              esac
-              EOF
-              chmod 0700 /tmp/git-askpass
-              export GIT_ASKPASS=/tmp/git-askpass
-              git config --global --add safe.directory '*'
-              git config --global init.defaultBranch main
-              umask 022
-
-              sync_repo() {
-                repo="$1"
-                repo_url="https://github.com/${repo}.git"
-                target="/cache/${repo}"
-                tmp="${target}.tmp.$$"
-
-                mkdir -p "$(dirname "$target")"
-                if git -C "$target" rev-parse --git-dir >/dev/null 2>&1; then
-                  echo "Updating $repo"
-                  git -C "$target" config gc.auto 0 || true
-                  git -C "$target" remote set-url origin "$repo_url" || git -C "$target" remote add origin "$repo_url"
-                  git -C "$target" -c gc.auto=0 fetch --prune --tags origin
-                  git -C "$target" remote set-head origin -a || true
-                  default_branch="$(git -C "$target" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
-                  if [ -z "$default_branch" ] || [ "$default_branch" = "(unknown)" ]; then
-                    default_branch=main
-                  fi
-                  git -C "$target" checkout -q -B "$default_branch" "origin/$default_branch"
-                  git -C "$target" clean -fd
-                else
-                  echo "Cloning $repo"
-                  rm -rf "$tmp" "$target"
-                  git clone --quiet "$repo_url" "$tmp"
-                  git -C "$tmp" config gc.auto 0
-                  mv "$tmp" "$target"
-                fi
-              }
-
-              while true; do
-                for repo in $REPOSITORIES; do
-                  if ! sync_repo "$repo"; then
-                    echo "Failed to sync $repo" >&2
-                  fi
-                done
-                sleep "$SYNC_INTERVAL_SECONDS"
-              done
-{{- end }}
           env:
             - name: REPOSITORIES
               value: {{ join " " .Values.repoCache.repositories | quote }}
@@ -156,7 +84,6 @@ spec:
               value: {{ .Values.repoCache.syncIntervalSeconds | quote }}
             - name: GIT_TERMINAL_PROMPT
               value: "0"
-{{- if .Values.repoCache.persistence.enabled }}
             - name: HTTPS_PROXY
               value: {{ include "centaur.firewallProxyUrl" . | quote }}
             - name: HTTP_PROXY
@@ -181,27 +108,12 @@ spec:
             - name: GITHUB_TOKEN_FILE
               value: /github-token/token
 {{- end }}
-{{- end }}
-{{- if .Values.repoCache.persistence.enabled }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: git-http
             initialDelaySeconds: 5
             periodSeconds: 10
-{{- else }}
-          readinessProbe:
-            exec:
-              command:
-                - /bin/bash
-                - -ec
-                - |
-                  for repo in $REPOSITORIES; do
-                    git -C "/cache/$repo" rev-parse --git-dir >/dev/null 2>&1 || exit 1
-                  done
-            initialDelaySeconds: 10
-            periodSeconds: 30
-{{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -216,32 +128,22 @@ spec:
           volumeMounts:
             - name: repo-cache
               mountPath: /cache
-{{- if .Values.repoCache.persistence.enabled }}
             - name: firewall-ca
               mountPath: /firewall-certs
               readOnly: true
-{{- end }}
-{{- if or (not .Values.repoCache.persistence.enabled) .Values.repoCache.githubToken.existingSecretName .Values.repoCache.githubToken.token }}
+{{- if or .Values.repoCache.githubToken.existingSecretName .Values.repoCache.githubToken.token }}
             - name: github-token
               mountPath: /github-token
               readOnly: true
 {{- end }}
       volumes:
         - name: repo-cache
-{{- if .Values.repoCache.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "centaur.repoCachePvcName" . }}
-{{- else }}
-          hostPath:
-            path: {{ .Values.repoCache.hostPath | quote }}
-            type: DirectoryOrCreate
-{{- end }}
-{{- if .Values.repoCache.persistence.enabled }}
         - name: firewall-ca
           secret:
             secretName: {{ include "centaur.trustedCaSecretName" . }}
-{{- end }}
-{{- if or (not .Values.repoCache.persistence.enabled) .Values.repoCache.githubToken.existingSecretName .Values.repoCache.githubToken.token }}
+{{- if or .Values.repoCache.githubToken.existingSecretName .Values.repoCache.githubToken.token }}
         - name: github-token
           secret:
             secretName: {{ include "centaur.repoCacheGithubTokenSecretName" . }}

--- a/contrib/chart/templates/repo-cache-hostpath.yaml
+++ b/contrib/chart/templates/repo-cache-hostpath.yaml
@@ -1,13 +1,11 @@
 {{- $repoCacheMode := include "centaur.repoCacheMode" . -}}
 {{- if and .Values.repoCache.enabled (eq $repoCacheMode "hostPath") }}
-# hostPath mode: one DaemonSet pod per node maintains working clones on node disk.
 {{- if not .Values.repoCache.repositories }}
 {{- fail "repoCache.repositories must contain at least one owner/repo entry when repoCache.mode=hostPath" }}
 {{- end }}
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
 {{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
 {{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
-# Sync loop for the legacy node-local repository cache.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -41,7 +39,6 @@ spec:
 {{ toYaml . | nindent 8 }}
 {{- end }}
       containers:
-        # Periodically clones or fetches the configured repositories into /cache.
         - name: repo-cache
           image: {{ printf "%s:%s" $repoCacheImageRepository $repoCacheImageTag | quote }}
           imagePullPolicy: {{ $repoCacheImagePullPolicy }}

--- a/contrib/chart/templates/repo-cache-hostpath.yaml
+++ b/contrib/chart/templates/repo-cache-hostpath.yaml
@@ -1,11 +1,13 @@
 {{- $repoCacheMode := include "centaur.repoCacheMode" . -}}
 {{- if and .Values.repoCache.enabled (eq $repoCacheMode "hostPath") }}
+# hostPath mode: one DaemonSet pod per node maintains working clones on node disk.
 {{- if not .Values.repoCache.repositories }}
 {{- fail "repoCache.repositories must contain at least one owner/repo entry when repoCache.mode=hostPath" }}
 {{- end }}
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
 {{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
 {{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
+# Sync loop for the legacy node-local repository cache.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -39,6 +41,7 @@ spec:
 {{ toYaml . | nindent 8 }}
 {{- end }}
       containers:
+        # Periodically clones or fetches the configured repositories into /cache.
         - name: repo-cache
           image: {{ printf "%s:%s" $repoCacheImageRepository $repoCacheImageTag | quote }}
           imagePullPolicy: {{ $repoCacheImagePullPolicy }}

--- a/contrib/chart/templates/repo-cache-hostpath.yaml
+++ b/contrib/chart/templates/repo-cache-hostpath.yaml
@@ -1,0 +1,153 @@
+{{- $repoCacheMode := include "centaur.repoCacheMode" . -}}
+{{- if and .Values.repoCache.enabled (eq $repoCacheMode "hostPath") }}
+{{- if not .Values.repoCache.repositories }}
+{{- fail "repoCache.repositories must contain at least one owner/repo entry when repoCache.mode=hostPath" }}
+{{- end }}
+{{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
+{{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
+{{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "repo-cache") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- with .Values.repoCache.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.repoCache.affinity }}
+      affinity:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.repoCache.tolerations }}
+      tolerations:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+      containers:
+        - name: repo-cache
+          image: {{ printf "%s:%s" $repoCacheImageRepository $repoCacheImageTag | quote }}
+          imagePullPolicy: {{ $repoCacheImagePullPolicy }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              set -o pipefail
+              token_file=/github-token/token
+              if [ ! -s "$token_file" ]; then
+                echo "GitHub token file is missing or empty: $token_file" >&2
+                exit 1
+              fi
+
+              cat > /tmp/git-askpass <<'EOF'
+              #!/bin/sh
+              case "$1" in
+                *Username*) printf '%s\n' x-access-token ;;
+                *Password*) cat /github-token/token ;;
+                *) printf '\n' ;;
+              esac
+              EOF
+              chmod 0700 /tmp/git-askpass
+              export GIT_ASKPASS=/tmp/git-askpass
+              git config --global --add safe.directory '*'
+              git config --global init.defaultBranch main
+              umask 022
+
+              sync_repo() {
+                repo="$1"
+                repo_url="https://github.com/${repo}.git"
+                target="/cache/${repo}"
+                tmp="${target}.tmp.$$"
+
+                mkdir -p "$(dirname "$target")"
+                if git -C "$target" rev-parse --git-dir >/dev/null 2>&1; then
+                  echo "Updating $repo"
+                  git -C "$target" config gc.auto 0 || true
+                  git -C "$target" remote set-url origin "$repo_url" || git -C "$target" remote add origin "$repo_url"
+                  git -C "$target" -c gc.auto=0 fetch --prune --tags origin
+                  git -C "$target" remote set-head origin -a || true
+                  default_branch="$(git -C "$target" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+                  if [ -z "$default_branch" ] || [ "$default_branch" = "(unknown)" ]; then
+                    default_branch=main
+                  fi
+                  git -C "$target" checkout -q -B "$default_branch" "origin/$default_branch"
+                  git -C "$target" clean -fd
+                else
+                  echo "Cloning $repo"
+                  rm -rf "$tmp" "$target"
+                  git clone --quiet "$repo_url" "$tmp"
+                  git -C "$tmp" config gc.auto 0
+                  mv "$tmp" "$target"
+                fi
+              }
+
+              while true; do
+                for repo in $REPOSITORIES; do
+                  if ! sync_repo "$repo"; then
+                    echo "Failed to sync $repo" >&2
+                  fi
+                done
+                sleep "$SYNC_INTERVAL_SECONDS"
+              done
+          env:
+            - name: REPOSITORIES
+              value: {{ join " " .Values.repoCache.repositories | quote }}
+            - name: SYNC_INTERVAL_SECONDS
+              value: {{ .Values.repoCache.syncIntervalSeconds | quote }}
+            - name: GIT_TERMINAL_PROMPT
+              value: "0"
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  for repo in $REPOSITORIES; do
+                    git -C "/cache/$repo" rev-parse --git-dir >/dev/null 2>&1 || exit 1
+                  done
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsUser: 0
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+{{ toYaml .Values.repoCache.resources | nindent 12 }}
+          volumeMounts:
+            - name: repo-cache
+              mountPath: /cache
+            - name: github-token
+              mountPath: /github-token
+              readOnly: true
+      volumes:
+        - name: repo-cache
+          hostPath:
+            path: {{ .Values.repoCache.hostPath | quote }}
+            type: DirectoryOrCreate
+        - name: github-token
+          secret:
+            secretName: {{ include "centaur.repoCacheGithubTokenSecretName" . }}
+            defaultMode: 256
+            items:
+              - key: {{ .Values.repoCache.githubToken.secretKey | quote }}
+                path: token
+{{- end }}

--- a/contrib/chart/templates/repo-cache-mirror.yaml
+++ b/contrib/chart/templates/repo-cache-mirror.yaml
@@ -1,9 +1,11 @@
 {{- $repoCacheMode := include "centaur.repoCacheMode" . -}}
-{{- if and .Values.repoCache.enabled (eq $repoCacheMode "gitMirror") }}
+{{- if and .Values.repoCache.enabled (eq $repoCacheMode "mirror") }}
+# mirror mode: sandboxes use an in-cluster HTTP Git cache instead of mounting storage.
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
 {{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
 {{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
 {{- if not .Values.repoCache.persistence.existingClaim }}
+# Persistent storage for bare repository mirrors.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -21,6 +23,7 @@ spec:
       storage: {{ .Values.repoCache.persistence.size }}
 ---
 {{- end }}
+# Stable HTTP endpoint used by Git URL rewrites inside sandbox images.
 apiVersion: v1
 kind: Service
 metadata:
@@ -35,6 +38,7 @@ spec:
       port: {{ .Values.repoCache.service.port }}
       targetPort: git-http
 ---
+# Single mirror server that lazily fetches repositories and serves Git smart HTTP.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,6 +73,7 @@ spec:
 {{ toYaml . | nindent 8 }}
 {{- end }}
       containers:
+        # Egress goes through iron-proxy so GitHub credentials stay out of sandboxes.
         - name: repo-cache
           image: {{ printf "%s:%s" $repoCacheImageRepository $repoCacheImageTag | quote }}
           imagePullPolicy: {{ $repoCacheImagePullPolicy }}

--- a/contrib/chart/templates/repo-cache-secret.yaml
+++ b/contrib/chart/templates/repo-cache-secret.yaml
@@ -1,6 +1,7 @@
+{{- $repoCacheMode := include "centaur.repoCacheMode" . -}}
 {{- if .Values.repoCache.enabled }}
-{{- if and (not .Values.repoCache.persistence.enabled) (not .Values.repoCache.githubToken.existingSecretName) (not .Values.repoCache.githubToken.token) }}
-{{- fail "repoCache.githubToken.token or repoCache.githubToken.existingSecretName is required when repoCache.enabled=true without persistence" }}
+{{- if and (eq $repoCacheMode "hostPath") (not .Values.repoCache.githubToken.existingSecretName) (not .Values.repoCache.githubToken.token) }}
+{{- fail "repoCache.githubToken.token or repoCache.githubToken.existingSecretName is required when repoCache.mode=hostPath" }}
 {{- end }}
 {{- if and .Values.repoCache.githubToken.token (not .Values.repoCache.githubToken.existingSecretName) }}
 apiVersion: v1

--- a/contrib/chart/templates/repo-cache-secret.yaml
+++ b/contrib/chart/templates/repo-cache-secret.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.repoCache.enabled }}
-{{- if and (not .Values.repoCache.githubToken.existingSecretName) (not .Values.repoCache.githubToken.token) }}
-{{- fail "repoCache.githubToken.token or repoCache.githubToken.existingSecretName is required when repoCache.enabled=true" }}
+{{- if and (not .Values.repoCache.persistence.enabled) (not .Values.repoCache.githubToken.existingSecretName) (not .Values.repoCache.githubToken.token) }}
+{{- fail "repoCache.githubToken.token or repoCache.githubToken.existingSecretName is required when repoCache.enabled=true without persistence" }}
 {{- end }}
-{{- if not .Values.repoCache.githubToken.existingSecretName }}
+{{- if and .Values.repoCache.githubToken.token (not .Values.repoCache.githubToken.existingSecretName) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.repoCache.enabled }}
-{{- if not .Values.repoCache.repositories }}
-{{- fail "repoCache.repositories must contain at least one owner/repo entry when repoCache.enabled=true" }}
+{{- if and (not .Values.repoCache.persistence.enabled) (not .Values.repoCache.repositories) }}
+{{- fail "repoCache.repositories must contain at least one owner/repo entry when repoCache.enabled=true without persistence" }}
 {{- end }}
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
 {{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
@@ -21,6 +21,22 @@ spec:
   resources:
     requests:
       storage: {{ .Values.repoCache.persistence.size }}
+---
+{{- end }}
+{{- if .Values.repoCache.persistence.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "repo-cache") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
+spec:
+  selector:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
+  ports:
+    - name: git-http
+      port: {{ .Values.repoCache.service.port }}
+      targetPort: git-http
 ---
 {{- end }}
 apiVersion: apps/v1
@@ -62,6 +78,15 @@ spec:
         - name: repo-cache
           image: {{ printf "%s:%s" $repoCacheImageRepository $repoCacheImageTag | quote }}
           imagePullPolicy: {{ $repoCacheImagePullPolicy }}
+{{- if .Values.repoCache.persistence.enabled }}
+          ports:
+            - name: git-http
+              containerPort: {{ .Values.repoCache.service.port }}
+{{- end }}
+{{- if .Values.repoCache.persistence.enabled }}
+          command:
+            - /usr/local/bin/repo-cache-server
+{{- else }}
           command:
             - /bin/bash
             - -ec
@@ -123,6 +148,7 @@ spec:
                 done
                 sleep "$SYNC_INTERVAL_SECONDS"
               done
+{{- end }}
           env:
             - name: REPOSITORIES
               value: {{ join " " .Values.repoCache.repositories | quote }}
@@ -130,6 +156,40 @@ spec:
               value: {{ .Values.repoCache.syncIntervalSeconds | quote }}
             - name: GIT_TERMINAL_PROMPT
               value: "0"
+{{- if .Values.repoCache.persistence.enabled }}
+            - name: HTTPS_PROXY
+              value: {{ include "centaur.firewallProxyUrl" . | quote }}
+            - name: HTTP_PROXY
+              value: {{ include "centaur.firewallProxyUrl" . | quote }}
+            - name: https_proxy
+              value: {{ include "centaur.firewallProxyUrl" . | quote }}
+            - name: http_proxy
+              value: {{ include "centaur.firewallProxyUrl" . | quote }}
+            - name: GIT_SSL_CAINFO
+              value: /firewall-certs/ca-cert.pem
+            - name: SSL_CERT_FILE
+              value: /firewall-certs/ca-cert.pem
+            - name: REQUESTS_CA_BUNDLE
+              value: /firewall-certs/ca-cert.pem
+            - name: NO_PROXY
+              value: {{ printf "localhost,127.0.0.1,%s" (include "centaur.firewallNoProxyHosts" .) | quote }}
+            - name: no_proxy
+              value: {{ printf "localhost,127.0.0.1,%s" (include "centaur.firewallNoProxyHosts" .) | quote }}
+            - name: REPO_CACHE_PORT
+              value: {{ .Values.repoCache.service.port | quote }}
+{{- if or .Values.repoCache.githubToken.existingSecretName .Values.repoCache.githubToken.token }}
+            - name: GITHUB_TOKEN_FILE
+              value: /github-token/token
+{{- end }}
+{{- end }}
+{{- if .Values.repoCache.persistence.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: git-http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+{{- else }}
           readinessProbe:
             exec:
               command:
@@ -141,6 +201,7 @@ spec:
                   done
             initialDelaySeconds: 10
             periodSeconds: 30
+{{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -155,9 +216,16 @@ spec:
           volumeMounts:
             - name: repo-cache
               mountPath: /cache
+{{- if .Values.repoCache.persistence.enabled }}
+            - name: firewall-ca
+              mountPath: /firewall-certs
+              readOnly: true
+{{- end }}
+{{- if or (not .Values.repoCache.persistence.enabled) .Values.repoCache.githubToken.existingSecretName .Values.repoCache.githubToken.token }}
             - name: github-token
               mountPath: /github-token
               readOnly: true
+{{- end }}
       volumes:
         - name: repo-cache
 {{- if .Values.repoCache.persistence.enabled }}
@@ -168,6 +236,12 @@ spec:
             path: {{ .Values.repoCache.hostPath | quote }}
             type: DirectoryOrCreate
 {{- end }}
+{{- if .Values.repoCache.persistence.enabled }}
+        - name: firewall-ca
+          secret:
+            secretName: {{ include "centaur.trustedCaSecretName" . }}
+{{- end }}
+{{- if or (not .Values.repoCache.persistence.enabled) .Values.repoCache.githubToken.existingSecretName .Values.repoCache.githubToken.token }}
         - name: github-token
           secret:
             secretName: {{ include "centaur.repoCacheGithubTokenSecretName" . }}
@@ -175,4 +249,5 @@ spec:
             items:
               - key: {{ .Values.repoCache.githubToken.secretKey | quote }}
                 path: token
+{{- end }}
 {{- end }}

--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -5,13 +5,34 @@
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
 {{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
 {{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
+{{- if and .Values.repoCache.persistence.enabled (not .Values.repoCache.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "centaur.repoCachePvcName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
+spec:
+  accessModes:
+{{ toYaml .Values.repoCache.persistence.accessModes | nindent 4 }}
+  {{- with .Values.repoCache.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.repoCache.persistence.size }}
+---
+{{- end }}
 apiVersion: apps/v1
-kind: DaemonSet
+kind: {{ ternary "Deployment" "DaemonSet" .Values.repoCache.persistence.enabled }}
 metadata:
   name: {{ include "centaur.componentName" (dict "root" . "component" "repo-cache") }}
   labels:
 {{ include "centaur.componentLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
 spec:
+{{- if .Values.repoCache.persistence.enabled }}
+  replicas: 1
+{{- end }}
   selector:
     matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 6 }}
@@ -139,9 +160,14 @@ spec:
               readOnly: true
       volumes:
         - name: repo-cache
+{{- if .Values.repoCache.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "centaur.repoCachePvcName" . }}
+{{- else }}
           hostPath:
             path: {{ .Values.repoCache.hostPath | quote }}
             type: DirectoryOrCreate
+{{- end }}
         - name: github-token
           secret:
             secretName: {{ include "centaur.repoCacheGithubTokenSecretName" . }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -1,11 +1,8 @@
 {{- $reposPath := .Values.sandbox.reposPath -}}
-{{- $reposPvcClaimName := "" -}}
+{{- $gitCacheURL := "" -}}
 {{- $apiExtraEnv := .Values.api.extraEnv | default dict -}}
 {{- if and .Values.repoCache.enabled .Values.repoCache.persistence.enabled -}}
-{{- if $reposPath -}}
-{{- fail "sandbox.reposPath cannot be set when repoCache.persistence.enabled=true" -}}
-{{- end -}}
-{{- $reposPvcClaimName = include "centaur.repoCachePvcName" . -}}
+{{- $gitCacheURL = printf "http://%s:%v/repos" (include "centaur.componentName" (dict "root" . "component" "repo-cache")) .Values.repoCache.service.port -}}
 {{- else if and .Values.repoCache.enabled (not $reposPath) -}}
 {{- $reposPath = .Values.repoCache.hostPath -}}
 {{- end -}}
@@ -372,9 +369,9 @@ spec:
             - name: REPOS_PATH
               value: {{ $reposPath | quote }}
 {{- end }}
-{{- if $reposPvcClaimName }}
-            - name: REPOS_PVC_CLAIM_NAME
-              value: {{ $reposPvcClaimName | quote }}
+{{- if $gitCacheURL }}
+            - name: CENTAUR_GIT_CACHE_URL
+              value: {{ $gitCacheURL | quote }}
 {{- end }}
 {{- with .Values.sandbox.extraEnv }}
 {{- $envList := list }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -2,7 +2,7 @@
 {{- $gitCacheURL := "" -}}
 {{- $repoCacheMode := include "centaur.repoCacheMode" . -}}
 {{- $apiExtraEnv := .Values.api.extraEnv | default dict -}}
-{{- if and .Values.repoCache.enabled (eq $repoCacheMode "gitMirror") -}}
+{{- if and .Values.repoCache.enabled (eq $repoCacheMode "mirror") -}}
 {{- $gitCacheURL = printf "http://%s:%v/repos" (include "centaur.componentName" (dict "root" . "component" "repo-cache")) .Values.repoCache.service.port -}}
 {{- else if and .Values.repoCache.enabled (eq $repoCacheMode "hostPath") (not $reposPath) -}}
 {{- $reposPath = .Values.repoCache.hostPath -}}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -1,9 +1,10 @@
 {{- $reposPath := .Values.sandbox.reposPath -}}
 {{- $gitCacheURL := "" -}}
+{{- $repoCacheMode := include "centaur.repoCacheMode" . -}}
 {{- $apiExtraEnv := .Values.api.extraEnv | default dict -}}
-{{- if and .Values.repoCache.enabled .Values.repoCache.persistence.enabled -}}
+{{- if and .Values.repoCache.enabled (eq $repoCacheMode "gitMirror") -}}
 {{- $gitCacheURL = printf "http://%s:%v/repos" (include "centaur.componentName" (dict "root" . "component" "repo-cache")) .Values.repoCache.service.port -}}
-{{- else if and .Values.repoCache.enabled (not $reposPath) -}}
+{{- else if and .Values.repoCache.enabled (eq $repoCacheMode "hostPath") (not $reposPath) -}}
 {{- $reposPath = .Values.repoCache.hostPath -}}
 {{- end -}}
 {{- if .Values.postgres.enabled }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -1,6 +1,12 @@
 {{- $reposPath := .Values.sandbox.reposPath -}}
+{{- $reposPvcClaimName := "" -}}
 {{- $apiExtraEnv := .Values.api.extraEnv | default dict -}}
-{{- if and .Values.repoCache.enabled (not $reposPath) -}}
+{{- if and .Values.repoCache.enabled .Values.repoCache.persistence.enabled -}}
+{{- if $reposPath -}}
+{{- fail "sandbox.reposPath cannot be set when repoCache.persistence.enabled=true" -}}
+{{- end -}}
+{{- $reposPvcClaimName = include "centaur.repoCachePvcName" . -}}
+{{- else if and .Values.repoCache.enabled (not $reposPath) -}}
 {{- $reposPath = .Values.repoCache.hostPath -}}
 {{- end -}}
 {{- if .Values.postgres.enabled }}
@@ -365,6 +371,10 @@ spec:
 {{- if $reposPath }}
             - name: REPOS_PATH
               value: {{ $reposPath | quote }}
+{{- end }}
+{{- if $reposPvcClaimName }}
+            - name: REPOS_PVC_CLAIM_NAME
+              value: {{ $reposPvcClaimName | quote }}
 {{- end }}
 {{- with .Values.sandbox.extraEnv }}
 {{- $envList := list }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -102,6 +102,19 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "hostPath": { "type": "string" },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingClaim": { "type": "string" },
+            "size": { "type": "string" },
+            "storageClassName": { "type": "string" },
+            "accessModes": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
         "repositories": {
           "type": "array",
           "items": { "type": "string" }

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -103,7 +103,7 @@
         "enabled": { "type": "boolean" },
         "mode": {
           "type": "string",
-          "enum": ["hostPath", "gitMirror"]
+          "enum": ["hostPath", "mirror"]
         },
         "hostPath": { "type": "string" },
         "service": {

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -101,6 +101,10 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
+        "mode": {
+          "type": "string",
+          "enum": ["hostPath", "gitMirror"]
+        },
         "hostPath": { "type": "string" },
         "service": {
           "type": "object",
@@ -111,7 +115,6 @@
         "persistence": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean" },
             "existingClaim": { "type": "string" },
             "size": { "type": "string" },
             "storageClassName": { "type": "string" },

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -102,6 +102,12 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "hostPath": { "type": "string" },
+        "service": {
+          "type": "object",
+          "properties": {
+            "port": { "type": "integer" }
+          }
+        },
         "persistence": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -151,7 +151,16 @@ sandbox:
 
 repoCache:
   enabled: false
+  # hostPath is kept for local/dev clusters. Production clusters should prefer
+  # persistence.enabled so sandboxes mount a PVC instead of a node filesystem path.
   hostPath: /var/lib/centaur/repos
+  persistence:
+    enabled: false
+    existingClaim: ""
+    size: 20Gi
+    storageClassName: ""
+    accessModes:
+      - ReadWriteOnce
   repositories: []
   syncIntervalSeconds: 300
   image:

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -151,13 +151,13 @@ sandbox:
 
 repoCache:
   enabled: false
-  # hostPath keeps the legacy per-node shared clone cache. gitMirror serves
-  # PVC-backed bare Git mirrors over HTTP and sandboxes do not mount the cache.
-  mode: hostPath # hostPath | gitMirror
+  # Select how sandboxes get faster Git checkouts.
+  # hostPath mounts a per-node cache; mirror serves a PVC-backed HTTP Git cache.
+  mode: hostPath # hostPath | mirror
   hostPath: /var/lib/centaur/repos
   service:
     port: 8080
-  # Used by mode=gitMirror. The hostPath mode always uses repoCache.hostPath.
+  # PVC settings used only by mode=mirror.
   persistence:
     existingClaim: ""
     size: 20Gi

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -151,13 +151,14 @@ sandbox:
 
 repoCache:
   enabled: false
-  # hostPath is the legacy/local mode. With persistence enabled, repo-cache
-  # serves PVC-backed bare Git mirrors over HTTP and sandboxes do not mount it.
+  # hostPath keeps the legacy per-node shared clone cache. gitMirror serves
+  # PVC-backed bare Git mirrors over HTTP and sandboxes do not mount the cache.
+  mode: hostPath # hostPath | gitMirror
   hostPath: /var/lib/centaur/repos
   service:
     port: 8080
+  # Used by mode=gitMirror. The hostPath mode always uses repoCache.hostPath.
   persistence:
-    enabled: false
     existingClaim: ""
     size: 20Gi
     storageClassName: ""

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -151,9 +151,11 @@ sandbox:
 
 repoCache:
   enabled: false
-  # hostPath is kept for local/dev clusters. Production clusters should prefer
-  # persistence.enabled so sandboxes mount a PVC instead of a node filesystem path.
+  # hostPath is the legacy/local mode. With persistence enabled, repo-cache
+  # serves PVC-backed bare Git mirrors over HTTP and sandboxes do not mount it.
   hostPath: /var/lib/centaur/repos
+  service:
+    port: 8080
   persistence:
     enabled: false
     existingClaim: ""

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -152,7 +152,9 @@ sandbox:
 repoCache:
   enabled: false
   # Select how sandboxes get faster Git checkouts.
-  # hostPath mounts a per-node cache; mirror serves a PVC-backed HTTP Git cache.
+  # hostPath mounts a per-node cache.
+  # mirror serves a PVC-backed HTTP Git cache and injects CENTAUR_GIT_CACHE_URL
+  # so the sandbox git wrapper accelerates reads while pushes use the origin.
   mode: hostPath # hostPath | mirror
   hostPath: /var/lib/centaur/repos
   service:

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -246,6 +246,37 @@ sandbox:
   runtimeClassName: gvisor
 ```
 
+### Repo Cache Mirror
+
+For clusters that should not grant sandbox pods node filesystem access, use the
+network repo-cache mode instead of mounting a shared repo directory:
+
+```yaml
+repoCache:
+  enabled: true
+  mode: mirror
+  persistence:
+    size: 20Gi
+    accessModes:
+      - ReadWriteOnce
+  githubToken:
+    existingSecretName: centaur-infra-env
+    secretKey: GITHUB_TOKEN
+```
+
+Mirror mode runs a PVC-backed repo-cache service that stores bare Git mirrors
+and exposes them over in-cluster HTTP. Sandboxes still run normal `git`
+commands: the sandbox image installs `/usr/local/bin/git` as a wrapper around
+the real `/usr/bin/git`. When `CENTAUR_GIT_CACHE_URL` is present, the wrapper
+adds temporary `url.*.insteadOf` config for read operations such as `clone`,
+`fetch`, `pull`, `ls-remote`, and `submodule`. Pushes and other commands bypass
+the cache and use the repository's configured remote.
+
+The chart sets `CENTAUR_GIT_CACHE_URL` and opens the sandbox-to-repo-cache
+NetworkPolicy path when `repoCache.enabled=true` and `repoCache.mode=mirror`.
+The repo-cache service uses `repoCache.githubToken` for upstream GitHub reads;
+do not put GitHub credentials directly into sandbox pods.
+
 The Kubernetes sandbox backend is the active runtime backend; there is no chart
 switch named `api.sandboxBackend`.
 

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -137,6 +137,7 @@ Kubernetes backend:
 | `KUBERNETES_API_POD_LABEL_SELECTOR` | Chart-rendered labels or `api.extraEnv`. | API pod selector for API-managed proxy policies. |
 | `KUBERNETES_EGRESS_DISCOVERY_ENABLED`, `KUBERNETES_EGRESS_SERVICE_NAMESPACE`, `KUBERNETES_CLUSTER_DOMAIN`, `KUBERNETES_EGRESS_TAILNET_FQDN_ANNOTATION` | `api.egressDiscovery.*`. | Egress service discovery for sandbox NetworkPolicies. |
 | `REPOS_PATH` | `sandbox.reposPath`. | Repo cache path mounted into sandboxes. |
+| `CENTAUR_GIT_CACHE_URL` | `repoCache.mode=mirror`. | In-cluster Git mirror URL injected into sandboxes; the sandbox `git` wrapper uses it for read operations and leaves pushes on the original remote. |
 
 Sandbox entrypoint and wrappers:
 

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -156,6 +156,37 @@ sandbox:
   runtimeClassName: gvisor
 ```
 
+### Repo Cache Mirror
+
+For clusters that should not grant sandbox pods node filesystem access, use the
+network repo-cache mode instead of mounting a shared repo directory:
+
+```yaml
+repoCache:
+  enabled: true
+  mode: mirror
+  persistence:
+    size: 20Gi
+    accessModes:
+      - ReadWriteOnce
+  githubToken:
+    existingSecretName: centaur-infra-env
+    secretKey: GITHUB_TOKEN
+```
+
+Mirror mode runs a PVC-backed repo-cache service that stores bare Git mirrors
+and exposes them over in-cluster HTTP. Sandboxes still run normal `git`
+commands: the sandbox image installs `/usr/local/bin/git` as a wrapper around
+the real `/usr/bin/git`. When `CENTAUR_GIT_CACHE_URL` is present, the wrapper
+adds temporary `url.*.insteadOf` config for read operations such as `clone`,
+`fetch`, `pull`, `ls-remote`, and `submodule`. Pushes and other commands bypass
+the cache and use the repository's configured remote.
+
+The chart sets `CENTAUR_GIT_CACHE_URL` and opens the sandbox-to-repo-cache
+NetworkPolicy path when `repoCache.enabled=true` and `repoCache.mode=mirror`.
+The repo-cache service uses `repoCache.githubToken` for upstream GitHub reads;
+do not put GitHub credentials directly into sandbox pods.
+
 The Kubernetes sandbox backend is the active runtime backend; there is no chart
 switch named `api.sandboxBackend`.
 

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -134,6 +134,7 @@ Kubernetes backend:
 | `KUBERNETES_API_POD_LABEL_SELECTOR` | Chart-rendered labels or `api.extraEnv`. | API pod selector for API-managed proxy policies. |
 | `KUBERNETES_EGRESS_DISCOVERY_ENABLED`, `KUBERNETES_EGRESS_SERVICE_NAMESPACE`, `KUBERNETES_CLUSTER_DOMAIN`, `KUBERNETES_EGRESS_TAILNET_FQDN_ANNOTATION` | `api.egressDiscovery.*`. | Egress service discovery for sandbox NetworkPolicies. |
 | `REPOS_PATH` | `sandbox.reposPath`. | Repo cache path mounted into sandboxes. |
+| `CENTAUR_GIT_CACHE_URL` | `repoCache.mode=mirror`. | In-cluster Git mirror URL injected into sandboxes; the sandbox `git` wrapper uses it for read operations and leaves pushes on the original remote. |
 
 Sandbox entrypoint and wrappers:
 

--- a/services/api/api/iron-proxy.base.yaml
+++ b/services/api/api/iron-proxy.base.yaml
@@ -25,6 +25,7 @@ transforms:
         - "host"
         - "content-type"
         - "content-length"
+        - "content-encoding"
         - "accept"
         - "accept-encoding"
         - "accept-language"

--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -103,6 +103,11 @@ def _sandbox_otel_endpoint_hosts(extra_env: list[tuple[str, str]]) -> list[str]:
     return hosts
 
 
+def _git_cache_host() -> str | None:
+    value = (os.getenv("CENTAUR_GIT_CACHE_URL") or "").strip()
+    return urlsplit(value).hostname or None
+
+
 def amp_mode() -> str:
     return (os.getenv("AMP_MODE") or "deep").strip() or "deep"
 
@@ -163,6 +168,9 @@ def container_env(
     api_host = urlsplit(api_url).hostname
     if api_host:
         no_proxy_hosts.append(api_host)
+    git_cache_host = _git_cache_host()
+    if git_cache_host:
+        no_proxy_hosts.append(git_cache_host)
     no_proxy_hosts.extend(_sandbox_otel_endpoint_hosts(extra_env))
     no_proxy = ",".join(dict.fromkeys(no_proxy_hosts))
     # Placeholder values for harness infra secrets. iron-proxy MITMs the

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -341,24 +341,13 @@ def _repos_path() -> str | None:
     return value or None
 
 
-def _repos_pvc_claim_name() -> str | None:
-    value = (os.getenv("REPOS_PVC_CLAIM_NAME") or "").strip()
+def _git_cache_url() -> str | None:
+    value = (os.getenv("CENTAUR_GIT_CACHE_URL") or "").strip().rstrip("/")
     return value or None
 
 
 def _repos_volume() -> dict[str, Any] | None:
     repos_path = _repos_path()
-    repos_pvc_claim_name = _repos_pvc_claim_name()
-    if repos_path and repos_pvc_claim_name:
-        raise ValueError("Only one of REPOS_PATH or REPOS_PVC_CLAIM_NAME may be set")
-    if repos_pvc_claim_name:
-        return {
-            "name": "repos",
-            "persistentVolumeClaim": {
-                "claimName": repos_pvc_claim_name,
-                "readOnly": True,
-            },
-        }
     if repos_path:
         return {
             "name": "repos",
@@ -1329,8 +1318,6 @@ class KubernetesExecutorBackend(SandboxBackend):
         await self._ensure_clients()
 
         repos_volume = _repos_volume()
-        if repo and not repos_volume:
-            raise ValueError("REPOS_PATH is required when AGENT_REPO is set")
 
         runtime_key = f"{thread_key}:{uuid.uuid4().hex[:8]}"
         pod_name = _resource_name("centaur-centaur-sandbox", runtime_key)
@@ -1369,6 +1356,9 @@ class KubernetesExecutorBackend(SandboxBackend):
             env.append(f"AGENT_PERSONA={persona}")
         if repo:
             env.append(f"AGENT_REPO={repo}")
+        git_cache_url = _git_cache_url()
+        if git_cache_url:
+            env.append(f"CENTAUR_GIT_CACHE_URL={git_cache_url}")
 
         labels = {
             "centaur.ai/sandbox-id": pod_name,

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -341,6 +341,35 @@ def _repos_path() -> str | None:
     return value or None
 
 
+def _repos_pvc_claim_name() -> str | None:
+    value = (os.getenv("REPOS_PVC_CLAIM_NAME") or "").strip()
+    return value or None
+
+
+def _repos_volume() -> dict[str, Any] | None:
+    repos_path = _repos_path()
+    repos_pvc_claim_name = _repos_pvc_claim_name()
+    if repos_path and repos_pvc_claim_name:
+        raise ValueError("Only one of REPOS_PATH or REPOS_PVC_CLAIM_NAME may be set")
+    if repos_pvc_claim_name:
+        return {
+            "name": "repos",
+            "persistentVolumeClaim": {
+                "claimName": repos_pvc_claim_name,
+                "readOnly": True,
+            },
+        }
+    if repos_path:
+        return {
+            "name": "repos",
+            "hostPath": {
+                "path": repos_path,
+                "type": "Directory",
+            },
+        }
+    return None
+
+
 def _overlay_image() -> str | None:
     value = (os.getenv("CENTAUR_OVERLAY_IMAGE") or "").strip()
     return value or None
@@ -1299,8 +1328,8 @@ class KubernetesExecutorBackend(SandboxBackend):
         _ensure_kubernetes_env()
         await self._ensure_clients()
 
-        repos_path = _repos_path()
-        if repo and not repos_path:
+        repos_volume = _repos_volume()
+        if repo and not repos_volume:
             raise ValueError("REPOS_PATH is required when AGENT_REPO is set")
 
         runtime_key = f"{thread_key}:{uuid.uuid4().hex[:8]}"
@@ -1421,7 +1450,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                 }
             )
 
-        if repos_path:
+        if repos_volume:
             volume_mounts.append(
                 {
                     "name": "repos",
@@ -1429,15 +1458,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                     "readOnly": True,
                 }
             )
-            volumes.append(
-                {
-                    "name": "repos",
-                    "hostPath": {
-                        "path": repos_path,
-                        "type": "Directory",
-                    },
-                }
-            )
+            volumes.append(repos_volume)
 
         self._configure_workload_volumes(volume_mounts, volumes)
 

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -1431,6 +1431,15 @@ def test_render_omits_managed_transforms_when_no_matching_secrets() -> None:
     assert "postgres" not in cfg
 
 
+def test_render_preserves_content_encoding_header_allowlist() -> None:
+    cfg = yaml.safe_load(render_proxy_yaml([]))
+    header_allowlist = next(
+        t for t in cfg["transforms"] if t["name"] == "header_allowlist"
+    )
+
+    assert "content-encoding" in header_allowlist["config"]["headers"]
+
+
 def test_render_emits_postgres_listeners_with_env_refs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1441,7 +1450,10 @@ def test_render_emits_postgres_listeners_with_env_refs(
     ]
     cfg = yaml.safe_load(render_proxy_yaml(secrets))
     listeners = cfg["postgres"]
-    assert [l["name"] for l in listeners] == ["analytics_pg", "database_url"]
+    assert [listener["name"] for listener in listeners] == [
+        "analytics_pg",
+        "database_url",
+    ]
     assert listeners[0]["listen"] == "0.0.0.0:5432"
     assert listeners[1]["listen"] == "0.0.0.0:5433"
     # upstream.dsn uses the secret_ref directly so iron-proxy can resolve it

--- a/services/api/tests/test_repo_cache_server.py
+++ b/services/api/tests/test_repo_cache_server.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import gzip
 import importlib.util
 import subprocess
 import sys
+import zlib
 from pathlib import Path
 from types import ModuleType
 
@@ -70,6 +72,27 @@ def test_is_receive_pack_detects_push_requests() -> None:
     assert not server._is_receive_pack(
         "/repos/github.com/org/repo.git/info/refs", "service=git-upload-pack"
     )
+
+
+def test_decode_request_body_accepts_git_http_content_encoding() -> None:
+    server = _load_repo_cache_server()
+    body = b"0032want abcdef\n0000"
+
+    assert server._decode_request_body(gzip.compress(body), "gzip") == body
+    assert server._decode_request_body(zlib.compress(body), "deflate") == body
+    assert server._decode_request_body(body, "identity") == body
+    assert server._decode_request_body(body, "") == body
+
+
+def test_decode_request_body_rejects_unknown_content_encoding() -> None:
+    server = _load_repo_cache_server()
+
+    try:
+        server._decode_request_body(b"body", "br")
+    except ValueError as exc:
+        assert "unsupported content encoding: br" in str(exc)
+    else:
+        raise AssertionError("expected unsupported encoding to raise")
 
 
 def test_ensure_mirror_clones_bare_repo_from_upstream(tmp_path, monkeypatch) -> None:

--- a/services/api/tests/test_repo_cache_server.py
+++ b/services/api/tests/test_repo_cache_server.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_repo_cache_server() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "services"
+        / "sandbox"
+        / "repo-cache-server.py"
+    )
+    spec = importlib.util.spec_from_file_location("repo_cache_server", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(*args: str, cwd: Path | None = None) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_parse_repo_from_path_accepts_git_http_paths() -> None:
+    server = _load_repo_cache_server()
+
+    assert server._parse_repo_from_path("/repos/github.com/org/repo.git/info/refs") == (
+        "org/repo",
+        "/github.com/org/repo.git/info/refs",
+    )
+    assert server._parse_repo_from_path(
+        "/repos/github.com/org/repo.git/git-upload-pack"
+    ) == (
+        "org/repo",
+        "/github.com/org/repo.git/git-upload-pack",
+    )
+
+
+def test_parse_repo_from_path_rejects_invalid_paths() -> None:
+    server = _load_repo_cache_server()
+
+    assert server._parse_repo_from_path("/healthz") is None
+    assert server._parse_repo_from_path("/repos/github.com/org.git/info/refs") is None
+    assert (
+        server._parse_repo_from_path("/repos/github.com/../repo.git/info/refs") is None
+    )
+
+
+def test_is_receive_pack_detects_push_requests() -> None:
+    server = _load_repo_cache_server()
+
+    assert server._is_receive_pack(
+        "/repos/github.com/org/repo.git/git-receive-pack", ""
+    )
+    assert server._is_receive_pack(
+        "/repos/github.com/org/repo.git/info/refs", "service=git-receive-pack"
+    )
+    assert not server._is_receive_pack(
+        "/repos/github.com/org/repo.git/info/refs", "service=git-upload-pack"
+    )
+
+
+def test_ensure_mirror_clones_bare_repo_from_upstream(tmp_path, monkeypatch) -> None:
+    server = _load_repo_cache_server()
+    origin_root = tmp_path / "origin"
+    bare = origin_root / "org" / "repo.git"
+    bare.parent.mkdir(parents=True)
+    _git("init", "--bare", str(bare))
+
+    work = tmp_path / "work"
+    _git("init", str(work))
+    _git("config", "user.email", "agent@example.com", cwd=work)
+    _git("config", "user.name", "Agent", cwd=work)
+    (work / "README.md").write_text("hello\n")
+    _git("add", "README.md", cwd=work)
+    _git("commit", "-m", "initial", cwd=work)
+    _git("branch", "-M", "main", cwd=work)
+    _git("remote", "add", "origin", str(bare), cwd=work)
+    _git("push", "origin", "main", cwd=work)
+
+    monkeypatch.setattr(server, "CACHE_ROOT", tmp_path / "cache" / "mirrors")
+    monkeypatch.setattr(server, "LOCK_ROOT", tmp_path / "cache" / "locks")
+    monkeypatch.setattr(server, "UPSTREAM_BASE_URL", origin_root.as_uri())
+    monkeypatch.setattr(server, "FETCH_INTERVAL_SECONDS", 3600)
+
+    mirror = server.ensure_mirror("org/repo")
+
+    assert mirror == tmp_path / "cache" / "mirrors" / "github.com" / "org" / "repo.git"
+    result = subprocess.run(
+        ["git", "-C", str(mirror), "rev-parse", "--is-bare-repository"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.stdout.strip() == "true"

--- a/services/api/tests/test_sandbox_entrypoint.py
+++ b/services/api/tests/test_sandbox_entrypoint.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 
 ENTRYPOINT_SH = Path(__file__).resolve().parents[2] / "sandbox" / "entrypoint.sh"
+GIT_CACHE_WRAPPER_SH = (
+    Path(__file__).resolve().parents[2] / "sandbox" / "git-cache-wrapper.sh"
+)
 
 
 def _write_codex_harness_config(home: Path) -> Path:
@@ -135,3 +138,82 @@ def test_sandbox_entrypoint_installs_codex_harness_config(tmp_path: Path) -> Non
 
     assert result.returncode == 0, result.stderr or result.stdout
     assert result.stdout == (harness_dir / "codex" / "config.toml").read_text()
+
+
+def test_sandbox_entrypoint_does_not_install_global_git_cache_rewrites(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    harness_dir = _write_codex_harness_config(home)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ENTRYPOINT_SH),
+            "sh",
+            "-lc",
+            "git config --global --get-all url.http://repo-cache:8080/repos/github.com/.insteadOf",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(home),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "CENTAUR_GIT_CACHE_URL": "http://repo-cache:8080/repos/",
+            "CENTAUR_HARNESS_CONFIG_DIR": str(harness_dir),
+        },
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+
+
+def test_git_cache_wrapper_does_not_rewrite_push(tmp_path: Path) -> None:
+    real_git = tmp_path / "git"
+    calls = tmp_path / "calls"
+    real_git.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$*\" >> \"$GIT_WRAPPER_CALLS\"\n"
+    )
+    real_git.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "CENTAUR_REAL_GIT": str(real_git),
+        "CENTAUR_GIT_CACHE_URL": "http://repo-cache:8080/repos/",
+        "GIT_WRAPPER_CALLS": str(calls),
+    }
+
+    clone = subprocess.run(
+        [
+            "bash",
+            str(GIT_CACHE_WRAPPER_SH),
+            "clone",
+            "https://github.com/tarrencev/centaur.git",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    push = subprocess.run(
+        [
+            "bash",
+            str(GIT_CACHE_WRAPPER_SH),
+            "push",
+            "origin",
+            "test-branch",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert clone.returncode == 0, clone.stderr or clone.stdout
+    assert push.returncode == 0, push.stderr or push.stdout
+    clone_call, push_call = calls.read_text().splitlines()
+    assert "url.http://repo-cache:8080/repos/github.com/.insteadOf=https://github.com/" in clone_call
+    assert "url.http://repo-cache:8080/repos/github.com/.insteadOf" not in push_call
+    assert push_call == "push origin test-branch"

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -1309,6 +1309,101 @@ async def test_create_mounts_repo_cache_host_path(
 
 
 @pytest.mark.asyncio
+async def test_create_mounts_repo_cache_pvc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = KubernetesExecutorBackend()
+    fake_core = FakeCoreApi()
+    fake_networking = FakeNetworkingApi()
+    backend._core = fake_core
+    backend._networking = fake_networking
+
+    monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv("FIREWALL_HOST", "firewall.internal")
+    monkeypatch.setenv("KUBERNETES_FIREWALL_CA_SECRET_NAME", "firewall-ca")
+    monkeypatch.setenv("REPOS_PVC_CLAIM_NAME", "centaur-repo-cache")
+    monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur-sandbox")
+    monkeypatch.setattr(
+        "api.sandbox.kubernetes._prompt_bundle",
+        lambda persona: f"prompt:{persona}",
+    )
+    monkeypatch.setattr(
+        "api.sandbox.kubernetes.container_env",
+        lambda *_args, **_kwargs: [
+            "CENTAUR_API_URL=http://api.internal:8000",
+            "CENTAUR_API_KEY=sandbox-token",
+        ],
+    )
+
+    monkeypatch.setattr(
+        "api.sandbox.kubernetes.build_harness_cmd", lambda *_args: ["amp-wrapper"]
+    )
+    monkeypatch.setattr("api.sandbox.kubernetes.image", lambda: "centaur-agent:test")
+
+    async def fake_ensure_clients() -> None:
+        return None
+
+    async def fake_wait_ready(_pod_name: str) -> float:
+        return 0.01
+
+    monkeypatch.setattr(backend, "_ensure_clients", fake_ensure_clients)
+    monkeypatch.setattr(backend, "_wait_pod_ready", fake_wait_ready)
+    monkeypatch.setattr(backend, "_wait_ready", fake_wait_ready)
+
+    await backend.create(
+        "slack:C123:123.456",
+        "amp",
+        "amp",
+        repo="paradigmxyz/centaur",
+    )
+
+    pod_body = fake_core.created_pods[1][1]
+    container = pod_body["spec"]["containers"][0]
+
+    assert any(
+        mount["name"] == "repos"
+        and mount["mountPath"] == "/home/agent/github"
+        and mount["readOnly"] is True
+        for mount in container["volumeMounts"]
+    )
+    assert {
+        "name": "repos",
+        "persistentVolumeClaim": {
+            "claimName": "centaur-repo-cache",
+            "readOnly": True,
+        },
+    } in pod_body["spec"]["volumes"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_multiple_repo_cache_volume_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = KubernetesExecutorBackend()
+
+    monkeypatch.setenv("AGENT_API_URL", "http://api:8000")
+    monkeypatch.setenv("FIREWALL_HOST", "firewall")
+    monkeypatch.setenv("KUBERNETES_FIREWALL_CA_SECRET_NAME", "firewall-ca")
+    monkeypatch.setenv("REPOS_PATH", "/var/lib/centaur/repos")
+    monkeypatch.setenv("REPOS_PVC_CLAIM_NAME", "centaur-repo-cache")
+
+    async def fake_ensure_clients() -> None:
+        return None
+
+    monkeypatch.setattr(backend, "_ensure_clients", fake_ensure_clients)
+
+    with pytest.raises(
+        ValueError, match="Only one of REPOS_PATH or REPOS_PVC_CLAIM_NAME"
+    ):
+        await backend.create(
+            "slack:C123:123.456",
+            "amp",
+            "amp",
+            repo="paradigmxyz/centaur",
+        )
+
+
+@pytest.mark.asyncio
 async def test_create_can_use_agent_sandbox_with_state_volume(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -487,27 +487,60 @@ async def test_ensure_clients_disables_proxy_env(
 
 
 @pytest.mark.asyncio
-async def test_create_requires_repo_cache_volume_for_repo(
+async def test_create_allows_agent_repo_without_repo_volume(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     backend = KubernetesExecutorBackend()
+    fake_core = FakeCoreApi()
+    fake_networking = FakeNetworkingApi()
+    backend._core = fake_core
+    backend._networking = fake_networking
 
-    monkeypatch.setenv("AGENT_API_URL", "http://api:8000")
-    monkeypatch.setenv("FIREWALL_HOST", "firewall")
+    monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:pass@db/centaur")
+    monkeypatch.setenv("FIREWALL_HOST", "firewall.internal")
     monkeypatch.setenv("KUBERNETES_FIREWALL_CA_SECRET_NAME", "firewall-ca")
+    monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur-sandbox")
+    monkeypatch.setattr(
+        "api.sandbox.kubernetes._prompt_bundle",
+        lambda persona: f"prompt:{persona}",
+    )
+    monkeypatch.setattr(
+        "api.sandbox.kubernetes.container_env",
+        lambda *_args, **_kwargs: [
+            "CENTAUR_API_URL=http://api.internal:8000",
+            "CENTAUR_API_KEY=sandbox-token",
+        ],
+    )
+    monkeypatch.setattr(
+        "api.sandbox.kubernetes.build_harness_cmd", lambda *_args: ["amp-wrapper"]
+    )
+    monkeypatch.setattr("api.sandbox.kubernetes.image", lambda: "centaur-agent:test")
 
     async def fake_ensure_clients() -> None:
         return None
 
-    monkeypatch.setattr(backend, "_ensure_clients", fake_ensure_clients)
+    async def fake_wait_ready(_pod_name: str) -> float:
+        return 0.01
 
-    with pytest.raises(ValueError, match="REPOS_PATH is required"):
-        await backend.create(
-            "slack:C123:123.456",
-            "amp",
-            "amp",
-            repo="paradigmxyz/centaur",
-        )
+    monkeypatch.setattr(backend, "_ensure_clients", fake_ensure_clients)
+    monkeypatch.setattr(backend, "_wait_pod_ready", fake_wait_ready)
+    monkeypatch.setattr(backend, "_wait_ready", fake_wait_ready)
+
+    await backend.create(
+        "slack:C123:123.456",
+        "amp",
+        "amp",
+        repo="paradigmxyz/centaur",
+    )
+
+    pod_body = fake_core.created_pods[1][1]
+    container = pod_body["spec"]["containers"][0]
+    env = {item["name"]: item["value"] for item in container["env"]}
+
+    assert env["AGENT_REPO"] == "paradigmxyz/centaur"
+    assert all(mount["name"] != "repos" for mount in container["volumeMounts"])
+    assert all(volume["name"] != "repos" for volume in pod_body["spec"]["volumes"])
 
 
 @pytest.mark.asyncio
@@ -1255,6 +1288,7 @@ async def test_create_mounts_repo_cache_host_path(
     backend._networking = fake_networking
 
     monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:pass@db/centaur")
     monkeypatch.setenv("FIREWALL_HOST", "firewall.internal")
     monkeypatch.setenv("KUBERNETES_FIREWALL_CA_SECRET_NAME", "firewall-ca")
     monkeypatch.setenv("REPOS_PATH", "/var/lib/centaur/repos")
@@ -1309,7 +1343,7 @@ async def test_create_mounts_repo_cache_host_path(
 
 
 @pytest.mark.asyncio
-async def test_create_mounts_repo_cache_pvc(
+async def test_create_passes_git_cache_url_without_repo_mount(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     backend = KubernetesExecutorBackend()
@@ -1319,9 +1353,10 @@ async def test_create_mounts_repo_cache_pvc(
     backend._networking = fake_networking
 
     monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:pass@db/centaur")
     monkeypatch.setenv("FIREWALL_HOST", "firewall.internal")
     monkeypatch.setenv("KUBERNETES_FIREWALL_CA_SECRET_NAME", "firewall-ca")
-    monkeypatch.setenv("REPOS_PVC_CLAIM_NAME", "centaur-repo-cache")
+    monkeypatch.setenv("CENTAUR_GIT_CACHE_URL", "http://repo-cache:8080/repos/")
     monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur-sandbox")
     monkeypatch.setattr(
         "api.sandbox.kubernetes._prompt_bundle",
@@ -1359,48 +1394,12 @@ async def test_create_mounts_repo_cache_pvc(
 
     pod_body = fake_core.created_pods[1][1]
     container = pod_body["spec"]["containers"][0]
+    env = {item["name"]: item["value"] for item in container["env"]}
 
-    assert any(
-        mount["name"] == "repos"
-        and mount["mountPath"] == "/home/agent/github"
-        and mount["readOnly"] is True
-        for mount in container["volumeMounts"]
-    )
-    assert {
-        "name": "repos",
-        "persistentVolumeClaim": {
-            "claimName": "centaur-repo-cache",
-            "readOnly": True,
-        },
-    } in pod_body["spec"]["volumes"]
-
-
-@pytest.mark.asyncio
-async def test_create_rejects_multiple_repo_cache_volume_sources(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    backend = KubernetesExecutorBackend()
-
-    monkeypatch.setenv("AGENT_API_URL", "http://api:8000")
-    monkeypatch.setenv("FIREWALL_HOST", "firewall")
-    monkeypatch.setenv("KUBERNETES_FIREWALL_CA_SECRET_NAME", "firewall-ca")
-    monkeypatch.setenv("REPOS_PATH", "/var/lib/centaur/repos")
-    monkeypatch.setenv("REPOS_PVC_CLAIM_NAME", "centaur-repo-cache")
-
-    async def fake_ensure_clients() -> None:
-        return None
-
-    monkeypatch.setattr(backend, "_ensure_clients", fake_ensure_clients)
-
-    with pytest.raises(
-        ValueError, match="Only one of REPOS_PATH or REPOS_PVC_CLAIM_NAME"
-    ):
-        await backend.create(
-            "slack:C123:123.456",
-            "amp",
-            "amp",
-            repo="paradigmxyz/centaur",
-        )
+    assert env["AGENT_REPO"] == "paradigmxyz/centaur"
+    assert env["CENTAUR_GIT_CACHE_URL"] == "http://repo-cache:8080/repos"
+    assert all(mount["name"] != "repos" for mount in container["volumeMounts"])
+    assert all(volume["name"] != "repos" for volume in pod_body["spec"]["volumes"])
 
 
 @pytest.mark.asyncio

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -223,6 +223,7 @@ def _default_per_sandbox_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KUBERNETES_FIREWALL_CA_KEY_SECRET_NAME", "firewall-ca-key")
     monkeypatch.setenv("KUBERNETES_SECRET_ENV_NAME", "centaur-infra-env")
     monkeypatch.delenv("KUBERNETES_BOOTSTRAP_SECRET_NAME", raising=False)
+    monkeypatch.delenv("CENTAUR_GIT_CACHE_URL", raising=False)
 
 
 def test_pod_resources_uses_default_limits_when_unset(
@@ -273,6 +274,24 @@ def test_container_env_includes_firewall_host_for_secret_bootstrap(
     assert env_map["OPENAI_API_KEY"] == "OPENAI_API_KEY"
     assert env_map["CENTAUR_TRACE_ID"] == "00000000-0000-0000-0000-000000000123"
     assert env_map["NO_PROXY"] == "localhost,127.0.0.1,firewall.internal,api.internal"
+    assert env_map["no_proxy"] == env_map["NO_PROXY"]
+
+
+def test_container_env_bypasses_proxy_for_git_cache_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_API_URL", "http://api.internal:8000")
+    monkeypatch.setenv(
+        "CENTAUR_GIT_CACHE_URL",
+        "http://centaur-repo-cache.centaur.svc.cluster.local:8080/repos/",
+    )
+
+    env = sandbox_container_env("thread-key", "sandbox-id", "firewall.internal")
+    env_map = dict(item.split("=", 1) for item in env)
+
+    assert "centaur-repo-cache.centaur.svc.cluster.local" in env_map[
+        "NO_PROXY"
+    ].split(",")
     assert env_map["no_proxy"] == env_map["NO_PROXY"]
 
 

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -192,6 +192,8 @@ COPY --link --chmod=755 services/sandbox/codex-app-wrapper.py /usr/local/bin/cod
 COPY --link --chmod=755 services/sandbox/claude-app-wrapper.py /usr/local/bin/claude-app-wrapper
 COPY --link --chmod=755 services/sandbox/harness_adapter.py /usr/local/bin/harness-adapter
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
+COPY --link --chmod=755 services/sandbox/git-cache-wrapper.sh /usr/local/bin/git
+COPY --link --chmod=755 services/sandbox/repo-cache-server.py /usr/local/bin/repo-cache-server
 COPY --link --chmod=755 services/sandbox/entrypoint.sh /entrypoint.sh
 
 USER agent

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -153,19 +153,22 @@ else
 fi
 if [ -n "${AGENT_REPO:-}" ]; then
     REPO_PATH="$HOME_DIR/github/$AGENT_REPO"
-    if ! git -C "$REPO_PATH" rev-parse --git-dir >/dev/null 2>&1; then
-        echo "AGENT_REPO is not a valid git repository: $REPO_PATH" >&2
-        exit 1
-    fi
+    REPO_URL="https://github.com/${AGENT_REPO}.git"
 
     if ! git -C "$WORKSPACE_DIR" rev-parse --git-dir >/dev/null 2>&1; then
         rm -rf "$WORKSPACE_DIR"
-        if ! git clone --quiet --shared "$REPO_PATH" "$WORKSPACE_DIR"; then
-            echo "shared clone failed for $REPO_PATH; retrying with regular clone" >&2
-            rm -rf "$WORKSPACE_DIR"
-            git clone --quiet "$REPO_PATH" "$WORKSPACE_DIR"
+        if git -C "$REPO_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+            if ! git clone --quiet --shared "$REPO_PATH" "$WORKSPACE_DIR"; then
+                echo "shared clone failed for $REPO_PATH; retrying with regular clone" >&2
+                rm -rf "$WORKSPACE_DIR"
+                git clone --quiet "$REPO_PATH" "$WORKSPACE_DIR"
+            fi
+        else
+            git clone --quiet "$REPO_URL" "$WORKSPACE_DIR"
         fi
 
+        git -C "$WORKSPACE_DIR" remote set-url origin "$REPO_URL" || true
+        git -C "$WORKSPACE_DIR" remote set-url --push origin "$REPO_URL" || true
         BRANCH="agent-$(date +%s)-${RANDOM}-${RANDOM}"
         git -C "$WORKSPACE_DIR" checkout -q -b "$BRANCH" || true
     fi

--- a/services/sandbox/git-cache-wrapper.sh
+++ b/services/sandbox/git-cache-wrapper.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+REAL_GIT="${CENTAUR_REAL_GIT:-/usr/bin/git}"
+CACHE_URL="${CENTAUR_GIT_CACHE_URL:-}"
+
+find_git_command() {
+    local expect_value=0
+    for arg in "$@"; do
+        if [ "$expect_value" = "1" ]; then
+            expect_value=0
+            continue
+        fi
+        case "$arg" in
+            -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--config-env)
+                expect_value=1
+                continue
+                ;;
+            --git-dir=*|--work-tree=*|--namespace=*|--exec-path=*|--config-env=*)
+                continue
+                ;;
+            --paginate|--no-pager|--bare|--version|--help|--html-path|--man-path|--info-path|--literal-pathspecs|--no-literal-pathspecs|--glob-pathspecs|--noglob-pathspecs|--icase-pathspecs)
+                continue
+                ;;
+            --*)
+                continue
+                ;;
+            -* )
+                continue
+                ;;
+            *)
+                printf '%s\n' "$arg"
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+should_use_cache() {
+    case "$1" in
+        clone|fetch|pull|ls-remote|submodule)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+cmd="$(find_git_command "$@" || true)"
+if [ -n "$CACHE_URL" ] && [ -n "$cmd" ] && should_use_cache "$cmd"; then
+    CACHE_URL="${CACHE_URL%/}"
+    exec "$REAL_GIT" \
+        -c "url.${CACHE_URL}/github.com/.insteadOf=https://github.com/" \
+        -c "url.${CACHE_URL}/github.com/.insteadOf=git@github.com:" \
+        -c "url.${CACHE_URL}/github.com/.insteadOf=ssh://git@github.com/" \
+        "$@"
+fi
+
+exec "$REAL_GIT" "$@"

--- a/services/sandbox/repo-cache-server.py
+++ b/services/sandbox/repo-cache-server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import fcntl
+import gzip
 import os
 import re
 import shutil
@@ -9,6 +10,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
@@ -174,6 +176,25 @@ def _is_receive_pack(path: str, query: str) -> bool:
     return "git-receive-pack" in services or path.endswith("/git-receive-pack")
 
 
+def _decode_request_body(body: bytes, content_encoding: str | None) -> bytes:
+    encodings = [
+        encoding.strip().lower()
+        for encoding in (content_encoding or "").split(",")
+        if encoding.strip()
+    ]
+    for encoding in reversed(encodings):
+        if encoding in {"identity"}:
+            continue
+        if encoding in {"gzip", "x-gzip"}:
+            body = gzip.decompress(body)
+            continue
+        if encoding == "deflate":
+            body = zlib.decompress(body)
+            continue
+        raise ValueError(f"unsupported content encoding: {encoding}")
+    return body
+
+
 def _prewarm_loop() -> None:
     while True:
         for repo in REPOSITORIES:
@@ -220,6 +241,13 @@ class RepoCacheHandler(BaseHTTPRequestHandler):
 
         content_length = int(self.headers.get("Content-Length") or "0")
         request_body = self.rfile.read(content_length) if content_length else b""
+        try:
+            request_body = _decode_request_body(
+                request_body, self.headers.get("Content-Encoding")
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.send_error(415, f"unsupported request content encoding: {exc}")
+            return
         env = os.environ.copy()
         env.update(
             {
@@ -230,7 +258,7 @@ class RepoCacheHandler(BaseHTTPRequestHandler):
                 "REQUEST_METHOD": self.command,
                 "REMOTE_ADDR": self.client_address[0],
                 "CONTENT_TYPE": self.headers.get("Content-Type", ""),
-                "CONTENT_LENGTH": str(content_length),
+                "CONTENT_LENGTH": str(len(request_body)),
             }
         )
         proc = subprocess.run(

--- a/services/sandbox/repo-cache-server.py
+++ b/services/sandbox/repo-cache-server.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import fcntl
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+CACHE_ROOT = Path(os.getenv("REPO_CACHE_ROOT", "/cache/mirrors"))
+LOCK_ROOT = Path(os.getenv("REPO_CACHE_LOCK_ROOT", "/cache/locks"))
+UPSTREAM_BASE_URL = os.getenv(
+    "REPO_CACHE_UPSTREAM_BASE_URL", "https://github.com"
+).rstrip("/")
+FETCH_INTERVAL_SECONDS = int(
+    os.getenv("REPO_CACHE_FETCH_INTERVAL_SECONDS")
+    or os.getenv("SYNC_INTERVAL_SECONDS")
+    or "300"
+)
+GITHUB_TOKEN_FILE = os.getenv("GITHUB_TOKEN_FILE", "/github-token/token")
+REPOSITORIES = [repo for repo in os.getenv("REPOSITORIES", "").split() if repo]
+PORT = int(os.getenv("REPO_CACHE_PORT", "8080"))
+
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def _git() -> str:
+    return os.getenv("REPO_CACHE_GIT", "/usr/bin/git")
+
+
+def _git_http_backend() -> str:
+    configured = os.getenv("GIT_HTTP_BACKEND")
+    if configured:
+        return configured
+    exec_path = subprocess.check_output([_git(), "--exec-path"], text=True).strip()
+    return str(Path(exec_path) / "git-http-backend")
+
+
+def _run(args: list[str], *, cwd: Path | None = None, timeout: int = 300) -> None:
+    env = os.environ.copy()
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    subprocess.run(args, cwd=cwd, env=env, check=True, timeout=timeout)
+
+
+def _configure_askpass() -> None:
+    token_path = Path(GITHUB_TOKEN_FILE)
+    if not token_path.exists() or token_path.stat().st_size == 0:
+        return
+    askpass = Path(tempfile.gettempdir()) / "repo-cache-git-askpass"
+    askpass.write_text(
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        "  *Username*) printf '%s\\n' x-access-token ;;\n"
+        f"  *Password*) cat {GITHUB_TOKEN_FILE!r} ;;\n"
+        "  *) printf '\\n' ;;\n"
+        "esac\n"
+    )
+    askpass.chmod(0o700)
+    os.environ["GIT_ASKPASS"] = str(askpass)
+    os.environ.setdefault("GIT_TERMINAL_PROMPT", "0")
+
+
+def _repo_dir(repo: str) -> Path:
+    return CACHE_ROOT / "github.com" / f"{repo}.git"
+
+
+def _lock_path(repo: str) -> Path:
+    return LOCK_ROOT / "github.com" / f"{repo}.lock"
+
+
+def _validate_repo(repo: str) -> None:
+    if not _REPO_RE.fullmatch(repo):
+        raise ValueError(f"invalid GitHub repo path: {repo}")
+    owner, name = repo.split("/", 1)
+    if owner in {".", ".."} or name in {".", ".."}:
+        raise ValueError(f"invalid GitHub repo path: {repo}")
+
+
+def _upstream_url(repo: str) -> str:
+    return f"{UPSTREAM_BASE_URL}/{repo}.git"
+
+
+def _last_fetch_path(target: Path) -> Path:
+    return target / "centaur-last-fetch"
+
+
+def _is_fresh(target: Path) -> bool:
+    marker = _last_fetch_path(target)
+    if not marker.exists():
+        return False
+    return time.time() - marker.stat().st_mtime < FETCH_INTERVAL_SECONDS
+
+
+def _mark_fetched(target: Path) -> None:
+    marker = _last_fetch_path(target)
+    marker.write_text(str(int(time.time())) + "\n")
+
+
+def ensure_mirror(repo: str, *, force_fetch: bool = False) -> Path:
+    _validate_repo(repo)
+    target = _repo_dir(repo)
+    lock_path = _lock_path(repo)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        if target.exists() and (target / "HEAD").exists():
+            if force_fetch or not _is_fresh(target):
+                _run(
+                    [
+                        _git(),
+                        "-C",
+                        str(target),
+                        "remote",
+                        "set-url",
+                        "origin",
+                        _upstream_url(repo),
+                    ]
+                )
+                _run([_git(), "-C", str(target), "remote", "update", "--prune"])
+                _mark_fetched(target)
+            return target
+
+        if target.exists():
+            shutil.rmtree(target)
+        tmp = target.with_name(f"{target.name}.tmp.{os.getpid()}.{int(time.time())}")
+        if tmp.exists():
+            shutil.rmtree(tmp)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            _run(
+                [_git(), "clone", "--mirror", _upstream_url(repo), str(tmp)],
+                timeout=600,
+            )
+            _mark_fetched(tmp)
+            tmp.replace(target)
+        except Exception:
+            shutil.rmtree(tmp, ignore_errors=True)
+            raise
+        return target
+
+
+def _parse_repo_from_path(path: str) -> tuple[str, str] | None:
+    prefix = "/repos/github.com/"
+    if not path.startswith(prefix):
+        return None
+    rest = path[len(prefix) :]
+    marker = ".git"
+    idx = rest.find(marker)
+    if idx < 0:
+        return None
+    repo = rest[:idx]
+    suffix = rest[idx + len(marker) :]
+    if suffix and not suffix.startswith("/"):
+        return None
+    try:
+        _validate_repo(repo)
+    except ValueError:
+        return None
+    path_info = f"/github.com/{repo}.git{suffix}"
+    return repo, path_info
+
+
+def _is_receive_pack(path: str, query: str) -> bool:
+    query_params = parse_qs(query)
+    services = query_params.get("service", [])
+    return "git-receive-pack" in services or path.endswith("/git-receive-pack")
+
+
+def _prewarm_loop() -> None:
+    while True:
+        for repo in REPOSITORIES:
+            try:
+                ensure_mirror(repo)
+            except Exception as exc:  # noqa: BLE001
+                print(f"repo-cache prewarm failed for {repo}: {exc}", flush=True)
+        time.sleep(FETCH_INTERVAL_SECONDS)
+
+
+class RepoCacheHandler(BaseHTTPRequestHandler):
+    server_version = "centaur-repo-cache/1.0"
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._handle_request()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._handle_request()
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        print(f"{self.address_string()} - {fmt % args}", flush=True)
+
+    def _handle_request(self) -> None:
+        split = urlsplit(self.path)
+        if split.path == "/healthz":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok\n")
+            return
+        parsed = _parse_repo_from_path(split.path)
+        if parsed is None:
+            self.send_error(404, "unknown repository path")
+            return
+        if _is_receive_pack(split.path, split.query):
+            self.send_error(403, "repo-cache is fetch-only")
+            return
+
+        repo, path_info = parsed
+        try:
+            ensure_mirror(repo)
+        except Exception as exc:  # noqa: BLE001
+            self.send_error(502, f"failed to mirror repository: {exc}")
+            return
+
+        content_length = int(self.headers.get("Content-Length") or "0")
+        request_body = self.rfile.read(content_length) if content_length else b""
+        env = os.environ.copy()
+        env.update(
+            {
+                "GIT_PROJECT_ROOT": str(CACHE_ROOT),
+                "GIT_HTTP_EXPORT_ALL": "1",
+                "PATH_INFO": path_info,
+                "QUERY_STRING": split.query,
+                "REQUEST_METHOD": self.command,
+                "REMOTE_ADDR": self.client_address[0],
+                "CONTENT_TYPE": self.headers.get("Content-Type", ""),
+                "CONTENT_LENGTH": str(content_length),
+            }
+        )
+        proc = subprocess.run(
+            [_git_http_backend()],
+            input=request_body,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            check=False,
+        )
+        if proc.stderr:
+            print(proc.stderr.decode("utf-8", "replace"), flush=True)
+        self._write_cgi_response(proc.stdout)
+
+    def _write_cgi_response(self, payload: bytes) -> None:
+        header_blob, sep, body = payload.partition(b"\r\n\r\n")
+        if not sep:
+            header_blob, sep, body = payload.partition(b"\n\n")
+        if not sep:
+            self.send_error(502, "invalid git-http-backend response")
+            return
+
+        status = 200
+        headers: list[tuple[str, str]] = []
+        for raw_line in header_blob.replace(b"\r\n", b"\n").split(b"\n"):
+            if not raw_line:
+                continue
+            line = raw_line.decode("iso-8859-1")
+            name, _, value = line.partition(":")
+            if not _:
+                continue
+            name = name.strip()
+            value = value.strip()
+            if name.lower() == "status":
+                try:
+                    status = int(value.split()[0])
+                except Exception:
+                    status = 200
+            else:
+                headers.append((name, value))
+        self.send_response(status)
+        for name, value in headers:
+            self.send_header(name, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main() -> None:
+    _configure_askpass()
+    if REPOSITORIES:
+        thread = threading.Thread(target=_prewarm_loop, daemon=True)
+        thread.start()
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), RepoCacheHandler)
+    print(f"repo-cache listening on :{PORT}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace sandbox-mounted repo-cache PVCs with a PVC-backed Git HTTP mirror service
- configure sandboxes to rewrite fetch-like GitHub commands through repo-cache while leaving pushes pointed at GitHub
- route persistent repo-cache GitHub egress through the API iron-proxy and allow sandbox -> repo-cache traffic via NetworkPolicy

## Verification
- uv run ruff check api/sandbox/kubernetes.py tests/test_sandbox_kubernetes_backend.py tests/test_repo_cache_server.py ../sandbox/repo-cache-server.py
- uv run pytest tests/test_sandbox_kubernetes_backend.py tests/test_repo_cache_server.py
- python3 -m json.tool contrib/chart/values.schema.json
- git diff --check

Note: I could not run helm template locally because helm is not installed on this machine.