### PR TITLE
allow setting of default persona

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.46
+version: 0.1.47
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -189,6 +189,10 @@ spec:
               value: info
             - name: CENTAUR_DEFAULT_HARNESS
               value: {{ .Values.api.defaultHarness | quote }}
+{{- if .Values.api.defaultPersona }}
+            - name: CENTAUR_DEFAULT_PERSONA
+              value: {{ .Values.api.defaultPersona | quote }}
+{{- end }}
             - name: TOOL_DIRS
 {{- if .Values.overlay.image.repository }}
               value: {{ printf "/app/tools:%s/tools" .Values.overlay.mountPath | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -86,6 +86,12 @@ api:
     pullPolicy: Always
   executionWorkerEnabled: false
   defaultHarness: codex
+  # Default persona (system-prompt overlay) for spawns that select none — e.g. a
+  # Slackbot thread's first turn. Must be a persona name available to the
+  # deployment (base or overlay). Empty (the default) means no overlay: bare
+  # spawns run under the base system prompt. Explicit --persona flags and sticky
+  # per-thread assignments are unaffected.
+  defaultPersona: ""
   # The API's worker claims workflow_runs and spawns a per-run sandbox to
   # execute each handler. Disable only if you're running your own claimer.
   workflowWorkerEnabled: true

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -51,6 +51,7 @@ Optional required-by-mode variables:
 | Env var | Set from | Controls |
 | --- | --- | --- |
 | `CENTAUR_DEFAULT_HARNESS` | `api.defaultHarness`. | Default harness for new executions. |
+| `CENTAUR_DEFAULT_PERSONA` | `api.defaultPersona`. | Default persona (system-prompt overlay) for spawns that select none, e.g. a Slackbot thread's first turn. Unset means no overlay (base prompt). Explicit `--persona` flags and sticky per-thread assignments are unaffected. |
 | `CENTAUR_ENVIRONMENT` | `api.extraEnv` or deployment env. | Environment label in traces and telemetry. |
 | `CENTAUR_LOG_LEVEL`, `LOG_LEVEL` | Helm sets `CENTAUR_LOG_LEVEL=info`; override in `api.extraEnv`. | API log level. |
 | `CENTAUR_SERVICE_NAME` | `api.extraEnv`. | Default API log `service` field. |

--- a/services/api/api/harness_config.py
+++ b/services/api/api/harness_config.py
@@ -16,3 +16,15 @@ _DEFAULT_HARNESS_ALIASES: dict[str, str] = {
 def default_harness() -> str:
     raw = (os.getenv("CENTAUR_DEFAULT_HARNESS") or "codex").strip().lower()
     return _DEFAULT_HARNESS_ALIASES.get(raw, "codex")
+
+
+def default_persona() -> str | None:
+    """Deployment-wide default persona for spawns that select none.
+
+    The persona analogue of ``CENTAUR_DEFAULT_HARNESS``. The value is a persona
+    name (a persona directory/``pyproject.toml`` ``type = "persona"`` entry,
+    matched case-sensitively, as personas are keyed by directory name). When
+    unset (the default) there is no default overlay and bare spawns run under
+    the base system prompt — preserving today's behavior.
+    """
+    return (os.getenv("CENTAUR_DEFAULT_PERSONA") or "").strip() or None

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -25,7 +25,7 @@ from api.agent import (
     stop_session,
 )
 from api import slackbot_client
-from api.harness_config import default_harness
+from api.harness_config import default_harness, default_persona
 from api.otel import (
     add_span_event,
     context_from_serialized,
@@ -562,6 +562,27 @@ async def spawn_assignment(
         effective_persona_id = active_assignment.get("persona_id")
         effective_agents_md_override = active_assignment.get("agents_md_override")
     else:
+        # When the caller specified nothing (no harness/engine/persona/override)
+        # and the thread has no active assignment, fall back to the deployment
+        # default persona — the persona analogue of CENTAUR_DEFAULT_HARNESS. This
+        # is the only spawn shape it touches: a fresh, unspecified thread (e.g. a
+        # Slackbot thread's first turn). An explicit selection or a sticky
+        # per-thread assignment both bypass this branch and are left untouched.
+        if attach_active_assignment:
+            default_persona_id = default_persona()
+            if default_persona_id:
+                from api.app import get_tool_manager
+
+                persona_info = get_tool_manager().get_persona(default_persona_id)
+                if persona_info is not None:
+                    persona_id = default_persona_id
+                else:
+                    # A misconfigured default must not break every bare thread;
+                    # log and fall through to base.
+                    log.warning(
+                        "default_persona_unknown", persona_id=default_persona_id
+                    )
+
         # Explicit harness wins; otherwise inherit from the persona's declared
         # engine; otherwise use the deployment default.
         if harness:

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -188,6 +188,130 @@ async def test_spawn_assignment_treats_harness_persona_selector_as_persona(db_po
 
 
 @pytest.mark.asyncio
+async def test_spawn_assignment_applies_default_persona_on_fresh_thread(
+    db_pool, monkeypatch
+):
+    from api.runtime_control import spawn_assignment
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_PERSONA", "eng")
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:default-persona"
+    session = SandboxSession(
+        sandbox_id=f"rt-{uuid.uuid4().hex[:8]}",
+        thread_key=thread_key,
+        harness="codex",
+        engine="codex",
+    )
+    get_or_spawn = AsyncMock(return_value=session)
+    tool_manager = SimpleNamespace(
+        get_persona=lambda name: (
+            SimpleNamespace(name="eng", engine="codex", default_repo=None)
+            if name == "eng"
+            else None
+        )
+    )
+
+    with (
+        patch("api.runtime_control.get_or_spawn", new=get_or_spawn),
+        patch("api.app.get_tool_manager", return_value=tool_manager),
+    ):
+        result = await spawn_assignment(
+            db_pool,
+            thread_key=thread_key,
+            spawn_id="spawn-default-persona",
+            harness=None,
+            engine=None,
+            persona_id=None,
+            agents_md_override=None,
+        )
+
+    # Bare thread inherits the configured default persona and its engine.
+    get_or_spawn.assert_awaited_once_with(
+        thread_key, "codex", engine=None, persona="eng"
+    )
+    assert result["persona_id"] == "eng"
+    assignment = await db_pool.fetchrow(
+        "SELECT harness, persona_id FROM agent_runtime_assignments WHERE thread_key = $1",
+        thread_key,
+    )
+    assert assignment is not None
+    assert assignment["harness"] == "codex"
+    assert assignment["persona_id"] == "eng"
+
+
+@pytest.mark.asyncio
+async def test_spawn_assignment_default_persona_ignored_for_explicit_harness(
+    db_pool, monkeypatch
+):
+    from api.runtime_control import spawn_assignment
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_PERSONA", "eng")
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:explicit-harness"
+    session = SandboxSession(
+        sandbox_id=f"rt-{uuid.uuid4().hex[:8]}",
+        thread_key=thread_key,
+        harness="codex",
+        engine="codex",
+    )
+    get_or_spawn = AsyncMock(return_value=session)
+    tool_manager = SimpleNamespace(get_persona=lambda name: None)
+
+    with (
+        patch("api.runtime_control.get_or_spawn", new=get_or_spawn),
+        patch("api.app.get_tool_manager", return_value=tool_manager),
+    ):
+        result = await spawn_assignment(
+            db_pool,
+            thread_key=thread_key,
+            spawn_id="spawn-explicit-harness",
+            harness="codex",
+            engine=None,
+            persona_id=None,
+            agents_md_override=None,
+        )
+
+    # An explicit selector bypasses the default-persona fallback entirely.
+    assert result["persona_id"] is None
+    get_or_spawn.assert_awaited_once_with(thread_key, "codex", engine=None)
+
+
+@pytest.mark.asyncio
+async def test_spawn_assignment_unknown_default_persona_falls_back_to_base(
+    db_pool, monkeypatch
+):
+    from api.runtime_control import spawn_assignment
+
+    monkeypatch.delenv("CENTAUR_DEFAULT_HARNESS", raising=False)
+    monkeypatch.setenv("CENTAUR_DEFAULT_PERSONA", "ghost")
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}:unknown-default-persona"
+    session = SandboxSession(
+        sandbox_id=f"rt-{uuid.uuid4().hex[:8]}",
+        thread_key=thread_key,
+        harness="codex",
+        engine="codex",
+    )
+    get_or_spawn = AsyncMock(return_value=session)
+    tool_manager = SimpleNamespace(get_persona=lambda name: None)
+
+    with (
+        patch("api.runtime_control.get_or_spawn", new=get_or_spawn),
+        patch("api.app.get_tool_manager", return_value=tool_manager),
+    ):
+        result = await spawn_assignment(
+            db_pool,
+            thread_key=thread_key,
+            spawn_id="spawn-unknown-default-persona",
+            harness=None,
+            engine=None,
+            persona_id=None,
+            agents_md_override=None,
+        )
+
+    # A misconfigured default must not break the thread — fall through to base.
+    assert result["persona_id"] is None
+    get_or_spawn.assert_awaited_once_with(thread_key, "codex", engine=None)
+
+
+@pytest.mark.asyncio
 async def test_db_insert_session_initial_state_tracks_inflight_turn(db_pool):
     from api.agent import _db_insert_session
 

--- a/services/api/tests/test_harness_config.py
+++ b/services/api/tests/test_harness_config.py
@@ -25,3 +25,27 @@ def test_default_harness_ignores_unknown_values(monkeypatch):
     monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "unknown")
 
     assert default_harness() == "codex"
+
+
+def test_default_persona_unset_is_none(monkeypatch):
+    from api.harness_config import default_persona
+
+    monkeypatch.delenv("CENTAUR_DEFAULT_PERSONA", raising=False)
+
+    assert default_persona() is None
+
+
+def test_default_persona_blank_is_none(monkeypatch):
+    from api.harness_config import default_persona
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_PERSONA", "   ")
+
+    assert default_persona() is None
+
+
+def test_default_persona_returns_name(monkeypatch):
+    from api.harness_config import default_persona
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_PERSONA", "  eng  ")
+
+    assert default_persona() == "eng"


### PR DESCRIPTION
One of our agent's primary capabilities/needs is to be able to answer product questions by referring to the actual code implementations, it allows our product-focused folks to easily determine what is and isn't implemented, what might be a bug vs. intentional, etc.

<img width="419" height="422" alt="Screenshot 2026-05-29 at 9 11 02 PM" src="https://github.com/user-attachments/assets/427fcacb-68ea-4b5d-a54d-20c939dcedfc" />

Our Centaur agent has struggled greatly with this, and I like the casual-ness of just being able to mention the bot and have it "work." Locally in my claude/codex I have a mock monorepo workspace with a special AGENTS.md that takes care of this problem for me, but I noticed there was no way to default that sort of unified system prompt + engine without having to add flags to messages. This PR allows that through the already established personas flow