### PR TITLE
Bypass proxy for observability services

### DIFF
--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -66,6 +66,8 @@ _PINNED_PROXY_ENV_KEYS = frozenset(
 
 _NO_PROXY_ENV_KEYS = frozenset({"NO_PROXY", "no_proxy"})
 
+OBSERVABILITY_NO_PROXY_HOSTS = ("victoriametrics", "victorialogs")
+
 
 def _set_env(env: list[str], name: str, value: str) -> None:
     prefix = f"{name}="
@@ -198,7 +200,12 @@ def container_env(
     if resume_thread_id:
         env.append(f"AMP_CONTINUE_THREAD_ID={resume_thread_id}")
 
-    no_proxy_hosts = ["localhost", "127.0.0.1", firewall_host]
+    no_proxy_hosts = [
+        "localhost",
+        "127.0.0.1",
+        firewall_host,
+        *OBSERVABILITY_NO_PROXY_HOSTS,
+    ]
     api_host = urlsplit(api_url).hostname
     if api_host:
         no_proxy_hosts.append(api_host)

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -37,6 +37,7 @@ from api.proxy_config import (
 )
 from api.sandbox.base import SandboxBackend, SandboxSession
 from api.sandbox.config import (
+    OBSERVABILITY_NO_PROXY_HOSTS,
     build_harness_cmd,
     container_env,
     image,
@@ -453,7 +454,12 @@ def _build_tool_server_container(
     secret_name = _secret_env_name()
     proxy_url = f"http://{firewall_host}:{_proxy_port()}"
     api_host = urlsplit(api_url).hostname or ""
-    no_proxy_hosts = ["localhost", "127.0.0.1", firewall_host]
+    no_proxy_hosts = [
+        "localhost",
+        "127.0.0.1",
+        firewall_host,
+        *OBSERVABILITY_NO_PROXY_HOSTS,
+    ]
     if api_host:
         no_proxy_hosts.append(api_host)
     no_proxy = ",".join(dict.fromkeys(no_proxy_hosts))

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -273,7 +273,15 @@ def test_container_env_includes_firewall_host_for_secret_bootstrap(
     assert env_map["AMP_API_KEY"] == "AMP_API_KEY"
     assert env_map["OPENAI_API_KEY"] == "OPENAI_API_KEY"
     assert env_map["CENTAUR_TRACE_ID"] == "00000000-0000-0000-0000-000000000123"
-    assert env_map["NO_PROXY"] == "localhost,127.0.0.1,firewall.internal,api.internal"
+    no_proxy_hosts = env_map["NO_PROXY"].split(",")
+    assert no_proxy_hosts[:6] == [
+        "localhost",
+        "127.0.0.1",
+        "firewall.internal",
+        "victoriametrics",
+        "victorialogs",
+        "api.internal",
+    ]
     assert env_map["no_proxy"] == env_map["NO_PROXY"]
 
 
@@ -325,6 +333,8 @@ def test_container_env_applies_kubernetes_sandbox_extra_env(
     # replaces, so it can't break sandbox egress.
     no_proxy_hosts = env_map["NO_PROXY"].split(",")
     assert "firewall.internal" in no_proxy_hosts
+    assert "victoriametrics" in no_proxy_hosts
+    assert "victorialogs" in no_proxy_hosts
     assert "api.internal" in no_proxy_hosts
     assert "metrics.internal" in no_proxy_hosts
     assert env_map["no_proxy"] == env_map["NO_PROXY"]
@@ -355,6 +365,8 @@ def test_container_env_extra_env_cannot_drop_critical_no_proxy_hosts(
     no_proxy_hosts = env_map["NO_PROXY"].split(",")
     assert "centaur-centaur-api" in no_proxy_hosts  # real API host survives
     assert "firewall.internal" in no_proxy_hosts
+    assert "victoriametrics" in no_proxy_hosts
+    assert "victorialogs" in no_proxy_hosts
     assert "centaur-api" in no_proxy_hosts  # operator's extra is still honored
 
 
@@ -591,6 +603,9 @@ def test_tool_server_container_has_verifiable_api_key(
     assert claims is not None
     assert claims["thread_key"] == "slack:C123:123.456"
     assert claims["container_id"] == "centaur-sandbox-pod-abc"
+    no_proxy_hosts = env["NO_PROXY"].split(",")
+    assert "victoriametrics" in no_proxy_hosts
+    assert "victorialogs" in no_proxy_hosts
 
 
 @pytest.mark.asyncio
@@ -788,10 +803,15 @@ async def test_create_builds_per_sandbox_proxy_resources(
     )
     assert sandbox_env["FIREWALL_HOST"] == proxy_service_name
     assert sandbox_env["HTTPS_PROXY"] == f"http://{proxy_service_name}:8080"
-    assert (
-        sandbox_env["NO_PROXY"]
-        == f"localhost,127.0.0.1,{proxy_service_name},api.internal"
-    )
+    no_proxy_hosts = sandbox_env["NO_PROXY"].split(",")
+    assert no_proxy_hosts[:6] == [
+        "localhost",
+        "127.0.0.1",
+        proxy_service_name,
+        "victoriametrics",
+        "victorialogs",
+        "api.internal",
+    ]
     assert proxy_pod["metadata"]["labels"] == {
         "centaur.ai/iron-proxy": "true",
         "centaur.ai/sandbox-id": session.sandbox_id,

--- a/services/sandbox/call.sh
+++ b/services/sandbox/call.sh
@@ -23,7 +23,7 @@ _append_no_proxy() {
 
 _api_host="$(_host_from_url "$U")"
 _tools_host="$(_host_from_url "$TU")"
-_append_no_proxy "localhost,127.0.0.1,api,centaur-api,centaur-centaur-api,centaur-api-proxy,.centaur.svc.cluster.local,${_api_host},${_tools_host}"
+_append_no_proxy "localhost,127.0.0.1,api,centaur-api,centaur-centaur-api,centaur-api-proxy,victoriametrics,victorialogs,.centaur.svc.cluster.local,${_api_host},${_tools_host}"
 # Prefer refreshed token (written on warm-pool claim) over original env var
 _KEY="${CENTAUR_API_KEY:-}"
 if [ -f /home/agent/.api_key ]; then


### PR DESCRIPTION
## Summary
- add VictoriaMetrics and VictoriaLogs service names to sandbox NO_PROXY
- propagate the same bypass list to the Kubernetes tool-server sidecar
- keep the sandbox call helper aligned with runtime env generation

## Validation
- uv run --project services/api pytest services/api/tests/test_sandbox_kubernetes_backend.py