### PR TITLE
fix: pass sandbox env to tool server sidecar

### DIFF
--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -483,6 +483,7 @@ def _build_tool_server_container(
         {"name": "TOOL_DIRS", "value": _tool_server_tool_dirs()},
         {"name": "PLUGIN_WATCHER_ENABLED", "value": "0"},
     ]
+    _apply_tool_server_extra_env(env, no_proxy)
 
     volume_mounts: list[dict[str, Any]] = [
         {
@@ -542,6 +543,48 @@ def _build_tool_server_container(
         },
         "volumeMounts": volume_mounts,
     }
+
+
+def _apply_tool_server_extra_env(env: list[dict[str, Any]], computed_no_proxy: str) -> None:
+    """Let the sidecar see operator sandbox env without breaking its wiring."""
+    pinned = {
+        "DATABASE_URL",
+        "SANDBOX_SIGNING_KEY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "NODE_EXTRA_CA_CERTS",
+        "CENTAUR_API_URL",
+        "CENTAUR_API_KEY",
+        "TOOL_DIRS",
+        "PLUGIN_WATCHER_ENABLED",
+    }
+    no_proxy_keys = {"NO_PROXY", "no_proxy"}
+    for name, value in sandbox_extra_env_map().items():
+        if name in pinned:
+            log.warning("tool_server_extra_env_ignored_pinned_var", key=name)
+            continue
+        if name in no_proxy_keys:
+            value = _merge_csv_env(computed_no_proxy, value)
+        _upsert_env_value(env, name, value)
+
+
+def _upsert_env_value(env: list[dict[str, Any]], name: str, value: str) -> None:
+    for item in env:
+        if item.get("name") == name:
+            item["value"] = value
+            item.pop("valueFrom", None)
+            return
+    env.append({"name": name, "value": value})
+
+
+def _merge_csv_env(base: str, extra: str) -> str:
+    values = [item.strip() for item in base.split(",") if item.strip()]
+    values.extend(item.strip() for item in extra.split(",") if item.strip())
+    return ",".join(dict.fromkeys(values))
 
 
 def _resource_name(prefix: str, raw: str, *, max_length: int = 63) -> str:

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -593,6 +593,50 @@ def test_tool_server_container_has_verifiable_api_key(
     assert claims["container_id"] == "centaur-sandbox-pod-abc"
 
 
+def test_tool_server_container_inherits_sandbox_extra_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_SIGNING_KEY", "test-signing-key")
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_IMAGE", "centaur-tools:test")
+    monkeypatch.setenv(
+        "KUBERNETES_SANDBOX_EXTRA_ENV",
+        json.dumps(
+            [
+                {
+                    "name": "LAMINAR_BASE_URL",
+                    "value": "http://stg-laminar-app-server.stg-laminar.svc.cluster.local:8000",
+                },
+                {"name": "LAMINAR_PROJECT_ID", "value": "project-staging"},
+                {
+                    "name": "NO_PROXY",
+                    "value": "stg-laminar-app-server,.stg-laminar.svc.cluster.local",
+                },
+                {"name": "HTTPS_PROXY", "value": "http://operator-proxy:8080"},
+            ]
+        ),
+    )
+
+    container = _build_tool_server_container(
+        thread_key="slack:C123:123.456",
+        container_name="centaur-sandbox-pod-abc",
+        firewall_host="firewall.internal",
+        api_url="http://api.internal:8000",
+        overlay_mount=None,
+        database_url="postgres://app_user@firewall.internal:5433/centaur",
+    )
+
+    env = {item["name"]: item.get("value") for item in container["env"]}
+    assert (
+        env["LAMINAR_BASE_URL"]
+        == "http://stg-laminar-app-server.stg-laminar.svc.cluster.local:8000"
+    )
+    assert env["LAMINAR_PROJECT_ID"] == "project-staging"
+    assert env["HTTPS_PROXY"] == "http://firewall.internal:8080"
+    assert "firewall.internal" in env["NO_PROXY"]
+    assert "api.internal" in env["NO_PROXY"]
+    assert "stg-laminar-app-server" in env["NO_PROXY"]
+
+
 @pytest.mark.asyncio
 async def test_create_builds_pod_and_prompt_secret(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- pass sandbox.extraEnv through to the per-sandbox tool-server sidecar
- keep sidecar proxy/database/API env pinned and merge NO_PROXY values
- add regression coverage for staging Laminar env reaching the sidecar

## Tests
- uv run --project services/api pytest services/api/tests/test_sandbox_kubernetes_backend.py -k 'tool_server_container'\n- uv run ruff check services/api/api/sandbox/kubernetes.py services/api/tests/test_sandbox_kubernetes_backend.py