### PR TITLE
fix(slackbot): stop splicing/duplicating claude-code answers (#268)

### DIFF
--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1840,6 +1840,65 @@ describe('CodexSessionRenderer', () => {
       task_count: 1
     })
   })
+
+  it('does not splice-corrupt or duplicate when a canonical snapshot diverges from streamed text (#268)', async () => {
+    // #268: live answer streaming uses a raw length-offset slice
+    // (state.answerText.slice(state.streamedAnswerText.length)). That assumes
+    // answerText only ever GROWS BY APPEND. But recomposeBuffers() rebuilds
+    // answerText from scratch each event, and the assistant-event merge can
+    // REPLACE the harness buffer (canonical branch). When the recomposed answer
+    // no longer extends what we already streamed, slicing by length splices at
+    // the wrong byte boundary -> the observed character corruption
+    // ("loops" -> "loours"), and the stale streamed prefix then defeats the
+    // renderer's startsWith()-based final-block dedup, duplicating the body.
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    // A running command creates a plan, which enables live answer streaming
+    // immediately (no 500ms pre-stream grace) — matching a turn that ran tools.
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'echo hi' }
+    })
+
+    // Opus-4-8 emits an interim (non-canonical) answer snapshot, streamed live.
+    await renderer.event(sessionId, {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'I run durable loops. ' }] }
+    })
+    // The canonical snapshot (carries message.model/usage) does NOT extend the
+    // interim text — the harness re-tokenized/normalized it. This is the event
+    // that triggers the buggy offset slice.
+    const canonical = 'I run resilient loops that survive restarts and catch CI failures.'
+    await renderer.event(sessionId, {
+      type: 'assistant',
+      uuid: 'u1',
+      request_id: 'r1',
+      session_id: 's1',
+      message: {
+        id: 'm1',
+        model: 'claude-opus-4-8',
+        usage: { input_tokens: 1, output_tokens: 1 },
+        content: [{ type: 'text', text: canonical }]
+      }
+    })
+    await renderer.event(sessionId, { type: 'result', result: canonical })
+
+    const visible = visibleMarkdown(calls)
+    // The canonical answer must appear verbatim, exactly once, with no
+    // mid-word splice from the superseded interim snapshot.
+    expect(visible).toContain(canonical)
+    expect(countOccurrences(visible, 'I run')).toBe(1)
+    expect(visible).not.toContain('durable loops.  that')
+  })
 })
 
 function planTasksFromCalls(calls: Array<{ method: string; params: any }>): any[] {

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -304,8 +304,27 @@ export class CodexSessionRenderer {
     if (!canStream) return
 
     if (state.commentaryText.length > state.streamedCommentaryText.length) return
-    if (state.answerText.length <= state.streamedAnswerText.length) return
-    const delta = state.answerText.slice(state.streamedAnswerText.length)
+    // #268: the live answer delta was sliced off state.answerText by raw length
+    // (answerText.slice(streamedAnswerText.length)), which assumes answerText
+    // only ever grows by append. recomposeBuffers() rebuilds answerText every
+    // event, and the harness answer buffer (claude-code `assistant` snapshots)
+    // can be REPLACED wholesale by a later canonical snapshot. Slicing a
+    // replaced buffer by the previously-streamed length splices at the wrong
+    // byte boundary ("loops" -> "loours"); the stale streamed prefix then no
+    // longer matches the canonical answer, so the renderer's startsWith()
+    // final-block dedup falls back to its own offset slice and duplicates the
+    // body too.
+    //
+    // Mid-turn we therefore stream only the codex per-item answer: each
+    // per-item buffer gets a clean canonical replacement on item.completed, so
+    // the composed item text only ever grows by append. The replaceable harness
+    // answer is held back until done() (opts.force), when it is final and
+    // nothing can contradict it. A startsWith guard keeps the slice honest in
+    // both cases — if the text we're about to stream does not extend what we
+    // already streamed, we skip rather than splice at a bad offset.
+    const streamableAnswer = opts.force ? state.answerText : compose(state.answerByItemId, '')
+    if (!streamableAnswer.startsWith(state.streamedAnswerText)) return
+    const delta = streamableAnswer.slice(state.streamedAnswerText.length)
     if (!delta) return
     const acceptedChars = await this.renderer.textDelta(agentSessionId, delta, {
       force: opts.force ?? false,


### PR DESCRIPTION
Fixes #268.

### Root cause
`CodexSessionRenderer.publishPendingAssistantText` computes the live answer delta by raw length offset:

```ts
const delta = state.answerText.slice(state.streamedAnswerText.length)
```

That assumes `answerText` only ever grows by append. It doesn't: `recomposeBuffers()` rebuilds `answerText` from scratch on every event, and the harness answer buffer (claude-code `assistant` snapshots) can be **replaced wholesale** by a later canonical snapshot (the `assistantEventLooksCanonical` branch in `applyAgentMessageUpdate`). Once the buffer is replaced, slicing it by the *previously streamed* length splices at the wrong byte boundary:

- **Character corruption** — the reported `loops` → `loours`, `you are` → `youare`, `L2` → `L2k`.
- **Duplication** — the stale streamed prefix no longer matches the canonical answer, so the renderer's `startsWith()`-based final-block dedup (`unstreamedMarkdownAfterLivePrefix`) misses and falls back to its own `markdown.slice(streamedTextSourceChars)`, re-emitting the body.

So both symptoms in #268 trace to the same unguarded offset slice.

### Fix
Mid-turn, stream **only the codex per-item answer**. Each per-item buffer gets a clean canonical replacement on `item.completed`, so the composed item text only ever grows by append and is safe to offset-slice. The replaceable **harness** answer is held back until `done()` (`opts.force`), when it's final and nothing can contradict it. A `startsWith` guard keeps the slice honest in both paths — if the text we're about to stream doesn't extend what we already streamed, we skip rather than splice at a bad offset.

```ts
const streamableAnswer = opts.force ? state.answerText : compose(state.answerByItemId, '')
if (!streamableAnswer.startsWith(state.streamedAnswerText)) return
const delta = streamableAnswer.slice(state.streamedAnswerText.length)
```

### Trade-off (your call)
With this change, the claude-code answer **text** renders when the turn completes rather than streaming token-by-token mid-turn. Tool calls, plan updates, and thinking still stream live; only the final answer body waits for `done()`. I picked correctness over live-typing as the safe default — but if you'd rather preserve live answer streaming, the alternative is a heavier renderer-side change (detect "streamed prefix no longer matches canonical" and *replace* the message instead of appending). Happy to take that direction instead.

### Tests
- New regression test deterministically reproduces the splice (interim snapshot streamed live, then a diverging canonical snapshot): fails on `main`, passes here.
- Full slackbot suite green: `96 pass, 0 fail`. `check:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)