### PR TITLE
fix(slack): list_bot_channels via users.conversations to avoid whole-workspace scan

### DIFF
--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -513,6 +513,13 @@ class SlackClient:
         as the fallback when native search lacks ``search:read``, and
         ``gather_context``'s Slack grab walks the bot's member channels).
 
+        Uses ``users.conversations``, which returns only the conversations the
+        bot is a member of. ``conversations.list`` would instead page through
+        every channel in the workspace and filter ``is_member`` client-side —
+        an O(workspace) scan that, on large workspaces, never finishes inside
+        the tool-call budget (so the cache below never warms and every call
+        re-scans the whole workspace from scratch).
+
         Args:
             limit: Maximum channels to return
             force_refresh: Ignore cache and fetch fresh data
@@ -533,7 +540,7 @@ class SlackClient:
         while True:
             try:
                 response = self._retry_on_ratelimit(
-                    self._client.conversations_list,
+                    self._client.users_conversations,
                     types="public_channel,private_channel",
                     limit=min(limit - len(channels), 200),
                     cursor=cursor,
@@ -542,22 +549,24 @@ class SlackClient:
             except SlackApiError as e:
                 self._raise_slack_api_error(
                     e,
-                    slack_method="conversations.list",
+                    slack_method="users.conversations",
                     access_path="bot_token",
                 )
 
+            # users.conversations only returns conversations the bot belongs
+            # to, so membership is implied — no client-side is_member filter
+            # (and no whole-workspace pagination) needed.
             for channel in response.get("channels", []):
-                if channel.get("is_member", False):
-                    channels.append(
-                        {
-                            "id": channel.get("id", ""),
-                            "name": channel.get("name", ""),
-                            "purpose": channel.get("purpose", {}).get("value", ""),
-                            "topic": channel.get("topic", {}).get("value", ""),
-                            "member_count": channel.get("num_members", 0),
-                            "is_private": channel.get("is_private", False),
-                        }
-                    )
+                channels.append(
+                    {
+                        "id": channel.get("id", ""),
+                        "name": channel.get("name", ""),
+                        "purpose": channel.get("purpose", {}).get("value", ""),
+                        "topic": channel.get("topic", {}).get("value", ""),
+                        "member_count": channel.get("num_members", 0),
+                        "is_private": channel.get("is_private", False),
+                    }
+                )
 
             cursor = response.get("response_metadata", {}).get("next_cursor")
             if not cursor or len(channels) >= limit:

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -29,6 +29,8 @@ class _FakeWebClient:
         self.users_pages: list[dict] = []
         self.list_calls: list[dict] = []
         self.list_pages: list[dict] = []
+        self.user_conversations_calls: list[dict] = []
+        self.user_conversations_pages: list[dict] = []
         self.api_calls: list[tuple[str, dict]] = []
         self.user_info_response: dict | None = None
         self.user_profile_response: dict | None = None
@@ -62,6 +64,10 @@ class _FakeWebClient:
     def conversations_list(self, **kwargs):
         self.list_calls.append(kwargs)
         return self.list_pages.pop(0)
+
+    def users_conversations(self, **kwargs):
+        self.user_conversations_calls.append(kwargs)
+        return self.user_conversations_pages.pop(0)
 
     def files_upload_v2(self, **kwargs):
         self.last_kwargs = kwargs
@@ -460,6 +466,40 @@ def test_list_channels_returns_cache_when_slack_rate_limited() -> None:
     fake_web_client.conversations_list = rate_limited_list  # type: ignore[method-assign]
 
     assert client.list_channels(limit=10) == cached_channels
+
+
+def test_list_bot_channels_uses_users_conversations() -> None:
+    client, fake_web_client = _make_client()
+    saved: list[list[dict]] = []
+    client._save_channel_cache = lambda result: saved.append(result)  # type: ignore[method-assign]
+
+    fake_web_client.user_conversations_pages = [
+        {
+            "channels": [
+                {"id": "C1", "name": "zeta", "is_private": False, "num_members": 3},
+                {"id": "C2", "name": "alpha", "is_private": True, "num_members": 5},
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+    ]
+
+    # Call the real implementation (the fixture stubs list_bot_channels out).
+    result = SlackClient.list_bot_channels(client, force_refresh=True)
+
+    # Membership is scoped via users.conversations rather than a whole-workspace
+    # conversations.list scan + client-side is_member filter.
+    assert len(fake_web_client.user_conversations_calls) == 1
+    call = fake_web_client.user_conversations_calls[0]
+    assert call["types"] == "public_channel,private_channel"
+    assert call["exclude_archived"] is True
+    assert fake_web_client.list_calls == []
+
+    # Every conversation returned by the API is kept (membership is implied),
+    # sorted by name, with the expected fields preserved.
+    assert [c["id"] for c in result] == ["C2", "C1"]
+    assert [c["name"] for c in result] == ["alpha", "zeta"]
+    assert result[0]["is_private"] is True
+    assert result[1]["member_count"] == 3
 
 
 def test_get_thread_replies_page_uses_bounded_default() -> None:


### PR DESCRIPTION
Fixes #291.

## Problem

`SlackClient.list_bot_channels` lists the bot's channels by paginating `conversations.list` over the **entire workspace** and filtering `is_member` client-side. Because the loop only exits on cursor exhaustion (a bot is a member of far fewer channels than `limit`), it walks every public + private channel in the workspace on every cold call.

On a large workspace this is thousands of `conversations.list` calls (we measured 1,236 in a ~3h window, 170 of them `429`-throttled). It exceeds the agent tool-call budget, so read-path tools — `get_channel_history` name resolution, the `_search_messages_local` fallback, and `gather_context`'s Slack grab — hang and return nothing. And because `_save_channel_cache` is only reached after the full walk completes, the cache never warms, so the next call re-scans from scratch.

## Fix

Use [`users.conversations`](https://api.slack.com/methods/users.conversations), which returns only the conversations the bot is a member of — normally a single page regardless of workspace size. This removes the whole-workspace pagination and the client-side `is_member` filter entirely.

- `types="public_channel,private_channel"` carries over unchanged, so private channels are still included.
- The returned dict shape is unchanged; field extraction already uses `.get(..., default)`, so any field a given workspace doesn't hydrate degrades gracefully rather than breaking callers.
- `_list_etl_channels` (which intentionally lists *all* public channels visible to the ETL user token, not just member channels) is left on `conversations.list`.

## Test

Adds `test_list_bot_channels_uses_users_conversations`: asserts the call goes through `users.conversations` with the expected params, that `conversations.list` is not called, and that every returned conversation is kept (membership implied) with fields and sort preserved. Full `tools/productivity/slack/tests/test_client.py` suite passes (34 tests); `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
