### PR TITLE
fix(tool-server): retry DB pool creation on startup race with iron-proxy

### DIFF
--- a/services/api/api/db.py
+++ b/services/api/api/db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 import subprocess
@@ -96,7 +97,13 @@ def _dbmate_url(database_url: str) -> str:
     return f"{database_url}{sep}sslmode=disable"
 
 
-async def create_pool(database_url: str, *, apply_migrations: bool = True) -> asyncpg.Pool:
+async def create_pool(
+    database_url: str,
+    *,
+    apply_migrations: bool = True,
+    min_size: int = 2,
+    max_size: int = 10,
+) -> asyncpg.Pool:
     # The sandbox tool-server sidecar reaches the DB through the per-sandbox
     # iron-proxy and is not a schema owner, so it opens a pool with
     # apply_migrations=False. The API (and shared tool-server) own migrations.
@@ -104,12 +111,59 @@ async def create_pool(database_url: str, *, apply_migrations: bool = True) -> as
         run_migrations(database_url)
     pool = await asyncpg.create_pool(
         database_url,
-        min_size=2,
-        max_size=10,
+        min_size=min_size,
+        max_size=max_size,
         command_timeout=60,
     )
     assert pool is not None
     return pool
+
+
+async def create_pool_with_retry(
+    database_url: str,
+    *,
+    apply_migrations: bool = True,
+    min_size: int = 2,
+    max_size: int = 10,
+    max_attempts: int = 30,
+    base_delay: float = 0.5,
+    max_delay: float = 5.0,
+) -> asyncpg.Pool:
+    """Create the pool with capped exponential backoff over connection errors.
+
+    Tolerates a DB endpoint that isn't accepting connections yet (e.g. the
+    tool-server sidecar racing its iron-proxy on startup). Re-raises the last
+    error once ``max_attempts`` is exhausted.
+    """
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return await create_pool(
+                database_url,
+                apply_migrations=apply_migrations,
+                min_size=min_size,
+                max_size=max_size,
+            )
+        except Exception as exc:
+            if attempt >= max_attempts:
+                log.error(
+                    "db_pool_create_exhausted",
+                    attempts=attempt,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+                raise
+            delay = min(max_delay, base_delay * 2 ** (attempt - 1))
+            log.warning(
+                "db_pool_create_retry",
+                attempt=attempt,
+                max_attempts=max_attempts,
+                delay=delay,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            await asyncio.sleep(delay)
 
 
 async def close_pool(pool: asyncpg.Pool) -> None:

--- a/services/api/api/tool_server_app.py
+++ b/services/api/api/tool_server_app.py
@@ -22,7 +22,7 @@ import structlog
 from fastapi import FastAPI
 
 from api.config import settings
-from api.db import close_pool, create_pool
+from api.db import close_pool, create_pool_with_retry
 from api.logging_config import configure_structlog
 from api.tool_manager import ToolManager, load_plugins_config
 
@@ -79,7 +79,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # the core DB through the iron-proxy (DATABASE_URL points at the proxy's
     # core listener) and the shared tool-server Deployment runs alongside the
     # API. Open the pool without running migrations; the API owns migrations.
-    app.state.db_pool = await create_pool(settings.database_url, apply_migrations=False)
+    # Retry because the sidecar can start before the proxy is listening, and
+    # cap at one connection — the sidecar's DB use is light.
+    app.state.db_pool = await create_pool_with_retry(
+        settings.database_url, apply_migrations=False, min_size=1, max_size=1
+    )
     watcher_task = asyncio.create_task(_watch_tools(app.state.tool_manager))
     try:
         yield

--- a/services/api/tests/test_create_pool_retry.py
+++ b/services/api/tests/test_create_pool_retry.py
@@ -1,0 +1,142 @@
+"""Tests for create_pool_with_retry — the tool-server's startup-race guard."""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_retries_until_endpoint_accepts(monkeypatch) -> None:
+    """ConnectionRefusedError on early attempts is retried, then succeeds."""
+    from api import db
+
+    sentinel_pool = object()
+    attempts = {"n": 0}
+
+    async def fake_create_pool(database_url, *, apply_migrations=True, min_size=2, max_size=10):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise ConnectionRefusedError(111, "Connection refused")
+        return sentinel_pool
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr(db, "create_pool", fake_create_pool)
+    monkeypatch.setattr(db.asyncio, "sleep", fake_sleep)
+
+    pool = await db.create_pool_with_retry(
+        "postgres://localhost/db", apply_migrations=False, base_delay=0.5
+    )
+
+    assert pool is sentinel_pool
+    assert attempts["n"] == 3
+    # Backoff applied once per failed attempt (two failures before success).
+    assert sleeps == [0.5, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_pool_size_is_forwarded(monkeypatch) -> None:
+    """min_size/max_size pass through to create_pool (tool-server uses 1/1)."""
+    from api import db
+
+    captured: dict[str, int] = {}
+
+    async def fake_create_pool(database_url, *, apply_migrations=True, min_size, max_size):
+        captured["min_size"] = min_size
+        captured["max_size"] = max_size
+        return object()
+
+    monkeypatch.setattr(db, "create_pool", fake_create_pool)
+
+    await db.create_pool_with_retry(
+        "postgres://localhost/db", apply_migrations=False, min_size=1, max_size=1
+    )
+
+    assert captured == {"min_size": 1, "max_size": 1}
+
+
+@pytest.mark.asyncio
+async def test_backoff_is_capped(monkeypatch) -> None:
+    from api import db
+
+    async def always_refused(database_url, *, apply_migrations=True, min_size=2, max_size=10):
+        raise ConnectionRefusedError(111, "Connection refused")
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr(db, "create_pool", always_refused)
+    monkeypatch.setattr(db.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(ConnectionRefusedError):
+        await db.create_pool_with_retry(
+            "postgres://localhost/db",
+            apply_migrations=False,
+            max_attempts=10,
+            base_delay=0.5,
+            max_delay=5.0,
+        )
+
+    # No sleep after the final (exhausting) attempt.
+    assert len(sleeps) == 9
+    assert max(sleeps) == 5.0
+    assert sleeps[-1] == 5.0
+
+
+@pytest.mark.asyncio
+async def test_postgres_starting_up_is_retried(monkeypatch) -> None:
+    """57P03 (CannotConnectNowError) is a transient startup condition."""
+    from api import db
+
+    sentinel_pool = object()
+    attempts = {"n": 0}
+
+    async def fake_create_pool(database_url, *, apply_migrations=True, min_size=2, max_size=10):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise asyncpg.CannotConnectNowError("the database system is starting up")
+        return sentinel_pool
+
+    async def fake_sleep(delay):
+        return None
+
+    monkeypatch.setattr(db, "create_pool", fake_create_pool)
+    monkeypatch.setattr(db.asyncio, "sleep", fake_sleep)
+
+    pool = await db.create_pool_with_retry(
+        "postgres://localhost/db", apply_migrations=False
+    )
+
+    assert pool is sentinel_pool
+    assert attempts["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_any_error_is_retried_then_reraised(monkeypatch) -> None:
+    """Every exception is retried; the last is re-raised once exhausted."""
+    from api import db
+
+    attempts = {"n": 0}
+
+    async def fake_create_pool(database_url, *, apply_migrations=True, min_size=2, max_size=10):
+        attempts["n"] += 1
+        raise ValueError("boom")
+
+    async def fake_sleep(delay):
+        return None
+
+    monkeypatch.setattr(db, "create_pool", fake_create_pool)
+    monkeypatch.setattr(db.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(ValueError):
+        await db.create_pool_with_retry(
+            "postgres://localhost/db", apply_migrations=False, max_attempts=4
+        )
+
+    assert attempts["n"] == 4


### PR DESCRIPTION
The tool-server sidecar reaches Postgres through the per-sandbox iron-proxy, a sibling container the kubelet starts concurrently with no ordering guarantee. Because asyncpg eagerly opens connections at pool-creation time, when the proxy's core-DB listener isn't bound yet the sidecar's lifespan hits `ConnectionRefusedError` and the container crash-loops.

This adds `create_pool_with_retry()` in `db.py` with capped exponential backoff over connection-class errors (refused, Postgres-starting-up, timeout) and wires the tool-server lifespan to use it; the last error is re-raised once attempts are exhausted so a permanent failure still surfaces loudly. Also pins the sidecar to a single connection (`min_size=max_size=1`).