### PR TITLE
fix(sandbox): point tool-server sidecar TOOL_DIRS at sandbox overlay mount

### DIFF
--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -191,11 +191,22 @@ def _workflow_run_pod_name(run_id: str) -> str:
 
 
 def _tool_server_tool_dirs() -> str:
-    """TOOL_DIRS the sidecar uses. Mirrors the API's TOOL_DIRS by default."""
+    """TOOL_DIRS the sidecar uses.
+
+    The API fully controls both of the sidecar's mounts, so it constructs the
+    path directly rather than inheriting (and rewriting) its own ``TOOL_DIRS``.
+    Base tools live at ``/app/tools`` in the shared image. The overlay, when
+    present, is mounted at ``_SANDBOX_OVERLAY_DIR`` — not the API's overlay
+    mount — so its tools are at ``<_SANDBOX_OVERLAY_DIR>/tools``. An explicit
+    ``KUBERNETES_TOOL_SERVER_TOOL_DIRS`` still wins as an escape hatch.
+    """
     value = (os.getenv("KUBERNETES_TOOL_SERVER_TOOL_DIRS") or "").strip()
     if value:
         return value
-    return (os.getenv("TOOL_DIRS") or "/app/tools").strip() or "/app/tools"
+    dirs = ["/app/tools"]
+    if _overlay_image():
+        dirs.append(f"{_SANDBOX_OVERLAY_DIR}/tools")
+    return ":".join(dirs)
 
 
 def _token_broker_name() -> str:

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -15,6 +15,7 @@ from api.sandbox.kubernetes import (
     KubernetesExecutorBackend,
     STDOUT_CHANNEL,
     _build_tool_server_container,
+    _tool_server_tool_dirs,
 )
 from api.sandbox.kubernetes_agent_sandbox import KubernetesAgentSandboxBackend
 from api.sandbox.registry import auto_configure
@@ -650,6 +651,42 @@ def test_tool_server_container_inherits_sandbox_extra_env(
     assert "firewall.internal" in env["NO_PROXY"]
     assert "api.internal" in env["NO_PROXY"]
     assert "stg-laminar-app-server" in env["NO_PROXY"]
+
+
+def test_tool_server_tool_dirs_points_overlay_at_sandbox_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sidecar mounts the overlay at /home/agent/overlay/org, not the API's
+    overlay mount. Its TOOL_DIRS must point there or every overlay tool silently
+    disappears."""
+    monkeypatch.delenv("KUBERNETES_TOOL_SERVER_TOOL_DIRS", raising=False)
+    monkeypatch.setenv("CENTAUR_OVERLAY_IMAGE", "centaur-overlay:test")
+
+    assert (
+        _tool_server_tool_dirs()
+        == "/app/tools:/home/agent/overlay/org/tools"
+    )
+
+
+def test_tool_server_tool_dirs_without_overlay_is_base_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KUBERNETES_TOOL_SERVER_TOOL_DIRS", raising=False)
+    monkeypatch.delenv("CENTAUR_OVERLAY_IMAGE", raising=False)
+
+    assert _tool_server_tool_dirs() == "/app/tools"
+
+
+def test_tool_server_tool_dirs_explicit_override_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "KUBERNETES_TOOL_SERVER_TOOL_DIRS",
+        "/custom/tools",
+    )
+    monkeypatch.setenv("CENTAUR_OVERLAY_IMAGE", "centaur-overlay:test")
+
+    assert _tool_server_tool_dirs() == "/custom/tools"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The tool-server sidecar reuses the API image and was inheriting the API's `TOOL_DIRS` verbatim, which references the API's overlay mount path. The sidecar mounts the overlay at a different path, so that path doesn't exist in the sandbox Pod and all overlay tools silently dropped out of discovery.

This constructs the sidecar's `TOOL_DIRS` directly from the mounts the API controls: `/app/tools` plus the sandbox overlay tools dir when an overlay image is set. `KUBERNETES_TOOL_SERVER_TOOL_DIRS` still works as an escape hatch.