### PR TITLE
fix(tool-server): install overlay tool deps in the sidecar before uvicorn

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -47,8 +47,9 @@ COPY workflows/ workflows/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-dev --inexact
 
+COPY services/api/tool-server-startup.sh /app/tool-server-startup.sh
 COPY services/api/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /app/tool-server-startup.sh /entrypoint.sh
 
 EXPOSE 8000
 

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -55,6 +55,11 @@ _CONTAINER_NAME = "sandbox"
 _AGENT_UID = 1001
 _SANDBOX_OVERLAY_ROOT = "/home/agent/overlay"
 _SANDBOX_OVERLAY_DIR = f"{_SANDBOX_OVERLAY_ROOT}/org"
+# Writable dir the tool-server sidecar installs overlay tool deps into. The
+# sidecar runs as a non-root user and cannot write the root-owned /app/.venv,
+# so install-tool-deps.sh installs here with `uv pip install --target` and the
+# sidecar puts it on PYTHONPATH. /tmp is writable regardless of the run-as user.
+_OVERLAY_TOOL_DEPS_DIR = "/tmp/overlay-tool-deps"
 _PROXY_LABEL = "centaur.ai/iron-proxy"
 _API_PROXY_POD_NAME = "centaur-api-proxy"
 _API_PROXY_SANDBOX_ID = "api"
@@ -529,15 +534,14 @@ def _build_tool_server_container(
         "name": "tool-server",
         "image": image_ref,
         "imagePullPolicy": _tool_server_image_pull_policy(),
-        # Same image as the API; different uvicorn target.
-        "command": ["/app/.venv/bin/uvicorn"],
-        "args": [
-            "api.tool_server_app:app",
-            "--host",
-            "0.0.0.0",
-            "--port",
-            str(port),
-        ],
+        # Same image as the API, but the sidecar overrides the image ENTRYPOINT,
+        # so the overlay tool-dep install the API gets via entrypoint.sh would be
+        # skipped. tool-server-startup.sh installs overlay deps into the writable
+        # _OVERLAY_TOOL_DEPS_DIR (passed as an arg) since this container is
+        # non-root and cannot write the venv, puts it on PYTHONPATH, then execs
+        # uvicorn.
+        "command": ["/app/tool-server-startup.sh"],
+        "args": [str(port), _OVERLAY_TOOL_DEPS_DIR],
         "env": env,
         "ports": [{"containerPort": port, "name": "tools"}],
         "readinessProbe": {

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -14,6 +14,7 @@ from api.sandbox.config import container_env as sandbox_container_env
 from api.sandbox.kubernetes import (
     KubernetesExecutorBackend,
     STDOUT_CHANNEL,
+    _OVERLAY_TOOL_DEPS_DIR,
     _build_tool_server_container,
     _tool_server_tool_dirs,
 )
@@ -651,6 +652,36 @@ def test_tool_server_container_inherits_sandbox_extra_env(
     assert "firewall.internal" in env["NO_PROXY"]
     assert "api.internal" in env["NO_PROXY"]
     assert "stg-laminar-app-server" in env["NO_PROXY"]
+
+
+def test_tool_server_container_installs_overlay_deps_before_uvicorn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sidecar overrides the image ENTRYPOINT, so it must run the overlay
+    tool-dep install itself. It runs as non-root, so deps go to a writable
+    --target dir — never the root-owned venv. tool-server-startup.sh puts that
+    dir on PYTHONPATH at runtime, so it is not set on the container spec."""
+    monkeypatch.setenv("SANDBOX_SIGNING_KEY", "test-signing-key")
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_IMAGE", "centaur-tools:test")
+
+    container = _build_tool_server_container(
+        thread_key="slack:C123:123.456",
+        container_name="centaur-sandbox-pod-abc",
+        firewall_host="firewall.internal",
+        api_url="http://api.internal:8000",
+        overlay_mount="/home/agent/overlay",
+        database_url="postgres://app_user@firewall.internal:5433/centaur",
+    )
+
+    # The startup script installs overlay deps (best-effort) then execs uvicorn.
+    # It gets the listen port and the writable deps target as args; the script
+    # exports PYTHONPATH itself, so it must not appear on the container spec.
+    assert container["command"] == ["/app/tool-server-startup.sh"]
+    port, target = container["args"]
+    assert target == _OVERLAY_TOOL_DEPS_DIR
+
+    env = {item["name"]: item.get("value") for item in container["env"]}
+    assert "PYTHONPATH" not in env
 
 
 def test_tool_server_tool_dirs_points_overlay_at_sandbox_mount(

--- a/services/api/tool-server-startup.sh
+++ b/services/api/tool-server-startup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Tool-server sidecar entrypoint: install overlay tool deps, then run uvicorn.
+#
+# The sidecar runs the API image but overrides its ENTRYPOINT, so it must do the
+# overlay tool-dep install itself (the API container gets it via entrypoint.sh).
+# The sidecar runs as a non-root user and cannot write the root-owned
+# /app/.venv, so deps install into a writable --target dir that this script
+# then puts on PYTHONPATH before exec'ing uvicorn.
+#
+# Overlay tools ship as source only, so their pyproject.toml dependencies are
+# not baked into the image. Base tools under /app/tools are installed at build
+# time and skipped here.
+#
+# Egress note: the sidecar reaches the package index through iron-proxy, so the
+# index hosts (e.g. pypi.org, files.pythonhosted.org) must be firewall-allowed
+# for the install to succeed.
+#
+# Args:
+#   $1  port for uvicorn to listen on
+#   $2  writable dir to install overlay tool deps into; also added to PYTHONPATH
+#
+# Best-effort: a failed install surfaces as a per-tool ImportError, so always
+# exec uvicorn afterward so /healthz still comes up.
+set -uo pipefail
+
+port="${1:?port required}"
+target="${2:?deps target dir required}"
+
+if [[ -n "${TOOL_DIRS:-}" ]]; then
+  deps_file="$(mktemp)"
+  IFS=':' read -ra _dirs <<< "$TOOL_DIRS"
+  for _d in "${_dirs[@]}"; do
+    [[ "$_d" == "/app/tools" ]] && continue   # baked into the image at build time
+    [[ -d "$_d" ]] || continue
+    /app/.venv/bin/python - "$_d" >> "$deps_file" 2>/dev/null <<'PY' || true
+import sys, tomllib, pathlib
+
+deps: set[str] = set()
+for path in pathlib.Path(sys.argv[1]).glob("**/pyproject.toml"):
+    try:
+        with open(path, "rb") as fh:
+            data = tomllib.load(fh)
+    except Exception:
+        continue
+    deps.update(data.get("project", {}).get("dependencies", []))
+print("\n".join(sorted(deps)))
+PY
+  done
+
+  sort -u "$deps_file" | grep -v '^[[:space:]]*$' > "${deps_file}.uniq" || true
+  mv -f "${deps_file}.uniq" "$deps_file"
+  if [[ -s "$deps_file" ]]; then
+    mkdir -p "$target"
+    # This container runs as a non-root user with no writable HOME, so uv would
+    # default its cache to /.cache/uv and fail to create it. Point it at a
+    # writable path. The cache is per-pod and ephemeral, which is fine.
+    export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
+    echo "tool-server-startup: installing overlay tool deps into $target" >&2
+    uv pip install --python /app/.venv/bin/python --target "$target" -r "$deps_file" \
+      || echo "tool-server-startup: dep install failed; affected tools will error at call time" >&2
+  fi
+  rm -f "$deps_file" "${deps_file}.uniq"
+fi
+
+# Make the installed overlay deps importable by the in-process tool loader.
+# Prepend so they take precedence, but keep any operator-provided PYTHONPATH.
+export PYTHONPATH="$target${PYTHONPATH:+:$PYTHONPATH}"
+
+exec /app/.venv/bin/uvicorn api.tool_server_app:app --host 0.0.0.0 --port "$port"


### PR DESCRIPTION
The tool-server sidecar overrides the image `ENTRYPOINT` to run uvicorn directly, so it skipped the overlay tool-dep install the API gets via `entrypoint.sh`. Overlay tools are imported in-process, so deps like `pynacl`/`psycopg2` were never importable in the sidecar and overlay tools failed to load with `ModuleNotFoundError` (surfaced once #303 pointed the sidecar's `TOOL_DIRS` at the overlay mount).

This adds `tool-server-startup.sh` as the sidecar's command: it installs overlay tool deps, then execs uvicorn. Since the sidecar runs as a non-root user that cannot write the root-owned `/app/.venv`, it installs into a writable `--target` dir (`/tmp/overlay-tool-deps`), points uv's cache at a writable path via `UV_CACHE_DIR`, and prepends the target to `PYTHONPATH` before exec. The API `entrypoint.sh` is unchanged, so the API path carries no risk.

Two operational preconditions: the package index must be reachable through iron-proxy (allowlist pypi.org / files.pythonhosted.org or a mirror), and overlay tools must declare wheel deps (e.g. `psycopg2-binary`, not `psycopg2`) since the image has no compiler.