### PR TITLE
fix(tool-server): pass pg_dsn env vars into the sidecar so secret() resolves

### DIFF
--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -447,6 +447,7 @@ def _build_tool_server_container(
     api_url: str,
     overlay_mount: str | None,
     database_url: str,
+    pg_dsns: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Build the tool-server sidecar container spec.
 
@@ -456,6 +457,15 @@ def _build_tool_server_container(
     sandbox's NetworkPolicy; the real credentials stay in the proxy pod.
     Caller is responsible for only invoking this when ``_tool_server_image()``
     is set.
+
+    ``pg_dsns`` maps each ``PgDsnSecret`` name to the local proxied DSN the
+    sandbox should see (same dict wired into the agent container). Tool code
+    runs in this sidecar, so a ``pg_dsn`` secret must reach it as an env var:
+    ``_resolve_secrets`` returns nothing for ``PgDsnSecret`` (it is delivered
+    via the environment, not ``ToolContext``), and the SDK's ``secret()`` reads
+    it from ``os.environ``. Without these, ``secret("<PG_DSN_NAME>")`` falls
+    through to the placeholder. The agent container alone having them is why a
+    tool like ``paradigmdb`` got the stub DSN.
 
     The sidecar runs tool code that calls back into the API (e.g. the slack
     tool offloading a downloaded file to ``/agent/attachments/upload``), so it
@@ -505,6 +515,11 @@ def _build_tool_server_container(
         {"name": "TOOL_DIRS", "value": _tool_server_tool_dirs()},
         {"name": "PLUGIN_WATCHER_ENABLED", "value": "0"},
     ]
+    # pg_dsn secrets reach tool code as env vars (see docstring). Add them
+    # before operator extra-env so an operator override still wins, matching
+    # the agent container's ordering in ``container_env``.
+    for name, dsn in (pg_dsns or {}).items():
+        env.append({"name": name, "value": dsn})
     _apply_tool_server_extra_env(env, no_proxy)
 
     volume_mounts: list[dict[str, Any]] = [
@@ -1631,6 +1646,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                         _SANDBOX_OVERLAY_ROOT if overlay_image else None
                     ),
                     database_url=core_pg["dsn"],
+                    pg_dsns=sandbox_pg_dsns,
                 )
             )
 

--- a/services/api/tests/test_tool_server_core_pg.py
+++ b/services/api/tests/test_tool_server_core_pg.py
@@ -50,6 +50,8 @@ def test_tool_server_container_uses_proxied_dsn_value(
 
     dsn = "postgresql://app_user:pw@proxy-host:5433/ai_v2"
     container = _build_tool_server_container(
+        thread_key="thread-1",
+        container_name="centaur-sandbox-1",
         firewall_host="proxy-host",
         api_url="http://api:8000",
         overlay_mount=None,
@@ -61,6 +63,33 @@ def test_tool_server_container_uses_proxied_dsn_value(
     assert env["DATABASE_URL"] == {"name": "DATABASE_URL", "value": dsn}
     # the signing key still comes from the secret
     assert "valueFrom" in env["SANDBOX_SIGNING_KEY"]
+
+
+def test_tool_server_container_includes_pg_dsn_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tool code runs in the sidecar, so pg_dsn secrets must reach it as env.
+
+    Without this, ``secret("EXAMPLE_DSN")`` resolves to the placeholder because
+    ``_resolve_secrets`` delivers ``PgDsnSecret`` via the environment, not
+    ``ToolContext`` — and only the agent container had it.
+    """
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_IMAGE", "centaur-api:latest")
+    monkeypatch.setenv("KUBERNETES_SECRET_ENV_NAME", "centaur-infra-env")
+
+    example_dsn = "postgresql://app_user:pw@proxy-host:5434/example"
+    container = _build_tool_server_container(
+        thread_key="thread-1",
+        container_name="centaur-sandbox-1",
+        firewall_host="proxy-host",
+        api_url="http://api:8000",
+        overlay_mount=None,
+        database_url="postgresql://app_user:pw@proxy-host:5433/ai_v2",
+        pg_dsns={"EXAMPLE_DSN": example_dsn},
+    )
+
+    env = {e["name"]: e for e in container["env"]}
+    assert env["EXAMPLE_DSN"] == {"name": "EXAMPLE_DSN", "value": example_dsn}
 
 
 def test_proxy_iron_env_includes_core_password_when_set(


### PR DESCRIPTION
Tool code runs in the tool-server sidecar, but pg_dsn secrets (e.g.
RESHIFT_DSN) were only set on the agent container env. _resolve_secrets
delivers PgDsnSecret via the environment rather than ToolContext, so
secret("RESHIFT_DSN") in the sidecar fell through to the placeholder.
Wire sandbox_pg_dsns into _build_tool_server_container so the sidecar
sees the same proxied DSNs as the agent container.

Also fixes a stale test that omitted the now-required thread_key/
container_name args.
