### PR TITLE
Add create-linear-project skill + create_project tool method

### DIFF
--- a/.agents/skills/create-linear-project/SKILL.md
+++ b/.agents/skills/create-linear-project/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: create-linear-project
+description: "Create a Linear project under the Darkbloom team through a required intake flow. Use when an admin asks to create/start/spin up a new Linear project, a new bet, or a new initiative to go after. Enforces a structured questionnaire (hypothesis, metrics, evidence, impact timing, priority, lead, dates) before anything is created."
+---
+
+# Create Linear Project (Darkbloom)
+
+We don't just create projects — we run a flow. Every new Darkbloom project must answer a
+fixed set of questions before it exists. This skill enforces that intake, then creates the
+project directly in Linear with no preview step.
+
+## Who can use this
+
+Project creation is a **mutation** — admins only (see the access policy). If a non-admin
+asks, decline per the standard read-only message. Do not run any step below for them.
+
+## The intake (all nine fields are required)
+
+Present this template verbatim on first invocation, then let the user reply freeform. They
+will not answer in template form — **you** slot their answers into the fields and keep
+asking only for what's still missing. Do not proceed until every field is filled.
+
+```
+═══ NEW LINEAR PROJECT — INTAKE (Darkbloom) ═══
+
+1. What is this?          — one-paragraph overview of the project
+2. Hypothesis             — the specific bet we're making
+3. Metrics to improve     — the full set of metrics we expect this to move
+4. Evidence               — what gives us direction; why this hypothesis is worth pursuing
+5. Impact timing          — do we expect immediate movement? if not, when does meaningful
+                            improvement land?
+6. Priority               — Urgent | High | Medium | Low
+7. Lead                   — who owns this?
+8. Start date             — YYYY-MM-DD
+9. Target date            — YYYY-MM-DD
+```
+
+Notes on gathering:
+- Fields 1 and 2 are **distinct**: "What is this?" is the overview; "Hypothesis" is the bet.
+- Keep a running tally. After each user reply, restate what's captured and list what's
+  still outstanding. Ask targeted follow-ups for the gaps — don't re-ask filled fields.
+- If a date is given relatively ("end of Q3"), resolve it to a concrete `YYYY-MM-DD` and
+  confirm the resolved value.
+
+## Mapping to Linear
+
+- **Team**: always Darkbloom — `teamIds: ["120662cb-3a74-4b46-8105-a80adee59391"]` (key `DAR`).
+  If you want to avoid hardcoding the id, resolve it live: `call linear teams` → the `DAR` row.
+- **Native fields**: priority → `priority`, lead → `lead_id`, start → `start_date`,
+  target → `target_date`.
+- **Fields 1–5 → the project overview document** (`content`), as the markdown template below.
+- **`description`**: a one-line summary derived from field 1 (Linear caps it at 255 chars).
+
+### Priority mapping
+
+| Label  | value |
+|--------|-------|
+| Urgent | 1 |
+| High   | 2 |
+| Medium | 3 |
+| Low    | 4 |
+
+### Lead resolution
+
+Resolve the lead name to a user id: `call linear users`, match on name, take `id`. If the
+name is ambiguous or unmatched, ask the user to disambiguate — don't guess.
+
+### `content` template (fields 1–5)
+
+```markdown
+## What is this?
+{field 1}
+
+## Hypothesis
+{field 2}
+
+## Metrics we expect to improve
+{field 3}
+
+## Evidence
+{field 4}
+
+## Expected impact timing
+{field 5}
+```
+
+## Create (directly — no preview)
+
+Once all nine fields are captured and the lead/team ids are resolved, create immediately:
+
+```bash
+call linear create_project '{
+  "name": "<project name>",
+  "team_ids": ["120662cb-3a74-4b46-8105-a80adee59391"],
+  "description": "<one-line summary from field 1>",
+  "content": "<the markdown template above>",
+  "lead_id": "<resolved user id>",
+  "priority": <1-4>,
+  "start_date": "YYYY-MM-DD",
+  "target_date": "YYYY-MM-DD"
+}'
+```
+
+Then confirm with the returned project `url`. If the call fails, report the error and the
+captured intake so nothing is lost — do not silently retry a mutation.
+
+## Guardrails
+
+- Never create with missing intake fields, even if the user says "just make it."
+- Do not render a confirmation preview — the user has opted into direct creation.
+- Don't create duplicate projects on retry: if a `create_project` call returned a project,
+  treat it as done even if downstream formatting failed.

--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -471,6 +471,86 @@ def project_detail(
     console.print(f"\n[dim]{result.get('url')}[/]")
 
 
+_PRIORITY_BY_NAME = {"urgent": 1, "high": 2, "medium": 3, "low": 4, "none": 0}
+
+
+@app.command("create-project")
+def create_project(
+    name: str = typer.Argument(..., help="Project name"),
+    team: list[str] = typer.Option(
+        ..., "--team", "-t", help="Team key (repeatable, e.g. -t DAR)"
+    ),
+    content_file: str = typer.Option(
+        None, "--content-file", help="Path to a markdown file for the project overview"
+    ),
+    description: str = typer.Option(None, "--description", "-d", help="Short summary"),
+    lead: str = typer.Option(None, "--lead", "-l", help="Lead name (partial match)"),
+    priority: str = typer.Option(
+        None, "--priority", "-p", help="urgent|high|medium|low|none"
+    ),
+    start_date: str = typer.Option(None, "--start", help="Start date YYYY-MM-DD"),
+    target_date: str = typer.Option(None, "--target", help="Target date YYYY-MM-DD"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Create a new project.
+
+    Examples:
+        linear create-project "Reduce p95 latency" -t DAR --priority high
+        linear create-project "New bet" -t DAR --content-file intake.md --lead Kydo
+    """
+    client = get_client()
+
+    teams = {t.get("key"): t.get("id") for t in client.teams()}
+    team_ids = []
+    for key in team:
+        if key not in teams:
+            console.print(f"[red]Unknown team key '{key}'.[/]")
+            raise typer.Exit(1)
+        team_ids.append(teams[key])
+
+    lead_id = None
+    if lead:
+        match = next(
+            (u for u in client.users() if lead.lower() in (u.get("name") or "").lower()),
+            None,
+        )
+        if not match:
+            console.print(f"[red]No user matching '{lead}'.[/]")
+            raise typer.Exit(1)
+        lead_id = match["id"]
+
+    priority_int = None
+    if priority:
+        priority_int = _PRIORITY_BY_NAME.get(priority.lower())
+        if priority_int is None:
+            console.print(f"[red]Invalid priority '{priority}'.[/]")
+            raise typer.Exit(1)
+
+    content = None
+    if content_file:
+        from pathlib import Path
+
+        content = Path(content_file).read_text()
+
+    result = client.create_project(
+        name=name,
+        team_ids=team_ids,
+        content=content,
+        description=description,
+        lead_id=lead_id,
+        priority=priority_int,
+        start_date=start_date,
+        target_date=target_date,
+    )
+
+    if json_output:
+        print(json.dumps(result, indent=2, default=str), file=sys.stdout)
+        raise typer.Exit()
+
+    console.print(f"[green]Created project:[/] [bold cyan]{result.get('name')}[/]")
+    console.print(f"[dim]{result.get('url')}[/]")
+
+
 @app.command()
 def cycles(
     team: str = typer.Option(None, "--team", "-t", help="Filter by team key"),

--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -355,6 +355,69 @@ class LinearClient:
         """
         return self._query(query, {"id": project_id}).get("project", {})
 
+    def create_project(
+        self,
+        name: str,
+        team_ids: list[str],
+        content: str | None = None,
+        description: str | None = None,
+        lead_id: str | None = None,
+        priority: int | None = None,
+        start_date: str | None = None,
+        target_date: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new project.
+
+        Args:
+            name: Project name.
+            team_ids: Team IDs the project belongs to (at least one required).
+            content: Markdown body for the project overview document. Use this
+                for the structured intake (hypothesis, metrics, evidence, etc.).
+            description: Short one-line summary (Linear caps this at 255 chars).
+            lead_id: User ID of the project lead. Resolve names via ``users()``.
+            priority: 0=none, 1=urgent, 2=high, 3=medium, 4=low.
+            start_date: Start date as YYYY-MM-DD.
+            target_date: Target date as YYYY-MM-DD.
+        """
+        if not team_ids:
+            raise ValueError("create_project requires at least one team id")
+
+        mutation = """
+        mutation ProjectCreate($input: ProjectCreateInput!) {
+            projectCreate(input: $input) {
+                success
+                project {
+                    id
+                    name
+                    description
+                    state
+                    priority
+                    startDate
+                    targetDate
+                    lead { id name }
+                    teams { nodes { id name key } }
+                    url
+                }
+            }
+        }
+        """
+        input_data: dict[str, Any] = {"name": name, "teamIds": team_ids}
+        if content:
+            input_data["content"] = content
+        if description:
+            input_data["description"] = description
+        if lead_id:
+            input_data["leadId"] = lead_id
+        if priority is not None:
+            input_data["priority"] = priority
+        if start_date:
+            input_data["startDate"] = start_date
+        if target_date:
+            input_data["targetDate"] = target_date
+
+        result = self._query(mutation, {"input": input_data})
+        return result.get("projectCreate", {}).get("project", {})
+
     def cycles(self, team_key: str | None = None, limit: int = 20) -> list[dict[str, Any]]:
         """List cycles, optionally filtered by team."""
         filter_str = ""


### PR DESCRIPTION
## What

Adds a gated intake **skill** for creating Linear projects under the **Darkbloom** team, backed by a new `create_project` method on the Linear tool.

### Why a skill (not a workflow)
Project creation is interactive + on-demand: present a template, take freeform replies across turns, slot them in, prompt for gaps, then create. Skills drive human-in-the-loop conversation; workflows are for unattended/recurring/durable jobs.

## Changes
- **`tools/productivity/linear/client.py`** — new `create_project(name, team_ids, content, description, lead_id, priority, start_date, target_date)` → Linear `projectCreate` mutation.
- **`tools/productivity/linear/cli.py`** — `linear create-project` command (resolves team keys + lead name, maps priority label → int).
- **`.agents/skills/create-linear-project/SKILL.md`** — the skill.

## Intake (all 9 required before creation)
1. What is this? · 2. Hypothesis · 3. Metrics to improve · 4. Evidence · 5. Impact timing · 6. Priority · 7. Lead · 8. Start date · 9. Target date

Mapping: fields 1–5 → project overview document (`content`); 6–9 → native fields (`priority`, `lead`, `startDate`, `targetDate`); always `teamIds: [DAR]`. Admin-only. Creates directly — no preview step.

## Notes
- Enforcement lives in the skill (guidance), not the tool. If hard server-side gating is wanted later, add required-field validation in `create_project`.
- Not yet exercised end-to-end (no test project created in Darkbloom); `create_project` becomes visible in `call linear` after merge + redeploy.