### PR TITLE
fix(slack): verify upload_file's share landed and surface silent drops

### DIFF
--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -14,10 +14,15 @@ from pathlib import Path
 from typing import Any, ClassVar
 from urllib.parse import quote, urljoin, urlparse
 
+import structlog
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 from centaur_sdk.tool_sdk import get_tool_context, save_attachment, secret
+
+# structlog so these lines render as JSON through the tool-server's
+# configure_structlog() pipeline, like the rest of the service's logs.
+logger = structlog.get_logger()
 
 # Cache for channel list to avoid repeated API calls
 
@@ -1861,6 +1866,33 @@ class SlackClient:
             raise ValueError(f"Attachment exceeds the {self._MAX_DOWNLOAD_BYTES}-byte limit")
         return body
 
+    @staticmethod
+    def _file_shared_in_thread(
+        shares: dict, channel: str, thread_ts: str | None
+    ) -> bool:
+        """Whether files.info `shares` shows the file landed in the target.
+
+        Slack's schema is ``shares.{public,private}[channel_id] -> [entries]``,
+        where each entry has the share-message ``ts`` and (for a threaded
+        share) ``thread_ts`` of the parent. The file is in our thread if any
+        entry for the channel matches our ``thread_ts`` (on either field, since
+        a root-level share reports ``ts == thread_ts``). With no thread
+        requested, any share into the channel counts.
+        """
+        entries: list = []
+        for scope in ("public", "private"):
+            by_channel = shares.get(scope) if isinstance(shares, dict) else None
+            if isinstance(by_channel, dict):
+                entries.extend(by_channel.get(channel) or [])
+        if not entries:
+            return False
+        if thread_ts is None:
+            return True
+        return any(
+            isinstance(e, dict) and thread_ts in (e.get("thread_ts"), e.get("ts"))
+            for e in entries
+        )
+
     def upload_file(
         self,
         channel: str | None = None,
@@ -1885,9 +1917,9 @@ class SlackClient:
         If channel/thread_ts are omitted and the tool runs in an active Slack
         thread, the destination is inferred from tool context.
 
-        alt_text: accessibility description for screen readers (max 1000 chars).
-            Strongly recommended for chart images so users with visual
-            impairments and indexers can understand what the image shows.
+        alt_text: accepted for backwards compatibility but currently NOT sent
+            to Slack, because slack_sdk's files_upload_v2 mishandles alt_txt
+            (https://github.com/slackapi/python-slack-sdk/issues/1818).
         """
         inferred_channel, inferred_thread_ts = self._current_slack_destination()
         requested_channel = channel or channel_id or inferred_channel
@@ -1917,7 +1949,9 @@ class SlackClient:
                 raise ValueError(
                     "One of content_base64, attachment_id, or attachment_url is required"
                 )
-            kwargs["content"] = upload_bytes
+            # Pass bytes via `file=` (binary upload) rather than `content=`,
+            # which slack_sdk treats as snippet text.
+            kwargs["file"] = upload_bytes
             kwargs["filename"] = effective_filename
             if title:
                 kwargs["title"] = title
@@ -1932,16 +1966,54 @@ class SlackClient:
                 kwargs["initial_comment"] = f"Uploaded `{effective_filename}`."
             if effective_thread_ts:
                 kwargs["thread_ts"] = effective_thread_ts
-            if alt_text:
-                # Slack's files.completeUploadExternal accepts alt_txt per file.
-                # slack_sdk's files_upload_v2 forwards top-level alt_txt onto the
-                # single-file upload payload.
-                kwargs["alt_txt"] = alt_text[:1000]
+            # We intentionally do NOT forward alt_text to Slack. Passing alt_txt
+            # through slack_sdk's files_upload_v2 is broken and can cause the
+            # upload/share to misbehave — see
+            # https://github.com/slackapi/python-slack-sdk/issues/1818. The
+            # parameter is kept on the signature for backwards compatibility but
+            # is deliberately ignored until the SDK bug is resolved.
+            _ = alt_text
 
+            # Upload once, then poll files.info with an exponential backoff
+            # (0/1/2/4/8s) to let the async share propagate. On a suspected
+            # drop, log the full files.info file object so the share state is
+            # visible.
             response = self._client.files_upload_v2(**kwargs)
             file_info = response.get("file", {})
+            file_id = file_info.get("id", "")
+
+            landed = False
+            verify_failed = False
+            info_file: dict = {}
+            for delay in (0, 1, 2, 4, 8):
+                if delay:
+                    time.sleep(delay)
+                try:
+                    info = self._client.files_info(file=file_id)
+                except Exception:
+                    # Verification unavailable (e.g. missing files:read scope).
+                    verify_failed = True
+                    break
+                info_file = info.get("file", {}) if info else {}
+                landed = self._file_shared_in_thread(
+                    info_file.get("shares") or {},
+                    resolved_channel,
+                    effective_thread_ts,
+                )
+                if landed:
+                    break
+
+            if not landed and not verify_failed:
+                logger.warning(
+                    "slack_upload_file_share_dropped",
+                    file_id=file_id,
+                    channel=resolved_channel,
+                    thread_ts=effective_thread_ts,
+                    files_info=info_file,
+                )
+
             return {
-                "id": file_info.get("id", ""),
+                "id": file_id,
                 "name": file_info.get("name", ""),
                 "permalink": file_info.get("permalink", ""),
                 "url": file_info.get("url_private", ""),

--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "typer>=0.12.0",
     "python-dotenv>=1.0.0",
     "rich>=13.0.0",
+    "structlog>=24.4.0",
 ]
 
 [project.scripts]

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -36,6 +36,14 @@ class _FakeWebClient:
         self.user_profile_response: dict | None = None
         self.user_profile_calls: list[dict] = []
         self.upload_exception: Exception | None = None
+        self.upload_count = 0
+        # Per-upload-attempt share outcomes consumed by files_upload_v2.
+        # True = Slack shares the file; False = silent drop (ok but no share).
+        # Empty list defaults every attempt to a successful share.
+        self.share_outcomes: list[bool] = []
+        self.files_info_calls: list[dict] = []
+        self.files_delete_calls: list[dict] = []
+        self._shares_by_file: dict[str, dict] = {}
 
     def chat_postMessage(self, **kwargs):
         self.last_kwargs = kwargs
@@ -73,7 +81,35 @@ class _FakeWebClient:
         self.last_kwargs = kwargs
         if self.upload_exception is not None:
             raise self.upload_exception
-        return {"file": {"id": "F123", "name": "upload.png"}}
+        self.upload_count += 1
+        file_id = f"F{self.upload_count}"
+        lands = self.share_outcomes.pop(0) if self.share_outcomes else True
+        if lands:
+            entry: dict = {"ts": "1.1", "channel_name": "paradigm-pulse"}
+            if kwargs.get("thread_ts"):
+                entry["thread_ts"] = kwargs["thread_ts"]
+            self._shares_by_file[file_id] = {
+                "public": {kwargs.get("channel", "C123"): [entry]}
+            }
+        else:
+            self._shares_by_file[file_id] = {}
+        return {
+            "file": {
+                "id": file_id,
+                "name": kwargs.get("filename", "upload.png"),
+                "permalink": f"https://slack.example/files/{file_id}",
+                "url_private": f"https://files.example/{file_id}",
+            }
+        }
+
+    def files_info(self, **kwargs):
+        self.files_info_calls.append(kwargs)
+        file_id = kwargs.get("file")
+        return {"file": {"id": file_id, "shares": self._shares_by_file.get(file_id, {})}}
+
+    def files_delete(self, **kwargs):
+        self.files_delete_calls.append(kwargs)
+        return {"ok": True}
 
     def api_call(self, method: str, *, params: dict):
         self.api_calls.append((method, params))
@@ -620,7 +656,7 @@ def test_upload_file_accepts_channel_id_alias_and_returns_preview() -> None:
     assert fake_web_client.last_kwargs is not None
     assert fake_web_client.last_kwargs["channel"] == "C123"
     assert fake_web_client.last_kwargs["filename"] == "data.csv"
-    assert fake_web_client.last_kwargs["content"] == b"a,b\n1,2\n"
+    assert fake_web_client.last_kwargs["file"] == b"a,b\n1,2\n"
     assert result["preview"] == {
         "size_bytes": 8,
         "mime_type": "text/csv",
@@ -669,6 +705,93 @@ def test_upload_file_infers_destination_from_team_scoped_thread_key() -> None:
     assert fake_web_client.last_kwargs is not None
     assert fake_web_client.last_kwargs["channel"] == "C123"
     assert fake_web_client.last_kwargs["thread_ts"] == "1780035646.228899"
+
+
+def test_upload_file_uploads_once_and_returns_when_share_lands(monkeypatch) -> None:
+    """The stripped path does a single upload and verifies via files.info; no
+    retry, no orphan deletion."""
+    import slack.client as slack_client_module
+
+    monkeypatch.setattr(slack_client_module.time, "sleep", lambda *a, **k: None)
+
+    client, fake_web_client = _make_client()
+
+    result = client.upload_file(
+        channel_id="C123",
+        thread_ts="1780035646.228899",
+        content_base64="dGVzdA==",
+        filename="random.csv",
+    )
+
+    assert fake_web_client.upload_count == 1
+    assert fake_web_client.files_delete_calls == []
+    assert result["id"] == "F1"
+
+
+def test_upload_file_returns_dropped_result_without_retry(monkeypatch) -> None:
+    """A silent share drop is logged but not retried or deleted; the (phantom)
+    result is returned so we can observe the raw rate."""
+    import slack.client as slack_client_module
+
+    monkeypatch.setattr(slack_client_module.time, "sleep", lambda *a, **k: None)
+
+    client, fake_web_client = _make_client()
+    fake_web_client.share_outcomes = [False]  # share never lands
+
+    result = client.upload_file(
+        channel_id="C123",
+        thread_ts="1780035646.228899",
+        content_base64="dGVzdA==",
+        filename="random.csv",
+    )
+
+    assert fake_web_client.upload_count == 1
+    assert fake_web_client.files_delete_calls == []
+    assert result["id"] == "F1"
+
+
+def test_upload_file_returns_result_when_verification_unavailable(monkeypatch) -> None:
+    """When files.info cannot confirm the share (e.g. missing files:read scope),
+    upload_file returns the result as-is."""
+    import slack.client as slack_client_module
+
+    monkeypatch.setattr(slack_client_module.time, "sleep", lambda *a, **k: None)
+
+    client, fake_web_client = _make_client()
+
+    def _boom(**_kwargs):
+        raise _make_slack_error(error="missing_scope", status_code=403)
+
+    fake_web_client.files_info = _boom  # type: ignore[method-assign]
+
+    result = client.upload_file(
+        channel_id="C123",
+        thread_ts="1780035646.228899",
+        content_base64="dGVzdA==",
+        filename="random.csv",
+    )
+
+    assert fake_web_client.upload_count == 1
+    assert fake_web_client.files_delete_calls == []
+    assert result["id"] == "F1"
+
+
+def test_upload_file_never_sends_alt_txt(monkeypatch) -> None:
+    """alt_text is accepted for compatibility but never forwarded to Slack,
+    because slack_sdk's files_upload_v2 mishandles alt_txt
+    (slackapi/python-slack-sdk#1818)."""
+    import slack.client as slack_client_module
+
+    monkeypatch.setattr(slack_client_module.time, "sleep", lambda *a, **k: None)
+
+    client, fake_web_client = _make_client()
+    client.upload_file(
+        channel_id="C123",
+        content_base64="dGVzdA==",
+        filename="chart.png",
+        alt_text="a bar chart",
+    )
+    assert "alt_txt" not in fake_web_client.last_kwargs
 
 
 def test_upload_file_rejects_local_path_argument() -> None:


### PR DESCRIPTION
Slack's `files.completeUploadExternal` intermittently returns `ok:true` but never shares the uploaded file, so `upload_file` would report success with a permalink that nobody can open while nothing appeared in the thread. This uploads bytes via `file=` instead of `content=`, stops forwarding `alt_txt` (which slack_sdk's `files_upload_v2` mishandles — slackapi/python-slack-sdk#1818), and verifies the share actually landed via `files.info` with a short backoff poll, logging the full `files.info` as JSON when a share is dropped so the failure is visible.