### PR TITLE
Fix silent Codex turn failure delivery

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -33,6 +33,7 @@ from api.sandbox.harness_protocol import (
     extract_thread_id,
     is_turn_done,
     messages_to_content_blocks,
+    terminal_result,
 )
 from api.deps import mint_sandbox_token
 from api.harness_config import default_harness
@@ -1080,45 +1081,6 @@ def _build_session_context(
     return "\n".join(lines)
 
 
-def _terminal_error_from_harness_event(event: dict) -> str | None:
-    """Return terminal error text when an end-of-turn event represents failure."""
-    event_type = event.get("type")
-
-    if event_type == "error":
-        err = event.get("error")
-        if isinstance(err, str) and err.strip():
-            return err.strip()
-        if isinstance(err, dict):
-            message = err.get("message")
-            if isinstance(message, str) and message.strip():
-                return message.strip()
-        message = event.get("message")
-        if isinstance(message, str) and message.strip():
-            return message.strip()
-        return "Harness reported an error"
-
-    if event_type == "result":
-        subtype = str(event.get("subtype") or "").strip().lower()
-        is_error = bool(event.get("is_error")) or (subtype not in {"", "success"})
-        if not is_error:
-            return None
-
-        err = event.get("error")
-        if isinstance(err, str) and err.strip():
-            return err.strip()
-        if isinstance(err, dict):
-            message = err.get("message")
-            if isinstance(message, str) and message.strip():
-                return message.strip()
-
-        result = event.get("result")
-        if isinstance(result, str) and result.strip():
-            return result.strip()
-        return "Harness reported an error"
-
-    return None
-
-
 async def _stream_stdout(
     session: SandboxSession,
     backend: Any,
@@ -1192,9 +1154,15 @@ async def _stream_stdout(
                 yield {"data": json.dumps(canonical, separators=(",", ":"))}
 
             if is_turn_done(session.engine, evt):
-                terminal_error = _terminal_error_from_harness_event(evt)
-                terminal_result = result_text or terminal_error or ""
-                rt.last_result = result_text
+                terminal = terminal_result(
+                    session.engine,
+                    evt,
+                    latest_result_text=result_text,
+                )
+                if terminal is None:
+                    continue
+                terminal_text = terminal.result_text or terminal.error_text
+                rt.last_result = terminal.result_text
                 # Persist agent_thread_id for conversation resume
                 if agent_thread_id and session.agent_thread_id != agent_thread_id:
                     try:
@@ -1216,23 +1184,23 @@ async def _stream_stdout(
                 # can't cancel the stream before durable state is committed.
                 await asyncio.gather(
                     _persist_turn_messages(
-                        session.thread_key, "", terminal_result, session.harness
+                        session.thread_key, "", terminal_text, session.harness
                     ),
-                    _db_complete_inflight_turn(session.thread_key, terminal_result),
+                    _db_complete_inflight_turn(session.thread_key, terminal_text),
                 )
                 turn_done_payload: dict[str, Any] = {
                     "type": "turn.done",
                     "turn_id": turn_id,
-                    "result": terminal_result,
+                    "result": terminal_text,
                     "agent_thread_id": agent_thread_id or "",
                 }
                 for key in ("cwd", "repo_owner", "repo_name", "git_ref", "git_commit"):
                     value = evt.get(key)
                     if isinstance(value, str) and value.strip():
                         turn_done_payload[key] = value.strip()
-                if terminal_error:
+                if terminal.is_error:
                     turn_done_payload["is_error"] = True
-                    turn_done_payload["error"] = terminal_error
+                    turn_done_payload["error"] = terminal.error_text
                 yield {"data": json.dumps(turn_done_payload)}
                 log.info(
                     "turn_done",
@@ -1241,7 +1209,7 @@ async def _stream_stdout(
                     harness=session.harness,
                     turn_id=turn_id,
                     duration_s=_elapsed_since(t0),
-                    reason="error" if terminal_error else "completed",
+                    reason=terminal.terminal_reason,
                 )
                 result_text = ""
                 agent_thread_id = None

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -59,7 +59,7 @@ from api.vm_metrics import (
     record_usage_observation,
 )
 from api.sandbox.normalize import normalize_harness_event
-from api.sandbox.harness_protocol import extract_result
+from api.sandbox.harness_protocol import extract_result, terminal_result
 from api.sandbox.registry import get_backend
 
 log = structlog.get_logger()
@@ -1125,7 +1125,7 @@ def _slackbot_streamed_answer_chars(value: Any) -> int:
 def _slackbot_live_delivery_covers_result(result_text: str, streamed_chars: int) -> bool:
     text = result_text.strip()
     if not text:
-        return True
+        return False
     return streamed_chars >= len(text)
 
 
@@ -3490,17 +3490,28 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         )
         return
 
-    result_text = extract_result(engine, turn_done_event) or latest_terminal_result_text
+    terminal = terminal_result(
+        engine,
+        turn_done_event,
+        latest_result_text=latest_terminal_result_text,
+    )
+    if terminal is None:
+        await _finalize_execution(
+            status="failed_permanent",
+            terminal_reason="invalid_terminal_event",
+            result_text="",
+            error_text="stream ended with invalid terminal event",
+        )
+        return
+
+    result_text = terminal.result_text
     repo_context = _extract_repo_context(turn_done_event)
     if repo_context:
         await _merge_execution_repo_context(pool, execution_id, repo_context)
-    error_text = turn_done_event.get("error")
-    if not isinstance(error_text, str):
-        error_text = ""
-    is_error = bool(turn_done_event.get("is_error")) or bool(error_text)
-    if is_error:
-        terminal_reason = "harness_error"
-        combined_error = (error_text or result_text or "harness_error").strip()
+    if terminal.is_error:
+        terminal_reason = terminal.terminal_reason
+        error_text = terminal.error_text
+        combined_error = (terminal.error_text or result_text or "harness_error").strip()
         if _matches_user_cancelled(error_text, result_text, combined_error):
             await _finalize_execution(
                 status="cancelled",
@@ -3541,7 +3552,7 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         if "timed out while reconnecting" in combined_error.lower():
             terminal_reason = "amp_reconnect_timeout"
         await _finalize_execution(
-            status="failed_permanent",
+            status=terminal.status,
             terminal_reason=terminal_reason,
             result_text=result_text,
             error_text=combined_error,
@@ -3549,8 +3560,8 @@ async def _process_execution_impl(pool, row: dict[str, Any]) -> None:
         return
 
     await _finalize_execution(
-        status="completed",
-        terminal_reason="completed",
+        status=terminal.status,
+        terminal_reason=terminal.terminal_reason,
         result_text=result_text,
         error_text=None,
     )

--- a/services/api/api/sandbox/harness_protocol.py
+++ b/services/api/api/sandbox/harness_protocol.py
@@ -7,6 +7,26 @@ pure — no I/O, no globals, no imports from other api modules.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TerminalResult:
+    """Engine-neutral terminal turn result.
+
+    This is the only shape downstream execution code should use when deciding
+    whether a harness turn completed, failed, or should be delivered.
+    """
+
+    status: str
+    terminal_reason: str
+    result_text: str
+    error_text: str
+
+    @property
+    def is_error(self) -> bool:
+        return bool(self.error_text)
+
 
 def _extract_error_message(event: dict) -> str:
     """Extract a human-readable error message from mixed event payload shapes."""
@@ -61,6 +81,94 @@ def is_turn_done(engine: str, event: dict) -> bool:
     if engine == "codex":
         return t in ("turn.completed", "turn.failed")
     return t == "agent_end"  # pi-mono
+
+
+def _amp_like_terminal_is_error(event: dict) -> bool:
+    subtype = str(event.get("subtype") or "").strip().lower()
+    return bool(event.get("is_error")) or (subtype not in {"", "success"})
+
+
+def terminal_result(
+    engine: str,
+    event: dict,
+    *,
+    latest_result_text: str = "",
+) -> TerminalResult | None:
+    """Return a validated terminal result for a raw or canonical harness event."""
+    if not is_turn_done(engine, event) and event.get("type") != "turn.done":
+        return None
+
+    t = event.get("type", "")
+    latest = latest_result_text.strip()
+
+    if t == "turn.done":
+        result = extract_result(engine, event) or latest
+        error = _extract_error_message(event).strip()
+        if bool(event.get("is_error")) or error:
+            combined = (error or result or "harness_error").strip()
+            return TerminalResult(
+                status="failed_permanent",
+                terminal_reason="harness_error",
+                result_text=result,
+                error_text=combined,
+            )
+        return TerminalResult(
+            status="completed",
+            terminal_reason="completed",
+            result_text=result,
+            error_text="",
+        )
+
+    if t == "error":
+        error = (_extract_error_message(event) or "Harness reported an error").strip()
+        return TerminalResult(
+            status="failed_permanent",
+            terminal_reason="harness_error",
+            result_text="",
+            error_text=error,
+        )
+
+    if engine in ("amp", "claude-code"):
+        result = extract_result(engine, event) or latest
+        if t == "result" and _amp_like_terminal_is_error(event):
+            error = (result or _extract_error_message(event) or "harness_error").strip()
+            return TerminalResult(
+                status="failed_permanent",
+                terminal_reason="harness_error",
+                result_text=result,
+                error_text=error,
+            )
+        return TerminalResult(
+            status="completed",
+            terminal_reason="completed",
+            result_text=result,
+            error_text="",
+        )
+
+    if engine == "codex":
+        if t == "turn.failed":
+            error = (_extract_error_message(event) or "Turn failed").strip()
+            return TerminalResult(
+                status="failed_permanent",
+                terminal_reason="harness_error",
+                result_text="",
+                error_text=error,
+            )
+        result = extract_result(engine, event) or latest
+        return TerminalResult(
+            status="completed",
+            terminal_reason="completed",
+            result_text=result,
+            error_text="",
+        )
+
+    result = extract_result(engine, event) or latest
+    return TerminalResult(
+        status="completed",
+        terminal_reason="completed",
+        result_text=result,
+        error_text="",
+    )
 
 
 def extract_result(engine: str, event: dict) -> str | None:

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -39,7 +39,7 @@ def test_slackbot_streamed_answer_chars_requires_positive_integer_offset():
     assert _slackbot_streamed_answer_chars("25") == 0
     assert _slackbot_streamed_answer_chars(-3) == 0
     assert _slackbot_streamed_answer_chars(25) == 25
-    assert _slackbot_live_delivery_covers_result("", 0) is True
+    assert _slackbot_live_delivery_covers_result("", 0) is False
     assert _slackbot_live_delivery_covers_result("already streamed", 16) is True
     assert _slackbot_live_delivery_covers_result("cut off report", 6) is False
 

--- a/services/api/tests/test_agent_resilience.py
+++ b/services/api/tests/test_agent_resilience.py
@@ -49,6 +49,19 @@ class _UnknownEventBackend:
         return "gone"
 
 
+class _CodexFailedBackend:
+    async def stream_stdout(self, _session):
+        yield json.dumps(
+            {
+                "type": "turn.failed",
+                "error": {"message": "model crashed"},
+            }
+        )
+
+    async def status(self, _session):
+        return "gone"
+
+
 def test_elapsed_since_uses_monotonic_delta_when_available() -> None:
     from api.agent import _elapsed_since
 
@@ -105,6 +118,46 @@ async def test_stream_stdout_reattaches_when_running_eof() -> None:
     )
     backend.close_streams.assert_awaited_once_with(session)
     backend.attach.assert_awaited_once_with(session)
+
+
+@pytest.mark.asyncio
+async def test_stream_stdout_preserves_codex_turn_failed_error() -> None:
+    from api.agent import _stream_stdout
+
+    session = SandboxSession(
+        sandbox_id="sbx-codex-failed",
+        thread_key="test:codex-failed",
+        harness="codex",
+        engine="codex",
+    )
+    rt = RuntimeState()
+    rt.turn_counter = 1
+    backend = _CodexFailedBackend()
+
+    with (
+        patch("api.agent._persist_turn_messages", new_callable=AsyncMock),
+        patch("api.agent._db_complete_inflight_turn", new_callable=AsyncMock),
+    ):
+        events = [
+            event
+            async for event in _stream_stdout(
+                session,
+                backend,
+                rt,
+                turn_id=1,
+                t0=time.monotonic(),
+            )
+        ]
+
+    decoded = [json.loads(item["data"]) for item in events]
+    assert {"type": "error", "error": "model crashed"} in decoded
+    assert any(
+        evt.get("type") == "turn.done"
+        and evt.get("is_error") is True
+        and evt.get("error") == "model crashed"
+        and evt.get("result") == "model crashed"
+        for evt in decoded
+    )
 
 
 @pytest.mark.asyncio

--- a/services/api/tests/test_harness_protocol.py
+++ b/services/api/tests/test_harness_protocol.py
@@ -6,6 +6,7 @@ from api.sandbox.harness_protocol import (
     extract_thread_id,
     is_turn_done,
     messages_to_content_blocks,
+    terminal_result,
 )
 
 
@@ -84,6 +85,20 @@ class TestIsTurnDone:
 
     def test_codex_turn_failed(self):
         assert is_turn_done("codex", {"type": "turn.failed"}) is True
+
+    def test_codex_turn_failed_error_extracts_result(self):
+        assert (
+            extract_result(
+                "codex",
+                {
+                    "type": "turn.done",
+                    "is_error": True,
+                    "error": "Turn failed",
+                    "result": "Turn failed",
+                },
+            )
+            == "Turn failed"
+        )
 
     def test_codex_other_event(self):
         assert is_turn_done("codex", {"type": "item.completed"}) is False
@@ -188,6 +203,58 @@ class TestExtractResult:
             },
         }
         assert extract_result("pi-mono", event) == "pi answer"
+
+
+class TestTerminalResult:
+    def test_codex_turn_failed_is_typed_failure(self):
+        terminal = terminal_result(
+            "codex",
+            {"type": "turn.failed", "error": {"message": "model crashed"}},
+            latest_result_text="",
+        )
+        assert terminal is not None
+        assert terminal.status == "failed_permanent"
+        assert terminal.terminal_reason == "harness_error"
+        assert terminal.result_text == ""
+        assert terminal.error_text == "model crashed"
+        assert terminal.is_error is True
+
+    def test_codex_turn_completed_uses_latest_result_text(self):
+        terminal = terminal_result(
+            "codex",
+            {"type": "turn.completed"},
+            latest_result_text="done",
+        )
+        assert terminal is not None
+        assert terminal.status == "completed"
+        assert terminal.terminal_reason == "completed"
+        assert terminal.result_text == "done"
+        assert terminal.error_text == ""
+
+    def test_amp_result_error_is_typed_failure(self):
+        terminal = terminal_result(
+            "amp",
+            {"type": "result", "subtype": "error", "result": "bad token"},
+            latest_result_text="",
+        )
+        assert terminal is not None
+        assert terminal.status == "failed_permanent"
+        assert terminal.error_text == "bad token"
+
+    def test_turn_done_error_is_typed_failure(self):
+        terminal = terminal_result(
+            "codex",
+            {
+                "type": "turn.done",
+                "is_error": True,
+                "result": "Turn failed",
+                "error": "Turn failed",
+            },
+        )
+        assert terminal is not None
+        assert terminal.status == "failed_permanent"
+        assert terminal.result_text == "Turn failed"
+        assert terminal.error_text == "Turn failed"
 
 
 class TestExtractThreadId:


### PR DESCRIPTION
## Summary
- preserve Codex turn.failed error text when synthesizing turn.done
- stop treating zero-char Slack live delivery as covering an empty terminal result
- add regressions for Codex turn.failed and live-delivery coverage

## Tests
- uv run pytest tests/test_agent_resilience.py tests/test_harness_protocol.py tests/test_normalize.py tests/test_agent_control_plane.py