### PR TITLE
feat(api-rs): add session store

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +68,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +82,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -91,10 +112,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -104,6 +134,18 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -186,6 +228,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "centaur-session-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "centaur-session-sqlx"
+version = "0.1.0"
+dependencies = [
+ "centaur-session-core",
+ "serde_json",
+ "sqlx",
+ "thiserror",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +302,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +340,36 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -313,6 +422,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,8 +470,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dyn-clone"
@@ -354,6 +503,9 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -372,10 +524,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -415,6 +606,28 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
 
 [[package]]
 name = "futures-io"
@@ -479,8 +692,32 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -490,10 +727,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -605,10 +884,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -617,7 +1005,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -654,6 +1044,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -762,16 +1164,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.8.0",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -797,12 +1267,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -833,6 +1346,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +1382,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -898,6 +1449,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,12 +1497,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -946,13 +1555,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -962,7 +1598,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -972,6 +1617,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1038,6 +1701,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -1092,6 +1775,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1132,6 +1821,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrecy"
@@ -1236,6 +1931,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +2014,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1306,6 +2026,236 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "time",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "time",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -1338,6 +2288,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +2317,62 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1391,6 +2408,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1516,7 +2544,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "sha1",
  "thiserror",
  "utf-8",
@@ -1535,10 +2563,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1553,16 +2608,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1591,7 +2682,129 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -1602,11 +2815,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1620,19 +2842,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1642,9 +2885,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1660,9 +2915,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1672,9 +2939,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1684,9 +2963,126 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1709,10 +3105,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -233,6 +233,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "strum",
  "thiserror",
  "time",
 ]
@@ -2263,6 +2264,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -106,6 +106,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,13 +231,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "centaur-api-server"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "bytes",
+ "centaur-sandbox-agent-k8s",
+ "centaur-sandbox-core",
+ "centaur-sandbox-local",
+ "centaur-session-core",
+ "centaur-session-sqlx",
+ "clap",
+ "futures-util",
+ "kube",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -228,12 +342,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "centaur-session-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "centaur-session-core",
+ "clap",
+ "crossterm",
+ "futures-util",
+ "ratatui",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
 name = "centaur-session-core"
 version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "strum",
+ "strum 0.28.0",
  "thiserror",
  "time",
 ]
@@ -255,6 +386,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -297,10 +434,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -371,6 +541,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -494,6 +689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +844,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +875,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -681,8 +900,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -692,9 +913,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -815,6 +1038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +1056,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -870,13 +1100,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1012,10 +1245,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1045,6 +1315,65 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1214,6 +1543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1568,36 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -1263,7 +1628,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1374,6 +1749,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1541,6 +1922,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +2058,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +2146,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +2220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,11 +2235,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1763,8 +2281,36 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1772,6 +2318,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1788,6 +2335,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1932,6 +2488,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,10 +2546,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2003,6 +2600,22 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2249,6 +2862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,11 +2886,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -2308,6 +2949,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2338,6 +2982,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2495,6 +3148,7 @@ dependencies = [
  "base64",
  "bitflags",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
  "mime",
@@ -2503,6 +3157,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2547,6 +3202,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2612,6 +3310,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,6 +3367,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -2672,6 +3405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,6 +3421,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2733,6 +3482,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2790,6 +3549,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +3571,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2830,6 +3631,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +3683,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2886,11 +3736,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2906,6 +3773,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,6 +3789,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2930,10 +3809,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2948,6 +3839,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,6 +3855,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2972,6 +3875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3891,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -30,6 +30,7 @@ kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
+strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
 time = { version = "0.3", features = ["serde"] }
 tokio = "1"

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "crates/centaur-sandbox-agent-k8s",
     "crates/centaur-sandbox-local",
     "crates/centaur-sandbox-manager",
+    "crates/centaur-session-core",
+    "crates/centaur-session-sqlx",
 ]
 resolver = "3"
 
@@ -20,10 +22,15 @@ centaur-sandbox-core = { path = "crates/centaur-sandbox-core" }
 centaur-sandbox-agent-k8s = { path = "crates/centaur-sandbox-agent-k8s" }
 centaur-sandbox-local = { path = "crates/centaur-sandbox-local" }
 centaur-sandbox-manager = { path = "crates/centaur-sandbox-manager" }
+centaur-session-core = { path = "crates/centaur-session-core" }
+centaur-session-sqlx = { path = "crates/centaur-session-sqlx" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
 thiserror = "2"
+time = { version = "0.3", features = ["serde"] }
 tokio = "1"
+uuid = { version = "1", features = ["serde", "v4"] }

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -1,10 +1,12 @@
 [workspace]
 members = [
+    "crates/centaur-api-server",
     "crates/centaur-sandbox-core",
     "crates/centaur-sandbox-e2e",
     "crates/centaur-sandbox-agent-k8s",
     "crates/centaur-sandbox-local",
     "crates/centaur-sandbox-manager",
+    "crates/centaur-session-cli",
     "crates/centaur-session-core",
     "crates/centaur-session-sqlx",
 ]
@@ -16,7 +18,9 @@ license = "MIT"
 repository = "https://github.com/paradigmxyz/centaur"
 
 [workspace.dependencies]
+anyhow = "1"
 async-trait = "0.1"
+axum = "0.8.9"
 bytes = { version = "1", features = ["serde"] }
 centaur-sandbox-core = { path = "crates/centaur-sandbox-core" }
 centaur-sandbox-agent-k8s = { path = "crates/centaur-sandbox-agent-k8s" }
@@ -25,13 +29,20 @@ centaur-sandbox-manager = { path = "crates/centaur-sandbox-manager" }
 centaur-session-core = { path = "crates/centaur-session-core" }
 centaur-session-sqlx = { path = "crates/centaur-session-sqlx" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
+crossterm = "0.28"
+futures-util = "0.3"
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
+ratatui = "0.29"
 sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
 time = { version = "0.3", features = ["serde"] }
 tokio = "1"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+urlencoding = "2"
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/services/api-rs/crates/centaur-api-server/Cargo.toml
+++ b/services/api-rs/crates/centaur-api-server/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "centaur-api-server"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+axum.workspace = true
+bytes.workspace = true
+centaur-sandbox-agent-k8s.workspace = true
+centaur-sandbox-core.workspace = true
+centaur-sandbox-local.workspace = true
+centaur-session-core.workspace = true
+centaur-session-sqlx.workspace = true
+clap.workspace = true
+futures-util.workspace = true
+kube.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json"] }

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -1,0 +1,735 @@
+use std::{
+    collections::{HashSet, VecDeque},
+    convert::Infallible,
+    sync::Arc,
+    time::Duration,
+};
+
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::{
+        IntoResponse, Response, Sse,
+        sse::{Event, KeepAlive},
+    },
+    routing::{get, post},
+};
+use bytes::Bytes;
+use centaur_sandbox_core::{
+    OutputStream, ReadOptions, ReadResult, SandboxBackend, SandboxError, SandboxId, SandboxSpec,
+    SandboxStatus,
+};
+use centaur_session_core::{
+    HarnessType, SessionEvent, SessionMessageInput, ThreadKey, ThreadKeyError,
+};
+use centaur_session_sqlx::{PgSessionStore, SessionStoreError, default_metadata};
+use futures_util::stream;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use thiserror::Error;
+use tokio::{sync::Mutex, time::sleep};
+use tracing::warn;
+
+const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
+const DEFAULT_IDLE_TIMEOUT_MS: u64 = 1_000;
+const DEFAULT_MAX_DURATION_MS: u64 = 60_000;
+type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
+
+#[derive(Clone)]
+pub struct AppState {
+    store: PgSessionStore,
+    sandbox_runtime: SandboxRuntime,
+    stdout_pumps: Arc<Mutex<HashSet<String>>>,
+}
+
+pub fn build_router(store: PgSessionStore) -> Router {
+    build_router_with_runtime(store, SandboxRuntime::Mock)
+}
+
+pub fn build_router_with_runtime(store: PgSessionStore, sandbox_runtime: SandboxRuntime) -> Router {
+    let state = AppState {
+        store,
+        sandbox_runtime,
+        stdout_pumps: Arc::new(Mutex::new(HashSet::new())),
+    };
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/api/session/{thread_key}", post(create_or_get_session))
+        .route("/api/session/{thread_key}/messages", post(append_messages))
+        .route("/api/session/{thread_key}/execute", post(execute_session))
+        .route("/api/session/{thread_key}/events", get(stream_events))
+        .with_state(state)
+}
+
+#[derive(Clone)]
+pub enum SandboxRuntime {
+    Mock,
+    Backend {
+        backend: Arc<dyn SandboxBackend>,
+        spec_factory: SandboxSpecFactory,
+    },
+}
+
+impl SandboxRuntime {
+    pub fn backend(backend: Arc<dyn SandboxBackend>, spec: SandboxSpec) -> Self {
+        let spec_factory = move |_thread_key: &ThreadKey, _execution_id: &str| spec.clone();
+        Self::backend_with_spec_factory(backend, spec_factory)
+    }
+
+    pub fn backend_with_spec_factory<F>(backend: Arc<dyn SandboxBackend>, spec_factory: F) -> Self
+    where
+        F: Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync + 'static,
+    {
+        Self::Backend {
+            backend,
+            spec_factory: Arc::new(spec_factory),
+        }
+    }
+}
+
+async fn healthz() -> Json<Value> {
+    Json(json!({"ok": true}))
+}
+
+async fn create_or_get_session(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Json(request): Json<CreateSessionRequest>,
+) -> Result<Json<Value>, ApiError> {
+    let thread_key = parse_thread_key(raw_thread_key)?;
+    let metadata = default_metadata(request.metadata);
+    let session = state
+        .store
+        .create_or_get_session(&thread_key, &request.harness_type, metadata)
+        .await?;
+    Ok(Json(serde_json::to_value(session)?))
+}
+
+async fn append_messages(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Json(request): Json<AppendMessagesRequest>,
+) -> Result<Json<AppendMessagesResponse>, ApiError> {
+    if request.messages.is_empty() {
+        return Err(ApiError::BadRequest(
+            "messages must not be empty".to_owned(),
+        ));
+    }
+    let thread_key = parse_thread_key(raw_thread_key)?;
+    let message_ids = state
+        .store
+        .append_messages(&thread_key, &request.messages)
+        .await?;
+    Ok(Json(AppendMessagesResponse {
+        ok: true,
+        message_ids,
+    }))
+}
+
+async fn execute_session(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Json(request): Json<ExecuteSessionRequest>,
+) -> Result<Json<ExecuteSessionResponse>, ApiError> {
+    let thread_key = parse_thread_key(raw_thread_key)?;
+    let session = state.store.get_session(&thread_key).await?;
+    validate_input_lines(&request.input_lines)?;
+    let pipe_options = PipeOptions::from_request(&request)?;
+
+    let execution = state
+        .store
+        .create_execution(&thread_key, default_metadata(request.metadata))
+        .await?;
+    let execution = state
+        .store
+        .mark_execution_running(&execution.execution_id)
+        .await?;
+    let sandbox_id = ensure_session_sandbox(
+        &state.store,
+        &state.sandbox_runtime,
+        &thread_key,
+        session.sandbox_id.as_deref(),
+        &execution.execution_id,
+    )
+    .await?;
+
+    state
+        .store
+        .append_event(
+            &thread_key,
+            Some(&execution.execution_id),
+            "session.execution_started",
+            json!({
+                "execution_id": execution.execution_id,
+                "thread_key": thread_key.as_str(),
+                "input_line_count": request.input_lines.len(),
+            }),
+        )
+        .await?;
+
+    let run_result = match &state.sandbox_runtime {
+        SandboxRuntime::Mock => {
+            run_mock_session_pipe(
+                &state.store,
+                &thread_key,
+                &execution.execution_id,
+                &sandbox_id,
+                pipe_options,
+            )
+            .await
+        }
+        SandboxRuntime::Backend { backend, .. } => {
+            match ensure_stdout_pump(&state, &thread_key, &sandbox_id).await {
+                Ok(()) => write_input_lines(
+                    backend.as_ref(),
+                    &SandboxId::new(&sandbox_id),
+                    &request.input_lines,
+                )
+                .await
+                .map(|()| 0),
+                Err(error) => Err(error),
+            }
+        }
+    };
+    let output_line_count = match run_result {
+        Ok(output_line_count) => output_line_count,
+        Err(error) => {
+            let error_message = error.to_string();
+            let _ = state
+                .store
+                .append_event(
+                    &thread_key,
+                    Some(&execution.execution_id),
+                    "session.execution_failed",
+                    json!({
+                        "execution_id": execution.execution_id,
+                        "thread_key": thread_key.as_str(),
+                        "error": error_message,
+                    }),
+                )
+                .await;
+            let _ = state
+                .store
+                .fail_execution(&execution.execution_id, &error_message)
+                .await;
+            return Err(error);
+        }
+    };
+
+    state
+        .store
+        .append_event(
+            &thread_key,
+            Some(&execution.execution_id),
+            "session.execution_completed",
+            json!({
+                "execution_id": execution.execution_id,
+                "thread_key": thread_key.as_str(),
+                "output_line_count": output_line_count,
+                "completion_reason": "input_accepted",
+            }),
+        )
+        .await?;
+
+    let execution = state
+        .store
+        .complete_execution(&execution.execution_id)
+        .await?;
+    Ok(Json(ExecuteSessionResponse {
+        ok: true,
+        execution_id: execution.execution_id,
+        thread_key: execution.thread_key,
+        status: execution.status.to_string(),
+    }))
+}
+
+async fn ensure_session_sandbox(
+    store: &PgSessionStore,
+    runtime: &SandboxRuntime,
+    thread_key: &ThreadKey,
+    existing_sandbox_id: Option<&str>,
+    execution_id: &str,
+) -> Result<String, ApiError> {
+    match runtime {
+        SandboxRuntime::Mock => {
+            if let Some(sandbox_id) = existing_sandbox_id {
+                return Ok(sandbox_id.to_owned());
+            }
+            let sandbox_id = format!("mock-sandbox-{execution_id}");
+            store
+                .update_sandbox_id(thread_key, Some(&sandbox_id))
+                .await?;
+            Ok(sandbox_id)
+        }
+        SandboxRuntime::Backend {
+            backend,
+            spec_factory,
+        } => {
+            if let Some(sandbox_id) = existing_sandbox_id {
+                let id = SandboxId::new(sandbox_id);
+                match backend.status(&id).await {
+                    Ok(SandboxStatus::Running | SandboxStatus::Created) => {
+                        return Ok(sandbox_id.to_owned());
+                    }
+                    Ok(_) | Err(SandboxError::NotFound(_)) => {}
+                    Err(error) => return Err(ApiError::Sandbox(error)),
+                }
+            }
+
+            let spec = spec_factory(thread_key, execution_id);
+            let handle = backend.create(spec).await.map_err(ApiError::Sandbox)?;
+            store
+                .update_sandbox_id(thread_key, Some(handle.id.as_str()))
+                .await?;
+            Ok(handle.id.into_string())
+        }
+    }
+}
+
+async fn run_mock_session_pipe(
+    store: &PgSessionStore,
+    thread_key: &ThreadKey,
+    execution_id: &str,
+    sandbox_id: &str,
+    options: PipeOptions,
+) -> Result<usize, ApiError> {
+    let mut output_line_count = 0;
+    let output_lines = mock_app_server_output_lines(thread_key, execution_id, sandbox_id);
+    for (index, line) in output_lines.iter().enumerate() {
+        append_output_line(store, thread_key, Some(execution_id), line).await?;
+        output_line_count += 1;
+        if index + 1 < output_lines.len() {
+            sleep(Duration::from_millis(200)).await;
+        }
+    }
+    if options.idle_timeout < Duration::from_millis(DEFAULT_IDLE_TIMEOUT_MS)
+        || options.max_duration < Duration::from_millis(DEFAULT_MAX_DURATION_MS)
+    {
+        sleep(options.idle_timeout).await;
+    }
+    Ok(output_line_count)
+}
+
+async fn ensure_stdout_pump(
+    state: &AppState,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+) -> Result<(), ApiError> {
+    let SandboxRuntime::Backend { backend, .. } = &state.sandbox_runtime else {
+        return Ok(());
+    };
+
+    let mut pumps = state.stdout_pumps.lock().await;
+    if !pumps.insert(sandbox_id.to_owned()) {
+        return Ok(());
+    }
+    drop(pumps);
+
+    let store = state.store.clone();
+    let backend = backend.clone();
+    let thread_key = thread_key.clone();
+    let sandbox_id = SandboxId::new(sandbox_id);
+    let pump_key = sandbox_id.as_str().to_owned();
+    let stdout_pumps = state.stdout_pumps.clone();
+
+    tokio::spawn(async move {
+        let result = run_stdout_pump(store.clone(), backend, thread_key.clone(), sandbox_id).await;
+        if let Err(error) = result {
+            warn!(%pump_key, %error, "session stdout pump failed");
+            let _ = store
+                .append_event(
+                    &thread_key,
+                    None,
+                    "session.stdout_pump_failed",
+                    json!({
+                        "sandbox_id": pump_key,
+                        "error": error.to_string(),
+                    }),
+                )
+                .await;
+        }
+        stdout_pumps.lock().await.remove(&pump_key);
+    });
+
+    Ok(())
+}
+
+async fn run_stdout_pump(
+    store: PgSessionStore,
+    backend: Arc<dyn SandboxBackend>,
+    thread_key: ThreadKey,
+    sandbox_id: SandboxId,
+) -> Result<(), ApiError> {
+    let mut buffer = String::new();
+    loop {
+        match backend
+            .read_bytes(
+                &sandbox_id,
+                ReadOptions {
+                    stream: OutputStream::Stdout,
+                    after_offset: None,
+                    max_bytes: 8192,
+                    timeout_ms: Some(1_000),
+                },
+            )
+            .await
+            .map_err(ApiError::Sandbox)?
+        {
+            ReadResult::Bytes { bytes, .. } => {
+                let chunk = std::str::from_utf8(&bytes).map_err(|err| {
+                    ApiError::BadRequest(format!("sandbox stdout was not UTF-8: {err}"))
+                })?;
+                buffer.push_str(chunk);
+
+                while let Some(index) = buffer.find('\n') {
+                    let line = buffer[..index].trim_end_matches('\r').to_owned();
+                    buffer.drain(..=index);
+                    append_output_line(&store, &thread_key, None, &line).await?;
+                }
+            }
+            ReadResult::TimedOut => {}
+            ReadResult::Eof => {
+                flush_partial_output(&store, &thread_key, None, &mut buffer).await?;
+                store
+                    .append_event(
+                        &thread_key,
+                        None,
+                        "session.stdout_eof",
+                        json!({
+                            "sandbox_id": sandbox_id.as_str(),
+                        }),
+                    )
+                    .await?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn write_input_lines(
+    backend: &dyn SandboxBackend,
+    sandbox_id: &SandboxId,
+    input_lines: &[String],
+) -> Result<(), ApiError> {
+    for line in input_lines {
+        write_input_line(backend, sandbox_id, line).await?;
+    }
+    Ok(())
+}
+
+async fn write_input_line(
+    backend: &dyn SandboxBackend,
+    sandbox_id: &SandboxId,
+    line: &str,
+) -> Result<(), ApiError> {
+    let mut bytes = Vec::with_capacity(line.len() + 1);
+    bytes.extend_from_slice(line.as_bytes());
+    bytes.push(b'\n');
+    backend
+        .write_bytes(sandbox_id, Bytes::from(bytes))
+        .await
+        .map_err(ApiError::Sandbox)?;
+    Ok(())
+}
+
+async fn flush_partial_output(
+    store: &PgSessionStore,
+    thread_key: &ThreadKey,
+    execution_id: Option<&str>,
+    buffer: &mut String,
+) -> Result<usize, ApiError> {
+    if buffer.is_empty() {
+        return Ok(0);
+    }
+    let line = buffer.trim_end_matches('\r').to_owned();
+    buffer.clear();
+    append_output_line(store, thread_key, execution_id, &line).await?;
+    Ok(1)
+}
+
+async fn append_output_line(
+    store: &PgSessionStore,
+    thread_key: &ThreadKey,
+    execution_id: Option<&str>,
+    line: &str,
+) -> Result<(), ApiError> {
+    store
+        .append_event(
+            thread_key,
+            execution_id,
+            SESSION_OUTPUT_LINE_EVENT,
+            Value::String(line.to_owned()),
+        )
+        .await?;
+    Ok(())
+}
+
+fn mock_app_server_output_lines(
+    thread_key: &ThreadKey,
+    execution_id: &str,
+    sandbox_id: &str,
+) -> Vec<String> {
+    let mock_thread_id = format!("mock-codex-thread-{sandbox_id}");
+    let mut lines = vec![
+        json!({
+            "type": "system",
+            "subtype": "wrapper_heartbeat",
+            "phase": "startup",
+            "thread_key": thread_key.as_str(),
+            "execution_id": execution_id,
+            "sandbox_id": sandbox_id,
+        }),
+        json!({
+            "type": "system",
+            "subtype": "wrapper_heartbeat",
+            "phase": "app_server_started",
+            "thread_key": thread_key.as_str(),
+            "execution_id": execution_id,
+            "sandbox_id": sandbox_id,
+        }),
+        json!({
+            "type": "thread.started",
+            "thread_id": mock_thread_id,
+        }),
+    ];
+
+    for turn_index in 1..=3 {
+        let mock_turn_id = format!("mock-turn-{execution_id}-{turn_index}");
+        lines.extend([
+            json!({
+                "type": "turn.started",
+                "turn_id": mock_turn_id,
+            }),
+            json!({
+                "type": "item.agentMessage.delta",
+                "turnId": mock_turn_id,
+                "session_id": mock_thread_id,
+                "delta": format!("PONG {turn_index}"),
+            }),
+            json!({
+                "type": "turn.completed",
+                "turn": {
+                    "id": mock_turn_id,
+                },
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 1,
+                },
+            }),
+        ]);
+    }
+
+    lines.into_iter().map(|value| value.to_string()).collect()
+}
+
+async fn stream_events(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Query(query): Query<EventsQuery>,
+) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    let thread_key = parse_thread_key(raw_thread_key)?;
+    let session = state.store.get_session(&thread_key).await?;
+    if let Some(sandbox_id) = session.sandbox_id.as_deref() {
+        ensure_stdout_pump(&state, &thread_key, sandbox_id).await?;
+    }
+
+    let stream = stream::unfold(
+        SessionEventStreamState {
+            store: state.store,
+            thread_key,
+            after_event_id: query.after_event_id.unwrap_or(0),
+            pending: VecDeque::new(),
+            done: false,
+        },
+        |mut state| async move {
+            loop {
+                if let Some(event) = state.pending.pop_front() {
+                    state.after_event_id = event.event_id;
+                    return Some((Ok(to_sse_event(event)), state));
+                }
+                if state.done {
+                    return None;
+                }
+                match state
+                    .store
+                    .list_events_after(&state.thread_key, state.after_event_id, 100)
+                    .await
+                {
+                    Ok(events) if events.is_empty() => sleep(Duration::from_millis(250)).await,
+                    Ok(events) => state.pending = events.into(),
+                    Err(error) => {
+                        state.done = true;
+                        let event = Event::default()
+                            .event("session.stream_error")
+                            .data(json!({"error": error.to_string()}).to_string());
+                        return Some((Ok(event), state));
+                    }
+                }
+            }
+        },
+    );
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+struct SessionEventStreamState {
+    store: PgSessionStore,
+    thread_key: ThreadKey,
+    after_event_id: i64,
+    pending: VecDeque<SessionEvent>,
+    done: bool,
+}
+
+fn to_sse_event(event: SessionEvent) -> Event {
+    let data = if event.event_type == SESSION_OUTPUT_LINE_EVENT {
+        event.payload.as_str().unwrap_or_default().to_owned()
+    } else {
+        serde_json::to_string(&event.payload).unwrap_or_else(|_| "{}".to_owned())
+    };
+    Event::default()
+        .id(event.event_id.to_string())
+        .event(event.event_type)
+        .data(data)
+}
+
+fn parse_thread_key(value: String) -> Result<ThreadKey, ApiError> {
+    ThreadKey::parse(value).map_err(ApiError::InvalidThreadKey)
+}
+
+fn validate_input_lines(lines: &[String]) -> Result<(), ApiError> {
+    for (index, line) in lines.iter().enumerate() {
+        if line.contains('\n') || line.contains('\r') {
+            return Err(ApiError::BadRequest(format!(
+                "input_lines[{index}] must be one line"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PipeOptions {
+    idle_timeout: Duration,
+    max_duration: Duration,
+}
+
+impl PipeOptions {
+    fn from_request(request: &ExecuteSessionRequest) -> Result<Self, ApiError> {
+        let idle_timeout = request
+            .idle_timeout_ms
+            .map(nonzero_duration_millis)
+            .transpose()?
+            .unwrap_or_else(|| Duration::from_millis(DEFAULT_IDLE_TIMEOUT_MS));
+        let max_duration = request
+            .max_duration_ms
+            .map(nonzero_duration_millis)
+            .transpose()?
+            .unwrap_or_else(|| Duration::from_millis(DEFAULT_MAX_DURATION_MS));
+
+        if idle_timeout > max_duration {
+            return Err(ApiError::BadRequest(
+                "idle_timeout_ms must be less than or equal to max_duration_ms".to_owned(),
+            ));
+        }
+
+        Ok(Self {
+            idle_timeout,
+            max_duration,
+        })
+    }
+}
+
+fn nonzero_duration_millis(value: u64) -> Result<Duration, ApiError> {
+    if value == 0 {
+        return Err(ApiError::BadRequest(
+            "duration values must be greater than zero".to_owned(),
+        ));
+    }
+    Ok(Duration::from_millis(value))
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateSessionRequest {
+    harness_type: HarnessType,
+    metadata: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AppendMessagesRequest {
+    messages: Vec<SessionMessageInput>,
+}
+
+#[derive(Debug, Serialize)]
+struct AppendMessagesResponse {
+    ok: bool,
+    message_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExecuteSessionRequest {
+    metadata: Option<Value>,
+    #[serde(default)]
+    input_lines: Vec<String>,
+    idle_timeout_ms: Option<u64>,
+    max_duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExecuteSessionResponse {
+    ok: bool,
+    execution_id: String,
+    thread_key: ThreadKey,
+    status: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EventsQuery {
+    after_event_id: Option<i64>,
+}
+
+#[derive(Debug, Error)]
+enum ApiError {
+    #[error(transparent)]
+    InvalidThreadKey(#[from] ThreadKeyError),
+    #[error("{0}")]
+    BadRequest(String),
+    #[error(transparent)]
+    Store(#[from] SessionStoreError),
+    #[error(transparent)]
+    Sandbox(#[from] SandboxError),
+    #[error(transparent)]
+    Serialize(#[from] serde_json::Error),
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            Self::InvalidThreadKey(_) | Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::Store(SessionStoreError::NotFound { .. }) => StatusCode::NOT_FOUND,
+            Self::Store(SessionStoreError::HarnessConflict { .. }) => StatusCode::CONFLICT,
+            Self::Store(_) | Self::Sandbox(_) | Self::Serialize(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+        let body = Json(json!({
+            "ok": false,
+            "error": self.to_string(),
+        }));
+        (status, body).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_router;
+    use centaur_session_sqlx::PgSessionStore;
+    use sqlx::PgPool;
+
+    #[tokio::test]
+    async fn router_builds() {
+        let pool =
+            PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
+        let _router = build_router(PgSessionStore::new(pool));
+    }
+}

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -1,0 +1,262 @@
+use std::{env, net::SocketAddr, sync::Arc, time::Duration};
+
+use centaur_api_server::{SandboxRuntime, build_router_with_runtime};
+use centaur_sandbox_agent_k8s::{AgentSandboxBackend, AgentSandboxConfig};
+use centaur_sandbox_core::SandboxSpec;
+use centaur_sandbox_local::LocalSandboxBackend;
+use centaur_session_core::ThreadKey;
+use centaur_session_sqlx::PgSessionStore;
+use clap::{Parser, ValueEnum};
+use thiserror::Error;
+use tokio::net::TcpListener;
+use tracing::info;
+use tracing_subscriber::{EnvFilter, fmt};
+
+#[tokio::main]
+async fn main() -> Result<(), ServerError> {
+    init_tracing();
+
+    let args = Args::parse();
+
+    let store = PgSessionStore::connect(&args.database_url).await?;
+    if args.run_migrations {
+        store.run_migrations().await?;
+    }
+    let sandbox_runtime = sandbox_runtime_from_args(&args).await?;
+
+    let listener = TcpListener::bind(args.bind_addr).await?;
+    info!(bind_addr = %args.bind_addr, "starting centaur api-rs server");
+
+    axum::serve(listener, build_router_with_runtime(store, sandbox_runtime))
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    fmt().with_env_filter(filter).json().init();
+}
+
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+async fn sandbox_runtime_from_args(args: &Args) -> Result<SandboxRuntime, ServerError> {
+    match args.session_sandbox_backend {
+        SandboxBackendKind::Mock => Ok(SandboxRuntime::Mock),
+        SandboxBackendKind::Local => Ok(SandboxRuntime::backend(
+            Arc::new(LocalSandboxBackend::new()),
+            local_mock_app_server_spec(),
+        )),
+        SandboxBackendKind::AgentK8s => {
+            let image = args
+                .session_sandbox_image
+                .clone()
+                .unwrap_or_else(|| default_sandbox_image(args.session_sandbox_workload).to_owned());
+            let mut config = AgentSandboxConfig::new(args.session_sandbox_k8s_namespace.clone());
+            config.image_pull_policy = args.session_sandbox_image_pull_policy.clone();
+            config.ready_timeout = Duration::from_secs(args.session_sandbox_ready_timeout_secs);
+
+            let client = if let Some(context) = args.session_sandbox_k8s_context.as_deref() {
+                let kube_config = kube::Config::from_kubeconfig(&kube::config::KubeConfigOptions {
+                    context: Some(context.to_owned()),
+                    ..kube::config::KubeConfigOptions::default()
+                })
+                .await?;
+                kube::Client::try_from(kube_config)?
+            } else {
+                kube::Client::try_default().await?
+            };
+            let backend = AgentSandboxBackend::new(client, config);
+
+            match args.session_sandbox_workload {
+                SandboxWorkloadKind::Mock => Ok(SandboxRuntime::backend(
+                    Arc::new(backend),
+                    agent_k8s_mock_app_server_spec(&image),
+                )),
+                SandboxWorkloadKind::CodexAppServer => {
+                    let env_template = codex_app_server_env_template(args);
+                    Ok(SandboxRuntime::backend_with_spec_factory(
+                        Arc::new(backend),
+                        move |thread_key, _execution_id| {
+                            codex_app_server_spec(&image, thread_key, &env_template)
+                        },
+                    ))
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+#[command(about = "Run the Centaur API Rust session control plane")]
+struct Args {
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: String,
+    #[arg(long, env = "BIND_ADDR", default_value = "127.0.0.1:8080")]
+    bind_addr: SocketAddr,
+    #[arg(long, env = "RUN_MIGRATIONS", default_value_t = false)]
+    run_migrations: bool,
+    #[arg(
+        long,
+        env = "SESSION_SANDBOX_BACKEND",
+        value_enum,
+        default_value = "mock"
+    )]
+    session_sandbox_backend: SandboxBackendKind,
+    #[arg(
+        long,
+        env = "SESSION_SANDBOX_WORKLOAD",
+        value_enum,
+        default_value = "mock"
+    )]
+    session_sandbox_workload: SandboxWorkloadKind,
+    #[arg(
+        long,
+        env = "SESSION_SANDBOX_K8S_NAMESPACE",
+        default_value = "centaur-sandbox-e2e"
+    )]
+    session_sandbox_k8s_namespace: String,
+    #[arg(long, env = "SESSION_SANDBOX_IMAGE")]
+    session_sandbox_image: Option<String>,
+    #[arg(long, env = "SESSION_SANDBOX_IMAGE_PULL_POLICY")]
+    session_sandbox_image_pull_policy: Option<String>,
+    #[arg(long, env = "SESSION_SANDBOX_READY_TIMEOUT_SECS", default_value_t = 90)]
+    session_sandbox_ready_timeout_secs: u64,
+    #[arg(long, env = "SESSION_SANDBOX_K8S_CONTEXT")]
+    session_sandbox_k8s_context: Option<String>,
+    #[arg(long, env = "SESSION_SANDBOX_CENTAUR_API_URL")]
+    session_sandbox_centaur_api_url: Option<String>,
+    #[arg(long, env = "CENTAUR_API_URL")]
+    centaur_api_url: Option<String>,
+    #[arg(long, env = "SESSION_SANDBOX_CENTAUR_API_KEY")]
+    session_sandbox_centaur_api_key: Option<String>,
+    #[arg(long, env = "CENTAUR_API_KEY")]
+    centaur_api_key: Option<String>,
+    #[arg(long, env = "SESSION_SANDBOX_PASSTHROUGH_ENV", value_delimiter = ',')]
+    session_sandbox_passthrough_env: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum SandboxBackendKind {
+    Mock,
+    Local,
+    #[value(name = "agent-k8s")]
+    AgentK8s,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum SandboxWorkloadKind {
+    Mock,
+    #[value(name = "codex-app-server")]
+    CodexAppServer,
+}
+
+fn default_sandbox_image(workload: SandboxWorkloadKind) -> &'static str {
+    match workload {
+        SandboxWorkloadKind::Mock => "busybox:1.36",
+        SandboxWorkloadKind::CodexAppServer => "centaur-agent:latest",
+    }
+}
+
+fn local_mock_app_server_spec() -> SandboxSpec {
+    SandboxSpec::new("/bin/sh")
+        .command(["/bin/sh", "-lc"])
+        .args([mock_app_server_script()])
+}
+
+fn agent_k8s_mock_app_server_spec(image: &str) -> SandboxSpec {
+    SandboxSpec::new(image)
+        .command(["/bin/sh", "-lc"])
+        .args([mock_app_server_script()])
+}
+
+fn codex_app_server_spec(
+    image: &str,
+    thread_key: &ThreadKey,
+    env_template: &[(String, String)],
+) -> SandboxSpec {
+    let mut spec = SandboxSpec::new(image).env("CENTAUR_THREAD_KEY", thread_key.as_str());
+    for (name, value) in env_template {
+        spec = spec.env(name.clone(), value.clone());
+    }
+    spec
+}
+
+fn codex_app_server_env_template(args: &Args) -> Vec<(String, String)> {
+    let mut envs = Vec::new();
+    push_env(
+        &mut envs,
+        "CENTAUR_API_URL",
+        args.session_sandbox_centaur_api_url
+            .as_deref()
+            .or(args.centaur_api_url.as_deref())
+            .unwrap_or("http://api:8000")
+            .to_owned(),
+    );
+    if let Some(api_key) = args
+        .session_sandbox_centaur_api_key
+        .as_deref()
+        .or(args.centaur_api_key.as_deref())
+    {
+        push_env(&mut envs, "CENTAUR_API_KEY", api_key.to_owned());
+    }
+
+    for name in &args.session_sandbox_passthrough_env {
+        if let Ok(value) = env::var(&name) {
+            push_env(&mut envs, &name, value);
+        }
+    }
+
+    envs
+}
+
+fn push_env(envs: &mut Vec<(String, String)>, name: &str, value: String) {
+    if let Some((_, existing_value)) = envs
+        .iter_mut()
+        .find(|(existing_name, _)| existing_name == name)
+    {
+        *existing_value = value;
+    } else {
+        envs.push((name.to_owned(), value));
+    }
+}
+
+fn mock_app_server_script() -> &'static str {
+    r#"while IFS= read -r line; do
+printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"startup"}'
+sleep 0.2
+printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"app_server_started"}'
+sleep 0.2
+printf '%s\n' '{"type":"thread.started","thread_id":"mock-codex-thread"}'
+sleep 0.2
+turn_index=1
+while [ "$turn_index" -le 3 ]; do
+  turn_id="mock-turn-$turn_index"
+  printf '{"type":"turn.started","turn_id":"%s"}\n' "$turn_id"
+  sleep 0.2
+  printf '{"type":"item.agentMessage.delta","turnId":"%s","session_id":"mock-codex-thread","delta":"PONG %s"}\n' "$turn_id" "$turn_index"
+  sleep 0.2
+  printf '{"type":"turn.completed","turn":{"id":"%s"},"usage":{"input_tokens":0,"output_tokens":1}}\n' "$turn_id"
+  sleep 0.2
+  turn_index=$((turn_index + 1))
+done
+done"#
+}
+
+#[derive(Debug, Error)]
+enum ServerError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Store(#[from] centaur_session_sqlx::SessionStoreError),
+    #[error(transparent)]
+    Sandbox(#[from] centaur_sandbox_core::SandboxError),
+    #[error(transparent)]
+    KubeConfig(#[from] kube::config::KubeconfigError),
+    #[error(transparent)]
+    KubeInferConfig(#[from] kube::config::InferConfigError),
+    #[error(transparent)]
+    Kube(#[from] kube::Error),
+}

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -48,6 +48,7 @@ pub struct AgentSandboxConfig {
     pub container_name: String,
     pub labels: BTreeMap<String, String>,
     pub annotations: BTreeMap<String, String>,
+    pub image_pull_policy: Option<String>,
     pub state_volume: Option<StateVolumeConfig>,
     pub ready_timeout: Duration,
 }
@@ -60,6 +61,7 @@ impl AgentSandboxConfig {
             container_name: DEFAULT_CONTAINER_NAME.to_owned(),
             labels: BTreeMap::new(),
             annotations: BTreeMap::new(),
+            image_pull_policy: None,
             state_volume: None,
             ready_timeout: Duration::from_secs(60),
         }
@@ -555,6 +557,11 @@ fn build_agent_sandbox(
         "stdinOnce": false,
         "tty": false,
     });
+    insert_optional(
+        &mut container,
+        "imagePullPolicy",
+        config.image_pull_policy.clone(),
+    );
     insert_optional(&mut container, "command", spec.command.clone());
     insert_optional(
         &mut container,

--- a/services/api-rs/crates/centaur-session-cli/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "centaur-session-cli"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+centaur-session-core.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+crossterm.workspace = true
+futures-util.workspace = true
+ratatui.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
+urlencoding.workspace = true
+uuid.workspace = true

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -1,0 +1,626 @@
+use anyhow::{Context, Result, bail};
+use centaur_session_core::ThreadKey;
+use clap::Parser;
+use futures_util::StreamExt;
+use reqwest::Client;
+use serde_json::{Value, json};
+use tokio::{
+    io::{self, AsyncBufReadExt, BufReader},
+    task::JoinHandle,
+};
+use uuid::Uuid;
+
+mod tui;
+
+const DEFAULT_MESSAGE: &str = "Reply with exactly PONG and nothing else.";
+
+#[derive(Debug, Parser)]
+#[command(about = "Create, execute, or attach to a Centaur session")]
+struct Args {
+    #[arg(long, env = "CENTAUR_API_URL", default_value = "http://127.0.0.1:8080")]
+    api_url: String,
+
+    #[arg(long)]
+    thread_key: Option<String>,
+
+    #[arg(long)]
+    attach: bool,
+
+    #[arg(long, default_value = "codex")]
+    harness_type: String,
+
+    #[arg(long)]
+    message: Option<String>,
+
+    #[arg(long = "input-line")]
+    input_lines: Vec<String>,
+
+    #[arg(long, default_value_t = 1_000)]
+    idle_timeout_ms: u64,
+
+    #[arg(long, default_value_t = 60_000)]
+    max_duration_ms: u64,
+
+    #[arg(long, default_value_t = 0)]
+    after_event_id: i64,
+
+    #[arg(long)]
+    all_events: bool,
+
+    #[arg(long)]
+    exit_on_terminal: bool,
+
+    #[arg(long)]
+    exit_on_output_type: Option<String>,
+
+    #[arg(long, alias = "stdin")]
+    stdin_events: bool,
+
+    #[arg(long)]
+    tui: bool,
+
+    #[arg(long)]
+    debug: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    let attach_mode = attach_mode(&args);
+    validate_mode(&args, attach_mode)?;
+    let (thread_key, generated_thread_key) = thread_key_arg(&args, attach_mode)?;
+    let thread_key = ThreadKey::parse(thread_key)?;
+    if generated_thread_key {
+        eprintln!("thread_key={}", thread_key.as_str());
+    }
+    let client = Client::new();
+    let base_url = args.api_url.trim_end_matches('/').to_owned();
+    let session_url = session_url(&base_url, thread_key.as_str());
+
+    if attach_mode {
+        let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
+        if args.tui {
+            return tui::run(
+                client,
+                thread_key.as_str().to_owned(),
+                session_url,
+                events_response,
+                tui::TuiOptions {
+                    debug_visible: args.debug,
+                    idle_timeout_ms: args.idle_timeout_ms,
+                    max_duration_ms: args.max_duration_ms,
+                    exit_on_terminal: args.exit_on_terminal,
+                    exit_on_output_type: args.exit_on_output_type,
+                },
+            )
+            .await;
+        }
+        return run_stream_and_optional_stdin(
+            client,
+            session_url,
+            events_response,
+            args.all_events,
+            args.exit_on_terminal,
+            args.exit_on_output_type,
+            args.stdin_events,
+            args.idle_timeout_ms,
+            args.max_duration_ms,
+        )
+        .await;
+    }
+
+    post_json(
+        &client,
+        &session_url,
+        json!({
+            "harness_type": args.harness_type,
+            "metadata": {
+                "source": "centaur-session-cli",
+            },
+        }),
+    )
+    .await
+    .context("create session")?;
+
+    let initial_input_lines = if should_send_initial_turn(&args) {
+        let input_lines = session_input_lines(&args)?;
+        let message = message_text(&args);
+        append_user_message(&client, &session_url, message)
+            .await
+            .context("append message")?;
+        Some(input_lines)
+    } else {
+        None
+    };
+
+    let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
+
+    if let Some(input_lines) = initial_input_lines {
+        execute_input_lines(
+            &client,
+            &session_url,
+            input_lines,
+            args.idle_timeout_ms,
+            args.max_duration_ms,
+        )
+        .await
+        .context("execute initial turn")?;
+    }
+
+    if args.tui {
+        return tui::run(
+            client,
+            thread_key.as_str().to_owned(),
+            session_url,
+            events_response,
+            tui::TuiOptions {
+                debug_visible: args.debug,
+                idle_timeout_ms: args.idle_timeout_ms,
+                max_duration_ms: args.max_duration_ms,
+                exit_on_terminal: args.exit_on_terminal,
+                exit_on_output_type: args.exit_on_output_type,
+            },
+        )
+        .await;
+    }
+
+    run_stream_and_optional_stdin(
+        client,
+        session_url,
+        events_response,
+        args.all_events,
+        args.exit_on_terminal,
+        args.exit_on_output_type,
+        args.stdin_events,
+        args.idle_timeout_ms,
+        args.max_duration_ms,
+    )
+    .await
+}
+
+fn attach_mode(args: &Args) -> bool {
+    args.attach
+        || (args.after_event_id > 0
+            && args.thread_key.is_some()
+            && args.message.is_none()
+            && args.input_lines.is_empty())
+}
+
+fn validate_mode(args: &Args, attach_mode: bool) -> Result<()> {
+    if attach_mode && args.thread_key.is_none() {
+        bail!("attach mode requires --thread-key");
+    }
+    if args.attach && (args.message.is_some() || !args.input_lines.is_empty()) {
+        bail!("--attach does not accept --message or --input-line");
+    }
+    if args.tui && args.stdin_events {
+        bail!("--tui cannot be combined with --stdin-events");
+    }
+    Ok(())
+}
+
+fn thread_key_arg(args: &Args, attach_mode: bool) -> Result<(String, bool)> {
+    match (&args.thread_key, attach_mode) {
+        (Some(thread_key), _) => Ok((thread_key.clone(), false)),
+        (None, true) => bail!("--attach requires --thread-key"),
+        (None, false) => Ok((format!("cli:{}", Uuid::new_v4().simple()), true)),
+    }
+}
+
+async fn post_json(client: &Client, url: &str, payload: Value) -> Result<Value> {
+    let response = client
+        .post(url)
+        .json(&payload)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    let status = response.status();
+    let body = response.text().await?;
+    ensure_success(status, body.clone()).with_context(|| format!("POST {url}"))?;
+    serde_json::from_str(&body).with_context(|| format!("decode response from {url}"))
+}
+
+fn ensure_success(status: reqwest::StatusCode, body: String) -> Result<()> {
+    if status.is_success() {
+        return Ok(());
+    }
+    bail!("HTTP {status}: {body}");
+}
+
+async fn ensure_response_success(response: reqwest::Response) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response.text().await?;
+    bail!("HTTP {status}: {body}");
+}
+
+async fn open_event_stream(
+    client: &Client,
+    session_url: &str,
+    after_event_id: i64,
+) -> Result<reqwest::Response> {
+    let events_url = format!("{session_url}/events?after_event_id={after_event_id}");
+    let events_response = client
+        .get(&events_url)
+        .send()
+        .await
+        .context("open event stream")?;
+    ensure_response_success(events_response)
+        .await
+        .context("open event stream")
+}
+
+pub(crate) async fn append_user_message(
+    client: &Client,
+    session_url: &str,
+    text: &str,
+) -> Result<()> {
+    post_json(
+        client,
+        &format!("{session_url}/messages"),
+        json!({
+            "messages": [{
+                "role": "user",
+                "parts": [{"type": "text", "text": text}],
+                "metadata": {
+                    "source": "centaur-session-cli",
+                },
+            }],
+        }),
+    )
+    .await
+    .context("append message")?;
+    Ok(())
+}
+
+pub(crate) async fn execute_input_lines(
+    client: &Client,
+    session_url: &str,
+    input_lines: Vec<String>,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<()> {
+    post_json(
+        client,
+        &format!("{session_url}/execute"),
+        json!({
+            "metadata": {
+                "source": "centaur-session-cli",
+            },
+            "input_lines": input_lines,
+            "idle_timeout_ms": idle_timeout_ms,
+            "max_duration_ms": max_duration_ms,
+        }),
+    )
+    .await
+    .context("execute session")?;
+    Ok(())
+}
+
+async fn run_stream_and_optional_stdin(
+    client: Client,
+    session_url: String,
+    events_response: reqwest::Response,
+    all_events: bool,
+    exit_on_terminal: bool,
+    exit_on_output_type: Option<String>,
+    stdin_events: bool,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<()> {
+    let stream_future = stream_output_lines(
+        events_response,
+        all_events,
+        exit_on_terminal,
+        exit_on_output_type,
+    );
+    tokio::pin!(stream_future);
+
+    if !stdin_events {
+        return stream_future.await;
+    }
+
+    let mut stdin_task = spawn_stdin_events(client, session_url, idle_timeout_ms, max_duration_ms);
+
+    tokio::select! {
+        stream_result = &mut stream_future => {
+            stdin_task.abort();
+            stream_result
+        }
+        stdin_result = &mut stdin_task => {
+            stdin_result.context("join stdin event task")??;
+            stream_future.await
+        }
+    }
+}
+
+fn spawn_stdin_events(
+    client: Client,
+    session_url: String,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> JoinHandle<Result<()>> {
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(io::stdin()).lines();
+        while let Some(line) = lines.next_line().await.context("read stdin event")? {
+            let event = match StdinEvent::parse(&line)? {
+                Some(event) => event,
+                None => continue,
+            };
+            match event {
+                StdinEvent::Message(text) => {
+                    append_user_message(&client, &session_url, &text).await?;
+                    execute_input_lines(
+                        &client,
+                        &session_url,
+                        vec![user_input_line(&text)?],
+                        idle_timeout_ms,
+                        max_duration_ms,
+                    )
+                    .await?;
+                }
+                StdinEvent::InputLine(line) => {
+                    execute_input_lines(
+                        &client,
+                        &session_url,
+                        vec![line],
+                        idle_timeout_ms,
+                        max_duration_ms,
+                    )
+                    .await?;
+                }
+                StdinEvent::InputLines(lines) => {
+                    execute_input_lines(
+                        &client,
+                        &session_url,
+                        lines,
+                        idle_timeout_ms,
+                        max_duration_ms,
+                    )
+                    .await?;
+                }
+                StdinEvent::Quit => break,
+            }
+        }
+        Ok(())
+    })
+}
+
+async fn stream_output_lines(
+    response: reqwest::Response,
+    all_events: bool,
+    exit_on_terminal: bool,
+    exit_on_output_type: Option<String>,
+) -> Result<()> {
+    let mut chunks = response.bytes_stream();
+    let mut buffer = String::new();
+
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk.context("read event stream")?;
+        buffer.push_str(std::str::from_utf8(&chunk).context("event stream is not UTF-8")?);
+
+        while let Some((frame_end, separator_len)) = next_frame(&buffer) {
+            let frame = buffer[..frame_end].to_owned();
+            buffer.drain(..frame_end + separator_len);
+
+            let Some(event) = SseFrame::parse(&frame) else {
+                continue;
+            };
+
+            if event.event == "session.output.line" {
+                println!(
+                    "{}\t{}",
+                    event.id.as_deref().unwrap_or("unknown"),
+                    event.data
+                );
+                if output_type_matches(&event.data, exit_on_output_type.as_deref()) {
+                    return Ok(());
+                }
+            } else if all_events {
+                let data = parse_json_or_string(&event.data);
+                println!(
+                    "{}",
+                    serde_json::to_string(&json!({
+                        "sse_event": event.event,
+                        "id": event.id,
+                        "data": data,
+                    }))?
+                );
+            }
+
+            if exit_on_terminal && is_terminal_event(&event.event) {
+                return Ok(());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn output_type_matches(data: &str, expected_type: Option<&str>) -> bool {
+    let Some(expected_type) = expected_type else {
+        return false;
+    };
+    serde_json::from_str::<Value>(data)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("type")
+                .and_then(Value::as_str)
+                .map(|event_type| event_type == expected_type)
+        })
+        .unwrap_or(false)
+}
+
+fn session_input_lines(args: &Args) -> Result<Vec<String>> {
+    if !args.input_lines.is_empty() {
+        return Ok(args.input_lines.clone());
+    }
+    let message = message_text(args);
+    Ok(vec![user_input_line(message)?])
+}
+
+fn should_send_initial_turn(args: &Args) -> bool {
+    args.message.is_some() || !args.input_lines.is_empty() || (!args.stdin_events && !args.tui)
+}
+
+pub(crate) fn user_input_line(text: &str) -> Result<String> {
+    Ok(serde_json::to_string(&json!({
+        "type": "user",
+        "message": {
+            "content": [{"type": "text", "text": text}],
+        },
+    }))?)
+}
+
+fn message_text(args: &Args) -> &str {
+    args.message.as_deref().unwrap_or(DEFAULT_MESSAGE)
+}
+
+fn session_url(base_url: &str, thread_key: &str) -> String {
+    format!("{base_url}/api/session/{}", urlencoding::encode(thread_key))
+}
+
+pub(crate) fn next_frame(buffer: &str) -> Option<(usize, usize)> {
+    let lf = buffer.find("\n\n").map(|index| (index, 2));
+    let crlf = buffer.find("\r\n\r\n").map(|index| (index, 4));
+    match (lf, crlf) {
+        (Some(left), Some(right)) => Some(if left.0 <= right.0 { left } else { right }),
+        (Some(frame), None) | (None, Some(frame)) => Some(frame),
+        (None, None) => None,
+    }
+}
+
+pub(crate) fn parse_json_or_string(data: &str) -> Value {
+    serde_json::from_str(data).unwrap_or_else(|_| Value::String(data.to_owned()))
+}
+
+pub(crate) fn is_terminal_event(event: &str) -> bool {
+    matches!(
+        event,
+        "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
+    )
+}
+
+#[derive(Debug)]
+pub(crate) enum StdinEvent {
+    Message(String),
+    InputLine(String),
+    InputLines(Vec<String>),
+    Quit,
+}
+
+impl StdinEvent {
+    pub(crate) fn parse(line: &str) -> Result<Option<Self>> {
+        let line = line.trim();
+        if line.is_empty() {
+            return Ok(None);
+        }
+        if matches!(line, "/quit" | "/exit") {
+            return Ok(Some(Self::Quit));
+        }
+        if let Some(text) = line.strip_prefix("/message ") {
+            return Ok(Some(Self::Message(text.trim().to_owned())));
+        }
+        if let Some(raw_line) = line.strip_prefix("/input ") {
+            return Ok(Some(Self::InputLine(raw_line.trim().to_owned())));
+        }
+        if let Some(raw_lines) = line.strip_prefix("/execute ") {
+            return parse_execute_command(raw_lines.trim()).map(Some);
+        }
+        if line.starts_with('/') {
+            bail!("unknown stdin command: {line}");
+        }
+        if line.starts_with('{') {
+            return parse_json_stdin_event(line).map(Some);
+        }
+        Ok(Some(Self::Message(line.to_owned())))
+    }
+}
+
+fn parse_execute_command(value: &str) -> Result<StdinEvent> {
+    if value.starts_with('[') {
+        let lines =
+            serde_json::from_str::<Vec<String>>(value).context("parse /execute JSON array")?;
+        return Ok(StdinEvent::InputLines(lines));
+    }
+    Ok(StdinEvent::InputLine(value.to_owned()))
+}
+
+fn parse_json_stdin_event(line: &str) -> Result<StdinEvent> {
+    let value = serde_json::from_str::<Value>(line).context("parse stdin JSON event")?;
+    match value.get("type").and_then(Value::as_str) {
+        Some("message") => {
+            let text = value
+                .get("text")
+                .and_then(Value::as_str)
+                .context("stdin message event requires string field `text`")?;
+            Ok(StdinEvent::Message(text.to_owned()))
+        }
+        Some("input_line") => {
+            let raw_line = value
+                .get("line")
+                .and_then(Value::as_str)
+                .context("stdin input_line event requires string field `line`")?;
+            Ok(StdinEvent::InputLine(raw_line.to_owned()))
+        }
+        Some("execute") => {
+            let lines = value
+                .get("input_lines")
+                .and_then(Value::as_array)
+                .context("stdin execute event requires array field `input_lines`")?
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map(ToOwned::to_owned)
+                        .context("stdin execute input_lines must be strings")
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(StdinEvent::InputLines(lines))
+        }
+        Some("quit" | "exit") => Ok(StdinEvent::Quit),
+        _ => Ok(StdinEvent::InputLine(line.to_owned())),
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SseFrame {
+    pub(crate) id: Option<String>,
+    pub(crate) event: String,
+    pub(crate) data: String,
+}
+
+impl SseFrame {
+    pub(crate) fn parse(frame: &str) -> Option<Self> {
+        let frame = frame.replace("\r\n", "\n");
+        let mut id = None;
+        let mut event = "message".to_owned();
+        let mut data = Vec::new();
+
+        for line in frame.lines() {
+            if line.is_empty() || line.starts_with(':') {
+                continue;
+            }
+            if let Some(value) = line.strip_prefix("id:") {
+                id = Some(value.trim_start().to_owned());
+            } else if let Some(value) = line.strip_prefix("event:") {
+                event = value.trim_start().to_owned();
+            } else if let Some(value) = line.strip_prefix("data:") {
+                data.push(value.trim_start().to_owned());
+            }
+        }
+
+        if data.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            id,
+            event,
+            data: data.join("\n"),
+        })
+    }
+}

--- a/services/api-rs/crates/centaur-session-cli/src/tui.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/tui.rs
@@ -1,0 +1,710 @@
+use std::{
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use crossterm::{
+    cursor::{Hide, Show},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use futures_util::StreamExt;
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+use reqwest::Client;
+use serde_json::Value;
+use tokio::{
+    sync::mpsc,
+    time::{self, Duration as TokioDuration},
+};
+
+use crate::{
+    SseFrame, StdinEvent, append_user_message, execute_input_lines, is_terminal_event, next_frame,
+    output_type_matches, parse_json_or_string, user_input_line,
+};
+
+const MAX_MAIN_LINES: usize = 1_000;
+const MAX_DEBUG_LINES: usize = 1_000;
+
+pub(crate) struct TuiOptions {
+    pub(crate) debug_visible: bool,
+    pub(crate) idle_timeout_ms: u64,
+    pub(crate) max_duration_ms: u64,
+    pub(crate) exit_on_terminal: bool,
+    pub(crate) exit_on_output_type: Option<String>,
+}
+
+pub(crate) async fn run(
+    client: Client,
+    thread_key: String,
+    session_url: String,
+    events_response: reqwest::Response,
+    options: TuiOptions,
+) -> Result<()> {
+    let _terminal_restore = TerminalRestore::enter()?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
+    terminal.clear()?;
+
+    let (terminal_tx, mut terminal_rx) = mpsc::channel(64);
+    let _terminal_reader = TerminalEventReader::spawn(terminal_tx);
+    let (frame_tx, mut frame_rx) = mpsc::channel(256);
+    let (notice_tx, mut notice_rx) = mpsc::channel(64);
+
+    spawn_stream_task(events_response, frame_tx, notice_tx.clone());
+
+    let mut app = TuiApp::new(thread_key, options.debug_visible);
+    let mut tick = time::interval(TokioDuration::from_millis(100));
+
+    loop {
+        terminal.draw(|frame| draw(frame, &app))?;
+
+        tokio::select! {
+            _ = tick.tick() => {}
+            Some(event) = terminal_rx.recv() => {
+                if handle_terminal_event(
+                    &mut app,
+                    event,
+                    &client,
+                    &session_url,
+                    &options,
+                    notice_tx.clone(),
+                )? {
+                    break;
+                }
+            }
+            Some(frame) = frame_rx.recv() => {
+                if app.handle_sse_frame(frame, &options) {
+                    break;
+                }
+            }
+            Some(notice) = notice_rx.recv() => {
+                app.handle_notice(notice);
+            }
+            else => break,
+        }
+    }
+
+    Ok(())
+}
+
+fn spawn_stream_task(
+    response: reqwest::Response,
+    frame_tx: mpsc::Sender<SseFrame>,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) {
+    tokio::spawn(async move {
+        if let Err(error) = stream_sse_frames(response, frame_tx).await {
+            let _ = notice_tx
+                .send(TuiNotice::Error(format!("stream error: {error:#}")))
+                .await;
+        }
+    });
+}
+
+async fn stream_sse_frames(
+    response: reqwest::Response,
+    frame_tx: mpsc::Sender<SseFrame>,
+) -> Result<()> {
+    let mut chunks = response.bytes_stream();
+    let mut buffer = String::new();
+
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk.context("read event stream")?;
+        buffer.push_str(std::str::from_utf8(&chunk).context("event stream is not UTF-8")?);
+
+        while let Some((frame_end, separator_len)) = next_frame(&buffer) {
+            let frame = buffer[..frame_end].to_owned();
+            buffer.drain(..frame_end + separator_len);
+
+            if let Some(event) = SseFrame::parse(&frame) {
+                if frame_tx.send(event).await.is_err() {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_terminal_event(
+    app: &mut TuiApp,
+    event: TerminalInput,
+    client: &Client,
+    session_url: &str,
+    options: &TuiOptions,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) -> Result<bool> {
+    let TerminalInput::Key(key) = event else {
+        return Ok(false);
+    };
+
+    match key.code {
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => return Ok(true),
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => return Ok(true),
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => app.input.clear(),
+        KeyCode::F(2) => app.toggle_debug(),
+        KeyCode::Enter => {
+            let line = app.input.trim().to_owned();
+            app.input.clear();
+            return submit_input_line(app, line, client, session_url, options, notice_tx);
+        }
+        KeyCode::Backspace => {
+            app.input.pop();
+        }
+        KeyCode::Char(ch) => {
+            if key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT {
+                app.input.push(ch);
+            }
+        }
+        _ => {}
+    }
+
+    Ok(false)
+}
+
+fn submit_input_line(
+    app: &mut TuiApp,
+    line: String,
+    client: &Client,
+    session_url: &str,
+    options: &TuiOptions,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) -> Result<bool> {
+    if line.is_empty() {
+        return Ok(false);
+    }
+    match line.as_str() {
+        "/debug" => {
+            app.toggle_debug();
+            return Ok(false);
+        }
+        "/clear" => {
+            app.clear();
+            return Ok(false);
+        }
+        "/help" => {
+            app.status =
+                "Enter sends | F2 or /debug toggles events | /input raw | /quit exits".to_owned();
+            return Ok(false);
+        }
+        _ => {}
+    }
+
+    let Some(event) = StdinEvent::parse(&line)? else {
+        return Ok(false);
+    };
+    if matches!(event, StdinEvent::Quit) {
+        return Ok(true);
+    }
+
+    app.note_submitted_event(&event);
+    spawn_send_task(
+        event,
+        client.clone(),
+        session_url.to_owned(),
+        options.idle_timeout_ms,
+        options.max_duration_ms,
+        notice_tx,
+    );
+    Ok(false)
+}
+
+fn spawn_send_task(
+    event: StdinEvent,
+    client: Client,
+    session_url: String,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) {
+    tokio::spawn(async move {
+        let notice =
+            match send_stdin_event(event, client, session_url, idle_timeout_ms, max_duration_ms)
+                .await
+            {
+                Ok(message) => TuiNotice::Info(message),
+                Err(error) => TuiNotice::Error(format!("{error:#}")),
+            };
+        let _ = notice_tx.send(notice).await;
+    });
+}
+
+async fn send_stdin_event(
+    event: StdinEvent,
+    client: Client,
+    session_url: String,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<String> {
+    match event {
+        StdinEvent::Message(text) => {
+            append_user_message(&client, &session_url, &text).await?;
+            execute_input_lines(
+                &client,
+                &session_url,
+                vec![user_input_line(&text)?],
+                idle_timeout_ms,
+                max_duration_ms,
+            )
+            .await?;
+            Ok("message sent".to_owned())
+        }
+        StdinEvent::InputLine(line) => {
+            execute_input_lines(
+                &client,
+                &session_url,
+                vec![line],
+                idle_timeout_ms,
+                max_duration_ms,
+            )
+            .await?;
+            Ok("input line sent".to_owned())
+        }
+        StdinEvent::InputLines(lines) => {
+            let count = lines.len();
+            execute_input_lines(
+                &client,
+                &session_url,
+                lines,
+                idle_timeout_ms,
+                max_duration_ms,
+            )
+            .await?;
+            Ok(format!("{count} input lines sent"))
+        }
+        StdinEvent::Quit => Ok("quit".to_owned()),
+    }
+}
+
+fn draw(frame: &mut Frame<'_>, app: &TuiApp) {
+    let area = frame.area();
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    draw_header(frame, layout[0], app);
+    draw_body(frame, layout[1], app);
+    draw_input(frame, layout[2], app);
+    draw_footer(frame, layout[3], app);
+}
+
+fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let debug_state = if app.debug_visible {
+        "debug:on"
+    } else {
+        "debug:off"
+    };
+    let last_event = app.last_event_id.as_deref().unwrap_or("-");
+    let title = Line::from(vec![
+        Span::styled(
+            "Centaur Session",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(app.thread_key.clone(), Style::default().fg(Color::Yellow)),
+        Span::raw("  "),
+        Span::raw(format!("event:{last_event}  {debug_state}")),
+    ]);
+    let help = Line::from("Enter send  F2 debug  Ctrl-U clear input  Ctrl-D quit  /help");
+    frame.render_widget(
+        Paragraph::new(vec![title, help]).block(Block::default().borders(Borders::BOTTOM)),
+        area,
+    );
+}
+
+fn draw_body(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    if app.debug_visible {
+        if area.width >= 100 {
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
+                .split(area);
+            draw_main(frame, chunks[0], app);
+            draw_debug(frame, chunks[1], app);
+        } else {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                .split(area);
+            draw_main(frame, chunks[0], app);
+            draw_debug(frame, chunks[1], app);
+        }
+    } else {
+        draw_main(frame, area, app);
+    }
+}
+
+fn draw_main(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let lines = tail_lines(&app.main_lines, area.height.saturating_sub(2) as usize);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().title("Session").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_debug(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let lines = tail_lines(&app.debug_lines, area.height.saturating_sub(2) as usize);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().title("Events").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let visible = visible_input(&app.input, area.width.saturating_sub(2) as usize);
+    let cursor_x = area
+        .x
+        .saturating_add(1)
+        .saturating_add(visible.chars().count() as u16)
+        .min(area.x.saturating_add(area.width.saturating_sub(2)));
+    let cursor_y = area.y.saturating_add(1);
+
+    frame.render_widget(
+        Paragraph::new(visible)
+            .block(Block::default().title("Input").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+    frame.set_cursor_position((cursor_x, cursor_y));
+}
+
+fn draw_footer(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    frame.render_widget(
+        Paragraph::new(app.status.clone()).style(Style::default().fg(Color::DarkGray)),
+        area,
+    );
+}
+
+fn tail_lines(lines: &[String], max: usize) -> Vec<Line<'static>> {
+    let start = lines.len().saturating_sub(max.max(1));
+    lines[start..]
+        .iter()
+        .map(|line| Line::raw(line.clone()))
+        .collect()
+}
+
+fn visible_input(input: &str, max_chars: usize) -> String {
+    let chars = input.chars().collect::<Vec<_>>();
+    let start = chars.len().saturating_sub(max_chars.max(1));
+    chars[start..].iter().collect()
+}
+
+#[derive(Debug)]
+enum TerminalInput {
+    Key(KeyEvent),
+    Resize,
+}
+
+struct TerminalEventReader {
+    stop: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl TerminalEventReader {
+    fn spawn(sender: mpsc::Sender<TerminalInput>) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let reader_stop = Arc::clone(&stop);
+        let handle = thread::spawn(move || {
+            while !reader_stop.load(Ordering::Relaxed) {
+                let Ok(has_event) = event::poll(Duration::from_millis(100)) else {
+                    continue;
+                };
+                if !has_event {
+                    continue;
+                }
+                match event::read() {
+                    Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => {
+                        if sender.blocking_send(TerminalInput::Key(key)).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(Event::Resize(_, _)) => {
+                        if sender.blocking_send(TerminalInput::Resize).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(_) | Err(_) => {}
+                }
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for TerminalEventReader {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+struct TerminalRestore;
+
+impl TerminalRestore {
+    fn enter() -> Result<Self> {
+        enable_raw_mode().context("enable terminal raw mode")?;
+        execute!(io::stdout(), EnterAlternateScreen, Hide).context("enter alternate screen")?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalRestore {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), Show, LeaveAlternateScreen);
+    }
+}
+
+enum TuiNotice {
+    Info(String),
+    Error(String),
+}
+
+struct TuiApp {
+    thread_key: String,
+    input: String,
+    main_lines: Vec<String>,
+    debug_lines: Vec<String>,
+    debug_visible: bool,
+    status: String,
+    last_event_id: Option<String>,
+    current_agent_line: Option<usize>,
+}
+
+impl TuiApp {
+    fn new(thread_key: String, debug_visible: bool) -> Self {
+        Self {
+            thread_key,
+            input: String::new(),
+            main_lines: vec![
+                "session ready".to_owned(),
+                "type a message and press Enter; use F2 for raw events".to_owned(),
+            ],
+            debug_lines: Vec::new(),
+            debug_visible,
+            status: "ready".to_owned(),
+            last_event_id: None,
+            current_agent_line: None,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.main_lines.clear();
+        self.debug_lines.clear();
+        self.current_agent_line = None;
+        self.status = "cleared".to_owned();
+    }
+
+    fn toggle_debug(&mut self) {
+        self.debug_visible = !self.debug_visible;
+        self.status = if self.debug_visible {
+            "debug events visible".to_owned()
+        } else {
+            "debug events hidden".to_owned()
+        };
+    }
+
+    fn note_submitted_event(&mut self, event: &StdinEvent) {
+        match event {
+            StdinEvent::Message(text) => {
+                self.push_main_line(format!("you: {text}"));
+                self.status = "sending message".to_owned();
+            }
+            StdinEvent::InputLine(_) => {
+                self.push_main_line("system: sending raw input line".to_owned());
+                self.status = "sending raw input line".to_owned();
+            }
+            StdinEvent::InputLines(lines) => {
+                self.push_main_line(format!("system: sending {} raw input lines", lines.len()));
+                self.status = "sending raw input lines".to_owned();
+            }
+            StdinEvent::Quit => {}
+        }
+    }
+
+    fn handle_notice(&mut self, notice: TuiNotice) {
+        match notice {
+            TuiNotice::Info(message) => self.status = message,
+            TuiNotice::Error(message) => {
+                self.status = format!("error: {message}");
+                self.push_main_line(format!("error: {message}"));
+            }
+        }
+    }
+
+    fn handle_sse_frame(&mut self, frame: SseFrame, options: &TuiOptions) -> bool {
+        self.last_event_id = frame.id.clone();
+        self.push_debug_line(format_debug_frame(&frame));
+
+        if frame.event == "session.output.line" {
+            self.handle_output_line(&frame.data);
+            if output_type_matches(&frame.data, options.exit_on_output_type.as_deref()) {
+                self.status = format!(
+                    "matched output type {}",
+                    options.exit_on_output_type.as_deref().unwrap_or_default()
+                );
+                return true;
+            }
+        } else if frame.event == "session.execution_started" {
+            self.push_main_line("system: execution started".to_owned());
+            self.status = "execution started".to_owned();
+        } else if is_terminal_event(&frame.event) {
+            self.current_agent_line = None;
+            self.push_main_line(format!("system: {}", frame.event));
+            self.status = frame.event.clone();
+            if options.exit_on_terminal {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn handle_output_line(&mut self, data: &str) {
+        let Ok(value) = serde_json::from_str::<Value>(data) else {
+            self.push_main_line(format!("stdout: {data}"));
+            return;
+        };
+
+        let Some(event_type) = value.get("type").and_then(Value::as_str) else {
+            self.push_main_line(format!("stdout: {}", compact_json(&value, 240)));
+            return;
+        };
+
+        match event_type {
+            "item.agentMessage.delta" => {
+                if let Some(delta) = value.get("delta").and_then(Value::as_str) {
+                    self.append_agent_delta(delta);
+                }
+            }
+            "item.completed" => {
+                if let Some(text) = completed_agent_text(&value) {
+                    if self.current_agent_line.is_none() {
+                        self.push_main_line(format!("assistant: {text}"));
+                    }
+                    self.current_agent_line = None;
+                }
+            }
+            "turn.completed" => {
+                self.current_agent_line = None;
+                self.push_main_line("system: turn completed".to_owned());
+                self.status = "turn completed".to_owned();
+            }
+            "result" => {
+                self.current_agent_line = None;
+                if let Some(result) = value.get("result").and_then(Value::as_str) {
+                    self.push_main_line(format!("result: {result}"));
+                } else {
+                    self.push_main_line(format!("result: {}", compact_json(&value, 240)));
+                }
+            }
+            "system" => {
+                let subtype = value
+                    .get("subtype")
+                    .and_then(Value::as_str)
+                    .unwrap_or("event");
+                self.push_main_line(format!("system: {subtype}"));
+            }
+            other => {
+                self.push_main_line(format!("event: {other}"));
+            }
+        }
+    }
+
+    fn append_agent_delta(&mut self, delta: &str) {
+        if self.current_agent_line.is_none() {
+            self.push_main_line("assistant: ".to_owned());
+            self.current_agent_line = self.main_lines.len().checked_sub(1);
+        }
+        if let Some(index) = self.current_agent_line {
+            if let Some(line) = self.main_lines.get_mut(index) {
+                line.push_str(delta);
+            }
+        }
+    }
+
+    fn push_main_line(&mut self, line: String) {
+        self.main_lines.push(line);
+        if self.main_lines.len() > MAX_MAIN_LINES {
+            self.main_lines.remove(0);
+            self.current_agent_line = self
+                .current_agent_line
+                .and_then(|index| index.checked_sub(1));
+        }
+    }
+
+    fn push_debug_line(&mut self, line: String) {
+        self.debug_lines.push(line);
+        if self.debug_lines.len() > MAX_DEBUG_LINES {
+            self.debug_lines.remove(0);
+        }
+    }
+}
+
+fn completed_agent_text(value: &Value) -> Option<&str> {
+    let item = value.get("item")?;
+    if item.get("type").and_then(Value::as_str) != Some("agentMessage") {
+        return None;
+    }
+    item.get("text").and_then(Value::as_str)
+}
+
+fn format_debug_frame(frame: &SseFrame) -> String {
+    let id = frame.id.as_deref().unwrap_or("-");
+    let data = parse_json_or_string(&frame.data);
+    format!(
+        "{} {} {}",
+        id,
+        frame.event,
+        truncate(&compact_json(&data, 1_000), 1_000)
+    )
+}
+
+fn compact_json(value: &Value, max_chars: usize) -> String {
+    let rendered = match value {
+        Value::String(value) => value.clone(),
+        _ => serde_json::to_string(value).unwrap_or_else(|_| "<invalid json>".to_owned()),
+    };
+    truncate(&rendered, max_chars)
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}

--- a/services/api-rs/crates/centaur-session-core/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "centaur-session-core"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+time.workspace = true

--- a/services/api-rs/crates/centaur-session-core/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-core/Cargo.toml
@@ -8,5 +8,6 @@ repository.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+strum.workspace = true
 thiserror.workspace = true
 time.workspace = true

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use time::OffsetDateTime;
 
 pub const MAX_THREAD_KEY_BYTES: usize = 512;
-pub const MAX_HARNESS_TYPE_BYTES: usize = 64;
+pub const SUPPORTED_HARNESS_TYPES: &[&str] = &["codex", "amp", "claudecode"];
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ThreadKey(String);
@@ -116,21 +116,34 @@ fn validate_thread_key(value: &str) -> Result<(), ThreadKeyError> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct HarnessType(String);
+pub enum HarnessType {
+    Codex,
+    Amp,
+    ClaudeCode,
+}
 
 impl HarnessType {
     pub fn parse(value: impl Into<String>) -> Result<Self, HarnessTypeError> {
         let value = value.into();
-        validate_harness_type(&value)?;
-        Ok(Self(value))
+        match value.as_str() {
+            "" => Err(HarnessTypeError::Empty),
+            "codex" => Ok(Self::Codex),
+            "amp" => Ok(Self::Amp),
+            "claudecode" => Ok(Self::ClaudeCode),
+            _ => Err(HarnessTypeError::Unsupported),
+        }
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
+        match self {
+            Self::Codex => "codex",
+            Self::Amp => "amp",
+            Self::ClaudeCode => "claudecode",
+        }
     }
 
     pub fn into_string(self) -> String {
-        self.0
+        self.as_str().to_owned()
     }
 }
 
@@ -171,25 +184,8 @@ impl<'de> Deserialize<'de> for HarnessType {
 pub enum HarnessTypeError {
     #[error("harness_type is required")]
     Empty,
-    #[error("harness_type must be at most {MAX_HARNESS_TYPE_BYTES} bytes")]
-    TooLong,
-    #[error("harness_type may only contain ASCII lowercase letters, digits, '-' and '_'")]
-    InvalidCharacter,
-}
-
-fn validate_harness_type(value: &str) -> Result<(), HarnessTypeError> {
-    if value.is_empty() {
-        return Err(HarnessTypeError::Empty);
-    }
-    if value.len() > MAX_HARNESS_TYPE_BYTES {
-        return Err(HarnessTypeError::TooLong);
-    }
-    if !value.bytes().all(|byte| {
-        byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-' || byte == b'_'
-    }) {
-        return Err(HarnessTypeError::InvalidCharacter);
-    }
-    Ok(())
+    #[error("harness_type must be one of: codex, amp, claudecode")]
+    Unsupported,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -398,11 +394,21 @@ mod tests {
     }
 
     #[test]
-    fn harness_type_rejects_spaces() {
-        let err = HarnessType::parse("claude code").unwrap_err();
+    fn harness_type_accepts_supported_values() {
+        assert_eq!(HarnessType::parse("codex").unwrap(), HarnessType::Codex);
+        assert_eq!(HarnessType::parse("amp").unwrap(), HarnessType::Amp);
+        assert_eq!(
+            HarnessType::parse("claudecode").unwrap(),
+            HarnessType::ClaudeCode
+        );
+    }
+
+    #[test]
+    fn harness_type_rejects_unsupported_values() {
+        let err = HarnessType::parse("claude-code").unwrap_err();
         assert_eq!(
             err.to_string(),
-            "harness_type may only contain ASCII lowercase letters, digits, '-' and '_'"
+            "harness_type must be one of: codex, amp, claudecode"
         );
     }
 }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -7,11 +7,11 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use serde_json::Value;
+use strum::{AsRefStr, Display, EnumString};
 use thiserror::Error;
 use time::OffsetDateTime;
 
 pub const MAX_THREAD_KEY_BYTES: usize = 512;
-pub const SUPPORTED_HARNESS_TYPES: &[&str] = &["codex", "amp", "claudecode"];
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ThreadKey(String);
@@ -115,96 +115,26 @@ fn validate_thread_key(value: &str) -> Result<(), ThreadKeyError> {
     Ok(())
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, AsRefStr, Display, EnumString,
+)]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum HarnessType {
     Codex,
     Amp,
     ClaudeCode,
 }
 
-impl HarnessType {
-    pub fn parse(value: impl Into<String>) -> Result<Self, HarnessTypeError> {
-        let value = value.into();
-        match value.as_str() {
-            "" => Err(HarnessTypeError::Empty),
-            "codex" => Ok(Self::Codex),
-            "amp" => Ok(Self::Amp),
-            "claudecode" => Ok(Self::ClaudeCode),
-            _ => Err(HarnessTypeError::Unsupported),
-        }
-    }
-
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Codex => "codex",
-            Self::Amp => "amp",
-            Self::ClaudeCode => "claudecode",
-        }
-    }
-
-    pub fn into_string(self) -> String {
-        self.as_str().to_owned()
-    }
-}
-
-impl fmt::Display for HarnessType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for HarnessType {
-    type Err = HarnessTypeError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Self::parse(value)
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Error)]
-pub enum HarnessTypeError {
-    #[error("harness_type is required")]
-    Empty,
-    #[error("harness_type must be one of: codex, amp, claudecode")]
-    Unsupported,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum SessionStatus {
     Active,
     Idle,
     Executing,
     Failed,
     Archived,
-}
-
-impl SessionStatus {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Active => "active",
-            Self::Idle => "idle",
-            Self::Executing => "executing",
-            Self::Failed => "failed",
-            Self::Archived => "archived",
-        }
-    }
-}
-
-impl FromStr for SessionStatus {
-    type Err = ParseEnumError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "active" => Ok(Self::Active),
-            "idle" => Ok(Self::Idle),
-            "executing" => Ok(Self::Executing),
-            "failed" => Ok(Self::Failed),
-            "archived" => Ok(Self::Archived),
-            _ => Err(ParseEnumError::new("session status", value)),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -218,38 +148,14 @@ pub struct Session {
     pub updated_at: OffsetDateTime,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum MessageRole {
     User,
     Assistant,
     System,
     Tool,
-}
-
-impl MessageRole {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::User => "user",
-            Self::Assistant => "assistant",
-            Self::System => "system",
-            Self::Tool => "tool",
-        }
-    }
-}
-
-impl FromStr for MessageRole {
-    type Err = ParseEnumError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "user" => Ok(Self::User),
-            "assistant" => Ok(Self::Assistant),
-            "system" => Ok(Self::System),
-            "tool" => Ok(Self::Tool),
-            _ => Err(ParseEnumError::new("message role", value)),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -270,41 +176,15 @@ pub struct SessionMessage {
     pub created_at: OffsetDateTime,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum ExecutionStatus {
     Queued,
     Running,
     Completed,
     Failed,
     Cancelled,
-}
-
-impl ExecutionStatus {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Queued => "queued",
-            Self::Running => "running",
-            Self::Completed => "completed",
-            Self::Failed => "failed",
-            Self::Cancelled => "cancelled",
-        }
-    }
-}
-
-impl FromStr for ExecutionStatus {
-    type Err = ParseEnumError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "queued" => Ok(Self::Queued),
-            "running" => Ok(Self::Running),
-            "completed" => Ok(Self::Completed),
-            "failed" => Ok(Self::Failed),
-            "cancelled" => Ok(Self::Cancelled),
-            _ => Err(ParseEnumError::new("execution status", value)),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -330,28 +210,14 @@ pub struct SessionEvent {
     pub created_at: OffsetDateTime,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Error)]
-#[error("invalid {kind}: {value}")]
-pub struct ParseEnumError {
-    kind: &'static str,
-    value: String,
-}
-
-impl ParseEnumError {
-    fn new(kind: &'static str, value: &str) -> Self {
-        Self {
-            kind,
-            value: value.to_owned(),
-        }
-    }
-}
-
 pub fn empty_object() -> Value {
     Value::Object(serde_json::Map::new())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::{HarnessType, ThreadKey};
 
     #[test]
@@ -377,10 +243,10 @@ mod tests {
 
     #[test]
     fn harness_type_accepts_supported_values() {
-        assert_eq!(HarnessType::parse("codex").unwrap(), HarnessType::Codex);
-        assert_eq!(HarnessType::parse("amp").unwrap(), HarnessType::Amp);
+        assert_eq!(HarnessType::from_str("codex").unwrap(), HarnessType::Codex);
+        assert_eq!(HarnessType::from_str("amp").unwrap(), HarnessType::Amp);
         assert_eq!(
-            HarnessType::parse("claudecode").unwrap(),
+            HarnessType::from_str("claudecode").unwrap(),
             HarnessType::ClaudeCode
         );
     }
@@ -399,10 +265,6 @@ mod tests {
 
     #[test]
     fn harness_type_rejects_unsupported_values() {
-        let err = HarnessType::parse("claude-code").unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "harness_type must be one of: codex, amp, claudecode"
-        );
+        assert!(HarnessType::from_str("claude-code").is_err());
     }
 }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -1,0 +1,408 @@
+//! Durable session control-plane types.
+//!
+//! A session is the public control-plane object for one ongoing agent
+//! conversation. `thread_key` is the canonical identifier.
+
+use std::{fmt, str::FromStr};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use serde_json::Value;
+use thiserror::Error;
+use time::OffsetDateTime;
+
+pub const MAX_THREAD_KEY_BYTES: usize = 512;
+pub const MAX_HARNESS_TYPE_BYTES: usize = 64;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ThreadKey(String);
+
+impl ThreadKey {
+    pub fn parse(value: impl Into<String>) -> Result<Self, ThreadKeyError> {
+        let value = value.into();
+        validate_thread_key(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for ThreadKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ThreadKey {
+    type Err = ThreadKeyError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for ThreadKey {
+    type Error = ThreadKeyError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl AsRef<str> for ThreadKey {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Serialize for ThreadKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ThreadKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+pub enum ThreadKeyError {
+    #[error("thread_key is required")]
+    Empty,
+    #[error("thread_key must be at most {MAX_THREAD_KEY_BYTES} bytes")]
+    TooLong,
+    #[error("thread_key must be namespaced as '<source>:<id>'")]
+    MissingNamespace,
+    #[error("thread_key must not contain ASCII control characters")]
+    ControlCharacter,
+    #[error("thread_key must not be raw JSON")]
+    RawJson,
+}
+
+fn validate_thread_key(value: &str) -> Result<(), ThreadKeyError> {
+    if value.is_empty() {
+        return Err(ThreadKeyError::Empty);
+    }
+    if value.len() > MAX_THREAD_KEY_BYTES {
+        return Err(ThreadKeyError::TooLong);
+    }
+    if value.starts_with('{') || value.starts_with('[') {
+        return Err(ThreadKeyError::RawJson);
+    }
+    if value.chars().any(|ch| ch.is_ascii_control()) {
+        return Err(ThreadKeyError::ControlCharacter);
+    }
+    let Some((namespace, rest)) = value.split_once(':') else {
+        return Err(ThreadKeyError::MissingNamespace);
+    };
+    if namespace.is_empty() || rest.is_empty() {
+        return Err(ThreadKeyError::MissingNamespace);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct HarnessType(String);
+
+impl HarnessType {
+    pub fn parse(value: impl Into<String>) -> Result<Self, HarnessTypeError> {
+        let value = value.into();
+        validate_harness_type(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for HarnessType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for HarnessType {
+    type Err = HarnessTypeError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl Serialize for HarnessType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for HarnessType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+pub enum HarnessTypeError {
+    #[error("harness_type is required")]
+    Empty,
+    #[error("harness_type must be at most {MAX_HARNESS_TYPE_BYTES} bytes")]
+    TooLong,
+    #[error("harness_type may only contain ASCII lowercase letters, digits, '-' and '_'")]
+    InvalidCharacter,
+}
+
+fn validate_harness_type(value: &str) -> Result<(), HarnessTypeError> {
+    if value.is_empty() {
+        return Err(HarnessTypeError::Empty);
+    }
+    if value.len() > MAX_HARNESS_TYPE_BYTES {
+        return Err(HarnessTypeError::TooLong);
+    }
+    if !value.bytes().all(|byte| {
+        byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-' || byte == b'_'
+    }) {
+        return Err(HarnessTypeError::InvalidCharacter);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    Active,
+    Idle,
+    Executing,
+    Failed,
+    Archived,
+}
+
+impl SessionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Idle => "idle",
+            Self::Executing => "executing",
+            Self::Failed => "failed",
+            Self::Archived => "archived",
+        }
+    }
+}
+
+impl FromStr for SessionStatus {
+    type Err = ParseEnumError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "active" => Ok(Self::Active),
+            "idle" => Ok(Self::Idle),
+            "executing" => Ok(Self::Executing),
+            "failed" => Ok(Self::Failed),
+            "archived" => Ok(Self::Archived),
+            _ => Err(ParseEnumError::new("session status", value)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Session {
+    pub thread_key: ThreadKey,
+    pub sandbox_id: Option<String>,
+    pub harness_type: HarnessType,
+    pub harness_thread_id: Option<String>,
+    pub status: SessionStatus,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageRole {
+    User,
+    Assistant,
+    System,
+    Tool,
+}
+
+impl MessageRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+            Self::System => "system",
+            Self::Tool => "tool",
+        }
+    }
+}
+
+impl FromStr for MessageRole {
+    type Err = ParseEnumError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "user" => Ok(Self::User),
+            "assistant" => Ok(Self::Assistant),
+            "system" => Ok(Self::System),
+            "tool" => Ok(Self::Tool),
+            _ => Err(ParseEnumError::new("message role", value)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionMessageInput {
+    pub role: MessageRole,
+    pub parts: Vec<Value>,
+    #[serde(default = "empty_object")]
+    pub metadata: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionMessage {
+    pub message_id: String,
+    pub thread_key: ThreadKey,
+    pub role: MessageRole,
+    pub parts: Vec<Value>,
+    pub metadata: Value,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl ExecutionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl FromStr for ExecutionStatus {
+    type Err = ParseEnumError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            "running" => Ok(Self::Running),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "cancelled" => Ok(Self::Cancelled),
+            _ => Err(ParseEnumError::new("execution status", value)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionExecution {
+    pub execution_id: String,
+    pub thread_key: ThreadKey,
+    pub status: ExecutionStatus,
+    pub metadata: Value,
+    pub error: Option<String>,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+    pub started_at: Option<OffsetDateTime>,
+    pub completed_at: Option<OffsetDateTime>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionEvent {
+    pub event_id: i64,
+    pub thread_key: ThreadKey,
+    pub execution_id: Option<String>,
+    pub event_type: String,
+    pub payload: Value,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+#[error("invalid {kind}: {value}")]
+pub struct ParseEnumError {
+    kind: &'static str,
+    value: String,
+}
+
+impl ParseEnumError {
+    fn new(kind: &'static str, value: &str) -> Self {
+        Self {
+            kind,
+            value: value.to_owned(),
+        }
+    }
+}
+
+pub fn empty_object() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HarnessType, ThreadKey};
+
+    #[test]
+    fn thread_key_accepts_namespaced_values() {
+        let key = ThreadKey::parse("slack:C123:1780000000.000000").unwrap();
+        assert_eq!(key.as_str(), "slack:C123:1780000000.000000");
+    }
+
+    #[test]
+    fn thread_key_rejects_missing_namespace() {
+        let err = ThreadKey::parse("not-namespaced").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "thread_key must be namespaced as '<source>:<id>'"
+        );
+    }
+
+    #[test]
+    fn thread_key_rejects_unbounded_payload_shape() {
+        let err = ThreadKey::parse("{\"thread\":\"x\"}").unwrap_err();
+        assert_eq!(err.to_string(), "thread_key must not be raw JSON");
+    }
+
+    #[test]
+    fn harness_type_rejects_spaces() {
+        let err = HarnessType::parse("claude code").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "harness_type may only contain ASCII lowercase letters, digits, '-' and '_'"
+        );
+    }
+}

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -115,7 +115,8 @@ fn validate_thread_key(value: &str) -> Result<(), ThreadKeyError> {
     Ok(())
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum HarnessType {
     Codex,
     Amp,
@@ -158,25 +159,6 @@ impl FromStr for HarnessType {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         Self::parse(value)
-    }
-}
-
-impl Serialize for HarnessType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for HarnessType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        Self::parse(value).map_err(de::Error::custom)
     }
 }
 
@@ -400,6 +382,18 @@ mod tests {
         assert_eq!(
             HarnessType::parse("claudecode").unwrap(),
             HarnessType::ClaudeCode
+        );
+    }
+
+    #[test]
+    fn harness_type_serializes_as_wire_value() {
+        assert_eq!(
+            serde_json::to_value(HarnessType::ClaudeCode).unwrap(),
+            serde_json::json!("claudecode")
+        );
+        assert_eq!(
+            serde_json::from_value::<HarnessType>(serde_json::json!("codex")).unwrap(),
+            HarnessType::Codex
         );
     }
 

--- a/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "centaur-session-sqlx"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+centaur-session-core.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+thiserror.workspace = true
+time.workspace = true
+uuid.workspace = true

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0001_session_control_plane.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0001_session_control_plane.sql
@@ -9,7 +9,8 @@ create table if not exists sessions (
     updated_at timestamptz not null default now(),
     constraint sessions_thread_key_len check (octet_length(thread_key) <= 512),
     constraint sessions_thread_key_namespaced check (position(':' in thread_key) > 1),
-    constraint sessions_harness_type_len check (octet_length(harness_type) between 1 and 64)
+    constraint sessions_harness_type_len check (octet_length(harness_type) between 1 and 64),
+    constraint sessions_harness_type_supported check (harness_type in ('codex', 'amp', 'claudecode'))
 );
 
 create table if not exists session_messages (

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0001_session_control_plane.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0001_session_control_plane.sql
@@ -1,0 +1,56 @@
+create table if not exists sessions (
+    thread_key text primary key,
+    sandbox_id text,
+    harness_type text not null,
+    harness_thread_id text,
+    status text not null,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint sessions_thread_key_len check (octet_length(thread_key) <= 512),
+    constraint sessions_thread_key_namespaced check (position(':' in thread_key) > 1),
+    constraint sessions_harness_type_len check (octet_length(harness_type) between 1 and 64)
+);
+
+create table if not exists session_messages (
+    message_id text primary key,
+    thread_key text not null references sessions(thread_key) on delete cascade,
+    role text not null,
+    parts jsonb not null,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists session_messages_thread_created_idx
+    on session_messages (thread_key, created_at, message_id);
+
+create table if not exists session_executions (
+    execution_id text primary key,
+    thread_key text not null references sessions(thread_key) on delete cascade,
+    status text not null,
+    metadata jsonb not null default '{}'::jsonb,
+    error text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    started_at timestamptz,
+    completed_at timestamptz
+);
+
+create index if not exists session_executions_thread_created_idx
+    on session_executions (thread_key, created_at, execution_id);
+
+create unique index if not exists session_executions_one_active_idx
+    on session_executions (thread_key)
+    where status in ('queued', 'running');
+
+create table if not exists session_events (
+    event_id bigint generated always as identity primary key,
+    thread_key text not null references sessions(thread_key) on delete cascade,
+    execution_id text references session_executions(execution_id) on delete set null,
+    event_type text not null,
+    payload jsonb not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists session_events_thread_event_idx
+    on session_events (thread_key, event_id);

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -163,39 +163,6 @@ impl PgSessionStore {
         row.try_into()
     }
 
-    pub async fn claim_next_execution(
-        &self,
-        thread_key: &ThreadKey,
-    ) -> Result<Option<SessionExecution>, SessionStoreError> {
-        let row = sqlx::query_as::<_, SessionExecutionRow>(
-            r#"
-            update session_executions
-            set status = $2, started_at = coalesce(started_at, now()), updated_at = now()
-            where execution_id = (
-                select execution_id
-                from session_executions
-                where thread_key = $1 and status = $3
-                order by created_at, execution_id
-                for update skip locked
-                limit 1
-            )
-            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
-            "#,
-        )
-        .bind(thread_key.as_str())
-        .bind(ExecutionStatus::Running.as_str())
-        .bind(ExecutionStatus::Queued.as_str())
-        .fetch_optional(&self.pool)
-        .await?;
-
-        if let Some(row) = row {
-            self.set_session_status(&row.thread_key, SessionStatus::Executing)
-                .await?;
-            return row.try_into().map(Some);
-        }
-        Ok(None)
-    }
-
     pub async fn mark_execution_running(
         &self,
         execution_id: &str,

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -26,7 +26,7 @@ impl PgSessionStore {
 
     pub async fn connect(database_url: &str) -> Result<Self, SessionStoreError> {
         let pool = PgPoolOptions::new()
-            .max_connections(10)
+            .max_connections(50)
             .connect(database_url)
             .await?;
         Ok(Self::new(pool))

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -1,0 +1,525 @@
+//! SQLx-backed session repository.
+
+use std::str::FromStr;
+
+use centaur_session_core::{
+    ExecutionStatus, HarnessType, Session, SessionEvent, SessionExecution, SessionMessage,
+    SessionMessageInput, SessionStatus, ThreadKey, empty_object,
+};
+use serde_json::Value;
+use sqlx::{FromRow, PgPool, postgres::PgPoolOptions};
+use thiserror::Error;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+#[derive(Clone)]
+pub struct PgSessionStore {
+    pool: PgPool,
+}
+
+impl PgSessionStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn connect(database_url: &str) -> Result<Self, SessionStoreError> {
+        let pool = PgPoolOptions::new()
+            .max_connections(10)
+            .connect(database_url)
+            .await?;
+        Ok(Self::new(pool))
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), SessionStoreError> {
+        MIGRATOR.run(&self.pool).await?;
+        Ok(())
+    }
+
+    pub async fn create_or_get_session(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        metadata: Value,
+    ) -> Result<Session, SessionStoreError> {
+        sqlx::query(
+            r#"
+            insert into sessions (thread_key, harness_type, status, metadata)
+            values ($1, $2, $3, $4)
+            on conflict (thread_key) do nothing
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(harness_type.as_str())
+        .bind(SessionStatus::Idle.as_str())
+        .bind(metadata)
+        .execute(&self.pool)
+        .await?;
+
+        let session = self.get_session(thread_key).await?;
+        if session.harness_type != *harness_type {
+            return Err(SessionStoreError::HarnessConflict {
+                thread_key: thread_key.as_str().to_owned(),
+                existing: session.harness_type.into_string(),
+                requested: harness_type.as_str().to_owned(),
+            });
+        }
+        Ok(session)
+    }
+
+    pub async fn get_session(&self, thread_key: &ThreadKey) -> Result<Session, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            select thread_key, sandbox_id, harness_type, harness_thread_id, status, created_at, updated_at
+            from sessions
+            where thread_key = $1
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| SessionStoreError::NotFound {
+            thread_key: thread_key.as_str().to_owned(),
+        })?;
+
+        row.try_into()
+    }
+
+    pub async fn append_messages(
+        &self,
+        thread_key: &ThreadKey,
+        messages: &[SessionMessageInput],
+    ) -> Result<Vec<String>, SessionStoreError> {
+        let mut tx = self.pool.begin().await?;
+        let mut message_ids = Vec::with_capacity(messages.len());
+
+        for message in messages {
+            let message_id = prefixed_id("msg");
+            let parts = Value::Array(message.parts.clone());
+            sqlx::query(
+                r#"
+                insert into session_messages (message_id, thread_key, role, parts, metadata)
+                values ($1, $2, $3, $4, $5)
+                "#,
+            )
+            .bind(&message_id)
+            .bind(thread_key.as_str())
+            .bind(message.role.as_str())
+            .bind(parts)
+            .bind(message.metadata.clone())
+            .execute(&mut *tx)
+            .await?;
+            message_ids.push(message_id);
+        }
+
+        tx.commit().await?;
+        Ok(message_ids)
+    }
+
+    pub async fn list_messages(
+        &self,
+        thread_key: &ThreadKey,
+    ) -> Result<Vec<SessionMessage>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, SessionMessageRow>(
+            r#"
+            select message_id, thread_key, role, parts, metadata, created_at
+            from session_messages
+            where thread_key = $1
+            order by created_at, message_id
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    pub async fn create_execution(
+        &self,
+        thread_key: &ThreadKey,
+        metadata: Value,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let execution_id = prefixed_id("exe");
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            insert into session_executions (execution_id, thread_key, status, metadata)
+            values ($1, $2, $3, $4)
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(&execution_id)
+        .bind(thread_key.as_str())
+        .bind(ExecutionStatus::Queued.as_str())
+        .bind(metadata)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn claim_next_execution(
+        &self,
+        thread_key: &ThreadKey,
+    ) -> Result<Option<SessionExecution>, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2, started_at = coalesce(started_at, now()), updated_at = now()
+            where execution_id = (
+                select execution_id
+                from session_executions
+                where thread_key = $1 and status = $3
+                order by created_at, execution_id
+                for update skip locked
+                limit 1
+            )
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(ExecutionStatus::Running.as_str())
+        .bind(ExecutionStatus::Queued.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if let Some(row) = row {
+            self.set_session_status(&row.thread_key, SessionStatus::Executing)
+                .await?;
+            return row.try_into().map(Some);
+        }
+        Ok(None)
+    }
+
+    pub async fn mark_execution_running(
+        &self,
+        execution_id: &str,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2, started_at = coalesce(started_at, now()), updated_at = now()
+            where execution_id = $1
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Running.as_str())
+        .fetch_one(&self.pool)
+        .await?;
+
+        self.set_session_status(&row.thread_key, SessionStatus::Executing)
+            .await?;
+        row.try_into()
+    }
+
+    pub async fn complete_execution(
+        &self,
+        execution_id: &str,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2, completed_at = coalesce(completed_at, now()), updated_at = now()
+            where execution_id = $1
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Completed.as_str())
+        .fetch_one(&self.pool)
+        .await?;
+
+        self.set_session_status(&row.thread_key, SessionStatus::Idle)
+            .await?;
+        row.try_into()
+    }
+
+    pub async fn fail_execution(
+        &self,
+        execution_id: &str,
+        error: &str,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2, error = $3, completed_at = coalesce(completed_at, now()), updated_at = now()
+            where execution_id = $1
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Failed.as_str())
+        .bind(error)
+        .fetch_one(&self.pool)
+        .await?;
+
+        self.set_session_status(&row.thread_key, SessionStatus::Failed)
+            .await?;
+        row.try_into()
+    }
+
+    pub async fn append_event(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: Option<&str>,
+        event_type: &str,
+        payload: Value,
+    ) -> Result<SessionEvent, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionEventRow>(
+            r#"
+            insert into session_events (thread_key, execution_id, event_type, payload)
+            values ($1, $2, $3, $4)
+            returning event_id, thread_key, execution_id, event_type, payload, created_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(execution_id)
+        .bind(event_type)
+        .bind(payload)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn list_events_after(
+        &self,
+        thread_key: &ThreadKey,
+        after_event_id: i64,
+        limit: i64,
+    ) -> Result<Vec<SessionEvent>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, SessionEventRow>(
+            r#"
+            select event_id, thread_key, execution_id, event_type, payload, created_at
+            from session_events
+            where thread_key = $1 and event_id > $2
+            order by event_id
+            limit $3
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(after_event_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    pub async fn update_sandbox_id(
+        &self,
+        thread_key: &ThreadKey,
+        sandbox_id: Option<&str>,
+    ) -> Result<Session, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            update sessions
+            set sandbox_id = $2, updated_at = now()
+            where thread_key = $1
+            returning thread_key, sandbox_id, harness_type, harness_thread_id, status, created_at, updated_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(sandbox_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn update_harness_thread_id(
+        &self,
+        thread_key: &ThreadKey,
+        harness_thread_id: Option<&str>,
+    ) -> Result<Session, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            update sessions
+            set harness_thread_id = $2, updated_at = now()
+            where thread_key = $1
+            returning thread_key, sandbox_id, harness_type, harness_thread_id, status, created_at, updated_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(harness_thread_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    async fn set_session_status(
+        &self,
+        thread_key: &str,
+        status: SessionStatus,
+    ) -> Result<(), SessionStoreError> {
+        sqlx::query(
+            r#"
+            update sessions
+            set status = $2, updated_at = now()
+            where thread_key = $1
+            "#,
+        )
+        .bind(thread_key)
+        .bind(status.as_str())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SessionStoreError {
+    #[error("session not found for thread_key {thread_key}")]
+    NotFound { thread_key: String },
+    #[error(
+        "session {thread_key} already exists with harness_type {existing}, requested {requested}"
+    )]
+    HarnessConflict {
+        thread_key: String,
+        existing: String,
+        requested: String,
+    },
+    #[error("invalid persisted value: {0}")]
+    InvalidPersistedValue(String),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(transparent)]
+    Migrate(#[from] sqlx::migrate::MigrateError),
+}
+
+#[derive(Debug, FromRow)]
+struct SessionRow {
+    thread_key: String,
+    sandbox_id: Option<String>,
+    harness_type: String,
+    harness_thread_id: Option<String>,
+    status: String,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+}
+
+impl TryFrom<SessionRow> for Session {
+    type Error = SessionStoreError;
+
+    fn try_from(row: SessionRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            thread_key: parse_persisted(row.thread_key)?,
+            sandbox_id: row.sandbox_id,
+            harness_type: parse_persisted(row.harness_type)?,
+            harness_thread_id: row.harness_thread_id,
+            status: parse_persisted(row.status)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct SessionMessageRow {
+    message_id: String,
+    thread_key: String,
+    role: String,
+    parts: Value,
+    metadata: Value,
+    created_at: OffsetDateTime,
+}
+
+impl TryFrom<SessionMessageRow> for SessionMessage {
+    type Error = SessionStoreError;
+
+    fn try_from(row: SessionMessageRow) -> Result<Self, Self::Error> {
+        let parts = match row.parts {
+            Value::Array(parts) => parts,
+            other => vec![other],
+        };
+        Ok(Self {
+            message_id: row.message_id,
+            thread_key: parse_persisted(row.thread_key)?,
+            role: parse_persisted(row.role)?,
+            parts,
+            metadata: row.metadata,
+            created_at: row.created_at,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct SessionExecutionRow {
+    execution_id: String,
+    thread_key: String,
+    status: String,
+    metadata: Value,
+    error: Option<String>,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+    started_at: Option<OffsetDateTime>,
+    completed_at: Option<OffsetDateTime>,
+}
+
+impl TryFrom<SessionExecutionRow> for SessionExecution {
+    type Error = SessionStoreError;
+
+    fn try_from(row: SessionExecutionRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            execution_id: row.execution_id,
+            thread_key: parse_persisted(row.thread_key)?,
+            status: parse_persisted(row.status)?,
+            metadata: row.metadata,
+            error: row.error,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            started_at: row.started_at,
+            completed_at: row.completed_at,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct SessionEventRow {
+    event_id: i64,
+    thread_key: String,
+    execution_id: Option<String>,
+    event_type: String,
+    payload: Value,
+    created_at: OffsetDateTime,
+}
+
+impl TryFrom<SessionEventRow> for SessionEvent {
+    type Error = SessionStoreError;
+
+    fn try_from(row: SessionEventRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            event_id: row.event_id,
+            thread_key: parse_persisted(row.thread_key)?,
+            execution_id: row.execution_id,
+            event_type: row.event_type,
+            payload: row.payload,
+            created_at: row.created_at,
+        })
+    }
+}
+
+fn parse_persisted<T>(value: String) -> Result<T, SessionStoreError>
+where
+    T: FromStr,
+    T::Err: std::fmt::Display,
+{
+    value
+        .parse()
+        .map_err(|err: T::Err| SessionStoreError::InvalidPersistedValue(err.to_string()))
+}
+
+fn prefixed_id(prefix: &str) -> String {
+    format!("{prefix}_{}", Uuid::new_v4().simple())
+}
+
+pub fn default_metadata(metadata: Option<Value>) -> Value {
+    metadata.unwrap_or_else(empty_object)
+}

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -55,8 +55,8 @@ impl PgSessionStore {
             "#,
         )
         .bind(thread_key.as_str())
-        .bind(harness_type.as_str())
-        .bind(SessionStatus::Idle.as_str())
+        .bind(harness_type.as_ref())
+        .bind(SessionStatus::Idle.as_ref())
         .bind(metadata)
         .execute(&self.pool)
         .await?;
@@ -65,8 +65,8 @@ impl PgSessionStore {
         if session.harness_type != *harness_type {
             return Err(SessionStoreError::HarnessConflict {
                 thread_key: thread_key.as_str().to_owned(),
-                existing: session.harness_type.into_string(),
-                requested: harness_type.as_str().to_owned(),
+                existing: session.harness_type.to_string(),
+                requested: harness_type.as_ref().to_owned(),
             });
         }
         Ok(session)
@@ -109,7 +109,7 @@ impl PgSessionStore {
             )
             .bind(&message_id)
             .bind(thread_key.as_str())
-            .bind(message.role.as_str())
+            .bind(message.role.as_ref())
             .bind(parts)
             .bind(message.metadata.clone())
             .execute(&mut *tx)
@@ -155,7 +155,7 @@ impl PgSessionStore {
         )
         .bind(&execution_id)
         .bind(thread_key.as_str())
-        .bind(ExecutionStatus::Queued.as_str())
+        .bind(ExecutionStatus::Queued.as_ref())
         .bind(metadata)
         .fetch_one(&self.pool)
         .await?;
@@ -176,7 +176,7 @@ impl PgSessionStore {
             "#,
         )
         .bind(execution_id)
-        .bind(ExecutionStatus::Running.as_str())
+        .bind(ExecutionStatus::Running.as_ref())
         .fetch_one(&self.pool)
         .await?;
 
@@ -198,7 +198,7 @@ impl PgSessionStore {
             "#,
         )
         .bind(execution_id)
-        .bind(ExecutionStatus::Completed.as_str())
+        .bind(ExecutionStatus::Completed.as_ref())
         .fetch_one(&self.pool)
         .await?;
 
@@ -221,7 +221,7 @@ impl PgSessionStore {
             "#,
         )
         .bind(execution_id)
-        .bind(ExecutionStatus::Failed.as_str())
+        .bind(ExecutionStatus::Failed.as_ref())
         .bind(error)
         .fetch_one(&self.pool)
         .await?;
@@ -334,7 +334,7 @@ impl PgSessionStore {
             "#,
         )
         .bind(thread_key)
-        .bind(status.as_str())
+        .bind(status.as_ref())
         .execute(&self.pool)
         .await?;
         Ok(())

--- a/services/api-rs/rfcs/0002-session-control-plane.md
+++ b/services/api-rs/rfcs/0002-session-control-plane.md
@@ -1,0 +1,405 @@
+# RFC 0002: Session Control Plane
+
+Status: Draft
+Owner: TBD
+Target: `services/api-rs`
+
+## Summary
+
+Introduce `Session` as the durable control-plane object above the sandbox
+runtime abstraction from RFC 0001. A session represents one ongoing agent
+conversation, regardless of whether it was started by Slack, a workflow, a CLI,
+or another caller.
+
+The session is the source of truth for:
+
+- the external thread identity
+- the current sandbox assignment
+- the harness type
+- the harness-native thread/session identifier
+- persisted input messages
+- execution state
+- replayable output events
+
+The public API should be small:
+
+- `POST /api/session/{thread_key}`: idempotently create or return a session
+- `POST /api/session/{thread_key}/messages`: append durable input
+- `POST /api/session/{thread_key}/execute`: run the session
+- `GET /api/session/{thread_key}/events`: stream or replay session output over
+  SSE
+
+## Goals
+
+- Make `Session` the core control-plane model.
+- Use `thread_key` as the public identity and database primary key for a
+  session.
+- Keep exactly one current `sandbox_id` on a session. If a sandbox dies and is
+  replaced, the session row points at the new sandbox.
+- Persist `harness_type` and `harness_thread_id` on the session so the control
+  plane can resume the correct harness conversation.
+- Keep clients thin: create/get session, append messages, execute, stream events.
+- Make output replayable through durable session events, not process-local
+  streams.
+- Keep this layer independent from any specific caller such as Slack or
+  workflows.
+
+## Non-goals
+
+- Exposing sandbox create, pause, resume, or stop as public API endpoints.
+- Designing every migration detail from the current Python API.
+- Preserving `assignment_generation` as a public client concept.
+- Designing Slack final delivery, workflow scheduling, tool discovery, API key
+  management, or persona selection in detail.
+- Making `sandbox_id` historical. The session stores the current sandbox only;
+  historical sandbox lifecycle can be represented as events if needed.
+
+## Relationship to RFC 0001
+
+RFC 0001 defines a backend-neutral sandbox runtime layer. This RFC defines the
+durable Centaur control-plane object that calls that layer.
+
+The split is:
+
+- sandbox layer: creates isolated workloads and moves bytes
+- session layer: decides which sandbox belongs to which conversation, persists
+  caller-supplied input/output bytes as lines, and exposes replayable state to
+  clients
+
+`Session` should not leak backend transport details. It may store a
+`sandbox_id`, but clients should not attach to that sandbox directly.
+
+## Core Model
+
+A session is one durable agent conversation.
+
+```text
+Session {
+  thread_key: string        // primary key
+  sandbox_id: string | null
+  harness_type: string
+  harness_thread_id: string | null
+  status: active | executing | idle | failed | archived
+  created_at: timestamp
+  updated_at: timestamp
+}
+```
+
+Field notes:
+
+- `thread_key` is the unique public key and storage primary key. For Slack it
+  can be the Slack thread key. For workflows it can be a workflow-owned key. For
+  CLI or test callers it can be any caller-owned stable key.
+- `sandbox_id` is the current runtime assignment. It is nullable before the
+  first execution and can be overwritten when the control plane replaces a dead
+  sandbox.
+- `harness_type` selects the harness adapter, for example `amp`,
+  `claude-code`, or `codex`.
+- `harness_thread_id` is the harness-native conversation identifier when the
+  harness exposes one. It is nullable until the first harness turn returns it.
+
+### Ownership
+
+The session row is authoritative. In-memory workers, live SSE connections, and
+sandbox observations are caches or transports. On restart, the API should be
+able to recover session state from the database and continue from the latest
+durable message, execution, event, and current sandbox binding.
+
+### Sandbox Replacement
+
+A session has at most one current sandbox. If the current sandbox is gone or
+unhealthy, the control plane may create a replacement sandbox and atomically
+overwrite `session.sandbox_id`.
+
+Replacement should emit lifecycle events so operators can see what happened, but
+clients should continue addressing the session, not the sandbox.
+
+## Durable State
+
+The first implementation can use a small set of tables:
+
+| Table | Purpose |
+|-------|---------|
+| `sessions` | One row per durable conversation, keyed by `thread_key` |
+| `session_messages` | Durable user, assistant, system, and tool-visible input/output messages keyed by `thread_key` |
+| `session_executions` | One row per requested execution keyed by `thread_key` |
+| `session_events` | Replayable projected output and lifecycle events keyed by `thread_key` |
+
+The exact schema can evolve, but the invariant should hold: if a client has a
+`thread_key` and last seen event id, it can reconnect and recover session output
+without relying on a still-open process stream.
+
+`thread_key` should be constrained rather than arbitrary unbounded text:
+
+- namespaced by source, for example `slack:C123:1780000000.000000`
+- stable for the lifetime of the conversation
+- globally unique, or unique inside an explicit tenant scope
+- bounded to a practical maximum length, for example 512 bytes
+- not raw JSON, raw URLs, or other unbounded caller payloads
+
+## API
+
+### Create or Get Session
+
+```text
+POST /api/session/{thread_key}
+```
+
+Creates a session for `thread_key` or returns the existing session. The
+`thread_key` path segment must be URL-encoded by clients when it contains
+reserved characters.
+
+Example request:
+
+```json
+{
+  "harness_type": "amp",
+  "metadata": {
+    "source": "slack",
+    "channel_id": "C123",
+    "user_id": "U123"
+  }
+}
+```
+
+Example response:
+
+```json
+{
+  "thread_key": "slack:C123:1780000000.000000",
+  "sandbox_id": null,
+  "harness_type": "amp",
+  "harness_thread_id": null,
+  "status": "idle"
+}
+```
+
+Idempotency rules:
+
+- `thread_key` is unique.
+- Repeating the same request returns the existing session.
+- If the existing session has a different `harness_type`, the API should reject
+  the request with `409 Conflict` rather than silently changing the session.
+
+### Append Messages
+
+```text
+POST /api/session/{thread_key}/messages
+```
+
+Appends one or more durable messages to the session. This endpoint persists
+input; it does not execute the harness by itself.
+
+Example request:
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "parts": [
+        {"type": "text", "text": "Reply with exactly PONG and nothing else."}
+      ],
+      "metadata": {
+        "source": "slack",
+        "user_id": "U123"
+      }
+    }
+  ]
+}
+```
+
+Example response:
+
+```json
+{
+  "ok": true,
+  "message_ids": ["msg_123"]
+}
+```
+
+Message `parts` are durable transcript data for clients and operators. The API
+stores them but does not translate them into harness-specific stdin during
+execution; the caller that invokes `/execute` supplies the opaque input lines
+that should be written to the sandbox.
+
+### Execute Session
+
+```text
+POST /api/session/{thread_key}/execute
+```
+
+Requests one execution of the session. The API serializes executions per
+session, ensures there is a usable current sandbox, writes caller-supplied input
+lines to sandbox stdin, and stores each stdout line as a durable session event.
+
+The API is deliberately oblivious to the producer/consumer format. Codex
+app-server JSONL, Anthropic-shaped turns, or any future protocol are just opaque
+newline-delimited strings at this layer.
+
+Example request:
+
+```json
+{
+  "input_lines": [
+    "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG and nothing else.\"}]}}"
+  ],
+  "idle_timeout_ms": 1000,
+  "max_duration_ms": 60000,
+  "metadata": {
+    "source": "slack"
+  }
+}
+```
+
+Example response:
+
+```json
+{
+  "ok": true,
+  "execution_id": "exe_123",
+  "thread_key": "slack:C123:1780000000.000000",
+  "status": "queued"
+}
+```
+
+Execution rules:
+
+- Only one execution may run for a session at a time.
+- If no sandbox is assigned, the API creates one and stores its `sandbox_id`.
+- If the assigned sandbox is gone, the API replaces it and overwrites
+  `sandbox_id`.
+- `input_lines` are written to sandbox stdin exactly as newline-delimited lines.
+- Each stdout line is appended to `session_events` before being streamed to
+  clients as `session.output.line`.
+- Execution completion is transport-level. The first implementation may use an
+  idle timeout and max duration; it must not parse Codex, harness, or app-server
+  event names to decide completion.
+- If a producer or consumer discovers a harness-native thread id, it can report
+  that separately; the session API should not infer it by parsing output lines.
+
+### Stream Session Events
+
+```text
+GET /api/session/{thread_key}/events?after_event_id=0
+```
+
+Streams durable session events as Server-Sent Events. The stream is scoped to the
+session, not to a live worker. A client can disconnect and reconnect with the
+last seen event id.
+
+Example stream:
+
+```text
+id: 101
+event: session.execution_started
+data: {"execution_id":"exe_123","thread_key":"slack:C123:1780000000.000000"}
+
+id: 102
+event: session.output.line
+data: {"type":"item.agentMessage.delta","delta":"P"}
+
+id: 103
+event: session.output.line
+data: {"type":"item.agentMessage.delta","delta":"ONG"}
+
+id: 104
+event: session.execution_completed
+data: {"execution_id":"exe_123","output_line_count":2}
+```
+
+SSE rules:
+
+- Every event has a monotonically increasing session event id.
+- `after_event_id` is exclusive.
+- If there are existing events after `after_event_id`, the API replays them
+  before waiting for new events.
+- `session.output.line` event `data:` is the raw line, not JSON encoded again by
+  the API. It may contain Codex app-server JSONL, another JSONL protocol, or
+  plain text.
+- Terminal execution state is represented as a durable event.
+- The session stream does not close just because one execution reaches a
+  terminal state; callers may keep one SSE connection open across later
+  executions on the same session.
+- Clients do not need to know the current `sandbox_id` to stream output.
+
+## Control-Plane Flow
+
+```text
+caller
+  POST /api/session/{thread_key}
+    -> create or get session
+
+caller
+  POST /api/session/{thread_key}/messages
+    -> persist user input
+
+caller
+  POST /api/session/{thread_key}/execute
+    -> get execution_id
+
+caller
+  GET /api/session/{thread_key}/events?after_event_id=...
+    -> replay and stream output
+```
+
+Internally, execution follows this shape:
+
+```text
+load session
+claim session execution lock
+ensure current sandbox exists
+write request input_lines to sandbox stdin
+persist stdout lines as session.output.line events
+mark execution terminal
+release execution lock
+```
+
+## Compatibility Path
+
+The current Python API has separate `spawn`, `message`, `execute`, and thread
+events endpoints. The session API keeps the same useful client shape but removes
+assignment generation from the protocol and keeps `thread_key` as the only
+session address.
+
+A migration can be incremental:
+
+1. Add session tables and endpoints.
+2. Implement the endpoints as wrappers around the existing execution machinery.
+3. Teach Slackbot, workflows, and CLI callers to use sessions.
+4. Keep legacy endpoints as compatibility shims until callers have moved.
+5. Remove legacy public concepts once sessions are the only client contract.
+
+## Testing Strategy
+
+- Unit test idempotent session creation by `thread_key`.
+- Unit test `thread_key` as the canonical public address for messages,
+  execution, and events.
+- Unit test `409 Conflict` on incompatible `harness_type`.
+- Unit test message append ordering.
+- Unit test per-session execution serialization.
+- Unit test sandbox replacement updates only the current `sandbox_id`.
+- Unit test `/execute` writes opaque `input_lines` without inspecting them.
+- Unit test stdout lines are stored and replayed without parsing or JSON
+  re-encoding.
+- Integration test create -> messages -> execute -> events replay.
+- Integration test SSE reconnect with `after_event_id`.
+- Integration test API restart recovery from persisted session state.
+
+## Open Questions
+
+- Should `harness_type` be immutable for the lifetime of a session?
+- How much transcript history should each execution send to the harness by
+  default?
+- Should cancellation be part of this RFC, for example
+  `POST /api/session/{thread_key}/cancel`?
+- Should archival release the current sandbox immediately or keep it warm for a
+  short grace period?
+
+## Recommendation
+
+Start with `Session` as the only public durable conversation object. Keep the
+API small, make `thread_key` the canonical public address and primary key, treat
+`sandbox_id` as a replaceable current binding, and make SSE replay come from
+durable session events. This gives Slack, workflows, and future clients one
+protocol without exposing sandbox lifecycle details.


### PR DESCRIPTION
## Summary

This PR adds the durable session data model and SQLx-backed store. It is the first control-plane PR above the sandbox runtime stack.

## What changed

- Adds `centaur-session-core` with session, message, execution, event, harness, and thread-key domain types.
- Makes `thread_key` the public primary session identifier, matching the RFC direction to avoid exposing a separate public `session_id`.
- Adds validation for thread keys and harness names.
- Adds `centaur-session-sqlx`, a Postgres-backed implementation of the session store.
- Adds the initial migration for sessions, messages, executions, and durable session events.
- Adds append/replay semantics for event storage, including monotonically increasing event ids for reconnectable consumers.
- Adds `rfcs/0002-session-control-plane.md` describing the simplified session API shape and SSE replay contract.

## Review notes

This is the right PR to review persistence boundaries: schema shape, idempotent session creation, event ordering, and whether the store stays format-oblivious enough to act as a pipe between producers and consumers.

## Out of scope

- No HTTP endpoints yet.
- No CLI yet.
- No concrete sandbox execution wiring through the API server yet.
- No Codex App Server JSONL parsing. Event payloads are stored as opaque JSON values.

## Testing

- `cargo test --workspace` from `services/api-rs`.