### PR TITLE
feat(api-rs): wire Codex sandbox e2e path

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -231,6 +231,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,7 +348,9 @@ dependencies = [
  "anyhow",
  "centaur-session-core",
  "clap",
+ "crossterm",
  "futures-util",
+ "ratatui",
  "reqwest",
  "serde_json",
  "tokio",
@@ -347,7 +364,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "strum",
+ "strum 0.28.0",
  "thiserror",
  "time",
 ]
@@ -442,6 +459,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +541,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -1189,6 +1245,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1277,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1456,6 +1543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1568,15 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1526,6 +1628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1646,6 +1749,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1949,6 +2058,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2232,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2418,6 +2561,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,11 +2886,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -3118,6 +3310,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3410,6 +3631,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,6 +3654,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -3438,6 +3681,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -29,12 +29,14 @@ centaur-sandbox-manager = { path = "crates/centaur-sandbox-manager" }
 centaur-session-core = { path = "crates/centaur-session-core" }
 centaur-session-sqlx = { path = "crates/centaur-session-sqlx" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
+crossterm = "0.28"
 futures-util = "0.3"
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
+ratatui = "0.29"
 sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -1,4 +1,9 @@
-use std::{collections::VecDeque, convert::Infallible, sync::Arc, time::Duration};
+use std::{
+    collections::{HashSet, VecDeque},
+    convert::Infallible,
+    sync::Arc,
+    time::Duration,
+};
 
 use axum::{
     Json, Router,
@@ -23,16 +28,19 @@ use futures_util::stream;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use thiserror::Error;
-use tokio::time::{Instant, sleep};
+use tokio::{sync::Mutex, time::sleep};
+use tracing::warn;
 
 const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 const DEFAULT_IDLE_TIMEOUT_MS: u64 = 1_000;
 const DEFAULT_MAX_DURATION_MS: u64 = 60_000;
+type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
 
 #[derive(Clone)]
 pub struct AppState {
     store: PgSessionStore,
     sandbox_runtime: SandboxRuntime,
+    stdout_pumps: Arc<Mutex<HashSet<String>>>,
 }
 
 pub fn build_router(store: PgSessionStore) -> Router {
@@ -43,6 +51,7 @@ pub fn build_router_with_runtime(store: PgSessionStore, sandbox_runtime: Sandbox
     let state = AppState {
         store,
         sandbox_runtime,
+        stdout_pumps: Arc::new(Mutex::new(HashSet::new())),
     };
     Router::new()
         .route("/healthz", get(healthz))
@@ -58,13 +67,24 @@ pub enum SandboxRuntime {
     Mock,
     Backend {
         backend: Arc<dyn SandboxBackend>,
-        spec: SandboxSpec,
+        spec_factory: SandboxSpecFactory,
     },
 }
 
 impl SandboxRuntime {
     pub fn backend(backend: Arc<dyn SandboxBackend>, spec: SandboxSpec) -> Self {
-        Self::Backend { backend, spec }
+        let spec_factory = move |_thread_key: &ThreadKey, _execution_id: &str| spec.clone();
+        Self::backend_with_spec_factory(backend, spec_factory)
+    }
+
+    pub fn backend_with_spec_factory<F>(backend: Arc<dyn SandboxBackend>, spec_factory: F) -> Self
+    where
+        F: Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync + 'static,
+    {
+        Self::Backend {
+            backend,
+            spec_factory: Arc::new(spec_factory),
+        }
     }
 }
 
@@ -148,17 +168,31 @@ async fn execute_session(
         )
         .await?;
 
-    let output_line_count = match run_session_pipe(
-        &state.store,
-        &state.sandbox_runtime,
-        &thread_key,
-        &execution.execution_id,
-        &sandbox_id,
-        &request.input_lines,
-        pipe_options,
-    )
-    .await
-    {
+    let run_result = match &state.sandbox_runtime {
+        SandboxRuntime::Mock => {
+            run_mock_session_pipe(
+                &state.store,
+                &thread_key,
+                &execution.execution_id,
+                &sandbox_id,
+                pipe_options,
+            )
+            .await
+        }
+        SandboxRuntime::Backend { backend, .. } => {
+            match ensure_stdout_pump(&state, &thread_key, &sandbox_id).await {
+                Ok(()) => write_input_lines(
+                    backend.as_ref(),
+                    &SandboxId::new(&sandbox_id),
+                    &request.input_lines,
+                )
+                .await
+                .map(|()| 0),
+                Err(error) => Err(error),
+            }
+        }
+    };
+    let output_line_count = match run_result {
         Ok(output_line_count) => output_line_count,
         Err(error) => {
             let error_message = error.to_string();
@@ -193,6 +227,7 @@ async fn execute_session(
                 "execution_id": execution.execution_id,
                 "thread_key": thread_key.as_str(),
                 "output_line_count": output_line_count,
+                "completion_reason": "input_accepted",
             }),
         )
         .await?;
@@ -227,7 +262,10 @@ async fn ensure_session_sandbox(
                 .await?;
             Ok(sandbox_id)
         }
-        SandboxRuntime::Backend { backend, spec } => {
+        SandboxRuntime::Backend {
+            backend,
+            spec_factory,
+        } => {
             if let Some(sandbox_id) = existing_sandbox_id {
                 let id = SandboxId::new(sandbox_id);
                 match backend.status(&id).await {
@@ -239,10 +277,8 @@ async fn ensure_session_sandbox(
                 }
             }
 
-            let handle = backend
-                .create(spec.clone())
-                .await
-                .map_err(ApiError::Sandbox)?;
+            let spec = spec_factory(thread_key, execution_id);
+            let handle = backend.create(spec).await.map_err(ApiError::Sandbox)?;
             store
                 .update_sandbox_id(thread_key, Some(handle.id.as_str()))
                 .await?;
@@ -251,97 +287,135 @@ async fn ensure_session_sandbox(
     }
 }
 
-async fn run_session_pipe(
+async fn run_mock_session_pipe(
     store: &PgSessionStore,
-    runtime: &SandboxRuntime,
     thread_key: &ThreadKey,
     execution_id: &str,
     sandbox_id: &str,
-    input_lines: &[String],
     options: PipeOptions,
 ) -> Result<usize, ApiError> {
-    match runtime {
-        SandboxRuntime::Mock => {
-            let mut output_line_count = 0;
-            let output_lines = mock_app_server_output_lines(thread_key, execution_id, sandbox_id);
-            for (index, line) in output_lines.iter().enumerate() {
-                append_output_line(store, thread_key, execution_id, line).await?;
-                output_line_count += 1;
-                if index + 1 < output_lines.len() {
-                    sleep(Duration::from_millis(200)).await;
-                }
-            }
-            Ok(output_line_count)
+    let mut output_line_count = 0;
+    let output_lines = mock_app_server_output_lines(thread_key, execution_id, sandbox_id);
+    for (index, line) in output_lines.iter().enumerate() {
+        append_output_line(store, thread_key, Some(execution_id), line).await?;
+        output_line_count += 1;
+        if index + 1 < output_lines.len() {
+            sleep(Duration::from_millis(200)).await;
         }
-        SandboxRuntime::Backend { backend, .. } => {
-            let id = SandboxId::new(sandbox_id);
-            for line in input_lines {
-                write_input_line(backend.as_ref(), &id, line).await?;
+    }
+    if options.idle_timeout < Duration::from_millis(DEFAULT_IDLE_TIMEOUT_MS)
+        || options.max_duration < Duration::from_millis(DEFAULT_MAX_DURATION_MS)
+    {
+        sleep(options.idle_timeout).await;
+    }
+    Ok(output_line_count)
+}
+
+async fn ensure_stdout_pump(
+    state: &AppState,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+) -> Result<(), ApiError> {
+    let SandboxRuntime::Backend { backend, .. } = &state.sandbox_runtime else {
+        return Ok(());
+    };
+
+    let mut pumps = state.stdout_pumps.lock().await;
+    if !pumps.insert(sandbox_id.to_owned()) {
+        return Ok(());
+    }
+    drop(pumps);
+
+    let store = state.store.clone();
+    let backend = backend.clone();
+    let thread_key = thread_key.clone();
+    let sandbox_id = SandboxId::new(sandbox_id);
+    let pump_key = sandbox_id.as_str().to_owned();
+    let stdout_pumps = state.stdout_pumps.clone();
+
+    tokio::spawn(async move {
+        let result = run_stdout_pump(store.clone(), backend, thread_key.clone(), sandbox_id).await;
+        if let Err(error) = result {
+            warn!(%pump_key, %error, "session stdout pump failed");
+            let _ = store
+                .append_event(
+                    &thread_key,
+                    None,
+                    "session.stdout_pump_failed",
+                    json!({
+                        "sandbox_id": pump_key,
+                        "error": error.to_string(),
+                    }),
+                )
+                .await;
+        }
+        stdout_pumps.lock().await.remove(&pump_key);
+    });
+
+    Ok(())
+}
+
+async fn run_stdout_pump(
+    store: PgSessionStore,
+    backend: Arc<dyn SandboxBackend>,
+    thread_key: ThreadKey,
+    sandbox_id: SandboxId,
+) -> Result<(), ApiError> {
+    let mut buffer = String::new();
+    loop {
+        match backend
+            .read_bytes(
+                &sandbox_id,
+                ReadOptions {
+                    stream: OutputStream::Stdout,
+                    after_offset: None,
+                    max_bytes: 8192,
+                    timeout_ms: Some(1_000),
+                },
+            )
+            .await
+            .map_err(ApiError::Sandbox)?
+        {
+            ReadResult::Bytes { bytes, .. } => {
+                let chunk = std::str::from_utf8(&bytes).map_err(|err| {
+                    ApiError::BadRequest(format!("sandbox stdout was not UTF-8: {err}"))
+                })?;
+                buffer.push_str(chunk);
+
+                while let Some(index) = buffer.find('\n') {
+                    let line = buffer[..index].trim_end_matches('\r').to_owned();
+                    buffer.drain(..=index);
+                    append_output_line(&store, &thread_key, None, &line).await?;
+                }
             }
-
-            let mut buffer = String::new();
-            let mut output_line_count = 0;
-            let started_at = Instant::now();
-            let mut last_output_at: Option<Instant> = None;
-            let deadline = started_at + options.max_duration;
-
-            loop {
-                if Instant::now() >= deadline {
-                    output_line_count +=
-                        flush_partial_output(store, thread_key, execution_id, &mut buffer).await?;
-                    return Ok(output_line_count);
-                }
-
-                match backend
-                    .read_bytes(
-                        &id,
-                        ReadOptions {
-                            stream: OutputStream::Stdout,
-                            after_offset: None,
-                            max_bytes: 8192,
-                            timeout_ms: Some(1_000),
-                        },
+            ReadResult::TimedOut => {}
+            ReadResult::Eof => {
+                flush_partial_output(&store, &thread_key, None, &mut buffer).await?;
+                store
+                    .append_event(
+                        &thread_key,
+                        None,
+                        "session.stdout_eof",
+                        json!({
+                            "sandbox_id": sandbox_id.as_str(),
+                        }),
                     )
-                    .await
-                    .map_err(ApiError::Sandbox)?
-                {
-                    ReadResult::Bytes { bytes, .. } => {
-                        let chunk = std::str::from_utf8(&bytes).map_err(|err| {
-                            ApiError::BadRequest(format!("sandbox stdout was not UTF-8: {err}"))
-                        })?;
-                        last_output_at = Some(Instant::now());
-                        buffer.push_str(chunk);
-
-                        while let Some(index) = buffer.find('\n') {
-                            let line = buffer[..index].trim_end_matches('\r').to_owned();
-                            buffer.drain(..=index);
-                            append_output_line(store, thread_key, execution_id, &line).await?;
-                            output_line_count += 1;
-                        }
-                    }
-                    ReadResult::TimedOut => {
-                        let idle_reference = last_output_at.unwrap_or(started_at);
-                        if idle_reference.elapsed() >= options.idle_timeout
-                            && (output_line_count > 0
-                                || !buffer.is_empty()
-                                || input_lines.is_empty())
-                        {
-                            output_line_count +=
-                                flush_partial_output(store, thread_key, execution_id, &mut buffer)
-                                    .await?;
-                            return Ok(output_line_count);
-                        }
-                    }
-                    ReadResult::Eof => {
-                        output_line_count +=
-                            flush_partial_output(store, thread_key, execution_id, &mut buffer)
-                                .await?;
-                        return Ok(output_line_count);
-                    }
-                }
+                    .await?;
+                return Ok(());
             }
         }
     }
+}
+
+async fn write_input_lines(
+    backend: &dyn SandboxBackend,
+    sandbox_id: &SandboxId,
+    input_lines: &[String],
+) -> Result<(), ApiError> {
+    for line in input_lines {
+        write_input_line(backend, sandbox_id, line).await?;
+    }
+    Ok(())
 }
 
 async fn write_input_line(
@@ -362,7 +436,7 @@ async fn write_input_line(
 async fn flush_partial_output(
     store: &PgSessionStore,
     thread_key: &ThreadKey,
-    execution_id: &str,
+    execution_id: Option<&str>,
     buffer: &mut String,
 ) -> Result<usize, ApiError> {
     if buffer.is_empty() {
@@ -377,13 +451,13 @@ async fn flush_partial_output(
 async fn append_output_line(
     store: &PgSessionStore,
     thread_key: &ThreadKey,
-    execution_id: &str,
+    execution_id: Option<&str>,
     line: &str,
 ) -> Result<(), ApiError> {
     store
         .append_event(
             thread_key,
-            Some(execution_id),
+            execution_id,
             SESSION_OUTPUT_LINE_EVENT,
             Value::String(line.to_owned()),
         )
@@ -455,7 +529,10 @@ async fn stream_events(
     Query(query): Query<EventsQuery>,
 ) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, ApiError> {
     let thread_key = parse_thread_key(raw_thread_key)?;
-    state.store.get_session(&thread_key).await?;
+    let session = state.store.get_session(&thread_key).await?;
+    if let Some(sandbox_id) = session.sandbox_id.as_deref() {
+        ensure_stdout_pump(&state, &thread_key, sandbox_id).await?;
+    }
 
     let stream = stream::unfold(
         SessionEventStreamState {

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -1,9 +1,10 @@
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{env, net::SocketAddr, sync::Arc, time::Duration};
 
 use centaur_api_server::{SandboxRuntime, build_router_with_runtime};
 use centaur_sandbox_agent_k8s::{AgentSandboxBackend, AgentSandboxConfig};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_sandbox_local::LocalSandboxBackend;
+use centaur_session_core::ThreadKey;
 use centaur_session_sqlx::PgSessionStore;
 use clap::{Parser, ValueEnum};
 use thiserror::Error;
@@ -49,24 +50,41 @@ async fn sandbox_runtime_from_args(args: &Args) -> Result<SandboxRuntime, Server
             local_mock_app_server_spec(),
         )),
         SandboxBackendKind::AgentK8s => {
+            let image = args
+                .session_sandbox_image
+                .clone()
+                .unwrap_or_else(|| default_sandbox_image(args.session_sandbox_workload).to_owned());
             let mut config = AgentSandboxConfig::new(args.session_sandbox_k8s_namespace.clone());
+            config.image_pull_policy = args.session_sandbox_image_pull_policy.clone();
             config.ready_timeout = Duration::from_secs(args.session_sandbox_ready_timeout_secs);
 
-            let backend = if let Some(context) = args.session_sandbox_k8s_context.as_deref() {
+            let client = if let Some(context) = args.session_sandbox_k8s_context.as_deref() {
                 let kube_config = kube::Config::from_kubeconfig(&kube::config::KubeConfigOptions {
                     context: Some(context.to_owned()),
                     ..kube::config::KubeConfigOptions::default()
                 })
                 .await?;
-                AgentSandboxBackend::new(kube::Client::try_from(kube_config)?, config)
+                kube::Client::try_from(kube_config)?
             } else {
-                AgentSandboxBackend::try_default(config.namespace.clone()).await?
+                kube::Client::try_default().await?
             };
+            let backend = AgentSandboxBackend::new(client, config);
 
-            Ok(SandboxRuntime::backend(
-                Arc::new(backend),
-                agent_k8s_mock_app_server_spec(&args.session_sandbox_image),
-            ))
+            match args.session_sandbox_workload {
+                SandboxWorkloadKind::Mock => Ok(SandboxRuntime::backend(
+                    Arc::new(backend),
+                    agent_k8s_mock_app_server_spec(&image),
+                )),
+                SandboxWorkloadKind::CodexAppServer => {
+                    let env_template = codex_app_server_env_template(args);
+                    Ok(SandboxRuntime::backend_with_spec_factory(
+                        Arc::new(backend),
+                        move |thread_key, _execution_id| {
+                            codex_app_server_spec(&image, thread_key, &env_template)
+                        },
+                    ))
+                }
+            }
         }
     }
 }
@@ -89,16 +107,35 @@ struct Args {
     session_sandbox_backend: SandboxBackendKind,
     #[arg(
         long,
+        env = "SESSION_SANDBOX_WORKLOAD",
+        value_enum,
+        default_value = "mock"
+    )]
+    session_sandbox_workload: SandboxWorkloadKind,
+    #[arg(
+        long,
         env = "SESSION_SANDBOX_K8S_NAMESPACE",
         default_value = "centaur-sandbox-e2e"
     )]
     session_sandbox_k8s_namespace: String,
-    #[arg(long, env = "SESSION_SANDBOX_IMAGE", default_value = "busybox:1.36")]
-    session_sandbox_image: String,
+    #[arg(long, env = "SESSION_SANDBOX_IMAGE")]
+    session_sandbox_image: Option<String>,
+    #[arg(long, env = "SESSION_SANDBOX_IMAGE_PULL_POLICY")]
+    session_sandbox_image_pull_policy: Option<String>,
     #[arg(long, env = "SESSION_SANDBOX_READY_TIMEOUT_SECS", default_value_t = 90)]
     session_sandbox_ready_timeout_secs: u64,
     #[arg(long, env = "SESSION_SANDBOX_K8S_CONTEXT")]
     session_sandbox_k8s_context: Option<String>,
+    #[arg(long, env = "SESSION_SANDBOX_CENTAUR_API_URL")]
+    session_sandbox_centaur_api_url: Option<String>,
+    #[arg(long, env = "CENTAUR_API_URL")]
+    centaur_api_url: Option<String>,
+    #[arg(long, env = "SESSION_SANDBOX_CENTAUR_API_KEY")]
+    session_sandbox_centaur_api_key: Option<String>,
+    #[arg(long, env = "CENTAUR_API_KEY")]
+    centaur_api_key: Option<String>,
+    #[arg(long, env = "SESSION_SANDBOX_PASSTHROUGH_ENV", value_delimiter = ',')]
+    session_sandbox_passthrough_env: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -107,6 +144,20 @@ enum SandboxBackendKind {
     Local,
     #[value(name = "agent-k8s")]
     AgentK8s,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum SandboxWorkloadKind {
+    Mock,
+    #[value(name = "codex-app-server")]
+    CodexAppServer,
+}
+
+fn default_sandbox_image(workload: SandboxWorkloadKind) -> &'static str {
+    match workload {
+        SandboxWorkloadKind::Mock => "busybox:1.36",
+        SandboxWorkloadKind::CodexAppServer => "centaur-agent:latest",
+    }
 }
 
 fn local_mock_app_server_spec() -> SandboxSpec {
@@ -119,6 +170,57 @@ fn agent_k8s_mock_app_server_spec(image: &str) -> SandboxSpec {
     SandboxSpec::new(image)
         .command(["/bin/sh", "-lc"])
         .args([mock_app_server_script()])
+}
+
+fn codex_app_server_spec(
+    image: &str,
+    thread_key: &ThreadKey,
+    env_template: &[(String, String)],
+) -> SandboxSpec {
+    let mut spec = SandboxSpec::new(image).env("CENTAUR_THREAD_KEY", thread_key.as_str());
+    for (name, value) in env_template {
+        spec = spec.env(name.clone(), value.clone());
+    }
+    spec
+}
+
+fn codex_app_server_env_template(args: &Args) -> Vec<(String, String)> {
+    let mut envs = Vec::new();
+    push_env(
+        &mut envs,
+        "CENTAUR_API_URL",
+        args.session_sandbox_centaur_api_url
+            .as_deref()
+            .or(args.centaur_api_url.as_deref())
+            .unwrap_or("http://api:8000")
+            .to_owned(),
+    );
+    if let Some(api_key) = args
+        .session_sandbox_centaur_api_key
+        .as_deref()
+        .or(args.centaur_api_key.as_deref())
+    {
+        push_env(&mut envs, "CENTAUR_API_KEY", api_key.to_owned());
+    }
+
+    for name in &args.session_sandbox_passthrough_env {
+        if let Ok(value) = env::var(&name) {
+            push_env(&mut envs, &name, value);
+        }
+    }
+
+    envs
+}
+
+fn push_env(envs: &mut Vec<(String, String)>, name: &str, value: String) {
+    if let Some((_, existing_value)) = envs
+        .iter_mut()
+        .find(|(existing_name, _)| existing_name == name)
+    {
+        *existing_value = value;
+    } else {
+        envs.push((name.to_owned(), value));
+    }
 }
 
 fn mock_app_server_script() -> &'static str {

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -48,6 +48,7 @@ pub struct AgentSandboxConfig {
     pub container_name: String,
     pub labels: BTreeMap<String, String>,
     pub annotations: BTreeMap<String, String>,
+    pub image_pull_policy: Option<String>,
     pub state_volume: Option<StateVolumeConfig>,
     pub ready_timeout: Duration,
 }
@@ -60,6 +61,7 @@ impl AgentSandboxConfig {
             container_name: DEFAULT_CONTAINER_NAME.to_owned(),
             labels: BTreeMap::new(),
             annotations: BTreeMap::new(),
+            image_pull_policy: None,
             state_volume: None,
             ready_timeout: Duration::from_secs(60),
         }
@@ -555,6 +557,11 @@ fn build_agent_sandbox(
         "stdinOnce": false,
         "tty": false,
     });
+    insert_optional(
+        &mut container,
+        "imagePullPolicy",
+        config.image_pull_policy.clone(),
+    );
     insert_optional(&mut container, "command", spec.command.clone());
     insert_optional(
         &mut container,

--- a/services/api-rs/crates/centaur-session-cli/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-cli/Cargo.toml
@@ -9,9 +9,11 @@ repository.workspace = true
 anyhow.workspace = true
 centaur-session-core.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+crossterm.workspace = true
 futures-util.workspace = true
+ratatui.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
 urlencoding.workspace = true
 uuid.workspace = true

--- a/services/api-rs/crates/centaur-session-cli/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-cli/Cargo.toml
@@ -12,6 +12,6 @@ clap = { workspace = true, features = ["derive", "env"] }
 futures-util.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt-multi-thread"] }
 urlencoding.workspace = true
 uuid.workspace = true

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -44,6 +44,9 @@ struct Args {
 
     #[arg(long)]
     exit_on_terminal: bool,
+
+    #[arg(long)]
+    exit_on_output_type: Option<String>,
 }
 
 #[tokio::main]
@@ -62,7 +65,13 @@ async fn main() -> Result<()> {
 
     if attach_mode {
         let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
-        return stream_output_lines(events_response, args.all_events, args.exit_on_terminal).await;
+        return stream_output_lines(
+            events_response,
+            args.all_events,
+            args.exit_on_terminal,
+            args.exit_on_output_type,
+        )
+        .await;
     }
 
     let input_lines = session_input_lines(&args)?;
@@ -107,8 +116,12 @@ async fn main() -> Result<()> {
         args.max_duration_ms,
     );
 
-    let stream_future =
-        stream_output_lines(events_response, args.all_events, args.exit_on_terminal);
+    let stream_future = stream_output_lines(
+        events_response,
+        args.all_events,
+        args.exit_on_terminal,
+        args.exit_on_output_type,
+    );
     tokio::pin!(stream_future);
 
     tokio::select! {
@@ -224,6 +237,7 @@ async fn stream_output_lines(
     response: reqwest::Response,
     all_events: bool,
     exit_on_terminal: bool,
+    exit_on_output_type: Option<String>,
 ) -> Result<()> {
     let mut chunks = response.bytes_stream();
     let mut buffer = String::new();
@@ -246,6 +260,9 @@ async fn stream_output_lines(
                     event.id.as_deref().unwrap_or("unknown"),
                     event.data
                 );
+                if output_type_matches(&event.data, exit_on_output_type.as_deref()) {
+                    return Ok(());
+                }
             } else if all_events {
                 let data = parse_json_or_string(&event.data);
                 println!(
@@ -265,6 +282,21 @@ async fn stream_output_lines(
     }
 
     Ok(())
+}
+
+fn output_type_matches(data: &str, expected_type: Option<&str>) -> bool {
+    let Some(expected_type) = expected_type else {
+        return false;
+    };
+    serde_json::from_str::<Value>(data)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("type")
+                .and_then(Value::as_str)
+                .map(|event_type| event_type == expected_type)
+        })
+        .unwrap_or(false)
 }
 
 fn session_input_lines(args: &Args) -> Result<Vec<String>> {

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -4,7 +4,10 @@ use clap::Parser;
 use futures_util::StreamExt;
 use reqwest::Client;
 use serde_json::{Value, json};
-use tokio::task::JoinHandle;
+use tokio::{
+    io::{self, AsyncBufReadExt, BufReader},
+    task::JoinHandle,
+};
 use uuid::Uuid;
 
 const DEFAULT_MESSAGE: &str = "Reply with exactly PONG and nothing else.";
@@ -47,6 +50,9 @@ struct Args {
 
     #[arg(long)]
     exit_on_output_type: Option<String>,
+
+    #[arg(long, alias = "stdin")]
+    stdin_events: bool,
 }
 
 #[tokio::main]
@@ -65,17 +71,19 @@ async fn main() -> Result<()> {
 
     if attach_mode {
         let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
-        return stream_output_lines(
+        return run_stream_and_optional_stdin(
+            client,
+            session_url,
             events_response,
             args.all_events,
             args.exit_on_terminal,
             args.exit_on_output_type,
+            args.stdin_events,
+            args.idle_timeout_ms,
+            args.max_duration_ms,
         )
         .await;
     }
-
-    let input_lines = session_input_lines(&args)?;
-    let message = message_text(&args);
 
     post_json(
         &client,
@@ -90,50 +98,43 @@ async fn main() -> Result<()> {
     .await
     .context("create session")?;
 
-    post_json(
-        &client,
-        &format!("{session_url}/messages"),
-        json!({
-            "messages": [{
-                "role": "user",
-                "parts": [{"type": "text", "text": message}],
-                "metadata": {
-                    "source": "centaur-session-cli",
-                },
-            }],
-        }),
-    )
-    .await
-    .context("append message")?;
+    let initial_input_lines = if should_send_initial_turn(&args) {
+        let input_lines = session_input_lines(&args)?;
+        let message = message_text(&args);
+        append_user_message(&client, &session_url, message)
+            .await
+            .context("append message")?;
+        Some(input_lines)
+    } else {
+        None
+    };
 
     let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
 
-    let mut execute_task = spawn_execute(
-        client.clone(),
-        format!("{session_url}/execute"),
-        input_lines,
-        args.idle_timeout_ms,
-        args.max_duration_ms,
-    );
+    if let Some(input_lines) = initial_input_lines {
+        execute_input_lines(
+            &client,
+            &session_url,
+            input_lines,
+            args.idle_timeout_ms,
+            args.max_duration_ms,
+        )
+        .await
+        .context("execute initial turn")?;
+    }
 
-    let stream_future = stream_output_lines(
+    run_stream_and_optional_stdin(
+        client,
+        session_url,
         events_response,
         args.all_events,
         args.exit_on_terminal,
         args.exit_on_output_type,
-    );
-    tokio::pin!(stream_future);
-
-    tokio::select! {
-        stream_result = &mut stream_future => {
-            execute_task.await.context("join execute task")??;
-            stream_result
-        }
-        execute_result = &mut execute_task => {
-            execute_result.context("join execute task")??;
-            stream_future.await
-        }
-    }
+        args.stdin_events,
+        args.idle_timeout_ms,
+        args.max_duration_ms,
+    )
+    .await
 }
 
 fn attach_mode(args: &Args) -> bool {
@@ -207,28 +208,134 @@ async fn open_event_stream(
         .context("open event stream")
 }
 
-fn spawn_execute(
-    client: Client,
-    url: String,
+async fn append_user_message(client: &Client, session_url: &str, text: &str) -> Result<()> {
+    post_json(
+        client,
+        &format!("{session_url}/messages"),
+        json!({
+            "messages": [{
+                "role": "user",
+                "parts": [{"type": "text", "text": text}],
+                "metadata": {
+                    "source": "centaur-session-cli",
+                },
+            }],
+        }),
+    )
+    .await
+    .context("append message")?;
+    Ok(())
+}
+
+async fn execute_input_lines(
+    client: &Client,
+    session_url: &str,
     input_lines: Vec<String>,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<()> {
+    post_json(
+        client,
+        &format!("{session_url}/execute"),
+        json!({
+            "metadata": {
+                "source": "centaur-session-cli",
+            },
+            "input_lines": input_lines,
+            "idle_timeout_ms": idle_timeout_ms,
+            "max_duration_ms": max_duration_ms,
+        }),
+    )
+    .await
+    .context("execute session")?;
+    Ok(())
+}
+
+async fn run_stream_and_optional_stdin(
+    client: Client,
+    session_url: String,
+    events_response: reqwest::Response,
+    all_events: bool,
+    exit_on_terminal: bool,
+    exit_on_output_type: Option<String>,
+    stdin_events: bool,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<()> {
+    let stream_future = stream_output_lines(
+        events_response,
+        all_events,
+        exit_on_terminal,
+        exit_on_output_type,
+    );
+    tokio::pin!(stream_future);
+
+    if !stdin_events {
+        return stream_future.await;
+    }
+
+    let mut stdin_task = spawn_stdin_events(client, session_url, idle_timeout_ms, max_duration_ms);
+
+    tokio::select! {
+        stream_result = &mut stream_future => {
+            stdin_task.abort();
+            stream_result
+        }
+        stdin_result = &mut stdin_task => {
+            stdin_result.context("join stdin event task")??;
+            stream_future.await
+        }
+    }
+}
+
+fn spawn_stdin_events(
+    client: Client,
+    session_url: String,
     idle_timeout_ms: u64,
     max_duration_ms: u64,
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {
-        post_json(
-            &client,
-            &url,
-            json!({
-                "metadata": {
-                    "source": "centaur-session-cli",
-                },
-                "input_lines": input_lines,
-                "idle_timeout_ms": idle_timeout_ms,
-                "max_duration_ms": max_duration_ms,
-            }),
-        )
-        .await
-        .context("execute session")?;
+        let mut lines = BufReader::new(io::stdin()).lines();
+        while let Some(line) = lines.next_line().await.context("read stdin event")? {
+            let event = match StdinEvent::parse(&line)? {
+                Some(event) => event,
+                None => continue,
+            };
+            match event {
+                StdinEvent::Message(text) => {
+                    append_user_message(&client, &session_url, &text).await?;
+                    execute_input_lines(
+                        &client,
+                        &session_url,
+                        vec![user_input_line(&text)?],
+                        idle_timeout_ms,
+                        max_duration_ms,
+                    )
+                    .await?;
+                }
+                StdinEvent::InputLine(line) => {
+                    execute_input_lines(
+                        &client,
+                        &session_url,
+                        vec![line],
+                        idle_timeout_ms,
+                        max_duration_ms,
+                    )
+                    .await?;
+                }
+                StdinEvent::InputLines(lines) => {
+                    execute_input_lines(
+                        &client,
+                        &session_url,
+                        lines,
+                        idle_timeout_ms,
+                        max_duration_ms,
+                    )
+                    .await?;
+                }
+                StdinEvent::Quit => break,
+            }
+        }
         Ok(())
     })
 }
@@ -304,12 +411,20 @@ fn session_input_lines(args: &Args) -> Result<Vec<String>> {
         return Ok(args.input_lines.clone());
     }
     let message = message_text(args);
-    Ok(vec![serde_json::to_string(&json!({
+    Ok(vec![user_input_line(message)?])
+}
+
+fn should_send_initial_turn(args: &Args) -> bool {
+    args.message.is_some() || !args.input_lines.is_empty() || !args.stdin_events
+}
+
+fn user_input_line(text: &str) -> Result<String> {
+    Ok(serde_json::to_string(&json!({
         "type": "user",
         "message": {
-            "content": [{"type": "text", "text": message}],
+            "content": [{"type": "text", "text": text}],
         },
-    }))?])
+    }))?)
 }
 
 fn message_text(args: &Args) -> &str {
@@ -339,6 +454,88 @@ fn is_terminal_event(event: &str) -> bool {
         event,
         "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
     )
+}
+
+#[derive(Debug)]
+enum StdinEvent {
+    Message(String),
+    InputLine(String),
+    InputLines(Vec<String>),
+    Quit,
+}
+
+impl StdinEvent {
+    fn parse(line: &str) -> Result<Option<Self>> {
+        let line = line.trim();
+        if line.is_empty() {
+            return Ok(None);
+        }
+        if matches!(line, "/quit" | "/exit") {
+            return Ok(Some(Self::Quit));
+        }
+        if let Some(text) = line.strip_prefix("/message ") {
+            return Ok(Some(Self::Message(text.trim().to_owned())));
+        }
+        if let Some(raw_line) = line.strip_prefix("/input ") {
+            return Ok(Some(Self::InputLine(raw_line.trim().to_owned())));
+        }
+        if let Some(raw_lines) = line.strip_prefix("/execute ") {
+            return parse_execute_command(raw_lines.trim()).map(Some);
+        }
+        if line.starts_with('/') {
+            bail!("unknown stdin command: {line}");
+        }
+        if line.starts_with('{') {
+            return parse_json_stdin_event(line).map(Some);
+        }
+        Ok(Some(Self::Message(line.to_owned())))
+    }
+}
+
+fn parse_execute_command(value: &str) -> Result<StdinEvent> {
+    if value.starts_with('[') {
+        let lines =
+            serde_json::from_str::<Vec<String>>(value).context("parse /execute JSON array")?;
+        return Ok(StdinEvent::InputLines(lines));
+    }
+    Ok(StdinEvent::InputLine(value.to_owned()))
+}
+
+fn parse_json_stdin_event(line: &str) -> Result<StdinEvent> {
+    let value = serde_json::from_str::<Value>(line).context("parse stdin JSON event")?;
+    match value.get("type").and_then(Value::as_str) {
+        Some("message") => {
+            let text = value
+                .get("text")
+                .and_then(Value::as_str)
+                .context("stdin message event requires string field `text`")?;
+            Ok(StdinEvent::Message(text.to_owned()))
+        }
+        Some("input_line") => {
+            let raw_line = value
+                .get("line")
+                .and_then(Value::as_str)
+                .context("stdin input_line event requires string field `line`")?;
+            Ok(StdinEvent::InputLine(raw_line.to_owned()))
+        }
+        Some("execute") => {
+            let lines = value
+                .get("input_lines")
+                .and_then(Value::as_array)
+                .context("stdin execute event requires array field `input_lines`")?
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map(ToOwned::to_owned)
+                        .context("stdin execute input_lines must be strings")
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(StdinEvent::InputLines(lines))
+        }
+        Some("quit" | "exit") => Ok(StdinEvent::Quit),
+        _ => Ok(StdinEvent::InputLine(line.to_owned())),
+    }
 }
 
 #[derive(Debug)]

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -10,6 +10,8 @@ use tokio::{
 };
 use uuid::Uuid;
 
+mod tui;
+
 const DEFAULT_MESSAGE: &str = "Reply with exactly PONG and nothing else.";
 
 #[derive(Debug, Parser)]
@@ -53,6 +55,12 @@ struct Args {
 
     #[arg(long, alias = "stdin")]
     stdin_events: bool,
+
+    #[arg(long)]
+    tui: bool,
+
+    #[arg(long)]
+    debug: bool,
 }
 
 #[tokio::main]
@@ -71,6 +79,22 @@ async fn main() -> Result<()> {
 
     if attach_mode {
         let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
+        if args.tui {
+            return tui::run(
+                client,
+                thread_key.as_str().to_owned(),
+                session_url,
+                events_response,
+                tui::TuiOptions {
+                    debug_visible: args.debug,
+                    idle_timeout_ms: args.idle_timeout_ms,
+                    max_duration_ms: args.max_duration_ms,
+                    exit_on_terminal: args.exit_on_terminal,
+                    exit_on_output_type: args.exit_on_output_type,
+                },
+            )
+            .await;
+        }
         return run_stream_and_optional_stdin(
             client,
             session_url,
@@ -123,6 +147,23 @@ async fn main() -> Result<()> {
         .context("execute initial turn")?;
     }
 
+    if args.tui {
+        return tui::run(
+            client,
+            thread_key.as_str().to_owned(),
+            session_url,
+            events_response,
+            tui::TuiOptions {
+                debug_visible: args.debug,
+                idle_timeout_ms: args.idle_timeout_ms,
+                max_duration_ms: args.max_duration_ms,
+                exit_on_terminal: args.exit_on_terminal,
+                exit_on_output_type: args.exit_on_output_type,
+            },
+        )
+        .await;
+    }
+
     run_stream_and_optional_stdin(
         client,
         session_url,
@@ -151,6 +192,9 @@ fn validate_mode(args: &Args, attach_mode: bool) -> Result<()> {
     }
     if args.attach && (args.message.is_some() || !args.input_lines.is_empty()) {
         bail!("--attach does not accept --message or --input-line");
+    }
+    if args.tui && args.stdin_events {
+        bail!("--tui cannot be combined with --stdin-events");
     }
     Ok(())
 }
@@ -208,7 +252,11 @@ async fn open_event_stream(
         .context("open event stream")
 }
 
-async fn append_user_message(client: &Client, session_url: &str, text: &str) -> Result<()> {
+pub(crate) async fn append_user_message(
+    client: &Client,
+    session_url: &str,
+    text: &str,
+) -> Result<()> {
     post_json(
         client,
         &format!("{session_url}/messages"),
@@ -227,7 +275,7 @@ async fn append_user_message(client: &Client, session_url: &str, text: &str) -> 
     Ok(())
 }
 
-async fn execute_input_lines(
+pub(crate) async fn execute_input_lines(
     client: &Client,
     session_url: &str,
     input_lines: Vec<String>,
@@ -391,7 +439,7 @@ async fn stream_output_lines(
     Ok(())
 }
 
-fn output_type_matches(data: &str, expected_type: Option<&str>) -> bool {
+pub(crate) fn output_type_matches(data: &str, expected_type: Option<&str>) -> bool {
     let Some(expected_type) = expected_type else {
         return false;
     };
@@ -415,10 +463,10 @@ fn session_input_lines(args: &Args) -> Result<Vec<String>> {
 }
 
 fn should_send_initial_turn(args: &Args) -> bool {
-    args.message.is_some() || !args.input_lines.is_empty() || !args.stdin_events
+    args.message.is_some() || !args.input_lines.is_empty() || (!args.stdin_events && !args.tui)
 }
 
-fn user_input_line(text: &str) -> Result<String> {
+pub(crate) fn user_input_line(text: &str) -> Result<String> {
     Ok(serde_json::to_string(&json!({
         "type": "user",
         "message": {
@@ -435,7 +483,7 @@ fn session_url(base_url: &str, thread_key: &str) -> String {
     format!("{base_url}/api/session/{}", urlencoding::encode(thread_key))
 }
 
-fn next_frame(buffer: &str) -> Option<(usize, usize)> {
+pub(crate) fn next_frame(buffer: &str) -> Option<(usize, usize)> {
     let lf = buffer.find("\n\n").map(|index| (index, 2));
     let crlf = buffer.find("\r\n\r\n").map(|index| (index, 4));
     match (lf, crlf) {
@@ -445,11 +493,11 @@ fn next_frame(buffer: &str) -> Option<(usize, usize)> {
     }
 }
 
-fn parse_json_or_string(data: &str) -> Value {
+pub(crate) fn parse_json_or_string(data: &str) -> Value {
     serde_json::from_str(data).unwrap_or_else(|_| Value::String(data.to_owned()))
 }
 
-fn is_terminal_event(event: &str) -> bool {
+pub(crate) fn is_terminal_event(event: &str) -> bool {
     matches!(
         event,
         "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
@@ -457,7 +505,7 @@ fn is_terminal_event(event: &str) -> bool {
 }
 
 #[derive(Debug)]
-enum StdinEvent {
+pub(crate) enum StdinEvent {
     Message(String),
     InputLine(String),
     InputLines(Vec<String>),
@@ -465,7 +513,7 @@ enum StdinEvent {
 }
 
 impl StdinEvent {
-    fn parse(line: &str) -> Result<Option<Self>> {
+    pub(crate) fn parse(line: &str) -> Result<Option<Self>> {
         let line = line.trim();
         if line.is_empty() {
             return Ok(None);
@@ -539,14 +587,14 @@ fn parse_json_stdin_event(line: &str) -> Result<StdinEvent> {
 }
 
 #[derive(Debug)]
-struct SseFrame {
-    id: Option<String>,
-    event: String,
-    data: String,
+pub(crate) struct SseFrame {
+    pub(crate) id: Option<String>,
+    pub(crate) event: String,
+    pub(crate) data: String,
 }
 
 impl SseFrame {
-    fn parse(frame: &str) -> Option<Self> {
+    pub(crate) fn parse(frame: &str) -> Option<Self> {
         let frame = frame.replace("\r\n", "\n");
         let mut id = None;
         let mut event = "message".to_owned();

--- a/services/api-rs/crates/centaur-session-cli/src/tui.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/tui.rs
@@ -1,0 +1,710 @@
+use std::{
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use crossterm::{
+    cursor::{Hide, Show},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use futures_util::StreamExt;
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+use reqwest::Client;
+use serde_json::Value;
+use tokio::{
+    sync::mpsc,
+    time::{self, Duration as TokioDuration},
+};
+
+use crate::{
+    SseFrame, StdinEvent, append_user_message, execute_input_lines, is_terminal_event, next_frame,
+    output_type_matches, parse_json_or_string, user_input_line,
+};
+
+const MAX_MAIN_LINES: usize = 1_000;
+const MAX_DEBUG_LINES: usize = 1_000;
+
+pub(crate) struct TuiOptions {
+    pub(crate) debug_visible: bool,
+    pub(crate) idle_timeout_ms: u64,
+    pub(crate) max_duration_ms: u64,
+    pub(crate) exit_on_terminal: bool,
+    pub(crate) exit_on_output_type: Option<String>,
+}
+
+pub(crate) async fn run(
+    client: Client,
+    thread_key: String,
+    session_url: String,
+    events_response: reqwest::Response,
+    options: TuiOptions,
+) -> Result<()> {
+    let _terminal_restore = TerminalRestore::enter()?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
+    terminal.clear()?;
+
+    let (terminal_tx, mut terminal_rx) = mpsc::channel(64);
+    let _terminal_reader = TerminalEventReader::spawn(terminal_tx);
+    let (frame_tx, mut frame_rx) = mpsc::channel(256);
+    let (notice_tx, mut notice_rx) = mpsc::channel(64);
+
+    spawn_stream_task(events_response, frame_tx, notice_tx.clone());
+
+    let mut app = TuiApp::new(thread_key, options.debug_visible);
+    let mut tick = time::interval(TokioDuration::from_millis(100));
+
+    loop {
+        terminal.draw(|frame| draw(frame, &app))?;
+
+        tokio::select! {
+            _ = tick.tick() => {}
+            Some(event) = terminal_rx.recv() => {
+                if handle_terminal_event(
+                    &mut app,
+                    event,
+                    &client,
+                    &session_url,
+                    &options,
+                    notice_tx.clone(),
+                )? {
+                    break;
+                }
+            }
+            Some(frame) = frame_rx.recv() => {
+                if app.handle_sse_frame(frame, &options) {
+                    break;
+                }
+            }
+            Some(notice) = notice_rx.recv() => {
+                app.handle_notice(notice);
+            }
+            else => break,
+        }
+    }
+
+    Ok(())
+}
+
+fn spawn_stream_task(
+    response: reqwest::Response,
+    frame_tx: mpsc::Sender<SseFrame>,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) {
+    tokio::spawn(async move {
+        if let Err(error) = stream_sse_frames(response, frame_tx).await {
+            let _ = notice_tx
+                .send(TuiNotice::Error(format!("stream error: {error:#}")))
+                .await;
+        }
+    });
+}
+
+async fn stream_sse_frames(
+    response: reqwest::Response,
+    frame_tx: mpsc::Sender<SseFrame>,
+) -> Result<()> {
+    let mut chunks = response.bytes_stream();
+    let mut buffer = String::new();
+
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk.context("read event stream")?;
+        buffer.push_str(std::str::from_utf8(&chunk).context("event stream is not UTF-8")?);
+
+        while let Some((frame_end, separator_len)) = next_frame(&buffer) {
+            let frame = buffer[..frame_end].to_owned();
+            buffer.drain(..frame_end + separator_len);
+
+            if let Some(event) = SseFrame::parse(&frame) {
+                if frame_tx.send(event).await.is_err() {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_terminal_event(
+    app: &mut TuiApp,
+    event: TerminalInput,
+    client: &Client,
+    session_url: &str,
+    options: &TuiOptions,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) -> Result<bool> {
+    let TerminalInput::Key(key) = event else {
+        return Ok(false);
+    };
+
+    match key.code {
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => return Ok(true),
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => return Ok(true),
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => app.input.clear(),
+        KeyCode::F(2) => app.toggle_debug(),
+        KeyCode::Enter => {
+            let line = app.input.trim().to_owned();
+            app.input.clear();
+            return submit_input_line(app, line, client, session_url, options, notice_tx);
+        }
+        KeyCode::Backspace => {
+            app.input.pop();
+        }
+        KeyCode::Char(ch) => {
+            if key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT {
+                app.input.push(ch);
+            }
+        }
+        _ => {}
+    }
+
+    Ok(false)
+}
+
+fn submit_input_line(
+    app: &mut TuiApp,
+    line: String,
+    client: &Client,
+    session_url: &str,
+    options: &TuiOptions,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) -> Result<bool> {
+    if line.is_empty() {
+        return Ok(false);
+    }
+    match line.as_str() {
+        "/debug" => {
+            app.toggle_debug();
+            return Ok(false);
+        }
+        "/clear" => {
+            app.clear();
+            return Ok(false);
+        }
+        "/help" => {
+            app.status =
+                "Enter sends | F2 or /debug toggles events | /input raw | /quit exits".to_owned();
+            return Ok(false);
+        }
+        _ => {}
+    }
+
+    let Some(event) = StdinEvent::parse(&line)? else {
+        return Ok(false);
+    };
+    if matches!(event, StdinEvent::Quit) {
+        return Ok(true);
+    }
+
+    app.note_submitted_event(&event);
+    spawn_send_task(
+        event,
+        client.clone(),
+        session_url.to_owned(),
+        options.idle_timeout_ms,
+        options.max_duration_ms,
+        notice_tx,
+    );
+    Ok(false)
+}
+
+fn spawn_send_task(
+    event: StdinEvent,
+    client: Client,
+    session_url: String,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) {
+    tokio::spawn(async move {
+        let notice =
+            match send_stdin_event(event, client, session_url, idle_timeout_ms, max_duration_ms)
+                .await
+            {
+                Ok(message) => TuiNotice::Info(message),
+                Err(error) => TuiNotice::Error(format!("{error:#}")),
+            };
+        let _ = notice_tx.send(notice).await;
+    });
+}
+
+async fn send_stdin_event(
+    event: StdinEvent,
+    client: Client,
+    session_url: String,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<String> {
+    match event {
+        StdinEvent::Message(text) => {
+            append_user_message(&client, &session_url, &text).await?;
+            execute_input_lines(
+                &client,
+                &session_url,
+                vec![user_input_line(&text)?],
+                idle_timeout_ms,
+                max_duration_ms,
+            )
+            .await?;
+            Ok("message sent".to_owned())
+        }
+        StdinEvent::InputLine(line) => {
+            execute_input_lines(
+                &client,
+                &session_url,
+                vec![line],
+                idle_timeout_ms,
+                max_duration_ms,
+            )
+            .await?;
+            Ok("input line sent".to_owned())
+        }
+        StdinEvent::InputLines(lines) => {
+            let count = lines.len();
+            execute_input_lines(
+                &client,
+                &session_url,
+                lines,
+                idle_timeout_ms,
+                max_duration_ms,
+            )
+            .await?;
+            Ok(format!("{count} input lines sent"))
+        }
+        StdinEvent::Quit => Ok("quit".to_owned()),
+    }
+}
+
+fn draw(frame: &mut Frame<'_>, app: &TuiApp) {
+    let area = frame.area();
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    draw_header(frame, layout[0], app);
+    draw_body(frame, layout[1], app);
+    draw_input(frame, layout[2], app);
+    draw_footer(frame, layout[3], app);
+}
+
+fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let debug_state = if app.debug_visible {
+        "debug:on"
+    } else {
+        "debug:off"
+    };
+    let last_event = app.last_event_id.as_deref().unwrap_or("-");
+    let title = Line::from(vec![
+        Span::styled(
+            "Centaur Session",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(app.thread_key.clone(), Style::default().fg(Color::Yellow)),
+        Span::raw("  "),
+        Span::raw(format!("event:{last_event}  {debug_state}")),
+    ]);
+    let help = Line::from("Enter send  F2 debug  Ctrl-U clear input  Ctrl-D quit  /help");
+    frame.render_widget(
+        Paragraph::new(vec![title, help]).block(Block::default().borders(Borders::BOTTOM)),
+        area,
+    );
+}
+
+fn draw_body(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    if app.debug_visible {
+        if area.width >= 100 {
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
+                .split(area);
+            draw_main(frame, chunks[0], app);
+            draw_debug(frame, chunks[1], app);
+        } else {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                .split(area);
+            draw_main(frame, chunks[0], app);
+            draw_debug(frame, chunks[1], app);
+        }
+    } else {
+        draw_main(frame, area, app);
+    }
+}
+
+fn draw_main(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let lines = tail_lines(&app.main_lines, area.height.saturating_sub(2) as usize);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().title("Session").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_debug(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let lines = tail_lines(&app.debug_lines, area.height.saturating_sub(2) as usize);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().title("Events").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let visible = visible_input(&app.input, area.width.saturating_sub(2) as usize);
+    let cursor_x = area
+        .x
+        .saturating_add(1)
+        .saturating_add(visible.chars().count() as u16)
+        .min(area.x.saturating_add(area.width.saturating_sub(2)));
+    let cursor_y = area.y.saturating_add(1);
+
+    frame.render_widget(
+        Paragraph::new(visible)
+            .block(Block::default().title("Input").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+    frame.set_cursor_position((cursor_x, cursor_y));
+}
+
+fn draw_footer(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    frame.render_widget(
+        Paragraph::new(app.status.clone()).style(Style::default().fg(Color::DarkGray)),
+        area,
+    );
+}
+
+fn tail_lines(lines: &[String], max: usize) -> Vec<Line<'static>> {
+    let start = lines.len().saturating_sub(max.max(1));
+    lines[start..]
+        .iter()
+        .map(|line| Line::raw(line.clone()))
+        .collect()
+}
+
+fn visible_input(input: &str, max_chars: usize) -> String {
+    let chars = input.chars().collect::<Vec<_>>();
+    let start = chars.len().saturating_sub(max_chars.max(1));
+    chars[start..].iter().collect()
+}
+
+#[derive(Debug)]
+enum TerminalInput {
+    Key(KeyEvent),
+    Resize,
+}
+
+struct TerminalEventReader {
+    stop: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl TerminalEventReader {
+    fn spawn(sender: mpsc::Sender<TerminalInput>) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let reader_stop = Arc::clone(&stop);
+        let handle = thread::spawn(move || {
+            while !reader_stop.load(Ordering::Relaxed) {
+                let Ok(has_event) = event::poll(Duration::from_millis(100)) else {
+                    continue;
+                };
+                if !has_event {
+                    continue;
+                }
+                match event::read() {
+                    Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => {
+                        if sender.blocking_send(TerminalInput::Key(key)).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(Event::Resize(_, _)) => {
+                        if sender.blocking_send(TerminalInput::Resize).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(_) | Err(_) => {}
+                }
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for TerminalEventReader {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+struct TerminalRestore;
+
+impl TerminalRestore {
+    fn enter() -> Result<Self> {
+        enable_raw_mode().context("enable terminal raw mode")?;
+        execute!(io::stdout(), EnterAlternateScreen, Hide).context("enter alternate screen")?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalRestore {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), Show, LeaveAlternateScreen);
+    }
+}
+
+enum TuiNotice {
+    Info(String),
+    Error(String),
+}
+
+struct TuiApp {
+    thread_key: String,
+    input: String,
+    main_lines: Vec<String>,
+    debug_lines: Vec<String>,
+    debug_visible: bool,
+    status: String,
+    last_event_id: Option<String>,
+    current_agent_line: Option<usize>,
+}
+
+impl TuiApp {
+    fn new(thread_key: String, debug_visible: bool) -> Self {
+        Self {
+            thread_key,
+            input: String::new(),
+            main_lines: vec![
+                "session ready".to_owned(),
+                "type a message and press Enter; use F2 for raw events".to_owned(),
+            ],
+            debug_lines: Vec::new(),
+            debug_visible,
+            status: "ready".to_owned(),
+            last_event_id: None,
+            current_agent_line: None,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.main_lines.clear();
+        self.debug_lines.clear();
+        self.current_agent_line = None;
+        self.status = "cleared".to_owned();
+    }
+
+    fn toggle_debug(&mut self) {
+        self.debug_visible = !self.debug_visible;
+        self.status = if self.debug_visible {
+            "debug events visible".to_owned()
+        } else {
+            "debug events hidden".to_owned()
+        };
+    }
+
+    fn note_submitted_event(&mut self, event: &StdinEvent) {
+        match event {
+            StdinEvent::Message(text) => {
+                self.push_main_line(format!("you: {text}"));
+                self.status = "sending message".to_owned();
+            }
+            StdinEvent::InputLine(_) => {
+                self.push_main_line("system: sending raw input line".to_owned());
+                self.status = "sending raw input line".to_owned();
+            }
+            StdinEvent::InputLines(lines) => {
+                self.push_main_line(format!("system: sending {} raw input lines", lines.len()));
+                self.status = "sending raw input lines".to_owned();
+            }
+            StdinEvent::Quit => {}
+        }
+    }
+
+    fn handle_notice(&mut self, notice: TuiNotice) {
+        match notice {
+            TuiNotice::Info(message) => self.status = message,
+            TuiNotice::Error(message) => {
+                self.status = format!("error: {message}");
+                self.push_main_line(format!("error: {message}"));
+            }
+        }
+    }
+
+    fn handle_sse_frame(&mut self, frame: SseFrame, options: &TuiOptions) -> bool {
+        self.last_event_id = frame.id.clone();
+        self.push_debug_line(format_debug_frame(&frame));
+
+        if frame.event == "session.output.line" {
+            self.handle_output_line(&frame.data);
+            if output_type_matches(&frame.data, options.exit_on_output_type.as_deref()) {
+                self.status = format!(
+                    "matched output type {}",
+                    options.exit_on_output_type.as_deref().unwrap_or_default()
+                );
+                return true;
+            }
+        } else if frame.event == "session.execution_started" {
+            self.push_main_line("system: execution started".to_owned());
+            self.status = "execution started".to_owned();
+        } else if is_terminal_event(&frame.event) {
+            self.current_agent_line = None;
+            self.push_main_line(format!("system: {}", frame.event));
+            self.status = frame.event.clone();
+            if options.exit_on_terminal {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn handle_output_line(&mut self, data: &str) {
+        let Ok(value) = serde_json::from_str::<Value>(data) else {
+            self.push_main_line(format!("stdout: {data}"));
+            return;
+        };
+
+        let Some(event_type) = value.get("type").and_then(Value::as_str) else {
+            self.push_main_line(format!("stdout: {}", compact_json(&value, 240)));
+            return;
+        };
+
+        match event_type {
+            "item.agentMessage.delta" => {
+                if let Some(delta) = value.get("delta").and_then(Value::as_str) {
+                    self.append_agent_delta(delta);
+                }
+            }
+            "item.completed" => {
+                if let Some(text) = completed_agent_text(&value) {
+                    if self.current_agent_line.is_none() {
+                        self.push_main_line(format!("assistant: {text}"));
+                    }
+                    self.current_agent_line = None;
+                }
+            }
+            "turn.completed" => {
+                self.current_agent_line = None;
+                self.push_main_line("system: turn completed".to_owned());
+                self.status = "turn completed".to_owned();
+            }
+            "result" => {
+                self.current_agent_line = None;
+                if let Some(result) = value.get("result").and_then(Value::as_str) {
+                    self.push_main_line(format!("result: {result}"));
+                } else {
+                    self.push_main_line(format!("result: {}", compact_json(&value, 240)));
+                }
+            }
+            "system" => {
+                let subtype = value
+                    .get("subtype")
+                    .and_then(Value::as_str)
+                    .unwrap_or("event");
+                self.push_main_line(format!("system: {subtype}"));
+            }
+            other => {
+                self.push_main_line(format!("event: {other}"));
+            }
+        }
+    }
+
+    fn append_agent_delta(&mut self, delta: &str) {
+        if self.current_agent_line.is_none() {
+            self.push_main_line("assistant: ".to_owned());
+            self.current_agent_line = self.main_lines.len().checked_sub(1);
+        }
+        if let Some(index) = self.current_agent_line {
+            if let Some(line) = self.main_lines.get_mut(index) {
+                line.push_str(delta);
+            }
+        }
+    }
+
+    fn push_main_line(&mut self, line: String) {
+        self.main_lines.push(line);
+        if self.main_lines.len() > MAX_MAIN_LINES {
+            self.main_lines.remove(0);
+            self.current_agent_line = self
+                .current_agent_line
+                .and_then(|index| index.checked_sub(1));
+        }
+    }
+
+    fn push_debug_line(&mut self, line: String) {
+        self.debug_lines.push(line);
+        if self.debug_lines.len() > MAX_DEBUG_LINES {
+            self.debug_lines.remove(0);
+        }
+    }
+}
+
+fn completed_agent_text(value: &Value) -> Option<&str> {
+    let item = value.get("item")?;
+    if item.get("type").and_then(Value::as_str) != Some("agentMessage") {
+        return None;
+    }
+    item.get("text").and_then(Value::as_str)
+}
+
+fn format_debug_frame(frame: &SseFrame) -> String {
+    let id = frame.id.as_deref().unwrap_or("-");
+    let data = parse_json_or_string(&frame.data);
+    format!(
+        "{} {} {}",
+        id,
+        frame.event,
+        truncate(&compact_json(&data, 1_000), 1_000)
+    )
+}
+
+fn compact_json(value: &Value, max_chars: usize) -> String {
+    let rendered = match value {
+        Value::String(value) => value.clone(),
+        _ => serde_json::to_string(value).unwrap_or_else(|_| "<invalid json>".to_owned()),
+    };
+    truncate(&rendered, max_chars)
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}


### PR DESCRIPTION
## Summary

This PR wires the v1 path for exercising a real `centaur-agent` sandbox image from the Rust session CLI. The API remains format-oblivious: it writes opaque input lines to sandbox stdin and stores opaque stdout lines as durable session events for SSE consumers. The CLI now has both scripted stdin mode and a harness-style TUI for keeping a session open while inspecting raw events.

## What changed

- Changes backend execution so `POST /execute` writes input to sandbox stdin and returns after the write is accepted.
- Adds a process-local stdout pump per sandbox/session; the pump continuously reads sandbox stdout and appends each line as `session.output.line`.
- Lazily restarts the stdout pump when an SSE consumer reconnects to a session with a live sandbox id.
- Adds `SESSION_SANDBOX_WORKLOAD=codex-app-server` for AgentSandbox mode, which runs the `centaur-agent` image default `codex-app-wrapper` command instead of the mock shell script.
- Adds session-specific sandbox env injection, including `CENTAUR_THREAD_KEY`, `CENTAUR_API_URL`, optional `CENTAUR_API_KEY`, and explicit passthrough via `SESSION_SANDBOX_PASSTHROUGH_ENV`.
- Adds `SESSION_SANDBOX_IMAGE_PULL_POLICY` support for AgentSandbox containers, useful for Kind-loaded `centaur-agent:latest` images.
- Adds CLI `--exit-on-output-type`, so e2e runs can exit on a streamed opaque Codex line such as `{"type":"turn.completed"}` without teaching the API about Codex.
- Adds CLI `--stdin-events` / `--stdin`, which keeps the SSE stream open while reading newline-delimited commands or events from stdin.
- Adds CLI `--tui` with a session transcript pane, input box, and raw SSE/event debug pane; `--debug` starts the event pane open.

## CLI TUI mode

`--tui` starts an alternate-screen terminal UI. Without `--message` or `--input-line`, it creates or attaches to the session and waits for input instead of sending the default PONG turn.

Controls:

```text
Enter       send current input as a message
F2          toggle raw event debug pane
Ctrl-U      clear input
Ctrl-D      quit
/debug      toggle raw event debug pane
/clear      clear transcript/debug panes
/help       show command hint
/input ...  send one raw sandbox input line
/execute ... send one raw sandbox input line or JSON array of lines
/quit       quit
```

The main pane lightly projects known Codex app-server JSONL into a readable transcript (`assistant` deltas, turn status, result/system markers). The debug pane still shows raw SSE ids, event names, and event payloads so API behavior remains inspectable without baking Codex semantics into the API.

Example:

```bash
cargo run -p centaur-session-cli -- \
  --api-url http://127.0.0.1:8080 \
  --thread-key cli:tui-1 \
  --tui \
  --debug
```

## CLI stdin mode

`--stdin-events` suppresses the default initial PONG turn unless `--message` or `--input-line` is also passed. This lets the CLI create or attach to a session, open the event stream, and then accept input over stdin.

Supported stdin lines:

```text
/message Reply with exactly PONG and nothing else.
/input {"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}
/execute {"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}
/execute ["{...raw line 1...}", "{...raw line 2...}"]
{"type":"message","text":"Reply with exactly PONG and nothing else."}
{"type":"input_line","line":"{...raw line...}"}
{"type":"execute","input_lines":["{...raw line...}"]}
/quit
```

Raw non-command text is treated as `/message <text>`. Unknown JSON objects are passed through as raw input lines.

When stdin reaches EOF, the CLI continues streaming SSE unless `--exit-on-terminal` or `--exit-on-output-type` ends the stream. That keeps interactive attach behavior intact while still allowing scripted usage with an explicit exit condition.

## V1 semantics

This intentionally does not spool sandbox stdout while the API is down. On API restart, the next execute or SSE attach checks the existing `sandbox_id`, reattaches if the sandbox is still running, and starts a fresh stdout pump from that point forward. Events already stored in Postgres remain replayable by `after_event_id`.

## Example local shape

```bash
SESSION_SANDBOX_BACKEND=agent-k8s \
SESSION_SANDBOX_WORKLOAD=codex-app-server \
SESSION_SANDBOX_IMAGE=centaur-agent:latest \
SESSION_SANDBOX_IMAGE_PULL_POLICY=IfNotPresent \
SESSION_SANDBOX_PASSTHROUGH_ENV=OPENAI_API_KEY,CODEX_API_KEY,CODEX_AUTH_MODE,HTTPS_PROXY,HTTP_PROXY,NO_PROXY \
RUN_MIGRATIONS=true \
DATABASE_URL=... \
cargo run -p centaur-api-server

printf '%s\n' '/message Reply with exactly PONG and nothing else.' | cargo run -p centaur-session-cli -- \
  --api-url http://127.0.0.1:8080 \
  --stdin-events \
  --all-events \
  --exit-on-output-type turn.completed
```

## Local e2e evidence

Ran the real path locally against `kind-centaur-api-rs-e2e` after loading `centaur-agent:latest` into the Kind node and starting the Rust API with a local `OPENAI_API_KEY`. The CLI streamed Codex app-server events through the API/SSE pipe and exited on `turn.completed`.

Observed output included:

```text
29  {"type":"item.agentMessage.delta",...,"delta":"P",...}
30  {"type":"item.agentMessage.delta",...,"delta":"ONG",...}
31  {"type":"item.completed","item":{"type":"agentMessage",...,"text":"PONG",...}}
32  {"type":"turn.completed",...}
```

Also verified the stdin path with:

```bash
printf '%s\n' '/message Reply with exactly PONG and nothing else.' | cargo run -p centaur-session-cli -- --api-url http://127.0.0.1:8080 --stdin-events --all-events --exit-on-output-type turn.completed
```

That run produced a generated `thread_key`, streamed session event ids, and ended after `turn.completed` with `PONG` in the output.

Verified the TUI path in a PTY with:

```bash
cargo run -p centaur-session-cli -- --api-url http://127.0.0.1:8080 --thread-key cli:tui-smoke-20260601 --tui --debug --exit-on-output-type turn.completed
```

Typed `Reply with exactly PONG and nothing else.`, saw raw event ids in the debug pane, saw `assistant: PONG` in the session pane, and the process exited on `turn.completed`.

## Testing

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test --workspace` from `services/api-rs`
- `cargo test -p centaur-session-cli`
- Real local e2e: CLI prompt produced `PONG` and streamed `turn.completed` from Codex app-server via AgentSandbox
- Stdin smoke: piped `/message ...` into `--stdin-events`; CLI created a session, printed event ids, streamed `PONG`, and exited on `turn.completed`
- TUI smoke: PTY-launched `--tui --debug`, typed a prompt, observed raw event ids plus projected `assistant: PONG`, and exited on `turn.completed`
