### PR TITLE
[codex] wire harness server blocks mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,18 @@
 .venv
 
 # Node
-services/slackbot/node_modules
+node_modules
+**/node_modules
+
+# Build outputs
+target
+**/target
+dist
+**/dist
+.next
+**/.next
+coverage
+**/coverage
 
 # Sandbox cached repos (4GB+)
 services/sandbox/repos

--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -1,8 +1,14 @@
 use std::env;
-use std::io::{self, Write};
-use std::process::{Command as ProcessCommand, Stdio};
+use std::io::{self, BufRead, Write};
+use std::process::{Child, ChildStdin, Command as ProcessCommand, Stdio};
+use std::sync::mpsc::{self, Receiver};
 use std::thread;
 
+use codex_app_server_protocol::UserInput;
+use serde_json::{Value, json};
+
+use crate::server::{BlocksCommand, parse_blocks_line, write_blocks_error};
+use crate::util::write_value;
 use crate::{AppServerRuntime, HarnessServerError, Result};
 
 #[derive(Debug, Default)]
@@ -57,6 +63,348 @@ impl AppServerRuntime for CodexHarnessServer {
         }
         Ok(())
     }
+}
+
+pub(crate) fn run_codex_blocks_server() -> Result<()> {
+    let mut codex = CodexJsonRpcChild::spawn()?;
+    let mut stdout = io::stdout().lock();
+    let mut request_id = 1_i64;
+    let mut thread_id: Option<String> = None;
+
+    let initialize_id = next_request_id(&mut request_id);
+    codex.send_request(
+        initialize_id,
+        "initialize",
+        json!({
+            "clientInfo": {
+                "name": "centaur-harness-server",
+                "title": null,
+                "version": env!("CARGO_PKG_VERSION"),
+            },
+            "capabilities": null,
+        }),
+    )?;
+    codex.read_response_or_forward(initialize_id, &mut stdout)?;
+
+    let stdin = io::stdin();
+    for raw in stdin.lock().lines() {
+        let line = raw?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match parse_blocks_line(trimmed) {
+            Ok(BlocksCommand::User {
+                input,
+                client_user_message_id,
+            }) => {
+                if let Err(error) = run_codex_user_turn(
+                    &mut codex,
+                    &mut stdout,
+                    &mut request_id,
+                    &mut thread_id,
+                    input,
+                    client_user_message_id,
+                ) {
+                    let fallback_thread_id = thread_id.as_deref().unwrap_or("codex");
+                    eprintln!("Codex blocks turn failed: {error:#}");
+                    write_blocks_error(&mut stdout, fallback_thread_id, "turn", error.to_string())?;
+                }
+            }
+            Ok(BlocksCommand::Interrupt) => {
+                eprintln!(
+                    "Codex blocks interrupt ignored: no active stdin reader while a turn runs"
+                );
+            }
+            Err(error) => {
+                eprintln!("invalid Codex blocks input: {error:#}");
+                write_blocks_error(
+                    &mut stdout,
+                    thread_id.as_deref().unwrap_or("codex"),
+                    "input",
+                    error.to_string(),
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn run_codex_user_turn<W: Write>(
+    codex: &mut CodexJsonRpcChild,
+    stdout: &mut W,
+    request_id: &mut i64,
+    thread_id: &mut Option<String>,
+    input: Vec<UserInput>,
+    client_user_message_id: Option<String>,
+) -> Result<()> {
+    if thread_id.is_none() {
+        *thread_id = Some(start_or_resume_thread(codex, stdout, request_id)?);
+    }
+    let current_thread_id = thread_id
+        .as_ref()
+        .expect("thread id was initialized")
+        .clone();
+
+    let mut params = json!({
+        "threadId": current_thread_id,
+        "input": input,
+    });
+    if let Some(client_user_message_id) = client_user_message_id {
+        params["clientUserMessageId"] = Value::String(client_user_message_id);
+    }
+
+    let turn_request_id = next_request_id(request_id);
+    codex.send_request(turn_request_id, "turn/start", params)?;
+    let result = codex.read_response_or_forward(turn_request_id, stdout)?;
+    let turn_id = result
+        .pointer("/turn/id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            HarnessServerError::Protocol("turn/start response missing turn.id".to_string())
+        })?
+        .to_string();
+    codex.read_until_turn_terminal(stdout, thread_id.as_deref().unwrap_or_default(), &turn_id)
+}
+
+fn start_or_resume_thread<W: Write>(
+    codex: &mut CodexJsonRpcChild,
+    stdout: &mut W,
+    request_id: &mut i64,
+) -> Result<String> {
+    let cwd = env::current_dir()?.display().to_string();
+    let resume = env::var("CODEX_CONTINUE_THREAD_ID")
+        .or_else(|_| env::var("AMP_CONTINUE_THREAD_ID"))
+        .unwrap_or_default();
+    let (method, params) = if resume.trim().is_empty() {
+        (
+            "thread/start",
+            json!({
+                "cwd": cwd,
+                "approvalPolicy": "never",
+                "approvalsReviewer": "user",
+                "sandbox": "danger-full-access",
+            }),
+        )
+    } else {
+        (
+            "thread/resume",
+            json!({
+                "threadId": resume.trim(),
+                "cwd": cwd,
+                "approvalPolicy": "never",
+                "approvalsReviewer": "user",
+                "sandbox": "danger-full-access",
+                "excludeTurns": false,
+            }),
+        )
+    };
+
+    let id = next_request_id(request_id);
+    codex.send_request(id, method, params)?;
+    let result = codex.read_response_or_forward(id, stdout)?;
+    result
+        .pointer("/thread/id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| HarnessServerError::Protocol(format!("{method} response missing thread.id")))
+}
+
+struct CodexJsonRpcChild {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: Receiver<io::Result<String>>,
+}
+
+impl CodexJsonRpcChild {
+    fn spawn() -> Result<Self> {
+        let bin = codex_bin();
+        let mut child = ProcessCommand::new(&bin)
+            .args(["app-server", "--listen", "stdio://"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|source| HarnessServerError::SpawnCodex {
+                bin: bin.clone(),
+                source,
+            })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or(HarnessServerError::CodexStdinUnavailable)?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(HarnessServerError::CodexStdoutUnavailable)?;
+        let mut stderr = child
+            .stderr
+            .take()
+            .ok_or(HarnessServerError::CodexStderrUnavailable)?;
+        thread::spawn(move || {
+            let mut parent_stderr = io::stderr().lock();
+            let _ = io::copy(&mut stderr, &mut parent_stderr);
+        });
+
+        let (stdout_tx, stdout_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let reader = io::BufReader::new(stdout);
+            for raw in reader.lines() {
+                let should_stop = raw.is_err();
+                if stdout_tx.send(raw).is_err() || should_stop {
+                    break;
+                }
+            }
+        });
+
+        Ok(Self {
+            child,
+            stdin,
+            stdout: stdout_rx,
+        })
+    }
+
+    fn send_request(&mut self, id: i64, method: &str, params: Value) -> Result<()> {
+        self.write_value(&json!({
+            "id": id,
+            "method": method,
+            "params": params,
+        }))
+    }
+
+    fn send_error_response(&mut self, request: &Value) -> Result<()> {
+        let id = request.get("id").cloned().unwrap_or(Value::Null);
+        self.write_value(&json!({
+            "id": id,
+            "error": {
+                "code": -32000,
+                "message": "Centaur blocks mode cannot service app-server client requests",
+                "data": null,
+            },
+        }))
+    }
+
+    fn write_value(&mut self, value: &Value) -> Result<()> {
+        serde_json::to_writer(&mut self.stdin, value)?;
+        self.stdin.write_all(b"\n")?;
+        self.stdin.flush()?;
+        Ok(())
+    }
+
+    fn read_response_or_forward<W: Write>(
+        &mut self,
+        expected_id: i64,
+        stdout: &mut W,
+    ) -> Result<Value> {
+        loop {
+            let value = self.read_value()?;
+            if is_server_request(&value) {
+                self.send_error_response(&value)?;
+                continue;
+            }
+            if response_id(&value) == Some(expected_id) {
+                if let Some(error) = value.get("error") {
+                    return Err(HarnessServerError::Protocol(format!(
+                        "Codex app-server request {expected_id} failed: {error}"
+                    )));
+                }
+                return Ok(value.get("result").cloned().unwrap_or(Value::Null));
+            }
+            if notification_method(&value).is_some() {
+                write_value(stdout, &value)?;
+            }
+        }
+    }
+
+    fn read_until_turn_terminal<W: Write>(
+        &mut self,
+        stdout: &mut W,
+        thread_id: &str,
+        turn_id: &str,
+    ) -> Result<()> {
+        loop {
+            let value = self.read_value()?;
+            if is_server_request(&value) {
+                self.send_error_response(&value)?;
+                continue;
+            }
+            if notification_method(&value).is_some() {
+                let terminal = is_terminal_notification(&value, thread_id, turn_id);
+                write_value(stdout, &value)?;
+                if terminal {
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn read_value(&mut self) -> Result<Value> {
+        loop {
+            let line = match self.stdout.recv() {
+                Ok(line) => line?,
+                Err(_) => {
+                    let status = self.child.wait()?;
+                    return Err(HarnessServerError::CodexExited { status });
+                }
+            };
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            return Ok(serde_json::from_str(trimmed)?);
+        }
+    }
+}
+
+impl Drop for CodexJsonRpcChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn is_server_request(value: &Value) -> bool {
+    value.get("id").is_some() && value.get("method").is_some()
+}
+
+fn response_id(value: &Value) -> Option<i64> {
+    value.get("id").and_then(Value::as_i64)
+}
+
+fn notification_method(value: &Value) -> Option<&str> {
+    if value.get("id").is_some() {
+        return None;
+    }
+    value.get("method").and_then(Value::as_str)
+}
+
+fn is_terminal_notification(value: &Value, thread_id: &str, turn_id: &str) -> bool {
+    match notification_method(value) {
+        Some("turn/completed") | Some("turn/failed") => {
+            let notification_thread = value
+                .pointer("/params/threadId")
+                .and_then(Value::as_str)
+                .unwrap_or(thread_id);
+            let notification_turn = value
+                .pointer("/params/turn/id")
+                .or_else(|| value.pointer("/params/turnId"))
+                .and_then(Value::as_str)
+                .unwrap_or(turn_id);
+            notification_thread == thread_id && notification_turn == turn_id
+        }
+        Some("error") => true,
+        _ => false,
+    }
+}
+
+fn next_request_id(request_id: &mut i64) -> i64 {
+    let id = *request_id;
+    *request_id += 1;
+    id
 }
 
 fn codex_bin() -> String {

--- a/crates/harness-server/src/error.rs
+++ b/crates/harness-server/src/error.rs
@@ -23,6 +23,8 @@ pub enum HarnessServerError {
         #[source]
         source: serde_json::Error,
     },
+    #[error("invalid blocks-mode input: {message}")]
+    InvalidBlocksInput { message: String },
     #[error("unknown threadId {thread_id}")]
     UnknownThread { thread_id: String },
     #[error("cwd must be absolute: {path}")]

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -11,7 +11,7 @@ mod validation;
 pub mod wire;
 
 pub use error::{HarnessServerError, Result};
-pub use server::{run_harness_server, run_validate_jsonrpc, server_for};
+pub use server::{run_blocks_server, run_harness_server, run_validate_jsonrpc, server_for};
 pub use traits::{
     AppServerNormalizer, AppServerRuntime, HarnessKind, HarnessServer, NormalizedContent,
     NormalizedEvent, NormalizedToolResult, ThreadState,

--- a/crates/harness-server/src/main.rs
+++ b/crates/harness-server/src/main.rs
@@ -1,6 +1,7 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use harness_server::{
-    HarnessKind, Result, run_harness_server, run_validate_agent_deltas, run_validate_jsonrpc,
+    HarnessKind, Result, run_blocks_server, run_harness_server, run_validate_agent_deltas,
+    run_validate_jsonrpc,
 };
 
 #[derive(Debug, Parser)]
@@ -16,12 +17,24 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 #[command(rename_all = "kebab-case")]
 enum CliCommand {
-    Codex,
+    Codex(HarnessCommand),
     #[command(alias = "claude")]
-    ClaudeCode,
-    Amp,
+    ClaudeCode(HarnessCommand),
+    Amp(HarnessCommand),
     ValidateJsonrpc,
     ValidateAgentDeltas,
+}
+
+#[derive(Debug, Parser)]
+struct HarnessCommand {
+    #[arg(long, value_enum, default_value_t = ServerMode::Blocks)]
+    mode: ServerMode,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ServerMode {
+    Blocks,
+    Jsonrpc,
 }
 
 fn main() {
@@ -32,11 +45,22 @@ fn main() {
 }
 
 fn run() -> Result<()> {
-    match Cli::parse().command.unwrap_or(CliCommand::Codex) {
-        CliCommand::Codex => run_harness_server(HarnessKind::Codex),
-        CliCommand::ClaudeCode => run_harness_server(HarnessKind::ClaudeCode),
-        CliCommand::Amp => run_harness_server(HarnessKind::Amp),
+    match Cli::parse()
+        .command
+        .unwrap_or(CliCommand::Codex(HarnessCommand {
+            mode: ServerMode::Blocks,
+        })) {
+        CliCommand::Codex(command) => run_mode(HarnessKind::Codex, command.mode),
+        CliCommand::ClaudeCode(command) => run_mode(HarnessKind::ClaudeCode, command.mode),
+        CliCommand::Amp(command) => run_mode(HarnessKind::Amp, command.mode),
         CliCommand::ValidateJsonrpc => run_validate_jsonrpc(),
         CliCommand::ValidateAgentDeltas => run_validate_agent_deltas(),
+    }
+}
+
+fn run_mode(kind: HarnessKind, mode: ServerMode) -> Result<()> {
+    match mode {
+        ServerMode::Blocks => run_blocks_server(kind),
+        ServerMode::Jsonrpc => run_harness_server(kind),
     }
 }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -13,6 +13,7 @@ use codex_app_server_protocol::{
     ThreadStartResponse, TurnInterruptParams, TurnInterruptResponse, TurnStartParams,
     TurnStartResponse, TurnStatus, TurnSteerParams, TurnSteerResponse, UserInput,
 };
+use serde::Deserialize;
 use serde_json::{Value, json};
 use uuid::Uuid;
 
@@ -40,6 +41,14 @@ pub fn run_harness_server(kind: HarnessKind) -> Result<()> {
     server_for(kind).run_stdio()
 }
 
+pub fn run_blocks_server(kind: HarnessKind) -> Result<()> {
+    match kind {
+        HarnessKind::Codex => crate::codex::run_codex_blocks_server(),
+        HarnessKind::ClaudeCode => run_blocks_app_server(&ClaudeCodeHarness),
+        HarnessKind::Amp => run_blocks_app_server(&AmpHarness),
+    }
+}
+
 pub fn run_validate_jsonrpc() -> Result<()> {
     let stdin = io::stdin();
     for raw in stdin.lock().lines() {
@@ -55,6 +64,49 @@ pub fn run_validate_jsonrpc() -> Result<()> {
                 })?;
         }
     }
+    Ok(())
+}
+
+pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout().lock();
+    let mut state = initial_blocks_thread_state(harness)?;
+    let (_request_tx, request_rx) = mpsc::channel();
+
+    for raw in stdin.lock().lines() {
+        let line = raw?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match parse_blocks_line(trimmed) {
+            Ok(BlocksCommand::User {
+                input,
+                client_user_message_id,
+            }) => {
+                if let Err(error) = run_blocks_turn(
+                    harness,
+                    &mut state,
+                    input,
+                    client_user_message_id,
+                    &mut stdout,
+                    &request_rx,
+                ) {
+                    eprintln!("blocks turn failed: {error:#}");
+                    write_blocks_error(&mut stdout, &state.id, "turn", error.to_string())?;
+                }
+            }
+            Ok(BlocksCommand::Interrupt) => {
+                eprintln!("blocks interrupt ignored: no active stdin reader while a turn runs");
+            }
+            Err(error) => {
+                eprintln!("invalid blocks input: {error:#}");
+                write_blocks_error(&mut stdout, &state.id, "input", error.to_string())?;
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -97,6 +149,148 @@ pub(crate) fn run_app_server<H: HarnessServer>(harness: &H) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn initial_blocks_thread_state<H: HarnessServer>(harness: &H) -> Result<ThreadState> {
+    let cwd = env::current_dir()?;
+    let params = ThreadStartParams::default();
+    Ok(harness.thread_state(&params, cwd))
+}
+
+fn run_blocks_turn<H: HarnessServer, W: Write>(
+    harness: &H,
+    state: &mut ThreadState,
+    input: Vec<UserInput>,
+    client_user_message_id: Option<String>,
+    stdout: &mut W,
+    request_rx: &Receiver<JSONRPCRequest>,
+) -> Result<()> {
+    let turn_id = format!("turn-{}", Uuid::new_v4().simple());
+    let mut normalizer = normalizer_for(harness, state, &turn_id);
+    for notification in normalizer.start_notifications(!state.thread_started_sent)? {
+        if matches!(notification, ServerNotification::ThreadStarted(_)) {
+            state.thread_started_sent = true;
+        }
+        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+    }
+    for notification in normalizer.emit_user_message(client_user_message_id, input.clone())? {
+        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+    }
+
+    let outcome = run_harness_turn(harness, state, &input, &mut normalizer, stdout, request_rx);
+    match outcome {
+        Ok(Some(turn)) => state.completed_turns.push(turn),
+        Ok(None) => {}
+        Err(error) => {
+            let message = error.to_string();
+            let normalized = NormalizedEvent::Error {
+                message: message.clone(),
+            };
+            for notification in normalizer.process_event(&normalized)? {
+                write_value(stdout, &notification_to_wire_value(&notification)?)?;
+            }
+            if let Some(notification) = normalizer.finish_turn(Some(message))? {
+                if let ServerNotification::TurnCompleted(completed) = &notification {
+                    state.completed_turns.push(completed.turn.clone());
+                }
+                write_value(stdout, &notification_to_wire_value(&notification)?)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) enum BlocksCommand {
+    User {
+        input: Vec<UserInput>,
+        client_user_message_id: Option<String>,
+    },
+    Interrupt,
+}
+
+#[derive(Debug, Deserialize)]
+struct BlocksLine {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    message: Option<BlocksMessage>,
+    #[serde(default)]
+    content: Option<BlocksContent>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    client_user_message_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BlocksMessage {
+    #[serde(default)]
+    content: Option<BlocksContent>,
+    #[serde(default)]
+    id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum BlocksContent {
+    Inputs(Vec<UserInput>),
+    Text(String),
+}
+
+pub(crate) fn parse_blocks_line(line: &str) -> Result<BlocksCommand> {
+    let parsed: BlocksLine =
+        serde_json::from_str(line).map_err(|source| HarnessServerError::InvalidBlocksInput {
+            message: source.to_string(),
+        })?;
+
+    match parsed.kind.as_str() {
+        "user" => {
+            let content = parsed
+                .message
+                .as_ref()
+                .and_then(|message| message.content.as_ref())
+                .or(parsed.content.as_ref());
+            let mut input = match content {
+                Some(content) => blocks_content_to_user_input(content),
+                None => parsed
+                    .text
+                    .map(|text| {
+                        vec![UserInput::Text {
+                            text,
+                            text_elements: Vec::new(),
+                        }]
+                    })
+                    .unwrap_or_default(),
+            };
+            if input.is_empty() {
+                input.push(UserInput::Text {
+                    text: "continue".to_string(),
+                    text_elements: Vec::new(),
+                });
+            }
+            Ok(BlocksCommand::User {
+                input,
+                client_user_message_id: parsed
+                    .client_user_message_id
+                    .or_else(|| parsed.message.and_then(|message| message.id)),
+            })
+        }
+        "interrupt" => Ok(BlocksCommand::Interrupt),
+        kind => Err(HarnessServerError::InvalidBlocksInput {
+            message: format!("unsupported blocks input type `{kind}`"),
+        }),
+    }
+}
+
+fn blocks_content_to_user_input(content: &BlocksContent) -> Vec<UserInput> {
+    match content {
+        BlocksContent::Inputs(input) => input.clone(),
+        BlocksContent::Text(text) => vec![UserInput::Text {
+            text: text.clone(),
+            text_elements: Vec::new(),
+        }],
+    }
 }
 
 fn handle_request<H: HarnessServer, W: Write>(
@@ -580,5 +774,29 @@ fn write_error<W: Write>(stdout: &mut W, id: RequestId, code: i64, message: Stri
                 data: None,
             },
         }))?,
+    )
+}
+
+pub(crate) fn write_blocks_error<W: Write>(
+    stdout: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+    message: String,
+) -> Result<()> {
+    write_value(
+        stdout,
+        &json!({
+            "method": "error",
+            "params": {
+                "error": {
+                    "message": message,
+                    "codexErrorInfo": null,
+                    "additionalDetails": null
+                },
+                "willRetry": false,
+                "threadId": thread_id,
+                "turnId": turn_id
+            }
+        }),
     )
 }

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
@@ -29,6 +30,14 @@ impl Harness {
     }
 
     fn args(self) -> &'static [&'static str] {
+        match self {
+            Self::ClaudeCode => &["claude-code", "--mode", "jsonrpc"],
+            Self::Amp => &["amp", "--mode", "jsonrpc"],
+            Self::Codex => &["codex", "--mode", "jsonrpc"],
+        }
+    }
+
+    fn blocks_args(self) -> &'static [&'static str] {
         match self {
             Self::ClaudeCode => &["claude-code"],
             Self::Amp => &["amp"],
@@ -117,6 +126,123 @@ fn fake_amp_app_server_streams_codex_v2_notifications() {
     assert_completed_turn(&run.turn);
     assert_eq!(run.turn.text_from_deltas, "amp");
     assert_codex_v2_turn(&run.turn);
+}
+
+#[test]
+fn fake_claude_blocks_mode_accepts_user_blocks_by_default() {
+    let fake_claude = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}' ",
+        "'{\"type\":\"assistant\",\"is_partial\":true,\"message\":{\"id\":\"msg_1\",\"content\":[{\"type\":\"text\",\"text\":\"blo\"}]}}' ",
+        "'{\"type\":\"assistant\",\"is_partial\":true,\"message\":{\"id\":\"msg_1\",\"content\":[{\"type\":\"text\",\"text\":\"blocks\"}]}}' ",
+        "'{\"type\":\"assistant\",\"is_partial\":false,\"message\":{\"id\":\"msg_1\",\"content\":[{\"type\":\"text\",\"text\":\"blocks\"}]}}' ",
+        "'{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"blocks\"}'"
+    );
+
+    let run = run_blocks_turn(BridgeTurnConfig {
+        harness: Harness::ClaudeCode,
+        command_override: Some(fake_claude.to_string()),
+        prompt: "say blocks".to_string(),
+        timeout: Duration::from_secs(10),
+    });
+
+    assert_completed_turn(&run.turn);
+    assert_eq!(run.turn.text_from_deltas, "blocks");
+    assert_codex_v2_turn(&run.turn);
+    assert!(
+        run.stdout_lines
+            .iter()
+            .all(|line| response_id(&serde_json::from_str(line).expect("JSON stdout")).is_none()),
+        "blocks mode should emit notifications only, not JSON-RPC responses"
+    );
+}
+
+#[test]
+fn fake_amp_blocks_mode_accepts_user_blocks_by_default() {
+    let fake_amp = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"T-amp-session\"}' ",
+        "'{\"type\":\"assistant\",\"is_partial\":true,\"message\":{\"id\":\"msg_1\",\"content\":[{\"type\":\"text\",\"text\":\"bl\"}]}}' ",
+        "'{\"type\":\"assistant\",\"is_partial\":true,\"message\":{\"id\":\"msg_1\",\"content\":[{\"type\":\"text\",\"text\":\"block amp\"}]}}' ",
+        "'{\"type\":\"assistant\",\"is_partial\":false,\"message\":{\"id\":\"msg_1\",\"content\":[{\"type\":\"text\",\"text\":\"block amp\"}]}}' ",
+        "'{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"block amp\"}'"
+    );
+
+    let run = run_blocks_turn(BridgeTurnConfig {
+        harness: Harness::Amp,
+        command_override: Some(fake_amp.to_string()),
+        prompt: "say block amp".to_string(),
+        timeout: Duration::from_secs(10),
+    });
+
+    assert_completed_turn(&run.turn);
+    assert_eq!(run.turn.text_from_deltas, "block amp");
+    assert_codex_v2_turn(&run.turn);
+}
+
+#[test]
+fn fake_codex_blocks_mode_spawns_app_server_and_translates_user_blocks() {
+    let fake_codex = temp_path("fake-codex.sh");
+    let fake_codex_log = temp_path("fake-codex-requests.jsonl");
+    let script = fake_codex_app_server_script(&fake_codex_log);
+    std::fs::write(&fake_codex, script).expect("write fake codex script");
+    let mut permissions = std::fs::metadata(&fake_codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, permissions).expect("chmod fake codex script");
+
+    let mut bridge = BridgeProcess::spawn_harness_blocks(
+        Harness::Codex,
+        None,
+        Some((
+            "CODEX_BIN",
+            fake_codex.to_str().expect("utf-8 fake codex path"),
+        )),
+    );
+    let turn = bridge.run_blocks_user_turn("say codex blocks", Duration::from_secs(10));
+    let stdout_lines = bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_eq!(turn.text_from_deltas, "codex blocks");
+    assert_codex_v2_turn(&turn);
+    assert!(
+        stdout_lines
+            .iter()
+            .all(|line| response_id(&serde_json::from_str(line).expect("JSON stdout")).is_none()),
+        "blocks mode should emit notifications only, not JSON-RPC responses"
+    );
+
+    let requests = std::fs::read_to_string(&fake_codex_log).expect("read fake codex request log");
+    let requests: Vec<Value> = requests
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("fake codex request JSON"))
+        .collect();
+    assert!(
+        requests
+            .iter()
+            .any(|value| value.get("method").and_then(Value::as_str) == Some("thread/start")),
+        "blocks mode should start a Codex app-server thread; requests={requests:?}"
+    );
+    let turn_start = requests
+        .iter()
+        .find(|value| value.get("method").and_then(Value::as_str) == Some("turn/start"))
+        .unwrap_or_else(|| panic!("blocks mode did not send turn/start; requests={requests:?}"));
+    assert_eq!(
+        turn_start
+            .pointer("/params/threadId")
+            .and_then(Value::as_str),
+        Some("thread-1")
+    );
+    assert_eq!(
+        turn_start
+            .pointer("/params/input/0/text")
+            .and_then(Value::as_str),
+        Some("say codex blocks")
+    );
+
+    let _ = std::fs::remove_file(fake_codex);
+    let _ = std::fs::remove_file(fake_codex_log);
 }
 
 #[test]
@@ -303,7 +429,7 @@ fn real_harnesses_basic_steer_and_resume() {
             harness,
             command_override: None,
             start_prompt:
-                "If a steering update arrives, follow it. Otherwise reply exactly INITIAL."
+                "Before answering, run a shell command that sleeps for 8 seconds. If a steering update arrives while you are waiting, follow it. Otherwise reply exactly INITIAL."
                     .to_string(),
             steer_prompt: format!("Steering update: reply exactly {marker} and nothing else."),
             timeout: Duration::from_secs(240),
@@ -407,6 +533,14 @@ fn run_bridge_turn(config: BridgeTurnConfig) -> BridgeRun {
     BridgeRun { stdout_lines, turn }
 }
 
+fn run_blocks_turn(config: BridgeTurnConfig) -> BridgeRun {
+    let mut bridge =
+        BridgeProcess::spawn_harness_blocks(config.harness, config.command_override, None);
+    let turn = bridge.run_blocks_user_turn(&config.prompt, config.timeout);
+    let stdout_lines = bridge.finish_successfully();
+    BridgeRun { stdout_lines, turn }
+}
+
 fn run_bridge_two_turns(config: BridgeTwoTurnConfig) -> BridgeTwoTurnRun {
     let mut bridge = BridgeProcess::spawn_harness(config.harness, config.command_override, None);
     let thread_id = bridge.initialize_and_start_thread(config.harness, config.timeout);
@@ -481,6 +615,37 @@ impl BridgeProcess {
         let mut command = Command::new(bin);
         command
             .args(harness.args())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        for env_key in [
+            "CENTAUR_CLAUDE_APP_BRIDGE_COMMAND",
+            "CENTAUR_AMP_APP_BRIDGE_COMMAND",
+        ] {
+            command.env_remove(env_key);
+        }
+        if let Some(env_key) = harness.command_override_env()
+            && let Some(raw) = command_override
+        {
+            command.env(env_key, raw);
+        }
+        if let Some((key, value)) = extra_env {
+            command.env(key, value);
+        }
+
+        Self::spawn_command(command)
+    }
+
+    fn spawn_harness_blocks(
+        harness: Harness,
+        command_override: Option<String>,
+        extra_env: Option<(&str, &str)>,
+    ) -> Self {
+        let bin = env!("CARGO_BIN_EXE_harness-server");
+        let mut command = Command::new(bin);
+        command
+            .args(harness.blocks_args())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -605,6 +770,7 @@ impl BridgeProcess {
         let deadline = Instant::now() + timeout;
         let mut capture = TurnCapture::default();
         let mut steer_sent = false;
+        let mut turn_started = false;
 
         loop {
             let value = self.read_json(deadline);
@@ -615,20 +781,6 @@ impl BridgeProcess {
                         .and_then(Value::as_str)
                         .unwrap_or_else(|| panic!("turn/start did not return turn id: {value}"))
                         .to_string();
-                    if let Some(plan) = steer.as_ref()
-                        && !steer_sent
-                    {
-                        self.send(json!({
-                            "id": plan.request_id,
-                            "method": "turn/steer",
-                            "params": {
-                                "threadId": thread_id,
-                                "expectedTurnId": capture.turn_id,
-                                "input": [{"type": "text", "text": plan.prompt, "text_elements": []}],
-                            },
-                        }));
-                        steer_sent = true;
-                    }
                 } else if let Some(plan) = steer.as_mut()
                     && id == plan.request_id
                 {
@@ -642,6 +794,65 @@ impl BridgeProcess {
 
             if let Some(method) = value.get("method").and_then(Value::as_str) {
                 assert_notification_thread_id(&value, thread_id);
+                capture.consume_notification(method, &value);
+                if method == "turn/started"
+                    && capture.turn_id.is_empty()
+                    && let Some(turn_id) = value.pointer("/params/turn/id").and_then(Value::as_str)
+                {
+                    capture.turn_id = turn_id.to_string();
+                }
+                if method == "turn/started" {
+                    turn_started = true;
+                }
+                if let Some(plan) = steer.as_ref()
+                    && !steer_sent
+                    && turn_started
+                    && !capture.turn_id.is_empty()
+                {
+                    self.send(json!({
+                        "id": plan.request_id,
+                        "method": "turn/steer",
+                        "params": {
+                            "threadId": thread_id,
+                            "expectedTurnId": capture.turn_id,
+                            "input": [{"type": "text", "text": plan.prompt, "text_elements": []}],
+                        },
+                    }));
+                    steer_sent = true;
+                }
+                if method == "turn/completed" {
+                    break;
+                }
+            }
+        }
+
+        capture
+    }
+
+    fn run_blocks_user_turn(&mut self, prompt: &str, timeout: Duration) -> TurnCapture {
+        self.send(json!({
+            "type": "user",
+            "thread_key": "slack:C123:123.456",
+            "trace_metadata": {
+                "source": "slackbotv2",
+                "action": "execute"
+            },
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": prompt}],
+            },
+        }));
+
+        let deadline = Instant::now() + timeout;
+        let mut capture = TurnCapture::default();
+
+        loop {
+            let value = self.read_json(deadline);
+            assert!(
+                response_id(&value).is_none(),
+                "blocks mode emitted JSON-RPC response: {value}"
+            );
+            if let Some(method) = value.get("method").and_then(Value::as_str) {
                 capture.consume_notification(method, &value);
                 if method == "turn/started"
                     && capture.turn_id.is_empty()
@@ -1125,6 +1336,61 @@ fn codex_bin() -> String {
         }
     }
     "codex".to_string()
+}
+
+fn fake_codex_app_server_script(log_path: &Path) -> String {
+    let mut script = String::new();
+    script.push_str("#!/bin/sh\n");
+    script.push_str("log=");
+    script.push_str(&shell_quote(log_path));
+    script.push_str(
+        r#"
+touch "$log"
+if [ "${1:-}" = "app-server" ] && [ "${2:-}" = "--help" ]; then
+  printf '%s\n' '--listen stdio://'
+  exit 0
+fi
+if [ "${1:-}" != "app-server" ]; then
+  printf '%s\n' 'expected app-server command' >&2
+  exit 64
+fi
+
+request_id() {
+  printf '%s' "$1" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p'
+}
+
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  case "$line" in
+    *'"method":"initialize"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"userAgent":"fake-codex"}}\n' "$id"
+      ;;
+    *'"method":"thread/start"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"thread":{"id":"thread-1"}}}\n' "$id"
+      ;;
+    *'"method":"thread/resume"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"thread":{"id":"thread-1"}}}\n' "$id"
+      ;;
+    *'"method":"turn/start"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"turn":{"id":"turn-1"}}}\n' "$id"
+      printf '%s\n' '{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"itemsView":"full","status":"inProgress","error":null,"startedAt":1,"completedAt":null,"durationMs":null}}}'
+      printf '%s\n' '{"method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"answer-1","delta":"codex blocks"}}'
+      printf '%s\n' '{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","item":{"type":"agentMessage","id":"answer-1","text":"codex blocks","phase":null,"memoryCitation":null},"completedAtMs":2}}'
+      printf '%s\n' '{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[{"type":"agentMessage","id":"answer-1","text":"codex blocks","phase":null,"memoryCitation":null}],"itemsView":"full","status":"completed","error":null,"startedAt":1,"completedAt":2,"durationMs":1}}}'
+      ;;
+    *)
+      printf '%s\n' "unexpected request: $line" >&2
+      exit 65
+      ;;
+  esac
+done
+"#,
+    );
+    script
 }
 
 fn temp_path(name: &str) -> PathBuf {

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -34,7 +34,7 @@ use tracing::warn;
 const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 const DEFAULT_IDLE_TIMEOUT_MS: u64 = 1_000;
 const DEFAULT_MAX_DURATION_MS: u64 = 60_000;
-type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
+type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &HarnessType, &str) -> SandboxSpec + Send + Sync>;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -73,13 +73,15 @@ pub enum SandboxRuntime {
 
 impl SandboxRuntime {
     pub fn backend(backend: Arc<dyn SandboxBackend>, spec: SandboxSpec) -> Self {
-        let spec_factory = move |_thread_key: &ThreadKey, _execution_id: &str| spec.clone();
+        let spec_factory = move |_thread_key: &ThreadKey,
+                                 _harness_type: &HarnessType,
+                                 _execution_id: &str| { spec.clone() };
         Self::backend_with_spec_factory(backend, spec_factory)
     }
 
     pub fn backend_with_spec_factory<F>(backend: Arc<dyn SandboxBackend>, spec_factory: F) -> Self
     where
-        F: Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync + 'static,
+        F: Fn(&ThreadKey, &HarnessType, &str) -> SandboxSpec + Send + Sync + 'static,
     {
         Self::Backend {
             backend,
@@ -149,6 +151,7 @@ async fn execute_session(
         &state.store,
         &state.sandbox_runtime,
         &thread_key,
+        &session.harness_type,
         session.sandbox_id.as_deref(),
         &execution.execution_id,
     )
@@ -248,6 +251,7 @@ async fn ensure_session_sandbox(
     store: &PgSessionStore,
     runtime: &SandboxRuntime,
     thread_key: &ThreadKey,
+    harness_type: &HarnessType,
     existing_sandbox_id: Option<&str>,
     execution_id: &str,
 ) -> Result<String, ApiError> {
@@ -277,7 +281,7 @@ async fn ensure_session_sandbox(
                 }
             }
 
-            let spec = spec_factory(thread_key, execution_id);
+            let spec = spec_factory(thread_key, harness_type, execution_id);
             let handle = backend.create(spec).await.map_err(ApiError::Sandbox)?;
             store
                 .update_sandbox_id(thread_key, Some(handle.id.as_str()))

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -4,7 +4,7 @@ use centaur_api_server::{SandboxRuntime, build_router_with_runtime};
 use centaur_sandbox_agent_k8s::{AgentSandboxBackend, AgentSandboxConfig};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_sandbox_local::LocalSandboxBackend;
-use centaur_session_core::ThreadKey;
+use centaur_session_core::{HarnessType, ThreadKey};
 use centaur_session_sqlx::PgSessionStore;
 use thiserror::Error;
 use tokio::net::TcpListener;
@@ -50,10 +50,36 @@ async fn sandbox_runtime_from_env() -> Result<SandboxRuntime, ServerError> {
     let backend = env::var("SESSION_SANDBOX_BACKEND").unwrap_or_else(|_| "mock".to_owned());
     match backend.as_str() {
         "mock" => Ok(SandboxRuntime::Mock),
-        "local" => Ok(SandboxRuntime::backend(
-            Arc::new(LocalSandboxBackend::new()),
-            local_mock_app_server_spec(),
-        )),
+        "local" => {
+            let workload =
+                env::var("SESSION_SANDBOX_WORKLOAD").unwrap_or_else(|_| "mock".to_owned());
+            let backend = Arc::new(LocalSandboxBackend::new());
+            match workload.as_str() {
+                "mock" => Ok(SandboxRuntime::backend(
+                    backend,
+                    local_mock_app_server_spec(),
+                )),
+                "codex-app-server" => {
+                    let harness_server = env::var("SESSION_LOCAL_HARNESS_SERVER_BIN")
+                        .unwrap_or_else(|_| {
+                            "crates/harness-server/target/debug/harness-server".to_owned()
+                        });
+                    let env_template = codex_app_server_env_template();
+                    Ok(SandboxRuntime::backend_with_spec_factory(
+                        backend,
+                        move |thread_key, harness_type, _execution_id| {
+                            local_codex_app_server_spec(
+                                &harness_server,
+                                harness_server_kind(harness_type),
+                                thread_key,
+                                &env_template,
+                            )
+                        },
+                    ))
+                }
+                other => Err(ServerError::InvalidSandboxWorkload(other.to_owned())),
+            }
+        }
         "agent-k8s" => {
             let namespace = env::var("SESSION_SANDBOX_K8S_NAMESPACE")
                 .unwrap_or_else(|_| "centaur-sandbox-e2e".to_owned());
@@ -94,8 +120,8 @@ async fn sandbox_runtime_from_env() -> Result<SandboxRuntime, ServerError> {
                     let env_template = codex_app_server_env_template();
                     Ok(SandboxRuntime::backend_with_spec_factory(
                         Arc::new(backend),
-                        move |thread_key, _execution_id| {
-                            codex_app_server_spec(&image, thread_key, &env_template)
+                        move |thread_key, harness_type, _execution_id| {
+                            codex_app_server_spec(&image, harness_type, thread_key, &env_template)
                         },
                     ))
                 }
@@ -112,6 +138,32 @@ fn local_mock_app_server_spec() -> SandboxSpec {
         .args([mock_app_server_script()])
 }
 
+fn local_codex_app_server_spec(
+    harness_server: &str,
+    harness_kind: &str,
+    thread_key: &ThreadKey,
+    env_template: &[(String, String)],
+) -> SandboxSpec {
+    let script = format!(
+        "exec {} {} 2>/tmp/centaur-harness-server-{}.$$.stderr",
+        shell_quote(harness_server),
+        shell_quote(harness_kind),
+        shell_quote(harness_kind)
+    );
+    let mut spec = SandboxSpec::new("/bin/sh")
+        .command(["/bin/sh", "-lc"])
+        .args([script])
+        .env("CENTAUR_THREAD_KEY", thread_key.as_str());
+    for (name, value) in env_template {
+        spec = spec.env(name.clone(), value.clone());
+    }
+    spec
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 fn agent_k8s_mock_app_server_spec(image: &str) -> SandboxSpec {
     SandboxSpec::new(image)
         .command(["/bin/sh", "-lc"])
@@ -120,14 +172,26 @@ fn agent_k8s_mock_app_server_spec(image: &str) -> SandboxSpec {
 
 fn codex_app_server_spec(
     image: &str,
+    harness_type: &HarnessType,
     thread_key: &ThreadKey,
     env_template: &[(String, String)],
 ) -> SandboxSpec {
-    let mut spec = SandboxSpec::new(image).env("CENTAUR_THREAD_KEY", thread_key.as_str());
+    let mut spec = SandboxSpec::new(image)
+        .args(["harness-server", harness_server_kind(harness_type)])
+        .env("CENTAUR_THREAD_KEY", thread_key.as_str());
     for (name, value) in env_template {
         spec = spec.env(name.clone(), value.clone());
     }
     spec
+}
+
+fn harness_server_kind(harness_type: &HarnessType) -> &str {
+    match harness_type.as_str() {
+        "claude" | "claude-code" => "claude-code",
+        "amp" => "amp",
+        "codex" => "codex",
+        other => other,
+    }
 }
 
 fn codex_app_server_env_template() -> Vec<(String, String)> {

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -187,15 +187,17 @@ COPY --link --chmod=644 services/sandbox/claude-credentials.json /etc/centaur/cl
 COPY --link --chmod=755 services/sandbox/call.sh /usr/local/bin/call
 COPY --link --chmod=755 services/sandbox/slack-upload.sh /usr/local/bin/slack-upload
 COPY --link --chmod=755 services/sandbox/md2docx.py /usr/local/bin/md2docx
-COPY --link --chmod=755 services/sandbox/amp-wrapper.py /usr/local/bin/amp-wrapper
-COPY --link --chmod=755 services/sandbox/codex-app-wrapper.py /usr/local/bin/codex-app-wrapper
-COPY --link --chmod=755 services/sandbox/claude-app-wrapper.py /usr/local/bin/claude-app-wrapper
-COPY --link --chmod=755 services/sandbox/harness_adapter.py /usr/local/bin/harness-adapter
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
 COPY --link --chmod=755 services/sandbox/entrypoint.sh /entrypoint.sh
 
 USER agent
 WORKDIR /home/agent
+
+COPY --link --chown=1001:1001 crates/harness-server/ /tmp/harness-server/
+RUN --mount=type=cache,target=/home/agent/.cargo/registry,uid=1001,gid=1001,sharing=locked \
+    --mount=type=cache,target=/home/agent/.cargo/git,uid=1001,gid=1001,sharing=locked \
+    cargo install --locked --path /tmp/harness-server --root /home/agent/.local \
+    && rm -rf /tmp/harness-server
 
 # No RUN instructions after these — all repo-local content at the very end.
 COPY --link --chown=1001:1001 .agents/skills/ /home/agent/.agents/skills/
@@ -203,5 +205,5 @@ COPY --link --chown=1001:1001 harness/ /home/agent/harness/
 COPY --link --chown=1001:1001 services/sandbox/SYSTEM_PROMPT.md /home/agent/AGENTS.md
 
 ENTRYPOINT ["/entrypoint.sh"]
-# Default CMD uses Codex app-server through Centaur's NDJSON bridge.
-CMD ["codex-app-wrapper"]
+# Default CMD uses Rust blocks mode; pass --mode=jsonrpc for raw App Server JSON-RPC.
+CMD ["harness-server", "codex"]

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -196,6 +196,8 @@ WORKDIR /home/agent
 COPY --link --chown=1001:1001 crates/harness-server/ /tmp/harness-server/
 RUN --mount=type=cache,target=/home/agent/.cargo/registry,uid=1001,gid=1001,sharing=locked \
     --mount=type=cache,target=/home/agent/.cargo/git,uid=1001,gid=1001,sharing=locked \
+    --mount=type=cache,target=/home/agent/.cache/harness-server-target,uid=1001,gid=1001,sharing=locked \
+    CARGO_TARGET_DIR=/home/agent/.cache/harness-server-target \
     cargo install --locked --path /tmp/harness-server --root /home/agent/.local \
     && rm -rf /tmp/harness-server
 

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -222,9 +222,9 @@ fi
 # Switch to workspace so the harness reads workspace/AGENTS.md (with persona overlay)
 cd "$WORKSPACE_DIR"
 
-HARNESS_ADAPTER="${CENTAUR_HARNESS_ADAPTER:-/usr/local/bin/harness-adapter}"
-if [ -x "$HARNESS_ADAPTER" ]; then
-    "$HARNESS_ADAPTER" "${1:-}" "$TARGET_PROMPT"
+if [ "${1:-}" = "harness-server" ] && [ "${2:-}" = "amp" ] && [ -f "$TARGET_PROMPT" ]; then
+    rm -f "$WORKSPACE_DIR/AGENT.md"
+    ln -s "$(basename "$TARGET_PROMPT")" "$WORKSPACE_DIR/AGENT.md"
 fi
 
 # Codex reads its auth file when the app server starts. Complete this before

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1015,7 +1015,13 @@ function emptyTurn(id: string, status: 'completed' | 'inProgress'): Turn {
 }
 
 function isTerminalCodexPayload(payload: Record<string, unknown>): boolean {
-  return payload.type === 'turn.completed' || payload.type === 'turn.failed' || payload.method === 'error'
+  return (
+    payload.type === 'turn.completed' ||
+    payload.type === 'turn.failed' ||
+    payload.method === 'turn/completed' ||
+    payload.method === 'turn/failed' ||
+    payload.method === 'error'
+  )
 }
 
 function sessionErrorNotification(event: ParsedSessionEvent): ServerNotification {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -675,7 +675,22 @@ function sampleCodexNotifications(answer: string): ServerNotification[] {
 function sampleCodexOutputLines(answer: string): string[] {
   return [
     ...sampleCodexNotifications(answer).map(notification => JSON.stringify(notification)),
-    JSON.stringify({ type: 'turn.completed', turn: { id: 'turn-1', items: [] } })
+    JSON.stringify({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'turn-1',
+          items: [],
+          itemsView: 'full',
+          status: 'completed',
+          error: null,
+          startedAt: 1,
+          completedAt: 2,
+          durationMs: 1
+        }
+      }
+    })
   ]
 }
 


### PR DESCRIPTION
Stacked on #323.

## Summary
- add `harness-server <codex|claude-code|amp> --mode <blocks|jsonrpc>` with `blocks` as the default
- accept Slackbot-style user block input in blocks mode and emit Codex App Server notifications without JSON-RPC responses
- run Codex blocks mode by spawning `codex app-server --listen stdio://` and translating user blocks to native app-server JSON-RPC requests
- install the Rust harness-server into the sandbox image and make Codex the default sandbox command
- keep Slackbot input construction intact, but recognize real App Server terminal notifications (`turn/completed`, `turn/failed`)

## Validation
- `cargo test --manifest-path crates/harness-server/Cargo.toml`
- `cargo test --manifest-path crates/harness-server/Cargo.toml --test app_server_stdio -- --ignored`
- `pnpm --filter slackbotv2 test`
- `pnpm --filter slackbotv2 check:types`
- real blocks-mode smoke tests against `harness-server claude-code`, `harness-server amp`, and `harness-server codex` with Slackbot-shaped user blocks
