### PR TITLE
feat: add renderer v2 contract

### DIFF
--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@centaur/rendering",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "bun test test/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@std/ulid": "npm:@jsr/std__ulid",
+    "chat": "^4.29.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/rendering/src/chat-sdk.ts
+++ b/packages/rendering/src/chat-sdk.ts
@@ -1,0 +1,383 @@
+import {
+  codeBlock,
+  link as chatLink,
+  paragraph,
+  parseMarkdown,
+  root,
+  strong,
+  text as chatText,
+  type Content,
+  type PostableMessage,
+  type Root,
+  type StreamChunk
+} from 'chat'
+import { ulid } from '@std/ulid'
+import { z } from 'zod'
+import {
+  rendererContentToMarkdown,
+  rendererMetadataSchema,
+  rendererTargetSchema,
+  type RendererContent,
+  type RendererDoneEvent,
+  type RendererEvent,
+  type RendererOpenInput,
+  type RendererTarget,
+  type RendererTask
+} from './schema'
+import {
+  parseRendererDoneEvent,
+  parseRendererEvent,
+  parseRendererOpenInput,
+  type RendererInterface,
+  type RendererOpenResult,
+  type RendererRenderResult
+} from './interface'
+
+export const chatSDKPostableMessageSchema = z.custom<PostableMessage>(() => true)
+
+export const chatSDKMarkdownTextChunkSchema = z
+  .object({
+    type: z.literal('markdown_text'),
+    text: z.string()
+  })
+  .strict()
+
+export const chatSDKTaskUpdateChunkSchema = z
+  .object({
+    type: z.literal('task_update'),
+    id: z.string(),
+    title: z.string(),
+    status: z.enum(['pending', 'in_progress', 'complete', 'error']),
+    details: z.string().optional(),
+    output: z.string().optional()
+  })
+  .strict()
+
+export const chatSDKPlanUpdateChunkSchema = z
+  .object({
+    type: z.literal('plan_update'),
+    title: z.string()
+  })
+  .strict()
+
+export const chatSDKStreamChunkSchema = z.discriminatedUnion('type', [
+  chatSDKMarkdownTextChunkSchema,
+  chatSDKTaskUpdateChunkSchema,
+  chatSDKPlanUpdateChunkSchema
+])
+
+export const chatSDKRendererMetadataSchema = z
+  .object({
+    sessionId: z.string(),
+    title: z.string(),
+    header: z.string().optional(),
+    target: rendererTargetSchema,
+    extra: rendererMetadataSchema.optional()
+  })
+  .strict()
+
+export const chatSDKSessionOpenedOperationSchema = z
+  .object({
+    type: z.literal('chat.session.opened'),
+    sessionId: z.string(),
+    postable: chatSDKPostableMessageSchema,
+    metadata: chatSDKRendererMetadataSchema
+  })
+  .strict()
+
+export const chatSDKMessageUpsertOperationSchema = z
+  .object({
+    type: z.literal('chat.message.upsert'),
+    sessionId: z.string(),
+    postable: chatSDKPostableMessageSchema,
+    metadata: chatSDKRendererMetadataSchema
+  })
+  .strict()
+
+export const chatSDKStreamAppendOperationSchema = z
+  .object({
+    type: z.literal('chat.stream.append'),
+    sessionId: z.string(),
+    chunks: z.array(chatSDKStreamChunkSchema)
+  })
+  .strict()
+
+export const chatSDKStatusUpdateOperationSchema = z
+  .object({
+    type: z.literal('chat.status.update'),
+    sessionId: z.string(),
+    status: z.string()
+  })
+  .strict()
+
+export const chatSDKSessionClosedOperationSchema = z
+  .object({
+    type: z.literal('chat.session.closed'),
+    sessionId: z.string(),
+    postable: chatSDKPostableMessageSchema,
+    metadata: chatSDKRendererMetadataSchema
+  })
+  .strict()
+
+export const chatSDKOperationSchema = z.discriminatedUnion('type', [
+  chatSDKSessionOpenedOperationSchema,
+  chatSDKMessageUpsertOperationSchema,
+  chatSDKStreamAppendOperationSchema,
+  chatSDKStatusUpdateOperationSchema,
+  chatSDKSessionClosedOperationSchema
+])
+
+export type ChatSDKPostableMessage = PostableMessage
+export type ChatSDKMarkdownTextChunk = z.output<typeof chatSDKMarkdownTextChunkSchema>
+export type ChatSDKTaskUpdateChunk = z.output<typeof chatSDKTaskUpdateChunkSchema>
+export type ChatSDKPlanUpdateChunk = z.output<typeof chatSDKPlanUpdateChunkSchema>
+export type ChatSDKStreamChunk = z.output<typeof chatSDKStreamChunkSchema>
+export type ChatSDKRendererMetadata = z.output<typeof chatSDKRendererMetadataSchema>
+export type ChatSDKOperation = z.output<typeof chatSDKOperationSchema>
+
+type ChatSDKSessionState = {
+  sessionId: string
+  title: string
+  header?: string
+  target: RendererTarget
+  metadata?: Record<string, unknown>
+  text: string
+  status?: string
+  tasks: Map<string, RendererTask>
+  planStarted: boolean
+  done: boolean
+}
+
+export class ChatSDKRenderer implements RendererInterface<ChatSDKOperation[]> {
+  readonly kind = 'chat-sdk'
+  private readonly sessions = new Map<string, ChatSDKSessionState>()
+
+  async open(input: RendererOpenInput): Promise<RendererOpenResult<ChatSDKOperation[]>> {
+    const parsed = parseRendererOpenInput(input)
+    const sessionId = parsed.sessionId ?? ulid()
+    const state: ChatSDKSessionState = {
+      sessionId,
+      title: parsed.title,
+      header: parsed.header?.trim() || undefined,
+      target: parsed.target,
+      metadata: parsed.metadata,
+      text: '',
+      tasks: new Map(),
+      planStarted: false,
+      done: false
+    }
+    this.sessions.set(sessionId, state)
+    return {
+      sessionId,
+      output: [
+        {
+          type: 'chat.session.opened',
+          sessionId,
+          postable: postableForState(state),
+          metadata: metadataForState(state)
+        }
+      ]
+    }
+  }
+
+  async render(
+    sessionId: string,
+    event: RendererEvent
+  ): Promise<RendererRenderResult<ChatSDKOperation[]>> {
+    const parsed = parseRendererEvent(event)
+    if (parsed.type === 'renderer.done') return this.close(sessionId, parsed)
+
+    const state = this.requireSession(sessionId)
+    if (parsed.type === 'renderer.status') {
+      state.status = parsed.status
+      return {
+        output: [
+          {
+            type: 'chat.status.update',
+            sessionId,
+            status: parsed.status
+          },
+          upsertOperation(state)
+        ]
+      }
+    }
+
+    if (parsed.type === 'renderer.message.delta') {
+      state.text += parsed.text
+      return {
+        output: [
+          ...(parsed.text
+            ? [
+                {
+                  type: 'chat.stream.append' as const,
+                  sessionId,
+                  chunks: [{ type: 'markdown_text' as const, text: parsed.text }]
+                }
+              ]
+            : []),
+          upsertOperation(state)
+        ]
+      }
+    }
+
+    if (parsed.type === 'renderer.message.snapshot') {
+      state.text = parsed.text
+      return { output: [upsertOperation(state)] }
+    }
+
+    state.tasks.set(parsed.task.id, parsed.task)
+    const chunks = taskStreamChunks(state, parsed.task)
+    return {
+      output: [
+        ...(chunks.length
+          ? [
+              {
+                type: 'chat.stream.append' as const,
+                sessionId,
+                chunks
+              }
+            ]
+          : []),
+        upsertOperation(state)
+      ]
+    }
+  }
+
+  async close(
+    sessionId: string,
+    event: RendererDoneEvent = { type: 'renderer.done' }
+  ): Promise<RendererRenderResult<ChatSDKOperation[]>> {
+    const parsed = parseRendererDoneEvent(event)
+    const state = this.requireSession(sessionId)
+    if (parsed.finalText !== undefined) state.text = parsed.finalText
+    if (parsed.error) {
+      state.tasks.set('renderer-error', {
+        id: 'renderer-error',
+        title: parsed.error,
+        status: 'error'
+      })
+    }
+    state.status = parsed.isError ? 'Error' : ''
+    state.done = true
+    const postable = postableForState(state)
+    const metadata = metadataForState(state)
+    this.sessions.delete(sessionId)
+    return {
+      output: [
+        {
+          type: 'chat.message.upsert',
+          sessionId,
+          postable,
+          metadata
+        },
+        {
+          type: 'chat.session.closed',
+          sessionId,
+          postable,
+          metadata
+        }
+      ]
+    }
+  }
+
+  private requireSession(sessionId: string): ChatSDKSessionState {
+    const state = this.sessions.get(sessionId)
+    if (!state) throw new Error('renderer_session_not_found')
+    return state
+  }
+}
+
+function upsertOperation(state: ChatSDKSessionState): ChatSDKOperation {
+  return {
+    type: 'chat.message.upsert',
+    sessionId: state.sessionId,
+    postable: postableForState(state),
+    metadata: metadataForState(state)
+  }
+}
+
+function metadataForState(state: ChatSDKSessionState): ChatSDKRendererMetadata {
+  return {
+    sessionId: state.sessionId,
+    title: state.title,
+    header: state.header,
+    target: state.target,
+    extra: state.metadata
+  }
+}
+
+function postableForState(state: ChatSDKSessionState): PostableMessage {
+  return { ast: astForState(state) }
+}
+
+function astForState(state: ChatSDKSessionState): Root {
+  const children: Content[] = []
+  if (state.header) {
+    children.push(paragraph([chatText(state.header)]))
+  }
+  if (state.status) {
+    children.push(paragraph([strong([chatText('Status: ')]), chatText(state.status)]))
+  }
+  for (const task of state.tasks.values()) {
+    children.push(...taskToAst(task))
+  }
+  if (state.text.trim()) {
+    children.push(...parseMarkdown(state.text).children)
+  }
+  return root(children)
+}
+
+function taskToAst(task: RendererTask): Content[] {
+  const children: Content[] = [
+    paragraph([strong([chatText(`${task.status}: `)]), chatText(task.title)])
+  ]
+  if (task.details?.length) {
+    children.push(paragraph([strong([chatText('Details')])]))
+    children.push(...contentToAst(task.details))
+  }
+  if (task.output?.length) {
+    children.push(paragraph([strong([chatText('Output')])]))
+    children.push(...contentToAst(task.output))
+  }
+  return children
+}
+
+function contentToAst(content: RendererContent[]): Content[] {
+  const children: Content[] = []
+  let inline: Content[] = []
+  const flushInline = () => {
+    if (!inline.length) return
+    children.push(paragraph(inline))
+    inline = []
+  }
+
+  for (const part of content) {
+    if (part.type === 'text') {
+      inline.push(chatText(part.text))
+    } else if (part.type === 'link') {
+      inline.push(chatLink(part.url, [chatText(part.text ?? part.url)]))
+    } else {
+      flushInline()
+      children.push(codeBlock(part.text, part.language))
+    }
+  }
+  flushInline()
+  return children
+}
+
+function taskStreamChunks(state: ChatSDKSessionState, task: RendererTask): StreamChunk[] {
+  const chunks: StreamChunk[] = []
+  if (!state.planStarted) {
+    state.planStarted = true
+    chunks.push({ type: 'plan_update', title: state.title })
+  }
+  chunks.push({
+    type: 'task_update',
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    ...(task.details?.length ? { details: rendererContentToMarkdown(task.details) } : {}),
+    ...(task.output?.length ? { output: rendererContentToMarkdown(task.output) } : {})
+  })
+  return chunks
+}

--- a/packages/rendering/src/index.ts
+++ b/packages/rendering/src/index.ts
@@ -1,0 +1,3 @@
+export * from './schema'
+export * from './interface'
+export * from './chat-sdk'

--- a/packages/rendering/src/interface.ts
+++ b/packages/rendering/src/interface.ts
@@ -1,0 +1,44 @@
+import {
+  rendererDoneEventSchema,
+  rendererEventSchema,
+  rendererOpenInputSchema,
+  type ParsedRendererDoneEvent,
+  type ParsedRendererEvent,
+  type ParsedRendererOpenInput,
+  type RendererDoneEvent,
+  type RendererEvent,
+  type RendererOpenInput
+} from './schema'
+
+export type RendererOpenResult<TOutput> = {
+  sessionId: string
+  output: TOutput
+}
+
+export type RendererRenderResult<TOutput> = {
+  output: TOutput
+}
+
+export interface RendererInterface<
+  TOutput,
+  TOpenInput = RendererOpenInput,
+  TEvent = RendererEvent,
+  TDoneEvent = RendererDoneEvent
+> {
+  readonly kind: string
+  open(input: TOpenInput): Promise<RendererOpenResult<TOutput>>
+  render(sessionId: string, event: TEvent): Promise<RendererRenderResult<TOutput>>
+  close(sessionId: string, event?: TDoneEvent): Promise<RendererRenderResult<TOutput>>
+}
+
+export function parseRendererOpenInput(input: unknown): ParsedRendererOpenInput {
+  return rendererOpenInputSchema.parse(input)
+}
+
+export function parseRendererEvent(input: unknown): ParsedRendererEvent {
+  return rendererEventSchema.parse(input)
+}
+
+export function parseRendererDoneEvent(input: unknown): ParsedRendererDoneEvent {
+  return rendererDoneEventSchema.parse(input)
+}

--- a/packages/rendering/src/schema.ts
+++ b/packages/rendering/src/schema.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod'
+
+export const rendererMetadataSchema = z.record(z.string(), z.unknown())
+
+export const rendererTaskStatusSchema = z.enum(['pending', 'in_progress', 'complete', 'error'])
+
+export const rendererTextContentSchema = z
+  .object({
+    type: z.literal('text'),
+    text: z.string()
+  })
+  .strict()
+
+export const rendererCodeContentSchema = z
+  .object({
+    type: z.literal('code'),
+    text: z.string(),
+    language: z.string().optional()
+  })
+  .strict()
+
+export const rendererLinkContentSchema = z
+  .object({
+    type: z.literal('link'),
+    url: z.string().min(1),
+    text: z.string().optional()
+  })
+  .strict()
+
+export const rendererContentSchema = z.discriminatedUnion('type', [
+  rendererTextContentSchema,
+  rendererCodeContentSchema,
+  rendererLinkContentSchema
+])
+
+export const rendererTaskSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    status: rendererTaskStatusSchema.default('in_progress'),
+    details: z.array(rendererContentSchema).optional(),
+    output: z.array(rendererContentSchema).optional(),
+    metadata: rendererMetadataSchema.optional()
+  })
+  .strict()
+
+export const rendererTargetSchema = z
+  .object({
+    platform: z.string().min(1),
+    threadKey: z.string().optional(),
+    surface: z.string().optional(),
+    metadata: rendererMetadataSchema.optional()
+  })
+  .strict()
+
+export const rendererOpenInputSchema = z
+  .object({
+    type: z.literal('renderer.session.open'),
+    sessionId: z.string().min(1).optional(),
+    title: z.string().min(1).default('Centaur execution'),
+    header: z.string().optional(),
+    target: rendererTargetSchema,
+    metadata: rendererMetadataSchema.optional()
+  })
+  .strict()
+
+export const rendererStatusEventSchema = z
+  .object({
+    type: z.literal('renderer.status'),
+    status: z.string(),
+    loadingMessages: z.array(z.string()).optional()
+  })
+  .strict()
+
+export const rendererMessageDeltaEventSchema = z
+  .object({
+    type: z.literal('renderer.message.delta'),
+    role: z.literal('assistant').default('assistant'),
+    text: z.string(),
+    flush: z.boolean().optional()
+  })
+  .strict()
+
+export const rendererMessageSnapshotEventSchema = z
+  .object({
+    type: z.literal('renderer.message.snapshot'),
+    role: z.literal('assistant').default('assistant'),
+    text: z.string()
+  })
+  .strict()
+
+export const rendererTaskUpdateEventSchema = z
+  .object({
+    type: z.literal('renderer.task.update'),
+    task: rendererTaskSchema
+  })
+  .strict()
+
+export const rendererDoneEventSchema = z
+  .object({
+    type: z.literal('renderer.done'),
+    finalText: z.string().optional(),
+    isError: z.boolean().optional(),
+    error: z.string().optional()
+  })
+  .strict()
+
+export const rendererEventSchema = z.discriminatedUnion('type', [
+  rendererStatusEventSchema,
+  rendererMessageDeltaEventSchema,
+  rendererMessageSnapshotEventSchema,
+  rendererTaskUpdateEventSchema,
+  rendererDoneEventSchema
+])
+
+export const rendererInputSchema = z.discriminatedUnion('type', [
+  rendererOpenInputSchema,
+  rendererStatusEventSchema,
+  rendererMessageDeltaEventSchema,
+  rendererMessageSnapshotEventSchema,
+  rendererTaskUpdateEventSchema,
+  rendererDoneEventSchema
+])
+
+export type RendererMetadata = z.output<typeof rendererMetadataSchema>
+export type RendererTaskStatus = z.output<typeof rendererTaskStatusSchema>
+export type RendererContent = z.output<typeof rendererContentSchema>
+export type RendererTask = z.output<typeof rendererTaskSchema>
+export type RendererTarget = z.output<typeof rendererTargetSchema>
+export type RendererOpenInput = z.input<typeof rendererOpenInputSchema>
+export type ParsedRendererOpenInput = z.output<typeof rendererOpenInputSchema>
+export type RendererStatusEvent = z.input<typeof rendererStatusEventSchema>
+export type ParsedRendererStatusEvent = z.output<typeof rendererStatusEventSchema>
+export type RendererMessageDeltaEvent = z.input<typeof rendererMessageDeltaEventSchema>
+export type ParsedRendererMessageDeltaEvent = z.output<typeof rendererMessageDeltaEventSchema>
+export type RendererMessageSnapshotEvent = z.input<typeof rendererMessageSnapshotEventSchema>
+export type ParsedRendererMessageSnapshotEvent = z.output<typeof rendererMessageSnapshotEventSchema>
+export type RendererTaskUpdateEvent = z.input<typeof rendererTaskUpdateEventSchema>
+export type ParsedRendererTaskUpdateEvent = z.output<typeof rendererTaskUpdateEventSchema>
+export type RendererDoneEvent = z.input<typeof rendererDoneEventSchema>
+export type ParsedRendererDoneEvent = z.output<typeof rendererDoneEventSchema>
+export type RendererEvent = z.input<typeof rendererEventSchema>
+export type ParsedRendererEvent = z.output<typeof rendererEventSchema>
+export type RendererInput = z.input<typeof rendererInputSchema>
+export type ParsedRendererInput = z.output<typeof rendererInputSchema>
+
+export function rendererContentToMarkdown(
+  content: RendererContent[] | undefined
+): string | undefined {
+  if (!content?.length) return undefined
+  return content
+    .map(part => {
+      if (part.type === 'text') return part.text
+      if (part.type === 'link') return part.text ? `[${part.text}](${part.url})` : part.url
+      const language = part.language ?? ''
+      return `\`\`\`${language}\n${part.text}\n\`\`\``
+    })
+    .join('\n')
+}

--- a/packages/rendering/test/chat-sdk.test.ts
+++ b/packages/rendering/test/chat-sdk.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'bun:test'
+import { toPlainText, type Root } from 'chat'
+import { ChatSDKRenderer, type ChatSDKOperation } from '../src/chat-sdk'
+import { rendererEventSchema } from '../src/schema'
+
+const target = {
+  platform: 'test',
+  threadKey: 'test:thread-1'
+}
+
+describe('v2 ChatSDKRenderer', () => {
+  it('validates renderer events with zod', () => {
+    expect(
+      rendererEventSchema.safeParse({
+        type: 'renderer.task.update',
+        task: { id: 'cmd-1', title: 'Run command', status: 'complete' }
+      }).success
+    ).toBe(true)
+
+    expect(
+      rendererEventSchema.safeParse({
+        type: 'renderer.task.update',
+        task: { id: 'cmd-1', title: 'Run command', status: 'done' }
+      }).success
+    ).toBe(false)
+  })
+
+  it('maps renderer events into real Chat SDK postable messages and stream chunks', async () => {
+    const renderer = new ChatSDKRenderer()
+    const open = await renderer.open({
+      type: 'renderer.session.open',
+      title: 'Centaur execution',
+      header: 'base - codex',
+      target
+    })
+
+    expect(open.output[0]).toMatchObject({
+      type: 'chat.session.opened',
+      sessionId: open.sessionId
+    })
+    expect(postableText(operation(open.output, 'chat.session.opened')?.postable)).toContain(
+      'base - codex'
+    )
+
+    const text = await renderer.render(open.sessionId, {
+      type: 'renderer.message.delta',
+      text: 'Hello'
+    })
+    expect(text.output.find(operation => operation.type === 'chat.stream.append')).toMatchObject({
+      type: 'chat.stream.append',
+      chunks: [{ type: 'markdown_text', text: 'Hello' }]
+    })
+    expect(postableText(upsertPostable(text.output))).toContain('Hello')
+
+    const task = await renderer.render(open.sessionId, {
+      type: 'renderer.task.update',
+      task: {
+        id: 'cmd-1',
+        title: 'Run command',
+        status: 'complete',
+        details: [{ type: 'code', language: 'sh', text: 'pnpm test' }]
+      }
+    })
+    expect(task.output.find(operation => operation.type === 'chat.stream.append')).toMatchObject({
+      type: 'chat.stream.append',
+      chunks: [
+        { type: 'plan_update', title: 'Centaur execution' },
+        {
+          type: 'task_update',
+          id: 'cmd-1',
+          title: 'Run command',
+          status: 'complete',
+          details: '```sh\npnpm test\n```'
+        }
+      ]
+    })
+    expect(postableText(upsertPostable(task.output))).toContain('Run command')
+
+    const done = await renderer.close(open.sessionId, {
+      type: 'renderer.done',
+      finalText: 'Final answer'
+    })
+    expect(postableText(operation(done.output, 'chat.session.closed')?.postable)).toContain(
+      'Final answer'
+    )
+  })
+})
+
+function operation<T extends ChatSDKOperation['type']>(
+  output: ChatSDKOperation[],
+  type: T
+): Extract<ChatSDKOperation, { type: T }> | undefined {
+  return output.find((item): item is Extract<ChatSDKOperation, { type: T }> => item.type === type)
+}
+
+function upsertPostable(output: ChatSDKOperation[]): unknown {
+  return operation(output, 'chat.message.upsert')?.postable
+}
+
+function postableText(postable: unknown): string {
+  const ast = (postable as { ast?: Root } | undefined)?.ast
+  expect(ast?.type).toBe('root')
+  return toPlainText(ast as Root)
+}

--- a/packages/rendering/tsconfig.json
+++ b/packages/rendering/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,27 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  packages/rendering:
+    dependencies:
+      '@std/ulid':
+        specifier: npm:@jsr/std__ulid
+        version: '@jsr/std__ulid@1.0.0-rc.4'
+      chat:
+        specifier: ^4.29.0
+        version: 4.29.0(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   services/slackbot:
     dependencies:
+      '@centaur/rendering':
+        specifier: workspace:*
+        version: link:../../packages/rendering
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -583,17 +602,29 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@25.9.0':
     resolution: {integrity: sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260518.1':
     resolution: {integrity: sha512-5n6xnR8jsDjrjHkf30hVVzby/cTusPrc0f6S3hQLrTdACC9JejsrHMHV1rRu55gSAIZhhBY0pqvG3/VKB9J0tA==}
@@ -671,6 +702,9 @@ packages:
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -688,6 +722,9 @@ packages:
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   bun-types@1.3.14:
     resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
@@ -695,9 +732,27 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  chat@4.29.0:
+    resolution: {integrity: sha512-KdPfzaie5ivYytyRICTERg5xT+LeCbYefokvNAqTHe92eqkFaoTMXXkSitikxJVWhZIb2YoXF1b9UZHyzSzKzw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      ai: ^6.0.182
+      zod: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
+      zod:
+        optional: true
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -719,13 +774,23 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -754,6 +819,10 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -770,6 +839,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -844,6 +916,10 @@ packages:
 
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -923,12 +999,135 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1010,6 +1209,18 @@ packages:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remend@1.3.0:
+    resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -1051,6 +1262,9 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1066,6 +1280,27 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.0:
     resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
@@ -1157,6 +1392,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -1496,15 +1734,27 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@25.9.0':
     dependencies:
       undici-types: 7.24.6
 
   '@types/retry@0.12.0': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260518.1':
     optional: true
@@ -1578,6 +1828,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@workflow/serde@4.1.0-beta.2': {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -1606,6 +1858,8 @@ snapshots:
       - debug
       - supports-color
 
+  bail@2.0.2: {}
+
   bun-types@1.3.14:
     dependencies:
       '@types/node': 25.9.0
@@ -1615,7 +1869,25 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities@2.0.2: {}
+
+  chat@4.29.0(zod@4.4.3):
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.0
+      unified: 11.0.5
+    optionalDependencies:
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   combined-stream@1.0.8:
     dependencies:
@@ -1629,9 +1901,19 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -1665,6 +1947,8 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  escape-string-regexp@5.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -1676,6 +1960,8 @@ snapshots:
   eventsource-parser@3.0.6: {}
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -1739,6 +2025,8 @@ snapshots:
 
   is-electron@2.2.2: {}
 
+  is-plain-obj@4.1.0: {}
+
   is-stream@2.0.1: {}
 
   jiti@2.6.1:
@@ -1793,11 +2081,308 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  longest-streak@3.1.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -1899,6 +2484,34 @@ snapshots:
 
   proxy-from-env@2.1.0: {}
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remend@1.3.0: {}
+
   retry@0.13.1: {}
 
   rolldown@1.0.0-rc.9:
@@ -1943,6 +2556,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  trough@2.2.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -1951,6 +2566,45 @@ snapshots:
   typescript@6.0.3: {}
 
   undici-types@7.24.6: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.0(@types/node@25.9.0)(jiti@2.6.1)(yaml@2.8.4):
     dependencies:
@@ -2002,3 +2656,5 @@ snapshots:
   yaml@2.8.4: {}
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/services/api/api/slackbot_client.py
+++ b/services/api/api/slackbot_client.py
@@ -157,6 +157,58 @@ async def open_agent_session(
     return session_id or None
 
 
+async def open_renderer_session(
+    *,
+    delivery: dict[str, Any],
+    metadata: dict[str, Any],
+    thread_key: str,
+    title: str = "Centaur execution",
+    header: str | None = None,
+) -> str | None:
+    if not enabled() or not is_slack_delivery(delivery):
+        return None
+    channel = channel_id(delivery)
+    parent_ts = thread_ts(delivery)
+    team_id = recipient_team_id(delivery, thread_key)
+    user_id = recipient_user_id(delivery, metadata)
+    if not channel or not parent_ts or not team_id or not user_id:
+        return None
+    body: dict[str, Any] = {
+        "type": "renderer.session.open",
+        "title": title,
+        "target": {
+            "platform": "slack",
+            "threadKey": thread_key,
+            "slack": {
+                "channel": channel,
+                "parentTs": parent_ts,
+                "recipientTeamId": team_id,
+                "recipientUserId": user_id,
+            },
+        },
+    }
+    header_text = (header or "").strip()
+    if header_text:
+        body["header"] = header_text
+    result = await post("/api/v2/rendering/sessions", body)
+    session_id = str((result or {}).get("session_id") or "").strip()
+    return session_id or None
+
+
+async def renderer_event(
+    session_id: str | None,
+    event: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not session_id:
+        return None
+    return await post(
+        f"/api/v2/rendering/sessions/{session_id}/events",
+        sanitize_slack_event(event),
+        timeout=httpx.Timeout(60.0, connect=2.0),
+        suppress_http_span=True,
+    )
+
+
 async def session_text(session_id: str | None, markdown: str) -> None:
     sanitized = sanitize_for_slack(markdown)
     if not session_id or not sanitized.strip():

--- a/services/api/tests/test_slackbot_client.py
+++ b/services/api/tests/test_slackbot_client.py
@@ -127,3 +127,74 @@ async def test_harness_event_suppresses_auto_http_span(monkeypatch):
         fake.calls[0]["url"]
         == "http://slackbot.test/api/slack/agent-sessions/sess/harness-event"
     )
+
+
+@pytest.mark.asyncio
+async def test_open_renderer_session_posts_v2_contract():
+    fake = _FakeClient([_response(200, {"ok": True, "session_id": "rnd-1"})])
+    with patch("api.slackbot_client.httpx.AsyncClient", return_value=fake):
+        from api import slackbot_client
+
+        result = await slackbot_client.open_renderer_session(
+            delivery={
+                "platform": "slack",
+                "channel": "C123",
+                "thread_ts": "1778866921.505479",
+                "recipient_team_id": "T123",
+                "recipient_user_id": "U123",
+            },
+            metadata={},
+            thread_key="slack:T123:C123:1778866921.505479",
+            title="Centaur execution",
+            header="base - codex",
+        )
+
+    assert result == "rnd-1"
+    assert fake.calls[0]["url"] == "http://slackbot.test/api/v2/rendering/sessions"
+    assert fake.calls[0]["json"] == {
+        "type": "renderer.session.open",
+        "title": "Centaur execution",
+        "header": "base - codex",
+        "target": {
+            "platform": "slack",
+            "threadKey": "slack:T123:C123:1778866921.505479",
+            "slack": {
+                "channel": "C123",
+                "parentTs": "1778866921.505479",
+                "recipientTeamId": "T123",
+                "recipientUserId": "U123",
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_renderer_event_posts_v2_event_and_suppresses_auto_http_span(monkeypatch):
+    from api import slackbot_client
+
+    fake = _FakeClient([_response(200, {"ok": True})])
+    entered = 0
+
+    @contextmanager
+    def suppress():
+        nonlocal entered
+        entered += 1
+        yield
+
+    monkeypatch.setattr(slackbot_client, "suppress_http_instrumentation", suppress)
+    with patch("api.slackbot_client.httpx.AsyncClient", return_value=fake):
+        result = await slackbot_client.renderer_event(
+            "rnd-1",
+            {"type": "renderer.message.delta", "text": "hello <@U123>"},
+        )
+
+    assert result == {"ok": True}
+    assert entered == 1
+    assert (
+        fake.calls[0]["url"]
+        == "http://slackbot.test/api/v2/rendering/sessions/rnd-1/events"
+    )
+    assert fake.calls[0]["json"] == {
+        "type": "renderer.message.delta",
+        "text": "hello <@U123>",
+    }

--- a/services/slackbot/package.json
+++ b/services/slackbot/package.json
@@ -17,6 +17,7 @@
     "check:types": "bun tsgo --project tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@centaur/rendering": "workspace:*",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.218.0",
     "@opentelemetry/resources": "^2.7.1",

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -26,6 +26,7 @@ import { normalizeSlackEnvelope } from './slack/normalize'
 import { markdownToStreamChunks } from './slack/render'
 import { verifySlackSignature } from './slack/signature'
 import { shouldAckWithReaction } from './slack/trivial-ack'
+import { registerRenderingV2Routes } from './rendering/routes'
 import type { NormalizedSlackEvent, SlackEnvelope } from './slack/types'
 import type { AnyBlock, AnyChunk } from '@slack/types'
 import type { WebClient } from '@slack/web-api'
@@ -119,6 +120,14 @@ const apiKeyMiddleware: MiddlewareHandler<{ Variables: Variables }> = async (c, 
   }
   await next()
 }
+
+registerRenderingV2Routes(app, {
+  apiKeyMiddleware,
+  resolveClient: async () => {
+    const { client } = await resolver.resolve({})
+    return client
+  }
+})
 
 const slackSignatureMiddleware: MiddlewareHandler<{ Variables: Variables }> = async (c, next) => {
   const rawBody = await c.req.raw.text()

--- a/services/slackbot/src/rendering/routes.test.ts
+++ b/services/slackbot/src/rendering/routes.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'bun:test'
+import { Hono, type MiddlewareHandler } from 'hono'
+import { registerRenderingV2Routes } from './routes'
+
+type Variables = {
+  slackRawBody: string
+}
+
+type RenderingV2TestResponse = {
+  ok: boolean
+  renderer?: string
+  session_id: string
+  output: Array<Record<string, unknown>>
+}
+
+describe('v2 rendering routes', () => {
+  it('opens a Slack renderer session and accepts renderer events', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const app = renderingTestApp(calls)
+
+    const opened = await app.request('/api/v2/rendering/sessions', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        type: 'renderer.session.open',
+        title: 'Centaur execution',
+        header: 'base - codex',
+        target: {
+          platform: 'slack',
+          threadKey: 'slack:T123:C123:1778866921.505479',
+          slack: {
+            channel: 'C123',
+            parentTs: '1778866921.505479',
+            recipientTeamId: 'T123',
+            recipientUserId: 'U123'
+          }
+        }
+      })
+    })
+
+    expect(opened.status).toBe(200)
+    const openedBody = (await opened.json()) as RenderingV2TestResponse
+    expect(openedBody).toMatchObject({
+      ok: true,
+      renderer: 'slack-chat-sdk'
+    })
+    expect(openedBody.output[0]).toMatchObject({
+      type: 'slack.session.opened',
+      sessionId: openedBody.session_id
+    })
+
+    const event = await app.request(`/api/v2/rendering/sessions/${openedBody.session_id}/events`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        type: 'renderer.message.delta',
+        text: 'Hello.'
+      })
+    })
+    expect(event.status).toBe(200)
+    const eventBody = (await event.json()) as RenderingV2TestResponse
+    expect(eventBody.output[0]).toMatchObject({
+      type: 'slack.text.delta',
+      acceptedChars: 6
+    })
+
+    const done = await app.request(`/api/v2/rendering/sessions/${openedBody.session_id}/events`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        type: 'renderer.done',
+        finalText: 'Hello.'
+      })
+    })
+    expect(done.status).toBe(200)
+    const doneBody = (await done.json()) as RenderingV2TestResponse
+    expect(doneBody.output[0]).toMatchObject({
+      type: 'slack.session.closed',
+      sessionId: openedBody.session_id
+    })
+    expect(calls.map(call => call.method)).toContain('chat.startStream')
+    expect(calls.map(call => call.method)).toContain('chat.stopStream')
+  })
+
+  it('rejects malformed renderer payloads before calling Slack', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const app = renderingTestApp(calls)
+
+    const response = await app.request('/api/v2/rendering/sessions', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        type: 'renderer.session.open',
+        target: { platform: 'slack' }
+      })
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: 'invalid_renderer_payload'
+    })
+    expect(calls).toHaveLength(0)
+  })
+})
+
+function renderingTestApp(calls: Array<{ method: string; params: any }>) {
+  const app = new Hono<{ Variables: Variables }>()
+  registerRenderingV2Routes(app, {
+    apiKeyMiddleware: testApiKeyMiddleware,
+    resolveClient: async () =>
+      ({
+        assistant: {
+          threads: {
+            setStatus: async (params: any) => {
+              calls.push({ method: 'assistant.threads.setStatus', params })
+              return { ok: true }
+            }
+          }
+        },
+        chat: {
+          startStream: async (params: any) => {
+            calls.push({ method: 'chat.startStream', params })
+            return { ok: true, ts: '1778866940.295499' }
+          },
+          appendStream: async (params: any) => {
+            calls.push({ method: 'chat.appendStream', params })
+            return { ok: true }
+          },
+          stopStream: async (params: any) => {
+            calls.push({ method: 'chat.stopStream', params })
+            return { ok: true }
+          },
+          update: async (params: any) => {
+            calls.push({ method: 'chat.update', params })
+            return { ok: true }
+          }
+        }
+      }) as any
+  })
+  return app
+}
+
+const testApiKeyMiddleware: MiddlewareHandler<{ Variables: Variables }> = async (c, next) => {
+  if (c.req.header('authorization') !== 'Bearer test-key') {
+    return c.json({ ok: false, error: 'unauthorized' }, 401)
+  }
+  await next()
+}
+
+function authHeaders(): HeadersInit {
+  return {
+    authorization: 'Bearer test-key',
+    'content-type': 'application/json'
+  }
+}

--- a/services/slackbot/src/rendering/routes.ts
+++ b/services/slackbot/src/rendering/routes.ts
@@ -1,0 +1,85 @@
+import { Hono, type Context, type MiddlewareHandler } from 'hono'
+import type { WebClient } from '@slack/web-api'
+import { rendererEventSchema } from '@centaur/rendering'
+import { z } from 'zod'
+import { SlackChatSDKRenderer, slackRendererOpenInputSchema } from './slack'
+
+type RenderingRouteVariables = {
+  slackRawBody: string
+}
+
+export type RenderingV2RouteDeps = {
+  apiKeyMiddleware: MiddlewareHandler<{ Variables: RenderingRouteVariables }>
+  resolveClient(): Promise<WebClient>
+}
+
+export function registerRenderingV2Routes(
+  app: Hono<{ Variables: RenderingRouteVariables }>,
+  deps: RenderingV2RouteDeps
+): void {
+  let renderer: SlackChatSDKRenderer | null = null
+
+  const rendererFor = async (): Promise<SlackChatSDKRenderer> => {
+    if (renderer) return renderer
+    renderer = new SlackChatSDKRenderer(await deps.resolveClient())
+    return renderer
+  }
+
+  app.post('/api/v2/rendering/sessions', deps.apiKeyMiddleware, async c => {
+    try {
+      const input = slackRendererOpenInputSchema.parse(await c.req.json())
+      const activeRenderer = await rendererFor()
+      const result = await activeRenderer.open(input)
+      return c.json({
+        ok: true,
+        renderer: activeRenderer.kind,
+        session_id: result.sessionId,
+        output: result.output
+      })
+    } catch (error) {
+      return rendererErrorResponse(c, error)
+    }
+  })
+
+  app.post('/api/v2/rendering/sessions/:session_id/events', deps.apiKeyMiddleware, async c => {
+    try {
+      const sessionId = c.req.param('session_id')
+      const event = rendererEventSchema.parse(await c.req.json())
+      const activeRenderer = await rendererFor()
+      const result =
+        event.type === 'renderer.done'
+          ? await activeRenderer.close(sessionId, event)
+          : await activeRenderer.render(sessionId, event)
+      return c.json({
+        ok: true,
+        renderer: activeRenderer.kind,
+        session_id: sessionId,
+        output: result.output
+      })
+    } catch (error) {
+      return rendererErrorResponse(c, error)
+    }
+  })
+}
+
+function rendererErrorResponse(c: Context, error: unknown) {
+  if (error instanceof z.ZodError) {
+    return c.json(
+      {
+        ok: false,
+        error: 'invalid_renderer_payload',
+        issues: error.issues
+      },
+      400
+    )
+  }
+  const data = (error as { data?: unknown })?.data
+  if (data && typeof data === 'object') return c.json(data, 502)
+  return c.json(
+    {
+      ok: false,
+      error: error instanceof Error ? error.message : 'renderer_error'
+    },
+    502
+  )
+}

--- a/services/slackbot/src/rendering/slack.test.ts
+++ b/services/slackbot/src/rendering/slack.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'bun:test'
+import { SlackChatSDKRenderer } from './slack'
+
+describe('v2 SlackChatSDKRenderer', () => {
+  it('layers Slack delivery above the ChatSDK renderer', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async (params: any) => {
+            calls.push({ method: 'assistant.threads.setStatus', params })
+            return { ok: true }
+          }
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async (params: any) => {
+          calls.push({ method: 'chat.update', params })
+          return { ok: true }
+        }
+      }
+    }
+
+    const renderer = new SlackChatSDKRenderer(client as any)
+    const open = await renderer.open({
+      type: 'renderer.session.open',
+      title: 'Centaur execution',
+      header: 'base - codex',
+      target: {
+        platform: 'slack',
+        threadKey: 'slack:T123:C123:1778866921.505479',
+        slack: {
+          channel: 'C123',
+          parentTs: '1778866921.505479',
+          recipientTeamId: 'T123',
+          recipientUserId: 'U123'
+        }
+      }
+    })
+
+    expect(open.output[0]).toMatchObject({
+      type: 'slack.session.opened',
+      sessionId: open.sessionId
+    })
+    expect(open.output[0]?.chat[0]?.type).toBe('chat.session.opened')
+
+    const text = await renderer.render(open.sessionId, {
+      type: 'renderer.message.delta',
+      text: 'Hello.'
+    })
+    expect(text.output[0]).toMatchObject({
+      type: 'slack.text.delta',
+      acceptedChars: 6
+    })
+
+    const task = await renderer.render(open.sessionId, {
+      type: 'renderer.task.update',
+      task: {
+        id: 'cmd-1',
+        title: 'Run command',
+        status: 'complete',
+        details: [{ type: 'code', language: 'sh', text: 'pnpm test' }]
+      }
+    })
+    expect(task.output[0]).toMatchObject({
+      type: 'slack.task.updated',
+      taskId: 'cmd-1'
+    })
+
+    const done = await renderer.close(open.sessionId, {
+      type: 'renderer.done',
+      finalText: 'Hello.'
+    })
+    expect(done.output[0]).toMatchObject({
+      type: 'slack.session.closed',
+      sessionId: open.sessionId
+    })
+    expect(done.output[0]?.chat.at(-1)?.type).toBe('chat.session.closed')
+
+    const start = calls.find(call => call.method === 'chat.startStream')
+    expect(start?.params.chunks).toContainEqual({
+      type: 'markdown_text',
+      text: '_base - codex_\n'
+    })
+    expect(start?.params.chunks).toContainEqual({
+      type: 'markdown_text',
+      text: 'Hello.'
+    })
+
+    const taskUpdates = calls
+      .flatMap(call => call.params.chunks ?? [])
+      .filter(chunk => chunk.type === 'task_update')
+    expect(taskUpdates.at(-1)).toMatchObject({
+      id: 'cmd-1',
+      title: 'Run command',
+      status: 'complete',
+      details: '```sh\npnpm test\n```'
+    })
+    expect(calls.map(call => call.method)).toContain('chat.stopStream')
+  })
+})

--- a/services/slackbot/src/rendering/slack.ts
+++ b/services/slackbot/src/rendering/slack.ts
@@ -1,0 +1,307 @@
+import type { WebClient } from '@slack/web-api'
+import {
+  ChatSDKRenderer,
+  chatSDKOperationSchema,
+  parseRendererDoneEvent,
+  parseRendererEvent,
+  rendererContentToMarkdown,
+  rendererOpenInputSchema,
+  rendererTargetSchema,
+  type ParsedRendererMessageSnapshotEvent,
+  type RendererDoneEvent,
+  type RendererEvent,
+  type RendererInterface,
+  type RendererOpenInput,
+  type RendererOpenResult,
+  type RendererRenderResult
+} from '@centaur/rendering'
+import { z } from 'zod'
+import { AgentSessionRenderer } from '../slack/agent-session'
+
+export const slackRendererTargetSchema = z
+  .object({
+    channel: z.string().min(1),
+    parentTs: z.string().min(1),
+    recipientTeamId: z.string().min(1),
+    recipientUserId: z.string().min(1)
+  })
+  .strict()
+
+export const slackRendererTargetEnvelopeSchema = rendererTargetSchema
+  .extend({
+    platform: z.literal('slack'),
+    slack: slackRendererTargetSchema
+  })
+  .strict()
+
+export const slackRendererOpenInputSchema = rendererOpenInputSchema
+  .extend({
+    target: slackRendererTargetEnvelopeSchema
+  })
+  .strict()
+
+export type SlackRendererTarget = z.output<typeof slackRendererTargetSchema>
+export type SlackRendererOpenInput = z.input<typeof slackRendererOpenInputSchema>
+export type ParsedSlackRendererOpenInput = z.output<typeof slackRendererOpenInputSchema>
+
+export function parseSlackRendererOpenInput(input: unknown): ParsedSlackRendererOpenInput {
+  return slackRendererOpenInputSchema.parse(input)
+}
+
+export const slackSessionOpenedOperationSchema = z
+  .object({
+    type: z.literal('slack.session.opened'),
+    sessionId: z.string(),
+    agentSessionId: z.string(),
+    chat: z.array(chatSDKOperationSchema)
+  })
+  .strict()
+
+export const slackStatusUpdatedOperationSchema = z
+  .object({
+    type: z.literal('slack.status.updated'),
+    sessionId: z.string(),
+    status: z.string(),
+    chat: z.array(chatSDKOperationSchema)
+  })
+  .strict()
+
+export const slackTextDeltaOperationSchema = z
+  .object({
+    type: z.literal('slack.text.delta'),
+    sessionId: z.string(),
+    acceptedChars: z.number().int().nonnegative(),
+    chat: z.array(chatSDKOperationSchema)
+  })
+  .strict()
+
+export const slackTaskUpdatedOperationSchema = z
+  .object({
+    type: z.literal('slack.task.updated'),
+    sessionId: z.string(),
+    taskId: z.string(),
+    chat: z.array(chatSDKOperationSchema)
+  })
+  .strict()
+
+export const slackSessionClosedOperationSchema = z
+  .object({
+    type: z.literal('slack.session.closed'),
+    sessionId: z.string(),
+    streamedTextChars: z.number().int().nonnegative(),
+    chat: z.array(chatSDKOperationSchema)
+  })
+  .strict()
+
+export const slackRendererOperationSchema = z.discriminatedUnion('type', [
+  slackSessionOpenedOperationSchema,
+  slackStatusUpdatedOperationSchema,
+  slackTextDeltaOperationSchema,
+  slackTaskUpdatedOperationSchema,
+  slackSessionClosedOperationSchema
+])
+
+export type SlackRendererOperation = z.output<typeof slackRendererOperationSchema>
+
+type SlackRendererSessionState = {
+  agentSessionId: string
+  target: SlackRendererTarget
+  deliveredText: string
+}
+
+export class SlackChatSDKRenderer implements RendererInterface<
+  SlackRendererOperation[],
+  SlackRendererOpenInput
+> {
+  readonly kind = 'slack-chat-sdk'
+  private readonly agentRenderer: AgentSessionRenderer
+  private readonly sessions = new Map<string, SlackRendererSessionState>()
+
+  constructor(
+    private readonly client: WebClient,
+    private readonly chatRenderer: ChatSDKRenderer = new ChatSDKRenderer()
+  ) {
+    this.agentRenderer = new AgentSessionRenderer(client)
+  }
+
+  async open(input: SlackRendererOpenInput): Promise<RendererOpenResult<SlackRendererOperation[]>> {
+    const parsed = parseSlackRendererOpenInput(input)
+    const target = parsed.target.slack
+    const chat = await this.chatRenderer.open(chatOpenInputFor(parsed))
+    const agent = await this.agentRenderer.open({
+      channel: target.channel,
+      parentTs: target.parentTs,
+      recipientTeamId: target.recipientTeamId,
+      recipientUserId: target.recipientUserId,
+      title: parsed.title,
+      header: parsed.header
+    })
+
+    this.sessions.set(chat.sessionId, {
+      agentSessionId: agent.sessionId,
+      target,
+      deliveredText: ''
+    })
+
+    return {
+      sessionId: chat.sessionId,
+      output: [
+        {
+          type: 'slack.session.opened',
+          sessionId: chat.sessionId,
+          agentSessionId: agent.sessionId,
+          chat: chat.output
+        }
+      ]
+    }
+  }
+
+  async render(
+    sessionId: string,
+    event: RendererEvent
+  ): Promise<RendererRenderResult<SlackRendererOperation[]>> {
+    const parsed = parseRendererEvent(event)
+    if (parsed.type === 'renderer.done') return this.close(sessionId, parsed)
+
+    const state = this.requireSession(sessionId)
+    const chat = await this.chatRenderer.render(sessionId, parsed)
+
+    if (parsed.type === 'renderer.status') {
+      const response = await this.client.assistant.threads.setStatus({
+        channel_id: state.target.channel,
+        thread_ts: state.target.parentTs,
+        status: parsed.status,
+        ...(parsed.status || parsed.loadingMessages?.length
+          ? { loading_messages: parsed.loadingMessages ?? [parsed.status] }
+          : {})
+      })
+      if (!response.ok) throw new Error(response.error ?? 'assistant.threads.setStatus failed')
+      return {
+        output: [
+          {
+            type: 'slack.status.updated',
+            sessionId,
+            status: parsed.status,
+            chat: chat.output
+          }
+        ]
+      }
+    }
+
+    if (parsed.type === 'renderer.message.delta') {
+      const acceptedChars = await this.agentRenderer.textDelta(state.agentSessionId, parsed.text, {
+        force: parsed.flush ?? true,
+        planPrefix: true
+      })
+      state.deliveredText += parsed.text.slice(0, acceptedChars)
+      return {
+        output: [
+          {
+            type: 'slack.text.delta',
+            sessionId,
+            acceptedChars,
+            chat: chat.output
+          }
+        ]
+      }
+    }
+
+    if (parsed.type === 'renderer.message.snapshot') {
+      const acceptedChars = await this.renderSnapshot(state, parsed)
+      return {
+        output: [
+          {
+            type: 'slack.text.delta',
+            sessionId,
+            acceptedChars,
+            chat: chat.output
+          }
+        ]
+      }
+    }
+
+    await this.agentRenderer.step(state.agentSessionId, {
+      id: parsed.task.id,
+      title: parsed.task.title,
+      status: parsed.task.status,
+      details: rendererContentToMarkdown(parsed.task.details),
+      output: rendererContentToMarkdown(parsed.task.output)
+    })
+    return {
+      output: [
+        {
+          type: 'slack.task.updated',
+          sessionId,
+          taskId: parsed.task.id,
+          chat: chat.output
+        }
+      ]
+    }
+  }
+
+  async close(
+    sessionId: string,
+    event: RendererDoneEvent = { type: 'renderer.done' }
+  ): Promise<RendererRenderResult<SlackRendererOperation[]>> {
+    const parsed = parseRendererDoneEvent(event)
+    const state = this.requireSession(sessionId)
+    const chat = await this.chatRenderer.close(sessionId, parsed)
+    const done = await this.agentRenderer.done(state.agentSessionId, {
+      streamFinalUpdates: true,
+      answerMarkdown: parsed.finalText
+    })
+    this.sessions.delete(sessionId)
+    return {
+      output: [
+        {
+          type: 'slack.session.closed',
+          sessionId,
+          streamedTextChars: done.streamedTextChars,
+          chat: chat.output
+        }
+      ]
+    }
+  }
+
+  private async renderSnapshot(
+    state: SlackRendererSessionState,
+    event: ParsedRendererMessageSnapshotEvent
+  ): Promise<number> {
+    const delta = snapshotDelta(state.deliveredText, event.text)
+    if (!delta) {
+      state.deliveredText = event.text
+      return 0
+    }
+    const acceptedChars = await this.agentRenderer.textDelta(state.agentSessionId, delta, {
+      force: true,
+      planPrefix: true
+    })
+    state.deliveredText = event.text
+    return acceptedChars
+  }
+
+  private requireSession(sessionId: string): SlackRendererSessionState {
+    const state = this.sessions.get(sessionId)
+    if (!state) throw new Error('renderer_session_not_found')
+    return state
+  }
+}
+
+function chatOpenInputFor(input: ParsedSlackRendererOpenInput): RendererOpenInput {
+  return {
+    ...input,
+    target: {
+      platform: input.target.platform,
+      threadKey: input.target.threadKey,
+      surface: input.target.surface,
+      metadata: input.target.metadata
+    }
+  }
+}
+
+function snapshotDelta(previous: string, next: string): string {
+  if (!next) return ''
+  if (!previous) return next
+  if (next.startsWith(previous)) return next.slice(previous.length)
+  return next
+}


### PR DESCRIPTION
## Summary
- add @centaur/rendering with the generic renderer schema and interface
- implement ChatSDKRenderer with the real chat package as one renderer implementation
- add SlackChatSDKRenderer and v2 Slackbot routes as a Slack adapter above ChatSDK
- add API client helpers for opening renderer sessions and forwarding renderer events

## Layering
- RendererInterface and renderer.* events are the Slack-agnostic boundary.
- ChatSDKRenderer implements that renderer boundary using Chat SDK PostableMessage and StreamChunk output.
- SlackChatSDKRenderer sits above ChatSDKRenderer and owns Slack-specific target validation and delivery.

## Tests
- pnpm --filter @centaur/rendering typecheck
- pnpm --filter @centaur/rendering test
- bun tsgo --project tsconfig.json --noEmit
- bun test src/*.test.ts src/**/*.test.ts
- .venv/bin/pytest tests/test_slackbot_client.py
- .venv/bin/ruff check api/slackbot_client.py tests/test_slackbot_client.py
- .venv/bin/ruff format --check api/slackbot_client.py tests/test_slackbot_client.py