### PR TITLE
feat: add canonical renderer pipeline

### DIFF
--- a/packages/harness-events/src/index.ts
+++ b/packages/harness-events/src/index.ts
@@ -1,4 +1,10 @@
 export { normalizeHarnessEvent } from "./normalize";
-export type { CanonicalEvent, ContentBlock, SubagentActivity } from "./types";
+export type {
+  CanonicalEvent,
+  ContentBlock,
+  RustSessionStreamEvent,
+  ServerNotification,
+  SubagentActivity,
+} from "./types";
 export { asString, asRecord, asList, asNumber, asBoolean } from "./parse-utils";
 export { splitThreadKey, normalizeThreadKey } from "./thread-key";

--- a/packages/harness-events/src/normalize.ts
+++ b/packages/harness-events/src/normalize.ts
@@ -639,7 +639,7 @@ function normalizeCodexEvent(event: Record<string, unknown>): CanonicalEvent[] {
   }
 
   if (eventType === 'assistant') {
-    return [event]
+    return [event as CanonicalEvent]
   }
 
   if (eventType === 'error') {

--- a/packages/harness-events/src/types.ts
+++ b/packages/harness-events/src/types.ts
@@ -65,3 +65,12 @@ export type CanonicalEvent =
         | 'item.reasoning.textDelta'
       [key: string]: unknown
     }
+
+export type ServerNotification = { type: string } & Record<string, any>
+
+export type RustSessionStreamEvent = {
+  eventId?: number
+  eventKind?: string
+  event?: string
+  data?: unknown
+}

--- a/packages/harness-events/tsconfig.json
+++ b/packages/harness-events/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "outDir": "dist"
   },
   "include": ["src"]

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -1,13 +1,18 @@
 {
-  "name": "@centaur/harness-events",
+  "name": "@centaur/rendering",
   "version": "0.1.0",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
+    "test": "bun test src",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@centaur/harness-events": "workspace:*"
+  },
   "devDependencies": {
+    "@types/bun": "^1.3.13",
     "@types/node": "^25.7.0",
     "typescript": "5.9.3"
   }

--- a/packages/rendering/src/chat-sdk.test.ts
+++ b/packages/rendering/src/chat-sdk.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test'
+import { ChatSDKRenderer } from './chat-sdk'
+import { rendererEventTypes } from './schema'
+import type { RendererInterface } from './interface'
+
+describe('ChatSDKRenderer', () => {
+  it('implements the generic renderer interface over renderer events', () => {
+    const renderer: RendererInterface = new ChatSDKRenderer()
+
+    expect(renderer.open({ title: 'Execution' })).toEqual([])
+    expect(
+      renderer.render('session-1', {
+        type: 'renderer.message.delta',
+        delta: 'hello'
+      })
+    ).toEqual([
+      {
+        type: 'chat.stream.append',
+        chunks: [{ type: 'markdown_text', text: 'hello' }],
+        force: undefined,
+        planPrefix: undefined
+      }
+    ])
+    expect(
+      renderer.close('session-1', {
+        type: 'renderer.done',
+        answerMarkdown: 'done'
+      })
+    ).toEqual([
+      {
+        type: 'chat.session.closed',
+        message: { text: 'done', error: undefined },
+        streamFinalUpdates: undefined
+      }
+    ])
+  })
+
+  it('exposes the renderer contract event names', () => {
+    expect(rendererEventTypes).toContain('renderer.session.open')
+    expect(rendererEventTypes).toContain('renderer.status')
+    expect(rendererEventTypes).toContain('renderer.message.delta')
+    expect(rendererEventTypes).toContain('renderer.message.snapshot')
+    expect(rendererEventTypes).toContain('renderer.task.update')
+    expect(rendererEventTypes).toContain('renderer.done')
+  })
+})

--- a/packages/rendering/src/chat-sdk.ts
+++ b/packages/rendering/src/chat-sdk.ts
@@ -1,0 +1,114 @@
+import type { RendererEvent, RendererTaskBlock, RendererTaskUpdate } from './types'
+import type { RendererInterface } from './interface'
+
+export type ChatSDKStreamChunk =
+  | { type: 'markdown_text'; text: string }
+  | {
+      type: 'task_update'
+      id: string
+      title: string
+      status: string
+      details?: string
+      output?: string
+    }
+  | { type: 'plan_update'; title: string }
+
+export type ChatSDKPostableMessage = {
+  text?: string
+  title?: string
+  error?: string
+}
+
+export type ChatSDKStreamAppend = {
+  type: 'chat.stream.append'
+  chunks: ChatSDKStreamChunk[]
+  force?: boolean
+  planPrefix?: boolean
+}
+
+export type ChatSDKMessageUpsert = {
+  type: 'chat.message.upsert'
+  message: ChatSDKPostableMessage
+}
+
+export type ChatSDKSessionClosed = {
+  type: 'chat.session.closed'
+  message?: ChatSDKPostableMessage
+  streamFinalUpdates?: boolean
+}
+
+export type ChatSDKOutput = ChatSDKMessageUpsert | ChatSDKSessionClosed | ChatSDKStreamAppend
+
+export class ChatSDKRenderer implements RendererInterface<ChatSDKOutput> {
+  open(): ChatSDKOutput[] {
+    return []
+  }
+
+  render(_sessionId: string, event: RendererEvent): ChatSDKOutput[] {
+    return this.consume(event)
+  }
+
+  close(_sessionId: string, event?: Extract<RendererEvent, { type: 'renderer.done' }>): ChatSDKOutput[] {
+    return event ? this.consume(event) : []
+  }
+
+  consume(event: RendererEvent): ChatSDKOutput[] {
+    if (event.type === 'renderer.session.open') {
+      return []
+    }
+    if (event.type === 'renderer.status') {
+      return [{ type: 'chat.message.upsert', message: { text: event.status } }]
+    }
+    if (event.type === 'renderer.message.delta') {
+      return [
+        {
+          type: 'chat.stream.append',
+          chunks: [{ type: 'markdown_text', text: event.delta }],
+          force: event.force,
+          planPrefix: event.planPrefix
+        }
+      ]
+    }
+    if (event.type === 'renderer.message.snapshot') {
+      return [{ type: 'chat.message.upsert', message: { text: event.markdown } }]
+    }
+    if (event.type === 'renderer.task.update') {
+      return [{ type: 'chat.stream.append', chunks: [taskChunk(event.task)] }]
+    }
+    if (event.type === 'renderer.title.update') {
+      return [{ type: 'chat.message.upsert', message: { title: event.title } }]
+    }
+    return [
+      {
+        type: 'chat.session.closed',
+        message: {
+          text: event.answerMarkdown,
+          error: event.error
+        },
+        streamFinalUpdates: event.streamFinalUpdates
+      }
+    ]
+  }
+}
+
+function taskChunk(task: RendererTaskUpdate): ChatSDKStreamChunk {
+  return {
+    type: 'task_update',
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    ...(task.details?.length ? { details: taskBodyToChatSdkText(task.details) } : {}),
+    ...(task.output?.length ? { output: taskBodyToChatSdkText(task.output) } : {})
+  }
+}
+
+function taskBodyToChatSdkText(blocks: RendererTaskBlock[]): string {
+  return blocks
+    .map(block => {
+      if (block.type === 'text') return block.text
+      const language = block.language ?? ''
+      return `\`\`\`${language}\n${block.text}\n\`\`\``
+    })
+    .filter(Boolean)
+    .join('\n')
+}

--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'bun:test'
+import { CodexAppServerRendererEventMapper } from './codex-app-server'
+import type { RendererTaskBlock } from './types'
+
+describe('CodexAppServerRendererEventMapper', () => {
+  it('maps final answer deltas to generic renderer message deltas after activity exists', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+
+    const commandEvents = mapper.process({
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'pnpm test' }
+    })
+    expect(commandEvents).toContainEqual({
+      type: 'renderer.task.update',
+      task: {
+        id: 'cmd-1',
+        title: '1. Command execution',
+        status: 'in_progress',
+        details: [
+          {
+            type: 'code',
+            language: 'sh',
+            text: 'pnpm test'
+          }
+        ],
+        output: undefined
+      },
+      flush: true
+    })
+
+    expect(
+      mapper.process({
+        type: 'item.started',
+        item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
+      })
+    ).toEqual([])
+
+    expect(
+      mapper.process({
+        type: 'item.agentMessage.delta',
+        itemId: 'msg-1',
+        delta: 'Done.'
+      })
+    ).toContainEqual({
+      type: 'renderer.message.delta',
+      delta: 'Done.',
+      force: false,
+      planPrefix: true
+    })
+  })
+
+  it('maps commentary to Thinking task updates instead of message deltas', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'thinking-1', type: 'agentMessage', phase: 'commentary' }
+    })
+    mapper.process({
+      type: 'item.agentMessage.delta',
+      itemId: 'thinking-1',
+      delta: 'Checking the runtime.'
+    })
+
+    const events = mapper.process({
+      type: 'item.completed',
+      item: {
+        id: 'thinking-1',
+        type: 'agentMessage',
+        phase: 'commentary',
+        text: 'Checking the runtime.'
+      }
+    })
+
+    expect(events.some(event => event.type === 'renderer.message.delta')).toBe(false)
+    const task = events.find(event => event.type === 'renderer.task.update')
+    expect(task).toMatchObject({
+      type: 'renderer.task.update',
+      task: {
+        id: 'thinking-thinking-1',
+        title: 'Thinking',
+        status: 'complete'
+      }
+    })
+    expect(plain(task?.type === 'renderer.task.update' ? task.task.details : undefined)).toContain(
+      'Checking the runtime.'
+    )
+  })
+
+  it('parses Rust session output lines before mapping app-server notifications', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+    mapper.process({
+      eventKind: 'session.output.line',
+      data: JSON.stringify({
+        type: 'item.started',
+        item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
+      })
+    })
+    const events = mapper.process({
+      eventKind: 'session.output.line',
+      data: JSON.stringify({
+        type: 'turn.done',
+        result: 'PONG'
+      })
+    })
+
+    expect(events).toContainEqual({
+      type: 'renderer.message.delta',
+      delta: 'PONG',
+      force: true,
+      planPrefix: false
+    })
+    expect(events.at(-1)).toMatchObject({
+      type: 'renderer.done',
+      answerMarkdown: 'PONG'
+    })
+  })
+
+  it('accepts already-parsed Rust session output payloads from API clients', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+    mapper.process({
+      eventKind: 'session.output.line',
+      data: {
+        type: 'item.started',
+        item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
+      }
+    })
+
+    const events = mapper.process({
+      eventKind: 'session.output.line',
+      data: {
+        type: 'turn.done',
+        result: 'PONG'
+      }
+    })
+
+    expect(events).toContainEqual({
+      type: 'renderer.message.delta',
+      delta: 'PONG',
+      force: true,
+      planPrefix: false
+    })
+  })
+
+  it('maps thread name updates without making them Slack-specific', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+
+    expect(
+      mapper.process({
+        type: 'thread/name/updated',
+        name: 'Investigate staging deploy'
+      })
+    ).toEqual([{ type: 'renderer.title.update', title: 'Investigate staging deploy' }])
+  })
+
+  it('marks open tasks as errors on Rust session failures and emits done', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'kubectl get pods' }
+    })
+
+    const events = mapper.process({
+      eventKind: 'session.execution_failed',
+      data: { error: 'sandbox exited' }
+    })
+
+    expect(events).toContainEqual({
+      type: 'renderer.task.update',
+      task: {
+        id: 'cmd-1',
+        title: '1. Command execution',
+        status: 'error',
+        details: undefined,
+        output: undefined
+      },
+      flush: true
+    })
+    expect(events.at(-1)).toMatchObject({
+      type: 'renderer.done',
+      error: 'sandbox exited'
+    })
+  })
+})
+
+function plain(elements: RendererTaskBlock[] | undefined): string {
+  return (elements ?? [])
+    .map(element => element.text)
+    .join('')
+}

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -1,0 +1,1254 @@
+import type {
+  RustSessionStreamEvent,
+  ServerNotification
+} from '@centaur/harness-events'
+import { elementsToPlainText, preformatted as pre, section, text } from './rich-text'
+import type {
+  RendererEvent,
+  RendererLogInfo,
+  RendererTaskBlock,
+  RendererSourceMapper,
+  RendererTaskStatus
+} from './types'
+
+const COMMAND_EXECUTION_TITLE = 'Command execution'
+const PRE_STREAM_GRACE_MS = 500
+
+const limits = {
+  stream: {
+    planTitleChars: 256,
+    taskTitleChars: 128
+  },
+  finalPlan: {
+    taskTitleChars: 140,
+    taskOutputCodeBlockLines: 4,
+    outputPreviewChars: 2_200
+  }
+} as const
+
+type AgentMessagePhase = 'commentary' | 'final_answer'
+
+type HarnessTask = {
+  id: string
+  title: string
+  status: RendererTaskStatus
+  details: RendererTaskBlock[]
+  output: RendererTaskBlock[]
+  commandIndex?: number
+}
+
+type CodexMapperState = {
+  threadId: string
+  stepCounter: number
+  nextCommandIndex: number
+  answerByItemId: Map<string, string>
+  harnessAnswerText: string
+  answerText: string
+  commentaryByItemId: Map<string, string>
+  harnessCommentaryText: string
+  commentaryText: string
+  completedItemIds: Set<string>
+  firstBufferedTextAt: number | null
+  streamedCommentaryText: string
+  streamedAnswerText: string
+  agentMessagePhase: AgentMessagePhase | null
+  agentMessagePhaseByItemId: Map<string, AgentMessagePhase>
+  planText: string
+  taskByUseId: Map<string, HarnessTask>
+  commandOutputById: Map<string, string>
+  emittedActivityRunByTaskId: Set<string>
+  emittedActivityOutputByTaskId: Set<string>
+  done: boolean
+}
+
+export type CodexAppServerRendererEventMapperOptions = {
+  sessionId?: string
+  logInfo?: RendererLogInfo
+}
+
+export class CodexAppServerRendererEventMapper
+  implements RendererSourceMapper<ServerNotification | RustSessionStreamEvent | unknown>
+{
+  private readonly state: CodexMapperState = newState()
+  private readonly sessionId: string
+  private readonly logInfo?: RendererLogInfo
+
+  constructor(options: CodexAppServerRendererEventMapperOptions = {}) {
+    this.sessionId = options.sessionId ?? ''
+    this.logInfo = options.logInfo
+  }
+
+  process(source: ServerNotification | RustSessionStreamEvent | unknown): RendererEvent[] {
+    if (this.state.done) return []
+
+    const rustMapped = rustSessionEventToServerNotification(source)
+    if (rustMapped?.kind === 'failed') return this.fail(rustMapped.error)
+    if (rustMapped?.kind === 'completed') return this.flush()
+    if (rustMapped?.kind === 'notification') return this.processNotification(rustMapped.notification)
+
+    if (!isRecord(source)) return []
+    return this.processNotification(source as ServerNotification)
+  }
+
+  flush(): RendererEvent[] {
+    if (this.state.done) return []
+    this.state.done = true
+    const out: RendererEvent[] = []
+    completeThinkingTasks(this.state)
+    completeOpenTasks(this.state)
+    this.emitActivitySummary(out, { final: true })
+    this.emitPendingAssistantText(out, { force: true })
+    out.push({
+      type: 'renderer.done',
+      answerMarkdown: this.state.answerText,
+      streamFinalUpdates: true,
+      threadId: this.state.threadId || undefined
+    })
+    return out
+  }
+
+  isDone(): boolean {
+    return this.state.done
+  }
+
+  threadId(): string {
+    return this.state.threadId
+  }
+
+  answerText(): string {
+    return this.state.answerText
+  }
+
+  private processNotification(event: ServerNotification): RendererEvent[] {
+    const out: RendererEvent[] = []
+    if (event?.session_id) this.state.threadId = String(event.session_id)
+    if (event?.thread_id) this.state.threadId = String(event.thread_id)
+
+    const title = threadTitleUpdate(event)
+    if (title) out.push({ type: 'renderer.title.update', title })
+
+    trackAgentMessageLifecycle(event, this.state)
+    ensureCommentarySegmentBreak(event, this.state)
+
+    const structuredPlan = structuredPlanUpdate(event)
+    if (structuredPlan) {
+      for (const [index, item] of structuredPlan.entries()) {
+        setPlanTask(this.state, index, String(item.step ?? ''), planStatus(item.status))
+      }
+      this.emitActivitySummary(out)
+    }
+
+    const planText = planTextUpdate(event)
+    if (planText) {
+      this.state.planText =
+        event?.type === 'item.plan.delta' ? this.state.planText + planText : planText
+      const steps = parsePlanText(this.state.planText)
+      for (const [index, item] of steps.entries()) {
+        setPlanTask(this.state, index, item.step, item.status)
+      }
+      this.emitActivitySummary(out)
+    }
+
+    const command = commandExecution(event)
+    if (command) {
+      const id = commandId(command)
+      const aggregatedOutput = commandAggregatedOutput(command)
+      if (aggregatedOutput) this.state.commandOutputById.set(id, aggregatedOutput)
+      const existing = this.state.taskByUseId.get(id)
+      const commandIndex = commandNumber(this.state, existing)
+      const task = commandTask(
+        command,
+        String(event?.type ?? ''),
+        existing,
+        this.state.commandOutputById.get(id),
+        commandIndex
+      )
+      const merged = mergeTask(existing, task)
+      this.state.taskByUseId.set(merged.id, merged)
+      this.emitActivitySummary(out)
+    }
+
+    const fileChange = fileChangeEvent(event)
+    if (fileChange) {
+      const existing = this.state.taskByUseId.get(fileChangeId(fileChange))
+      const task = fileChangeTask(fileChange, String(event?.type ?? ''), existing)
+      const merged = mergeTask(existing, task)
+      this.state.taskByUseId.set(merged.id, merged)
+      this.emitActivitySummary(out)
+    }
+
+    const outputDelta = commandOutputDelta(event)
+    if (outputDelta) {
+      const current = this.state.commandOutputById.get(outputDelta.id) ?? ''
+      const output = current + outputDelta.delta
+      this.state.commandOutputById.set(outputDelta.id, output)
+      const existing = this.state.taskByUseId.get(outputDelta.id)
+      const commandIndex = commandNumber(this.state, existing)
+      const task =
+        existing ??
+        ({
+          id: outputDelta.id,
+          title: commandExecutionTitle(commandIndex),
+          status: 'in_progress',
+          details: [],
+          output: [],
+          commandIndex
+        } satisfies HarnessTask)
+      const updated = {
+        ...task,
+        title: commandExecutionTitle(commandIndex),
+        commandIndex,
+        output: commandOutputElements(output)
+      }
+      this.state.taskByUseId.set(outputDelta.id, updated)
+      this.emitActivitySummary(out)
+    }
+
+    for (const tool of toolUses(event)) {
+      const commandIndex = tool.name === 'Bash' ? commandNumber(this.state) : undefined
+      const task: HarnessTask = {
+        id: `task-${++this.state.stepCounter}`,
+        title: tool.name === 'Bash' ? commandExecutionTitle(commandIndex) : titleFor(tool),
+        status: 'in_progress',
+        details: detailElementsForTool(tool),
+        output: [],
+        ...(commandIndex !== undefined ? { commandIndex } : {})
+      }
+      this.state.taskByUseId.set(String(tool.id), task)
+      this.emitActivitySummary(out)
+    }
+
+    for (const result of toolResults(event)) {
+      const toolUseId = String(result.tool_use_id ?? '')
+      const task = this.state.taskByUseId.get(toolUseId) ?? {
+        id: `task-${++this.state.stepCounter}`,
+        title: 'Tool result',
+        status: 'in_progress',
+        details: [],
+        output: []
+      }
+      this.state.taskByUseId.set(toolUseId || task.id, task)
+      task.status = 'complete'
+      task.output = outputElementsForResult(result)
+      this.emitActivitySummary(out)
+    }
+
+    if (eventCarriesAgentMessageText(event)) {
+      const buffer = this.activeAssistantBuffer(event)
+      const update = this.applyAgentMessageUpdate(event, buffer)
+      if (update.bufferChanged) {
+        this.emitPendingAssistantText(out)
+      }
+      if (update.correction) {
+        this.logCanonicalCorrection(event, update.correction)
+      }
+      if (buffer === 'commentary' && event?.type === 'item.completed') {
+        upsertThinkingTask(this.state, event)
+        this.emitActivitySummary(out)
+      }
+    }
+
+    const reasoningMessage = reasoningText(event).trim()
+    if (reasoningMessage) {
+      const task: HarnessTask = {
+        id: `reasoning-${++this.state.stepCounter}`,
+        title: 'Thinking',
+        status: 'complete',
+        details: [section([text(reasoningMessage)])],
+        output: []
+      }
+      this.state.taskByUseId.set(task.id, task)
+      this.emitActivitySummary(out)
+    }
+
+    if (isTerminalCodexAppServerEvent(event)) {
+      const resultText = terminalResultText(event)
+      const willClose = Boolean(resultText || event?.type !== 'result')
+      this.logCodexTerminalEventReceived(event, {
+        resultText,
+        willClose
+      })
+      if (resultText && !this.state.answerText.trim()) {
+        this.state.harnessAnswerText += resultText
+        recomposeBuffers(this.state)
+        this.emitPendingAssistantText(out, { force: true })
+      }
+      if (willClose) {
+        out.push(...this.flush())
+      }
+    }
+
+    return out
+  }
+
+  private fail(error: string): RendererEvent[] {
+    if (this.state.done) return []
+    this.state.done = true
+    const out: RendererEvent[] = []
+    let hadOpenTask = false
+    for (const [id, task] of this.state.taskByUseId) {
+      if (task.status !== 'in_progress' && task.status !== 'pending') continue
+      hadOpenTask = true
+      this.state.taskByUseId.set(id, { ...task, status: 'error' })
+    }
+    if (!this.state.taskByUseId.size || !hadOpenTask) {
+      this.state.taskByUseId.set('execution-error', {
+        id: 'execution-error',
+        title: 'Execution failed',
+        status: 'error',
+        details: [section([text(error || 'Execution failed')])],
+        output: []
+      })
+    }
+    this.emitActivitySummary(out, { final: true })
+    this.emitPendingAssistantText(out, { force: true })
+    out.push({
+      type: 'renderer.done',
+      answerMarkdown: this.state.answerText,
+      error,
+      streamFinalUpdates: true,
+      threadId: this.state.threadId || undefined
+    })
+    return out
+  }
+
+  private emitActivitySummary(out: RendererEvent[], opts: { final?: boolean } = {}): void {
+    const tasks = Array.from(this.state.taskByUseId.values())
+    if (!tasks.length) return
+    for (const update of changedActivityTaskUpdates(this.state, tasks, opts)) {
+      out.push({
+        type: 'renderer.task.update',
+        task: {
+          id: update.id,
+          title: update.title,
+          status: update.status,
+          details: update.details,
+          output: update.output
+        },
+        flush: true
+      })
+    }
+    this.emitPendingAssistantText(out)
+  }
+
+  private emitPendingAssistantText(
+    out: RendererEvent[],
+    opts: { force?: boolean } = {}
+  ): void {
+    if (
+      this.state.firstBufferedTextAt === null &&
+      (this.state.commentaryText.trim() || this.state.answerText.trim())
+    ) {
+      this.state.firstBufferedTextAt = Date.now()
+    }
+    this.state.streamedCommentaryText = this.state.commentaryText
+    const hasPlan = this.state.taskByUseId.size > 0
+    const graceExpired =
+      this.state.firstBufferedTextAt !== null &&
+      Date.now() - this.state.firstBufferedTextAt >= PRE_STREAM_GRACE_MS
+    const canStream = hasPlan || opts.force || graceExpired
+    if (!canStream) return
+
+    if (this.state.commentaryText.length > this.state.streamedCommentaryText.length) return
+    if (this.state.answerText.length <= this.state.streamedAnswerText.length) return
+    const delta = this.state.answerText.slice(this.state.streamedAnswerText.length)
+    if (!delta) return
+    this.state.streamedAnswerText += delta
+    out.push({
+      type: 'renderer.message.delta',
+      delta,
+      force: opts.force ?? false,
+      planPrefix: hasPlan
+    })
+  }
+
+  private activeAssistantBuffer(event: ServerNotification): 'commentary' | 'answer' {
+    if (event?.type === 'item.agentMessage.delta' || event?.type === 'item.completed') {
+      const codexId = agentMessageEventId(event)
+      const itemPhase = this.state.agentMessagePhaseByItemId.get(codexId)
+      if (itemPhase) return itemPhase === 'final_answer' ? 'answer' : 'commentary'
+      if (
+        event?.type === 'item.completed' &&
+        (event?.item?.type === 'agentMessage' || event?.item?.type === 'agent_message') &&
+        this.state.taskByUseId.size > 0
+      ) {
+        this.log('codex_renderer_unphased_final_agent_message_classified', {
+          agent_session_id: this.sessionId,
+          centaur_thread_key: event?.centaur_thread_key,
+          execution_id: event?.centaur_execution_id,
+          assignment_generation: event?.centaur_assignment_generation,
+          codex_id: codexId,
+          codex_item_id: codexId,
+          codex_item_type: event?.item?.type,
+          codex_session_id: this.state.threadId || event?.session_id || event?.thread_id,
+          task_count: this.state.taskByUseId.size,
+          commentary_chars: this.state.commentaryText.length,
+          answer_chars: this.state.answerText.length,
+          item_text_chars: String(event?.item?.text ?? '').length
+        })
+        return 'answer'
+      }
+      return this.state.agentMessagePhase === 'final_answer' ? 'answer' : 'commentary'
+    }
+    return 'answer'
+  }
+
+  private applyAgentMessageUpdate(
+    event: ServerNotification,
+    buffer: 'answer' | 'commentary'
+  ): {
+    bufferChanged: boolean
+    correction?: { previous: string; canonical: string }
+  } {
+    const itemId = agentMessageEventId(event)
+
+    if (event?.type === 'item.agentMessage.delta') {
+      if (!itemId || this.state.completedItemIds.has(itemId)) return { bufferChanged: false }
+      const delta = extractDeltaText(event)
+      if (!delta) return { bufferChanged: false }
+      const byId = buffer === 'answer' ? this.state.answerByItemId : this.state.commentaryByItemId
+      byId.set(itemId, (byId.get(itemId) ?? '') + delta)
+      recomposeBuffers(this.state)
+      return { bufferChanged: true }
+    }
+
+    if (event?.type === 'item.completed') {
+      const canonical = String(event?.item?.text ?? '')
+      if (!canonical) return { bufferChanged: false }
+      if (!itemId) {
+        this.log('codex_renderer_item_completed_missing_id', {
+          agent_session_id: this.sessionId,
+          centaur_thread_key: event?.centaur_thread_key,
+          execution_id: event?.centaur_execution_id,
+          canonical_text_chars: canonical.length,
+          canonical_hash: textHash(canonical)
+        })
+        return { bufferChanged: false }
+      }
+      const byId = buffer === 'answer' ? this.state.answerByItemId : this.state.commentaryByItemId
+      const previous = byId.get(itemId) ?? ''
+      this.state.completedItemIds.add(itemId)
+      if (canonical === previous) return { bufferChanged: false }
+      byId.set(itemId, canonical)
+      recomposeBuffers(this.state)
+      return {
+        bufferChanged: true,
+        correction: previous ? { previous, canonical } : undefined
+      }
+    }
+
+    if (event?.type === 'assistant') {
+      const assistantText = assistantTextFromAssistantEvent(event)
+      if (!assistantText) return { bufferChanged: false }
+      const key = buffer === 'answer' ? 'harnessAnswerText' : 'harnessCommentaryText'
+      const before = this.state[key]
+      if (assistantText === before || before.endsWith(assistantText)) return { bufferChanged: false }
+      if (assistantEventLooksCanonical(event)) {
+        this.state[key] = assistantText
+      } else if (assistantText.startsWith(before)) {
+        this.state[key] = assistantText
+      } else {
+        this.state[key] = before + assistantText
+      }
+      recomposeBuffers(this.state)
+      return { bufferChanged: true }
+    }
+
+    return { bufferChanged: false }
+  }
+
+  private logCanonicalCorrection(
+    event: ServerNotification,
+    correction: { previous: string; canonical: string }
+  ): void {
+    const { previous, canonical } = correction
+    const charsDiff = canonical.length - previous.length
+    this.log('codex_renderer_canonical_answer_correction', {
+      agent_session_id: this.sessionId,
+      centaur_thread_key: event?.centaur_thread_key,
+      execution_id: event?.centaur_execution_id,
+      assignment_generation: event?.centaur_assignment_generation,
+      event_type: event?.type,
+      codex_id: agentMessageEventId(event),
+      codex_item_id: agentMessageEventId(event),
+      codex_item_type: event?.item?.type,
+      codex_item_phase: event?.item?.phase,
+      codex_session_id: this.state.threadId || event?.session_id || event?.thread_id,
+      delta_total_chars: previous.length,
+      canonical_text_chars: canonical.length,
+      chars_diff: charsDiff,
+      delta_hash: textHash(previous),
+      canonical_hash: textHash(canonical)
+    })
+  }
+
+  private logCodexTerminalEventReceived(
+    event: ServerNotification,
+    opts: { resultText: string; willClose: boolean }
+  ): void {
+    this.log('codex_renderer_terminal_event_received', {
+      agent_session_id: this.sessionId,
+      centaur_thread_key: event?.centaur_thread_key,
+      execution_id: event?.centaur_execution_id,
+      assignment_generation: event?.centaur_assignment_generation,
+      event_type: event?.type,
+      codex_session_id: this.state.threadId || event?.session_id || event?.thread_id,
+      already_completed: false,
+      will_close: opts.willClose,
+      result_text_chars: opts.resultText.length,
+      answer_chars_before_event: this.state.answerText.length,
+      task_count: this.state.taskByUseId.size
+    })
+  }
+
+  private log(event: string, fields: Record<string, unknown>): void {
+    this.logInfo?.(event, fields)
+  }
+}
+
+export function codexAppServerToRendererEvents(
+  sources: Array<ServerNotification | RustSessionStreamEvent | unknown>
+): RendererEvent[] {
+  const mapper = new CodexAppServerRendererEventMapper()
+  return sources.flatMap(source => mapper.process(source))
+}
+
+export type RustSessionMappingResult =
+  | { kind: 'notification'; notification: ServerNotification }
+  | { kind: 'failed'; error: string }
+  | { kind: 'completed' }
+  | null
+
+export function rustSessionEventToServerNotification(source: unknown): RustSessionMappingResult {
+  if (!isRecord(source)) return null
+  const eventKind = String(source.eventKind ?? source.event ?? '')
+  if (!eventKind.startsWith('session.')) return null
+
+  if (eventKind === 'session.output.line') {
+    const data = source.data
+    if (isRecord(data) && typeof data.type === 'string') {
+      return { kind: 'notification', notification: data as ServerNotification }
+    }
+    const line = typeof data === 'string' ? data : isRecord(data) ? String(data.raw ?? '') : ''
+    const notification = parseServerNotificationLine(line)
+    if (notification) return { kind: 'notification', notification }
+    return {
+      kind: 'notification',
+      notification: {
+        type: 'command_execution',
+        command: 'Session output',
+        aggregated_output: line,
+        status: 'completed'
+      }
+    }
+  }
+
+  if (
+    eventKind === 'session.execution_failed' ||
+    eventKind === 'session.stream_error' ||
+    eventKind === 'session.stdout_pump_failed'
+  ) {
+    const data = isRecord(source.data) ? source.data : source
+    return { kind: 'failed', error: String(data.error ?? 'Execution failed') }
+  }
+
+  if (
+    eventKind === 'session.execution_completed' ||
+    eventKind === 'session.execution_cancelled'
+  ) {
+    return { kind: 'completed' }
+  }
+
+  return null
+}
+
+export function isTerminalCodexAppServerEvent(event: unknown): boolean {
+  return (
+    isRecord(event) &&
+    (event.type === 'result' || event.type === 'turn.done' || event.type === 'turn.completed')
+  )
+}
+
+function newState(): CodexMapperState {
+  return {
+    threadId: '',
+    stepCounter: 0,
+    nextCommandIndex: 0,
+    answerByItemId: new Map(),
+    harnessAnswerText: '',
+    answerText: '',
+    commentaryByItemId: new Map(),
+    harnessCommentaryText: '',
+    commentaryText: '',
+    completedItemIds: new Set(),
+    firstBufferedTextAt: null,
+    streamedCommentaryText: '',
+    streamedAnswerText: '',
+    agentMessagePhase: null,
+    agentMessagePhaseByItemId: new Map(),
+    planText: '',
+    taskByUseId: new Map(),
+    commandOutputById: new Map(),
+    emittedActivityRunByTaskId: new Set(),
+    emittedActivityOutputByTaskId: new Set(),
+    done: false
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function parseServerNotificationLine(line: string): ServerNotification | null {
+  if (!line.trim()) return null
+  try {
+    const parsed = JSON.parse(line) as unknown
+    if (isRecord(parsed) && typeof parsed.type === 'string') return parsed as ServerNotification
+  } catch {}
+  return null
+}
+
+function content(event: any): any[] {
+  return Array.isArray(event?.message?.content) ? event.message.content : []
+}
+
+function agentMessageItemPhase(item: any): AgentMessagePhase | null {
+  const phase = String(item?.phase ?? '').toLowerCase()
+  if (phase === 'commentary') return 'commentary'
+  if (phase === 'final_answer' || phase === 'finalanswer') return 'final_answer'
+  return null
+}
+
+function trackAgentMessageLifecycle(event: any, state: CodexMapperState): void {
+  if (event?.type !== 'item.started' && event?.type !== 'item.completed') return
+  const phase = agentMessageItemPhase(event?.item)
+  if (!phase) return
+  state.agentMessagePhase = phase
+  const id = agentMessageEventId(event)
+  if (id) state.agentMessagePhaseByItemId.set(id, phase)
+}
+
+function agentMessageEventId(event: any): string {
+  return String(event?.itemId ?? event?.item_id ?? event?.item?.id ?? '')
+}
+
+function ensureCommentarySegmentBreak(event: any, state: CodexMapperState): void {
+  if (event?.type !== 'item.started') return
+  if (agentMessageItemPhase(event?.item) !== 'commentary') return
+  const lastId = lastInsertedKey(state.commentaryByItemId)
+  if (lastId) {
+    const prior = state.commentaryByItemId.get(lastId) ?? ''
+    if (prior.trim() && !prior.endsWith('\n\n')) {
+      state.commentaryByItemId.set(lastId, prior.endsWith('\n') ? `${prior}\n` : `${prior}\n\n`)
+    }
+  } else if (state.harnessCommentaryText.trim() && !state.harnessCommentaryText.endsWith('\n\n')) {
+    state.harnessCommentaryText = state.harnessCommentaryText.endsWith('\n')
+      ? `${state.harnessCommentaryText}\n`
+      : `${state.harnessCommentaryText}\n\n`
+  } else {
+    return
+  }
+  recomposeBuffers(state)
+}
+
+function lastInsertedKey<K>(map: Map<K, unknown>): K | undefined {
+  let last: K | undefined
+  for (const key of map.keys()) last = key
+  return last
+}
+
+function commentaryItemId(event: any): string {
+  return String(event?.itemId ?? event?.item_id ?? event?.item?.id ?? '')
+}
+
+function upsertThinkingTask(state: CodexMapperState, event: any): void {
+  const id = commentaryItemId(event)
+  if (!id) return
+  const body = String(event?.item?.text ?? state.commentaryByItemId.get(id) ?? '').trim()
+  if (!body) return
+  if (state.commentaryByItemId.get(id) !== body) {
+    state.commentaryByItemId.set(id, body)
+    recomposeBuffers(state)
+  }
+  state.taskByUseId.set(`thinking-${id}`, {
+    id: `thinking-${id}`,
+    title: 'Thinking',
+    status: 'complete',
+    details: [section([text(body)])],
+    output: []
+  })
+}
+
+function completeThinkingTasks(state: CodexMapperState): void {
+  for (const [id, body] of state.commentaryByItemId) {
+    upsertThinkingTask(state, { item: { id, text: body } })
+  }
+}
+
+function eventCarriesAgentMessageText(event: any): boolean {
+  if (event?.type === 'item.agentMessage.delta') return Boolean(extractDeltaText(event))
+  if (event?.type === 'assistant') return Boolean(assistantTextFromAssistantEvent(event))
+  if (event?.type === 'item.completed') {
+    const itemType = event?.item?.type
+    if (itemType !== 'agentMessage' && itemType !== 'agent_message') return false
+    return Boolean(String(event?.item?.text ?? ''))
+  }
+  return false
+}
+
+function recomposeBuffers(state: CodexMapperState): void {
+  state.answerText = compose(state.answerByItemId, state.harnessAnswerText)
+  state.commentaryText = compose(state.commentaryByItemId, state.harnessCommentaryText)
+}
+
+function compose(byItemId: Map<string, string>, trailing: string): string {
+  let out = ''
+  for (const value of byItemId.values()) out += value
+  return trailing ? out + trailing : out
+}
+
+function extractDeltaText(event: any): string {
+  const delta = event?.delta ?? event?.text ?? event?.content ?? ''
+  if (delta && typeof delta === 'object') return String(delta.text ?? delta.content ?? '')
+  return String(delta)
+}
+
+function assistantTextFromAssistantEvent(event: any): string {
+  return content(event)
+    .map(part => (part?.type === 'text' ? (part.text ?? '') : ''))
+    .filter(Boolean)
+    .join('')
+}
+
+function assistantEventLooksCanonical(event: any): boolean {
+  const message = event?.message
+  return Boolean(
+    event?.uuid ||
+      event?.request_id ||
+      event?.session_id ||
+      message?.id ||
+      message?.model ||
+      message?.usage
+  )
+}
+
+function textHash(value: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+function reasoningText(event: any): string {
+  if (event?.type !== 'reasoning') return ''
+  return String(event.text ?? event.thinking ?? '')
+}
+
+function terminalResultText(event: any): string {
+  for (const key of ['result', 'result_text', 'text', 'final_text']) {
+    const value = event?.[key]
+    if (typeof value !== 'string') continue
+    const resultText = value.trim()
+    if (resultText) return resultText
+  }
+  return ''
+}
+
+function toolUses(event: any): any[] {
+  if (event?.type !== 'assistant') return []
+  return content(event).filter(part => part?.type === 'tool_use')
+}
+
+function toolResults(event: any): any[] {
+  if (event?.type !== 'user' && event?.type !== 'tool') return []
+  const direct = Array.isArray(event?.content) ? event.content : []
+  return direct.filter((part: any) => part?.type === 'tool_result' || part?.tool_use_id)
+}
+
+function commandExecution(event: any): Record<string, any> | null {
+  if (event?.type === 'command_execution') return event
+  if (
+    event?.type !== 'item.started' &&
+    event?.type !== 'item.updated' &&
+    event?.type !== 'item.completed'
+  )
+    return null
+  const item = event.item
+  if (!item || (item.type !== 'commandExecution' && item.type !== 'command_execution')) return null
+  return item
+}
+
+function fileChangeEvent(event: any): Record<string, any> | null {
+  if (event?.type === 'file_change') return event
+  if (
+    event?.type !== 'item.started' &&
+    event?.type !== 'item.updated' &&
+    event?.type !== 'item.completed'
+  )
+    return null
+  const item = event.item
+  if (!item || (item.type !== 'fileChange' && item.type !== 'file_change')) return null
+  return item
+}
+
+function structuredPlanUpdate(event: any): Array<{ step: string; status?: string }> | null {
+  if (event?.type !== 'turn.plan.updated') return null
+  return Array.isArray(event.plan) ? event.plan : null
+}
+
+function planTextUpdate(event: any): string {
+  if (event?.type === 'item.plan.delta') {
+    return String(event.delta ?? event.text ?? '')
+  }
+  if (event?.type === 'item.completed' && event?.item?.type === 'plan') {
+    return String(event.item.text ?? '')
+  }
+  return ''
+}
+
+function threadTitleUpdate(event: any): string {
+  const eventType = String(event?.type ?? '')
+  if (
+    eventType !== 'thread/name/updated' &&
+    eventType !== 'thread.name.updated' &&
+    eventType !== 'thread.name_updated'
+  ) {
+    return ''
+  }
+  return String(event?.name ?? event?.title ?? event?.thread?.name ?? '').trim()
+}
+
+function parsePlanText(value: string): Array<{ step: string; status: RendererTaskStatus }> {
+  return value
+    .split('\n')
+    .map(line => {
+      const trimmed = line.trim()
+      if (!/^[-*]\s+|\d+[.)]\s+/.test(trimmed)) return null
+      return {
+        step: trimmed,
+        status: /\[[xX]\]/.test(trimmed) ? ('complete' as const) : ('pending' as const)
+      }
+    })
+    .filter(item => item !== null)
+}
+
+function planStatus(value: string | undefined): RendererTaskStatus {
+  const status = String(value ?? '').toLowerCase()
+  if (status === 'inprogress' || status === 'in_progress' || status === 'running')
+    return 'in_progress'
+  if (status === 'completed' || status === 'complete' || status === 'done') return 'complete'
+  if (status === 'failed' || status === 'error') return 'complete'
+  return 'pending'
+}
+
+function stripPlanMarker(value: string): string {
+  return value
+    .replace(/^\s*(?:[-*]|\d+[.)])\s+/, '')
+    .replace(/^\[[ xX]\]\s+/, '')
+    .trim()
+}
+
+function setPlanTask(
+  state: CodexMapperState,
+  index: number,
+  step: string,
+  status: RendererTaskStatus
+): void {
+  const title = oneLine(stripPlanMarker(step), limits.stream.planTitleChars)
+  if (!title) return
+  state.taskByUseId.set(`plan-${index + 1}`, {
+    id: `plan-${index + 1}`,
+    title,
+    status,
+    details: [],
+    output: []
+  })
+}
+
+function completeOpenTasks(state: CodexMapperState): void {
+  for (const [id, task] of state.taskByUseId) {
+    if (task.status !== 'in_progress' && task.status !== 'pending') continue
+    state.taskByUseId.set(id, { ...task, status: 'complete' })
+  }
+}
+
+function changedActivityTaskUpdates(
+  state: CodexMapperState,
+  tasks: HarnessTask[],
+  opts: { final?: boolean } = {}
+): Array<{
+  id: string
+  title: string
+  status: RendererTaskStatus
+  details?: RendererTaskBlock[]
+  output?: RendererTaskBlock[]
+}> {
+  const updates: Array<{
+    id: string
+    title: string
+    status: RendererTaskStatus
+    details?: RendererTaskBlock[]
+    output?: RendererTaskBlock[]
+  }> = []
+  for (const task of tasks) {
+    let details: RendererTaskBlock[] | undefined
+    let output: RendererTaskBlock[] | undefined
+    if (opts.final) {
+      if (task.details.length && !state.emittedActivityRunByTaskId.has(task.id)) {
+        state.emittedActivityRunByTaskId.add(task.id)
+        details = activityRunBlock(task)
+      }
+      if (task.output.length && !state.emittedActivityOutputByTaskId.has(task.id)) {
+        state.emittedActivityOutputByTaskId.add(task.id)
+        output = activityOutputBlock(task)
+      }
+    } else if (task.details.length && !state.emittedActivityRunByTaskId.has(task.id)) {
+      state.emittedActivityRunByTaskId.add(task.id)
+      details = activityRunBlock(task)
+    }
+    if (
+      !opts.final &&
+      task.status === 'complete' &&
+      task.output.length &&
+      !state.emittedActivityOutputByTaskId.has(task.id)
+    ) {
+      state.emittedActivityOutputByTaskId.add(task.id)
+      output = activityOutputBlock(task)
+    }
+    if (!details && !output && !opts.final) continue
+    updates.push({
+      id: task.id,
+      title: task.title,
+      status: task.status,
+      details,
+      output
+    })
+  }
+  return updates
+}
+
+function activityRunBlock(task: HarnessTask): RendererTaskBlock[] {
+  if (task.title === 'Thinking' && task.details.length) {
+    return task.details
+  }
+  const command = firstPreformattedBody(task.details)
+  if (command) {
+    return [pre(command, shellLanguage(firstPreformattedLanguage(task.details)))]
+  }
+  return task.details
+}
+
+function activityOutputBlock(task: HarnessTask): RendererTaskBlock[] {
+  return [pre(elementsToPlainText(task.output), firstPreformattedLanguage(task.output) ?? 'text')]
+}
+
+function firstPreformattedBody(elements: RendererTaskBlock[]): string {
+  return elements.find(element => element.type === 'code')?.text ?? ''
+}
+
+function firstPreformattedLanguage(elements: RendererTaskBlock[]): string | undefined {
+  return elements.find(element => element.type === 'code')?.language
+}
+
+function shellLanguage(language: string | undefined): string {
+  return language === 'bash' || !language ? 'sh' : language
+}
+
+function shellLanguageForCommand(_command: string): string {
+  return 'sh'
+}
+
+function commandOutputDelta(event: any): { id: string; delta: string } | null {
+  if (event?.type !== 'item.commandExecution.outputDelta') return null
+  const id = String(event.itemId ?? event.item_id ?? '')
+  const delta = String(event.delta ?? '')
+  return id && delta ? { id, delta } : null
+}
+
+function commandId(item: any): string {
+  return String(item.id ?? item.itemId ?? item.command_id ?? item.command ?? 'command')
+}
+
+function fileChangeId(item: any): string {
+  return String(item.id ?? item.itemId ?? item.path ?? 'file-change')
+}
+
+function commandNumber(state: CodexMapperState, existing?: HarnessTask): number {
+  if (existing?.commandIndex !== undefined) return existing.commandIndex
+  state.nextCommandIndex += 1
+  return state.nextCommandIndex
+}
+
+function commandTask(
+  item: any,
+  eventType: string,
+  existing?: HarnessTask,
+  accumulatedOutput?: string,
+  commandIndex?: number
+): HarnessTask {
+  const id = commandId(item)
+  const rawCommand = String(item.command ?? 'Command')
+  const displayCommand =
+    rawCommand === 'Command' ? rawCommand : oneLine(unwrapShellCommand(rawCommand), 220)
+  const status = commandStatus(item, eventType)
+  const exitCode = item.exitCode ?? item.exit_code
+  const failed = isCommandFailure(item, eventType)
+  const isCompletionUpdate =
+    eventType === 'item.completed' || status === 'complete' || status === 'error'
+  const output = commandOutputElements(accumulatedOutput ?? '', exitCode)
+  return {
+    id,
+    title: commandExecutionTitle(commandIndex),
+    status,
+    ...(commandIndex !== undefined ? { commandIndex } : {}),
+    details:
+      isCompletionUpdate && existing && !failed
+        ? []
+        : [pre(displayCommand, shellLanguageForCommand(displayCommand))],
+    output
+  }
+}
+
+function commandAggregatedOutput(item: any): string {
+  for (const key of ['aggregated_output', 'aggregatedOutput', 'output', 'stdout', 'stderr']) {
+    const value = item?.[key]
+    if (typeof value === 'string' && value) return value
+  }
+  return ''
+}
+
+function commandOutputElements(output: string, exitCode?: number | null): RendererTaskBlock[] {
+  const elements: RendererTaskBlock[] = []
+  const normalizedOutput =
+    exitCode !== null && exitCode !== undefined && exitCode !== 0
+      ? `exit code ${exitCode}${output ? `\n${output}` : ''}`
+      : output
+  if (normalizedOutput) {
+    const formatted = formatCommandOutput(normalizedOutput)
+    elements.push(pre(formatted.body, formatted.language))
+  }
+  return elements
+}
+
+function formatCommandOutput(output: string): { body: string; language: string } {
+  const trimmed = output.trim()
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      const pretty = JSON.stringify(JSON.parse(trimmed), null, 2)
+      return {
+        body: clipLines(pretty, limits.finalPlan.taskOutputCodeBlockLines),
+        language: 'json'
+      }
+    } catch {}
+  }
+  return {
+    body: clipLines(output, limits.finalPlan.taskOutputCodeBlockLines),
+    language: languageFromContent(output)
+  }
+}
+
+function fileChangeTask(item: any, eventType: string, existing?: HarnessTask): HarnessTask {
+  const id = fileChangeId(item)
+  const changes = Array.isArray(item.changes) ? item.changes : []
+  const paths = changes.map((change: any) => String(change.path ?? '')).filter(Boolean)
+  const uniquePaths: string[] = Array.from(new Set(paths))
+  const diff = changes
+    .map((change: any) => String(change.diff ?? change.unified_diff ?? '').trim())
+    .filter(Boolean)
+    .join('\n\n')
+  return {
+    id,
+    title:
+      uniquePaths.length === 1
+        ? `Edit ${uniquePaths[0]}`
+        : uniquePaths.length > 1
+          ? `Edit ${uniquePaths.length} files`
+          : 'Apply file changes',
+    status: itemStatus(item, eventType),
+    details: uniquePaths.length
+      ? [section([text('Files: '), text(uniquePaths.join(', '), { code: true })])]
+      : (existing?.details ?? []),
+    output: diff ? [pre(clip(diff), 'diff')] : (existing?.output ?? [])
+  }
+}
+
+function mergeTask(existing: HarnessTask | undefined, update: HarnessTask): HarnessTask {
+  return {
+    ...update,
+    details: update.details.length ? update.details : (existing?.details ?? []),
+    output: update.output.length ? update.output : (existing?.output ?? [])
+  }
+}
+
+function commandStatus(item: any, eventType: string): RendererTaskStatus {
+  if (isCommandFailure(item, eventType)) return 'complete'
+  return itemStatus(item, eventType, item.exitCode ?? item.exit_code)
+}
+
+function isCommandFailure(item: any, eventType: string): boolean {
+  const status = String(item.status ?? '').toLowerCase()
+  const exitCode = item.exitCode ?? item.exit_code
+  return (
+    status === 'failed' ||
+    (eventType === 'item.completed' &&
+      exitCode !== 0 &&
+      exitCode !== null &&
+      exitCode !== undefined)
+  )
+}
+
+function itemStatus(item: any, eventType: string, _exitCode?: number | null): RendererTaskStatus {
+  const status = String(item.status ?? '').toLowerCase()
+  if (status === 'failed' || status === 'declined') return 'complete'
+  if (status === 'completed' || eventType === 'item.completed') {
+    return 'complete'
+  }
+  return 'in_progress'
+}
+
+function titleFor(tool: any): string {
+  if (tool.name === 'create_file') return 'Create file'
+  if (tool.name === 'edit_file') return 'Edit file'
+  return `Use ${tool.name ?? 'tool'}`
+}
+
+function detailElementsForTool(tool: any): RendererTaskBlock[] {
+  if (tool.name === 'Bash') {
+    const command = oneLine(unwrapShellCommand(bashCommand(tool.input)), 220)
+    return [pre(command, shellLanguageForCommand(command))]
+  }
+  if (tool.name === 'create_file') {
+    const path = stringInput(tool.input, 'path', 'file')
+    return [
+      section([text('Created '), text(path, { code: true })]),
+      pre(stringInput(tool.input, 'content'), languageFromPath(path))
+    ]
+  }
+  if (tool.name === 'edit_file') {
+    const path = stringInput(tool.input, 'path', 'file')
+    const newStr = stringInput(tool.input, 'new_str')
+    const diff = stringInput(tool.input, 'diff')
+    const fileContent = stringInput(tool.input, 'content')
+    if (newStr)
+      return [
+        section([text('Edited '), text(path, { code: true })]),
+        pre(newStr, languageFromPath(path))
+      ]
+    if (diff)
+      return [section([text('Edited '), text(path, { code: true })]), pre(stripFence(diff), 'diff')]
+    if (fileContent)
+      return [
+        section([text('Edited '), text(path, { code: true })]),
+        pre(fileContent, languageFromPath(path))
+      ]
+    return [section([text('Edited '), text(path, { code: true })])]
+  }
+  if (tool.name === 'Read') {
+    return [
+      section([
+        text('Read '),
+        text(stringInput(tool.input, 'file_path', stringInput(tool.input, 'path', 'file')), {
+          code: true
+        })
+      ])
+    ]
+  }
+  return [pre(JSON.stringify(tool.input ?? {}, null, 2), 'json')]
+}
+
+function outputElementsForResult(result: any): RendererTaskBlock[] {
+  let raw = result.content ?? ''
+  if (Array.isArray(raw))
+    raw = raw
+      .map((part: any) => (typeof part === 'string' ? part : (part?.text ?? JSON.stringify(part))))
+      .join('\n')
+  raw = String(raw ?? '')
+  try {
+    const parsed = JSON.parse(raw) as any
+    if (typeof parsed.diff === 'string') return [pre(stripFence(parsed.diff), 'diff')]
+    if (parsed.output !== undefined)
+      raw =
+        typeof parsed.output === 'string' && parsed.output
+          ? parsed.output
+          : `exitCode ${parsed.exitCode}`
+  } catch {}
+  const formatted = formatCommandOutput(raw)
+  if (formatted.body.includes('\n') || result.is_error) {
+    return [pre(formatted.body, formatted.language)]
+  }
+  return [section([text(oneLine(raw || 'Done'))])]
+}
+
+function stripFence(value: string): string {
+  return value
+    .trim()
+    .replace(/^```[a-zA-Z0-9_-]*\n?/, '')
+    .replace(/\n?```$/, '')
+}
+
+function bashCommand(input: any): string {
+  return stringInput(input, 'command', stringInput(input, 'cmd'))
+}
+
+function stringInput(input: any, key: string, fallback = ''): string {
+  const value = input?.[key]
+  return typeof value === 'string' ? value : fallback
+}
+
+function languageFromPath(path: string): string {
+  const name = path.split('/').pop() ?? ''
+  const extension = name.includes('.') ? name.split('.').pop() : ''
+  return extension?.toLowerCase() || 'text'
+}
+
+function languageFromContent(value: string): string {
+  const trimmed = value.trim()
+  if (
+    /^(export\s+)?(async\s+)?function\s|^type\s+\w+\s*=|^interface\s+\w+|^const\s+\w+\s*[:=]/m.test(
+      trimmed
+    )
+  )
+    return 'ts'
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json'
+  return 'text'
+}
+
+function clip(value: string, max: number = limits.finalPlan.outputPreviewChars): string {
+  return value.length > max ? `${value.slice(0, max)}\n/* truncated */` : value
+}
+
+function clipLines(value: string, maxLines: number): string {
+  if (maxLines <= 0) return ''
+  const lines = value.split('\n')
+  if (lines.length <= maxLines) return value
+  if (maxLines === 1) return '// truncated'
+  return [...lines.slice(0, maxLines - 1), '// truncated'].join('\n')
+}
+
+function oneLine(value: string, max: number = limits.finalPlan.taskTitleChars): string {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  return normalized.length > max ? `${normalized.slice(0, max - 3)}...` : normalized
+}
+
+function unwrapShellCommand(command: string): string {
+  const trimmed = command.trim()
+  if (!trimmed) return trimmed
+
+  const bashLc = /^\/bin\/bash\s+-lc\s+([\s\S]+)$/i.exec(trimmed)
+  if (!bashLc?.[1]) return trimmed
+
+  let inner = bashLc[1].trim()
+  if (
+    (inner.startsWith("'") && inner.endsWith("'")) ||
+    (inner.startsWith('"') && inner.endsWith('"'))
+  ) {
+    inner = inner.slice(1, -1)
+  }
+  return inner.trim() || trimmed
+}
+
+function commandExecutionTitle(index?: number): string {
+  return index !== undefined ? `${index}. ${COMMAND_EXECUTION_TITLE}` : COMMAND_EXECUTION_TITLE
+}

--- a/packages/rendering/src/index.ts
+++ b/packages/rendering/src/index.ts
@@ -1,0 +1,28 @@
+export {
+  CodexAppServerRendererEventMapper,
+  codexAppServerToRendererEvents,
+  isTerminalCodexAppServerEvent,
+  rustSessionEventToServerNotification
+} from './codex-app-server'
+export { ChatSDKRenderer } from './chat-sdk'
+export type { RendererInterface, RendererSession } from './interface'
+export { rendererEventTypes } from './schema'
+export type { RendererEventType, RendererSessionOpenInput } from './schema'
+export type {
+  ChatSDKOutput,
+  ChatSDKPostableMessage,
+  ChatSDKStreamAppend,
+  ChatSDKStreamChunk,
+  ChatSDKMessageUpsert,
+  ChatSDKSessionClosed
+} from './chat-sdk'
+export type {
+  RendererEvent,
+  RendererLogInfo,
+  RendererSourceMapper,
+  RendererTask,
+  RendererTaskBlock,
+  RendererTaskBody,
+  RendererTaskStatus,
+  RendererTaskUpdate
+} from './types'

--- a/packages/rendering/src/interface.ts
+++ b/packages/rendering/src/interface.ts
@@ -1,0 +1,11 @@
+import type { RendererEvent, RendererSessionOpenInput } from './types'
+
+export type RendererSession = {
+  sessionId: string
+}
+
+export interface RendererInterface<TOutput = unknown> {
+  open(input: RendererSessionOpenInput): TOutput[] | Promise<TOutput[]>
+  render(sessionId: string, event: RendererEvent): TOutput[] | Promise<TOutput[]>
+  close(sessionId: string, event?: Extract<RendererEvent, { type: 'renderer.done' }>): TOutput[] | Promise<TOutput[]>
+}

--- a/packages/rendering/src/rich-text.ts
+++ b/packages/rendering/src/rich-text.ts
@@ -1,0 +1,38 @@
+import type { RendererTaskBlock } from './types'
+
+type InlineText = {
+  type: 'text'
+  text: string
+  style?: { bold?: boolean; italic?: boolean; strike?: boolean; code?: boolean }
+}
+
+export function section(elements: InlineText[]): RendererTaskBlock {
+  return { type: 'text', text: elements.map(element => element.text).join('') }
+}
+
+export function preformatted(text: string, language?: string): RendererTaskBlock {
+  return {
+    type: 'code',
+    text: clip(text, 12_000),
+    ...(language ? { language } : {}),
+  }
+}
+
+export function text(text: string, style?: InlineText['style']): InlineText {
+  return { type: 'text', text, ...(style ? { style } : {}) }
+}
+
+export function elementsToPlainText(elements: RendererTaskBlock[]): string {
+  return elements.map(elementToPlainText).filter(Boolean).join('\n')
+}
+
+function elementToPlainText(element: RendererTaskBlock): string {
+  if (element.type === 'code') {
+    return element.text
+  }
+  return element.text
+}
+
+function clip(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}...` : value
+}

--- a/packages/rendering/src/schema.ts
+++ b/packages/rendering/src/schema.ts
@@ -1,0 +1,21 @@
+export type {
+  RendererEvent,
+  RendererSessionOpenInput,
+  RendererTask,
+  RendererTaskBlock,
+  RendererTaskBody,
+  RendererTaskStatus,
+  RendererTaskUpdate
+} from './types'
+
+export const rendererEventTypes = [
+  'renderer.session.open',
+  'renderer.status',
+  'renderer.message.delta',
+  'renderer.message.snapshot',
+  'renderer.task.update',
+  'renderer.title.update',
+  'renderer.done'
+] as const
+
+export type RendererEventType = (typeof rendererEventTypes)[number]

--- a/packages/rendering/src/types.ts
+++ b/packages/rendering/src/types.ts
@@ -1,0 +1,66 @@
+export type RendererTaskStatus = 'pending' | 'in_progress' | 'complete' | 'error'
+
+export type RendererTaskBlock =
+  | { type: 'text'; text: string }
+  | { type: 'code'; text: string; language?: string }
+
+export type RendererTaskBody = RendererTaskBlock[]
+
+export type RendererTask = {
+  id: string
+  title: string
+  status: RendererTaskStatus
+  details?: RendererTaskBody
+  output?: RendererTaskBody
+}
+
+export type RendererTaskUpdate = RendererTask
+
+export type RendererSessionOpenInput = {
+  title?: string
+  target?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+}
+
+export type RendererEvent =
+  | {
+      type: 'renderer.session.open'
+      input?: RendererSessionOpenInput
+    }
+  | {
+      type: 'renderer.status'
+      status: string
+    }
+  | {
+      type: 'renderer.message.delta'
+      delta: string
+      force?: boolean
+      planPrefix?: boolean
+    }
+  | {
+      type: 'renderer.message.snapshot'
+      markdown: string
+    }
+  | {
+      type: 'renderer.task.update'
+      task: RendererTaskUpdate
+      flush?: boolean
+    }
+  | {
+      type: 'renderer.title.update'
+      title: string
+    }
+  | {
+      type: 'renderer.done'
+      answerMarkdown?: string
+      error?: string
+      streamFinalUpdates?: boolean
+      threadId?: string
+    }
+
+export interface RendererSourceMapper<TSource> {
+  process(source: TSource): RendererEvent[]
+  flush(): RendererEvent[]
+}
+
+export type RendererLogInfo = (event: string, fields: Record<string, unknown>) => void

--- a/packages/rendering/tsconfig.json
+++ b/packages/rendering/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "src",
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "target": "ESNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "types": ["bun", "node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,12 +29,34 @@ importers:
 
   packages/harness-events:
     devDependencies:
+      '@types/node':
+        specifier: ^25.7.0
+        version: 25.9.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+  packages/rendering:
+    dependencies:
+      '@centaur/harness-events':
+        specifier: workspace:*
+        version: link:../harness-events
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.13
+        version: 1.3.14
+      '@types/node':
+        specifier: ^25.7.0
+        version: 25.9.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
 
   services/slackbot:
     dependencies:
+      '@centaur/rendering':
+        specifier: workspace:*
+        version: link:../../packages/rendering
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -53,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -231,6 +231,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,7 +345,9 @@ dependencies = [
  "anyhow",
  "centaur-session-core",
  "clap",
+ "crossterm",
  "futures-util",
+ "ratatui",
  "reqwest",
  "serde_json",
  "tokio",
@@ -438,6 +455,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +537,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -662,7 +718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1185,6 +1241,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1273,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1452,6 +1539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,6 +1564,15 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1522,6 +1624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1532,7 +1635,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1642,6 +1745,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1945,6 +2054,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2231,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,7 +2299,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2414,6 +2557,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,7 +2635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2694,6 +2858,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +2879,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -3093,6 +3285,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,13 +3606,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -12,6 +12,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,6 +32,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -41,10 +62,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -54,6 +84,18 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -134,10 +176,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "centaur-session-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "centaur-session-sqlx"
+version = "0.1.0"
+dependencies = [
+ "centaur-session-core",
+ "serde_json",
+ "sqlx",
+ "thiserror",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
@@ -163,6 +242,36 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -215,6 +324,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,8 +372,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dyn-clone"
@@ -256,6 +405,9 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -274,10 +426,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -317,6 +508,28 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
 
 [[package]]
 name = "futures-io"
@@ -381,8 +594,32 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -390,6 +627,54 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -501,10 +786,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -513,7 +907,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -544,6 +940,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -652,16 +1060,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.8.0",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -687,12 +1163,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -717,6 +1236,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +1272,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -782,6 +1339,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,12 +1387,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -830,13 +1445,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -846,7 +1488,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -856,6 +1507,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -922,6 +1591,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1711,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrecy"
@@ -1120,6 +1821,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1884,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1904,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1190,6 +1916,236 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "time",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "time",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -1222,6 +2178,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +2207,62 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1275,6 +2298,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1400,7 +2434,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "sha1",
  "thiserror",
  "utf-8",
@@ -1419,10 +2453,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1437,10 +2498,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1469,7 +2566,129 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -1480,11 +2699,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1498,19 +2726,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1520,9 +2769,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1538,9 +2799,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1550,9 +2823,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1562,9 +2847,126 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1587,10 +2989,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -18,6 +18,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +104,28 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -165,6 +237,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -250,6 +324,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "centaur-session-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "centaur-session-core",
+ "clap",
+ "futures-util",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
 name = "centaur-session-core"
 version = "0.1.0"
 dependencies = [
@@ -276,6 +365,77 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -469,6 +629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +718,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -668,8 +840,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -679,9 +853,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -864,13 +1040,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1006,6 +1185,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1224,65 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1223,6 +1473,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1592,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -1547,6 +1809,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +2012,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +2086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +2106,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1769,8 +2134,36 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1778,6 +2171,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1794,6 +2188,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2029,6 +2432,22 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2313,6 +2732,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2509,6 +2931,7 @@ dependencies = [
  "base64",
  "bitflags",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
  "mime",
@@ -2517,6 +2940,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2699,6 +3123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +3139,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -2739,6 +3175,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2790,6 +3236,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2847,6 +3303,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,6 +3325,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2887,6 +3385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,6 +3415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2943,11 +3459,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2963,6 +3496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,6 +3512,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2987,10 +3532,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3005,6 +3562,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3578,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3029,6 +3598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,6 +3614,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -56,6 +56,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +166,28 @@ checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "centaur-api-server"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "bytes",
+ "centaur-sandbox-agent-k8s",
+ "centaur-sandbox-core",
+ "centaur-sandbox-local",
+ "centaur-session-core",
+ "centaur-session-sqlx",
+ "futures-util",
+ "kube",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -538,6 +612,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +643,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -716,6 +802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +820,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1130,6 +1223,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1267,15 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1821,6 +1938,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +1993,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2209,6 +2346,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2561,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2532,6 +2721,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "crates/centaur-sandbox-agent-k8s",
     "crates/centaur-sandbox-local",
     "crates/centaur-sandbox-manager",
+    "crates/centaur-session-core",
+    "crates/centaur-session-sqlx",
 ]
 resolver = "3"
 
@@ -20,9 +22,14 @@ centaur-sandbox-core = { path = "crates/centaur-sandbox-core" }
 centaur-sandbox-agent-k8s = { path = "crates/centaur-sandbox-agent-k8s" }
 centaur-sandbox-local = { path = "crates/centaur-sandbox-local" }
 centaur-sandbox-manager = { path = "crates/centaur-sandbox-manager" }
+centaur-session-core = { path = "crates/centaur-session-core" }
+centaur-session-sqlx = { path = "crates/centaur-session-sqlx" }
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
 thiserror = "2"
+time = { version = "0.3", features = ["serde"] }
 tokio = "1"
+uuid = { version = "1", features = ["serde", "v4"] }

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/centaur-sandbox-agent-k8s",
     "crates/centaur-sandbox-local",
     "crates/centaur-sandbox-manager",
+    "crates/centaur-session-cli",
     "crates/centaur-session-core",
     "crates/centaur-session-sqlx",
 ]
@@ -17,6 +18,7 @@ license = "MIT"
 repository = "https://github.com/paradigmxyz/centaur"
 
 [workspace.dependencies]
+anyhow = "1"
 async-trait = "0.1"
 axum = "0.8.9"
 bytes = { version = "1", features = ["serde"] }
@@ -26,15 +28,18 @@ centaur-sandbox-local = { path = "crates/centaur-sandbox-local" }
 centaur-sandbox-manager = { path = "crates/centaur-sandbox-manager" }
 centaur-session-core = { path = "crates/centaur-session-core" }
 centaur-session-sqlx = { path = "crates/centaur-session-sqlx" }
+clap = "4.6.1"
 futures-util = "0.3"
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
 sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
 thiserror = "2"
 time = { version = "0.3", features = ["serde"] }
 tokio = "1"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+urlencoding = "2"
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/centaur-api-server",
     "crates/centaur-sandbox-core",
     "crates/centaur-sandbox-e2e",
     "crates/centaur-sandbox-agent-k8s",
@@ -17,6 +18,7 @@ repository = "https://github.com/paradigmxyz/centaur"
 
 [workspace.dependencies]
 async-trait = "0.1"
+axum = "0.8.9"
 bytes = { version = "1", features = ["serde"] }
 centaur-sandbox-core = { path = "crates/centaur-sandbox-core" }
 centaur-sandbox-agent-k8s = { path = "crates/centaur-sandbox-agent-k8s" }
@@ -24,6 +26,7 @@ centaur-sandbox-local = { path = "crates/centaur-sandbox-local" }
 centaur-sandbox-manager = { path = "crates/centaur-sandbox-manager" }
 centaur-session-core = { path = "crates/centaur-session-core" }
 centaur-session-sqlx = { path = "crates/centaur-session-sqlx" }
+futures-util = "0.3"
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }
@@ -32,4 +35,6 @@ sqlx = { version = "0.8.6", default-features = false, features = ["derive", "jso
 thiserror = "2"
 time = { version = "0.3", features = ["serde"] }
 tokio = "1"
+tracing = "0.1"
+tracing-subscriber = "0.3"
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -29,12 +29,14 @@ centaur-sandbox-manager = { path = "crates/centaur-sandbox-manager" }
 centaur-session-core = { path = "crates/centaur-session-core" }
 centaur-session-sqlx = { path = "crates/centaur-session-sqlx" }
 clap = "4.6.1"
+crossterm = "0.28"
 futures-util = "0.3"
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
+ratatui = "0.29"
 sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
 thiserror = "2"
 time = { version = "0.3", features = ["serde"] }

--- a/services/api-rs/crates/centaur-api-server/Cargo.toml
+++ b/services/api-rs/crates/centaur-api-server/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "centaur-api-server"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+axum.workspace = true
+bytes.workspace = true
+centaur-sandbox-agent-k8s.workspace = true
+centaur-sandbox-core.workspace = true
+centaur-sandbox-local.workspace = true
+centaur-session-core.workspace = true
+centaur-session-sqlx.workspace = true
+futures-util.workspace = true
+kube.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json"] }

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -1,4 +1,9 @@
-use std::{collections::VecDeque, convert::Infallible, sync::Arc, time::Duration};
+use std::{
+    collections::{HashSet, VecDeque},
+    convert::Infallible,
+    sync::Arc,
+    time::Duration,
+};
 
 use axum::{
     Json, Router,
@@ -23,16 +28,19 @@ use futures_util::stream;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use thiserror::Error;
-use tokio::time::{Instant, sleep};
+use tokio::{sync::Mutex, time::sleep};
+use tracing::warn;
 
 const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 const DEFAULT_IDLE_TIMEOUT_MS: u64 = 1_000;
 const DEFAULT_MAX_DURATION_MS: u64 = 60_000;
+type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
 
 #[derive(Clone)]
 pub struct AppState {
     store: PgSessionStore,
     sandbox_runtime: SandboxRuntime,
+    stdout_pumps: Arc<Mutex<HashSet<String>>>,
 }
 
 pub fn build_router(store: PgSessionStore) -> Router {
@@ -43,6 +51,7 @@ pub fn build_router_with_runtime(store: PgSessionStore, sandbox_runtime: Sandbox
     let state = AppState {
         store,
         sandbox_runtime,
+        stdout_pumps: Arc::new(Mutex::new(HashSet::new())),
     };
     Router::new()
         .route("/healthz", get(healthz))
@@ -58,13 +67,24 @@ pub enum SandboxRuntime {
     Mock,
     Backend {
         backend: Arc<dyn SandboxBackend>,
-        spec: SandboxSpec,
+        spec_factory: SandboxSpecFactory,
     },
 }
 
 impl SandboxRuntime {
     pub fn backend(backend: Arc<dyn SandboxBackend>, spec: SandboxSpec) -> Self {
-        Self::Backend { backend, spec }
+        let spec_factory = move |_thread_key: &ThreadKey, _execution_id: &str| spec.clone();
+        Self::backend_with_spec_factory(backend, spec_factory)
+    }
+
+    pub fn backend_with_spec_factory<F>(backend: Arc<dyn SandboxBackend>, spec_factory: F) -> Self
+    where
+        F: Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync + 'static,
+    {
+        Self::Backend {
+            backend,
+            spec_factory: Arc::new(spec_factory),
+        }
     }
 }
 
@@ -148,17 +168,31 @@ async fn execute_session(
         )
         .await?;
 
-    let output_line_count = match run_session_pipe(
-        &state.store,
-        &state.sandbox_runtime,
-        &thread_key,
-        &execution.execution_id,
-        &sandbox_id,
-        &request.input_lines,
-        pipe_options,
-    )
-    .await
-    {
+    let run_result = match &state.sandbox_runtime {
+        SandboxRuntime::Mock => {
+            run_mock_session_pipe(
+                &state.store,
+                &thread_key,
+                &execution.execution_id,
+                &sandbox_id,
+                pipe_options,
+            )
+            .await
+        }
+        SandboxRuntime::Backend { backend, .. } => {
+            match ensure_stdout_pump(&state, &thread_key, &sandbox_id).await {
+                Ok(()) => write_input_lines(
+                    backend.as_ref(),
+                    &SandboxId::new(&sandbox_id),
+                    &request.input_lines,
+                )
+                .await
+                .map(|()| 0),
+                Err(error) => Err(error),
+            }
+        }
+    };
+    let output_line_count = match run_result {
         Ok(output_line_count) => output_line_count,
         Err(error) => {
             let error_message = error.to_string();
@@ -193,6 +227,7 @@ async fn execute_session(
                 "execution_id": execution.execution_id,
                 "thread_key": thread_key.as_str(),
                 "output_line_count": output_line_count,
+                "completion_reason": "input_accepted",
             }),
         )
         .await?;
@@ -227,7 +262,10 @@ async fn ensure_session_sandbox(
                 .await?;
             Ok(sandbox_id)
         }
-        SandboxRuntime::Backend { backend, spec } => {
+        SandboxRuntime::Backend {
+            backend,
+            spec_factory,
+        } => {
             if let Some(sandbox_id) = existing_sandbox_id {
                 let id = SandboxId::new(sandbox_id);
                 match backend.status(&id).await {
@@ -239,10 +277,8 @@ async fn ensure_session_sandbox(
                 }
             }
 
-            let handle = backend
-                .create(spec.clone())
-                .await
-                .map_err(ApiError::Sandbox)?;
+            let spec = spec_factory(thread_key, execution_id);
+            let handle = backend.create(spec).await.map_err(ApiError::Sandbox)?;
             store
                 .update_sandbox_id(thread_key, Some(handle.id.as_str()))
                 .await?;
@@ -251,97 +287,135 @@ async fn ensure_session_sandbox(
     }
 }
 
-async fn run_session_pipe(
+async fn run_mock_session_pipe(
     store: &PgSessionStore,
-    runtime: &SandboxRuntime,
     thread_key: &ThreadKey,
     execution_id: &str,
     sandbox_id: &str,
-    input_lines: &[String],
     options: PipeOptions,
 ) -> Result<usize, ApiError> {
-    match runtime {
-        SandboxRuntime::Mock => {
-            let mut output_line_count = 0;
-            let output_lines = mock_app_server_output_lines(thread_key, execution_id, sandbox_id);
-            for (index, line) in output_lines.iter().enumerate() {
-                append_output_line(store, thread_key, execution_id, line).await?;
-                output_line_count += 1;
-                if index + 1 < output_lines.len() {
-                    sleep(Duration::from_millis(200)).await;
-                }
-            }
-            Ok(output_line_count)
+    let mut output_line_count = 0;
+    let output_lines = mock_app_server_output_lines(thread_key, execution_id, sandbox_id);
+    for (index, line) in output_lines.iter().enumerate() {
+        append_output_line(store, thread_key, Some(execution_id), line).await?;
+        output_line_count += 1;
+        if index + 1 < output_lines.len() {
+            sleep(Duration::from_millis(200)).await;
         }
-        SandboxRuntime::Backend { backend, .. } => {
-            let id = SandboxId::new(sandbox_id);
-            for line in input_lines {
-                write_input_line(backend.as_ref(), &id, line).await?;
+    }
+    if options.idle_timeout < Duration::from_millis(DEFAULT_IDLE_TIMEOUT_MS)
+        || options.max_duration < Duration::from_millis(DEFAULT_MAX_DURATION_MS)
+    {
+        sleep(options.idle_timeout).await;
+    }
+    Ok(output_line_count)
+}
+
+async fn ensure_stdout_pump(
+    state: &AppState,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+) -> Result<(), ApiError> {
+    let SandboxRuntime::Backend { backend, .. } = &state.sandbox_runtime else {
+        return Ok(());
+    };
+
+    let mut pumps = state.stdout_pumps.lock().await;
+    if !pumps.insert(sandbox_id.to_owned()) {
+        return Ok(());
+    }
+    drop(pumps);
+
+    let store = state.store.clone();
+    let backend = backend.clone();
+    let thread_key = thread_key.clone();
+    let sandbox_id = SandboxId::new(sandbox_id);
+    let pump_key = sandbox_id.as_str().to_owned();
+    let stdout_pumps = state.stdout_pumps.clone();
+
+    tokio::spawn(async move {
+        let result = run_stdout_pump(store.clone(), backend, thread_key.clone(), sandbox_id).await;
+        if let Err(error) = result {
+            warn!(%pump_key, %error, "session stdout pump failed");
+            let _ = store
+                .append_event(
+                    &thread_key,
+                    None,
+                    "session.stdout_pump_failed",
+                    json!({
+                        "sandbox_id": pump_key,
+                        "error": error.to_string(),
+                    }),
+                )
+                .await;
+        }
+        stdout_pumps.lock().await.remove(&pump_key);
+    });
+
+    Ok(())
+}
+
+async fn run_stdout_pump(
+    store: PgSessionStore,
+    backend: Arc<dyn SandboxBackend>,
+    thread_key: ThreadKey,
+    sandbox_id: SandboxId,
+) -> Result<(), ApiError> {
+    let mut buffer = String::new();
+    loop {
+        match backend
+            .read_bytes(
+                &sandbox_id,
+                ReadOptions {
+                    stream: OutputStream::Stdout,
+                    after_offset: None,
+                    max_bytes: 8192,
+                    timeout_ms: Some(1_000),
+                },
+            )
+            .await
+            .map_err(ApiError::Sandbox)?
+        {
+            ReadResult::Bytes { bytes, .. } => {
+                let chunk = std::str::from_utf8(&bytes).map_err(|err| {
+                    ApiError::BadRequest(format!("sandbox stdout was not UTF-8: {err}"))
+                })?;
+                buffer.push_str(chunk);
+
+                while let Some(index) = buffer.find('\n') {
+                    let line = buffer[..index].trim_end_matches('\r').to_owned();
+                    buffer.drain(..=index);
+                    append_output_line(&store, &thread_key, None, &line).await?;
+                }
             }
-
-            let mut buffer = String::new();
-            let mut output_line_count = 0;
-            let started_at = Instant::now();
-            let mut last_output_at: Option<Instant> = None;
-            let deadline = started_at + options.max_duration;
-
-            loop {
-                if Instant::now() >= deadline {
-                    output_line_count +=
-                        flush_partial_output(store, thread_key, execution_id, &mut buffer).await?;
-                    return Ok(output_line_count);
-                }
-
-                match backend
-                    .read_bytes(
-                        &id,
-                        ReadOptions {
-                            stream: OutputStream::Stdout,
-                            after_offset: None,
-                            max_bytes: 8192,
-                            timeout_ms: Some(1_000),
-                        },
+            ReadResult::TimedOut => {}
+            ReadResult::Eof => {
+                flush_partial_output(&store, &thread_key, None, &mut buffer).await?;
+                store
+                    .append_event(
+                        &thread_key,
+                        None,
+                        "session.stdout_eof",
+                        json!({
+                            "sandbox_id": sandbox_id.as_str(),
+                        }),
                     )
-                    .await
-                    .map_err(ApiError::Sandbox)?
-                {
-                    ReadResult::Bytes { bytes, .. } => {
-                        let chunk = std::str::from_utf8(&bytes).map_err(|err| {
-                            ApiError::BadRequest(format!("sandbox stdout was not UTF-8: {err}"))
-                        })?;
-                        last_output_at = Some(Instant::now());
-                        buffer.push_str(chunk);
-
-                        while let Some(index) = buffer.find('\n') {
-                            let line = buffer[..index].trim_end_matches('\r').to_owned();
-                            buffer.drain(..=index);
-                            append_output_line(store, thread_key, execution_id, &line).await?;
-                            output_line_count += 1;
-                        }
-                    }
-                    ReadResult::TimedOut => {
-                        let idle_reference = last_output_at.unwrap_or(started_at);
-                        if idle_reference.elapsed() >= options.idle_timeout
-                            && (output_line_count > 0
-                                || !buffer.is_empty()
-                                || input_lines.is_empty())
-                        {
-                            output_line_count +=
-                                flush_partial_output(store, thread_key, execution_id, &mut buffer)
-                                    .await?;
-                            return Ok(output_line_count);
-                        }
-                    }
-                    ReadResult::Eof => {
-                        output_line_count +=
-                            flush_partial_output(store, thread_key, execution_id, &mut buffer)
-                                .await?;
-                        return Ok(output_line_count);
-                    }
-                }
+                    .await?;
+                return Ok(());
             }
         }
     }
+}
+
+async fn write_input_lines(
+    backend: &dyn SandboxBackend,
+    sandbox_id: &SandboxId,
+    input_lines: &[String],
+) -> Result<(), ApiError> {
+    for line in input_lines {
+        write_input_line(backend, sandbox_id, line).await?;
+    }
+    Ok(())
 }
 
 async fn write_input_line(
@@ -362,7 +436,7 @@ async fn write_input_line(
 async fn flush_partial_output(
     store: &PgSessionStore,
     thread_key: &ThreadKey,
-    execution_id: &str,
+    execution_id: Option<&str>,
     buffer: &mut String,
 ) -> Result<usize, ApiError> {
     if buffer.is_empty() {
@@ -377,13 +451,13 @@ async fn flush_partial_output(
 async fn append_output_line(
     store: &PgSessionStore,
     thread_key: &ThreadKey,
-    execution_id: &str,
+    execution_id: Option<&str>,
     line: &str,
 ) -> Result<(), ApiError> {
     store
         .append_event(
             thread_key,
-            Some(execution_id),
+            execution_id,
             SESSION_OUTPUT_LINE_EVENT,
             Value::String(line.to_owned()),
         )
@@ -455,7 +529,10 @@ async fn stream_events(
     Query(query): Query<EventsQuery>,
 ) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, ApiError> {
     let thread_key = parse_thread_key(raw_thread_key)?;
-    state.store.get_session(&thread_key).await?;
+    let session = state.store.get_session(&thread_key).await?;
+    if let Some(sandbox_id) = session.sandbox_id.as_deref() {
+        ensure_stdout_pump(&state, &thread_key, sandbox_id).await?;
+    }
 
     let stream = stream::unfold(
         SessionEventStreamState {

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -1,0 +1,658 @@
+use std::{collections::VecDeque, convert::Infallible, sync::Arc, time::Duration};
+
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::{
+        IntoResponse, Response, Sse,
+        sse::{Event, KeepAlive},
+    },
+    routing::{get, post},
+};
+use bytes::Bytes;
+use centaur_sandbox_core::{
+    OutputStream, ReadOptions, ReadResult, SandboxBackend, SandboxError, SandboxId, SandboxSpec,
+    SandboxStatus,
+};
+use centaur_session_core::{
+    HarnessType, SessionEvent, SessionMessageInput, ThreadKey, ThreadKeyError,
+};
+use centaur_session_sqlx::{PgSessionStore, SessionStoreError, default_metadata};
+use futures_util::stream;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use thiserror::Error;
+use tokio::time::{Instant, sleep};
+
+const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
+const DEFAULT_IDLE_TIMEOUT_MS: u64 = 1_000;
+const DEFAULT_MAX_DURATION_MS: u64 = 60_000;
+
+#[derive(Clone)]
+pub struct AppState {
+    store: PgSessionStore,
+    sandbox_runtime: SandboxRuntime,
+}
+
+pub fn build_router(store: PgSessionStore) -> Router {
+    build_router_with_runtime(store, SandboxRuntime::Mock)
+}
+
+pub fn build_router_with_runtime(store: PgSessionStore, sandbox_runtime: SandboxRuntime) -> Router {
+    let state = AppState {
+        store,
+        sandbox_runtime,
+    };
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/api/session/{thread_key}", post(create_or_get_session))
+        .route("/api/session/{thread_key}/messages", post(append_messages))
+        .route("/api/session/{thread_key}/execute", post(execute_session))
+        .route("/api/session/{thread_key}/events", get(stream_events))
+        .with_state(state)
+}
+
+#[derive(Clone)]
+pub enum SandboxRuntime {
+    Mock,
+    Backend {
+        backend: Arc<dyn SandboxBackend>,
+        spec: SandboxSpec,
+    },
+}
+
+impl SandboxRuntime {
+    pub fn backend(backend: Arc<dyn SandboxBackend>, spec: SandboxSpec) -> Self {
+        Self::Backend { backend, spec }
+    }
+}
+
+async fn healthz() -> Json<Value> {
+    Json(json!({"ok": true}))
+}
+
+async fn create_or_get_session(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Json(request): Json<CreateSessionRequest>,
+) -> Result<Json<Value>, ApiError> {
+    let thread_key = parse_thread_key(raw_thread_key)?;
+    let metadata = default_metadata(request.metadata);
+    let session = state
+        .store
+        .create_or_get_session(&thread_key, &request.harness_type, metadata)
+        .await?;
+    Ok(Json(serde_json::to_value(session)?))
+}
+
+async fn append_messages(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Json(request): Json<AppendMessagesRequest>,
+) -> Result<Json<AppendMessagesResponse>, ApiError> {
+    if request.messages.is_empty() {
+        return Err(ApiError::BadRequest(
+            "messages must not be empty".to_owned(),
+        ));
+    }
+    let thread_key = parse_thread_key(raw_thread_key)?;
+    let message_ids = state
+        .store
+        .append_messages(&thread_key, &request.messages)
+        .await?;
+    Ok(Json(AppendMessagesResponse {
+        ok: true,
+        message_ids,
+    }))
+}
+
+async fn execute_session(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Json(request): Json<ExecuteSessionRequest>,
+) -> Result<Json<ExecuteSessionResponse>, ApiError> {
+    let thread_key = parse_thread_key(raw_thread_key)?;
+    let session = state.store.get_session(&thread_key).await?;
+    validate_input_lines(&request.input_lines)?;
+    let pipe_options = PipeOptions::from_request(&request)?;
+
+    let execution = state
+        .store
+        .create_execution(&thread_key, default_metadata(request.metadata))
+        .await?;
+    let execution = state
+        .store
+        .mark_execution_running(&execution.execution_id)
+        .await?;
+    let sandbox_id = ensure_session_sandbox(
+        &state.store,
+        &state.sandbox_runtime,
+        &thread_key,
+        session.sandbox_id.as_deref(),
+        &execution.execution_id,
+    )
+    .await?;
+
+    state
+        .store
+        .append_event(
+            &thread_key,
+            Some(&execution.execution_id),
+            "session.execution_started",
+            json!({
+                "execution_id": execution.execution_id,
+                "thread_key": thread_key.as_str(),
+                "input_line_count": request.input_lines.len(),
+            }),
+        )
+        .await?;
+
+    let output_line_count = match run_session_pipe(
+        &state.store,
+        &state.sandbox_runtime,
+        &thread_key,
+        &execution.execution_id,
+        &sandbox_id,
+        &request.input_lines,
+        pipe_options,
+    )
+    .await
+    {
+        Ok(output_line_count) => output_line_count,
+        Err(error) => {
+            let error_message = error.to_string();
+            let _ = state
+                .store
+                .append_event(
+                    &thread_key,
+                    Some(&execution.execution_id),
+                    "session.execution_failed",
+                    json!({
+                        "execution_id": execution.execution_id,
+                        "thread_key": thread_key.as_str(),
+                        "error": error_message,
+                    }),
+                )
+                .await;
+            let _ = state
+                .store
+                .fail_execution(&execution.execution_id, &error_message)
+                .await;
+            return Err(error);
+        }
+    };
+
+    state
+        .store
+        .append_event(
+            &thread_key,
+            Some(&execution.execution_id),
+            "session.execution_completed",
+            json!({
+                "execution_id": execution.execution_id,
+                "thread_key": thread_key.as_str(),
+                "output_line_count": output_line_count,
+            }),
+        )
+        .await?;
+
+    let execution = state
+        .store
+        .complete_execution(&execution.execution_id)
+        .await?;
+    Ok(Json(ExecuteSessionResponse {
+        ok: true,
+        execution_id: execution.execution_id,
+        thread_key: execution.thread_key,
+        status: execution.status.as_str().to_owned(),
+    }))
+}
+
+async fn ensure_session_sandbox(
+    store: &PgSessionStore,
+    runtime: &SandboxRuntime,
+    thread_key: &ThreadKey,
+    existing_sandbox_id: Option<&str>,
+    execution_id: &str,
+) -> Result<String, ApiError> {
+    match runtime {
+        SandboxRuntime::Mock => {
+            if let Some(sandbox_id) = existing_sandbox_id {
+                return Ok(sandbox_id.to_owned());
+            }
+            let sandbox_id = format!("mock-sandbox-{execution_id}");
+            store
+                .update_sandbox_id(thread_key, Some(&sandbox_id))
+                .await?;
+            Ok(sandbox_id)
+        }
+        SandboxRuntime::Backend { backend, spec } => {
+            if let Some(sandbox_id) = existing_sandbox_id {
+                let id = SandboxId::new(sandbox_id);
+                match backend.status(&id).await {
+                    Ok(SandboxStatus::Running | SandboxStatus::Created) => {
+                        return Ok(sandbox_id.to_owned());
+                    }
+                    Ok(_) | Err(SandboxError::NotFound(_)) => {}
+                    Err(error) => return Err(ApiError::Sandbox(error)),
+                }
+            }
+
+            let handle = backend
+                .create(spec.clone())
+                .await
+                .map_err(ApiError::Sandbox)?;
+            store
+                .update_sandbox_id(thread_key, Some(handle.id.as_str()))
+                .await?;
+            Ok(handle.id.into_string())
+        }
+    }
+}
+
+async fn run_session_pipe(
+    store: &PgSessionStore,
+    runtime: &SandboxRuntime,
+    thread_key: &ThreadKey,
+    execution_id: &str,
+    sandbox_id: &str,
+    input_lines: &[String],
+    options: PipeOptions,
+) -> Result<usize, ApiError> {
+    match runtime {
+        SandboxRuntime::Mock => {
+            let mut output_line_count = 0;
+            let output_lines = mock_app_server_output_lines(thread_key, execution_id, sandbox_id);
+            for (index, line) in output_lines.iter().enumerate() {
+                append_output_line(store, thread_key, execution_id, line).await?;
+                output_line_count += 1;
+                if index + 1 < output_lines.len() {
+                    sleep(Duration::from_millis(200)).await;
+                }
+            }
+            Ok(output_line_count)
+        }
+        SandboxRuntime::Backend { backend, .. } => {
+            let id = SandboxId::new(sandbox_id);
+            for line in input_lines {
+                write_input_line(backend.as_ref(), &id, line).await?;
+            }
+
+            let mut buffer = String::new();
+            let mut output_line_count = 0;
+            let started_at = Instant::now();
+            let mut last_output_at: Option<Instant> = None;
+            let deadline = started_at + options.max_duration;
+
+            loop {
+                if Instant::now() >= deadline {
+                    output_line_count +=
+                        flush_partial_output(store, thread_key, execution_id, &mut buffer).await?;
+                    return Ok(output_line_count);
+                }
+
+                match backend
+                    .read_bytes(
+                        &id,
+                        ReadOptions {
+                            stream: OutputStream::Stdout,
+                            after_offset: None,
+                            max_bytes: 8192,
+                            timeout_ms: Some(1_000),
+                        },
+                    )
+                    .await
+                    .map_err(ApiError::Sandbox)?
+                {
+                    ReadResult::Bytes { bytes, .. } => {
+                        let chunk = std::str::from_utf8(&bytes).map_err(|err| {
+                            ApiError::BadRequest(format!("sandbox stdout was not UTF-8: {err}"))
+                        })?;
+                        last_output_at = Some(Instant::now());
+                        buffer.push_str(chunk);
+
+                        while let Some(index) = buffer.find('\n') {
+                            let line = buffer[..index].trim_end_matches('\r').to_owned();
+                            buffer.drain(..=index);
+                            append_output_line(store, thread_key, execution_id, &line).await?;
+                            output_line_count += 1;
+                        }
+                    }
+                    ReadResult::TimedOut => {
+                        let idle_reference = last_output_at.unwrap_or(started_at);
+                        if idle_reference.elapsed() >= options.idle_timeout
+                            && (output_line_count > 0
+                                || !buffer.is_empty()
+                                || input_lines.is_empty())
+                        {
+                            output_line_count +=
+                                flush_partial_output(store, thread_key, execution_id, &mut buffer)
+                                    .await?;
+                            return Ok(output_line_count);
+                        }
+                    }
+                    ReadResult::Eof => {
+                        output_line_count +=
+                            flush_partial_output(store, thread_key, execution_id, &mut buffer)
+                                .await?;
+                        return Ok(output_line_count);
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn write_input_line(
+    backend: &dyn SandboxBackend,
+    sandbox_id: &SandboxId,
+    line: &str,
+) -> Result<(), ApiError> {
+    let mut bytes = Vec::with_capacity(line.len() + 1);
+    bytes.extend_from_slice(line.as_bytes());
+    bytes.push(b'\n');
+    backend
+        .write_bytes(sandbox_id, Bytes::from(bytes))
+        .await
+        .map_err(ApiError::Sandbox)?;
+    Ok(())
+}
+
+async fn flush_partial_output(
+    store: &PgSessionStore,
+    thread_key: &ThreadKey,
+    execution_id: &str,
+    buffer: &mut String,
+) -> Result<usize, ApiError> {
+    if buffer.is_empty() {
+        return Ok(0);
+    }
+    let line = buffer.trim_end_matches('\r').to_owned();
+    buffer.clear();
+    append_output_line(store, thread_key, execution_id, &line).await?;
+    Ok(1)
+}
+
+async fn append_output_line(
+    store: &PgSessionStore,
+    thread_key: &ThreadKey,
+    execution_id: &str,
+    line: &str,
+) -> Result<(), ApiError> {
+    store
+        .append_event(
+            thread_key,
+            Some(execution_id),
+            SESSION_OUTPUT_LINE_EVENT,
+            Value::String(line.to_owned()),
+        )
+        .await?;
+    Ok(())
+}
+
+fn mock_app_server_output_lines(
+    thread_key: &ThreadKey,
+    execution_id: &str,
+    sandbox_id: &str,
+) -> Vec<String> {
+    let mock_thread_id = format!("mock-codex-thread-{sandbox_id}");
+    let mut lines = vec![
+        json!({
+            "type": "system",
+            "subtype": "wrapper_heartbeat",
+            "phase": "startup",
+            "thread_key": thread_key.as_str(),
+            "execution_id": execution_id,
+            "sandbox_id": sandbox_id,
+        }),
+        json!({
+            "type": "system",
+            "subtype": "wrapper_heartbeat",
+            "phase": "app_server_started",
+            "thread_key": thread_key.as_str(),
+            "execution_id": execution_id,
+            "sandbox_id": sandbox_id,
+        }),
+        json!({
+            "type": "thread.started",
+            "thread_id": mock_thread_id,
+        }),
+    ];
+
+    for turn_index in 1..=3 {
+        let mock_turn_id = format!("mock-turn-{execution_id}-{turn_index}");
+        lines.extend([
+            json!({
+                "type": "turn.started",
+                "turn_id": mock_turn_id,
+            }),
+            json!({
+                "type": "item.agentMessage.delta",
+                "turnId": mock_turn_id,
+                "session_id": mock_thread_id,
+                "delta": format!("PONG {turn_index}"),
+            }),
+            json!({
+                "type": "turn.completed",
+                "turn": {
+                    "id": mock_turn_id,
+                },
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 1,
+                },
+            }),
+        ]);
+    }
+
+    lines.into_iter().map(|value| value.to_string()).collect()
+}
+
+async fn stream_events(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Query(query): Query<EventsQuery>,
+) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    let thread_key = parse_thread_key(raw_thread_key)?;
+    state.store.get_session(&thread_key).await?;
+
+    let stream = stream::unfold(
+        SessionEventStreamState {
+            store: state.store,
+            thread_key,
+            after_event_id: query.after_event_id.unwrap_or(0),
+            pending: VecDeque::new(),
+            done: false,
+        },
+        |mut state| async move {
+            loop {
+                if let Some(event) = state.pending.pop_front() {
+                    state.after_event_id = event.event_id;
+                    return Some((Ok(to_sse_event(event)), state));
+                }
+                if state.done {
+                    return None;
+                }
+                match state
+                    .store
+                    .list_events_after(&state.thread_key, state.after_event_id, 100)
+                    .await
+                {
+                    Ok(events) if events.is_empty() => sleep(Duration::from_millis(250)).await,
+                    Ok(events) => state.pending = events.into(),
+                    Err(error) => {
+                        state.done = true;
+                        let event = Event::default()
+                            .event("session.stream_error")
+                            .data(json!({"error": error.to_string()}).to_string());
+                        return Some((Ok(event), state));
+                    }
+                }
+            }
+        },
+    );
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+struct SessionEventStreamState {
+    store: PgSessionStore,
+    thread_key: ThreadKey,
+    after_event_id: i64,
+    pending: VecDeque<SessionEvent>,
+    done: bool,
+}
+
+fn to_sse_event(event: SessionEvent) -> Event {
+    let data = if event.event_type == SESSION_OUTPUT_LINE_EVENT {
+        event.payload.as_str().unwrap_or_default().to_owned()
+    } else {
+        serde_json::to_string(&event.payload).unwrap_or_else(|_| "{}".to_owned())
+    };
+    Event::default()
+        .id(event.event_id.to_string())
+        .event(event.event_type)
+        .data(data)
+}
+
+fn parse_thread_key(value: String) -> Result<ThreadKey, ApiError> {
+    ThreadKey::parse(value).map_err(ApiError::InvalidThreadKey)
+}
+
+fn validate_input_lines(lines: &[String]) -> Result<(), ApiError> {
+    for (index, line) in lines.iter().enumerate() {
+        if line.contains('\n') || line.contains('\r') {
+            return Err(ApiError::BadRequest(format!(
+                "input_lines[{index}] must be one line"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PipeOptions {
+    idle_timeout: Duration,
+    max_duration: Duration,
+}
+
+impl PipeOptions {
+    fn from_request(request: &ExecuteSessionRequest) -> Result<Self, ApiError> {
+        let idle_timeout = request
+            .idle_timeout_ms
+            .map(nonzero_duration_millis)
+            .transpose()?
+            .unwrap_or_else(|| Duration::from_millis(DEFAULT_IDLE_TIMEOUT_MS));
+        let max_duration = request
+            .max_duration_ms
+            .map(nonzero_duration_millis)
+            .transpose()?
+            .unwrap_or_else(|| Duration::from_millis(DEFAULT_MAX_DURATION_MS));
+
+        if idle_timeout > max_duration {
+            return Err(ApiError::BadRequest(
+                "idle_timeout_ms must be less than or equal to max_duration_ms".to_owned(),
+            ));
+        }
+
+        Ok(Self {
+            idle_timeout,
+            max_duration,
+        })
+    }
+}
+
+fn nonzero_duration_millis(value: u64) -> Result<Duration, ApiError> {
+    if value == 0 {
+        return Err(ApiError::BadRequest(
+            "duration values must be greater than zero".to_owned(),
+        ));
+    }
+    Ok(Duration::from_millis(value))
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateSessionRequest {
+    harness_type: HarnessType,
+    metadata: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AppendMessagesRequest {
+    messages: Vec<SessionMessageInput>,
+}
+
+#[derive(Debug, Serialize)]
+struct AppendMessagesResponse {
+    ok: bool,
+    message_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExecuteSessionRequest {
+    metadata: Option<Value>,
+    #[serde(default)]
+    input_lines: Vec<String>,
+    idle_timeout_ms: Option<u64>,
+    max_duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExecuteSessionResponse {
+    ok: bool,
+    execution_id: String,
+    thread_key: ThreadKey,
+    status: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EventsQuery {
+    after_event_id: Option<i64>,
+}
+
+#[derive(Debug, Error)]
+enum ApiError {
+    #[error(transparent)]
+    InvalidThreadKey(#[from] ThreadKeyError),
+    #[error("{0}")]
+    BadRequest(String),
+    #[error(transparent)]
+    Store(#[from] SessionStoreError),
+    #[error(transparent)]
+    Sandbox(#[from] SandboxError),
+    #[error(transparent)]
+    Serialize(#[from] serde_json::Error),
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            Self::InvalidThreadKey(_) | Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::Store(SessionStoreError::NotFound { .. }) => StatusCode::NOT_FOUND,
+            Self::Store(SessionStoreError::HarnessConflict { .. }) => StatusCode::CONFLICT,
+            Self::Store(_) | Self::Sandbox(_) | Self::Serialize(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+        let body = Json(json!({
+            "ok": false,
+            "error": self.to_string(),
+        }));
+        (status, body).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_router;
+    use centaur_session_sqlx::PgSessionStore;
+    use sqlx::PgPool;
+
+    #[tokio::test]
+    async fn router_builds() {
+        let pool =
+            PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
+        let _router = build_router(PgSessionStore::new(pool));
+    }
+}

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -4,6 +4,7 @@ use centaur_api_server::{SandboxRuntime, build_router_with_runtime};
 use centaur_sandbox_agent_k8s::{AgentSandboxBackend, AgentSandboxConfig};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_sandbox_local::LocalSandboxBackend;
+use centaur_session_core::ThreadKey;
 use centaur_session_sqlx::PgSessionStore;
 use thiserror::Error;
 use tokio::net::TcpListener;
@@ -56,9 +57,15 @@ async fn sandbox_runtime_from_env() -> Result<SandboxRuntime, ServerError> {
         "agent-k8s" => {
             let namespace = env::var("SESSION_SANDBOX_K8S_NAMESPACE")
                 .unwrap_or_else(|_| "centaur-sandbox-e2e".to_owned());
+            let workload =
+                env::var("SESSION_SANDBOX_WORKLOAD").unwrap_or_else(|_| "mock".to_owned());
             let image =
-                env::var("SESSION_SANDBOX_IMAGE").unwrap_or_else(|_| "busybox:1.36".to_owned());
+                env::var("SESSION_SANDBOX_IMAGE").unwrap_or_else(|_| match workload.as_str() {
+                    "codex-app-server" => "centaur-agent:latest".to_owned(),
+                    _ => "busybox:1.36".to_owned(),
+                });
             let mut config = AgentSandboxConfig::new(namespace);
+            config.image_pull_policy = env::var("SESSION_SANDBOX_IMAGE_PULL_POLICY").ok();
             config.ready_timeout = Duration::from_secs(
                 env::var("SESSION_SANDBOX_READY_TIMEOUT_SECS")
                     .ok()
@@ -66,21 +73,34 @@ async fn sandbox_runtime_from_env() -> Result<SandboxRuntime, ServerError> {
                     .unwrap_or(90),
             );
 
-            let backend = if let Ok(context) = env::var("SESSION_SANDBOX_K8S_CONTEXT") {
+            let client = if let Ok(context) = env::var("SESSION_SANDBOX_K8S_CONTEXT") {
                 let kube_config = kube::Config::from_kubeconfig(&kube::config::KubeConfigOptions {
                     context: Some(context),
                     ..kube::config::KubeConfigOptions::default()
                 })
                 .await?;
-                AgentSandboxBackend::new(kube::Client::try_from(kube_config)?, config)
+                kube::Client::try_from(kube_config)?
             } else {
-                AgentSandboxBackend::try_default(config.namespace.clone()).await?
+                kube::Client::try_default().await?
             };
+            let backend = AgentSandboxBackend::new(client, config);
 
-            Ok(SandboxRuntime::backend(
-                Arc::new(backend),
-                agent_k8s_mock_app_server_spec(&image),
-            ))
+            match workload.as_str() {
+                "mock" => Ok(SandboxRuntime::backend(
+                    Arc::new(backend),
+                    agent_k8s_mock_app_server_spec(&image),
+                )),
+                "codex-app-server" => {
+                    let env_template = codex_app_server_env_template();
+                    Ok(SandboxRuntime::backend_with_spec_factory(
+                        Arc::new(backend),
+                        move |thread_key, _execution_id| {
+                            codex_app_server_spec(&image, thread_key, &env_template)
+                        },
+                    ))
+                }
+                other => Err(ServerError::InvalidSandboxWorkload(other.to_owned())),
+            }
         }
         other => Err(ServerError::InvalidSandboxBackend(other.to_owned())),
     }
@@ -96,6 +116,64 @@ fn agent_k8s_mock_app_server_spec(image: &str) -> SandboxSpec {
     SandboxSpec::new(image)
         .command(["/bin/sh", "-lc"])
         .args([mock_app_server_script()])
+}
+
+fn codex_app_server_spec(
+    image: &str,
+    thread_key: &ThreadKey,
+    env_template: &[(String, String)],
+) -> SandboxSpec {
+    let mut spec = SandboxSpec::new(image).env("CENTAUR_THREAD_KEY", thread_key.as_str());
+    for (name, value) in env_template {
+        spec = spec.env(name.clone(), value.clone());
+    }
+    spec
+}
+
+fn codex_app_server_env_template() -> Vec<(String, String)> {
+    let mut envs = Vec::new();
+    push_env(
+        &mut envs,
+        "CENTAUR_API_URL",
+        env::var("SESSION_SANDBOX_CENTAUR_API_URL")
+            .or_else(|_| env::var("CENTAUR_API_URL"))
+            .unwrap_or_else(|_| "http://api:8000".to_owned()),
+    );
+    if let Ok(api_key) =
+        env::var("SESSION_SANDBOX_CENTAUR_API_KEY").or_else(|_| env::var("CENTAUR_API_KEY"))
+    {
+        push_env(&mut envs, "CENTAUR_API_KEY", api_key);
+    }
+
+    for name in passthrough_env_names() {
+        if let Ok(value) = env::var(&name) {
+            push_env(&mut envs, &name, value);
+        }
+    }
+
+    envs
+}
+
+fn passthrough_env_names() -> impl Iterator<Item = String> {
+    env::var("SESSION_SANDBOX_PASSTHROUGH_ENV")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>()
+        .into_iter()
+}
+
+fn push_env(envs: &mut Vec<(String, String)>, name: &str, value: String) {
+    if let Some((_, existing_value)) = envs
+        .iter_mut()
+        .find(|(existing_name, _)| existing_name == name)
+    {
+        *existing_value = value;
+    } else {
+        envs.push((name.to_owned(), value));
+    }
 }
 
 fn mock_app_server_script() -> &'static str {
@@ -126,6 +204,8 @@ enum ServerError {
     MissingDatabaseUrl,
     #[error("unknown SESSION_SANDBOX_BACKEND {0:?}; expected mock, local, or agent-k8s")]
     InvalidSandboxBackend(String),
+    #[error("unknown SESSION_SANDBOX_WORKLOAD {0:?}; expected mock or codex-app-server")]
+    InvalidSandboxWorkload(String),
     #[error(transparent)]
     AddrParse(#[from] std::net::AddrParseError),
     #[error(transparent)]

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -1,0 +1,143 @@
+use std::{env, net::SocketAddr, sync::Arc, time::Duration};
+
+use centaur_api_server::{SandboxRuntime, build_router_with_runtime};
+use centaur_sandbox_agent_k8s::{AgentSandboxBackend, AgentSandboxConfig};
+use centaur_sandbox_core::SandboxSpec;
+use centaur_sandbox_local::LocalSandboxBackend;
+use centaur_session_sqlx::PgSessionStore;
+use thiserror::Error;
+use tokio::net::TcpListener;
+use tracing::info;
+use tracing_subscriber::{EnvFilter, fmt};
+
+#[tokio::main]
+async fn main() -> Result<(), ServerError> {
+    init_tracing();
+
+    let database_url = env::var("DATABASE_URL").map_err(|_| ServerError::MissingDatabaseUrl)?;
+    let bind_addr = env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:8080".to_owned());
+    let bind_addr: SocketAddr = bind_addr.parse()?;
+    let run_migrations = env::var("RUN_MIGRATIONS")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes"))
+        .unwrap_or(false);
+
+    let store = PgSessionStore::connect(&database_url).await?;
+    if run_migrations {
+        store.run_migrations().await?;
+    }
+    let sandbox_runtime = sandbox_runtime_from_env().await?;
+
+    let listener = TcpListener::bind(bind_addr).await?;
+    info!(%bind_addr, "starting centaur api-rs server");
+
+    axum::serve(listener, build_router_with_runtime(store, sandbox_runtime))
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    fmt().with_env_filter(filter).json().init();
+}
+
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+async fn sandbox_runtime_from_env() -> Result<SandboxRuntime, ServerError> {
+    let backend = env::var("SESSION_SANDBOX_BACKEND").unwrap_or_else(|_| "mock".to_owned());
+    match backend.as_str() {
+        "mock" => Ok(SandboxRuntime::Mock),
+        "local" => Ok(SandboxRuntime::backend(
+            Arc::new(LocalSandboxBackend::new()),
+            local_mock_app_server_spec(),
+        )),
+        "agent-k8s" => {
+            let namespace = env::var("SESSION_SANDBOX_K8S_NAMESPACE")
+                .unwrap_or_else(|_| "centaur-sandbox-e2e".to_owned());
+            let image =
+                env::var("SESSION_SANDBOX_IMAGE").unwrap_or_else(|_| "busybox:1.36".to_owned());
+            let mut config = AgentSandboxConfig::new(namespace);
+            config.ready_timeout = Duration::from_secs(
+                env::var("SESSION_SANDBOX_READY_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|value| value.parse().ok())
+                    .unwrap_or(90),
+            );
+
+            let backend = if let Ok(context) = env::var("SESSION_SANDBOX_K8S_CONTEXT") {
+                let kube_config = kube::Config::from_kubeconfig(&kube::config::KubeConfigOptions {
+                    context: Some(context),
+                    ..kube::config::KubeConfigOptions::default()
+                })
+                .await?;
+                AgentSandboxBackend::new(kube::Client::try_from(kube_config)?, config)
+            } else {
+                AgentSandboxBackend::try_default(config.namespace.clone()).await?
+            };
+
+            Ok(SandboxRuntime::backend(
+                Arc::new(backend),
+                agent_k8s_mock_app_server_spec(&image),
+            ))
+        }
+        other => Err(ServerError::InvalidSandboxBackend(other.to_owned())),
+    }
+}
+
+fn local_mock_app_server_spec() -> SandboxSpec {
+    SandboxSpec::new("/bin/sh")
+        .command(["/bin/sh", "-lc"])
+        .args([mock_app_server_script()])
+}
+
+fn agent_k8s_mock_app_server_spec(image: &str) -> SandboxSpec {
+    SandboxSpec::new(image)
+        .command(["/bin/sh", "-lc"])
+        .args([mock_app_server_script()])
+}
+
+fn mock_app_server_script() -> &'static str {
+    r#"while IFS= read -r line; do
+printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"startup"}'
+sleep 0.2
+printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"app_server_started"}'
+sleep 0.2
+printf '%s\n' '{"type":"thread.started","thread_id":"mock-codex-thread"}'
+sleep 0.2
+turn_index=1
+while [ "$turn_index" -le 3 ]; do
+  turn_id="mock-turn-$turn_index"
+  printf '{"type":"turn.started","turn_id":"%s"}\n' "$turn_id"
+  sleep 0.2
+  printf '{"type":"item.agentMessage.delta","turnId":"%s","session_id":"mock-codex-thread","delta":"PONG %s"}\n' "$turn_id" "$turn_index"
+  sleep 0.2
+  printf '{"type":"turn.completed","turn":{"id":"%s"},"usage":{"input_tokens":0,"output_tokens":1}}\n' "$turn_id"
+  sleep 0.2
+  turn_index=$((turn_index + 1))
+done
+done"#
+}
+
+#[derive(Debug, Error)]
+enum ServerError {
+    #[error("DATABASE_URL is required")]
+    MissingDatabaseUrl,
+    #[error("unknown SESSION_SANDBOX_BACKEND {0:?}; expected mock, local, or agent-k8s")]
+    InvalidSandboxBackend(String),
+    #[error(transparent)]
+    AddrParse(#[from] std::net::AddrParseError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Store(#[from] centaur_session_sqlx::SessionStoreError),
+    #[error(transparent)]
+    Sandbox(#[from] centaur_sandbox_core::SandboxError),
+    #[error(transparent)]
+    KubeConfig(#[from] kube::config::KubeconfigError),
+    #[error(transparent)]
+    KubeInferConfig(#[from] kube::config::InferConfigError),
+    #[error(transparent)]
+    Kube(#[from] kube::Error),
+}

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -48,6 +48,7 @@ pub struct AgentSandboxConfig {
     pub container_name: String,
     pub labels: BTreeMap<String, String>,
     pub annotations: BTreeMap<String, String>,
+    pub image_pull_policy: Option<String>,
     pub state_volume: Option<StateVolumeConfig>,
     pub ready_timeout: Duration,
 }
@@ -60,6 +61,7 @@ impl AgentSandboxConfig {
             container_name: DEFAULT_CONTAINER_NAME.to_owned(),
             labels: BTreeMap::new(),
             annotations: BTreeMap::new(),
+            image_pull_policy: None,
             state_volume: None,
             ready_timeout: Duration::from_secs(60),
         }
@@ -555,6 +557,11 @@ fn build_agent_sandbox(
         "stdinOnce": false,
         "tty": false,
     });
+    insert_optional(
+        &mut container,
+        "imagePullPolicy",
+        config.image_pull_policy.clone(),
+    );
     insert_optional(&mut container, "command", spec.command.clone());
     insert_optional(
         &mut container,

--- a/services/api-rs/crates/centaur-session-cli/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-cli/Cargo.toml
@@ -9,9 +9,11 @@ repository.workspace = true
 anyhow.workspace = true
 centaur-session-core.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+crossterm.workspace = true
 futures-util.workspace = true
+ratatui.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
 urlencoding.workspace = true
 uuid.workspace = true

--- a/services/api-rs/crates/centaur-session-cli/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-cli/Cargo.toml
@@ -12,6 +12,6 @@ clap = { workspace = true, features = ["derive", "env"] }
 futures-util.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt-multi-thread"] }
 urlencoding.workspace = true
 uuid.workspace = true

--- a/services/api-rs/crates/centaur-session-cli/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "centaur-session-cli"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+centaur-session-core.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+futures-util.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+urlencoding.workspace = true
+uuid.workspace = true

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -44,6 +44,9 @@ struct Args {
 
     #[arg(long)]
     exit_on_terminal: bool,
+
+    #[arg(long)]
+    exit_on_output_type: Option<String>,
 }
 
 #[tokio::main]
@@ -62,7 +65,13 @@ async fn main() -> Result<()> {
 
     if attach_mode {
         let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
-        return stream_output_lines(events_response, args.all_events, args.exit_on_terminal).await;
+        return stream_output_lines(
+            events_response,
+            args.all_events,
+            args.exit_on_terminal,
+            args.exit_on_output_type,
+        )
+        .await;
     }
 
     let input_lines = session_input_lines(&args)?;
@@ -107,8 +116,12 @@ async fn main() -> Result<()> {
         args.max_duration_ms,
     );
 
-    let stream_future =
-        stream_output_lines(events_response, args.all_events, args.exit_on_terminal);
+    let stream_future = stream_output_lines(
+        events_response,
+        args.all_events,
+        args.exit_on_terminal,
+        args.exit_on_output_type,
+    );
     tokio::pin!(stream_future);
 
     tokio::select! {
@@ -224,6 +237,7 @@ async fn stream_output_lines(
     response: reqwest::Response,
     all_events: bool,
     exit_on_terminal: bool,
+    exit_on_output_type: Option<String>,
 ) -> Result<()> {
     let mut chunks = response.bytes_stream();
     let mut buffer = String::new();
@@ -246,6 +260,9 @@ async fn stream_output_lines(
                     event.id.as_deref().unwrap_or("unknown"),
                     event.data
                 );
+                if output_type_matches(&event.data, exit_on_output_type.as_deref()) {
+                    return Ok(());
+                }
             } else if all_events {
                 let data = parse_json_or_string(&event.data);
                 println!(
@@ -265,6 +282,21 @@ async fn stream_output_lines(
     }
 
     Ok(())
+}
+
+fn output_type_matches(data: &str, expected_type: Option<&str>) -> bool {
+    let Some(expected_type) = expected_type else {
+        return false;
+    };
+    serde_json::from_str::<Value>(data)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("type")
+                .and_then(Value::as_str)
+                .map(|event_type| event_type == expected_type)
+        })
+        .unwrap_or(false)
 }
 
 fn session_input_lines(args: &Args) -> Result<Vec<String>> {

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -1,0 +1,349 @@
+use anyhow::{Context, Result, bail};
+use centaur_session_core::ThreadKey;
+use clap::Parser;
+use futures_util::StreamExt;
+use reqwest::Client;
+use serde_json::{Value, json};
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+const DEFAULT_MESSAGE: &str = "Reply with exactly PONG and nothing else.";
+
+#[derive(Debug, Parser)]
+#[command(about = "Create, execute, or attach to a Centaur session")]
+struct Args {
+    #[arg(long, env = "CENTAUR_API_URL", default_value = "http://127.0.0.1:8080")]
+    api_url: String,
+
+    #[arg(long)]
+    thread_key: Option<String>,
+
+    #[arg(long)]
+    attach: bool,
+
+    #[arg(long, default_value = "codex")]
+    harness_type: String,
+
+    #[arg(long)]
+    message: Option<String>,
+
+    #[arg(long = "input-line")]
+    input_lines: Vec<String>,
+
+    #[arg(long, default_value_t = 1_000)]
+    idle_timeout_ms: u64,
+
+    #[arg(long, default_value_t = 60_000)]
+    max_duration_ms: u64,
+
+    #[arg(long, default_value_t = 0)]
+    after_event_id: i64,
+
+    #[arg(long)]
+    all_events: bool,
+
+    #[arg(long)]
+    exit_on_terminal: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    let attach_mode = attach_mode(&args);
+    validate_mode(&args, attach_mode)?;
+    let (thread_key, generated_thread_key) = thread_key_arg(&args, attach_mode)?;
+    let thread_key = ThreadKey::parse(thread_key)?;
+    if generated_thread_key {
+        eprintln!("thread_key={}", thread_key.as_str());
+    }
+    let client = Client::new();
+    let base_url = args.api_url.trim_end_matches('/').to_owned();
+    let session_url = session_url(&base_url, thread_key.as_str());
+
+    if attach_mode {
+        let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
+        return stream_output_lines(events_response, args.all_events, args.exit_on_terminal).await;
+    }
+
+    let input_lines = session_input_lines(&args)?;
+    let message = message_text(&args);
+
+    post_json(
+        &client,
+        &session_url,
+        json!({
+            "harness_type": args.harness_type,
+            "metadata": {
+                "source": "centaur-session-cli",
+            },
+        }),
+    )
+    .await
+    .context("create session")?;
+
+    post_json(
+        &client,
+        &format!("{session_url}/messages"),
+        json!({
+            "messages": [{
+                "role": "user",
+                "parts": [{"type": "text", "text": message}],
+                "metadata": {
+                    "source": "centaur-session-cli",
+                },
+            }],
+        }),
+    )
+    .await
+    .context("append message")?;
+
+    let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
+
+    let mut execute_task = spawn_execute(
+        client.clone(),
+        format!("{session_url}/execute"),
+        input_lines,
+        args.idle_timeout_ms,
+        args.max_duration_ms,
+    );
+
+    let stream_future =
+        stream_output_lines(events_response, args.all_events, args.exit_on_terminal);
+    tokio::pin!(stream_future);
+
+    tokio::select! {
+        stream_result = &mut stream_future => {
+            execute_task.await.context("join execute task")??;
+            stream_result
+        }
+        execute_result = &mut execute_task => {
+            execute_result.context("join execute task")??;
+            stream_future.await
+        }
+    }
+}
+
+fn attach_mode(args: &Args) -> bool {
+    args.attach
+        || (args.after_event_id > 0
+            && args.thread_key.is_some()
+            && args.message.is_none()
+            && args.input_lines.is_empty())
+}
+
+fn validate_mode(args: &Args, attach_mode: bool) -> Result<()> {
+    if attach_mode && args.thread_key.is_none() {
+        bail!("attach mode requires --thread-key");
+    }
+    if args.attach && (args.message.is_some() || !args.input_lines.is_empty()) {
+        bail!("--attach does not accept --message or --input-line");
+    }
+    Ok(())
+}
+
+fn thread_key_arg(args: &Args, attach_mode: bool) -> Result<(String, bool)> {
+    match (&args.thread_key, attach_mode) {
+        (Some(thread_key), _) => Ok((thread_key.clone(), false)),
+        (None, true) => bail!("--attach requires --thread-key"),
+        (None, false) => Ok((format!("cli:{}", Uuid::new_v4().simple()), true)),
+    }
+}
+
+async fn post_json(client: &Client, url: &str, payload: Value) -> Result<Value> {
+    let response = client
+        .post(url)
+        .json(&payload)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    let status = response.status();
+    let body = response.text().await?;
+    ensure_success(status, body.clone()).with_context(|| format!("POST {url}"))?;
+    serde_json::from_str(&body).with_context(|| format!("decode response from {url}"))
+}
+
+fn ensure_success(status: reqwest::StatusCode, body: String) -> Result<()> {
+    if status.is_success() {
+        return Ok(());
+    }
+    bail!("HTTP {status}: {body}");
+}
+
+async fn ensure_response_success(response: reqwest::Response) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response.text().await?;
+    bail!("HTTP {status}: {body}");
+}
+
+async fn open_event_stream(
+    client: &Client,
+    session_url: &str,
+    after_event_id: i64,
+) -> Result<reqwest::Response> {
+    let events_url = format!("{session_url}/events?after_event_id={after_event_id}");
+    let events_response = client
+        .get(&events_url)
+        .send()
+        .await
+        .context("open event stream")?;
+    ensure_response_success(events_response)
+        .await
+        .context("open event stream")
+}
+
+fn spawn_execute(
+    client: Client,
+    url: String,
+    input_lines: Vec<String>,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> JoinHandle<Result<()>> {
+    tokio::spawn(async move {
+        post_json(
+            &client,
+            &url,
+            json!({
+                "metadata": {
+                    "source": "centaur-session-cli",
+                },
+                "input_lines": input_lines,
+                "idle_timeout_ms": idle_timeout_ms,
+                "max_duration_ms": max_duration_ms,
+            }),
+        )
+        .await
+        .context("execute session")?;
+        Ok(())
+    })
+}
+
+async fn stream_output_lines(
+    response: reqwest::Response,
+    all_events: bool,
+    exit_on_terminal: bool,
+) -> Result<()> {
+    let mut chunks = response.bytes_stream();
+    let mut buffer = String::new();
+
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk.context("read event stream")?;
+        buffer.push_str(std::str::from_utf8(&chunk).context("event stream is not UTF-8")?);
+
+        while let Some((frame_end, separator_len)) = next_frame(&buffer) {
+            let frame = buffer[..frame_end].to_owned();
+            buffer.drain(..frame_end + separator_len);
+
+            let Some(event) = SseFrame::parse(&frame) else {
+                continue;
+            };
+
+            if event.event == "session.output.line" {
+                println!(
+                    "{}\t{}",
+                    event.id.as_deref().unwrap_or("unknown"),
+                    event.data
+                );
+            } else if all_events {
+                let data = parse_json_or_string(&event.data);
+                println!(
+                    "{}",
+                    serde_json::to_string(&json!({
+                        "sse_event": event.event,
+                        "id": event.id,
+                        "data": data,
+                    }))?
+                );
+            }
+
+            if exit_on_terminal && is_terminal_event(&event.event) {
+                return Ok(());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn session_input_lines(args: &Args) -> Result<Vec<String>> {
+    if !args.input_lines.is_empty() {
+        return Ok(args.input_lines.clone());
+    }
+    let message = message_text(args);
+    Ok(vec![serde_json::to_string(&json!({
+        "type": "user",
+        "message": {
+            "content": [{"type": "text", "text": message}],
+        },
+    }))?])
+}
+
+fn message_text(args: &Args) -> &str {
+    args.message.as_deref().unwrap_or(DEFAULT_MESSAGE)
+}
+
+fn session_url(base_url: &str, thread_key: &str) -> String {
+    format!("{base_url}/api/session/{}", urlencoding::encode(thread_key))
+}
+
+fn next_frame(buffer: &str) -> Option<(usize, usize)> {
+    let lf = buffer.find("\n\n").map(|index| (index, 2));
+    let crlf = buffer.find("\r\n\r\n").map(|index| (index, 4));
+    match (lf, crlf) {
+        (Some(left), Some(right)) => Some(if left.0 <= right.0 { left } else { right }),
+        (Some(frame), None) | (None, Some(frame)) => Some(frame),
+        (None, None) => None,
+    }
+}
+
+fn parse_json_or_string(data: &str) -> Value {
+    serde_json::from_str(data).unwrap_or_else(|_| Value::String(data.to_owned()))
+}
+
+fn is_terminal_event(event: &str) -> bool {
+    matches!(
+        event,
+        "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
+    )
+}
+
+#[derive(Debug)]
+struct SseFrame {
+    id: Option<String>,
+    event: String,
+    data: String,
+}
+
+impl SseFrame {
+    fn parse(frame: &str) -> Option<Self> {
+        let frame = frame.replace("\r\n", "\n");
+        let mut id = None;
+        let mut event = "message".to_owned();
+        let mut data = Vec::new();
+
+        for line in frame.lines() {
+            if line.is_empty() || line.starts_with(':') {
+                continue;
+            }
+            if let Some(value) = line.strip_prefix("id:") {
+                id = Some(value.trim_start().to_owned());
+            } else if let Some(value) = line.strip_prefix("event:") {
+                event = value.trim_start().to_owned();
+            } else if let Some(value) = line.strip_prefix("data:") {
+                data.push(value.trim_start().to_owned());
+            }
+        }
+
+        if data.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            id,
+            event,
+            data: data.join("\n"),
+        })
+    }
+}

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -4,7 +4,10 @@ use clap::Parser;
 use futures_util::StreamExt;
 use reqwest::Client;
 use serde_json::{Value, json};
-use tokio::task::JoinHandle;
+use tokio::{
+    io::{self, AsyncBufReadExt, BufReader},
+    task::JoinHandle,
+};
 use uuid::Uuid;
 
 const DEFAULT_MESSAGE: &str = "Reply with exactly PONG and nothing else.";
@@ -47,6 +50,9 @@ struct Args {
 
     #[arg(long)]
     exit_on_output_type: Option<String>,
+
+    #[arg(long, alias = "stdin")]
+    stdin_events: bool,
 }
 
 #[tokio::main]
@@ -65,17 +71,19 @@ async fn main() -> Result<()> {
 
     if attach_mode {
         let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
-        return stream_output_lines(
+        return run_stream_and_optional_stdin(
+            client,
+            session_url,
             events_response,
             args.all_events,
             args.exit_on_terminal,
             args.exit_on_output_type,
+            args.stdin_events,
+            args.idle_timeout_ms,
+            args.max_duration_ms,
         )
         .await;
     }
-
-    let input_lines = session_input_lines(&args)?;
-    let message = message_text(&args);
 
     post_json(
         &client,
@@ -90,50 +98,43 @@ async fn main() -> Result<()> {
     .await
     .context("create session")?;
 
-    post_json(
-        &client,
-        &format!("{session_url}/messages"),
-        json!({
-            "messages": [{
-                "role": "user",
-                "parts": [{"type": "text", "text": message}],
-                "metadata": {
-                    "source": "centaur-session-cli",
-                },
-            }],
-        }),
-    )
-    .await
-    .context("append message")?;
+    let initial_input_lines = if should_send_initial_turn(&args) {
+        let input_lines = session_input_lines(&args)?;
+        let message = message_text(&args);
+        append_user_message(&client, &session_url, message)
+            .await
+            .context("append message")?;
+        Some(input_lines)
+    } else {
+        None
+    };
 
     let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
 
-    let mut execute_task = spawn_execute(
-        client.clone(),
-        format!("{session_url}/execute"),
-        input_lines,
-        args.idle_timeout_ms,
-        args.max_duration_ms,
-    );
+    if let Some(input_lines) = initial_input_lines {
+        execute_input_lines(
+            &client,
+            &session_url,
+            input_lines,
+            args.idle_timeout_ms,
+            args.max_duration_ms,
+        )
+        .await
+        .context("execute initial turn")?;
+    }
 
-    let stream_future = stream_output_lines(
+    run_stream_and_optional_stdin(
+        client,
+        session_url,
         events_response,
         args.all_events,
         args.exit_on_terminal,
         args.exit_on_output_type,
-    );
-    tokio::pin!(stream_future);
-
-    tokio::select! {
-        stream_result = &mut stream_future => {
-            execute_task.await.context("join execute task")??;
-            stream_result
-        }
-        execute_result = &mut execute_task => {
-            execute_result.context("join execute task")??;
-            stream_future.await
-        }
-    }
+        args.stdin_events,
+        args.idle_timeout_ms,
+        args.max_duration_ms,
+    )
+    .await
 }
 
 fn attach_mode(args: &Args) -> bool {
@@ -207,28 +208,134 @@ async fn open_event_stream(
         .context("open event stream")
 }
 
-fn spawn_execute(
-    client: Client,
-    url: String,
+async fn append_user_message(client: &Client, session_url: &str, text: &str) -> Result<()> {
+    post_json(
+        client,
+        &format!("{session_url}/messages"),
+        json!({
+            "messages": [{
+                "role": "user",
+                "parts": [{"type": "text", "text": text}],
+                "metadata": {
+                    "source": "centaur-session-cli",
+                },
+            }],
+        }),
+    )
+    .await
+    .context("append message")?;
+    Ok(())
+}
+
+async fn execute_input_lines(
+    client: &Client,
+    session_url: &str,
     input_lines: Vec<String>,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<()> {
+    post_json(
+        client,
+        &format!("{session_url}/execute"),
+        json!({
+            "metadata": {
+                "source": "centaur-session-cli",
+            },
+            "input_lines": input_lines,
+            "idle_timeout_ms": idle_timeout_ms,
+            "max_duration_ms": max_duration_ms,
+        }),
+    )
+    .await
+    .context("execute session")?;
+    Ok(())
+}
+
+async fn run_stream_and_optional_stdin(
+    client: Client,
+    session_url: String,
+    events_response: reqwest::Response,
+    all_events: bool,
+    exit_on_terminal: bool,
+    exit_on_output_type: Option<String>,
+    stdin_events: bool,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<()> {
+    let stream_future = stream_output_lines(
+        events_response,
+        all_events,
+        exit_on_terminal,
+        exit_on_output_type,
+    );
+    tokio::pin!(stream_future);
+
+    if !stdin_events {
+        return stream_future.await;
+    }
+
+    let mut stdin_task = spawn_stdin_events(client, session_url, idle_timeout_ms, max_duration_ms);
+
+    tokio::select! {
+        stream_result = &mut stream_future => {
+            stdin_task.abort();
+            stream_result
+        }
+        stdin_result = &mut stdin_task => {
+            stdin_result.context("join stdin event task")??;
+            stream_future.await
+        }
+    }
+}
+
+fn spawn_stdin_events(
+    client: Client,
+    session_url: String,
     idle_timeout_ms: u64,
     max_duration_ms: u64,
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {
-        post_json(
-            &client,
-            &url,
-            json!({
-                "metadata": {
-                    "source": "centaur-session-cli",
-                },
-                "input_lines": input_lines,
-                "idle_timeout_ms": idle_timeout_ms,
-                "max_duration_ms": max_duration_ms,
-            }),
-        )
-        .await
-        .context("execute session")?;
+        let mut lines = BufReader::new(io::stdin()).lines();
+        while let Some(line) = lines.next_line().await.context("read stdin event")? {
+            let event = match StdinEvent::parse(&line)? {
+                Some(event) => event,
+                None => continue,
+            };
+            match event {
+                StdinEvent::Message(text) => {
+                    append_user_message(&client, &session_url, &text).await?;
+                    execute_input_lines(
+                        &client,
+                        &session_url,
+                        vec![user_input_line(&text)?],
+                        idle_timeout_ms,
+                        max_duration_ms,
+                    )
+                    .await?;
+                }
+                StdinEvent::InputLine(line) => {
+                    execute_input_lines(
+                        &client,
+                        &session_url,
+                        vec![line],
+                        idle_timeout_ms,
+                        max_duration_ms,
+                    )
+                    .await?;
+                }
+                StdinEvent::InputLines(lines) => {
+                    execute_input_lines(
+                        &client,
+                        &session_url,
+                        lines,
+                        idle_timeout_ms,
+                        max_duration_ms,
+                    )
+                    .await?;
+                }
+                StdinEvent::Quit => break,
+            }
+        }
         Ok(())
     })
 }
@@ -304,12 +411,20 @@ fn session_input_lines(args: &Args) -> Result<Vec<String>> {
         return Ok(args.input_lines.clone());
     }
     let message = message_text(args);
-    Ok(vec![serde_json::to_string(&json!({
+    Ok(vec![user_input_line(message)?])
+}
+
+fn should_send_initial_turn(args: &Args) -> bool {
+    args.message.is_some() || !args.input_lines.is_empty() || !args.stdin_events
+}
+
+fn user_input_line(text: &str) -> Result<String> {
+    Ok(serde_json::to_string(&json!({
         "type": "user",
         "message": {
-            "content": [{"type": "text", "text": message}],
+            "content": [{"type": "text", "text": text}],
         },
-    }))?])
+    }))?)
 }
 
 fn message_text(args: &Args) -> &str {
@@ -339,6 +454,88 @@ fn is_terminal_event(event: &str) -> bool {
         event,
         "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
     )
+}
+
+#[derive(Debug)]
+enum StdinEvent {
+    Message(String),
+    InputLine(String),
+    InputLines(Vec<String>),
+    Quit,
+}
+
+impl StdinEvent {
+    fn parse(line: &str) -> Result<Option<Self>> {
+        let line = line.trim();
+        if line.is_empty() {
+            return Ok(None);
+        }
+        if matches!(line, "/quit" | "/exit") {
+            return Ok(Some(Self::Quit));
+        }
+        if let Some(text) = line.strip_prefix("/message ") {
+            return Ok(Some(Self::Message(text.trim().to_owned())));
+        }
+        if let Some(raw_line) = line.strip_prefix("/input ") {
+            return Ok(Some(Self::InputLine(raw_line.trim().to_owned())));
+        }
+        if let Some(raw_lines) = line.strip_prefix("/execute ") {
+            return parse_execute_command(raw_lines.trim()).map(Some);
+        }
+        if line.starts_with('/') {
+            bail!("unknown stdin command: {line}");
+        }
+        if line.starts_with('{') {
+            return parse_json_stdin_event(line).map(Some);
+        }
+        Ok(Some(Self::Message(line.to_owned())))
+    }
+}
+
+fn parse_execute_command(value: &str) -> Result<StdinEvent> {
+    if value.starts_with('[') {
+        let lines =
+            serde_json::from_str::<Vec<String>>(value).context("parse /execute JSON array")?;
+        return Ok(StdinEvent::InputLines(lines));
+    }
+    Ok(StdinEvent::InputLine(value.to_owned()))
+}
+
+fn parse_json_stdin_event(line: &str) -> Result<StdinEvent> {
+    let value = serde_json::from_str::<Value>(line).context("parse stdin JSON event")?;
+    match value.get("type").and_then(Value::as_str) {
+        Some("message") => {
+            let text = value
+                .get("text")
+                .and_then(Value::as_str)
+                .context("stdin message event requires string field `text`")?;
+            Ok(StdinEvent::Message(text.to_owned()))
+        }
+        Some("input_line") => {
+            let raw_line = value
+                .get("line")
+                .and_then(Value::as_str)
+                .context("stdin input_line event requires string field `line`")?;
+            Ok(StdinEvent::InputLine(raw_line.to_owned()))
+        }
+        Some("execute") => {
+            let lines = value
+                .get("input_lines")
+                .and_then(Value::as_array)
+                .context("stdin execute event requires array field `input_lines`")?
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map(ToOwned::to_owned)
+                        .context("stdin execute input_lines must be strings")
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(StdinEvent::InputLines(lines))
+        }
+        Some("quit" | "exit") => Ok(StdinEvent::Quit),
+        _ => Ok(StdinEvent::InputLine(line.to_owned())),
+    }
 }
 
 #[derive(Debug)]

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -10,6 +10,8 @@ use tokio::{
 };
 use uuid::Uuid;
 
+mod tui;
+
 const DEFAULT_MESSAGE: &str = "Reply with exactly PONG and nothing else.";
 
 #[derive(Debug, Parser)]
@@ -53,6 +55,12 @@ struct Args {
 
     #[arg(long, alias = "stdin")]
     stdin_events: bool,
+
+    #[arg(long)]
+    tui: bool,
+
+    #[arg(long)]
+    debug: bool,
 }
 
 #[tokio::main]
@@ -71,6 +79,22 @@ async fn main() -> Result<()> {
 
     if attach_mode {
         let events_response = open_event_stream(&client, &session_url, args.after_event_id).await?;
+        if args.tui {
+            return tui::run(
+                client,
+                thread_key.as_str().to_owned(),
+                session_url,
+                events_response,
+                tui::TuiOptions {
+                    debug_visible: args.debug,
+                    idle_timeout_ms: args.idle_timeout_ms,
+                    max_duration_ms: args.max_duration_ms,
+                    exit_on_terminal: args.exit_on_terminal,
+                    exit_on_output_type: args.exit_on_output_type,
+                },
+            )
+            .await;
+        }
         return run_stream_and_optional_stdin(
             client,
             session_url,
@@ -123,6 +147,23 @@ async fn main() -> Result<()> {
         .context("execute initial turn")?;
     }
 
+    if args.tui {
+        return tui::run(
+            client,
+            thread_key.as_str().to_owned(),
+            session_url,
+            events_response,
+            tui::TuiOptions {
+                debug_visible: args.debug,
+                idle_timeout_ms: args.idle_timeout_ms,
+                max_duration_ms: args.max_duration_ms,
+                exit_on_terminal: args.exit_on_terminal,
+                exit_on_output_type: args.exit_on_output_type,
+            },
+        )
+        .await;
+    }
+
     run_stream_and_optional_stdin(
         client,
         session_url,
@@ -151,6 +192,9 @@ fn validate_mode(args: &Args, attach_mode: bool) -> Result<()> {
     }
     if args.attach && (args.message.is_some() || !args.input_lines.is_empty()) {
         bail!("--attach does not accept --message or --input-line");
+    }
+    if args.tui && args.stdin_events {
+        bail!("--tui cannot be combined with --stdin-events");
     }
     Ok(())
 }
@@ -208,7 +252,11 @@ async fn open_event_stream(
         .context("open event stream")
 }
 
-async fn append_user_message(client: &Client, session_url: &str, text: &str) -> Result<()> {
+pub(crate) async fn append_user_message(
+    client: &Client,
+    session_url: &str,
+    text: &str,
+) -> Result<()> {
     post_json(
         client,
         &format!("{session_url}/messages"),
@@ -227,7 +275,7 @@ async fn append_user_message(client: &Client, session_url: &str, text: &str) -> 
     Ok(())
 }
 
-async fn execute_input_lines(
+pub(crate) async fn execute_input_lines(
     client: &Client,
     session_url: &str,
     input_lines: Vec<String>,
@@ -391,7 +439,7 @@ async fn stream_output_lines(
     Ok(())
 }
 
-fn output_type_matches(data: &str, expected_type: Option<&str>) -> bool {
+pub(crate) fn output_type_matches(data: &str, expected_type: Option<&str>) -> bool {
     let Some(expected_type) = expected_type else {
         return false;
     };
@@ -415,10 +463,10 @@ fn session_input_lines(args: &Args) -> Result<Vec<String>> {
 }
 
 fn should_send_initial_turn(args: &Args) -> bool {
-    args.message.is_some() || !args.input_lines.is_empty() || !args.stdin_events
+    args.message.is_some() || !args.input_lines.is_empty() || (!args.stdin_events && !args.tui)
 }
 
-fn user_input_line(text: &str) -> Result<String> {
+pub(crate) fn user_input_line(text: &str) -> Result<String> {
     Ok(serde_json::to_string(&json!({
         "type": "user",
         "message": {
@@ -435,7 +483,7 @@ fn session_url(base_url: &str, thread_key: &str) -> String {
     format!("{base_url}/api/session/{}", urlencoding::encode(thread_key))
 }
 
-fn next_frame(buffer: &str) -> Option<(usize, usize)> {
+pub(crate) fn next_frame(buffer: &str) -> Option<(usize, usize)> {
     let lf = buffer.find("\n\n").map(|index| (index, 2));
     let crlf = buffer.find("\r\n\r\n").map(|index| (index, 4));
     match (lf, crlf) {
@@ -445,11 +493,11 @@ fn next_frame(buffer: &str) -> Option<(usize, usize)> {
     }
 }
 
-fn parse_json_or_string(data: &str) -> Value {
+pub(crate) fn parse_json_or_string(data: &str) -> Value {
     serde_json::from_str(data).unwrap_or_else(|_| Value::String(data.to_owned()))
 }
 
-fn is_terminal_event(event: &str) -> bool {
+pub(crate) fn is_terminal_event(event: &str) -> bool {
     matches!(
         event,
         "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
@@ -457,7 +505,7 @@ fn is_terminal_event(event: &str) -> bool {
 }
 
 #[derive(Debug)]
-enum StdinEvent {
+pub(crate) enum StdinEvent {
     Message(String),
     InputLine(String),
     InputLines(Vec<String>),
@@ -465,7 +513,7 @@ enum StdinEvent {
 }
 
 impl StdinEvent {
-    fn parse(line: &str) -> Result<Option<Self>> {
+    pub(crate) fn parse(line: &str) -> Result<Option<Self>> {
         let line = line.trim();
         if line.is_empty() {
             return Ok(None);
@@ -539,14 +587,14 @@ fn parse_json_stdin_event(line: &str) -> Result<StdinEvent> {
 }
 
 #[derive(Debug)]
-struct SseFrame {
-    id: Option<String>,
-    event: String,
-    data: String,
+pub(crate) struct SseFrame {
+    pub(crate) id: Option<String>,
+    pub(crate) event: String,
+    pub(crate) data: String,
 }
 
 impl SseFrame {
-    fn parse(frame: &str) -> Option<Self> {
+    pub(crate) fn parse(frame: &str) -> Option<Self> {
         let frame = frame.replace("\r\n", "\n");
         let mut id = None;
         let mut event = "message".to_owned();

--- a/services/api-rs/crates/centaur-session-cli/src/tui.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/tui.rs
@@ -1,0 +1,710 @@
+use std::{
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use crossterm::{
+    cursor::{Hide, Show},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use futures_util::StreamExt;
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+use reqwest::Client;
+use serde_json::Value;
+use tokio::{
+    sync::mpsc,
+    time::{self, Duration as TokioDuration},
+};
+
+use crate::{
+    SseFrame, StdinEvent, append_user_message, execute_input_lines, is_terminal_event, next_frame,
+    output_type_matches, parse_json_or_string, user_input_line,
+};
+
+const MAX_MAIN_LINES: usize = 1_000;
+const MAX_DEBUG_LINES: usize = 1_000;
+
+pub(crate) struct TuiOptions {
+    pub(crate) debug_visible: bool,
+    pub(crate) idle_timeout_ms: u64,
+    pub(crate) max_duration_ms: u64,
+    pub(crate) exit_on_terminal: bool,
+    pub(crate) exit_on_output_type: Option<String>,
+}
+
+pub(crate) async fn run(
+    client: Client,
+    thread_key: String,
+    session_url: String,
+    events_response: reqwest::Response,
+    options: TuiOptions,
+) -> Result<()> {
+    let _terminal_restore = TerminalRestore::enter()?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
+    terminal.clear()?;
+
+    let (terminal_tx, mut terminal_rx) = mpsc::channel(64);
+    let _terminal_reader = TerminalEventReader::spawn(terminal_tx);
+    let (frame_tx, mut frame_rx) = mpsc::channel(256);
+    let (notice_tx, mut notice_rx) = mpsc::channel(64);
+
+    spawn_stream_task(events_response, frame_tx, notice_tx.clone());
+
+    let mut app = TuiApp::new(thread_key, options.debug_visible);
+    let mut tick = time::interval(TokioDuration::from_millis(100));
+
+    loop {
+        terminal.draw(|frame| draw(frame, &app))?;
+
+        tokio::select! {
+            _ = tick.tick() => {}
+            Some(event) = terminal_rx.recv() => {
+                if handle_terminal_event(
+                    &mut app,
+                    event,
+                    &client,
+                    &session_url,
+                    &options,
+                    notice_tx.clone(),
+                )? {
+                    break;
+                }
+            }
+            Some(frame) = frame_rx.recv() => {
+                if app.handle_sse_frame(frame, &options) {
+                    break;
+                }
+            }
+            Some(notice) = notice_rx.recv() => {
+                app.handle_notice(notice);
+            }
+            else => break,
+        }
+    }
+
+    Ok(())
+}
+
+fn spawn_stream_task(
+    response: reqwest::Response,
+    frame_tx: mpsc::Sender<SseFrame>,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) {
+    tokio::spawn(async move {
+        if let Err(error) = stream_sse_frames(response, frame_tx).await {
+            let _ = notice_tx
+                .send(TuiNotice::Error(format!("stream error: {error:#}")))
+                .await;
+        }
+    });
+}
+
+async fn stream_sse_frames(
+    response: reqwest::Response,
+    frame_tx: mpsc::Sender<SseFrame>,
+) -> Result<()> {
+    let mut chunks = response.bytes_stream();
+    let mut buffer = String::new();
+
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk.context("read event stream")?;
+        buffer.push_str(std::str::from_utf8(&chunk).context("event stream is not UTF-8")?);
+
+        while let Some((frame_end, separator_len)) = next_frame(&buffer) {
+            let frame = buffer[..frame_end].to_owned();
+            buffer.drain(..frame_end + separator_len);
+
+            if let Some(event) = SseFrame::parse(&frame) {
+                if frame_tx.send(event).await.is_err() {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_terminal_event(
+    app: &mut TuiApp,
+    event: TerminalInput,
+    client: &Client,
+    session_url: &str,
+    options: &TuiOptions,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) -> Result<bool> {
+    let TerminalInput::Key(key) = event else {
+        return Ok(false);
+    };
+
+    match key.code {
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => return Ok(true),
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => return Ok(true),
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => app.input.clear(),
+        KeyCode::F(2) => app.toggle_debug(),
+        KeyCode::Enter => {
+            let line = app.input.trim().to_owned();
+            app.input.clear();
+            return submit_input_line(app, line, client, session_url, options, notice_tx);
+        }
+        KeyCode::Backspace => {
+            app.input.pop();
+        }
+        KeyCode::Char(ch) => {
+            if key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT {
+                app.input.push(ch);
+            }
+        }
+        _ => {}
+    }
+
+    Ok(false)
+}
+
+fn submit_input_line(
+    app: &mut TuiApp,
+    line: String,
+    client: &Client,
+    session_url: &str,
+    options: &TuiOptions,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) -> Result<bool> {
+    if line.is_empty() {
+        return Ok(false);
+    }
+    match line.as_str() {
+        "/debug" => {
+            app.toggle_debug();
+            return Ok(false);
+        }
+        "/clear" => {
+            app.clear();
+            return Ok(false);
+        }
+        "/help" => {
+            app.status =
+                "Enter sends | F2 or /debug toggles events | /input raw | /quit exits".to_owned();
+            return Ok(false);
+        }
+        _ => {}
+    }
+
+    let Some(event) = StdinEvent::parse(&line)? else {
+        return Ok(false);
+    };
+    if matches!(event, StdinEvent::Quit) {
+        return Ok(true);
+    }
+
+    app.note_submitted_event(&event);
+    spawn_send_task(
+        event,
+        client.clone(),
+        session_url.to_owned(),
+        options.idle_timeout_ms,
+        options.max_duration_ms,
+        notice_tx,
+    );
+    Ok(false)
+}
+
+fn spawn_send_task(
+    event: StdinEvent,
+    client: Client,
+    session_url: String,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+    notice_tx: mpsc::Sender<TuiNotice>,
+) {
+    tokio::spawn(async move {
+        let notice =
+            match send_stdin_event(event, client, session_url, idle_timeout_ms, max_duration_ms)
+                .await
+            {
+                Ok(message) => TuiNotice::Info(message),
+                Err(error) => TuiNotice::Error(format!("{error:#}")),
+            };
+        let _ = notice_tx.send(notice).await;
+    });
+}
+
+async fn send_stdin_event(
+    event: StdinEvent,
+    client: Client,
+    session_url: String,
+    idle_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<String> {
+    match event {
+        StdinEvent::Message(text) => {
+            append_user_message(&client, &session_url, &text).await?;
+            execute_input_lines(
+                &client,
+                &session_url,
+                vec![user_input_line(&text)?],
+                idle_timeout_ms,
+                max_duration_ms,
+            )
+            .await?;
+            Ok("message sent".to_owned())
+        }
+        StdinEvent::InputLine(line) => {
+            execute_input_lines(
+                &client,
+                &session_url,
+                vec![line],
+                idle_timeout_ms,
+                max_duration_ms,
+            )
+            .await?;
+            Ok("input line sent".to_owned())
+        }
+        StdinEvent::InputLines(lines) => {
+            let count = lines.len();
+            execute_input_lines(
+                &client,
+                &session_url,
+                lines,
+                idle_timeout_ms,
+                max_duration_ms,
+            )
+            .await?;
+            Ok(format!("{count} input lines sent"))
+        }
+        StdinEvent::Quit => Ok("quit".to_owned()),
+    }
+}
+
+fn draw(frame: &mut Frame<'_>, app: &TuiApp) {
+    let area = frame.area();
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    draw_header(frame, layout[0], app);
+    draw_body(frame, layout[1], app);
+    draw_input(frame, layout[2], app);
+    draw_footer(frame, layout[3], app);
+}
+
+fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let debug_state = if app.debug_visible {
+        "debug:on"
+    } else {
+        "debug:off"
+    };
+    let last_event = app.last_event_id.as_deref().unwrap_or("-");
+    let title = Line::from(vec![
+        Span::styled(
+            "Centaur Session",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(app.thread_key.clone(), Style::default().fg(Color::Yellow)),
+        Span::raw("  "),
+        Span::raw(format!("event:{last_event}  {debug_state}")),
+    ]);
+    let help = Line::from("Enter send  F2 debug  Ctrl-U clear input  Ctrl-D quit  /help");
+    frame.render_widget(
+        Paragraph::new(vec![title, help]).block(Block::default().borders(Borders::BOTTOM)),
+        area,
+    );
+}
+
+fn draw_body(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    if app.debug_visible {
+        if area.width >= 100 {
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
+                .split(area);
+            draw_main(frame, chunks[0], app);
+            draw_debug(frame, chunks[1], app);
+        } else {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                .split(area);
+            draw_main(frame, chunks[0], app);
+            draw_debug(frame, chunks[1], app);
+        }
+    } else {
+        draw_main(frame, area, app);
+    }
+}
+
+fn draw_main(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let lines = tail_lines(&app.main_lines, area.height.saturating_sub(2) as usize);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().title("Session").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_debug(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let lines = tail_lines(&app.debug_lines, area.height.saturating_sub(2) as usize);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().title("Events").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    let visible = visible_input(&app.input, area.width.saturating_sub(2) as usize);
+    let cursor_x = area
+        .x
+        .saturating_add(1)
+        .saturating_add(visible.chars().count() as u16)
+        .min(area.x.saturating_add(area.width.saturating_sub(2)));
+    let cursor_y = area.y.saturating_add(1);
+
+    frame.render_widget(
+        Paragraph::new(visible)
+            .block(Block::default().title("Input").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+    frame.set_cursor_position((cursor_x, cursor_y));
+}
+
+fn draw_footer(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
+    frame.render_widget(
+        Paragraph::new(app.status.clone()).style(Style::default().fg(Color::DarkGray)),
+        area,
+    );
+}
+
+fn tail_lines(lines: &[String], max: usize) -> Vec<Line<'static>> {
+    let start = lines.len().saturating_sub(max.max(1));
+    lines[start..]
+        .iter()
+        .map(|line| Line::raw(line.clone()))
+        .collect()
+}
+
+fn visible_input(input: &str, max_chars: usize) -> String {
+    let chars = input.chars().collect::<Vec<_>>();
+    let start = chars.len().saturating_sub(max_chars.max(1));
+    chars[start..].iter().collect()
+}
+
+#[derive(Debug)]
+enum TerminalInput {
+    Key(KeyEvent),
+    Resize,
+}
+
+struct TerminalEventReader {
+    stop: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl TerminalEventReader {
+    fn spawn(sender: mpsc::Sender<TerminalInput>) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let reader_stop = Arc::clone(&stop);
+        let handle = thread::spawn(move || {
+            while !reader_stop.load(Ordering::Relaxed) {
+                let Ok(has_event) = event::poll(Duration::from_millis(100)) else {
+                    continue;
+                };
+                if !has_event {
+                    continue;
+                }
+                match event::read() {
+                    Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => {
+                        if sender.blocking_send(TerminalInput::Key(key)).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(Event::Resize(_, _)) => {
+                        if sender.blocking_send(TerminalInput::Resize).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(_) | Err(_) => {}
+                }
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for TerminalEventReader {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+struct TerminalRestore;
+
+impl TerminalRestore {
+    fn enter() -> Result<Self> {
+        enable_raw_mode().context("enable terminal raw mode")?;
+        execute!(io::stdout(), EnterAlternateScreen, Hide).context("enter alternate screen")?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalRestore {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), Show, LeaveAlternateScreen);
+    }
+}
+
+enum TuiNotice {
+    Info(String),
+    Error(String),
+}
+
+struct TuiApp {
+    thread_key: String,
+    input: String,
+    main_lines: Vec<String>,
+    debug_lines: Vec<String>,
+    debug_visible: bool,
+    status: String,
+    last_event_id: Option<String>,
+    current_agent_line: Option<usize>,
+}
+
+impl TuiApp {
+    fn new(thread_key: String, debug_visible: bool) -> Self {
+        Self {
+            thread_key,
+            input: String::new(),
+            main_lines: vec![
+                "session ready".to_owned(),
+                "type a message and press Enter; use F2 for raw events".to_owned(),
+            ],
+            debug_lines: Vec::new(),
+            debug_visible,
+            status: "ready".to_owned(),
+            last_event_id: None,
+            current_agent_line: None,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.main_lines.clear();
+        self.debug_lines.clear();
+        self.current_agent_line = None;
+        self.status = "cleared".to_owned();
+    }
+
+    fn toggle_debug(&mut self) {
+        self.debug_visible = !self.debug_visible;
+        self.status = if self.debug_visible {
+            "debug events visible".to_owned()
+        } else {
+            "debug events hidden".to_owned()
+        };
+    }
+
+    fn note_submitted_event(&mut self, event: &StdinEvent) {
+        match event {
+            StdinEvent::Message(text) => {
+                self.push_main_line(format!("you: {text}"));
+                self.status = "sending message".to_owned();
+            }
+            StdinEvent::InputLine(_) => {
+                self.push_main_line("system: sending raw input line".to_owned());
+                self.status = "sending raw input line".to_owned();
+            }
+            StdinEvent::InputLines(lines) => {
+                self.push_main_line(format!("system: sending {} raw input lines", lines.len()));
+                self.status = "sending raw input lines".to_owned();
+            }
+            StdinEvent::Quit => {}
+        }
+    }
+
+    fn handle_notice(&mut self, notice: TuiNotice) {
+        match notice {
+            TuiNotice::Info(message) => self.status = message,
+            TuiNotice::Error(message) => {
+                self.status = format!("error: {message}");
+                self.push_main_line(format!("error: {message}"));
+            }
+        }
+    }
+
+    fn handle_sse_frame(&mut self, frame: SseFrame, options: &TuiOptions) -> bool {
+        self.last_event_id = frame.id.clone();
+        self.push_debug_line(format_debug_frame(&frame));
+
+        if frame.event == "session.output.line" {
+            self.handle_output_line(&frame.data);
+            if output_type_matches(&frame.data, options.exit_on_output_type.as_deref()) {
+                self.status = format!(
+                    "matched output type {}",
+                    options.exit_on_output_type.as_deref().unwrap_or_default()
+                );
+                return true;
+            }
+        } else if frame.event == "session.execution_started" {
+            self.push_main_line("system: execution started".to_owned());
+            self.status = "execution started".to_owned();
+        } else if is_terminal_event(&frame.event) {
+            self.current_agent_line = None;
+            self.push_main_line(format!("system: {}", frame.event));
+            self.status = frame.event.clone();
+            if options.exit_on_terminal {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn handle_output_line(&mut self, data: &str) {
+        let Ok(value) = serde_json::from_str::<Value>(data) else {
+            self.push_main_line(format!("stdout: {data}"));
+            return;
+        };
+
+        let Some(event_type) = value.get("type").and_then(Value::as_str) else {
+            self.push_main_line(format!("stdout: {}", compact_json(&value, 240)));
+            return;
+        };
+
+        match event_type {
+            "item.agentMessage.delta" => {
+                if let Some(delta) = value.get("delta").and_then(Value::as_str) {
+                    self.append_agent_delta(delta);
+                }
+            }
+            "item.completed" => {
+                if let Some(text) = completed_agent_text(&value) {
+                    if self.current_agent_line.is_none() {
+                        self.push_main_line(format!("assistant: {text}"));
+                    }
+                    self.current_agent_line = None;
+                }
+            }
+            "turn.completed" => {
+                self.current_agent_line = None;
+                self.push_main_line("system: turn completed".to_owned());
+                self.status = "turn completed".to_owned();
+            }
+            "result" => {
+                self.current_agent_line = None;
+                if let Some(result) = value.get("result").and_then(Value::as_str) {
+                    self.push_main_line(format!("result: {result}"));
+                } else {
+                    self.push_main_line(format!("result: {}", compact_json(&value, 240)));
+                }
+            }
+            "system" => {
+                let subtype = value
+                    .get("subtype")
+                    .and_then(Value::as_str)
+                    .unwrap_or("event");
+                self.push_main_line(format!("system: {subtype}"));
+            }
+            other => {
+                self.push_main_line(format!("event: {other}"));
+            }
+        }
+    }
+
+    fn append_agent_delta(&mut self, delta: &str) {
+        if self.current_agent_line.is_none() {
+            self.push_main_line("assistant: ".to_owned());
+            self.current_agent_line = self.main_lines.len().checked_sub(1);
+        }
+        if let Some(index) = self.current_agent_line {
+            if let Some(line) = self.main_lines.get_mut(index) {
+                line.push_str(delta);
+            }
+        }
+    }
+
+    fn push_main_line(&mut self, line: String) {
+        self.main_lines.push(line);
+        if self.main_lines.len() > MAX_MAIN_LINES {
+            self.main_lines.remove(0);
+            self.current_agent_line = self
+                .current_agent_line
+                .and_then(|index| index.checked_sub(1));
+        }
+    }
+
+    fn push_debug_line(&mut self, line: String) {
+        self.debug_lines.push(line);
+        if self.debug_lines.len() > MAX_DEBUG_LINES {
+            self.debug_lines.remove(0);
+        }
+    }
+}
+
+fn completed_agent_text(value: &Value) -> Option<&str> {
+    let item = value.get("item")?;
+    if item.get("type").and_then(Value::as_str) != Some("agentMessage") {
+        return None;
+    }
+    item.get("text").and_then(Value::as_str)
+}
+
+fn format_debug_frame(frame: &SseFrame) -> String {
+    let id = frame.id.as_deref().unwrap_or("-");
+    let data = parse_json_or_string(&frame.data);
+    format!(
+        "{} {} {}",
+        id,
+        frame.event,
+        truncate(&compact_json(&data, 1_000), 1_000)
+    )
+}
+
+fn compact_json(value: &Value, max_chars: usize) -> String {
+    let rendered = match value {
+        Value::String(value) => value.clone(),
+        _ => serde_json::to_string(value).unwrap_or_else(|_| "<invalid json>".to_owned()),
+    };
+    truncate(&rendered, max_chars)
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}

--- a/services/api-rs/crates/centaur-session-core/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "centaur-session-core"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+time.workspace = true

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -1,0 +1,408 @@
+//! Durable session control-plane types.
+//!
+//! A session is the public control-plane object for one ongoing agent
+//! conversation. `thread_key` is the canonical identifier.
+
+use std::{fmt, str::FromStr};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use serde_json::Value;
+use thiserror::Error;
+use time::OffsetDateTime;
+
+pub const MAX_THREAD_KEY_BYTES: usize = 512;
+pub const MAX_HARNESS_TYPE_BYTES: usize = 64;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ThreadKey(String);
+
+impl ThreadKey {
+    pub fn parse(value: impl Into<String>) -> Result<Self, ThreadKeyError> {
+        let value = value.into();
+        validate_thread_key(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for ThreadKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ThreadKey {
+    type Err = ThreadKeyError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for ThreadKey {
+    type Error = ThreadKeyError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl AsRef<str> for ThreadKey {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Serialize for ThreadKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ThreadKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+pub enum ThreadKeyError {
+    #[error("thread_key is required")]
+    Empty,
+    #[error("thread_key must be at most {MAX_THREAD_KEY_BYTES} bytes")]
+    TooLong,
+    #[error("thread_key must be namespaced as '<source>:<id>'")]
+    MissingNamespace,
+    #[error("thread_key must not contain ASCII control characters")]
+    ControlCharacter,
+    #[error("thread_key must not be raw JSON")]
+    RawJson,
+}
+
+fn validate_thread_key(value: &str) -> Result<(), ThreadKeyError> {
+    if value.is_empty() {
+        return Err(ThreadKeyError::Empty);
+    }
+    if value.len() > MAX_THREAD_KEY_BYTES {
+        return Err(ThreadKeyError::TooLong);
+    }
+    if value.starts_with('{') || value.starts_with('[') {
+        return Err(ThreadKeyError::RawJson);
+    }
+    if value.chars().any(|ch| ch.is_ascii_control()) {
+        return Err(ThreadKeyError::ControlCharacter);
+    }
+    let Some((namespace, rest)) = value.split_once(':') else {
+        return Err(ThreadKeyError::MissingNamespace);
+    };
+    if namespace.is_empty() || rest.is_empty() {
+        return Err(ThreadKeyError::MissingNamespace);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct HarnessType(String);
+
+impl HarnessType {
+    pub fn parse(value: impl Into<String>) -> Result<Self, HarnessTypeError> {
+        let value = value.into();
+        validate_harness_type(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for HarnessType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for HarnessType {
+    type Err = HarnessTypeError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl Serialize for HarnessType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for HarnessType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+pub enum HarnessTypeError {
+    #[error("harness_type is required")]
+    Empty,
+    #[error("harness_type must be at most {MAX_HARNESS_TYPE_BYTES} bytes")]
+    TooLong,
+    #[error("harness_type may only contain ASCII lowercase letters, digits, '-' and '_'")]
+    InvalidCharacter,
+}
+
+fn validate_harness_type(value: &str) -> Result<(), HarnessTypeError> {
+    if value.is_empty() {
+        return Err(HarnessTypeError::Empty);
+    }
+    if value.len() > MAX_HARNESS_TYPE_BYTES {
+        return Err(HarnessTypeError::TooLong);
+    }
+    if !value.bytes().all(|byte| {
+        byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-' || byte == b'_'
+    }) {
+        return Err(HarnessTypeError::InvalidCharacter);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    Active,
+    Idle,
+    Executing,
+    Failed,
+    Archived,
+}
+
+impl SessionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Idle => "idle",
+            Self::Executing => "executing",
+            Self::Failed => "failed",
+            Self::Archived => "archived",
+        }
+    }
+}
+
+impl FromStr for SessionStatus {
+    type Err = ParseEnumError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "active" => Ok(Self::Active),
+            "idle" => Ok(Self::Idle),
+            "executing" => Ok(Self::Executing),
+            "failed" => Ok(Self::Failed),
+            "archived" => Ok(Self::Archived),
+            _ => Err(ParseEnumError::new("session status", value)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Session {
+    pub thread_key: ThreadKey,
+    pub sandbox_id: Option<String>,
+    pub harness_type: HarnessType,
+    pub harness_thread_id: Option<String>,
+    pub status: SessionStatus,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageRole {
+    User,
+    Assistant,
+    System,
+    Tool,
+}
+
+impl MessageRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+            Self::System => "system",
+            Self::Tool => "tool",
+        }
+    }
+}
+
+impl FromStr for MessageRole {
+    type Err = ParseEnumError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "user" => Ok(Self::User),
+            "assistant" => Ok(Self::Assistant),
+            "system" => Ok(Self::System),
+            "tool" => Ok(Self::Tool),
+            _ => Err(ParseEnumError::new("message role", value)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionMessageInput {
+    pub role: MessageRole,
+    pub parts: Vec<Value>,
+    #[serde(default = "empty_object")]
+    pub metadata: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionMessage {
+    pub message_id: String,
+    pub thread_key: ThreadKey,
+    pub role: MessageRole,
+    pub parts: Vec<Value>,
+    pub metadata: Value,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl ExecutionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl FromStr for ExecutionStatus {
+    type Err = ParseEnumError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            "running" => Ok(Self::Running),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "cancelled" => Ok(Self::Cancelled),
+            _ => Err(ParseEnumError::new("execution status", value)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionExecution {
+    pub execution_id: String,
+    pub thread_key: ThreadKey,
+    pub status: ExecutionStatus,
+    pub metadata: Value,
+    pub error: Option<String>,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+    pub started_at: Option<OffsetDateTime>,
+    pub completed_at: Option<OffsetDateTime>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionEvent {
+    pub event_id: i64,
+    pub thread_key: ThreadKey,
+    pub execution_id: Option<String>,
+    pub event_type: String,
+    pub payload: Value,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+#[error("invalid {kind}: {value}")]
+pub struct ParseEnumError {
+    kind: &'static str,
+    value: String,
+}
+
+impl ParseEnumError {
+    fn new(kind: &'static str, value: &str) -> Self {
+        Self {
+            kind,
+            value: value.to_owned(),
+        }
+    }
+}
+
+pub fn empty_object() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HarnessType, ThreadKey};
+
+    #[test]
+    fn thread_key_accepts_namespaced_values() {
+        let key = ThreadKey::parse("slack:C123:1780000000.000000").unwrap();
+        assert_eq!(key.as_str(), "slack:C123:1780000000.000000");
+    }
+
+    #[test]
+    fn thread_key_rejects_missing_namespace() {
+        let err = ThreadKey::parse("not-namespaced").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "thread_key must be namespaced as '<source>:<id>'"
+        );
+    }
+
+    #[test]
+    fn thread_key_rejects_unbounded_payload_shape() {
+        let err = ThreadKey::parse("{\"thread\":\"x\"}").unwrap_err();
+        assert_eq!(err.to_string(), "thread_key must not be raw JSON");
+    }
+
+    #[test]
+    fn harness_type_rejects_spaces() {
+        let err = HarnessType::parse("claude code").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "harness_type may only contain ASCII lowercase letters, digits, '-' and '_'"
+        );
+    }
+}

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -378,8 +378,8 @@ mod tests {
 
     #[test]
     fn thread_key_accepts_namespaced_values() {
-        let key = ThreadKey::parse("slack:C123:1780000000.000000").unwrap();
-        assert_eq!(key.as_str(), "slack:C123:1780000000.000000");
+        let key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+        assert_eq!(key.as_str(), "chat:C123:1780000000.000000");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "centaur-session-sqlx"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+centaur-session-core.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+thiserror.workspace = true
+time.workspace = true
+uuid.workspace = true

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0001_session_control_plane.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0001_session_control_plane.sql
@@ -1,0 +1,56 @@
+create table if not exists sessions (
+    thread_key text primary key,
+    sandbox_id text,
+    harness_type text not null,
+    harness_thread_id text,
+    status text not null,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint sessions_thread_key_len check (octet_length(thread_key) <= 512),
+    constraint sessions_thread_key_namespaced check (position(':' in thread_key) > 1),
+    constraint sessions_harness_type_len check (octet_length(harness_type) between 1 and 64)
+);
+
+create table if not exists session_messages (
+    message_id text primary key,
+    thread_key text not null references sessions(thread_key) on delete cascade,
+    role text not null,
+    parts jsonb not null,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists session_messages_thread_created_idx
+    on session_messages (thread_key, created_at, message_id);
+
+create table if not exists session_executions (
+    execution_id text primary key,
+    thread_key text not null references sessions(thread_key) on delete cascade,
+    status text not null,
+    metadata jsonb not null default '{}'::jsonb,
+    error text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    started_at timestamptz,
+    completed_at timestamptz
+);
+
+create index if not exists session_executions_thread_created_idx
+    on session_executions (thread_key, created_at, execution_id);
+
+create unique index if not exists session_executions_one_active_idx
+    on session_executions (thread_key)
+    where status in ('queued', 'running');
+
+create table if not exists session_events (
+    event_id bigint generated always as identity primary key,
+    thread_key text not null references sessions(thread_key) on delete cascade,
+    execution_id text references session_executions(execution_id) on delete set null,
+    event_type text not null,
+    payload jsonb not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists session_events_thread_event_idx
+    on session_events (thread_key, event_id);

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -1,0 +1,525 @@
+//! SQLx-backed session repository.
+
+use std::str::FromStr;
+
+use centaur_session_core::{
+    ExecutionStatus, HarnessType, Session, SessionEvent, SessionExecution, SessionMessage,
+    SessionMessageInput, SessionStatus, ThreadKey, empty_object,
+};
+use serde_json::Value;
+use sqlx::{FromRow, PgPool, postgres::PgPoolOptions};
+use thiserror::Error;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+#[derive(Clone)]
+pub struct PgSessionStore {
+    pool: PgPool,
+}
+
+impl PgSessionStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn connect(database_url: &str) -> Result<Self, SessionStoreError> {
+        let pool = PgPoolOptions::new()
+            .max_connections(10)
+            .connect(database_url)
+            .await?;
+        Ok(Self::new(pool))
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), SessionStoreError> {
+        MIGRATOR.run(&self.pool).await?;
+        Ok(())
+    }
+
+    pub async fn create_or_get_session(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        metadata: Value,
+    ) -> Result<Session, SessionStoreError> {
+        sqlx::query(
+            r#"
+            insert into sessions (thread_key, harness_type, status, metadata)
+            values ($1, $2, $3, $4)
+            on conflict (thread_key) do nothing
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(harness_type.as_str())
+        .bind(SessionStatus::Idle.as_str())
+        .bind(metadata)
+        .execute(&self.pool)
+        .await?;
+
+        let session = self.get_session(thread_key).await?;
+        if session.harness_type != *harness_type {
+            return Err(SessionStoreError::HarnessConflict {
+                thread_key: thread_key.as_str().to_owned(),
+                existing: session.harness_type.into_string(),
+                requested: harness_type.as_str().to_owned(),
+            });
+        }
+        Ok(session)
+    }
+
+    pub async fn get_session(&self, thread_key: &ThreadKey) -> Result<Session, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            select thread_key, sandbox_id, harness_type, harness_thread_id, status, created_at, updated_at
+            from sessions
+            where thread_key = $1
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| SessionStoreError::NotFound {
+            thread_key: thread_key.as_str().to_owned(),
+        })?;
+
+        row.try_into()
+    }
+
+    pub async fn append_messages(
+        &self,
+        thread_key: &ThreadKey,
+        messages: &[SessionMessageInput],
+    ) -> Result<Vec<String>, SessionStoreError> {
+        let mut tx = self.pool.begin().await?;
+        let mut message_ids = Vec::with_capacity(messages.len());
+
+        for message in messages {
+            let message_id = prefixed_id("msg");
+            let parts = Value::Array(message.parts.clone());
+            sqlx::query(
+                r#"
+                insert into session_messages (message_id, thread_key, role, parts, metadata)
+                values ($1, $2, $3, $4, $5)
+                "#,
+            )
+            .bind(&message_id)
+            .bind(thread_key.as_str())
+            .bind(message.role.as_str())
+            .bind(parts)
+            .bind(message.metadata.clone())
+            .execute(&mut *tx)
+            .await?;
+            message_ids.push(message_id);
+        }
+
+        tx.commit().await?;
+        Ok(message_ids)
+    }
+
+    pub async fn list_messages(
+        &self,
+        thread_key: &ThreadKey,
+    ) -> Result<Vec<SessionMessage>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, SessionMessageRow>(
+            r#"
+            select message_id, thread_key, role, parts, metadata, created_at
+            from session_messages
+            where thread_key = $1
+            order by created_at, message_id
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    pub async fn create_execution(
+        &self,
+        thread_key: &ThreadKey,
+        metadata: Value,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let execution_id = prefixed_id("exe");
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            insert into session_executions (execution_id, thread_key, status, metadata)
+            values ($1, $2, $3, $4)
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(&execution_id)
+        .bind(thread_key.as_str())
+        .bind(ExecutionStatus::Queued.as_str())
+        .bind(metadata)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn claim_next_execution(
+        &self,
+        thread_key: &ThreadKey,
+    ) -> Result<Option<SessionExecution>, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2, started_at = coalesce(started_at, now()), updated_at = now()
+            where execution_id = (
+                select execution_id
+                from session_executions
+                where thread_key = $1 and status = $3
+                order by created_at, execution_id
+                for update skip locked
+                limit 1
+            )
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(ExecutionStatus::Running.as_str())
+        .bind(ExecutionStatus::Queued.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if let Some(row) = row {
+            self.set_session_status(&row.thread_key, SessionStatus::Executing)
+                .await?;
+            return row.try_into().map(Some);
+        }
+        Ok(None)
+    }
+
+    pub async fn mark_execution_running(
+        &self,
+        execution_id: &str,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2, started_at = coalesce(started_at, now()), updated_at = now()
+            where execution_id = $1
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Running.as_str())
+        .fetch_one(&self.pool)
+        .await?;
+
+        self.set_session_status(&row.thread_key, SessionStatus::Executing)
+            .await?;
+        row.try_into()
+    }
+
+    pub async fn complete_execution(
+        &self,
+        execution_id: &str,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2, completed_at = coalesce(completed_at, now()), updated_at = now()
+            where execution_id = $1
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Completed.as_str())
+        .fetch_one(&self.pool)
+        .await?;
+
+        self.set_session_status(&row.thread_key, SessionStatus::Idle)
+            .await?;
+        row.try_into()
+    }
+
+    pub async fn fail_execution(
+        &self,
+        execution_id: &str,
+        error: &str,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2, error = $3, completed_at = coalesce(completed_at, now()), updated_at = now()
+            where execution_id = $1
+            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Failed.as_str())
+        .bind(error)
+        .fetch_one(&self.pool)
+        .await?;
+
+        self.set_session_status(&row.thread_key, SessionStatus::Failed)
+            .await?;
+        row.try_into()
+    }
+
+    pub async fn append_event(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: Option<&str>,
+        event_type: &str,
+        payload: Value,
+    ) -> Result<SessionEvent, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionEventRow>(
+            r#"
+            insert into session_events (thread_key, execution_id, event_type, payload)
+            values ($1, $2, $3, $4)
+            returning event_id, thread_key, execution_id, event_type, payload, created_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(execution_id)
+        .bind(event_type)
+        .bind(payload)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn list_events_after(
+        &self,
+        thread_key: &ThreadKey,
+        after_event_id: i64,
+        limit: i64,
+    ) -> Result<Vec<SessionEvent>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, SessionEventRow>(
+            r#"
+            select event_id, thread_key, execution_id, event_type, payload, created_at
+            from session_events
+            where thread_key = $1 and event_id > $2
+            order by event_id
+            limit $3
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(after_event_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    pub async fn update_sandbox_id(
+        &self,
+        thread_key: &ThreadKey,
+        sandbox_id: Option<&str>,
+    ) -> Result<Session, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            update sessions
+            set sandbox_id = $2, updated_at = now()
+            where thread_key = $1
+            returning thread_key, sandbox_id, harness_type, harness_thread_id, status, created_at, updated_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(sandbox_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn update_harness_thread_id(
+        &self,
+        thread_key: &ThreadKey,
+        harness_thread_id: Option<&str>,
+    ) -> Result<Session, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            update sessions
+            set harness_thread_id = $2, updated_at = now()
+            where thread_key = $1
+            returning thread_key, sandbox_id, harness_type, harness_thread_id, status, created_at, updated_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(harness_thread_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    async fn set_session_status(
+        &self,
+        thread_key: &str,
+        status: SessionStatus,
+    ) -> Result<(), SessionStoreError> {
+        sqlx::query(
+            r#"
+            update sessions
+            set status = $2, updated_at = now()
+            where thread_key = $1
+            "#,
+        )
+        .bind(thread_key)
+        .bind(status.as_str())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SessionStoreError {
+    #[error("session not found for thread_key {thread_key}")]
+    NotFound { thread_key: String },
+    #[error(
+        "session {thread_key} already exists with harness_type {existing}, requested {requested}"
+    )]
+    HarnessConflict {
+        thread_key: String,
+        existing: String,
+        requested: String,
+    },
+    #[error("invalid persisted value: {0}")]
+    InvalidPersistedValue(String),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(transparent)]
+    Migrate(#[from] sqlx::migrate::MigrateError),
+}
+
+#[derive(Debug, FromRow)]
+struct SessionRow {
+    thread_key: String,
+    sandbox_id: Option<String>,
+    harness_type: String,
+    harness_thread_id: Option<String>,
+    status: String,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+}
+
+impl TryFrom<SessionRow> for Session {
+    type Error = SessionStoreError;
+
+    fn try_from(row: SessionRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            thread_key: parse_persisted(row.thread_key)?,
+            sandbox_id: row.sandbox_id,
+            harness_type: parse_persisted(row.harness_type)?,
+            harness_thread_id: row.harness_thread_id,
+            status: parse_persisted(row.status)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct SessionMessageRow {
+    message_id: String,
+    thread_key: String,
+    role: String,
+    parts: Value,
+    metadata: Value,
+    created_at: OffsetDateTime,
+}
+
+impl TryFrom<SessionMessageRow> for SessionMessage {
+    type Error = SessionStoreError;
+
+    fn try_from(row: SessionMessageRow) -> Result<Self, Self::Error> {
+        let parts = match row.parts {
+            Value::Array(parts) => parts,
+            other => vec![other],
+        };
+        Ok(Self {
+            message_id: row.message_id,
+            thread_key: parse_persisted(row.thread_key)?,
+            role: parse_persisted(row.role)?,
+            parts,
+            metadata: row.metadata,
+            created_at: row.created_at,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct SessionExecutionRow {
+    execution_id: String,
+    thread_key: String,
+    status: String,
+    metadata: Value,
+    error: Option<String>,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+    started_at: Option<OffsetDateTime>,
+    completed_at: Option<OffsetDateTime>,
+}
+
+impl TryFrom<SessionExecutionRow> for SessionExecution {
+    type Error = SessionStoreError;
+
+    fn try_from(row: SessionExecutionRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            execution_id: row.execution_id,
+            thread_key: parse_persisted(row.thread_key)?,
+            status: parse_persisted(row.status)?,
+            metadata: row.metadata,
+            error: row.error,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            started_at: row.started_at,
+            completed_at: row.completed_at,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct SessionEventRow {
+    event_id: i64,
+    thread_key: String,
+    execution_id: Option<String>,
+    event_type: String,
+    payload: Value,
+    created_at: OffsetDateTime,
+}
+
+impl TryFrom<SessionEventRow> for SessionEvent {
+    type Error = SessionStoreError;
+
+    fn try_from(row: SessionEventRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            event_id: row.event_id,
+            thread_key: parse_persisted(row.thread_key)?,
+            execution_id: row.execution_id,
+            event_type: row.event_type,
+            payload: row.payload,
+            created_at: row.created_at,
+        })
+    }
+}
+
+fn parse_persisted<T>(value: String) -> Result<T, SessionStoreError>
+where
+    T: FromStr,
+    T::Err: std::fmt::Display,
+{
+    value
+        .parse()
+        .map_err(|err: T::Err| SessionStoreError::InvalidPersistedValue(err.to_string()))
+}
+
+fn prefixed_id(prefix: &str) -> String {
+    format!("{prefix}_{}", Uuid::new_v4().simple())
+}
+
+pub fn default_metadata(metadata: Option<Value>) -> Value {
+    metadata.unwrap_or_else(empty_object)
+}

--- a/services/api-rs/rfcs/0001-sandbox-abstraction.md
+++ b/services/api-rs/rfcs/0001-sandbox-abstraction.md
@@ -34,7 +34,7 @@ runtime layer.
 ## Non-goals
 
 - Exposing sandbox create/stop/pause/resume through public API endpoints.
-- Porting durable execution, workflow engine, Slack delivery, API key issuance,
+- Porting durable execution, workflow engine, chat delivery, API key issuance,
   tool discovery, or assignment management.
 - Encoding Centaur-specific agent concepts in `SandboxSpec`.
 - Designing the final database schema for sandbox ownership.

--- a/services/api-rs/rfcs/0002-session-control-plane.md
+++ b/services/api-rs/rfcs/0002-session-control-plane.md
@@ -1,0 +1,405 @@
+# RFC 0002: Session Control Plane
+
+Status: Draft
+Owner: TBD
+Target: `services/api-rs`
+
+## Summary
+
+Introduce `Session` as the durable control-plane object above the sandbox
+runtime abstraction from RFC 0001. A session represents one ongoing agent
+conversation, regardless of whether it was started by Slack, a workflow, a CLI,
+or another caller.
+
+The session is the source of truth for:
+
+- the external thread identity
+- the current sandbox assignment
+- the harness type
+- the harness-native thread/session identifier
+- persisted input messages
+- execution state
+- replayable output events
+
+The public API should be small:
+
+- `POST /api/session/{thread_key}`: idempotently create or return a session
+- `POST /api/session/{thread_key}/messages`: append durable input
+- `POST /api/session/{thread_key}/execute`: run the session
+- `GET /api/session/{thread_key}/events`: stream or replay session output over
+  SSE
+
+## Goals
+
+- Make `Session` the core control-plane model.
+- Use `thread_key` as the public identity and database primary key for a
+  session.
+- Keep exactly one current `sandbox_id` on a session. If a sandbox dies and is
+  replaced, the session row points at the new sandbox.
+- Persist `harness_type` and `harness_thread_id` on the session so the control
+  plane can resume the correct harness conversation.
+- Keep clients thin: create/get session, append messages, execute, stream events.
+- Make output replayable through durable session events, not process-local
+  streams.
+- Keep this layer independent from any specific caller such as Slack or
+  workflows.
+
+## Non-goals
+
+- Exposing sandbox create, pause, resume, or stop as public API endpoints.
+- Designing every migration detail from the current Python API.
+- Preserving `assignment_generation` as a public client concept.
+- Designing Slack final delivery, workflow scheduling, tool discovery, API key
+  management, or persona selection in detail.
+- Making `sandbox_id` historical. The session stores the current sandbox only;
+  historical sandbox lifecycle can be represented as events if needed.
+
+## Relationship to RFC 0001
+
+RFC 0001 defines a backend-neutral sandbox runtime layer. This RFC defines the
+durable Centaur control-plane object that calls that layer.
+
+The split is:
+
+- sandbox layer: creates isolated workloads and moves bytes
+- session layer: decides which sandbox belongs to which conversation, persists
+  caller-supplied input/output bytes as lines, and exposes replayable state to
+  clients
+
+`Session` should not leak backend transport details. It may store a
+`sandbox_id`, but clients should not attach to that sandbox directly.
+
+## Core Model
+
+A session is one durable agent conversation.
+
+```text
+Session {
+  thread_key: string        // primary key
+  sandbox_id: string | null
+  harness_type: string
+  harness_thread_id: string | null
+  status: active | executing | idle | failed | archived
+  created_at: timestamp
+  updated_at: timestamp
+}
+```
+
+Field notes:
+
+- `thread_key` is the unique public key and storage primary key. For Slack it
+  can be the Slack thread key. For workflows it can be a workflow-owned key. For
+  CLI or test callers it can be any caller-owned stable key.
+- `sandbox_id` is the current runtime assignment. It is nullable before the
+  first execution and can be overwritten when the control plane replaces a dead
+  sandbox.
+- `harness_type` selects the harness adapter, for example `amp`,
+  `claude-code`, or `codex`.
+- `harness_thread_id` is the harness-native conversation identifier when the
+  harness exposes one. It is nullable until the first harness turn returns it.
+
+### Ownership
+
+The session row is authoritative. In-memory workers, live SSE connections, and
+sandbox observations are caches or transports. On restart, the API should be
+able to recover session state from the database and continue from the latest
+durable message, execution, event, and current sandbox binding.
+
+### Sandbox Replacement
+
+A session has at most one current sandbox. If the current sandbox is gone or
+unhealthy, the control plane may create a replacement sandbox and atomically
+overwrite `session.sandbox_id`.
+
+Replacement should emit lifecycle events so operators can see what happened, but
+clients should continue addressing the session, not the sandbox.
+
+## Durable State
+
+The first implementation can use a small set of tables:
+
+| Table | Purpose |
+|-------|---------|
+| `sessions` | One row per durable conversation, keyed by `thread_key` |
+| `session_messages` | Durable user, assistant, system, and tool-visible input/output messages keyed by `thread_key` |
+| `session_executions` | One row per requested execution keyed by `thread_key` |
+| `session_events` | Replayable projected output and lifecycle events keyed by `thread_key` |
+
+The exact schema can evolve, but the invariant should hold: if a client has a
+`thread_key` and last seen event id, it can reconnect and recover session output
+without relying on a still-open process stream.
+
+`thread_key` should be constrained rather than arbitrary unbounded text:
+
+- namespaced by source, for example `slack:C123:1780000000.000000`
+- stable for the lifetime of the conversation
+- globally unique, or unique inside an explicit tenant scope
+- bounded to a practical maximum length, for example 512 bytes
+- not raw JSON, raw URLs, or other unbounded caller payloads
+
+## API
+
+### Create or Get Session
+
+```text
+POST /api/session/{thread_key}
+```
+
+Creates a session for `thread_key` or returns the existing session. The
+`thread_key` path segment must be URL-encoded by clients when it contains
+reserved characters.
+
+Example request:
+
+```json
+{
+  "harness_type": "amp",
+  "metadata": {
+    "source": "slack",
+    "channel_id": "C123",
+    "user_id": "U123"
+  }
+}
+```
+
+Example response:
+
+```json
+{
+  "thread_key": "slack:C123:1780000000.000000",
+  "sandbox_id": null,
+  "harness_type": "amp",
+  "harness_thread_id": null,
+  "status": "idle"
+}
+```
+
+Idempotency rules:
+
+- `thread_key` is unique.
+- Repeating the same request returns the existing session.
+- If the existing session has a different `harness_type`, the API should reject
+  the request with `409 Conflict` rather than silently changing the session.
+
+### Append Messages
+
+```text
+POST /api/session/{thread_key}/messages
+```
+
+Appends one or more durable messages to the session. This endpoint persists
+input; it does not execute the harness by itself.
+
+Example request:
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "parts": [
+        {"type": "text", "text": "Reply with exactly PONG and nothing else."}
+      ],
+      "metadata": {
+        "source": "slack",
+        "user_id": "U123"
+      }
+    }
+  ]
+}
+```
+
+Example response:
+
+```json
+{
+  "ok": true,
+  "message_ids": ["msg_123"]
+}
+```
+
+Message `parts` are durable transcript data for clients and operators. The API
+stores them but does not translate them into harness-specific stdin during
+execution; the caller that invokes `/execute` supplies the opaque input lines
+that should be written to the sandbox.
+
+### Execute Session
+
+```text
+POST /api/session/{thread_key}/execute
+```
+
+Requests one execution of the session. The API serializes executions per
+session, ensures there is a usable current sandbox, writes caller-supplied input
+lines to sandbox stdin, and stores each stdout line as a durable session event.
+
+The API is deliberately oblivious to the producer/consumer format. Codex
+app-server JSONL, Anthropic-shaped turns, or any future protocol are just opaque
+newline-delimited strings at this layer.
+
+Example request:
+
+```json
+{
+  "input_lines": [
+    "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG and nothing else.\"}]}}"
+  ],
+  "idle_timeout_ms": 1000,
+  "max_duration_ms": 60000,
+  "metadata": {
+    "source": "slack"
+  }
+}
+```
+
+Example response:
+
+```json
+{
+  "ok": true,
+  "execution_id": "exe_123",
+  "thread_key": "slack:C123:1780000000.000000",
+  "status": "queued"
+}
+```
+
+Execution rules:
+
+- Only one execution may run for a session at a time.
+- If no sandbox is assigned, the API creates one and stores its `sandbox_id`.
+- If the assigned sandbox is gone, the API replaces it and overwrites
+  `sandbox_id`.
+- `input_lines` are written to sandbox stdin exactly as newline-delimited lines.
+- Each stdout line is appended to `session_events` before being streamed to
+  clients as `session.output.line`.
+- Execution completion is transport-level. The first implementation may use an
+  idle timeout and max duration; it must not parse Codex, harness, or app-server
+  event names to decide completion.
+- If a producer or consumer discovers a harness-native thread id, it can report
+  that separately; the session API should not infer it by parsing output lines.
+
+### Stream Session Events
+
+```text
+GET /api/session/{thread_key}/events?after_event_id=0
+```
+
+Streams durable session events as Server-Sent Events. The stream is scoped to the
+session, not to a live worker. A client can disconnect and reconnect with the
+last seen event id.
+
+Example stream:
+
+```text
+id: 101
+event: session.execution_started
+data: {"execution_id":"exe_123","thread_key":"slack:C123:1780000000.000000"}
+
+id: 102
+event: session.output.line
+data: {"type":"item.agentMessage.delta","delta":"P"}
+
+id: 103
+event: session.output.line
+data: {"type":"item.agentMessage.delta","delta":"ONG"}
+
+id: 104
+event: session.execution_completed
+data: {"execution_id":"exe_123","output_line_count":2}
+```
+
+SSE rules:
+
+- Every event has a monotonically increasing session event id.
+- `after_event_id` is exclusive.
+- If there are existing events after `after_event_id`, the API replays them
+  before waiting for new events.
+- `session.output.line` event `data:` is the raw line, not JSON encoded again by
+  the API. It may contain Codex app-server JSONL, another JSONL protocol, or
+  plain text.
+- Terminal execution state is represented as a durable event.
+- The session stream does not close just because one execution reaches a
+  terminal state; callers may keep one SSE connection open across later
+  executions on the same session.
+- Clients do not need to know the current `sandbox_id` to stream output.
+
+## Control-Plane Flow
+
+```text
+caller
+  POST /api/session/{thread_key}
+    -> create or get session
+
+caller
+  POST /api/session/{thread_key}/messages
+    -> persist user input
+
+caller
+  POST /api/session/{thread_key}/execute
+    -> get execution_id
+
+caller
+  GET /api/session/{thread_key}/events?after_event_id=...
+    -> replay and stream output
+```
+
+Internally, execution follows this shape:
+
+```text
+load session
+claim session execution lock
+ensure current sandbox exists
+write request input_lines to sandbox stdin
+persist stdout lines as session.output.line events
+mark execution terminal
+release execution lock
+```
+
+## Compatibility Path
+
+The current Python API has separate `spawn`, `message`, `execute`, and thread
+events endpoints. The session API keeps the same useful client shape but removes
+assignment generation from the protocol and keeps `thread_key` as the only
+session address.
+
+A migration can be incremental:
+
+1. Add session tables and endpoints.
+2. Implement the endpoints as wrappers around the existing execution machinery.
+3. Teach Slackbot, workflows, and CLI callers to use sessions.
+4. Keep legacy endpoints as compatibility shims until callers have moved.
+5. Remove legacy public concepts once sessions are the only client contract.
+
+## Testing Strategy
+
+- Unit test idempotent session creation by `thread_key`.
+- Unit test `thread_key` as the canonical public address for messages,
+  execution, and events.
+- Unit test `409 Conflict` on incompatible `harness_type`.
+- Unit test message append ordering.
+- Unit test per-session execution serialization.
+- Unit test sandbox replacement updates only the current `sandbox_id`.
+- Unit test `/execute` writes opaque `input_lines` without inspecting them.
+- Unit test stdout lines are stored and replayed without parsing or JSON
+  re-encoding.
+- Integration test create -> messages -> execute -> events replay.
+- Integration test SSE reconnect with `after_event_id`.
+- Integration test API restart recovery from persisted session state.
+
+## Open Questions
+
+- Should `harness_type` be immutable for the lifetime of a session?
+- How much transcript history should each execution send to the harness by
+  default?
+- Should cancellation be part of this RFC, for example
+  `POST /api/session/{thread_key}/cancel`?
+- Should archival release the current sandbox immediately or keep it warm for a
+  short grace period?
+
+## Recommendation
+
+Start with `Session` as the only public durable conversation object. Keep the
+API small, make `thread_key` the canonical public address and primary key, treat
+`sandbox_id` as a replaceable current binding, and make SSE replay come from
+durable session events. This gives Slack, workflows, and future clients one
+protocol without exposing sandbox lifecycle details.

--- a/services/api-rs/rfcs/0002-session-control-plane.md
+++ b/services/api-rs/rfcs/0002-session-control-plane.md
@@ -8,8 +8,8 @@ Target: `services/api-rs`
 
 Introduce `Session` as the durable control-plane object above the sandbox
 runtime abstraction from RFC 0001. A session represents one ongoing agent
-conversation, regardless of whether it was started by Slack, a workflow, a CLI,
-or another caller.
+conversation, regardless of whether it was started by a chat app, a workflow, a
+CLI, or another caller.
 
 The session is the source of truth for:
 
@@ -41,7 +41,7 @@ The public API should be small:
 - Keep clients thin: create/get session, append messages, execute, stream events.
 - Make output replayable through durable session events, not process-local
   streams.
-- Keep this layer independent from any specific caller such as Slack or
+- Keep this layer independent from any specific caller such as a chat app or
   workflows.
 
 ## Non-goals
@@ -49,7 +49,7 @@ The public API should be small:
 - Exposing sandbox create, pause, resume, or stop as public API endpoints.
 - Designing every migration detail from the current Python API.
 - Preserving `assignment_generation` as a public client concept.
-- Designing Slack final delivery, workflow scheduling, tool discovery, API key
+- Designing chat final delivery, workflow scheduling, tool discovery, API key
   management, or persona selection in detail.
 - Making `sandbox_id` historical. The session stores the current sandbox only;
   historical sandbox lifecycle can be represented as events if needed.
@@ -87,9 +87,9 @@ Session {
 
 Field notes:
 
-- `thread_key` is the unique public key and storage primary key. For Slack it
-  can be the Slack thread key. For workflows it can be a workflow-owned key. For
-  CLI or test callers it can be any caller-owned stable key.
+- `thread_key` is the unique public key and storage primary key. For chat apps
+  it can be the chat thread key. For workflows it can be a workflow-owned key.
+  For CLI or test callers it can be any caller-owned stable key.
 - `sandbox_id` is the current runtime assignment. It is nullable before the
   first execution and can be overwritten when the control plane replaces a dead
   sandbox.
@@ -131,7 +131,7 @@ without relying on a still-open process stream.
 
 `thread_key` should be constrained rather than arbitrary unbounded text:
 
-- namespaced by source, for example `slack:C123:1780000000.000000`
+- namespaced by source, for example `chat:C123:1780000000.000000`
 - stable for the lifetime of the conversation
 - globally unique, or unique inside an explicit tenant scope
 - bounded to a practical maximum length, for example 512 bytes
@@ -155,7 +155,7 @@ Example request:
 {
   "harness_type": "amp",
   "metadata": {
-    "source": "slack",
+    "source": "chat",
     "channel_id": "C123",
     "user_id": "U123"
   }
@@ -166,7 +166,7 @@ Example response:
 
 ```json
 {
-  "thread_key": "slack:C123:1780000000.000000",
+  "thread_key": "chat:C123:1780000000.000000",
   "sandbox_id": null,
   "harness_type": "amp",
   "harness_thread_id": null,
@@ -201,7 +201,7 @@ Example request:
         {"type": "text", "text": "Reply with exactly PONG and nothing else."}
       ],
       "metadata": {
-        "source": "slack",
+        "source": "chat",
         "user_id": "U123"
       }
     }
@@ -247,7 +247,7 @@ Example request:
   "idle_timeout_ms": 1000,
   "max_duration_ms": 60000,
   "metadata": {
-    "source": "slack"
+    "source": "chat"
   }
 }
 ```
@@ -258,7 +258,7 @@ Example response:
 {
   "ok": true,
   "execution_id": "exe_123",
-  "thread_key": "slack:C123:1780000000.000000",
+  "thread_key": "chat:C123:1780000000.000000",
   "status": "queued"
 }
 ```
@@ -293,7 +293,7 @@ Example stream:
 ```text
 id: 101
 event: session.execution_started
-data: {"execution_id":"exe_123","thread_key":"slack:C123:1780000000.000000"}
+data: {"execution_id":"exe_123","thread_key":"chat:C123:1780000000.000000"}
 
 id: 102
 event: session.output.line
@@ -366,7 +366,7 @@ A migration can be incremental:
 
 1. Add session tables and endpoints.
 2. Implement the endpoints as wrappers around the existing execution machinery.
-3. Teach Slackbot, workflows, and CLI callers to use sessions.
+3. Teach chat adapters, workflows, and CLI callers to use sessions.
 4. Keep legacy endpoints as compatibility shims until callers have moved.
 5. Remove legacy public concepts once sessions are the only client contract.
 
@@ -401,5 +401,5 @@ A migration can be incremental:
 Start with `Session` as the only public durable conversation object. Keep the
 API small, make `thread_key` the canonical public address and primary key, treat
 `sandbox_id` as a replaceable current binding, and make SSE replay come from
-durable session events. This gives Slack, workflows, and future clients one
-protocol without exposing sandbox lifecycle details.
+durable session events. This gives chat adapters, workflows, and future clients
+one protocol without exposing sandbox lifecycle details.

--- a/services/slackbot/package.json
+++ b/services/slackbot/package.json
@@ -17,6 +17,7 @@
     "check:types": "bun tsgo --project tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@centaur/rendering": "workspace:*",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.218.0",
     "@opentelemetry/resources": "^2.7.1",

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -16,18 +16,19 @@ import {
   spanAttributes,
   withSpan
 } from './otel'
-import { AgentSessionRenderer, withAgentSessionLock } from './slack/agent-session'
+import { SlackChatSDKRenderer, SlackStreamRenderer, type SlackStreamChunk } from './rendering/slack'
+import { withAgentSessionLock } from './slack/agent-session'
 import { authorizeSlackOrg } from './slack/authorization'
 import { CodexSessionRenderer, hasActiveCodexSession } from './slack/codex-session'
 import { EventDeduper, slackDedupKey } from './slack/dedup'
 import { duplicateSlackAlertText, type DuplicateSlackEventDetails } from './slack/duplicate-alert'
 import { EnvSlackInstallationStore, SlackClientResolver } from './slack/installations'
 import { normalizeSlackEnvelope } from './slack/normalize'
-import { markdownToStreamChunks } from './slack/render'
 import { verifySlackSignature } from './slack/signature'
 import { shouldAckWithReaction } from './slack/trivial-ack'
 import type { NormalizedSlackEvent, SlackEnvelope } from './slack/types'
-import type { AnyBlock, AnyChunk } from '@slack/types'
+import type { RendererTaskBody } from '@centaur/rendering'
+import type { AnyBlock } from '@slack/types'
 import type { WebClient } from '@slack/web-api'
 
 const config = loadConfig()
@@ -256,22 +257,24 @@ app.post('/api/slack/streams/start', apiKeyMiddleware, async c => {
     channel: string
     thread_ts: string
     markdown?: string
-    chunks?: AnyChunk[]
+    chunks?: SlackStreamChunk[]
     recipient_team_id?: string
     recipient_user_id?: string
     task_display_mode?: 'plan' | 'timeline'
   }>()
   const { client } = await resolver.resolve({})
   try {
-    const response = await client.chat.startStream({
-      channel: body.channel,
-      thread_ts: body.thread_ts,
-      chunks: body.chunks ?? markdownToStreamChunks(body.markdown ?? ' '),
-      recipient_team_id: body.recipient_team_id,
-      recipient_user_id: body.recipient_user_id,
-      task_display_mode: body.task_display_mode
+    const response = await new SlackStreamRenderer(client).start({
+      target: {
+        channel: body.channel,
+        threadTs: body.thread_ts,
+        recipientTeamId: body.recipient_team_id,
+        recipientUserId: body.recipient_user_id
+      },
+      markdown: body.markdown,
+      chunks: body.chunks,
+      taskDisplayMode: body.task_display_mode
     })
-    if (!response.ok) return c.json(response, 502)
     return c.json({ ok: true, channel: response.channel, ts: response.ts })
   } catch (error) {
     return slackApiErrorResponse(c, error)
@@ -283,16 +286,18 @@ app.post('/api/slack/streams/append', apiKeyMiddleware, async c => {
     channel: string
     ts: string
     markdown?: string
-    chunks?: AnyChunk[]
+    chunks?: SlackStreamChunk[]
   }>()
   const { client } = await resolver.resolve({})
   try {
-    const response = await client.chat.appendStream({
-      channel: body.channel,
-      ts: body.ts,
-      chunks: body.chunks ?? markdownToStreamChunks(body.markdown ?? ' ')
+    const response = await new SlackStreamRenderer(client).append({
+      target: {
+        channel: body.channel,
+        ts: body.ts
+      },
+      markdown: body.markdown,
+      chunks: body.chunks
     })
-    if (!response.ok) return c.json(response, 502)
     return c.json({ ok: true, channel: response.channel, ts: response.ts })
   } catch (error) {
     return slackApiErrorResponse(c, error)
@@ -304,18 +309,20 @@ app.post('/api/slack/streams/stop', apiKeyMiddleware, async c => {
     channel: string
     ts: string
     markdown?: string
-    chunks?: AnyChunk[]
+    chunks?: SlackStreamChunk[]
     blocks?: AnyBlock[]
   }>()
   const { client } = await resolver.resolve({})
   try {
-    const response = await client.chat.stopStream({
-      channel: body.channel,
-      ts: body.ts,
-      chunks: body.chunks ?? (body.markdown ? markdownToStreamChunks(body.markdown) : undefined),
+    const response = await new SlackStreamRenderer(client).stop({
+      target: {
+        channel: body.channel,
+        ts: body.ts
+      },
+      markdown: body.markdown,
+      chunks: body.chunks,
       blocks: body.blocks
     })
-    if (!response.ok) return c.json(response, 502)
     return c.json({ ok: true, channel: response.channel, ts: response.ts })
   } catch (error) {
     return slackApiErrorResponse(c, error)
@@ -333,13 +340,15 @@ app.post('/api/slack/agent-sessions', apiKeyMiddleware, async c => {
   }>()
   const { client } = await resolver.resolve({})
   try {
-    const result = await new AgentSessionRenderer(client).open({
-      channel: body.channel,
-      parentTs: body.parent_ts,
-      recipientTeamId: body.recipient_team_id,
-      recipientUserId: body.recipient_user_id,
+    const result = await new SlackChatSDKRenderer(client).open({
       title: body.title,
-      header: body.header
+      header: body.header,
+      target: {
+        channel: body.channel,
+        parentTs: body.parent_ts,
+        recipientTeamId: body.recipient_team_id,
+        recipientUserId: body.recipient_user_id
+      }
     })
     return c.json({ ok: true, session_id: result.sessionId })
   } catch (error) {
@@ -353,7 +362,10 @@ app.post('/api/slack/agent-sessions/:session_id/text', apiKeyMiddleware, async c
   try {
     const sessionId = c.req.param('session_id')
     await withAgentSessionLock(sessionId, () =>
-      new AgentSessionRenderer(client).text(sessionId, body.markdown)
+      new SlackChatSDKRenderer(client).render(sessionId, {
+        type: 'renderer.message.delta',
+        delta: body.markdown
+      })
     )
     return c.json({ ok: true })
   } catch (error) {
@@ -373,7 +385,16 @@ app.post('/api/slack/agent-sessions/:session_id/step', apiKeyMiddleware, async c
   try {
     const sessionId = c.req.param('session_id')
     await withAgentSessionLock(sessionId, () =>
-      new AgentSessionRenderer(client).step(sessionId, body)
+      new SlackChatSDKRenderer(client).render(sessionId, {
+        type: 'renderer.task.update',
+        task: {
+          id: body.id,
+          title: body.title,
+          status: body.status ?? 'in_progress',
+          details: rendererTaskBody(body.details),
+          output: rendererTaskBody(body.output)
+        }
+      })
     )
     return c.json({ ok: true })
   } catch (error) {
@@ -390,7 +411,7 @@ app.post('/api/slack/agent-sessions/:session_id/done', apiKeyMiddleware, async c
       if (hasActiveCodexSession(sessionId)) {
         await new CodexSessionRenderer(client).done(sessionId, body.thread_id)
       } else {
-        await new AgentSessionRenderer(client).done(sessionId)
+        await new SlackChatSDKRenderer(client).close(sessionId, { type: 'renderer.done' })
       }
     })
     return c.json({ ok: true })
@@ -658,6 +679,11 @@ function slackApiErrorResponse(c: Context, error: unknown) {
     },
     502
   )
+}
+
+function rendererTaskBody(markdown: string | undefined): RendererTaskBody | undefined {
+  if (!markdown) return undefined
+  return [{ type: 'text', text: markdown }]
 }
 
 type SlackCommandPayload = {

--- a/services/slackbot/src/rendering/slack.test.ts
+++ b/services/slackbot/src/rendering/slack.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'bun:test'
+import { SlackChatSDKRenderer, SlackStreamRenderer } from './slack'
+
+describe('Slack rendering adapters', () => {
+  it('drives legacy agent sessions from renderer events', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const renderer = new SlackChatSDKRenderer(slackClient(calls) as any)
+
+    const opened = await renderer.open({
+      title: 'Centaur execution',
+      target: {
+        channel: 'C123',
+        parentTs: '1778866921.505479',
+        recipientTeamId: 'T123',
+        recipientUserId: 'U123'
+      }
+    })
+
+    expect(opened.sessionId).toBeTruthy()
+
+    await renderer.render(opened.sessionId!, {
+      type: 'renderer.message.delta',
+      delta: 'Working on it.'
+    })
+    await renderer.render(opened.sessionId!, {
+      type: 'renderer.task.update',
+      task: {
+        id: 'task-1',
+        title: 'Run command',
+        status: 'in_progress',
+        details: [{ type: 'text', text: '```bash\npnpm test\n```' }]
+      }
+    })
+    const closed = await renderer.close(opened.sessionId!, { type: 'renderer.done' })
+
+    const streamed = calls
+      .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
+      .flatMap(call => call.params.chunks ?? [])
+
+    expect(streamed).toContainEqual({ type: 'markdown_text', text: 'Working on it.' })
+    expect(streamed).toContainEqual({
+      type: 'task_update',
+      id: 'task-1',
+      title: 'Run command',
+      status: 'in_progress',
+      details: '```bash\npnpm test\n```'
+    })
+    expect(closed.closed).toBe(true)
+    expect(calls.some(call => call.method === 'chat.stopStream')).toBe(true)
+  })
+
+  it('maps legacy stream markdown through Chat SDK-shaped stream chunks', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const renderer = new SlackStreamRenderer(slackClient(calls) as any)
+
+    const started = await renderer.start({
+      target: {
+        channel: 'C123',
+        threadTs: '1778866921.505479',
+        recipientTeamId: 'T123',
+        recipientUserId: 'U123'
+      },
+      markdown: 'Hello'
+    })
+    await renderer.append({
+      target: { channel: 'C123', ts: started.ts! },
+      chunks: [{ type: 'markdown_text', text: ' world' }]
+    })
+    await renderer.stop({
+      target: { channel: 'C123', ts: started.ts! },
+      markdown: 'Done.'
+    })
+
+    expect(calls.find(call => call.method === 'chat.startStream')?.params.chunks).toEqual([
+      { type: 'markdown_text', text: 'Hello' }
+    ])
+    expect(calls.find(call => call.method === 'chat.appendStream')?.params.chunks).toEqual([
+      { type: 'markdown_text', text: ' world' }
+    ])
+    expect(calls.find(call => call.method === 'chat.stopStream')?.params.chunks).toEqual([
+      { type: 'markdown_text', text: 'Done.' }
+    ])
+  })
+})
+
+function slackClient(calls: Array<{ method: string; params: any }>) {
+  return {
+    assistant: {
+      threads: {
+        setStatus: async (params: any) => {
+          calls.push({ method: 'assistant.threads.setStatus', params })
+          return { ok: true }
+        }
+      }
+    },
+    chat: {
+      startStream: async (params: any) => {
+        calls.push({ method: 'chat.startStream', params })
+        return { ok: true, channel: params.channel, ts: '1778866940.295499' }
+      },
+      appendStream: async (params: any) => {
+        calls.push({ method: 'chat.appendStream', params })
+        return { ok: true, channel: params.channel, ts: params.ts }
+      },
+      stopStream: async (params: any) => {
+        calls.push({ method: 'chat.stopStream', params })
+        return { ok: true, channel: params.channel, ts: params.ts }
+      },
+      update: async (params: any) => {
+        calls.push({ method: 'chat.update', params })
+        return { ok: true }
+      }
+    }
+  }
+}

--- a/services/slackbot/src/rendering/slack.ts
+++ b/services/slackbot/src/rendering/slack.ts
@@ -1,0 +1,254 @@
+import type { AnyBlock, AnyChunk } from '@slack/types'
+import type { WebClient } from '@slack/web-api'
+import {
+  ChatSDKRenderer,
+  type ChatSDKOutput,
+  type ChatSDKStreamChunk,
+  type RendererEvent,
+  type RendererSessionOpenInput
+} from '@centaur/rendering'
+import { AgentSessionRenderer } from '../slack/agent-session'
+import { markdownToStreamChunks } from '../slack/render'
+
+export type SlackRendererOpenInput = RendererSessionOpenInput & {
+  target: {
+    channel: string
+    parentTs: string
+    recipientTeamId: string
+    recipientUserId: string
+  }
+  header?: string
+}
+
+export type SlackRenderResult = {
+  closed?: boolean
+  sessionId?: string
+  streamedTextChars?: number
+}
+
+export type SlackStreamChunk = ChatSDKStreamChunk | AnyChunk
+
+export type SlackStreamOpenInput = {
+  target: {
+    channel: string
+    threadTs: string
+    recipientTeamId?: string
+    recipientUserId?: string
+  }
+  markdown?: string
+  chunks?: SlackStreamChunk[]
+  taskDisplayMode?: 'plan' | 'timeline'
+}
+
+export type SlackStreamAppendInput = {
+  target: {
+    channel: string
+    ts: string
+  }
+  markdown?: string
+  chunks?: SlackStreamChunk[]
+}
+
+export type SlackStreamStopInput = SlackStreamAppendInput & {
+  blocks?: AnyBlock[]
+}
+
+export type SlackStreamResult = {
+  channel?: string
+  ts?: string
+}
+
+export class SlackChatSDKRenderer {
+  private readonly chatSdk = new ChatSDKRenderer()
+  private readonly agentRenderer: AgentSessionRenderer
+
+  constructor(client: WebClient) {
+    this.agentRenderer = new AgentSessionRenderer(client)
+  }
+
+  async open(input: SlackRendererOpenInput): Promise<SlackRenderResult> {
+    validateSlackTarget(input.target)
+    const { sessionId } = await this.agentRenderer.open({
+      channel: input.target.channel,
+      parentTs: input.target.parentTs,
+      recipientTeamId: input.target.recipientTeamId,
+      recipientUserId: input.target.recipientUserId,
+      title: input.title,
+      header: input.header
+    })
+    return { sessionId }
+  }
+
+  async render(sessionId: string, event: RendererEvent): Promise<SlackRenderResult> {
+    return this.deliver(sessionId, this.chatSdk.render(sessionId, event))
+  }
+
+  async close(
+    sessionId: string,
+    event?: Extract<RendererEvent, { type: 'renderer.done' }>
+  ): Promise<SlackRenderResult> {
+    return this.deliver(sessionId, this.chatSdk.close(sessionId, event))
+  }
+
+  private async deliver(sessionId: string, outputs: ChatSDKOutput[]): Promise<SlackRenderResult> {
+    const result: SlackRenderResult = {}
+    for (const output of outputs) {
+      if (output.type === 'chat.stream.append') {
+        for (const chunk of output.chunks) {
+          const streamed = await this.deliverStreamChunk(sessionId, chunk, output)
+          if (streamed !== undefined) result.streamedTextChars = streamed
+        }
+      } else if (output.type === 'chat.message.upsert') {
+        if (output.message.title) {
+          await this.agentRenderer.title(sessionId, output.message.title)
+        } else if (output.message.text) {
+          await this.agentRenderer.textDelta(sessionId, output.message.text, { force: true })
+          result.streamedTextChars = this.agentRenderer.streamedTextChars(sessionId)
+        }
+      } else if (output.type === 'chat.session.closed') {
+        const { streamedTextChars } = await this.agentRenderer.done(sessionId, {
+          streamFinalUpdates: output.streamFinalUpdates ?? true,
+          answerMarkdown: output.message?.text
+        })
+        result.closed = true
+        result.streamedTextChars = streamedTextChars
+      }
+    }
+    return result
+  }
+
+  private async deliverStreamChunk(
+    sessionId: string,
+    chunk: ChatSDKStreamChunk,
+    output: Extract<ChatSDKOutput, { type: 'chat.stream.append' }>
+  ): Promise<number | undefined> {
+    if (chunk.type === 'markdown_text') {
+      await this.agentRenderer.textDelta(sessionId, chunk.text, {
+        force: output.force ?? false,
+        planPrefix: output.planPrefix
+      })
+      return this.agentRenderer.streamedTextChars(sessionId)
+    }
+    if (chunk.type === 'task_update') {
+      await this.agentRenderer.step(
+        sessionId,
+        {
+          id: chunk.id,
+          title: chunk.title,
+          status: chunk.status as any,
+          details: chunk.details,
+          output: chunk.output
+        },
+        { flush: true }
+      )
+    }
+    return undefined
+  }
+}
+
+export class SlackStreamRenderer {
+  private readonly chatSdk = new ChatSDKRenderer()
+
+  constructor(private readonly client: WebClient) {}
+
+  async start(input: SlackStreamOpenInput): Promise<SlackStreamResult> {
+    const response = assertSlackOk(
+      'chat.startStream',
+      (await this.client.chat.startStream({
+        channel: input.target.channel,
+        thread_ts: input.target.threadTs,
+        chunks: this.streamChunks(input.markdown ?? ' ', input.chunks),
+        recipient_team_id: input.target.recipientTeamId,
+        recipient_user_id: input.target.recipientUserId,
+        task_display_mode: input.taskDisplayMode
+      })) as SlackStreamApiResponse
+    )
+    return { channel: response.channel, ts: response.ts }
+  }
+
+  async append(input: SlackStreamAppendInput): Promise<SlackStreamResult> {
+    const response = assertSlackOk(
+      'chat.appendStream',
+      (await this.client.chat.appendStream({
+        channel: input.target.channel,
+        ts: input.target.ts,
+        chunks: this.streamChunks(input.markdown ?? ' ', input.chunks)
+      })) as SlackStreamApiResponse
+    )
+    return { channel: response.channel, ts: response.ts }
+  }
+
+  async stop(input: SlackStreamStopInput): Promise<SlackStreamResult> {
+    const response = assertSlackOk(
+      'chat.stopStream',
+      (await this.client.chat.stopStream({
+        channel: input.target.channel,
+        ts: input.target.ts,
+        chunks: this.optionalStreamChunks(input.markdown, input.chunks),
+        blocks: input.blocks
+      })) as SlackStreamApiResponse
+    )
+    return { channel: response.channel, ts: response.ts }
+  }
+
+  private streamChunks(markdown: string, chunks?: SlackStreamChunk[]): AnyChunk[] {
+    return slackChunksFromChatSdk(chunks ?? this.rendererMarkdownChunks(markdown))
+  }
+
+  private optionalStreamChunks(
+    markdown?: string,
+    chunks?: SlackStreamChunk[]
+  ): AnyChunk[] | undefined {
+    if (chunks) return slackChunksFromChatSdk(chunks)
+    if (markdown) return slackChunksFromChatSdk(this.rendererMarkdownChunks(markdown))
+    return undefined
+  }
+
+  private rendererMarkdownChunks(markdown: string): ChatSDKStreamChunk[] {
+    return this.chatSdk
+      .render('legacy-slack-stream', {
+        type: 'renderer.message.delta',
+        delta: markdown
+      })
+      .flatMap(output => (output.type === 'chat.stream.append' ? output.chunks : []))
+  }
+}
+
+function validateSlackTarget(target: SlackRendererOpenInput['target']): void {
+  if (!target.channel || !target.parentTs || !target.recipientTeamId || !target.recipientUserId) {
+    throw new Error('missing_slack_renderer_target')
+  }
+}
+
+function slackChunksFromChatSdk(chunks: SlackStreamChunk[]): AnyChunk[] {
+  return chunks.flatMap(chunk =>
+    isMarkdownTextChunk(chunk) ? markdownToStreamChunks(chunk.text) : [chunk as AnyChunk]
+  )
+}
+
+function isMarkdownTextChunk(
+  chunk: SlackStreamChunk
+): chunk is Extract<ChatSDKStreamChunk, { type: 'markdown_text' }> {
+  return (
+    Boolean(chunk) &&
+    typeof chunk === 'object' &&
+    'type' in chunk &&
+    chunk.type === 'markdown_text' &&
+    'text' in chunk &&
+    typeof chunk.text === 'string'
+  )
+}
+
+type SlackStreamApiResponse = {
+  ok?: boolean
+  error?: string
+  channel?: string
+  ts?: string
+}
+
+function assertSlackOk(method: string, response: SlackStreamApiResponse): SlackStreamApiResponse {
+  if (response.ok) return response
+  const error = new Error(response.error ?? `${method} failed`) as Error & { data?: unknown }
+  error.data = response
+  throw error
+}

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -173,6 +173,19 @@ export class AgentSessionRenderer {
     return streamedTextSourceChars(state)
   }
 
+  async title(sessionId: string, title: string): Promise<void> {
+    const state = requireSession(sessionId)
+    state.title = title
+    const threads = this.client.assistant?.threads
+    if (!threads?.setTitle) return
+    const response = await threads.setTitle({
+      channel_id: state.channel,
+      thread_ts: state.parentTs,
+      title
+    })
+    if (!response.ok) throw new Error(response.error ?? 'assistant.threads.setTitle failed')
+  }
+
   async blocks(
     sessionId: string,
     blocks: AnyBlock[],

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -1,53 +1,17 @@
-import { createHash } from 'crypto'
 import type { WebClient } from '@slack/web-api'
-import { slackReplyLimits } from '../constants'
-import { logInfo } from '../logging'
-import { AgentSessionRenderer } from './agent-session'
 import {
-  clipLines,
-  preformatted as pre,
-  richText,
-  section,
-  text,
-  type StreamRichText,
-  type StreamRichTextElement
-} from './streaming'
+  CodexAppServerRendererEventMapper,
+  isTerminalCodexAppServerEvent,
+  rustSessionEventToServerNotification,
+  type RendererEvent
+} from '@centaur/rendering'
+import { logInfo } from '../logging'
+import { SlackChatSDKRenderer } from '../rendering/slack'
 
-const COMMAND_EXECUTION_TITLE = 'Command execution'
-
-type AgentMessagePhase = 'commentary' | 'final_answer'
-
-type HarnessTask = {
-  id: string
-  title: string
-  status: 'pending' | 'in_progress' | 'complete' | 'error'
-  details: StreamRichTextElement[]
-  output: StreamRichTextElement[]
-  commandIndex?: number
-}
-
-type CodexSessionState = {
+type ActiveCodexSessionState = {
+  mapper: CodexAppServerRendererEventMapper
   threadId: string
-  stepCounter: number
-  nextCommandIndex: number
-  answerByItemId: Map<string, string>
-  harnessAnswerText: string
-  answerText: string
-  commentaryByItemId: Map<string, string>
-  harnessCommentaryText: string
-  commentaryText: string
-  completedItemIds: Set<string>
-  firstBufferedTextAt: number | null
-  streamedCommentaryText: string
-  streamedAnswerText: string
-  deliveredAnswerChars: number
-  agentMessagePhase: AgentMessagePhase | null
-  agentMessagePhaseByItemId: Map<string, AgentMessagePhase>
-  planText: string
-  taskByUseId: Map<string, HarnessTask>
-  commandOutputById: Map<string, string>
-  emittedActivityRunByTaskId: Set<string>
-  emittedActivityOutputByTaskId: Set<string>
+  streamedAnswerChars: number
   done: boolean
 }
 
@@ -57,25 +21,24 @@ type CompletedCodexSessionState = {
   completedAt: number
 }
 
-const states = new Map<string, CodexSessionState>()
+const states = new Map<string, ActiveCodexSessionState>()
 const completedStates = new Map<string, CompletedCodexSessionState>()
-const PRE_STREAM_GRACE_MS = 500
 const COMPLETED_STATE_TTL_MS = 10 * 60 * 1000
 
 export class CodexSessionRenderer {
-  private readonly renderer: AgentSessionRenderer
+  private readonly renderer: SlackChatSDKRenderer
 
   constructor(client: WebClient) {
-    this.renderer = new AgentSessionRenderer(client)
+    this.renderer = new SlackChatSDKRenderer(client)
   }
 
   async event(
     agentSessionId: string,
-    event: any
+    event: unknown
   ): Promise<{ threadId?: string; done: boolean; streamedAnswerChars: number }> {
     const completed = completedState(agentSessionId)
     if (completed) {
-      if (isTerminalTurnEvent(event)) {
+      if (isTerminalSourceEvent(event)) {
         logCodexTerminalEventIgnoredAfterDone(agentSessionId, event, completed)
       }
       return {
@@ -84,157 +47,25 @@ export class CodexSessionRenderer {
         streamedAnswerChars: completed.streamedAnswerChars
       }
     }
+
     const state = getState(agentSessionId)
-    if (event?.session_id) state.threadId = String(event.session_id)
-    if (event?.thread_id) state.threadId = String(event.thread_id)
-
-    trackAgentMessageLifecycle(event, state)
-    ensureCommentarySegmentBreak(event, state)
-
-    const structuredPlan = structuredPlanUpdate(event)
-    if (structuredPlan) {
-      await this.publishStructuredPlan(agentSessionId, state, structuredPlan)
-    }
-
-    const planText = planTextUpdate(event)
-    if (planText) {
-      state.planText = event?.type === 'item.plan.delta' ? state.planText + planText : planText
-      await this.publishPlanText(agentSessionId, state, state.planText)
-    }
-
-    const command = commandExecution(event)
-    if (command) {
-      const id = commandId(command)
-      const aggregatedOutput = commandAggregatedOutput(command)
-      if (aggregatedOutput) state.commandOutputById.set(id, aggregatedOutput)
-      const existing = state.taskByUseId.get(id)
-      const commandIndex = commandNumber(state, existing)
-      const task = commandTask(
-        command,
-        event?.type,
-        existing,
-        state.commandOutputById.get(id),
-        commandIndex
-      )
-      const merged = mergeTask(existing, task)
-      state.taskByUseId.set(merged.id, merged)
-      await this.publishActivitySummary(agentSessionId, state)
-    }
-
-    const fileChange = fileChangeEvent(event)
-    if (fileChange) {
-      const existing = state.taskByUseId.get(fileChangeId(fileChange))
-      const task = fileChangeTask(fileChange, event?.type, existing)
-      const merged = mergeTask(existing, task)
-      state.taskByUseId.set(merged.id, merged)
-      await this.publishActivitySummary(agentSessionId, state)
-    }
-
-    const outputDelta = commandOutputDelta(event)
-    if (outputDelta) {
-      const current = state.commandOutputById.get(outputDelta.id) ?? ''
-      const output = current + outputDelta.delta
-      state.commandOutputById.set(outputDelta.id, output)
-      const existing = state.taskByUseId.get(outputDelta.id)
-      const commandIndex = commandNumber(state, existing)
-      const task =
-        existing ??
-        ({
-          id: outputDelta.id,
-          title: commandExecutionTitle(commandIndex),
-          status: 'in_progress',
-          details: [],
-          output: [],
-          commandIndex
-        } satisfies HarnessTask)
-      const updated = {
-        ...task,
-        title: commandExecutionTitle(commandIndex),
-        commandIndex,
-        output: commandOutputElements(output)
-      }
-      state.taskByUseId.set(outputDelta.id, updated)
-      await this.publishActivitySummary(agentSessionId, state)
-    }
-
-    for (const tool of toolUses(event)) {
-      const commandIndex = tool.name === 'Bash' ? commandNumber(state) : undefined
-      const task: HarnessTask = {
-        id: `task-${++state.stepCounter}`,
-        title: tool.name === 'Bash' ? commandExecutionTitle(commandIndex) : titleFor(tool),
-        status: 'in_progress',
-        details: detailElementsForTool(tool),
-        output: [],
-        ...(commandIndex !== undefined ? { commandIndex } : {})
-      }
-      state.taskByUseId.set(String(tool.id), task)
-      await this.publishActivitySummary(agentSessionId, state)
-    }
-
-    for (const result of toolResults(event)) {
-      const toolUseId = String(result.tool_use_id ?? '')
-      const task = state.taskByUseId.get(toolUseId) ?? {
-        id: `task-${++state.stepCounter}`,
-        title: 'Tool result',
-        status: 'in_progress',
-        details: [],
-        output: []
-      }
-      state.taskByUseId.set(toolUseId || task.id, task)
-      task.status = 'complete'
-      task.output = outputElementsForResult(result)
-      await this.publishActivitySummary(agentSessionId, state)
-    }
-
-    if (eventCarriesAgentMessageText(event)) {
-      const buffer = activeAssistantBuffer(state, event, agentSessionId)
-      const update = applyAgentMessageUpdate(state, event, buffer, agentSessionId)
-      if (update.bufferChanged) {
-        await this.publishPendingAssistantText(agentSessionId, state)
-      }
-      if (update.correction) {
-        logCanonicalCorrection(agentSessionId, event, state, update.correction)
-      }
-      if (buffer === 'commentary' && event?.type === 'item.completed') {
-        upsertThinkingTask(state, event)
-        await this.publishActivitySummary(agentSessionId, state)
-      }
-    }
-
-    const reasoningMessage = reasoningText(event).trim()
-    if (reasoningMessage) {
-      const task: HarnessTask = {
-        id: `reasoning-${++state.stepCounter}`,
-        title: 'Thinking',
-        status: 'complete',
-        details: [section([text(reasoningMessage)])],
-        output: []
-      }
-      state.taskByUseId.set(task.id, task)
-      await this.publishActivitySummary(agentSessionId, state)
-    }
-
-    if (isTerminalTurnEvent(event)) {
-      const resultText = terminalResultText(event)
-      const willClose = Boolean(resultText || event?.type !== 'result')
-      logCodexTerminalEventReceived(agentSessionId, event, state, {
-        resultText,
-        willClose
+    const rendererEvents = state.mapper.process(event)
+    await this.consumeRendererEvents(agentSessionId, state, rendererEvents)
+    if (state.mapper.threadId()) state.threadId = state.mapper.threadId()
+    if (state.done || state.mapper.isDone()) {
+      state.done = true
+      completedStates.set(agentSessionId, {
+        threadId: state.threadId,
+        streamedAnswerChars: state.streamedAnswerChars,
+        completedAt: Date.now()
       })
-      if (resultText && !state.answerText.trim()) {
-        state.harnessAnswerText += resultText
-        recomposeBuffers(state)
-        await this.publishPendingAssistantText(agentSessionId, state, { force: true })
-      }
-      if (willClose) {
-        await this.done(agentSessionId)
-      }
+      states.delete(agentSessionId)
     }
 
     return {
       threadId: state.threadId || undefined,
       done: state.done,
-      streamedAnswerChars: state.deliveredAnswerChars
+      streamedAnswerChars: state.streamedAnswerChars
     }
   }
 
@@ -242,103 +73,36 @@ export class CodexSessionRenderer {
     const state = getState(agentSessionId)
     if (state.done) return
     if (threadId) state.threadId = threadId
-    state.done = true
-    completeThinkingTasks(state)
-    completeOpenTasks(state)
-    await this.publishActivitySummary(agentSessionId, state, { final: true })
-    await this.publishPendingAssistantText(agentSessionId, state, { force: true })
-    const { streamedTextChars } = await this.renderer.done(agentSessionId, {
-      streamFinalUpdates: true,
-      answerMarkdown: state.answerText
-    })
-    state.deliveredAnswerChars = streamedTextChars
+    await this.consumeRendererEvents(agentSessionId, state, state.mapper.flush())
     state.done = true
     completedStates.set(agentSessionId, {
       threadId: state.threadId,
-      streamedAnswerChars: state.deliveredAnswerChars,
+      streamedAnswerChars: state.streamedAnswerChars,
       completedAt: Date.now()
     })
     states.delete(agentSessionId)
   }
 
-  private async publishActivitySummary(
+  private async consumeRendererEvents(
     agentSessionId: string,
-    state: CodexSessionState,
-    opts: { final?: boolean } = {}
+    state: ActiveCodexSessionState,
+    events: RendererEvent[]
   ): Promise<void> {
-    const tasks = Array.from(state.taskByUseId.values())
-    if (!tasks.length) return
-    for (const update of changedActivityTaskUpdates(state, tasks, opts)) {
-      await this.renderer.step(
-        agentSessionId,
-        {
-          id: update.id,
-          title: update.title,
-          status: update.status,
-          details: update.details,
-          output: update.output
-        },
-        { flush: true }
-      )
+    for (const event of events) {
+      if (event.type === 'renderer.task.update') {
+        await this.renderer.render(agentSessionId, event)
+      } else if (event.type === 'renderer.message.delta') {
+        const result = await this.renderer.render(agentSessionId, event)
+        if (result.streamedTextChars !== undefined) state.streamedAnswerChars = result.streamedTextChars
+      } else if (event.type === 'renderer.title.update') {
+        await this.renderer.render(agentSessionId, event)
+      } else if (event.type === 'renderer.done') {
+        if (event.threadId) state.threadId = event.threadId
+        const result = await this.renderer.render(agentSessionId, event)
+        if (result.streamedTextChars !== undefined) state.streamedAnswerChars = result.streamedTextChars
+        if (result.closed) state.done = true
+      }
     }
-    await this.publishPendingAssistantText(agentSessionId, state)
-  }
-
-  private async publishPendingAssistantText(
-    agentSessionId: string,
-    state: CodexSessionState,
-    opts: { force?: boolean } = {}
-  ): Promise<void> {
-    if (
-      state.firstBufferedTextAt === null &&
-      (state.commentaryText.trim() || state.answerText.trim())
-    ) {
-      state.firstBufferedTextAt = Date.now()
-    }
-    state.streamedCommentaryText = state.commentaryText
-    const hasPlan = state.taskByUseId.size > 0
-    const graceExpired =
-      state.firstBufferedTextAt !== null &&
-      Date.now() - state.firstBufferedTextAt >= PRE_STREAM_GRACE_MS
-    const canStream = hasPlan || opts.force || graceExpired
-    if (!canStream) return
-
-    if (state.commentaryText.length > state.streamedCommentaryText.length) return
-    if (state.answerText.length <= state.streamedAnswerText.length) return
-    const delta = state.answerText.slice(state.streamedAnswerText.length)
-    if (!delta) return
-    const acceptedChars = await this.renderer.textDelta(agentSessionId, delta, {
-      force: opts.force ?? false,
-      planPrefix: hasPlan
-    })
-    if (acceptedChars > 0) {
-      state.streamedAnswerText += delta.slice(0, acceptedChars)
-      state.deliveredAnswerChars = this.renderer.streamedTextChars(agentSessionId)
-    }
-  }
-
-  private async publishStructuredPlan(
-    agentSessionId: string,
-    state: CodexSessionState,
-    plan: Array<{ step: string; status?: string }>
-  ): Promise<void> {
-    for (const [index, item] of plan.entries()) {
-      setPlanTask(state, index, String(item.step ?? ''), planStatus(item.status))
-    }
-    await this.publishActivitySummary(agentSessionId, state)
-  }
-
-  private async publishPlanText(
-    agentSessionId: string,
-    state: CodexSessionState,
-    value: string
-  ): Promise<void> {
-    const steps = parsePlanText(value)
-    if (!steps.length) return
-    for (const [index, item] of steps.entries()) {
-      setPlanTask(state, index, item.step, item.status)
-    }
-    await this.publishActivitySummary(agentSessionId, state)
   }
 }
 
@@ -347,31 +111,16 @@ export function hasActiveCodexSession(agentSessionId: string): boolean {
   return Boolean(state && !state.done)
 }
 
-function getState(agentSessionId: string): CodexSessionState {
+function getState(agentSessionId: string): ActiveCodexSessionState {
   let state = states.get(agentSessionId)
   if (!state) {
     state = {
+      mapper: new CodexAppServerRendererEventMapper({
+        sessionId: agentSessionId,
+        logInfo: slackCodexLogInfo
+      }),
       threadId: '',
-      stepCounter: 0,
-      nextCommandIndex: 0,
-      answerByItemId: new Map(),
-      harnessAnswerText: '',
-      answerText: '',
-      commentaryByItemId: new Map(),
-      harnessCommentaryText: '',
-      commentaryText: '',
-      completedItemIds: new Set(),
-      firstBufferedTextAt: null,
-      streamedCommentaryText: '',
-      streamedAnswerText: '',
-      deliveredAnswerChars: 0,
-      agentMessagePhase: null,
-      agentMessagePhaseByItemId: new Map(),
-      planText: '',
-      taskByUseId: new Map(),
-      commandOutputById: new Map(),
-      emittedActivityRunByTaskId: new Set(),
-      emittedActivityOutputByTaskId: new Set(),
+      streamedAnswerChars: 0,
       done: false
     }
     states.set(agentSessionId, state)
@@ -379,287 +128,16 @@ function getState(agentSessionId: string): CodexSessionState {
   return state
 }
 
-function content(event: any): any[] {
-  return Array.isArray(event?.message?.content) ? event.message.content : []
+const slackLogEventNames: Record<string, string> = {
+  codex_renderer_canonical_answer_correction: 'slack_codex_canonical_answer_correction',
+  codex_renderer_item_completed_missing_id: 'slack_codex_item_completed_missing_id',
+  codex_renderer_terminal_event_received: 'slack_codex_terminal_event_received',
+  codex_renderer_unphased_final_agent_message_classified:
+    'slack_codex_unphased_final_agent_message_classified'
 }
 
-function agentMessageItemPhase(item: any): AgentMessagePhase | null {
-  const phase = String(item?.phase ?? '').toLowerCase()
-  if (phase === 'commentary') return 'commentary'
-  if (phase === 'final_answer' || phase === 'finalanswer') return 'final_answer'
-  return null
-}
-
-function trackAgentMessageLifecycle(event: any, state: CodexSessionState): void {
-  if (event?.type !== 'item.started' && event?.type !== 'item.completed') return
-  const phase = agentMessageItemPhase(event?.item)
-  if (!phase) return
-  state.agentMessagePhase = phase
-  const id = agentMessageEventId(event)
-  if (id) state.agentMessagePhaseByItemId.set(id, phase)
-}
-
-function agentMessageEventId(event: any): string {
-  return String(event?.itemId ?? event?.item_id ?? event?.item?.id ?? '')
-}
-
-/** Codex may emit several commentary agentMessages in one turn; keep a blank line between them. */
-function ensureCommentarySegmentBreak(event: any, state: CodexSessionState): void {
-  if (event?.type !== 'item.started') return
-  if (agentMessageItemPhase(event?.item) !== 'commentary') return
-  const lastId = lastInsertedKey(state.commentaryByItemId)
-  if (lastId) {
-    const prior = state.commentaryByItemId.get(lastId) ?? ''
-    if (prior.trim() && !prior.endsWith('\n\n')) {
-      state.commentaryByItemId.set(lastId, prior.endsWith('\n') ? `${prior}\n` : `${prior}\n\n`)
-    }
-  } else if (state.harnessCommentaryText.trim() && !state.harnessCommentaryText.endsWith('\n\n')) {
-    state.harnessCommentaryText = state.harnessCommentaryText.endsWith('\n')
-      ? `${state.harnessCommentaryText}\n`
-      : `${state.harnessCommentaryText}\n\n`
-  } else {
-    return
-  }
-  recomposeBuffers(state)
-}
-
-function lastInsertedKey<K>(map: Map<K, unknown>): K | undefined {
-  let last: K | undefined
-  for (const key of map.keys()) last = key
-  return last
-}
-
-function commentaryItemId(event: any): string {
-  return String(event?.itemId ?? event?.item_id ?? event?.item?.id ?? '')
-}
-
-function upsertThinkingTask(state: CodexSessionState, event: any): void {
-  const id = commentaryItemId(event)
-  if (!id) return
-  const body = String(event?.item?.text ?? state.commentaryByItemId.get(id) ?? '').trim()
-  if (!body) return
-  if (state.commentaryByItemId.get(id) !== body) {
-    state.commentaryByItemId.set(id, body)
-    recomposeBuffers(state)
-  }
-  state.taskByUseId.set(`thinking-${id}`, {
-    id: `thinking-${id}`,
-    title: 'Thinking',
-    status: 'complete',
-    details: [section([text(body)])],
-    output: []
-  })
-}
-
-function completeThinkingTasks(state: CodexSessionState): void {
-  for (const [id, body] of state.commentaryByItemId) {
-    upsertThinkingTask(state, { item: { id, text: body } })
-  }
-}
-
-function activeAssistantBuffer(
-  state: CodexSessionState,
-  event: any,
-  agentSessionId: string
-): 'commentary' | 'answer' {
-  if (event?.type === 'item.agentMessage.delta' || event?.type === 'item.completed') {
-    const codexId = agentMessageEventId(event)
-    const itemPhase = state.agentMessagePhaseByItemId.get(codexId)
-    if (itemPhase) return itemPhase === 'final_answer' ? 'answer' : 'commentary'
-    if (
-      event?.type === 'item.completed' &&
-      (event?.item?.type === 'agentMessage' || event?.item?.type === 'agent_message') &&
-      state.taskByUseId.size > 0
-    ) {
-      logInfo('slack_codex_unphased_final_agent_message_classified', {
-        agent_session_id: agentSessionId,
-        centaur_thread_key: event?.centaur_thread_key,
-        execution_id: event?.centaur_execution_id,
-        assignment_generation: event?.centaur_assignment_generation,
-        codex_id: codexId,
-        codex_item_id: codexId,
-        codex_item_type: event?.item?.type,
-        codex_session_id: state.threadId || event?.session_id || event?.thread_id,
-        task_count: state.taskByUseId.size,
-        commentary_chars: state.commentaryText.length,
-        answer_chars: state.answerText.length,
-        item_text_chars: String(event?.item?.text ?? '').length
-      })
-      return 'answer'
-    }
-    return state.agentMessagePhase === 'final_answer' ? 'answer' : 'commentary'
-  }
-  return 'answer'
-}
-
-function eventCarriesAgentMessageText(event: any): boolean {
-  if (event?.type === 'item.agentMessage.delta') return Boolean(extractDeltaText(event))
-  if (event?.type === 'assistant') return Boolean(assistantTextFromAssistantEvent(event))
-  if (event?.type === 'item.completed') {
-    const itemType = event?.item?.type
-    if (itemType !== 'agentMessage' && itemType !== 'agent_message') return false
-    return Boolean(String(event?.item?.text ?? ''))
-  }
-  return false
-}
-
-type AgentMessageUpdateResult = {
-  bufferChanged: boolean
-  correction?: { previous: string; canonical: string }
-}
-
-function applyAgentMessageUpdate(
-  state: CodexSessionState,
-  event: any,
-  buffer: 'answer' | 'commentary',
-  agentSessionId: string
-): AgentMessageUpdateResult {
-  const itemId = agentMessageEventId(event)
-
-  if (event?.type === 'item.agentMessage.delta') {
-    if (!itemId || state.completedItemIds.has(itemId)) return { bufferChanged: false }
-    const delta = extractDeltaText(event)
-    if (!delta) return { bufferChanged: false }
-    const byId = buffer === 'answer' ? state.answerByItemId : state.commentaryByItemId
-    byId.set(itemId, (byId.get(itemId) ?? '') + delta)
-    recomposeBuffers(state)
-    return { bufferChanged: true }
-  }
-
-  if (event?.type === 'item.completed') {
-    const canonical = String(event?.item?.text ?? '')
-    if (!canonical) return { bufferChanged: false }
-    if (!itemId) {
-      // Without an item id we cannot map this canonical text to the per-item buffer it
-      // was meant to replace. Falling back to a flat append would re-introduce the
-      // pre-fix duplication, so we drop and log instead. Codex always emits an id in
-      // observed prod streams; this branch defends against malformed events.
-      logInfo('slack_codex_item_completed_missing_id', {
-        agent_session_id: agentSessionId,
-        centaur_thread_key: event?.centaur_thread_key,
-        execution_id: event?.centaur_execution_id,
-        canonical_text_chars: canonical.length,
-        canonical_hash: textHash(canonical)
-      })
-      return { bufferChanged: false }
-    }
-    const byId = buffer === 'answer' ? state.answerByItemId : state.commentaryByItemId
-    const previous = byId.get(itemId) ?? ''
-    state.completedItemIds.add(itemId)
-    if (canonical === previous) return { bufferChanged: false }
-    byId.set(itemId, canonical)
-    recomposeBuffers(state)
-    return {
-      bufferChanged: true,
-      correction: previous ? { previous, canonical } : undefined
-    }
-  }
-
-  if (event?.type === 'assistant') {
-    const text = assistantTextFromAssistantEvent(event)
-    if (!text) return { bufferChanged: false }
-    const key = buffer === 'answer' ? 'harnessAnswerText' : 'harnessCommentaryText'
-    const before = state[key]
-    if (text === before || before.endsWith(text)) return { bufferChanged: false }
-    if (assistantEventLooksCanonical(event)) {
-      state[key] = text
-    } else if (text.startsWith(before)) {
-      state[key] = text
-    } else {
-      state[key] = before + text
-    }
-    recomposeBuffers(state)
-    return { bufferChanged: true }
-  }
-
-  return { bufferChanged: false }
-}
-
-function recomposeBuffers(state: CodexSessionState): void {
-  state.answerText = compose(state.answerByItemId, state.harnessAnswerText)
-  state.commentaryText = compose(state.commentaryByItemId, state.harnessCommentaryText)
-}
-
-function compose(byItemId: Map<string, string>, trailing: string): string {
-  let out = ''
-  for (const value of byItemId.values()) out += value
-  return trailing ? out + trailing : out
-}
-
-function extractDeltaText(event: any): string {
-  const delta = event?.delta ?? event?.text ?? event?.content ?? ''
-  if (delta && typeof delta === 'object') return String(delta.text ?? delta.content ?? '')
-  return String(delta)
-}
-
-function assistantTextFromAssistantEvent(event: any): string {
-  return content(event)
-    .map(part => (part?.type === 'text' ? (part.text ?? '') : ''))
-    .filter(Boolean)
-    .join('')
-}
-
-function assistantEventLooksCanonical(event: any): boolean {
-  const message = event?.message
-  return Boolean(
-    event?.uuid ||
-    event?.request_id ||
-    event?.session_id ||
-    message?.id ||
-    message?.model ||
-    message?.usage
-  )
-}
-
-function logCanonicalCorrection(
-  agentSessionId: string,
-  event: any,
-  state: CodexSessionState,
-  correction: { previous: string; canonical: string }
-): void {
-  const { previous, canonical } = correction
-  const charsDiff = canonical.length - previous.length
-  logInfo('slack_codex_canonical_answer_correction', {
-    agent_session_id: agentSessionId,
-    centaur_thread_key: event?.centaur_thread_key,
-    execution_id: event?.centaur_execution_id,
-    assignment_generation: event?.centaur_assignment_generation,
-    event_type: event?.type,
-    codex_id: agentMessageEventId(event),
-    codex_item_id: agentMessageEventId(event),
-    codex_item_type: event?.item?.type,
-    codex_item_phase: event?.item?.phase,
-    codex_session_id: state.threadId || event?.session_id || event?.thread_id,
-    delta_total_chars: previous.length,
-    canonical_text_chars: canonical.length,
-    chars_diff: charsDiff,
-    delta_hash: textHash(previous),
-    canonical_hash: textHash(canonical),
-    streamed_answer_chars: state.deliveredAnswerChars
-  })
-}
-
-function textHash(value: string): string {
-  return createHash('sha256').update(value).digest('hex').slice(0, 16)
-}
-
-function reasoningText(event: any): string {
-  if (event?.type !== 'reasoning') return ''
-  return String(event.text ?? event.thinking ?? '')
-}
-
-function isTerminalTurnEvent(event: any): boolean {
-  return event?.type === 'result' || event?.type === 'turn.done' || event?.type === 'turn.completed'
-}
-
-function terminalResultText(event: any): string {
-  for (const key of ['result', 'result_text', 'text', 'final_text']) {
-    const value = event?.[key]
-    if (typeof value !== 'string') continue
-    const text = value.trim()
-    if (text) return text
-  }
-  return ''
+function slackCodexLogInfo(event: string, fields: Record<string, unknown>): void {
+  logInfo(slackLogEventNames[event] ?? event, fields)
 }
 
 function completedState(agentSessionId: string): CompletedCodexSessionState | undefined {
@@ -672,40 +150,25 @@ function completedState(agentSessionId: string): CompletedCodexSessionState | un
   return completed
 }
 
-function logCodexTerminalEventReceived(
-  agentSessionId: string,
-  event: any,
-  state: CodexSessionState,
-  opts: { resultText: string; willClose: boolean }
-): void {
-  logInfo('slack_codex_terminal_event_received', {
-    agent_session_id: agentSessionId,
-    centaur_thread_key: event?.centaur_thread_key,
-    execution_id: event?.centaur_execution_id,
-    assignment_generation: event?.centaur_assignment_generation,
-    event_type: event?.type,
-    codex_session_id: state.threadId || event?.session_id || event?.thread_id,
-    already_completed: false,
-    will_close: opts.willClose,
-    result_text_chars: opts.resultText.length,
-    answer_chars_before_event: state.answerText.length,
-    streamed_answer_chars_before_event: state.deliveredAnswerChars,
-    task_count: state.taskByUseId.size
-  })
+function isTerminalSourceEvent(event: unknown): boolean {
+  if (isTerminalCodexAppServerEvent(event)) return true
+  const rustMapped = rustSessionEventToServerNotification(event)
+  return rustMapped?.kind === 'completed' || rustMapped?.kind === 'failed'
 }
 
 function logCodexTerminalEventIgnoredAfterDone(
   agentSessionId: string,
-  event: any,
+  event: unknown,
   completed: CompletedCodexSessionState
 ): void {
   logInfo('slack_codex_terminal_event_ignored_after_done', {
     agent_session_id: agentSessionId,
-    centaur_thread_key: event?.centaur_thread_key,
-    execution_id: event?.centaur_execution_id,
-    assignment_generation: event?.centaur_assignment_generation,
-    event_type: event?.type,
-    codex_session_id: completed.threadId || event?.session_id || event?.thread_id,
+    centaur_thread_key: recordValue(event, 'centaur_thread_key'),
+    execution_id: recordValue(event, 'centaur_execution_id'),
+    assignment_generation: recordValue(event, 'centaur_assignment_generation'),
+    event_type: recordValue(event, 'type') ?? recordValue(event, 'eventKind') ?? recordValue(event, 'event'),
+    codex_session_id:
+      completed.threadId || recordValue(event, 'session_id') || recordValue(event, 'thread_id'),
     already_completed: true,
     will_close: false,
     result_text_chars: terminalResultText(event).length,
@@ -714,512 +177,19 @@ function logCodexTerminalEventIgnoredAfterDone(
   })
 }
 
-function toolUses(event: any): any[] {
-  if (event?.type !== 'assistant') return []
-  return content(event).filter(part => part?.type === 'tool_use')
-}
-
-function toolResults(event: any): any[] {
-  if (event?.type !== 'user' && event?.type !== 'tool') return []
-  const direct = Array.isArray(event?.content) ? event.content : []
-  return direct.filter((part: any) => part?.type === 'tool_result' || part?.tool_use_id)
-}
-
-function commandExecution(event: any): Record<string, any> | null {
-  if (event?.type === 'command_execution') return event
-  if (
-    event?.type !== 'item.started' &&
-    event?.type !== 'item.updated' &&
-    event?.type !== 'item.completed'
-  )
-    return null
-  const item = event.item
-  if (!item || (item.type !== 'commandExecution' && item.type !== 'command_execution')) return null
-  return item
-}
-
-function fileChangeEvent(event: any): Record<string, any> | null {
-  if (event?.type === 'file_change') return event
-  if (
-    event?.type !== 'item.started' &&
-    event?.type !== 'item.updated' &&
-    event?.type !== 'item.completed'
-  )
-    return null
-  const item = event.item
-  if (!item || (item.type !== 'fileChange' && item.type !== 'file_change')) return null
-  return item
-}
-
-function structuredPlanUpdate(event: any): Array<{ step: string; status?: string }> | null {
-  if (event?.type !== 'turn.plan.updated') return null
-  return Array.isArray(event.plan) ? event.plan : null
-}
-
-function planTextUpdate(event: any): string {
-  if (event?.type === 'item.plan.delta') {
-    return String(event.delta ?? event.text ?? '')
-  }
-  if (event?.type === 'item.completed' && event?.item?.type === 'plan') {
-    return String(event.item.text ?? '')
+function terminalResultText(event: unknown): string {
+  if (!event || typeof event !== 'object') return ''
+  const record = event as Record<string, unknown>
+  for (const key of ['result', 'result_text', 'text', 'final_text']) {
+    const value = record[key]
+    if (typeof value !== 'string') continue
+    const text = value.trim()
+    if (text) return text
   }
   return ''
 }
 
-function parsePlanText(value: string): Array<{ step: string; status: HarnessTask['status'] }> {
-  return value
-    .split('\n')
-    .map(line => {
-      const trimmed = line.trim()
-      if (!/^[-*]\s+|\d+[.)]\s+/.test(trimmed)) return null
-      return {
-        step: trimmed,
-        status: /\[[xX]\]/.test(trimmed) ? ('complete' as const) : ('pending' as const)
-      }
-    })
-    .filter(item => item !== null)
-}
-
-function planStatus(value: string | undefined): HarnessTask['status'] {
-  const status = String(value ?? '').toLowerCase()
-  if (status === 'inprogress' || status === 'in_progress' || status === 'running')
-    return 'in_progress'
-  if (status === 'completed' || status === 'complete' || status === 'done') return 'complete'
-  if (status === 'failed' || status === 'error') return 'complete'
-  return 'pending'
-}
-
-function stripPlanMarker(value: string): string {
-  return value
-    .replace(/^\s*(?:[-*]|\d+[.)])\s+/, '')
-    .replace(/^\[[ xX]\]\s+/, '')
-    .trim()
-}
-
-function setPlanTask(
-  state: CodexSessionState,
-  index: number,
-  step: string,
-  status: HarnessTask['status']
-): void {
-  const title = oneLine(stripPlanMarker(step), slackReplyLimits.stream.planTitleChars)
-  if (!title) return
-  state.taskByUseId.set(`plan-${index + 1}`, {
-    id: `plan-${index + 1}`,
-    title,
-    status,
-    details: [],
-    output: []
-  })
-}
-
-function completeOpenTasks(state: CodexSessionState): void {
-  for (const [id, task] of state.taskByUseId) {
-    if (task.status !== 'in_progress' && task.status !== 'pending') continue
-    state.taskByUseId.set(id, { ...task, status: 'complete' })
-  }
-}
-
-function changedActivityTaskUpdates(
-  state: CodexSessionState,
-  tasks: HarnessTask[],
-  opts: { final?: boolean } = {}
-): Array<{
-  id: string
-  title: string
-  status: HarnessTask['status']
-  details?: StreamRichText
-  output?: StreamRichText
-}> {
-  const updates: Array<{
-    id: string
-    title: string
-    status: HarnessTask['status']
-    details?: StreamRichText
-    output?: StreamRichText
-  }> = []
-  for (const task of tasks) {
-    let details: StreamRichText | undefined
-    let output: StreamRichText | undefined
-    if (opts.final) {
-      if (task.details.length && !state.emittedActivityRunByTaskId.has(task.id)) {
-        state.emittedActivityRunByTaskId.add(task.id)
-        details = activityRunBlock(task)
-      }
-      if (task.output.length && !state.emittedActivityOutputByTaskId.has(task.id)) {
-        state.emittedActivityOutputByTaskId.add(task.id)
-        output = activityOutputBlock(task)
-      }
-    } else if (task.details.length && !state.emittedActivityRunByTaskId.has(task.id)) {
-      state.emittedActivityRunByTaskId.add(task.id)
-      details = activityRunBlock(task)
-    }
-    if (
-      !opts.final &&
-      task.status === 'complete' &&
-      task.output.length &&
-      !state.emittedActivityOutputByTaskId.has(task.id)
-    ) {
-      state.emittedActivityOutputByTaskId.add(task.id)
-      output = activityOutputBlock(task)
-    }
-    if (!details && !output && !opts.final) continue
-    updates.push({
-      id: task.id,
-      title: task.title,
-      status: task.status,
-      details,
-      output
-    })
-  }
-  return updates
-}
-
-function activityRunBlock(task: HarnessTask): StreamRichText {
-  if (task.title === 'Thinking' && task.details.length) {
-    return richText(task.details)
-  }
-  const command = firstPreformattedBody(task.details)
-  if (command) {
-    return richText([pre(command, shellLanguage(firstPreformattedLanguage(task.details)))])
-  }
-  return richText(task.details)
-}
-
-function activityOutputBlock(task: HarnessTask): StreamRichText {
-  return richText([
-    pre(elementsToPlainText(task.output), firstPreformattedLanguage(task.output) ?? 'text')
-  ])
-}
-
-function firstPreformattedBody(elements: StreamRichTextElement[]): string {
-  return (
-    elements
-      .find(element => element.type === 'rich_text_preformatted')
-      ?.elements.map(inline => inline.text ?? '')
-      .join('') ?? ''
-  )
-}
-
-function firstPreformattedLanguage(elements: StreamRichTextElement[]): string | undefined {
-  return elements.find(element => element.type === 'rich_text_preformatted')?.language
-}
-
-function shellLanguage(language: string | undefined): string {
-  return language === 'bash' || !language ? 'sh' : language
-}
-
-function shellLanguageForCommand(_command: string): string {
-  return 'sh'
-}
-
-function commandOutputDelta(event: any): { id: string; delta: string } | null {
-  if (event?.type !== 'item.commandExecution.outputDelta') return null
-  const id = String(event.itemId ?? event.item_id ?? '')
-  const delta = String(event.delta ?? '')
-  return id && delta ? { id, delta } : null
-}
-
-function commandId(item: any): string {
-  return String(item.id ?? item.itemId ?? item.command_id ?? item.command ?? 'command')
-}
-
-function fileChangeId(item: any): string {
-  return String(item.id ?? item.itemId ?? item.path ?? 'file-change')
-}
-
-function commandNumber(state: CodexSessionState, existing?: HarnessTask): number {
-  if (existing?.commandIndex !== undefined) return existing.commandIndex
-  state.nextCommandIndex += 1
-  return state.nextCommandIndex
-}
-
-function commandTask(
-  item: any,
-  eventType: string,
-  existing?: HarnessTask,
-  accumulatedOutput?: string,
-  commandIndex?: number
-): HarnessTask {
-  const id = commandId(item)
-  const rawCommand = String(item.command ?? 'Command')
-  const displayCommand =
-    rawCommand === 'Command' ? rawCommand : oneLine(unwrapShellCommand(rawCommand), 220)
-  const status = commandStatus(item, eventType)
-  const exitCode = item.exitCode ?? item.exit_code
-  const failed = isCommandFailure(item, eventType)
-  const isCompletionUpdate =
-    eventType === 'item.completed' || status === 'complete' || status === 'error'
-  const output = commandOutputElements(accumulatedOutput ?? '', exitCode)
-  return {
-    id,
-    title: commandExecutionTitle(commandIndex),
-    status,
-    ...(commandIndex !== undefined ? { commandIndex } : {}),
-    details:
-      isCompletionUpdate && existing && !failed
-        ? []
-        : [pre(displayCommand, shellLanguageForCommand(displayCommand))],
-    output
-  }
-}
-
-function commandAggregatedOutput(item: any): string {
-  for (const key of ['aggregated_output', 'aggregatedOutput', 'output', 'stdout', 'stderr']) {
-    const value = item?.[key]
-    if (typeof value === 'string' && value) return value
-  }
-  return ''
-}
-
-function commandOutputElements(output: string, exitCode?: number | null): StreamRichTextElement[] {
-  const elements: StreamRichTextElement[] = []
-  const normalizedOutput =
-    exitCode !== null && exitCode !== undefined && exitCode !== 0
-      ? `exit code ${exitCode}${output ? `\n${output}` : ''}`
-      : output
-  if (normalizedOutput) {
-    const formatted = formatCommandOutput(normalizedOutput)
-    elements.push(pre(formatted.body, formatted.language))
-  }
-  return elements
-}
-
-function formatCommandOutput(output: string): { body: string; language: string } {
-  const trimmed = output.trim()
-  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-    try {
-      const pretty = JSON.stringify(JSON.parse(trimmed), null, 2)
-      return {
-        body: clipLines(pretty, slackReplyLimits.finalPlan.taskOutputCodeBlockLines),
-        language: 'json'
-      }
-    } catch {}
-  }
-  return {
-    body: clipLines(output, slackReplyLimits.finalPlan.taskOutputCodeBlockLines),
-    language: languageFromContent(output)
-  }
-}
-
-function fileChangeTask(item: any, eventType: string, existing?: HarnessTask): HarnessTask {
-  const id = fileChangeId(item)
-  const changes = Array.isArray(item.changes) ? item.changes : []
-  const paths = changes.map((change: any) => String(change.path ?? '')).filter(Boolean)
-  const uniquePaths: string[] = Array.from(new Set(paths))
-  const diff = changes
-    .map((change: any) => String(change.diff ?? change.unified_diff ?? '').trim())
-    .filter(Boolean)
-    .join('\n\n')
-  return {
-    id,
-    title:
-      uniquePaths.length === 1
-        ? `Edit ${uniquePaths[0]}`
-        : uniquePaths.length > 1
-          ? `Edit ${uniquePaths.length} files`
-          : 'Apply file changes',
-    status: itemStatus(item, eventType),
-    details: uniquePaths.length
-      ? [section([text('Files: '), text(uniquePaths.join(', '), { code: true })])]
-      : (existing?.details ?? []),
-    output: diff ? [pre(clip(diff), 'diff')] : (existing?.output ?? [])
-  }
-}
-
-function mergeTask(existing: HarnessTask | undefined, update: HarnessTask): HarnessTask {
-  return {
-    ...update,
-    details: update.details.length ? update.details : (existing?.details ?? []),
-    output: update.output.length ? update.output : (existing?.output ?? [])
-  }
-}
-
-function commandStatus(item: any, eventType: string): HarnessTask['status'] {
-  if (isCommandFailure(item, eventType)) return 'complete'
-  return itemStatus(item, eventType, item.exitCode ?? item.exit_code)
-}
-
-function isCommandFailure(item: any, eventType: string): boolean {
-  const status = String(item.status ?? '').toLowerCase()
-  const exitCode = item.exitCode ?? item.exit_code
-  return (
-    status === 'failed' ||
-    (eventType === 'item.completed' &&
-      exitCode !== 0 &&
-      exitCode !== null &&
-      exitCode !== undefined)
-  )
-}
-
-function itemStatus(
-  item: any,
-  eventType: string,
-  _exitCode?: number | null
-): HarnessTask['status'] {
-  const status = String(item.status ?? '').toLowerCase()
-  if (status === 'failed' || status === 'declined') return 'complete'
-  if (status === 'completed' || eventType === 'item.completed') {
-    return 'complete'
-  }
-  return 'in_progress'
-}
-
-function elementsToPlainText(elements: StreamRichTextElement[]): string {
-  return elements.map(elementToPlainText).filter(Boolean).join('\n')
-}
-
-function elementToPlainText(element: StreamRichTextElement): string {
-  if (element.type === 'rich_text_preformatted') {
-    const body = element.elements?.map(inline => inline.text ?? '').join('') ?? ''
-    return body
-  }
-  if (element.type === 'rich_text_section') {
-    return (element.elements ?? [])
-      .map(inline => {
-        if ('url' in inline) return inline.text ?? inline.url
-        if ('user_id' in inline) return `<@${inline.user_id}>`
-        return inline.text ?? ''
-      })
-      .join('')
-  }
-  return ''
-}
-
-function titleFor(tool: any): string {
-  if (tool.name === 'create_file') return 'Create file'
-  if (tool.name === 'edit_file') return 'Edit file'
-  return `Use ${tool.name ?? 'tool'}`
-}
-
-function detailElementsForTool(tool: any): StreamRichTextElement[] {
-  if (tool.name === 'Bash') {
-    const command = oneLine(unwrapShellCommand(bashCommand(tool.input)), 220)
-    return [pre(command, shellLanguageForCommand(command))]
-  }
-  if (tool.name === 'create_file') {
-    const path = stringInput(tool.input, 'path', 'file')
-    return [
-      section([text('Created '), text(path, { code: true })]),
-      pre(stringInput(tool.input, 'content'), languageFromPath(path))
-    ]
-  }
-  if (tool.name === 'edit_file') {
-    const path = stringInput(tool.input, 'path', 'file')
-    const newStr = stringInput(tool.input, 'new_str')
-    const diff = stringInput(tool.input, 'diff')
-    const fileContent = stringInput(tool.input, 'content')
-    if (newStr)
-      return [
-        section([text('Edited '), text(path, { code: true })]),
-        pre(newStr, languageFromPath(path))
-      ]
-    if (diff)
-      return [section([text('Edited '), text(path, { code: true })]), pre(stripFence(diff), 'diff')]
-    if (fileContent)
-      return [
-        section([text('Edited '), text(path, { code: true })]),
-        pre(fileContent, languageFromPath(path))
-      ]
-    return [section([text('Edited '), text(path, { code: true })])]
-  }
-  if (tool.name === 'Read') {
-    return [
-      section([
-        text('Read '),
-        text(stringInput(tool.input, 'file_path', stringInput(tool.input, 'path', 'file')), {
-          code: true
-        })
-      ])
-    ]
-  }
-  return [pre(JSON.stringify(tool.input ?? {}, null, 2), 'json')]
-}
-
-function outputElementsForResult(result: any): StreamRichTextElement[] {
-  let raw = result.content ?? ''
-  if (Array.isArray(raw))
-    raw = raw
-      .map((part: any) => (typeof part === 'string' ? part : (part?.text ?? JSON.stringify(part))))
-      .join('\n')
-  raw = String(raw ?? '')
-  try {
-    const parsed = JSON.parse(raw) as any
-    if (typeof parsed.diff === 'string') return [pre(stripFence(parsed.diff), 'diff')]
-    if (parsed.output !== undefined)
-      raw =
-        typeof parsed.output === 'string' && parsed.output
-          ? parsed.output
-          : `exitCode ${parsed.exitCode}`
-  } catch {}
-  const formatted = formatCommandOutput(raw)
-  if (formatted.body.includes('\n') || result.is_error) {
-    return [pre(formatted.body, formatted.language)]
-  }
-  return [section([text(oneLine(raw || 'Done'))])]
-}
-
-function stripFence(value: string): string {
-  return value
-    .trim()
-    .replace(/^```[a-zA-Z0-9_-]*\n?/, '')
-    .replace(/\n?```$/, '')
-}
-
-function bashCommand(input: any): string {
-  return stringInput(input, 'command', stringInput(input, 'cmd'))
-}
-
-function stringInput(input: any, key: string, fallback = ''): string {
-  const value = input?.[key]
-  return typeof value === 'string' ? value : fallback
-}
-
-function languageFromPath(path: string): string {
-  const name = path.split('/').pop() ?? ''
-  const extension = name.includes('.') ? name.split('.').pop() : ''
-  return extension?.toLowerCase() || 'text'
-}
-
-function languageFromContent(value: string): string {
-  const trimmed = value.trim()
-  if (
-    /^(export\s+)?(async\s+)?function\s|^type\s+\w+\s*=|^interface\s+\w+|^const\s+\w+\s*[:=]/m.test(
-      trimmed
-    )
-  )
-    return 'ts'
-  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json'
-  return 'text'
-}
-
-function clip(value: string, max: number = slackReplyLimits.finalPlan.outputPreviewChars): string {
-  return value.length > max ? `${value.slice(0, max)}\n/* truncated */` : value
-}
-
-function oneLine(value: string, max: number = slackReplyLimits.finalPlan.taskTitleChars): string {
-  const normalized = value.replace(/\s+/g, ' ').trim()
-  return normalized.length > max ? `${normalized.slice(0, max - 1)}…` : normalized
-}
-
-/** Strip harness wrappers like `/bin/bash -lc 'call tools'`. */
-function unwrapShellCommand(command: string): string {
-  const trimmed = command.trim()
-  if (!trimmed) return trimmed
-
-  const bashLc = /^\/bin\/bash\s+-lc\s+([\s\S]+)$/i.exec(trimmed)
-  if (!bashLc?.[1]) return trimmed
-
-  let inner = bashLc[1].trim()
-  if (
-    (inner.startsWith("'") && inner.endsWith("'")) ||
-    (inner.startsWith('"') && inner.endsWith('"'))
-  ) {
-    inner = inner.slice(1, -1)
-  }
-  return inner.trim() || trimmed
-}
-
-function commandExecutionTitle(index?: number): string {
-  return index !== undefined ? `${index}. ${COMMAND_EXECUTION_TITLE}` : COMMAND_EXECUTION_TITLE
+function recordValue(event: unknown, key: string): unknown {
+  if (!event || typeof event !== 'object') return undefined
+  return (event as Record<string, unknown>)[key]
 }


### PR DESCRIPTION
## Target

This targets the renderer split described in the [PR #328 architecture comment](https://github.com/paradigmxyz/centaur/pull/328#issuecomment-4589040797):

- Rust/session API remains below rendering and emits [`session.*` events](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/api-rs/crates/centaur-session-core/src/lib.rs#L346) plus opaque output lines.
- [`@centaur/rendering`](https://github.com/paradigmxyz/centaur/tree/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering) owns source mapping from Rust/Codex notification shapes to [`renderer.*` events](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/types.ts#L25).
- [`ChatSDKRenderer`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/chat-sdk.ts#L42) converts `renderer.*` events into Chat SDK-shaped messages and stream chunks.
- Slackbot owns Slack target validation and Slack side effects in [`SlackChatSDKRenderer` / `SlackStreamRenderer`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/slackbot/src/rendering/slack.ts#L61) above the Chat SDK layer.

## Renderer layers

This PR keeps the rendering path split into caller-neutral layers:

1. **Session event layer**: Rust and harness packages emit transport/session events without Slack-specific concepts. Code: [`SessionEvent`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/api-rs/crates/centaur-session-core/src/lib.rs#L346), [`RustSessionStreamEvent`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/harness-events/src/types.ts#L71).
2. **Renderer event layer**: `@centaur/rendering` maps Codex app-server and Rust session notifications into generic `renderer.*` events. Code: [`RendererEvent`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/types.ts#L25), [`RendererInterface`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/interface.ts#L7), [`CodexAppServerRendererEventMapper`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/codex-app-server.ts#L69), [`rustSessionEventToServerNotification`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/codex-app-server.ts#L522).
3. **Chat SDK layer**: `ChatSDKRenderer` turns renderer events into Chat SDK-shaped message and stream operations. Code: [`ChatSDKRenderer`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/chat-sdk.ts#L42), [`chat-sdk.test.ts`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/chat-sdk.test.ts).
4. **Slack adapter layer**: Slackbot adapts Chat SDK-shaped output into Slack streams, agent-session state, titles, status, and final delivery side effects. Code: [`SlackChatSDKRenderer`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/slackbot/src/rendering/slack.ts#L61), [`SlackStreamRenderer`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/slackbot/src/rendering/slack.ts#L149), [`CodexSessionRenderer`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/slackbot/src/slack/codex-session.ts#L28), [endpoint wiring](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/slackbot/src/index.ts#L267).

## Changes

- Add [`@centaur/rendering`](https://github.com/paradigmxyz/centaur/tree/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering) with renderer schema, [`RendererInterface`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/interface.ts#L7), Codex app-server mapper, [`ChatSDKRenderer`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering/src/chat-sdk.ts#L42), and tests.
- Route Slackbot Codex sessions through [`@centaur/rendering`](https://github.com/paradigmxyz/centaur/tree/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/rendering) and a [`SlackChatSDKRenderer`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/slackbot/src/rendering/slack.ts#L61) adapter.
- Route legacy Slack stream and agent-session endpoints through Slack rendering adapters instead of direct endpoint-local rendering. Code: [`SlackStreamRenderer`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/slackbot/src/rendering/slack.ts#L149), [legacy endpoint wiring](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/slackbot/src/index.ts#L267), [`slack.test.ts`](https://github.com/paradigmxyz/centaur/blob/ca8e3a5d360e180ea0944332e82763e1605cc440/services/slackbot/src/rendering/slack.test.ts).
- Export Rust session/Codex notification event types from [`@centaur/harness-events`](https://github.com/paradigmxyz/centaur/tree/ca8e3a5d360e180ea0944332e82763e1605cc440/packages/harness-events/src).
- Keep [`services/api-rs`](https://github.com/paradigmxyz/centaur/tree/ca8e3a5d360e180ea0944332e82763e1605cc440/services/api-rs) caller-neutral by removing Slack examples from session docs/tests.

## Verification

- `pnpm --filter @centaur/rendering typecheck`
- `pnpm --filter @centaur/rendering test`
- `pnpm --filter @centaur/harness-events typecheck`
- `pnpm --filter slackbot check:types`
- `pnpm --filter slackbot test`
- `cargo test -p centaur-session-core`
- `git diff --check`
- `rg` over `packages/rendering` and `services/api-rs` for Slack/renderer boundary leaks
- `just build-one slackbot`
- `just deploy`
- In-cluster Slackbot health request returned `{"ok":true,"service":"slackbot","commit":"local"}`

Note: an authenticated in-cluster harness-event smoke reached Slackbot, but the local Slack installation token returned `invalid_auth` before renderer execution. The renderer path is covered by the mocked Slackbot tests above.
