### PR TITLE
docs: document macos local setup and Slack quickstart guidance

### DIFF
--- a/docs/pages/mac-mini-setup.mdx
+++ b/docs/pages/mac-mini-setup.mdx
@@ -14,6 +14,38 @@ Centaur publishes development images to GHCR. On a single small host, the
 simplest setup is to point the local chart at those images instead of building
 and importing images into k3s' container runtime.
 
+If you are evaluating on macOS, especially Apple Silicon, use the local-build
+path below. Native k3s is Linux-only, and published images are currently x86 only. In that case, build the images locally and load them into the local cluster runtime.
+
+## macOS local evaluation with kind
+
+This is the quickest reproducible laptop path when GHCR images do not match
+your Mac's architecture.
+
+```bash
+brew install just kubectl helm jq kind cloudflared
+kind create cluster --name centaur
+kubectl config use-context kind-centaur
+```
+
+Export the same bootstrap secrets as the Linux path below, then build and load
+local images:
+
+```bash
+just build
+kind load docker-image \
+  centaur-api:latest \
+  centaur-slackbot:latest \
+  centaur-iron-proxy:latest \
+  centaur-agent:latest \
+  --name centaur
+```
+
+Kind nodes have their own containerd image store, so local `docker build` images
+are not visible to Kubernetes until you run `kind load docker-image`. The same
+separate-image-store rule applies to k3s; use `just up k3s` there to import
+images into k3s containerd.
+
 ## 1. Install k3s
 
 Run these commands on the machine that will host Centaur:
@@ -100,3 +132,31 @@ Expected shape:
 
 Then continue with the [Quickstart](/quickstart) smoke test and agent-turn
 verification steps.
+
+## 6. Optional: expose local Slackbot with a tunnel
+
+If you are running Centaur only on your laptop, Slack cannot reach the in-cluster
+Slackbot service directly. Use any HTTPS tunnel that can forward to localhost,
+such as Cloudflare Tunnel, ngrok, zrok, or Tailscale Funnel. For example, with
+Cloudflare Tunnel, forward Slackbot to localhost and expose it with a temporary
+HTTPS URL:
+
+```bash
+kubectl port-forward -n centaur svc/centaur-centaur-slackbot 3001:3001
+```
+
+In another terminal:
+
+```bash
+cloudflared tunnel --url http://localhost:3001
+```
+
+Use the generated `https://*.trycloudflare.com` URL as the host in the
+[Quickstart Slack webhook setup](/quickstart#61-set-up-the-slack-app):
+
+```text
+https://<trycloudflare-host>/api/webhooks/slack
+```
+
+Temporary tunnel URLs usually change when the tunnel restarts, so update the
+Slack Request URL each time or configure a named tunnel/domain.

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -29,7 +29,8 @@ You also need Docker and a local Kubernetes cluster. This can be lightweight:
 k3s works on a small VPS, DigitalOcean droplet, Linux box, or Mac Mini-style
 host. Docker Desktop with Kubernetes enabled, kind, and minikube are also fine
 as long as `kubectl` points at that local cluster and it can run the Helm chart.
-The [Mac Mini-style setup guide](/mac-mini-setup) walks through the k3s path.
+The [Mac Mini-style setup guide](/mac-mini-setup) walks through the k3s path
+and includes notes for macOS/kind local evaluation.
 
 Check the target before booting Centaur:
 
@@ -147,11 +148,32 @@ If you changed the namespace or release name, set `CENTAUR_NAMESPACE` and
 `CENTAUR_RELEASE` before running `just smoke` so the recipe targets the right
 deployment.
 
-## 6. Try Slack after the API works
+## 6. Setup Slack integration
 
-Mention the bot in a test channel where the Slack app is installed:
+Slack needs to reach the Slackbot webhook at a public HTTPS URL. Configure your
+network, ingress, or local tunnel so the Slackbot route is reachable at:
 
 ```text
+https://<your-host>/api/webhooks/slack
+```
+
+In your Slack app's **Event Subscriptions** settings, set the Request URL to the
+Slackbot webhook URL above.
+
+Subscribe to the `app_mention` bot event. For a minimal channel-mention test,
+the app also needs Bot Token Scopes that let it read mentions and write replies,
+for example `app_mentions:read` and `chat:write`. If you enable DM events such
+as `message.im`, Slack will also require direct-message scopes such as
+`im:history`.
+
+Save changes and reinstall the app.
+
+## 7. Try Slack mentions
+
+Invite the bot to a test channel and mention it:
+
+```text
+/invite @<your bot's username>
 @<your bot's username> reply with exactly PONG
 ```
 
@@ -163,3 +185,5 @@ If Slack receives the mention but no agent runs, inspect Slackbot logs:
 ```bash
 just logs slackbot
 ```
+
+You should see `POST /api/webhooks/slack`.

--- a/docs/public/md/mac-mini-setup.md
+++ b/docs/public/md/mac-mini-setup.md
@@ -14,6 +14,38 @@ Centaur publishes development images to GHCR. On a single small host, the
 simplest setup is to point the local chart at those images instead of building
 and importing images into k3s' container runtime.
 
+If you are evaluating on macOS, especially Apple Silicon, use the local-build
+path below. Native k3s is Linux-only, and published images are currently x86 only. In that case, build the images locally and load them into the local cluster runtime.
+
+## macOS local evaluation with kind
+
+This is the quickest reproducible laptop path when GHCR images do not match
+your Mac's architecture.
+
+```bash
+brew install just kubectl helm jq kind cloudflared
+kind create cluster --name centaur
+kubectl config use-context kind-centaur
+```
+
+Export the same bootstrap secrets as the Linux path below, then build and load
+local images:
+
+```bash
+just build
+kind load docker-image \
+  centaur-api:latest \
+  centaur-slackbot:latest \
+  centaur-iron-proxy:latest \
+  centaur-agent:latest \
+  --name centaur
+```
+
+Kind nodes have their own containerd image store, so local `docker build` images
+are not visible to Kubernetes until you run `kind load docker-image`. The same
+separate-image-store rule applies to k3s; use `just up k3s` there to import
+images into k3s containerd.
+
 ## 1. Install k3s
 
 Run these commands on the machine that will host Centaur:
@@ -100,3 +132,31 @@ Expected shape:
 
 Then continue with the [Quickstart](/quickstart) smoke test and agent-turn
 verification steps.
+
+## 6. Optional: expose local Slackbot with a tunnel
+
+If you are running Centaur only on your laptop, Slack cannot reach the in-cluster
+Slackbot service directly. Use any HTTPS tunnel that can forward to localhost,
+such as Cloudflare Tunnel, ngrok, zrok, or Tailscale Funnel. For example, with
+Cloudflare Tunnel, forward Slackbot to localhost and expose it with a temporary
+HTTPS URL:
+
+```bash
+kubectl port-forward -n centaur svc/centaur-centaur-slackbot 3001:3001
+```
+
+In another terminal:
+
+```bash
+cloudflared tunnel --url http://localhost:3001
+```
+
+Use the generated `https://*.trycloudflare.com` URL as the host in the
+[Quickstart Slack webhook setup](/quickstart#61-set-up-the-slack-app):
+
+```text
+https://<trycloudflare-host>/api/webhooks/slack
+```
+
+Temporary tunnel URLs usually change when the tunnel restarts, so update the
+Slack Request URL each time or configure a named tunnel/domain.

--- a/docs/public/md/quickstart.md
+++ b/docs/public/md/quickstart.md
@@ -29,7 +29,8 @@ You also need Docker and a local Kubernetes cluster. This can be lightweight:
 k3s works on a small VPS, DigitalOcean droplet, Linux box, or Mac Mini-style
 host. Docker Desktop with Kubernetes enabled, kind, and minikube are also fine
 as long as `kubectl` points at that local cluster and it can run the Helm chart.
-The [Mac Mini-style setup guide](/mac-mini-setup) walks through the k3s path.
+The [Mac Mini-style setup guide](/mac-mini-setup) walks through the k3s path
+and includes notes for macOS/kind local evaluation.
 
 Check the target before booting Centaur:
 
@@ -147,11 +148,32 @@ If you changed the namespace or release name, set `CENTAUR_NAMESPACE` and
 `CENTAUR_RELEASE` before running `just smoke` so the recipe targets the right
 deployment.
 
-## 6. Try Slack after the API works
+## 6. Setup Slack integration
 
-Mention the bot in a test channel where the Slack app is installed:
+Slack needs to reach the Slackbot webhook at a public HTTPS URL. Configure your
+network, ingress, or local tunnel so the Slackbot route is reachable at:
 
 ```text
+https://<your-host>/api/webhooks/slack
+```
+
+In your Slack app's **Event Subscriptions** settings, set the Request URL to the
+Slackbot webhook URL above.
+
+Subscribe to the `app_mention` bot event. For a minimal channel-mention test,
+the app also needs Bot Token Scopes that let it read mentions and write replies,
+for example `app_mentions:read` and `chat:write`. If you enable DM events such
+as `message.im`, Slack will also require direct-message scopes such as
+`im:history`.
+
+Save changes and reinstall the app.
+
+## 7. Try Slack mentions
+
+Invite the bot to a test channel and mention it:
+
+```text
+/invite @<your bot's username>
 @<your bot's username> reply with exactly PONG
 ```
 
@@ -163,3 +185,5 @@ If Slack receives the mention but no agent runs, inspect Slackbot logs:
 ```bash
 just logs slackbot
 ```
+
+You should see `POST /api/webhooks/slack`.


### PR DESCRIPTION
The existing local setup docs do not work smoothly on a macOS laptop, especially on Apple Silicon: the currently published Centaur images are x86-only, so the GHCR path fails on local arm64 clusters. I spent a lot of time debugging image pull failures, kind image loading, local Slack webhook access, and required Slack scopes before getting a working end-to-end smoke test.

Document the reproducible path so other developers can test Centaur quickly without rediscovering the same issues:
- add macOS/kind local image loading guidance to the Mac Mini setup doc
- explain why local Docker images must be loaded into kind/containerd
- make Slack quickstart setup more generic around the public webhook URL
- document minimal Slack app event/scopes for channel mention testing
- add local tunnel guidance for exposing Slackbot during laptop testing

Reproduced docs in the md and mdx sections, but not sure how you guys keep those in sync. Just manually like this?