### PR TITLE
feat: add Google Drive Docs ETL

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.46
+version: 0.1.47
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -257,6 +257,14 @@ spec:
             - name: SLACK_SYNC_THREAD_LOOKBACK_DAYS
               value: {{ .Values.api.slackSyncThreadLookbackDays | quote }}
 {{- end }}
+{{- if not (hasKey $apiExtraEnv "GOOGLE_DRIVE_ETL_ENABLED") }}
+            - name: GOOGLE_DRIVE_ETL_ENABLED
+              value: {{ ternary "1" "0" .Values.api.googleDriveEtlEnabled | quote }}
+{{- end }}
+{{- if not (hasKey $apiExtraEnv "GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS") }}
+            - name: GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS
+              value: {{ .Values.api.googleDriveSyncIntervalSeconds | quote }}
+{{- end }}
 {{- if not (hasKey $apiExtraEnv "COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS") }}
             - name: COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS
               value: {{ .Values.api.companyContextDocumentsIntervalSeconds | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -97,6 +97,8 @@ api:
   slackBackfillChannelBatchLimit: 20
   slackSyncBackfillLookbackDays: 30
   slackSyncThreadLookbackDays: 3
+  googleDriveEtlEnabled: false
+  googleDriveSyncIntervalSeconds: 14400
   companyContextDocumentsIntervalSeconds: 14400
   slackEtlExcludedChannelPatterns: ""
   victoriaMetricsPushEnabled: false

--- a/services/api/api/vm_metrics.py
+++ b/services/api/api/vm_metrics.py
@@ -811,6 +811,52 @@ async def refresh_etl_metrics(pool: Pool) -> None:
         max(max_sync_freshness_s, 0.0)
     )
 
+    drive_scope_rows = await pool.fetch(
+        "SELECT scope_id, watermark_time, last_success_at, last_error, updated_at "
+        "FROM google_drive_sync_checkpoints"
+    )
+    drive_active_scopes = len(drive_scope_rows)
+    if os.getenv("GOOGLE_DRIVE_ETL_ENABLED", "").strip().lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        drive_active_scopes = max(drive_active_scopes, 1)
+    ETL_ACTIVE_SCOPES.labels(source="google_drive", source_type="doc").set(
+        drive_active_scopes
+    )
+    failed_scopes = 0
+    max_lag_s = 0.0
+    max_sync_freshness_s = 0.0
+    for row in drive_scope_rows:
+        has_error = bool(str(row["last_error"] or "").strip())
+        if has_error:
+            failed_scopes += 1
+        watermark_time = row["watermark_time"]
+        if isinstance(watermark_time, dt.datetime):
+            max_lag_s = max(
+                max_lag_s,
+                (now - watermark_time.astimezone(dt.timezone.utc)).total_seconds(),
+            )
+        if not has_error:
+            success_at = row["last_success_at"] or row["updated_at"]
+            if isinstance(success_at, dt.datetime):
+                max_sync_freshness_s = max(
+                    max_sync_freshness_s,
+                    (now - success_at.astimezone(dt.timezone.utc)).total_seconds(),
+                )
+    ETL_FAILED_SCOPES.labels(source="google_drive", source_type="doc").set(
+        failed_scopes
+    )
+    ETL_SOURCE_CURSOR_LAG_SECONDS.labels(source="google_drive", source_type="doc").set(
+        max(max_lag_s, 0.0)
+    )
+    ETL_SCOPE_SYNC_FRESHNESS_SECONDS.labels(
+        source="google_drive", source_type="doc"
+    ).set(max(max_sync_freshness_s, 0.0))
+
     backfill_rows = await pool.fetch(
         "SELECT job_type, status, COUNT(*) AS cnt, MIN(updated_at) AS oldest_updated_at "
         "FROM slack_sync_backfill_jobs "
@@ -850,6 +896,25 @@ async def refresh_etl_metrics(pool: Pool) -> None:
         else:
             projection_lag_s = max((now - raw_latest).total_seconds(), 0.0)
     COMPANY_CONTEXT_PROJECTION_LAG_SECONDS.labels(source="slack").set(projection_lag_s)
+
+    raw_latest = await pool.fetchval(
+        "SELECT MAX(updated_at) FROM google_drive_sync_files"
+    )
+    projected_latest = await pool.fetchval(
+        "SELECT MAX(source_updated_at) FROM company_context_documents "
+        "WHERE source = 'google_drive'"
+    )
+    projection_lag_s = 0.0
+    if isinstance(raw_latest, dt.datetime):
+        raw_latest = raw_latest.astimezone(dt.timezone.utc)
+        if isinstance(projected_latest, dt.datetime):
+            projected_latest = projected_latest.astimezone(dt.timezone.utc)
+            projection_lag_s = max((raw_latest - projected_latest).total_seconds(), 0.0)
+        else:
+            projection_lag_s = max((now - raw_latest).total_seconds(), 0.0)
+    COMPANY_CONTEXT_PROJECTION_LAG_SECONDS.labels(source="google_drive").set(
+        projection_lag_s
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/services/api/db/migrations/038_google_drive_sync.sql
+++ b/services/api/db/migrations/038_google_drive_sync.sql
@@ -1,0 +1,75 @@
+-- migrate:up
+
+CREATE TABLE IF NOT EXISTS google_drive_sync_runs (
+    run_id             TEXT PRIMARY KEY,
+    workflow_run_id    TEXT,
+    mode               TEXT NOT NULL DEFAULT 'incremental',
+    status             TEXT NOT NULL,
+    scopes_requested   JSONB NOT NULL DEFAULT '[]'::jsonb,
+    scopes_synced      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    scopes_failed      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    files_seen         INTEGER NOT NULL DEFAULT 0,
+    files_upserted     INTEGER NOT NULL DEFAULT 0,
+    docs_fetched       INTEGER NOT NULL DEFAULT 0,
+    docs_upserted      INTEGER NOT NULL DEFAULT 0,
+    started_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at        TIMESTAMPTZ,
+    error_text         TEXT NOT NULL DEFAULT '',
+    metadata           JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_google_drive_sync_runs_started
+    ON google_drive_sync_runs (started_at DESC);
+
+CREATE TABLE IF NOT EXISTS google_drive_sync_files (
+    file_id                  TEXT PRIMARY KEY,
+    name                     TEXT NOT NULL DEFAULT '',
+    mime_type                TEXT NOT NULL DEFAULT '',
+    web_view_link            TEXT NOT NULL DEFAULT '',
+    drive_id                 TEXT NOT NULL DEFAULT '',
+    parent_ids               JSONB NOT NULL DEFAULT '[]'::jsonb,
+    owners                   JSONB NOT NULL DEFAULT '[]'::jsonb,
+    last_modifying_user      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    trashed                  BOOLEAN NOT NULL DEFAULT FALSE,
+    source_created_at        TIMESTAMPTZ,
+    source_modified_at       TIMESTAMPTZ,
+    text_content             TEXT NOT NULL DEFAULT '',
+    text_hash                TEXT NOT NULL DEFAULT '',
+    raw_payload              JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source_run_id            TEXT REFERENCES google_drive_sync_runs(run_id) ON DELETE SET NULL,
+    first_seen_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_content_synced_at   TIMESTAMPTZ,
+    last_error               TEXT NOT NULL DEFAULT '',
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_google_drive_sync_files_modified
+    ON google_drive_sync_files (source_modified_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_google_drive_sync_files_text
+    ON google_drive_sync_files
+    USING GIN (to_tsvector('english', coalesce(text_content, '')));
+
+CREATE INDEX IF NOT EXISTS idx_google_drive_sync_files_parents
+    ON google_drive_sync_files USING GIN (parent_ids);
+
+CREATE TABLE IF NOT EXISTS google_drive_sync_checkpoints (
+    scope_id          TEXT PRIMARY KEY,
+    watermark_time    TIMESTAMPTZ,
+    last_run_id       TEXT REFERENCES google_drive_sync_runs(run_id) ON DELETE SET NULL,
+    last_success_at   TIMESTAMPTZ,
+    last_error        TEXT NOT NULL DEFAULT '',
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS google_drive_sync_checkpoints;
+DROP INDEX IF EXISTS idx_google_drive_sync_files_parents;
+DROP INDEX IF EXISTS idx_google_drive_sync_files_text;
+DROP INDEX IF EXISTS idx_google_drive_sync_files_modified;
+DROP TABLE IF EXISTS google_drive_sync_files;
+DROP INDEX IF EXISTS idx_google_drive_sync_runs_started;
+DROP TABLE IF EXISTS google_drive_sync_runs;

--- a/services/api/tests/test_company_context_documents.py
+++ b/services/api/tests/test_company_context_documents.py
@@ -22,8 +22,9 @@ class FakeCtx:
 @pytest_asyncio.fixture(autouse=True)
 async def _clear_company_context_tables(db_pool):
     await db_pool.execute(
-        "TRUNCATE TABLE company_context_documents, slack_sync_backfill_jobs, slack_sync_checkpoints, "
-        "slack_sync_messages, slack_sync_runs, slack_sync_users, slack_sync_channels, "
+        "TRUNCATE TABLE company_context_documents, google_drive_sync_checkpoints, "
+        "google_drive_sync_files, google_drive_sync_runs, slack_sync_backfill_jobs, "
+        "slack_sync_checkpoints, slack_sync_messages, slack_sync_runs, slack_sync_users, slack_sync_channels, "
         "workflow_runs CASCADE",
     )
     yield
@@ -62,6 +63,18 @@ def test_schedule_respects_env_overrides(monkeypatch):
 
     assert reloaded.SCHEDULE["enabled"] is False
     assert reloaded.SCHEDULE["interval_seconds"] == 300
+
+
+def test_schedule_enabled_when_google_drive_etl_enabled(monkeypatch):
+    monkeypatch.delenv("SLACK_ETL_ENABLED", raising=False)
+    monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "true")
+    monkeypatch.delenv("COMPANY_CONTEXT_DOCUMENTS_ENABLED", raising=False)
+
+    from workflows import company_context_documents
+
+    reloaded = importlib.reload(company_context_documents)
+
+    assert reloaded.SCHEDULE["enabled"] is True
 
 
 async def _seed_slack_basics(db_pool) -> None:
@@ -128,7 +141,9 @@ async def test_projects_channel_day_and_thread_documents(db_pool):
         ("1770000003.000000", "U1", "Use #team-eng context", thread_ts, 0),
         ("1770000004.000000", "U2", "Ship pg_search separately", thread_ts, 0),
     ]
-    for offset, (message_ts, user_id, text, parent_ts, reply_count) in enumerate(messages):
+    for offset, (message_ts, user_id, text, parent_ts, reply_count) in enumerate(
+        messages
+    ):
         await _insert_message(
             db_pool,
             message_ts=message_ts,
@@ -192,7 +207,9 @@ async def test_projects_documents_without_user_rows(db_pool):
         ("1770000003.000000", "UMISSING1", "Reply three", thread_ts, 0),
         ("1770000004.000000", "UMISSING2", "Reply four", thread_ts, 0),
     ]
-    for offset, (message_ts, user_id, text, parent_ts, reply_count) in enumerate(messages):
+    for offset, (message_ts, user_id, text, parent_ts, reply_count) in enumerate(
+        messages
+    ):
         await _insert_message(
             db_pool,
             message_ts=message_ts,
@@ -270,12 +287,91 @@ async def test_uses_previous_successful_watermark_for_incremental_projection(db_
 
     assert result["changed_messages"] == 1
     assert result["documents_upserted"] == 1
-    assert await db_pool.fetchval(
-        "SELECT COUNT(*) FROM company_context_documents",
-    ) == 1
+    assert (
+        await db_pool.fetchval(
+            "SELECT COUNT(*) FROM company_context_documents",
+        )
+        == 1
+    )
     doc = await db_pool.fetchrow(
         "SELECT document_id, body FROM company_context_documents",
     )
     assert doc["document_id"] == "slack:channel_day:C_PUBLIC:2026-05-06"
     assert "New message" in doc["body"]
     assert "Old message" not in doc["body"]
+
+
+@pytest.mark.asyncio
+async def test_projects_google_drive_documents(db_pool, monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "false")
+    monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "true")
+
+    from workflows import company_context_documents
+
+    created_at = dt.datetime(2026, 5, 1, 12, 0, tzinfo=dt.timezone.utc)
+    modified_at = dt.datetime(2026, 5, 2, 12, 0, tzinfo=dt.timezone.utc)
+    updated_at = dt.datetime(2026, 5, 3, 12, 0, tzinfo=dt.timezone.utc)
+    await db_pool.execute(
+        "INSERT INTO google_drive_sync_files ("
+        "file_id, name, mime_type, web_view_link, drive_id, parent_ids, owners, "
+        "last_modifying_user, source_created_at, source_modified_at, text_content, "
+        "text_hash, raw_payload, last_error, updated_at"
+        ") VALUES ("
+        "'doc-1', 'Investment memo', 'application/vnd.google-apps.document', "
+        "'https://docs.google.com/document/d/doc-1/edit', 'shared-drive-1', "
+        "$1::jsonb, $2::jsonb, $3::jsonb, $4, $5, $6, 'hash', $7::jsonb, '', $8"
+        ")",
+        json.dumps(["folder-1"]),
+        json.dumps(
+            [
+                {
+                    "emailAddress": "owner@example.com",
+                    "displayName": "Owner Example",
+                }
+            ]
+        ),
+        json.dumps(
+            {
+                "emailAddress": "editor@example.com",
+                "displayName": "Editor Example",
+            }
+        ),
+        created_at,
+        modified_at,
+        "Doc body\nWith details",
+        json.dumps({"id": "doc-1"}),
+        updated_at,
+    )
+
+    result = await company_context_documents.handler(
+        company_context_documents.Input(watermark_overlap_seconds=0),
+        FakeCtx(db_pool),
+    )
+
+    assert result["status"] == "completed"
+    assert result["changed_messages"] == 0
+    assert result["changed_drive_files"] == 1
+    assert result["drive_documents"] == 1
+    assert result["documents_upserted"] == 1
+    assert result["watermark"] == updated_at.isoformat()
+
+    row = await db_pool.fetchrow(
+        "SELECT document_id, source, source_type, title, body, url, author_id, "
+        "author_name, occurred_at, source_updated_at, metadata "
+        "FROM company_context_documents",
+    )
+    assert row["document_id"] == "google_drive:doc:doc-1"
+    assert row["source"] == "google_drive"
+    assert row["source_type"] == "google_doc"
+    assert row["title"] == "Investment memo"
+    assert "Doc body\nWith details" in row["body"]
+    assert "Modified: 2026-05-02 12:00:00 UTC" in row["body"]
+    assert row["url"] == "https://docs.google.com/document/d/doc-1/edit"
+    assert row["author_id"] == "owner@example.com"
+    assert row["author_name"] == "Owner Example"
+    assert row["occurred_at"] == created_at
+    assert row["source_updated_at"] == modified_at
+    metadata = json.loads(row["metadata"])
+    assert metadata["file_id"] == "doc-1"
+    assert metadata["parent_ids"] == ["folder-1"]
+    assert metadata["owners"][0]["emailAddress"] == "owner@example.com"

--- a/services/api/tests/test_google_drive_sync.py
+++ b/services/api/tests/test_google_drive_sync.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+import json
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+
+class FakeCtx:
+    def __init__(self, db_pool, run_id: str = "wfr-test-google-drive-sync"):
+        self._pool = db_pool
+        self.run_id = run_id
+        self.logs: list[tuple[str, dict[str, Any]]] = []
+
+    def log(self, msg: str, **kwargs: Any) -> None:
+        self.logs.append((msg, kwargs))
+
+
+class FakeDriveClient:
+    def __init__(self, pages: list[dict[str, Any]], texts: dict[str, str]):
+        self.pages = list(pages)
+        self.texts = texts
+        self.list_calls: list[dict[str, Any]] = []
+        self.text_calls: list[str] = []
+
+    def list_docs(
+        self,
+        *,
+        query: str,
+        page_size: int,
+        page_token: str | None = None,
+    ) -> dict[str, Any]:
+        self.list_calls.append(
+            {"query": query, "page_size": page_size, "page_token": page_token}
+        )
+        if self.pages:
+            return self.pages.pop(0)
+        return {"files": []}
+
+    def docs_get_text(self, document_id: str) -> str:
+        self.text_calls.append(document_id)
+        value = self.texts[document_id]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_google_drive_tables(db_pool):
+    await db_pool.execute(
+        "TRUNCATE TABLE company_context_documents, google_drive_sync_checkpoints, "
+        "google_drive_sync_files, google_drive_sync_runs, workflow_runs CASCADE",
+    )
+    yield
+
+
+def test_schedule_defaults_disabled_with_four_hour_interval(monkeypatch):
+    monkeypatch.delenv("GOOGLE_DRIVE_ETL_ENABLED", raising=False)
+    monkeypatch.delenv("GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS", raising=False)
+
+    from workflows import google_drive_sync
+
+    reloaded = importlib.reload(google_drive_sync)
+
+    assert reloaded.SCHEDULE == {
+        "schedule_id": "google_drive_sync",
+        "interval_seconds": 14400,
+        "enabled": False,
+        "no_delivery": True,
+    }
+
+
+def test_schedule_respects_env_overrides(monkeypatch):
+    monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "true")
+    monkeypatch.setenv("GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS", "300")
+
+    from workflows import google_drive_sync
+
+    reloaded = importlib.reload(google_drive_sync)
+
+    assert reloaded.SCHEDULE["enabled"] is True
+    assert reloaded.SCHEDULE["interval_seconds"] == 300
+
+
+@pytest.mark.asyncio
+async def test_syncs_google_docs_into_raw_tables(db_pool, monkeypatch):
+    from workflows import google_drive_sync
+
+    monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "true")
+    fake = FakeDriveClient(
+        pages=[
+            {
+                "files": [
+                    {
+                        "id": "doc-1",
+                        "name": "Investment memo",
+                        "mimeType": "application/vnd.google-apps.document",
+                        "webViewLink": "https://docs.google.com/document/d/doc-1/edit",
+                        "driveId": "shared-drive-1",
+                        "parents": ["folder-1"],
+                        "owners": [
+                            {
+                                "emailAddress": "owner@example.com",
+                                "displayName": "Owner Example",
+                            }
+                        ],
+                        "lastModifyingUser": {
+                            "emailAddress": "editor@example.com",
+                            "displayName": "Editor Example",
+                        },
+                        "createdTime": "2026-05-01T12:00:00Z",
+                        "modifiedTime": "2026-05-02T12:00:00Z",
+                    }
+                ],
+            }
+        ],
+        texts={"doc-1": "Doc body\nWith details"},
+    )
+    monkeypatch.setattr(google_drive_sync, "_client", lambda: fake)
+
+    result = await google_drive_sync.handler(
+        google_drive_sync.Input(limit=25, watermark_overlap_seconds=0),
+        FakeCtx(db_pool),
+    )
+
+    assert result["status"] == "completed"
+    assert result["files_seen"] == 1
+    assert result["docs_upserted"] == 1
+    assert fake.list_calls[0]["page_size"] == 25
+    assert " in parents" not in fake.list_calls[0]["query"]
+    assert (
+        "mimeType = 'application/vnd.google-apps.document'"
+        in fake.list_calls[0]["query"]
+    )
+
+    row = await db_pool.fetchrow(
+        "SELECT file_id, name, text_content, web_view_link, parent_ids, owners, "
+        "source_modified_at, last_error FROM google_drive_sync_files",
+    )
+    assert row["file_id"] == "doc-1"
+    assert row["name"] == "Investment memo"
+    assert row["text_content"] == "Doc body\nWith details"
+    assert row["web_view_link"] == "https://docs.google.com/document/d/doc-1/edit"
+    assert json.loads(row["parent_ids"]) == ["folder-1"]
+    assert json.loads(row["owners"])[0]["emailAddress"] == "owner@example.com"
+    assert row["source_modified_at"] == dt.datetime(
+        2026, 5, 2, 12, 0, tzinfo=dt.timezone.utc
+    )
+    assert row["last_error"] == ""
+
+    checkpoint = await db_pool.fetchrow(
+        "SELECT scope_id, watermark_time FROM google_drive_sync_checkpoints",
+    )
+    assert checkpoint["scope_id"] == "all_visible"
+    assert checkpoint["watermark_time"] == dt.datetime(
+        2026, 5, 2, 12, 0, tzinfo=dt.timezone.utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_syncs_all_visible_docs_without_scope_config(db_pool, monkeypatch):
+    from workflows import google_drive_sync
+
+    monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "true")
+    fake = FakeDriveClient(pages=[{"files": []}], texts={})
+    monkeypatch.setattr(google_drive_sync, "_client", lambda: fake)
+
+    result = await google_drive_sync.handler(
+        google_drive_sync.Input(),
+        FakeCtx(db_pool),
+    )
+
+    assert result["status"] == "completed"
+    assert (
+        "mimeType = 'application/vnd.google-apps.document'"
+        in fake.list_calls[0]["query"]
+    )
+    assert " in parents" not in fake.list_calls[0]["query"]
+
+
+@pytest.mark.asyncio
+async def test_incremental_query_uses_checkpoint_overlap(db_pool, monkeypatch):
+    from workflows import google_drive_sync
+
+    monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "true")
+    await db_pool.execute(
+        "INSERT INTO google_drive_sync_checkpoints (scope_id, watermark_time) "
+        "VALUES ('all_visible', $1)",
+        dt.datetime(2026, 5, 10, 12, 0, tzinfo=dt.timezone.utc),
+    )
+    fake = FakeDriveClient(pages=[{"files": []}], texts={})
+    monkeypatch.setattr(google_drive_sync, "_client", lambda: fake)
+
+    result = await google_drive_sync.handler(
+        google_drive_sync.Input(watermark_overlap_seconds=60),
+        FakeCtx(db_pool),
+    )
+
+    assert result["status"] == "completed"
+    assert "modifiedTime > '2026-05-10T11:59:00Z'" in fake.list_calls[0]["query"]

--- a/services/api/tests/test_slack_sync.py
+++ b/services/api/tests/test_slack_sync.py
@@ -169,7 +169,8 @@ async def _clear_slack_sync_tables(db_pool, monkeypatch):
     monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
     monkeypatch.delenv("SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS", raising=False)
     await db_pool.execute(
-        "TRUNCATE TABLE slack_sync_backfill_jobs, slack_sync_checkpoints, "
+        "TRUNCATE TABLE company_context_documents, google_drive_sync_checkpoints, "
+        "google_drive_sync_files, google_drive_sync_runs, slack_sync_backfill_jobs, slack_sync_checkpoints, "
         "slack_sync_messages, slack_sync_runs, slack_sync_users, slack_sync_channels CASCADE",
     )
     yield
@@ -1508,11 +1509,40 @@ async def test_etl_freshness_metrics_refresh_from_slack_sync_tables(db_pool):
         json.dumps({"thread_ts": "3000000.000000"}),
         now - dt.timedelta(seconds=60),
     )
+    await db_pool.execute(
+        "INSERT INTO google_drive_sync_checkpoints ("
+        "scope_id, watermark_time, last_success_at, last_error, updated_at"
+        ") VALUES ('all_visible', $1, $2, '', $2)",
+        now - dt.timedelta(seconds=90),
+        now - dt.timedelta(seconds=45),
+    )
+    await db_pool.execute(
+        "INSERT INTO google_drive_sync_files ("
+        "file_id, name, mime_type, source_modified_at, text_content, text_hash, updated_at"
+        ") VALUES ("
+        "'doc-1', 'Drive doc', 'application/vnd.google-apps.document', $1, "
+        "'Drive body', 'hash', $2"
+        ")",
+        now - dt.timedelta(seconds=120),
+        now - dt.timedelta(seconds=20),
+    )
+    await db_pool.execute(
+        "INSERT INTO company_context_documents ("
+        "document_id, source, source_type, source_document_id, title, body, "
+        "source_updated_at, content_hash"
+        ") VALUES ("
+        "'google_drive:doc:doc-1', 'google_drive', 'google_doc', 'doc-1', "
+        "'Drive doc', 'Drive body', $1, 'hash'"
+        ")",
+        now - dt.timedelta(seconds=70),
+    )
 
     metrics = (await render_metrics(db_pool)).decode()
 
     assert 'etl_active_scopes{source="slack",source_type="channel"} 2' in metrics
     assert 'etl_failed_scopes{source="slack",source_type="channel"} 1' in metrics
+    assert 'etl_active_scopes{source="google_drive",source_type="doc"} 1' in metrics
+    assert 'etl_failed_scopes{source="google_drive",source_type="doc"} 0' in metrics
     assert (
         'etl_backfill_jobs{job_type="channel_bootstrap",source="slack",status="pending"} 1'
         in metrics
@@ -1537,6 +1567,24 @@ async def test_etl_freshness_metrics_refresh_from_slack_sync_tables(db_pool):
     )
     assert freshness_match is not None
     assert 25 <= float(freshness_match.group(1)) < 100
+    drive_lag_match = re.search(
+        r'etl_source_cursor_lag_seconds\{source="google_drive",source_type="doc"\} ([0-9.]+)',
+        metrics,
+    )
+    assert drive_lag_match is not None
+    assert float(drive_lag_match.group(1)) >= 80
+    drive_freshness_match = re.search(
+        r'etl_scope_sync_freshness_seconds\{source="google_drive",source_type="doc"\} ([0-9.]+)',
+        metrics,
+    )
+    assert drive_freshness_match is not None
+    assert 40 <= float(drive_freshness_match.group(1)) < 120
+    drive_projection_lag_match = re.search(
+        r'company_context_projection_lag_seconds\{source="google_drive"\} ([0-9.]+)',
+        metrics,
+    )
+    assert drive_projection_lag_match is not None
+    assert float(drive_projection_lag_match.group(1)) >= 45
     age_match = re.search(
         r'etl_backfill_job_age_seconds\{job_type="channel_bootstrap",source="slack",status="pending"\} ([0-9.]+)',
         metrics,

--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -1,4 +1,4 @@
-"""Workflow: project synced Slack messages into company context documents."""
+"""Workflow: project synced source rows into company context documents."""
 
 from __future__ import annotations
 
@@ -59,7 +59,10 @@ SCHEDULE = {
         DEFAULT_SYNC_INTERVAL_SECONDS,
     ),
     "enabled": (
-        _env_flag_enabled("SLACK_ETL_ENABLED")
+        (
+            _env_flag_enabled("SLACK_ETL_ENABLED")
+            or _env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED")
+        )
         and _env_flag_enabled("COMPANY_CONTEXT_DOCUMENTS_ENABLED", default=True)
     ),
     "no_delivery": True,
@@ -68,7 +71,7 @@ SCHEDULE = {
 
 @dataclass
 class Input:
-    """Runtime options for projecting Slack sync rows into context documents."""
+    """Runtime options for projecting synced source rows into context documents."""
 
     since: str | None = None
     watermark_overlap_seconds: int = DEFAULT_WATERMARK_OVERLAP_SECONDS
@@ -137,6 +140,12 @@ def _resolve_slack_mentions(
 def _content_hash(*parts: Any) -> str:
     """Hash projected document content so future syncs can detect changes cheaply."""
     return hashlib.sha256(canonical_json(parts).encode("utf-8")).hexdigest()
+
+
+def _source_enabled() -> bool:
+    return _env_flag_enabled("SLACK_ETL_ENABLED") or _env_flag_enabled(
+        "GOOGLE_DRIVE_ETL_ENABLED"
+    )
 
 
 async def _latest_successful_watermark(pool, current_run_id: str) -> dt.datetime | None:
@@ -212,8 +221,42 @@ async def _load_changed_message_keys(pool, since: dt.datetime | None) -> dict[st
             for row in channel_day_rows
             if isinstance(row["day"], dt.date)
         ],
-        "threads": [(str(row["channel_id"]), str(row["thread_ts"])) for row in thread_rows],
+        "threads": [
+            (str(row["channel_id"]), str(row["thread_ts"])) for row in thread_rows
+        ],
         "changed_messages": int(stats["changed_messages"] or 0) if stats else 0,
+        "max_updated_at": max_updated_at,
+    }
+
+
+async def _load_changed_drive_files(pool, since: dt.datetime | None) -> dict[str, Any]:
+    """Find Google Drive files whose synced content changed."""
+    if since is None:
+        where_sql = "WHERE last_error = '' AND trashed = FALSE"
+        args: list[Any] = []
+    else:
+        where_sql = "WHERE last_error = '' AND trashed = FALSE AND updated_at > $1"
+        args = [since]
+
+    rows = await pool.fetch(
+        "SELECT file_id, name, mime_type, web_view_link, drive_id, parent_ids, owners, "
+        "last_modifying_user, source_created_at, source_modified_at, text_content, "
+        "text_hash, raw_payload, updated_at "
+        f"FROM google_drive_sync_files {where_sql} "
+        "ORDER BY source_modified_at NULLS LAST, file_id",
+        *args,
+    )
+    stats = await pool.fetchrow(
+        f"SELECT COUNT(*) AS changed_files, MAX(updated_at) AS max_updated_at "
+        f"FROM google_drive_sync_files {where_sql}",
+        *args,
+    )
+    max_updated_at = stats["max_updated_at"] if stats else None
+    if isinstance(max_updated_at, dt.datetime):
+        max_updated_at = max_updated_at.astimezone(dt.timezone.utc)
+    return {
+        "files": list(rows),
+        "changed_files": int(stats["changed_files"] or 0) if stats else 0,
         "max_updated_at": max_updated_at,
     }
 
@@ -222,38 +265,42 @@ async def _load_channel_day_messages(pool, channel_id: str, day: dt.date) -> lis
     """Load all messages for one Slack channel/day aggregate."""
     start = dt.datetime.combine(day, dt.time.min, tzinfo=dt.timezone.utc)
     end = start + dt.timedelta(days=1)
-    return list(await pool.fetch(
-        "SELECT m.channel_id, c.channel_name, m.message_ts, m.occurred_at, "
-        "m.thread_ts, m.parent_message_ts, m.user_id, u.user_name, u.real_name, "
-        "u.display_name, m.text, m.permalink, m.reply_count, m.updated_at "
-        "FROM slack_sync_messages m "
-        "LEFT JOIN slack_sync_channels c ON c.channel_id = m.channel_id "
-        "LEFT JOIN slack_sync_users u ON u.user_id = m.user_id "
-        "WHERE m.channel_id = $1 "
-        "  AND m.occurred_at >= $2 "
-        "  AND m.occurred_at < $3 "
-        "ORDER BY m.occurred_at, m.message_ts",
-        channel_id,
-        start,
-        end,
-    ))
+    return list(
+        await pool.fetch(
+            "SELECT m.channel_id, c.channel_name, m.message_ts, m.occurred_at, "
+            "m.thread_ts, m.parent_message_ts, m.user_id, u.user_name, u.real_name, "
+            "u.display_name, m.text, m.permalink, m.reply_count, m.updated_at "
+            "FROM slack_sync_messages m "
+            "LEFT JOIN slack_sync_channels c ON c.channel_id = m.channel_id "
+            "LEFT JOIN slack_sync_users u ON u.user_id = m.user_id "
+            "WHERE m.channel_id = $1 "
+            "  AND m.occurred_at >= $2 "
+            "  AND m.occurred_at < $3 "
+            "ORDER BY m.occurred_at, m.message_ts",
+            channel_id,
+            start,
+            end,
+        )
+    )
 
 
 async def _load_thread_messages(pool, channel_id: str, thread_ts: str) -> list[Any]:
     """Load all messages for one Slack thread aggregate."""
-    return list(await pool.fetch(
-        "SELECT m.channel_id, c.channel_name, m.message_ts, m.occurred_at, "
-        "m.thread_ts, m.parent_message_ts, m.user_id, u.user_name, u.real_name, "
-        "u.display_name, m.text, m.permalink, m.reply_count, m.updated_at "
-        "FROM slack_sync_messages m "
-        "LEFT JOIN slack_sync_channels c ON c.channel_id = m.channel_id "
-        "LEFT JOIN slack_sync_users u ON u.user_id = m.user_id "
-        "WHERE m.channel_id = $1 "
-        "  AND m.thread_ts = $2 "
-        "ORDER BY m.occurred_at, m.message_ts",
-        channel_id,
-        thread_ts,
-    ))
+    return list(
+        await pool.fetch(
+            "SELECT m.channel_id, c.channel_name, m.message_ts, m.occurred_at, "
+            "m.thread_ts, m.parent_message_ts, m.user_id, u.user_name, u.real_name, "
+            "u.display_name, m.text, m.permalink, m.reply_count, m.updated_at "
+            "FROM slack_sync_messages m "
+            "LEFT JOIN slack_sync_channels c ON c.channel_id = m.channel_id "
+            "LEFT JOIN slack_sync_users u ON u.user_id = m.user_id "
+            "WHERE m.channel_id = $1 "
+            "  AND m.thread_ts = $2 "
+            "ORDER BY m.occurred_at, m.message_ts",
+            channel_id,
+            thread_ts,
+        )
+    )
 
 
 def _channel_day_document(
@@ -268,10 +315,14 @@ def _channel_day_document(
     if not messages:
         return None
 
-    channel_name = str(messages[0]["channel_name"] or channels_by_id.get(channel_id) or channel_id)
+    channel_name = str(
+        messages[0]["channel_name"] or channels_by_id.get(channel_id) or channel_id
+    )
     title = f"#{channel_name} - {day.isoformat()}"
     lines = [f"# {title}", ""]
-    last_updated = max(row["updated_at"].astimezone(dt.timezone.utc) for row in messages)
+    last_updated = max(
+        row["updated_at"].astimezone(dt.timezone.utc) for row in messages
+    )
     occurred_at = messages[0]["occurred_at"]
 
     for row in messages:
@@ -283,12 +334,14 @@ def _channel_day_document(
         )
         reply_count = int(row["reply_count"] or 0)
         reply_suffix = f" - {reply_count} replies" if reply_count else ""
-        lines.extend([
-            f"### {speaker} - {_format_time(row['occurred_at'])}{reply_suffix}",
-            "",
-            text,
-            "",
-        ])
+        lines.extend(
+            [
+                f"### {speaker} - {_format_time(row['occurred_at'])}{reply_suffix}",
+                "",
+                text,
+                "",
+            ]
+        )
 
     body = "\n".join(lines).strip()
     source_document_id = f"{channel_id}:{day.isoformat()}"
@@ -331,7 +384,9 @@ def _thread_document(
     if len(messages) < MIN_THREAD_MESSAGES:
         return None
 
-    channel_name = str(messages[0]["channel_name"] or channels_by_id.get(channel_id) or channel_id)
+    channel_name = str(
+        messages[0]["channel_name"] or channels_by_id.get(channel_id) or channel_id
+    )
     first = messages[0]
     first_text = _resolve_slack_mentions(
         str(first["text"] or ""),
@@ -340,7 +395,9 @@ def _thread_document(
     )
     title = _sanitize_heading(first_text)
     participants = sorted({_display_name(row) for row in messages if row["user_id"]})
-    last_updated = max(row["updated_at"].astimezone(dt.timezone.utc) for row in messages)
+    last_updated = max(
+        row["updated_at"].astimezone(dt.timezone.utc) for row in messages
+    )
     permalink = str(first["permalink"] or "")
     source_document_id = f"{channel_id}:{thread_ts}"
 
@@ -363,7 +420,9 @@ def _thread_document(
             users_by_id=users_by_id,
             channels_by_id=channels_by_id,
         )
-        lines.extend([f"### {speaker} - {_format_time(row['occurred_at'])}", "", text, ""])
+        lines.extend(
+            [f"### {speaker} - {_format_time(row['occurred_at'])}", "", text, ""]
+        )
 
     body = "\n".join(lines).strip()
     metadata = {
@@ -391,6 +450,87 @@ def _thread_document(
         "occurred_at": first["occurred_at"],
         "source_updated_at": last_updated,
         "content_hash": _content_hash(title, body, permalink, metadata),
+        "metadata": metadata,
+    }
+
+
+def _jsonb_value(row: Any, key: str, default: Any) -> Any:
+    value = row.get(key) if hasattr(row, "get") else row[key]
+    return decode_jsonb(value, default)
+
+
+def _drive_author(row: Any) -> tuple[str, str]:
+    owners = _jsonb_value(row, "owners", [])
+    if isinstance(owners, list):
+        for owner in owners:
+            if not isinstance(owner, dict):
+                continue
+            email = str(owner.get("emailAddress") or "").strip()
+            name = str(owner.get("displayName") or email).strip()
+            if email or name:
+                return email, name
+    last_modifying_user = _jsonb_value(row, "last_modifying_user", {})
+    if isinstance(last_modifying_user, dict):
+        email = str(last_modifying_user.get("emailAddress") or "").strip()
+        name = str(last_modifying_user.get("displayName") or email).strip()
+        if email or name:
+            return email, name
+    return "", ""
+
+
+def _drive_document(row: Any) -> dict[str, Any] | None:
+    """Render one synced Google Doc into a context document."""
+    file_id = str(row["file_id"] or "")
+    if not file_id:
+        return None
+    title = str(row["name"] or "Untitled Google Doc")
+    text = str(row["text_content"] or "").strip()
+    url = str(row["web_view_link"] or "")
+    parent_ids = _jsonb_value(row, "parent_ids", [])
+    owners = _jsonb_value(row, "owners", [])
+    last_modifying_user = _jsonb_value(row, "last_modifying_user", {})
+    raw_payload = _jsonb_value(row, "raw_payload", {})
+    author_id, author_name = _drive_author(row)
+    source_modified_at = row["source_modified_at"]
+    source_created_at = row["source_created_at"]
+
+    lines = [
+        f"# {title}",
+        "",
+        "- Source: Google Drive",
+        f"- Modified: {_format_time(source_modified_at)}",
+    ]
+    if url:
+        lines.append(f"- URL: {url}")
+    lines.extend(["", "---", "", text])
+    body = "\n".join(lines).strip()
+    metadata = {
+        "file_id": file_id,
+        "drive_id": str(row["drive_id"] or ""),
+        "parent_ids": parent_ids if isinstance(parent_ids, list) else [],
+        "owners": owners if isinstance(owners, list) else [],
+        "last_modifying_user": (
+            last_modifying_user if isinstance(last_modifying_user, dict) else {}
+        ),
+        "mime_type": str(row["mime_type"] or ""),
+        "raw_payload": raw_payload if isinstance(raw_payload, dict) else {},
+    }
+    return {
+        "document_id": f"google_drive:doc:{file_id}",
+        "source": "google_drive",
+        "source_type": "google_doc",
+        "source_document_id": file_id,
+        "source_chunk_id": "",
+        "parent_document_id": None,
+        "title": title,
+        "body": body,
+        "url": url,
+        "author_id": author_id,
+        "author_name": author_name,
+        "access_scope": "company",
+        "occurred_at": source_created_at or source_modified_at,
+        "source_updated_at": source_modified_at,
+        "content_hash": _content_hash(title, body, url, metadata),
         "metadata": metadata,
     }
 
@@ -462,16 +602,18 @@ async def _delete_document(pool, document_id: str) -> bool:
 
 
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
-    """Project changed Slack sync rows into embeddable company context documents."""
+    """Project changed sync rows into embeddable company context documents."""
     if not (
-        _env_flag_enabled("SLACK_ETL_ENABLED")
+        _source_enabled()
         and _env_flag_enabled("COMPANY_CONTEXT_DOCUMENTS_ENABLED", default=True)
     ):
         ctx.log("company_context_documents_skipped_disabled")
         return {"status": "skipped", "reason": "company_context_documents_disabled"}
 
     explicit_since = _parse_datetime(inp.since)
-    last_watermark = explicit_since or await _latest_successful_watermark(ctx._pool, ctx.run_id)
+    last_watermark = explicit_since or await _latest_successful_watermark(
+        ctx._pool, ctx.run_id
+    )
     overlap_seconds = _nonnegative_int(
         inp.watermark_overlap_seconds,
         DEFAULT_WATERMARK_OVERLAP_SECONDS,
@@ -482,8 +624,26 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         else None
     )
 
-    users_by_id, channels_by_id = await _load_slack_lookup_maps(ctx._pool)
-    changed = await _load_changed_message_keys(ctx._pool, since)
+    slack_enabled = _env_flag_enabled("SLACK_ETL_ENABLED")
+    google_drive_enabled = _env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED")
+    changed = {
+        "channel_days": [],
+        "threads": [],
+        "changed_messages": 0,
+        "max_updated_at": None,
+    }
+    users_by_id: dict[str, str] = {}
+    channels_by_id: dict[str, str] = {}
+    if slack_enabled:
+        users_by_id, channels_by_id = await _load_slack_lookup_maps(ctx._pool)
+        changed = await _load_changed_message_keys(ctx._pool, since)
+    drive_changed = {
+        "files": [],
+        "changed_files": 0,
+        "max_updated_at": None,
+    }
+    if google_drive_enabled:
+        drive_changed = await _load_changed_drive_files(ctx._pool, since)
 
     documents_upserted = 0
     documents_deleted = 0
@@ -532,7 +692,9 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             channels_by_id=channels_by_id,
         )
         if document is None:
-            if await _delete_document(ctx._pool, f"slack:thread:{channel_id}:{thread_ts}"):
+            if await _delete_document(
+                ctx._pool, f"slack:thread:{channel_id}:{thread_ts}"
+            ):
                 documents_deleted += 1
                 record_company_context_documents_changed(
                     "slack",
@@ -554,12 +716,41 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         if action in {"inserted", "updated"}:
             documents_upserted += 1
 
-    watermark = changed["max_updated_at"] or last_watermark
+    for row in drive_changed["files"]:
+        document = _drive_document(row)
+        if document is None:
+            continue
+        observe_company_context_document_size(
+            "google_drive",
+            str(document["source_type"]),
+            len(str(document["body"] or "")),
+        )
+        action = await _upsert_document(ctx._pool, document)
+        record_company_context_documents_changed(
+            "google_drive",
+            str(document["source_type"]),
+            action,
+        )
+        if action in {"inserted", "updated"}:
+            documents_upserted += 1
+
+    watermark_candidates = [
+        value
+        for value in (
+            changed["max_updated_at"],
+            drive_changed["max_updated_at"],
+            last_watermark,
+        )
+        if value is not None
+    ]
+    watermark = max(watermark_candidates) if watermark_candidates else None
     result = {
         "status": "completed",
         "changed_messages": changed["changed_messages"],
+        "changed_drive_files": drive_changed["changed_files"],
         "channel_day_documents": len(changed["channel_days"]),
         "thread_candidates": len(changed["threads"]),
+        "drive_documents": len(drive_changed["files"]),
         "documents_upserted": documents_upserted,
         "documents_deleted": documents_deleted,
         "watermark": watermark.isoformat() if watermark else None,

--- a/workflows/google_drive_sync.py
+++ b/workflows/google_drive_sync.py
@@ -1,0 +1,558 @@
+"""Workflow: sync Google Drive Docs visible to the configured ETL account."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import importlib.util
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from api.runtime_control import canonical_json
+from api.vm_metrics import (
+    record_etl_items_failed,
+    record_etl_items_seen,
+    record_etl_items_upserted,
+)
+from api.workflow_engine import WorkflowContext
+from workflows.slack_sync_shared import env_flag_enabled, positive_int
+
+WORKFLOW_NAME = "google_drive_sync"
+
+GOOGLE_DOC_MIME_TYPE = "application/vnd.google-apps.document"
+DEFAULT_SYNC_INTERVAL_SECONDS = 4 * 60 * 60
+DEFAULT_PAGE_SIZE = 100
+DEFAULT_WATERMARK_OVERLAP_SECONDS = 60
+
+
+SCHEDULE = {
+    "schedule_id": "google_drive_sync",
+    "interval_seconds": positive_int(
+        os.getenv("GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS"),
+        DEFAULT_SYNC_INTERVAL_SECONDS,
+    ),
+    "enabled": env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED", default=False),
+    "no_delivery": True,
+}
+
+
+@dataclass
+class Input:
+    """Runtime options for a manual Google Drive sync workflow run."""
+
+    since: str | None = None
+    limit: int = DEFAULT_PAGE_SIZE
+    watermark_overlap_seconds: int = DEFAULT_WATERMARK_OVERLAP_SECONDS
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class GoogleDriveSyncClient(Protocol):
+    """Small adapter protocol used by the Drive ETL workflow."""
+
+    def list_docs(
+        self,
+        *,
+        query: str,
+        page_size: int,
+        page_token: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    def docs_get_text(self, document_id: str) -> str: ...
+
+
+class GSuiteDriveClient:
+    """Adapter around the gsuite tool module.
+
+    The gsuite module routes google-api-python-client traffic through
+    iron-proxy, so workflows inherit the same OAuth refresh-token mechanism as
+    sandbox tools when their pod has HTTPS_PROXY/CA env wired from the API.
+    """
+
+    def __init__(self, module: Any):
+        self._module = module
+
+    def list_docs(
+        self,
+        *,
+        query: str,
+        page_size: int,
+        page_token: str | None = None,
+    ) -> dict[str, Any]:
+        service = self._module.get_drive_service()
+        kwargs: dict[str, Any] = {
+            "q": query,
+            "pageSize": page_size,
+            "fields": (
+                "nextPageToken, files("
+                "id, name, mimeType, webViewLink, driveId, parents, owners, "
+                "lastModifyingUser, trashed, createdTime, modifiedTime"
+                ")"
+            ),
+            "includeItemsFromAllDrives": True,
+            "supportsAllDrives": True,
+            "orderBy": "modifiedTime",
+        }
+        if page_token:
+            kwargs["pageToken"] = page_token
+        return service.files().list(**kwargs).execute()
+
+    def docs_get_text(self, document_id: str) -> str:
+        return str(self._module.docs_get_text(document_id) or "")
+
+
+def _repo_gsuite_client_paths() -> list[Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    return [
+        repo_root / "tools" / "productivity" / "gsuite" / "client.py",
+        repo_root / "tools" / "gsuite" / "client.py",
+    ]
+
+
+def _load_gsuite_module_from_path(client_path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "_google_drive_sync_gsuite_client",
+        client_path,
+    )
+    if not spec or not spec.loader:
+        raise ImportError(f"Could not load gsuite client module from {client_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _gsuite_module() -> Any:
+    try:
+        from gsuite import client as gsuite_client
+
+        return gsuite_client
+    except ModuleNotFoundError:
+        for client_path in _repo_gsuite_client_paths():
+            if client_path.exists():
+                return _load_gsuite_module_from_path(client_path)
+        candidates = ", ".join(str(path) for path in _repo_gsuite_client_paths())
+        raise FileNotFoundError(
+            f"Could not find gsuite client module. Tried: {candidates}"
+        )
+
+
+def _client() -> GoogleDriveSyncClient:
+    return GSuiteDriveClient(_gsuite_module())
+
+
+def _parse_datetime(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _rfc3339(value: dt.datetime) -> str:
+    return value.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _drive_literal(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _content_hash(*parts: Any) -> str:
+    return hashlib.sha256(canonical_json(parts).encode("utf-8")).hexdigest()
+
+
+def _file_modified_time(file: dict[str, Any]) -> dt.datetime | None:
+    return _parse_datetime(str(file.get("modifiedTime") or ""))
+
+
+def _file_created_time(file: dict[str, Any]) -> dt.datetime | None:
+    return _parse_datetime(str(file.get("createdTime") or ""))
+
+
+def _owner_names(owners: Any) -> list[str]:
+    if not isinstance(owners, list):
+        return []
+    names: list[str] = []
+    for owner in owners:
+        if not isinstance(owner, dict):
+            continue
+        name = str(owner.get("displayName") or owner.get("emailAddress") or "").strip()
+        if name:
+            names.append(name)
+    return names
+
+
+def _build_query(
+    *,
+    modified_after: dt.datetime | None,
+) -> str:
+    parts = [
+        f"mimeType = {_drive_literal(GOOGLE_DOC_MIME_TYPE)}",
+        "trashed = false",
+    ]
+    if modified_after:
+        parts.append(f"modifiedTime > {_drive_literal(_rfc3339(modified_after))}")
+    return " and ".join(parts)
+
+
+async def _load_checkpoint(pool, scope_id: str) -> dict[str, Any] | None:
+    row = await pool.fetchrow(
+        "SELECT watermark_time, last_error FROM google_drive_sync_checkpoints "
+        "WHERE scope_id = $1",
+        scope_id,
+    )
+    return dict(row) if row else None
+
+
+async def _update_checkpoint_success(
+    pool,
+    *,
+    scope_id: str,
+    watermark_time: dt.datetime | None,
+    run_id: str,
+) -> None:
+    await pool.execute(
+        "INSERT INTO google_drive_sync_checkpoints ("
+        "scope_id, watermark_time, last_run_id, last_success_at, "
+        "last_error, updated_at"
+        ") VALUES ($1, $2, $3, NOW(), '', NOW()) "
+        "ON CONFLICT (scope_id) DO UPDATE SET "
+        "watermark_time = COALESCE(EXCLUDED.watermark_time, google_drive_sync_checkpoints.watermark_time), "
+        "last_run_id = EXCLUDED.last_run_id, "
+        "last_success_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        scope_id,
+        watermark_time,
+        run_id,
+    )
+
+
+async def _update_checkpoint_failure(
+    pool,
+    *,
+    scope_id: str,
+    run_id: str,
+    error: str,
+) -> None:
+    await pool.execute(
+        "INSERT INTO google_drive_sync_checkpoints ("
+        "scope_id, last_run_id, last_error, updated_at"
+        ") VALUES ($1, $2, $3, NOW()) "
+        "ON CONFLICT (scope_id) DO UPDATE SET "
+        "last_run_id = EXCLUDED.last_run_id, "
+        "last_error = EXCLUDED.last_error, "
+        "updated_at = NOW()",
+        scope_id,
+        run_id,
+        error,
+    )
+
+
+async def _record_run_start(
+    pool,
+    *,
+    run_id: str,
+    workflow_run_id: str,
+    scopes_requested: list[dict[str, str]],
+    metadata: dict[str, Any],
+) -> None:
+    await pool.execute(
+        "INSERT INTO google_drive_sync_runs ("
+        "run_id, workflow_run_id, mode, status, scopes_requested, metadata"
+        ") VALUES ($1, $2, 'incremental', 'running', $3::jsonb, $4::jsonb) "
+        "ON CONFLICT (run_id) DO UPDATE SET "
+        "workflow_run_id = EXCLUDED.workflow_run_id, "
+        "status = 'running', "
+        "scopes_requested = EXCLUDED.scopes_requested, "
+        "scopes_synced = '[]'::jsonb, "
+        "scopes_failed = '[]'::jsonb, "
+        "files_seen = 0, "
+        "files_upserted = 0, "
+        "docs_fetched = 0, "
+        "docs_upserted = 0, "
+        "finished_at = NULL, "
+        "error_text = '', "
+        "metadata = EXCLUDED.metadata",
+        run_id,
+        workflow_run_id,
+        canonical_json(scopes_requested),
+        canonical_json(metadata),
+    )
+
+
+async def _record_run_finish(
+    pool,
+    *,
+    run_id: str,
+    status: str,
+    scopes_synced: list[dict[str, str]],
+    scopes_failed: list[dict[str, str]],
+    counts: dict[str, int],
+    error_text: str = "",
+) -> None:
+    await pool.execute(
+        "UPDATE google_drive_sync_runs SET "
+        "status = $2, scopes_synced = $3::jsonb, scopes_failed = $4::jsonb, "
+        "files_seen = $5, files_upserted = $6, docs_fetched = $7, docs_upserted = $8, "
+        "finished_at = NOW(), error_text = $9 "
+        "WHERE run_id = $1",
+        run_id,
+        status,
+        canonical_json(scopes_synced),
+        canonical_json(scopes_failed),
+        counts.get("files_seen", 0),
+        counts.get("files_upserted", 0),
+        counts.get("docs_fetched", 0),
+        counts.get("docs_upserted", 0),
+        error_text,
+    )
+
+
+async def _record_file_error(
+    pool,
+    *,
+    file_id: str,
+    error: str,
+    run_id: str,
+) -> None:
+    await pool.execute(
+        "INSERT INTO google_drive_sync_files ("
+        "file_id, last_error, source_run_id, last_seen_at, updated_at"
+        ") VALUES ($1, $2, $3, NOW(), NOW()) "
+        "ON CONFLICT (file_id) DO UPDATE SET "
+        "last_error = EXCLUDED.last_error, "
+        "source_run_id = EXCLUDED.source_run_id, "
+        "updated_at = NOW()",
+        file_id,
+        error,
+        run_id,
+    )
+
+
+async def _upsert_file(
+    pool,
+    *,
+    file: dict[str, Any],
+    text: str,
+    run_id: str,
+) -> None:
+    owners = file.get("owners") if isinstance(file.get("owners"), list) else []
+    last_modifying_user = (
+        file.get("lastModifyingUser")
+        if isinstance(file.get("lastModifyingUser"), dict)
+        else {}
+    )
+    parent_ids = file.get("parents") if isinstance(file.get("parents"), list) else []
+    await pool.execute(
+        "INSERT INTO google_drive_sync_files ("
+        "file_id, name, mime_type, web_view_link, drive_id, parent_ids, owners, "
+        "last_modifying_user, trashed, source_created_at, source_modified_at, "
+        "text_content, text_hash, raw_payload, source_run_id, last_seen_at, "
+        "last_content_synced_at, last_error, updated_at"
+        ") VALUES ("
+        "$1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb, $9, $10, $11, "
+        "$12, $13, $14::jsonb, $15, NOW(), NOW(), '', NOW()"
+        ") ON CONFLICT (file_id) DO UPDATE SET "
+        "name = EXCLUDED.name, "
+        "mime_type = EXCLUDED.mime_type, "
+        "web_view_link = EXCLUDED.web_view_link, "
+        "drive_id = EXCLUDED.drive_id, "
+        "parent_ids = EXCLUDED.parent_ids, "
+        "owners = EXCLUDED.owners, "
+        "last_modifying_user = EXCLUDED.last_modifying_user, "
+        "trashed = EXCLUDED.trashed, "
+        "source_created_at = EXCLUDED.source_created_at, "
+        "source_modified_at = EXCLUDED.source_modified_at, "
+        "text_content = EXCLUDED.text_content, "
+        "text_hash = EXCLUDED.text_hash, "
+        "raw_payload = EXCLUDED.raw_payload, "
+        "source_run_id = EXCLUDED.source_run_id, "
+        "last_seen_at = NOW(), "
+        "last_content_synced_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        str(file.get("id") or ""),
+        str(file.get("name") or ""),
+        str(file.get("mimeType") or ""),
+        str(file.get("webViewLink") or ""),
+        str(file.get("driveId") or ""),
+        canonical_json(parent_ids),
+        canonical_json(owners),
+        canonical_json(last_modifying_user),
+        bool(file.get("trashed")),
+        _file_created_time(file),
+        _file_modified_time(file),
+        text,
+        _content_hash(text),
+        canonical_json(file),
+        run_id,
+    )
+
+
+def _workflow_run_id_to_sync_run_id(workflow_run_id: str) -> str:
+    safe_run_id = "".join(char if char.isalnum() else "_" for char in workflow_run_id)
+    return f"google_drive_sync_{safe_run_id}"
+
+
+def _scope_ref(scope_id: str, reason: str | None = None) -> dict[str, str]:
+    result = {"scope_id": scope_id}
+    if reason:
+        result["reason"] = reason
+    return result
+
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    """Sync changed Google Docs into raw Drive sync tables."""
+    if not env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED", default=False):
+        ctx.log("google_drive_sync_skipped_disabled")
+        return {"status": "skipped", "reason": "google_drive_etl_disabled"}
+
+    limit = positive_int(inp.limit, DEFAULT_PAGE_SIZE)
+    overlap_seconds = max(int(inp.watermark_overlap_seconds), 0)
+    run_id = _workflow_run_id_to_sync_run_id(ctx.run_id)
+
+    scope_id = "all_visible"
+    explicit_since = _parse_datetime(inp.since)
+    checkpoint = await _load_checkpoint(ctx._pool, scope_id)
+    watermark = explicit_since
+    if watermark is None and checkpoint and checkpoint.get("watermark_time"):
+        watermark = checkpoint["watermark_time"].astimezone(dt.timezone.utc)
+    if watermark is not None:
+        watermark = watermark - dt.timedelta(seconds=overlap_seconds)
+    query = _build_query(modified_after=watermark)
+
+    await _record_run_start(
+        ctx._pool,
+        run_id=run_id,
+        workflow_run_id=ctx.run_id,
+        scopes_requested=[_scope_ref(scope_id)],
+        metadata={
+            **inp.metadata,
+            "page_size": limit,
+        },
+    )
+
+    client = _client()
+    synced: list[dict[str, str]] = []
+    failed: list[dict[str, str]] = []
+    counts = {
+        "files_seen": 0,
+        "files_upserted": 0,
+        "docs_fetched": 0,
+        "docs_upserted": 0,
+    }
+
+    for scope_id, query in [(scope_id, query)]:
+        successful_watermark: dt.datetime | None = None
+        try:
+            page_token: str | None = None
+            while True:
+                page = client.list_docs(
+                    query=query, page_size=limit, page_token=page_token
+                )
+                files = [
+                    file
+                    for file in page.get("files", [])
+                    if str(file.get("id") or "")
+                    and str(file.get("mimeType") or "") == GOOGLE_DOC_MIME_TYPE
+                ]
+                counts["files_seen"] += len(files)
+                record_etl_items_seen("google_drive", "doc", "file", len(files))
+                for file in files:
+                    file_id = str(file.get("id") or "")
+                    modified_at = _file_modified_time(file)
+                    try:
+                        text = client.docs_get_text(file_id)
+                        counts["docs_fetched"] += 1
+                        await _upsert_file(
+                            ctx._pool, file=file, text=text, run_id=run_id
+                        )
+                        counts["files_upserted"] += 1
+                        counts["docs_upserted"] += 1
+                        record_etl_items_upserted("google_drive", "doc", "file", 1)
+                        if modified_at and (
+                            successful_watermark is None
+                            or modified_at > successful_watermark
+                        ):
+                            successful_watermark = modified_at
+                    except Exception as exc:
+                        error = str(exc)
+                        failed.append(_scope_ref(scope_id, f"file:{file_id}:{error}"))
+                        record_etl_items_failed(
+                            "google_drive",
+                            "doc",
+                            "file",
+                            "permission_error"
+                            if "permission" in error.lower() or "403" in error
+                            else "api_error",
+                        )
+                        await _record_file_error(
+                            ctx._pool,
+                            file_id=file_id,
+                            error=error,
+                            run_id=run_id,
+                        )
+                page_token = page.get("nextPageToken")
+                if not page_token:
+                    break
+            await _update_checkpoint_success(
+                ctx._pool,
+                scope_id=scope_id,
+                watermark_time=successful_watermark,
+                run_id=run_id,
+            )
+            synced.append(_scope_ref(scope_id))
+            ctx.log(
+                "google_drive_sync_scope_completed",
+                scope_id=scope_id,
+                watermark=_rfc3339(successful_watermark)
+                if successful_watermark
+                else "",
+            )
+        except Exception as exc:
+            error = str(exc)
+            failed.append(_scope_ref(scope_id, error))
+            record_etl_items_failed("google_drive", "doc", "scope", "api_error")
+            await _update_checkpoint_failure(
+                ctx._pool,
+                scope_id=scope_id,
+                run_id=run_id,
+                error=error,
+            )
+            ctx.log(
+                "google_drive_sync_scope_failed",
+                scope_id=scope_id,
+                error=error,
+            )
+
+    status = "completed"
+    error_text = ""
+    if failed and synced:
+        status = "partial_failed"
+        error_text = f"{len(failed)} Drive item(s) failed"
+    elif failed:
+        status = "failed"
+        error_text = f"{len(failed)} Drive item(s) failed"
+
+    await _record_run_finish(
+        ctx._pool,
+        run_id=run_id,
+        status=status,
+        scopes_synced=synced,
+        scopes_failed=failed,
+        counts=counts,
+        error_text=error_text,
+    )
+
+    return {
+        "status": status,
+        "run_id": run_id,
+        "scopes_synced": len(synced),
+        "scopes_failed": len(failed),
+        **counts,
+    }

--- a/workflows/google_drive_sync.py
+++ b/workflows/google_drive_sync.py
@@ -497,6 +497,13 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                             error=error,
                             run_id=run_id,
                         )
+                        ctx.log(
+                            "google_drive_sync_file_failed",
+                            scope_id=scope_id,
+                            file_id=file_id,
+                            file_name=str(file.get("name") or ""),
+                            error=error,
+                        )
                 page_token = page.get("nextPageToken")
                 if not page_token:
                     break
@@ -510,6 +517,10 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             ctx.log(
                 "google_drive_sync_scope_completed",
                 scope_id=scope_id,
+                files_seen=counts["files_seen"],
+                files_upserted=counts["files_upserted"],
+                docs_fetched=counts["docs_fetched"],
+                docs_upserted=counts["docs_upserted"],
                 watermark=_rfc3339(successful_watermark)
                 if successful_watermark
                 else "",


### PR DESCRIPTION
## Summary
- add a scheduled Google Drive Docs ETL that syncs accessible Google Docs into raw Drive sync tables
- project synced Google Docs into `company_context_documents` so they participate in existing company-context search/BM25 indexing
- add shared ETL metrics/logs for Google Drive freshness, active/failed scopes, item counts, failures, and projection lag
- simplify Drive config to index all accessible docs by default when `GOOGLE_DRIVE_ETL_ENABLED` is enabled

## Validation
- `uv run ruff check api/vm_metrics.py ../../workflows/google_drive_sync.py tests/test_slack_sync.py`
- import smoke for `api.vm_metrics` and `workflows.google_drive_sync`
- `uv run pytest tests/test_slack_sync.py::test_etl_freshness_metrics_refresh_from_slack_sync_tables tests/test_google_drive_sync.py -rs` collected 6 tests, but all skipped because local Docker/OrbStack socket was unavailable (`/Users/akshaan/.orbstack/run/docker.sock`)
