### PR TITLE
docs: fix deploying-in-production LOCAL_DEV_API_KEY usage

### DIFF
--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -65,6 +65,7 @@ Minimum keys:
 | `SLACK_BOT_TOKEN` | Slackbot | Bot User OAuth Token from the Slack app. |
 | `SLACK_SIGNING_SECRET` | Slackbot/API | Used to verify Slack webhook signatures. |
 | `SLACKBOT_API_KEY` | Slackbot to API | Static service token; API bootstraps it into Postgres on startup with `agent` scope. |
+| `LOCAL_DEV_API_KEY` | Initial operator/admin access | Optional but recommended for first boot; API bootstraps it into Postgres on startup with `admin`, `agent`, `threads`, and `tools:*` scopes. |
 | `OP_CONNECT_TOKEN` | [iron-proxy](https://docs.iron.sh) 1Password Connect source (preferred) | Needed when `ironProxy.secretSource` is `onepassword-connect`. |
 | `OP_SERVICE_ACCOUNT_TOKEN` | [iron-proxy](https://docs.iron.sh) 1Password service-account source | Needed when `ironProxy.secretSource` is `onepassword`. |
 | `OP_VAULT` | [iron-proxy](https://docs.iron.sh) 1Password source | Vault name or id used for `op://` references (either mode). |
@@ -171,9 +172,8 @@ helm upgrade --install centaur contrib/chart \
 
 ## 6. Verify the deployment
 
-Check health from inside the API deployment first. Localhost is accepted for
-operator-only routes, so this avoids needing an external admin key for the first
-smoke check:
+Check health from inside the API deployment first. The basic health and
+readiness endpoints do not require auth:
 
 ```bash
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
@@ -181,49 +181,75 @@ kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
 
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
   curl -fsS http://localhost:8000/health/ready | jq
-
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS http://localhost:8000/health/tools | jq
 ```
 
-If you need to call operator routes from outside the cluster, create an admin
-API key from inside the API deployment and save the returned plaintext key:
+Operator routes such as `/health/tools` and `/admin/*` require an admin API key.
+There is no localhost auth bypass. Bootstrap the first admin key by setting
+`LOCAL_DEV_API_KEY` in `centaur-infra-env` before API startup, or patch it in and
+restart the API:
+
+```bash
+export ADMIN_KEY="aiv2_$(openssl rand -hex 32)"
+
+kubectl patch secret -n centaur-system centaur-infra-env \
+  --type merge \
+  -p "{\"stringData\":{\"LOCAL_DEV_API_KEY\":\"${ADMIN_KEY}\"}}"
+
+kubectl rollout restart -n centaur-system deploy/centaur-centaur-api
+kubectl rollout status -n centaur-system deploy/centaur-centaur-api
+```
+
+Then verify tool discovery with that key:
+
+```bash
+kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
+  curl -fsS http://localhost:8000/health/tools \
+    -H "X-Api-Key: ${ADMIN_KEY}" | jq
+```
+
+You can create a named operator key and save the returned plaintext key:
 
 ```bash
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
   curl -fsS -X POST http://localhost:8000/admin/api-keys \
     -H "Content-Type: application/json" \
+    -H "X-Api-Key: ${ADMIN_KEY}" \
     -d '{"name":"operator","scopes":["admin"],"created_by":"ops"}' | jq
 ```
 
-External operator calls then use:
+External operator calls use the same header:
 
 ```bash
 curl -s "$CENTAUR_API_URL/health/tools" \
   -H "X-Api-Key: $ADMIN_KEY" | jq
 ```
 
-Run one agent turn from inside the API deployment:
+Run one agent turn from inside the API deployment. Use either the admin key or a
+service key with `agent` scope, such as `SLACKBOT_API_KEY`:
 
 ```bash
 THREAD_KEY=production-smoke-codex
 
 SPAWN=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/spawn \
   -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${ADMIN_KEY}" \
   -d "{\"thread_key\":\"${THREAD_KEY}\"}")
 ASSIGNMENT_GENERATION=$(printf '%s' "$SPAWN" | jq -r '.assignment_generation')
 
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/message \
   -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${ADMIN_KEY}" \
   -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG.\"}]}"
 
 EXECUTE=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/execute \
   -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${ADMIN_KEY}" \
   -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"delivery\":{\"platform\":\"dev\"}}")
 EXECUTION_ID=$(printf '%s' "$EXECUTE" | jq -r '.execution_id')
 
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s \
-  "http://localhost:8000/agent/executions/${EXECUTION_ID}" | jq
+  "http://localhost:8000/agent/executions/${EXECUTION_ID}" \
+  -H "X-Api-Key: ${ADMIN_KEY}" | jq
 ```
 
 Then run the same prompt through Slack:


### PR DESCRIPTION
Update the production deployment guide to match the current auth model. PR #23 removed the localhost/IP-based auth bypass, so operator and agent verification commands now need an API key even when run through kubectl exec.

Document the existing LOCAL_DEV_API_KEY bootstrap path for the first admin key, then use X-Api-Key on /health/tools, /admin/api-keys, and agent smoke-test requests. This aligns the guide with the service-key bootstrap behavior and the auth-aware smoke flow fixed in #309.

## Follow-up suggestion

Consider renaming LOCAL_DEV_API_KEY to BOOTSTRAP_ADMIN_API_KEY. The current name is misleading because this key is not local-dev-specific; it is the bootstrap admin API key used to create the first operator key in production deployments too.