### PR TITLE
fix: clarify Slack PR prompter attribution

### DIFF
--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -1037,6 +1037,7 @@ def _build_session_context(
                     "",
                     "- If you create a GitHub PR for this Slack request, "
                     f"the PR body MUST contain this standalone line: `Prompted by: {github_handle}`",
+                    "- The credited prompter is the requester in this section, not the Slack thread OP/root author.",
                     "- This is a GitHub PR body requirement, not a Slack response mention rule.",
                     "- Assign the PR to the requester when possible: "
                     f"`{github_login}`",

--- a/services/api/tests/test_integration.py
+++ b/services/api/tests/test_integration.py
@@ -594,6 +594,7 @@ class TestBuildSessionContext:
         assert "GitHub handle verified: yes" in ctx
         assert "GitHub PR Attribution" in ctx
         assert "Prompted by: @alice" in ctx
+        assert "not the Slack thread OP/root author" in ctx
         assert "Assign the PR to the requester when possible: `alice`" in ctx
         assert "not a Slack response mention rule" in ctx
 
@@ -657,6 +658,25 @@ class TestBuildSessionContext:
         )
 
         assert await _get_latest_thread_user_id(thread_key) == "U123"
+
+    @pytest.mark.asyncio
+    async def test_latest_thread_user_id_prefers_newest_requester_over_thread_op(
+        self, db_pool
+    ):
+        from api.agent import _get_latest_thread_user_id
+
+        thread_key = "test:requester-not-thread-op"
+        await db_pool.execute(
+            "INSERT INTO chat_messages (id, thread_key, role, parts, user_id, metadata, created_at) "
+            "VALUES "
+            "($1, $2, 'user', '[]'::jsonb, 'U_THREAD_OP', '{}'::jsonb, NOW() - INTERVAL '5 minutes'), "
+            "($3, $2, 'user', '[]'::jsonb, 'U_PROMPTER', '{}'::jsonb, NOW())",
+            "msg-thread-op",
+            thread_key,
+            "msg-current-prompter",
+        )
+
+        assert await _get_latest_thread_user_id(thread_key) == "U_PROMPTER"
 
     @pytest.mark.asyncio
     async def test_latest_thread_user_id_reads_execution_delivery(self, db_pool):


### PR DESCRIPTION
## Summary
- Clarify the generated Slack PR attribution instructions to credit the requester/prompter.
- Add regression coverage that the latest requester wins over an older thread OP/root author.

## Testing
- `uv run pytest tests/test_integration.py::TestBuildSessionContext::test_requester_identity_with_github_handle`
- `uv run pytest tests/test_integration.py::TestBuildSessionContext::test_requester_identity_with_github_handle tests/test_integration.py::TestBuildSessionContext::test_latest_thread_user_id_prefers_newest_requester_over_thread_op` (DB-backed test skipped locally without the integration DB fixture)

Prompted by: @DaniPopes