### PR TITLE
refactor: extract GSuite integration helpers

### DIFF
--- a/services/api/api/integrations/__init__.py
+++ b/services/api/api/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Internal integration clients shared by workflows and tool wrappers."""

--- a/services/api/api/integrations/gsuite/__init__.py
+++ b/services/api/api/integrations/gsuite/__init__.py
@@ -1,0 +1,1 @@
+"""Google Workspace integration helpers."""

--- a/services/api/api/integrations/gsuite/docs.py
+++ b/services/api/api/integrations/gsuite/docs.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+from api.integrations.gsuite.http import build_http
+
+
+def get_docs_service():
+    """Return a proxy-authenticated Google Docs v1 service."""
+    from googleapiclient.discovery import build
+
+    return build("docs", "v1", http=build_http())
+
+
+def docs_get(document_id: str, include_tabs: bool = True) -> dict[str, Any]:
+    """Fetch a Google Doc with body/tab content."""
+    service = get_docs_service()
+    return (
+        service.documents()
+        .get(documentId=document_id, includeTabsContent=include_tabs)
+        .execute()
+    )
+
+
+def extract_text_from_content(content: list[dict[str, Any]]) -> str:
+    """Extract plain text from Google Docs structural content."""
+    text_parts: list[str] = []
+    for element in content:
+        if "paragraph" in element:
+            for para_element in element["paragraph"].get("elements", []):
+                if "textRun" in para_element:
+                    text_parts.append(para_element["textRun"].get("content", ""))
+        elif "table" in element:
+            for row in element["table"].get("tableRows", []):
+                for cell in row.get("tableCells", []):
+                    text_parts.append(extract_text_from_content(cell.get("content", [])))
+    return "".join(text_parts)
+
+
+def docs_text_from_document(doc: dict[str, Any]) -> str:
+    """Extract plain text from a Google Docs API document response."""
+    if doc.get("tabs"):
+        all_text = []
+        for tab in doc["tabs"]:
+            doc_tab = tab.get("documentTab", {})
+            body = doc_tab.get("body", {})
+            all_text.append(extract_text_from_content(body.get("content", [])))
+        return "\n".join(all_text)
+    return extract_text_from_content(doc.get("body", {}).get("content", []))
+
+
+def docs_get_text(document_id: str) -> str:
+    """Return plain text content from a Google Doc."""
+    return docs_text_from_document(docs_get(document_id))

--- a/services/api/api/integrations/gsuite/drive.py
+++ b/services/api/api/integrations/gsuite/drive.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+from api.integrations.gsuite.docs import docs_get_text
+from api.integrations.gsuite.http import build_http
+
+GOOGLE_DOC_MIME_TYPE = "application/vnd.google-apps.document"
+
+
+def get_drive_service():
+    """Return a proxy-authenticated Google Drive v3 service."""
+    from googleapiclient.discovery import build
+
+    return build("drive", "v3", http=build_http())
+
+
+class GoogleDriveReadonlyClient:
+    """Read-only Drive/Docs client used by ETL workflows."""
+
+    def list_docs(
+        self,
+        *,
+        query: str,
+        page_size: int,
+        page_token: str | None = None,
+    ) -> dict[str, Any]:
+        service = get_drive_service()
+        kwargs: dict[str, Any] = {
+            "q": query,
+            "pageSize": page_size,
+            "fields": (
+                "nextPageToken, files("
+                "id, name, mimeType, webViewLink, driveId, parents, owners, "
+                "lastModifyingUser, trashed, createdTime, modifiedTime"
+                ")"
+            ),
+            "includeItemsFromAllDrives": True,
+            "supportsAllDrives": True,
+            "orderBy": "modifiedTime",
+        }
+        if page_token:
+            kwargs["pageToken"] = page_token
+        return service.files().list(**kwargs).execute()
+
+    def docs_get_text(self, document_id: str) -> str:
+        return str(docs_get_text(document_id) or "")

--- a/services/api/api/integrations/gsuite/http.py
+++ b/services/api/api/integrations/gsuite/http.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+from urllib.parse import urlsplit
+
+
+def build_http():
+    """Build a google-api-python-client HTTP transport routed through iron-proxy.
+
+    Google REST clients use httplib2, so we wire proxy and CA settings
+    explicitly. The imports stay lazy so workflow modules can load in test
+    environments that have not installed tool-only Google dependencies.
+    """
+    import httplib2
+    import socks
+
+    proxy_url = os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
+    proxy_info = None
+    if proxy_url:
+        parts = urlsplit(proxy_url)
+        proxy_info = httplib2.ProxyInfo(
+            proxy_type=socks.PROXY_TYPE_HTTP,
+            proxy_host=parts.hostname,
+            proxy_port=parts.port or 8080,
+        )
+    ca_certs = os.environ.get("SSL_CERT_FILE") or os.environ.get(
+        "REQUESTS_CA_BUNDLE"
+    )
+    return httplib2.Http(proxy_info=proxy_info, ca_certs=ca_certs)

--- a/services/api/tests/test_gsuite_integrations.py
+++ b/services/api/tests/test_gsuite_integrations.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+
+def test_docs_text_from_document_extracts_body_and_tables():
+    from api.integrations.gsuite.docs import docs_text_from_document
+
+    doc = {
+        "body": {
+            "content": [
+                {
+                    "paragraph": {
+                        "elements": [{"textRun": {"content": "Intro\n"}}],
+                    },
+                },
+                {
+                    "table": {
+                        "tableRows": [
+                            {
+                                "tableCells": [
+                                    {
+                                        "content": [
+                                            {
+                                                "paragraph": {
+                                                    "elements": [
+                                                        {
+                                                            "textRun": {
+                                                                "content": "Cell"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+            ]
+        }
+    }
+
+    assert docs_text_from_document(doc) == "Intro\nCell"
+
+
+def test_docs_text_from_document_extracts_tabs():
+    from api.integrations.gsuite.docs import docs_text_from_document
+
+    doc = {
+        "tabs": [
+            {
+                "documentTab": {
+                    "body": {
+                        "content": [
+                            {
+                                "paragraph": {
+                                    "elements": [{"textRun": {"content": "Tab one"}}]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "documentTab": {
+                    "body": {
+                        "content": [
+                            {
+                                "paragraph": {
+                                    "elements": [{"textRun": {"content": "Tab two"}}]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+        ]
+    }
+
+    assert docs_text_from_document(doc) == "Tab one\nTab two"
+
+
+def test_drive_readonly_client_lists_google_docs(monkeypatch):
+    from api.integrations.gsuite import drive
+
+    captured: dict[str, object] = {}
+
+    class FakeListRequest:
+        def execute(self):
+            return {"files": [{"id": "doc-1"}]}
+
+    class FakeFiles:
+        def list(self, **kwargs):
+            captured.update(kwargs)
+            return FakeListRequest()
+
+    class FakeDriveService:
+        def files(self):
+            return FakeFiles()
+
+    monkeypatch.setattr(drive, "get_drive_service", lambda: FakeDriveService())
+
+    client = drive.GoogleDriveReadonlyClient()
+    result = client.list_docs(
+        query="mimeType = 'application/vnd.google-apps.document'",
+        page_size=25,
+        page_token="next",
+    )
+
+    assert result == {"files": [{"id": "doc-1"}]}
+    assert captured["pageSize"] == 25
+    assert captured["pageToken"] == "next"
+    assert captured["includeItemsFromAllDrives"] is True
+    assert captured["supportsAllDrives"] is True
+    assert "lastModifyingUser" in str(captured["fields"])

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -17,6 +17,11 @@ from google.auth.credentials import AnonymousCredentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
 
+try:
+    from api.integrations.gsuite.http import build_http as _shared_build_http
+except ModuleNotFoundError:
+    _shared_build_http = None
+
 
 def _build_http() -> httplib2.Http:
     """Build an httplib2 client routed through iron-proxy.
@@ -37,6 +42,9 @@ def _build_http() -> httplib2.Http:
     Falls back to a direct, default-CA client when the proxy env vars are
     absent (local use outside the sandbox).
     """
+    if _shared_build_http is not None:
+        return _shared_build_http()
+
     proxy_url = os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
     proxy_info = None
     if proxy_url:

--- a/workflows/google_drive_sync.py
+++ b/workflows/google_drive_sync.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import datetime as dt
 import hashlib
-import importlib.util
 import os
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, Protocol
 
+from api.integrations.gsuite.drive import GOOGLE_DOC_MIME_TYPE, GoogleDriveReadonlyClient
 from api.runtime_control import canonical_json
 from api.vm_metrics import (
     record_etl_items_failed,
@@ -20,8 +19,6 @@ from api.workflow_engine import WorkflowContext
 from workflows.slack_sync_shared import env_flag_enabled, positive_int
 
 WORKFLOW_NAME = "google_drive_sync"
-
-GOOGLE_DOC_MIME_TYPE = "application/vnd.google-apps.document"
 DEFAULT_SYNC_INTERVAL_SECONDS = 4 * 60 * 60
 DEFAULT_PAGE_SIZE = 100
 DEFAULT_WATERMARK_OVERLAP_SECONDS = 60
@@ -62,83 +59,8 @@ class GoogleDriveSyncClient(Protocol):
     def docs_get_text(self, document_id: str) -> str: ...
 
 
-class GSuiteDriveClient:
-    """Adapter around the gsuite tool module.
-
-    The gsuite module routes google-api-python-client traffic through
-    iron-proxy, so workflows inherit the same OAuth refresh-token mechanism as
-    sandbox tools when their pod has HTTPS_PROXY/CA env wired from the API.
-    """
-
-    def __init__(self, module: Any):
-        self._module = module
-
-    def list_docs(
-        self,
-        *,
-        query: str,
-        page_size: int,
-        page_token: str | None = None,
-    ) -> dict[str, Any]:
-        service = self._module.get_drive_service()
-        kwargs: dict[str, Any] = {
-            "q": query,
-            "pageSize": page_size,
-            "fields": (
-                "nextPageToken, files("
-                "id, name, mimeType, webViewLink, driveId, parents, owners, "
-                "lastModifyingUser, trashed, createdTime, modifiedTime"
-                ")"
-            ),
-            "includeItemsFromAllDrives": True,
-            "supportsAllDrives": True,
-            "orderBy": "modifiedTime",
-        }
-        if page_token:
-            kwargs["pageToken"] = page_token
-        return service.files().list(**kwargs).execute()
-
-    def docs_get_text(self, document_id: str) -> str:
-        return str(self._module.docs_get_text(document_id) or "")
-
-
-def _repo_gsuite_client_paths() -> list[Path]:
-    repo_root = Path(__file__).resolve().parents[1]
-    return [
-        repo_root / "tools" / "productivity" / "gsuite" / "client.py",
-        repo_root / "tools" / "gsuite" / "client.py",
-    ]
-
-
-def _load_gsuite_module_from_path(client_path: Path) -> Any:
-    spec = importlib.util.spec_from_file_location(
-        "_google_drive_sync_gsuite_client",
-        client_path,
-    )
-    if not spec or not spec.loader:
-        raise ImportError(f"Could not load gsuite client module from {client_path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-def _gsuite_module() -> Any:
-    try:
-        from gsuite import client as gsuite_client
-
-        return gsuite_client
-    except ModuleNotFoundError:
-        for client_path in _repo_gsuite_client_paths():
-            if client_path.exists():
-                return _load_gsuite_module_from_path(client_path)
-        candidates = ", ".join(str(path) for path in _repo_gsuite_client_paths())
-        raise FileNotFoundError(
-            f"Could not find gsuite client module. Tried: {candidates}"
-        )
-
-
 def _client() -> GoogleDriveSyncClient:
-    return GSuiteDriveClient(_gsuite_module())
+    return GoogleDriveReadonlyClient()
 
 
 def _parse_datetime(value: str | None) -> dt.datetime | None:


### PR DESCRIPTION
## Summary
- add API-owned internal GSuite helper modules for proxy-aware HTTP, Docs text extraction, and read-only Drive access
- update the Google Drive ETL to use the internal read-only client instead of importing/loading the GSuite tool client by file path
- let the GSuite tool reuse the shared proxy HTTP builder when running inside the API image while preserving its standalone fallback
- add focused tests for Docs text extraction and Drive list request construction

## Validation
- uv run ruff check api/integrations tests/test_gsuite_integrations.py ../../workflows/google_drive_sync.py
- uv run pytest tests/test_gsuite_integrations.py -q
- uv run ruff check ../../tools/productivity/gsuite/client.py --select E9,F
- uv run pytest tests/test_google_drive_sync.py -q (collected but skipped 5 DB-backed tests locally)
- git diff --check

## Not run
- just build-one api: blocked because local Docker/OrbStack socket is unavailable (unix:///Users/akshaan/.orbstack/run/docker.sock)
