### PR TITLE
Allow Codex reasoning effort override

### DIFF
--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -148,6 +148,7 @@ Sandbox entrypoint and wrappers:
 | `GOOGLE_APPLICATION_CREDENTIALS` | Sandbox entrypoint or `sandbox.extraEnv`. | Google ADC path; entrypoint creates a local stub when unset. |
 | `CODEX_API_KEY`, `CODEX_HOME`, `CODEX_CONTINUE_THREAD_ID` | `sandbox.extraEnv` or runtime resume. | Codex auth/config/resume behavior. |
 | `CODEX_AUTH_MODE` | `sandbox.extraEnv`. | Codex auth flow: `api_key` (default, hits `api.openai.com`) or `access_token` (hits `chatgpt.com` via the brokered ChatGPT login). See [Codex Auth Modes](/deploying-in-production#codex-auth-modes). |
+| `CODEX_MODEL_REASONING_EFFORT` | `sandbox.extraEnv`. | Optional Codex `model_reasoning_effort` override written into the sandbox's Codex config. |
 | `CLAUDE_MODEL`, `CLAUDE_CONTINUE_SESSION_ID` | `sandbox.extraEnv` or runtime resume. | Claude model and resume behavior. |
 | `CLAUDE_CODE_AUTH_MODE` | `sandbox.extraEnv`. | Claude Code auth flow: `api_key` (default, uses `ANTHROPIC_API_KEY`) or `access_token` (Claude.ai Pro or Max via the brokered OAuth login). See [Claude Auth Modes](/deploying-in-production#claude-auth-modes). |
 | `DEPLOY_ENV`, `ENVIRONMENT`, `TRACEPARENT` | Deployment env or wrapper-generated. | Runtime environment and trace context. |

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -144,6 +144,7 @@ Sandbox entrypoint and wrappers:
 | `AGENT_REPO`, `AGENT_PERSONA` | Runtime assignment metadata. | Workspace repo clone and persona prompt. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Sandbox entrypoint or `sandbox.extraEnv`. | Google ADC path; entrypoint creates a local stub when unset. |
 | `CODEX_API_KEY`, `CODEX_HOME`, `CODEX_CONTINUE_THREAD_ID` | `sandbox.extraEnv` or runtime resume. | Codex auth/config/resume behavior. |
+| `CODEX_MODEL_REASONING_EFFORT` | `sandbox.extraEnv`. | Optional Codex `model_reasoning_effort` override written into the sandbox's Codex config. |
 | `CLAUDE_MODEL`, `CLAUDE_CONTINUE_SESSION_ID` | `sandbox.extraEnv` or runtime resume. | Claude model and resume behavior. |
 | `DEPLOY_ENV`, `ENVIRONMENT`, `TRACEPARENT` | Deployment env or wrapper-generated. | Runtime environment and trace context. |
 | `CALL_TIMEOUT_SECONDS` | Sandbox env before running `call`. | Curl watchdog for API tool calls. |

--- a/services/api/tests/test_sandbox_entrypoint.py
+++ b/services/api/tests/test_sandbox_entrypoint.py
@@ -135,3 +135,33 @@ def test_sandbox_entrypoint_installs_codex_harness_config(tmp_path: Path) -> Non
 
     assert result.returncode == 0, result.stderr or result.stdout
     assert result.stdout == (harness_dir / "codex" / "config.toml").read_text()
+
+
+def test_sandbox_entrypoint_overrides_codex_reasoning_effort(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    harness_dir = _write_codex_harness_config(home)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ENTRYPOINT_SH),
+            "sh",
+            "-lc",
+            'cat "$HOME/.codex/config.toml"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(home),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "CENTAUR_HARNESS_CONFIG_DIR": str(harness_dir),
+            "CODEX_MODEL_REASONING_EFFORT": "medium",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert 'model_reasoning_effort = "medium"' in result.stdout
+    assert 'model_reasoning_effort = "low"' not in result.stdout
+    assert 'model = "gpt-5.5"' in result.stdout
+    assert 'service_tier = "fast"' in result.stdout

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -99,6 +99,27 @@ else
     echo "missing Codex harness config: $HARNESS_CONFIG_DIR/codex/config.toml" >&2
     exit 1
 fi
+if [ -n "${CODEX_MODEL_REASONING_EFFORT:-}" ]; then
+    python3 - "$HOME_DIR/.codex/config.toml" <<'PYEOF'
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+key = "model_reasoning_effort"
+value = os.environ["CODEX_MODEL_REASONING_EFFORT"].strip()
+if not value:
+    raise SystemExit("CODEX_MODEL_REASONING_EFFORT must not be empty")
+line = f"{key} = {json.dumps(value)}"
+text = path.read_text()
+updated = re.sub(rf"(?m)^{key}\s*=.*$", line, text, count=1)
+if updated == text:
+    updated = text.rstrip() + "\n" + line + "\n"
+path.write_text(updated)
+PYEOF
+fi
 
 # ── Claude Code settings ────────────────────────────────────────────────────
 mkdir -p "$HOME_DIR/.claude"


### PR DESCRIPTION
## Summary
- add CODEX_MODEL_REASONING_EFFORT as a sandbox env override for Codex config
- keep the baked-in default unchanged when the env var is absent
- document the sandbox.extraEnv setting and cover it in sandbox entrypoint tests

## Test plan
- uv sync --group dev
- uv run pytest -q tests/test_sandbox_entrypoint.py
- uv run ruff check api/ tests/test_sandbox_entrypoint.py
- bash -n services/sandbox/entrypoint.sh