### PR TITLE
feat: add google calendar etl

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.47
+version: 0.1.48
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -265,6 +265,14 @@ spec:
             - name: GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS
               value: {{ .Values.api.googleDriveSyncIntervalSeconds | quote }}
 {{- end }}
+{{- if not (hasKey $apiExtraEnv "GOOGLE_CALENDAR_ETL_ENABLED") }}
+            - name: GOOGLE_CALENDAR_ETL_ENABLED
+              value: {{ ternary "1" "0" .Values.api.googleCalendarEtlEnabled | quote }}
+{{- end }}
+{{- if not (hasKey $apiExtraEnv "GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS") }}
+            - name: GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS
+              value: {{ .Values.api.googleCalendarSyncIntervalSeconds | quote }}
+{{- end }}
 {{- if not (hasKey $apiExtraEnv "COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS") }}
             - name: COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS
               value: {{ .Values.api.companyContextDocumentsIntervalSeconds | quote }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -70,6 +70,10 @@
         "slackSyncIntervalSeconds": { "type": "integer" },
         "slackSyncLookbackDays": { "type": "integer" },
         "slackSyncThreadLookbackDays": { "type": "integer" },
+        "googleDriveEtlEnabled": { "type": "boolean" },
+        "googleDriveSyncIntervalSeconds": { "type": "integer" },
+        "googleCalendarEtlEnabled": { "type": "boolean" },
+        "googleCalendarSyncIntervalSeconds": { "type": "integer" },
         "companyContextDocumentsIntervalSeconds": { "type": "integer" }
       }
     },

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -99,6 +99,8 @@ api:
   slackSyncThreadLookbackDays: 3
   googleDriveEtlEnabled: false
   googleDriveSyncIntervalSeconds: 14400
+  googleCalendarEtlEnabled: false
+  googleCalendarSyncIntervalSeconds: 14400
   companyContextDocumentsIntervalSeconds: 14400
   slackEtlExcludedChannelPatterns: ""
   victoriaMetricsPushEnabled: false

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -176,6 +176,15 @@ Slack ETL workflows:
 | `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `api.extraEnv` or chart batch limit. | Backfill enablement and batch sizing. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `api.extraEnv`. | Enables company-context projection when Slack ETL is on. |
 
+Google Workspace ETL workflows:
+
+| Env var | Set from | Controls |
+| --- | --- | --- |
+| `GOOGLE_DRIVE_ETL_ENABLED` | `api.googleDriveEtlEnabled`. | Enables Google Drive Docs sync. |
+| `GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS` | `api.googleDriveSyncIntervalSeconds`. | Google Drive Docs sync schedule interval. |
+| `GOOGLE_CALENDAR_ETL_ENABLED` | `api.googleCalendarEtlEnabled`. | Enables Google Calendar sync. |
+| `GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS` | `api.googleCalendarSyncIntervalSeconds`. | Google Calendar sync schedule interval. |
+
 ## Observability and Retention
 
 | Env var | Set from | Controls |

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -170,6 +170,15 @@ Slack ETL workflows:
 | `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `api.extraEnv` or chart batch limit. | Backfill enablement and batch sizing. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `api.extraEnv`. | Enables company-context projection when Slack ETL is on. |
 
+Google Workspace ETL workflows:
+
+| Env var | Set from | Controls |
+| --- | --- | --- |
+| `GOOGLE_DRIVE_ETL_ENABLED` | `api.googleDriveEtlEnabled`. | Enables Google Drive Docs sync. |
+| `GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS` | `api.googleDriveSyncIntervalSeconds`. | Google Drive Docs sync schedule interval. |
+| `GOOGLE_CALENDAR_ETL_ENABLED` | `api.googleCalendarEtlEnabled`. | Enables Google Calendar sync. |
+| `GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS` | `api.googleCalendarSyncIntervalSeconds`. | Google Calendar sync schedule interval. |
+
 ## Observability and Retention
 
 | Env var | Set from | Controls |

--- a/services/api/api/integrations/gsuite/calendar.py
+++ b/services/api/api/integrations/gsuite/calendar.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any
+
+from api.integrations.gsuite.http import build_http
+
+
+def get_calendar_service():
+    """Return a proxy-authenticated Google Calendar v3 service."""
+    from googleapiclient.discovery import build
+
+    return build("calendar", "v3", http=build_http())
+
+
+class GoogleCalendarReadonlyClient:
+    """Read-only Calendar client used by ETL workflows."""
+
+    def list_calendars(self, *, page_token: str | None = None) -> dict[str, Any]:
+        service = get_calendar_service()
+        kwargs: dict[str, Any] = {
+            "showHidden": True,
+            "fields": (
+                "nextPageToken, items("
+                "id, summary, description, location, timeZone, accessRole, primary, "
+                "selected, hidden, backgroundColor, foregroundColor"
+                ")"
+            ),
+        }
+        if page_token:
+            kwargs["pageToken"] = page_token
+        return service.calendarList().list(**kwargs).execute()
+
+    def list_events(
+        self,
+        *,
+        calendar_id: str,
+        page_size: int,
+        page_token: str | None = None,
+        sync_token: str | None = None,
+    ) -> dict[str, Any]:
+        service = get_calendar_service()
+        kwargs: dict[str, Any] = {
+            "calendarId": calendar_id,
+            "maxResults": page_size,
+            "showDeleted": True,
+            "fields": (
+                "nextPageToken, nextSyncToken, items("
+                "id, iCalUID, status, summary, description, location, htmlLink, "
+                "created, updated, start, end, creator, organizer, attendees, "
+                "recurringEventId, originalStartTime, transparency, visibility, "
+                "eventType, sequence, hangoutLink, conferenceData"
+                ")"
+            ),
+        }
+        if page_token:
+            kwargs["pageToken"] = page_token
+        if sync_token:
+            kwargs["syncToken"] = sync_token
+        return service.events().list(**kwargs).execute()

--- a/services/api/api/vm_metrics.py
+++ b/services/api/api/vm_metrics.py
@@ -857,6 +857,53 @@ async def refresh_etl_metrics(pool: Pool) -> None:
         source="google_drive", source_type="doc"
     ).set(max(max_sync_freshness_s, 0.0))
 
+    calendar_scope_rows = await pool.fetch(
+        "SELECT cal.calendar_id, cp.watermark_time, cp.last_success_at, cp.last_error, cp.updated_at "
+        "FROM google_calendar_sync_calendars cal "
+        "LEFT JOIN google_calendar_sync_checkpoints cp ON cp.calendar_id = cal.calendar_id"
+    )
+    calendar_active_scopes = len(calendar_scope_rows)
+    if os.getenv("GOOGLE_CALENDAR_ETL_ENABLED", "").strip().lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        calendar_active_scopes = max(calendar_active_scopes, 1)
+    ETL_ACTIVE_SCOPES.labels(source="google_calendar", source_type="calendar").set(
+        calendar_active_scopes
+    )
+    failed_scopes = 0
+    max_lag_s = 0.0
+    max_sync_freshness_s = 0.0
+    for row in calendar_scope_rows:
+        has_error = bool(str(row["last_error"] or "").strip())
+        if has_error:
+            failed_scopes += 1
+        watermark_time = row["watermark_time"]
+        if isinstance(watermark_time, dt.datetime):
+            max_lag_s = max(
+                max_lag_s,
+                (now - watermark_time.astimezone(dt.timezone.utc)).total_seconds(),
+            )
+        if not has_error:
+            success_at = row["last_success_at"] or row["updated_at"]
+            if isinstance(success_at, dt.datetime):
+                max_sync_freshness_s = max(
+                    max_sync_freshness_s,
+                    (now - success_at.astimezone(dt.timezone.utc)).total_seconds(),
+                )
+    ETL_FAILED_SCOPES.labels(source="google_calendar", source_type="calendar").set(
+        failed_scopes
+    )
+    ETL_SOURCE_CURSOR_LAG_SECONDS.labels(
+        source="google_calendar", source_type="calendar"
+    ).set(max(max_lag_s, 0.0))
+    ETL_SCOPE_SYNC_FRESHNESS_SECONDS.labels(
+        source="google_calendar", source_type="calendar"
+    ).set(max(max_sync_freshness_s, 0.0))
+
     backfill_rows = await pool.fetch(
         "SELECT job_type, status, COUNT(*) AS cnt, MIN(updated_at) AS oldest_updated_at "
         "FROM slack_sync_backfill_jobs "
@@ -913,6 +960,25 @@ async def refresh_etl_metrics(pool: Pool) -> None:
         else:
             projection_lag_s = max((now - raw_latest).total_seconds(), 0.0)
     COMPANY_CONTEXT_PROJECTION_LAG_SECONDS.labels(source="google_drive").set(
+        projection_lag_s
+    )
+
+    raw_latest = await pool.fetchval(
+        "SELECT MAX(source_updated_at) FROM google_calendar_sync_events"
+    )
+    projected_latest = await pool.fetchval(
+        "SELECT MAX(source_updated_at) FROM company_context_documents "
+        "WHERE source = 'google_calendar'"
+    )
+    projection_lag_s = 0.0
+    if isinstance(raw_latest, dt.datetime):
+        raw_latest = raw_latest.astimezone(dt.timezone.utc)
+        if isinstance(projected_latest, dt.datetime):
+            projected_latest = projected_latest.astimezone(dt.timezone.utc)
+            projection_lag_s = max((raw_latest - projected_latest).total_seconds(), 0.0)
+        else:
+            projection_lag_s = max((now - raw_latest).total_seconds(), 0.0)
+    COMPANY_CONTEXT_PROJECTION_LAG_SECONDS.labels(source="google_calendar").set(
         projection_lag_s
     )
 

--- a/services/api/db/migrations/039_google_calendar_sync.sql
+++ b/services/api/db/migrations/039_google_calendar_sync.sql
@@ -1,0 +1,119 @@
+-- migrate:up
+
+CREATE TABLE IF NOT EXISTS google_calendar_sync_runs (
+    run_id              TEXT PRIMARY KEY,
+    workflow_run_id     TEXT,
+    mode                TEXT NOT NULL DEFAULT 'incremental',
+    status              TEXT NOT NULL,
+    calendars_requested JSONB NOT NULL DEFAULT '[]'::jsonb,
+    calendars_synced    JSONB NOT NULL DEFAULT '[]'::jsonb,
+    calendars_failed    JSONB NOT NULL DEFAULT '[]'::jsonb,
+    calendars_seen      INTEGER NOT NULL DEFAULT 0,
+    calendars_upserted  INTEGER NOT NULL DEFAULT 0,
+    events_seen         INTEGER NOT NULL DEFAULT 0,
+    events_upserted     INTEGER NOT NULL DEFAULT 0,
+    events_cancelled    INTEGER NOT NULL DEFAULT 0,
+    started_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at         TIMESTAMPTZ,
+    error_text          TEXT NOT NULL DEFAULT '',
+    metadata            JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_google_calendar_sync_runs_started
+    ON google_calendar_sync_runs (started_at DESC);
+
+CREATE TABLE IF NOT EXISTS google_calendar_sync_calendars (
+    calendar_id      TEXT PRIMARY KEY,
+    summary          TEXT NOT NULL DEFAULT '',
+    description      TEXT NOT NULL DEFAULT '',
+    location         TEXT NOT NULL DEFAULT '',
+    time_zone        TEXT NOT NULL DEFAULT '',
+    access_role      TEXT NOT NULL DEFAULT '',
+    is_primary       BOOLEAN NOT NULL DEFAULT FALSE,
+    is_selected      BOOLEAN NOT NULL DEFAULT FALSE,
+    is_hidden        BOOLEAN NOT NULL DEFAULT FALSE,
+    background_color TEXT NOT NULL DEFAULT '',
+    foreground_color TEXT NOT NULL DEFAULT '',
+    raw_payload      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source_run_id    TEXT REFERENCES google_calendar_sync_runs(run_id) ON DELETE SET NULL,
+    first_seen_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error       TEXT NOT NULL DEFAULT '',
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_google_calendar_sync_calendars_summary
+    ON google_calendar_sync_calendars (summary);
+
+CREATE TABLE IF NOT EXISTS google_calendar_sync_events (
+    calendar_id           TEXT NOT NULL REFERENCES google_calendar_sync_calendars(calendar_id) ON DELETE CASCADE,
+    event_id              TEXT NOT NULL,
+    i_cal_uid             TEXT NOT NULL DEFAULT '',
+    status                TEXT NOT NULL DEFAULT '',
+    summary               TEXT NOT NULL DEFAULT '',
+    description           TEXT NOT NULL DEFAULT '',
+    location              TEXT NOT NULL DEFAULT '',
+    html_link             TEXT NOT NULL DEFAULT '',
+    creator               JSONB NOT NULL DEFAULT '{}'::jsonb,
+    organizer             JSONB NOT NULL DEFAULT '{}'::jsonb,
+    attendees             JSONB NOT NULL DEFAULT '[]'::jsonb,
+    start_payload         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    end_payload           JSONB NOT NULL DEFAULT '{}'::jsonb,
+    start_at              TIMESTAMPTZ,
+    end_at                TIMESTAMPTZ,
+    is_all_day            BOOLEAN NOT NULL DEFAULT FALSE,
+    recurring_event_id    TEXT NOT NULL DEFAULT '',
+    original_start        JSONB NOT NULL DEFAULT '{}'::jsonb,
+    transparency          TEXT NOT NULL DEFAULT '',
+    visibility            TEXT NOT NULL DEFAULT '',
+    event_type            TEXT NOT NULL DEFAULT '',
+    sequence              INTEGER NOT NULL DEFAULT 0,
+    source_created_at     TIMESTAMPTZ,
+    source_updated_at     TIMESTAMPTZ,
+    content_text          TEXT NOT NULL DEFAULT '',
+    content_hash          TEXT NOT NULL DEFAULT '',
+    raw_payload           JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source_run_id         TEXT REFERENCES google_calendar_sync_runs(run_id) ON DELETE SET NULL,
+    first_seen_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error            TEXT NOT NULL DEFAULT '',
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (calendar_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_google_calendar_sync_events_start
+    ON google_calendar_sync_events (start_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_google_calendar_sync_events_updated
+    ON google_calendar_sync_events (source_updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_google_calendar_sync_events_text
+    ON google_calendar_sync_events
+    USING GIN (to_tsvector('english', coalesce(content_text, '')));
+
+CREATE INDEX IF NOT EXISTS idx_google_calendar_sync_events_attendees
+    ON google_calendar_sync_events USING GIN (attendees);
+
+CREATE TABLE IF NOT EXISTS google_calendar_sync_checkpoints (
+    calendar_id      TEXT PRIMARY KEY REFERENCES google_calendar_sync_calendars(calendar_id) ON DELETE CASCADE,
+    sync_token       TEXT NOT NULL DEFAULT '',
+    watermark_time   TIMESTAMPTZ,
+    last_run_id      TEXT REFERENCES google_calendar_sync_runs(run_id) ON DELETE SET NULL,
+    last_success_at  TIMESTAMPTZ,
+    last_error       TEXT NOT NULL DEFAULT '',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS google_calendar_sync_checkpoints;
+DROP INDEX IF EXISTS idx_google_calendar_sync_events_attendees;
+DROP INDEX IF EXISTS idx_google_calendar_sync_events_text;
+DROP INDEX IF EXISTS idx_google_calendar_sync_events_updated;
+DROP INDEX IF EXISTS idx_google_calendar_sync_events_start;
+DROP TABLE IF EXISTS google_calendar_sync_events;
+DROP INDEX IF EXISTS idx_google_calendar_sync_calendars_summary;
+DROP TABLE IF EXISTS google_calendar_sync_calendars;
+DROP INDEX IF EXISTS idx_google_calendar_sync_runs_started;
+DROP TABLE IF EXISTS google_calendar_sync_runs;

--- a/services/api/tests/test_company_context_documents.py
+++ b/services/api/tests/test_company_context_documents.py
@@ -23,9 +23,10 @@ class FakeCtx:
 async def _clear_company_context_tables(db_pool):
     await db_pool.execute(
         "TRUNCATE TABLE company_context_documents, google_drive_sync_checkpoints, "
-        "google_drive_sync_files, google_drive_sync_runs, slack_sync_backfill_jobs, "
-        "slack_sync_checkpoints, slack_sync_messages, slack_sync_runs, slack_sync_users, slack_sync_channels, "
-        "workflow_runs CASCADE",
+        "google_drive_sync_files, google_drive_sync_runs, google_calendar_sync_checkpoints, "
+        "google_calendar_sync_events, google_calendar_sync_calendars, google_calendar_sync_runs, "
+        "slack_sync_backfill_jobs, slack_sync_checkpoints, slack_sync_messages, "
+        "slack_sync_runs, slack_sync_users, slack_sync_channels, workflow_runs CASCADE",
     )
     yield
 
@@ -68,6 +69,20 @@ def test_schedule_respects_env_overrides(monkeypatch):
 def test_schedule_enabled_when_google_drive_etl_enabled(monkeypatch):
     monkeypatch.delenv("SLACK_ETL_ENABLED", raising=False)
     monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "true")
+    monkeypatch.delenv("GOOGLE_CALENDAR_ETL_ENABLED", raising=False)
+    monkeypatch.delenv("COMPANY_CONTEXT_DOCUMENTS_ENABLED", raising=False)
+
+    from workflows import company_context_documents
+
+    reloaded = importlib.reload(company_context_documents)
+
+    assert reloaded.SCHEDULE["enabled"] is True
+
+
+def test_schedule_enabled_when_google_calendar_etl_enabled(monkeypatch):
+    monkeypatch.delenv("SLACK_ETL_ENABLED", raising=False)
+    monkeypatch.delenv("GOOGLE_DRIVE_ETL_ENABLED", raising=False)
+    monkeypatch.setenv("GOOGLE_CALENDAR_ETL_ENABLED", "true")
     monkeypatch.delenv("COMPANY_CONTEXT_DOCUMENTS_ENABLED", raising=False)
 
     from workflows import company_context_documents
@@ -375,3 +390,143 @@ async def test_projects_google_drive_documents(db_pool, monkeypatch):
     assert metadata["file_id"] == "doc-1"
     assert metadata["parent_ids"] == ["folder-1"]
     assert metadata["owners"][0]["emailAddress"] == "owner@example.com"
+
+
+@pytest.mark.asyncio
+async def test_projects_google_calendar_events(db_pool, monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "false")
+    monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "false")
+    monkeypatch.setenv("GOOGLE_CALENDAR_ETL_ENABLED", "true")
+
+    from workflows import company_context_documents
+
+    created_at = dt.datetime(2026, 5, 1, 12, 0, tzinfo=dt.timezone.utc)
+    updated_at = dt.datetime(2026, 5, 2, 12, 0, tzinfo=dt.timezone.utc)
+    synced_at = dt.datetime(2026, 5, 3, 12, 0, tzinfo=dt.timezone.utc)
+    starts_at = dt.datetime(2026, 5, 6, 16, 0, tzinfo=dt.timezone.utc)
+    ends_at = dt.datetime(2026, 5, 6, 17, 0, tzinfo=dt.timezone.utc)
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_runs (run_id, status) "
+        "VALUES ('run-calendar', 'completed')",
+    )
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_calendars (calendar_id, summary) "
+        "VALUES ('primary@example.com', 'Primary')",
+    )
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_events ("
+        "calendar_id, event_id, i_cal_uid, status, summary, description, location, "
+        "html_link, creator, organizer, attendees, start_payload, end_payload, "
+        "start_at, end_at, source_created_at, source_updated_at, content_text, "
+        "content_hash, raw_payload, updated_at"
+        ") VALUES ("
+        "'primary@example.com', 'event-1', 'ical-1', 'confirmed', "
+        "'Partner diligence sync', 'Review roadmap and diligence notes', "
+        "'Zoom', 'https://calendar.google.com/event?eid=event-1', "
+        "$1::jsonb, $2::jsonb, $3::jsonb, $4::jsonb, $5::jsonb, "
+        "$6, $7, $8, $9, 'Partner diligence sync Review roadmap', "
+        "'hash-1', $10::jsonb, $11"
+        ")",
+        json.dumps({"email": "creator@example.com", "displayName": "Creator"}),
+        json.dumps({"email": "organizer@example.com", "displayName": "Organizer"}),
+        json.dumps(
+            [
+                {"email": "alice@example.com", "displayName": "Alice Example"},
+                {"email": "bob@example.com"},
+            ]
+        ),
+        json.dumps({"dateTime": starts_at.isoformat()}),
+        json.dumps({"dateTime": ends_at.isoformat()}),
+        starts_at,
+        ends_at,
+        created_at,
+        updated_at,
+        json.dumps({"id": "event-1"}),
+        synced_at,
+    )
+
+    result = await company_context_documents.handler(
+        company_context_documents.Input(watermark_overlap_seconds=0),
+        FakeCtx(db_pool),
+    )
+
+    assert result["status"] == "completed"
+    assert result["changed_calendar_events"] == 1
+    assert result["calendar_event_documents"] == 1
+    assert result["documents_upserted"] == 1
+    assert result["watermark"] == synced_at.isoformat()
+
+    row = await db_pool.fetchrow(
+        "SELECT document_id, source, source_type, title, body, url, author_id, "
+        "author_name, occurred_at, source_updated_at, metadata "
+        "FROM company_context_documents",
+    )
+    assert row["document_id"] == "google_calendar:event:primary@example.com:event-1"
+    assert row["source"] == "google_calendar"
+    assert row["source_type"] == "calendar_event"
+    assert row["title"] == "Partner diligence sync"
+    assert "Calendar: Primary" in row["body"]
+    assert "Attendees: Alice Example, bob@example.com" in row["body"]
+    assert "Review roadmap and diligence notes" in row["body"]
+    assert row["url"] == "https://calendar.google.com/event?eid=event-1"
+    assert row["author_id"] == "organizer@example.com"
+    assert row["author_name"] == "Organizer"
+    assert row["occurred_at"] == starts_at
+    assert row["source_updated_at"] == updated_at
+    metadata = json.loads(row["metadata"])
+    assert metadata["calendar_id"] == "primary@example.com"
+    assert metadata["event_id"] == "event-1"
+    assert metadata["attendees"][0]["displayName"] == "Alice Example"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_google_calendar_events_delete_projected_documents(
+    db_pool,
+    monkeypatch,
+):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "false")
+    monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "false")
+    monkeypatch.setenv("GOOGLE_CALENDAR_ETL_ENABLED", "true")
+
+    from workflows import company_context_documents
+
+    updated_at = dt.datetime(2026, 5, 3, 12, 0, tzinfo=dt.timezone.utc)
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_runs (run_id, status) "
+        "VALUES ('run-calendar', 'completed')",
+    )
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_calendars (calendar_id, summary) "
+        "VALUES ('primary@example.com', 'Primary')",
+    )
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_events ("
+        "calendar_id, event_id, status, source_updated_at, updated_at"
+        ") VALUES ('primary@example.com', 'event-1', 'cancelled', $1, $1)",
+        updated_at,
+    )
+    await db_pool.execute(
+        "INSERT INTO company_context_documents ("
+        "document_id, source, source_type, source_document_id, title, body, "
+        "content_hash"
+        ") VALUES ("
+        "'google_calendar:event:primary@example.com:event-1', 'google_calendar', "
+        "'calendar_event', 'primary@example.com:event-1', 'Old event', 'Old body', "
+        "'old-hash'"
+        ")",
+    )
+
+    result = await company_context_documents.handler(
+        company_context_documents.Input(watermark_overlap_seconds=0),
+        FakeCtx(db_pool),
+    )
+
+    assert result["changed_calendar_events"] == 1
+    assert result["calendar_event_documents"] == 1
+    assert result["documents_deleted"] == 1
+    assert (
+        await db_pool.fetchval(
+            "SELECT COUNT(*) FROM company_context_documents",
+        )
+        == 0
+    )

--- a/services/api/tests/test_google_calendar_sync.py
+++ b/services/api/tests/test_google_calendar_sync.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+import json
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+
+class FakeCtx:
+    def __init__(self, db_pool, run_id: str = "wfr-test-google-calendar-sync"):
+        self._pool = db_pool
+        self.run_id = run_id
+        self.logs: list[tuple[str, dict[str, Any]]] = []
+
+    def log(self, msg: str, **kwargs: Any) -> None:
+        self.logs.append((msg, kwargs))
+
+
+class _GoneResponse:
+    status = 410
+
+
+class SyncTokenGone(Exception):
+    resp = _GoneResponse()
+
+
+class FakeCalendarClient:
+    def __init__(
+        self,
+        *,
+        calendar_pages: list[dict[str, Any]],
+        event_pages: dict[str, list[dict[str, Any] | Exception]],
+    ) -> None:
+        self.calendar_pages = list(calendar_pages)
+        self.event_pages = {key: list(value) for key, value in event_pages.items()}
+        self.calendar_calls: list[dict[str, Any]] = []
+        self.event_calls: list[dict[str, Any]] = []
+
+    def list_calendars(self, *, page_token: str | None = None) -> dict[str, Any]:
+        self.calendar_calls.append({"page_token": page_token})
+        if self.calendar_pages:
+            return self.calendar_pages.pop(0)
+        return {"items": []}
+
+    def list_events(
+        self,
+        *,
+        calendar_id: str,
+        page_size: int,
+        page_token: str | None = None,
+        sync_token: str | None = None,
+    ) -> dict[str, Any]:
+        self.event_calls.append(
+            {
+                "calendar_id": calendar_id,
+                "page_size": page_size,
+                "page_token": page_token,
+                "sync_token": sync_token,
+            }
+        )
+        page = self.event_pages[calendar_id].pop(0)
+        if isinstance(page, Exception):
+            raise page
+        return page
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_google_calendar_tables(db_pool):
+    await db_pool.execute(
+        "TRUNCATE TABLE google_calendar_sync_checkpoints, google_calendar_sync_events, "
+        "google_calendar_sync_calendars, google_calendar_sync_runs, workflow_runs CASCADE",
+    )
+    yield
+
+
+def test_schedule_defaults_disabled_with_four_hour_interval(monkeypatch):
+    monkeypatch.delenv("GOOGLE_CALENDAR_ETL_ENABLED", raising=False)
+    monkeypatch.delenv("GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS", raising=False)
+
+    from workflows import google_calendar_sync
+
+    reloaded = importlib.reload(google_calendar_sync)
+
+    assert reloaded.SCHEDULE == {
+        "schedule_id": "google_calendar_sync",
+        "interval_seconds": 14400,
+        "enabled": False,
+        "no_delivery": True,
+    }
+
+
+def test_schedule_respects_env_overrides(monkeypatch):
+    monkeypatch.setenv("GOOGLE_CALENDAR_ETL_ENABLED", "true")
+    monkeypatch.setenv("GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS", "300")
+
+    from workflows import google_calendar_sync
+
+    reloaded = importlib.reload(google_calendar_sync)
+
+    assert reloaded.SCHEDULE["enabled"] is True
+    assert reloaded.SCHEDULE["interval_seconds"] == 300
+
+
+@pytest.mark.asyncio
+async def test_syncs_calendar_events_into_raw_tables(db_pool, monkeypatch):
+    from workflows import google_calendar_sync
+
+    monkeypatch.setenv("GOOGLE_CALENDAR_ETL_ENABLED", "true")
+    fake = FakeCalendarClient(
+        calendar_pages=[
+            {
+                "items": [
+                    {
+                        "id": "primary@example.com",
+                        "summary": "Primary",
+                        "timeZone": "America/Los_Angeles",
+                        "accessRole": "owner",
+                        "primary": True,
+                    }
+                ]
+            }
+        ],
+        event_pages={
+            "primary@example.com": [
+                {
+                    "items": [
+                        {
+                            "id": "event-1",
+                            "iCalUID": "ical-1@example.com",
+                            "status": "confirmed",
+                            "summary": "Roadmap review",
+                            "description": "Discuss launch plan",
+                            "location": "Room 1",
+                            "htmlLink": "https://calendar.google.com/event?eid=event-1",
+                            "created": "2026-05-01T10:00:00Z",
+                            "updated": "2026-05-02T10:00:00Z",
+                            "start": {"dateTime": "2026-05-03T17:00:00Z"},
+                            "end": {"dateTime": "2026-05-03T18:00:00Z"},
+                            "creator": {"email": "alice@example.com"},
+                            "organizer": {"email": "bob@example.com"},
+                            "attendees": [
+                                {"email": "carol@example.com", "displayName": "Carol"}
+                            ],
+                            "visibility": "default",
+                            "eventType": "default",
+                            "sequence": 3,
+                        }
+                    ],
+                    "nextSyncToken": "sync-token-1",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(google_calendar_sync, "_client", lambda: fake)
+
+    result = await google_calendar_sync.handler(
+        google_calendar_sync.Input(limit=25),
+        FakeCtx(db_pool),
+    )
+
+    assert result["status"] == "completed"
+    assert result["calendars_seen"] == 1
+    assert result["events_upserted"] == 1
+    assert fake.event_calls == [
+        {
+            "calendar_id": "primary@example.com",
+            "page_size": 25,
+            "page_token": None,
+            "sync_token": None,
+        }
+    ]
+
+    calendar = await db_pool.fetchrow(
+        "SELECT calendar_id, summary, time_zone, access_role, is_primary "
+        "FROM google_calendar_sync_calendars",
+    )
+    assert calendar["calendar_id"] == "primary@example.com"
+    assert calendar["summary"] == "Primary"
+    assert calendar["time_zone"] == "America/Los_Angeles"
+    assert calendar["access_role"] == "owner"
+    assert calendar["is_primary"] is True
+
+    event = await db_pool.fetchrow(
+        "SELECT calendar_id, event_id, summary, description, location, attendees, "
+        "start_at, end_at, source_updated_at, content_text, status "
+        "FROM google_calendar_sync_events",
+    )
+    assert event["calendar_id"] == "primary@example.com"
+    assert event["event_id"] == "event-1"
+    assert event["summary"] == "Roadmap review"
+    assert event["description"] == "Discuss launch plan"
+    assert event["location"] == "Room 1"
+    assert json.loads(event["attendees"])[0]["email"] == "carol@example.com"
+    assert event["start_at"] == dt.datetime(2026, 5, 3, 17, 0, tzinfo=dt.timezone.utc)
+    assert event["end_at"] == dt.datetime(2026, 5, 3, 18, 0, tzinfo=dt.timezone.utc)
+    assert event["source_updated_at"] == dt.datetime(
+        2026, 5, 2, 10, 0, tzinfo=dt.timezone.utc
+    )
+    assert "Roadmap review" in event["content_text"]
+    assert "Carol" in event["content_text"]
+    assert event["status"] == "confirmed"
+
+    checkpoint = await db_pool.fetchrow(
+        "SELECT calendar_id, sync_token, watermark_time FROM google_calendar_sync_checkpoints",
+    )
+    assert checkpoint["calendar_id"] == "primary@example.com"
+    assert checkpoint["sync_token"] == "sync-token-1"
+    assert checkpoint["watermark_time"] == dt.datetime(
+        2026, 5, 2, 10, 0, tzinfo=dt.timezone.utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_incremental_sync_uses_checkpoint_token(db_pool, monkeypatch):
+    from workflows import google_calendar_sync
+
+    monkeypatch.setenv("GOOGLE_CALENDAR_ETL_ENABLED", "true")
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_runs (run_id, status) VALUES ('seed', 'completed')"
+    )
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_calendars (calendar_id, summary) "
+        "VALUES ('primary@example.com', 'Primary')",
+    )
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_checkpoints (calendar_id, sync_token, watermark_time) "
+        "VALUES ('primary@example.com', 'old-token', $1)",
+        dt.datetime(2026, 5, 1, tzinfo=dt.timezone.utc),
+    )
+    fake = FakeCalendarClient(
+        calendar_pages=[{"items": [{"id": "primary@example.com", "summary": "Primary"}]}],
+        event_pages={
+            "primary@example.com": [
+                {
+                    "items": [
+                        {
+                            "id": "event-2",
+                            "status": "cancelled",
+                            "updated": "2026-05-03T10:00:00Z",
+                        }
+                    ],
+                    "nextSyncToken": "new-token",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(google_calendar_sync, "_client", lambda: fake)
+
+    result = await google_calendar_sync.handler(
+        google_calendar_sync.Input(),
+        FakeCtx(db_pool),
+    )
+
+    assert result["status"] == "completed"
+    assert result["events_cancelled"] == 1
+    assert fake.event_calls[0]["sync_token"] == "old-token"
+    checkpoint = await db_pool.fetchrow(
+        "SELECT sync_token FROM google_calendar_sync_checkpoints "
+        "WHERE calendar_id = 'primary@example.com'",
+    )
+    assert checkpoint["sync_token"] == "new-token"
+
+
+@pytest.mark.asyncio
+async def test_expired_sync_token_retries_full_sync(db_pool, monkeypatch):
+    from workflows import google_calendar_sync
+
+    monkeypatch.setenv("GOOGLE_CALENDAR_ETL_ENABLED", "true")
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_calendars (calendar_id, summary) "
+        "VALUES ('primary@example.com', 'Primary')",
+    )
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_checkpoints (calendar_id, sync_token) "
+        "VALUES ('primary@example.com', 'expired-token')",
+    )
+    fake = FakeCalendarClient(
+        calendar_pages=[{"items": [{"id": "primary@example.com", "summary": "Primary"}]}],
+        event_pages={
+            "primary@example.com": [
+                SyncTokenGone("410 Gone"),
+                {"items": [], "nextSyncToken": "replacement-token"},
+            ]
+        },
+    )
+    monkeypatch.setattr(google_calendar_sync, "_client", lambda: fake)
+    ctx = FakeCtx(db_pool)
+
+    result = await google_calendar_sync.handler(
+        google_calendar_sync.Input(),
+        ctx,
+    )
+
+    assert result["status"] == "completed"
+    assert fake.event_calls[0]["sync_token"] == "expired-token"
+    assert fake.event_calls[1]["sync_token"] is None
+    checkpoint = await db_pool.fetchrow(
+        "SELECT sync_token FROM google_calendar_sync_checkpoints "
+        "WHERE calendar_id = 'primary@example.com'",
+    )
+    assert checkpoint["sync_token"] == "replacement-token"
+    assert any(log[0] == "google_calendar_sync_token_expired" for log in ctx.logs)

--- a/services/api/tests/test_google_drive_sync.py
+++ b/services/api/tests/test_google_drive_sync.py
@@ -52,7 +52,9 @@ class FakeDriveClient:
 async def _clear_google_drive_tables(db_pool):
     await db_pool.execute(
         "TRUNCATE TABLE company_context_documents, google_drive_sync_checkpoints, "
-        "google_drive_sync_files, google_drive_sync_runs, workflow_runs CASCADE",
+        "google_drive_sync_files, google_drive_sync_runs, google_calendar_sync_checkpoints, "
+        "google_calendar_sync_events, google_calendar_sync_calendars, google_calendar_sync_runs, "
+        "workflow_runs CASCADE",
     )
     yield
 

--- a/services/api/tests/test_slack_sync.py
+++ b/services/api/tests/test_slack_sync.py
@@ -170,8 +170,10 @@ async def _clear_slack_sync_tables(db_pool, monkeypatch):
     monkeypatch.delenv("SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS", raising=False)
     await db_pool.execute(
         "TRUNCATE TABLE company_context_documents, google_drive_sync_checkpoints, "
-        "google_drive_sync_files, google_drive_sync_runs, slack_sync_backfill_jobs, slack_sync_checkpoints, "
-        "slack_sync_messages, slack_sync_runs, slack_sync_users, slack_sync_channels CASCADE",
+        "google_drive_sync_files, google_drive_sync_runs, google_calendar_sync_checkpoints, "
+        "google_calendar_sync_events, google_calendar_sync_calendars, google_calendar_sync_runs, "
+        "slack_sync_backfill_jobs, slack_sync_checkpoints, slack_sync_messages, "
+        "slack_sync_runs, slack_sync_users, slack_sync_channels CASCADE",
     )
     yield
 
@@ -1518,6 +1520,23 @@ async def test_etl_freshness_metrics_refresh_from_slack_sync_tables(db_pool):
         now - dt.timedelta(seconds=20),
     )
     await db_pool.execute(
+        "INSERT INTO google_calendar_sync_calendars (calendar_id, summary, updated_at) "
+        "VALUES ('primary@example.com', 'Primary', $1), ('team@example.com', 'Team', $2)",
+        now - dt.timedelta(seconds=40),
+        now - dt.timedelta(seconds=35),
+    )
+    await db_pool.execute(
+        "INSERT INTO google_calendar_sync_checkpoints ("
+        "calendar_id, sync_token, watermark_time, last_success_at, last_error, updated_at"
+        ") VALUES "
+        "('primary@example.com', 'token-1', $1, $2, '', $2), "
+        "('team@example.com', 'token-2', $3, NULL, 'api_error', $4)",
+        now - dt.timedelta(seconds=150),
+        now - dt.timedelta(seconds=55),
+        now - dt.timedelta(seconds=240),
+        now - dt.timedelta(seconds=50),
+    )
+    await db_pool.execute(
         "INSERT INTO company_context_documents ("
         "document_id, source, source_type, source_document_id, title, body, "
         "source_updated_at, content_hash"
@@ -1534,6 +1553,8 @@ async def test_etl_freshness_metrics_refresh_from_slack_sync_tables(db_pool):
     assert 'etl_failed_scopes{source="slack",source_type="channel"} 1' in metrics
     assert 'etl_active_scopes{source="google_drive",source_type="doc"} 1' in metrics
     assert 'etl_failed_scopes{source="google_drive",source_type="doc"} 0' in metrics
+    assert 'etl_active_scopes{source="google_calendar",source_type="calendar"} 2' in metrics
+    assert 'etl_failed_scopes{source="google_calendar",source_type="calendar"} 1' in metrics
     assert (
         'etl_backfill_jobs{job_type="channel_bootstrap",source="slack",status="pending"} 1'
         in metrics
@@ -1570,6 +1591,18 @@ async def test_etl_freshness_metrics_refresh_from_slack_sync_tables(db_pool):
     )
     assert drive_freshness_match is not None
     assert 40 <= float(drive_freshness_match.group(1)) < 120
+    calendar_lag_match = re.search(
+        r'etl_source_cursor_lag_seconds\{source="google_calendar",source_type="calendar"\} ([0-9.]+)',
+        metrics,
+    )
+    assert calendar_lag_match is not None
+    assert float(calendar_lag_match.group(1)) >= 200
+    calendar_freshness_match = re.search(
+        r'etl_scope_sync_freshness_seconds\{source="google_calendar",source_type="calendar"\} ([0-9.]+)',
+        metrics,
+    )
+    assert calendar_freshness_match is not None
+    assert 50 <= float(calendar_freshness_match.group(1)) < 130
     drive_projection_lag_match = re.search(
         r'company_context_projection_lag_seconds\{source="google_drive"\} ([0-9.]+)',
         metrics,

--- a/tools/productivity/gsuite/pyproject.toml
+++ b/tools/productivity/gsuite/pyproject.toml
@@ -30,6 +30,7 @@ build-backend = "hatchling.build"
 module = "client.py"
 hosts = [
     "gmail.googleapis.com",
+    "calendar.googleapis.com",
     "www.googleapis.com",
     "docs.googleapis.com",
     "sheets.googleapis.com",
@@ -46,6 +47,7 @@ hosts = [
 secrets = [
     { type = "oauth_token", grant = "refresh_token", name = "GOOGLE_TOKEN_JSON", token_endpoint = "https://oauth2.googleapis.com/token", hosts = [
         "gmail.googleapis.com",
+        "calendar.googleapis.com",
         "www.googleapis.com",
         "docs.googleapis.com",
         "sheets.googleapis.com",

--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -62,6 +62,7 @@ SCHEDULE = {
         (
             _env_flag_enabled("SLACK_ETL_ENABLED")
             or _env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED")
+            or _env_flag_enabled("GOOGLE_CALENDAR_ETL_ENABLED")
         )
         and _env_flag_enabled("COMPANY_CONTEXT_DOCUMENTS_ENABLED", default=True)
     ),
@@ -143,8 +144,10 @@ def _content_hash(*parts: Any) -> str:
 
 
 def _source_enabled() -> bool:
-    return _env_flag_enabled("SLACK_ETL_ENABLED") or _env_flag_enabled(
-        "GOOGLE_DRIVE_ETL_ENABLED"
+    return (
+        _env_flag_enabled("SLACK_ETL_ENABLED")
+        or _env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED")
+        or _env_flag_enabled("GOOGLE_CALENDAR_ETL_ENABLED")
     )
 
 
@@ -257,6 +260,48 @@ async def _load_changed_drive_files(pool, since: dt.datetime | None) -> dict[str
     return {
         "files": list(rows),
         "changed_files": int(stats["changed_files"] or 0) if stats else 0,
+        "max_updated_at": max_updated_at,
+    }
+
+
+async def _load_changed_calendar_events(
+    pool,
+    since: dt.datetime | None,
+) -> dict[str, Any]:
+    """Find Google Calendar events whose synced content changed."""
+    if since is None:
+        where_sql = "WHERE e.last_error = ''"
+        args: list[Any] = []
+    else:
+        where_sql = "WHERE e.last_error = '' AND e.updated_at > $1"
+        args = [since]
+
+    rows = await pool.fetch(
+        "SELECT e.calendar_id, c.summary AS calendar_summary, c.time_zone, "
+        "e.event_id, e.i_cal_uid, e.status, e.summary, e.description, e.location, "
+        "e.html_link, e.creator, e.organizer, e.attendees, e.start_payload, "
+        "e.end_payload, e.start_at, e.end_at, e.is_all_day, e.recurring_event_id, "
+        "e.original_start, e.transparency, e.visibility, e.event_type, e.sequence, "
+        "e.source_created_at, e.source_updated_at, e.content_text, e.content_hash, "
+        "e.raw_payload, e.updated_at "
+        "FROM google_calendar_sync_events e "
+        "LEFT JOIN google_calendar_sync_calendars c ON c.calendar_id = e.calendar_id "
+        f"{where_sql} "
+        "ORDER BY e.source_updated_at NULLS LAST, e.start_at NULLS LAST, "
+        "e.calendar_id, e.event_id",
+        *args,
+    )
+    stats = await pool.fetchrow(
+        f"SELECT COUNT(*) AS changed_events, MAX(updated_at) AS max_updated_at "
+        f"FROM google_calendar_sync_events e {where_sql}",
+        *args,
+    )
+    max_updated_at = stats["max_updated_at"] if stats else None
+    if isinstance(max_updated_at, dt.datetime):
+        max_updated_at = max_updated_at.astimezone(dt.timezone.utc)
+    return {
+        "events": list(rows),
+        "changed_events": int(stats["changed_events"] or 0) if stats else 0,
         "max_updated_at": max_updated_at,
     }
 
@@ -535,6 +580,113 @@ def _drive_document(row: Any) -> dict[str, Any] | None:
     }
 
 
+def _calendar_person(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict):
+        return "", ""
+    email = str(value.get("email") or "").strip()
+    name = str(value.get("displayName") or email).strip()
+    return email, name
+
+
+def _calendar_attendee_names(attendees: Any) -> list[str]:
+    if not isinstance(attendees, list):
+        return []
+    names: list[str] = []
+    for attendee in attendees:
+        if not isinstance(attendee, dict):
+            continue
+        email = str(attendee.get("email") or "").strip()
+        name = str(attendee.get("displayName") or email).strip()
+        if name:
+            names.append(name)
+    return names
+
+
+def _calendar_event_document(row: Any) -> dict[str, Any] | None:
+    """Render one synced Google Calendar event into a context document."""
+    calendar_id = str(row["calendar_id"] or "")
+    event_id = str(row["event_id"] or "")
+    if not calendar_id or not event_id:
+        return None
+    title = str(row["summary"] or "Untitled calendar event")
+    description = str(row["description"] or "").strip()
+    location = str(row["location"] or "").strip()
+    url = str(row["html_link"] or "")
+    calendar_summary = str(row["calendar_summary"] or calendar_id)
+    status = str(row["status"] or "")
+    creator = _jsonb_value(row, "creator", {})
+    organizer = _jsonb_value(row, "organizer", {})
+    attendees = _jsonb_value(row, "attendees", [])
+    attendee_names = _calendar_attendee_names(attendees)
+    author_id, author_name = _calendar_person(organizer)
+    if not author_id and not author_name:
+        author_id, author_name = _calendar_person(creator)
+
+    start_at = row["start_at"]
+    end_at = row["end_at"]
+    source_updated_at = row["source_updated_at"]
+    source_created_at = row["source_created_at"]
+    occurred_at = start_at or source_created_at or source_updated_at
+    lines = [
+        f"# {title}",
+        "",
+        "- Source: Google Calendar",
+        f"- Calendar: {calendar_summary}",
+        f"- Status: {status or 'unknown'}",
+        f"- Starts: {_format_time(start_at)}",
+        f"- Ends: {_format_time(end_at)}",
+    ]
+    if location:
+        lines.append(f"- Location: {location}")
+    if attendee_names:
+        lines.append(f"- Attendees: {', '.join(attendee_names)}")
+    if url:
+        lines.append(f"- URL: {url}")
+    if description:
+        lines.extend(["", "---", "", description])
+    body = "\n".join(lines).strip()
+    metadata = {
+        "calendar_id": calendar_id,
+        "calendar_summary": calendar_summary,
+        "event_id": event_id,
+        "i_cal_uid": str(row["i_cal_uid"] or ""),
+        "status": status,
+        "location": location,
+        "creator": creator if isinstance(creator, dict) else {},
+        "organizer": organizer if isinstance(organizer, dict) else {},
+        "attendees": attendees if isinstance(attendees, list) else [],
+        "is_all_day": bool(row["is_all_day"]),
+        "recurring_event_id": str(row["recurring_event_id"] or ""),
+        "transparency": str(row["transparency"] or ""),
+        "visibility": str(row["visibility"] or ""),
+        "event_type": str(row["event_type"] or ""),
+    }
+    return {
+        "document_id": f"google_calendar:event:{calendar_id}:{event_id}",
+        "source": "google_calendar",
+        "source_type": "calendar_event",
+        "source_document_id": f"{calendar_id}:{event_id}",
+        "source_chunk_id": "",
+        "parent_document_id": None,
+        "title": title,
+        "body": body,
+        "url": url,
+        "author_id": author_id,
+        "author_name": author_name,
+        "access_scope": "company",
+        "occurred_at": occurred_at,
+        "source_updated_at": source_updated_at,
+        "content_hash": _content_hash(title, body, url, metadata),
+        "metadata": metadata,
+    }
+
+
+def _calendar_event_document_id(row: Any) -> str:
+    calendar_id = str(row["calendar_id"] or "")
+    event_id = str(row["event_id"] or "")
+    return f"google_calendar:event:{calendar_id}:{event_id}"
+
+
 async def _upsert_document(pool, document: dict[str, Any]) -> str:
     """Upsert a projected document and return inserted/updated/noop."""
     existing_hash = await pool.fetchval(
@@ -626,6 +778,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
 
     slack_enabled = _env_flag_enabled("SLACK_ETL_ENABLED")
     google_drive_enabled = _env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED")
+    google_calendar_enabled = _env_flag_enabled("GOOGLE_CALENDAR_ETL_ENABLED")
     changed = {
         "channel_days": [],
         "threads": [],
@@ -644,6 +797,13 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     }
     if google_drive_enabled:
         drive_changed = await _load_changed_drive_files(ctx._pool, since)
+    calendar_changed = {
+        "events": [],
+        "changed_events": 0,
+        "max_updated_at": None,
+    }
+    if google_calendar_enabled:
+        calendar_changed = await _load_changed_calendar_events(ctx._pool, since)
 
     documents_upserted = 0
     documents_deleted = 0
@@ -734,11 +894,39 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         if action in {"inserted", "updated"}:
             documents_upserted += 1
 
+    for row in calendar_changed["events"]:
+        if str(row["status"] or "") == "cancelled":
+            if await _delete_document(ctx._pool, _calendar_event_document_id(row)):
+                documents_deleted += 1
+                record_company_context_documents_changed(
+                    "google_calendar",
+                    "calendar_event",
+                    "deleted",
+                )
+            continue
+        document = _calendar_event_document(row)
+        if document is None:
+            continue
+        observe_company_context_document_size(
+            "google_calendar",
+            str(document["source_type"]),
+            len(str(document["body"] or "")),
+        )
+        action = await _upsert_document(ctx._pool, document)
+        record_company_context_documents_changed(
+            "google_calendar",
+            str(document["source_type"]),
+            action,
+        )
+        if action in {"inserted", "updated"}:
+            documents_upserted += 1
+
     watermark_candidates = [
         value
         for value in (
             changed["max_updated_at"],
             drive_changed["max_updated_at"],
+            calendar_changed["max_updated_at"],
             last_watermark,
         )
         if value is not None
@@ -748,9 +936,11 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         "status": "completed",
         "changed_messages": changed["changed_messages"],
         "changed_drive_files": drive_changed["changed_files"],
+        "changed_calendar_events": calendar_changed["changed_events"],
         "channel_day_documents": len(changed["channel_days"]),
         "thread_candidates": len(changed["threads"]),
         "drive_documents": len(drive_changed["files"]),
+        "calendar_event_documents": len(calendar_changed["events"]),
         "documents_upserted": documents_upserted,
         "documents_deleted": documents_deleted,
         "watermark": watermark.isoformat() if watermark else None,

--- a/workflows/google_calendar_sync.py
+++ b/workflows/google_calendar_sync.py
@@ -1,0 +1,628 @@
+"""Workflow: sync Google Calendar metadata and events into Postgres."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import os
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from api.integrations.gsuite.calendar import GoogleCalendarReadonlyClient
+from api.runtime_control import canonical_json
+from api.vm_metrics import (
+    record_etl_items_failed,
+    record_etl_items_seen,
+    record_etl_items_upserted,
+)
+from api.workflow_engine import WorkflowContext
+from workflows.slack_sync_shared import env_flag_enabled, positive_int
+
+WORKFLOW_NAME = "google_calendar_sync"
+DEFAULT_SYNC_INTERVAL_SECONDS = 4 * 60 * 60
+DEFAULT_PAGE_SIZE = 250
+
+
+SCHEDULE = {
+    "schedule_id": "google_calendar_sync",
+    "interval_seconds": positive_int(
+        os.getenv("GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS"),
+        DEFAULT_SYNC_INTERVAL_SECONDS,
+    ),
+    "enabled": env_flag_enabled("GOOGLE_CALENDAR_ETL_ENABLED", default=False),
+    "no_delivery": True,
+}
+
+
+@dataclass
+class Input:
+    """Runtime options for a manual Google Calendar sync workflow run."""
+
+    calendar_ids: list[str] = field(default_factory=list)
+    limit: int = DEFAULT_PAGE_SIZE
+    reset_sync: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class GoogleCalendarSyncClient(Protocol):
+    """Small adapter protocol used by the Calendar ETL workflow."""
+
+    def list_calendars(self, *, page_token: str | None = None) -> dict[str, Any]: ...
+
+    def list_events(
+        self,
+        *,
+        calendar_id: str,
+        page_size: int,
+        page_token: str | None = None,
+        sync_token: str | None = None,
+    ) -> dict[str, Any]: ...
+
+
+def _client() -> GoogleCalendarSyncClient:
+    return GoogleCalendarReadonlyClient()
+
+
+def _parse_datetime(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _event_boundary(payload: Any) -> tuple[dt.datetime | None, bool]:
+    if not isinstance(payload, dict):
+        return None, False
+    if payload.get("dateTime"):
+        return _parse_datetime(str(payload.get("dateTime") or "")), False
+    if payload.get("date"):
+        parsed = _parse_datetime(f"{payload.get('date')}T00:00:00Z")
+        return parsed, True
+    return None, False
+
+
+def _content_hash(*parts: Any) -> str:
+    return hashlib.sha256(canonical_json(parts).encode("utf-8")).hexdigest()
+
+
+def _workflow_run_id_to_sync_run_id(workflow_run_id: str) -> str:
+    safe_run_id = "".join(char if char.isalnum() else "_" for char in workflow_run_id)
+    return f"google_calendar_sync_{safe_run_id}"
+
+
+def _calendar_ref(calendar_id: str, reason: str | None = None) -> dict[str, str]:
+    result = {"calendar_id": calendar_id}
+    if reason:
+        result["reason"] = reason
+    return result
+
+
+def _is_sync_token_expired(error: Exception) -> bool:
+    response = getattr(error, "resp", None) or getattr(error, "response", None)
+    status = getattr(response, "status", None) or getattr(response, "status_code", None)
+    try:
+        numeric_status = int(status or 0)
+    except (TypeError, ValueError):
+        numeric_status = 0
+    return numeric_status == 410 or "410" in str(error)
+
+
+def _int_value(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _attendee_names(attendees: Any) -> list[str]:
+    if not isinstance(attendees, list):
+        return []
+    names: list[str] = []
+    for attendee in attendees:
+        if not isinstance(attendee, dict):
+            continue
+        value = str(attendee.get("displayName") or attendee.get("email") or "").strip()
+        if value:
+            names.append(value)
+    return names
+
+
+def _event_content_text(calendar: dict[str, Any], event: dict[str, Any]) -> str:
+    start_at, _ = _event_boundary(event.get("start"))
+    end_at, _ = _event_boundary(event.get("end"))
+    parts = [
+        str(event.get("summary") or ""),
+        str(event.get("description") or ""),
+        str(event.get("location") or ""),
+        str(calendar.get("summary") or ""),
+        " ".join(_attendee_names(event.get("attendees"))),
+    ]
+    if start_at:
+        parts.append(start_at.isoformat())
+    if end_at:
+        parts.append(end_at.isoformat())
+    return "\n".join(part for part in parts if part.strip())
+
+
+async def _record_run_start(
+    pool,
+    *,
+    run_id: str,
+    workflow_run_id: str,
+    calendars_requested: list[dict[str, str]],
+    metadata: dict[str, Any],
+) -> None:
+    await pool.execute(
+        "INSERT INTO google_calendar_sync_runs ("
+        "run_id, workflow_run_id, mode, status, calendars_requested, metadata"
+        ") VALUES ($1, $2, 'incremental', 'running', $3::jsonb, $4::jsonb) "
+        "ON CONFLICT (run_id) DO UPDATE SET "
+        "workflow_run_id = EXCLUDED.workflow_run_id, "
+        "status = 'running', "
+        "calendars_requested = EXCLUDED.calendars_requested, "
+        "calendars_synced = '[]'::jsonb, "
+        "calendars_failed = '[]'::jsonb, "
+        "calendars_seen = 0, "
+        "calendars_upserted = 0, "
+        "events_seen = 0, "
+        "events_upserted = 0, "
+        "events_cancelled = 0, "
+        "finished_at = NULL, "
+        "error_text = '', "
+        "metadata = EXCLUDED.metadata",
+        run_id,
+        workflow_run_id,
+        canonical_json(calendars_requested),
+        canonical_json(metadata),
+    )
+
+
+async def _record_run_finish(
+    pool,
+    *,
+    run_id: str,
+    status: str,
+    calendars_synced: list[dict[str, str]],
+    calendars_failed: list[dict[str, str]],
+    counts: dict[str, int],
+    error_text: str = "",
+) -> None:
+    await pool.execute(
+        "UPDATE google_calendar_sync_runs SET "
+        "status = $2, calendars_synced = $3::jsonb, calendars_failed = $4::jsonb, "
+        "calendars_seen = $5, calendars_upserted = $6, events_seen = $7, "
+        "events_upserted = $8, events_cancelled = $9, "
+        "finished_at = NOW(), error_text = $10 "
+        "WHERE run_id = $1",
+        run_id,
+        status,
+        canonical_json(calendars_synced),
+        canonical_json(calendars_failed),
+        counts.get("calendars_seen", 0),
+        counts.get("calendars_upserted", 0),
+        counts.get("events_seen", 0),
+        counts.get("events_upserted", 0),
+        counts.get("events_cancelled", 0),
+        error_text,
+    )
+
+
+async def _load_checkpoint(pool, calendar_id: str) -> dict[str, Any] | None:
+    row = await pool.fetchrow(
+        "SELECT sync_token, watermark_time, last_error FROM google_calendar_sync_checkpoints "
+        "WHERE calendar_id = $1",
+        calendar_id,
+    )
+    return dict(row) if row else None
+
+
+async def _update_checkpoint_success(
+    pool,
+    *,
+    calendar_id: str,
+    sync_token: str,
+    watermark_time: dt.datetime | None,
+    run_id: str,
+) -> None:
+    await pool.execute(
+        "INSERT INTO google_calendar_sync_checkpoints ("
+        "calendar_id, sync_token, watermark_time, last_run_id, last_success_at, "
+        "last_error, updated_at"
+        ") VALUES ($1, $2, $3, $4, NOW(), '', NOW()) "
+        "ON CONFLICT (calendar_id) DO UPDATE SET "
+        "sync_token = EXCLUDED.sync_token, "
+        "watermark_time = COALESCE(EXCLUDED.watermark_time, google_calendar_sync_checkpoints.watermark_time), "
+        "last_run_id = EXCLUDED.last_run_id, "
+        "last_success_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        calendar_id,
+        sync_token,
+        watermark_time,
+        run_id,
+    )
+
+
+async def _update_checkpoint_failure(
+    pool,
+    *,
+    calendar_id: str,
+    run_id: str,
+    error: str,
+) -> None:
+    await pool.execute(
+        "INSERT INTO google_calendar_sync_checkpoints ("
+        "calendar_id, last_run_id, last_error, updated_at"
+        ") VALUES ($1, $2, $3, NOW()) "
+        "ON CONFLICT (calendar_id) DO UPDATE SET "
+        "last_run_id = EXCLUDED.last_run_id, "
+        "last_error = EXCLUDED.last_error, "
+        "updated_at = NOW()",
+        calendar_id,
+        run_id,
+        error,
+    )
+
+
+async def _upsert_calendar(pool, *, calendar: dict[str, Any], run_id: str) -> None:
+    await pool.execute(
+        "INSERT INTO google_calendar_sync_calendars ("
+        "calendar_id, summary, description, location, time_zone, access_role, "
+        "is_primary, is_selected, is_hidden, background_color, foreground_color, "
+        "raw_payload, source_run_id, last_seen_at, last_error, updated_at"
+        ") VALUES ("
+        "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, NOW(), '', NOW()"
+        ") ON CONFLICT (calendar_id) DO UPDATE SET "
+        "summary = EXCLUDED.summary, "
+        "description = EXCLUDED.description, "
+        "location = EXCLUDED.location, "
+        "time_zone = EXCLUDED.time_zone, "
+        "access_role = EXCLUDED.access_role, "
+        "is_primary = EXCLUDED.is_primary, "
+        "is_selected = EXCLUDED.is_selected, "
+        "is_hidden = EXCLUDED.is_hidden, "
+        "background_color = EXCLUDED.background_color, "
+        "foreground_color = EXCLUDED.foreground_color, "
+        "raw_payload = EXCLUDED.raw_payload, "
+        "source_run_id = EXCLUDED.source_run_id, "
+        "last_seen_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        str(calendar.get("id") or ""),
+        str(calendar.get("summary") or ""),
+        str(calendar.get("description") or ""),
+        str(calendar.get("location") or ""),
+        str(calendar.get("timeZone") or ""),
+        str(calendar.get("accessRole") or ""),
+        bool(calendar.get("primary")),
+        bool(calendar.get("selected")),
+        bool(calendar.get("hidden")),
+        str(calendar.get("backgroundColor") or ""),
+        str(calendar.get("foregroundColor") or ""),
+        canonical_json(calendar),
+        run_id,
+    )
+
+
+async def _record_calendar_error(
+    pool,
+    *,
+    calendar_id: str,
+    error: str,
+    run_id: str,
+) -> None:
+    await pool.execute(
+        "UPDATE google_calendar_sync_calendars SET "
+        "last_error = $2, source_run_id = $3, updated_at = NOW() "
+        "WHERE calendar_id = $1",
+        calendar_id,
+        error,
+        run_id,
+    )
+
+
+async def _upsert_event(
+    pool,
+    *,
+    calendar: dict[str, Any],
+    event: dict[str, Any],
+    run_id: str,
+) -> None:
+    calendar_id = str(calendar.get("id") or "")
+    start_at, is_all_day = _event_boundary(event.get("start"))
+    end_at, _ = _event_boundary(event.get("end"))
+    content_text = _event_content_text(calendar, event)
+    await pool.execute(
+        "INSERT INTO google_calendar_sync_events ("
+        "calendar_id, event_id, i_cal_uid, status, summary, description, location, "
+        "html_link, creator, organizer, attendees, start_payload, end_payload, "
+        "start_at, end_at, is_all_day, recurring_event_id, original_start, "
+        "transparency, visibility, event_type, sequence, source_created_at, "
+        "source_updated_at, content_text, content_hash, raw_payload, source_run_id, "
+        "last_seen_at, last_error, updated_at"
+        ") VALUES ("
+        "$1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11::jsonb, "
+        "$12::jsonb, $13::jsonb, $14, $15, $16, $17, $18::jsonb, $19, $20, $21, "
+        "$22, $23, $24, $25, $26, $27::jsonb, $28, NOW(), '', NOW()"
+        ") ON CONFLICT (calendar_id, event_id) DO UPDATE SET "
+        "i_cal_uid = EXCLUDED.i_cal_uid, "
+        "status = EXCLUDED.status, "
+        "summary = EXCLUDED.summary, "
+        "description = EXCLUDED.description, "
+        "location = EXCLUDED.location, "
+        "html_link = EXCLUDED.html_link, "
+        "creator = EXCLUDED.creator, "
+        "organizer = EXCLUDED.organizer, "
+        "attendees = EXCLUDED.attendees, "
+        "start_payload = EXCLUDED.start_payload, "
+        "end_payload = EXCLUDED.end_payload, "
+        "start_at = EXCLUDED.start_at, "
+        "end_at = EXCLUDED.end_at, "
+        "is_all_day = EXCLUDED.is_all_day, "
+        "recurring_event_id = EXCLUDED.recurring_event_id, "
+        "original_start = EXCLUDED.original_start, "
+        "transparency = EXCLUDED.transparency, "
+        "visibility = EXCLUDED.visibility, "
+        "event_type = EXCLUDED.event_type, "
+        "sequence = EXCLUDED.sequence, "
+        "source_created_at = EXCLUDED.source_created_at, "
+        "source_updated_at = EXCLUDED.source_updated_at, "
+        "content_text = EXCLUDED.content_text, "
+        "content_hash = EXCLUDED.content_hash, "
+        "raw_payload = EXCLUDED.raw_payload, "
+        "source_run_id = EXCLUDED.source_run_id, "
+        "last_seen_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        calendar_id,
+        str(event.get("id") or ""),
+        str(event.get("iCalUID") or ""),
+        str(event.get("status") or ""),
+        str(event.get("summary") or ""),
+        str(event.get("description") or ""),
+        str(event.get("location") or ""),
+        str(event.get("htmlLink") or ""),
+        canonical_json(event.get("creator") if isinstance(event.get("creator"), dict) else {}),
+        canonical_json(event.get("organizer") if isinstance(event.get("organizer"), dict) else {}),
+        canonical_json(event.get("attendees") if isinstance(event.get("attendees"), list) else []),
+        canonical_json(event.get("start") if isinstance(event.get("start"), dict) else {}),
+        canonical_json(event.get("end") if isinstance(event.get("end"), dict) else {}),
+        start_at,
+        end_at,
+        is_all_day,
+        str(event.get("recurringEventId") or ""),
+        canonical_json(
+            event.get("originalStartTime")
+            if isinstance(event.get("originalStartTime"), dict)
+            else {}
+        ),
+        str(event.get("transparency") or ""),
+        str(event.get("visibility") or ""),
+        str(event.get("eventType") or ""),
+        _int_value(event.get("sequence")),
+        _parse_datetime(str(event.get("created") or "")),
+        _parse_datetime(str(event.get("updated") or "")),
+        content_text,
+        _content_hash(content_text),
+        canonical_json(event),
+        run_id,
+    )
+
+
+async def _list_visible_calendars(client: GoogleCalendarSyncClient) -> list[dict[str, Any]]:
+    calendars: list[dict[str, Any]] = []
+    page_token: str | None = None
+    while True:
+        page = client.list_calendars(page_token=page_token)
+        for calendar in page.get("items", []) or []:
+            if str(calendar.get("id") or ""):
+                calendars.append(calendar)
+        page_token = page.get("nextPageToken")
+        if not page_token:
+            break
+    return calendars
+
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    """Sync Google Calendar calendars and changed events into raw sync tables."""
+    if not env_flag_enabled("GOOGLE_CALENDAR_ETL_ENABLED", default=False):
+        ctx.log("google_calendar_sync_skipped_disabled")
+        return {"status": "skipped", "reason": "google_calendar_etl_disabled"}
+
+    page_size = positive_int(inp.limit, DEFAULT_PAGE_SIZE)
+    run_id = _workflow_run_id_to_sync_run_id(ctx.run_id)
+    requested_ids = {calendar_id.strip() for calendar_id in inp.calendar_ids if calendar_id.strip()}
+    requested = [_calendar_ref(calendar_id) for calendar_id in sorted(requested_ids)]
+    if not requested:
+        requested = [_calendar_ref("all_visible")]
+
+    await _record_run_start(
+        ctx._pool,
+        run_id=run_id,
+        workflow_run_id=ctx.run_id,
+        calendars_requested=requested,
+        metadata={
+            **inp.metadata,
+            "page_size": page_size,
+            "reset_sync": inp.reset_sync,
+        },
+    )
+
+    client = _client()
+    synced: list[dict[str, str]] = []
+    failed: list[dict[str, str]] = []
+    counts = {
+        "calendars_seen": 0,
+        "calendars_upserted": 0,
+        "events_seen": 0,
+        "events_upserted": 0,
+        "events_cancelled": 0,
+    }
+
+    try:
+        calendars = await _list_visible_calendars(client)
+    except Exception as exc:
+        error = str(exc)
+        record_etl_items_failed("google_calendar", "calendar", "scope", "api_error")
+        await _record_run_finish(
+            ctx._pool,
+            run_id=run_id,
+            status="failed",
+            calendars_synced=[],
+            calendars_failed=[_calendar_ref("all_visible", error)],
+            counts=counts,
+            error_text=error,
+        )
+        ctx.log("google_calendar_sync_list_calendars_failed", error=error)
+        return {"status": "failed", "run_id": run_id, **counts}
+
+    by_id = {str(calendar.get("id") or ""): calendar for calendar in calendars}
+    if requested_ids:
+        calendars_to_sync = []
+        for calendar_id in sorted(requested_ids):
+            calendars_to_sync.append(by_id.get(calendar_id) or {"id": calendar_id, "summary": calendar_id})
+    else:
+        calendars_to_sync = calendars
+
+    counts["calendars_seen"] = len(calendars_to_sync)
+    record_etl_items_seen(
+        "google_calendar", "calendar", "calendar", len(calendars_to_sync)
+    )
+
+    for calendar in calendars_to_sync:
+        calendar_id = str(calendar.get("id") or "")
+        if not calendar_id:
+            continue
+        await _upsert_calendar(ctx._pool, calendar=calendar, run_id=run_id)
+        counts["calendars_upserted"] += 1
+        record_etl_items_upserted("google_calendar", "calendar", "calendar", 1)
+
+        checkpoint = await _load_checkpoint(ctx._pool, calendar_id)
+        sync_token = "" if inp.reset_sync else str((checkpoint or {}).get("sync_token") or "")
+        page_token: str | None = None
+        next_sync_token = sync_token
+        successful_watermark: dt.datetime | None = None
+        retried_full_sync = False
+        try:
+            while True:
+                try:
+                    page = client.list_events(
+                        calendar_id=calendar_id,
+                        page_size=page_size,
+                        page_token=page_token,
+                        sync_token=sync_token or None,
+                    )
+                except Exception as exc:
+                    if sync_token and not retried_full_sync and _is_sync_token_expired(exc):
+                        ctx.log(
+                            "google_calendar_sync_token_expired",
+                            calendar_id=calendar_id,
+                            error=str(exc),
+                        )
+                        sync_token = ""
+                        page_token = None
+                        next_sync_token = ""
+                        retried_full_sync = True
+                        continue
+                    raise
+
+                events = [
+                    event
+                    for event in page.get("items", []) or []
+                    if str(event.get("id") or "")
+                ]
+                counts["events_seen"] += len(events)
+                record_etl_items_seen(
+                    "google_calendar", "calendar", "event", len(events)
+                )
+                for event in events:
+                    await _upsert_event(
+                        ctx._pool,
+                        calendar=calendar,
+                        event=event,
+                        run_id=run_id,
+                    )
+                    counts["events_upserted"] += 1
+                    if str(event.get("status") or "") == "cancelled":
+                        counts["events_cancelled"] += 1
+                    record_etl_items_upserted("google_calendar", "calendar", "event", 1)
+                    updated_at = _parse_datetime(str(event.get("updated") or ""))
+                    if updated_at and (
+                        successful_watermark is None
+                        or updated_at > successful_watermark
+                    ):
+                        successful_watermark = updated_at
+
+                page_token = page.get("nextPageToken")
+                if not page_token:
+                    next_sync_token = str(page.get("nextSyncToken") or next_sync_token or "")
+                    break
+
+            await _update_checkpoint_success(
+                ctx._pool,
+                calendar_id=calendar_id,
+                sync_token=next_sync_token,
+                watermark_time=successful_watermark,
+                run_id=run_id,
+            )
+            synced.append(_calendar_ref(calendar_id))
+            ctx.log(
+                "google_calendar_sync_calendar_completed",
+                calendar_id=calendar_id,
+                events_seen=counts["events_seen"],
+                events_upserted=counts["events_upserted"],
+                sync_token_present=bool(next_sync_token),
+            )
+        except Exception as exc:
+            error = str(exc)
+            failed.append(_calendar_ref(calendar_id, error))
+            record_etl_items_failed("google_calendar", "calendar", "scope", "api_error")
+            await _record_calendar_error(
+                ctx._pool,
+                calendar_id=calendar_id,
+                error=error,
+                run_id=run_id,
+            )
+            await _update_checkpoint_failure(
+                ctx._pool,
+                calendar_id=calendar_id,
+                run_id=run_id,
+                error=error,
+            )
+            ctx.log(
+                "google_calendar_sync_calendar_failed",
+                calendar_id=calendar_id,
+                error=error,
+            )
+
+    status = "completed"
+    error_text = ""
+    if failed and synced:
+        status = "partial_failed"
+        error_text = f"{len(failed)} calendar(s) failed"
+    elif failed:
+        status = "failed"
+        error_text = f"{len(failed)} calendar(s) failed"
+
+    await _record_run_finish(
+        ctx._pool,
+        run_id=run_id,
+        status=status,
+        calendars_synced=synced,
+        calendars_failed=failed,
+        counts=counts,
+        error_text=error_text,
+    )
+
+    return {
+        "status": status,
+        "run_id": run_id,
+        "calendars_synced": len(synced),
+        "calendars_failed": len(failed),
+        **counts,
+    }


### PR DESCRIPTION
## Summary
- add a read-only Google Calendar integration client and scheduled calendar sync workflow
- add raw Calendar sync tables for runs, calendars, events, and checkpoints
- project synced Calendar events into company context documents and add shared ETL/projection metrics
- add Helm values/env config and docs for Calendar ETL

## Testing
- uv run ruff check ../../workflows/google_calendar_sync.py ../../workflows/company_context_documents.py api/integrations/gsuite/calendar.py api/vm_metrics.py tests/test_google_calendar_sync.py tests/test_company_context_documents.py tests/test_google_drive_sync.py tests/test_slack_sync.py
- uv run python -m py_compile ../../workflows/google_calendar_sync.py ../../workflows/company_context_documents.py api/integrations/gsuite/calendar.py api/vm_metrics.py tests/test_google_calendar_sync.py tests/test_company_context_documents.py
- helm lint contrib/chart
- uv run pytest tests/test_google_calendar_sync.py tests/test_company_context_documents.py tests/test_slack_sync.py::test_etl_freshness_metrics_refresh_from_slack_sync_tables -q (skipped DB-backed tests; local test database unavailable)