### PR TITLE
fix(slackbot): avoid corrupting final delivery when the streamed-char offset lands mid-token

### DIFF
--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -454,6 +454,75 @@ describe("final delivery polling", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("posts the full answer instead of corrupting it when the streamed-char offset lands mid-token", async () => {
+    // `slackbot_streamed_answer_chars` counts streamed *source* characters, which
+    // can drift from `result_text` (normalization / reflow / answer revisions). An
+    // offset that lands inside a word must not be blindly sliced — that drops
+    // characters (e.g. "market cap" -> "marketountries"). The full, uncorrupted
+    // answer should be posted instead.
+    const originalFetch = globalThis.fetch;
+    const resultText = "USDT ~$190B and USDC ~$78B are ~90% of the stablecoin market.";
+    const midTokenOffset = 8; // inside "~$190B" — a blind slice would yield "90B and USDC ..."
+    const fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        if (url.pathname === "/agent/final-deliveries/claim") {
+          return jsonResponse({
+            deliveries: [
+              {
+                execution_id: "exe-midtoken",
+                thread_key: "slack:T123:C123:1778883099.579529",
+                delivery: {
+                  platform: "slack",
+                  channel: "C123",
+                  thread_ts: "1778883099.579529",
+                },
+                final_payload: {
+                  result_text: resultText,
+                  slackbot_streamed_answer_chars: midTokenOffset,
+                },
+              },
+            ],
+          });
+        }
+        if (url.pathname === "/agent/final-deliveries/exe-midtoken/delivered") {
+          return jsonResponse({ ok: true });
+        }
+        throw new Error(`unexpected request: ${url.pathname}`);
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const slackCalls: Array<{ method: string; params: any }> = [];
+    const client = {
+      chat: {
+        postMessage: async (params: any) => {
+          slackCalls.push({ method: "chat.postMessage", params });
+          return { ok: true };
+        },
+      },
+      conversations: {
+        replies: async () => ({ ok: true, messages: [] }),
+      },
+    };
+
+    try {
+      await pollFinalDeliveriesOnce(config, client as any);
+
+      const posts = slackCalls.filter(
+        (call) => call.method === "chat.postMessage",
+      );
+      expect(posts).toHaveLength(1);
+      const post = posts[0];
+      if (!post) throw new Error("expected one Slack post");
+      expect(post.params.text).toBe(resultText);
+      // a blind slice at the mid-token offset would have started with "90B…"
+      expect(post.params.text.startsWith("90B")).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 function jsonResponse(body: unknown): Response {

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -272,6 +272,19 @@ function continuationText(payload: any, text: string): string | null {
   if (!Number.isFinite(rawOffset) || rawOffset <= 0) return null;
   const offset = Math.floor(rawOffset);
   if (offset >= text.length) return null;
+  // `slackbot_streamed_answer_chars` counts the *source* characters streamed live,
+  // which can drift from the canonical `text` (markdown normalization, whitespace
+  // reflow, and post-hoc answer revisions all change lengths). Slicing `text`
+  // blindly at this offset can therefore land mid-token and drop characters
+  // (e.g. "market cap" rendered as "marketountries"). We only have the count
+  // here, not the streamed string, so we cannot verify the prefix — but we can
+  // refuse to cut mid-token: only treat the offset as a split point when it falls
+  // on a whitespace boundary in `text`. When it is misaligned, fall back to the
+  // full answer (re-showing the already-streamed prefix is strictly preferable to
+  // emitting corrupted text).
+  const before = text[offset - 1] ?? "";
+  const at = text[offset] ?? "";
+  if (!/\s/.test(before) && !/\s/.test(at)) return text;
   return text.slice(offset).trimStart();
 }
 


### PR DESCRIPTION
## Problem

Agent answers delivered to Slack are intermittently corrupted — characters are dropped or words merge (observed in production: "market cap" → "marketountries", "defillama.com" → "vama.com", "authenticate" → "thenticate"). The content is correct server-side; only the Slack render is mangled.

## Root cause

`continuationText` (`services/slackbot/src/centaur/final-delivery.ts`) blind-slices the canonical `result_text` at `slackbot_streamed_answer_chars`:

```ts
return text.slice(offset).trimStart();
```

That offset counts the **source characters streamed live** (the per-delta source-char accumulator in `agent-session.ts` / `codex-session.ts`), which is a *different string-space* than `result_text`:

- markdown normalization adds boundary characters to the live stream that aren't in the source count;
- whitespace / paragraph reflow changes lengths;
- the harness can revise the final answer — the code even logs `slack_codex_canonical_answer_correction` when the canonical answer length differs from what was streamed.

When the offset is misaligned, `text.slice(offset)` lands mid-token and drops characters. The offset is accumulated server-side with `max(...)`, so overshoot is sticky.

## Fix

`continuationText` only has the offset count, not the streamed string, so it can't verify the prefix. This guards the slice: only treat the offset as a split point when it lands on a **whitespace boundary** in `result_text`; when it's misaligned, fall back to posting the full answer (re-showing the already-streamed prefix is strictly preferable to emitting corrupted text). The aligned suffix-continuation path (live delivery cut off at a clean boundary) is unchanged.

## Tests

Adds a regression test (offset lands mid-token → the full answer is posted, not a corrupted slice). The existing "posts only the missing suffix when live delivery was cut off" test still passes.

```
bun test src/centaur/final-delivery.test.ts  →  6 pass, 0 fail
```

## Note

A more complete fix would plumb the streamed prefix text through (or compute the continuation server-side, where both strings are available) so the split point can be verified exactly rather than heuristically. Happy to follow up if you'd prefer that direction — this change is a minimal, safe guard against the user-visible corruption.
