### PR TITLE
refactor: share Linear API client

### DIFF
--- a/services/api/api/integrations/linear/__init__.py
+++ b/services/api/api/integrations/linear/__init__.py
@@ -1,0 +1,13 @@
+from api.integrations.linear.client import (
+    GRAPHQL_ENDPOINT,
+    UPLOADS_PREFIX,
+    LinearGraphQLClient,
+)
+from api.integrations.linear.readonly import LinearReadonlyClient
+
+__all__ = [
+    "GRAPHQL_ENDPOINT",
+    "UPLOADS_PREFIX",
+    "LinearGraphQLClient",
+    "LinearReadonlyClient",
+]

--- a/services/api/api/integrations/linear/client.py
+++ b/services/api/api/integrations/linear/client.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import httpx
+
+from centaur_sdk import secret
+
+UPLOADS_PREFIX = "https://uploads.linear.app/"
+GRAPHQL_ENDPOINT = "https://api.linear.app/graphql"
+DEFAULT_PAGE_SIZE = 100
+MAX_PAGE_SIZE = 250
+
+
+class LinearGraphQLClient:
+    """Authenticated Linear GraphQL client shared by tools and ETL workflows."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        http_client: httpx.Client | None = None,
+        timeout: float = 10.0,
+    ) -> None:
+        self.api_key = api_key or secret("LINEAR_API_KEY", "")
+        if not self.api_key:
+            raise RuntimeError(
+                "LINEAR_API_KEY not set.\n"
+                "Get one at https://linear.app/settings/account/security -> Personal API Keys"
+            )
+        self._http = http_client or httpx.Client(
+            base_url=GRAPHQL_ENDPOINT,
+            headers={"Authorization": self.api_key, "Content-Type": "application/json"},
+            timeout=timeout,
+        )
+
+    def _query(
+        self, query: str, variables: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Execute a Linear GraphQL query or mutation."""
+        resp = self._http.post("", json={"query": query, "variables": variables or {}})
+        resp.raise_for_status()
+        data = resp.json()
+        if "errors" in data:
+            errors = data["errors"]
+            msg = errors[0].get("message", str(errors))
+            raise RuntimeError(f"Linear API error: {msg}")
+        return data.get("data", {})
+
+    def _connection_nodes(
+        self,
+        query: str,
+        *,
+        connection_path: Sequence[str],
+        variables: dict[str, Any] | None = None,
+        limit: int | None = None,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> list[dict[str, Any]]:
+        """Collect nodes from a cursor-paginated Linear connection."""
+        if limit is not None and limit <= 0:
+            return []
+
+        requested_page_size = max(1, min(int(page_size), MAX_PAGE_SIZE))
+        remaining = limit
+        cursor: str | None = None
+        nodes: list[dict[str, Any]] = []
+
+        while remaining is None or remaining > 0:
+            batch_size = requested_page_size
+            if remaining is not None:
+                batch_size = min(batch_size, remaining)
+
+            page_variables = dict(variables or {})
+            page_variables.update({"first": batch_size, "after": cursor})
+            data = self._query(query, page_variables)
+
+            connection: Any = data
+            for key in connection_path:
+                if not isinstance(connection, dict):
+                    connection = {}
+                    break
+                connection = connection.get(key, {})
+            if not isinstance(connection, dict):
+                return nodes
+
+            page_nodes = connection.get("nodes") or []
+            nodes.extend(page_nodes)
+            if remaining is not None:
+                remaining -= len(page_nodes)
+
+            page_info = connection.get("pageInfo") or {}
+            cursor = page_info.get("endCursor")
+            if not page_info.get("hasNextPage") or not cursor or not page_nodes:
+                break
+
+        return nodes

--- a/services/api/api/integrations/linear/readonly.py
+++ b/services/api/api/integrations/linear/readonly.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import base64
+import mimetypes
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from api.integrations.linear.client import UPLOADS_PREFIX, LinearGraphQLClient
+
+
+def _linear_string_literal(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _team_key_filter(team_key: str) -> str:
+    return f"team: {{ key: {{ eq: {_linear_string_literal(team_key)} }} }}"
+
+
+class LinearReadonlyClient(LinearGraphQLClient):
+    """Read-only Linear API surface used by tools and ETL workflows."""
+
+    def me(self) -> dict[str, Any]:
+        """Get authenticated user info."""
+        query = """
+        query Me {
+            viewer { id name email }
+        }
+        """
+        return self._query(query).get("viewer", {})
+
+    def teams(self, limit: int = 50) -> list[dict[str, Any]]:
+        """List teams."""
+        query = """
+        query Teams($first: Int!, $after: String) {
+            teams(first: $first, after: $after) {
+                nodes { id name key description }
+                pageInfo { hasNextPage endCursor }
+            }
+        }
+        """
+        return self._connection_nodes(query, connection_path=("teams",), limit=limit)
+
+    def issues(
+        self,
+        team_key: str | None = None,
+        assignee: str | None = None,
+        state: str | None = None,
+        limit: int = 50,
+        include_archived: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List issues with optional filters."""
+        filters = []
+        if team_key:
+            filters.append(_team_key_filter(team_key))
+        if assignee:
+            if assignee.lower() == "me":
+                filters.append("assignee: { isMe: { eq: true } }")
+            else:
+                filters.append(
+                    f"assignee: {{ name: {{ containsIgnoreCase: {_linear_string_literal(assignee)} }} }}"
+                )
+        if state:
+            filters.append(
+                f"state: {{ name: {{ containsIgnoreCase: {_linear_string_literal(state)} }} }}"
+            )
+
+        filter_arg = f"filter: {{ {', '.join(filters)} }}, " if filters else ""
+        query = f"""
+        query Issues($first: Int!, $after: String, $includeArchived: Boolean) {{
+            issues(
+                {filter_arg}
+                first: $first,
+                after: $after,
+                includeArchived: $includeArchived,
+                orderBy: updatedAt
+            ) {{
+                nodes {{
+                    id
+                    identifier
+                    title
+                    description
+                    priority
+                    priorityLabel
+                    state {{ id name color }}
+                    assignee {{ id name }}
+                    team {{ id name key }}
+                    project {{ id name }}
+                    cycle {{ id name number }}
+                    labels {{ nodes {{ id name color }} }}
+                    dueDate
+                    createdAt
+                    updatedAt
+                    url
+                }}
+                pageInfo {{ hasNextPage endCursor }}
+            }}
+        }}
+        """
+        return self._connection_nodes(
+            query,
+            connection_path=("issues",),
+            variables={"includeArchived": include_archived},
+            limit=limit,
+        )
+
+    def issue(self, issue_id: str) -> dict[str, Any]:
+        """Get a single issue by ID or identifier."""
+        query = """
+        query Issue($id: String!) {
+            issue(id: $id) {
+                id
+                identifier
+                title
+                description
+                priority
+                priorityLabel
+                state { id name color }
+                assignee { id name }
+                team { id name key }
+                project { id name }
+                cycle { id name number }
+                labels { nodes { id name color } }
+                comments { nodes { id body user { name } createdAt } }
+                parent { id identifier title }
+                children { nodes { id identifier title state { name } } }
+                dueDate
+                createdAt
+                updatedAt
+                url
+            }
+        }
+        """
+        return self._query(query, {"id": issue_id}).get("issue", {})
+
+    def fetch_asset(self, url: str, filename: str | None = None) -> dict[str, Any]:
+        """Download a Linear-hosted asset such as an embedded screenshot."""
+        if not url.startswith(UPLOADS_PREFIX):
+            raise ValueError(
+                f"fetch_asset only retrieves {UPLOADS_PREFIX}... URLs; got {url!r}"
+            )
+
+        resp = httpx.get(
+            url,
+            headers={"Authorization": self.api_key},
+            follow_redirects=False,
+            timeout=30.0,
+        )
+        location = resp.headers.get("location")
+        if resp.is_redirect and location:
+            resp = httpx.get(location, follow_redirects=True, timeout=30.0)
+        resp.raise_for_status()
+
+        content = resp.content
+        mime_type = (
+            resp.headers.get("content-type", "application/octet-stream")
+            .split(";")[0]
+            .strip()
+        )
+        if not filename:
+            stem = urlparse(url).path.rstrip("/").rsplit("/", 1)[-1] or "asset"
+            ext = mimetypes.guess_extension(mime_type) or ""
+            filename = f"linear-{stem[:16]}{ext}"
+
+        return {
+            "data": base64.b64encode(content).decode(),
+            "mime_type": mime_type,
+            "filename": filename,
+            "byte_length": len(content),
+        }
+
+    def projects(self, limit: int = 50) -> list[dict[str, Any]]:
+        """List projects."""
+        query = """
+        query Projects($first: Int!, $after: String) {
+            projects(first: $first, after: $after, orderBy: updatedAt) {
+                nodes {
+                    id
+                    name
+                    description
+                    state
+                    progress
+                    startDate
+                    targetDate
+                    lead { id name }
+                    teams { nodes { id name key } }
+                    url
+                }
+                pageInfo { hasNextPage endCursor }
+            }
+        }
+        """
+        return self._connection_nodes(query, connection_path=("projects",), limit=limit)
+
+    def project(self, project_id: str) -> dict[str, Any]:
+        """Get a single project."""
+        query = """
+        query Project($id: String!) {
+            project(id: $id) {
+                id
+                name
+                description
+                state
+                progress
+                startDate
+                targetDate
+                lead { id name }
+                teams { nodes { id name key } }
+                issues { nodes { id identifier title state { name } } }
+                url
+            }
+        }
+        """
+        return self._query(query, {"id": project_id}).get("project", {})
+
+    def cycles(
+        self, team_key: str | None = None, limit: int = 20
+    ) -> list[dict[str, Any]]:
+        """List cycles, optionally filtered by team."""
+        filter_arg = ""
+        if team_key:
+            filter_arg = f"filter: {{ {_team_key_filter(team_key)} }}, "
+
+        query = f"""
+        query Cycles($first: Int!, $after: String) {{
+            cycles({filter_arg}first: $first, after: $after, orderBy: updatedAt) {{
+                nodes {{
+                    id
+                    name
+                    number
+                    startsAt
+                    endsAt
+                    progress
+                    team {{ id name key }}
+                    issues {{ nodes {{ id identifier title state {{ name }} }} }}
+                }}
+                pageInfo {{ hasNextPage endCursor }}
+            }}
+        }}
+        """
+        return self._connection_nodes(query, connection_path=("cycles",), limit=limit)
+
+    def workflow_states(self, team_key: str | None = None) -> list[dict[str, Any]]:
+        """List workflow states, optionally filtered by team."""
+        filter_arg = ""
+        if team_key:
+            filter_arg = f"filter: {{ {_team_key_filter(team_key)} }}, "
+
+        query = f"""
+        query WorkflowStates($first: Int!, $after: String) {{
+            workflowStates({filter_arg}first: $first, after: $after) {{
+                nodes {{
+                    id
+                    name
+                    color
+                    type
+                    position
+                    team {{ id name key }}
+                }}
+                pageInfo {{ hasNextPage endCursor }}
+            }}
+        }}
+        """
+        return self._connection_nodes(
+            query, connection_path=("workflowStates",), limit=100
+        )
+
+    def labels(self, team_key: str | None = None) -> list[dict[str, Any]]:
+        """List issue labels, optionally filtered by team."""
+        filter_arg = ""
+        if team_key:
+            filter_arg = f"filter: {{ {_team_key_filter(team_key)} }}, "
+
+        query = f"""
+        query Labels($first: Int!, $after: String) {{
+            issueLabels({filter_arg}first: $first, after: $after) {{
+                nodes {{
+                    id
+                    name
+                    color
+                    team {{ id name key }}
+                }}
+                pageInfo {{ hasNextPage endCursor }}
+            }}
+        }}
+        """
+        return self._connection_nodes(
+            query, connection_path=("issueLabels",), limit=100
+        )
+
+    def users(self, limit: int = 100) -> list[dict[str, Any]]:
+        """List workspace users."""
+        query = """
+        query Users($first: Int!, $after: String) {
+            users(first: $first, after: $after) {
+                nodes { id name email displayName active }
+                pageInfo { hasNextPage endCursor }
+            }
+        }
+        """
+        return self._connection_nodes(query, connection_path=("users",), limit=limit)
+
+    def search_issues(self, query_str: str, limit: int = 25) -> list[dict[str, Any]]:
+        """Search issues by text."""
+        query = """
+        query SearchIssues($query: String!, $first: Int!, $after: String) {
+            searchIssues(query: $query, first: $first, after: $after) {
+                nodes {
+                    id
+                    identifier
+                    title
+                    state { name }
+                    assignee { name }
+                    team { key }
+                    dueDate
+                    url
+                }
+                pageInfo { hasNextPage endCursor }
+            }
+        }
+        """
+        return self._connection_nodes(
+            query,
+            connection_path=("searchIssues",),
+            variables={"query": query_str},
+            limit=limit,
+        )

--- a/services/api/tests/test_linear_integrations.py
+++ b/services/api/tests/test_linear_integrations.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+
+
+class FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class FakeHttpClient:
+    def __init__(self, payloads: list[dict]):
+        self.payloads = list(payloads)
+        self.requests: list[dict] = []
+
+    def post(self, path: str, *, json: dict) -> FakeResponse:
+        self.requests.append({"path": path, "json": json})
+        return FakeResponse(self.payloads.pop(0))
+
+
+def test_linear_graphql_client_raises_api_errors():
+    from api.integrations.linear import LinearGraphQLClient
+
+    client = LinearGraphQLClient(
+        api_key="lin-test",
+        http_client=FakeHttpClient(
+            [{"errors": [{"message": "Nope"}]}],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Linear API error: Nope"):
+        client._query("query Test { viewer { id } }")
+
+
+def test_linear_readonly_client_paginates_connections():
+    from api.integrations.linear import LinearReadonlyClient
+
+    http = FakeHttpClient(
+        [
+            {
+                "data": {
+                    "teams": {
+                        "nodes": [
+                            {"id": "team-1", "key": "ENG"},
+                            {"id": "team-2", "key": "DES"},
+                        ],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "cursor-2"},
+                    }
+                }
+            },
+            {
+                "data": {
+                    "teams": {
+                        "nodes": [{"id": "team-3", "key": "OPS"}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            },
+        ]
+    )
+    client = LinearReadonlyClient(api_key="lin-test", http_client=http)
+
+    result = client.teams(limit=3)
+
+    assert [team["id"] for team in result] == ["team-1", "team-2", "team-3"]
+    assert http.requests[0]["json"]["variables"] == {"first": 3, "after": None}
+    assert http.requests[1]["json"]["variables"] == {"first": 1, "after": "cursor-2"}
+
+
+def test_linear_readonly_client_builds_issue_filters():
+    from api.integrations.linear import LinearReadonlyClient
+
+    http = FakeHttpClient(
+        [
+            {
+                "data": {
+                    "issues": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        ]
+    )
+    client = LinearReadonlyClient(api_key="lin-test", http_client=http)
+
+    client.issues(team_key='EN"G', assignee="Ada", state="In Progress", limit=1)
+
+    query = http.requests[0]["json"]["query"]
+    assert 'team: { key: { eq: "EN\\"G" } }' in query
+    assert 'assignee: { name: { containsIgnoreCase: "Ada" } }' in query
+    assert 'state: { name: { containsIgnoreCase: "In Progress" } }' in query
+
+
+def test_linear_tool_client_keeps_mutations_and_inherits_readonly_methods():
+    from tools.productivity.linear.client import LinearClient
+
+    assert "projects" in LinearClient.__dict__
+    assert "search_issues" in LinearClient.__dict__
+
+    class FakeLinearClient(LinearClient):
+        def __init__(self):
+            self.calls = []
+
+        def _query(self, query: str, variables: dict | None = None) -> dict:
+            self.calls.append({"query": query, "variables": variables})
+            if "query Projects" in query:
+                return {
+                    "projects": {
+                        "nodes": [{"id": "project-1", "name": "Roadmap"}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            return {
+                "issueCreate": {
+                    "issue": {
+                        "id": "issue-1",
+                        "identifier": "ENG-1",
+                        "title": "Test",
+                    }
+                }
+            }
+
+    client = FakeLinearClient()
+    projects = client.projects(limit=1)
+    created = client.create_issue("Test", team_id="team-1", priority=2)
+
+    assert projects == [{"id": "project-1", "name": "Roadmap"}]
+    assert created["identifier"] == "ENG-1"
+    assert client.calls[1]["variables"]["input"] == {
+        "title": "Test",
+        "teamId": "team-1",
+        "priority": 2,
+    }

--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -1,65 +1,34 @@
-"""Linear GraphQL API client."""
+"""Linear GraphQL API client for the Linear tool."""
 
-import base64
-import mimetypes
+from __future__ import annotations
+
+import sys
+from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
-import httpx
+try:
+    from api.integrations.linear import LinearReadonlyClient
+except ModuleNotFoundError:
+    api_src = Path(__file__).resolve().parents[3] / "services" / "api"
+    if api_src.exists():
+        sys.path.insert(0, str(api_src))
+    from api.integrations.linear import LinearReadonlyClient
 
-from centaur_sdk import secret
 
-UPLOADS_PREFIX = "https://uploads.linear.app/"
+class LinearClient(LinearReadonlyClient):
+    """Tool-facing Linear client.
 
-GRAPHQL_ENDPOINT = "https://api.linear.app/graphql"
-
-
-class LinearClient:
-    """Client for Linear's GraphQL API."""
-
-    def __init__(self, api_key: str | None = None):
-        self.api_key = api_key or secret("LINEAR_API_KEY", "")
-        if not self.api_key:
-            raise RuntimeError(
-                "LINEAR_API_KEY not set.\n"
-                "Get one at https://linear.app/settings/account/security → Personal API Keys"
-            )
-        self._http = httpx.Client(
-            base_url=GRAPHQL_ENDPOINT,
-            headers={"Authorization": self.api_key, "Content-Type": "application/json"},
-            timeout=10.0,
-        )
-
-    def _query(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
-        """Execute a GraphQL query."""
-        resp = self._http.post("", json={"query": query, "variables": variables or {}})
-        resp.raise_for_status()
-        data = resp.json()
-        if "errors" in data:
-            errors = data["errors"]
-            msg = errors[0].get("message", str(errors))
-            raise RuntimeError(f"Linear API error: {msg}")
-        return data.get("data", {})
+    Read-only GraphQL methods live in ``api.integrations.linear`` so workflows
+    can reuse them. Tool-only mutations stay here.
+    """
 
     def me(self) -> dict[str, Any]:
         """Get authenticated user info."""
-        query = """
-        query Me {
-            viewer { id name email }
-        }
-        """
-        return self._query(query).get("viewer", {})
+        return super().me()
 
     def teams(self, limit: int = 50) -> list[dict[str, Any]]:
-        """List all teams."""
-        query = """
-        query Teams($first: Int!) {
-            teams(first: $first) {
-                nodes { id name key description }
-            }
-        }
-        """
-        return self._query(query, {"first": limit}).get("teams", {}).get("nodes", [])
+        """List teams."""
+        return super().teams(limit=limit)
 
     def issues(
         self,
@@ -69,142 +38,50 @@ class LinearClient:
         limit: int = 50,
         include_archived: bool = False,
     ) -> list[dict[str, Any]]:
-        """List issues with optional filters.
-
-        Args:
-            team_key: Filter by team key (e.g., "ENG")
-            assignee: Filter by assignee name or "me"
-            state: Filter by state name (e.g., "In Progress", "Done")
-            limit: Max results
-            include_archived: Include archived issues
-        """
-        filters = []
-        if team_key:
-            filters.append(f'team: {{ key: {{ eq: "{team_key}" }} }}')
-        if assignee:
-            if assignee.lower() == "me":
-                filters.append("assignee: { isMe: { eq: true } }")
-            else:
-                filters.append(f'assignee: {{ name: {{ containsIgnoreCase: "{assignee}" }} }}')
-        if state:
-            filters.append(f'state: {{ name: {{ containsIgnoreCase: "{state}" }} }}')
-
-        filter_str = ", ".join(filters)
-        filter_arg = f"filter: {{ {filter_str} }}, " if filters else ""
-
-        query = f"""
-        query Issues($first: Int!, $includeArchived: Boolean) {{
-            issues({filter_arg}first: $first, includeArchived: $includeArchived, orderBy: updatedAt) {{
-                nodes {{
-                    id
-                    identifier
-                    title
-                    description
-                    priority
-                    priorityLabel
-                    state {{ id name color }}
-                    assignee {{ id name }}
-                    team {{ id name key }}
-                    project {{ id name }}
-                    cycle {{ id name number }}
-                    labels {{ nodes {{ id name color }} }}
-                    dueDate
-                    createdAt
-                    updatedAt
-                    url
-                }}
-            }}
-        }}
-        """
-        return (
-            self._query(query, {"first": limit, "includeArchived": include_archived})
-            .get("issues", {})
-            .get("nodes", [])
+        """List issues with optional filters."""
+        return super().issues(
+            team_key=team_key,
+            assignee=assignee,
+            state=state,
+            limit=limit,
+            include_archived=include_archived,
         )
 
     def issue(self, issue_id: str) -> dict[str, Any]:
-        """Get a single issue by ID or identifier (e.g., ENG-123)."""
-        query = """
-        query Issue($id: String!) {
-            issue(id: $id) {
-                id
-                identifier
-                title
-                description
-                priority
-                priorityLabel
-                state { id name color }
-                assignee { id name }
-                team { id name key }
-                project { id name }
-                cycle { id name number }
-                labels { nodes { id name color } }
-                comments { nodes { id body user { name } createdAt } }
-                parent { id identifier title }
-                children { nodes { id identifier title state { name } } }
-                dueDate
-                createdAt
-                updatedAt
-                url
-            }
-        }
-        """
-        return self._query(query, {"id": issue_id}).get("issue", {})
+        """Get a single issue by ID or identifier."""
+        return super().issue(issue_id)
 
     def fetch_asset(self, url: str, filename: str | None = None) -> dict[str, Any]:
-        """Download a Linear-hosted asset (e.g. a screenshot embedded in an
-        issue description or comment) so it can be viewed.
+        """Download a Linear-hosted asset such as an embedded screenshot."""
+        return super().fetch_asset(url, filename=filename)
 
-        Inline images in Linear render as bare ``https://uploads.linear.app/...``
-        URLs that require the same ``Authorization`` header as the GraphQL API,
-        so an unauthenticated ``curl`` from a sandbox gets a 401. This fetches
-        the bytes with the API key and returns them as an attachment: assets
-        larger than ~64 KB come back as a ``download_url`` you pull locally
-        (``curl http://api:8000<download_url> -o shot.png``) and open with
-        ``look_at``; smaller ones are inlined as base64 in ``data``.
+    def projects(self, limit: int = 50) -> list[dict[str, Any]]:
+        """List projects."""
+        return super().projects(limit=limit)
 
-        Args:
-            url: A ``https://uploads.linear.app/...`` asset URL.
-            filename: Optional name for the saved attachment; derived from the
-                URL and content type when omitted.
-        """
-        if not url.startswith(UPLOADS_PREFIX):
-            raise ValueError(
-                f"fetch_asset only retrieves {UPLOADS_PREFIX}... URLs; got {url!r}"
-            )
+    def project(self, project_id: str) -> dict[str, Any]:
+        """Get a single project."""
+        return super().project(project_id)
 
-        # uploads.linear.app gates on the API key, then may 302 to a
-        # self-authorizing CDN URL. Follow that hop WITHOUT the auth header so
-        # it doesn't collide with the signed-URL credentials — this mirrors
-        # curl -L, which drops the Authorization header on cross-host redirects.
-        resp = httpx.get(
-            url,
-            headers={"Authorization": self.api_key},
-            follow_redirects=False,
-            timeout=30.0,
-        )
-        location = resp.headers.get("location")
-        if resp.is_redirect and location:
-            resp = httpx.get(location, follow_redirects=True, timeout=30.0)
-        resp.raise_for_status()
+    def cycles(self, team_key: str | None = None, limit: int = 20) -> list[dict[str, Any]]:
+        """List cycles, optionally filtered by team."""
+        return super().cycles(team_key=team_key, limit=limit)
 
-        content = resp.content
-        mime_type = (
-            resp.headers.get("content-type", "application/octet-stream")
-            .split(";")[0]
-            .strip()
-        )
-        if not filename:
-            stem = urlparse(url).path.rstrip("/").rsplit("/", 1)[-1] or "asset"
-            ext = mimetypes.guess_extension(mime_type) or ""
-            filename = f"linear-{stem[:16]}{ext}"
+    def workflow_states(self, team_key: str | None = None) -> list[dict[str, Any]]:
+        """List workflow states, optionally filtered by team."""
+        return super().workflow_states(team_key=team_key)
 
-        return {
-            "data": base64.b64encode(content).decode(),
-            "mime_type": mime_type,
-            "filename": filename,
-            "byte_length": len(content),
-        }
+    def labels(self, team_key: str | None = None) -> list[dict[str, Any]]:
+        """List issue labels, optionally filtered by team."""
+        return super().labels(team_key=team_key)
+
+    def users(self, limit: int = 100) -> list[dict[str, Any]]:
+        """List workspace users."""
+        return super().users(limit=limit)
+
+    def search_issues(self, query_str: str, limit: int = 25) -> list[dict[str, Any]]:
+        """Search issues by text."""
+        return super().search_issues(query_str=query_str, limit=limit)
 
     def create_issue(
         self,
@@ -312,118 +189,7 @@ class LinearClient:
         result = self._query(mutation, {"input": {"issueId": issue_id, "body": body}})
         return result.get("commentCreate", {}).get("comment", {})
 
-    def projects(self, limit: int = 50) -> list[dict[str, Any]]:
-        """List all projects."""
-        query = """
-        query Projects($first: Int!) {
-            projects(first: $first, orderBy: updatedAt) {
-                nodes {
-                    id
-                    name
-                    description
-                    state
-                    progress
-                    startDate
-                    targetDate
-                    lead { id name }
-                    teams { nodes { id name key } }
-                    url
-                }
-            }
-        }
-        """
-        return self._query(query, {"first": limit}).get("projects", {}).get("nodes", [])
-
-    def project(self, project_id: str) -> dict[str, Any]:
-        """Get a single project."""
-        query = """
-        query Project($id: String!) {
-            project(id: $id) {
-                id
-                name
-                description
-                state
-                progress
-                startDate
-                targetDate
-                lead { id name }
-                teams { nodes { id name key } }
-                issues { nodes { id identifier title state { name } } }
-                url
-            }
-        }
-        """
-        return self._query(query, {"id": project_id}).get("project", {})
-
-    def cycles(self, team_key: str | None = None, limit: int = 20) -> list[dict[str, Any]]:
-        """List cycles, optionally filtered by team."""
-        filter_str = ""
-        if team_key:
-            filter_str = f'filter: {{ team: {{ key: {{ eq: "{team_key}" }} }} }}, '
-
-        query = f"""
-        query Cycles($first: Int!) {{
-            cycles({filter_str}first: $first, orderBy: updatedAt) {{
-                nodes {{
-                    id
-                    name
-                    number
-                    startsAt
-                    endsAt
-                    progress
-                    team {{ id name key }}
-                    issues {{ nodes {{ id identifier title state {{ name }} }} }}
-                }}
-            }}
-        }}
-        """
-        return self._query(query, {"first": limit}).get("cycles", {}).get("nodes", [])
-
-    def workflow_states(self, team_key: str | None = None) -> list[dict[str, Any]]:
-        """List workflow states, optionally filtered by team."""
-        filter_str = ""
-        if team_key:
-            filter_str = f'filter: {{ team: {{ key: {{ eq: "{team_key}" }} }} }}, '
-
-        query = f"""
-        query WorkflowStates {{
-            workflowStates({filter_str}first: 100) {{
-                nodes {{
-                    id
-                    name
-                    color
-                    type
-                    position
-                    team {{ id name key }}
-                }}
-            }}
-        }}
-        """
-        return self._query(query).get("workflowStates", {}).get("nodes", [])
-
-    def labels(self, team_key: str | None = None) -> list[dict[str, Any]]:
-        """List labels, optionally filtered by team."""
-        filter_str = ""
-        if team_key:
-            filter_str = f'filter: {{ team: {{ key: {{ eq: "{team_key}" }} }} }}, '
-
-        query = f"""
-        query Labels {{
-            issueLabels({filter_str}first: 100) {{
-                nodes {{
-                    id
-                    name
-                    color
-                    team {{ id name key }}
-                }}
-            }}
-        }}
-        """
-        return self._query(query).get("issueLabels", {}).get("nodes", [])
-
-    def _resolve_label_ids(
-        self, names: list[str], team_key: str | None = None
-    ) -> dict[str, str]:
+    def _resolve_label_ids(self, names: list[str], team_key: str | None = None) -> dict[str, str]:
         """Resolve label names to IDs, preferring a team-scoped label over a
         workspace label of the same name. Raises if any requested name is
         missing, or is ambiguous within its chosen scope.
@@ -437,9 +203,7 @@ class LinearClient:
             }
         }
         """
-        nodes = (
-            self._query(query, {"names": names}).get("issueLabels", {}).get("nodes", [])
-        )
+        nodes = self._query(query, {"names": names}).get("issueLabels", {}).get("nodes", [])
 
         team_hits: dict[str, list[str]] = {n: [] for n in names}
         workspace_hits: dict[str, list[str]] = {n: [] for n in names}
@@ -473,8 +237,7 @@ class LinearClient:
             )
         if dup:
             raise RuntimeError(
-                f"ambiguous label(s): {', '.join(dup)}. "
-                "Each must exist exactly once in its scope."
+                f"ambiguous label(s): {', '.join(dup)}. Each must exist exactly once in its scope."
             )
         return resolved
 
@@ -513,41 +276,6 @@ class LinearClient:
         result = self._query(mutation, {"id": issue_id, "labelId": label_id})
         return {"success": result.get("issueRemoveLabel", {}).get("success", False)}
 
-    def users(self, limit: int = 100) -> list[dict[str, Any]]:
-        """List workspace users."""
-        query = """
-        query Users($first: Int!) {
-            users(first: $first) {
-                nodes { id name email displayName active }
-            }
-        }
-        """
-        return self._query(query, {"first": limit}).get("users", {}).get("nodes", [])
-
-    def search_issues(self, query_str: str, limit: int = 25) -> list[dict[str, Any]]:
-        """Search issues by text."""
-        query = """
-        query SearchIssues($query: String!, $first: Int!) {
-            searchIssues(query: $query, first: $first) {
-                nodes {
-                    id
-                    identifier
-                    title
-                    state { name }
-                    assignee { name }
-                    team { key }
-                    dueDate
-                    url
-                }
-            }
-        }
-        """
-        return (
-            self._query(query, {"query": query_str, "first": limit})
-            .get("searchIssues", {})
-            .get("nodes", [])
-        )
-
     def create_issue_relation(
         self,
         issue_id: str,
@@ -585,7 +313,6 @@ class LinearClient:
         }
         result = self._query(mutation, {"input": input_data})
         return result.get("issueRelationCreate", {})
-
 
 
 def _client() -> LinearClient:


### PR DESCRIPTION
## Summary
- Add shared `api.integrations.linear` GraphQL/read-only clients for Linear auth, pagination, and read APIs
- Refactor the Linear tool client to reuse the shared read-only client while retaining tool-specific mutations
- Add targeted tests for GraphQL errors, cursor pagination, filter generation, and tool method exposure

## Validation
- `uv run --project services/api pytest services/api/tests/test_linear_integrations.py`
- `uv run --project services/api ruff check services/api/api/integrations/linear services/api/tests/test_linear_integrations.py tools/productivity/linear/client.py`
- `just build-one api`
- Rolled out local `deploy/centaur-centaur-api` with rebuilt `centaur-api:latest`; fresh API logs show Linear tool loaded with the full method set: `add_comment`, `add_label`, `create_issue`, `create_issue_relation`, `cycles`, `fetch_asset`, `issue`, `issues`, `labels`, `me`, `project`, `projects`, `remove_label`, `search_issues`, `teams`, `update_issue`, `users`, `workflow_states`

Note: `just deploy` hit an existing/unrelated Helm field-manager conflict on `centaur-centaur-slackbot` annotation `checksum/infra-secrets`, so I restarted only the local API deployment after the successful API image build.
