### PR TITLE
refactor(api-rs): wake session streams with postgres notify

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -392,6 +392,7 @@ name = "centaur-session-sqlx"
 version = "0.1.0"
 dependencies = [
  "centaur-session-core",
+ "serde",
  "serde_json",
  "sqlx",
  "thiserror",

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -13,6 +13,6 @@ centaur-session-sqlx.workspace = true
 futures-util.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["io-util", "sync", "time"] }
+tokio = { workspace = true, features = ["io-util", "macros", "sync", "time"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -12,17 +12,24 @@ use centaur_sandbox_manager::SandboxManager;
 use centaur_session_core::{
     HarnessType, Session, SessionEvent, SessionExecution, SessionMessageInput, ThreadKey,
 };
-use centaur_session_sqlx::{PgSessionStore, SessionStoreError, default_metadata};
+use centaur_session_sqlx::{
+    PgSessionStore, SessionEventListener, SessionStoreError, default_metadata,
+};
 use futures_util::{SinkExt, Stream, StreamExt, stream};
 use serde_json::{Value, json};
 use thiserror::Error;
-use tokio::{io, sync::Mutex, time::sleep};
+use tokio::{
+    io,
+    sync::Mutex,
+    time::{Instant, Interval, MissedTickBehavior, interval_at},
+};
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
 use tracing::warn;
 
 pub const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 
 const MAX_SESSION_OUTPUT_LINE_BYTES: usize = 1024 * 1024;
+const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
@@ -69,6 +76,8 @@ struct EventStreamState {
     thread_key: ThreadKey,
     after_event_id: i64,
     pending: VecDeque<SessionEvent>,
+    listener: SessionEventListener,
+    safety_tick: Interval,
     done: bool,
 }
 
@@ -206,10 +215,13 @@ impl SessionRuntime {
             self.ensure_session_pipe(thread_key, sandbox_id).await?;
         }
 
+        let listener = self.store.listen_session_events().await?;
+
         Ok(session_event_stream(
             self.store.clone(),
             thread_key.clone(),
             after_event_id,
+            listener,
         ))
     }
 
@@ -389,6 +401,7 @@ fn session_event_stream(
     store: PgSessionStore,
     thread_key: ThreadKey,
     after_event_id: i64,
+    listener: SessionEventListener,
 ) -> impl Stream<Item = Result<SessionEvent, SessionRuntimeError>> {
     stream::unfold(
         EventStreamState {
@@ -396,6 +409,15 @@ fn session_event_stream(
             thread_key,
             after_event_id,
             pending: VecDeque::new(),
+            listener,
+            safety_tick: {
+                let mut tick = interval_at(
+                    Instant::now() + EVENT_STREAM_SAFETY_POLL_INTERVAL,
+                    EVENT_STREAM_SAFETY_POLL_INTERVAL,
+                );
+                tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                tick
+            },
             done: false,
         },
         |mut state| async move {
@@ -412,7 +434,26 @@ fn session_event_stream(
                     .list_events_after(&state.thread_key, state.after_event_id, 100)
                     .await
                 {
-                    Ok(events) if events.is_empty() => sleep(Duration::from_millis(250)).await,
+                    Ok(events) if events.is_empty() => loop {
+                        tokio::select! {
+                            notification = state.listener.recv() => {
+                                match notification {
+                                    Ok(notification)
+                                        if notification.thread_key == state.thread_key.as_str()
+                                            && notification.event_id > state.after_event_id =>
+                                    {
+                                        break;
+                                    }
+                                    Ok(_) => {}
+                                    Err(error) => {
+                                        state.done = true;
+                                        return Some((Err(SessionRuntimeError::Store(error)), state));
+                                    }
+                                }
+                            }
+                            _ = state.safety_tick.tick() => break,
+                        }
+                    },
                     Ok(events) => state.pending = events.into(),
                     Err(error) => {
                         state.done = true;

--- a/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 
 [dependencies]
 centaur-session-core.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0002_session_event_notifications.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0002_session_event_notifications.sql
@@ -1,0 +1,23 @@
+create or replace function notify_session_event_insert()
+returns trigger
+language plpgsql
+as $$
+begin
+    perform pg_notify(
+        'centaur_session_events',
+        json_build_object(
+            'thread_key', new.thread_key,
+            'event_id', new.event_id
+        )::text
+    );
+
+    return new;
+end;
+$$;
+
+drop trigger if exists session_events_notify_insert on session_events;
+
+create trigger session_events_notify_insert
+after insert on session_events
+for each row
+execute function notify_session_event_insert();

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -6,13 +6,19 @@ use centaur_session_core::{
     ExecutionStatus, HarnessType, Session, SessionEvent, SessionExecution, SessionMessage,
     SessionMessageInput, SessionStatus, ThreadKey, empty_object,
 };
+use serde::Deserialize;
 use serde_json::Value;
-use sqlx::{FromRow, PgPool, postgres::PgPoolOptions};
+use sqlx::{
+    FromRow, PgPool,
+    postgres::{PgListener, PgPoolOptions},
+};
 use thiserror::Error;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+pub const SESSION_EVENTS_CHANNEL: &str = "centaur_session_events";
 
 #[derive(Clone)]
 pub struct PgSessionStore {
@@ -39,6 +45,12 @@ impl PgSessionStore {
     pub async fn run_migrations(&self) -> Result<(), SessionStoreError> {
         MIGRATOR.run(&self.pool).await?;
         Ok(())
+    }
+
+    pub async fn listen_session_events(&self) -> Result<SessionEventListener, SessionStoreError> {
+        let mut listener = PgListener::connect_with(&self.pool).await?;
+        listener.listen(SESSION_EVENTS_CHANNEL).await?;
+        Ok(SessionEventListener { listener })
     }
 
     pub async fn create_or_get_session(
@@ -341,6 +353,36 @@ impl PgSessionStore {
     }
 }
 
+pub struct SessionEventListener {
+    listener: PgListener,
+}
+
+impl SessionEventListener {
+    pub async fn recv(&mut self) -> Result<SessionEventNotification, SessionStoreError> {
+        loop {
+            let notification = self.listener.recv().await?;
+            if notification.channel() != SESSION_EVENTS_CHANNEL {
+                continue;
+            }
+
+            let payload = notification.payload();
+            return serde_json::from_str(payload).map_err(|error| {
+                SessionStoreError::InvalidNotification {
+                    channel: notification.channel().to_owned(),
+                    payload: payload.to_owned(),
+                    error,
+                }
+            });
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct SessionEventNotification {
+    pub thread_key: String,
+    pub event_id: i64,
+}
+
 #[derive(Debug, Error)]
 pub enum SessionStoreError {
     #[error("session not found for thread_key {thread_key}")]
@@ -355,6 +397,12 @@ pub enum SessionStoreError {
     },
     #[error("invalid persisted value: {0}")]
     InvalidPersistedValue(String),
+    #[error("invalid notification payload on {channel}: {payload}: {error}")]
+    InvalidNotification {
+        channel: String,
+        payload: String,
+        error: serde_json::Error,
+    },
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
     #[error(transparent)]
@@ -489,4 +537,23 @@ fn prefixed_id(prefix: &str) -> String {
 
 pub fn default_metadata(metadata: Option<Value>) -> Value {
     metadata.unwrap_or_else(empty_object)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SessionEventNotification;
+
+    #[test]
+    fn parses_session_event_notification_payload() {
+        let notification: SessionEventNotification =
+            serde_json::from_str(r#"{"thread_key":"cli:test","event_id":42}"#).unwrap();
+
+        assert_eq!(
+            notification,
+            SessionEventNotification {
+                thread_key: "cli:test".to_owned(),
+                event_id: 42,
+            }
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- add a `session_events` insert trigger that publishes thread/event IDs through Postgres `LISTEN/NOTIFY`
- add a SQLx session-event listener and typed notification payload parsing
- wake durable session event streams from notifications, with the existing DB replay path retained as the source of truth and a slower safety tick as fallback

## Stack

- Stacked on #334. This PR contains only the session event notification delta.

## Validation

- `cargo fmt --all --check`
- `cargo test -p centaur-session-sqlx -p centaur-session-runtime -p centaur-api-server -p centaur-session-cli`
- `cargo clippy -p centaur-session-sqlx -p centaur-session-runtime -p centaur-api-server -p centaur-session-cli --all-targets -- -D warnings`