### PR TITLE
feat(chart): add flag-gated iron-control module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -520,6 +520,12 @@ Tool credentials (e.g., `ANTHROPIC_API_KEY`, `AMP_API_KEY`) are never materializ
 
 For local development, infra secrets are stored in Kubernetes Secrets created by `just bootstrap-secrets`; application secrets continue to come from 1Password.
 
+### iron-control
+
+[iron-control](https://github.com/ironsh/iron-control) is an optional Rails control plane for authenticated API access and encrypted secret storage. It is off by default; enable it with `--set ironControl.enabled=true` (or set `ironControl.enabled: true` in a values file). When enabled, it runs against a dedicated `iron_control_production` database on the bundled Postgres (a separate logical DB so its Rails `schema_migrations` table never collides with the API's dbmate table), created by an idempotent init container.
+
+`just bootstrap-secrets` seeds the required keys into `centaur-infra-env`: the three ActiveRecord encryption keys, `SECRET_KEY_BASE`, and the initial admin password/API key are auto-generated (only when absent, never rotated in place). `IRON_CONTROL_DATABASE_URL` defaults to the bundled Postgres server with no database path (so Rails resolves each connection's database name from the image's `database.yml`); export it before running `just bootstrap-secrets` to point at an external server. Override the admin email with `IRON_CONTROL_INITIAL_USER_EMAIL` (default `admin@centaur.local`).
+
 ## Observability & Audit Logs
 
 ### Architecture

--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.48
+version: 0.1.49
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -140,3 +140,19 @@ registered refresh_token OAuthTokenSecrets by the API server at startup.
 {{- define "centaur.tokenBrokerUrl" -}}
 {{- printf "http://%s:%v" (include "centaur.tokenBrokerHost" .) .Values.tokenBroker.service.httpPort -}}
 {{- end -}}
+
+{{- /*
+iron-control — Rails control plane for authenticated API access and encrypted
+secret storage. Flag-gated (ironControl.enabled), in-cluster ClusterIP Service.
+*/ -}}
+{{- define "centaur.ironControlName" -}}
+{{- include "centaur.componentName" (dict "root" . "component" "iron-control") -}}
+{{- end -}}
+
+{{- define "centaur.ironControlHost" -}}
+{{- include "centaur.ironControlName" . -}}
+{{- end -}}
+
+{{- define "centaur.ironControlUrl" -}}
+{{- printf "http://%s:%v" (include "centaur.ironControlHost" .) .Values.ironControl.service.httpPort -}}
+{{- end -}}

--- a/contrib/chart/templates/iron-control.yaml
+++ b/contrib/chart/templates/iron-control.yaml
@@ -1,0 +1,211 @@
+{{- if .Values.ironControl.enabled }}
+{{- $secretEnv := include "centaur.secretEnvName" . }}
+{{- $prefix := .Values.secretManager.envPrefix }}
+# iron-control — Rails control plane for authenticated API access and encrypted
+# secret storage. The chart owns the Deployment shape (image, port, env,
+# security context) so operators tune it via `helm upgrade`. It runs against a
+# dedicated `iron_control_production` database on the bundled Postgres (a separate logical
+# DB so its Rails schema_migrations table never collides with the API's dbmate
+# table); the create-db init container provisions that DB idempotently. All
+# secret material — the primary DB URL, the bootstrap user/API-key, the three
+# ActiveRecord encryption keys, and SECRET_KEY_BASE — comes from the shared
+# infra Secret via explicit secretKeyRefs (NOT envFrom, which would leak the
+# API's ai_v2 DATABASE_URL into iron-control's env).
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "centaur.ironControlName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
+spec:
+  selector:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.ironControl.service.httpPort }}
+      targetPort: {{ .Values.ironControl.service.httpPort }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "centaur.ironControlName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
+spec:
+  replicas: {{ .Values.ironControl.replicaCount }}
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/infra-secrets: {{ include "centaur.infraSecretsChecksum" . }}
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        # Create the dedicated logical DB on the bundled Postgres. Idempotent:
+        # guarded by a pg_database existence check, and the CREATE tolerates a
+        # lost race against a concurrent replica. Connects as the admin (ai_v2)
+        # DSN, whose `tempo` superuser can create databases.
+        - name: create-db
+          image: {{ printf "%s:%s" .Values.postgres.image.repository .Values.postgres.image.tag | quote }}
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              exists=$(psql "$ADMIN_DATABASE_URL" -tAc \
+                "SELECT 1 FROM pg_database WHERE datname = '$DB_NAME'")
+              if [ "$exists" != "1" ]; then
+                psql "$ADMIN_DATABASE_URL" -c "CREATE DATABASE \"$DB_NAME\"" || true
+              fi
+          env:
+            - name: ADMIN_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sDATABASE_URL" $prefix }}
+            - name: DB_NAME
+              value: {{ .Values.ironControl.database.name | quote }}
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+            seccompProfile:
+              type: RuntimeDefault
+      containers:
+        - name: iron-control
+          image: {{ printf "%s:%s" .Values.ironControl.image.repository .Values.ironControl.image.tag | quote }}
+          imagePullPolicy: {{ .Values.ironControl.image.pullPolicy }}
+          env:
+            # Explicit secretKeyRefs only — never envFrom the shared Secret, or
+            # its DATABASE_URL (ai_v2) would leak into iron-control's env. Env
+            # var names match the IRON_CONTROL_* secret keys 1:1 (except
+            # SECRET_KEY_BASE, which Rails reads by its standard name). The DB
+            # URL carries connection info only (no database path) so each Rails
+            # connection's db name comes from the image's database.yml.
+            - name: IRON_CONTROL_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_DATABASE_URL" $prefix }}
+            - name: IRON_CONTROL_INITIAL_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_INITIAL_USER_EMAIL" $prefix }}
+            - name: IRON_CONTROL_INITIAL_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_INITIAL_USER_PASSWORD" $prefix }}
+            - name: IRON_CONTROL_INITIAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_INITIAL_API_KEY" $prefix }}
+            - name: IRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY" $prefix }}
+            - name: IRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY" $prefix }}
+            - name: IRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT" $prefix }}
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+            - name: RAILS_ENV
+              value: {{ .Values.ironControl.railsEnv | quote }}
+            - name: PORT
+              value: {{ .Values.ironControl.service.httpPort | quote }}
+            - name: RAILS_LOG_TO_STDOUT
+              value: "1"
+            - name: RAILS_SERVE_STATIC_FILES
+              value: "1"
+          ports:
+            - containerPort: {{ .Values.ironControl.service.httpPort }}
+              name: http
+          startupProbe:
+            httpGet:
+              path: /up
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /up
+              port: http
+            failureThreshold: 6
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /up
+              port: http
+            failureThreshold: 6
+            periodSeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+            # No readOnlyRootFilesystem — Rails writes to tmp/ at runtime.
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+{{ toYaml .Values.ironControl.resources | nindent 12 }}
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.ironControlName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # The API is the natural control-plane caller. Widen this when a concrete
+    # client integrates. (kubectl port-forward works regardless — it arrives
+    # via the kubelet, not pod-to-pod.)
+    - from:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.ironControl.service.httpPort }}
+  egress:
+{{- if .Values.postgres.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "postgres") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 5432
+{{- end }}
+    # Outbound HTTPS (external DB DSNs, IdPs, etc.).
+    - ports:
+        - protocol: TCP
+          port: 443
+{{- end }}
+{{- end }}

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -56,6 +56,11 @@ spec:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "slackbot") | nindent 14 }}
 {{- end }}
+{{- if .Values.ironControl.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 14 }}
+{{- end }}
         - podSelector:
             matchLabels:
               centaur.ai/component: workflow-run

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -48,6 +48,35 @@
         "port": { "type": "integer" }
       }
     },
+    "ironControl": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicaCount": { "type": "integer" },
+        "railsEnv": { "type": "string" },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "httpPort": { "type": "integer" }
+          }
+        },
+        "resources": { "type": "object" }
+      }
+    },
     "secrets": {
       "type": "object",
       "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -63,6 +63,32 @@ tokenBroker:
   ttl: 1m
   resources: {}
 
+# iron-control — Rails control plane for authenticated API access + encrypted
+# secret storage. Off by default; enable per-environment. Uses a dedicated
+# `iron_control_production` database on the bundled Postgres (its own logical DB so its
+# Rails schema_migrations table never collides with the API's dbmate table); an
+# init container creates the DB idempotently. DATABASE_URL, bootstrap
+# user/API-key, and the three ActiveRecord encryption keys are injected from the
+# shared infra Secret. Point IRON_CONTROL_DATABASE_URL elsewhere to use an
+# external DB.
+ironControl:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: ironsh/iron-control
+    tag: latest
+    pullPolicy: IfNotPresent
+  railsEnv: production
+  database:
+    # Logical DB created on the bundled Postgres by the create-db init
+    # container. Must match the primary connection's `database:` in the image's
+    # database.yml — the connection URL carries no database path, so Rails
+    # resolves the name from there.
+    name: iron_control_production
+  service:
+    httpPort: 3000
+  resources: {}
+
 # Values for the upstream 1Password Connect subchart
 # (https://github.com/1Password/connect-helm-charts/tree/main/charts/connect).
 # Deployment is gated on onepasswordConnect.connect.create AND on

--- a/contrib/scripts/bootstrap-k8s-secrets.sh
+++ b/contrib/scripts/bootstrap-k8s-secrets.sh
@@ -22,6 +22,15 @@ Optional local-dev admin key:
   LOCAL_DEV_API_KEY            seeded as the admin bearer for the API service
                                (envFrom centaur-infra-env). Re-run with --force
                                or kubectl patch to rotate.
+
+Optional iron-control bootstrap (consumed when ironControl.enabled=true):
+  IRON_CONTROL_DATABASE_URL    overrides the derived DSN (default points at the
+                               bundled Postgres server with no database path, so
+                               Rails resolves db names from its database.yml)
+  IRON_CONTROL_INITIAL_USER_EMAIL
+                               initial admin email (default admin@centaur.local)
+  The initial password, API key, the three ActiveRecord encryption keys, and
+  SECRET_KEY_BASE are auto-generated when absent (never rotated in place).
 EOF
 }
 
@@ -114,6 +123,44 @@ if secret_exists centaur-infra-env; then
   if [[ -n "${LOCAL_DEV_API_KEY:-}" ]]; then
     patch_data+=("\"LOCAL_DEV_API_KEY\":\"$(printf '%s' "$LOCAL_DEV_API_KEY" | base64 | tr -d '\n')\"")
   fi
+  # iron-control keys: top up only when absent so we never rotate them out from
+  # under a running pod (its ActiveRecord-encrypted data would become
+  # undecryptable). Generated values mirror the create path.
+  if ! secret_key_present IRON_CONTROL_DATABASE_URL; then
+    if [[ -n "${IRON_CONTROL_DATABASE_URL:-}" ]]; then
+      ic_db_url="$IRON_CONTROL_DATABASE_URL"
+    else
+      # Reuse the same Postgres host/credentials as the API's DATABASE_URL but
+      # strip the database path, so Rails resolves the database name from the
+      # image's database.yml. Avoids decoding the password ourselves.
+      existing_db_url="$(kubectl -n "$NAMESPACE" get secret centaur-infra-env \
+        -o 'jsonpath={.data.DATABASE_URL}' | openssl base64 -d -A)"
+      ic_db_url="${existing_db_url%/ai_v2}"
+    fi
+    patch_data+=("\"IRON_CONTROL_DATABASE_URL\":\"$(printf '%s' "$ic_db_url" | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_INITIAL_USER_EMAIL; then
+    ic_email="${IRON_CONTROL_INITIAL_USER_EMAIL:-admin@centaur.local}"
+    patch_data+=("\"IRON_CONTROL_INITIAL_USER_EMAIL\":\"$(printf '%s' "$ic_email" | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_INITIAL_USER_PASSWORD; then
+    patch_data+=("\"IRON_CONTROL_INITIAL_USER_PASSWORD\":\"$(rand_hex | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_INITIAL_API_KEY; then
+    patch_data+=("\"IRON_CONTROL_INITIAL_API_KEY\":\"$(printf 'iak_%s' "$(rand_hex)" | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY; then
+    patch_data+=("\"IRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY\":\"$(rand_hex | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY; then
+    patch_data+=("\"IRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY\":\"$(rand_hex | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT; then
+    patch_data+=("\"IRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT\":\"$(rand_hex | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_SECRET_KEY_BASE; then
+    patch_data+=("\"IRON_CONTROL_SECRET_KEY_BASE\":\"$(printf '%s%s' "$(rand_hex)" "$(rand_hex)" | base64 | tr -d '\n')\"")
+  fi
   if [[ "${#patch_data[@]}" -gt 0 ]]; then
     patch_json="{\"data\":{$(IFS=,; echo "${patch_data[*]}")}}"
     kubectl -n "$NAMESPACE" patch secret centaur-infra-env --type merge -p "$patch_json" >/dev/null
@@ -123,6 +170,12 @@ if secret_exists centaur-infra-env; then
 else
   POSTGRES_PASSWORD="$(rand_hex)"
   DATABASE_URL="postgresql://tempo:${POSTGRES_PASSWORD}@centaur-centaur-postgres:5432/ai_v2"
+  # iron-control runs against a dedicated logical DB on the same Postgres. The
+  # URL carries connection info only (no database path) so Rails resolves each
+  # connection's database name from the image's database.yml. Override via the
+  # IRON_CONTROL_DATABASE_URL env var to point at an external server.
+  IRON_CONTROL_DATABASE_URL="${IRON_CONTROL_DATABASE_URL:-postgresql://tempo:${POSTGRES_PASSWORD}@centaur-centaur-postgres:5432}"
+  IRON_CONTROL_INITIAL_USER_EMAIL="${IRON_CONTROL_INITIAL_USER_EMAIL:-admin@centaur.local}"
   secret_args=(
     -n "$NAMESPACE" create secret generic centaur-infra-env
     --from-literal=IRON_MANAGEMENT_API_KEY="$(rand_hex)"
@@ -135,6 +188,14 @@ else
     --from-literal=SLACKBOT_API_KEY="$SLACKBOT_API_KEY"
     --from-literal=POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
     --from-literal=DATABASE_URL="$DATABASE_URL"
+    --from-literal=IRON_CONTROL_DATABASE_URL="$IRON_CONTROL_DATABASE_URL"
+    --from-literal=IRON_CONTROL_INITIAL_USER_EMAIL="$IRON_CONTROL_INITIAL_USER_EMAIL"
+    --from-literal=IRON_CONTROL_INITIAL_USER_PASSWORD="$(rand_hex)"
+    --from-literal=IRON_CONTROL_INITIAL_API_KEY="iak_$(rand_hex)"
+    --from-literal=IRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY="$(rand_hex)"
+    --from-literal=IRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY="$(rand_hex)"
+    --from-literal=IRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT="$(rand_hex)"
+    --from-literal=IRON_CONTROL_SECRET_KEY_BASE="$(rand_hex)$(rand_hex)"
   )
   if [[ -n "${OP_CONNECT_TOKEN:-}" ]]; then
     secret_args+=(--from-literal=OP_CONNECT_TOKEN="$OP_CONNECT_TOKEN")


### PR DESCRIPTION
Boots iron-control (the Rails control plane) as an opt-in Helm chart module behind `ironControl.enabled` (off by default), modeled on the existing iron-token-broker integration. It runs against a dedicated `iron_control_production` database on the bundled Postgres, provisioned idempotently by a `create-db` init container so its Rails `schema_migrations` table never collides with the API's dbmate table.

The connection URL carries connection info only (no database path), so Rails resolves each connection's db name from the image's `database.yml`. All secrets are namespaced under `IRON_CONTROL_*` in `centaur-infra-env` and seeded by `bootstrap-secrets` (generated when absent, never rotated in place); the container env var names match those keys 1:1, except `SECRET_KEY_BASE` which Rails reads by its standard name. Secrets are injected via explicit secretKeyRefs (never envFrom, which would leak the API's ai_v2 DSN). In-cluster only via a ClusterIP Service plus NetworkPolicy. Bumps the chart to 0.1.48.