### PR TITLE
fix: make sandbox tool CLIs importable

### DIFF
--- a/services/api/tests/test_sandbox_entrypoint.py
+++ b/services/api/tests/test_sandbox_entrypoint.py
@@ -135,3 +135,33 @@ def test_sandbox_entrypoint_installs_codex_harness_config(tmp_path: Path) -> Non
 
     assert result.returncode == 0, result.stderr or result.stdout
     assert result.stdout == (harness_dir / "codex" / "config.toml").read_text()
+
+
+def test_sandbox_entrypoint_exports_pythonpath_for_tool_clis(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    harness_dir = _write_codex_harness_config(home)
+    (home / "github" / "centaur").mkdir(parents=True)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ENTRYPOINT_SH),
+            "sh",
+            "-lc",
+            'printf "%s" "$PYTHONPATH"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(home),
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "CENTAUR_HARNESS_CONFIG_DIR": str(harness_dir),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    entries = result.stdout.split(":")
+    assert str(home / "github") in entries
+    assert str(home / "github" / "centaur") in entries
+    assert str(home / "workspace") in entries

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -181,7 +181,8 @@ RUN rm -f /etc/sudoers.d/agent
 # BuildKit's COPY --link creates parent directories without an explicit mode,
 # which can leave /etc/centaur without the execute bit for non-root users.
 # Pre-create it as 0755 so the agent user can traverse into it at runtime.
-RUN install -d -m 0755 /etc/centaur
+RUN install -d -m 0755 /etc/centaur /opt/centaur
+COPY --link centaur_sdk/ /opt/centaur/centaur_sdk/
 COPY --link --chmod=644 services/sandbox/codex-auth.json /etc/centaur/codex-auth.default.json
 COPY --link --chmod=644 services/sandbox/claude-credentials.json /etc/centaur/claude-credentials.default.json
 COPY --link --chmod=755 services/sandbox/call.sh /usr/local/bin/call

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -202,6 +202,26 @@ if [ -d "$WS_SKILLS" ]; then
     ln -sf "$WS_SKILLS" "$WORKSPACE_DIR/.claude/skills"
 fi
 
+_add_pythonpath_entry() {
+    local entry="$1"
+    [ -d "$entry" ] || return 0
+    case ":${PYTHONPATH:-}:" in
+        *":$entry:"*) ;;
+        *) export PYTHONPATH="$entry${PYTHONPATH:+:$PYTHONPATH}" ;;
+    esac
+}
+
+# Tool CLIs can run in subprocess venvs from `centaur-tools`; keep the local
+# Centaur SDK importable without requiring it to be published to PyPI.
+_add_pythonpath_entry "/opt/centaur"
+_add_pythonpath_entry "$HOME_DIR/github"
+_add_pythonpath_entry "$HOME_DIR/github/centaur"
+_add_pythonpath_entry "$WORKSPACE_DIR"
+if [ -n "${CENTAUR_OVERLAY_DIR:-}" ]; then
+    _add_pythonpath_entry "$CENTAUR_OVERLAY_DIR"
+fi
+unset -f _add_pythonpath_entry
+
 # ── Assemble system prompt from bind mounts ──────────────────────────────────
 # Base prompt: mounted as AGENTS_BASE.md when present, fallback to baked-in AGENTS.md.
 # Org/persona overlays are mounted alongside the base prompt when present.

--- a/tools/business/ashby/pyproject.toml
+++ b/tools/business/ashby/pyproject.toml
@@ -4,6 +4,7 @@ description = "Ashby ATS CLI for AI agents — query candidates, jobs, applicati
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/business/pylon/pyproject.toml
+++ b/tools/business/pylon/pyproject.toml
@@ -4,6 +4,7 @@ description = "Pylon CLI for AI agents - support issues, accounts, contacts"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/comms/twitter/pyproject.toml
+++ b/tools/comms/twitter/pyproject.toml
@@ -4,6 +4,7 @@ description = "Twitter CLI for user profiles, followers, tweets, and search"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "typer>=0.12.0",
     "rich>=13.0.0",
     "httpx>=0.28.1",

--- a/tools/crypto/arkham/pyproject.toml
+++ b/tools/crypto/arkham/pyproject.toml
@@ -4,6 +4,7 @@ description = "Arkham Intelligence CLI for blockchain analytics and wallet track
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/crypto/coindesk/pyproject.toml
+++ b/tools/crypto/coindesk/pyproject.toml
@@ -4,6 +4,7 @@ description = "CoinDesk CLI for crypto news"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "feedparser>=6.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",

--- a/tools/crypto/standard-metrics/pyproject.toml
+++ b/tools/crypto/standard-metrics/pyproject.toml
@@ -4,6 +4,7 @@ description = "Standard Metrics CLI for portfolio company data and analytics"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/infra/reth-log-analyzer/pyproject.toml
+++ b/tools/infra/reth-log-analyzer/pyproject.toml
@@ -4,6 +4,7 @@ description = "Parse reth logs and generate performance graphs"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "typer>=0.12.0",
     "rich>=13.0.0",
     "pandas>=2.0.0",

--- a/tools/infra/reth/pyproject.toml
+++ b/tools/infra/reth/pyproject.toml
@@ -4,6 +4,7 @@ description = "Reth CLI for AI agents - execution timings, performance metrics"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/media/transcriber/pyproject.toml
+++ b/tools/media/transcriber/pyproject.toml
@@ -4,6 +4,7 @@ description = "Local-first voice transcription CLI using Whisper"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "typer>=0.12.0",
     "rich>=13.0.0",
 ]

--- a/tools/productivity/granola/pyproject.toml
+++ b/tools/productivity/granola/pyproject.toml
@@ -4,6 +4,7 @@ description = "Granola meeting notes CLI for AI agents"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/research/congress/pyproject.toml
+++ b/tools/research/congress/pyproject.toml
@@ -4,6 +4,7 @@ description = "Congress.gov API CLI"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/research/fedreg/pyproject.toml
+++ b/tools/research/fedreg/pyproject.toml
@@ -4,6 +4,7 @@ description = "Federal Register CLI for regulatory data"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/research/googlenews/pyproject.toml
+++ b/tools/research/googlenews/pyproject.toml
@@ -4,6 +4,7 @@ description = "Google News RSS CLI for news search and headlines"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "feedparser>=6.0.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/research/harmonic/pyproject.toml
+++ b/tools/research/harmonic/pyproject.toml
@@ -4,6 +4,7 @@ description = "Harmonic.AI API CLI for startup discovery and company/people enri
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/research/listennotes/pyproject.toml
+++ b/tools/research/listennotes/pyproject.toml
@@ -4,6 +4,7 @@ description = "Listen Notes CLI for podcast data"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/research/newsapi/pyproject.toml
+++ b/tools/research/newsapi/pyproject.toml
@@ -4,6 +4,7 @@ description = "NewsAPI CLI for news search and headlines"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/research/openfec/pyproject.toml
+++ b/tools/research/openfec/pyproject.toml
@@ -4,6 +4,7 @@ description = "OpenFEC CLI for federal election data"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/research/plural/pyproject.toml
+++ b/tools/research/plural/pyproject.toml
@@ -4,6 +4,7 @@ description = "Plural (Open States) API — state legislation, legislators, comm
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/research/sensortower/pyproject.toml
+++ b/tools/research/sensortower/pyproject.toml
@@ -4,6 +4,7 @@ description = "SensorTower CLI for mobile app analytics"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",


### PR DESCRIPTION
## Summary
- bake local centaur_sdk source into the sandbox image and add stable repo/workspace roots to PYTHONPATH for tool subprocesses
- add missing python-dotenv declarations for tool CLIs that call load_dotenv()
- add a sandbox entrypoint regression test for tool CLI import paths

## Tests
- uv run --project services/api pytest services/api/tests/test_sandbox_entrypoint.py
- checked every tools/**/cli.py importing dotenv has python-dotenv in its pyproject