### PR TITLE
fix: preserve final Slack answers after plans

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -321,6 +321,37 @@ describe('CodexAppServerRendererEventMapper', () => {
     })
   })
 
+  it('omits binary command output from task updates', async () => {
+    const chunks = await collect(
+      codexAppServerToChatSdkStream(
+        toAsyncIterable([
+          {
+            method: 'item/completed',
+            params: {
+              threadId: 'thread-1',
+              turnId: 'turn-1',
+              item: {
+                id: 'cmd-1',
+                type: 'commandExecution',
+                command: 'head -40 $(which centaur-tools)',
+                status: 'completed',
+                aggregatedOutput: `ELF\u0000\u0001\u0002\u0003${'\u0004'.repeat(16)}`,
+                exitCode: 0
+              }
+            }
+          }
+        ])
+      )
+    )
+
+    const taskChunk = chunks.find(
+      (chunk): chunk is Extract<(typeof chunks)[number], { type: 'task_update' }> =>
+        chunk.type === 'task_update' && chunk.id === 'cmd-1'
+    )
+    expect(taskChunk?.output).toContain('[binary output omitted;')
+    expect(taskChunk?.output).not.toContain('\u0000')
+  })
+
   it('marks open tasks as errors on Rust session failures and emits done', () => {
     const mapper = new CodexAppServerRendererEventMapper()
     mapper.process({

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -1153,7 +1153,12 @@ function commandOutputElements(output: string, exitCode?: number | null): Render
 }
 
 function formatCommandOutput(output: string): { body: string; language: string } {
-  const trimmed = output.trim()
+  const sanitized = sanitizeCommandOutput(output)
+  if (sanitized.binary) {
+    return { body: sanitized.body, language: 'text' }
+  }
+
+  const trimmed = sanitized.body.trim()
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
     try {
       const pretty = JSON.stringify(JSON.parse(trimmed), null, 2)
@@ -1164,9 +1169,39 @@ function formatCommandOutput(output: string): { body: string; language: string }
     } catch {}
   }
   return {
-    body: clipLines(output, limits.finalPlan.taskOutputCodeBlockLines),
-    language: languageFromContent(output)
+    body: clipLines(sanitized.body, limits.finalPlan.taskOutputCodeBlockLines),
+    language: languageFromContent(sanitized.body)
   }
+}
+
+function sanitizeCommandOutput(output: string): { body: string; binary: boolean } {
+  if (!looksLikeBinaryOutput(output)) {
+    return {
+      body: output.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '?'),
+      binary: false
+    }
+  }
+
+  const exitCodePrefix = /^exit code \d+\n/.exec(output)?.[0] ?? ''
+  return {
+    body: `${exitCodePrefix}[binary output omitted; ${output.length - exitCodePrefix.length} chars received]`,
+    binary: true
+  }
+}
+
+function looksLikeBinaryOutput(output: string): boolean {
+  const sample = output.slice(0, 4096)
+  if (!sample) return false
+  if (sample.includes('\u0000')) return true
+
+  let controlChars = 0
+  for (let index = 0; index < sample.length; index += 1) {
+    const code = sample.charCodeAt(index)
+    if ((code < 32 && code !== 9 && code !== 10 && code !== 13) || code === 127) {
+      controlChars += 1
+    }
+  }
+  return controlChars >= 8 || controlChars / sample.length > 0.02
 }
 
 function fileChangeTask(item: any, eventType: string, existing?: HarnessTask): HarnessTask {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -316,6 +316,8 @@ type SlackStreamingAdapter = {
 }
 
 type SlackStreamPayload = { [key: string]: unknown }
+const SLACK_MAX_BLOCKS = 50
+const SLACK_SECTION_TEXT_MAX_CHARS = 3000
 
 type SlackStreamingClient = {
   chatStream(input: SlackStreamPayload): SlackStreamer
@@ -405,13 +407,49 @@ function patchSlackAdapterStreaming(adapter: unknown, botToken: string, logger: 
 
     renderer.finish()
     const finalCommittable = renderer.getCommittableText()
-    await flushMarkdownDelta(finalCommittable.slice(lastAppended.length))
-    const result = await streamer.stop(options.stopBlocks ? { blocks: options.stopBlocks } : undefined)
+    const finalDelta = finalCommittable.slice(lastAppended.length)
+    await flushMarkdownDelta(finalDelta)
+    lastAppended = finalCommittable
+    const stopPayload: SlackStreamPayload = {}
+    const stopBlocks =
+      options.stopBlocks && finalCommittable.trim()
+        ? appendFinalMarkdownBlocks(options.stopBlocks, finalCommittable)
+        : options.stopBlocks
+    if (stopBlocks) {
+      stopPayload.blocks = stopBlocks
+    }
+    const result = await streamer.stop(Object.keys(stopPayload).length ? stopPayload : undefined)
     const messageTs = result.message?.ts ?? result.ts
     if (!messageTs) throw new Error('Slack stream completed without a message timestamp')
     logger.debug('Slack: token-bound stream complete', { messageId: messageTs })
     return { id: messageTs, threadId, raw: result }
   }
+}
+
+function appendFinalMarkdownBlocks(blocks: unknown[], markdown: string): unknown[] {
+  const finalBlocks = markdownSectionBlocks(markdown)
+  const available = Math.max(0, SLACK_MAX_BLOCKS - finalBlocks.length)
+  return [...blocks.slice(0, available), ...finalBlocks]
+}
+
+function markdownSectionBlocks(markdown: string): unknown[] {
+  const text = markdown.trim()
+  if (!text) return []
+
+  const blocks: unknown[] = []
+  let remaining = text
+  while (remaining && blocks.length < SLACK_MAX_BLOCKS) {
+    const chunk = remaining.slice(0, SLACK_SECTION_TEXT_MAX_CHARS)
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: chunk
+      }
+    })
+    remaining = remaining.slice(chunk.length)
+  }
+  return blocks
 }
 
 async function setAssistantStatus(thread: Thread, status: string): Promise<void> {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1475,7 +1475,13 @@ function expectSlackPlanStreamShape(
     expect(transcript.stop.body.recipient_user_id).toBeUndefined()
     expect(transcript.stop.body.recipient_team_id).toBeUndefined()
     expect(transcript.stop.body.task_display_mode).toBeUndefined()
-    expect(transcript.stop.body.markdown_text).toBeUndefined()
+    const stopFinalText = [
+      stringField(transcript.stop.body.markdown_text),
+      blocksText(transcript.stop.body.blocks)
+    ]
+      .filter(Boolean)
+      .join('\n')
+    if (stopFinalText) expect(stopFinalText).toContain(answer)
 
     expect(markdownChunks).toEqual([{ type: 'markdown_text', text: answer }])
     expect(markdownText).toBe(answer)
@@ -1603,6 +1609,20 @@ function chunkText(chunk: Record<string, unknown>): string {
 function chunksText(value: unknown): string {
   return streamChunks(value)
     .map(chunkText)
+    .filter(Boolean)
+    .join('\n')
+}
+
+function blocksText(value: unknown): string {
+  if (!Array.isArray(value)) return ''
+  return value
+    .map(block => {
+      if (!block || typeof block !== 'object' || Array.isArray(block)) return ''
+      const text = (block as Record<string, unknown>).text
+      if (typeof text === 'string') return text
+      if (!text || typeof text !== 'object' || Array.isArray(text)) return ''
+      return stringField((text as Record<string, unknown>).text)
+    })
     .filter(Boolean)
     .join('\n')
 }


### PR DESCRIPTION
## Summary
- append final assistant markdown to Slack stop blocks when plan stop blocks are present, so finalized Slack messages cannot end as plan-only
- sanitize binary/control-heavy command output before rendering task output blocks
- cover binary command output and Slack stream finalization behavior in tests

## Tests
- bun test packages/rendering/src
- bun test services/slackbotv2/test/chat-sdk-emulate.test.ts
- pnpm --filter @centaur/rendering typecheck
- pnpm --filter slackbotv2 check:types