### PR TITLE
[codex] pass sandbox tool paths and package tool CLIs

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -14,12 +14,15 @@ use centaur_iron_proxy::{
     load_fragment_files,
 };
 use centaur_sandbox_agent_k8s::{AgentSandboxBackend, AgentSandboxConfig, IronProxyConfig};
+use centaur_sandbox_core::{Mount, MountKind};
 use centaur_sandbox_local::LocalSandboxBackend;
 use centaur_session_core::HarnessType;
 use centaur_session_runtime::SandboxWorkloadMode;
 use clap::{Args as ClapArgs, Parser, ValueEnum};
 
 use crate::ServerError;
+
+const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
 
 #[derive(Debug, Parser)]
 #[command(about = "Run the Centaur API Rust session control plane")]
@@ -103,6 +106,8 @@ struct SandboxArgs {
     centaur_api_url_override: Option<String>,
     #[arg(long, env = "CENTAUR_API_URL")]
     centaur_api_url: Option<String>,
+    #[arg(long = "repos-path", env = "REPOS_PATH")]
+    repos_path: Option<String>,
     #[arg(
         long = "session-sandbox-passthrough-env",
         env = "SESSION_SANDBOX_PASSTHROUGH_ENV",
@@ -167,7 +172,22 @@ impl SandboxArgs {
         match self.workload {
             SandboxWorkloadKind::Mock => SandboxWorkloadMode::mock_app_server(image),
             SandboxWorkloadKind::CodexAppServer => {
-                SandboxWorkloadMode::codex_app_server(image, self.codex_app_server_env_template())
+                let mut workload = SandboxWorkloadMode::codex_app_server(
+                    image,
+                    self.codex_app_server_env_template(),
+                );
+                if let Some(repos_path) = clean_optional_value(self.repos_path.as_deref()) {
+                    workload = workload.mount(
+                        Mount::new(
+                            MountKind::Bind {
+                                source_path: repos_path,
+                            },
+                            SANDBOX_REPOS_MOUNT_PATH,
+                        )
+                        .read_only(),
+                    );
+                }
+                workload
             }
         }
     }
@@ -570,6 +590,13 @@ fn parse_host_port(value: &str) -> Option<u16> {
     value.rsplit_once(':')?.1.parse().ok()
 }
 
+fn clean_optional_value(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn parse_label_selector_arg(value: &str) -> Result<BTreeMap<String, String>, String> {
     let mut labels = BTreeMap::new();
     for item in value
@@ -689,6 +716,34 @@ mod tests {
                 "http://host.docker.internal:8080".to_owned()
             )]
         );
+    }
+
+    #[test]
+    fn codex_workload_mounts_repos_path_read_only() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-workload",
+            "codex-app-server",
+            "--repos-path",
+            "/var/lib/centaur/repos",
+        ])
+        .unwrap();
+
+        let workload = args.sandbox.container_workload_mode();
+        let SandboxWorkloadMode::CodexAppServer { mounts, .. } = workload else {
+            panic!("expected codex app server workload");
+        };
+
+        assert!(mounts.iter().any(|mount| {
+            mount.target_path == SANDBOX_REPOS_MOUNT_PATH
+                && mount.read_only
+                && mount.kind
+                    == (MountKind::Bind {
+                        source_path: "/var/lib/centaur/repos".to_owned(),
+                    })
+        }));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use centaur_sandbox_core::{
-    SandboxBackend, SandboxError, SandboxId, SandboxIoGuard, SandboxRead, SandboxSpec,
+    Mount, SandboxBackend, SandboxError, SandboxId, SandboxIoGuard, SandboxRead, SandboxSpec,
     SandboxStatus, SandboxWrite,
 };
 use centaur_sandbox_manager::SandboxManager;
@@ -55,6 +55,7 @@ pub enum SandboxWorkloadMode {
     CodexAppServer {
         image: String,
         env: Vec<(String, String)>,
+        mounts: Vec<Mount>,
     },
 }
 
@@ -355,7 +356,16 @@ impl SandboxWorkloadMode {
         Self::CodexAppServer {
             image: image.into(),
             env: env.into_iter().collect(),
+            mounts: Vec::new(),
         }
+    }
+
+    pub fn mount(mut self, mount: Mount) -> Self {
+        match &mut self {
+            Self::MockAppServer { .. } => {}
+            Self::CodexAppServer { mounts, .. } => mounts.push(mount),
+        }
+        self
     }
 
     fn spec(&self, thread_key: &ThreadKey) -> SandboxSpec {
@@ -363,9 +373,12 @@ impl SandboxWorkloadMode {
             Self::MockAppServer { image } => SandboxSpec::new(image)
                 .command(["/bin/sh", "-lc"])
                 .args([mock_app_server_script()]),
-            Self::CodexAppServer { image, env } => {
+            Self::CodexAppServer { image, env, mounts } => {
                 let mut spec =
                     SandboxSpec::new(image).env("CENTAUR_THREAD_KEY", thread_key.as_str());
+                for mount in mounts {
+                    spec = spec.mount(mount.clone());
+                }
                 for (name, value) in env {
                     spec = spec.env(name.clone(), value.clone());
                 }
@@ -573,6 +586,42 @@ fn nonzero_duration_millis(value: u64) -> Result<Duration, SessionRuntimeError> 
         ));
     }
     Ok(Duration::from_millis(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use centaur_sandbox_core::MountKind;
+
+    #[test]
+    fn codex_workload_applies_mounts_to_sandbox_spec() {
+        let workload = SandboxWorkloadMode::codex_app_server(
+            "centaur-agent:latest",
+            [("CENTAUR_API_URL".to_owned(), "http://api:8000".to_owned())],
+        )
+        .mount(
+            Mount::new(
+                MountKind::Bind {
+                    source_path: "/host/github".to_owned(),
+                },
+                "/home/agent/github",
+            )
+            .read_only(),
+        );
+        let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+
+        let spec = workload.spec(&thread_key);
+
+        assert_eq!(spec.mounts.len(), 1);
+        assert_eq!(spec.mounts[0].target_path, "/home/agent/github");
+        assert!(spec.mounts[0].read_only);
+        assert_eq!(
+            spec.mounts[0].kind,
+            MountKind::Bind {
+                source_path: "/host/github".to_owned(),
+            }
+        );
+    }
 }
 
 #[derive(Debug, Error)]

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -5,6 +5,23 @@ HOME_DIR="$(eval echo ~)"
 FIREWALL_HOSTNAME="${FIREWALL_HOST:-firewall}"
 STATE_DIR="${CENTAUR_STATE_DIR:-$HOME_DIR/state}"
 
+append_tool_dirs() {
+    if [ -z "${1:-}" ]; then
+        return
+    fi
+    if [ -n "${TOOL_DIRS:-}" ]; then
+        TOOL_DIRS="${TOOL_DIRS}:$1"
+    else
+        TOOL_DIRS="$1"
+    fi
+}
+
+append_tool_dirs "${TOOLS_PATH:-}"
+append_tool_dirs "${TOOLS_OVERLAY_PATH:-}"
+if [ -n "${TOOL_DIRS:-}" ]; then
+    export TOOL_DIRS
+fi
+
 if [ -d "$STATE_DIR" ] && [ -w "$STATE_DIR" ]; then
     mkdir -p "$STATE_DIR/workspace" "$STATE_DIR/uploads" "$STATE_DIR/branches" "$STATE_DIR/codex" "$STATE_DIR/claude"
     rm -rf "$HOME_DIR/.codex" "$HOME_DIR/.claude" "$HOME_DIR/uploads" "$HOME_DIR/branches"
@@ -201,26 +218,6 @@ if [ -d "$WS_SKILLS" ]; then
     rm -rf "$WORKSPACE_DIR/.claude/skills"
     ln -sf "$WS_SKILLS" "$WORKSPACE_DIR/.claude/skills"
 fi
-
-_add_pythonpath_entry() {
-    local entry="$1"
-    [ -d "$entry" ] || return 0
-    case ":${PYTHONPATH:-}:" in
-        *":$entry:"*) ;;
-        *) export PYTHONPATH="$entry${PYTHONPATH:+:$PYTHONPATH}" ;;
-    esac
-}
-
-# Tool CLIs can run in subprocess venvs from `centaur-tools`; keep the local
-# Centaur SDK importable without requiring it to be published to PyPI.
-_add_pythonpath_entry "/opt/centaur"
-_add_pythonpath_entry "$HOME_DIR/github"
-_add_pythonpath_entry "$HOME_DIR/github/centaur"
-_add_pythonpath_entry "$WORKSPACE_DIR"
-if [ -n "${CENTAUR_OVERLAY_DIR:-}" ]; then
-    _add_pythonpath_entry "$CENTAUR_OVERLAY_DIR"
-fi
-unset -f _add_pythonpath_entry
 
 # ── Assemble system prompt from bind mounts ──────────────────────────────────
 # Base prompt: mounted as AGENTS_BASE.md when present, fallback to baked-in AGENTS.md.

--- a/tools/README.md
+++ b/tools/README.md
@@ -45,3 +45,26 @@ Use `secret("KEY")` to access. Never use `os.environ` — tool secrets are scope
 The open-source tool inventory lives in this `tools/` tree and changes over time. To see what ships in the current repo, inspect the directories here or run Centaur and call `call tools` from a sandbox session.
 
 Private deployments may mount additional overlay tool directories, so a running Centaur instance can expose more tools than are present in this repo.
+
+## Sandbox Tool Paths
+
+Sandbox startup accepts `TOOLS_PATH` and `TOOLS_OVERLAY_PATH` and appends them to
+`TOOL_DIRS` for `centaur-tools` discovery. Pass them from the API process with
+`SESSION_SANDBOX_PASSTHROUGH_ENV=TOOLS_PATH,TOOLS_OVERLAY_PATH`.
+
+`TOOLS_PATH` should point at the base mounted tool directory. `TOOLS_OVERLAY_PATH`
+is appended after it so overlay tools can replace base tools with the same name.
+
+For repo-cache overlays, set `REPOS_PATH` on the API process to the host path
+where the repo-cache syncs repositories. The sandbox mounts that path read-only
+at `/home/agent/github`, so overlay tools can come from the cached repo:
+
+```bash
+REPOS_PATH=/var/lib/centaur/repos
+TOOLS_PATH=/home/agent/github/paradigmxyz/centaur/tools
+TOOLS_OVERLAY_PATH=/home/agent/github/acme/centaur-overlay/tools
+SESSION_SANDBOX_PASSTHROUGH_ENV=TOOLS_PATH,TOOLS_OVERLAY_PATH
+```
+
+The repo-cache is responsible for syncing `acme/centaur-overlay`; sandbox
+startup only points `centaur-tools` at the already-mounted source tree.

--- a/tools/business/ashby/pyproject.toml
+++ b/tools/business/ashby/pyproject.toml
@@ -11,6 +11,15 @@ dependencies = [
     "pypdf>=6.6.0",
 ]
 
+[project.scripts]
+ashby = "centaur_tool_ashby.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_ashby"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/business/attio/pyproject.toml
+++ b/tools/business/attio/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-attio = "attio.cli:app"
+attio = "centaur_tool_attio.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_attio"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/business/pylon/pyproject.toml
+++ b/tools/business/pylon/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+pylon = "centaur_tool_pylon.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_pylon"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/comms/telegram/pyproject.toml
+++ b/tools/comms/telegram/pyproject.toml
@@ -11,6 +11,15 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+telegram = "centaur_tool_telegram.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_telegram"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/comms/twitter/pyproject.toml
+++ b/tools/comms/twitter/pyproject.toml
@@ -13,6 +13,15 @@ dependencies = [
     "pydantic-settings>=2.0.0",
 ]
 
+[project.scripts]
+twitter = "centaur_tool_twitter.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_twitter"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/crypto/alchemy/pyproject.toml
+++ b/tools/crypto/alchemy/pyproject.toml
@@ -9,6 +9,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+alchemy = "centaur_tool_alchemy.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_alchemy"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/crypto/allium/pyproject.toml
+++ b/tools/crypto/allium/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-allium = "allium.cli:app"
+allium = "centaur_tool_allium.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_allium"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/arkham/pyproject.toml
+++ b/tools/crypto/arkham/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+arkham = "centaur_tool_arkham.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_arkham"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/crypto/coindesk/pyproject.toml
+++ b/tools/crypto/coindesk/pyproject.toml
@@ -11,6 +11,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+coindesk = "centaur_tool_coindesk.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_coindesk"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/crypto/coingecko/pyproject.toml
+++ b/tools/crypto/coingecko/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-coingecko = "coingecko.cli:app"
+coingecko = "centaur_tool_coingecko.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_coingecko"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/coinmetrics/pyproject.toml
+++ b/tools/crypto/coinmetrics/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-coinmetrics = "coinmetrics.cli:app"
+coinmetrics = "centaur_tool_coinmetrics.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_coinmetrics"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/databento/pyproject.toml
+++ b/tools/crypto/databento/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-databento = "databento.cli:app"
+databento = "centaur_tool_databento.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_databento"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/debank/pyproject.toml
+++ b/tools/crypto/debank/pyproject.toml
@@ -9,6 +9,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+debank = "centaur_tool_debank.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_debank"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/crypto/defillama/pyproject.toml
+++ b/tools/crypto/defillama/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-defillama = "defillama.cli:app"
+defillama = "centaur_tool_defillama.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_defillama"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/dune/pyproject.toml
+++ b/tools/crypto/dune/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-dune = "dune.cli:app"
+dune = "centaur_tool_dune.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_dune"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/eodhd/pyproject.toml
+++ b/tools/crypto/eodhd/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-eodhd = "eodhd.cli:app"
+eodhd = "centaur_tool_eodhd.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_eodhd"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/kalshi/pyproject.toml
+++ b/tools/crypto/kalshi/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-kalshi = "kalshi.cli:app"
+kalshi = "centaur_tool_kalshi.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_kalshi"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/messari/pyproject.toml
+++ b/tools/crypto/messari/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-messari = "messari.cli:app"
+messari = "centaur_tool_messari.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_messari"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/nansen/pyproject.toml
+++ b/tools/crypto/nansen/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-nansen = "nansen.cli:app"
+nansen = "centaur_tool_nansen.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_nansen"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/polymarket/pyproject.toml
+++ b/tools/crypto/polymarket/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-polymarket = "polymarket.cli:app"
+polymarket = "centaur_tool_polymarket.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_polymarket"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/crypto/standard-metrics/pyproject.toml
+++ b/tools/crypto/standard-metrics/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+standard-metrics = "centaur_tool_standard_metrics.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_standard_metrics"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/crypto/theblock/pyproject.toml
+++ b/tools/crypto/theblock/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+theblock = "centaur_tool_theblock.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_theblock"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/infra/grafana/pyproject.toml
+++ b/tools/infra/grafana/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-grafana = "grafana.cli:app"
+grafana = "centaur_tool_grafana.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_grafana"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/infra/posthog/pyproject.toml
+++ b/tools/infra/posthog/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-posthog = "posthog.cli:app"
+posthog = "centaur_tool_posthog.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_posthog"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/infra/profslice/pyproject.toml
+++ b/tools/infra/profslice/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+profslice = "centaur_tool_profslice.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_profslice"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/infra/reth-log-analyzer/pyproject.toml
+++ b/tools/infra/reth-log-analyzer/pyproject.toml
@@ -11,6 +11,15 @@ dependencies = [
     "matplotlib>=3.7.0",
 ]
 
+[project.scripts]
+reth-log-analyzer = "centaur_tool_reth_log_analyzer.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_reth_log_analyzer"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/infra/reth/pyproject.toml
+++ b/tools/infra/reth/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+reth = "centaur_tool_reth.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_reth"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/infra/vlogs/pyproject.toml
+++ b/tools/infra/vlogs/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-vlogs = "vlogs.cli:app"
+vlogs = "centaur_tool_vlogs.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_vlogs"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/media/nano-banana/pyproject.toml
+++ b/tools/media/nano-banana/pyproject.toml
@@ -12,6 +12,15 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+nano-banana = "centaur_tool_nano_banana.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_nano_banana"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/media/transcriber/pyproject.toml
+++ b/tools/media/transcriber/pyproject.toml
@@ -9,6 +9,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+transcriber = "centaur_tool_transcriber.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_transcriber"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/media/veo3/pyproject.toml
+++ b/tools/media/veo3/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+veo3 = "centaur_tool_veo3.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_veo3"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/productivity/airtable/pyproject.toml
+++ b/tools/productivity/airtable/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-airtable = "airtable.cli:app"
+airtable = "centaur_tool_airtable.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_airtable"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/productivity/figma/pyproject.toml
+++ b/tools/productivity/figma/pyproject.toml
@@ -9,6 +9,15 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+figma = "centaur_tool_figma.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_figma"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/productivity/granola/pyproject.toml
+++ b/tools/productivity/granola/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+granola = "centaur_tool_granola.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_granola"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/productivity/gsuite/pyproject.toml
+++ b/tools/productivity/gsuite/pyproject.toml
@@ -19,7 +19,13 @@ dependencies = [
 ]
 
 [project.scripts]
-gsuite = "gsuite.cli:app"
+gsuite = "centaur_tool_gsuite.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_gsuite"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/productivity/linear/pyproject.toml
+++ b/tools/productivity/linear/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-linear = "linear.cli:app"
+linear = "centaur_tool_linear.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_linear"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/productivity/notion/pyproject.toml
+++ b/tools/productivity/notion/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-notion = "notion.cli:app"
+notion = "centaur_tool_notion.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_notion"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/productivity/opentable/pyproject.toml
+++ b/tools/productivity/opentable/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+opentable = "centaur_tool_opentable.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_opentable"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.scripts]
-slack = "slack.cli:app"
+slack = "centaur_tool_slack.cli:app"
 
 [build-system]
 requires = ["hatchling"]
@@ -22,6 +22,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["."]
 
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_slack"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/research/archiver/pyproject.toml
+++ b/tools/research/archiver/pyproject.toml
@@ -13,6 +13,15 @@ dependencies = [
     "requests>=2.32.5",
 ]
 
+[project.scripts]
+archiver = "centaur_tool_archiver.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_archiver"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/congress/pyproject.toml
+++ b/tools/research/congress/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+congress = "centaur_tool_congress.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_congress"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/crunchbase/pyproject.toml
+++ b/tools/research/crunchbase/pyproject.toml
@@ -9,6 +9,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+crunchbase = "centaur_tool_crunchbase.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_crunchbase"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/fedreg/pyproject.toml
+++ b/tools/research/fedreg/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+fedreg = "centaur_tool_fedreg.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_fedreg"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/googlenews/pyproject.toml
+++ b/tools/research/googlenews/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+googlenews = "centaur_tool_googlenews.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_googlenews"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/harmonic/pyproject.toml
+++ b/tools/research/harmonic/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+harmonic = "centaur_tool_harmonic.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_harmonic"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/legistorm/pyproject.toml
+++ b/tools/research/legistorm/pyproject.toml
@@ -9,6 +9,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+legistorm = "centaur_tool_legistorm.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_legistorm"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/listennotes/pyproject.toml
+++ b/tools/research/listennotes/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+listennotes = "centaur_tool_listennotes.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_listennotes"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/newsapi/pyproject.toml
+++ b/tools/research/newsapi/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+newsapi = "centaur_tool_newsapi.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_newsapi"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/openfec/pyproject.toml
+++ b/tools/research/openfec/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+openfec = "centaur_tool_openfec.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_openfec"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/plural/pyproject.toml
+++ b/tools/research/plural/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+plural = "centaur_tool_plural.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_plural"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/sensortower/pyproject.toml
+++ b/tools/research/sensortower/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "rich>=13.0.0",
 ]
 
+[project.scripts]
+sensortower = "centaur_tool_sensortower.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_sensortower"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/similarweb/pyproject.toml
+++ b/tools/research/similarweb/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [project.scripts]
-similarweb = "similarweb.cli:app"
+similarweb = "centaur_tool_similarweb.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_similarweb"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/research/websearch/pyproject.toml
+++ b/tools/research/websearch/pyproject.toml
@@ -13,6 +13,15 @@ dependencies = [
     "typer>=0.12.0",
 ]
 
+[project.scripts]
+websearch = "centaur_tool_websearch.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_websearch"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/youtube/pyproject.toml
+++ b/tools/research/youtube/pyproject.toml
@@ -10,6 +10,15 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+youtube = "centaur_tool_youtube.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_youtube"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary

- Sandbox startup appends `TOOLS_PATH` and `TOOLS_OVERLAY_PATH` to `TOOL_DIRS` for `centaur-tools` discovery.
- `TOOLS_OVERLAY_PATH` is appended after `TOOLS_PATH`, so overlay tools can replace base tools with the same name.
- Repo-cache overlays use API `REPOS_PATH` mounted read-only at `/home/agent/github`; point `TOOLS_OVERLAY_PATH` at `/home/agent/github/<org>/<overlay-repo>/tools`.
- Operators can pass tool path env from the API process with `SESSION_SANDBOX_PASSTHROUGH_ENV=TOOLS_PATH,TOOLS_OVERLAY_PATH`.
- Python tool `pyproject.toml` files use collision-safe `centaur_tool_*` module names plus hatch source mapping for package/console-script correctness.
- Adds api-rs regression coverage for the `REPOS_PATH` sandbox mount and runtime mount propagation.

## Validation

- `git diff --check`
- `bash -n services/sandbox/entrypoint.sh`
- `cargo test -p centaur-api-server codex_workload_mounts_repos_path_read_only`
- `cargo test -p centaur-session-runtime codex_workload_applies_mounts_to_sandbox_spec`
- parsed 54 changed tool `pyproject.toml` files with Python `tomllib`
