### PR TITLE
Make Rust API rollouts zero-downtime

### DIFF
--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -111,6 +111,12 @@ metadata:
 {{ include "centaur.componentLabels" (dict "root" . "component" "api") | nindent 4 }}
 spec:
   replicas: {{ .Values.api.replicaCount }}
+  minReadySeconds: {{ .Values.api.minReadySeconds }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.api.rollingUpdate.maxSurge | quote }}
+      maxUnavailable: {{ .Values.api.rollingUpdate.maxUnavailable | quote }}
   selector:
     matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api") | nindent 6 }}
@@ -233,6 +239,10 @@ spec:
               value: {{ ternary "1" "0" .Values.api.warmPoolEnabled | quote }}
             - name: PLUGIN_WATCHER_ENABLED
               value: {{ ternary "1" "0" .Values.api.pluginWatcherEnabled | quote }}
+{{- if not (hasKey $apiExtraEnv "SHUTDOWN_READINESS_DRAIN_DELAY_S") }}
+            - name: SHUTDOWN_READINESS_DRAIN_DELAY_S
+              value: {{ .Values.api.shutdownReadinessDrainDelaySeconds | quote }}
+{{- end }}
 {{- if not (hasKey $apiExtraEnv "SLACK_ETL_ENABLED") }}
             - name: SLACK_ETL_ENABLED
               value: {{ ternary "1" "0" .Values.api.slackEtlEnabled | quote }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -243,6 +243,10 @@ spec:
             - name: SHUTDOWN_READINESS_DRAIN_DELAY_S
               value: {{ .Values.api.shutdownReadinessDrainDelaySeconds | quote }}
 {{- end }}
+{{- if not (hasKey $apiExtraEnv "SHUTDOWN_SESSION_DRAIN_TIMEOUT_S") }}
+            - name: SHUTDOWN_SESSION_DRAIN_TIMEOUT_S
+              value: {{ .Values.api.shutdownSessionDrainTimeoutSeconds | quote }}
+{{- end }}
 {{- if not (hasKey $apiExtraEnv "SLACK_ETL_ENABLED") }}
             - name: SLACK_ETL_ENABLED
               value: {{ ternary "1" "0" .Values.api.slackEtlEnabled | quote }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -115,8 +115,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: {{ .Values.api.rollingUpdate.maxSurge | quote }}
-      maxUnavailable: {{ .Values.api.rollingUpdate.maxUnavailable | quote }}
+      maxSurge: {{ .Values.api.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.api.rollingUpdate.maxUnavailable }}
   selector:
     matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api") | nindent 6 }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -123,6 +123,7 @@ api:
     tailnetFqdnAnnotation: tailscale.com/tailnet-fqdn
   terminationGracePeriodSeconds: 600
   shutdownReadinessDrainDelaySeconds: 5
+  shutdownSessionDrainTimeoutSeconds: 540
   extraEnv: {}
   resources: {}
 

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -80,6 +80,10 @@ secrets:
 
 api:
   replicaCount: 1
+  minReadySeconds: 2
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
   image:
     repository: centaur-api
     tag: latest
@@ -109,15 +113,16 @@ api:
     periodSeconds: 10
     timeoutSeconds: 5
   readinessProbe:
-    failureThreshold: 6
-    periodSeconds: 10
-    timeoutSeconds: 5
+    failureThreshold: 1
+    periodSeconds: 2
+    timeoutSeconds: 1
   egressDiscovery:
     enabled: true
     namespace: centaur-egress
     clusterDomain: cluster.local
     tailnetFqdnAnnotation: tailscale.com/tailnet-fqdn
   terminationGracePeriodSeconds: 35
+  shutdownReadinessDrainDelaySeconds: 5
   extraEnv: {}
   resources: {}
 

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -121,7 +121,7 @@ api:
     namespace: centaur-egress
     clusterDomain: cluster.local
     tailnetFqdnAnnotation: tailscale.com/tailnet-fqdn
-  terminationGracePeriodSeconds: 35
+  terminationGracePeriodSeconds: 600
   shutdownReadinessDrainDelaySeconds: 5
   extraEnv: {}
   resources: {}

--- a/services/api-rs/Justfile
+++ b/services/api-rs/Justfile
@@ -10,10 +10,10 @@ agent_sandbox_generated := "crates/centaur-sandbox-agent-k8s/src/generated/agent
 agent_sandbox_controller_image := "registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.4.6"
 agent_sandbox_rbac_url := "https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/" + agent_sandbox_ref + "/k8s/rbac.generated.yaml"
 agent_sandbox_controller_url := "https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/" + agent_sandbox_ref + "/k8s/controller.yaml"
-kind_e2e_cluster := "centaur-api-rs-e2e"
-kind_e2e_context := "kind-" + kind_e2e_cluster
-kind_e2e_namespace := "centaur-sandbox-e2e"
-kind_e2e_tmp := "target/e2e"
+k3d_e2e_cluster := "centaur-api-rs-e2e"
+k3d_e2e_context := "k3d-" + k3d_e2e_cluster
+k3d_e2e_namespace := "centaur-sandbox-e2e"
+k3d_e2e_tmp := "target/e2e"
 
 default:
     just --list
@@ -28,28 +28,39 @@ codegen-agent-sandbox-crd:
     kopium --filename "{{agent_sandbox_crd_tmp}}" --api-version v1alpha1 --schema disabled --derive PartialEq > "{{agent_sandbox_generated}}"
     cargo fmt --all
 
-kind-e2e-up:
-    command -v kind >/dev/null || { echo "kind is required" >&2; exit 127; }
+k3d-e2e-up:
+    command -v k3d >/dev/null || { echo "k3d is required" >&2; exit 127; }
     command -v kubectl >/dev/null || { echo "kubectl is required" >&2; exit 127; }
-    kind get clusters | grep -qx "{{kind_e2e_cluster}}" || kind create cluster --name "{{kind_e2e_cluster}}" --wait 120s
-    if docker image inspect centaur-iron-proxy:latest >/dev/null 2>&1; then kind load docker-image --name "{{kind_e2e_cluster}}" centaur-iron-proxy:latest; fi
-    mkdir -p "{{kind_e2e_tmp}}"
-    curl -fsSL "{{agent_sandbox_crd_url}}" -o "{{kind_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
-    curl -fsSL "{{agent_sandbox_rbac_url}}" -o "{{kind_e2e_tmp}}/rbac.generated.yaml"
+    k3d cluster get "{{k3d_e2e_cluster}}" >/dev/null 2>&1 || k3d cluster create "{{k3d_e2e_cluster}}" --wait --timeout 120s
+    k3d kubeconfig merge "{{k3d_e2e_cluster}}" --kubeconfig-switch-context=false >/dev/null
+    kubectl --context "{{k3d_e2e_context}}" wait node --all --for=condition=Ready --timeout=120s
+    if docker image inspect centaur-iron-proxy:latest >/dev/null 2>&1; then k3d image import -c "{{k3d_e2e_cluster}}" centaur-iron-proxy:latest; fi
+    mkdir -p "{{k3d_e2e_tmp}}"
+    curl -fsSL "{{agent_sandbox_crd_url}}" -o "{{k3d_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
+    curl -fsSL "{{agent_sandbox_rbac_url}}" -o "{{k3d_e2e_tmp}}/rbac.generated.yaml"
     curl -fsSL "{{agent_sandbox_controller_url}}" \
       | sed 's#ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller.*#{{agent_sandbox_controller_image}}#' \
-      > "{{kind_e2e_tmp}}/controller.yaml"
-    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
-    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/rbac.generated.yaml"
-    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/controller.yaml"
-    kubectl --context "{{kind_e2e_context}}" create namespace "{{kind_e2e_namespace}}" --dry-run=client -o yaml | kubectl --context "{{kind_e2e_context}}" apply -f -
-    kubectl --context "{{kind_e2e_context}}" -n agent-sandbox-system rollout status deploy/agent-sandbox-controller --timeout=120s
+      > "{{k3d_e2e_tmp}}/controller.yaml"
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/rbac.generated.yaml"
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/controller.yaml"
+    kubectl --context "{{k3d_e2e_context}}" create namespace "{{k3d_e2e_namespace}}" --dry-run=client -o yaml | kubectl --context "{{k3d_e2e_context}}" apply -f -
+    kubectl --context "{{k3d_e2e_context}}" -n agent-sandbox-system rollout status deploy/agent-sandbox-controller --timeout=120s
 
-e2e-kind: kind-e2e-up
+e2e-k3d: k3d-e2e-up
     SANDBOX_E2E_IMPLS=all \
-    SANDBOX_E2E_K8S_CONTEXT="{{kind_e2e_context}}" \
-    SANDBOX_E2E_K8S_NAMESPACE="{{kind_e2e_namespace}}" \
+    SANDBOX_E2E_K8S_CONTEXT="{{k3d_e2e_context}}" \
+    SANDBOX_E2E_K8S_NAMESPACE="{{k3d_e2e_namespace}}" \
     cargo test -p centaur-sandbox-e2e -- --ignored --nocapture
 
-kind-e2e-down:
-    kind delete cluster --name "{{kind_e2e_cluster}}"
+k3d-e2e-down:
+    k3d cluster delete "{{k3d_e2e_cluster}}"
+
+kind-e2e-up: k3d-e2e-up
+    @echo "kind-e2e-up is deprecated; used k3d-e2e-up instead."
+
+e2e-kind: e2e-k3d
+    @echo "e2e-kind is deprecated; used e2e-k3d instead."
+
+kind-e2e-down: k3d-e2e-down
+    @echo "kind-e2e-down is deprecated; used k3d-e2e-down instead."

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -36,6 +36,7 @@ impl IntoResponse for ApiError {
             Self::Runtime(SessionRuntimeError::Store(SessionStoreError::HarnessConflict {
                 ..
             })) => StatusCode::CONFLICT,
+            Self::Runtime(SessionRuntimeError::PipeLeaseUnavailable { .. }) => StatusCode::CONFLICT,
             Self::Runtime(_) | Self::Serialize(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         let body = Json(json!({

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -5,7 +5,10 @@ pub mod types;
 
 pub use centaur_session_runtime::{SandboxRuntime, SessionRuntime};
 pub use error::ApiError;
-pub use routes::{build_router_with_runtime, build_router_with_session_runtime};
+pub use routes::{
+    ServerLifecycle, build_router_with_runtime, build_router_with_runtime_and_lifecycle,
+    build_router_with_session_runtime, build_router_with_session_runtime_and_lifecycle,
+};
 
 #[cfg(test)]
 mod tests {
@@ -23,7 +26,7 @@ mod tests {
     use centaur_session_sqlx::PgSessionStore;
     use sqlx::PgPool;
 
-    use super::build_router_with_runtime;
+    use super::{ServerLifecycle, build_router_with_runtime};
 
     #[tokio::test]
     async fn router_builds() {
@@ -33,6 +36,16 @@ mod tests {
             PgSessionStore::new(pool),
             SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
         );
+    }
+
+    #[test]
+    fn server_lifecycle_starts_ready_and_can_drain() {
+        let lifecycle = ServerLifecycle::new_ready();
+        assert!(lifecycle.is_ready());
+
+        lifecycle.mark_draining();
+
+        assert!(!lifecycle.is_ready());
     }
 
     #[derive(Default)]

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -14,7 +14,7 @@ use centaur_session_sqlx::PgSessionStore;
 use clap::{Parser, ValueEnum};
 use thiserror::Error;
 use tokio::net::TcpListener;
-use tracing::info;
+use tracing::{info, warn};
 use tracing_subscriber::{EnvFilter, fmt as tracing_fmt};
 
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
@@ -36,6 +36,7 @@ async fn main() -> Result<(), ServerError> {
         sandbox_runtime,
         session_runtime_options_from_args(&args),
     );
+    let shutdown_session_runtime = session_runtime.clone();
 
     let lifecycle = ServerLifecycle::new_ready();
     let listener = TcpListener::bind(args.bind_addr).await?;
@@ -48,6 +49,8 @@ async fn main() -> Result<(), ServerError> {
     .with_graceful_shutdown(shutdown_signal(
         lifecycle,
         Duration::from_secs(args.shutdown_readiness_drain_delay_s),
+        shutdown_session_runtime,
+        Duration::from_secs(args.shutdown_session_drain_timeout_s),
     ))
     .await?;
     Ok(())
@@ -58,7 +61,12 @@ fn init_tracing() {
     tracing_fmt().with_env_filter(filter).json().init();
 }
 
-async fn shutdown_signal(lifecycle: ServerLifecycle, drain_delay: Duration) {
+async fn shutdown_signal(
+    lifecycle: ServerLifecycle,
+    drain_delay: Duration,
+    session_runtime: SessionRuntime,
+    session_drain_timeout: Duration,
+) {
     let signal = wait_for_shutdown_signal().await;
     lifecycle.mark_draining();
     info!(
@@ -69,7 +77,29 @@ async fn shutdown_signal(lifecycle: ServerLifecycle, drain_delay: Duration) {
     if !drain_delay.is_zero() {
         tokio::time::sleep(drain_delay).await;
     }
-    info!("readiness drain complete; stopping listener");
+
+    let active_inputs = session_runtime.active_input_count().await;
+    if active_inputs > 0 {
+        let active_pipes = session_runtime.active_pipe_count().await;
+        info!(
+            active_inputs,
+            active_pipes,
+            timeout_ms = session_drain_timeout.as_millis(),
+            "waiting for active session inputs to drain before shutdown"
+        );
+        if !session_runtime
+            .wait_for_no_active_inputs(session_drain_timeout)
+            .await
+        {
+            let active_inputs = session_runtime.active_input_count().await;
+            let active_pipes = session_runtime.active_pipe_count().await;
+            warn!(
+                active_inputs,
+                active_pipes, "session input drain timeout reached; stopping listener"
+            );
+        }
+    }
+    info!("shutdown drain complete; stopping listener");
 }
 
 async fn wait_for_shutdown_signal() -> &'static str {
@@ -196,6 +226,8 @@ struct Args {
     run_migrations: bool,
     #[arg(long, env = "SHUTDOWN_READINESS_DRAIN_DELAY_S", default_value_t = 5)]
     shutdown_readiness_drain_delay_s: u64,
+    #[arg(long, env = "SHUTDOWN_SESSION_DRAIN_TIMEOUT_S", default_value_t = 540)]
+    shutdown_session_drain_timeout_s: u64,
     #[arg(
         long,
         env = "SESSION_PIPE_LEASE_TTL_S",

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -1,6 +1,8 @@
 use std::{collections::BTreeMap, env, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
-use centaur_api_server::{SandboxRuntime, build_router_with_runtime};
+use centaur_api_server::{
+    SandboxRuntime, ServerLifecycle, build_router_with_runtime_and_lifecycle,
+};
 use centaur_iron_proxy::{SourceKind, SourcePolicy, discover_fragment_files, load_fragment_files};
 use centaur_sandbox_agent_k8s::{
     AgentSandboxBackend, AgentSandboxConfig, IronProxyPodConfig, StateVolumeConfig,
@@ -30,12 +32,19 @@ async fn main() -> Result<(), ServerError> {
     }
     let sandbox_runtime = sandbox_runtime_from_args(&args).await?;
 
+    let lifecycle = ServerLifecycle::new_ready();
     let listener = TcpListener::bind(args.bind_addr).await?;
     info!(bind_addr = %args.bind_addr, "starting centaur api-rs server");
 
-    axum::serve(listener, build_router_with_runtime(store, sandbox_runtime))
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    axum::serve(
+        listener,
+        build_router_with_runtime_and_lifecycle(store, sandbox_runtime, lifecycle.clone()),
+    )
+    .with_graceful_shutdown(shutdown_signal(
+        lifecycle,
+        Duration::from_secs(args.shutdown_readiness_drain_delay_s),
+    ))
+    .await?;
     Ok(())
 }
 
@@ -44,8 +53,40 @@ fn init_tracing() {
     tracing_fmt().with_env_filter(filter).json().init();
 }
 
-async fn shutdown_signal() {
-    let _ = tokio::signal::ctrl_c().await;
+async fn shutdown_signal(lifecycle: ServerLifecycle, drain_delay: Duration) {
+    let signal = wait_for_shutdown_signal().await;
+    lifecycle.mark_draining();
+    info!(
+        signal,
+        drain_delay_ms = drain_delay.as_millis(),
+        "received shutdown signal; marking server unready before graceful shutdown"
+    );
+    if !drain_delay.is_zero() {
+        tokio::time::sleep(drain_delay).await;
+    }
+    info!("readiness drain complete; stopping listener");
+}
+
+async fn wait_for_shutdown_signal() -> &'static str {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+        "ctrl_c"
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        let mut signal = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler");
+        let _ = signal.recv().await;
+        "sigterm"
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<&'static str>();
+
+    tokio::select! {
+        signal = ctrl_c => signal,
+        signal = terminate => signal,
+    }
 }
 
 async fn sandbox_runtime_from_args(args: &Args) -> Result<SandboxRuntime, ServerError> {
@@ -127,6 +168,8 @@ struct Args {
     bind_addr: SocketAddr,
     #[arg(long, env = "RUN_MIGRATIONS", default_value_t = false)]
     run_migrations: bool,
+    #[arg(long, env = "SHUTDOWN_READINESS_DRAIN_DELAY_S", default_value_t = 5)]
+    shutdown_readiness_drain_delay_s: u64,
     #[arg(
         long,
         env = "KUBERNETES_SANDBOX_BACKEND",

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, env, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use centaur_api_server::{
-    SandboxRuntime, ServerLifecycle, build_router_with_runtime_and_lifecycle,
+    SandboxRuntime, ServerLifecycle, build_router_with_session_runtime_and_lifecycle,
 };
 use centaur_iron_proxy::{SourceKind, SourcePolicy, discover_fragment_files, load_fragment_files};
 use centaur_sandbox_agent_k8s::{
@@ -9,7 +9,7 @@ use centaur_sandbox_agent_k8s::{
 };
 use centaur_sandbox_core::{Mount, MountKind};
 use centaur_sandbox_local::LocalSandboxBackend;
-use centaur_session_runtime::SandboxWorkloadMode;
+use centaur_session_runtime::{SandboxWorkloadMode, SessionRuntime, SessionRuntimeOptions};
 use centaur_session_sqlx::PgSessionStore;
 use clap::{Parser, ValueEnum};
 use thiserror::Error;
@@ -31,6 +31,11 @@ async fn main() -> Result<(), ServerError> {
         store.run_migrations().await?;
     }
     let sandbox_runtime = sandbox_runtime_from_args(&args).await?;
+    let session_runtime = SessionRuntime::with_options(
+        store,
+        sandbox_runtime,
+        session_runtime_options_from_args(&args),
+    );
 
     let lifecycle = ServerLifecycle::new_ready();
     let listener = TcpListener::bind(args.bind_addr).await?;
@@ -38,7 +43,7 @@ async fn main() -> Result<(), ServerError> {
 
     axum::serve(
         listener,
-        build_router_with_runtime_and_lifecycle(store, sandbox_runtime, lifecycle.clone()),
+        build_router_with_session_runtime_and_lifecycle(session_runtime, lifecycle.clone()),
     )
     .with_graceful_shutdown(shutdown_signal(
         lifecycle,
@@ -118,7 +123,8 @@ async fn sandbox_runtime_from_args(args: &Args) -> Result<SandboxRuntime, Server
 
 fn local_workload_mode(args: &Args) -> Result<SandboxWorkloadMode, ServerError> {
     match args.kubernetes_sandbox_workload {
-        SandboxWorkloadKind::Mock => Ok(SandboxWorkloadMode::mock_app_server(
+        SandboxWorkloadKind::Mock => Ok(mock_workload_mode(
+            args,
             args.kubernetes_agent_image
                 .clone()
                 .unwrap_or_else(|| "local-mock-app-server".to_owned()),
@@ -139,7 +145,7 @@ fn container_workload_mode(args: &Args) -> SandboxWorkloadMode {
         .clone()
         .unwrap_or_else(|| default_sandbox_image(args.kubernetes_sandbox_workload).to_owned());
     match args.kubernetes_sandbox_workload {
-        SandboxWorkloadKind::Mock => SandboxWorkloadMode::mock_app_server(image),
+        SandboxWorkloadKind::Mock => mock_workload_mode(args, image),
         SandboxWorkloadKind::CodexAppServer => {
             let mut workload =
                 SandboxWorkloadMode::codex_app_server(image, codex_app_server_env_template(args));
@@ -159,6 +165,21 @@ fn container_workload_mode(args: &Args) -> SandboxWorkloadMode {
     }
 }
 
+fn mock_workload_mode(args: &Args, image: String) -> SandboxWorkloadMode {
+    SandboxWorkloadMode::mock_app_server_with_options(
+        image,
+        args.kubernetes_mock_turns_per_input,
+        args.kubernetes_mock_event_delay_ms,
+    )
+}
+
+fn session_runtime_options_from_args(args: &Args) -> SessionRuntimeOptions {
+    SessionRuntimeOptions {
+        pipe_lease_ttl: Duration::from_secs(args.session_pipe_lease_ttl_s),
+        pipe_lease_renew_interval: Duration::from_secs(args.session_pipe_lease_renew_interval_s),
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(about = "Run the Centaur API Rust control plane")]
 struct Args {
@@ -166,10 +187,29 @@ struct Args {
     database_url: String,
     #[arg(long, env = "BIND_ADDR", default_value = "127.0.0.1:8080")]
     bind_addr: SocketAddr,
-    #[arg(long, env = "RUN_MIGRATIONS", default_value_t = false)]
+    #[arg(
+        long,
+        env = "RUN_MIGRATIONS",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        default_value_t = false
+    )]
     run_migrations: bool,
     #[arg(long, env = "SHUTDOWN_READINESS_DRAIN_DELAY_S", default_value_t = 5)]
     shutdown_readiness_drain_delay_s: u64,
+    #[arg(
+        long,
+        env = "SESSION_PIPE_LEASE_TTL_S",
+        value_parser = clap::value_parser!(u64).range(1..),
+        default_value_t = 45
+    )]
+    session_pipe_lease_ttl_s: u64,
+    #[arg(
+        long,
+        env = "SESSION_PIPE_LEASE_RENEW_INTERVAL_S",
+        value_parser = clap::value_parser!(u64).range(1..),
+        default_value_t = 15
+    )]
+    session_pipe_lease_renew_interval_s: u64,
     #[arg(
         long,
         env = "KUBERNETES_SANDBOX_BACKEND",
@@ -202,6 +242,10 @@ struct Args {
     kubernetes_sandbox_image_pull_secrets: Vec<String>,
     #[arg(long, env = "KUBERNETES_SANDBOX_READY_TIMEOUT_S", default_value_t = 90)]
     kubernetes_sandbox_ready_timeout_s: u64,
+    #[arg(long, env = "KUBERNETES_MOCK_TURNS_PER_INPUT", default_value_t = 3)]
+    kubernetes_mock_turns_per_input: u32,
+    #[arg(long, env = "KUBERNETES_MOCK_EVENT_DELAY_MS", default_value_t = 200)]
+    kubernetes_mock_event_delay_ms: u64,
     #[arg(long, env = "KUBERNETES_CONTEXT")]
     kubernetes_context: Option<String>,
     #[arg(long, env = "KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME")]
@@ -211,6 +255,7 @@ struct Args {
     #[arg(
         long,
         env = "KUBERNETES_SANDBOX_STATE_VOLUME_ENABLED",
+        value_parser = clap::builder::BoolishValueParser::new(),
         default_value_t = false
     )]
     kubernetes_sandbox_state_volume_enabled: bool,

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -1,10 +1,17 @@
-use std::{convert::Infallible, convert::TryFrom};
+use std::{
+    convert::{Infallible, TryFrom},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
+    http::StatusCode,
     response::{
-        Sse,
+        IntoResponse, Response, Sse,
         sse::{Event, KeepAlive},
     },
     routing::{get, post},
@@ -26,24 +33,88 @@ use crate::{
 #[derive(Clone)]
 pub struct AppState {
     runtime: SessionRuntime,
+    lifecycle: ServerLifecycle,
+}
+
+#[derive(Clone, Debug)]
+pub struct ServerLifecycle {
+    ready: Arc<AtomicBool>,
+}
+
+impl ServerLifecycle {
+    pub fn new_ready() -> Self {
+        Self {
+            ready: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    pub fn mark_draining(&self) {
+        self.ready.store(false, Ordering::SeqCst);
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::SeqCst)
+    }
+}
+
+impl Default for ServerLifecycle {
+    fn default() -> Self {
+        Self::new_ready()
+    }
 }
 
 pub fn build_router_with_runtime(store: PgSessionStore, sandbox_runtime: SandboxRuntime) -> Router {
-    build_router_with_session_runtime(SessionRuntime::new(store, sandbox_runtime))
+    build_router_with_runtime_and_lifecycle(store, sandbox_runtime, ServerLifecycle::new_ready())
+}
+
+pub fn build_router_with_runtime_and_lifecycle(
+    store: PgSessionStore,
+    sandbox_runtime: SandboxRuntime,
+    lifecycle: ServerLifecycle,
+) -> Router {
+    build_router_with_session_runtime_and_lifecycle(
+        SessionRuntime::new(store, sandbox_runtime),
+        lifecycle,
+    )
 }
 
 pub fn build_router_with_session_runtime(runtime: SessionRuntime) -> Router {
+    build_router_with_session_runtime_and_lifecycle(runtime, ServerLifecycle::new_ready())
+}
+
+pub fn build_router_with_session_runtime_and_lifecycle(
+    runtime: SessionRuntime,
+    lifecycle: ServerLifecycle,
+) -> Router {
     Router::new()
+        .route("/health", get(healthz))
         .route("/healthz", get(healthz))
+        .route("/health/ready", get(readyz))
+        .route("/readyz", get(readyz))
         .route("/api/session/{thread_key}", post(create_or_get_session))
         .route("/api/session/{thread_key}/messages", post(append_messages))
         .route("/api/session/{thread_key}/execute", post(execute_session))
         .route("/api/session/{thread_key}/events", get(stream_events))
-        .with_state(AppState { runtime })
+        .with_state(AppState { runtime, lifecycle })
 }
 
 async fn healthz() -> Json<Value> {
     Json(json!({"ok": true}))
+}
+
+async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
+    readiness_response(&state.lifecycle)
+}
+
+fn readiness_response(lifecycle: &ServerLifecycle) -> Response {
+    if lifecycle.is_ready() {
+        return (StatusCode::OK, Json(json!({"ok": true}))).into_response();
+    }
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({"ok": false, "status": "draining"})),
+    )
+        .into_response()
 }
 
 async fn create_or_get_session(
@@ -121,4 +192,23 @@ async fn stream_events(
         Ok(sse)
     });
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ServerLifecycle, readiness_response};
+    use axum::http::StatusCode;
+
+    #[test]
+    fn readiness_response_reflects_draining_state() {
+        let lifecycle = ServerLifecycle::new_ready();
+        assert_eq!(readiness_response(&lifecycle).status(), StatusCode::OK);
+
+        lifecycle.mark_draining();
+
+        assert_eq!(
+            readiness_response(&lifecycle).status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
 }

--- a/services/api-rs/crates/centaur-sandbox-e2e/tests/failure.rs
+++ b/services/api-rs/crates/centaur-sandbox-e2e/tests/failure.rs
@@ -5,7 +5,7 @@ use test_case::test_case;
 #[test_case("local"; "local")]
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn failed_create_cleans_up_observed_resources(implementation_name: &'static str) {
     if let Some(implementation) = support::implementation_if_requested(implementation_name).await {
         support::failed_create_cleans_up_observed_resources(&implementation).await;

--- a/services/api-rs/crates/centaur-sandbox-e2e/tests/io.rs
+++ b/services/api-rs/crates/centaur-sandbox-e2e/tests/io.rs
@@ -5,7 +5,7 @@ use test_case::test_case;
 #[test_case("local"; "local")]
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn byte_io_round_trips(implementation_name: &'static str) {
     if let Some(implementation) = support::implementation_if_requested(implementation_name).await {
         support::byte_io_round_trips(&implementation).await;
@@ -15,7 +15,7 @@ async fn byte_io_round_trips(implementation_name: &'static str) {
 #[test_case("local"; "local")]
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn stdin_drop_closes_write_half(implementation_name: &'static str) {
     if let Some(implementation) = support::implementation_if_requested(implementation_name).await {
         support::stdin_drop_closes_write_half(&implementation).await;
@@ -25,7 +25,7 @@ async fn stdin_drop_closes_write_half(implementation_name: &'static str) {
 #[test_case("local"; "local")]
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn pause_blocks_read_write_until_resume(implementation_name: &'static str) {
     if let Some(implementation) = support::implementation_if_requested(implementation_name).await {
         support::pause_blocks_read_write_until_resume(&implementation).await;

--- a/services/api-rs/crates/centaur-sandbox-e2e/tests/lifecycle.rs
+++ b/services/api-rs/crates/centaur-sandbox-e2e/tests/lifecycle.rs
@@ -5,7 +5,7 @@ use test_case::test_case;
 #[test_case("local"; "local")]
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn create_stop_cleans_up(implementation_name: &'static str) {
     if let Some(implementation) = support::implementation_if_requested(implementation_name).await {
         support::create_stop_cleans_up(&implementation).await;
@@ -15,7 +15,7 @@ async fn create_stop_cleans_up(implementation_name: &'static str) {
 #[test_case("local"; "local")]
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn pause_resume_restores_running(implementation_name: &'static str) {
     if let Some(implementation) = support::implementation_if_requested(implementation_name).await {
         support::pause_resume_restores_running(&implementation).await;
@@ -25,7 +25,7 @@ async fn pause_resume_restores_running(implementation_name: &'static str) {
 #[test_case("local"; "local")]
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn unexpected_shutdown_reports_drift(implementation_name: &'static str) {
     if let Some(implementation) = support::implementation_if_requested(implementation_name).await {
         support::unexpected_shutdown_reports_drift(&implementation).await;
@@ -35,7 +35,7 @@ async fn unexpected_shutdown_reports_drift(implementation_name: &'static str) {
 #[test_case("local"; "local")]
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn missing_sandbox_operations_are_consistent(implementation_name: &'static str) {
     if let Some(implementation) = support::implementation_if_requested(implementation_name).await {
         support::missing_sandbox_operations_are_consistent(&implementation).await;

--- a/services/api-rs/crates/centaur-sandbox-e2e/tests/proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-e2e/tests/proxy.rs
@@ -4,7 +4,7 @@ use test_case::test_case;
 
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn env_secret_proxy_rewrites_https_request_before_receiver(
     implementation_name: &'static str,
 ) {

--- a/services/api-rs/crates/centaur-sandbox-e2e/tests/reconnect.rs
+++ b/services/api-rs/crates/centaur-sandbox-e2e/tests/reconnect.rs
@@ -5,7 +5,7 @@ use test_case::test_case;
 #[test_case("local"; "local")]
 #[test_case("agent-k8s"; "agent_k8s")]
 #[tokio::test]
-#[ignore = "requires sandbox e2e infrastructure; run `just e2e-kind`"]
+#[ignore = "requires sandbox e2e infrastructure; run `just e2e-k3d`"]
 async fn reconnect_can_observe_and_stop(implementation_name: &'static str) {
     if let Some(implementation) = support::implementation_if_requested(implementation_name).await {
         support::reconnect_can_observe_and_stop(&implementation).await;

--- a/services/api-rs/crates/centaur-sandbox-e2e/tests/support/mod.rs
+++ b/services/api-rs/crates/centaur-sandbox-e2e/tests/support/mod.rs
@@ -1070,7 +1070,7 @@ async fn agent_k8s_client_and_namespace(args: &E2eArgs) -> (Client, String) {
         .sandbox_e2e_k8s_context
         .clone()
         .or_else(|| args.kube_context.clone())
-        .unwrap_or_else(|| "kind-centaur-api-rs-e2e".to_owned());
+        .unwrap_or_else(|| "k3d-centaur-api-rs-e2e".to_owned());
     let namespace = args
         .sandbox_e2e_k8s_namespace
         .clone()

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, VecDeque},
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -24,7 +24,7 @@ use thiserror::Error;
 use tokio::{
     io,
     sync::Mutex,
-    time::{Instant, Interval, MissedTickBehavior, interval, interval_at, sleep},
+    time::{Instant, Interval, MissedTickBehavior, interval, interval_at, sleep, timeout},
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
 use tracing::warn;
@@ -93,6 +93,7 @@ impl Default for SessionRuntimeOptions {
 struct SessionPipe {
     stdin: Arc<Mutex<SessionInputSink>>,
     lease: Arc<PipeLeaseState>,
+    active_inputs: Arc<AtomicUsize>,
 }
 
 #[derive(Debug, Default)]
@@ -171,6 +172,36 @@ impl SessionRuntime {
             ));
         }
         Ok(self.store.append_messages(thread_key, messages).await?)
+    }
+
+    pub async fn active_pipe_count(&self) -> usize {
+        self.sandbox_pipes.lock().await.len()
+    }
+
+    pub async fn active_input_count(&self) -> usize {
+        self.sandbox_pipes
+            .lock()
+            .await
+            .values()
+            .map(|pipe| pipe.active_inputs.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub async fn wait_for_no_active_inputs(&self, wait_timeout: Duration) -> bool {
+        if wait_timeout.is_zero() {
+            return self.active_input_count().await == 0;
+        }
+
+        timeout(wait_timeout, async {
+            loop {
+                if self.active_input_count().await == 0 {
+                    return;
+                }
+                sleep(Duration::from_millis(250)).await;
+            }
+        })
+        .await
+        .is_ok()
     }
 
     pub async fn execute_session(
@@ -373,12 +404,14 @@ impl SessionRuntime {
             }
         };
         let lease = Arc::new(PipeLeaseState::default());
+        let active_inputs = Arc::new(AtomicUsize::new(0));
         let pipe = SessionPipe {
             stdin: Arc::new(Mutex::new(FramedWrite::new(
                 io.stdin,
                 LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
             ))),
             lease: lease.clone(),
+            active_inputs: active_inputs.clone(),
         };
 
         self.sandbox_pipes
@@ -422,6 +455,7 @@ impl SessionRuntime {
                 stdout,
                 guard,
                 lease.clone(),
+                active_inputs,
             )
             .await;
             if let Err(error) = result {
@@ -551,17 +585,17 @@ printf '%s\n' '{{"type":"system","subtype":"wrapper_heartbeat","phase":"app_serv
 sleep {delay_seconds}
 printf '%s\n' '{{"type":"thread.started","thread_id":"mock-codex-thread"}}'
 sleep {delay_seconds}
-turn_index=1
-while [ "$turn_index" -le {turns_per_input} ]; do
-  turn_id="mock-turn-$turn_index"
-  printf '{{"type":"turn.started","turn_id":"%s"}}\n' "$turn_id"
+turn_id="mock-turn-1"
+printf '{{"type":"turn.started","turn_id":"%s"}}\n' "$turn_id"
+sleep {delay_seconds}
+delta_index=1
+while [ "$delta_index" -le {turns_per_input} ]; do
+  printf '{{"type":"item.agentMessage.delta","turnId":"%s","session_id":"mock-codex-thread","delta":"PONG %s"}}\n' "$turn_id" "$delta_index"
   sleep {delay_seconds}
-  printf '{{"type":"item.agentMessage.delta","turnId":"%s","session_id":"mock-codex-thread","delta":"PONG %s"}}\n' "$turn_id" "$turn_index"
-  sleep {delay_seconds}
-  printf '{{"type":"turn.completed","turn":{{"id":"%s"}},"usage":{{"input_tokens":0,"output_tokens":1}}}}\n' "$turn_id"
-  sleep {delay_seconds}
-  turn_index=$((turn_index + 1))
+  delta_index=$((delta_index + 1))
 done
+printf '{{"type":"turn.completed","turn":{{"id":"%s"}},"usage":{{"input_tokens":0,"output_tokens":1}}}}\n' "$turn_id"
+sleep {delay_seconds}
 done"#
     )
 }
@@ -641,6 +675,7 @@ async fn run_stdout_pump(
     stdout: SandboxRead,
     _guard: SandboxIoGuard,
     lease: Arc<PipeLeaseState>,
+    active_inputs: Arc<AtomicUsize>,
 ) -> Result<(), SessionRuntimeError> {
     let mut stdout = FramedRead::new(
         stdout,
@@ -652,6 +687,9 @@ async fn run_stdout_pump(
             break;
         }
         append_output_line(&store, &thread_key, None, &line).await?;
+        if is_terminal_output_line(&line) {
+            mark_one_input_complete(&active_inputs);
+        }
     }
     store
         .append_event(
@@ -717,9 +755,29 @@ async fn write_input_lines(
 ) -> Result<(), SessionRuntimeError> {
     let mut stdin = pipe.stdin.lock().await;
     for line in input_lines {
-        stdin.send(line).await.map_err(codec_error_to_runtime)?;
+        pipe.active_inputs.fetch_add(1, Ordering::Relaxed);
+        if let Err(error) = stdin.send(line).await {
+            mark_one_input_complete(&pipe.active_inputs);
+            return Err(codec_error_to_runtime(error));
+        }
     }
     Ok(())
+}
+
+fn mark_one_input_complete(active_inputs: &AtomicUsize) {
+    let _ = active_inputs.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+        count.checked_sub(1)
+    });
+}
+
+fn is_terminal_output_line(line: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(line) else {
+        return false;
+    };
+    matches!(
+        value.get("type").and_then(Value::as_str),
+        Some("turn.completed" | "turn.done" | "result")
+    )
 }
 
 async fn append_output_line(

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1,7 +1,10 @@
 use std::{
     collections::{HashMap, VecDeque},
-    sync::Arc,
-    time::Duration,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use centaur_sandbox_core::{
@@ -21,7 +24,7 @@ use thiserror::Error;
 use tokio::{
     io,
     sync::Mutex,
-    time::{Instant, Interval, MissedTickBehavior, interval_at},
+    time::{Instant, Interval, MissedTickBehavior, interval, interval_at, sleep},
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
 use tracing::warn;
@@ -30,6 +33,8 @@ pub const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 
 const MAX_SESSION_OUTPUT_LINE_BYTES: usize = 1024 * 1024;
 const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
+const PIPE_LEASE_TTL: Duration = Duration::from_secs(45);
+const PIPE_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(15);
 
 type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
@@ -39,6 +44,7 @@ pub struct SessionRuntime {
     store: PgSessionStore,
     sandbox_runtime: SandboxRuntime,
     sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    pipe_owner_id: Arc<str>,
 }
 
 #[derive(Clone)]
@@ -70,6 +76,31 @@ pub struct ExecuteSessionInput {
 #[derive(Clone)]
 struct SessionPipe {
     stdin: Arc<Mutex<SessionInputSink>>,
+    lease: Arc<PipeLeaseState>,
+}
+
+#[derive(Debug, Default)]
+struct PipeLeaseState {
+    stop: AtomicBool,
+    lost: AtomicBool,
+}
+
+impl PipeLeaseState {
+    fn stop(&self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+
+    fn is_stopped(&self) -> bool {
+        self.stop.load(Ordering::Relaxed)
+    }
+
+    fn mark_lost(&self) {
+        self.lost.store(true, Ordering::Relaxed);
+    }
+
+    fn is_lost(&self) -> bool {
+        self.lost.load(Ordering::Relaxed)
+    }
 }
 
 struct EventStreamState {
@@ -88,6 +119,7 @@ impl SessionRuntime {
             store,
             sandbox_runtime,
             sandbox_pipes: Arc::new(Mutex::new(HashMap::new())),
+            pipe_owner_id: Arc::from(default_pipe_owner_id()),
         }
     }
 
@@ -213,7 +245,24 @@ impl SessionRuntime {
     > {
         let session = self.store.get_session(thread_key).await?;
         if let Some(sandbox_id) = session.sandbox_id.as_deref() {
-            self.ensure_session_pipe(thread_key, sandbox_id).await?;
+            match self.ensure_session_pipe(thread_key, sandbox_id).await {
+                Ok(_) => {}
+                Err(SessionRuntimeError::PipeLeaseUnavailable { sandbox_id }) => {
+                    warn!(%sandbox_id, "session pipe is owned by another api replica");
+                    let runtime = self.clone();
+                    let thread_key = thread_key.clone();
+                    tokio::spawn(async move {
+                        sleep(PIPE_LEASE_TTL).await;
+                        match runtime.ensure_session_pipe(&thread_key, &sandbox_id).await {
+                            Ok(_) | Err(SessionRuntimeError::PipeLeaseUnavailable { .. }) => {}
+                            Err(error) => {
+                                warn!(%sandbox_id, %error, "delayed session pipe reclaim failed");
+                            }
+                        }
+                    });
+                }
+                Err(error) => return Err(error),
+            }
         }
 
         let listener = self.store.listen_session_events().await?;
@@ -256,21 +305,49 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         sandbox_id: &str,
     ) -> Result<SessionPipe, SessionRuntimeError> {
-        if let Some(pipe) = self.sandbox_pipes.lock().await.get(sandbox_id).cloned() {
-            return Ok(pipe);
+        {
+            let mut pipes = self.sandbox_pipes.lock().await;
+            if let Some(pipe) = pipes.get(sandbox_id).cloned() {
+                if !pipe.lease.is_lost() {
+                    return Ok(pipe);
+                }
+                pipes.remove(sandbox_id);
+            }
         }
 
-        let io = self
+        let owner_id = self.pipe_owner_id.to_string();
+        let claimed = self
+            .store
+            .try_claim_pipe_lease(thread_key, sandbox_id, &owner_id, PIPE_LEASE_TTL)
+            .await?;
+        if !claimed {
+            return Err(SessionRuntimeError::PipeLeaseUnavailable {
+                sandbox_id: sandbox_id.to_owned(),
+            });
+        }
+
+        let io = match self
             .sandbox_runtime
             .manager
             .open_io(&SandboxId::new(sandbox_id))
-            .await?
-            .into_parts();
+            .await
+        {
+            Ok(io) => io.into_parts(),
+            Err(error) => {
+                let _ = self
+                    .store
+                    .release_pipe_lease(thread_key, sandbox_id, &owner_id)
+                    .await;
+                return Err(error.into());
+            }
+        };
+        let lease = Arc::new(PipeLeaseState::default());
         let pipe = SessionPipe {
             stdin: Arc::new(Mutex::new(FramedWrite::new(
                 io.stdin,
                 LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
             ))),
+            lease: lease.clone(),
         };
 
         self.sandbox_pipes
@@ -285,10 +362,33 @@ impl SessionRuntime {
         let stderr = io.stderr;
         let guard = io.guard;
         let stderr_key = pump_key.clone();
+        let renew_store = store.clone();
+        let renew_thread_key = thread_key.clone();
+        let renew_key = pump_key.clone();
+        let renew_owner_id = owner_id.clone();
+        let renew_lease = lease.clone();
 
         tokio::spawn(async move {
-            let result =
-                run_stdout_pump(store.clone(), thread_key.clone(), &pump_key, stdout, guard).await;
+            renew_pipe_lease_until_stopped(
+                renew_store,
+                renew_thread_key,
+                renew_key,
+                renew_owner_id,
+                renew_lease,
+            )
+            .await;
+        });
+
+        tokio::spawn(async move {
+            let result = run_stdout_pump(
+                store.clone(),
+                thread_key.clone(),
+                &pump_key,
+                stdout,
+                guard,
+                lease.clone(),
+            )
+            .await;
             if let Err(error) = result {
                 warn!(%pump_key, %error, "session stdout pump failed");
                 let _ = store
@@ -303,6 +403,10 @@ impl SessionRuntime {
                     )
                     .await;
             }
+            lease.stop();
+            let _ = store
+                .release_pipe_lease(&thread_key, &pump_key, &owner_id)
+                .await;
             sandbox_pipes.lock().await.remove(&pump_key);
         });
 
@@ -484,6 +588,7 @@ async fn run_stdout_pump(
     sandbox_id: &str,
     stdout: SandboxRead,
     _guard: SandboxIoGuard,
+    lease: Arc<PipeLeaseState>,
 ) -> Result<(), SessionRuntimeError> {
     let mut stdout = FramedRead::new(
         stdout,
@@ -491,6 +596,9 @@ async fn run_stdout_pump(
     );
     while let Some(line) = stdout.next().await {
         let line = line.map_err(codec_error_to_runtime)?;
+        if lease.is_lost() {
+            break;
+        }
         append_output_line(&store, &thread_key, None, &line).await?;
     }
     store
@@ -504,6 +612,40 @@ async fn run_stdout_pump(
         )
         .await?;
     Ok(())
+}
+
+async fn renew_pipe_lease_until_stopped(
+    store: PgSessionStore,
+    thread_key: ThreadKey,
+    sandbox_id: String,
+    owner_id: String,
+    lease: Arc<PipeLeaseState>,
+) {
+    let mut tick = interval(PIPE_LEASE_RENEW_INTERVAL);
+    tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    loop {
+        tick.tick().await;
+        if lease.is_stopped() {
+            return;
+        }
+        match store
+            .renew_pipe_lease(&thread_key, &sandbox_id, &owner_id, PIPE_LEASE_TTL)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                lease.mark_lost();
+                warn!(%sandbox_id, "session pipe lease was lost to another api replica");
+                return;
+            }
+            Err(error) => {
+                lease.mark_lost();
+                warn!(%sandbox_id, %error, "failed to renew session pipe lease");
+                return;
+            }
+        }
+    }
 }
 
 async fn drain_stderr(mut stderr: SandboxRead) -> Result<(), SessionRuntimeError> {
@@ -588,10 +730,21 @@ fn nonzero_duration_millis(value: u64) -> Result<Duration, SessionRuntimeError> 
     Ok(Duration::from_millis(value))
 }
 
+fn default_pipe_owner_id() -> String {
+    let host = std::env::var("HOSTNAME").unwrap_or_else(|_| "localhost".to_owned());
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{host}-{}-{nanos}", std::process::id())
+}
+
 #[derive(Debug, Error)]
 pub enum SessionRuntimeError {
     #[error("{0}")]
     BadRequest(String),
+    #[error("sandbox pipe {sandbox_id} is owned by another api replica; retry shortly")]
+    PipeLeaseUnavailable { sandbox_id: String },
     #[error(transparent)]
     Store(#[from] SessionStoreError),
     #[error(transparent)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -33,8 +33,6 @@ pub const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 
 const MAX_SESSION_OUTPUT_LINE_BYTES: usize = 1024 * 1024;
 const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
-const PIPE_LEASE_TTL: Duration = Duration::from_secs(45);
-const PIPE_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(15);
 
 type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
@@ -45,6 +43,7 @@ pub struct SessionRuntime {
     sandbox_runtime: SandboxRuntime,
     sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
     pipe_owner_id: Arc<str>,
+    options: SessionRuntimeOptions,
 }
 
 #[derive(Clone)]
@@ -57,6 +56,8 @@ pub struct SandboxRuntime {
 pub enum SandboxWorkloadMode {
     MockAppServer {
         image: String,
+        turns_per_input: u32,
+        event_delay_ms: u64,
     },
     CodexAppServer {
         image: String,
@@ -71,6 +72,21 @@ pub struct ExecuteSessionInput {
     pub input_lines: Vec<String>,
     pub idle_timeout_ms: Option<u64>,
     pub max_duration_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionRuntimeOptions {
+    pub pipe_lease_ttl: Duration,
+    pub pipe_lease_renew_interval: Duration,
+}
+
+impl Default for SessionRuntimeOptions {
+    fn default() -> Self {
+        Self {
+            pipe_lease_ttl: Duration::from_secs(45),
+            pipe_lease_renew_interval: Duration::from_secs(15),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -115,11 +131,20 @@ struct EventStreamState {
 
 impl SessionRuntime {
     pub fn new(store: PgSessionStore, sandbox_runtime: SandboxRuntime) -> Self {
+        Self::with_options(store, sandbox_runtime, SessionRuntimeOptions::default())
+    }
+
+    pub fn with_options(
+        store: PgSessionStore,
+        sandbox_runtime: SandboxRuntime,
+        options: SessionRuntimeOptions,
+    ) -> Self {
         Self {
             store,
             sandbox_runtime,
             sandbox_pipes: Arc::new(Mutex::new(HashMap::new())),
             pipe_owner_id: Arc::from(default_pipe_owner_id()),
+            options,
         }
     }
 
@@ -251,8 +276,9 @@ impl SessionRuntime {
                     warn!(%sandbox_id, "session pipe is owned by another api replica");
                     let runtime = self.clone();
                     let thread_key = thread_key.clone();
+                    let reclaim_delay = self.options.pipe_lease_ttl;
                     tokio::spawn(async move {
-                        sleep(PIPE_LEASE_TTL).await;
+                        sleep(reclaim_delay).await;
                         match runtime.ensure_session_pipe(&thread_key, &sandbox_id).await {
                             Ok(_) | Err(SessionRuntimeError::PipeLeaseUnavailable { .. }) => {}
                             Err(error) => {
@@ -318,7 +344,12 @@ impl SessionRuntime {
         let owner_id = self.pipe_owner_id.to_string();
         let claimed = self
             .store
-            .try_claim_pipe_lease(thread_key, sandbox_id, &owner_id, PIPE_LEASE_TTL)
+            .try_claim_pipe_lease(
+                thread_key,
+                sandbox_id,
+                &owner_id,
+                self.options.pipe_lease_ttl,
+            )
             .await?;
         if !claimed {
             return Err(SessionRuntimeError::PipeLeaseUnavailable {
@@ -367,6 +398,8 @@ impl SessionRuntime {
         let renew_key = pump_key.clone();
         let renew_owner_id = owner_id.clone();
         let renew_lease = lease.clone();
+        let lease_ttl = self.options.pipe_lease_ttl;
+        let renew_interval = self.options.pipe_lease_renew_interval;
 
         tokio::spawn(async move {
             renew_pipe_lease_until_stopped(
@@ -375,6 +408,8 @@ impl SessionRuntime {
                 renew_key,
                 renew_owner_id,
                 renew_lease,
+                lease_ttl,
+                renew_interval,
             )
             .await;
         });
@@ -448,8 +483,18 @@ impl SandboxRuntime {
 
 impl SandboxWorkloadMode {
     pub fn mock_app_server(image: impl Into<String>) -> Self {
+        Self::mock_app_server_with_options(image, 3, 200)
+    }
+
+    pub fn mock_app_server_with_options(
+        image: impl Into<String>,
+        turns_per_input: u32,
+        event_delay_ms: u64,
+    ) -> Self {
         Self::MockAppServer {
             image: image.into(),
+            turns_per_input,
+            event_delay_ms,
         }
     }
 
@@ -474,9 +519,13 @@ impl SandboxWorkloadMode {
 
     fn spec(&self, thread_key: &ThreadKey) -> SandboxSpec {
         match self {
-            Self::MockAppServer { image } => SandboxSpec::new(image)
+            Self::MockAppServer {
+                image,
+                turns_per_input,
+                event_delay_ms,
+            } => SandboxSpec::new(image)
                 .command(["/bin/sh", "-lc"])
-                .args([mock_app_server_script()]),
+                .args([mock_app_server_script(*turns_per_input, *event_delay_ms)]),
             Self::CodexAppServer { image, env, mounts } => {
                 let mut spec =
                     SandboxSpec::new(image).env("CENTAUR_THREAD_KEY", thread_key.as_str());
@@ -492,26 +541,29 @@ impl SandboxWorkloadMode {
     }
 }
 
-fn mock_app_server_script() -> &'static str {
-    r#"while IFS= read -r line; do
-printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"startup"}'
-sleep 0.2
-printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"app_server_started"}'
-sleep 0.2
-printf '%s\n' '{"type":"thread.started","thread_id":"mock-codex-thread"}'
-sleep 0.2
+fn mock_app_server_script(turns_per_input: u32, event_delay_ms: u64) -> String {
+    let delay_seconds = format!("{}.{:03}", event_delay_ms / 1_000, event_delay_ms % 1_000);
+    format!(
+        r#"while IFS= read -r line; do
+printf '%s\n' '{{"type":"system","subtype":"wrapper_heartbeat","phase":"startup"}}'
+sleep {delay_seconds}
+printf '%s\n' '{{"type":"system","subtype":"wrapper_heartbeat","phase":"app_server_started"}}'
+sleep {delay_seconds}
+printf '%s\n' '{{"type":"thread.started","thread_id":"mock-codex-thread"}}'
+sleep {delay_seconds}
 turn_index=1
-while [ "$turn_index" -le 3 ]; do
+while [ "$turn_index" -le {turns_per_input} ]; do
   turn_id="mock-turn-$turn_index"
-  printf '{"type":"turn.started","turn_id":"%s"}\n' "$turn_id"
-  sleep 0.2
-  printf '{"type":"item.agentMessage.delta","turnId":"%s","session_id":"mock-codex-thread","delta":"PONG %s"}\n' "$turn_id" "$turn_index"
-  sleep 0.2
-  printf '{"type":"turn.completed","turn":{"id":"%s"},"usage":{"input_tokens":0,"output_tokens":1}}\n' "$turn_id"
-  sleep 0.2
+  printf '{{"type":"turn.started","turn_id":"%s"}}\n' "$turn_id"
+  sleep {delay_seconds}
+  printf '{{"type":"item.agentMessage.delta","turnId":"%s","session_id":"mock-codex-thread","delta":"PONG %s"}}\n' "$turn_id" "$turn_index"
+  sleep {delay_seconds}
+  printf '{{"type":"turn.completed","turn":{{"id":"%s"}},"usage":{{"input_tokens":0,"output_tokens":1}}}}\n' "$turn_id"
+  sleep {delay_seconds}
   turn_index=$((turn_index + 1))
 done
 done"#
+    )
 }
 
 fn session_event_stream(
@@ -620,8 +672,10 @@ async fn renew_pipe_lease_until_stopped(
     sandbox_id: String,
     owner_id: String,
     lease: Arc<PipeLeaseState>,
+    lease_ttl: Duration,
+    renew_interval: Duration,
 ) {
-    let mut tick = interval(PIPE_LEASE_RENEW_INTERVAL);
+    let mut tick = interval(renew_interval);
     tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
     loop {
@@ -630,7 +684,7 @@ async fn renew_pipe_lease_until_stopped(
             return;
         }
         match store
-            .renew_pipe_lease(&thread_key, &sandbox_id, &owner_id, PIPE_LEASE_TTL)
+            .renew_pipe_lease(&thread_key, &sandbox_id, &owner_id, lease_ttl)
             .await
         {
             Ok(true) => {}

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0003_session_pipe_leases.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0003_session_pipe_leases.sql
@@ -1,0 +1,7 @@
+alter table sessions
+    add column if not exists pipe_owner_id text,
+    add column if not exists pipe_lease_expires_at timestamptz;
+
+create index if not exists sessions_pipe_lease_expires_idx
+    on sessions (pipe_lease_expires_at)
+    where pipe_owner_id is not null;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -1,6 +1,6 @@
 //! SQLx-backed session repository.
 
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
 use centaur_session_core::{
     ExecutionStatus, HarnessType, Session, SessionEvent, SessionExecution, SessionMessage,
@@ -331,6 +331,91 @@ impl PgSessionStore {
         .await?;
 
         row.try_into()
+    }
+
+    pub async fn try_claim_pipe_lease(
+        &self,
+        thread_key: &ThreadKey,
+        sandbox_id: &str,
+        owner_id: &str,
+        ttl: Duration,
+    ) -> Result<bool, SessionStoreError> {
+        let result = sqlx::query(
+            r#"
+            update sessions
+            set
+                pipe_owner_id = $3,
+                pipe_lease_expires_at = now() + ($4::double precision * interval '1 second'),
+                updated_at = now()
+            where thread_key = $1
+                and sandbox_id = $2
+                and (
+                    pipe_owner_id is null
+                    or pipe_owner_id = $3
+                    or pipe_lease_expires_at is null
+                    or pipe_lease_expires_at < now()
+                )
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(sandbox_id)
+        .bind(owner_id)
+        .bind(ttl.as_secs_f64())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn renew_pipe_lease(
+        &self,
+        thread_key: &ThreadKey,
+        sandbox_id: &str,
+        owner_id: &str,
+        ttl: Duration,
+    ) -> Result<bool, SessionStoreError> {
+        let result = sqlx::query(
+            r#"
+            update sessions
+            set
+                pipe_lease_expires_at = now() + ($4::double precision * interval '1 second'),
+                updated_at = now()
+            where thread_key = $1
+                and sandbox_id = $2
+                and pipe_owner_id = $3
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(sandbox_id)
+        .bind(owner_id)
+        .bind(ttl.as_secs_f64())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn release_pipe_lease(
+        &self,
+        thread_key: &ThreadKey,
+        sandbox_id: &str,
+        owner_id: &str,
+    ) -> Result<(), SessionStoreError> {
+        sqlx::query(
+            r#"
+            update sessions
+            set pipe_owner_id = null, pipe_lease_expires_at = null, updated_at = now()
+            where thread_key = $1
+                and sandbox_id = $2
+                and pipe_owner_id = $3
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(sandbox_id)
+        .bind(owner_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     async fn set_session_status(


### PR DESCRIPTION
## Summary

- add SQLx-backed sandbox pipe owner leases for Rust API session runtime
- prevent duplicate stdout pumps across horizontally scaled API replicas while preserving durable Postgres event replay
- keep stream reconnects useful during rollouts with delayed lease reclaim after expiry
- add Rust API lifecycle readiness: `/health` and `/healthz` stay live, `/health/ready` and `/readyz` fail once shutdown starts
- handle SIGTERM/ctrl-c by marking the API unready, waiting a configurable drain delay, then entering Axum graceful shutdown
- configure the API Deployment for rolling updates with `maxUnavailable: 0`, `maxSurge: 1`, `minReadySeconds`, faster readiness failure, and the drain-delay env var

## Validation

- `cargo test -p centaur-api-server`
- `cargo test -p centaur-session-sqlx -p centaur-session-runtime -p centaur-api-server`
- `cargo test --workspace`
- `helm template centaur contrib/chart`
- `helm lint contrib/chart`

## Notes

Stacked on #326 (`codex/rust-api-iron-proxy`). No Python/dbmate or Slackbot TypeScript changes.
