### PR TITLE
[codex] use SandboxWarmPool CRDs for warm sandboxes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,13 @@
 .venv
 
 # Node
+node_modules
+**/node_modules
 services/slackbot/node_modules
+
+# Rust build outputs
+target
+**/target
 
 # Sandbox cached repos (4GB+)
 services/sandbox/repos
@@ -14,6 +20,7 @@ services/sandbox/repos
 .ruff_cache
 .pytest_cache
 __pycache__
+**/__pycache__
 
 # Logs
 logs/

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
 name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",
  "centaur-session-core",

--- a/services/api-rs/Justfile
+++ b/services/api-rs/Justfile
@@ -12,11 +12,12 @@ agent_sandbox_crd_tmp := "target/codegen/agents.x-k8s.io_sandboxes.yaml"
 agent_sandbox_generated := "crates/centaur-sandbox-agent-k8s/src/generated/agents_x_k8s_io.rs"
 agent_sandbox_controller_image := "registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.4.6"
 agent_sandbox_rbac_url := "https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/" + agent_sandbox_ref + "/k8s/rbac.generated.yaml"
+agent_sandbox_extensions_rbac_url := "https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/" + agent_sandbox_ref + "/k8s/extensions-rbac.generated.yaml"
 agent_sandbox_controller_url := "https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/" + agent_sandbox_ref + "/k8s/controller.yaml"
-kind_e2e_cluster := "centaur-api-rs-e2e"
-kind_e2e_context := "kind-" + kind_e2e_cluster
-kind_e2e_namespace := "centaur-sandbox-e2e"
-kind_e2e_tmp := "target/e2e"
+k3d_e2e_cluster := "centaur-api-rs-e2e"
+k3d_e2e_context := "k3d-" + k3d_e2e_cluster
+k3d_e2e_namespace := "centaur-sandbox-e2e"
+k3d_e2e_tmp := "target/e2e"
 
 default:
     just --list
@@ -31,34 +32,55 @@ codegen-agent-sandbox-crd:
     kopium --filename "{{agent_sandbox_crd_tmp}}" --api-version v1alpha1 --schema disabled --derive PartialEq > "{{agent_sandbox_generated}}"
     cargo fmt --all
 
-kind-e2e-up:
-    command -v kind >/dev/null || { echo "kind is required" >&2; exit 127; }
+k3d-e2e-up:
+    command -v k3d >/dev/null || { echo "k3d is required" >&2; exit 127; }
     command -v kubectl >/dev/null || { echo "kubectl is required" >&2; exit 127; }
-    kind get clusters | grep -qx "{{kind_e2e_cluster}}" || kind create cluster --name "{{kind_e2e_cluster}}" --wait 120s
-    if docker image inspect centaur-iron-proxy:latest >/dev/null 2>&1; then kind load docker-image --name "{{kind_e2e_cluster}}" centaur-iron-proxy:latest; fi
-    mkdir -p "{{kind_e2e_tmp}}"
-    curl -fsSL "{{agent_sandbox_crd_url}}" -o "{{kind_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
-    curl -fsSL "{{agent_sandbox_template_crd_url}}" -o "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxtemplates.yaml"
-    curl -fsSL "{{agent_sandbox_claim_crd_url}}" -o "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxclaims.yaml"
-    curl -fsSL "{{agent_sandbox_warm_pool_crd_url}}" -o "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxwarmpools.yaml"
-    curl -fsSL "{{agent_sandbox_rbac_url}}" -o "{{kind_e2e_tmp}}/rbac.generated.yaml"
+    k3d cluster get "{{k3d_e2e_cluster}}" >/dev/null 2>&1 || k3d cluster create "{{k3d_e2e_cluster}}" --wait
+    for i in {1..30}; do kubectl --context "{{k3d_e2e_context}}" get --raw=/readyz >/dev/null 2>&1 && break; sleep 1; if [ "$i" = 30 ]; then kubectl --context "{{k3d_e2e_context}}" get --raw=/readyz; fi; done
+    if docker image inspect centaur-iron-proxy:latest >/dev/null 2>&1; then k3d image import centaur-iron-proxy:latest --cluster "{{k3d_e2e_cluster}}"; fi
+    mkdir -p "{{k3d_e2e_tmp}}"
+    curl -fsSL "{{agent_sandbox_crd_url}}" -o "{{k3d_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
+    curl -fsSL "{{agent_sandbox_template_crd_url}}" -o "{{k3d_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxtemplates.yaml"
+    curl -fsSL "{{agent_sandbox_claim_crd_url}}" -o "{{k3d_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxclaims.yaml"
+    curl -fsSL "{{agent_sandbox_warm_pool_crd_url}}" -o "{{k3d_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxwarmpools.yaml"
+    curl -fsSL "{{agent_sandbox_rbac_url}}" -o "{{k3d_e2e_tmp}}/rbac.generated.yaml"
+    curl -fsSL "{{agent_sandbox_extensions_rbac_url}}" -o "{{k3d_e2e_tmp}}/extensions-rbac.generated.yaml"
     curl -fsSL "{{agent_sandbox_controller_url}}" \
       | sed 's#ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller.*#{{agent_sandbox_controller_image}}#' \
-      > "{{kind_e2e_tmp}}/controller.yaml"
-    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
-    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxtemplates.yaml"
-    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxclaims.yaml"
-    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxwarmpools.yaml"
-    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/rbac.generated.yaml"
-    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/controller.yaml"
-    kubectl --context "{{kind_e2e_context}}" create namespace "{{kind_e2e_namespace}}" --dry-run=client -o yaml | kubectl --context "{{kind_e2e_context}}" apply -f -
-    kubectl --context "{{kind_e2e_context}}" -n agent-sandbox-system rollout status deploy/agent-sandbox-controller --timeout=120s
+      | awk '{ print } /--leader-elect=true/ { print "        - --extensions=true" }' \
+      > "{{k3d_e2e_tmp}}/controller.yaml"
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxtemplates.yaml"
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxclaims.yaml"
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxwarmpools.yaml"
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/rbac.generated.yaml"
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/extensions-rbac.generated.yaml"
+    kubectl --context "{{k3d_e2e_context}}" create clusterrolebinding agent-sandbox-controller-extensions --clusterrole=agent-sandbox-controller-extensions --serviceaccount=agent-sandbox-system:agent-sandbox-controller --dry-run=client -o yaml | kubectl --context "{{k3d_e2e_context}}" apply -f -
+    kubectl --context "{{k3d_e2e_context}}" apply -f "{{k3d_e2e_tmp}}/controller.yaml"
+    kubectl --context "{{k3d_e2e_context}}" -n agent-sandbox-system rollout status deploy/agent-sandbox-controller --timeout=120s
+    kubectl --context "{{k3d_e2e_context}}" -n agent-sandbox-system patch deploy agent-sandbox-controller --type=json --patch '[{"op":"replace","path":"/spec/template/spec/containers/0/args","value":["--leader-elect=true","--extensions=true"]}]'
+    kubectl --context "{{k3d_e2e_context}}" -n agent-sandbox-system rollout status deploy/agent-sandbox-controller --timeout=120s
+    for i in {1..60}; do \
+      args="$(kubectl --context "{{k3d_e2e_context}}" -n agent-sandbox-system get pods -l app=agent-sandbox-controller -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{" "}{.spec.containers[0].args}{"\n"}{end}')" ; \
+      running="$(printf '%s\n' "$args" | grep -c ' Running ' || true)" ; \
+      missing="$(printf '%s\n' "$args" | grep ' Running ' | grep -vc -- '--extensions=true' || true)" ; \
+      [ "$running" -ge 1 ] && [ "$missing" = 0 ] && break ; \
+      sleep 1 ; \
+      if [ "$i" = 60 ]; then printf '%s\n' "$args"; exit 1; fi ; \
+    done
+    kubectl --context "{{k3d_e2e_context}}" create namespace "{{k3d_e2e_namespace}}" --dry-run=client -o yaml | kubectl --context "{{k3d_e2e_context}}" apply -f -
 
-e2e-kind: kind-e2e-up
+e2e-k3d: k3d-e2e-up
     SANDBOX_E2E_IMPLS=all \
-    SANDBOX_E2E_K8S_CONTEXT="{{kind_e2e_context}}" \
-    SANDBOX_E2E_K8S_NAMESPACE="{{kind_e2e_namespace}}" \
+    SANDBOX_E2E_K8S_CONTEXT="{{k3d_e2e_context}}" \
+    SANDBOX_E2E_K8S_NAMESPACE="{{k3d_e2e_namespace}}" \
     cargo test -p centaur-sandbox-e2e -- --ignored --nocapture
 
-kind-e2e-down:
-    kind delete cluster --name "{{kind_e2e_cluster}}"
+k3d-e2e-down:
+    k3d cluster delete "{{k3d_e2e_cluster}}"
+
+kind-e2e-up: k3d-e2e-up
+
+e2e-kind: e2e-k3d
+
+kind-e2e-down: k3d-e2e-down

--- a/services/api-rs/Justfile
+++ b/services/api-rs/Justfile
@@ -5,6 +5,9 @@ kopium_version := "0.23.0"
 # Latest upstream Agent Sandbox release when this was pinned: v0.4.6.
 agent_sandbox_ref := "d0c124d4a1fded4ed4aecb92753696b4dd8de17b"
 agent_sandbox_crd_url := "https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/" + agent_sandbox_ref + "/helm/crds/agents.x-k8s.io_sandboxes.yaml"
+agent_sandbox_template_crd_url := "https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/" + agent_sandbox_ref + "/helm/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml"
+agent_sandbox_claim_crd_url := "https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/" + agent_sandbox_ref + "/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml"
+agent_sandbox_warm_pool_crd_url := "https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/" + agent_sandbox_ref + "/helm/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml"
 agent_sandbox_crd_tmp := "target/codegen/agents.x-k8s.io_sandboxes.yaml"
 agent_sandbox_generated := "crates/centaur-sandbox-agent-k8s/src/generated/agents_x_k8s_io.rs"
 agent_sandbox_controller_image := "registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.4.6"
@@ -35,11 +38,17 @@ kind-e2e-up:
     if docker image inspect centaur-iron-proxy:latest >/dev/null 2>&1; then kind load docker-image --name "{{kind_e2e_cluster}}" centaur-iron-proxy:latest; fi
     mkdir -p "{{kind_e2e_tmp}}"
     curl -fsSL "{{agent_sandbox_crd_url}}" -o "{{kind_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
+    curl -fsSL "{{agent_sandbox_template_crd_url}}" -o "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxtemplates.yaml"
+    curl -fsSL "{{agent_sandbox_claim_crd_url}}" -o "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxclaims.yaml"
+    curl -fsSL "{{agent_sandbox_warm_pool_crd_url}}" -o "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxwarmpools.yaml"
     curl -fsSL "{{agent_sandbox_rbac_url}}" -o "{{kind_e2e_tmp}}/rbac.generated.yaml"
     curl -fsSL "{{agent_sandbox_controller_url}}" \
       | sed 's#ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller.*#{{agent_sandbox_controller_image}}#' \
       > "{{kind_e2e_tmp}}/controller.yaml"
     kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/agents.x-k8s.io_sandboxes.yaml"
+    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxtemplates.yaml"
+    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxclaims.yaml"
+    kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/extensions.agents.x-k8s.io_sandboxwarmpools.yaml"
     kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/rbac.generated.yaml"
     kubectl --context "{{kind_e2e_context}}" apply -f "{{kind_e2e_tmp}}/controller.yaml"
     kubectl --context "{{kind_e2e_context}}" create namespace "{{kind_e2e_namespace}}" --dry-run=client -o yaml | kubectl --context "{{kind_e2e_context}}" apply -f -

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -102,10 +102,8 @@ fn container_workload_mode(args: &Args) -> SandboxWorkloadMode {
         SandboxWorkloadKind::Mock => SandboxWorkloadMode::mock_app_server(image),
         SandboxWorkloadKind::CodexAppServer => {
             let mut workload =
-                SandboxWorkloadMode::codex_app_server(image, codex_app_server_env_template(args));
-            if args.kubernetes_sandbox_warm_pool_enabled {
-                workload = workload.without_thread_key_env();
-            }
+                SandboxWorkloadMode::codex_app_server(image, codex_app_server_env_template(args))
+                    .without_thread_key_env();
             if let Some(repos_path) = clean_optional_value(args.repos_path.as_deref()) {
                 workload = workload.mount(
                     Mount::new(
@@ -163,12 +161,6 @@ struct Args {
     kubernetes_sandbox_image_pull_secrets: Vec<String>,
     #[arg(long, env = "KUBERNETES_SANDBOX_READY_TIMEOUT_S", default_value_t = 90)]
     kubernetes_sandbox_ready_timeout_s: u64,
-    #[arg(
-        long,
-        env = "KUBERNETES_SANDBOX_WARM_POOL_ENABLED",
-        default_value_t = false
-    )]
-    kubernetes_sandbox_warm_pool_enabled: bool,
     #[arg(long, env = "KUBERNETES_SANDBOX_WARM_POOL_NAME")]
     kubernetes_sandbox_warm_pool_name: Option<String>,
     #[arg(long, env = "KUBERNETES_SANDBOX_WARM_POOL_TEMPLATE_NAME")]
@@ -364,7 +356,7 @@ fn agent_sandbox_config_from_args(args: &Args) -> Result<AgentSandboxConfig, Ser
     config.state_volume = sandbox_state_volume_from_args(args);
     config.iron_proxy = iron_proxy_config_from_args(args)?;
     config.warm_pool = sandbox_warm_pool_config_from_args(args)?;
-    if config.warm_pool.is_some() && config.iron_proxy.is_some() {
+    if config.iron_proxy.is_some() {
         return Err(ServerError::UnsupportedConfig(
             "SandboxWarmPool mode cannot be combined with per-sandbox iron-proxy resources"
                 .to_owned(),
@@ -373,12 +365,7 @@ fn agent_sandbox_config_from_args(args: &Args) -> Result<AgentSandboxConfig, Ser
     Ok(config)
 }
 
-fn sandbox_warm_pool_config_from_args(
-    args: &Args,
-) -> Result<Option<SandboxWarmPoolConfig>, ServerError> {
-    if !args.kubernetes_sandbox_warm_pool_enabled {
-        return Ok(None);
-    }
+fn sandbox_warm_pool_config_from_args(args: &Args) -> Result<SandboxWarmPoolConfig, ServerError> {
     if args.kubernetes_sandbox_warm_pool_replicas < 0 {
         return Err(ServerError::UnsupportedConfig(
             "KUBERNETES_SANDBOX_WARM_POOL_REPLICAS must be non-negative".to_owned(),
@@ -398,7 +385,7 @@ fn sandbox_warm_pool_config_from_args(
         WarmPoolUpdateStrategyArg::OnReplenish => SandboxWarmPoolUpdateStrategy::OnReplenish,
         WarmPoolUpdateStrategyArg::Recreate => SandboxWarmPoolUpdateStrategy::Recreate,
     };
-    Ok(Some(config))
+    Ok(config)
 }
 
 fn iron_proxy_config_from_args(args: &Args) -> Result<Option<IronProxyPodConfig>, ServerError> {
@@ -725,7 +712,6 @@ mod tests {
             "centaur-api-server",
             "--database-url",
             "postgresql://postgres@localhost/centaur",
-            "--kubernetes-sandbox-warm-pool-enabled",
             "--kubernetes-sandbox-warm-pool-name",
             "codex-warm",
             "--kubernetes-sandbox-warm-pool-template-name",
@@ -740,7 +726,7 @@ mod tests {
         .unwrap();
 
         let config = agent_sandbox_config_from_args(&args).unwrap();
-        let warm_pool = config.warm_pool.unwrap();
+        let warm_pool = config.warm_pool;
 
         assert_eq!(warm_pool.pool_name, "codex-warm");
         assert_eq!(warm_pool.template_name, "codex-template");
@@ -758,7 +744,6 @@ mod tests {
             "centaur-api-server",
             "--database-url",
             "postgresql://postgres@localhost/centaur",
-            "--kubernetes-sandbox-warm-pool-enabled",
             "--kubernetes-sandbox-iron-proxy-mode",
             "enabled",
             "--kubernetes-firewall-ca-secret-name",

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -3,7 +3,8 @@ use std::{collections::BTreeMap, env, net::SocketAddr, path::PathBuf, sync::Arc,
 use centaur_api_server::{SandboxRuntime, build_router_with_runtime};
 use centaur_iron_proxy::{SourceKind, SourcePolicy, discover_fragment_files, load_fragment_files};
 use centaur_sandbox_agent_k8s::{
-    AgentSandboxBackend, AgentSandboxConfig, IronProxyPodConfig, StateVolumeConfig,
+    AgentSandboxBackend, AgentSandboxConfig, IronProxyPodConfig, SandboxWarmPoolConfig,
+    SandboxWarmPoolUpdateStrategy, StateVolumeConfig,
 };
 use centaur_sandbox_core::{Mount, MountKind};
 use centaur_sandbox_local::LocalSandboxBackend;
@@ -102,6 +103,9 @@ fn container_workload_mode(args: &Args) -> SandboxWorkloadMode {
         SandboxWorkloadKind::CodexAppServer => {
             let mut workload =
                 SandboxWorkloadMode::codex_app_server(image, codex_app_server_env_template(args));
+            if args.kubernetes_sandbox_warm_pool_enabled {
+                workload = workload.without_thread_key_env();
+            }
             if let Some(repos_path) = clean_optional_value(args.repos_path.as_deref()) {
                 workload = workload.mount(
                     Mount::new(
@@ -159,6 +163,35 @@ struct Args {
     kubernetes_sandbox_image_pull_secrets: Vec<String>,
     #[arg(long, env = "KUBERNETES_SANDBOX_READY_TIMEOUT_S", default_value_t = 90)]
     kubernetes_sandbox_ready_timeout_s: u64,
+    #[arg(
+        long,
+        env = "KUBERNETES_SANDBOX_WARM_POOL_ENABLED",
+        default_value_t = false
+    )]
+    kubernetes_sandbox_warm_pool_enabled: bool,
+    #[arg(long, env = "KUBERNETES_SANDBOX_WARM_POOL_NAME")]
+    kubernetes_sandbox_warm_pool_name: Option<String>,
+    #[arg(long, env = "KUBERNETES_SANDBOX_WARM_POOL_TEMPLATE_NAME")]
+    kubernetes_sandbox_warm_pool_template_name: Option<String>,
+    #[arg(
+        long,
+        env = "KUBERNETES_SANDBOX_WARM_POOL_REPLICAS",
+        default_value_t = 1
+    )]
+    kubernetes_sandbox_warm_pool_replicas: i32,
+    #[arg(
+        long,
+        env = "KUBERNETES_SANDBOX_WARM_POOL_UPDATE_STRATEGY",
+        value_enum,
+        default_value = "on-replenish"
+    )]
+    kubernetes_sandbox_warm_pool_update_strategy: WarmPoolUpdateStrategyArg,
+    #[arg(
+        long,
+        env = "KUBERNETES_SANDBOX_WARM_POOL_API_VERSION",
+        default_value = "v1alpha1"
+    )]
+    kubernetes_sandbox_warm_pool_api_version: String,
     #[arg(long, env = "KUBERNETES_CONTEXT")]
     kubernetes_context: Option<String>,
     #[arg(long, env = "KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME")]
@@ -297,6 +330,13 @@ enum IronProxyMode {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum WarmPoolUpdateStrategyArg {
+    #[value(name = "on-replenish")]
+    OnReplenish,
+    Recreate,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum IronProxySecretSourceArg {
     Env,
     #[value(name = "onepassword")]
@@ -323,7 +363,42 @@ fn agent_sandbox_config_from_args(args: &Args) -> Result<AgentSandboxConfig, Ser
         clean_optional_value(args.kubernetes_sandbox_service_account_name.as_deref());
     config.state_volume = sandbox_state_volume_from_args(args);
     config.iron_proxy = iron_proxy_config_from_args(args)?;
+    config.warm_pool = sandbox_warm_pool_config_from_args(args)?;
+    if config.warm_pool.is_some() && config.iron_proxy.is_some() {
+        return Err(ServerError::UnsupportedConfig(
+            "SandboxWarmPool mode cannot be combined with per-sandbox iron-proxy resources"
+                .to_owned(),
+        ));
+    }
     Ok(config)
+}
+
+fn sandbox_warm_pool_config_from_args(
+    args: &Args,
+) -> Result<Option<SandboxWarmPoolConfig>, ServerError> {
+    if !args.kubernetes_sandbox_warm_pool_enabled {
+        return Ok(None);
+    }
+    if args.kubernetes_sandbox_warm_pool_replicas < 0 {
+        return Err(ServerError::UnsupportedConfig(
+            "KUBERNETES_SANDBOX_WARM_POOL_REPLICAS must be non-negative".to_owned(),
+        ));
+    }
+    let pool_name = clean_optional_value(args.kubernetes_sandbox_warm_pool_name.as_deref())
+        .unwrap_or_else(|| "centaur-agent-warm-pool".to_owned());
+    let template_name =
+        clean_optional_value(args.kubernetes_sandbox_warm_pool_template_name.as_deref())
+            .unwrap_or_else(|| format!("{pool_name}-template"));
+    let mut config = SandboxWarmPoolConfig::new(pool_name, template_name);
+    config.replicas = args.kubernetes_sandbox_warm_pool_replicas;
+    config.api_version =
+        clean_optional_value(Some(args.kubernetes_sandbox_warm_pool_api_version.as_str()))
+            .unwrap_or_else(|| "v1alpha1".to_owned());
+    config.update_strategy = match args.kubernetes_sandbox_warm_pool_update_strategy {
+        WarmPoolUpdateStrategyArg::OnReplenish => SandboxWarmPoolUpdateStrategy::OnReplenish,
+        WarmPoolUpdateStrategyArg::Recreate => SandboxWarmPoolUpdateStrategy::Recreate,
+    };
+    Ok(Some(config))
 }
 
 fn iron_proxy_config_from_args(args: &Args) -> Result<Option<IronProxyPodConfig>, ServerError> {
@@ -642,6 +717,61 @@ mod tests {
         assert_eq!(config.source_policy.ttl, "5m");
         assert_eq!(config.source_policy.token_broker_ttl, "30s");
         assert_eq!(config.harness_auth_modes["codex"], "access_token");
+    }
+
+    #[test]
+    fn clap_drives_sandbox_warm_pool_config() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgresql://postgres@localhost/centaur",
+            "--kubernetes-sandbox-warm-pool-enabled",
+            "--kubernetes-sandbox-warm-pool-name",
+            "codex-warm",
+            "--kubernetes-sandbox-warm-pool-template-name",
+            "codex-template",
+            "--kubernetes-sandbox-warm-pool-replicas",
+            "4",
+            "--kubernetes-sandbox-warm-pool-update-strategy",
+            "recreate",
+            "--kubernetes-sandbox-warm-pool-api-version",
+            "v1beta1",
+        ])
+        .unwrap();
+
+        let config = agent_sandbox_config_from_args(&args).unwrap();
+        let warm_pool = config.warm_pool.unwrap();
+
+        assert_eq!(warm_pool.pool_name, "codex-warm");
+        assert_eq!(warm_pool.template_name, "codex-template");
+        assert_eq!(warm_pool.replicas, 4);
+        assert_eq!(warm_pool.api_version, "v1beta1");
+        assert!(matches!(
+            warm_pool.update_strategy,
+            SandboxWarmPoolUpdateStrategy::Recreate
+        ));
+    }
+
+    #[test]
+    fn warm_pool_rejects_per_sandbox_iron_proxy_config() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgresql://postgres@localhost/centaur",
+            "--kubernetes-sandbox-warm-pool-enabled",
+            "--kubernetes-sandbox-iron-proxy-mode",
+            "enabled",
+            "--kubernetes-firewall-ca-secret-name",
+            "firewall-ca-cert",
+            "--kubernetes-firewall-ca-key-secret-name",
+            "firewall-ca-key",
+        ])
+        .unwrap();
+
+        let error = agent_sandbox_config_from_args(&args).unwrap_err();
+
+        assert!(error.to_string().contains("SandboxWarmPool"));
+        assert!(error.to_string().contains("iron-proxy"));
     }
 }
 

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -102,8 +102,7 @@ fn container_workload_mode(args: &Args) -> SandboxWorkloadMode {
         SandboxWorkloadKind::Mock => SandboxWorkloadMode::mock_app_server(image),
         SandboxWorkloadKind::CodexAppServer => {
             let mut workload =
-                SandboxWorkloadMode::codex_app_server(image, codex_app_server_env_template(args))
-                    .without_thread_key_env();
+                SandboxWorkloadMode::codex_app_server(image, codex_app_server_env_template(args));
             if let Some(repos_path) = clean_optional_value(args.repos_path.as_deref()) {
                 workload = workload.mount(
                     Mount::new(
@@ -356,12 +355,6 @@ fn agent_sandbox_config_from_args(args: &Args) -> Result<AgentSandboxConfig, Ser
     config.state_volume = sandbox_state_volume_from_args(args);
     config.iron_proxy = iron_proxy_config_from_args(args)?;
     config.warm_pool = sandbox_warm_pool_config_from_args(args)?;
-    if config.iron_proxy.is_some() {
-        return Err(ServerError::UnsupportedConfig(
-            "SandboxWarmPool mode cannot be combined with per-sandbox iron-proxy resources"
-                .to_owned(),
-        ));
-    }
     Ok(config)
 }
 
@@ -601,6 +594,7 @@ fn clean_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
 
 fn codex_app_server_env_template(args: &Args) -> Vec<(String, String)> {
     let mut envs = Vec::new();
+    push_env(&mut envs, "CENTAUR_HARNESS_KIND", "codex".to_owned());
     push_env(
         &mut envs,
         "CENTAUR_API_URL",
@@ -662,6 +656,23 @@ mod tests {
         assert_eq!(labels["component"], "worker");
         assert!(parse_label_selector_arg("app").is_err());
         assert!(parse_label_selector_arg("app=").is_err());
+    }
+
+    #[test]
+    fn codex_workload_env_sets_harness_kind_for_proxy_fragments() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgresql://postgres@localhost/centaur",
+        ])
+        .unwrap();
+
+        let env = codex_app_server_env_template(&args)
+            .into_iter()
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(env["CENTAUR_HARNESS_KIND"], "codex");
+        assert_eq!(env["CENTAUR_API_URL"], "http://api:8000");
     }
 
     #[test]
@@ -739,7 +750,7 @@ mod tests {
     }
 
     #[test]
-    fn warm_pool_rejects_per_sandbox_iron_proxy_config() {
+    fn warm_pool_allows_iron_proxy_config() {
         let args = Args::try_parse_from([
             "centaur-api-server",
             "--database-url",
@@ -753,10 +764,12 @@ mod tests {
         ])
         .unwrap();
 
-        let error = agent_sandbox_config_from_args(&args).unwrap_err();
+        let config = agent_sandbox_config_from_args(&args).unwrap();
+        let iron_proxy = config.iron_proxy.unwrap();
 
-        assert!(error.to_string().contains("SandboxWarmPool"));
-        assert!(error.to_string().contains("iron-proxy"));
+        assert_eq!(config.warm_pool.pool_name, "centaur-agent-warm-pool");
+        assert_eq!(iron_proxy.ca_cert_secret_name, "firewall-ca-cert");
+        assert_eq!(iron_proxy.ca_key_secret_name, "firewall-ca-key");
     }
 }
 

--- a/services/api-rs/crates/centaur-iron-proxy/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/lib.rs
@@ -458,6 +458,7 @@ pub fn render_proxy_yaml_with_source_policy(
         .into_iter()
         .map(|transform| resolve_fragment_transform_sources(transform, source_policy))
         .collect::<Vec<_>>();
+    let managed = merge_managed_transforms(managed);
     if !managed.is_empty() {
         insert_before_header_allowlist(&mut transforms, managed);
     }
@@ -788,6 +789,58 @@ fn existing_unmanaged_transforms(cfg: &Mapping) -> Vec<Value> {
         .collect()
 }
 
+fn merge_managed_transforms(transforms: Vec<Value>) -> Vec<Value> {
+    let mut merged = Vec::<Value>::new();
+    let mut by_name = BTreeMap::<String, usize>::new();
+    for transform in transforms {
+        let Some(name) = transform_name(&transform).map(ToOwned::to_owned) else {
+            merged.push(transform);
+            continue;
+        };
+        if !MANAGED_TRANSFORMS.contains(&name.as_str()) {
+            merged.push(transform);
+            continue;
+        }
+        if let Some(index) = by_name.get(&name).copied() {
+            merge_transform_config(&mut merged[index], transform);
+        } else {
+            by_name.insert(name, merged.len());
+            merged.push(transform);
+        }
+    }
+    merged
+}
+
+fn merge_transform_config(target: &mut Value, source: Value) {
+    let Some(target_config) = target
+        .as_mapping_mut()
+        .and_then(|map| map.get_mut(&string_value("config")))
+        .and_then(Value::as_mapping_mut)
+    else {
+        return;
+    };
+    let Some(source_config) = source
+        .as_mapping()
+        .and_then(|map| map.get(&string_value("config")))
+        .and_then(Value::as_mapping)
+    else {
+        return;
+    };
+    for (key, source_value) in source_config {
+        match target_config.get_mut(key) {
+            Some(Value::Sequence(target_items)) => {
+                if let Value::Sequence(source_items) = source_value {
+                    target_items.extend(source_items.iter().cloned());
+                }
+            }
+            Some(_) => {}
+            None => {
+                target_config.insert(key.clone(), source_value.clone());
+            }
+        }
+    }
+}
+
 fn insert_before_header_allowlist(transforms: &mut Vec<Value>, managed: Vec<Value>) {
     if let Some(index) = transforms
         .iter()
@@ -973,6 +1026,34 @@ transforms:
             "OPENAI_API_KEY"
         );
         assert!(cfg["transforms"][1]["config"]["secrets"][0]["old"].is_null());
+    }
+
+    #[test]
+    fn merges_managed_secret_transforms_from_infra_and_harness_fragments() {
+        let infra = infra_fragment().unwrap();
+        let codex = harness_fragment("codex", "api_key").unwrap().unwrap();
+
+        let rendered = render_proxy_yaml(None, &[infra, codex], None).unwrap();
+        let cfg = parse_rendered(&rendered);
+
+        assert_eq!(
+            transform_names(&cfg),
+            vec!["allowlist", "secrets", "header_allowlist"]
+        );
+        let secrets = cfg["transforms"][1]["config"]["secrets"]
+            .as_sequence()
+            .unwrap();
+        assert_eq!(secrets.len(), 6);
+        assert!(
+            secrets
+                .iter()
+                .any(|secret| secret["source"]["var"].as_str() == Some("OPENAI_API_KEY"))
+        );
+        assert!(
+            secrets
+                .iter()
+                .any(|secret| secret["source"]["var"].as_str() == Some("GITHUB_TOKEN"))
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -17,7 +17,10 @@ use centaur_sandbox_core::{
 use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Pod, Service};
 use k8s_openapi::api::networking::v1::NetworkPolicy;
-use kube::api::{AttachParams, DeleteParams, ListParams, Patch, PatchParams, PostParams};
+use kube::api::{
+    ApiResource, AttachParams, DeleteParams, DynamicObject, GroupVersionKind, ListParams, Patch,
+    PatchParams, PostParams,
+};
 use kube::{Api, Client, Error};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -31,12 +34,18 @@ pub mod generated;
 
 const BACKEND_NAME: &str = "agent-sandbox-k8s";
 const DEFAULT_CONTAINER_NAME: &str = "agent";
+const EXTENSIONS_GROUP: &str = "extensions.agents.x-k8s.io";
+const DEFAULT_WARM_POOL_API_VERSION: &str = "v1alpha1";
 const MANAGED_LABEL: &str = "centaur.ai/managed";
 const MANAGED_BY_LABEL: &str = "centaur.ai/managed-by";
 const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
+const SANDBOX_CLAIM_LABEL: &str = "centaur.ai/sandbox-claim";
+const SANDBOX_TEMPLATE_LABEL: &str = "centaur.ai/sandbox-template";
+const SANDBOX_WARM_POOL_LABEL: &str = "centaur.ai/sandbox-warm-pool";
 const MANAGED_BY_VALUE: &str = "api-rs";
 const TOKEN_BROKER_LABEL: &str = "centaur.ai/iron-token-broker";
 const TOKEN_BROKER_CONFIG_KEY: &str = "iron-token-broker.yaml";
+const THREAD_KEY_ENV: &str = "CENTAUR_THREAD_KEY";
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -53,6 +62,7 @@ pub struct AgentSandboxConfig {
     pub service_account_name: Option<String>,
     pub state_volume: Option<StateVolumeConfig>,
     pub iron_proxy: Option<IronProxyPodConfig>,
+    pub warm_pool: Option<SandboxWarmPoolConfig>,
     pub ready_timeout: Duration,
 }
 
@@ -70,6 +80,7 @@ impl AgentSandboxConfig {
             service_account_name: None,
             state_volume: None,
             iron_proxy: None,
+            warm_pool: None,
             ready_timeout: Duration::from_secs(60),
         }
     }
@@ -141,6 +152,42 @@ impl IronProxyPodConfig {
     pub fn with_fragments(mut self, fragments: Vec<ProxyFragment>) -> Self {
         self.fragments = fragments;
         self
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SandboxWarmPoolConfig {
+    pub api_version: String,
+    pub pool_name: String,
+    pub template_name: String,
+    pub replicas: i32,
+    pub update_strategy: SandboxWarmPoolUpdateStrategy,
+}
+
+impl SandboxWarmPoolConfig {
+    pub fn new(pool_name: impl Into<String>, template_name: impl Into<String>) -> Self {
+        Self {
+            api_version: DEFAULT_WARM_POOL_API_VERSION.to_owned(),
+            pool_name: pool_name.into(),
+            template_name: template_name.into(),
+            replicas: 1,
+            update_strategy: SandboxWarmPoolUpdateStrategy::OnReplenish,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxWarmPoolUpdateStrategy {
+    OnReplenish,
+    Recreate,
+}
+
+impl SandboxWarmPoolUpdateStrategy {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::OnReplenish => "OnReplenish",
+            Self::Recreate => "Recreate",
+        }
     }
 }
 
@@ -224,6 +271,29 @@ impl AgentSandboxBackend {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
+    fn sandbox_templates(&self, warm_pool: &SandboxWarmPoolConfig) -> Api<DynamicObject> {
+        let resource = extension_resource(
+            &warm_pool.api_version,
+            "SandboxTemplate",
+            "sandboxtemplates",
+        );
+        Api::namespaced_with(self.client.clone(), &self.config.namespace, &resource)
+    }
+
+    fn sandbox_warm_pools(&self, warm_pool: &SandboxWarmPoolConfig) -> Api<DynamicObject> {
+        let resource = extension_resource(
+            &warm_pool.api_version,
+            "SandboxWarmPool",
+            "sandboxwarmpools",
+        );
+        Api::namespaced_with(self.client.clone(), &self.config.namespace, &resource)
+    }
+
+    fn sandbox_claims(&self, warm_pool: &SandboxWarmPoolConfig) -> Api<DynamicObject> {
+        let resource = extension_resource(&warm_pool.api_version, "SandboxClaim", "sandboxclaims");
+        Api::namespaced_with(self.client.clone(), &self.config.namespace, &resource)
+    }
+
     async fn get_sandbox(&self, id: &SandboxId) -> SandboxResult<Option<crd::Sandbox>> {
         match self.sandboxes().get(id.as_str()).await {
             Ok(sandbox) => Ok(Some(sandbox)),
@@ -263,6 +333,134 @@ impl AgentSandboxBackend {
             Err(err) if is_not_found(&err) => Ok(()),
             Err(err) => Err(map_kube_error("delete sandbox state pvc", err)),
         }
+    }
+
+    async fn reconcile_warm_pool(
+        &self,
+        spec: &SandboxSpec,
+        warm_pool: &SandboxWarmPoolConfig,
+    ) -> SandboxResult<()> {
+        let template = build_sandbox_template(warm_pool, spec, &self.config)?;
+        let pool = build_sandbox_warm_pool(warm_pool);
+        let params = PatchParams::apply(&self.config.field_manager).force();
+        self.sandbox_templates(warm_pool)
+            .patch(&warm_pool.template_name, &params, &Patch::Apply(&template))
+            .await
+            .map_err(|err| map_kube_error("apply sandbox warm-pool template", err))?;
+        self.sandbox_warm_pools(warm_pool)
+            .patch(&warm_pool.pool_name, &params, &Patch::Apply(&pool))
+            .await
+            .map_err(|err| map_kube_error("apply sandbox warm pool", err))?;
+        Ok(())
+    }
+
+    async fn create_from_warm_pool(
+        &self,
+        spec: SandboxSpec,
+        warm_pool: &SandboxWarmPoolConfig,
+    ) -> SandboxResult<SandboxHandle> {
+        validate_warm_pool_spec(&spec, &self.config)?;
+        self.reconcile_warm_pool(&spec, warm_pool).await?;
+        self.wait_for_warm_pool_ready(warm_pool).await?;
+
+        let claim_id = SandboxId::new(next_sandbox_name());
+        let claim = build_sandbox_claim(&claim_id, warm_pool, &self.config);
+        self.sandbox_claims(warm_pool)
+            .create(&PostParams::default(), &claim)
+            .await
+            .map_err(|err| map_kube_error("create sandbox warm-pool claim", err))?;
+
+        match self.wait_for_sandbox_claim(&claim_id, warm_pool).await {
+            Ok(id) => Ok(SandboxHandle::new(id, BACKEND_NAME)),
+            Err(err) => {
+                let _ = self.delete_sandbox_claim(&claim_id, warm_pool).await;
+                Err(err)
+            }
+        }
+    }
+
+    async fn wait_for_warm_pool_ready(
+        &self,
+        warm_pool: &SandboxWarmPoolConfig,
+    ) -> SandboxResult<()> {
+        if warm_pool.replicas <= 0 {
+            return Ok(());
+        }
+        let deadline = Instant::now() + self.config.ready_timeout;
+        loop {
+            let pool = self
+                .sandbox_warm_pools(warm_pool)
+                .get(&warm_pool.pool_name)
+                .await
+                .map_err(|err| map_kube_error("get sandbox warm pool", err))?;
+            if warm_pool_ready_replicas(&pool) > 0 {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(SandboxError::NotReady(format!(
+                    "sandbox warm pool {} did not report ready replicas before timeout",
+                    warm_pool.pool_name
+                )));
+            }
+            sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    async fn wait_for_sandbox_claim(
+        &self,
+        claim_id: &SandboxId,
+        warm_pool: &SandboxWarmPoolConfig,
+    ) -> SandboxResult<SandboxId> {
+        let deadline = Instant::now() + self.config.ready_timeout;
+        loop {
+            let claim = self
+                .sandbox_claims(warm_pool)
+                .get(claim_id.as_str())
+                .await
+                .map_err(|err| map_kube_error("get sandbox warm-pool claim", err))?;
+            if let Some(name) = claim_sandbox_name(&claim) {
+                let id = SandboxId::new(name);
+                self.wait_until_running(&id).await?;
+                return Ok(id);
+            }
+            if Instant::now() >= deadline {
+                return Err(SandboxError::NotReady(format!(
+                    "sandbox warm-pool claim {} was not assigned before timeout",
+                    claim_id.as_str()
+                )));
+            }
+            sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    async fn delete_sandbox_claim(
+        &self,
+        claim_id: &SandboxId,
+        warm_pool: &SandboxWarmPoolConfig,
+    ) -> SandboxResult<()> {
+        match self
+            .sandbox_claims(warm_pool)
+            .delete(claim_id.as_str(), &DeleteParams::default())
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(err) if is_not_found(&err) => Ok(()),
+            Err(err) => Err(map_kube_error("delete sandbox warm-pool claim", err)),
+        }
+    }
+
+    async fn delete_warm_pool_claim_for_sandbox(&self, id: &SandboxId) -> SandboxResult<()> {
+        let Some(warm_pool) = &self.config.warm_pool else {
+            return Ok(());
+        };
+        let Some(sandbox) = self.get_sandbox(id).await? else {
+            return Ok(());
+        };
+        for claim_name in sandbox_claim_owner_names(&sandbox) {
+            self.delete_sandbox_claim(&SandboxId::new(claim_name), warm_pool)
+                .await?;
+        }
+        Ok(())
     }
 
     fn resolve_iron_proxy(
@@ -676,6 +874,10 @@ impl SandboxBackend for AgentSandboxBackend {
     }
 
     async fn create(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
+        if let Some(warm_pool) = &self.config.warm_pool {
+            return self.create_from_warm_pool(spec, warm_pool).await;
+        }
+
         let id = SandboxId::new(next_sandbox_name());
         let resolved_iron_proxy = self.resolve_iron_proxy(&id, &spec)?;
         if let Err(err) = self
@@ -740,6 +942,7 @@ impl SandboxBackend for AgentSandboxBackend {
     }
 
     async fn stop(&self, id: &SandboxId) -> SandboxResult<()> {
+        self.delete_warm_pool_claim_for_sandbox(id).await?;
         match self
             .sandboxes()
             .delete(id.as_str(), &DeleteParams::default())
@@ -799,6 +1002,151 @@ fn pod_ready(pod: &Pod) -> bool {
                 .iter()
                 .any(|condition| condition.type_ == "Ready" && condition.status == "True")
         })
+}
+
+fn extension_resource(api_version: &str, kind: &str, plural: &str) -> ApiResource {
+    ApiResource::from_gvk_with_plural(
+        &GroupVersionKind::gvk(EXTENSIONS_GROUP, api_version, kind),
+        plural,
+    )
+}
+
+fn validate_warm_pool_spec(spec: &SandboxSpec, config: &AgentSandboxConfig) -> SandboxResult<()> {
+    if config.iron_proxy.is_some() {
+        return Err(SandboxError::InvalidSpec(
+            "SandboxWarmPool mode cannot be combined with per-sandbox iron-proxy resources"
+                .to_owned(),
+        ));
+    }
+    if spec_env(spec, THREAD_KEY_ENV).is_some() {
+        return Err(SandboxError::InvalidSpec(format!(
+            "SandboxWarmPool templates cannot include per-thread {THREAD_KEY_ENV}; pass thread context with each turn instead"
+        )));
+    }
+    Ok(())
+}
+
+fn build_sandbox_template(
+    warm_pool: &SandboxWarmPoolConfig,
+    spec: &SandboxSpec,
+    config: &AgentSandboxConfig,
+) -> SandboxResult<DynamicObject> {
+    let template_id = SandboxId::new(warm_pool.template_name.clone());
+    let sandbox = build_agent_sandbox(&template_id, spec, config, None)?;
+    let mut template_spec = serde_json::to_value(&sandbox.spec).map_err(|err| {
+        SandboxError::InvalidSpec(format!("invalid sandbox warm-pool template: {err}"))
+    })?;
+    let spec_object = template_spec.as_object_mut().ok_or_else(|| {
+        SandboxError::InvalidSpec("sandbox warm-pool template spec must be an object".to_owned())
+    })?;
+    spec_object.remove("replicas");
+    spec_object.remove("shutdownPolicy");
+    spec_object.remove("shutdownTime");
+    if let Some(labels) = spec_object
+        .get_mut("podTemplate")
+        .and_then(|pod_template| pod_template.get_mut("metadata"))
+        .and_then(|metadata| metadata.get_mut("labels"))
+        .and_then(Value::as_object_mut)
+    {
+        labels.remove(SANDBOX_ID_LABEL);
+    }
+
+    let mut template = DynamicObject::new(
+        &warm_pool.template_name,
+        &extension_resource(
+            &warm_pool.api_version,
+            "SandboxTemplate",
+            "sandboxtemplates",
+        ),
+    )
+    .data(json!({ "spec": template_spec }));
+    template.metadata.labels = Some(warm_pool_labels(warm_pool));
+    template.metadata.annotations = Some(config.annotations.clone());
+    Ok(template)
+}
+
+fn build_sandbox_warm_pool(warm_pool: &SandboxWarmPoolConfig) -> DynamicObject {
+    let mut pool = DynamicObject::new(
+        &warm_pool.pool_name,
+        &extension_resource(
+            &warm_pool.api_version,
+            "SandboxWarmPool",
+            "sandboxwarmpools",
+        ),
+    )
+    .data(json!({
+        "spec": {
+            "replicas": warm_pool.replicas,
+            "sandboxTemplateRef": {
+                "name": warm_pool.template_name,
+            },
+            "updateStrategy": {
+                "type": warm_pool.update_strategy.as_str(),
+            },
+        },
+    }));
+    pool.metadata.labels = Some(warm_pool_labels(warm_pool));
+    pool
+}
+
+fn build_sandbox_claim(
+    claim_id: &SandboxId,
+    warm_pool: &SandboxWarmPoolConfig,
+    config: &AgentSandboxConfig,
+) -> DynamicObject {
+    let mut claim = DynamicObject::new(
+        claim_id.as_str(),
+        &extension_resource(&warm_pool.api_version, "SandboxClaim", "sandboxclaims"),
+    )
+    .data(json!({
+        "spec": {
+            "sandboxTemplateRef": {
+                "name": warm_pool.template_name,
+            },
+            "warmpool": warm_pool.pool_name,
+            "additionalPodMetadata": {
+                "labels": claimed_sandbox_labels(claim_id, warm_pool),
+                "annotations": config.annotations.clone(),
+            },
+        },
+    }));
+    claim.metadata.labels = Some(claim_labels(claim_id, warm_pool));
+    claim.metadata.annotations = Some(config.annotations.clone());
+    claim
+}
+
+fn claim_sandbox_name(claim: &DynamicObject) -> Option<String> {
+    claim
+        .data
+        .pointer("/status/sandbox/name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn warm_pool_ready_replicas(pool: &DynamicObject) -> i64 {
+    pool.data
+        .pointer("/status/readyReplicas")
+        .and_then(Value::as_i64)
+        .unwrap_or_default()
+}
+
+fn sandbox_claim_owner_names(sandbox: &crd::Sandbox) -> Vec<String> {
+    sandbox
+        .metadata
+        .owner_references
+        .as_ref()
+        .into_iter()
+        .flatten()
+        .filter(|owner| {
+            owner.kind == "SandboxClaim"
+                && owner
+                    .api_version
+                    .starts_with(&format!("{EXTENSIONS_GROUP}/"))
+        })
+        .map(|owner| owner.name.clone())
+        .collect()
 }
 
 fn build_agent_sandbox(
@@ -1572,6 +1920,47 @@ fn base_resource_labels(id: &SandboxId) -> BTreeMap<String, String> {
     ])
 }
 
+fn warm_pool_labels(warm_pool: &SandboxWarmPoolConfig) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (MANAGED_LABEL.to_owned(), "true".to_owned()),
+        (MANAGED_BY_LABEL.to_owned(), MANAGED_BY_VALUE.to_owned()),
+        (
+            SANDBOX_WARM_POOL_LABEL.to_owned(),
+            warm_pool.pool_name.clone(),
+        ),
+        (
+            SANDBOX_TEMPLATE_LABEL.to_owned(),
+            warm_pool.template_name.clone(),
+        ),
+    ])
+}
+
+fn claim_labels(
+    claim_id: &SandboxId,
+    warm_pool: &SandboxWarmPoolConfig,
+) -> BTreeMap<String, String> {
+    let mut labels = sandbox_labels(claim_id);
+    labels.insert(
+        SANDBOX_WARM_POOL_LABEL.to_owned(),
+        warm_pool.pool_name.clone(),
+    );
+    labels.insert(
+        SANDBOX_TEMPLATE_LABEL.to_owned(),
+        warm_pool.template_name.clone(),
+    );
+    labels.insert(SANDBOX_CLAIM_LABEL.to_owned(), claim_id.as_str().to_owned());
+    labels
+}
+
+fn claimed_sandbox_labels(
+    claim_id: &SandboxId,
+    warm_pool: &SandboxWarmPoolConfig,
+) -> BTreeMap<String, String> {
+    let mut labels = claim_labels(claim_id, warm_pool);
+    labels.remove(SANDBOX_ID_LABEL);
+    labels
+}
+
 fn insert_optional<T>(target: &mut Value, key: &str, value: Option<T>)
 where
     T: serde::Serialize,
@@ -1694,6 +2083,137 @@ mod tests {
         let image_pull_secrets = pod_spec.image_pull_secrets.as_ref().unwrap();
         assert_eq!(image_pull_secrets[0].name.as_deref(), Some("regcred"));
         assert_eq!(image_pull_secrets[1].name.as_deref(), Some("mirrorcred"));
+    }
+
+    #[test]
+    fn builds_sandbox_warm_pool_extension_objects() {
+        let mut warm_pool = SandboxWarmPoolConfig::new("centaur-warm", "centaur-warm-template");
+        warm_pool.replicas = 3;
+        warm_pool.update_strategy = SandboxWarmPoolUpdateStrategy::Recreate;
+        let spec = SandboxSpec::new("centaur-agent:latest")
+            .env("CENTAUR_API_URL", "http://api:8000")
+            .resources(ResourceLimits::new().memory_bytes(1024 * 1024 * 1024));
+        let mut config = AgentSandboxConfig::new("centaur")
+            .state_volume(StateVolumeConfig::new("/home/agent/state", "10Gi"));
+        config
+            .annotations
+            .insert("centaur.ai/test".to_owned(), "true".to_owned());
+
+        let template = build_sandbox_template(&warm_pool, &spec, &config).unwrap();
+        let pool = build_sandbox_warm_pool(&warm_pool);
+
+        let template_types = template.types.as_ref().unwrap();
+        assert_eq!(
+            template_types.api_version,
+            "extensions.agents.x-k8s.io/v1alpha1"
+        );
+        assert_eq!(template_types.kind, "SandboxTemplate");
+        assert_eq!(
+            template.metadata.labels.as_ref().unwrap()[SANDBOX_WARM_POOL_LABEL],
+            "centaur-warm"
+        );
+        assert_eq!(
+            template.metadata.annotations.as_ref().unwrap()["centaur.ai/test"],
+            "true"
+        );
+        assert!(template.data["spec"].get("replicas").is_none());
+        assert!(template.data["spec"].get("shutdownPolicy").is_none());
+        assert_eq!(
+            template.data["spec"]["podTemplate"]["spec"]["containers"][0]["image"],
+            "centaur-agent:latest"
+        );
+        assert!(
+            template.data["spec"]["podTemplate"]["metadata"]["labels"]
+                .get(SANDBOX_ID_LABEL)
+                .is_none()
+        );
+        assert_eq!(
+            template.data["spec"]["volumeClaimTemplates"][0]["metadata"]["name"],
+            "state"
+        );
+
+        let pool_types = pool.types.as_ref().unwrap();
+        assert_eq!(pool_types.kind, "SandboxWarmPool");
+        assert_eq!(pool.data["spec"]["replicas"], 3);
+        assert_eq!(
+            pool.data["spec"]["sandboxTemplateRef"]["name"],
+            "centaur-warm-template"
+        );
+        assert_eq!(pool.data["spec"]["updateStrategy"]["type"], "Recreate");
+    }
+
+    #[test]
+    fn builds_sandbox_claim_without_env_so_pool_adoption_stays_warm() {
+        let warm_pool = SandboxWarmPoolConfig::new("centaur-warm", "centaur-template");
+        let config = AgentSandboxConfig::new("centaur");
+
+        let claim = build_sandbox_claim(&SandboxId::new("asbx-claim"), &warm_pool, &config);
+
+        let claim_types = claim.types.as_ref().unwrap();
+        assert_eq!(claim_types.kind, "SandboxClaim");
+        assert_eq!(
+            claim.data["spec"]["sandboxTemplateRef"]["name"],
+            "centaur-template"
+        );
+        assert_eq!(claim.data["spec"]["warmpool"], "centaur-warm");
+        assert!(claim.data["spec"].get("env").is_none());
+        assert_eq!(
+            claim.data["spec"]["additionalPodMetadata"]["labels"][SANDBOX_CLAIM_LABEL],
+            "asbx-claim"
+        );
+    }
+
+    #[test]
+    fn reads_sandbox_warm_pool_ready_replicas() {
+        let warm_pool = SandboxWarmPoolConfig::new("centaur-warm", "centaur-template");
+        let mut pool = build_sandbox_warm_pool(&warm_pool);
+
+        assert_eq!(warm_pool_ready_replicas(&pool), 0);
+
+        pool.data["status"] = json!({"readyReplicas": 2});
+
+        assert_eq!(warm_pool_ready_replicas(&pool), 2);
+    }
+
+    #[test]
+    fn warm_pool_validation_rejects_cold_starting_inputs() {
+        let mut config = AgentSandboxConfig::new("centaur");
+        let spec = SandboxSpec::new("centaur-agent:latest").env(THREAD_KEY_ENV, "test:thread");
+
+        let error = validate_warm_pool_spec(&spec, &config).unwrap_err();
+        assert!(error.to_string().contains(THREAD_KEY_ENV));
+
+        config.iron_proxy = Some(IronProxyPodConfig::new(
+            "centaur-iron-proxy:latest",
+            "firewall-ca-cert",
+            "firewall-ca-key",
+        ));
+        let error = validate_warm_pool_spec(&SandboxSpec::new("centaur-agent:latest"), &config)
+            .unwrap_err();
+        assert!(error.to_string().contains("iron-proxy"));
+    }
+
+    #[test]
+    fn extracts_sandbox_claim_owner_names() {
+        let mut sandbox = build_agent_sandbox(
+            &SandboxId::new("asbx-adopted"),
+            &SandboxSpec::new("centaur-agent:latest"),
+            &AgentSandboxConfig::new("centaur"),
+            None,
+        )
+        .unwrap();
+        sandbox.metadata.owner_references = Some(vec![
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
+                api_version: "extensions.agents.x-k8s.io/v1beta1".to_owned(),
+                kind: "SandboxClaim".to_owned(),
+                name: "asbx-claim".to_owned(),
+                uid: "uid-1".to_owned(),
+                block_owner_deletion: None,
+                controller: None,
+            },
+        ]);
+
+        assert_eq!(sandbox_claim_owner_names(&sandbox), ["asbx-claim"]);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! The Agent Sandbox CRD types are generated from the upstream CRD with
 //! `just codegen-agent-sandbox-crd`.
+#![cfg_attr(test, allow(dead_code))]
 
 use std::collections::BTreeMap;
 use std::pin::Pin;
@@ -9,13 +10,19 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use centaur_iron_proxy::{CorePgListener, ProxyFragment, SourceKind, SourcePolicy};
+#[cfg(test)]
+use centaur_iron_proxy::SourceKind;
+use centaur_iron_proxy::{CorePgListener, ProxyFragment, SourcePolicy};
 use centaur_sandbox_core::{
     MountKind, ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
     SandboxResult, SandboxSpec, SandboxStatus,
 };
+#[cfg(test)]
 use k8s_openapi::api::apps::v1::Deployment;
-use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Pod, Service};
+#[cfg(test)]
+use k8s_openapi::api::core::v1::{ConfigMap, Service};
+use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
+#[cfg(test)]
 use k8s_openapi::api::networking::v1::NetworkPolicy;
 use kube::api::{
     ApiResource, AttachParams, DeleteParams, DynamicObject, GroupVersionKind, ListParams, Patch,
@@ -23,9 +30,11 @@ use kube::api::{
 };
 use kube::{Api, Client, Error};
 use serde_json::{Value, json};
+#[cfg(test)]
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::{Instant, sleep};
+#[cfg(test)]
 use uuid::Uuid;
 
 pub use generated::agents_x_k8s_io as crd;
@@ -43,7 +52,9 @@ const SANDBOX_CLAIM_LABEL: &str = "centaur.ai/sandbox-claim";
 const SANDBOX_TEMPLATE_LABEL: &str = "centaur.ai/sandbox-template";
 const SANDBOX_WARM_POOL_LABEL: &str = "centaur.ai/sandbox-warm-pool";
 const MANAGED_BY_VALUE: &str = "api-rs";
+#[cfg(test)]
 const TOKEN_BROKER_LABEL: &str = "centaur.ai/iron-token-broker";
+#[cfg(test)]
 const TOKEN_BROKER_CONFIG_KEY: &str = "iron-token-broker.yaml";
 const THREAD_KEY_ENV: &str = "CENTAUR_THREAD_KEY";
 
@@ -62,7 +73,7 @@ pub struct AgentSandboxConfig {
     pub service_account_name: Option<String>,
     pub state_volume: Option<StateVolumeConfig>,
     pub iron_proxy: Option<IronProxyPodConfig>,
-    pub warm_pool: Option<SandboxWarmPoolConfig>,
+    pub warm_pool: SandboxWarmPoolConfig,
     pub ready_timeout: Duration,
 }
 
@@ -80,7 +91,7 @@ impl AgentSandboxConfig {
             service_account_name: None,
             state_volume: None,
             iron_proxy: None,
-            warm_pool: None,
+            warm_pool: SandboxWarmPoolConfig::default(),
             ready_timeout: Duration::from_secs(60),
         }
     }
@@ -176,6 +187,15 @@ impl SandboxWarmPoolConfig {
     }
 }
 
+impl Default for SandboxWarmPoolConfig {
+    fn default() -> Self {
+        Self::new(
+            "centaur-agent-warm-pool",
+            "centaur-agent-warm-pool-template",
+        )
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SandboxWarmPoolUpdateStrategy {
     OnReplenish,
@@ -255,18 +275,22 @@ impl AgentSandboxBackend {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
+    #[cfg(test)]
     fn config_maps(&self) -> Api<ConfigMap> {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
+    #[cfg(test)]
     fn services(&self) -> Api<Service> {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
+    #[cfg(test)]
     fn network_policies(&self) -> Api<NetworkPolicy> {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
+    #[cfg(test)]
     fn deployments(&self) -> Api<Deployment> {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
@@ -450,9 +474,7 @@ impl AgentSandboxBackend {
     }
 
     async fn delete_warm_pool_claim_for_sandbox(&self, id: &SandboxId) -> SandboxResult<()> {
-        let Some(warm_pool) = &self.config.warm_pool else {
-            return Ok(());
-        };
+        let warm_pool = &self.config.warm_pool;
         let Some(sandbox) = self.get_sandbox(id).await? else {
             return Ok(());
         };
@@ -463,6 +485,7 @@ impl AgentSandboxBackend {
         Ok(())
     }
 
+    #[cfg(test)]
     fn resolve_iron_proxy(
         &self,
         id: &SandboxId,
@@ -523,6 +546,7 @@ impl AgentSandboxBackend {
         }))
     }
 
+    #[cfg(test)]
     async fn create_iron_proxy_configmap(
         &self,
         id: &SandboxId,
@@ -551,6 +575,7 @@ impl AgentSandboxBackend {
             .map_err(|err| map_kube_error("create iron-proxy configmap", err))
     }
 
+    #[cfg(test)]
     async fn delete_iron_proxy_configmap(&self, id: &SandboxId) -> SandboxResult<()> {
         if self.config.iron_proxy.is_none() {
             return Ok(());
@@ -566,6 +591,7 @@ impl AgentSandboxBackend {
         }
     }
 
+    #[cfg(test)]
     async fn reconcile_token_broker(&self, iron_proxy: &IronProxyPodConfig) -> SandboxResult<()> {
         let Some(token_broker_name) = iron_proxy.token_broker_name.as_deref() else {
             return Ok(());
@@ -590,6 +616,7 @@ impl AgentSandboxBackend {
         Ok(())
     }
 
+    #[cfg(test)]
     async fn apply_token_broker_configmap(
         &self,
         iron_proxy: &IronProxyPodConfig,
@@ -637,6 +664,7 @@ impl AgentSandboxBackend {
         }
     }
 
+    #[cfg(test)]
     async fn patch_token_broker_config_hash(
         &self,
         token_broker_name: &str,
@@ -664,6 +692,7 @@ impl AgentSandboxBackend {
         }
     }
 
+    #[cfg(test)]
     async fn create_iron_proxy_resources(
         &self,
         id: &SandboxId,
@@ -684,6 +713,7 @@ impl AgentSandboxBackend {
         self.wait_until_proxy_running(resolved).await
     }
 
+    #[cfg(test)]
     async fn create_iron_proxy_service(
         &self,
         id: &SandboxId,
@@ -697,6 +727,7 @@ impl AgentSandboxBackend {
             .map_err(|err| map_kube_error("create iron-proxy service", err))
     }
 
+    #[cfg(test)]
     async fn create_iron_proxy_pod(
         &self,
         id: &SandboxId,
@@ -713,6 +744,7 @@ impl AgentSandboxBackend {
             .map_err(|err| map_kube_error("create iron-proxy pod", err))
     }
 
+    #[cfg(test)]
     async fn create_iron_proxy_network_policies(
         &self,
         id: &SandboxId,
@@ -730,6 +762,7 @@ impl AgentSandboxBackend {
         Ok(())
     }
 
+    #[cfg(test)]
     async fn delete_iron_proxy_resources(&self, id: &SandboxId) -> SandboxResult<()> {
         if self.config.iron_proxy.is_none() {
             return Ok(());
@@ -755,6 +788,7 @@ impl AgentSandboxBackend {
         self.delete_iron_proxy_configmap(id).await
     }
 
+    #[cfg(test)]
     async fn delete_iron_proxy_pods_for_sandbox(&self, id: &SandboxId) -> SandboxResult<()> {
         let params = ListParams::default().labels(&format!(
             "centaur.ai/iron-proxy=true,{SANDBOX_ID_LABEL}={}",
@@ -795,6 +829,7 @@ impl AgentSandboxBackend {
         }
     }
 
+    #[cfg(test)]
     async fn wait_until_proxy_running(&self, resolved: &ResolvedIronProxy) -> SandboxResult<()> {
         let deadline = Instant::now() + self.config.ready_timeout;
         let pod_name = &resolved.proxy_pod_name;
@@ -874,34 +909,8 @@ impl SandboxBackend for AgentSandboxBackend {
     }
 
     async fn create(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
-        if let Some(warm_pool) = &self.config.warm_pool {
-            return self.create_from_warm_pool(spec, warm_pool).await;
-        }
-
-        let id = SandboxId::new(next_sandbox_name());
-        let resolved_iron_proxy = self.resolve_iron_proxy(&id, &spec)?;
-        if let Err(err) = self
-            .create_iron_proxy_resources(&id, resolved_iron_proxy.as_ref())
+        self.create_from_warm_pool(spec, &self.config.warm_pool)
             .await
-        {
-            let _ = self.delete_iron_proxy_resources(&id).await;
-            return Err(err);
-        }
-        let sandbox = build_agent_sandbox(&id, &spec, &self.config, resolved_iron_proxy.as_ref())?;
-        let create_result = self
-            .sandboxes()
-            .create(&PostParams::default(), &sandbox)
-            .await
-            .map_err(|err| map_kube_error("create sandbox", err));
-        if let Err(err) = create_result {
-            let _ = self.delete_iron_proxy_resources(&id).await;
-            return Err(err);
-        }
-        if let Err(err) = self.wait_until_running(&id).await {
-            let _ = self.stop(&id).await;
-            return Err(err);
-        }
-        Ok(SandboxHandle::new(id, BACKEND_NAME))
     }
 
     async fn open_io(&self, id: &SandboxId) -> SandboxResult<SandboxIo> {
@@ -951,8 +960,7 @@ impl SandboxBackend for AgentSandboxBackend {
             Ok(_) => self.delete_state_pvc(id).await,
             Err(err) if is_not_found(&err) => self.delete_state_pvc(id).await,
             Err(err) => Err(map_kube_error("delete sandbox", err)),
-        }?;
-        self.delete_iron_proxy_resources(id).await
+        }
     }
 
     async fn pause(&self, id: &SandboxId) -> SandboxResult<()> {
@@ -1374,10 +1382,12 @@ fn proxy_env(
     env
 }
 
+#[cfg(test)]
 fn proxied_pg_url(host: &str, port: u16, password: &str, database: &str) -> String {
     format!("postgresql://app_user:{password}@{host}:{port}/{database}")
 }
 
+#[cfg(test)]
 fn proxy_password() -> String {
     Uuid::new_v4().simple().to_string()
 }
@@ -1439,6 +1449,7 @@ fn spec_env<'a>(spec: &'a SandboxSpec, name: &str) -> Option<&'a str> {
         .filter(|value| !value.trim().is_empty())
 }
 
+#[cfg(test)]
 fn iron_proxy_container(iron_proxy: &IronProxyPodConfig, resolved: &ResolvedIronProxy) -> Value {
     let mut env = BTreeMap::<String, Value>::new();
     if let Some(secret_name) = &iron_proxy.secret_env_name {
@@ -1564,6 +1575,7 @@ fn iron_proxy_container(iron_proxy: &IronProxyPodConfig, resolved: &ResolvedIron
     container
 }
 
+#[cfg(test)]
 fn insert_env_value(env: &mut BTreeMap<String, Value>, name: &str, value: impl AsRef<str>) {
     env.insert(
         name.to_owned(),
@@ -1571,6 +1583,7 @@ fn insert_env_value(env: &mut BTreeMap<String, Value>, name: &str, value: impl A
     );
 }
 
+#[cfg(test)]
 fn insert_env_secret_ref(
     env: &mut BTreeMap<String, Value>,
     name: &str,
@@ -1591,6 +1604,7 @@ fn insert_env_secret_ref(
     );
 }
 
+#[cfg(test)]
 fn iron_proxy_volumes(id: &SandboxId, iron_proxy: &IronProxyPodConfig) -> Vec<Value> {
     vec![
         json!({
@@ -1606,6 +1620,7 @@ fn iron_proxy_volumes(id: &SandboxId, iron_proxy: &IronProxyPodConfig) -> Vec<Va
     ]
 }
 
+#[cfg(test)]
 fn build_iron_proxy_pod(
     id: &SandboxId,
     pod_name: &str,
@@ -1637,6 +1652,7 @@ fn build_iron_proxy_pod(
         .map_err(|err| SandboxError::InvalidSpec(format!("invalid iron-proxy pod: {err}")))
 }
 
+#[cfg(test)]
 fn build_iron_proxy_service(
     id: &SandboxId,
     resolved: &ResolvedIronProxy,
@@ -1676,6 +1692,7 @@ fn build_iron_proxy_service(
         .map_err(|err| SandboxError::InvalidSpec(format!("invalid iron-proxy service: {err}")))
 }
 
+#[cfg(test)]
 fn build_iron_proxy_network_policies(
     id: &SandboxId,
     resolved: &ResolvedIronProxy,
@@ -1776,6 +1793,7 @@ fn build_iron_proxy_network_policies(
         .collect()
 }
 
+#[cfg(test)]
 fn dns_egress_rule() -> Value {
     json!({
         "to": [{
@@ -1790,6 +1808,7 @@ fn dns_egress_rule() -> Value {
     })
 }
 
+#[cfg(test)]
 fn iron_proxy_broker_port(iron_proxy: &IronProxyPodConfig) -> Option<u16> {
     iron_proxy
         .extra_env
@@ -1803,6 +1822,7 @@ fn iron_proxy_broker_port(iron_proxy: &IronProxyPodConfig) -> Option<u16> {
         })
 }
 
+#[cfg(test)]
 fn url_port(value: &str) -> Option<u16> {
     let without_scheme = value
         .split_once("://")
@@ -1850,14 +1870,17 @@ fn state_pvc_name(id: &SandboxId) -> String {
     format!("state-{}", id.as_str())
 }
 
+#[cfg(test)]
 fn iron_proxy_configmap_name(id: &SandboxId) -> String {
     format!("{}-iron-proxy", id.as_str())
 }
 
+#[cfg(test)]
 fn iron_proxy_pod_name(id: &SandboxId) -> String {
     format!("{}-proxy", id.as_str())
 }
 
+#[cfg(test)]
 fn new_iron_proxy_pod_name(id: &SandboxId) -> String {
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1867,18 +1890,22 @@ fn new_iron_proxy_pod_name(id: &SandboxId) -> String {
     format!("{}-proxy-{millis}-{sequence}", id.as_str())
 }
 
+#[cfg(test)]
 fn iron_proxy_service_name(id: &SandboxId) -> String {
     format!("{}-proxy", id.as_str())
 }
 
+#[cfg(test)]
 fn iron_proxy_sandbox_egress_policy_name(id: &SandboxId) -> String {
     format!("{}-sandbox-egress", id.as_str())
 }
 
+#[cfg(test)]
 fn iron_proxy_policy_name(id: &SandboxId) -> String {
     format!("{}-proxy-net", id.as_str())
 }
 
+#[cfg(test)]
 fn iron_token_broker_configmap_name(iron_proxy: &IronProxyPodConfig) -> SandboxResult<String> {
     if let Some(name) = iron_proxy.token_broker_configmap_name.as_deref() {
         return Ok(name.to_owned());
@@ -1891,6 +1918,7 @@ fn iron_token_broker_configmap_name(iron_proxy: &IronProxyPodConfig) -> SandboxR
     Ok(format!("{name}-config"))
 }
 
+#[cfg(test)]
 fn token_broker_labels() -> BTreeMap<String, String> {
     BTreeMap::from([
         (TOKEN_BROKER_LABEL.to_owned(), "true".to_owned()),
@@ -1907,6 +1935,7 @@ fn sandbox_labels(id: &SandboxId) -> BTreeMap<String, String> {
     labels
 }
 
+#[cfg(test)]
 fn iron_proxy_labels(id: &SandboxId) -> BTreeMap<String, String> {
     let mut labels = base_resource_labels(id);
     labels.insert("centaur.ai/iron-proxy".to_owned(), "true".to_owned());
@@ -1979,6 +2008,7 @@ fn image_pull_secret_refs(names: &[String]) -> Option<Vec<Value>> {
     })
 }
 
+#[cfg(test)]
 fn short_sha256(value: &str) -> String {
     let digest = Sha256::digest(value.as_bytes());
     format!("{digest:x}").chars().take(16).collect()

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -419,6 +419,28 @@ impl AgentSandboxBackend {
         }
     }
 
+    async fn claim_prewarmed_from_warm_pool(
+        &self,
+        spec: SandboxSpec,
+        warm_pool: &SandboxWarmPoolConfig,
+    ) -> SandboxResult<SandboxHandle> {
+        validate_warm_pool_spec(&spec, &self.config)?;
+        let claim_id = SandboxId::new(next_sandbox_name());
+        let claim = build_sandbox_claim(&claim_id, warm_pool, &self.config);
+        self.sandbox_claims(warm_pool)
+            .create(&PostParams::default(), &claim)
+            .await
+            .map_err(|err| map_kube_error("create sandbox warm-pool claim", err))?;
+
+        match self.wait_for_sandbox_claim(&claim_id, warm_pool).await {
+            Ok(id) => Ok(SandboxHandle::new(id, BACKEND_NAME)),
+            Err(err) => {
+                let _ = self.delete_sandbox_claim(&claim_id, warm_pool).await;
+                Err(err)
+            }
+        }
+    }
+
     fn spawn_warm_pool_proxy_prewarm(
         &self,
         warm_pool: SandboxWarmPoolConfig,
@@ -1111,6 +1133,11 @@ impl SandboxBackend for AgentSandboxBackend {
             .await
     }
 
+    async fn claim_prewarmed(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
+        self.claim_prewarmed_from_warm_pool(spec, &self.config.warm_pool)
+            .await
+    }
+
     async fn prewarm(&self, spec: SandboxSpec) -> SandboxResult<Vec<SandboxId>> {
         let warm_pool = &self.config.warm_pool;
         validate_warm_pool_spec(&spec, &self.config)?;
@@ -1637,6 +1664,7 @@ fn codex_app_server_readiness_probe(spec: &SandboxSpec) -> Option<Value> {
                 ],
             },
             "periodSeconds": 1,
+            "timeoutSeconds": 5,
             "failureThreshold": 30,
         })
     })
@@ -2731,6 +2759,7 @@ mod tests {
                 .contains("app-server")
         );
         assert_eq!(container["readinessProbe"]["periodSeconds"], 1);
+        assert_eq!(container["readinessProbe"]["timeoutSeconds"], 5);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -10,19 +10,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-#[cfg(test)]
-use centaur_iron_proxy::SourceKind;
-use centaur_iron_proxy::{CorePgListener, ProxyFragment, SourcePolicy};
+use centaur_iron_proxy::{CorePgListener, ProxyFragment, SourceKind, SourcePolicy};
 use centaur_sandbox_core::{
     MountKind, ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
     SandboxResult, SandboxSpec, SandboxStatus,
 };
-#[cfg(test)]
 use k8s_openapi::api::apps::v1::Deployment;
-#[cfg(test)]
-use k8s_openapi::api::core::v1::{ConfigMap, Service};
-use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
-#[cfg(test)]
+use k8s_openapi::api::core::v1::{ConfigMap, Endpoints, PersistentVolumeClaim, Pod, Service};
 use k8s_openapi::api::networking::v1::NetworkPolicy;
 use kube::api::{
     ApiResource, AttachParams, DeleteParams, DynamicObject, GroupVersionKind, ListParams, Patch,
@@ -30,11 +24,9 @@ use kube::api::{
 };
 use kube::{Api, Client, Error};
 use serde_json::{Value, json};
-#[cfg(test)]
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::{Instant, sleep};
-#[cfg(test)]
 use uuid::Uuid;
 
 pub use generated::agents_x_k8s_io as crd;
@@ -52,11 +44,10 @@ const SANDBOX_CLAIM_LABEL: &str = "centaur.ai/sandbox-claim";
 const SANDBOX_TEMPLATE_LABEL: &str = "centaur.ai/sandbox-template";
 const SANDBOX_WARM_POOL_LABEL: &str = "centaur.ai/sandbox-warm-pool";
 const MANAGED_BY_VALUE: &str = "api-rs";
-#[cfg(test)]
 const TOKEN_BROKER_LABEL: &str = "centaur.ai/iron-token-broker";
-#[cfg(test)]
 const TOKEN_BROKER_CONFIG_KEY: &str = "iron-token-broker.yaml";
 const THREAD_KEY_ENV: &str = "CENTAUR_THREAD_KEY";
+const SANDBOX_POD_NAME_ENV: &str = "CENTAUR_SANDBOX_POD_NAME";
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -216,7 +207,6 @@ struct ResolvedIronProxy {
     config_yaml: String,
     placeholder_env: BTreeMap<String, String>,
     proxy_host: String,
-    proxy_pod_name: String,
     proxy_port: u16,
     listen_ports: Vec<u16>,
     pg_dsn_env: BTreeMap<String, String>,
@@ -275,22 +265,22 @@ impl AgentSandboxBackend {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
-    #[cfg(test)]
     fn config_maps(&self) -> Api<ConfigMap> {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
-    #[cfg(test)]
+    fn endpoints(&self) -> Api<Endpoints> {
+        Api::namespaced(self.client.clone(), &self.config.namespace)
+    }
+
     fn services(&self) -> Api<Service> {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
-    #[cfg(test)]
     fn network_policies(&self) -> Api<NetworkPolicy> {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
-    #[cfg(test)]
     fn deployments(&self) -> Api<Deployment> {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
@@ -363,8 +353,16 @@ impl AgentSandboxBackend {
         &self,
         spec: &SandboxSpec,
         warm_pool: &SandboxWarmPoolConfig,
-    ) -> SandboxResult<()> {
-        let template = build_sandbox_template(warm_pool, spec, &self.config)?;
+    ) -> SandboxResult<Option<ResolvedIronProxy>> {
+        let resolved_iron_proxy = self.resolve_iron_proxy(spec)?;
+        if resolved_iron_proxy.is_some() {
+            if let Some(iron_proxy) = &self.config.iron_proxy {
+                self.reconcile_token_broker(iron_proxy).await?;
+            }
+        }
+
+        let template =
+            build_sandbox_template(warm_pool, spec, &self.config, resolved_iron_proxy.as_ref())?;
         let pool = build_sandbox_warm_pool(warm_pool);
         let params = PatchParams::apply(&self.config.field_manager).force();
         self.sandbox_templates(warm_pool)
@@ -375,7 +373,7 @@ impl AgentSandboxBackend {
             .patch(&warm_pool.pool_name, &params, &Patch::Apply(&pool))
             .await
             .map_err(|err| map_kube_error("apply sandbox warm pool", err))?;
-        Ok(())
+        Ok(resolved_iron_proxy)
     }
 
     async fn create_from_warm_pool(
@@ -384,7 +382,10 @@ impl AgentSandboxBackend {
         warm_pool: &SandboxWarmPoolConfig,
     ) -> SandboxResult<SandboxHandle> {
         validate_warm_pool_spec(&spec, &self.config)?;
-        self.reconcile_warm_pool(&spec, warm_pool).await?;
+        let resolved_iron_proxy = self.reconcile_warm_pool(&spec, warm_pool).await?;
+        if let Some(resolved) = resolved_iron_proxy.clone() {
+            self.spawn_warm_pool_proxy_prewarm(warm_pool.clone(), resolved);
+        }
         self.wait_for_warm_pool_ready(warm_pool).await?;
 
         let claim_id = SandboxId::new(next_sandbox_name());
@@ -395,12 +396,79 @@ impl AgentSandboxBackend {
             .map_err(|err| map_kube_error("create sandbox warm-pool claim", err))?;
 
         match self.wait_for_sandbox_claim(&claim_id, warm_pool).await {
-            Ok(id) => Ok(SandboxHandle::new(id, BACKEND_NAME)),
+            Ok(id) => {
+                if let Some(resolved) = resolved_iron_proxy.as_ref()
+                    && let Err(err) = self
+                        .create_iron_proxy_resources(&id, &claim_id, resolved)
+                        .await
+                {
+                    let _ = self.delete_sandbox_claim(&claim_id, warm_pool).await;
+                    let _ = self.delete_iron_proxy_resources(&id).await;
+                    return Err(err);
+                }
+                if let Some(resolved) = resolved_iron_proxy.clone() {
+                    self.spawn_warm_pool_proxy_prewarm(warm_pool.clone(), resolved);
+                }
+                Ok(SandboxHandle::new(id, BACKEND_NAME))
+            }
             Err(err) => {
                 let _ = self.delete_sandbox_claim(&claim_id, warm_pool).await;
                 Err(err)
             }
         }
+    }
+
+    fn spawn_warm_pool_proxy_prewarm(
+        &self,
+        warm_pool: SandboxWarmPoolConfig,
+        resolved: ResolvedIronProxy,
+    ) {
+        let backend = self.clone();
+        tokio::spawn(async move {
+            if backend.wait_for_warm_pool_ready(&warm_pool).await.is_ok() {
+                let _ = backend
+                    .prewarm_ready_warm_pool_proxies(&warm_pool, &resolved)
+                    .await;
+            }
+        });
+    }
+
+    async fn prewarm_ready_warm_pool_proxies(
+        &self,
+        warm_pool: &SandboxWarmPoolConfig,
+        resolved: &ResolvedIronProxy,
+    ) -> SandboxResult<()> {
+        let sandboxes = self
+            .sandboxes()
+            .list(&ListParams::default())
+            .await
+            .map_err(|err| map_kube_error("list warm-pool sandboxes", err))?;
+        for sandbox in sandboxes {
+            if !is_unclaimed_warm_pool_sandbox(&sandbox, warm_pool) {
+                continue;
+            }
+            let Some(name) = sandbox.metadata.name.clone() else {
+                continue;
+            };
+            let id = SandboxId::new(name);
+            let pod_name = sandbox_pod_name(&sandbox, &id);
+            let pod = match self.pods().get(&pod_name).await {
+                Ok(pod) => pod,
+                Err(err) if is_not_found(&err) => continue,
+                Err(err) => return Err(map_kube_error("get warm-pool sandbox pod", err)),
+            };
+            if !pod_ready(&pod) {
+                continue;
+            }
+            self.create_iron_proxy_configmap(&id, Some(resolved))
+                .await?;
+            self.create_iron_proxy_service(&id, resolved).await?;
+            self.create_iron_proxy_pod(&id, resolved).await?;
+            self.wait_until_proxy_running(&iron_proxy_pod_name(&id))
+                .await?;
+            self.wait_until_proxy_endpoint_ready(&id, resolved).await?;
+        }
+        Ok(())
     }
 
     async fn wait_for_warm_pool_ready(
@@ -445,6 +513,7 @@ impl AgentSandboxBackend {
             if let Some(name) = claim_sandbox_name(&claim) {
                 let id = SandboxId::new(name);
                 self.wait_until_running(&id).await?;
+                self.label_claimed_sandbox(&id, claim_id, warm_pool).await?;
                 return Ok(id);
             }
             if Instant::now() >= deadline {
@@ -473,6 +542,35 @@ impl AgentSandboxBackend {
         }
     }
 
+    async fn label_claimed_sandbox(
+        &self,
+        id: &SandboxId,
+        claim_id: &SandboxId,
+        warm_pool: &SandboxWarmPoolConfig,
+    ) -> SandboxResult<()> {
+        let labels = adopted_sandbox_labels(id, claim_id, warm_pool);
+        let patch = Patch::Merge(json!({
+            "metadata": {
+                "labels": labels,
+            },
+        }));
+        self.sandboxes()
+            .patch(id.as_str(), &PatchParams::default(), &patch)
+            .await
+            .map_err(|err| map_kube_error("label claimed sandbox", err))?;
+
+        let sandbox = self
+            .get_sandbox(id)
+            .await?
+            .ok_or_else(|| SandboxError::NotFound(id.as_str().to_owned()))?;
+        let pod_name = sandbox_pod_name(&sandbox, id);
+        self.pods()
+            .patch(&pod_name, &PatchParams::default(), &patch)
+            .await
+            .map(|_| ())
+            .map_err(|err| map_kube_error("label claimed sandbox pod", err))
+    }
+
     async fn delete_warm_pool_claim_for_sandbox(&self, id: &SandboxId) -> SandboxResult<()> {
         let warm_pool = &self.config.warm_pool;
         let Some(sandbox) = self.get_sandbox(id).await? else {
@@ -485,12 +583,7 @@ impl AgentSandboxBackend {
         Ok(())
     }
 
-    #[cfg(test)]
-    fn resolve_iron_proxy(
-        &self,
-        id: &SandboxId,
-        spec: &SandboxSpec,
-    ) -> SandboxResult<Option<ResolvedIronProxy>> {
+    fn resolve_iron_proxy(&self, spec: &SandboxSpec) -> SandboxResult<Option<ResolvedIronProxy>> {
         let Some(iron_proxy) = &self.config.iron_proxy else {
             return Ok(None);
         };
@@ -522,7 +615,7 @@ impl AgentSandboxBackend {
             .map_err(|err| SandboxError::InvalidSpec(format!("iron-proxy proxy port: {err}")))?;
         let listen_ports = centaur_iron_proxy::listen_ports_from_yaml(&config_yaml)
             .map_err(|err| SandboxError::InvalidSpec(format!("iron-proxy listen ports: {err}")))?;
-        let proxy_host = iron_proxy_service_name(id);
+        let proxy_host = sandbox_proxy_host_template();
         let mut pg_dsn_env = BTreeMap::new();
         let mut pg_proxy_password_env = BTreeMap::new();
         for entry in centaur_iron_proxy::pg_dsn_envs(&fragments) {
@@ -538,7 +631,6 @@ impl AgentSandboxBackend {
             config_yaml,
             placeholder_env,
             proxy_host,
-            proxy_pod_name: new_iron_proxy_pod_name(id),
             proxy_port,
             listen_ports,
             pg_dsn_env,
@@ -546,7 +638,6 @@ impl AgentSandboxBackend {
         }))
     }
 
-    #[cfg(test)]
     async fn create_iron_proxy_configmap(
         &self,
         id: &SandboxId,
@@ -556,7 +647,6 @@ impl AgentSandboxBackend {
             return Ok(());
         };
         let name = iron_proxy_configmap_name(id);
-        let _ = self.delete_iron_proxy_configmap(id).await;
         let mut data = BTreeMap::new();
         data.insert("proxy.yaml".to_owned(), resolved.config_yaml.clone());
         let body = ConfigMap {
@@ -568,30 +658,31 @@ impl AgentSandboxBackend {
             data: Some(data),
             ..Default::default()
         };
-        self.config_maps()
-            .create(&PostParams::default(), &body)
-            .await
-            .map(|_| ())
-            .map_err(|err| map_kube_error("create iron-proxy configmap", err))
-    }
-
-    #[cfg(test)]
-    async fn delete_iron_proxy_configmap(&self, id: &SandboxId) -> SandboxResult<()> {
-        if self.config.iron_proxy.is_none() {
-            return Ok(());
-        }
         match self
             .config_maps()
-            .delete(&iron_proxy_configmap_name(id), &DeleteParams::default())
+            .create(&PostParams::default(), &body)
             .await
         {
             Ok(_) => Ok(()),
-            Err(err) if is_not_found(&err) => Ok(()),
-            Err(err) => Err(map_kube_error("delete iron-proxy configmap", err)),
+            Err(err) if is_already_exists(&err) => {
+                let patch = Patch::Merge(json!({
+                    "metadata": {"labels": iron_proxy_labels(id)},
+                    "data": body.data,
+                }));
+                self.config_maps()
+                    .patch(
+                        &iron_proxy_configmap_name(id),
+                        &PatchParams::default(),
+                        &patch,
+                    )
+                    .await
+                    .map(|_| ())
+                    .map_err(|err| map_kube_error("patch iron-proxy configmap", err))
+            }
+            Err(err) => Err(map_kube_error("create iron-proxy configmap", err)),
         }
     }
 
-    #[cfg(test)]
     async fn reconcile_token_broker(&self, iron_proxy: &IronProxyPodConfig) -> SandboxResult<()> {
         let Some(token_broker_name) = iron_proxy.token_broker_name.as_deref() else {
             return Ok(());
@@ -616,7 +707,6 @@ impl AgentSandboxBackend {
         Ok(())
     }
 
-    #[cfg(test)]
     async fn apply_token_broker_configmap(
         &self,
         iron_proxy: &IronProxyPodConfig,
@@ -664,7 +754,6 @@ impl AgentSandboxBackend {
         }
     }
 
-    #[cfg(test)]
     async fn patch_token_broker_config_hash(
         &self,
         token_broker_name: &str,
@@ -692,42 +781,58 @@ impl AgentSandboxBackend {
         }
     }
 
-    #[cfg(test)]
     async fn create_iron_proxy_resources(
         &self,
         id: &SandboxId,
-        resolved: Option<&ResolvedIronProxy>,
+        claim_id: &SandboxId,
+        resolved: &ResolvedIronProxy,
     ) -> SandboxResult<()> {
-        let Some(resolved) = resolved else {
-            return Ok(());
-        };
-        if let Some(iron_proxy) = &self.config.iron_proxy {
-            self.reconcile_token_broker(iron_proxy).await?;
-        }
-        self.delete_iron_proxy_resources(id).await?;
         self.create_iron_proxy_configmap(id, Some(resolved)).await?;
         self.create_iron_proxy_service(id, resolved).await?;
-        self.create_iron_proxy_network_policies(id, resolved)
-            .await?;
+        self.create_iron_proxy_network_policies(
+            id,
+            resolved,
+            &sandbox_claim_selector_labels(claim_id),
+            &sandbox_labels(id),
+        )
+        .await?;
         self.create_iron_proxy_pod(id, resolved).await?;
-        self.wait_until_proxy_running(resolved).await
+        self.wait_until_proxy_running(&iron_proxy_pod_name(id))
+            .await?;
+        self.wait_until_proxy_endpoint_ready(id, resolved).await
     }
 
-    #[cfg(test)]
     async fn create_iron_proxy_service(
         &self,
         id: &SandboxId,
         resolved: &ResolvedIronProxy,
     ) -> SandboxResult<()> {
         let service = build_iron_proxy_service(id, resolved)?;
-        self.services()
+        match self
+            .services()
             .create(&PostParams::default(), &service)
             .await
-            .map(|_| ())
-            .map_err(|err| map_kube_error("create iron-proxy service", err))
+        {
+            Ok(_) => Ok(()),
+            Err(err) if is_already_exists(&err) => {
+                let patch = Patch::Merge(json!({
+                    "metadata": {"labels": service.metadata.labels},
+                    "spec": service.spec,
+                }));
+                self.services()
+                    .patch(
+                        &iron_proxy_service_name(id),
+                        &PatchParams::default(),
+                        &patch,
+                    )
+                    .await
+                    .map(|_| ())
+                    .map_err(|err| map_kube_error("patch iron-proxy service", err))
+            }
+            Err(err) => Err(map_kube_error("create iron-proxy service", err)),
+        }
     }
 
-    #[cfg(test)]
     async fn create_iron_proxy_pod(
         &self,
         id: &SandboxId,
@@ -736,33 +841,86 @@ impl AgentSandboxBackend {
         let Some(iron_proxy) = &self.config.iron_proxy else {
             return Ok(());
         };
-        let pod = build_iron_proxy_pod(id, &resolved.proxy_pod_name, iron_proxy, resolved)?;
-        self.pods()
-            .create(&PostParams::default(), &pod)
-            .await
-            .map(|_| ())
-            .map_err(|err| map_kube_error("create iron-proxy pod", err))
+        let pod_name = iron_proxy_pod_name(id);
+        let pod = build_iron_proxy_pod(id, &pod_name, iron_proxy, resolved)?;
+        match self.pods().get(&pod_name).await {
+            Ok(existing)
+                if proxy_pod_config_hash(&existing)
+                    == Some(short_sha256(&resolved.config_yaml)) =>
+            {
+                Ok(())
+            }
+            Ok(_) => {
+                let _ = self
+                    .pods()
+                    .delete(&pod_name, &DeleteParams::default())
+                    .await;
+                self.wait_until_proxy_gone(&pod_name).await?;
+                self.pods()
+                    .create(&PostParams::default(), &pod)
+                    .await
+                    .map(|_| ())
+                    .map_err(|err| map_kube_error("create iron-proxy pod", err))
+            }
+            Err(err) if is_not_found(&err) => self
+                .pods()
+                .create(&PostParams::default(), &pod)
+                .await
+                .map(|_| ())
+                .or_else(|err| {
+                    if is_already_exists(&err) {
+                        Ok(())
+                    } else {
+                        Err(err)
+                    }
+                })
+                .map_err(|err| map_kube_error("create iron-proxy pod", err)),
+            Err(err) => Err(map_kube_error("get iron-proxy pod", err)),
+        }
     }
 
-    #[cfg(test)]
     async fn create_iron_proxy_network_policies(
         &self,
         id: &SandboxId,
         resolved: &ResolvedIronProxy,
+        sandbox_selector_labels: &BTreeMap<String, String>,
+        resource_labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         let Some(iron_proxy) = &self.config.iron_proxy else {
             return Ok(());
         };
-        for policy in build_iron_proxy_network_policies(id, resolved, iron_proxy)? {
-            self.network_policies()
+        for policy in build_iron_proxy_network_policies(
+            id,
+            resolved,
+            iron_proxy,
+            sandbox_selector_labels,
+            resource_labels,
+        )? {
+            match self
+                .network_policies()
                 .create(&PostParams::default(), &policy)
                 .await
-                .map_err(|err| map_kube_error("create iron-proxy network policy", err))?;
+            {
+                Ok(_) => {}
+                Err(err) if is_already_exists(&err) => {
+                    let name = policy.metadata.name.as_deref().ok_or_else(|| {
+                        SandboxError::InvalidSpec("iron-proxy policy missing name".to_owned())
+                    })?;
+                    let patch = Patch::Merge(json!({
+                        "metadata": {"labels": policy.metadata.labels},
+                        "spec": policy.spec,
+                    }));
+                    self.network_policies()
+                        .patch(name, &PatchParams::default(), &patch)
+                        .await
+                        .map_err(|err| map_kube_error("patch iron-proxy network policy", err))?;
+                }
+                Err(err) => return Err(map_kube_error("create iron-proxy network policy", err)),
+            }
         }
         Ok(())
     }
 
-    #[cfg(test)]
     async fn delete_iron_proxy_resources(&self, id: &SandboxId) -> SandboxResult<()> {
         if self.config.iron_proxy.is_none() {
             return Ok(());
@@ -771,10 +929,13 @@ impl AgentSandboxBackend {
             .pods()
             .delete(&iron_proxy_pod_name(id), &DeleteParams::default())
             .await;
-        let _ = self.delete_iron_proxy_pods_for_sandbox(id).await;
         let _ = self
             .services()
             .delete(&iron_proxy_service_name(id), &DeleteParams::default())
+            .await;
+        let _ = self
+            .config_maps()
+            .delete(&iron_proxy_configmap_name(id), &DeleteParams::default())
             .await;
         for name in [
             iron_proxy_sandbox_egress_policy_name(id),
@@ -784,25 +945,6 @@ impl AgentSandboxBackend {
                 .network_policies()
                 .delete(&name, &DeleteParams::default())
                 .await;
-        }
-        self.delete_iron_proxy_configmap(id).await
-    }
-
-    #[cfg(test)]
-    async fn delete_iron_proxy_pods_for_sandbox(&self, id: &SandboxId) -> SandboxResult<()> {
-        let params = ListParams::default().labels(&format!(
-            "centaur.ai/iron-proxy=true,{SANDBOX_ID_LABEL}={}",
-            id.as_str()
-        ));
-        let pods = self
-            .pods()
-            .list(&params)
-            .await
-            .map_err(|err| map_kube_error("list iron-proxy pods", err))?;
-        for pod in pods.items {
-            if let Some(name) = pod.metadata.name {
-                let _ = self.pods().delete(&name, &DeleteParams::default()).await;
-            }
         }
         Ok(())
     }
@@ -829,10 +971,8 @@ impl AgentSandboxBackend {
         }
     }
 
-    #[cfg(test)]
-    async fn wait_until_proxy_running(&self, resolved: &ResolvedIronProxy) -> SandboxResult<()> {
+    async fn wait_until_proxy_running(&self, pod_name: &str) -> SandboxResult<()> {
         let deadline = Instant::now() + self.config.ready_timeout;
-        let pod_name = &resolved.proxy_pod_name;
         loop {
             match self.pods().get(pod_name).await {
                 Ok(pod) if sandbox_status_from_pod(1, Some(&pod)) == SandboxStatus::Running => {
@@ -859,6 +999,53 @@ impl AgentSandboxBackend {
                     )));
                 }
                 Err(err) => return Err(map_kube_error("wait iron-proxy pod", err)),
+            }
+        }
+    }
+
+    async fn wait_until_proxy_endpoint_ready(
+        &self,
+        id: &SandboxId,
+        resolved: &ResolvedIronProxy,
+    ) -> SandboxResult<()> {
+        let service_name = iron_proxy_service_name(id);
+        let deadline = Instant::now() + self.config.ready_timeout;
+        loop {
+            match self.endpoints().get(&service_name).await {
+                Ok(endpoints) if endpoint_has_ready_port(&endpoints, resolved.proxy_port) => {
+                    return Ok(());
+                }
+                Ok(_) if Instant::now() >= deadline => {
+                    return Err(SandboxError::NotReady(format!(
+                        "iron-proxy service {service_name} did not publish ready endpoints before timeout"
+                    )));
+                }
+                Ok(_) => sleep(Duration::from_millis(200)).await,
+                Err(err) if is_not_found(&err) && Instant::now() < deadline => {
+                    sleep(Duration::from_millis(200)).await;
+                }
+                Err(err) if is_not_found(&err) => {
+                    return Err(SandboxError::NotReady(format!(
+                        "iron-proxy service {service_name} endpoints were not created before timeout"
+                    )));
+                }
+                Err(err) => return Err(map_kube_error("wait iron-proxy endpoints", err)),
+            }
+        }
+    }
+
+    async fn wait_until_proxy_gone(&self, pod_name: &str) -> SandboxResult<()> {
+        let deadline = Instant::now() + self.config.ready_timeout;
+        loop {
+            match self.pods().get(pod_name).await {
+                Err(err) if is_not_found(&err) => return Ok(()),
+                Err(err) => return Err(map_kube_error("get iron-proxy pod", err)),
+                Ok(_) if Instant::now() >= deadline => {
+                    return Err(SandboxError::NotReady(format!(
+                        "iron-proxy pod {pod_name} was not deleted before timeout"
+                    )));
+                }
+                Ok(_) => sleep(Duration::from_millis(500)).await,
             }
         }
     }
@@ -932,8 +1119,9 @@ impl SandboxBackend for AgentSandboxBackend {
     }
 
     async fn list_observed(&self) -> SandboxResult<Vec<ObservedSandbox>> {
-        let params =
-            ListParams::default().labels(&format!("{MANAGED_BY_LABEL}={MANAGED_BY_VALUE}"));
+        let params = ListParams::default().labels(&format!(
+            "{MANAGED_BY_LABEL}={MANAGED_BY_VALUE},{SANDBOX_CLAIM_LABEL}"
+        ));
         let sandboxes = self
             .sandboxes()
             .list(&params)
@@ -952,6 +1140,7 @@ impl SandboxBackend for AgentSandboxBackend {
 
     async fn stop(&self, id: &SandboxId) -> SandboxResult<()> {
         self.delete_warm_pool_claim_for_sandbox(id).await?;
+        self.delete_iron_proxy_resources(id).await?;
         match self
             .sandboxes()
             .delete(id.as_str(), &DeleteParams::default())
@@ -1012,6 +1201,22 @@ fn pod_ready(pod: &Pod) -> bool {
         })
 }
 
+fn endpoint_has_ready_port(endpoints: &Endpoints, port: u16) -> bool {
+    endpoints.subsets.as_ref().is_some_and(|subsets| {
+        subsets.iter().any(|subset| {
+            subset
+                .addresses
+                .as_ref()
+                .is_some_and(|addresses| !addresses.is_empty())
+                && subset.ports.as_ref().is_some_and(|ports| {
+                    ports
+                        .iter()
+                        .any(|endpoint_port| endpoint_port.port == i32::from(port))
+                })
+        })
+    })
+}
+
 fn extension_resource(api_version: &str, kind: &str, plural: &str) -> ApiResource {
     ApiResource::from_gvk_with_plural(
         &GroupVersionKind::gvk(EXTENSIONS_GROUP, api_version, kind),
@@ -1019,13 +1224,7 @@ fn extension_resource(api_version: &str, kind: &str, plural: &str) -> ApiResourc
     )
 }
 
-fn validate_warm_pool_spec(spec: &SandboxSpec, config: &AgentSandboxConfig) -> SandboxResult<()> {
-    if config.iron_proxy.is_some() {
-        return Err(SandboxError::InvalidSpec(
-            "SandboxWarmPool mode cannot be combined with per-sandbox iron-proxy resources"
-                .to_owned(),
-        ));
-    }
+fn validate_warm_pool_spec(spec: &SandboxSpec, _config: &AgentSandboxConfig) -> SandboxResult<()> {
     if spec_env(spec, THREAD_KEY_ENV).is_some() {
         return Err(SandboxError::InvalidSpec(format!(
             "SandboxWarmPool templates cannot include per-thread {THREAD_KEY_ENV}; pass thread context with each turn instead"
@@ -1038,9 +1237,10 @@ fn build_sandbox_template(
     warm_pool: &SandboxWarmPoolConfig,
     spec: &SandboxSpec,
     config: &AgentSandboxConfig,
+    resolved_iron_proxy: Option<&ResolvedIronProxy>,
 ) -> SandboxResult<DynamicObject> {
     let template_id = SandboxId::new(warm_pool.template_name.clone());
-    let sandbox = build_agent_sandbox(&template_id, spec, config, None)?;
+    let sandbox = build_agent_sandbox(&template_id, spec, config, resolved_iron_proxy)?;
     let mut template_spec = serde_json::to_value(&sandbox.spec).map_err(|err| {
         SandboxError::InvalidSpec(format!("invalid sandbox warm-pool template: {err}"))
     })?;
@@ -1050,6 +1250,12 @@ fn build_sandbox_template(
     spec_object.remove("replicas");
     spec_object.remove("shutdownPolicy");
     spec_object.remove("shutdownTime");
+    if let (Some(iron_proxy), Some(_)) = (&config.iron_proxy, resolved_iron_proxy) {
+        spec_object.insert(
+            "networkPolicy".to_owned(),
+            sandbox_template_network_policy(iron_proxy),
+        );
+    }
     if let Some(labels) = spec_object
         .get_mut("podTemplate")
         .and_then(|pod_template| pod_template.get_mut("metadata"))
@@ -1057,6 +1263,9 @@ fn build_sandbox_template(
         .and_then(Value::as_object_mut)
     {
         labels.remove(SANDBOX_ID_LABEL);
+        for (name, value) in warm_pool_pod_labels(warm_pool) {
+            labels.insert(name, json!(value));
+        }
     }
 
     let mut template = DynamicObject::new(
@@ -1140,6 +1349,14 @@ fn warm_pool_ready_replicas(pool: &DynamicObject) -> i64 {
         .unwrap_or_default()
 }
 
+fn proxy_pod_config_hash(pod: &Pod) -> Option<String> {
+    pod.metadata
+        .labels
+        .as_ref()
+        .and_then(|labels| labels.get("centaur.ai/config-hash"))
+        .cloned()
+}
+
 fn sandbox_claim_owner_names(sandbox: &crd::Sandbox) -> Vec<String> {
     sandbox
         .metadata
@@ -1155,6 +1372,53 @@ fn sandbox_claim_owner_names(sandbox: &crd::Sandbox) -> Vec<String> {
         })
         .map(|owner| owner.name.clone())
         .collect()
+}
+
+fn is_unclaimed_warm_pool_sandbox(
+    sandbox: &crd::Sandbox,
+    warm_pool: &SandboxWarmPoolConfig,
+) -> bool {
+    let owned_by_pool = sandbox
+        .metadata
+        .owner_references
+        .as_ref()
+        .into_iter()
+        .flatten()
+        .any(|owner| {
+            owner.kind == "SandboxWarmPool"
+                && owner.name == warm_pool.pool_name
+                && owner
+                    .api_version
+                    .starts_with(&format!("{EXTENSIONS_GROUP}/"))
+        });
+    if !owned_by_pool {
+        return false;
+    }
+    let template_matches = sandbox
+        .metadata
+        .annotations
+        .as_ref()
+        .and_then(|annotations| annotations.get("agents.x-k8s.io/sandbox-template-ref"))
+        .is_none_or(|template| template == &warm_pool.template_name);
+    let is_claimed = sandbox
+        .metadata
+        .labels
+        .as_ref()
+        .is_some_and(|labels| labels.contains_key(SANDBOX_CLAIM_LABEL));
+    template_matches && !is_claimed
+}
+
+fn sandbox_pod_name(sandbox: &crd::Sandbox, id: &SandboxId) -> String {
+    sandbox
+        .metadata
+        .annotations
+        .as_ref()
+        .and_then(|annotations| annotations.get("agents.x-k8s.io/pod-name"))
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| id.as_str().to_owned())
 }
 
 fn build_agent_sandbox(
@@ -1194,6 +1458,11 @@ fn build_agent_sandbox(
     );
     insert_optional(
         &mut container,
+        "readinessProbe",
+        codex_app_server_readiness_probe(spec),
+    );
+    insert_optional(
+        &mut container,
         "env",
         (!spec.env.is_empty() || resolved_iron_proxy.is_some())
             .then(|| env_json(spec, resolved_iron_proxy)),
@@ -1208,7 +1477,7 @@ fn build_agent_sandbox(
             "mountPath": state_volume.mount_path,
         }));
     }
-    if let Some(iron_proxy) = &config.iron_proxy {
+    if let (Some(iron_proxy), Some(_)) = (&config.iron_proxy, resolved_iron_proxy) {
         volume_mounts.push(json!({
             "name": "iron-proxy-ca-cert",
             "mountPath": "/firewall-certs",
@@ -1276,6 +1545,23 @@ fn build_agent_sandbox(
     Ok(sandbox)
 }
 
+fn codex_app_server_readiness_probe(spec: &SandboxSpec) -> Option<Value> {
+    let args = spec.args.iter().map(String::as_str).collect::<Vec<_>>();
+    (args == ["codex", "app-server", "--listen", "stdio://"]).then(|| {
+        json!({
+            "exec": {
+                "command": [
+                    "/bin/sh",
+                    "-lc",
+                    "tr '\\0' ' ' </proc/1/cmdline | grep -q 'app-server .*--listen .*stdio://'",
+                ],
+            },
+            "periodSeconds": 1,
+            "failureThreshold": 30,
+        })
+    })
+}
+
 fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
     let mut volumes = Vec::with_capacity(spec.mounts.len());
     let mut mounts = Vec::with_capacity(spec.mounts.len());
@@ -1310,23 +1596,45 @@ fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
 }
 
 fn env_json(spec: &SandboxSpec, resolved_iron_proxy: Option<&ResolvedIronProxy>) -> Vec<Value> {
-    let mut env = BTreeMap::<String, String>::new();
+    let mut env = BTreeMap::<String, Value>::new();
     for item in &spec.env {
-        env.insert(item.name.clone(), item.value.clone());
+        env.insert(
+            item.name.clone(),
+            json!({"name": item.name.clone(), "value": item.value.clone()}),
+        );
     }
     if let Some(resolved_iron_proxy) = resolved_iron_proxy {
+        env.entry(SANDBOX_POD_NAME_ENV.to_owned())
+            .or_insert_with(|| {
+                json!({
+                    "name": SANDBOX_POD_NAME_ENV,
+                    "valueFrom": {
+                        "fieldRef": {
+                            "fieldPath": "metadata.name",
+                        },
+                    },
+                })
+            });
         for (name, value) in &resolved_iron_proxy.placeholder_env {
-            env.entry(name.clone()).or_insert_with(|| value.clone());
+            env.entry(name.clone())
+                .or_insert_with(|| json!({ "name": name, "value": value }));
         }
         for (name, value) in &resolved_iron_proxy.pg_dsn_env {
-            env.entry(name.clone()).or_insert_with(|| value.clone());
+            env.entry(name.clone())
+                .or_insert_with(|| json!({ "name": name, "value": value }));
         }
         let api_host = env
             .get("CENTAUR_API_URL")
-            .and_then(|value| host_from_url(value));
+            .and_then(|item| item.get("value"))
+            .and_then(Value::as_str)
+            .and_then(host_from_url);
         let no_proxy_extra = ["NO_PROXY", "no_proxy"]
             .into_iter()
-            .filter_map(|name| env.get(name).map(String::as_str))
+            .filter_map(|name| {
+                env.get(name)
+                    .and_then(|item| item.get("value"))
+                    .and_then(Value::as_str)
+            })
             .collect::<Vec<_>>();
         for (name, value) in proxy_env(
             &resolved_iron_proxy.proxy_host,
@@ -1334,12 +1642,14 @@ fn env_json(spec: &SandboxSpec, resolved_iron_proxy: Option<&ResolvedIronProxy>)
             api_host.as_deref(),
             &no_proxy_extra,
         ) {
-            env.insert(name, value);
+            env.insert(name.clone(), json!({ "name": name, "value": value }));
         }
     }
-    env.into_iter()
-        .map(|(name, value)| json!({ "name": name, "value": value }))
-        .collect()
+    env.into_values().collect()
+}
+
+fn sandbox_proxy_host_template() -> String {
+    format!("$({SANDBOX_POD_NAME_ENV})-proxy")
 }
 
 fn proxy_env(
@@ -1382,12 +1692,10 @@ fn proxy_env(
     env
 }
 
-#[cfg(test)]
 fn proxied_pg_url(host: &str, port: u16, password: &str, database: &str) -> String {
     format!("postgresql://app_user:{password}@{host}:{port}/{database}")
 }
 
-#[cfg(test)]
 fn proxy_password() -> String {
     Uuid::new_v4().simple().to_string()
 }
@@ -1449,7 +1757,6 @@ fn spec_env<'a>(spec: &'a SandboxSpec, name: &str) -> Option<&'a str> {
         .filter(|value| !value.trim().is_empty())
 }
 
-#[cfg(test)]
 fn iron_proxy_container(iron_proxy: &IronProxyPodConfig, resolved: &ResolvedIronProxy) -> Value {
     let mut env = BTreeMap::<String, Value>::new();
     if let Some(secret_name) = &iron_proxy.secret_env_name {
@@ -1463,7 +1770,7 @@ fn iron_proxy_container(iron_proxy: &IronProxyPodConfig, resolved: &ResolvedIron
         insert_env_value(
             &mut env,
             "IRON_MANAGEMENT_API_KEY",
-            "unused-local-sidecar-key",
+            "unused-local-proxy-key",
         );
     }
     for (name, value) in &iron_proxy.extra_env {
@@ -1575,7 +1882,6 @@ fn iron_proxy_container(iron_proxy: &IronProxyPodConfig, resolved: &ResolvedIron
     container
 }
 
-#[cfg(test)]
 fn insert_env_value(env: &mut BTreeMap<String, Value>, name: &str, value: impl AsRef<str>) {
     env.insert(
         name.to_owned(),
@@ -1583,7 +1889,6 @@ fn insert_env_value(env: &mut BTreeMap<String, Value>, name: &str, value: impl A
     );
 }
 
-#[cfg(test)]
 fn insert_env_secret_ref(
     env: &mut BTreeMap<String, Value>,
     name: &str,
@@ -1604,7 +1909,6 @@ fn insert_env_secret_ref(
     );
 }
 
-#[cfg(test)]
 fn iron_proxy_volumes(id: &SandboxId, iron_proxy: &IronProxyPodConfig) -> Vec<Value> {
     vec![
         json!({
@@ -1620,14 +1924,17 @@ fn iron_proxy_volumes(id: &SandboxId, iron_proxy: &IronProxyPodConfig) -> Vec<Va
     ]
 }
 
-#[cfg(test)]
 fn build_iron_proxy_pod(
     id: &SandboxId,
     pod_name: &str,
     iron_proxy: &IronProxyPodConfig,
     resolved: &ResolvedIronProxy,
 ) -> SandboxResult<Pod> {
-    let labels = iron_proxy_labels(id);
+    let mut labels = iron_proxy_labels(id);
+    labels.insert(
+        "centaur.ai/config-hash".to_owned(),
+        short_sha256(&resolved.config_yaml),
+    );
     let mut pod_spec = json!({
         "automountServiceAccountToken": false,
         "restartPolicy": "Never",
@@ -1652,7 +1959,6 @@ fn build_iron_proxy_pod(
         .map_err(|err| SandboxError::InvalidSpec(format!("invalid iron-proxy pod: {err}")))
 }
 
-#[cfg(test)]
 fn build_iron_proxy_service(
     id: &SandboxId,
     resolved: &ResolvedIronProxy,
@@ -1692,11 +1998,12 @@ fn build_iron_proxy_service(
         .map_err(|err| SandboxError::InvalidSpec(format!("invalid iron-proxy service: {err}")))
 }
 
-#[cfg(test)]
 fn build_iron_proxy_network_policies(
     id: &SandboxId,
     resolved: &ResolvedIronProxy,
     iron_proxy: &IronProxyPodConfig,
+    sandbox_selector_labels: &BTreeMap<String, String>,
+    resource_labels: &BTreeMap<String, String>,
 ) -> SandboxResult<Vec<NetworkPolicy>> {
     let mut sandbox_to_proxy_ports = vec![json!({"protocol": "TCP", "port": resolved.proxy_port})];
     for port in resolved
@@ -1712,10 +2019,10 @@ fn build_iron_proxy_network_policies(
         "kind": "NetworkPolicy",
         "metadata": {
             "name": iron_proxy_sandbox_egress_policy_name(id),
-            "labels": sandbox_labels(id),
+            "labels": resource_labels,
         },
         "spec": {
-            "podSelector": {"matchLabels": sandbox_labels(id)},
+            "podSelector": {"matchLabels": sandbox_selector_labels},
             "policyTypes": ["Egress"],
             "egress": [
                 {
@@ -1776,7 +2083,7 @@ fn build_iron_proxy_network_policies(
             "policyTypes": ["Ingress", "Egress"],
             "ingress": [
                 {
-                    "from": [{"podSelector": {"matchLabels": sandbox_labels(id)}}],
+                    "from": [{"podSelector": {"matchLabels": sandbox_selector_labels}}],
                     "ports": sandbox_to_proxy_ports,
                 }
             ],
@@ -1793,14 +2100,21 @@ fn build_iron_proxy_network_policies(
         .collect()
 }
 
-#[cfg(test)]
+fn sandbox_template_network_policy(iron_proxy: &IronProxyPodConfig) -> Value {
+    json!({
+        "ingress": [],
+        "egress": [
+            {
+                "to": [{"podSelector": {"matchLabels": iron_proxy.api_pod_labels.clone()}}],
+                "ports": [{"protocol": "TCP", "port": 8000}],
+            },
+            dns_egress_rule(),
+        ],
+    })
+}
+
 fn dns_egress_rule() -> Value {
     json!({
-        "to": [{
-            "namespaceSelector": {
-                "matchLabels": {"kubernetes.io/metadata.name": "kube-system"},
-            },
-        }],
         "ports": [
             {"protocol": "UDP", "port": 53},
             {"protocol": "TCP", "port": 53},
@@ -1808,7 +2122,6 @@ fn dns_egress_rule() -> Value {
     })
 }
 
-#[cfg(test)]
 fn iron_proxy_broker_port(iron_proxy: &IronProxyPodConfig) -> Option<u16> {
     iron_proxy
         .extra_env
@@ -1822,7 +2135,6 @@ fn iron_proxy_broker_port(iron_proxy: &IronProxyPodConfig) -> Option<u16> {
         })
 }
 
-#[cfg(test)]
 fn url_port(value: &str) -> Option<u16> {
     let without_scheme = value
         .split_once("://")
@@ -1870,42 +2182,26 @@ fn state_pvc_name(id: &SandboxId) -> String {
     format!("state-{}", id.as_str())
 }
 
-#[cfg(test)]
 fn iron_proxy_configmap_name(id: &SandboxId) -> String {
     format!("{}-iron-proxy", id.as_str())
 }
 
-#[cfg(test)]
 fn iron_proxy_pod_name(id: &SandboxId) -> String {
     format!("{}-proxy", id.as_str())
 }
 
-#[cfg(test)]
-fn new_iron_proxy_pod_name(id: &SandboxId) -> String {
-    let millis = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis();
-    let sequence = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-    format!("{}-proxy-{millis}-{sequence}", id.as_str())
-}
-
-#[cfg(test)]
 fn iron_proxy_service_name(id: &SandboxId) -> String {
     format!("{}-proxy", id.as_str())
 }
 
-#[cfg(test)]
 fn iron_proxy_sandbox_egress_policy_name(id: &SandboxId) -> String {
     format!("{}-sandbox-egress", id.as_str())
 }
 
-#[cfg(test)]
 fn iron_proxy_policy_name(id: &SandboxId) -> String {
     format!("{}-proxy-net", id.as_str())
 }
 
-#[cfg(test)]
 fn iron_token_broker_configmap_name(iron_proxy: &IronProxyPodConfig) -> SandboxResult<String> {
     if let Some(name) = iron_proxy.token_broker_configmap_name.as_deref() {
         return Ok(name.to_owned());
@@ -1918,7 +2214,6 @@ fn iron_token_broker_configmap_name(iron_proxy: &IronProxyPodConfig) -> SandboxR
     Ok(format!("{name}-config"))
 }
 
-#[cfg(test)]
 fn token_broker_labels() -> BTreeMap<String, String> {
     BTreeMap::from([
         (TOKEN_BROKER_LABEL.to_owned(), "true".to_owned()),
@@ -1935,7 +2230,10 @@ fn sandbox_labels(id: &SandboxId) -> BTreeMap<String, String> {
     labels
 }
 
-#[cfg(test)]
+fn sandbox_claim_selector_labels(claim_id: &SandboxId) -> BTreeMap<String, String> {
+    BTreeMap::from([(SANDBOX_CLAIM_LABEL.to_owned(), claim_id.as_str().to_owned())])
+}
+
 fn iron_proxy_labels(id: &SandboxId) -> BTreeMap<String, String> {
     let mut labels = base_resource_labels(id);
     labels.insert("centaur.ai/iron-proxy".to_owned(), "true".to_owned());
@@ -1964,6 +2262,15 @@ fn warm_pool_labels(warm_pool: &SandboxWarmPoolConfig) -> BTreeMap<String, Strin
     ])
 }
 
+fn warm_pool_pod_labels(warm_pool: &SandboxWarmPoolConfig) -> BTreeMap<String, String> {
+    let mut labels = warm_pool_labels(warm_pool);
+    labels.insert(
+        "app.kubernetes.io/name".to_owned(),
+        "centaur-sandbox".to_owned(),
+    );
+    labels
+}
+
 fn claim_labels(
     claim_id: &SandboxId,
     warm_pool: &SandboxWarmPoolConfig,
@@ -1990,6 +2297,24 @@ fn claimed_sandbox_labels(
     labels
 }
 
+fn adopted_sandbox_labels(
+    id: &SandboxId,
+    claim_id: &SandboxId,
+    warm_pool: &SandboxWarmPoolConfig,
+) -> BTreeMap<String, String> {
+    let mut labels = sandbox_labels(id);
+    labels.insert(
+        SANDBOX_WARM_POOL_LABEL.to_owned(),
+        warm_pool.pool_name.clone(),
+    );
+    labels.insert(
+        SANDBOX_TEMPLATE_LABEL.to_owned(),
+        warm_pool.template_name.clone(),
+    );
+    labels.insert(SANDBOX_CLAIM_LABEL.to_owned(), claim_id.as_str().to_owned());
+    labels
+}
+
 fn insert_optional<T>(target: &mut Value, key: &str, value: Option<T>)
 where
     T: serde::Serialize,
@@ -2008,7 +2333,6 @@ fn image_pull_secret_refs(names: &[String]) -> Option<Vec<Value>> {
     })
 }
 
-#[cfg(test)]
 fn short_sha256(value: &str) -> String {
     let digest = Sha256::digest(value.as_bytes());
     format!("{digest:x}").chars().take(16).collect()
@@ -2027,6 +2351,10 @@ fn is_not_found(err: &Error) -> bool {
     matches!(err, Error::Api(api_error) if api_error.code == 404)
 }
 
+fn is_already_exists(err: &Error) -> bool {
+    matches!(err, Error::Api(api_error) if api_error.code == 409)
+}
+
 fn map_kube_error(operation: &str, err: Error) -> SandboxError {
     if is_not_found(&err) {
         SandboxError::NotFound(operation.to_owned())
@@ -2038,7 +2366,9 @@ fn map_kube_error(operation: &str, err: Error) -> SandboxError {
 #[cfg(test)]
 mod tests {
     use centaur_sandbox_core::{ResourceLimits, SandboxSpec};
-    use k8s_openapi::api::core::v1::{PodCondition, PodStatus};
+    use k8s_openapi::api::core::v1::{
+        EndpointAddress, EndpointPort, EndpointSubset, PodCondition, PodStatus,
+    };
     use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 
     use super::*;
@@ -2129,7 +2459,7 @@ mod tests {
             .annotations
             .insert("centaur.ai/test".to_owned(), "true".to_owned());
 
-        let template = build_sandbox_template(&warm_pool, &spec, &config).unwrap();
+        let template = build_sandbox_template(&warm_pool, &spec, &config, None).unwrap();
         let pool = build_sandbox_warm_pool(&warm_pool);
 
         let template_types = template.types.as_ref().unwrap();
@@ -2173,6 +2503,127 @@ mod tests {
     }
 
     #[test]
+    fn builds_warm_pool_template_with_per_sandbox_iron_proxy_env() {
+        let warm_pool = SandboxWarmPoolConfig::new("centaur-warm", "centaur-warm-template");
+        let spec = SandboxSpec::new("centaur-agent:latest")
+            .env("CENTAUR_API_URL", "http://api:8000")
+            .env("NO_PROXY", "metadata.internal");
+        let mut config = AgentSandboxConfig::new("centaur");
+        config.iron_proxy = Some(IronProxyPodConfig::new(
+            "centaur-iron-proxy:latest",
+            "firewall-ca-cert",
+            "firewall-ca-key",
+        ));
+        let resolved = ResolvedIronProxy {
+            config_yaml: "transforms: []\n".to_owned(),
+            placeholder_env: BTreeMap::from([(
+                "ANTHROPIC_API_KEY".to_owned(),
+                "iron-proxy-placeholder".to_owned(),
+            )]),
+            proxy_host: sandbox_proxy_host_template(),
+            proxy_port: 18080,
+            listen_ports: vec![18080],
+            pg_dsn_env: BTreeMap::new(),
+            pg_proxy_password_env: BTreeMap::new(),
+        };
+
+        let template = build_sandbox_template(&warm_pool, &spec, &config, Some(&resolved)).unwrap();
+        let pod_template = &template.data["spec"]["podTemplate"];
+        let labels = pod_template["metadata"]["labels"].as_object().unwrap();
+        assert!(labels.get(SANDBOX_ID_LABEL).is_none());
+        assert_eq!(labels[SANDBOX_WARM_POOL_LABEL], "centaur-warm");
+        assert_eq!(labels[SANDBOX_TEMPLATE_LABEL], "centaur-warm-template");
+
+        assert_eq!(
+            pod_template["spec"]["containers"].as_array().unwrap().len(),
+            1
+        );
+        assert!(
+            pod_template["spec"]["containers"][0]["env"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|item| item["name"] == SANDBOX_POD_NAME_ENV
+                    && item["valueFrom"]["fieldRef"]["fieldPath"] == "metadata.name")
+        );
+        let env = pod_template["spec"]["containers"][0]["env"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|item| {
+                Some((
+                    item["name"].as_str()?.to_owned(),
+                    item["value"].as_str()?.to_owned(),
+                ))
+            })
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            env["HTTPS_PROXY"],
+            "http://$(CENTAUR_SANDBOX_POD_NAME)-proxy:18080"
+        );
+        assert_eq!(
+            env["HTTP_PROXY"],
+            "http://$(CENTAUR_SANDBOX_POD_NAME)-proxy:18080"
+        );
+        assert_eq!(env["FIREWALL_HOST"], "$(CENTAUR_SANDBOX_POD_NAME)-proxy");
+        assert_eq!(env["ANTHROPIC_API_KEY"], "iron-proxy-placeholder");
+        assert!(env["NO_PROXY"].contains("api"));
+        assert!(env["NO_PROXY"].contains("$(CENTAUR_SANDBOX_POD_NAME)-proxy"));
+        assert!(env["NO_PROXY"].contains("metadata.internal"));
+
+        let template_egress = template.data["spec"]["networkPolicy"]["egress"]
+            .as_array()
+            .unwrap();
+        assert!(template_egress.iter().any(|rule| {
+            rule["to"][0]["podSelector"]["matchLabels"]["app.kubernetes.io/component"] == "api"
+                && rule["ports"][0]["port"] == 8000
+        }));
+        assert!(template_egress.iter().any(|rule| {
+            rule.get("to").is_none()
+                && rule["ports"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|port| port["port"] == 53)
+        }));
+        assert!(
+            template_egress.iter().all(|rule| {
+                !rule["ports"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|port| port["port"] == 443 || port["port"] == 5432)
+            }),
+            "warm sandbox template must not allow direct external HTTPS/Postgres egress"
+        );
+    }
+
+    #[test]
+    fn codex_app_server_template_waits_for_direct_process_readiness() {
+        let warm_pool = SandboxWarmPoolConfig::new("centaur-warm", "centaur-warm-template");
+        let spec = SandboxSpec::new("centaur-agent:latest").args([
+            "codex",
+            "app-server",
+            "--listen",
+            "stdio://",
+        ]);
+        let config = AgentSandboxConfig::new("centaur");
+
+        let template = build_sandbox_template(&warm_pool, &spec, &config, None).unwrap();
+        let container = &template.data["spec"]["podTemplate"]["spec"]["containers"][0];
+
+        assert_eq!(container["args"][0], "codex");
+        assert_eq!(container["args"][1], "app-server");
+        assert!(
+            container["readinessProbe"]["exec"]["command"][2]
+                .as_str()
+                .unwrap()
+                .contains("app-server")
+        );
+        assert_eq!(container["readinessProbe"]["periodSeconds"], 1);
+    }
+
+    #[test]
     fn builds_sandbox_claim_without_env_so_pool_adoption_stays_warm() {
         let warm_pool = SandboxWarmPoolConfig::new("centaur-warm", "centaur-template");
         let config = AgentSandboxConfig::new("centaur");
@@ -2194,6 +2645,60 @@ mod tests {
     }
 
     #[test]
+    fn adopted_sandbox_labels_include_real_sandbox_id_and_claim_id() {
+        let warm_pool = SandboxWarmPoolConfig::new("centaur-warm", "centaur-template");
+        let labels = adopted_sandbox_labels(
+            &SandboxId::new("asbx-adopted"),
+            &SandboxId::new("asbx-claim"),
+            &warm_pool,
+        );
+
+        assert_eq!(labels[SANDBOX_ID_LABEL], "asbx-adopted");
+        assert_eq!(labels[SANDBOX_CLAIM_LABEL], "asbx-claim");
+        assert_eq!(labels[SANDBOX_WARM_POOL_LABEL], "centaur-warm");
+        assert_eq!(labels[SANDBOX_TEMPLATE_LABEL], "centaur-template");
+        assert_eq!(labels[MANAGED_BY_LABEL], MANAGED_BY_VALUE);
+    }
+
+    #[test]
+    fn identifies_unclaimed_warm_pool_sandboxes_for_proxy_prewarm() {
+        let warm_pool = SandboxWarmPoolConfig::new("centaur-warm", "centaur-template");
+        let config = AgentSandboxConfig::new("centaur");
+        let mut sandbox = build_agent_sandbox(
+            &SandboxId::new("centaur-warm-abcd"),
+            &SandboxSpec::new("centaur-agent:latest"),
+            &config,
+            None,
+        )
+        .unwrap();
+        sandbox.metadata.owner_references = Some(vec![
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
+                api_version: format!("{EXTENSIONS_GROUP}/v1alpha1"),
+                kind: "SandboxWarmPool".to_owned(),
+                name: "centaur-warm".to_owned(),
+                uid: "warm-pool-uid".to_owned(),
+                ..Default::default()
+            },
+        ]);
+        sandbox.metadata.annotations = Some(BTreeMap::from([(
+            "agents.x-k8s.io/sandbox-template-ref".to_owned(),
+            "centaur-template".to_owned(),
+        )]));
+        sandbox.metadata.labels = Some(BTreeMap::new());
+
+        assert!(is_unclaimed_warm_pool_sandbox(&sandbox, &warm_pool));
+
+        sandbox
+            .metadata
+            .labels
+            .as_mut()
+            .unwrap()
+            .insert(SANDBOX_CLAIM_LABEL.to_owned(), "asbx-claim".to_owned());
+
+        assert!(!is_unclaimed_warm_pool_sandbox(&sandbox, &warm_pool));
+    }
+
+    #[test]
     fn reads_sandbox_warm_pool_ready_replicas() {
         let warm_pool = SandboxWarmPoolConfig::new("centaur-warm", "centaur-template");
         let mut pool = build_sandbox_warm_pool(&warm_pool);
@@ -2206,7 +2711,7 @@ mod tests {
     }
 
     #[test]
-    fn warm_pool_validation_rejects_cold_starting_inputs() {
+    fn warm_pool_validation_rejects_per_thread_template_inputs() {
         let mut config = AgentSandboxConfig::new("centaur");
         let spec = SandboxSpec::new("centaur-agent:latest").env(THREAD_KEY_ENV, "test:thread");
 
@@ -2218,9 +2723,7 @@ mod tests {
             "firewall-ca-cert",
             "firewall-ca-key",
         ));
-        let error = validate_warm_pool_spec(&SandboxSpec::new("centaur-agent:latest"), &config)
-            .unwrap_err();
-        assert!(error.to_string().contains("iron-proxy"));
+        validate_warm_pool_spec(&SandboxSpec::new("centaur-agent:latest"), &config).unwrap();
     }
 
     #[test]
@@ -2260,13 +2763,13 @@ mod tests {
                 "OPENAI_API_KEY".to_owned(),
                 "OPENAI_API_KEY".to_owned(),
             )]),
-            proxy_host: "asbx-test-proxy".to_owned(),
-            proxy_pod_name: "asbx-test-proxy-123".to_owned(),
+            proxy_host: sandbox_proxy_host_template(),
             proxy_port: 18080,
             listen_ports: vec![8080],
             pg_dsn_env: BTreeMap::from([(
                 "WAREHOUSE_DSN".to_owned(),
-                "postgresql://app_user:pg-pass@asbx-test-proxy:5432/warehouse".to_owned(),
+                "postgresql://app_user:pg-pass@$(CENTAUR_SANDBOX_POD_NAME)-proxy:5432/warehouse"
+                    .to_owned(),
             )]),
             pg_proxy_password_env: BTreeMap::new(),
         };
@@ -2307,12 +2810,18 @@ mod tests {
         assert_eq!(agent_env["OPENAI_API_KEY"], "OPENAI_API_KEY");
         assert_eq!(
             agent_env["WAREHOUSE_DSN"],
-            "postgresql://app_user:pg-pass@asbx-test-proxy:5432/warehouse"
+            "postgresql://app_user:pg-pass@$(CENTAUR_SANDBOX_POD_NAME)-proxy:5432/warehouse"
         );
-        assert_eq!(agent_env["FIREWALL_HOST"], "asbx-test-proxy");
+        assert_eq!(
+            agent_env["FIREWALL_HOST"],
+            "$(CENTAUR_SANDBOX_POD_NAME)-proxy"
+        );
         assert_eq!(agent_env["FIREWALL_PROXY_PORT"], "18080");
-        assert_eq!(agent_env["HTTPS_PROXY"], "http://asbx-test-proxy:18080");
-        assert!(agent_env["NO_PROXY"].contains("asbx-test-proxy"));
+        assert_eq!(
+            agent_env["HTTPS_PROXY"],
+            "http://$(CENTAUR_SANDBOX_POD_NAME)-proxy:18080"
+        );
+        assert!(agent_env["NO_PROXY"].contains("$(CENTAUR_SANDBOX_POD_NAME)-proxy"));
         assert!(agent_env["NO_PROXY"].contains("centaur-centaur-api"));
         assert!(agent_env["NO_PROXY"].contains("otel.local"));
         assert_eq!(
@@ -2367,13 +2876,13 @@ mod tests {
                 ("OPENAI_API_KEY".to_owned(), "OPENAI_API_KEY".to_owned()),
                 ("GITHUB_TOKEN".to_owned(), "GITHUB_TOKEN".to_owned()),
             ]),
-            proxy_host: "asbx-sec-proxy".to_owned(),
-            proxy_pod_name: "asbx-sec-proxy-123".to_owned(),
+            proxy_host: sandbox_proxy_host_template(),
             proxy_port: 18080,
             listen_ports: vec![18080],
             pg_dsn_env: BTreeMap::from([(
                 "WAREHOUSE_DSN".to_owned(),
-                "postgresql://app_user:pg-pass@asbx-sec-proxy:5440/warehouse".to_owned(),
+                "postgresql://app_user:pg-pass@$(CENTAUR_SANDBOX_POD_NAME)-proxy:5440/warehouse"
+                    .to_owned(),
             )]),
             pg_proxy_password_env: BTreeMap::from([(
                 "PG_PROXY_PASSWORD_WAREHOUSE".to_owned(),
@@ -2397,10 +2906,16 @@ mod tests {
         assert_eq!(env["GITHUB_TOKEN"], "GITHUB_TOKEN");
         assert_eq!(
             env["WAREHOUSE_DSN"],
-            "postgresql://app_user:pg-pass@asbx-sec-proxy:5440/warehouse"
+            "postgresql://app_user:pg-pass@$(CENTAUR_SANDBOX_POD_NAME)-proxy:5440/warehouse"
         );
-        assert_eq!(env["HTTPS_PROXY"], "http://asbx-sec-proxy:18080");
-        assert_eq!(env["HTTP_PROXY"], "http://asbx-sec-proxy:18080");
+        assert_eq!(
+            env["HTTPS_PROXY"],
+            "http://$(CENTAUR_SANDBOX_POD_NAME)-proxy:18080"
+        );
+        assert_eq!(
+            env["HTTP_PROXY"],
+            "http://$(CENTAUR_SANDBOX_POD_NAME)-proxy:18080"
+        );
 
         for proxy_only_name in [
             "IRON_MANAGEMENT_API_KEY",
@@ -2459,8 +2974,7 @@ mod tests {
         let resolved = ResolvedIronProxy {
             config_yaml: "transforms: []\n".to_owned(),
             placeholder_env: BTreeMap::new(),
-            proxy_host: "asbx-test-proxy".to_owned(),
-            proxy_pod_name: "asbx-test-proxy-123".to_owned(),
+            proxy_host: sandbox_proxy_host_template(),
             proxy_port: 18080,
             listen_ports: vec![5432, 8080, 18080],
             pg_dsn_env: BTreeMap::new(),
@@ -2471,8 +2985,8 @@ mod tests {
         };
 
         let pod =
-            build_iron_proxy_pod(&id, &resolved.proxy_pod_name, &iron_proxy, &resolved).unwrap();
-        assert_eq!(pod.metadata.name.as_deref(), Some("asbx-test-proxy-123"));
+            build_iron_proxy_pod(&id, &iron_proxy_pod_name(&id), &iron_proxy, &resolved).unwrap();
+        assert_eq!(pod.metadata.name.as_deref(), Some("asbx-test-proxy"));
         assert_eq!(
             pod.spec
                 .as_ref()
@@ -2600,13 +3114,22 @@ mod tests {
         assert_eq!(service_ports["tcp-8080"], 8080);
         assert_eq!(service_ports["tcp-5432"], 5432);
 
-        let policies = build_iron_proxy_network_policies(&id, &resolved, &iron_proxy).unwrap();
+        let claim_id = SandboxId::new("asbx-claim");
+        let sandbox_selector_labels = sandbox_claim_selector_labels(&claim_id);
+        let policies = build_iron_proxy_network_policies(
+            &id,
+            &resolved,
+            &iron_proxy,
+            &sandbox_selector_labels,
+            &sandbox_selector_labels,
+        )
+        .unwrap();
         assert_eq!(policies.len(), 2);
         let policy_json = policy_json_by_name(&policies);
         assert_eq!(
             policy_json["asbx-test-sandbox-egress"]["spec"]["podSelector"]["matchLabels"]
-                [MANAGED_LABEL],
-            "true"
+                [SANDBOX_CLAIM_LABEL],
+            "asbx-claim"
         );
         assert_eq!(
             policy_json["asbx-test-proxy-net"]["spec"]["podSelector"]["matchLabels"]["centaur.ai/iron-proxy"],
@@ -2633,9 +3156,7 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .iter()
-                .any(|rule| rule["to"][0]["namespaceSelector"]["matchLabels"]
-                    ["kubernetes.io/metadata.name"]
-                    == "kube-system"
+                .any(|rule| rule.get("to").is_none()
                     && rule["ports"]
                         .as_array()
                         .unwrap()
@@ -2676,15 +3197,23 @@ mod tests {
         let resolved = ResolvedIronProxy {
             config_yaml: "transforms: []\n".to_owned(),
             placeholder_env: BTreeMap::new(),
-            proxy_host: "asbx-sec-proxy".to_owned(),
-            proxy_pod_name: "asbx-sec-proxy-123".to_owned(),
+            proxy_host: sandbox_proxy_host_template(),
             proxy_port: 18080,
             listen_ports: vec![18080, 5440],
             pg_dsn_env: BTreeMap::new(),
             pg_proxy_password_env: BTreeMap::new(),
         };
 
-        let policies = build_iron_proxy_network_policies(&id, &resolved, &iron_proxy).unwrap();
+        let claim_id = SandboxId::new("asbx-claim-sec");
+        let sandbox_selector_labels = sandbox_claim_selector_labels(&claim_id);
+        let policies = build_iron_proxy_network_policies(
+            &id,
+            &resolved,
+            &iron_proxy,
+            &sandbox_selector_labels,
+            &sandbox_selector_labels,
+        )
+        .unwrap();
         let policy_json = policy_json_by_name(&policies);
         let sandbox_egress = policy_json["asbx-sec-sandbox-egress"]["spec"]["egress"]
             .as_array()
@@ -2710,8 +3239,7 @@ mod tests {
                 && rule["ports"][0]["port"] == 8000
         }));
         assert!(sandbox_egress.iter().any(|rule| {
-            rule["to"][0]["namespaceSelector"]["matchLabels"]["kubernetes.io/metadata.name"]
-                == "kube-system"
+            rule.get("to").is_none()
                 && rule["ports"]
                     .as_array()
                     .unwrap()
@@ -2719,8 +3247,15 @@ mod tests {
                     .any(|port| port["port"] == 53)
         }));
         assert!(
-            sandbox_egress.iter().all(|rule| rule.get("to").is_some()),
-            "sandbox egress must not contain broad IP rules"
+            sandbox_egress.iter().all(|rule| {
+                rule.get("to").is_some()
+                    || rule["ports"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .all(|port| port["port"] == 53)
+            }),
+            "sandbox egress must not contain broad non-DNS rules"
         );
         assert!(
             sandbox_egress.iter().all(|rule| {
@@ -2737,12 +3272,8 @@ mod tests {
         let proxy_ingress = proxy_policy["spec"]["ingress"].as_array().unwrap();
         assert_eq!(proxy_ingress.len(), 1);
         assert_eq!(
-            proxy_ingress[0]["from"][0]["podSelector"]["matchLabels"][SANDBOX_ID_LABEL],
-            "asbx-sec"
-        );
-        assert_eq!(
-            proxy_ingress[0]["from"][0]["podSelector"]["matchLabels"][MANAGED_LABEL],
-            "true"
+            proxy_ingress[0]["from"][0]["podSelector"]["matchLabels"][SANDBOX_CLAIM_LABEL],
+            "asbx-claim-sec"
         );
         let proxy_egress = proxy_policy["spec"]["egress"].as_array().unwrap();
         assert!(proxy_egress.iter().any(|rule| {
@@ -2813,6 +3344,40 @@ mod tests {
         let labels = token_broker_labels();
         assert_eq!(labels[TOKEN_BROKER_LABEL], "true");
         assert_eq!(short_sha256("abc"), "ba7816bf8f01cfea");
+    }
+
+    #[test]
+    fn endpoint_ready_port_requires_ready_address_and_matching_port() {
+        let endpoints = Endpoints {
+            subsets: Some(vec![EndpointSubset {
+                addresses: Some(vec![EndpointAddress {
+                    ip: "10.42.0.10".to_owned(),
+                    ..EndpointAddress::default()
+                }]),
+                ports: Some(vec![EndpointPort {
+                    port: 18080,
+                    ..EndpointPort::default()
+                }]),
+                ..EndpointSubset::default()
+            }]),
+            ..Endpoints::default()
+        };
+
+        assert!(endpoint_has_ready_port(&endpoints, 18080));
+        assert!(!endpoint_has_ready_port(&endpoints, 18081));
+
+        let no_ready_addresses = Endpoints {
+            subsets: Some(vec![EndpointSubset {
+                addresses: Some(Vec::new()),
+                ports: Some(vec![EndpointPort {
+                    port: 18080,
+                    ..EndpointPort::default()
+                }]),
+                ..EndpointSubset::default()
+            }]),
+            ..Endpoints::default()
+        };
+        assert!(!endpoint_has_ready_port(&no_ready_addresses, 18080));
     }
 
     fn pod_with_phase_and_ready(phase: &str, ready: bool) -> Pod {

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -43,6 +43,7 @@ const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
 const SANDBOX_CLAIM_LABEL: &str = "centaur.ai/sandbox-claim";
 const SANDBOX_TEMPLATE_LABEL: &str = "centaur.ai/sandbox-template";
 const SANDBOX_WARM_POOL_LABEL: &str = "centaur.ai/sandbox-warm-pool";
+const PREWARMED_RUNTIME_LABEL: &str = "centaur.ai/prewarmed-runtime";
 const MANAGED_BY_VALUE: &str = "api-rs";
 const TOKEN_BROKER_LABEL: &str = "centaur.ai/iron-token-broker";
 const TOKEN_BROKER_CONFIG_KEY: &str = "iron-token-broker.yaml";
@@ -438,11 +439,28 @@ impl AgentSandboxBackend {
         warm_pool: &SandboxWarmPoolConfig,
         resolved: &ResolvedIronProxy,
     ) -> SandboxResult<()> {
+        for id in self.ready_unclaimed_warm_pool_sandboxes(warm_pool).await? {
+            self.create_iron_proxy_configmap(&id, Some(resolved))
+                .await?;
+            self.create_iron_proxy_service(&id, resolved).await?;
+            self.create_iron_proxy_pod(&id, resolved).await?;
+            self.wait_until_proxy_running(&iron_proxy_pod_name(&id))
+                .await?;
+            self.wait_until_proxy_endpoint_ready(&id, resolved).await?;
+        }
+        Ok(())
+    }
+
+    async fn ready_unclaimed_warm_pool_sandboxes(
+        &self,
+        warm_pool: &SandboxWarmPoolConfig,
+    ) -> SandboxResult<Vec<SandboxId>> {
         let sandboxes = self
             .sandboxes()
             .list(&ListParams::default())
             .await
             .map_err(|err| map_kube_error("list warm-pool sandboxes", err))?;
+        let mut ids = Vec::new();
         for sandbox in sandboxes {
             if !is_unclaimed_warm_pool_sandbox(&sandbox, warm_pool) {
                 continue;
@@ -457,18 +475,11 @@ impl AgentSandboxBackend {
                 Err(err) if is_not_found(&err) => continue,
                 Err(err) => return Err(map_kube_error("get warm-pool sandbox pod", err)),
             };
-            if !pod_ready(&pod) {
-                continue;
+            if pod_ready(&pod) {
+                ids.push(id);
             }
-            self.create_iron_proxy_configmap(&id, Some(resolved))
-                .await?;
-            self.create_iron_proxy_service(&id, resolved).await?;
-            self.create_iron_proxy_pod(&id, resolved).await?;
-            self.wait_until_proxy_running(&iron_proxy_pod_name(&id))
-                .await?;
-            self.wait_until_proxy_endpoint_ready(&id, resolved).await?;
         }
-        Ok(())
+        Ok(ids)
     }
 
     async fn wait_for_warm_pool_ready(
@@ -1100,6 +1111,44 @@ impl SandboxBackend for AgentSandboxBackend {
             .await
     }
 
+    async fn prewarm(&self, spec: SandboxSpec) -> SandboxResult<Vec<SandboxId>> {
+        let warm_pool = &self.config.warm_pool;
+        validate_warm_pool_spec(&spec, &self.config)?;
+        let resolved_iron_proxy = self.reconcile_warm_pool(&spec, warm_pool).await?;
+        self.wait_for_warm_pool_ready(warm_pool).await?;
+        if let Some(resolved) = resolved_iron_proxy.as_ref() {
+            self.prewarm_ready_warm_pool_proxies(warm_pool, resolved)
+                .await?;
+        }
+        self.ready_unclaimed_warm_pool_sandboxes(warm_pool).await
+    }
+
+    async fn mark_prewarmed(&self, id: &SandboxId, marker: &str) -> SandboxResult<()> {
+        let label_value = k8s_label_value(marker);
+        let patch = Patch::Merge(json!({
+            "metadata": {
+                "labels": {
+                    PREWARMED_RUNTIME_LABEL: label_value,
+                },
+            },
+        }));
+        self.sandboxes()
+            .patch(id.as_str(), &PatchParams::default(), &patch)
+            .await
+            .map_err(|err| map_kube_error("label prewarmed sandbox", err))?;
+
+        let sandbox = self
+            .get_sandbox(id)
+            .await?
+            .ok_or_else(|| SandboxError::NotFound(id.as_str().to_owned()))?;
+        let pod_name = sandbox_pod_name(&sandbox, id);
+        self.pods()
+            .patch(&pod_name, &PatchParams::default(), &patch)
+            .await
+            .map(|_| ())
+            .map_err(|err| map_kube_error("label prewarmed sandbox pod", err))
+    }
+
     async fn open_io(&self, id: &SandboxId) -> SandboxResult<SandboxIo> {
         self.attach_io(id).await
     }
@@ -1500,6 +1549,13 @@ fn build_agent_sandbox(
     });
     insert_optional(
         &mut pod_spec,
+        "initContainers",
+        resolved_iron_proxy
+            .is_some()
+            .then(|| vec![direct_https_block_init_container(spec, config)]),
+    );
+    insert_optional(
+        &mut pod_spec,
         "imagePullSecrets",
         image_pull_secret_refs(&config.image_pull_secrets),
     );
@@ -1543,6 +1599,30 @@ fn build_agent_sandbox(
     sandbox.metadata.labels = Some(labels);
     sandbox.metadata.annotations = Some(config.annotations.clone());
     Ok(sandbox)
+}
+
+fn direct_https_block_init_container(spec: &SandboxSpec, config: &AgentSandboxConfig) -> Value {
+    let mut container = json!({
+        "name": "block-direct-https",
+        "image": spec.image,
+        "command": ["/bin/sh", "-lc"],
+        "args": [
+            "set -eu\niptables -w -A OUTPUT -p tcp --dport 443 -j REJECT\niptables -w -A OUTPUT -p udp --dport 443 -j REJECT\nprintf '%s\\n' direct-https-block-installed\n"
+        ],
+        "securityContext": {
+            "runAsUser": 0,
+            "runAsNonRoot": false,
+            "allowPrivilegeEscalation": false,
+            "capabilities": {"drop": ["ALL"], "add": ["NET_ADMIN"]},
+            "seccompProfile": {"type": "RuntimeDefault"}
+        },
+    });
+    insert_optional(
+        &mut container,
+        "imagePullPolicy",
+        config.image_pull_policy.clone(),
+    );
+    container
 }
 
 fn codex_app_server_readiness_probe(spec: &SandboxSpec) -> Option<Value> {
@@ -2194,6 +2274,36 @@ fn iron_proxy_service_name(id: &SandboxId) -> String {
     format!("{}-proxy", id.as_str())
 }
 
+fn k8s_label_value(value: &str) -> String {
+    let mut sanitized: String = value
+        .chars()
+        .map(|ch| match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '-',
+        })
+        .take(63)
+        .collect();
+    while sanitized
+        .as_bytes()
+        .first()
+        .is_some_and(|byte| !byte.is_ascii_alphanumeric())
+    {
+        sanitized.remove(0);
+    }
+    while sanitized
+        .as_bytes()
+        .last()
+        .is_some_and(|byte| !byte.is_ascii_alphanumeric())
+    {
+        sanitized.pop();
+    }
+    if sanitized.is_empty() {
+        "set".to_owned()
+    } else {
+        sanitized
+    }
+}
+
 fn iron_proxy_sandbox_egress_policy_name(id: &SandboxId) -> String {
     format!("{}-sandbox-egress", id.as_str())
 }
@@ -2789,6 +2899,32 @@ mod tests {
         let containers = &pod_spec.containers;
         assert_eq!(containers.len(), 1);
         assert_eq!(containers[0].name, "agent");
+        let init_containers = pod_spec.init_containers.as_ref().unwrap();
+        assert_eq!(init_containers.len(), 1);
+        assert_eq!(init_containers[0].name, "block-direct-https");
+        assert_eq!(
+            init_containers[0]
+                .security_context
+                .as_ref()
+                .and_then(|context| context.run_as_user),
+            Some(0)
+        );
+        assert!(
+            init_containers[0]
+                .security_context
+                .as_ref()
+                .and_then(|context| context.capabilities.as_ref())
+                .and_then(|capabilities| capabilities.add.as_ref())
+                .is_some_and(|capabilities| capabilities.contains(&"NET_ADMIN".to_owned()))
+        );
+        assert!(
+            init_containers[0]
+                .args
+                .as_ref()
+                .unwrap()
+                .join("\n")
+                .contains("--dport 443 -j REJECT")
+        );
         assert_eq!(
             sandbox
                 .spec

--- a/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
@@ -23,6 +23,12 @@ pub trait SandboxBackend: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// Claim backend-owned warm capacity that was already reconciled and
+    /// pre-initialized by [`SandboxBackend::prewarm`].
+    async fn claim_prewarmed(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
+        self.create(spec).await
+    }
+
     /// Mark a warm sandbox whose interactive runtime has been initialized by
     /// the control plane before it is assigned to a user thread.
     async fn mark_prewarmed(&self, _id: &SandboxId, _marker: &str) -> SandboxResult<()> {

--- a/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
@@ -17,6 +17,18 @@ pub trait SandboxBackend: Send + Sync {
     /// Create a sandbox from the supplied workload spec and return its handle.
     async fn create(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle>;
 
+    /// Prepare backend-owned warm capacity for the supplied workload and return
+    /// currently claimable sandbox IDs, if this backend supports prewarming.
+    async fn prewarm(&self, _spec: SandboxSpec) -> SandboxResult<Vec<SandboxId>> {
+        Ok(Vec::new())
+    }
+
+    /// Mark a warm sandbox whose interactive runtime has been initialized by
+    /// the control plane before it is assigned to a user thread.
+    async fn mark_prewarmed(&self, _id: &SandboxId, _marker: &str) -> SandboxResult<()> {
+        Ok(())
+    }
+
     /// Open owned stdin/stdout/stderr handles for a running sandbox.
     async fn open_io(&self, id: &SandboxId) -> SandboxResult<SandboxIo>;
 

--- a/services/api-rs/crates/centaur-sandbox-e2e/tests/support/mod.rs
+++ b/services/api-rs/crates/centaur-sandbox-e2e/tests/support/mod.rs
@@ -6,18 +6,25 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use centaur_iron_proxy::{SourcePolicy, load_fragment_str};
-use centaur_sandbox_agent_k8s::{AgentSandboxBackend, AgentSandboxConfig, IronProxyPodConfig};
+use centaur_sandbox_agent_k8s::{
+    AgentSandboxBackend, AgentSandboxConfig, IronProxyPodConfig, SandboxWarmPoolConfig,
+};
 use centaur_sandbox_core::{
     SandboxBackend, SandboxId, SandboxRead, SandboxSpec, SandboxStatus, SandboxWrite,
 };
 use centaur_sandbox_local::LocalSandboxBackend;
 use centaur_sandbox_manager::{DriftReason, ReconcileOutcome, SandboxManager};
 use clap::Parser;
-use k8s_openapi::api::core::v1::{Pod, Secret, Service, ServicePort, ServiceSpec};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_openapi::api::core::v1::{Endpoints, Pod, Secret, Service, ServicePort, ServiceSpec};
+use k8s_openapi::api::networking::v1::{
+    NetworkPolicy, NetworkPolicyIngressRule, NetworkPolicyPeer, NetworkPolicyPort,
+    NetworkPolicySpec,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::api::{DeleteParams, ListParams, LogParams, PostParams};
 use kube::config::KubeConfigOptions;
@@ -29,6 +36,7 @@ const ALL_IMPLEMENTATIONS: &[&str] = &["local", "agent-k8s"];
 const PROXY_E2E_PLACEHOLDER: &str = "TEST_API_TOKEN";
 const PROXY_E2E_REAL_SECRET: &str = "real-env-secret-from-sandbox-e2e";
 const RECEIVER_PORT: i32 = 443;
+static NEXT_K8S_NAME: AtomicU64 = AtomicU64::new(0);
 
 type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -397,6 +405,8 @@ async fn run_env_secret_proxy_e2e(
     cleanup.sandbox(implementation.receiver_backend.clone(), receiver.id.clone());
     create_receiver_service(implementation, &receiver.id).await?;
     cleanup.service(implementation.receiver_service_name.clone());
+    let receiver_policy = create_receiver_ingress_policy(implementation, &receiver.id).await?;
+    cleanup.network_policy(receiver_policy);
 
     let mut receiver_io = receiver_manager.open_io(&receiver.id).await?.into_parts();
     receiver_io.stdin.write_all(b"start\n").await?;
@@ -405,6 +415,13 @@ async fn run_env_secret_proxy_e2e(
         &mut receiver_io.stdout,
         "RECEIVER_READY\n",
         Duration::from_secs(15),
+    )
+    .await?;
+    wait_for_service_endpoint(
+        &implementation.client,
+        &implementation.namespace,
+        &implementation.receiver_service_name,
+        RECEIVER_PORT,
     )
     .await?;
 
@@ -573,6 +590,45 @@ async fn read_until(
     }
 }
 
+async fn wait_for_service_endpoint(
+    client: &Client,
+    namespace: &str,
+    service_name: &str,
+    port: i32,
+) -> TestResult<()> {
+    let endpoints: Api<Endpoints> = Api::namespaced(client.clone(), namespace);
+    let mut latest = String::new();
+    timeout(Duration::from_secs(15), async {
+        let mut ticks = interval(Duration::from_millis(100));
+        loop {
+            match endpoints.get(service_name).await {
+                Ok(endpoint) if endpoint_has_ready_port(&endpoint, port) => return Ok(()),
+                Ok(endpoint) => latest = format!("{endpoint:?}"),
+                Err(err) => latest = err.to_string(),
+            }
+            ticks.tick().await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        format!("service {service_name} did not publish a ready endpoint on port {port}: {latest}")
+    })?
+}
+
+fn endpoint_has_ready_port(endpoints: &Endpoints, port: i32) -> bool {
+    endpoints.subsets.as_ref().is_some_and(|subsets| {
+        subsets.iter().any(|subset| {
+            subset
+                .addresses
+                .as_ref()
+                .is_some_and(|addresses| !addresses.is_empty())
+                && subset.ports.as_ref().is_some_and(|ports| {
+                    ports.iter().any(|endpoint_port| endpoint_port.port == port)
+                })
+        })
+    })
+}
+
 fn drop_stdin(stdin: SandboxWrite) {
     drop(stdin);
 }
@@ -731,6 +787,60 @@ async fn create_receiver_service(
     Ok(())
 }
 
+async fn create_receiver_ingress_policy(
+    implementation: &ProxyE2eImplementation,
+    receiver_id: &SandboxId,
+) -> TestResult<String> {
+    let policies: Api<NetworkPolicy> =
+        Api::namespaced(implementation.client.clone(), &implementation.namespace);
+    let name = format!("{}-ingress", implementation.receiver_service_name);
+    let _ = policies.delete(&name, &DeleteParams::default()).await;
+    policies
+        .create(
+            &PostParams::default(),
+            &NetworkPolicy {
+                metadata: ObjectMeta {
+                    name: Some(name.clone()),
+                    labels: Some(BTreeMap::from([(
+                        "centaur.ai/e2e".to_owned(),
+                        "iron-proxy-env-secret".to_owned(),
+                    )])),
+                    ..ObjectMeta::default()
+                },
+                spec: Some(NetworkPolicySpec {
+                    pod_selector: Some(LabelSelector {
+                        match_labels: Some(BTreeMap::from([(
+                            "centaur.ai/sandbox-id".to_owned(),
+                            receiver_id.as_str().to_owned(),
+                        )])),
+                        ..LabelSelector::default()
+                    }),
+                    policy_types: Some(vec!["Ingress".to_owned()]),
+                    ingress: Some(vec![NetworkPolicyIngressRule {
+                        from: Some(vec![NetworkPolicyPeer {
+                            pod_selector: Some(LabelSelector {
+                                match_labels: Some(BTreeMap::from([(
+                                    "centaur.ai/iron-proxy".to_owned(),
+                                    "true".to_owned(),
+                                )])),
+                                ..LabelSelector::default()
+                            }),
+                            ..NetworkPolicyPeer::default()
+                        }]),
+                        ports: Some(vec![NetworkPolicyPort {
+                            port: Some(IntOrString::Int(RECEIVER_PORT)),
+                            protocol: Some("TCP".to_owned()),
+                            ..NetworkPolicyPort::default()
+                        }]),
+                    }]),
+                    ..NetworkPolicySpec::default()
+                }),
+            },
+        )
+        .await?;
+    Ok(name)
+}
+
 async fn create_secret(
     client: &Client,
     namespace: &str,
@@ -765,6 +875,7 @@ struct ProxyE2eCleanup {
     namespace: String,
     sandboxes: Vec<(Arc<dyn SandboxBackend>, SandboxId)>,
     services: Vec<String>,
+    network_policies: Vec<String>,
     secrets: Vec<String>,
 }
 
@@ -775,6 +886,7 @@ impl ProxyE2eCleanup {
             namespace: implementation.namespace.clone(),
             sandboxes: Vec::new(),
             services: Vec::new(),
+            network_policies: Vec::new(),
             secrets: Vec::new(),
         }
     }
@@ -785,6 +897,10 @@ impl ProxyE2eCleanup {
 
     fn service(&mut self, name: String) {
         self.services.push(name);
+    }
+
+    fn network_policy(&mut self, name: String) {
+        self.network_policies.push(name);
     }
 
     fn secret(&mut self, name: String) {
@@ -799,6 +915,13 @@ impl ProxyE2eCleanup {
         let services: Api<Service> = Api::namespaced(self.client.clone(), &self.namespace);
         for name in self.services.drain(..).rev() {
             let _ = services.delete(&name, &DeleteParams::default()).await;
+        }
+        let network_policies: Api<NetworkPolicy> =
+            Api::namespaced(self.client.clone(), &self.namespace);
+        for name in self.network_policies.drain(..).rev() {
+            let _ = network_policies
+                .delete(&name, &DeleteParams::default())
+                .await;
         }
         let secrets: Api<Secret> = Api::namespaced(self.client.clone(), &self.namespace);
         for name in self.secrets.drain(..).rev() {
@@ -945,7 +1068,14 @@ fn unique_k8s_name(prefix: &str) -> String {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis();
-    format!("{prefix}-{}-{millis}", std::process::id())
+    let sequence = NEXT_K8S_NAME.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{}-{millis}-{sequence}", std::process::id())
+}
+
+fn use_unique_warm_pool(config: &mut AgentSandboxConfig, prefix: &str) {
+    let pool_name = unique_k8s_name(prefix);
+    let template_name = format!("{pool_name}-template");
+    config.warm_pool = SandboxWarmPoolConfig::new(pool_name, template_name);
 }
 
 struct TempDir {
@@ -990,6 +1120,7 @@ async fn agent_k8s_implementation() -> SandboxImplementation {
     let image = args.sandbox_e2e_k8s_image;
     let mut config = AgentSandboxConfig::new(namespace);
     config.ready_timeout = Duration::from_secs(90);
+    use_unique_warm_pool(&mut config, "sandbox-e2e");
     let backend = Arc::new(AgentSandboxBackend::new(client.clone(), config.clone()));
 
     SandboxImplementation {
@@ -1017,9 +1148,11 @@ async fn agent_k8s_proxy_implementation() -> ProxyE2eImplementation {
 
     let mut receiver_config = AgentSandboxConfig::new(namespace.clone());
     receiver_config.ready_timeout = Duration::from_secs(120);
+    use_unique_warm_pool(&mut receiver_config, "proxy-e2e-receiver");
 
     let mut sender_config = AgentSandboxConfig::new(namespace.clone());
     sender_config.ready_timeout = Duration::from_secs(120);
+    use_unique_warm_pool(&mut sender_config, "proxy-e2e-sender");
     let mut iron_proxy = IronProxyPodConfig::new(
         args.sandbox_e2e_iron_proxy_image,
         ca_cert_secret_name.clone(),

--- a/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
@@ -48,6 +48,13 @@ where
         Ok(handle)
     }
 
+    pub async fn claim_prewarmed(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
+        let handle = self.backend.claim_prewarmed(spec.clone()).await?;
+        self.store
+            .set(handle.id.clone(), DesiredSandboxState::Running(spec));
+        Ok(handle)
+    }
+
     pub async fn prewarm(&self, spec: SandboxSpec) -> SandboxResult<Vec<SandboxId>> {
         self.backend.prewarm(spec).await
     }

--- a/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
@@ -48,6 +48,14 @@ where
         Ok(handle)
     }
 
+    pub async fn prewarm(&self, spec: SandboxSpec) -> SandboxResult<Vec<SandboxId>> {
+        self.backend.prewarm(spec).await
+    }
+
+    pub async fn mark_prewarmed(&self, id: &SandboxId, marker: &str) -> SandboxResult<()> {
+        self.backend.mark_prewarmed(id, marker).await
+    }
+
     pub async fn open_io(&self, id: &SandboxId) -> SandboxResult<SandboxIo> {
         self.backend.open_io(id).await
     }

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -16,3 +16,6 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "sync", "time"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
+
+[dev-dependencies]
+async-trait.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{HashMap, VecDeque},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicI64, Ordering},
+    },
     time::Duration,
 };
 
@@ -20,8 +23,8 @@ use serde_json::{Value, json};
 use thiserror::Error;
 use tokio::{
     io,
-    sync::Mutex,
-    time::{Instant, Interval, MissedTickBehavior, interval_at},
+    sync::{Mutex, broadcast, oneshot},
+    time::{Instant, Interval, MissedTickBehavior, interval_at, timeout},
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
 use tracing::warn;
@@ -33,6 +36,10 @@ const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
+
+const CODEX_WORKSPACE_DIR: &str = "/home/agent/workspace";
+const CODEX_APP_SERVER_RPC_TIMEOUT: Duration = Duration::from_secs(60);
+const CODEX_APP_SERVER_INIT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ExistingSandboxReuse {
@@ -52,6 +59,13 @@ pub struct SessionRuntime {
 pub struct SandboxRuntime {
     manager: Arc<SandboxManager>,
     spec_factory: SandboxSpecFactory,
+    protocol: SandboxProtocol,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SandboxProtocol {
+    Line,
+    CodexAppServer,
 }
 
 #[derive(Clone, Debug)]
@@ -63,7 +77,6 @@ pub enum SandboxWorkloadMode {
         image: String,
         env: Vec<(String, String)>,
         mounts: Vec<Mount>,
-        thread_key_env: bool,
     },
 }
 
@@ -76,8 +89,42 @@ pub struct ExecuteSessionInput {
 }
 
 #[derive(Clone)]
-struct SessionPipe {
+enum SessionPipe {
+    Line(LineSessionPipe),
+    CodexAppServer(CodexAppServerPipe),
+}
+
+#[derive(Clone)]
+struct LineSessionPipe {
     stdin: Arc<Mutex<SessionInputSink>>,
+}
+
+#[derive(Clone)]
+struct CodexAppServerPipe {
+    stdin: Arc<Mutex<SessionInputSink>>,
+    next_request_id: Arc<AtomicI64>,
+    responses: Arc<Mutex<HashMap<i64, oneshot::Sender<Value>>>>,
+    notifications: broadcast::Sender<CodexNotification>,
+    state: Arc<Mutex<CodexAppServerState>>,
+    execute_lock: Arc<Mutex<()>>,
+}
+
+#[derive(Clone, Debug)]
+struct CodexNotification {
+    terminal: Option<CodexTerminal>,
+}
+
+#[derive(Clone, Debug)]
+enum CodexTerminal {
+    Completed,
+    Failed(String),
+}
+
+#[derive(Debug, Default)]
+struct CodexAppServerState {
+    initialized: bool,
+    thread_id: Option<String>,
+    active_turn_id: Option<String>,
 }
 
 struct EventStreamState {
@@ -135,7 +182,7 @@ impl SessionRuntime {
 
         let execution = self
             .store
-            .create_execution(thread_key, default_metadata(input.metadata))
+            .create_execution(thread_key, default_metadata(input.metadata.clone()))
             .await?;
         let execution = self
             .store
@@ -162,12 +209,23 @@ impl SessionRuntime {
             )
             .await?;
 
-        let write_result = match self.ensure_session_pipe(thread_key, &sandbox_id).await {
-            Ok(pipe) => write_input_lines(&pipe, &input.input_lines).await,
+        let execution_result = match self.ensure_session_pipe(thread_key, &sandbox_id).await {
+            Ok(SessionPipe::Line(pipe)) => {
+                write_line_protocol_turn(&pipe, &input.input_lines).await
+            }
+            Ok(SessionPipe::CodexAppServer(pipe)) => {
+                self.execute_codex_app_server_turn(
+                    thread_key,
+                    session.harness_thread_id.as_deref(),
+                    &pipe,
+                    &input,
+                )
+                .await
+            }
             Err(error) => Err(error),
         };
 
-        match write_result {
+        match execution_result {
             Ok(()) => {}
             Err(error) => {
                 let error_message = error.to_string();
@@ -200,7 +258,7 @@ impl SessionRuntime {
                 json!({
                     "execution_id": execution.execution_id,
                     "thread_key": thread_key.as_str(),
-                    "completion_reason": "input_accepted",
+                    "completion_reason": "terminal_output",
                 }),
             )
             .await?;
@@ -276,17 +334,11 @@ impl SessionRuntime {
             .open_io(&SandboxId::new(sandbox_id))
             .await?
             .into_parts();
-        let pipe = SessionPipe {
-            stdin: Arc::new(Mutex::new(FramedWrite::new(
-                io.stdin,
-                LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
-            ))),
-        };
+        let stdin = Arc::new(Mutex::new(FramedWrite::new(
+            io.stdin,
+            LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
+        )));
 
-        self.sandbox_pipes
-            .lock()
-            .await
-            .insert(sandbox_id.to_owned(), pipe.clone());
         let store = self.store.clone();
         let thread_key = thread_key.clone();
         let pump_key = sandbox_id.to_owned();
@@ -295,26 +347,105 @@ impl SessionRuntime {
         let stderr = io.stderr;
         let guard = io.guard;
         let stderr_key = pump_key.clone();
+        let pipe = match self.sandbox_runtime.protocol {
+            SandboxProtocol::Line => {
+                let pipe = SessionPipe::Line(LineSessionPipe { stdin });
+                self.sandbox_pipes
+                    .lock()
+                    .await
+                    .insert(sandbox_id.to_owned(), pipe.clone());
 
-        tokio::spawn(async move {
-            let result =
-                run_stdout_pump(store.clone(), thread_key.clone(), &pump_key, stdout, guard).await;
-            if let Err(error) = result {
-                warn!(%pump_key, %error, "session stdout pump failed");
-                let _ = store
-                    .append_event(
-                        &thread_key,
-                        None,
-                        "session.stdout_pump_failed",
-                        json!({
-                            "sandbox_id": pump_key.as_str(),
-                            "error": error.to_string(),
-                        }),
+                tokio::spawn(async move {
+                    let result = run_line_stdout_pump(
+                        store.clone(),
+                        thread_key.clone(),
+                        &pump_key,
+                        stdout,
+                        guard,
                     )
                     .await;
+                    if let Err(error) = result {
+                        warn!(%pump_key, %error, "session stdout pump failed");
+                        let _ = store
+                            .append_event(
+                                &thread_key,
+                                None,
+                                "session.stdout_pump_failed",
+                                json!({
+                                    "sandbox_id": pump_key.as_str(),
+                                    "error": error.to_string(),
+                                }),
+                            )
+                            .await;
+                    }
+                    sandbox_pipes.lock().await.remove(&pump_key);
+                });
+                pipe
             }
-            sandbox_pipes.lock().await.remove(&pump_key);
-        });
+            SandboxProtocol::CodexAppServer => {
+                let (notifications, _) = broadcast::channel(256);
+                let pipe = SessionPipe::CodexAppServer(CodexAppServerPipe {
+                    stdin,
+                    next_request_id: Arc::new(AtomicI64::new(1)),
+                    responses: Arc::new(Mutex::new(HashMap::new())),
+                    notifications,
+                    state: Arc::new(Mutex::new(CodexAppServerState::default())),
+                    execute_lock: Arc::new(Mutex::new(())),
+                });
+                self.sandbox_pipes
+                    .lock()
+                    .await
+                    .insert(sandbox_id.to_owned(), pipe.clone());
+
+                let SessionPipe::CodexAppServer(codex_pipe) = pipe.clone() else {
+                    unreachable!("constructed codex pipe")
+                };
+                let pump_store = store.clone();
+                let pump_thread_key = thread_key.clone();
+                let pump_key = pump_key.clone();
+                let pump_responses = codex_pipe.responses.clone();
+                let pump_notifications = codex_pipe.notifications.clone();
+                let pump_state = codex_pipe.state.clone();
+                tokio::spawn(async move {
+                    let result = run_codex_app_server_stdout_pump(
+                        pump_store.clone(),
+                        pump_thread_key.clone(),
+                        &pump_key,
+                        stdout,
+                        guard,
+                        pump_responses,
+                        pump_notifications,
+                        pump_state,
+                    )
+                    .await;
+                    if let Err(error) = result {
+                        warn!(%pump_key, %error, "codex app-server stdout pump failed");
+                        let _ = pump_store
+                            .append_event(
+                                &pump_thread_key,
+                                None,
+                                "session.stdout_pump_failed",
+                                json!({
+                                    "sandbox_id": pump_key.as_str(),
+                                    "error": error.to_string(),
+                                }),
+                            )
+                            .await;
+                    }
+                    sandbox_pipes.lock().await.remove(&pump_key);
+                });
+                initialize_codex_app_server(&codex_pipe).await?;
+                append_output_line(
+                    &self.store,
+                    &thread_key,
+                    None,
+                    &json!({"type": "system", "subtype": "app_server", "phase": "initialized"})
+                        .to_string(),
+                )
+                .await?;
+                pipe
+            }
+        };
 
         tokio::spawn(async move {
             if let Err(error) = drain_stderr(stderr).await {
@@ -323,6 +454,35 @@ impl SessionRuntime {
         });
 
         Ok(pipe)
+    }
+
+    async fn execute_codex_app_server_turn(
+        &self,
+        thread_key: &ThreadKey,
+        resume_thread_id: Option<&str>,
+        pipe: &CodexAppServerPipe,
+        input: &ExecuteSessionInput,
+    ) -> Result<(), SessionRuntimeError> {
+        let _execute_guard = pipe.execute_lock.lock().await;
+        let thread_id = ensure_codex_thread(pipe, resume_thread_id).await?;
+        self.store
+            .update_harness_thread_id(thread_key, Some(thread_id.as_str()))
+            .await?;
+        if resume_thread_id != Some(thread_id.as_str()) {
+            append_output_line(
+                &self.store,
+                thread_key,
+                None,
+                &json!({"type": "thread.started", "thread_id": thread_id}).to_string(),
+            )
+            .await?;
+        }
+
+        for line in &input.input_lines {
+            execute_codex_input_line(&self.store, thread_key, pipe, line, input.max_duration_ms)
+                .await?;
+        }
+        Ok(())
     }
 }
 
@@ -346,26 +506,45 @@ async fn try_reuse_existing_sandbox(
 impl SandboxRuntime {
     pub fn backend(backend: Arc<dyn SandboxBackend>, spec: SandboxSpec) -> Self {
         let spec_factory = move |_thread_key: &ThreadKey, _execution_id: &str| spec.clone();
-        Self::backend_with_spec_factory(backend, spec_factory)
+        Self::backend_with_spec_factory_and_protocol(backend, spec_factory, SandboxProtocol::Line)
     }
 
     pub fn backend_with_workload(
         backend: Arc<dyn SandboxBackend>,
         workload: SandboxWorkloadMode,
     ) -> Self {
+        let protocol = workload.protocol();
         Self::backend_with_spec_factory(backend, move |thread_key, _execution_id| {
             workload.spec(thread_key)
         })
+        .with_protocol(protocol)
     }
 
     pub fn backend_with_spec_factory<F>(backend: Arc<dyn SandboxBackend>, spec_factory: F) -> Self
     where
         F: Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync + 'static,
     {
+        Self::backend_with_spec_factory_and_protocol(backend, spec_factory, SandboxProtocol::Line)
+    }
+
+    fn backend_with_spec_factory_and_protocol<F>(
+        backend: Arc<dyn SandboxBackend>,
+        spec_factory: F,
+        protocol: SandboxProtocol,
+    ) -> Self
+    where
+        F: Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync + 'static,
+    {
         Self {
             manager: Arc::new(SandboxManager::new(backend)),
             spec_factory: Arc::new(spec_factory),
+            protocol,
         }
+    }
+
+    fn with_protocol(mut self, protocol: SandboxProtocol) -> Self {
+        self.protocol = protocol;
+        self
     }
 }
 
@@ -384,7 +563,6 @@ impl SandboxWorkloadMode {
             image: image.into(),
             env: env.into_iter().collect(),
             mounts: Vec::new(),
-            thread_key_env: true,
         }
     }
 
@@ -396,28 +574,14 @@ impl SandboxWorkloadMode {
         self
     }
 
-    pub fn without_thread_key_env(mut self) -> Self {
-        if let Self::CodexAppServer { thread_key_env, .. } = &mut self {
-            *thread_key_env = false;
-        }
-        self
-    }
-
-    fn spec(&self, thread_key: &ThreadKey) -> SandboxSpec {
+    fn spec(&self, _thread_key: &ThreadKey) -> SandboxSpec {
         match self {
             Self::MockAppServer { image } => SandboxSpec::new(image)
                 .command(["/bin/sh", "-lc"])
                 .args([mock_app_server_script()]),
-            Self::CodexAppServer {
-                image,
-                env,
-                mounts,
-                thread_key_env,
-            } => {
-                let mut spec = SandboxSpec::new(image);
-                if *thread_key_env {
-                    spec = spec.env("CENTAUR_THREAD_KEY", thread_key.as_str());
-                }
+            Self::CodexAppServer { image, env, mounts } => {
+                let mut spec =
+                    SandboxSpec::new(image).args(["codex", "app-server", "--listen", "stdio://"]);
                 for mount in mounts {
                     spec = spec.mount(mount.clone());
                 }
@@ -426,6 +590,13 @@ impl SandboxWorkloadMode {
                 }
                 spec
             }
+        }
+    }
+
+    fn protocol(&self) -> SandboxProtocol {
+        match self {
+            Self::MockAppServer { .. } => SandboxProtocol::Line,
+            Self::CodexAppServer { .. } => SandboxProtocol::CodexAppServer,
         }
     }
 }
@@ -450,6 +621,290 @@ while [ "$turn_index" -le 3 ]; do
   turn_index=$((turn_index + 1))
 done
 done"#
+}
+
+async fn initialize_codex_app_server(pipe: &CodexAppServerPipe) -> Result<(), SessionRuntimeError> {
+    {
+        let state = pipe.state.lock().await;
+        if state.initialized {
+            return Ok(());
+        }
+    }
+    codex_request(
+        pipe,
+        "initialize",
+        json!({
+            "clientInfo": {"name": "centaur", "title": "Centaur", "version": "0.1.0"},
+            "capabilities": {"experimentalApi": true},
+        }),
+        CODEX_APP_SERVER_INIT_TIMEOUT,
+    )
+    .await?;
+    codex_notify(pipe, "initialized", json!({})).await?;
+    pipe.state.lock().await.initialized = true;
+    Ok(())
+}
+
+async fn ensure_codex_thread(
+    pipe: &CodexAppServerPipe,
+    resume_thread_id: Option<&str>,
+) -> Result<String, SessionRuntimeError> {
+    if let Some(thread_id) = pipe.state.lock().await.thread_id.clone() {
+        return Ok(thread_id);
+    }
+
+    let resume_thread_id = resume_thread_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let result = if let Some(thread_id) = resume_thread_id {
+        codex_request(
+            pipe,
+            "thread/resume",
+            json!({"threadId": thread_id, "cwd": CODEX_WORKSPACE_DIR}),
+            CODEX_APP_SERVER_RPC_TIMEOUT,
+        )
+        .await?
+    } else {
+        codex_request(
+            pipe,
+            "thread/start",
+            json!({"cwd": CODEX_WORKSPACE_DIR}),
+            CODEX_APP_SERVER_RPC_TIMEOUT,
+        )
+        .await?
+    };
+    let thread_id = result
+        .get("thread")
+        .and_then(|thread| thread.get("id"))
+        .and_then(Value::as_str)
+        .or(resume_thread_id)
+        .ok_or_else(|| {
+            SessionRuntimeError::CodexAppServer(
+                "thread/start response did not include a thread id".to_owned(),
+            )
+        })?
+        .to_owned();
+    pipe.state.lock().await.thread_id = Some(thread_id.clone());
+    let _ = pipe
+        .notifications
+        .send(CodexNotification { terminal: None });
+    Ok(thread_id)
+}
+
+async fn execute_codex_input_line(
+    store: &PgSessionStore,
+    thread_key: &ThreadKey,
+    pipe: &CodexAppServerPipe,
+    line: &str,
+    max_duration_ms: Option<u64>,
+) -> Result<(), SessionRuntimeError> {
+    initialize_codex_app_server(pipe).await?;
+    let input = codex_input_from_line(line)?;
+    let thread_id =
+        pipe.state.lock().await.thread_id.clone().ok_or_else(|| {
+            SessionRuntimeError::CodexAppServer("missing Codex thread id".to_owned())
+        })?;
+
+    match input {
+        CodexInput::Interrupt => interrupt_codex_turn(pipe).await,
+        CodexInput::User { items } => {
+            let (goal, items) = split_goal(items);
+            if let Some(goal) = goal {
+                let mut terminal_events = pipe.notifications.subscribe();
+                codex_request(
+                    pipe,
+                    "thread/goal/set",
+                    json!({"threadId": thread_id, "objective": goal}),
+                    CODEX_APP_SERVER_RPC_TIMEOUT,
+                )
+                .await?;
+                let state = pipe.state.lock().await;
+                let session_id = state.thread_id.clone();
+                drop(state);
+                if let Some(session_id) = session_id {
+                    let _ = pipe
+                        .notifications
+                        .send(CodexNotification { terminal: None });
+                    emit_codex_synthetic_line(
+                        store,
+                        thread_key,
+                        pipe,
+                        json!({
+                            "type": "assistant",
+                            "session_id": session_id,
+                            "message": {"content": [{"type": "text", "text": "Goal set."}]},
+                        }),
+                    )
+                    .await?;
+                }
+                return wait_for_codex_terminal(&mut terminal_events, max_duration_ms).await;
+            }
+
+            let mut terminal_events = pipe.notifications.subscribe();
+            let result = codex_request(
+                pipe,
+                "turn/start",
+                json!({"threadId": thread_id, "input": items}),
+                CODEX_APP_SERVER_RPC_TIMEOUT,
+            )
+            .await?;
+            let turn_id = result
+                .get("turn")
+                .and_then(|turn| turn.get("id"))
+                .and_then(Value::as_str)
+                .or_else(|| result.get("turnId").and_then(Value::as_str))
+                .map(ToOwned::to_owned);
+            if let Some(turn_id) = turn_id {
+                pipe.state.lock().await.active_turn_id = Some(turn_id);
+            }
+            wait_for_codex_terminal(&mut terminal_events, max_duration_ms).await
+        }
+    }
+}
+
+async fn interrupt_codex_turn(pipe: &CodexAppServerPipe) -> Result<(), SessionRuntimeError> {
+    let state = pipe.state.lock().await;
+    let Some(thread_id) = state.thread_id.clone() else {
+        return Ok(());
+    };
+    let Some(turn_id) = state.active_turn_id.clone() else {
+        return Ok(());
+    };
+    drop(state);
+    codex_request(
+        pipe,
+        "turn/interrupt",
+        json!({"threadId": thread_id, "turnId": turn_id}),
+        Duration::from_secs(5),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn wait_for_codex_terminal(
+    terminal_events: &mut broadcast::Receiver<CodexNotification>,
+    max_duration_ms: Option<u64>,
+) -> Result<(), SessionRuntimeError> {
+    let wait = async {
+        loop {
+            match terminal_events.recv().await {
+                Ok(CodexNotification {
+                    terminal: Some(CodexTerminal::Completed),
+                }) => return Ok(()),
+                Ok(CodexNotification {
+                    terminal: Some(CodexTerminal::Failed(error)),
+                }) => return Err(SessionRuntimeError::CodexAppServer(error)),
+                Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Err(SessionRuntimeError::CodexAppServer(
+                        "codex app-server notification stream closed".to_owned(),
+                    ));
+                }
+            }
+        }
+    };
+
+    if let Some(max_duration_ms) = max_duration_ms {
+        timeout(Duration::from_millis(max_duration_ms), wait)
+            .await
+            .map_err(|_| {
+                SessionRuntimeError::CodexAppServer(format!(
+                    "codex turn did not complete within {max_duration_ms}ms"
+                ))
+            })?
+    } else {
+        wait.await
+    }
+}
+
+async fn codex_request(
+    pipe: &CodexAppServerPipe,
+    method: &str,
+    params: Value,
+    request_timeout: Duration,
+) -> Result<Value, SessionRuntimeError> {
+    let id = pipe.next_request_id.fetch_add(1, Ordering::Relaxed);
+    let (tx, rx) = oneshot::channel();
+    pipe.responses.lock().await.insert(id, tx);
+    let send_result = send_codex_json(
+        pipe,
+        json!({
+            "id": id,
+            "method": method,
+            "params": params,
+        }),
+    )
+    .await;
+    if let Err(error) = send_result {
+        pipe.responses.lock().await.remove(&id);
+        return Err(error);
+    }
+    let response = timeout(request_timeout, rx)
+        .await
+        .map_err(|_| {
+            SessionRuntimeError::CodexAppServer(format!(
+                "codex app-server request {method} timed out"
+            ))
+        })?
+        .map_err(|_| {
+            SessionRuntimeError::CodexAppServer(format!(
+                "codex app-server request {method} response channel closed"
+            ))
+        })?;
+    if let Some(error) = response.get("error") {
+        return Err(SessionRuntimeError::CodexAppServer(format!(
+            "codex app-server request {method} failed: {}",
+            error_message(error)
+        )));
+    }
+    Ok(response.get("result").cloned().unwrap_or_else(|| json!({})))
+}
+
+async fn codex_notify(
+    pipe: &CodexAppServerPipe,
+    method: &str,
+    params: Value,
+) -> Result<(), SessionRuntimeError> {
+    send_codex_json(
+        pipe,
+        json!({
+            "method": method,
+            "params": params,
+        }),
+    )
+    .await
+}
+
+async fn send_codex_json(
+    pipe: &CodexAppServerPipe,
+    payload: Value,
+) -> Result<(), SessionRuntimeError> {
+    let line = serde_json::to_string(&payload)
+        .map_err(|error| SessionRuntimeError::CodexAppServer(error.to_string()))?;
+    pipe.stdin
+        .lock()
+        .await
+        .send(line)
+        .await
+        .map_err(codec_error_to_runtime)
+}
+
+async fn emit_codex_synthetic_line(
+    store: &PgSessionStore,
+    thread_key: &ThreadKey,
+    pipe: &CodexAppServerPipe,
+    payload: Value,
+) -> Result<(), SessionRuntimeError> {
+    let terminal = match payload.get("type").and_then(Value::as_str) {
+        Some("turn.completed") => Some(CodexTerminal::Completed),
+        Some("turn.failed") => Some(CodexTerminal::Failed(error_message(&payload))),
+        _ => None,
+    };
+    if terminal.is_some() {
+        let _ = pipe.notifications.send(CodexNotification { terminal });
+    }
+    append_output_line(store, thread_key, None, &payload.to_string()).await?;
+    Ok(())
 }
 
 fn session_event_stream(
@@ -520,7 +975,7 @@ fn session_event_stream(
     )
 }
 
-async fn run_stdout_pump(
+async fn run_line_stdout_pump(
     store: PgSessionStore,
     thread_key: ThreadKey,
     sandbox_id: &str,
@@ -548,6 +1003,58 @@ async fn run_stdout_pump(
     Ok(())
 }
 
+async fn run_codex_app_server_stdout_pump(
+    store: PgSessionStore,
+    thread_key: ThreadKey,
+    sandbox_id: &str,
+    stdout: SandboxRead,
+    _guard: SandboxIoGuard,
+    responses: Arc<Mutex<HashMap<i64, oneshot::Sender<Value>>>>,
+    notifications: broadcast::Sender<CodexNotification>,
+    state: Arc<Mutex<CodexAppServerState>>,
+) -> Result<(), SessionRuntimeError> {
+    let mut stdout = FramedRead::new(
+        stdout,
+        LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
+    );
+    while let Some(line) = stdout.next().await {
+        let line = line.map_err(codec_error_to_runtime)?;
+        let msg: Value = serde_json::from_str(&line).map_err(|error| {
+            SessionRuntimeError::CodexAppServer(format!(
+                "codex app-server emitted invalid JSON: {error}"
+            ))
+        })?;
+
+        if let Some(id) = msg.get("id").and_then(Value::as_i64) {
+            if let Some(tx) = responses.lock().await.remove(&id) {
+                let _ = tx.send(msg);
+            }
+            continue;
+        }
+
+        let Some(method) = msg.get("method").and_then(Value::as_str) else {
+            continue;
+        };
+        if let Some((payload, notification)) =
+            translate_codex_notification(method, msg.get("params"), &state).await
+        {
+            append_output_line(&store, &thread_key, None, &payload.to_string()).await?;
+            let _ = notifications.send(notification);
+        }
+    }
+    store
+        .append_event(
+            &thread_key,
+            None,
+            "session.stdout_eof",
+            json!({
+                "sandbox_id": sandbox_id,
+            }),
+        )
+        .await?;
+    Ok(())
+}
+
 async fn drain_stderr(mut stderr: SandboxRead) -> Result<(), SessionRuntimeError> {
     io::copy(&mut stderr, &mut io::sink())
         .await
@@ -557,8 +1064,8 @@ async fn drain_stderr(mut stderr: SandboxRead) -> Result<(), SessionRuntimeError
     Ok(())
 }
 
-async fn write_input_lines(
-    pipe: &SessionPipe,
+async fn write_line_protocol_turn(
+    pipe: &LineSessionPipe,
     input_lines: &[String],
 ) -> Result<(), SessionRuntimeError> {
     let mut stdin = pipe.stdin.lock().await;
@@ -566,6 +1073,222 @@ async fn write_input_lines(
         stdin.send(line).await.map_err(codec_error_to_runtime)?;
     }
     Ok(())
+}
+
+#[derive(Debug)]
+enum CodexInput {
+    User { items: Vec<Value> },
+    Interrupt,
+}
+
+fn codex_input_from_line(line: &str) -> Result<CodexInput, SessionRuntimeError> {
+    let parsed = serde_json::from_str::<Value>(line).unwrap_or_else(|_| {
+        json!({
+            "type": "user",
+            "message": {
+                "content": [{"type": "text", "text": line}],
+            },
+        })
+    });
+    match parsed.get("type").and_then(Value::as_str) {
+        Some("interrupt") => Ok(CodexInput::Interrupt),
+        Some("user") | None => Ok(CodexInput::User {
+            items: input_items_from_turn(&parsed),
+        }),
+        Some(other) => Err(SessionRuntimeError::BadRequest(format!(
+            "unsupported Codex session input type {other:?}"
+        ))),
+    }
+}
+
+fn input_items_from_turn(turn_input: &Value) -> Vec<Value> {
+    let content = turn_input
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_array);
+    let Some(blocks) = content else {
+        return vec![json!({"type": "text", "text": "continue"})];
+    };
+    let text = text_from_content_blocks(blocks);
+    vec![json!({"type": "text", "text": if text.is_empty() { "continue" } else { &text }})]
+}
+
+fn text_from_content_blocks(blocks: &[Value]) -> String {
+    let mut parts = Vec::new();
+    for block in blocks {
+        match block.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(text) = block.get("text").and_then(Value::as_str) {
+                    parts.push(text.to_owned());
+                }
+            }
+            Some("image") => parts.push(
+                "[User sent an image attachment; if needed, ask them to upload it as a file reference.]"
+                    .to_owned(),
+            ),
+            _ => parts.push(block.to_string()),
+        }
+    }
+    parts
+        .into_iter()
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn split_goal(items: Vec<Value>) -> (Option<String>, Vec<Value>) {
+    if items.len() != 1 || items[0].get("type").and_then(Value::as_str) != Some("text") {
+        return (None, items);
+    }
+    let text = items[0]
+        .get("text")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim();
+    let Some(goal) = text.strip_prefix("/goal") else {
+        return (None, items);
+    };
+    let goal = goal.trim();
+    if goal.is_empty() {
+        (None, items)
+    } else {
+        (Some(goal.to_owned()), Vec::new())
+    }
+}
+
+async fn translate_codex_notification(
+    method: &str,
+    params: Option<&Value>,
+    state: &Arc<Mutex<CodexAppServerState>>,
+) -> Option<(Value, CodexNotification)> {
+    let params = params
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let dotted_type = method.replace('/', ".");
+    let mut payload = serde_json::Map::new();
+    payload.insert("type".to_owned(), Value::String(dotted_type));
+    let mut terminal = None;
+
+    match method {
+        "thread/started" => {
+            let thread_id = params
+                .get("thread")
+                .and_then(|thread| thread.get("id"))
+                .and_then(Value::as_str)
+                .or_else(|| params.get("threadId").and_then(Value::as_str))
+                .map(ToOwned::to_owned);
+            if let Some(thread_id) = thread_id {
+                state.lock().await.thread_id = Some(thread_id.clone());
+                payload.insert(
+                    "type".to_owned(),
+                    Value::String("thread.started".to_owned()),
+                );
+                payload.insert("thread_id".to_owned(), Value::String(thread_id));
+            }
+        }
+        "turn/started" => {
+            let turn_id = params
+                .get("turn")
+                .and_then(|turn| turn.get("id"))
+                .and_then(Value::as_str)
+                .or_else(|| params.get("turnId").and_then(Value::as_str))
+                .map(ToOwned::to_owned);
+            if let Some(turn_id) = turn_id {
+                state.lock().await.active_turn_id = Some(turn_id.clone());
+                payload.insert("type".to_owned(), Value::String("turn.started".to_owned()));
+                payload.insert("turn_id".to_owned(), Value::String(turn_id));
+            }
+        }
+        "item/agentMessage/delta" => {
+            extend_payload(&mut payload, params);
+            let thread_id = state.lock().await.thread_id.clone();
+            if let Some(thread_id) = thread_id
+                && !payload.contains_key("session_id")
+                && !payload.contains_key("thread_id")
+            {
+                payload.insert("session_id".to_owned(), Value::String(thread_id));
+            }
+        }
+        "item/completed" => {
+            payload.insert(
+                "item".to_owned(),
+                params
+                    .get("item")
+                    .cloned()
+                    .unwrap_or_else(|| Value::Object(params)),
+            );
+        }
+        "item/started" | "item/updated" => {
+            payload.insert(
+                "item".to_owned(),
+                params
+                    .get("item")
+                    .cloned()
+                    .unwrap_or_else(|| Value::Object(params)),
+            );
+        }
+        "turn/completed" => {
+            let turn = params.get("turn").cloned().unwrap_or_else(|| json!({}));
+            payload.insert(
+                "type".to_owned(),
+                Value::String("turn.completed".to_owned()),
+            );
+            payload.insert("turn".to_owned(), turn.clone());
+            payload.insert(
+                "usage".to_owned(),
+                params
+                    .get("usage")
+                    .cloned()
+                    .or_else(|| turn.get("usage").cloned())
+                    .unwrap_or(Value::Null),
+            );
+            state.lock().await.active_turn_id = None;
+            terminal = Some(CodexTerminal::Completed);
+        }
+        "turn/failed" | "error" => {
+            payload.insert("type".to_owned(), Value::String("turn.failed".to_owned()));
+            payload.insert(
+                "error".to_owned(),
+                params
+                    .get("error")
+                    .cloned()
+                    .unwrap_or_else(|| Value::Object(params.clone())),
+            );
+            state.lock().await.active_turn_id = None;
+            terminal = Some(CodexTerminal::Failed(error_message(&Value::Object(params))));
+        }
+        "item/commandExecution/outputDelta"
+        | "item/fileChange/outputDelta"
+        | "item/plan/delta"
+        | "item/reasoning/summaryTextDelta"
+        | "item/reasoning/summaryPartAdded"
+        | "item/reasoning/textDelta"
+        | "turn/plan/updated"
+        | "thread/goal/updated"
+        | "thread/goal/cleared" => extend_payload(&mut payload, params),
+        _ => return None,
+    }
+
+    Some((Value::Object(payload), CodexNotification { terminal }))
+}
+
+fn extend_payload(
+    payload: &mut serde_json::Map<String, Value>,
+    params: serde_json::Map<String, Value>,
+) {
+    for (key, value) in params {
+        payload.insert(key, value);
+    }
+}
+
+fn error_message(value: &Value) -> String {
+    value
+        .get("message")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("error").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| value.to_string())
 }
 
 async fn append_output_line(
@@ -634,6 +1357,8 @@ fn nonzero_duration_millis(value: u64) -> Result<Duration, SessionRuntimeError> 
 pub enum SessionRuntimeError {
     #[error("{0}")]
     BadRequest(String),
+    #[error("codex app-server: {0}")]
+    CodexAppServer(String),
     #[error(transparent)]
     Store(#[from] SessionStoreError),
     #[error(transparent)]
@@ -654,7 +1379,7 @@ mod tests {
     };
 
     #[test]
-    fn codex_workload_applies_mounts_and_env() {
+    fn codex_workload_applies_mounts_and_env_without_per_thread_env() {
         let workload = SandboxWorkloadMode::codex_app_server(
             "centaur-agent:latest",
             [("CENTAUR_API_URL".to_owned(), "http://api:8000".to_owned())],
@@ -672,6 +1397,11 @@ mod tests {
 
         let spec = workload.spec(&thread_key);
 
+        assert_eq!(
+            spec.args,
+            vec!["codex", "app-server", "--listen", "stdio://"]
+        );
+        assert!(spec.command.is_none());
         assert_eq!(spec.mounts.len(), 1);
         assert_eq!(spec.mounts[0].target_path, "/home/agent/github");
         assert!(spec.mounts[0].read_only);
@@ -681,11 +1411,7 @@ mod tests {
                 source_path: "/host/github".to_owned(),
             }
         );
-        assert!(
-            spec.env
-                .iter()
-                .any(|env| env.name == "CENTAUR_THREAD_KEY" && env.value == "test:thread")
-        );
+        assert!(!spec.env.iter().any(|env| env.name == "CENTAUR_THREAD_KEY"));
         assert!(
             spec.env
                 .iter()
@@ -694,22 +1420,41 @@ mod tests {
     }
 
     #[test]
-    fn codex_workload_can_skip_thread_key_env_for_warm_templates() {
-        let workload = SandboxWorkloadMode::codex_app_server(
-            "centaur-agent:latest",
-            [("CENTAUR_API_URL".to_owned(), "http://api:8000".to_owned())],
+    fn codex_input_extracts_goal_from_session_user_line() {
+        let input = codex_input_from_line(
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"/goal ship warm containers"}]}}"#,
         )
-        .without_thread_key_env();
-        let thread_key = ThreadKey::parse("test:thread").unwrap();
+        .unwrap();
 
-        let spec = workload.spec(&thread_key);
+        let CodexInput::User { items } = input else {
+            panic!("expected user input");
+        };
+        let (goal, remaining) = split_goal(items);
+        assert_eq!(goal.as_deref(), Some("ship warm containers"));
+        assert!(remaining.is_empty());
+    }
 
-        assert!(!spec.env.iter().any(|env| env.name == "CENTAUR_THREAD_KEY"));
-        assert!(
-            spec.env
-                .iter()
-                .any(|env| env.name == "CENTAUR_API_URL" && env.value == "http://api:8000")
-        );
+    #[tokio::test]
+    async fn codex_turn_completed_notification_becomes_terminal_output() {
+        let state = Arc::new(tokio::sync::Mutex::new(CodexAppServerState::default()));
+
+        let (payload, notification) = translate_codex_notification(
+            "turn/completed",
+            Some(&json!({
+                "turn": {"id": "turn-1"},
+                "usage": {"input_tokens": 1, "output_tokens": 2},
+            })),
+            &state,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(payload["type"], "turn.completed");
+        assert_eq!(payload["turn"]["id"], "turn-1");
+        assert!(matches!(
+            notification.terminal,
+            Some(CodexTerminal::Completed)
+        ));
     }
 
     #[tokio::test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -34,6 +34,13 @@ const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ExistingSandboxReuse {
+    Reused,
+    Resumed,
+    Missing,
+}
+
 #[derive(Clone)]
 pub struct SessionRuntime {
     store: PgSessionStore,
@@ -56,6 +63,7 @@ pub enum SandboxWorkloadMode {
         image: String,
         env: Vec<(String, String)>,
         mounts: Vec<Mount>,
+        thread_key_env: bool,
     },
 }
 
@@ -233,13 +241,15 @@ impl SessionRuntime {
         execution_id: &str,
     ) -> Result<String, SessionRuntimeError> {
         if let Some(sandbox_id) = existing_sandbox_id {
-            let id = SandboxId::new(sandbox_id);
-            match self.sandbox_runtime.manager.status(&id).await {
-                Ok(SandboxStatus::Running | SandboxStatus::Created) => {
+            match try_reuse_existing_sandbox(&self.sandbox_runtime.manager, sandbox_id).await? {
+                ExistingSandboxReuse::Reused => {
                     return Ok(sandbox_id.to_owned());
                 }
-                Ok(_) | Err(SandboxError::NotFound(_)) => {}
-                Err(error) => return Err(SessionRuntimeError::Sandbox(error)),
+                ExistingSandboxReuse::Resumed => {
+                    self.sandbox_pipes.lock().await.remove(sandbox_id);
+                    return Ok(sandbox_id.to_owned());
+                }
+                ExistingSandboxReuse::Missing => {}
             }
         }
 
@@ -316,6 +326,23 @@ impl SessionRuntime {
     }
 }
 
+async fn try_reuse_existing_sandbox(
+    manager: &SandboxManager,
+    sandbox_id: &str,
+) -> Result<ExistingSandboxReuse, SessionRuntimeError> {
+    let id = SandboxId::new(sandbox_id);
+    match manager.status(&id).await {
+        Ok(SandboxStatus::Running) => Ok(ExistingSandboxReuse::Reused),
+        Ok(SandboxStatus::Created | SandboxStatus::Suspended) => {
+            manager.resume(&id).await?;
+            Ok(ExistingSandboxReuse::Resumed)
+        }
+        Ok(SandboxStatus::Stopped | SandboxStatus::Gone | SandboxStatus::Unknown(_))
+        | Err(SandboxError::NotFound(_)) => Ok(ExistingSandboxReuse::Missing),
+        Err(error) => Err(SessionRuntimeError::Sandbox(error)),
+    }
+}
+
 impl SandboxRuntime {
     pub fn backend(backend: Arc<dyn SandboxBackend>, spec: SandboxSpec) -> Self {
         let spec_factory = move |_thread_key: &ThreadKey, _execution_id: &str| spec.clone();
@@ -357,6 +384,7 @@ impl SandboxWorkloadMode {
             image: image.into(),
             env: env.into_iter().collect(),
             mounts: Vec::new(),
+            thread_key_env: true,
         }
     }
 
@@ -368,14 +396,28 @@ impl SandboxWorkloadMode {
         self
     }
 
+    pub fn without_thread_key_env(mut self) -> Self {
+        if let Self::CodexAppServer { thread_key_env, .. } = &mut self {
+            *thread_key_env = false;
+        }
+        self
+    }
+
     fn spec(&self, thread_key: &ThreadKey) -> SandboxSpec {
         match self {
             Self::MockAppServer { image } => SandboxSpec::new(image)
                 .command(["/bin/sh", "-lc"])
                 .args([mock_app_server_script()]),
-            Self::CodexAppServer { image, env, mounts } => {
-                let mut spec =
-                    SandboxSpec::new(image).env("CENTAUR_THREAD_KEY", thread_key.as_str());
+            Self::CodexAppServer {
+                image,
+                env,
+                mounts,
+                thread_key_env,
+            } => {
+                let mut spec = SandboxSpec::new(image);
+                if *thread_key_env {
+                    spec = spec.env("CENTAUR_THREAD_KEY", thread_key.as_str());
+                }
                 for mount in mounts {
                     spec = spec.mount(mount.clone());
                 }
@@ -601,7 +643,15 @@ pub enum SessionRuntimeError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use centaur_sandbox_core::MountKind;
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+
+    use async_trait::async_trait;
+    use centaur_sandbox_core::{
+        MountKind, ObservedSandbox, SandboxHandle, SandboxIo, SandboxResult,
+    };
 
     #[test]
     fn codex_workload_applies_mounts_and_env() {
@@ -641,5 +691,148 @@ mod tests {
                 .iter()
                 .any(|env| env.name == "CENTAUR_API_URL" && env.value == "http://api:8000")
         );
+    }
+
+    #[test]
+    fn codex_workload_can_skip_thread_key_env_for_warm_templates() {
+        let workload = SandboxWorkloadMode::codex_app_server(
+            "centaur-agent:latest",
+            [("CENTAUR_API_URL".to_owned(), "http://api:8000".to_owned())],
+        )
+        .without_thread_key_env();
+        let thread_key = ThreadKey::parse("test:thread").unwrap();
+
+        let spec = workload.spec(&thread_key);
+
+        assert!(!spec.env.iter().any(|env| env.name == "CENTAUR_THREAD_KEY"));
+        assert!(
+            spec.env
+                .iter()
+                .any(|env| env.name == "CENTAUR_API_URL" && env.value == "http://api:8000")
+        );
+    }
+
+    #[tokio::test]
+    async fn existing_suspended_sandbox_is_resumed_for_warm_reuse() {
+        let backend = Arc::new(FakeBackend::new([("sandbox-1", SandboxStatus::Suspended)]));
+        let manager = SandboxManager::new(backend.clone());
+
+        let outcome = try_reuse_existing_sandbox(&manager, "sandbox-1")
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, ExistingSandboxReuse::Resumed);
+        assert_eq!(backend.status_of("sandbox-1"), Some(SandboxStatus::Running));
+        assert_eq!(backend.operations(), ["resume:sandbox-1"]);
+    }
+
+    #[tokio::test]
+    async fn missing_existing_sandbox_is_replaced() {
+        let backend = Arc::new(FakeBackend::new([]));
+        let manager = SandboxManager::new(backend.clone());
+
+        let outcome = try_reuse_existing_sandbox(&manager, "sandbox-1")
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, ExistingSandboxReuse::Missing);
+        assert_eq!(backend.operations(), Vec::<String>::new());
+    }
+
+    struct FakeBackend {
+        statuses: Mutex<HashMap<SandboxId, SandboxStatus>>,
+        operations: Mutex<Vec<String>>,
+    }
+
+    impl FakeBackend {
+        fn new<const N: usize>(statuses: [(&str, SandboxStatus); N]) -> Self {
+            Self {
+                statuses: Mutex::new(
+                    statuses
+                        .into_iter()
+                        .map(|(id, status)| (SandboxId::from(id), status))
+                        .collect(),
+                ),
+                operations: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn status_of(&self, id: &str) -> Option<SandboxStatus> {
+            self.statuses
+                .lock()
+                .expect("status lock poisoned")
+                .get(&SandboxId::from(id))
+                .cloned()
+        }
+
+        fn operations(&self) -> Vec<String> {
+            self.operations
+                .lock()
+                .expect("operations lock poisoned")
+                .clone()
+        }
+
+        fn set_status(&self, id: &SandboxId, status: SandboxStatus) {
+            self.statuses
+                .lock()
+                .expect("status lock poisoned")
+                .insert(id.clone(), status);
+        }
+
+        fn push_operation(&self, operation: &str, id: &SandboxId) {
+            self.operations
+                .lock()
+                .expect("operations lock poisoned")
+                .push(format!("{operation}:{}", id.as_str()));
+        }
+    }
+
+    #[async_trait]
+    impl SandboxBackend for FakeBackend {
+        fn name(&self) -> &'static str {
+            "fake"
+        }
+
+        async fn create(&self, _spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
+            unreachable!("reuse tests should not create sandboxes")
+        }
+
+        async fn open_io(&self, _id: &SandboxId) -> SandboxResult<SandboxIo> {
+            unreachable!("reuse tests should not open I/O")
+        }
+
+        async fn status(&self, id: &SandboxId) -> SandboxResult<SandboxStatus> {
+            Ok(self.status_of(id.as_str()).unwrap_or(SandboxStatus::Gone))
+        }
+
+        async fn observe(&self, id: &SandboxId) -> SandboxResult<ObservedSandbox> {
+            Ok(ObservedSandbox::new(
+                id.clone(),
+                self.name(),
+                self.status(id).await?,
+            ))
+        }
+
+        async fn list_observed(&self) -> SandboxResult<Vec<ObservedSandbox>> {
+            Ok(Vec::new())
+        }
+
+        async fn stop(&self, id: &SandboxId) -> SandboxResult<()> {
+            self.push_operation("stop", id);
+            self.set_status(id, SandboxStatus::Stopped);
+            Ok(())
+        }
+
+        async fn pause(&self, id: &SandboxId) -> SandboxResult<()> {
+            self.push_operation("pause", id);
+            self.set_status(id, SandboxStatus::Suspended);
+            Ok(())
+        }
+
+        async fn resume(&self, id: &SandboxId) -> SandboxResult<()> {
+            self.push_operation("resume", id);
+            self.set_status(id, SandboxStatus::Running);
+            Ok(())
+        }
     }
 }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -23,6 +23,7 @@ use serde_json::{Value, json};
 use thiserror::Error;
 use tokio::{
     io,
+    runtime::Handle,
     sync::{Mutex, broadcast, oneshot},
     time::{Instant, Interval, MissedTickBehavior, interval_at, timeout},
 };
@@ -41,6 +42,9 @@ const CODEX_WORKSPACE_DIR: &str = "/home/agent/workspace";
 const CODEX_APP_SERVER_RPC_TIMEOUT: Duration = Duration::from_secs(60);
 const CODEX_APP_SERVER_INIT_TIMEOUT: Duration = Duration::from_secs(30);
 const CODEX_APP_SERVER_PREWARMED_MARKER: &str = "codex-app-server-initialized";
+const CODEX_APP_SERVER_BACKGROUND_PREWARM_INTERVAL: Duration = Duration::from_millis(500);
+const CODEX_APP_SERVER_BACKGROUND_PREWARM_THREAD_KEY: &str = "warm:codex-app-server";
+const CODEX_APP_SERVER_BACKGROUND_PREWARM_EXECUTION_ID: &str = "background-prewarm";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ExistingSandboxReuse {
@@ -54,6 +58,7 @@ pub struct SessionRuntime {
     store: PgSessionStore,
     sandbox_runtime: SandboxRuntime,
     sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    codex_prewarm_lock: Arc<Mutex<()>>,
 }
 
 #[derive(Clone)]
@@ -142,10 +147,49 @@ struct EventStreamState {
 
 impl SessionRuntime {
     pub fn new(store: PgSessionStore, sandbox_runtime: SandboxRuntime) -> Self {
-        Self {
+        let runtime = Self {
             store,
             sandbox_runtime,
             sandbox_pipes: Arc::new(Mutex::new(HashMap::new())),
+            codex_prewarm_lock: Arc::new(Mutex::new(())),
+        };
+        runtime.spawn_codex_app_server_background_prewarm();
+        runtime
+    }
+
+    fn spawn_codex_app_server_background_prewarm(&self) {
+        if self.sandbox_runtime.protocol != SandboxProtocol::CodexAppServer {
+            return;
+        }
+        if Handle::try_current().is_err() {
+            warn!("skipping codex warm-pool background prewarm outside tokio runtime");
+            return;
+        }
+        let runtime = self.clone();
+        tokio::spawn(async move {
+            runtime.run_codex_app_server_background_prewarm().await;
+        });
+    }
+
+    async fn run_codex_app_server_background_prewarm(self) {
+        let thread_key = match ThreadKey::parse(CODEX_APP_SERVER_BACKGROUND_PREWARM_THREAD_KEY) {
+            Ok(thread_key) => thread_key,
+            Err(error) => {
+                warn!(%error, "invalid codex background prewarm thread key");
+                return;
+            }
+        };
+        let mut tick = interval_at(Instant::now(), CODEX_APP_SERVER_BACKGROUND_PREWARM_INTERVAL);
+        tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        loop {
+            tick.tick().await;
+            let spec = (self.sandbox_runtime.spec_factory)(
+                &thread_key,
+                CODEX_APP_SERVER_BACKGROUND_PREWARM_EXECUTION_ID,
+            );
+            if let Err(error) = self.prewarm_codex_app_server_pool(&spec).await {
+                warn!(%error, "codex warm-pool background prewarm failed");
+            }
         }
     }
 
@@ -315,10 +359,16 @@ impl SessionRuntime {
         }
 
         let spec = (self.sandbox_runtime.spec_factory)(thread_key, execution_id);
+        let mut claim_prewarmed = false;
         if self.sandbox_runtime.protocol == SandboxProtocol::CodexAppServer {
             self.prewarm_codex_app_server_pool(&spec).await?;
+            claim_prewarmed = self.has_unbound_prewarmed_codex_app_server_pipe().await;
         }
-        let handle = self.sandbox_runtime.manager.create_running(spec).await?;
+        let handle = if claim_prewarmed {
+            self.sandbox_runtime.manager.claim_prewarmed(spec).await?
+        } else {
+            self.sandbox_runtime.manager.create_running(spec).await?
+        };
         self.store
             .update_sandbox_id(thread_key, Some(handle.id.as_str()))
             .await?;
@@ -329,6 +379,13 @@ impl SessionRuntime {
         &self,
         spec: &SandboxSpec,
     ) -> Result<(), SessionRuntimeError> {
+        if self.has_unbound_prewarmed_codex_app_server_pipe().await {
+            return Ok(());
+        }
+        let _prewarm_guard = self.codex_prewarm_lock.lock().await;
+        if self.has_unbound_prewarmed_codex_app_server_pipe().await {
+            return Ok(());
+        }
         let candidates = self.sandbox_runtime.manager.prewarm(spec.clone()).await?;
         for id in candidates {
             let sandbox_id = id.as_str().to_owned();
@@ -354,6 +411,30 @@ impl SessionRuntime {
             }
         }
         Ok(())
+    }
+
+    async fn has_unbound_prewarmed_codex_app_server_pipe(&self) -> bool {
+        let pipes = self
+            .sandbox_pipes
+            .lock()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for pipe in pipes {
+            let SessionPipe::CodexAppServer(pipe) = pipe else {
+                continue;
+            };
+            if !pipe.prewarmed {
+                continue;
+            }
+            if pipe.output_thread_key.lock().await.is_none() {
+                return true;
+            }
+        }
+
+        false
     }
 
     async fn ensure_session_pipe(
@@ -565,18 +646,11 @@ impl SessionRuntime {
         input: &ExecuteSessionInput,
     ) -> Result<(), SessionRuntimeError> {
         let _execute_guard = pipe.execute_lock.lock().await;
-        let thread_id = ensure_codex_thread(pipe, resume_thread_id).await?;
-        self.store
-            .update_harness_thread_id(thread_key, Some(thread_id.as_str()))
-            .await?;
-        if resume_thread_id != Some(thread_id.as_str()) {
-            append_output_line(
-                &self.store,
-                thread_key,
-                None,
-                &json!({"type": "thread.started", "thread_id": thread_id}).to_string(),
-            )
-            .await?;
+        if resume_thread_id.is_some() || input_lines_require_codex_thread(&input.input_lines)? {
+            let thread_id = ensure_codex_thread(pipe, resume_thread_id).await?;
+            self.store
+                .update_harness_thread_id(thread_key, Some(thread_id.as_str()))
+                .await?;
         }
 
         for line in &input.input_lines {
@@ -731,7 +805,7 @@ async fn initialize_codex_app_server(pipe: &CodexAppServerPipe) -> Result<(), Se
             return Ok(());
         }
     }
-    codex_request(
+    let initialized = codex_request(
         pipe,
         "initialize",
         json!({
@@ -740,8 +814,14 @@ async fn initialize_codex_app_server(pipe: &CodexAppServerPipe) -> Result<(), Se
         }),
         CODEX_APP_SERVER_INIT_TIMEOUT,
     )
-    .await?;
-    codex_notify(pipe, "initialized", json!({})).await?;
+    .await;
+    match initialized {
+        Ok(_) => {
+            codex_notify(pipe, "initialized", json!({})).await?;
+        }
+        Err(error) if is_codex_already_initialized_error(&error) => {}
+        Err(error) => return Err(error),
+    }
     pipe.state.lock().await.initialized = true;
     Ok(())
 }
@@ -801,14 +881,13 @@ async fn execute_codex_input_line(
 ) -> Result<(), SessionRuntimeError> {
     initialize_codex_app_server(pipe).await?;
     let input = codex_input_from_line(line)?;
-    let thread_id =
-        pipe.state.lock().await.thread_id.clone().ok_or_else(|| {
-            SessionRuntimeError::CodexAppServer("missing Codex thread id".to_owned())
-        })?;
 
     match input {
         CodexInput::Interrupt => interrupt_codex_turn(pipe).await,
         CodexInput::User { items } => {
+            let thread_id = pipe.state.lock().await.thread_id.clone().ok_or_else(|| {
+                SessionRuntimeError::CodexAppServer("missing Codex thread id".to_owned())
+            })?;
             let (goal, items) = split_goal(items);
             if let Some(goal) = goal {
                 let mut terminal_events = pipe.notifications.subscribe();
@@ -861,6 +940,15 @@ async fn execute_codex_input_line(
             wait_for_codex_terminal(&mut terminal_events, max_duration_ms).await
         }
     }
+}
+
+fn input_lines_require_codex_thread(lines: &[String]) -> Result<bool, SessionRuntimeError> {
+    for line in lines {
+        if !matches!(codex_input_from_line(line)?, CodexInput::Interrupt) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 async fn interrupt_codex_turn(pipe: &CodexAppServerPipe) -> Result<(), SessionRuntimeError> {
@@ -1396,6 +1484,14 @@ fn error_message(value: &Value) -> String {
         .or_else(|| value.get("error").and_then(Value::as_str))
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| value.to_string())
+}
+
+fn is_codex_already_initialized_error(error: &SessionRuntimeError) -> bool {
+    matches!(
+        error,
+        SessionRuntimeError::CodexAppServer(message)
+            if message.contains("codex app-server request initialize failed: Already initialized")
+    )
 }
 
 async fn append_output_line(

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -40,6 +40,7 @@ type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
 const CODEX_WORKSPACE_DIR: &str = "/home/agent/workspace";
 const CODEX_APP_SERVER_RPC_TIMEOUT: Duration = Duration::from_secs(60);
 const CODEX_APP_SERVER_INIT_TIMEOUT: Duration = Duration::from_secs(30);
+const CODEX_APP_SERVER_PREWARMED_MARKER: &str = "codex-app-server-initialized";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ExistingSandboxReuse {
@@ -107,6 +108,8 @@ struct CodexAppServerPipe {
     notifications: broadcast::Sender<CodexNotification>,
     state: Arc<Mutex<CodexAppServerState>>,
     execute_lock: Arc<Mutex<()>>,
+    output_thread_key: Arc<Mutex<Option<ThreadKey>>>,
+    prewarmed: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -312,11 +315,45 @@ impl SessionRuntime {
         }
 
         let spec = (self.sandbox_runtime.spec_factory)(thread_key, execution_id);
+        if self.sandbox_runtime.protocol == SandboxProtocol::CodexAppServer {
+            self.prewarm_codex_app_server_pool(&spec).await?;
+        }
         let handle = self.sandbox_runtime.manager.create_running(spec).await?;
         self.store
             .update_sandbox_id(thread_key, Some(handle.id.as_str()))
             .await?;
         Ok(handle.id.into_string())
+    }
+
+    async fn prewarm_codex_app_server_pool(
+        &self,
+        spec: &SandboxSpec,
+    ) -> Result<(), SessionRuntimeError> {
+        let candidates = self.sandbox_runtime.manager.prewarm(spec.clone()).await?;
+        for id in candidates {
+            let sandbox_id = id.as_str().to_owned();
+            if self.sandbox_pipes.lock().await.contains_key(&sandbox_id) {
+                continue;
+            }
+            match self.open_codex_app_server_pipe(&sandbox_id, true).await {
+                Ok(pipe) => {
+                    self.sandbox_runtime
+                        .manager
+                        .mark_prewarmed(&id, CODEX_APP_SERVER_PREWARMED_MARKER)
+                        .await?;
+                    self.sandbox_pipes
+                        .lock()
+                        .await
+                        .insert(sandbox_id.clone(), SessionPipe::CodexAppServer(pipe));
+                }
+                Err(error) => {
+                    warn!(%sandbox_id, %error, "codex warm-pool pre-initialize failed");
+                    self.sandbox_pipes.lock().await.remove(&sandbox_id);
+                    return Err(error);
+                }
+            }
+        }
+        Ok(())
     }
 
     async fn ensure_session_pipe(
@@ -325,36 +362,39 @@ impl SessionRuntime {
         sandbox_id: &str,
     ) -> Result<SessionPipe, SessionRuntimeError> {
         if let Some(pipe) = self.sandbox_pipes.lock().await.get(sandbox_id).cloned() {
+            if let SessionPipe::CodexAppServer(codex_pipe) = &pipe {
+                self.bind_codex_app_server_pipe(thread_key, codex_pipe)
+                    .await?;
+            }
             return Ok(pipe);
         }
 
-        let io = self
-            .sandbox_runtime
-            .manager
-            .open_io(&SandboxId::new(sandbox_id))
-            .await?
-            .into_parts();
-        let stdin = Arc::new(Mutex::new(FramedWrite::new(
-            io.stdin,
-            LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
-        )));
-
-        let store = self.store.clone();
-        let thread_key = thread_key.clone();
-        let pump_key = sandbox_id.to_owned();
-        let sandbox_pipes = self.sandbox_pipes.clone();
-        let stdout = io.stdout;
-        let stderr = io.stderr;
-        let guard = io.guard;
-        let stderr_key = pump_key.clone();
         let pipe = match self.sandbox_runtime.protocol {
             SandboxProtocol::Line => {
+                let io = self
+                    .sandbox_runtime
+                    .manager
+                    .open_io(&SandboxId::new(sandbox_id))
+                    .await?
+                    .into_parts();
+                let stdin = Arc::new(Mutex::new(FramedWrite::new(
+                    io.stdin,
+                    LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
+                )));
                 let pipe = SessionPipe::Line(LineSessionPipe { stdin });
                 self.sandbox_pipes
                     .lock()
                     .await
                     .insert(sandbox_id.to_owned(), pipe.clone());
 
+                let store = self.store.clone();
+                let thread_key = thread_key.clone();
+                let pump_key = sandbox_id.to_owned();
+                let sandbox_pipes = self.sandbox_pipes.clone();
+                let stdout = io.stdout;
+                let stderr = io.stderr;
+                let guard = io.guard;
+                let stderr_key = pump_key.clone();
                 tokio::spawn(async move {
                     let result = run_line_stdout_pump(
                         store.clone(),
@@ -380,80 +420,141 @@ impl SessionRuntime {
                     }
                     sandbox_pipes.lock().await.remove(&pump_key);
                 });
+                tokio::spawn(async move {
+                    if let Err(error) = drain_stderr(stderr).await {
+                        warn!(%stderr_key, %error, "session stderr drain failed");
+                    }
+                });
                 pipe
             }
             SandboxProtocol::CodexAppServer => {
-                let (notifications, _) = broadcast::channel(256);
-                let pipe = SessionPipe::CodexAppServer(CodexAppServerPipe {
-                    stdin,
-                    next_request_id: Arc::new(AtomicI64::new(1)),
-                    responses: Arc::new(Mutex::new(HashMap::new())),
-                    notifications,
-                    state: Arc::new(Mutex::new(CodexAppServerState::default())),
-                    execute_lock: Arc::new(Mutex::new(())),
-                });
+                let codex_pipe = self.open_codex_app_server_pipe(sandbox_id, false).await?;
+                self.bind_codex_app_server_pipe(thread_key, &codex_pipe)
+                    .await?;
+                let pipe = SessionPipe::CodexAppServer(codex_pipe);
                 self.sandbox_pipes
                     .lock()
                     .await
                     .insert(sandbox_id.to_owned(), pipe.clone());
-
-                let SessionPipe::CodexAppServer(codex_pipe) = pipe.clone() else {
-                    unreachable!("constructed codex pipe")
-                };
-                let pump_store = store.clone();
-                let pump_thread_key = thread_key.clone();
-                let pump_key = pump_key.clone();
-                let pump_responses = codex_pipe.responses.clone();
-                let pump_notifications = codex_pipe.notifications.clone();
-                let pump_state = codex_pipe.state.clone();
-                tokio::spawn(async move {
-                    let result = run_codex_app_server_stdout_pump(
-                        pump_store.clone(),
-                        pump_thread_key.clone(),
-                        &pump_key,
-                        stdout,
-                        guard,
-                        pump_responses,
-                        pump_notifications,
-                        pump_state,
-                    )
-                    .await;
-                    if let Err(error) = result {
-                        warn!(%pump_key, %error, "codex app-server stdout pump failed");
-                        let _ = pump_store
-                            .append_event(
-                                &pump_thread_key,
-                                None,
-                                "session.stdout_pump_failed",
-                                json!({
-                                    "sandbox_id": pump_key.as_str(),
-                                    "error": error.to_string(),
-                                }),
-                            )
-                            .await;
-                    }
-                    sandbox_pipes.lock().await.remove(&pump_key);
-                });
-                initialize_codex_app_server(&codex_pipe).await?;
-                append_output_line(
-                    &self.store,
-                    &thread_key,
-                    None,
-                    &json!({"type": "system", "subtype": "app_server", "phase": "initialized"})
-                        .to_string(),
-                )
-                .await?;
                 pipe
             }
         };
 
+        Ok(pipe)
+    }
+
+    async fn open_codex_app_server_pipe(
+        &self,
+        sandbox_id: &str,
+        prewarmed: bool,
+    ) -> Result<CodexAppServerPipe, SessionRuntimeError> {
+        let io = self
+            .sandbox_runtime
+            .manager
+            .open_io(&SandboxId::new(sandbox_id))
+            .await?
+            .into_parts();
+        let stdin = Arc::new(Mutex::new(FramedWrite::new(
+            io.stdin,
+            LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
+        )));
+        let (notifications, _) = broadcast::channel(256);
+        let pipe = CodexAppServerPipe {
+            stdin,
+            next_request_id: Arc::new(AtomicI64::new(1)),
+            responses: Arc::new(Mutex::new(HashMap::new())),
+            notifications,
+            state: Arc::new(Mutex::new(CodexAppServerState::default())),
+            execute_lock: Arc::new(Mutex::new(())),
+            output_thread_key: Arc::new(Mutex::new(None)),
+            prewarmed,
+        };
+
+        let pump_store = self.store.clone();
+        let pump_key = sandbox_id.to_owned();
+        let pump_responses = pipe.responses.clone();
+        let pump_notifications = pipe.notifications.clone();
+        let pump_state = pipe.state.clone();
+        let pump_output_thread_key = pipe.output_thread_key.clone();
+        let sandbox_pipes = self.sandbox_pipes.clone();
+        let stdout = io.stdout;
+        let stderr = io.stderr;
+        let guard = io.guard;
+        let stderr_key = pump_key.clone();
+        tokio::spawn(async move {
+            let result = run_codex_app_server_stdout_pump(
+                pump_store.clone(),
+                &pump_key,
+                stdout,
+                guard,
+                pump_responses,
+                pump_notifications,
+                pump_state,
+                pump_output_thread_key.clone(),
+            )
+            .await;
+            if let Err(error) = result {
+                warn!(%pump_key, %error, "codex app-server stdout pump failed");
+                let thread_key = { pump_output_thread_key.lock().await.clone() };
+                if let Some(thread_key) = thread_key {
+                    let _ = pump_store
+                        .append_event(
+                            &thread_key,
+                            None,
+                            "session.stdout_pump_failed",
+                            json!({
+                                "sandbox_id": pump_key.as_str(),
+                                "error": error.to_string(),
+                            }),
+                        )
+                        .await;
+                }
+            }
+            sandbox_pipes.lock().await.remove(&pump_key);
+        });
         tokio::spawn(async move {
             if let Err(error) = drain_stderr(stderr).await {
                 warn!(%stderr_key, %error, "session stderr drain failed");
             }
         });
 
+        initialize_codex_app_server(&pipe).await?;
         Ok(pipe)
+    }
+
+    async fn bind_codex_app_server_pipe(
+        &self,
+        thread_key: &ThreadKey,
+        pipe: &CodexAppServerPipe,
+    ) -> Result<(), SessionRuntimeError> {
+        let mut output_thread_key = pipe.output_thread_key.lock().await;
+        match output_thread_key.as_ref() {
+            Some(existing) if existing != thread_key => {
+                return Err(SessionRuntimeError::CodexAppServer(format!(
+                    "codex app-server pipe is already bound to thread {existing}"
+                )));
+            }
+            Some(_) => return Ok(()),
+            None => {
+                *output_thread_key = Some(thread_key.clone());
+            }
+        }
+        drop(output_thread_key);
+
+        append_output_line(
+            &self.store,
+            thread_key,
+            None,
+            &json!({
+                "type": "system",
+                "subtype": "app_server",
+                "phase": "initialized",
+                "prewarmed": pipe.prewarmed,
+            })
+            .to_string(),
+        )
+        .await?;
+        Ok(())
     }
 
     async fn execute_codex_app_server_turn(
@@ -1005,13 +1106,13 @@ async fn run_line_stdout_pump(
 
 async fn run_codex_app_server_stdout_pump(
     store: PgSessionStore,
-    thread_key: ThreadKey,
     sandbox_id: &str,
     stdout: SandboxRead,
     _guard: SandboxIoGuard,
     responses: Arc<Mutex<HashMap<i64, oneshot::Sender<Value>>>>,
     notifications: broadcast::Sender<CodexNotification>,
     state: Arc<Mutex<CodexAppServerState>>,
+    output_thread_key: Arc<Mutex<Option<ThreadKey>>>,
 ) -> Result<(), SessionRuntimeError> {
     let mut stdout = FramedRead::new(
         stdout,
@@ -1038,20 +1139,26 @@ async fn run_codex_app_server_stdout_pump(
         if let Some((payload, notification)) =
             translate_codex_notification(method, msg.get("params"), &state).await
         {
-            append_output_line(&store, &thread_key, None, &payload.to_string()).await?;
+            let thread_key = { output_thread_key.lock().await.clone() };
+            if let Some(thread_key) = thread_key {
+                append_output_line(&store, &thread_key, None, &payload.to_string()).await?;
+            }
             let _ = notifications.send(notification);
         }
     }
-    store
-        .append_event(
-            &thread_key,
-            None,
-            "session.stdout_eof",
-            json!({
-                "sandbox_id": sandbox_id,
-            }),
-        )
-        .await?;
+    let thread_key = { output_thread_key.lock().await.clone() };
+    if let Some(thread_key) = thread_key {
+        store
+            .append_event(
+                &thread_key,
+                None,
+                "session.stdout_eof",
+                json!({
+                    "sandbox_id": sandbox_id,
+                }),
+            )
+            .await?;
+    }
     Ok(())
 }
 

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -201,7 +201,6 @@ COPY --link --from=centaur-tools-builder --chmod=755 /tmp/centaur-tools /usr/loc
 COPY --link --chmod=755 services/sandbox/slack-upload.sh /usr/local/bin/slack-upload
 COPY --link --chmod=755 services/sandbox/md2docx.py /usr/local/bin/md2docx
 COPY --link --chmod=755 services/sandbox/amp-wrapper.py /usr/local/bin/amp-wrapper
-COPY --link --chmod=755 services/sandbox/codex-app-wrapper.py /usr/local/bin/codex-app-wrapper
 COPY --link --chmod=755 services/sandbox/claude-app-wrapper.py /usr/local/bin/claude-app-wrapper
 COPY --link --chmod=755 services/sandbox/harness_adapter.py /usr/local/bin/harness-adapter
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
@@ -216,5 +215,4 @@ COPY --link --chown=1001:1001 harness/ /home/agent/harness/
 COPY --link --chown=1001:1001 services/sandbox/SYSTEM_PROMPT.md /home/agent/AGENTS.md
 
 ENTRYPOINT ["/entrypoint.sh"]
-# Default CMD uses Codex app-server through Centaur's NDJSON bridge.
-CMD ["codex-app-wrapper"]
+CMD ["codex", "app-server", "--listen", "stdio://"]

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -189,6 +189,9 @@ RUN --mount=type=cache,target=/home/agent/.cargo/registry,uid=1001,gid=1001,shar
 FROM toolchain AS sandbox
 
 USER root
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends iptables
 RUN rm -f /etc/sudoers.d/agent
 # BuildKit's COPY --link creates parent directories without an explicit mode,
 # which can leave /etc/centaur without the execute bit for non-root users.

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -252,8 +252,12 @@ if [ -n "${CENTAUR_TOOLS_URL:-}" ]; then
     done
 fi
 
-# Signal readiness
-touch "$HOME_DIR/.ready"
+# Signal readiness after auth/config setup. Codex warm pools run
+# `codex app-server` directly; the Rust session runtime owns JSON-RPC
+# initialization as soon as it claims and attaches to a warm sandbox.
+READY_FILE="${CENTAUR_READY_FILE:-$HOME_DIR/.ready}"
+export CENTAUR_READY_FILE="$READY_FILE"
+touch "$READY_FILE"
 
 # ── Background: slow auth tasks ─────────────────────────────────────────────
 {

--- a/services/sandbox/harness_adapter.py
+++ b/services/sandbox/harness_adapter.py
@@ -20,17 +20,12 @@ class AmpAdapter(HarnessAdapter):
         target.symlink_to(prompt.name)
 
 
-class CodexAdapter(HarnessAdapter):
-    pass
-
-
 class ClaudeCodeAdapter(HarnessAdapter):
     pass
 
 
 ADAPTERS = {
     "amp-wrapper": AmpAdapter,
-    "codex-app-wrapper": CodexAdapter,
     "claude-app-wrapper": ClaudeCodeAdapter,
 }
 


### PR DESCRIPTION
## Summary
- make the Rust Agent Sandbox backend always create sessions through SandboxTemplate, SandboxWarmPool, and SandboxClaim CRDs
- remove the warm-pool enable switch and drop the direct Sandbox creation fallback from the runtime create path
- wait for ready warm-pool replicas before claiming, then use the adopted Sandbox name as the runtime handle
- keep warm-pool templates reusable by omitting per-thread env from codex container templates and rejecting inputs/config that would force cold-start behavior
- install extension CRDs in the api-rs kind harness

## Testing
- cargo test -p centaur-sandbox-agent-k8s
- cargo test -p centaur-api-server
- cargo test -p centaur-session-runtime
- just build-one api-rs

Note: I did not run `just deploy` because the current Helm chart in this branch does not deploy the `api-rs` server image; the Rust server path is validated by crate tests and the Docker image build.