### PR TITLE
fix: use upstream Chat SDK Slack streaming

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,21 +128,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rendering
       '@chat-adapter/slack':
-        specifier: ^4.29.0
-        version: 4.29.0(zod@4.4.3)
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
       '@chat-adapter/state-pg':
-        specifier: ^4.29.0
-        version: 4.29.0(zod@4.4.3)
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
       chat:
-        specifier: ^4.29.0
-        version: 4.29.0(zod@4.4.3)
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
       hono:
         specifier: ^4.12.18
         version: 4.12.19
     devDependencies:
       '@chat-adapter/state-memory':
-        specifier: ^4.29.0
-        version: 4.29.0(zod@4.4.3)
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
       '@slack/web-api':
         specifier: ^7.15.2
         version: 7.16.0
@@ -164,20 +164,20 @@ importers:
 
 packages:
 
-  '@chat-adapter/shared@4.29.0':
-    resolution: {integrity: sha512-ARqTDoHJHKN9rpytbFPJbNmqqx3fOg5xwsTZdlingQPAssOSeHDBdqrFJkgDhyCRGbmDtG09cuS0FkVzeoh2qg==}
+  '@chat-adapter/shared@4.30.0':
+    resolution: {integrity: sha512-IuYtbn/p1FBXvp7JYGEMLCt07GHOMlyjx7OlZXPJwLTravcyJuP7Q6N31r6c1yubMhM8PLb8eT8l/YnjwYjs9Q==}
     engines: {node: '>=20'}
 
-  '@chat-adapter/slack@4.29.0':
-    resolution: {integrity: sha512-s2DXAwkTpmiIKSATXgrO879s1pqFwS70Y0JPd+TRGRzDeh6nfqt5dnKt5Bug0P1zwkB6DoPurhnYS9nqhSmD/w==}
+  '@chat-adapter/slack@4.30.0':
+    resolution: {integrity: sha512-ZB+G/JBKmaXzvl+DuUQPBb/gCwXP3fOtUK5Cyj6wLbbeeDYzi3NQPvpvieVum/GI4iuR8OUVcNAnVQiH6P6DOQ==}
     engines: {node: '>=20'}
 
-  '@chat-adapter/state-memory@4.29.0':
-    resolution: {integrity: sha512-+L5LPj9VkyXFXAcfFlTvf2JihuFfQV5U9TfXDlQeG7k6NMEA8irt4a0c6MTxFP7OI5YENknVwRGzmcUubvEWSw==}
+  '@chat-adapter/state-memory@4.30.0':
+    resolution: {integrity: sha512-huYnGBKBiY6s/GaYgtAmr0zM6ihvGl8/NOEV9oqY89jr6Zdnm/ZXdpXvDKdXoaxmDXCiZr2U54DbSDzpvGQ6fA==}
     engines: {node: '>=20'}
 
-  '@chat-adapter/state-pg@4.29.0':
-    resolution: {integrity: sha512-ocKWDly9my4kftWdVdfE/b9UczRBUFSPrxEHzQAPDNfkt1PjcIKFjDjWIADYSCeUL1MqLjSnu8pM3BE96kUJGQ==}
+  '@chat-adapter/state-pg@4.30.0':
+    resolution: {integrity: sha512-8qymxX34Fg7B0PJCoYi60Bck68Gnd4cW4U8hgvJBc5ZHm8K4XT4srV8G3AeDT7rVSmrW5diidcmROo8Z1ke6iw==}
     engines: {node: '>=20'}
 
   '@emnapi/core@1.8.1':
@@ -811,8 +811,8 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
-  chat@4.29.0:
-    resolution: {integrity: sha512-KdPfzaie5ivYytyRICTERg5xT+LeCbYefokvNAqTHe92eqkFaoTMXXkSitikxJVWhZIb2YoXF1b9UZHyzSzKzw==}
+  chat@4.30.0:
+    resolution: {integrity: sha512-8LXrauKckMmR83FcYC/R8nNEda5VJDDdIhZwUUu+hzaSbk4lqsro0IWm7rB1GGYXONRrUOG2XJlkNr4C15vgMA==}
     engines: {node: '>=20'}
     peerDependencies:
       ai: ^6.0.182
@@ -1537,20 +1537,20 @@ packages:
 
 snapshots:
 
-  '@chat-adapter/shared@4.29.0(zod@4.4.3)':
+  '@chat-adapter/shared@4.30.0(zod@4.4.3)':
     dependencies:
-      chat: 4.29.0(zod@4.4.3)
+      chat: 4.30.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.29.0(zod@4.4.3)':
+  '@chat-adapter/slack@4.30.0(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.29.0(zod@4.4.3)
+      '@chat-adapter/shared': 4.30.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7
       '@slack/web-api': 7.16.0
-      chat: 4.29.0(zod@4.4.3)
+      chat: 4.30.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - bufferutil
@@ -1559,17 +1559,17 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@chat-adapter/state-memory@4.29.0(zod@4.4.3)':
+  '@chat-adapter/state-memory@4.30.0(zod@4.4.3)':
     dependencies:
-      chat: 4.29.0(zod@4.4.3)
+      chat: 4.30.0(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/state-pg@4.29.0(zod@4.4.3)':
+  '@chat-adapter/state-pg@4.30.0(zod@4.4.3)':
     dependencies:
-      chat: 4.29.0(zod@4.4.3)
+      chat: 4.30.0(zod@4.4.3)
       pg: 8.21.0
     transitivePeerDependencies:
       - ai
@@ -2072,7 +2072,7 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  chat@4.29.0(zod@4.4.3):
+  chat@4.30.0(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0

--- a/services/slackbotv2/package.json
+++ b/services/slackbotv2/package.json
@@ -12,13 +12,13 @@
   "dependencies": {
     "@centaur/harness-events": "workspace:*",
     "@centaur/rendering": "workspace:*",
-    "@chat-adapter/slack": "^4.29.0",
-    "@chat-adapter/state-pg": "^4.29.0",
-    "chat": "^4.29.0",
+    "@chat-adapter/slack": "^4.30.0",
+    "@chat-adapter/state-pg": "^4.30.0",
+    "chat": "^4.30.0",
     "hono": "^4.12.18"
   },
   "devDependencies": {
-    "@chat-adapter/state-memory": "^4.29.0",
+    "@chat-adapter/state-memory": "^4.30.0",
     "@slack/web-api": "^7.15.2",
     "@types/bun": "^1.3.13",
     "@types/node": "^25.7.0",

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1,12 +1,10 @@
 import { Hono } from 'hono'
 import {
   Chat,
-  StreamingMarkdownRenderer,
   StreamingPlan,
   type Logger,
   type Message,
   type StateAdapter,
-  type StreamChunk,
   type Thread
 } from 'chat'
 import { createSlackAdapter } from '@chat-adapter/slack'
@@ -75,7 +73,6 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     userName,
     logger
   })
-  patchSlackAdapterStreaming(slack, options.botToken, logger)
   const chat = new Chat({
     userName,
     adapters: { slack },
@@ -303,153 +300,6 @@ function rendererOptions(thread: Thread, options: SlackbotV2Options): CodexAppSe
       }
     }
   }
-}
-
-type SlackStreamingAdapter = {
-  decodeThreadId(threadId: string): { channel: string; threadTs?: string }
-  getClientForToken?(token: string): SlackStreamingClient
-  stream?: (
-    threadId: string,
-    textStream: AsyncIterable<string | StreamChunk>,
-    options?: SlackStreamOptions
-  ) => Promise<{ id: string; raw: unknown; threadId: string }>
-}
-
-type SlackStreamPayload = { [key: string]: unknown }
-const SLACK_MAX_BLOCKS = 50
-const SLACK_SECTION_TEXT_MAX_CHARS = 3000
-
-type SlackStreamingClient = {
-  chatStream(input: SlackStreamPayload): SlackStreamer
-}
-
-type SlackStreamer = {
-  append(input: SlackStreamPayload): Promise<unknown>
-  stop(input?: SlackStreamPayload): Promise<{ message?: { ts?: string }; ts?: string }>
-}
-
-type SlackStreamOptions = {
-  recipientTeamId?: string
-  recipientUserId?: string
-  stopBlocks?: unknown[]
-  taskDisplayMode?: 'plan' | 'timeline' | 'dense'
-}
-
-function patchSlackAdapterStreaming(adapter: unknown, botToken: string, logger: Logger): void {
-  const slack = adapter as SlackStreamingAdapter
-  if (!slack.getClientForToken || !slack.stream) return
-
-  const originalStream = slack.stream.bind(slack)
-  slack.stream = async (threadId, textStream, options) => {
-    if (!(options?.recipientUserId && options?.recipientTeamId)) {
-      return originalStream(threadId, textStream, options)
-    }
-
-    const { channel, threadTs: rawThreadTs } = slack.decodeThreadId(threadId)
-    const threadTs = rawThreadTs || undefined
-    if (!threadTs) {
-      return originalStream(threadId, textStream, options)
-    }
-
-    logger.debug('Slack: starting token-bound stream', { channel, threadTs })
-    const client = slack.getClientForToken!(botToken)
-    const streamer = client.chatStream({
-      channel,
-      thread_ts: threadTs,
-      recipient_user_id: options.recipientUserId,
-      recipient_team_id: options.recipientTeamId,
-      ...(options.taskDisplayMode ? { task_display_mode: options.taskDisplayMode } : {})
-    })
-
-    let lastAppended = ''
-    let structuredChunksSupported = true
-    const renderer = new StreamingMarkdownRenderer({ wrapTablesForAppend: false })
-
-    const flushMarkdownDelta = async (delta: string): Promise<void> => {
-      if (!delta) return
-      await streamer.append({ markdown_text: delta })
-    }
-
-    const pushTextAndFlush = async (text: string): Promise<void> => {
-      renderer.push(text)
-      const committable = renderer.getCommittableText()
-      const delta = committable.slice(lastAppended.length)
-      await flushMarkdownDelta(delta)
-      lastAppended = committable
-    }
-
-    const sendStructuredChunk = async (chunk: StreamChunk): Promise<void> => {
-      if (!structuredChunksSupported) return
-      const committable = renderer.getCommittableText()
-      const delta = committable.slice(lastAppended.length)
-      await flushMarkdownDelta(delta)
-      lastAppended = committable
-      try {
-        await streamer.append({ chunks: [chunk] })
-      } catch (error) {
-        structuredChunksSupported = false
-        logger.warn('Slack structured streaming chunk failed; falling back to text-only stream', {
-          chunkType: chunk.type,
-          error
-        })
-      }
-    }
-
-    for await (const chunk of textStream) {
-      if (typeof chunk === 'string') {
-        await pushTextAndFlush(chunk)
-      } else if (chunk.type === 'markdown_text') {
-        await pushTextAndFlush(chunk.text)
-      } else {
-        await sendStructuredChunk(chunk)
-      }
-    }
-
-    renderer.finish()
-    const finalCommittable = renderer.getCommittableText()
-    const finalDelta = finalCommittable.slice(lastAppended.length)
-    await flushMarkdownDelta(finalDelta)
-    lastAppended = finalCommittable
-    const stopPayload: SlackStreamPayload = {}
-    const stopBlocks =
-      options.stopBlocks && finalCommittable.trim()
-        ? appendFinalMarkdownBlocks(options.stopBlocks, finalCommittable)
-        : options.stopBlocks
-    if (stopBlocks) {
-      stopPayload.blocks = stopBlocks
-    }
-    const result = await streamer.stop(Object.keys(stopPayload).length ? stopPayload : undefined)
-    const messageTs = result.message?.ts ?? result.ts
-    if (!messageTs) throw new Error('Slack stream completed without a message timestamp')
-    logger.debug('Slack: token-bound stream complete', { messageId: messageTs })
-    return { id: messageTs, threadId, raw: result }
-  }
-}
-
-function appendFinalMarkdownBlocks(blocks: unknown[], markdown: string): unknown[] {
-  const finalBlocks = markdownSectionBlocks(markdown)
-  const available = Math.max(0, SLACK_MAX_BLOCKS - finalBlocks.length)
-  return [...blocks.slice(0, available), ...finalBlocks]
-}
-
-function markdownSectionBlocks(markdown: string): unknown[] {
-  const text = markdown.trim()
-  if (!text) return []
-
-  const blocks: unknown[] = []
-  let remaining = text
-  while (remaining && blocks.length < SLACK_MAX_BLOCKS) {
-    const chunk = remaining.slice(0, SLACK_SECTION_TEXT_MAX_CHARS)
-    blocks.push({
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: chunk
-      }
-    })
-    remaining = remaining.slice(chunk.length)
-  }
-  return blocks
 }
 
 async function setAssistantStatus(thread: Thread, status: string): Promise<void> {


### PR DESCRIPTION
## Summary
- bump Slackbot v2 Chat SDK packages to 4.30.0
- remove the local Slack streaming adapter shim now that the token fix is upstream

## Test
- pnpm --filter slackbotv2 check:types
- pnpm --filter @centaur/rendering test