### PR TITLE
refactor: split non-iron api-rs CLI modules

### DIFF
--- a/services/api-rs/crates/centaur-session-cli/src/args.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/args.rs
@@ -1,0 +1,112 @@
+use centaur_session_core::{HarnessType, ThreadKey};
+use clap::Parser;
+use eyre::{Result, bail};
+use serde_json::json;
+use uuid::Uuid;
+
+const DEFAULT_MESSAGE: &str = "Reply with exactly PONG and nothing else.";
+
+#[derive(Debug, Parser)]
+#[command(about = "Create, execute, or attach to a Centaur session")]
+pub(crate) struct Args {
+    #[arg(long, env = "CENTAUR_API_URL", default_value = "http://127.0.0.1:8080", value_parser = api_base_url)]
+    pub(crate) api_url: String,
+
+    #[arg(long)]
+    thread_key: Option<ThreadKey>,
+
+    #[arg(long, requires = "thread_key", conflicts_with_all = ["message", "input_lines"])]
+    attach: bool,
+
+    #[arg(long, default_value = "codex")]
+    pub(crate) harness_type: HarnessType,
+
+    #[arg(long)]
+    message: Option<String>,
+
+    #[arg(long = "input-line")]
+    input_lines: Vec<String>,
+
+    #[arg(long, default_value_t = 1_000)]
+    pub(crate) idle_timeout_ms: u64,
+
+    #[arg(long, default_value_t = 60_000)]
+    pub(crate) max_duration_ms: u64,
+
+    #[arg(long, default_value_t = 0)]
+    pub(crate) after_event_id: i64,
+
+    #[arg(long)]
+    pub(crate) all_events: bool,
+
+    #[arg(long)]
+    pub(crate) exit_on_terminal: bool,
+
+    #[arg(long, value_parser = non_empty_value)]
+    pub(crate) exit_on_output_type: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SessionMode {
+    Attach,
+    Execute,
+}
+
+impl Args {
+    pub(crate) fn session_mode(&self) -> SessionMode {
+        let attach_mode = self.attach
+            || (self.after_event_id > 0
+                && self.thread_key.is_some()
+                && self.message.is_none()
+                && self.input_lines.is_empty());
+        if attach_mode {
+            SessionMode::Attach
+        } else {
+            SessionMode::Execute
+        }
+    }
+
+    pub(crate) fn thread_key(&self, mode: SessionMode) -> Result<(ThreadKey, bool)> {
+        match (&self.thread_key, mode) {
+            (Some(thread_key), _) => Ok((thread_key.clone(), false)),
+            (None, SessionMode::Attach) => bail!("--attach requires --thread-key"),
+            (None, SessionMode::Execute) => Ok((
+                ThreadKey::parse(format!("cli:{}", Uuid::new_v4().simple()))?,
+                true,
+            )),
+        }
+    }
+
+    pub(crate) fn input_lines(&self) -> Result<Vec<String>> {
+        if !self.input_lines.is_empty() {
+            return Ok(self.input_lines.clone());
+        }
+        Ok(vec![user_input_line(self.message_text())?])
+    }
+
+    pub(crate) fn message_text(&self) -> &str {
+        self.message.as_deref().unwrap_or(DEFAULT_MESSAGE)
+    }
+}
+
+fn user_input_line(text: &str) -> Result<String> {
+    Ok(serde_json::to_string(&json!({
+        "type": "user",
+        "message": {
+            "content": [{"type": "text", "text": text}],
+        },
+    }))?)
+}
+
+fn api_base_url(value: &str) -> std::result::Result<String, String> {
+    let value = value.trim_end_matches('/');
+    (!value.is_empty())
+        .then(|| value.to_owned())
+        .ok_or_else(|| "api_url must not be empty".to_owned())
+}
+
+fn non_empty_value(value: &str) -> std::result::Result<String, String> {
+    (!value.trim().is_empty())
+        .then(|| value.to_owned())
+        .ok_or_else(|| "value must not be empty".to_owned())
+}

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -1,74 +1,43 @@
+mod args;
+mod output;
+
 use centaur_api_server::{
-    client::{CentaurClient, SseEventStream},
+    client::CentaurClient,
     types::{AppendMessagesRequest, CreateSessionRequest, ExecuteSessionRequest},
 };
-use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
+use centaur_session_core::{MessageRole, SessionMessageInput};
 use clap::Parser;
-use eyre::{Result, WrapErr, bail};
-use futures_util::StreamExt;
+use eyre::{Result, WrapErr};
 use serde_json::{Value, json};
-use uuid::Uuid;
 
-const DEFAULT_MESSAGE: &str = "Reply with exactly PONG and nothing else.";
+use args::{Args, SessionMode};
+use output::stream_output_lines;
+
 const SOURCE: &str = "centaur-session-cli";
-
-#[derive(Debug, Parser)]
-#[command(about = "Create, execute, or attach to a Centaur session")]
-struct Args {
-    #[arg(long, env = "CENTAUR_API_URL", default_value = "http://127.0.0.1:8080", value_parser = api_base_url)]
-    api_url: String,
-
-    #[arg(long)]
-    thread_key: Option<ThreadKey>,
-
-    #[arg(long)]
-    attach: bool,
-
-    #[arg(long, default_value = "codex")]
-    harness_type: HarnessType,
-
-    #[arg(long)]
-    message: Option<String>,
-
-    #[arg(long = "input-line")]
-    input_lines: Vec<String>,
-
-    #[arg(long, default_value_t = 1_000)]
-    idle_timeout_ms: u64,
-
-    #[arg(long, default_value_t = 60_000)]
-    max_duration_ms: u64,
-
-    #[arg(long, default_value_t = 0)]
-    after_event_id: i64,
-
-    #[arg(long)]
-    all_events: bool,
-
-    #[arg(long)]
-    exit_on_terminal: bool,
-
-    #[arg(long, value_parser = non_empty_value)]
-    exit_on_output_type: Option<String>,
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let attach_mode = attach_mode(&args);
-    validate_mode(&args, attach_mode)?;
-    let (thread_key, generated_thread_key) = thread_key_arg(&args, attach_mode)?;
+    let mode = args.session_mode();
+    let (thread_key, generated_thread_key) = args.thread_key(mode)?;
     if generated_thread_key {
         eprintln!("thread_key={}", thread_key.as_str());
     }
+
     let client = CentaurClient::new(&args.api_url);
 
-    if attach_mode {
+    if mode == SessionMode::Attach {
         let events = client
             .stream_events(&thread_key, args.after_event_id)
             .await
             .wrap_err("open event stream")?;
-        return stream_output_lines(events, &args).await;
+        return stream_output_lines(
+            events,
+            args.all_events,
+            args.exit_on_terminal,
+            args.exit_on_output_type.as_deref(),
+        )
+        .await;
     }
 
     client
@@ -76,26 +45,21 @@ async fn main() -> Result<()> {
             &thread_key,
             CreateSessionRequest {
                 harness_type: args.harness_type,
-                metadata: Some(json!({
-                    "source": SOURCE,
-                })),
+                metadata: Some(source_metadata()),
             },
         )
         .await
         .wrap_err("create session")?;
 
-    let input_lines = session_input_lines(&args)?;
-    let message = message_text(&args);
+    let input_lines = args.input_lines()?;
     client
         .append_messages(
             &thread_key,
             AppendMessagesRequest {
                 messages: vec![SessionMessageInput {
                     role: MessageRole::User,
-                    parts: vec![json!({"type": "text", "text": message})],
-                    metadata: json!({
-                        "source": SOURCE,
-                    }),
+                    parts: vec![json!({"type": "text", "text": args.message_text()})],
+                    metadata: source_metadata(),
                 }],
             },
         )
@@ -111,9 +75,7 @@ async fn main() -> Result<()> {
         .execute_session(
             &thread_key,
             ExecuteSessionRequest {
-                metadata: Some(json!({
-                    "source": SOURCE,
-                })),
+                metadata: Some(source_metadata()),
                 input_lines,
                 idle_timeout_ms: Some(args.idle_timeout_ms),
                 max_duration_ms: Some(args.max_duration_ms),
@@ -122,124 +84,15 @@ async fn main() -> Result<()> {
         .await
         .wrap_err("execute initial turn")?;
 
-    stream_output_lines(events, &args).await
-}
-
-fn attach_mode(args: &Args) -> bool {
-    args.attach
-        || (args.after_event_id > 0
-            && args.thread_key.is_some()
-            && args.message.is_none()
-            && args.input_lines.is_empty())
-}
-
-fn validate_mode(args: &Args, attach_mode: bool) -> Result<()> {
-    if attach_mode && args.thread_key.is_none() {
-        bail!("attach mode requires --thread-key");
-    }
-    if args.attach && (args.message.is_some() || !args.input_lines.is_empty()) {
-        bail!("--attach does not accept --message or --input-line");
-    }
-    Ok(())
-}
-
-fn thread_key_arg(args: &Args, attach_mode: bool) -> Result<(ThreadKey, bool)> {
-    match (&args.thread_key, attach_mode) {
-        (Some(thread_key), _) => Ok((thread_key.clone(), false)),
-        (None, true) => bail!("--attach requires --thread-key"),
-        (None, false) => Ok((
-            ThreadKey::parse(format!("cli:{}", Uuid::new_v4().simple()))?,
-            true,
-        )),
-    }
-}
-
-async fn stream_output_lines(mut events: SseEventStream, args: &Args) -> Result<()> {
-    while let Some(event) = events.next().await {
-        let event = event.wrap_err("read event stream")?;
-
-        if event.event == "session.output.line" {
-            println!("{}\t{}", event_id_or_unknown(&event.id), event.data);
-            if output_type_matches(&event.data, args.exit_on_output_type.as_deref()) {
-                return Ok(());
-            }
-        } else if args.all_events {
-            let data = parse_json_or_string(&event.data);
-            println!(
-                "{}",
-                serde_json::to_string(&json!({
-                    "sse_event": event.event,
-                    "id": optional_event_id(&event.id),
-                    "data": data,
-                }))?
-            );
-        }
-
-        if args.exit_on_terminal && is_terminal_event(&event.event) {
-            return Ok(());
-        }
-    }
-
-    Ok(())
-}
-
-fn event_id_or_unknown(event_id: &str) -> &str {
-    optional_event_id(event_id).unwrap_or("unknown")
-}
-
-fn optional_event_id(event_id: &str) -> Option<&str> {
-    (!event_id.is_empty()).then_some(event_id)
-}
-
-pub(crate) fn output_type_matches(data: &str, expected_type: Option<&str>) -> bool {
-    let Some(expected_type) = expected_type else {
-        return false;
-    };
-    serde_json::from_str::<Value>(data)
-        .is_ok_and(|value| value.get("type").and_then(Value::as_str) == Some(expected_type))
-}
-
-fn session_input_lines(args: &Args) -> Result<Vec<String>> {
-    if !args.input_lines.is_empty() {
-        return Ok(args.input_lines.clone());
-    }
-    let message = message_text(args);
-    Ok(vec![user_input_line(message)?])
-}
-
-pub(crate) fn user_input_line(text: &str) -> Result<String> {
-    Ok(serde_json::to_string(&json!({
-        "type": "user",
-        "message": {
-            "content": [{"type": "text", "text": text}],
-        },
-    }))?)
-}
-
-fn message_text(args: &Args) -> &str {
-    args.message.as_deref().unwrap_or(DEFAULT_MESSAGE)
-}
-
-pub(crate) fn parse_json_or_string(data: &str) -> Value {
-    serde_json::from_str(data).unwrap_or_else(|_| Value::String(data.to_owned()))
-}
-
-pub(crate) fn is_terminal_event(event: &str) -> bool {
-    matches!(
-        event,
-        "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
+    stream_output_lines(
+        events,
+        args.all_events,
+        args.exit_on_terminal,
+        args.exit_on_output_type.as_deref(),
     )
+    .await
 }
 
-fn api_base_url(value: &str) -> std::result::Result<String, String> {
-    let value = value.trim_end_matches('/');
-    (!value.is_empty())
-        .then(|| value.to_owned())
-        .ok_or_else(|| "api_url must not be empty".to_owned())
-}
-
-fn non_empty_value(value: &str) -> std::result::Result<String, String> {
-    (!value.trim().is_empty())
-        .then(|| value.to_owned())
-        .ok_or_else(|| "value must not be empty".to_owned())
+fn source_metadata() -> Value {
+    json!({ "source": SOURCE })
 }

--- a/services/api-rs/crates/centaur-session-cli/src/output.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/output.rs
@@ -1,0 +1,65 @@
+use centaur_api_server::client::SseEventStream;
+use eyre::{Result, WrapErr};
+use futures_util::StreamExt;
+use serde_json::{Value, json};
+
+pub(crate) async fn stream_output_lines(
+    mut events: SseEventStream,
+    all_events: bool,
+    exit_on_terminal: bool,
+    exit_on_output_type: Option<&str>,
+) -> Result<()> {
+    while let Some(event) = events.next().await {
+        let event = event.wrap_err("read event stream")?;
+
+        if event.event == "session.output.line" {
+            println!("{}\t{}", event_id_or_unknown(&event.id), event.data);
+            if output_type_matches(&event.data, exit_on_output_type) {
+                return Ok(());
+            }
+        } else if all_events {
+            let data = parse_json_or_string(&event.data);
+            println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "sse_event": event.event,
+                    "id": optional_event_id(&event.id),
+                    "data": data,
+                }))?
+            );
+        }
+
+        if exit_on_terminal && is_terminal_event(&event.event) {
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}
+
+fn event_id_or_unknown(event_id: &str) -> &str {
+    optional_event_id(event_id).unwrap_or("unknown")
+}
+
+fn optional_event_id(event_id: &str) -> Option<&str> {
+    (!event_id.is_empty()).then_some(event_id)
+}
+
+fn output_type_matches(data: &str, expected_type: Option<&str>) -> bool {
+    let Some(expected_type) = expected_type else {
+        return false;
+    };
+    serde_json::from_str::<Value>(data)
+        .is_ok_and(|value| value.get("type").and_then(Value::as_str) == Some(expected_type))
+}
+
+fn parse_json_or_string(data: &str) -> Value {
+    serde_json::from_str(data).unwrap_or_else(|_| Value::String(data.to_owned()))
+}
+
+fn is_terminal_event(event: &str) -> bool {
+    matches!(
+        event,
+        "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
+    )
+}


### PR DESCRIPTION
Stacked on #326 / codex/rust-api-iron-proxy.

This keeps non-iron-proxy desloppification reviewable separately from the iron-proxy work.

Changes:
- Split centaur-session-cli parsing/mode logic into src/args.rs.
- Split SSE output rendering into src/output.rs.
- Keep src/main.rs as request orchestration only.

Validation:
- cargo fmt
- cargo check -p centaur-session-cli
- cargo test -p centaur-session-cli
- cargo check --workspace
- cargo test --workspace