### PR TITLE
feat: add Linear sync workflow

### DIFF
--- a/services/api/api/integrations/linear/readonly.py
+++ b/services/api/api/integrations/linear/readonly.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import datetime as dt
 import mimetypes
 from typing import Any
 from urllib.parse import urlparse
@@ -16,6 +17,17 @@ def _linear_string_literal(value: str) -> str:
 
 def _team_key_filter(team_key: str) -> str:
     return f"team: {{ key: {{ eq: {_linear_string_literal(team_key)} }} }}"
+
+
+def _linear_datetime(value: dt.datetime | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, dt.datetime):
+        parsed = value
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+    return value
 
 
 class LinearReadonlyClient(LinearGraphQLClient):
@@ -193,6 +205,64 @@ class LinearReadonlyClient(LinearGraphQLClient):
         """
         return self._connection_nodes(query, connection_path=("projects",), limit=limit)
 
+    def list_etl_projects(
+        self,
+        *,
+        page_size: int = 100,
+        cursor: str | None = None,
+        updated_after: dt.datetime | str | None = None,
+        include_archived: bool = True,
+    ) -> dict[str, Any]:
+        """List one page of projects with the fields needed by the ETL."""
+        filter_arg = ""
+        variables: dict[str, Any] = {
+            "first": page_size,
+            "after": cursor,
+            "includeArchived": include_archived,
+        }
+        updated_after_value = _linear_datetime(updated_after)
+        updated_after_var = ""
+        if updated_after_value:
+            filter_arg = "filter: { updatedAt: { gte: $updatedAfter } },"
+            updated_after_var = ",\n            $updatedAfter: DateTimeOrDuration"
+            variables["updatedAfter"] = updated_after_value
+
+        query = f"""
+        query LinearEtlProjects(
+            $first: Int!,
+            $after: String,
+            $includeArchived: Boolean
+            {updated_after_var}
+        ) {{
+            projects(
+                first: $first,
+                after: $after,
+                includeArchived: $includeArchived,
+                orderBy: updatedAt,
+                {filter_arg}
+            ) {{
+                nodes {{
+                    id
+                    name
+                    description
+                    slugId
+                    state
+                    status {{ id name type color }}
+                    lead {{ id name displayName email }}
+                    teams {{ nodes {{ id name key }} }}
+                    createdAt
+                    updatedAt
+                    archivedAt
+                    completedAt
+                    canceledAt
+                    url
+                }}
+                pageInfo {{ hasNextPage endCursor }}
+            }}
+        }}
+        """
+        return self._query(query, variables).get("projects", {})
+
     def project(self, project_id: str) -> dict[str, Any]:
         """Get a single project."""
         query = """
@@ -326,3 +396,126 @@ class LinearReadonlyClient(LinearGraphQLClient):
             variables={"query": query_str},
             limit=limit,
         )
+
+    def list_etl_issues(
+        self,
+        *,
+        page_size: int = 100,
+        cursor: str | None = None,
+        updated_after: dt.datetime | str | None = None,
+        include_archived: bool = True,
+    ) -> dict[str, Any]:
+        """List one page of issues with the fields needed by the ETL."""
+        filter_arg = ""
+        variables: dict[str, Any] = {
+            "first": page_size,
+            "after": cursor,
+            "includeArchived": include_archived,
+        }
+        updated_after_value = _linear_datetime(updated_after)
+        updated_after_var = ""
+        if updated_after_value:
+            filter_arg = "filter: { updatedAt: { gte: $updatedAfter } },"
+            updated_after_var = ",\n            $updatedAfter: DateTimeOrDuration"
+            variables["updatedAfter"] = updated_after_value
+
+        query = f"""
+        query LinearEtlIssues(
+            $first: Int!,
+            $after: String,
+            $includeArchived: Boolean
+            {updated_after_var}
+        ) {{
+            issues(
+                first: $first,
+                after: $after,
+                includeArchived: $includeArchived,
+                orderBy: updatedAt,
+                {filter_arg}
+            ) {{
+                nodes {{
+                    id
+                    identifier
+                    number
+                    title
+                    description
+                    url
+                    priority
+                    priorityLabel
+                    estimate
+                    dueDate
+                    team {{ id name key }}
+                    project {{ id name }}
+                    cycle {{ id name number }}
+                    state {{ id name type color }}
+                    assignee {{ id name displayName email }}
+                    creator {{ id name displayName email }}
+                    parent {{ id identifier title }}
+                    createdAt
+                    updatedAt
+                    archivedAt
+                    startedAt
+                    completedAt
+                    canceledAt
+                }}
+                pageInfo {{ hasNextPage endCursor }}
+            }}
+        }}
+        """
+        return self._query(query, variables).get("issues", {})
+
+    def list_etl_comments(
+        self,
+        *,
+        page_size: int = 100,
+        cursor: str | None = None,
+        updated_after: dt.datetime | str | None = None,
+        include_archived: bool = True,
+    ) -> dict[str, Any]:
+        """List one page of comments with the fields needed by the ETL."""
+        filter_arg = ""
+        variables: dict[str, Any] = {
+            "first": page_size,
+            "after": cursor,
+            "includeArchived": include_archived,
+        }
+        updated_after_value = _linear_datetime(updated_after)
+        updated_after_var = ""
+        if updated_after_value:
+            filter_arg = "filter: { updatedAt: { gte: $updatedAfter } },"
+            updated_after_var = ",\n            $updatedAfter: DateTimeOrDuration"
+            variables["updatedAfter"] = updated_after_value
+
+        query = f"""
+        query LinearEtlComments(
+            $first: Int!,
+            $after: String,
+            $includeArchived: Boolean
+            {updated_after_var}
+        ) {{
+            comments(
+                first: $first,
+                after: $after,
+                includeArchived: $includeArchived,
+                orderBy: updatedAt,
+                {filter_arg}
+            ) {{
+                nodes {{
+                    id
+                    body
+                    url
+                    issueId
+                    projectId
+                    parentId
+                    user {{ id name displayName email }}
+                    createdAt
+                    updatedAt
+                    archivedAt
+                    editedAt
+                    resolvedAt
+                }}
+                pageInfo {{ hasNextPage endCursor }}
+            }}
+        }}
+        """
+        return self._query(query, variables).get("comments", {})

--- a/services/api/api/vm_metrics.py
+++ b/services/api/api/vm_metrics.py
@@ -19,7 +19,9 @@ from asyncpg import Pool
 log = structlog.get_logger().bind(service="api", component="vm_metrics")
 
 _VM_URL = os.environ.get("VICTORIAMETRICS_URL", "http://victoriametrics:8428")
-_PUSH_ENABLED = os.environ.get("VICTORIAMETRICS_PUSH_ENABLED", "1").strip().lower() not in {
+_PUSH_ENABLED = os.environ.get(
+    "VICTORIAMETRICS_PUSH_ENABLED", "1"
+).strip().lower() not in {
     "0",
     "false",
     "no",
@@ -38,7 +40,9 @@ def _escape_label_value(v: str) -> str:
 
 
 class _MetricBase:
-    def __init__(self, name: str, help_text: str, label_names: list[str] | None = None) -> None:
+    def __init__(
+        self, name: str, help_text: str, label_names: list[str] | None = None
+    ) -> None:
         self.name = name
         self.help_text = help_text
         self.label_names: list[str] = list(label_names or [])
@@ -67,7 +71,9 @@ class _ChildProxy:
 
 
 class Counter(_MetricBase):
-    def __init__(self, name: str, help_text: str, label_names: list[str] | None = None) -> None:
+    def __init__(
+        self, name: str, help_text: str, label_names: list[str] | None = None
+    ) -> None:
         super().__init__(name, help_text, label_names)
         self._values: dict[tuple[tuple[str, str], ...], float] = {}
 
@@ -105,7 +111,9 @@ class _CounterChild:
 
 
 class Gauge(_MetricBase):
-    def __init__(self, name: str, help_text: str, label_names: list[str] | None = None) -> None:
+    def __init__(
+        self, name: str, help_text: str, label_names: list[str] | None = None
+    ) -> None:
         super().__init__(name, help_text, label_names)
         self._values: dict[tuple[tuple[str, str], ...], float] = {}
 
@@ -205,7 +213,10 @@ class Histogram(_MetricBase):
                     d["buckets"][i] += 1
 
     def render(self) -> str:
-        lines = [f"# HELP {self.name} {self.help_text}", f"# TYPE {self.name} histogram"]
+        lines = [
+            f"# HELP {self.name} {self.help_text}",
+            f"# TYPE {self.name} histogram",
+        ]
         with self._lock:
             snapshot = list(self._data.items())
         for key, d in snapshot:
@@ -216,10 +227,14 @@ class Histogram(_MetricBase):
                 cum += d["buckets"][i]
                 le_labels = dict(labels)
                 le_labels["le"] = str(bound)
-                lines.append(f"{self.name}_bucket{self._format_labels(le_labels)} {cum}")
+                lines.append(
+                    f"{self.name}_bucket{self._format_labels(le_labels)} {cum}"
+                )
             inf_labels = dict(labels)
             inf_labels["le"] = "+Inf"
-            lines.append(f"{self.name}_bucket{self._format_labels(inf_labels)} {d['count']}")
+            lines.append(
+                f"{self.name}_bucket{self._format_labels(inf_labels)} {d['count']}"
+            )
             lines.append(f"{self.name}_sum{lbl_str} {d['sum']}")
             lines.append(f"{self.name}_count{lbl_str} {d['count']}")
         return "\n".join(lines)
@@ -508,14 +523,18 @@ COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS = Histogram(
 # ---------------------------------------------------------------------------
 
 
-def observe_http_request(method: str, path: str, status: int, duration_s: float) -> None:
+def observe_http_request(
+    method: str, path: str, status: int, duration_s: float
+) -> None:
     HTTP_REQUESTS_TOTAL.labels(method=method, path=path, status=str(status)).inc()
     HTTP_REQUEST_DURATION_SECONDS.labels(method=method, path=path).observe(duration_s)
 
 
 def record_agent_execution(harness: str, status: str, duration_s: float) -> None:
     AGENT_EXECUTIONS_TOTAL.labels(harness=harness, status=status).inc()
-    AGENT_EXECUTION_DURATION_SECONDS.labels(harness=harness, status=status).observe(duration_s)
+    AGENT_EXECUTION_DURATION_SECONDS.labels(harness=harness, status=status).observe(
+        duration_s
+    )
 
 
 def record_execution_terminal(harness: str, status: str, terminal_reason: str) -> None:
@@ -526,13 +545,15 @@ def record_execution_terminal(harness: str, status: str, terminal_reason: str) -
     ).inc()
 
 
-def record_tool_call(tool_name: str, tool_method: str, success: bool, duration_s: float) -> None:
+def record_tool_call(
+    tool_name: str, tool_method: str, success: bool, duration_s: float
+) -> None:
     TOOL_CALLS_TOTAL.labels(
         tool_name=tool_name, tool_method=tool_method, success=str(success).lower()
     ).inc()
-    TOOL_CALL_DURATION_SECONDS.labels(tool_name=tool_name, tool_method=tool_method).observe(
-        duration_s
-    )
+    TOOL_CALL_DURATION_SECONDS.labels(
+        tool_name=tool_name, tool_method=tool_method
+    ).observe(duration_s)
 
 
 def record_execution_enqueued(harness: str) -> None:
@@ -552,7 +573,9 @@ def record_warm_pool_claim(outcome: str) -> None:
     WARM_POOL_CLAIMS_TOTAL.labels(outcome=outcome).inc()
 
 
-def record_message_observation(role: str, text_chars: int, attachment_count: int) -> None:
+def record_message_observation(
+    role: str, text_chars: int, attachment_count: int
+) -> None:
     has_attachments = "true" if attachment_count > 0 else "false"
     MESSAGE_EVENTS_TOTAL.labels(role=role, has_attachments=has_attachments).inc()
     MESSAGE_TEXT_CHARS.labels(role=role).observe(max(text_chars, 0))
@@ -582,14 +605,18 @@ def record_tool_error_category(tool_name: str, category: str) -> None:
 
 
 def record_execution_by_user(user_id: str, harness: str, status: str) -> None:
-    EXECUTION_BY_USER_TOTAL.labels(user_id=user_id, harness=harness, status=status).inc()
+    EXECUTION_BY_USER_TOTAL.labels(
+        user_id=user_id, harness=harness, status=status
+    ).inc()
 
 
-def record_workflow_run_terminal(workflow_name: str, status: str, duration_s: float) -> None:
+def record_workflow_run_terminal(
+    workflow_name: str, status: str, duration_s: float
+) -> None:
     WORKFLOW_RUNS_TOTAL.labels(workflow_name=workflow_name, status=status).inc()
-    WORKFLOW_RUN_DURATION_SECONDS.labels(workflow_name=workflow_name, status=status).observe(
-        duration_s
-    )
+    WORKFLOW_RUN_DURATION_SECONDS.labels(
+        workflow_name=workflow_name, status=status
+    ).observe(duration_s)
 
 
 def record_workflow_run_enqueued(workflow_name: str) -> None:
@@ -598,14 +625,18 @@ def record_workflow_run_enqueued(workflow_name: str) -> None:
 
 def record_workflow_run_claimed(workflow_name: str, queue_delay_s: float) -> None:
     WORKFLOW_RUNS_CLAIMED_TOTAL.labels(workflow_name=workflow_name).inc()
-    WORKFLOW_RUN_QUEUE_DELAY_SECONDS.labels(workflow_name=workflow_name).observe(queue_delay_s)
+    WORKFLOW_RUN_QUEUE_DELAY_SECONDS.labels(workflow_name=workflow_name).observe(
+        queue_delay_s
+    )
 
 
 def record_workflow_event_sent(event_type: str) -> None:
     WORKFLOW_EVENTS_TOTAL.labels(event_type=event_type).inc()
 
 
-def record_etl_items_seen(source: str, source_type: str, item_type: str, count: int) -> None:
+def record_etl_items_seen(
+    source: str, source_type: str, item_type: str, count: int
+) -> None:
     if count > 0:
         ETL_ITEMS_SEEN_TOTAL.labels(
             source=source,
@@ -614,7 +645,9 @@ def record_etl_items_seen(source: str, source_type: str, item_type: str, count: 
         ).inc(count)
 
 
-def record_etl_items_enqueued(source: str, source_type: str, item_type: str, count: int) -> None:
+def record_etl_items_enqueued(
+    source: str, source_type: str, item_type: str, count: int
+) -> None:
     if count > 0:
         ETL_ITEMS_ENQUEUED_TOTAL.labels(
             source=source,
@@ -623,7 +656,9 @@ def record_etl_items_enqueued(source: str, source_type: str, item_type: str, cou
         ).inc(count)
 
 
-def record_etl_items_upserted(source: str, source_type: str, item_type: str, count: int) -> None:
+def record_etl_items_upserted(
+    source: str, source_type: str, item_type: str, count: int
+) -> None:
     if count > 0:
         ETL_ITEMS_UPSERTED_TOTAL.labels(
             source=source,
@@ -632,7 +667,9 @@ def record_etl_items_upserted(source: str, source_type: str, item_type: str, cou
         ).inc(count)
 
 
-def record_etl_items_deleted(source: str, source_type: str, item_type: str, count: int) -> None:
+def record_etl_items_deleted(
+    source: str, source_type: str, item_type: str, count: int
+) -> None:
     if count > 0:
         ETL_ITEMS_DELETED_TOTAL.labels(
             source=source,
@@ -671,7 +708,9 @@ def record_company_context_documents_changed(
         ).inc(count)
 
 
-def observe_company_context_document_size(source: str, source_type: str, chars: int) -> None:
+def observe_company_context_document_size(
+    source: str, source_type: str, chars: int
+) -> None:
     COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS.labels(
         source=source,
         source_type=source_type,
@@ -791,7 +830,9 @@ async def refresh_etl_metrics(pool: Pool) -> None:
         watermark_ts = str(row["watermark_ts"] or "").strip()
         if watermark_ts:
             try:
-                watermark = dt.datetime.fromtimestamp(float(watermark_ts), tz=dt.timezone.utc)
+                watermark = dt.datetime.fromtimestamp(
+                    float(watermark_ts), tz=dt.timezone.utc
+                )
             except (TypeError, ValueError, OSError):
                 pass
             else:
@@ -902,6 +943,52 @@ async def refresh_etl_metrics(pool: Pool) -> None:
     ).set(max(max_lag_s, 0.0))
     ETL_SCOPE_SYNC_FRESHNESS_SECONDS.labels(
         source="google_calendar", source_type="calendar"
+    ).set(max(max_sync_freshness_s, 0.0))
+
+    linear_scope_rows = await pool.fetch(
+        "SELECT scope_id, watermark_time, last_success_at, last_error, updated_at "
+        "FROM linear_sync_checkpoints"
+    )
+    linear_active_scopes = len(linear_scope_rows)
+    if os.getenv("LINEAR_ETL_ENABLED", "").strip().lower() not in {
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        linear_active_scopes = max(linear_active_scopes, 3)
+    ETL_ACTIVE_SCOPES.labels(source="linear", source_type="workspace").set(
+        linear_active_scopes
+    )
+    failed_scopes = 0
+    max_lag_s = 0.0
+    max_sync_freshness_s = 0.0
+    for row in linear_scope_rows:
+        has_error = bool(str(row["last_error"] or "").strip())
+        if has_error:
+            failed_scopes += 1
+        watermark_time = row["watermark_time"]
+        if isinstance(watermark_time, dt.datetime):
+            max_lag_s = max(
+                max_lag_s,
+                (now - watermark_time.astimezone(dt.timezone.utc)).total_seconds(),
+            )
+        if not has_error:
+            success_at = row["last_success_at"] or row["updated_at"]
+            if isinstance(success_at, dt.datetime):
+                max_sync_freshness_s = max(
+                    max_sync_freshness_s,
+                    (now - success_at.astimezone(dt.timezone.utc)).total_seconds(),
+                )
+    ETL_FAILED_SCOPES.labels(source="linear", source_type="workspace").set(
+        failed_scopes
+    )
+    ETL_SOURCE_CURSOR_LAG_SECONDS.labels(source="linear", source_type="workspace").set(
+        max(max_lag_s, 0.0)
+    )
+    ETL_SCOPE_SYNC_FRESHNESS_SECONDS.labels(
+        source="linear", source_type="workspace"
     ).set(max(max_sync_freshness_s, 0.0))
 
     backfill_rows = await pool.fetch(

--- a/services/api/db/migrations/040_linear_sync.sql
+++ b/services/api/db/migrations/040_linear_sync.sql
@@ -1,0 +1,206 @@
+-- migrate:up
+
+CREATE TABLE IF NOT EXISTS linear_sync_runs (
+    run_id             TEXT PRIMARY KEY,
+    workflow_run_id    TEXT,
+    mode               TEXT NOT NULL DEFAULT 'incremental',
+    status             TEXT NOT NULL,
+    scopes_requested   JSONB NOT NULL DEFAULT '[]'::jsonb,
+    scopes_synced      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    scopes_failed      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    projects_seen      INTEGER NOT NULL DEFAULT 0,
+    projects_upserted  INTEGER NOT NULL DEFAULT 0,
+    issues_seen        INTEGER NOT NULL DEFAULT 0,
+    issues_upserted    INTEGER NOT NULL DEFAULT 0,
+    comments_seen      INTEGER NOT NULL DEFAULT 0,
+    comments_upserted  INTEGER NOT NULL DEFAULT 0,
+    started_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at        TIMESTAMPTZ,
+    error_text         TEXT NOT NULL DEFAULT '',
+    metadata           JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_runs_started
+    ON linear_sync_runs (started_at DESC);
+
+CREATE TABLE IF NOT EXISTS linear_sync_projects (
+    project_id          TEXT PRIMARY KEY,
+    name                TEXT NOT NULL DEFAULT '',
+    description         TEXT NOT NULL DEFAULT '',
+    slug_id             TEXT NOT NULL DEFAULT '',
+    url                 TEXT NOT NULL DEFAULT '',
+    state               TEXT NOT NULL DEFAULT '',
+    status_id           TEXT NOT NULL DEFAULT '',
+    status_name         TEXT NOT NULL DEFAULT '',
+    status_type         TEXT NOT NULL DEFAULT '',
+    lead_user_id        TEXT NOT NULL DEFAULT '',
+    lead_name           TEXT NOT NULL DEFAULT '',
+    team_ids            JSONB NOT NULL DEFAULT '[]'::jsonb,
+    team_keys           JSONB NOT NULL DEFAULT '[]'::jsonb,
+    content_text        TEXT NOT NULL DEFAULT '',
+    content_hash        TEXT NOT NULL DEFAULT '',
+    source_created_at   TIMESTAMPTZ,
+    source_updated_at   TIMESTAMPTZ,
+    source_archived_at  TIMESTAMPTZ,
+    source_completed_at TIMESTAMPTZ,
+    source_canceled_at  TIMESTAMPTZ,
+    raw_payload         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source_run_id       TEXT REFERENCES linear_sync_runs(run_id) ON DELETE SET NULL,
+    first_seen_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error          TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_projects_source_updated
+    ON linear_sync_projects (source_updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_projects_slug
+    ON linear_sync_projects (slug_id);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_projects_teams
+    ON linear_sync_projects USING GIN (team_ids);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_projects_text
+    ON linear_sync_projects
+    USING GIN (to_tsvector('english', coalesce(content_text, '')));
+
+CREATE TABLE IF NOT EXISTS linear_sync_issues (
+    issue_id            TEXT PRIMARY KEY,
+    identifier          TEXT NOT NULL DEFAULT '',
+    issue_number        INTEGER,
+    title               TEXT NOT NULL DEFAULT '',
+    description         TEXT NOT NULL DEFAULT '',
+    url                 TEXT NOT NULL DEFAULT '',
+    priority            INTEGER,
+    priority_label      TEXT NOT NULL DEFAULT '',
+    estimate            DOUBLE PRECISION,
+    due_date            DATE,
+    team_id             TEXT NOT NULL DEFAULT '',
+    team_key            TEXT NOT NULL DEFAULT '',
+    team_name           TEXT NOT NULL DEFAULT '',
+    project_id          TEXT NOT NULL DEFAULT '',
+    project_name        TEXT NOT NULL DEFAULT '',
+    cycle_id            TEXT NOT NULL DEFAULT '',
+    cycle_name          TEXT NOT NULL DEFAULT '',
+    state_id            TEXT NOT NULL DEFAULT '',
+    state_name          TEXT NOT NULL DEFAULT '',
+    state_type          TEXT NOT NULL DEFAULT '',
+    assignee_user_id    TEXT NOT NULL DEFAULT '',
+    assignee_name       TEXT NOT NULL DEFAULT '',
+    creator_user_id     TEXT NOT NULL DEFAULT '',
+    creator_name        TEXT NOT NULL DEFAULT '',
+    parent_issue_id     TEXT NOT NULL DEFAULT '',
+    parent_identifier   TEXT NOT NULL DEFAULT '',
+    content_text        TEXT NOT NULL DEFAULT '',
+    content_hash        TEXT NOT NULL DEFAULT '',
+    source_created_at   TIMESTAMPTZ,
+    source_updated_at   TIMESTAMPTZ,
+    source_archived_at  TIMESTAMPTZ,
+    source_started_at   TIMESTAMPTZ,
+    source_completed_at TIMESTAMPTZ,
+    source_canceled_at  TIMESTAMPTZ,
+    raw_payload         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source_run_id       TEXT REFERENCES linear_sync_runs(run_id) ON DELETE SET NULL,
+    first_seen_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error          TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_issues_source_updated
+    ON linear_sync_issues (source_updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_issues_identifier
+    ON linear_sync_issues (identifier);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_issues_project
+    ON linear_sync_issues (project_id);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_issues_team
+    ON linear_sync_issues (team_id);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_issues_state
+    ON linear_sync_issues (state_id);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_issues_assignee
+    ON linear_sync_issues (assignee_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_issues_text
+    ON linear_sync_issues
+    USING GIN (to_tsvector('english', coalesce(content_text, '')));
+
+CREATE TABLE IF NOT EXISTS linear_sync_comments (
+    comment_id          TEXT PRIMARY KEY,
+    issue_id            TEXT NOT NULL DEFAULT '',
+    project_id          TEXT NOT NULL DEFAULT '',
+    parent_comment_id   TEXT NOT NULL DEFAULT '',
+    user_id             TEXT NOT NULL DEFAULT '',
+    user_name           TEXT NOT NULL DEFAULT '',
+    body                TEXT NOT NULL DEFAULT '',
+    url                 TEXT NOT NULL DEFAULT '',
+    content_text        TEXT NOT NULL DEFAULT '',
+    content_hash        TEXT NOT NULL DEFAULT '',
+    source_created_at   TIMESTAMPTZ,
+    source_updated_at   TIMESTAMPTZ,
+    source_archived_at  TIMESTAMPTZ,
+    source_edited_at    TIMESTAMPTZ,
+    source_resolved_at  TIMESTAMPTZ,
+    raw_payload         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source_run_id       TEXT REFERENCES linear_sync_runs(run_id) ON DELETE SET NULL,
+    first_seen_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error          TEXT NOT NULL DEFAULT '',
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_comments_source_updated
+    ON linear_sync_comments (source_updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_comments_issue
+    ON linear_sync_comments (issue_id);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_comments_project
+    ON linear_sync_comments (project_id);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_comments_user
+    ON linear_sync_comments (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_linear_sync_comments_text
+    ON linear_sync_comments
+    USING GIN (to_tsvector('english', coalesce(content_text, '')));
+
+CREATE TABLE IF NOT EXISTS linear_sync_checkpoints (
+    scope_id         TEXT PRIMARY KEY,
+    watermark_time   TIMESTAMPTZ,
+    last_run_id      TEXT REFERENCES linear_sync_runs(run_id) ON DELETE SET NULL,
+    last_success_at  TIMESTAMPTZ,
+    last_error       TEXT NOT NULL DEFAULT '',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS linear_sync_checkpoints;
+DROP INDEX IF EXISTS idx_linear_sync_comments_text;
+DROP INDEX IF EXISTS idx_linear_sync_comments_user;
+DROP INDEX IF EXISTS idx_linear_sync_comments_project;
+DROP INDEX IF EXISTS idx_linear_sync_comments_issue;
+DROP INDEX IF EXISTS idx_linear_sync_comments_source_updated;
+DROP TABLE IF EXISTS linear_sync_comments;
+DROP INDEX IF EXISTS idx_linear_sync_issues_text;
+DROP INDEX IF EXISTS idx_linear_sync_issues_assignee;
+DROP INDEX IF EXISTS idx_linear_sync_issues_state;
+DROP INDEX IF EXISTS idx_linear_sync_issues_team;
+DROP INDEX IF EXISTS idx_linear_sync_issues_project;
+DROP INDEX IF EXISTS idx_linear_sync_issues_identifier;
+DROP INDEX IF EXISTS idx_linear_sync_issues_source_updated;
+DROP TABLE IF EXISTS linear_sync_issues;
+DROP INDEX IF EXISTS idx_linear_sync_projects_text;
+DROP INDEX IF EXISTS idx_linear_sync_projects_teams;
+DROP INDEX IF EXISTS idx_linear_sync_projects_slug;
+DROP INDEX IF EXISTS idx_linear_sync_projects_source_updated;
+DROP TABLE IF EXISTS linear_sync_projects;
+DROP INDEX IF EXISTS idx_linear_sync_runs_started;
+DROP TABLE IF EXISTS linear_sync_runs;

--- a/services/api/tests/test_linear_integrations.py
+++ b/services/api/tests/test_linear_integrations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime as dt
+
 import pytest
 
 
@@ -96,6 +98,106 @@ def test_linear_readonly_client_builds_issue_filters():
     assert 'team: { key: { eq: "EN\\"G" } }' in query
     assert 'assignee: { name: { containsIgnoreCase: "Ada" } }' in query
     assert 'state: { name: { containsIgnoreCase: "In Progress" } }' in query
+
+
+def test_linear_readonly_client_lists_etl_projects_with_incremental_filter():
+    from api.integrations.linear import LinearReadonlyClient
+
+    http = FakeHttpClient(
+        [
+            {
+                "data": {
+                    "projects": {
+                        "nodes": [{"id": "project-1", "name": "Roadmap"}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        ]
+    )
+    client = LinearReadonlyClient(api_key="lin-test", http_client=http)
+
+    result = client.list_etl_projects(
+        page_size=25,
+        cursor="cursor-1",
+        updated_after=dt.datetime(2026, 5, 1, 12, 0, tzinfo=dt.timezone.utc),
+        include_archived=True,
+    )
+
+    assert result["nodes"][0]["id"] == "project-1"
+    request = http.requests[0]["json"]
+    assert "projects(" in request["query"]
+    assert "filter: { updatedAt: { gte: $updatedAfter } }" in request["query"]
+    assert request["variables"] == {
+        "first": 25,
+        "after": "cursor-1",
+        "includeArchived": True,
+        "updatedAfter": "2026-05-01T12:00:00Z",
+    }
+
+
+def test_linear_readonly_client_lists_etl_issues_without_incremental_filter():
+    from api.integrations.linear import LinearReadonlyClient
+
+    http = FakeHttpClient(
+        [
+            {
+                "data": {
+                    "issues": {
+                        "nodes": [{"id": "issue-1", "identifier": "ENG-1"}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        ]
+    )
+    client = LinearReadonlyClient(api_key="lin-test", http_client=http)
+
+    result = client.list_etl_issues(page_size=50, include_archived=False)
+
+    assert result["nodes"][0]["identifier"] == "ENG-1"
+    request = http.requests[0]["json"]
+    assert "issues(" in request["query"]
+    assert "$updatedAfter" not in request["query"]
+    assert request["variables"] == {
+        "first": 50,
+        "after": None,
+        "includeArchived": False,
+    }
+
+
+def test_linear_readonly_client_lists_etl_comments_with_incremental_filter():
+    from api.integrations.linear import LinearReadonlyClient
+
+    http = FakeHttpClient(
+        [
+            {
+                "data": {
+                    "comments": {
+                        "nodes": [{"id": "comment-1", "issueId": "issue-1"}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        ]
+    )
+    client = LinearReadonlyClient(api_key="lin-test", http_client=http)
+
+    result = client.list_etl_comments(
+        page_size=10,
+        updated_after="2026-05-01T12:00:00Z",
+    )
+
+    assert result["nodes"][0]["id"] == "comment-1"
+    request = http.requests[0]["json"]
+    assert "comments(" in request["query"]
+    assert "filter: { updatedAt: { gte: $updatedAfter } }" in request["query"]
+    assert request["variables"] == {
+        "first": 10,
+        "after": None,
+        "includeArchived": True,
+        "updatedAfter": "2026-05-01T12:00:00Z",
+    }
 
 
 def test_linear_tool_client_keeps_mutations_and_inherits_readonly_methods():

--- a/services/api/tests/test_linear_sync.py
+++ b/services/api/tests/test_linear_sync.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+import json
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+
+class FakeCtx:
+    def __init__(self, db_pool, run_id: str = "wfr-test-linear-sync"):
+        self._pool = db_pool
+        self.run_id = run_id
+        self.logs: list[tuple[str, dict[str, Any]]] = []
+
+    def log(self, msg: str, **kwargs: Any) -> None:
+        self.logs.append((msg, kwargs))
+
+
+class FakeLinearClient:
+    def __init__(
+        self,
+        *,
+        project_pages: list[dict[str, Any]],
+        issue_pages: list[dict[str, Any]],
+        comment_pages: list[dict[str, Any]],
+    ) -> None:
+        self.project_pages = list(project_pages)
+        self.issue_pages = list(issue_pages)
+        self.comment_pages = list(comment_pages)
+        self.project_calls: list[dict[str, Any]] = []
+        self.issue_calls: list[dict[str, Any]] = []
+        self.comment_calls: list[dict[str, Any]] = []
+
+    def list_etl_projects(
+        self,
+        *,
+        page_size: int,
+        cursor: str | None = None,
+        updated_after: dt.datetime | str | None = None,
+        include_archived: bool = True,
+    ) -> dict[str, Any]:
+        self.project_calls.append(
+            {
+                "page_size": page_size,
+                "cursor": cursor,
+                "updated_after": updated_after,
+                "include_archived": include_archived,
+            }
+        )
+        if self.project_pages:
+            return self.project_pages.pop(0)
+        return {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}
+
+    def list_etl_issues(
+        self,
+        *,
+        page_size: int,
+        cursor: str | None = None,
+        updated_after: dt.datetime | str | None = None,
+        include_archived: bool = True,
+    ) -> dict[str, Any]:
+        self.issue_calls.append(
+            {
+                "page_size": page_size,
+                "cursor": cursor,
+                "updated_after": updated_after,
+                "include_archived": include_archived,
+            }
+        )
+        if self.issue_pages:
+            return self.issue_pages.pop(0)
+        return {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}
+
+    def list_etl_comments(
+        self,
+        *,
+        page_size: int,
+        cursor: str | None = None,
+        updated_after: dt.datetime | str | None = None,
+        include_archived: bool = True,
+    ) -> dict[str, Any]:
+        self.comment_calls.append(
+            {
+                "page_size": page_size,
+                "cursor": cursor,
+                "updated_after": updated_after,
+                "include_archived": include_archived,
+            }
+        )
+        if self.comment_pages:
+            return self.comment_pages.pop(0)
+        return {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_linear_sync_tables(db_pool):
+    await db_pool.execute(
+        "TRUNCATE TABLE linear_sync_checkpoints, linear_sync_comments, linear_sync_issues, "
+        "linear_sync_projects, linear_sync_runs, workflow_runs CASCADE",
+    )
+    yield
+
+
+def test_schedule_defaults_disabled_with_four_hour_interval(monkeypatch):
+    monkeypatch.delenv("LINEAR_ETL_ENABLED", raising=False)
+    monkeypatch.delenv("LINEAR_SYNC_INTERVAL_SECONDS", raising=False)
+
+    from workflows import linear_sync
+
+    reloaded = importlib.reload(linear_sync)
+
+    assert reloaded.SCHEDULE == {
+        "schedule_id": "linear_sync",
+        "interval_seconds": 14400,
+        "enabled": False,
+        "no_delivery": True,
+    }
+
+
+def test_schedule_respects_env_overrides(monkeypatch):
+    monkeypatch.setenv("LINEAR_ETL_ENABLED", "true")
+    monkeypatch.setenv("LINEAR_SYNC_INTERVAL_SECONDS", "600")
+
+    from workflows import linear_sync
+
+    reloaded = importlib.reload(linear_sync)
+
+    assert reloaded.SCHEDULE["enabled"] is True
+    assert reloaded.SCHEDULE["interval_seconds"] == 600
+
+
+@pytest.mark.asyncio
+async def test_syncs_linear_projects_issues_and_comments_into_raw_tables(
+    db_pool, monkeypatch
+):
+    from workflows import linear_sync
+
+    monkeypatch.setenv("LINEAR_ETL_ENABLED", "true")
+    fake = FakeLinearClient(
+        project_pages=[
+            {
+                "nodes": [
+                    {
+                        "id": "project-1",
+                        "name": "Launch plan",
+                        "description": "Ship the thing",
+                        "slugId": "LAUNCH",
+                        "url": "https://linear.app/acme/project/launch",
+                        "state": "started",
+                        "status": {
+                            "id": "status-1",
+                            "name": "On track",
+                            "type": "started",
+                        },
+                        "lead": {
+                            "id": "user-1",
+                            "name": "Ada Lovelace",
+                            "displayName": "Ada",
+                        },
+                        "teams": {
+                            "nodes": [
+                                {"id": "team-1", "name": "Engineering", "key": "ENG"}
+                            ]
+                        },
+                        "createdAt": "2026-05-01T10:00:00Z",
+                        "updatedAt": "2026-05-02T10:00:00Z",
+                        "completedAt": None,
+                        "canceledAt": None,
+                    }
+                ],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }
+        ],
+        issue_pages=[
+            {
+                "nodes": [
+                    {
+                        "id": "issue-1",
+                        "identifier": "ENG-101",
+                        "number": 101,
+                        "title": "Wire Linear sync",
+                        "description": "Store projects and issues",
+                        "url": "https://linear.app/acme/issue/ENG-101",
+                        "priority": 2,
+                        "priorityLabel": "High",
+                        "estimate": 3,
+                        "dueDate": "2026-05-10",
+                        "team": {"id": "team-1", "name": "Engineering", "key": "ENG"},
+                        "project": {"id": "project-1", "name": "Launch plan"},
+                        "cycle": {"id": "cycle-1", "name": "Cycle 1", "number": 1},
+                        "state": {
+                            "id": "state-1",
+                            "name": "In Progress",
+                            "type": "started",
+                        },
+                        "assignee": {"id": "user-1", "name": "Ada Lovelace"},
+                        "creator": {"id": "user-2", "name": "Grace Hopper"},
+                        "parent": {"id": "issue-parent", "identifier": "ENG-1"},
+                        "createdAt": "2026-05-01T11:00:00Z",
+                        "updatedAt": "2026-05-03T12:00:00Z",
+                        "startedAt": "2026-05-02T11:00:00Z",
+                        "completedAt": None,
+                        "canceledAt": None,
+                    }
+                ],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }
+        ],
+        comment_pages=[
+            {
+                "nodes": [
+                    {
+                        "id": "comment-1",
+                        "body": "Looks good for the launch plan.",
+                        "url": "https://linear.app/acme/comment/comment-1",
+                        "issueId": "issue-1",
+                        "projectId": "project-1",
+                        "parentId": None,
+                        "user": {"id": "user-2", "name": "Grace Hopper"},
+                        "createdAt": "2026-05-03T13:00:00Z",
+                        "updatedAt": "2026-05-03T13:30:00Z",
+                        "archivedAt": None,
+                        "editedAt": "2026-05-03T13:20:00Z",
+                        "resolvedAt": None,
+                    }
+                ],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }
+        ],
+    )
+    monkeypatch.setattr(linear_sync, "_client", lambda: fake)
+
+    result = await linear_sync.handler(
+        linear_sync.Input(limit=25, watermark_overlap_seconds=0),
+        FakeCtx(db_pool),
+    )
+
+    assert result["status"] == "completed"
+    assert result["projects_seen"] == 1
+    assert result["projects_upserted"] == 1
+    assert result["issues_seen"] == 1
+    assert result["issues_upserted"] == 1
+    assert result["comments_seen"] == 1
+    assert result["comments_upserted"] == 1
+    assert fake.project_calls[0]["page_size"] == 25
+    assert fake.issue_calls[0]["include_archived"] is True
+    assert fake.comment_calls[0]["include_archived"] is True
+
+    project = await db_pool.fetchrow(
+        "SELECT project_id, name, slug_id, status_name, lead_name, team_ids, "
+        "source_updated_at, raw_payload FROM linear_sync_projects",
+    )
+    assert project["project_id"] == "project-1"
+    assert project["name"] == "Launch plan"
+    assert project["slug_id"] == "LAUNCH"
+    assert project["status_name"] == "On track"
+    assert project["lead_name"] == "Ada Lovelace"
+    assert json.loads(project["team_ids"]) == ["team-1"]
+    assert project["source_updated_at"] == dt.datetime(
+        2026, 5, 2, 10, 0, tzinfo=dt.timezone.utc
+    )
+    assert json.loads(project["raw_payload"])["slugId"] == "LAUNCH"
+
+    issue = await db_pool.fetchrow(
+        "SELECT issue_id, identifier, issue_number, title, priority_label, "
+        "estimate, due_date, team_key, project_id, state_name, assignee_name, "
+        "parent_identifier, source_updated_at, raw_payload FROM linear_sync_issues",
+    )
+    assert issue["issue_id"] == "issue-1"
+    assert issue["identifier"] == "ENG-101"
+    assert issue["issue_number"] == 101
+    assert issue["title"] == "Wire Linear sync"
+    assert issue["priority_label"] == "High"
+    assert issue["estimate"] == 3
+    assert issue["due_date"] == dt.date(2026, 5, 10)
+    assert issue["team_key"] == "ENG"
+    assert issue["project_id"] == "project-1"
+    assert issue["state_name"] == "In Progress"
+    assert issue["assignee_name"] == "Ada Lovelace"
+    assert issue["parent_identifier"] == "ENG-1"
+    assert issue["source_updated_at"] == dt.datetime(
+        2026, 5, 3, 12, 0, tzinfo=dt.timezone.utc
+    )
+    assert json.loads(issue["raw_payload"])["identifier"] == "ENG-101"
+
+    comment = await db_pool.fetchrow(
+        "SELECT comment_id, issue_id, project_id, user_id, user_name, body, "
+        "source_updated_at, source_edited_at, raw_payload FROM linear_sync_comments",
+    )
+    assert comment["comment_id"] == "comment-1"
+    assert comment["issue_id"] == "issue-1"
+    assert comment["project_id"] == "project-1"
+    assert comment["user_id"] == "user-2"
+    assert comment["user_name"] == "Grace Hopper"
+    assert comment["body"] == "Looks good for the launch plan."
+    assert comment["source_updated_at"] == dt.datetime(
+        2026, 5, 3, 13, 30, tzinfo=dt.timezone.utc
+    )
+    assert comment["source_edited_at"] == dt.datetime(
+        2026, 5, 3, 13, 20, tzinfo=dt.timezone.utc
+    )
+    assert json.loads(comment["raw_payload"])["issueId"] == "issue-1"
+
+    checkpoints = await db_pool.fetch(
+        "SELECT scope_id, watermark_time FROM linear_sync_checkpoints ORDER BY scope_id",
+    )
+    assert [(row["scope_id"], row["watermark_time"]) for row in checkpoints] == [
+        ("comments", dt.datetime(2026, 5, 3, 13, 30, tzinfo=dt.timezone.utc)),
+        ("issues", dt.datetime(2026, 5, 3, 12, 0, tzinfo=dt.timezone.utc)),
+        ("projects", dt.datetime(2026, 5, 2, 10, 0, tzinfo=dt.timezone.utc)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_incremental_sync_uses_checkpoint_overlap(db_pool, monkeypatch):
+    from workflows import linear_sync
+
+    monkeypatch.setenv("LINEAR_ETL_ENABLED", "true")
+    await db_pool.execute(
+        "INSERT INTO linear_sync_checkpoints (scope_id, watermark_time) "
+        "VALUES ('projects', $1), ('issues', $1), ('comments', $1)",
+        dt.datetime(2026, 5, 10, 12, 0, tzinfo=dt.timezone.utc),
+    )
+    fake = FakeLinearClient(
+        project_pages=[{"nodes": [], "pageInfo": {"hasNextPage": False}}],
+        issue_pages=[{"nodes": [], "pageInfo": {"hasNextPage": False}}],
+        comment_pages=[{"nodes": [], "pageInfo": {"hasNextPage": False}}],
+    )
+    monkeypatch.setattr(linear_sync, "_client", lambda: fake)
+
+    result = await linear_sync.handler(
+        linear_sync.Input(watermark_overlap_seconds=300),
+        FakeCtx(db_pool),
+    )
+
+    assert result["status"] == "completed"
+    expected = dt.datetime(2026, 5, 10, 11, 55, tzinfo=dt.timezone.utc)
+    assert fake.project_calls[0]["updated_after"] == expected
+    assert fake.issue_calls[0]["updated_after"] == expected
+    assert fake.comment_calls[0]["updated_after"] == expected

--- a/services/api/tests/test_slack_sync.py
+++ b/services/api/tests/test_slack_sync.py
@@ -172,6 +172,8 @@ async def _clear_slack_sync_tables(db_pool, monkeypatch):
         "TRUNCATE TABLE company_context_documents, google_drive_sync_checkpoints, "
         "google_drive_sync_files, google_drive_sync_runs, google_calendar_sync_checkpoints, "
         "google_calendar_sync_events, google_calendar_sync_calendars, google_calendar_sync_runs, "
+        "linear_sync_checkpoints, linear_sync_comments, linear_sync_issues, "
+        "linear_sync_projects, linear_sync_runs, "
         "slack_sync_backfill_jobs, slack_sync_checkpoints, slack_sync_messages, "
         "slack_sync_runs, slack_sync_users, slack_sync_channels CASCADE",
     )
@@ -1537,6 +1539,23 @@ async def test_etl_freshness_metrics_refresh_from_slack_sync_tables(db_pool):
         now - dt.timedelta(seconds=50),
     )
     await db_pool.execute(
+        "INSERT INTO linear_sync_runs (run_id, status) VALUES ('linear-seed', 'completed')"
+    )
+    await db_pool.execute(
+        "INSERT INTO linear_sync_checkpoints ("
+        "scope_id, watermark_time, last_run_id, last_success_at, last_error, updated_at"
+        ") VALUES "
+        "('projects', $1, 'linear-seed', $2, '', $2), "
+        "('issues', $3, 'linear-seed', $4, '', $4), "
+        "('comments', $5, 'linear-seed', NULL, 'api_error', $6)",
+        now - dt.timedelta(seconds=180),
+        now - dt.timedelta(seconds=65),
+        now - dt.timedelta(seconds=210),
+        now - dt.timedelta(seconds=75),
+        now - dt.timedelta(seconds=300),
+        now - dt.timedelta(seconds=70),
+    )
+    await db_pool.execute(
         "INSERT INTO company_context_documents ("
         "document_id, source, source_type, source_document_id, title, body, "
         "source_updated_at, content_hash"
@@ -1553,8 +1572,16 @@ async def test_etl_freshness_metrics_refresh_from_slack_sync_tables(db_pool):
     assert 'etl_failed_scopes{source="slack",source_type="channel"} 1' in metrics
     assert 'etl_active_scopes{source="google_drive",source_type="doc"} 1' in metrics
     assert 'etl_failed_scopes{source="google_drive",source_type="doc"} 0' in metrics
-    assert 'etl_active_scopes{source="google_calendar",source_type="calendar"} 2' in metrics
-    assert 'etl_failed_scopes{source="google_calendar",source_type="calendar"} 1' in metrics
+    assert (
+        'etl_active_scopes{source="google_calendar",source_type="calendar"} 2'
+        in metrics
+    )
+    assert (
+        'etl_failed_scopes{source="google_calendar",source_type="calendar"} 1'
+        in metrics
+    )
+    assert 'etl_active_scopes{source="linear",source_type="workspace"} 3' in metrics
+    assert 'etl_failed_scopes{source="linear",source_type="workspace"} 1' in metrics
     assert (
         'etl_backfill_jobs{job_type="channel_bootstrap",source="slack",status="pending"} 1'
         in metrics
@@ -1603,6 +1630,18 @@ async def test_etl_freshness_metrics_refresh_from_slack_sync_tables(db_pool):
     )
     assert calendar_freshness_match is not None
     assert 50 <= float(calendar_freshness_match.group(1)) < 130
+    linear_lag_match = re.search(
+        r'etl_source_cursor_lag_seconds\{source="linear",source_type="workspace"\} ([0-9.]+)',
+        metrics,
+    )
+    assert linear_lag_match is not None
+    assert float(linear_lag_match.group(1)) >= 250
+    linear_freshness_match = re.search(
+        r'etl_scope_sync_freshness_seconds\{source="linear",source_type="workspace"\} ([0-9.]+)',
+        metrics,
+    )
+    assert linear_freshness_match is not None
+    assert 70 <= float(linear_freshness_match.group(1)) < 140
     drive_projection_lag_match = re.search(
         r'company_context_projection_lag_seconds\{source="google_drive"\} ([0-9.]+)',
         metrics,

--- a/workflows/linear_sync.py
+++ b/workflows/linear_sync.py
@@ -1,0 +1,819 @@
+"""Workflow: sync Linear projects, issues, and comments into Postgres."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import os
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from api.integrations.linear import LinearReadonlyClient
+from api.runtime_control import canonical_json
+from api.vm_metrics import (
+    record_etl_items_failed,
+    record_etl_items_seen,
+    record_etl_items_upserted,
+)
+from api.workflow_engine import WorkflowContext
+from workflows.slack_sync_shared import env_flag_enabled, positive_int
+
+WORKFLOW_NAME = "linear_sync"
+DEFAULT_SYNC_INTERVAL_SECONDS = 4 * 60 * 60
+DEFAULT_PAGE_SIZE = 100
+DEFAULT_WATERMARK_OVERLAP_SECONDS = 5 * 60
+
+PROJECTS_SCOPE = "projects"
+ISSUES_SCOPE = "issues"
+COMMENTS_SCOPE = "comments"
+
+
+SCHEDULE = {
+    "schedule_id": "linear_sync",
+    "interval_seconds": positive_int(
+        os.getenv("LINEAR_SYNC_INTERVAL_SECONDS"),
+        DEFAULT_SYNC_INTERVAL_SECONDS,
+    ),
+    "enabled": env_flag_enabled("LINEAR_ETL_ENABLED", default=False),
+    "no_delivery": True,
+}
+
+
+@dataclass
+class Input:
+    """Runtime options for a manual Linear sync workflow run."""
+
+    since: str | None = None
+    limit: int = DEFAULT_PAGE_SIZE
+    watermark_overlap_seconds: int = DEFAULT_WATERMARK_OVERLAP_SECONDS
+    include_archived: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class LinearSyncClient(Protocol):
+    """Small adapter protocol used by the Linear ETL workflow."""
+
+    def list_etl_projects(
+        self,
+        *,
+        page_size: int,
+        cursor: str | None = None,
+        updated_after: dt.datetime | str | None = None,
+        include_archived: bool = True,
+    ) -> dict[str, Any]: ...
+
+    def list_etl_issues(
+        self,
+        *,
+        page_size: int,
+        cursor: str | None = None,
+        updated_after: dt.datetime | str | None = None,
+        include_archived: bool = True,
+    ) -> dict[str, Any]: ...
+
+    def list_etl_comments(
+        self,
+        *,
+        page_size: int,
+        cursor: str | None = None,
+        updated_after: dt.datetime | str | None = None,
+        include_archived: bool = True,
+    ) -> dict[str, Any]: ...
+
+
+def _client() -> LinearSyncClient:
+    return LinearReadonlyClient()
+
+
+def _parse_datetime(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _parse_date(value: Any) -> dt.date | None:
+    if not value:
+        return None
+    try:
+        return dt.date.fromisoformat(str(value))
+    except ValueError:
+        return None
+
+
+def _source_datetime(payload: dict[str, Any], key: str) -> dt.datetime | None:
+    return _parse_datetime(str(payload.get(key) or ""))
+
+
+def _rfc3339(value: dt.datetime) -> str:
+    return value.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _content_hash(*parts: Any) -> str:
+    return hashlib.sha256(canonical_json(parts).encode("utf-8")).hexdigest()
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _connection_nodes(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    nodes = value.get("nodes")
+    if not isinstance(nodes, list):
+        return []
+    return [node for node in nodes if isinstance(node, dict)]
+
+
+def _text_value(value: Any) -> str:
+    return str(value or "")
+
+
+def _int_value(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _float_value(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _workflow_run_id_to_sync_run_id(workflow_run_id: str) -> str:
+    safe_run_id = "".join(char if char.isalnum() else "_" for char in workflow_run_id)
+    return f"linear_sync_{safe_run_id}"
+
+
+def _scope_ref(scope_id: str, reason: str | None = None) -> dict[str, str]:
+    result = {"scope_id": scope_id}
+    if reason:
+        result["reason"] = reason
+    return result
+
+
+def _failure_reason(error: str) -> str:
+    lowered = error.lower()
+    if "rate" in lowered or "429" in lowered:
+        return "rate_limited"
+    if (
+        "forbidden" in lowered
+        or "permission" in lowered
+        or "401" in lowered
+        or "403" in lowered
+    ):
+        return "permission_error"
+    if "database" in lowered or "postgres" in lowered:
+        return "write_error"
+    return "api_error"
+
+
+async def _load_checkpoint(pool, scope_id: str) -> dict[str, Any] | None:
+    row = await pool.fetchrow(
+        "SELECT watermark_time, last_error FROM linear_sync_checkpoints WHERE scope_id = $1",
+        scope_id,
+    )
+    return dict(row) if row else None
+
+
+async def _update_checkpoint_success(
+    pool,
+    *,
+    scope_id: str,
+    watermark_time: dt.datetime | None,
+    run_id: str,
+) -> None:
+    await pool.execute(
+        "INSERT INTO linear_sync_checkpoints ("
+        "scope_id, watermark_time, last_run_id, last_success_at, last_error, updated_at"
+        ") VALUES ($1, $2, $3, NOW(), '', NOW()) "
+        "ON CONFLICT (scope_id) DO UPDATE SET "
+        "watermark_time = COALESCE(EXCLUDED.watermark_time, linear_sync_checkpoints.watermark_time), "
+        "last_run_id = EXCLUDED.last_run_id, "
+        "last_success_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        scope_id,
+        watermark_time,
+        run_id,
+    )
+
+
+async def _update_checkpoint_failure(
+    pool,
+    *,
+    scope_id: str,
+    run_id: str,
+    error: str,
+) -> None:
+    await pool.execute(
+        "INSERT INTO linear_sync_checkpoints ("
+        "scope_id, last_run_id, last_error, updated_at"
+        ") VALUES ($1, $2, $3, NOW()) "
+        "ON CONFLICT (scope_id) DO UPDATE SET "
+        "last_run_id = EXCLUDED.last_run_id, "
+        "last_error = EXCLUDED.last_error, "
+        "updated_at = NOW()",
+        scope_id,
+        run_id,
+        error,
+    )
+
+
+async def _record_run_start(
+    pool,
+    *,
+    run_id: str,
+    workflow_run_id: str,
+    scopes_requested: list[dict[str, str]],
+    metadata: dict[str, Any],
+) -> None:
+    await pool.execute(
+        "INSERT INTO linear_sync_runs ("
+        "run_id, workflow_run_id, mode, status, scopes_requested, metadata"
+        ") VALUES ($1, $2, 'incremental', 'running', $3::jsonb, $4::jsonb) "
+        "ON CONFLICT (run_id) DO UPDATE SET "
+        "workflow_run_id = EXCLUDED.workflow_run_id, "
+        "status = 'running', "
+        "scopes_requested = EXCLUDED.scopes_requested, "
+        "scopes_synced = '[]'::jsonb, "
+        "scopes_failed = '[]'::jsonb, "
+        "projects_seen = 0, "
+        "projects_upserted = 0, "
+        "issues_seen = 0, "
+        "issues_upserted = 0, "
+        "comments_seen = 0, "
+        "comments_upserted = 0, "
+        "finished_at = NULL, "
+        "error_text = '', "
+        "metadata = EXCLUDED.metadata",
+        run_id,
+        workflow_run_id,
+        canonical_json(scopes_requested),
+        canonical_json(metadata),
+    )
+
+
+async def _record_run_finish(
+    pool,
+    *,
+    run_id: str,
+    status: str,
+    scopes_synced: list[dict[str, str]],
+    scopes_failed: list[dict[str, str]],
+    counts: dict[str, int],
+    error_text: str = "",
+) -> None:
+    await pool.execute(
+        "UPDATE linear_sync_runs SET "
+        "status = $2, scopes_synced = $3::jsonb, scopes_failed = $4::jsonb, "
+        "projects_seen = $5, projects_upserted = $6, issues_seen = $7, "
+        "issues_upserted = $8, comments_seen = $9, comments_upserted = $10, "
+        "finished_at = NOW(), error_text = $11 "
+        "WHERE run_id = $1",
+        run_id,
+        status,
+        canonical_json(scopes_synced),
+        canonical_json(scopes_failed),
+        counts.get("projects_seen", 0),
+        counts.get("projects_upserted", 0),
+        counts.get("issues_seen", 0),
+        counts.get("issues_upserted", 0),
+        counts.get("comments_seen", 0),
+        counts.get("comments_upserted", 0),
+        error_text,
+    )
+
+
+async def _upsert_project(
+    pool,
+    *,
+    project: dict[str, Any],
+    run_id: str,
+) -> None:
+    status = _json_object(project.get("status"))
+    lead = _json_object(project.get("lead"))
+    teams = _connection_nodes(project.get("teams"))
+    team_ids = [_text_value(team.get("id")) for team in teams if team.get("id")]
+    team_keys = [_text_value(team.get("key")) for team in teams if team.get("key")]
+    content_text = "\n".join(
+        part
+        for part in [
+            _text_value(project.get("name")),
+            _text_value(project.get("description")),
+            _text_value(status.get("name")),
+            _text_value(lead.get("name") or lead.get("displayName")),
+            " ".join(team_keys),
+        ]
+        if part.strip()
+    )
+    await pool.execute(
+        "INSERT INTO linear_sync_projects ("
+        "project_id, name, description, slug_id, url, state, status_id, "
+        "status_name, status_type, lead_user_id, lead_name, team_ids, team_keys, "
+        "content_text, content_hash, source_created_at, source_updated_at, "
+        "source_archived_at, source_completed_at, source_canceled_at, raw_payload, "
+        "source_run_id, last_seen_at, last_error, updated_at"
+        ") VALUES ("
+        "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, "
+        "$14, $15, $16, $17, $18, $19, $20, $21::jsonb, $22, NOW(), '', NOW()"
+        ") ON CONFLICT (project_id) DO UPDATE SET "
+        "name = EXCLUDED.name, "
+        "description = EXCLUDED.description, "
+        "slug_id = EXCLUDED.slug_id, "
+        "url = EXCLUDED.url, "
+        "state = EXCLUDED.state, "
+        "status_id = EXCLUDED.status_id, "
+        "status_name = EXCLUDED.status_name, "
+        "status_type = EXCLUDED.status_type, "
+        "lead_user_id = EXCLUDED.lead_user_id, "
+        "lead_name = EXCLUDED.lead_name, "
+        "team_ids = EXCLUDED.team_ids, "
+        "team_keys = EXCLUDED.team_keys, "
+        "content_text = EXCLUDED.content_text, "
+        "content_hash = EXCLUDED.content_hash, "
+        "source_created_at = EXCLUDED.source_created_at, "
+        "source_updated_at = EXCLUDED.source_updated_at, "
+        "source_archived_at = EXCLUDED.source_archived_at, "
+        "source_completed_at = EXCLUDED.source_completed_at, "
+        "source_canceled_at = EXCLUDED.source_canceled_at, "
+        "raw_payload = EXCLUDED.raw_payload, "
+        "source_run_id = EXCLUDED.source_run_id, "
+        "last_seen_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        _text_value(project.get("id")),
+        _text_value(project.get("name")),
+        _text_value(project.get("description")),
+        _text_value(project.get("slugId")),
+        _text_value(project.get("url")),
+        _text_value(project.get("state")),
+        _text_value(status.get("id")),
+        _text_value(status.get("name")),
+        _text_value(status.get("type")),
+        _text_value(lead.get("id")),
+        _text_value(lead.get("name") or lead.get("displayName")),
+        canonical_json(team_ids),
+        canonical_json(team_keys),
+        content_text,
+        _content_hash(content_text),
+        _source_datetime(project, "createdAt"),
+        _source_datetime(project, "updatedAt"),
+        _source_datetime(project, "archivedAt"),
+        _source_datetime(project, "completedAt"),
+        _source_datetime(project, "canceledAt"),
+        canonical_json(project),
+        run_id,
+    )
+
+
+async def _upsert_issue(
+    pool,
+    *,
+    issue: dict[str, Any],
+    run_id: str,
+) -> None:
+    team = _json_object(issue.get("team"))
+    project = _json_object(issue.get("project"))
+    cycle = _json_object(issue.get("cycle"))
+    state = _json_object(issue.get("state"))
+    assignee = _json_object(issue.get("assignee"))
+    creator = _json_object(issue.get("creator"))
+    parent = _json_object(issue.get("parent"))
+    content_text = "\n".join(
+        part
+        for part in [
+            _text_value(issue.get("identifier")),
+            _text_value(issue.get("title")),
+            _text_value(issue.get("description")),
+            _text_value(team.get("key")),
+            _text_value(team.get("name")),
+            _text_value(project.get("name")),
+            _text_value(state.get("name")),
+            _text_value(assignee.get("name") or assignee.get("displayName")),
+        ]
+        if part.strip()
+    )
+    await pool.execute(
+        "INSERT INTO linear_sync_issues ("
+        "issue_id, identifier, issue_number, title, description, url, priority, "
+        "priority_label, estimate, due_date, team_id, team_key, team_name, "
+        "project_id, project_name, cycle_id, cycle_name, state_id, state_name, "
+        "state_type, assignee_user_id, assignee_name, creator_user_id, "
+        "creator_name, parent_issue_id, parent_identifier, content_text, "
+        "content_hash, source_created_at, source_updated_at, source_archived_at, "
+        "source_started_at, source_completed_at, source_canceled_at, raw_payload, "
+        "source_run_id, last_seen_at, last_error, updated_at"
+        ") VALUES ("
+        "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, "
+        "$16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, "
+        "$29, $30, $31, $32, $33, $34, $35::jsonb, $36, NOW(), '', NOW()"
+        ") ON CONFLICT (issue_id) DO UPDATE SET "
+        "identifier = EXCLUDED.identifier, "
+        "issue_number = EXCLUDED.issue_number, "
+        "title = EXCLUDED.title, "
+        "description = EXCLUDED.description, "
+        "url = EXCLUDED.url, "
+        "priority = EXCLUDED.priority, "
+        "priority_label = EXCLUDED.priority_label, "
+        "estimate = EXCLUDED.estimate, "
+        "due_date = EXCLUDED.due_date, "
+        "team_id = EXCLUDED.team_id, "
+        "team_key = EXCLUDED.team_key, "
+        "team_name = EXCLUDED.team_name, "
+        "project_id = EXCLUDED.project_id, "
+        "project_name = EXCLUDED.project_name, "
+        "cycle_id = EXCLUDED.cycle_id, "
+        "cycle_name = EXCLUDED.cycle_name, "
+        "state_id = EXCLUDED.state_id, "
+        "state_name = EXCLUDED.state_name, "
+        "state_type = EXCLUDED.state_type, "
+        "assignee_user_id = EXCLUDED.assignee_user_id, "
+        "assignee_name = EXCLUDED.assignee_name, "
+        "creator_user_id = EXCLUDED.creator_user_id, "
+        "creator_name = EXCLUDED.creator_name, "
+        "parent_issue_id = EXCLUDED.parent_issue_id, "
+        "parent_identifier = EXCLUDED.parent_identifier, "
+        "content_text = EXCLUDED.content_text, "
+        "content_hash = EXCLUDED.content_hash, "
+        "source_created_at = EXCLUDED.source_created_at, "
+        "source_updated_at = EXCLUDED.source_updated_at, "
+        "source_archived_at = EXCLUDED.source_archived_at, "
+        "source_started_at = EXCLUDED.source_started_at, "
+        "source_completed_at = EXCLUDED.source_completed_at, "
+        "source_canceled_at = EXCLUDED.source_canceled_at, "
+        "raw_payload = EXCLUDED.raw_payload, "
+        "source_run_id = EXCLUDED.source_run_id, "
+        "last_seen_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        _text_value(issue.get("id")),
+        _text_value(issue.get("identifier")),
+        _int_value(issue.get("number")),
+        _text_value(issue.get("title")),
+        _text_value(issue.get("description")),
+        _text_value(issue.get("url")),
+        _int_value(issue.get("priority")),
+        _text_value(issue.get("priorityLabel")),
+        _float_value(issue.get("estimate")),
+        _parse_date(issue.get("dueDate")),
+        _text_value(team.get("id")),
+        _text_value(team.get("key")),
+        _text_value(team.get("name")),
+        _text_value(project.get("id")),
+        _text_value(project.get("name")),
+        _text_value(cycle.get("id")),
+        _text_value(cycle.get("name")),
+        _text_value(state.get("id")),
+        _text_value(state.get("name")),
+        _text_value(state.get("type")),
+        _text_value(assignee.get("id")),
+        _text_value(assignee.get("name") or assignee.get("displayName")),
+        _text_value(creator.get("id")),
+        _text_value(creator.get("name") or creator.get("displayName")),
+        _text_value(parent.get("id")),
+        _text_value(parent.get("identifier")),
+        content_text,
+        _content_hash(content_text),
+        _source_datetime(issue, "createdAt"),
+        _source_datetime(issue, "updatedAt"),
+        _source_datetime(issue, "archivedAt"),
+        _source_datetime(issue, "startedAt"),
+        _source_datetime(issue, "completedAt"),
+        _source_datetime(issue, "canceledAt"),
+        canonical_json(issue),
+        run_id,
+    )
+
+
+async def _upsert_comment(
+    pool,
+    *,
+    comment: dict[str, Any],
+    run_id: str,
+) -> None:
+    user = _json_object(comment.get("user"))
+    user_name = _text_value(user.get("name") or user.get("displayName"))
+    content_text = "\n".join(
+        part
+        for part in [
+            _text_value(comment.get("body")),
+            user_name,
+            _text_value(comment.get("issueId")),
+            _text_value(comment.get("projectId")),
+        ]
+        if part.strip()
+    )
+    await pool.execute(
+        "INSERT INTO linear_sync_comments ("
+        "comment_id, issue_id, project_id, parent_comment_id, user_id, user_name, "
+        "body, url, content_text, content_hash, source_created_at, source_updated_at, "
+        "source_archived_at, source_edited_at, source_resolved_at, raw_payload, "
+        "source_run_id, last_seen_at, last_error, updated_at"
+        ") VALUES ("
+        "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, "
+        "$16::jsonb, $17, NOW(), '', NOW()"
+        ") ON CONFLICT (comment_id) DO UPDATE SET "
+        "issue_id = EXCLUDED.issue_id, "
+        "project_id = EXCLUDED.project_id, "
+        "parent_comment_id = EXCLUDED.parent_comment_id, "
+        "user_id = EXCLUDED.user_id, "
+        "user_name = EXCLUDED.user_name, "
+        "body = EXCLUDED.body, "
+        "url = EXCLUDED.url, "
+        "content_text = EXCLUDED.content_text, "
+        "content_hash = EXCLUDED.content_hash, "
+        "source_created_at = EXCLUDED.source_created_at, "
+        "source_updated_at = EXCLUDED.source_updated_at, "
+        "source_archived_at = EXCLUDED.source_archived_at, "
+        "source_edited_at = EXCLUDED.source_edited_at, "
+        "source_resolved_at = EXCLUDED.source_resolved_at, "
+        "raw_payload = EXCLUDED.raw_payload, "
+        "source_run_id = EXCLUDED.source_run_id, "
+        "last_seen_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        _text_value(comment.get("id")),
+        _text_value(comment.get("issueId")),
+        _text_value(comment.get("projectId")),
+        _text_value(comment.get("parentId")),
+        _text_value(user.get("id")),
+        user_name,
+        _text_value(comment.get("body")),
+        _text_value(comment.get("url")),
+        content_text,
+        _content_hash(content_text),
+        _source_datetime(comment, "createdAt"),
+        _source_datetime(comment, "updatedAt"),
+        _source_datetime(comment, "archivedAt"),
+        _source_datetime(comment, "editedAt"),
+        _source_datetime(comment, "resolvedAt"),
+        canonical_json(comment),
+        run_id,
+    )
+
+
+async def _sync_projects(
+    *,
+    client: LinearSyncClient,
+    pool,
+    page_size: int,
+    updated_after: dt.datetime | None,
+    include_archived: bool,
+    run_id: str,
+) -> tuple[int, int, dt.datetime | None]:
+    seen = 0
+    upserted = 0
+    watermark: dt.datetime | None = None
+    cursor: str | None = None
+    while True:
+        page = client.list_etl_projects(
+            page_size=page_size,
+            cursor=cursor,
+            updated_after=updated_after,
+            include_archived=include_archived,
+        )
+        projects = [
+            project
+            for project in page.get("nodes", []) or []
+            if isinstance(project, dict) and project.get("id")
+        ]
+        seen += len(projects)
+        record_etl_items_seen("linear", "workspace", "project", len(projects))
+        for project in projects:
+            await _upsert_project(pool, project=project, run_id=run_id)
+            upserted += 1
+            record_etl_items_upserted("linear", "workspace", "project", 1)
+            updated_at = _source_datetime(project, "updatedAt")
+            if updated_at and (watermark is None or updated_at > watermark):
+                watermark = updated_at
+
+        page_info = (
+            page.get("pageInfo") if isinstance(page.get("pageInfo"), dict) else {}
+        )
+        cursor = page_info.get("endCursor")
+        if not page_info.get("hasNextPage") or not cursor:
+            break
+    return seen, upserted, watermark
+
+
+async def _sync_issues(
+    *,
+    client: LinearSyncClient,
+    pool,
+    page_size: int,
+    updated_after: dt.datetime | None,
+    include_archived: bool,
+    run_id: str,
+) -> tuple[int, int, dt.datetime | None]:
+    seen = 0
+    upserted = 0
+    watermark: dt.datetime | None = None
+    cursor: str | None = None
+    while True:
+        page = client.list_etl_issues(
+            page_size=page_size,
+            cursor=cursor,
+            updated_after=updated_after,
+            include_archived=include_archived,
+        )
+        issues = [
+            issue
+            for issue in page.get("nodes", []) or []
+            if isinstance(issue, dict) and issue.get("id")
+        ]
+        seen += len(issues)
+        record_etl_items_seen("linear", "workspace", "issue", len(issues))
+        for issue in issues:
+            await _upsert_issue(pool, issue=issue, run_id=run_id)
+            upserted += 1
+            record_etl_items_upserted("linear", "workspace", "issue", 1)
+            updated_at = _source_datetime(issue, "updatedAt")
+            if updated_at and (watermark is None or updated_at > watermark):
+                watermark = updated_at
+
+        page_info = (
+            page.get("pageInfo") if isinstance(page.get("pageInfo"), dict) else {}
+        )
+        cursor = page_info.get("endCursor")
+        if not page_info.get("hasNextPage") or not cursor:
+            break
+    return seen, upserted, watermark
+
+
+async def _sync_comments(
+    *,
+    client: LinearSyncClient,
+    pool,
+    page_size: int,
+    updated_after: dt.datetime | None,
+    include_archived: bool,
+    run_id: str,
+) -> tuple[int, int, dt.datetime | None]:
+    seen = 0
+    upserted = 0
+    watermark: dt.datetime | None = None
+    cursor: str | None = None
+    while True:
+        page = client.list_etl_comments(
+            page_size=page_size,
+            cursor=cursor,
+            updated_after=updated_after,
+            include_archived=include_archived,
+        )
+        comments = [
+            comment
+            for comment in page.get("nodes", []) or []
+            if isinstance(comment, dict) and comment.get("id")
+        ]
+        seen += len(comments)
+        record_etl_items_seen("linear", "workspace", "comment", len(comments))
+        for comment in comments:
+            await _upsert_comment(pool, comment=comment, run_id=run_id)
+            upserted += 1
+            record_etl_items_upserted("linear", "workspace", "comment", 1)
+            updated_at = _source_datetime(comment, "updatedAt")
+            if updated_at and (watermark is None or updated_at > watermark):
+                watermark = updated_at
+
+        page_info = (
+            page.get("pageInfo") if isinstance(page.get("pageInfo"), dict) else {}
+        )
+        cursor = page_info.get("endCursor")
+        if not page_info.get("hasNextPage") or not cursor:
+            break
+    return seen, upserted, watermark
+
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    """Sync changed Linear projects, issues, and comments into raw sync tables."""
+    if not env_flag_enabled("LINEAR_ETL_ENABLED", default=False):
+        ctx.log("linear_sync_skipped_disabled")
+        return {"status": "skipped", "reason": "linear_etl_disabled"}
+
+    page_size = positive_int(inp.limit, DEFAULT_PAGE_SIZE)
+    overlap_seconds = max(int(inp.watermark_overlap_seconds), 0)
+    run_id = _workflow_run_id_to_sync_run_id(ctx.run_id)
+    scopes_requested = [
+        _scope_ref(PROJECTS_SCOPE),
+        _scope_ref(ISSUES_SCOPE),
+        _scope_ref(COMMENTS_SCOPE),
+    ]
+
+    await _record_run_start(
+        ctx._pool,
+        run_id=run_id,
+        workflow_run_id=ctx.run_id,
+        scopes_requested=scopes_requested,
+        metadata={
+            **inp.metadata,
+            "page_size": page_size,
+            "include_archived": inp.include_archived,
+        },
+    )
+
+    client = _client()
+    explicit_since = _parse_datetime(inp.since)
+    synced: list[dict[str, str]] = []
+    failed: list[dict[str, str]] = []
+    counts = {
+        "projects_seen": 0,
+        "projects_upserted": 0,
+        "issues_seen": 0,
+        "issues_upserted": 0,
+        "comments_seen": 0,
+        "comments_upserted": 0,
+    }
+
+    for scope_id, sync_fn in [
+        (PROJECTS_SCOPE, _sync_projects),
+        (ISSUES_SCOPE, _sync_issues),
+        (COMMENTS_SCOPE, _sync_comments),
+    ]:
+        checkpoint = await _load_checkpoint(ctx._pool, scope_id)
+        watermark = explicit_since
+        if watermark is None and checkpoint and checkpoint.get("watermark_time"):
+            watermark = checkpoint["watermark_time"].astimezone(dt.timezone.utc)
+        if watermark is not None:
+            watermark = watermark - dt.timedelta(seconds=overlap_seconds)
+
+        try:
+            seen, upserted, successful_watermark = await sync_fn(
+                client=client,
+                pool=ctx._pool,
+                page_size=page_size,
+                updated_after=watermark,
+                include_archived=inp.include_archived,
+                run_id=run_id,
+            )
+            counts[f"{scope_id}_seen"] = seen
+            counts[f"{scope_id}_upserted"] = upserted
+            await _update_checkpoint_success(
+                ctx._pool,
+                scope_id=scope_id,
+                watermark_time=successful_watermark,
+                run_id=run_id,
+            )
+            synced.append(_scope_ref(scope_id))
+            ctx.log(
+                "linear_sync_scope_completed",
+                scope_id=scope_id,
+                items_seen=seen,
+                items_upserted=upserted,
+                watermark=_rfc3339(successful_watermark)
+                if successful_watermark
+                else "",
+            )
+        except Exception as exc:
+            error = str(exc)
+            failed.append(_scope_ref(scope_id, error))
+            record_etl_items_failed(
+                "linear", "workspace", "scope", _failure_reason(error)
+            )
+            await _update_checkpoint_failure(
+                ctx._pool,
+                scope_id=scope_id,
+                run_id=run_id,
+                error=error,
+            )
+            ctx.log("linear_sync_scope_failed", scope_id=scope_id, error=error)
+
+    status = "completed"
+    error_text = ""
+    if failed and synced:
+        status = "partial_failed"
+        error_text = f"{len(failed)} Linear scope(s) failed"
+    elif failed:
+        status = "failed"
+        error_text = f"{len(failed)} Linear scope(s) failed"
+
+    await _record_run_finish(
+        ctx._pool,
+        run_id=run_id,
+        status=status,
+        scopes_synced=synced,
+        scopes_failed=failed,
+        counts=counts,
+        error_text=error_text,
+    )
+
+    return {
+        "status": status,
+        "run_id": run_id,
+        "scopes_synced": len(synced),
+        "scopes_failed": len(failed),
+        **counts,
+    }


### PR DESCRIPTION
## Summary
- add Linear ETL page methods for projects, issues, and comments
- add linear_sync workflow with projects/issues/comments scopes, checkpoints, run tracking, and idempotent upserts
- add Postgres migration for Linear sync tables plus focused workflow/client tests

## Verification
- PYTHONPATH=/Users/akshaan/Desktop/centaur/services/api:/Users/akshaan/Desktop/centaur uv run ruff check api/integrations/linear/readonly.py ../../workflows/linear_sync.py tests/test_linear_sync.py tests/test_linear_integrations.py
- PYTHONPATH=/Users/akshaan/Desktop/centaur/services/api:/Users/akshaan/Desktop/centaur uv run pytest tests/test_linear_integrations.py tests/test_linear_sync.py
- just build-one api

Note: I stopped further local deploy/runtime smoke steps after the request to not run local deploy. An earlier `just deploy` attempt failed on an unrelated local Helm conflict in the slackbot deployment annotation.