### PR TITLE
feat: add company context date filters

### DIFF
--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -99,6 +99,33 @@ def _isoformat(value: Any) -> str | None:
     return None
 
 
+def _parse_datetime_filter(value: str | datetime | None, *, name: str) -> datetime | None:
+    """Parse optional date filters for tool calls."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        text = str(value).strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise ValueError(f"{name} must be an ISO 8601 date or timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _validate_date_window(start: datetime | None, end: datetime | None) -> None:
+    """Reject inverted date ranges before hitting Postgres."""
+    if start is not None and end is not None and start >= end:
+        raise ValueError("occurred_after must be earlier than occurred_before")
+
+
 def _normalize_text(value: str) -> str:
     """Collapse whitespace so previews stay compact and readable."""
     return re.sub(r"\s+", " ", value).strip()
@@ -292,6 +319,8 @@ class CompanyContextClient:
         limit: int,
         source: str | None,
         source_type: str | None,
+        occurred_after: datetime | None,
+        occurred_before: datetime | None,
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
@@ -299,7 +328,9 @@ class CompanyContextClient:
             search_terms = [query, *terms]
             source_param = len(search_terms) + 1
             source_type_param = len(search_terms) + 2
-            limit_param = len(search_terms) + 3
+            occurred_after_param = len(search_terms) + 3
+            occurred_before_param = len(search_terms) + 4
+            limit_param = len(search_terms) + 5
             rows = await conn.fetch(
                 f"""
                 SELECT
@@ -322,6 +353,10 @@ class CompanyContextClient:
                 WHERE {_search_where_clause(len(terms))}
                   AND (${source_param}::text IS NULL OR source = ${source_param})
                   AND (${source_type_param}::text IS NULL OR source_type = ${source_type_param})
+                  AND (${occurred_after_param}::timestamptz IS NULL
+                       OR occurred_at >= ${occurred_after_param})
+                  AND (${occurred_before_param}::timestamptz IS NULL
+                       OR occurred_at < ${occurred_before_param})
                 ORDER BY
                     paradedb.score(document_id)
                     * CASE source_type
@@ -335,6 +370,8 @@ class CompanyContextClient:
                 *search_terms,
                 source,
                 source_type,
+                occurred_after,
+                occurred_before,
                 limit,
             )
             results = []
@@ -354,6 +391,9 @@ class CompanyContextClient:
             live_error = None
             should_search_live_slack = source == "slack" and (
                 source_type is None or source_type.startswith("slack")
+            )
+            should_search_live_slack = (
+                should_search_live_slack and occurred_after is None and occurred_before is None
             )
             if should_search_live_slack:
                 latest = await self._latest_date_for_connection(
@@ -376,6 +416,8 @@ class CompanyContextClient:
                 "query": query,
                 "source": source,
                 "source_type": source_type,
+                "occurred_after": _isoformat(occurred_after),
+                "occurred_before": _isoformat(occurred_before),
                 "count": len(results) + len(live_results),
                 "indexed_count": len(results),
                 "live_count": len(live_results),
@@ -438,6 +480,8 @@ class CompanyContextClient:
         limit: int = DEFAULT_SEARCH_LIMIT,
         source: str | None = None,
         source_type: str | None = None,
+        occurred_after: str | datetime | None = None,
+        occurred_before: str | datetime | None = None,
     ) -> dict:
         """Search company context documents and return candidate document ids."""
         normalized_query = query.strip()
@@ -445,12 +489,114 @@ class CompanyContextClient:
             return {"status": "error", "error": "query cannot be empty"}
 
         try:
+            parsed_occurred_after = _parse_datetime_filter(
+                occurred_after,
+                name="occurred_after",
+            )
+            parsed_occurred_before = _parse_datetime_filter(
+                occurred_before,
+                name="occurred_before",
+            )
+            _validate_date_window(parsed_occurred_after, parsed_occurred_before)
             return asyncio.run(
                 self._search_async(
                     query=normalized_query,
                     limit=_clamp(limit, minimum=1, maximum=MAX_SEARCH_LIMIT),
                     source=source.strip() if source else None,
                     source_type=source_type.strip() if source_type else None,
+                    occurred_after=parsed_occurred_after,
+                    occurred_before=parsed_occurred_before,
+                )
+            )
+        except Exception as exc:
+            return {"status": "error", "error": str(exc)}
+
+    async def _list_documents_async(
+        self,
+        *,
+        limit: int,
+        source: str | None,
+        source_type: str | None,
+        occurred_after: datetime | None,
+        occurred_before: datetime | None,
+    ) -> dict[str, Any]:
+        conn = await self._connect()
+        try:
+            rows = await conn.fetch(
+                """
+                SELECT
+                    document_id,
+                    source,
+                    source_type,
+                    source_document_id,
+                    source_chunk_id,
+                    parent_document_id,
+                    title,
+                    url,
+                    author_name,
+                    access_scope,
+                    body,
+                    occurred_at,
+                    source_updated_at,
+                    metadata
+                FROM company_context_documents
+                WHERE ($1::text IS NULL OR source = $1)
+                  AND ($2::text IS NULL OR source_type = $2)
+                  AND ($3::timestamptz IS NULL OR occurred_at >= $3)
+                  AND ($4::timestamptz IS NULL OR occurred_at < $4)
+                ORDER BY occurred_at ASC NULLS LAST, source_updated_at DESC NULLS LAST,
+                         document_id ASC
+                LIMIT $5
+                """,
+                source,
+                source_type,
+                occurred_after,
+                occurred_before,
+                limit,
+            )
+            results = []
+            for row in rows:
+                result = _document_summary(row)
+                result["preview"] = _body_preview(str(_row_value(row, "body", "") or ""), query="")
+                results.append(result)
+            return {
+                "status": "ok",
+                "source": source,
+                "source_type": source_type,
+                "occurred_after": _isoformat(occurred_after),
+                "occurred_before": _isoformat(occurred_before),
+                "count": len(results),
+                "results": results,
+            }
+        finally:
+            await conn.close()
+
+    def list_documents(
+        self,
+        limit: int = DEFAULT_SEARCH_LIMIT,
+        source: str | None = None,
+        source_type: str | None = None,
+        occurred_after: str | datetime | None = None,
+        occurred_before: str | datetime | None = None,
+    ) -> dict:
+        """List company context documents, optionally bounded by occurred_at."""
+        try:
+            parsed_occurred_after = _parse_datetime_filter(
+                occurred_after,
+                name="occurred_after",
+            )
+            parsed_occurred_before = _parse_datetime_filter(
+                occurred_before,
+                name="occurred_before",
+            )
+            _validate_date_window(parsed_occurred_after, parsed_occurred_before)
+            return asyncio.run(
+                self._list_documents_async(
+                    limit=_clamp(limit, minimum=1, maximum=MAX_SEARCH_LIMIT),
+                    source=source.strip() if source else None,
+                    source_type=source_type.strip() if source_type else None,
+                    occurred_after=parsed_occurred_after,
+                    occurred_before=parsed_occurred_before,
                 )
             )
         except Exception as exc:

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "company_context"
-description = "Search indexed company history across multiple sources. Prefer this over direct Slack search for historical queries. Current sources: Slack."
+description = "Search indexed company history across multiple sources. Prefer this over direct Slack search for historical queries. Current sources: Slack, Google Drive, Google Calendar, Linear."
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -123,7 +123,16 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
     assert "WHEN 'slack_channel_day' THEN 0.75" in query
     assert "END DESC" in query
     assert "paradedb.score(document_id)" in query
-    assert args == ("ParadeDB BM25", "ParadeDB", "BM25", "slack", "slack_thread", 5)
+    assert args == (
+        "ParadeDB BM25",
+        "ParadeDB",
+        "BM25",
+        "slack",
+        "slack_thread",
+        None,
+        None,
+        5,
+    )
     assert fake.closed is True
 
 
@@ -259,9 +268,142 @@ def test_search_uses_or_terms_and_drops_stop_words(monkeypatch):
         "prod",
         None,
         None,
+        None,
+        None,
         3,
     )
 
+
+def test_search_applies_occurred_at_filters(monkeypatch):
+    fake = _FakeConnection(rows=[])
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").search(
+        "planning",
+        limit=4,
+        source="google_calendar",
+        source_type="calendar_event",
+        occurred_after="2026-05-01",
+        occurred_before="2026-05-08T12:30:00Z",
+    )
+
+    assert result["status"] == "ok"
+    assert result["occurred_after"] == "2026-05-01T00:00:00+00:00"
+    assert result["occurred_before"] == "2026-05-08T12:30:00+00:00"
+    query, args = fake.fetch_calls[0]
+    assert "OR occurred_at >= $5" in query
+    assert "OR occurred_at < $6" in query
+    assert args == (
+        "planning",
+        "planning",
+        "google_calendar",
+        "calendar_event",
+        dt.datetime(2026, 5, 1, tzinfo=dt.UTC),
+        dt.datetime(2026, 5, 8, 12, 30, tzinfo=dt.UTC),
+        4,
+    )
+
+
+def test_search_rejects_invalid_occurred_at_filter():
+    result = CompanyContextClient("postgresql://example").search(
+        "planning",
+        occurred_after="not-a-date",
+    )
+
+    assert result == {
+        "status": "error",
+        "error": "occurred_after must be an ISO 8601 date or timestamp",
+    }
+
+
+def test_search_rejects_inverted_occurred_at_filter():
+    result = CompanyContextClient("postgresql://example").search(
+        "planning",
+        occurred_after="2026-05-08",
+        occurred_before="2026-05-01",
+    )
+
+    assert result == {
+        "status": "error",
+        "error": "occurred_after must be earlier than occurred_before",
+    }
+
+
+def test_list_documents_returns_date_bounded_document_summaries(monkeypatch):
+    fake = _FakeConnection(
+        rows=[
+            {
+                "document_id": "google_calendar:calendar_event:evt_123",
+                "source": "google_calendar",
+                "source_type": "calendar_event",
+                "source_document_id": "evt_123",
+                "source_chunk_id": "",
+                "parent_document_id": None,
+                "title": "Planning sync",
+                "url": "https://calendar.example/event",
+                "author_name": "alice",
+                "access_scope": "company",
+                "body": "Planning sync with roadmap notes.",
+                "occurred_at": dt.datetime(2026, 5, 6, 15, 0, tzinfo=dt.UTC),
+                "source_updated_at": dt.datetime(2026, 5, 6, 15, 30, tzinfo=dt.UTC),
+                "metadata": {"calendar_id": "primary"},
+            }
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").list_documents(
+        limit=2,
+        source="google_calendar",
+        source_type="calendar_event",
+        occurred_after="2026-05-01",
+        occurred_before="2026-05-08",
+    )
+
+    assert result == {
+        "status": "ok",
+        "source": "google_calendar",
+        "source_type": "calendar_event",
+        "occurred_after": "2026-05-01T00:00:00+00:00",
+        "occurred_before": "2026-05-08T00:00:00+00:00",
+        "count": 1,
+        "results": [
+            {
+                "document_id": "google_calendar:calendar_event:evt_123",
+                "source": "google_calendar",
+                "source_type": "calendar_event",
+                "source_document_id": "evt_123",
+                "source_chunk_id": "",
+                "parent_document_id": None,
+                "title": "Planning sync",
+                "url": "https://calendar.example/event",
+                "author_name": "alice",
+                "access_scope": "company",
+                "occurred_at": "2026-05-06T15:00:00+00:00",
+                "source_updated_at": "2026-05-06T15:30:00+00:00",
+                "metadata": {"calendar_id": "primary"},
+                "preview": "Planning sync with roadmap notes.",
+            }
+        ],
+    }
+    query, args = fake.fetch_calls[0]
+    assert "ORDER BY occurred_at ASC NULLS LAST" in query
+    assert args == (
+        "google_calendar",
+        "calendar_event",
+        dt.datetime(2026, 5, 1, tzinfo=dt.UTC),
+        dt.datetime(2026, 5, 8, tzinfo=dt.UTC),
+        2,
+    )
+    assert fake.closed is True
 
 
 def test_latest_date_returns_latest_indexed_slack_timestamp(monkeypatch):


### PR DESCRIPTION
## Summary
- add occurred_at range filters to company_context.search
- add company_context.list_documents for date-bounded document retrieval without a BM25 query
- update the company context tool description to include Slack, Google Drive, Google Calendar, and Linear

## Tests
- uv run --with pytest --with asyncpg --with slack-sdk --with rich pytest tools/productivity/company_context/tests/test_client.py
- uv run --with ruff ruff check tools/productivity/company_context/client.py tools/productivity/company_context/tests/test_client.py