### PR TITLE
feat(tools): add Railway and Vercel

### DIFF
--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -37,6 +37,8 @@ These are broadly useful across most deployments and are good candidates to conf
 | `company_context` | Search indexed company history across internal sources | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
+| `railway` | Inspect Railway projects, services, deployments, and deployment logs | `RAILWAY_TOKEN`; optional: `RAILWAY_PROJECT_TOKEN` |
+| `vercel` | Inspect Vercel teams, projects, deployments, and deployment events | `VERCEL_TOKEN` |
 | `attio` | Work with CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
 | `pylon` | Read and manage support issues, accounts, contacts, teams, tags, and users | `PYLON_API_KEY` |
 
@@ -64,8 +66,10 @@ These are broadly useful across most deployments and are good candidates to conf
 | `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Product analytics through HogQL, events, pageviews, and breakdowns | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `profslice` | Extract Firefox Profiler data for analysis | None |
+| `railway` | Railway projects, services, deployments, and deployment logs | `RAILWAY_TOKEN`; optional: `RAILWAY_PROJECT_TOKEN` |
 | `reth` | Reth execution timing and performance metrics | None |
 | `reth-log-analyzer` | Parse Reth logs and generate performance graphs | None |
+| `vercel` | Vercel teams, projects, deployments, and deployment events | `VERCEL_TOKEN` |
 | `vlogs` | VictoriaLogs queries, fields, streams, and log analytics | None |
 | `vmetrics` | VictoriaMetrics PromQL/MetricsQL queries and metric discovery | None |
 

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -37,6 +37,8 @@ These are broadly useful across most deployments and are good candidates to conf
 | `company_context` | Search indexed company history across internal sources | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
+| `railway` | Inspect Railway projects, services, deployments, and deployment logs | `RAILWAY_TOKEN`; optional: `RAILWAY_PROJECT_TOKEN` |
+| `vercel` | Inspect Vercel teams, projects, deployments, and deployment events | `VERCEL_TOKEN` |
 | `attio` | Work with CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
 | `pylon` | Read and manage support issues, accounts, contacts, teams, tags, and users | `PYLON_API_KEY` |
 
@@ -64,9 +66,11 @@ These are broadly useful across most deployments and are good candidates to conf
 | `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Product analytics through HogQL, events, pageviews, and breakdowns | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `profslice` | Extract Firefox Profiler data for analysis | None |
+| `railway` | Railway projects, services, deployments, and deployment logs | `RAILWAY_TOKEN`; optional: `RAILWAY_PROJECT_TOKEN` |
 | `reth` | Reth execution timing and performance metrics | None |
 | `reth-log-analyzer` | Parse Reth logs and generate performance graphs | None |
 | `sentry` | Browse Sentry issues, issue details, events, stacktraces, and tag values (read-only) | `SENTRY_AUTH_TOKEN` |
+| `vercel` | Vercel teams, projects, deployments, and deployment events | `VERCEL_TOKEN` |
 | `vlogs` | VictoriaLogs queries, fields, streams, and log analytics | None |
 | `vmetrics` | VictoriaMetrics PromQL/MetricsQL queries and metric discovery | None |
 

--- a/tools/infra/railway/.env.example
+++ b/tools/infra/railway/.env.example
@@ -1,0 +1,6 @@
+# Railway account/workspace API token. Used as Authorization: Bearer <token>.
+RAILWAY_TOKEN=your-railway-token-here
+
+# Optional project-scoped token. If absent, token_kind="project" uses RAILWAY_TOKEN
+# in the Project-Access-Token header.
+# RAILWAY_PROJECT_TOKEN=your-railway-project-token-here

--- a/tools/infra/railway/client.py
+++ b/tools/infra/railway/client.py
@@ -1,0 +1,276 @@
+"""Railway GraphQL API client for read-only deployment inspection."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import httpx
+
+from centaur_sdk import secret
+
+API_BASE = "https://backboard.railway.com/graphql/v2"
+TokenKind = Literal["account", "project"]
+
+
+class RailwayClient:
+    """Read-only client for Railway's GraphQL API.
+
+    Railway supports account/workspace tokens through the ``Authorization``
+    header and project-scoped tokens through ``Project-Access-Token``. This
+    client can use either mode, but exposes only query operations.
+    """
+
+    def __init__(
+        self,
+        api_token: str | None = None,
+        project_token: str | None = None,
+        base_url: str = API_BASE,
+        timeout: float = 30.0,
+    ):
+        self._api_token = api_token
+        self._project_token = project_token
+        self.base_url = base_url
+        self.timeout = timeout
+        self._client: httpx.Client | None = None
+
+    def _token(self, token_kind: TokenKind) -> str:
+        if token_kind == "project":
+            token = self._project_token or secret("RAILWAY_PROJECT_TOKEN", "")
+            if not token:
+                token = self._api_token or secret("RAILWAY_TOKEN", "")
+        else:
+            token = self._api_token or secret("RAILWAY_TOKEN", "")
+        token = token.strip()
+        if not token:
+            raise RuntimeError("RAILWAY_TOKEN not set.")
+        return token
+
+    def _headers(self, token_kind: TokenKind) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        token = self._token(token_kind)
+        if token_kind == "project":
+            headers["Project-Access-Token"] = token
+        else:
+            headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    @property
+    def client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(timeout=self.timeout, follow_redirects=True)
+        return self._client
+
+    @staticmethod
+    def _assert_read_only(query: str) -> None:
+        stripped = query.lstrip()
+        lowered = stripped.lower()
+        if not stripped:
+            raise ValueError("GraphQL query is required.")
+        if lowered.startswith(("mutation", "subscription")):
+            raise ValueError("Railway tool only allows read-only GraphQL queries.")
+        if not (lowered.startswith("query") or stripped.startswith("{")):
+            raise ValueError("Railway GraphQL operations must be queries.")
+
+    def graphql(
+        self,
+        query: str,
+        variables: dict[str, Any] | None = None,
+        token_kind: TokenKind = "account",
+    ) -> dict[str, Any]:
+        """Run a read-only Railway GraphQL query.
+
+        Args:
+            query: A GraphQL query operation. Mutations and subscriptions are rejected.
+            variables: Optional GraphQL variables.
+            token_kind: ``account`` for bearer tokens or ``project`` for
+                project-scoped tokens.
+        """
+        self._assert_read_only(query)
+        response = self.client.post(
+            self.base_url,
+            headers=self._headers(token_kind),
+            json={"query": query, "variables": variables or {}},
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(f"Railway API error ({response.status_code}): {response.text}")
+        return response.json()
+
+    def whoami(self) -> dict[str, Any]:
+        """Return the account identity visible to an account/workspace token."""
+        return self.graphql(
+            """
+            query RailwayViewer {
+              me {
+                id
+                name
+                email
+              }
+            }
+            """
+        )
+
+    def project_token_info(self) -> dict[str, Any]:
+        """Return project/environment metadata visible to a project token."""
+        return self.graphql(
+            """
+            query RailwayProjectTokenInfo {
+              projectToken {
+                projectId
+                environmentId
+                project {
+                  id
+                  name
+                }
+                environment {
+                  id
+                  name
+                }
+              }
+            }
+            """,
+            token_kind="project",
+        )
+
+    def list_projects(self, first: int = 25) -> dict[str, Any]:
+        """List projects visible to the token."""
+        return self.graphql(
+            """
+            query RailwayProjects($first: Int!) {
+              projects(first: $first) {
+                edges {
+                  node {
+                    id
+                    name
+                    createdAt
+                    updatedAt
+                  }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+            """,
+            {"first": first},
+        )
+
+    def get_project(self, project_id: str) -> dict[str, Any]:
+        """Get a project's services and environments."""
+        return self.graphql(
+            """
+            query RailwayProject($projectId: String!) {
+              project(id: $projectId) {
+                id
+                name
+                createdAt
+                updatedAt
+                services {
+                  edges {
+                    node {
+                      id
+                      name
+                      createdAt
+                      updatedAt
+                    }
+                  }
+                }
+                environments {
+                  edges {
+                    node {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }
+            """,
+            {"projectId": project_id},
+        )
+
+    def list_deployments(
+        self,
+        project_id: str,
+        service_id: str | None = None,
+        environment_id: str | None = None,
+        first: int = 20,
+    ) -> dict[str, Any]:
+        """List recent deployments for a Railway project, service, or environment."""
+        input_payload: dict[str, Any] = {"projectId": project_id}
+        if service_id:
+            input_payload["serviceId"] = service_id
+        if environment_id:
+            input_payload["environmentId"] = environment_id
+        return self.graphql(
+            """
+            query RailwayDeployments($input: DeploymentListInput!, $first: Int!) {
+              deployments(input: $input, first: $first) {
+                edges {
+                  node {
+                    id
+                    status
+                    createdAt
+                    updatedAt
+                    service {
+                      id
+                      name
+                    }
+                    environment {
+                      id
+                      name
+                    }
+                  }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+            """,
+            {"input": input_payload, "first": first},
+        )
+
+    def deployment_logs(
+        self,
+        deployment_id: str,
+        limit: int = 100,
+        filter_query: str | None = None,
+    ) -> dict[str, Any]:
+        """Fetch recent logs for a deployment."""
+        return self.graphql(
+            """
+            query RailwayDeploymentLogs(
+              $deploymentId: String!,
+              $limit: Int!,
+              $filter: String
+            ) {
+              deploymentLogs(
+                deploymentId: $deploymentId,
+                limit: $limit,
+                filter: $filter
+              ) {
+                timestamp
+                message
+                severity
+              }
+            }
+            """,
+            {"deploymentId": deployment_id, "limit": limit, "filter": filter_query},
+        )
+
+    def close(self) -> None:
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> RailwayClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+
+def _client() -> RailwayClient:
+    return RailwayClient()

--- a/tools/infra/railway/pyproject.toml
+++ b/tools/infra/railway/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "railway"
+description = "Railway projects, services, deployments, and deployment logs (read-only)"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.centaur]
+module = "client.py"
+hosts = ["backboard.railway.com"]
+secrets = [
+    {type = "http", name = "RAILWAY_TOKEN", match_headers = ["Authorization", "Project-Access-Token"], hosts = ["backboard.railway.com"]},
+]
+optional_secrets = [
+    {type = "http", name = "RAILWAY_PROJECT_TOKEN", match_headers = ["Project-Access-Token"], hosts = ["backboard.railway.com"]},
+]

--- a/tools/infra/railway/test_railway_client.py
+++ b/tools/infra/railway/test_railway_client.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "railway_client", Path(__file__).with_name("client.py")
+)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+RailwayClient = module.RailwayClient
+
+
+class FakeResponse:
+    status_code = 200
+    text = "{}"
+
+    def __init__(self, payload: dict[str, Any]):
+        self.payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+class FakeHttp:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def post(self, url: str, headers: dict[str, str], json: dict[str, Any]) -> FakeResponse:
+        self.calls.append({"url": url, "headers": headers, "json": json})
+        return FakeResponse({"data": {"ok": True}})
+
+
+class RecordingRailwayClient(RailwayClient):
+    def __init__(self) -> None:
+        super().__init__(api_token="account-token", project_token="project-token")
+        self.fake_http = FakeHttp()
+
+    @property
+    def client(self) -> FakeHttp:
+        return self.fake_http
+
+
+def test_graphql_uses_account_bearer_header() -> None:
+    client = RecordingRailwayClient()
+
+    client.graphql("query { me { id } }")
+
+    call = client.fake_http.calls[-1]
+    assert call["headers"]["Authorization"] == "Bearer account-token"
+    assert "Project-Access-Token" not in call["headers"]
+
+
+def test_graphql_uses_project_access_token_header() -> None:
+    client = RecordingRailwayClient()
+
+    client.project_token_info()
+
+    call = client.fake_http.calls[-1]
+    assert call["headers"]["Project-Access-Token"] == "project-token"
+    assert "Authorization" not in call["headers"]
+
+
+def test_graphql_rejects_mutations() -> None:
+    client = RecordingRailwayClient()
+
+    with pytest.raises(ValueError, match="read-only"):
+        client.graphql("mutation { projectDelete(id: \"p\") }")
+
+
+def test_list_deployments_builds_input_payload() -> None:
+    client = RecordingRailwayClient()
+
+    client.list_deployments("project", service_id="service", environment_id="env", first=5)
+
+    variables = client.fake_http.calls[-1]["json"]["variables"]
+    assert variables == {
+        "input": {
+            "projectId": "project",
+            "serviceId": "service",
+            "environmentId": "env",
+        },
+        "first": 5,
+    }

--- a/tools/infra/vercel/.env.example
+++ b/tools/infra/vercel/.env.example
@@ -1,0 +1,2 @@
+# Vercel access token. Create a scoped token from Vercel account settings.
+VERCEL_TOKEN=your-vercel-token-here

--- a/tools/infra/vercel/client.py
+++ b/tools/infra/vercel/client.py
@@ -1,0 +1,182 @@
+"""Vercel REST API client for read-only deployment inspection."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from centaur_sdk import secret
+
+API_BASE = "https://api.vercel.com"
+
+
+class VercelClient:
+    """Read-only client for Vercel projects and deployments."""
+
+    def __init__(
+        self,
+        api_token: str | None = None,
+        base_url: str = API_BASE,
+        timeout: float = 30.0,
+    ):
+        self._api_token = api_token
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._client: httpx.Client | None = None
+
+    def _token(self) -> str:
+        token = (self._api_token or secret("VERCEL_TOKEN", "")).strip()
+        if not token:
+            raise RuntimeError("VERCEL_TOKEN not set.")
+        return token
+
+    @property
+    def client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(timeout=self.timeout, follow_redirects=True)
+        return self._client
+
+    @staticmethod
+    def _team_params(team_id: str | None = None, slug: str | None = None) -> dict[str, str]:
+        params: dict[str, str] = {}
+        if team_id:
+            params["teamId"] = team_id
+        if slug:
+            params["slug"] = slug
+        return params
+
+    def _request(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+        response = self.client.get(
+            f"{self.base_url}/{path.lstrip('/')}",
+            headers={"Authorization": f"Bearer {self._token()}"},
+            params=clean_params,
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(f"Vercel API error ({response.status_code}): {response.text}")
+        return response.json()
+
+    def get_user(self) -> dict[str, Any]:
+        """Return the authenticated Vercel user."""
+        return self._request("/v2/user")
+
+    def list_teams(
+        self,
+        limit: int = 20,
+        since: int | None = None,
+        until: int | None = None,
+    ) -> dict[str, Any]:
+        """List teams visible to the token."""
+        return self._request(
+            "/v2/teams",
+            {"limit": limit, "since": since, "until": until},
+        )
+
+    def list_projects(
+        self,
+        limit: int = 20,
+        search: str | None = None,
+        team_id: str | None = None,
+        slug: str | None = None,
+        from_: int | None = None,
+        repo_url: str | None = None,
+    ) -> dict[str, Any]:
+        """List projects visible to the token."""
+        params: dict[str, Any] = {
+            "limit": limit,
+            "search": search,
+            "from": from_,
+            "repoUrl": repo_url,
+            **self._team_params(team_id, slug),
+        }
+        return self._request("/v9/projects", params)
+
+    def get_project(
+        self,
+        project_id_or_name: str,
+        team_id: str | None = None,
+        slug: str | None = None,
+    ) -> dict[str, Any]:
+        """Get one project by id or name."""
+        encoded = quote(project_id_or_name, safe="")
+        return self._request(f"/v9/projects/{encoded}", self._team_params(team_id, slug))
+
+    def list_deployments(
+        self,
+        limit: int = 20,
+        app: str | None = None,
+        project_id: str | None = None,
+        target: str | None = None,
+        state: str | None = None,
+        team_id: str | None = None,
+        slug: str | None = None,
+        since: int | None = None,
+        until: int | None = None,
+        branch: str | None = None,
+        sha: str | None = None,
+    ) -> dict[str, Any]:
+        """List deployments with optional project, target, state, branch, or SHA filters."""
+        params: dict[str, Any] = {
+            "limit": limit,
+            "app": app,
+            "projectId": project_id,
+            "target": target,
+            "state": state,
+            "since": since,
+            "until": until,
+            "gitSource.ref": branch,
+            "gitSource.sha": sha,
+            **self._team_params(team_id, slug),
+        }
+        return self._request("/v6/deployments", params)
+
+    def get_deployment(
+        self,
+        deployment_id_or_url: str,
+        team_id: str | None = None,
+        slug: str | None = None,
+        with_git_repo_info: bool = True,
+    ) -> dict[str, Any]:
+        """Get a deployment by id or URL."""
+        encoded = quote(deployment_id_or_url, safe="")
+        params: dict[str, Any] = {
+            "withGitRepoInfo": str(with_git_repo_info).lower(),
+            **self._team_params(team_id, slug),
+        }
+        return self._request(f"/v13/deployments/{encoded}", params)
+
+    def get_deployment_events(
+        self,
+        deployment_id_or_url: str,
+        limit: int = 100,
+        team_id: str | None = None,
+        slug: str | None = None,
+        since: int | None = None,
+        until: int | None = None,
+    ) -> dict[str, Any]:
+        """Get recent build/runtime events for a deployment."""
+        encoded = quote(deployment_id_or_url, safe="")
+        params: dict[str, Any] = {
+            "limit": limit,
+            "since": since,
+            "until": until,
+            **self._team_params(team_id, slug),
+        }
+        return self._request(f"/v3/deployments/{encoded}/events", params)
+
+    def close(self) -> None:
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> VercelClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+
+def _client() -> VercelClient:
+    return VercelClient()

--- a/tools/infra/vercel/pyproject.toml
+++ b/tools/infra/vercel/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "vercel"
+description = "Vercel users, teams, projects, deployments, and deployment events (read-only)"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.centaur]
+module = "client.py"
+hosts = ["api.vercel.com"]
+secrets = [
+    {type = "http", name = "VERCEL_TOKEN", match_headers = ["Authorization"], hosts = ["api.vercel.com"]},
+]

--- a/tools/infra/vercel/test_vercel_client.py
+++ b/tools/infra/vercel/test_vercel_client.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+spec = importlib.util.spec_from_file_location(
+    "vercel_client", Path(__file__).with_name("client.py")
+)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+VercelClient = module.VercelClient
+
+
+class RecordingVercelClient(VercelClient):
+    def __init__(self) -> None:
+        super().__init__(api_token="vercel-token")
+        self.calls: list[dict[str, Any]] = []
+
+    def _request(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append({"path": path, "params": params or {}})
+        return {"ok": True}
+
+
+def test_list_projects_maps_team_and_search_params() -> None:
+    client = RecordingVercelClient()
+
+    client.list_projects(search="phylax", team_id="team_123", limit=10)
+
+    assert client.calls[-1] == {
+        "path": "/v9/projects",
+        "params": {
+            "limit": 10,
+            "search": "phylax",
+            "from": None,
+            "repoUrl": None,
+            "teamId": "team_123",
+        },
+    }
+
+
+def test_list_deployments_maps_filters() -> None:
+    client = RecordingVercelClient()
+
+    client.list_deployments(project_id="prj_123", state="READY", branch="main", sha="abc")
+
+    params = client.calls[-1]["params"]
+    assert client.calls[-1]["path"] == "/v6/deployments"
+    assert params["projectId"] == "prj_123"
+    assert params["state"] == "READY"
+    assert params["gitSource.ref"] == "main"
+    assert params["gitSource.sha"] == "abc"
+
+
+def test_get_deployment_url_encodes_identifier() -> None:
+    client = RecordingVercelClient()
+
+    client.get_deployment("https://example.vercel.app", slug="phylax")
+
+    assert client.calls[-1] == {
+        "path": "/v13/deployments/https%3A%2F%2Fexample.vercel.app",
+        "params": {"withGitRepoInfo": "true", "slug": "phylax"},
+    }


### PR DESCRIPTION
## Summary
- add a read-only Railway GraphQL tool for projects, services, deployments, and deployment logs
- add a read-only Vercel REST tool for users, teams, projects, deployments, and deployment events
- document Railway and Vercel in the tool directory

## Verification
- `PYTHONPATH=. uv run --with pytest --with httpx --with rich pytest tools/infra/railway/test_railway_client.py tools/infra/vercel/test_vercel_client.py`
- `uv run --with ruff ruff check tools/infra/railway tools/infra/vercel`