### PR TITLE
chore: trim sandbox image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,63 @@
 # Version control
-.git
+.git/
+.git/**
+**/.git/
+**/.git/**
 
 # Virtual environments
-.venv
+.venv/
+.venv/**
+**/.venv/
+**/.venv/**
 
 # Node
-services/slackbot/node_modules
+node_modules/
+node_modules/**
+**/node_modules/
+**/node_modules/**
+
+# Build outputs
+target/
+target/**
+**/target/
+**/target/**
+dist/
+dist/**
+**/dist/
+**/dist/**
+build/
+build/**
+**/build/
+**/build/**
+.next/
+.next/**
+**/.next/
+**/.next/**
+coverage/
+coverage/**
+**/coverage/
+**/coverage/**
 
 # Sandbox cached repos (4GB+)
 services/sandbox/repos
 
 # Caches
-.ruff_cache
-.pytest_cache
-__pycache__
+.ruff_cache/
+.ruff_cache/**
+**/.ruff_cache/
+**/.ruff_cache/**
+.pytest_cache/
+.pytest_cache/**
+**/.pytest_cache/
+**/.pytest_cache/**
+.mypy_cache/
+.mypy_cache/**
+**/.mypy_cache/
+**/.mypy_cache/**
+__pycache__/
+__pycache__/**
+**/__pycache__/
+**/__pycache__/**
 services/api-rs/target
 
 # Logs
@@ -26,6 +70,7 @@ logs/
 .idea
 .amp
 .windsurf
+.DS_Store
 
 # Docker
 .dockerignore

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM ubuntu:24.04 AS toolchain
 
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # ── System packages (cached unless base image changes) ───────────────────────
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -18,16 +20,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     texlive-latex-recommended texlive-fonts-recommended \
     texlive-plain-generic texlive-science tipa cm-super \
     procps htop \
-    && ln -sf /usr/bin/fdfind /usr/local/bin/fd
+    && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
+    && rm -rf /usr/share/doc /usr/share/man /usr/share/info
 
 # ── Python deps ──────────────────────────────────────────────────────────────
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
-    pip3 install --break-system-packages \
+    pip3 install --break-system-packages --no-compile \
     python-docx==1.2.0 lxml==6.0.2 docx-revisions==0.1.4 \
     matplotlib==3.10.8 numpy==2.4.4 pandas==3.0.2 \
     python-pptx==1.0.2 openpyxl==3.1.5 PyMuPDF==1.27.2 mammoth==1.12.0 \
     faster-whisper \
-    opentelemetry-proto==1.42.1
+    opentelemetry-proto==1.42.1 \
+    && find /usr/local/lib/python3.12 /usr/lib/python3 -type d -name __pycache__ -prune -exec rm -rf '{}' +
 
 # ── GitHub CLI + Node.js 24 (LTS) + Docker CLI (single layer, cached) ─────────────
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -41,7 +45,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
       | tee /etc/apt/sources.list.d/docker.list > /dev/null \
-    && apt-get update && apt-get install -y gh nodejs docker-ce-cli
+    && apt-get update && apt-get install -y --no-install-recommends gh nodejs docker-ce-cli \
+    && rm -rf /usr/share/doc /usr/share/man /usr/share/info
 
 # ── Non-root agent user ─────────────────────────────────────────────────────
 RUN useradd -m -s /bin/bash -u 1001 agent \
@@ -83,11 +88,13 @@ RUN set -eux; \
     nu --version | grep -F "${NUSHELL_VERSION}"
 
 # ── Global npm CLIs (root) ──────────────────────────────────────────────────
-RUN npm install -g --prefer-online --force \
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm install -g --prefer-online --force \
       "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
       "@openai/codex@${CODEX_VERSION}" \
       "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \
       agent-browser@0.26.0 \
+    && find /usr/lib/node_modules -type f \( -name '*.map' -o -name '*.tsbuildinfo' \) -delete \
     && claude --version | grep -F "${CLAUDE_CODE_VERSION}" \
     && codex --version | grep -F "${CODEX_VERSION}"
 
@@ -106,8 +113,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libatspi2.0-0t64 libcups2t64 libxshmfence1 libgbm1 \
         fonts-noto-color-emoji fonts-noto-cjk fonts-freefont-ttf; \
     else \
-      apt-get update && apt-get install -y --no-install-recommends \
-        chromium-browser || true; \
+      echo "Skipping browser install: Chrome for Testing does not publish Linux ARM64 builds"; \
     fi
 
 USER agent
@@ -126,7 +132,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     && rustc --version \
     && cargo --version \
     && rustfmt --version \
-    && clippy-driver --version
+    && clippy-driver --version \
+    && rm -rf "$HOME/.rustup/toolchains"/*/share/doc "$HOME/.rustup/toolchains"/*/share/man
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 RUN curl -fsSL https://bun.sh/install | bash -s "${BUN_VERSION}"
 RUN --mount=type=cache,target=/home/agent/.cache/uv,uid=1001,gid=1001,sharing=locked \


### PR DESCRIPTION
## Summary
- Broaden docker context ignores for nested build/cache directories.
- Trim sandbox image package caches, docs, source maps, Python caches, and unused apt recommends.
- Keep required sandbox binaries available while avoiding unnecessary Docker CLI plugins.

## Tests
- `just build-one sandbox`
- sandbox image smoke command for Python document deps, harness CLIs, Node/npm, Docker CLI, Rust tools, uv, bun, manim, forge/cast, amp, and agent-browser
- verified `centaur-agent:latest` image size after build: 5.18GB