### PR TITLE
feat: load iron proxy fragments from tool pyprojects

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "sha2",
  "strum 0.28.0",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -2577,6 +2578,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,6 +3242,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -4008,6 +4059,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -54,6 +54,7 @@ thiserror = "2"
 time = { version = "0.3", features = ["serde"] }
 tokio = "1"
 tokio-util = "0.7"
+toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 urlencoding = "2"

--- a/services/api-rs/crates/centaur-iron-proxy/Cargo.toml
+++ b/services/api-rs/crates/centaur-iron-proxy/Cargo.toml
@@ -11,3 +11,4 @@ serde_yaml.workspace = true
 sha2.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+toml.workspace = true

--- a/services/api-rs/crates/centaur-iron-proxy/src/error.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/error.rs
@@ -19,6 +19,11 @@ pub enum IronProxyConfigError {
         path: PathBuf,
         source: serde_yaml::Error,
     },
+    #[error("failed to parse tool pyproject {path}: {source}")]
+    ParsePyproject {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
     #[error("failed to parse iron-proxy base yaml: {0}")]
     ParseBase(serde_yaml::Error),
     #[error("failed to serialize iron-proxy yaml: {0}")]

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -4,7 +4,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{IronProxyConfigError, ProxyFragment, Result};
+use serde_yaml::{Mapping, Value};
+use toml::Value as TomlValue;
+
+use crate::{
+    IronProxyConfigError, ProxyFragment, Result, Secret, SecretReplace, Transform, TransformConfig,
+};
 
 const DEFAULT_PROXY_BASE_CONFIG_PATH: &str = "services/api/api/iron-proxy.base.yaml";
 const DEFAULT_INFRA_FRAGMENT_PATH: &str = "services/iron-proxy/infra.yaml";
@@ -21,6 +26,9 @@ pub struct HarnessFragmentFile {
 
 pub fn load_fragment_file(path: impl AsRef<Path>) -> Result<ProxyFragment> {
     let path = path.as_ref();
+    if path.file_name().and_then(|name| name.to_str()) == Some("pyproject.toml") {
+        return load_pyproject_fragment_file(path);
+    }
     let contents = read_file(path)?;
     serde_yaml::from_str(&contents).map_err(|source| IronProxyConfigError::ParseFragment {
         path: path.to_path_buf(),
@@ -112,13 +120,229 @@ fn visit_fragment_dir(dir: &Path, paths: &mut Vec<PathBuf>) -> Result<()> {
             })?;
         if file_type.is_dir() {
             visit_fragment_dir(&path, paths)?;
-        } else if file_type.is_file()
-            && path.file_name().and_then(|name| name.to_str()) == Some("iron.yaml")
-        {
-            paths.push(path);
+        } else if file_type.is_file() {
+            match path.file_name().and_then(|name| name.to_str()) {
+                Some("iron.yaml" | "pyproject.toml") => paths.push(path),
+                _ => {}
+            }
         }
     }
     Ok(())
+}
+
+fn load_pyproject_fragment_file(path: &Path) -> Result<ProxyFragment> {
+    let contents = read_file(path)?;
+    let pyproject: TomlValue =
+        toml::from_str(&contents).map_err(|source| IronProxyConfigError::ParsePyproject {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok(pyproject_fragment(&pyproject))
+}
+
+fn pyproject_fragment(pyproject: &TomlValue) -> ProxyFragment {
+    let Some(centaur) = pyproject
+        .get("tool")
+        .and_then(|tool| tool.get("centaur"))
+        .and_then(TomlValue::as_table)
+    else {
+        return ProxyFragment::default();
+    };
+
+    let default_hosts = string_array(centaur.get("hosts"));
+    let mut http_secrets = Vec::new();
+    let mut oauth_tokens = Vec::new();
+
+    for secret in centaur
+        .get("secrets")
+        .and_then(TomlValue::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(TomlValue::as_table)
+    {
+        match string_field(secret, "type") {
+            Some("http") => {
+                if let Some(parsed) = http_secret_from_tool_config(secret, &default_hosts) {
+                    http_secrets.push(parsed);
+                }
+            }
+            Some("oauth_token") => {
+                if let Some(parsed) = oauth_token_from_tool_config(secret, &default_hosts) {
+                    oauth_tokens.push(parsed);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut transforms = Vec::new();
+    if !http_secrets.is_empty() {
+        transforms.push(Transform {
+            name: "secrets".to_owned(),
+            config: TransformConfig {
+                secrets: http_secrets,
+                ..TransformConfig::default()
+            },
+            ..Transform::default()
+        });
+    }
+    if !oauth_tokens.is_empty() {
+        let mut extra = BTreeMap::new();
+        extra.insert("tokens".to_owned(), Value::Sequence(oauth_tokens));
+        transforms.push(Transform {
+            name: "oauth_token".to_owned(),
+            config: TransformConfig {
+                extra,
+                ..TransformConfig::default()
+            },
+            ..Transform::default()
+        });
+    }
+
+    ProxyFragment {
+        transforms,
+        ..ProxyFragment::default()
+    }
+}
+
+fn http_secret_from_tool_config(
+    secret: &toml::value::Table,
+    default_hosts: &[String],
+) -> Option<Secret> {
+    let proxy_value = string_field(secret, "name")?.to_owned();
+    let hosts = hosts_for_secret(secret, default_hosts);
+    if hosts.is_empty() {
+        return None;
+    }
+
+    let mut replace_extra = BTreeMap::new();
+    for key in ["match_headers", "match_path", "match_query"] {
+        if let Some(value) = secret.get(key).and_then(toml_value_to_yaml) {
+            replace_extra.insert(key.to_owned(), value);
+        }
+    }
+
+    Some(Secret {
+        replace: Some(SecretReplace {
+            proxy_value: Some(proxy_value),
+            extra: replace_extra,
+        }),
+        rules: host_rules(&hosts),
+        ..Secret::default()
+    })
+}
+
+fn oauth_token_from_tool_config(
+    secret: &toml::value::Table,
+    default_hosts: &[String],
+) -> Option<Value> {
+    let token_endpoint = string_field(secret, "token_endpoint")?;
+    let hosts = hosts_for_secret(secret, default_hosts);
+    if hosts.is_empty() {
+        return None;
+    }
+
+    let mut token = Mapping::new();
+    if let Some(grant) = string_field(secret, "grant") {
+        token.insert(string_value("grant"), string_value(grant));
+    }
+    token.insert(string_value("token_endpoint"), string_value(token_endpoint));
+    token.insert(string_value("rules"), Value::Sequence(host_rules(&hosts)));
+
+    if let Some(fields) = secret.get("fields").and_then(TomlValue::as_table) {
+        for (field_name, field_config) in fields {
+            if let Some(source) = oauth_field_source(field_config) {
+                token.insert(string_value(field_name), source);
+            }
+        }
+    }
+
+    Some(Value::Mapping(token))
+}
+
+fn oauth_field_source(field_config: &TomlValue) -> Option<Value> {
+    if let Some(placeholder) = field_config.as_str().and_then(non_empty) {
+        let mut source = Mapping::new();
+        source.insert(string_value("placeholder"), string_value(placeholder));
+        return Some(Value::Mapping(source));
+    }
+
+    let table = field_config.as_table()?;
+    let placeholder =
+        string_field(table, "placeholder").or_else(|| string_field(table, "secret_ref"))?;
+    let mut source = Mapping::new();
+    source.insert(string_value("placeholder"), string_value(placeholder));
+    if let Some(json_key) = string_field(table, "json_key") {
+        source.insert(string_value("json_key"), string_value(json_key));
+    }
+    Some(Value::Mapping(source))
+}
+
+fn hosts_for_secret(secret: &toml::value::Table, default_hosts: &[String]) -> Vec<String> {
+    let hosts = string_array(secret.get("hosts"));
+    if hosts.is_empty() {
+        default_hosts.to_vec()
+    } else {
+        hosts
+    }
+}
+
+fn host_rules(hosts: &[String]) -> Vec<Value> {
+    hosts
+        .iter()
+        .map(|host| {
+            let mut rule = Mapping::new();
+            rule.insert(string_value("host"), string_value(host));
+            Value::Mapping(rule)
+        })
+        .collect()
+}
+
+fn string_array(value: Option<&TomlValue>) -> Vec<String> {
+    value
+        .and_then(TomlValue::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(TomlValue::as_str)
+        .filter_map(non_empty)
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn string_field<'a>(table: &'a toml::value::Table, key: &str) -> Option<&'a str> {
+    table
+        .get(key)
+        .and_then(TomlValue::as_str)
+        .and_then(non_empty)
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn toml_value_to_yaml(value: &TomlValue) -> Option<Value> {
+    match value {
+        TomlValue::String(value) => Some(string_value(value)),
+        TomlValue::Integer(value) => serde_yaml::to_value(value).ok(),
+        TomlValue::Float(value) => serde_yaml::to_value(value).ok(),
+        TomlValue::Boolean(value) => Some(Value::Bool(*value)),
+        TomlValue::Datetime(value) => Some(string_value(value.to_string())),
+        TomlValue::Array(values) => Some(Value::Sequence(
+            values.iter().filter_map(toml_value_to_yaml).collect(),
+        )),
+        TomlValue::Table(values) => {
+            let values = values
+                .iter()
+                .filter_map(|(key, value)| Some((string_value(key), toml_value_to_yaml(value)?)))
+                .collect();
+            Some(Value::Mapping(values))
+        }
+    }
+}
+
+fn string_value(value: impl AsRef<str>) -> Value {
+    Value::String(value.as_ref().to_owned())
 }
 
 fn visit_harness_fragment_dir(dir: &Path, files: &mut Vec<HarnessFragmentFile>) -> Result<()> {

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -141,6 +141,8 @@ fn load_pyproject_fragment_file(path: &Path) -> Result<ProxyFragment> {
 }
 
 fn pyproject_fragment(pyproject: &TomlValue) -> ProxyFragment {
+    // TODO: Convert pyproject tool metadata into yaml fragments eventually so
+    // this path uses the same fragment representation as iron.yaml.
     let Some(centaur) = pyproject
         .get("tool")
         .and_then(|tool| tool.get("centaur"))

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -308,14 +308,24 @@ broker_credentials:
 }
 
 #[test]
-fn discovers_tool_local_iron_yaml_fragments() {
+fn discovers_tool_local_fragments() {
     let root = temp_dir("discover");
     let base_tool = root.join("tools").join("base").join("websearch");
     let overlay_tool = root.join("overlay").join("tools").join("slack");
     fs::create_dir_all(&base_tool).unwrap();
     fs::create_dir_all(&overlay_tool).unwrap();
     fs::write(base_tool.join("iron.yaml"), "transforms: []\n").unwrap();
+    fs::write(
+        base_tool.join("pyproject.toml"),
+        "[project]\nname = \"websearch\"\n",
+    )
+    .unwrap();
     fs::write(overlay_tool.join("iron.yaml"), "transforms: []\n").unwrap();
+    fs::write(
+        overlay_tool.join("pyproject.toml"),
+        "[project]\nname = \"slack\"\n",
+    )
+    .unwrap();
     fs::write(root.join("iron-proxy.yaml"), "transforms: []\n").unwrap();
 
     let discovered = discover_fragment_files(&[root.join("tools"), root.join("overlay")])
@@ -328,9 +338,68 @@ fn discovers_tool_local_iron_yaml_fragments() {
         discovered,
         vec![
             PathBuf::from("overlay/tools/slack/iron.yaml"),
+            PathBuf::from("overlay/tools/slack/pyproject.toml"),
             PathBuf::from("tools/base/websearch/iron.yaml"),
+            PathBuf::from("tools/base/websearch/pyproject.toml"),
         ]
     );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn converts_tool_pyproject_secrets_to_proxy_fragment() {
+    let root = temp_dir("pyproject");
+    let tool_dir = root.join("tools").join("productivity").join("gsuite");
+    fs::create_dir_all(&tool_dir).unwrap();
+    let pyproject = tool_dir.join("pyproject.toml");
+    fs::write(
+        &pyproject,
+        r#"
+[project]
+name = "gsuite"
+
+[tool.centaur]
+hosts = ["gmail.googleapis.com"]
+secrets = [
+  { type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"] },
+  { type = "oauth_token", grant = "refresh_token", name = "GOOGLE_TOKEN_JSON", token_endpoint = "https://oauth2.googleapis.com/token", hosts = ["www.googleapis.com"], fields = { refresh_token = { secret_ref = "GOOGLE_TOKEN_JSON", json_key = "refresh_token" }, client_id = { secret_ref = "GOOGLE_TOKEN_JSON", json_key = "client_id" }, client_secret = { secret_ref = "GOOGLE_TOKEN_JSON", json_key = "client_secret" } } },
+]
+"#,
+    )
+    .unwrap();
+
+    let fragment = load_fragment_file(&pyproject).unwrap();
+    let (_, cfg) = render_cfg(
+        &[fragment],
+        SourcePolicy::onepassword("centaur-agent", "10m"),
+    );
+    let names = transform_names(&cfg);
+    assert!(names.contains(&"secrets"));
+    assert!(names.contains(&"oauth_token"));
+
+    let transforms = cfg["transforms"].as_sequence().unwrap();
+    let secret = &transforms
+        .iter()
+        .find(|transform| transform["name"].as_str() == Some("secrets"))
+        .unwrap()["config"]["secrets"][0];
+    assert_eq!(
+        secret["source"]["secret_ref"],
+        "op://centaur-agent/SLACK_BOT_TOKEN/credential"
+    );
+    assert_eq!(secret["replace"]["match_headers"][0], "Authorization");
+    assert_eq!(secret["rules"][0]["host"], "slack.com");
+
+    let token = &transforms
+        .iter()
+        .find(|transform| transform["name"].as_str() == Some("oauth_token"))
+        .unwrap()["config"]["tokens"][0];
+    assert_eq!(
+        token["refresh_token"]["secret_ref"],
+        "op://centaur-agent/GOOGLE_TOKEN_JSON/credential"
+    );
+    assert_eq!(token["refresh_token"]["json_key"], "refresh_token");
+    assert_eq!(token["rules"][0]["host"], "www.googleapis.com");
 
     fs::remove_dir_all(root).unwrap();
 }


### PR DESCRIPTION
## Summary
- Discover `pyproject.toml` next to `iron.yaml` when loading local tool proxy fragments.
- Convert `[tool.centaur].secrets` HTTP and OAuth token entries into typed `ProxyFragment` transforms.
- Add coverage for fragment discovery and pyproject secret conversion/rendering.

## Tests
- `cd services/api-rs && cargo fmt --all`
- `cd services/api-rs && cargo test -p centaur-iron-proxy`