### PR TITLE
fix: improve sandbox tool smoke behavior

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -173,14 +173,17 @@ impl SandboxArgs {
     }
 
     fn codex_app_server_env_template(&self) -> Vec<(String, String)> {
-        let mut envs = vec![(
-            "CENTAUR_API_URL".to_owned(),
-            self.centaur_api_url_override
-                .as_deref()
-                .or(self.centaur_api_url.as_deref())
-                .unwrap_or("http://api:8000")
-                .to_owned(),
-        )];
+        let mut envs = vec![
+            ("CENTAUR_HARNESS_KIND".to_owned(), "codex".to_owned()),
+            (
+                "CENTAUR_API_URL".to_owned(),
+                self.centaur_api_url_override
+                    .as_deref()
+                    .or(self.centaur_api_url.as_deref())
+                    .unwrap_or("http://api:8000")
+                    .to_owned(),
+            ),
+        ];
 
         for name in &self.passthrough_env {
             let name = name.trim();
@@ -684,10 +687,13 @@ mod tests {
 
         assert_eq!(
             args.sandbox.codex_app_server_env_template(),
-            vec![(
-                "CENTAUR_API_URL".to_owned(),
-                "http://host.docker.internal:8080".to_owned()
-            )]
+            vec![
+                ("CENTAUR_HARNESS_KIND".to_owned(), "codex".to_owned()),
+                (
+                    "CENTAUR_API_URL".to_owned(),
+                    "http://host.docker.internal:8080".to_owned()
+                )
+            ]
         );
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -173,17 +173,14 @@ impl SandboxArgs {
     }
 
     fn codex_app_server_env_template(&self) -> Vec<(String, String)> {
-        let mut envs = vec![
-            ("CENTAUR_HARNESS_KIND".to_owned(), "codex".to_owned()),
-            (
-                "CENTAUR_API_URL".to_owned(),
-                self.centaur_api_url_override
-                    .as_deref()
-                    .or(self.centaur_api_url.as_deref())
-                    .unwrap_or("http://api:8000")
-                    .to_owned(),
-            ),
-        ];
+        let mut envs = vec![(
+            "CENTAUR_API_URL".to_owned(),
+            self.centaur_api_url_override
+                .as_deref()
+                .or(self.centaur_api_url.as_deref())
+                .unwrap_or("http://api:8000")
+                .to_owned(),
+        )];
 
         for name in &self.passthrough_env {
             let name = name.trim();
@@ -687,13 +684,10 @@ mod tests {
 
         assert_eq!(
             args.sandbox.codex_app_server_env_template(),
-            vec![
-                ("CENTAUR_HARNESS_KIND".to_owned(), "codex".to_owned()),
-                (
-                    "CENTAUR_API_URL".to_owned(),
-                    "http://host.docker.internal:8080".to_owned()
-                )
-            ]
+            vec![(
+                "CENTAUR_API_URL".to_owned(),
+                "http://host.docker.internal:8080".to_owned()
+            )]
         );
     }
 

--- a/tools/crypto/coindesk/client.py
+++ b/tools/crypto/coindesk/client.py
@@ -29,7 +29,7 @@ class CoinDeskClient:
             "User-Agent": self.USER_AGENT,
             "Accept": "application/rss+xml, application/xml, text/xml, */*",
             "Accept-Language": "en-US,en;q=0.9",
-            "Accept-Encoding": "gzip, deflate, br",
+            "Accept-Encoding": "gzip, deflate",
             "Referer": "https://www.coindesk.com/",
         }
         try:

--- a/tools/crypto/messari/cli.py
+++ b/tools/crypto/messari/cli.py
@@ -49,7 +49,9 @@ def assets(
     markdown: bool = typer.Option(False, "--markdown", "-m", help="Output as markdown table"),
 ):
     """List crypto assets."""
-    data = get_client().list_assets(limit=limit, fields=fields)
+    if fields:
+        console.print("[yellow]--fields is ignored by the current Messari metrics endpoint[/]")
+    data = get_client().list_assets(limit=limit)
 
     if json_output:
         print(json.dumps(data, indent=2))
@@ -331,7 +333,7 @@ def raw(
         print(json.dumps(data, indent=2))
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 if __name__ == "__main__":

--- a/tools/crypto/messari/client.py
+++ b/tools/crypto/messari/client.py
@@ -6,8 +6,8 @@ import httpx
 
 from centaur_sdk import secret
 
-BASE_URL_V1 = "https://data.messari.io/api/v1"
-BASE_URL_V2 = "https://data.messari.io/api/v2"
+BASE_URL_V1 = "https://api.messari.io/metrics/v1"
+BASE_URL_V2 = "https://api.messari.io/metrics/v2"
 
 
 class MessariClient:
@@ -22,7 +22,9 @@ class MessariClient:
             timeout=30.0,
         )
 
-    def _request(self, endpoint: str, version: int = 1, params: dict | None = None) -> dict[str, Any]:
+    def _request(
+        self, endpoint: str, version: int = 1, params: dict | None = None
+    ) -> dict[str, Any]:
         """Make request to Messari API."""
         base_url = BASE_URL_V1 if version == 1 else BASE_URL_V2
         url = f"{base_url}{endpoint}"
@@ -37,33 +39,30 @@ class MessariClient:
         return response.json()
 
     def list_assets(self, asset_key: str = "bitcoin", limit: int = 20) -> list[dict]:
-        """Get asset metrics (list endpoint deprecated, returns single asset metrics).
-
-        Note: The old /assets list endpoint has been disabled on data.messari.io.
-        This now returns metrics for a single asset as a workaround.
-        """
-        data = self._request(f"/assets/{asset_key}/metrics", version=1)
-        result = data.get("data", {})
-        return [result] if result else []
+        """List assets from the current Messari Metrics API."""
+        _ = asset_key
+        data = self._request("/assets", version=1, params={"limit": limit})
+        result = data.get("data", [])
+        return result if isinstance(result, list) else []
 
     def get_asset(self, asset_key: str) -> dict:
-        """Get asset metrics by slug (profile endpoint deprecated)."""
-        data = self._request(f"/assets/{asset_key}/metrics", version=1)
+        """Get asset details by slug or ID."""
+        data = self._request(f"/assets/{asset_key}", version=1)
         return data.get("data", {})
 
     def get_asset_metrics(self, asset_key: str) -> dict:
         """Get metrics for an asset."""
-        data = self._request(f"/assets/{asset_key}/metrics", version=1)
+        data = self._request(f"/assets/{asset_key}", version=1)
         return data.get("data", {})
 
     def get_asset_profile(self, asset_key: str) -> dict:
-        """Get asset metrics (profile endpoint deprecated, returns metrics instead)."""
-        data = self._request(f"/assets/{asset_key}/metrics", version=1)
+        """Get asset details; profile fields depend on Messari subscription tier."""
+        data = self._request(f"/assets/{asset_key}", version=1)
         return data.get("data", {})
 
     def get_asset_markets(self, asset_key: str) -> dict:
-        """Get asset metrics (markets endpoint deprecated, returns metrics instead)."""
-        data = self._request(f"/assets/{asset_key}/metrics", version=1)
+        """Get asset details; market fields depend on Messari subscription tier."""
+        data = self._request(f"/assets/{asset_key}", version=1)
         return data.get("data", {})
 
     def get_news(self, limit: int = 10) -> dict:
@@ -72,7 +71,7 @@ class MessariClient:
         Note: The /news endpoint has been disabled on data.messari.io.
         Returns bitcoin metrics as a fallback.
         """
-        data = self._request("/assets/bitcoin/metrics", version=1)
+        data = self._request("/assets/bitcoin", version=1)
         return data.get("data", {})
 
     def get_timeseries(
@@ -93,9 +92,7 @@ class MessariClient:
         )
         return data.get("data", {})
 
-    def raw_request(
-        self, endpoint: str, version: int = 1, params: dict | None = None
-    ) -> dict:
+    def raw_request(self, endpoint: str, version: int = 1, params: dict | None = None) -> dict:
         """Make a raw API call to any endpoint."""
         return self._request(endpoint, version=version, params=params)
 

--- a/tools/crypto/messari/pyproject.toml
+++ b/tools/crypto/messari/pyproject.toml
@@ -20,4 +20,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "MESSARI_API_KEY", match_headers = ["x-messari-api-key"], hosts = ["data.messari.io"]}]
+secrets = [{type = "http", name = "MESSARI_API_KEY", match_headers = ["x-messari-api-key"], hosts = ["api.messari.io"]}]

--- a/tools/crypto/theblock/client.py
+++ b/tools/crypto/theblock/client.py
@@ -1,5 +1,6 @@
 """The Block RSS client."""
 
+import re
 import subprocess
 
 import feedparser
@@ -9,6 +10,7 @@ class TheBlockClient:
     """Client for The Block RSS feed."""
 
     RSS_URL = "https://www.theblock.co/rss.xml"
+    READER_URL = f"https://r.jina.ai/http://{RSS_URL}"
     USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
     def __init__(self, timeout: float = 30.0):
@@ -33,24 +35,70 @@ class TheBlockClient:
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to fetch feed: curl returned {result.returncode}")
             content = result.stdout
-        except FileNotFoundError:
+        except FileNotFoundError as exc:
             feed = feedparser.parse(
                 self.RSS_URL,
                 request_headers={"User-Agent": self.USER_AGENT},
             )
             if feed.bozo and not feed.entries:
-                raise RuntimeError(f"Failed to fetch feed: {feed.bozo_exception}")
+                raise RuntimeError(f"Failed to fetch feed: {feed.bozo_exception}") from exc
             return self._parse_entries(feed.entries)
-        except subprocess.TimeoutExpired:
-            raise RuntimeError("Request timed out")
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("Request timed out") from exc
 
         feed = feedparser.parse(content)
         if feed.bozo and not feed.entries:
+            fallback = self._fetch_reader_feed()
+            if fallback:
+                return fallback
             raise RuntimeError(
                 "Failed to parse feed. The Block may be blocking automated requests."
             )
 
         return self._parse_entries(feed.entries)
+
+    def _fetch_reader_feed(self) -> list[dict]:
+        """Fetch The Block through Jina Reader when direct RSS parsing is blocked."""
+        try:
+            result = subprocess.run(
+                [
+                    "curl",
+                    "-s",
+                    "-A",
+                    self.USER_AGENT,
+                    "--compressed",
+                    self.READER_URL,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return []
+        if result.returncode != 0:
+            return []
+        return self._parse_reader_markdown(result.stdout)
+
+    def _parse_reader_markdown(self, content: str) -> list[dict]:
+        articles = []
+        seen = set()
+        for match in re.finditer(r"\[([^\]]+)\]\((https://www\.theblock\.co/[^)]+)\)", content):
+            title = re.sub(r"\s+", " ", match.group(1)).strip()
+            link = match.group(2).strip()
+            key = (title, link)
+            if not title or key in seen:
+                continue
+            seen.add(key)
+            articles.append(
+                {
+                    "title": title,
+                    "link": link,
+                    "published": "",
+                    "summary": "",
+                    "author": "",
+                }
+            )
+        return articles
 
     def _parse_entries(self, entries: list) -> list[dict]:
         """Parse feed entries into article dicts."""

--- a/tools/infra/posthog/client.py
+++ b/tools/infra/posthog/client.py
@@ -7,8 +7,14 @@ import httpx
 from centaur_sdk import secret
 
 
-class PostHogClient:
+def _is_placeholder_secret(value: str | None, name: str) -> bool:
+    if not value:
+        return True
+    stripped = value.strip()
+    return stripped == name or stripped.startswith(("__CENTAUR_", "CENTAUR_SECRET_"))
 
+
+class PostHogClient:
     """Client for PostHog API.
 
     Uses HogQL queries for flexible analytics. Requires a personal API key
@@ -55,12 +61,25 @@ class PostHogClient:
     @property
     def project_id(self) -> str:
         """Get project ID from instance or env var."""
-        if self._project_id:
+        if self._project_id and not _is_placeholder_secret(self._project_id, "POSTHOG_PROJECT_ID"):
             return self._project_id
         pid = secret("POSTHOG_PROJECT_ID", "")
-        if pid:
+        if not _is_placeholder_secret(pid, "POSTHOG_PROJECT_ID"):
+            self._project_id = pid
             return pid
-        raise RuntimeError("POSTHOG_PROJECT_ID not set.")
+        self._project_id = self._discover_project_id()
+        return self._project_id
+
+    def _discover_project_id(self) -> str:
+        """Use the first project visible to the API key when no project id is configured."""
+        payload = self._request("GET", "/api/projects/")
+        results = payload.get("results") if isinstance(payload, dict) else None
+        if not results:
+            raise RuntimeError("POSTHOG_PROJECT_ID not set and no PostHog projects were visible.")
+        project_id = results[0].get("id")
+        if project_id is None:
+            raise RuntimeError("POSTHOG_PROJECT_ID not set and project discovery returned no id.")
+        return str(project_id)
 
     @property
     def host(self) -> str:
@@ -104,9 +123,9 @@ class PostHogClient:
             response.raise_for_status()
             return response.json()
         except httpx.HTTPStatusError as e:
-            raise RuntimeError(f"API error: {e.response.status_code} - {e.response.text}")
+            raise RuntimeError(f"API error: {e.response.status_code} - {e.response.text}") from e
         except httpx.RequestError as e:
-            raise RuntimeError(f"Request failed: {e}")
+            raise RuntimeError(f"Request failed: {e}") from e
 
     def query(self, sql: str, name: str | None = None) -> dict:
         """Execute a HogQL query.
@@ -278,7 +297,6 @@ class PostHogClient:
 
     def __exit__(self, *args):
         self.close()
-
 
 
 def _client() -> PostHogClient:


### PR DESCRIPTION
## Summary
- Fix remaining smoke failures in Python tools: CoinDesk compression, Messari endpoint/CLI mismatch, The Block RSS fallback, and PostHog placeholder project IDs.
- Keep the latest `api-rs-control-plane` shape: the old Rust `centaur-tools` crate hunk is not reintroduced because that crate is no longer present on this base.

## Tests
- `uv run ruff format tools/crypto/coindesk/client.py tools/crypto/messari/cli.py tools/crypto/messari/client.py tools/crypto/theblock/client.py tools/infra/posthog/client.py`
- `uv run ruff check tools/crypto/coindesk/client.py tools/crypto/messari/cli.py tools/crypto/messari/client.py tools/crypto/theblock/client.py tools/infra/posthog/client.py`
- `python3 -m py_compile tools/crypto/coindesk/client.py tools/crypto/messari/cli.py tools/crypto/messari/client.py tools/crypto/theblock/client.py tools/infra/posthog/client.py`
- lightweight parser/runtime smoke for CoinDesk, The Block, Messari defaults, and PostHog placeholder handling
- `python -m messari.cli assets --help` with local PYTHONPATH/deps
- `cd services/api-rs && cargo test -p centaur-api-server` after removing the unused env-marker hunk