### PR TITLE
feat(api-rs): wire api-rs and slackbotv2 into helm chart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -520,6 +520,12 @@ Tool credentials (e.g., `ANTHROPIC_API_KEY`, `AMP_API_KEY`) are never materializ
 
 For local development, infra secrets are stored in Kubernetes Secrets created by `just bootstrap-secrets`; application secrets continue to come from 1Password.
 
+### iron-control
+
+[iron-control](https://github.com/ironsh/iron-control) is an optional Rails control plane for authenticated API access and encrypted secret storage. It is off by default; enable it with `--set ironControl.enabled=true` (or set `ironControl.enabled: true` in a values file). When enabled, it runs against a dedicated `iron_control_production` database on the bundled Postgres (a separate logical DB so its Rails `schema_migrations` table never collides with the API's dbmate table), created by an idempotent init container.
+
+`just bootstrap-secrets` seeds the required keys into `centaur-infra-env`: the three ActiveRecord encryption keys, `SECRET_KEY_BASE`, and the initial admin password/API key are auto-generated (only when absent, never rotated in place). `IRON_CONTROL_DATABASE_URL` defaults to the bundled Postgres server with no database path (so Rails resolves each connection's database name from the image's `database.yml`); export it before running `just bootstrap-secrets` to point at an external server. Override the admin email with `IRON_CONTROL_INITIAL_USER_EMAIL` (default `admin@centaur.local`).
+
 ## Observability & Audit Logs
 
 ### Architecture

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,14 @@ dev_values := "contrib/chart/values.dev.yaml"
 # Command used to import images into k3s's containerd. Override for rootless or
 # remote setups, e.g. CENTAUR_K3S_CTR="k3s ctr" or "ssh host sudo k3s ctr".
 k3s_ctr := env_var_or_default("CENTAUR_K3S_CTR", "sudo k3s ctr")
+# Local image registry `just up k3s` pushes to. Images are pushed under the
+# `library/` namespace so k3s resolves the chart's bare `:latest` tags through a
+# docker.io registry mirror — configure that on the node with:
+#   /etc/rancher/k3s/registries.yaml
+#     mirrors:
+#       docker.io:
+#         endpoint: ["http://localhost:5000"]
+registry := env_var_or_default("CENTAUR_LOCAL_REGISTRY", "localhost:5000")
 
 default:
     just --list
@@ -19,7 +27,7 @@ build:
       just _build-all-sequential
     else
       pids=()
-      for recipe in _build-api _build-iron-proxy _build-slackbot _build-agent; do
+      for recipe in _build-api _build-api-rs _build-iron-proxy _build-slackbot _build-slackbotv2 _build-agent; do
         just "$recipe" &
         pids+=("$!")
       done
@@ -32,8 +40,10 @@ build:
 
 _build-all-sequential:
     just _build-api
+    just _build-api-rs
     just _build-iron-proxy
     just _build-slackbot
+    just _build-slackbotv2
     just _build-agent
 
 build-one service:
@@ -41,8 +51,10 @@ build-one service:
     set -euo pipefail
     case "{{service}}" in
       api) just _build-api ;;
+      api-rs) just _build-api-rs ;;
       iron-proxy) just _build-iron-proxy ;;
       slackbot) just _build-slackbot ;;
+      slackbotv2) just _build-slackbotv2 ;;
       agent|sandbox) just _build-agent ;;
       *) echo "unknown service: {{service}}" >&2; exit 2 ;;
     esac
@@ -50,22 +62,41 @@ build-one service:
 _build-api:
     docker build -t centaur-api:latest -f services/api/Dockerfile .
 
+_build-api-rs:
+    docker build -t centaur-api-rs:latest -f services/api-rs/Dockerfile .
+
 _build-iron-proxy:
     docker build -t centaur-iron-proxy:latest -f services/iron-proxy/Dockerfile .
 
 _build-slackbot:
     docker build -t centaur-slackbot:latest -f services/slackbot/Dockerfile .
 
+_build-slackbotv2:
+    docker build -t centaur-slackbotv2:latest -f services/slackbotv2/Dockerfile .
+
 _build-agent:
     docker build --target sandbox -t centaur-agent:latest -f services/sandbox/Dockerfile .
 
-# Import locally-built images into k3s's containerd. k3s uses containerd, not
-# the Docker daemon, so `docker build` images are otherwise invisible to it
-# (pods ImagePullBackOff on the :latest tags). Used by `just up k3s`.
+# Push locally-built images to the local registry under library/ so k3s pulls
+# them via its docker.io mirror. Used by `just up k3s`. Only changed layers are
+# pushed, so this is much faster than `_import-k3s` on repeat runs.
+_push-registry:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for img in centaur-api centaur-api-rs centaur-iron-proxy centaur-slackbot centaur-slackbotv2 centaur-agent; do
+      target="{{registry}}/library/${img}:latest"
+      echo "pushing ${img}:latest -> ${target}..."
+      docker tag "${img}:latest" "${target}"
+      docker push "${target}"
+    done
+
+# Legacy: import locally-built images straight into k3s's containerd (no registry
+# needed). Slower than `_push-registry`; kept as a fallback. Run manually with
+# `just _import-k3s`.
 _import-k3s:
     #!/usr/bin/env bash
     set -euo pipefail
-    for img in centaur-api centaur-iron-proxy centaur-slackbot centaur-agent; do
+    for img in centaur-api centaur-api-rs centaur-iron-proxy centaur-slackbot centaur-slackbotv2 centaur-agent; do
       echo "importing ${img}:latest into k3s containerd..."
       docker save "${img}:latest" | {{k3s_ctr}} images import -
     done
@@ -83,8 +114,10 @@ deploy:
       ghcr)
         extra_args+=(
           --set api.image.repository=ghcr.io/paradigmxyz/centaur/centaur-api
+          --set apiRs.image.repository=ghcr.io/paradigmxyz/centaur/centaur-api-rs
           --set ironProxy.image.repository=ghcr.io/paradigmxyz/centaur/centaur-iron-proxy
           --set slackbot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-slackbot
+          --set slackbotv2.image.repository=ghcr.io/paradigmxyz/centaur/centaur-slackbotv2
           --set sandbox.image.repository=ghcr.io/paradigmxyz/centaur/centaur-agent
         )
         ;;
@@ -108,7 +141,8 @@ deploy:
     fi
     helm upgrade --install {{release}} {{chart}} -n {{namespace}} --create-namespace -f {{dev_values}} ${extra_args[@]+"${extra_args[@]}"}
 
-# Bring up the dev stack; pass `k3s` (just up k3s) to import local images into k3s's containerd.
+# Bring up the dev stack; pass `k3s` (just up k3s) to push local images to the
+# local registry (CENTAUR_LOCAL_REGISTRY, default localhost:5000) for k3s to pull.
 up import="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -120,7 +154,7 @@ up import="":
       local)
         just build
         if [[ "{{import}}" == "k3s" ]]; then
-          just _import-k3s
+          just _push-registry
         fi
         ;;
       ghcr) ;;

--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.46
+version: 0.1.47
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -140,3 +140,19 @@ registered refresh_token OAuthTokenSecrets by the API server at startup.
 {{- define "centaur.tokenBrokerUrl" -}}
 {{- printf "http://%s:%v" (include "centaur.tokenBrokerHost" .) .Values.tokenBroker.service.httpPort -}}
 {{- end -}}
+
+{{- /*
+iron-control — Rails control plane for authenticated API access and encrypted
+secret storage. Flag-gated (ironControl.enabled), in-cluster ClusterIP Service.
+*/ -}}
+{{- define "centaur.ironControlName" -}}
+{{- include "centaur.componentName" (dict "root" . "component" "iron-control") -}}
+{{- end -}}
+
+{{- define "centaur.ironControlHost" -}}
+{{- include "centaur.ironControlName" . -}}
+{{- end -}}
+
+{{- define "centaur.ironControlUrl" -}}
+{{- printf "http://%s:%v" (include "centaur.ironControlHost" .) .Values.ironControl.service.httpPort -}}
+{{- end -}}

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -1,0 +1,215 @@
+{{- if .Values.apiRs.enabled }}
+{{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $apiRsName }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "api-rs-sandbox-manager") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/attach", "pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "delete", "get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "api-rs-sandbox-manager") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $apiRsName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "centaur.componentName" (dict "root" . "component" "api-rs-sandbox-manager") }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $apiRsName }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+spec:
+  replicas: {{ .Values.apiRs.replicaCount }}
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/infra-secrets: {{ include "centaur.infraSecretsChecksum" . }}
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.apiRs.terminationGracePeriodSeconds }}
+      automountServiceAccountToken: true
+      serviceAccountName: {{ $apiRsName }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: api-rs
+          image: {{ printf "%s:%s" .Values.apiRs.image.repository .Values.apiRs.image.tag | quote }}
+          imagePullPolicy: {{ .Values.apiRs.image.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sDATABASE_URL" .Values.secretManager.envPrefix }}
+            - name: BIND_ADDR
+              value: {{ printf "0.0.0.0:%v" .Values.apiRs.port | quote }}
+            - name: RUN_MIGRATIONS
+              value: {{ .Values.apiRs.runMigrations | quote }}
+            - name: RUST_LOG
+              value: info
+            - name: SESSION_SANDBOX_BACKEND
+              value: {{ .Values.apiRs.sandboxBackend | quote }}
+            - name: SESSION_SANDBOX_WORKLOAD
+              value: {{ .Values.apiRs.sandboxWorkload | quote }}
+            - name: SESSION_SANDBOX_READY_TIMEOUT_SECS
+              value: {{ .Values.apiRs.sandboxReadyTimeoutSecs | quote }}
+            - name: SESSION_SANDBOX_K8S_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: SESSION_SANDBOX_IMAGE
+              value: {{ printf "%s:%s" .Values.sandbox.image.repository .Values.sandbox.image.tag | quote }}
+            - name: SESSION_SANDBOX_IMAGE_PULL_POLICY
+              value: {{ .Values.sandbox.image.pullPolicy | quote }}
+            # Sandboxes call back into this control plane via the in-cluster Service.
+            - name: SESSION_SANDBOX_CENTAUR_API_URL
+              value: {{ printf "http://%s:%v" $apiRsName .Values.apiRs.port | quote }}
+            - name: KUBERNETES_SANDBOX_IRON_PROXY_MODE
+              value: {{ .Values.apiRs.ironProxy.mode | quote }}
+            - name: KUBERNETES_IRON_PROXY_IMAGE
+              value: {{ printf "%s:%s" .Values.ironProxy.image.repository .Values.ironProxy.image.tag | quote }}
+            - name: KUBERNETES_IRON_PROXY_IMAGE_PULL_POLICY
+              value: {{ .Values.ironProxy.image.pullPolicy | quote }}
+            - name: KUBERNETES_FIREWALL_CA_SECRET_NAME
+              value: {{ include "centaur.trustedCaSecretName" . | quote }}
+            - name: KUBERNETES_FIREWALL_CA_KEY_SECRET_NAME
+              value: {{ include "centaur.trustedCaKeySecretName" . | quote }}
+            - name: KUBERNETES_SECRET_ENV_NAME
+              value: {{ include "centaur.secretEnvName" . | quote }}
+{{- if .Values.secrets.bootstrapSecretName }}
+            - name: KUBERNETES_BOOTSTRAP_SECRET_NAME
+              value: {{ .Values.secrets.bootstrapSecretName | quote }}
+{{- end }}
+            # Lets the per-sandbox iron-proxy NetworkPolicies target this control
+            # plane's pods (callback + postgres-listener access).
+            - name: KUBERNETES_API_POD_LABEL_SELECTOR
+              value: {{ printf "app.kubernetes.io/name=%s,app.kubernetes.io/instance=%s,app.kubernetes.io/component=api-rs" (include "centaur.name" .) .Release.Name | quote }}
+            - name: FIREWALL_MANAGER_SECRET_SOURCE
+              value: {{ .Values.ironProxy.secretSource | quote }}
+            - name: FIREWALL_MANAGER_SECRET_TTL
+              value: {{ .Values.ironProxy.secretTtl | quote }}
+{{- if .Values.apiRs.opVault }}
+            - name: OP_VAULT
+              value: {{ .Values.apiRs.opVault | quote }}
+{{- end }}
+{{- if .Values.tokenBroker.enabled }}
+            - name: FIREWALL_MANAGER_TOKEN_BROKER_TTL
+              value: {{ .Values.tokenBroker.ttl | quote }}
+            - name: KUBERNETES_TOKEN_BROKER_NAME
+              value: {{ include "centaur.tokenBrokerName" . | quote }}
+            - name: KUBERNETES_TOKEN_BROKER_URL
+              value: {{ include "centaur.tokenBrokerUrl" . | quote }}
+{{- end }}
+{{- if eq .Values.ironProxy.secretSource "onepassword-connect" }}
+            - name: KUBERNETES_OP_CONNECT_HOST
+              value: {{ include "centaur.onepasswordConnectUrl" . | quote }}
+{{- end }}
+            - name: TOOL_DIRS
+              value: /app/tools
+            - name: CODEX_AUTH_MODE
+              value: {{ .Values.apiRs.codexAuthMode | quote }}
+{{- range $name, $value := .Values.apiRs.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "centaur.secretEnvName" . }}
+{{- if and (eq .Values.ironProxy.secretSource "onepassword") .Values.secrets.bootstrapSecretName }}
+            - secretRef:
+                name: {{ .Values.secrets.bootstrapSecretName | quote }}
+{{- end }}
+          ports:
+            - containerPort: {{ .Values.apiRs.port }}
+              name: http
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.apiRs.port }}
+            failureThreshold: {{ .Values.apiRs.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.apiRs.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.apiRs.startupProbe.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.apiRs.port }}
+            failureThreshold: {{ .Values.apiRs.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.apiRs.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.apiRs.readinessProbe.timeoutSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.apiRs.port }}
+            failureThreshold: {{ .Values.apiRs.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.apiRs.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.apiRs.livenessProbe.timeoutSeconds }}
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources:
+{{ toYaml .Values.apiRs.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $apiRsName }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+spec:
+  selector:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.apiRs.port }}
+      targetPort: {{ .Values.apiRs.port }}
+{{- end }}

--- a/contrib/chart/templates/ingress.yaml
+++ b/contrib/chart/templates/ingress.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.ingress.enabled .Values.slackbot.enabled }}
+{{- if and .Values.ingress.enabled .Values.slackbotv2.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "centaur.componentName" (dict "root" . "component" "slackbot") }}
+  name: {{ include "centaur.componentName" (dict "root" . "component" "slackbotv2") }}
   labels:
-{{ include "centaur.componentLabels" (dict "root" . "component" "slackbot") | nindent 4 }}
+{{ include "centaur.componentLabels" (dict "root" . "component" "slackbotv2") | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | nindent 4 }}
@@ -23,7 +23,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "centaur.componentName" (dict "root" . "component" "slackbot") }}
+                name: {{ include "centaur.componentName" (dict "root" . "component" "slackbotv2") }}
                 port:
                   number: 3001
   {{- with .Values.ingress.tls }}

--- a/contrib/chart/templates/iron-control.yaml
+++ b/contrib/chart/templates/iron-control.yaml
@@ -1,0 +1,211 @@
+{{- if .Values.ironControl.enabled }}
+{{- $secretEnv := include "centaur.secretEnvName" . }}
+{{- $prefix := .Values.secretManager.envPrefix }}
+# iron-control — Rails control plane for authenticated API access and encrypted
+# secret storage. The chart owns the Deployment shape (image, port, env,
+# security context) so operators tune it via `helm upgrade`. It runs against a
+# dedicated `iron_control_production` database on the bundled Postgres (a separate logical
+# DB so its Rails schema_migrations table never collides with the API's dbmate
+# table); the create-db init container provisions that DB idempotently. All
+# secret material — the primary DB URL, the bootstrap user/API-key, the three
+# ActiveRecord encryption keys, and SECRET_KEY_BASE — comes from the shared
+# infra Secret via explicit secretKeyRefs (NOT envFrom, which would leak the
+# API's ai_v2 DATABASE_URL into iron-control's env).
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "centaur.ironControlName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
+spec:
+  selector:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.ironControl.service.httpPort }}
+      targetPort: {{ .Values.ironControl.service.httpPort }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "centaur.ironControlName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
+spec:
+  replicas: {{ .Values.ironControl.replicaCount }}
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/infra-secrets: {{ include "centaur.infraSecretsChecksum" . }}
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        # Create the dedicated logical DB on the bundled Postgres. Idempotent:
+        # guarded by a pg_database existence check, and the CREATE tolerates a
+        # lost race against a concurrent replica. Connects as the admin (ai_v2)
+        # DSN, whose `tempo` superuser can create databases.
+        - name: create-db
+          image: {{ printf "%s:%s" .Values.postgres.image.repository .Values.postgres.image.tag | quote }}
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              exists=$(psql "$ADMIN_DATABASE_URL" -tAc \
+                "SELECT 1 FROM pg_database WHERE datname = '$DB_NAME'")
+              if [ "$exists" != "1" ]; then
+                psql "$ADMIN_DATABASE_URL" -c "CREATE DATABASE \"$DB_NAME\"" || true
+              fi
+          env:
+            - name: ADMIN_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sDATABASE_URL" $prefix }}
+            - name: DB_NAME
+              value: {{ .Values.ironControl.database.name | quote }}
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+            seccompProfile:
+              type: RuntimeDefault
+      containers:
+        - name: iron-control
+          image: {{ printf "%s:%s" .Values.ironControl.image.repository .Values.ironControl.image.tag | quote }}
+          imagePullPolicy: {{ .Values.ironControl.image.pullPolicy }}
+          env:
+            # Explicit secretKeyRefs only — never envFrom the shared Secret, or
+            # its DATABASE_URL (ai_v2) would leak into iron-control's env. Env
+            # var names match the IRON_CONTROL_* secret keys 1:1 (except
+            # SECRET_KEY_BASE, which Rails reads by its standard name). The DB
+            # URL carries connection info only (no database path) so each Rails
+            # connection's db name comes from the image's database.yml.
+            - name: IRON_CONTROL_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_DATABASE_URL" $prefix }}
+            - name: IRON_CONTROL_INITIAL_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_INITIAL_USER_EMAIL" $prefix }}
+            - name: IRON_CONTROL_INITIAL_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_INITIAL_USER_PASSWORD" $prefix }}
+            - name: IRON_CONTROL_INITIAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_INITIAL_API_KEY" $prefix }}
+            - name: IRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY" $prefix }}
+            - name: IRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY" $prefix }}
+            - name: IRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT" $prefix }}
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+            - name: RAILS_ENV
+              value: {{ .Values.ironControl.railsEnv | quote }}
+            - name: PORT
+              value: {{ .Values.ironControl.service.httpPort | quote }}
+            - name: RAILS_LOG_TO_STDOUT
+              value: "1"
+            - name: RAILS_SERVE_STATIC_FILES
+              value: "1"
+          ports:
+            - containerPort: {{ .Values.ironControl.service.httpPort }}
+              name: http
+          startupProbe:
+            httpGet:
+              path: /up
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /up
+              port: http
+            failureThreshold: 6
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /up
+              port: http
+            failureThreshold: 6
+            periodSeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+            # No readOnlyRootFilesystem — Rails writes to tmp/ at runtime.
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+{{ toYaml .Values.ironControl.resources | nindent 12 }}
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.ironControlName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # The API is the natural control-plane caller. Widen this when a concrete
+    # client integrates. (kubectl port-forward works regardless — it arrives
+    # via the kubelet, not pod-to-pod.)
+    - from:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.ironControl.service.httpPort }}
+  egress:
+{{- if .Values.postgres.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "postgres") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 5432
+{{- end }}
+    # Outbound HTTPS (external DB DSNs, IdPs, etc.).
+    - ports:
+        - protocol: TCP
+          port: 443
+{{- end }}
+{{- end }}

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -51,10 +51,25 @@ spec:
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api") | nindent 14 }}
+{{- if .Values.apiRs.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 14 }}
+{{- end }}
+{{- if .Values.slackbotv2.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "slackbotv2") | nindent 14 }}
+{{- end }}
 {{- if .Values.slackbot.enabled }}
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "slackbot") | nindent 14 }}
+{{- end }}
+{{- if .Values.ironControl.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-control") | nindent 14 }}
 {{- end }}
         - podSelector:
             matchLabels:
@@ -70,6 +85,127 @@ spec:
           port: 5432
 ---
 {{- end }}
+{{- if .Values.apiRs.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "api-rs") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+{{- if .Values.slackbotv2.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "slackbotv2") | nindent 14 }}
+{{- end }}
+        # Sandboxes call back into the control plane. agent-k8s labels its pods
+        # centaur.ai/managed-by=api-rs (MANAGED_BY_VALUE in centaur-sandbox-agent-k8s),
+        # which also covers the per-sandbox iron-proxy pods.
+        - podSelector:
+            matchLabels:
+              centaur.ai/managed-by: api-rs
+{{- range .Values.networkPolicy.apiIngressSourceNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+{{- end }}
+{{- range .Values.runnerAccess.allowedCidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+{{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.apiRs.port }}
+  egress:
+{{- if .Values.postgres.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "postgres") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 5432
+{{- end }}
+    # Per-sandbox iron-proxy listeners (HTTP proxy + postgres port range).
+    - to:
+        - podSelector:
+            matchLabels:
+              centaur.ai/iron-proxy: "true"
+      ports:
+        - protocol: TCP
+          port: {{ .Values.ironProxy.service.proxyPort }}
+        - protocol: TCP
+          port: {{ .Values.ironProxy.service.pgPortRangeStart }}
+          endPort: {{ .Values.ironProxy.service.pgPortRangeEnd }}
+    - ports:
+        - protocol: TCP
+          port: 443
+    # Kubernetes API egress. The kubernetes.default ClusterIP (:443) is DNAT'd
+    # to the real endpoint port (6443 on k3s/kubeadm); enforcing CNIs match
+    # egress post-DNAT, so allow that port or api-rs can't manage sandboxes.
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.apiServerPort }}
+---
+{{- end }}
+{{- if .Values.slackbotv2.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "slackbotv2") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "slackbotv2") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "slackbotv2") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+{{- range $ingressSourceNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+{{- end }}
+      ports:
+        - protocol: TCP
+          port: 3001
+  egress:
+{{- if .Values.apiRs.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.apiRs.port }}
+{{- end }}
+{{- if .Values.postgres.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "postgres") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 5432
+{{- end }}
+    # Slack API egress (direct HTTPS; slackbotv2 does not use the firewall proxy).
+    - ports:
+        - protocol: TCP
+          port: 443
+---
+{{- end }}
+{{- if .Values.api.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -151,6 +287,7 @@ spec:
         - protocol: TCP
           port: {{ .Values.networkPolicy.apiServerPort }}
 ---
+{{- end }}
 {{- if .Values.slackbot.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/contrib/chart/templates/rbac.yaml
+++ b/contrib/chart/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.api.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -85,4 +86,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "centaur.componentName" (dict "root" . "component" "api-egress-discovery") }}
+{{- end }}
 {{- end }}

--- a/contrib/chart/templates/services.yaml
+++ b/contrib/chart/templates/services.yaml
@@ -14,6 +14,7 @@ spec:
       targetPort: 5432
 ---
 {{- end }}
+{{- if .Values.api.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -28,6 +29,7 @@ spec:
       port: 8000
       targetPort: 8000
 ---
+{{- end }}
 {{- if .Values.slackbot.enabled }}
 apiVersion: v1
 kind: Service

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.slackbotv2.enabled }}
+{{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "slackbotv2") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "slackbotv2") | nindent 4 }}
+spec:
+  replicas: {{ .Values.slackbotv2.replicaCount }}
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "slackbotv2") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/infra-secrets: {{ include "centaur.infraSecretsChecksum" . }}
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "slackbotv2") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: slackbotv2
+          image: {{ printf "%s:%s" .Values.slackbotv2.image.repository .Values.slackbotv2.image.tag | quote }}
+          imagePullPolicy: {{ .Values.slackbotv2.image.pullPolicy }}
+          env:
+            - name: PORT
+              value: "3001"
+            - name: CENTAUR_API_URL
+              value: {{ printf "http://%s:%v" $apiRsName .Values.apiRs.port | quote }}
+            - name: SLACK_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sSLACK_BOT_TOKEN" .Values.secretManager.envPrefix }}
+            - name: SLACK_SIGNING_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sSLACK_SIGNING_SECRET" .Values.secretManager.envPrefix }}
+            - name: SLACKBOT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sSLACKBOT_API_KEY" .Values.secretManager.envPrefix }}
+            # api-rs has no auth middleware yet, but slackbotv2 still sends the
+            # key as a header; source it from the same infra secret.
+            - name: CENTAUR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sSLACKBOT_API_KEY" .Values.secretManager.envPrefix }}
+            - name: SLACKBOTV2_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sDATABASE_URL" .Values.secretManager.envPrefix }}
+            - name: SLACKBOTV2_USER_NAME
+              value: {{ .Values.slackbotv2.userName | quote }}
+{{- if .Values.slackbotv2.assistantStatus }}
+            - name: SLACKBOTV2_ASSISTANT_STATUS
+              value: {{ .Values.slackbotv2.assistantStatus | quote }}
+{{- end }}
+{{- if .Values.slackbotv2.externalOrgAllowlist }}
+            - name: SLACKBOT_EXTERNAL_ORG_ALLOWLIST
+              value: {{ .Values.slackbotv2.externalOrgAllowlist | quote }}
+{{- end }}
+{{- if .Values.slackbotv2.triggerBotAllowlist }}
+            - name: SLACKBOT_TRIGGER_BOT_ALLOWLIST
+              value: {{ .Values.slackbotv2.triggerBotAllowlist | quote }}
+{{- end }}
+{{- range $name, $value := .Values.slackbotv2.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "centaur.secretEnvName" . }}
+          ports:
+            - containerPort: 3001
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources:
+{{ toYaml .Values.slackbotv2.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "slackbotv2") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "slackbotv2") | nindent 4 }}
+spec:
+  selector:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "slackbotv2") | nindent 4 }}
+  ports:
+    - name: http
+      port: 3001
+      targetPort: 3001
+{{- end }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -103,6 +103,7 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- if .Values.api.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -452,6 +453,7 @@ spec:
                 path: services/sandbox/SYSTEM_PROMPT.md
 {{- end }}
 ---
+{{- end }}
 {{- if .Values.slackbot.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/contrib/chart/values.dev.yaml
+++ b/contrib/chart/values.dev.yaml
@@ -13,7 +13,15 @@ postgres:
     existingSecretKey: POSTGRES_PASSWORD
 
 slackbot:
-  enabled: true
+  enabled: false
+  image:
+    pullPolicy: IfNotPresent
+
+slackbotv2:
+  image:
+    pullPolicy: IfNotPresent
+
+apiRs:
   image:
     pullPolicy: IfNotPresent
 

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -48,6 +48,35 @@
         "port": { "type": "integer" }
       }
     },
+    "ironControl": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicaCount": { "type": "integer" },
+        "railsEnv": { "type": "string" },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "httpPort": { "type": "integer" }
+          }
+        },
+        "resources": { "type": "object" }
+      }
+    },
     "secrets": {
       "type": "object",
       "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -63,6 +63,32 @@ tokenBroker:
   ttl: 1m
   resources: {}
 
+# iron-control — Rails control plane for authenticated API access + encrypted
+# secret storage. Off by default; enable per-environment. Uses a dedicated
+# `iron_control_production` database on the bundled Postgres (its own logical DB so its
+# Rails schema_migrations table never collides with the API's dbmate table); an
+# init container creates the DB idempotently. DATABASE_URL, bootstrap
+# user/API-key, and the three ActiveRecord encryption keys are injected from the
+# shared infra Secret. Point IRON_CONTROL_DATABASE_URL elsewhere to use an
+# external DB.
+ironControl:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: ironsh/iron-control
+    tag: latest
+    pullPolicy: IfNotPresent
+  railsEnv: production
+  database:
+    # Logical DB created on the bundled Postgres by the create-db init
+    # container. Must match the primary connection's `database:` in the image's
+    # database.yml — the connection URL carries no database path, so Rails
+    # resolves the name from there.
+    name: iron_control_production
+  service:
+    httpPort: 3000
+  resources: {}
+
 # Values for the upstream 1Password Connect subchart
 # (https://github.com/1Password/connect-helm-charts/tree/main/charts/connect).
 # Deployment is gated on onepasswordConnect.connect.create AND on
@@ -78,7 +104,12 @@ onepasswordConnect:
 secrets:
   bootstrapSecretName: ""
 
+# Legacy Python control plane. Superseded by apiRs (the Rust control plane);
+# disabled by default. It still owns subsystems not yet ported (workflows, warm
+# pool, Slack ETL, plugin watcher, egress discovery), so re-enable it if you need
+# those alongside api-rs.
 api:
+  enabled: false
   replicaCount: 1
   image:
     repository: centaur-api
@@ -169,8 +200,10 @@ repoCache:
   affinity: {}
   resources: {}
 
+# Installs the upstream agent-sandbox controller + CRDs (subchart). Required by
+# apiRs when apiRs.sandboxBackend is agent-k8s, which is the default.
 agentSandbox:
-  enabled: false
+  enabled: true
   namespace:
     create: true
     name: agent-sandbox-system
@@ -181,14 +214,73 @@ agentSandbox:
   controller:
     extensions: false
 
-slackbot:
+# Rust session control plane (services/api-rs). Owns sessions, agent-k8s
+# sandboxes (via the agents.x-k8s.io Sandbox CRD), and the per-sandbox
+# iron-proxy/firewall. Coexists with the Python `api`; reuses the same Postgres
+# and infra secret. Disable to fall back to the Python-only stack.
+apiRs:
   enabled: true
+  replicaCount: 1
+  image:
+    repository: centaur-api-rs
+    tag: latest
+    pullPolicy: Always
+  port: 8080
+  runMigrations: true
+  sandboxBackend: agent-k8s
+  sandboxWorkload: codex-app-server
+  sandboxReadyTimeoutSecs: 90
+  ironProxy:
+    mode: enabled
+  codexAuthMode: api_key
+  # 1Password vault the iron-proxy secret source reads from when
+  # ironProxy.secretSource is "onepassword". Empty falls back to the binary
+  # default ("ai-agents").
+  opVault: ""
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+  livenessProbe:
+    failureThreshold: 6
+    periodSeconds: 10
+    timeoutSeconds: 5
+  readinessProbe:
+    failureThreshold: 6
+    periodSeconds: 10
+    timeoutSeconds: 5
+  terminationGracePeriodSeconds: 35
+  extraEnv: {}
+  resources: {}
+
+# Legacy Slackbot that talks to the Python `api` on :8000. Superseded by
+# slackbotv2 (which talks to api-rs); disabled by default so the two bots don't
+# both answer the same Slack events. Re-enable only for a separate Slack app.
+slackbot:
+  enabled: false
   replicaCount: 1
   image:
     repository: centaur-slackbot
     tag: latest
     pullPolicy: Always
   runtimeErrorAlertChannel: ""
+  extraEnv: {}
+  resources: {}
+
+# Chat SDK Slackbot v2 — successor to `slackbot`. Forwards Slack events to the
+# api-rs control plane (:8080) and streams responses back. Listens on :3001 so
+# chart ingress/networkpolicy swap cleanly from slackbot.
+slackbotv2:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: centaur-slackbotv2
+    tag: latest
+    pullPolicy: Always
+  userName: centaur
+  assistantStatus: ""
+  externalOrgAllowlist: ""
+  triggerBotAllowlist: ""
   extraEnv: {}
   resources: {}
 

--- a/contrib/scripts/bootstrap-k8s-secrets.sh
+++ b/contrib/scripts/bootstrap-k8s-secrets.sh
@@ -22,6 +22,15 @@ Optional local-dev admin key:
   LOCAL_DEV_API_KEY            seeded as the admin bearer for the API service
                                (envFrom centaur-infra-env). Re-run with --force
                                or kubectl patch to rotate.
+
+Optional iron-control bootstrap (consumed when ironControl.enabled=true):
+  IRON_CONTROL_DATABASE_URL    overrides the derived DSN (default points at the
+                               bundled Postgres server with no database path, so
+                               Rails resolves db names from its database.yml)
+  IRON_CONTROL_INITIAL_USER_EMAIL
+                               initial admin email (default admin@centaur.local)
+  The initial password, API key, the three ActiveRecord encryption keys, and
+  SECRET_KEY_BASE are auto-generated when absent (never rotated in place).
 EOF
 }
 
@@ -114,6 +123,44 @@ if secret_exists centaur-infra-env; then
   if [[ -n "${LOCAL_DEV_API_KEY:-}" ]]; then
     patch_data+=("\"LOCAL_DEV_API_KEY\":\"$(printf '%s' "$LOCAL_DEV_API_KEY" | base64 | tr -d '\n')\"")
   fi
+  # iron-control keys: top up only when absent so we never rotate them out from
+  # under a running pod (its ActiveRecord-encrypted data would become
+  # undecryptable). Generated values mirror the create path.
+  if ! secret_key_present IRON_CONTROL_DATABASE_URL; then
+    if [[ -n "${IRON_CONTROL_DATABASE_URL:-}" ]]; then
+      ic_db_url="$IRON_CONTROL_DATABASE_URL"
+    else
+      # Reuse the same Postgres host/credentials as the API's DATABASE_URL but
+      # strip the database path, so Rails resolves the database name from the
+      # image's database.yml. Avoids decoding the password ourselves.
+      existing_db_url="$(kubectl -n "$NAMESPACE" get secret centaur-infra-env \
+        -o 'jsonpath={.data.DATABASE_URL}' | openssl base64 -d -A)"
+      ic_db_url="${existing_db_url%/ai_v2}"
+    fi
+    patch_data+=("\"IRON_CONTROL_DATABASE_URL\":\"$(printf '%s' "$ic_db_url" | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_INITIAL_USER_EMAIL; then
+    ic_email="${IRON_CONTROL_INITIAL_USER_EMAIL:-admin@centaur.local}"
+    patch_data+=("\"IRON_CONTROL_INITIAL_USER_EMAIL\":\"$(printf '%s' "$ic_email" | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_INITIAL_USER_PASSWORD; then
+    patch_data+=("\"IRON_CONTROL_INITIAL_USER_PASSWORD\":\"$(rand_hex | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_INITIAL_API_KEY; then
+    patch_data+=("\"IRON_CONTROL_INITIAL_API_KEY\":\"$(printf 'iak_%s' "$(rand_hex)" | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY; then
+    patch_data+=("\"IRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY\":\"$(rand_hex | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY; then
+    patch_data+=("\"IRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY\":\"$(rand_hex | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT; then
+    patch_data+=("\"IRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT\":\"$(rand_hex | base64 | tr -d '\n')\"")
+  fi
+  if ! secret_key_present IRON_CONTROL_SECRET_KEY_BASE; then
+    patch_data+=("\"IRON_CONTROL_SECRET_KEY_BASE\":\"$(printf '%s%s' "$(rand_hex)" "$(rand_hex)" | base64 | tr -d '\n')\"")
+  fi
   if [[ "${#patch_data[@]}" -gt 0 ]]; then
     patch_json="{\"data\":{$(IFS=,; echo "${patch_data[*]}")}}"
     kubectl -n "$NAMESPACE" patch secret centaur-infra-env --type merge -p "$patch_json" >/dev/null
@@ -123,6 +170,12 @@ if secret_exists centaur-infra-env; then
 else
   POSTGRES_PASSWORD="$(rand_hex)"
   DATABASE_URL="postgresql://tempo:${POSTGRES_PASSWORD}@centaur-centaur-postgres:5432/ai_v2"
+  # iron-control runs against a dedicated logical DB on the same Postgres. The
+  # URL carries connection info only (no database path) so Rails resolves each
+  # connection's database name from the image's database.yml. Override via the
+  # IRON_CONTROL_DATABASE_URL env var to point at an external server.
+  IRON_CONTROL_DATABASE_URL="${IRON_CONTROL_DATABASE_URL:-postgresql://tempo:${POSTGRES_PASSWORD}@centaur-centaur-postgres:5432}"
+  IRON_CONTROL_INITIAL_USER_EMAIL="${IRON_CONTROL_INITIAL_USER_EMAIL:-admin@centaur.local}"
   secret_args=(
     -n "$NAMESPACE" create secret generic centaur-infra-env
     --from-literal=IRON_MANAGEMENT_API_KEY="$(rand_hex)"
@@ -135,6 +188,14 @@ else
     --from-literal=SLACKBOT_API_KEY="$SLACKBOT_API_KEY"
     --from-literal=POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
     --from-literal=DATABASE_URL="$DATABASE_URL"
+    --from-literal=IRON_CONTROL_DATABASE_URL="$IRON_CONTROL_DATABASE_URL"
+    --from-literal=IRON_CONTROL_INITIAL_USER_EMAIL="$IRON_CONTROL_INITIAL_USER_EMAIL"
+    --from-literal=IRON_CONTROL_INITIAL_USER_PASSWORD="$(rand_hex)"
+    --from-literal=IRON_CONTROL_INITIAL_API_KEY="iak_$(rand_hex)"
+    --from-literal=IRON_CONTROL_AR_ENCRYPTION_PRIMARY_KEY="$(rand_hex)"
+    --from-literal=IRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY="$(rand_hex)"
+    --from-literal=IRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT="$(rand_hex)"
+    --from-literal=IRON_CONTROL_SECRET_KEY_BASE="$(rand_hex)$(rand_hex)"
   )
   if [[ -n "${OP_CONNECT_TOKEN:-}" ]]; then
     secret_args+=(--from-literal=OP_CONNECT_TOKEN="$OP_CONNECT_TOKEN")

--- a/services/api-rs/Dockerfile
+++ b/services/api-rs/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+# Build context is the repo root (see Justfile `_build-api-rs`) so the runtime
+# stage can bake the shared `tools/` tree used for iron-proxy fragment discovery.
+
+FROM rust:1-bookworm AS builder
+# aws-lc-rs (the rustls crypto provider) builds native code, so the builder
+# needs cmake + a C toolchain. No DATABASE_URL is required at build time:
+# centaur-session-sqlx only uses sqlx::migrate! (compile-time file embedding),
+# not the query-checking macros.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake perl build-essential pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+COPY services/api-rs/ ./
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p centaur-api-server \
+    && cp target/release/centaur-api-server /usr/local/bin/centaur-api-server
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/bin/centaur-api-server /usr/local/bin/centaur-api-server
+WORKDIR /app
+# Iron-proxy config the server reads at runtime. centaur-iron-proxy resolves
+# these by walking up from the working directory (fragment::repo_relative_path),
+# so keep the repo-relative layout under /app:
+#   services/iron-proxy/infra.yaml         (infra fragment)
+#   services/iron-proxy/harness/*.yaml     (per-harness fragments)
+#   services/api/api/iron-proxy.base.yaml  (proxy base config)
+COPY services/iron-proxy/infra.yaml services/iron-proxy/infra.yaml
+COPY services/iron-proxy/harness/ services/iron-proxy/harness/
+COPY services/api/api/iron-proxy.base.yaml services/api/api/iron-proxy.base.yaml
+# Tool metadata drives the per-sandbox iron-proxy egress allow-list.
+COPY tools/ tools/
+ENV TOOL_DIRS=/app/tools
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/centaur-api-server"]

--- a/services/slackbotv2/Dockerfile
+++ b/services/slackbotv2/Dockerfile
@@ -1,0 +1,21 @@
+FROM oven/bun:1.3.13-slim
+
+WORKDIR /repo
+ENV NODE_ENV=production
+
+RUN bun install -g pnpm@10.28.1
+
+# Workspace manifests first so dependency install is a cached layer. slackbotv2
+# depends on the @centaur/* workspace packages, so they must be present for
+# pnpm to link the `workspace:*` ranges.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/ packages/
+COPY services/slackbotv2/package.json services/slackbotv2/package.json
+RUN pnpm install --filter slackbotv2 --prod --frozen-lockfile
+
+COPY services/slackbotv2/ services/slackbotv2/
+WORKDIR /repo/services/slackbotv2
+
+EXPOSE 3001
+ENV PORT=3001
+CMD ["bun", "src/server.ts"]


### PR DESCRIPTION
Add Dockerfiles for the Rust control plane (centaur-api-server) and the
Chat SDK Slackbot v2, and deploy both via the chart alongside the Python
stack. api-rs runs the agent-k8s + codex sandbox backend with per-sandbox
iron-proxy; slackbotv2 replaces the legacy slackbot and targets api-rs.
Enables the agent-sandbox subchart, reuses the in-cluster postgres, and
repoints ingress/networkpolicy from slackbot to slackbotv2.
