### PR TITLE
fix(rendering): preserve full task output

### DIFF
--- a/packages/rendering/src/chat-sdk.test.ts
+++ b/packages/rendering/src/chat-sdk.test.ts
@@ -99,8 +99,9 @@ describe('ChatSDKRenderer', () => {
     ])
   })
 
-  it('bounds large task details and output before streaming to chat adapters', () => {
+  it('bounds large task details while preserving full task output', () => {
     const renderer = new ChatSDKRenderer()
+    const largeDetails = 'd'.repeat(10000)
     const largeOutput = 'x'.repeat(10000)
 
     const rendered = renderer.render('session-1', {
@@ -109,6 +110,7 @@ describe('ChatSDKRenderer', () => {
         id: 'cmd-1',
         title: '1. Command execution',
         status: 'complete',
+        details: [{ type: 'code', text: largeDetails, language: 'text' }],
         output: [{ type: 'code', text: largeOutput, language: 'text' }]
       }
     })
@@ -121,9 +123,9 @@ describe('ChatSDKRenderer', () => {
         status: 'complete'
       })
     )
-    expect(chunk?.type === 'task_update' ? chunk.output?.length : 0).toBeLessThanOrEqual(3000)
-    expect(chunk?.type === 'task_update' ? chunk.output : '').toContain(
-      '[truncated 7038 chars from task body]'
-    )
+    expect(chunk?.type === 'task_update' ? chunk.details?.length : 0).toBeLessThanOrEqual(3000)
+    expect(chunk?.type === 'task_update' ? chunk.details : '').toContain('[truncated')
+    expect(chunk?.type === 'task_update' ? chunk.output : '').toBe(largeOutput)
+    expect(chunk?.type === 'task_update' ? chunk.output : '').not.toContain('[truncated')
   })
 })

--- a/packages/rendering/src/chat-sdk.ts
+++ b/packages/rendering/src/chat-sdk.ts
@@ -109,15 +109,18 @@ function taskChunk(task: RendererTaskUpdate): ChatSDKStreamChunk {
     title: task.title,
     status: task.status,
     ...(task.details?.length ? { details: taskBodyToChatSdkText(task.details) } : {}),
-    ...(task.output?.length ? { output: taskBodyToChatSdkText(task.output, { fenceCode: false }) } : {})
+    ...(task.output?.length
+      ? { output: taskBodyToChatSdkText(task.output, { fenceCode: false, truncate: false }) }
+      : {})
   }
 }
 
 function taskBodyToChatSdkText(
   blocks: RendererTaskBlock[],
-  options: { fenceCode?: boolean } = {}
+  options: { fenceCode?: boolean; truncate?: boolean } = {}
 ): string {
   const fenceCode = options.fenceCode ?? true
+  const truncate = options.truncate ?? true
   const text = blocks
     .map(block => {
       if (block.type === 'text') return block.text
@@ -127,7 +130,7 @@ function taskBodyToChatSdkText(
     })
     .filter(Boolean)
     .join('\n')
-  return truncateTaskBody(text)
+  return truncate ? truncateTaskBody(text) : text
 }
 
 function truncateTaskBody(text: string): string {

--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -472,6 +472,76 @@ describe('CodexAppServerRendererEventMapper', () => {
     expect(rendered).toContain('SLACK_BOT_TOKEN=[REDACTED_TOKEN]')
   })
 
+  it('preserves full command output in task updates', async () => {
+    const longSuffix = 'x'.repeat(13_000)
+    const aggregatedOutput = `one\ntwo\nthree\nfour\nfive\n${longSuffix}`
+    const chunks = await collect(
+      codexAppServerToChatSdkStream(
+        toAsyncIterable([
+          {
+            method: 'item/completed',
+            params: {
+              threadId: 'thread-1',
+              turnId: 'turn-1',
+              item: {
+                id: 'cmd-1',
+                type: 'commandExecution',
+                command: 'cat long-output.log',
+                status: 'completed',
+                aggregatedOutput,
+                exitCode: 0
+              }
+            }
+          }
+        ])
+      )
+    )
+
+    const taskChunk = chunks.find(
+      (chunk): chunk is Extract<(typeof chunks)[number], { type: 'task_update' }> =>
+        chunk.type === 'task_update' && chunk.id === 'cmd-1'
+    )
+    expect(taskChunk?.output).toContain(aggregatedOutput)
+    expect(taskChunk?.output).not.toContain('// truncated')
+    expect(taskChunk?.output).not.toContain('/* truncated */')
+    expect(taskChunk?.output).not.toContain('[output truncated]')
+    expect(taskChunk?.output).not.toContain('[truncated')
+  })
+
+  it('preserves full file change diffs in task updates', async () => {
+    const longLine = `+${'diff-line'.repeat(400)}`
+    const diff = ['diff --git a/file.txt b/file.txt', '@@ -1 +1 @@', '-old', longLine].join('\n')
+    const chunks = await collect(
+      codexAppServerToChatSdkStream(
+        toAsyncIterable([
+          {
+            method: 'item/completed',
+            params: {
+              threadId: 'thread-1',
+              turnId: 'turn-1',
+              item: {
+                id: 'file-1',
+                type: 'fileChange',
+                status: 'completed',
+                changes: [{ path: 'file.txt', diff }]
+              }
+            }
+          }
+        ])
+      )
+    )
+
+    const taskChunk = chunks.find(
+      (chunk): chunk is Extract<(typeof chunks)[number], { type: 'task_update' }> =>
+        chunk.type === 'task_update' && chunk.id === 'file-1'
+    )
+    expect(taskChunk?.output).toContain(diff)
+    expect(taskChunk?.output).not.toContain('// truncated')
+    expect(taskChunk?.output).not.toContain('/* truncated */')
+    expect(taskChunk?.output).not.toContain('[output truncated]')
+    expect(taskChunk?.output).not.toContain('[truncated')
+  })
+
   it('omits binary command output from task updates', async () => {
     const chunks = await collect(
       codexAppServerToChatSdkStream(

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -23,9 +23,7 @@ const limits = {
     taskTitleChars: 128
   },
   finalPlan: {
-    taskTitleChars: 140,
-    taskOutputCodeBlockLines: 4,
-    outputPreviewChars: 2_200
+    taskTitleChars: 140
   }
 } as const
 
@@ -1178,13 +1176,13 @@ function formatCommandOutput(output: string): { body: string; language: string }
     try {
       const pretty = JSON.stringify(JSON.parse(trimmed), null, 2)
       return {
-        body: clipLines(pretty, limits.finalPlan.taskOutputCodeBlockLines),
+        body: pretty,
         language: 'json'
       }
     } catch {}
   }
   return {
-    body: clipLines(sanitized.body, limits.finalPlan.taskOutputCodeBlockLines),
+    body: sanitized.body,
     language: languageFromContent(sanitized.body)
   }
 }
@@ -1260,7 +1258,7 @@ function fileChangeTask(item: any, eventType: string, existing?: HarnessTask): H
     details: uniquePaths.length
       ? [section([text('Files: '), text(uniquePaths.join(', '), { code: true })])]
       : (existing?.details ?? []),
-    output: diff ? [pre(clip(diff), 'diff')] : (existing?.output ?? [])
+    output: diff ? [pre(diff, 'diff')] : (existing?.output ?? [])
   }
 }
 
@@ -1403,18 +1401,6 @@ function languageFromContent(value: string): string {
     return 'ts'
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json'
   return 'text'
-}
-
-function clip(value: string, max: number = limits.finalPlan.outputPreviewChars): string {
-  return value.length > max ? `${value.slice(0, max)}\n/* truncated */` : value
-}
-
-function clipLines(value: string, maxLines: number): string {
-  if (maxLines <= 0) return ''
-  const lines = value.split('\n')
-  if (lines.length <= maxLines) return value
-  if (maxLines === 1) return '// truncated'
-  return [...lines.slice(0, maxLines - 1), '// truncated'].join('\n')
 }
 
 function oneLine(value: string, max: number = limits.finalPlan.taskTitleChars): string {

--- a/packages/rendering/src/rich-text.ts
+++ b/packages/rendering/src/rich-text.ts
@@ -13,7 +13,7 @@ export function section(elements: InlineText[]): RendererTaskBlock {
 export function preformatted(text: string, language?: string): RendererTaskBlock {
   return {
     type: 'code',
-    text: clip(text, 12_000),
+    text,
     ...(language ? { language } : {}),
   }
 }
@@ -31,8 +31,4 @@ function elementToPlainText(element: RendererTaskBlock): string {
     return element.text
   }
   return element.text
-}
-
-function clip(value: string, max: number): string {
-  return value.length > max ? `${value.slice(0, max - 1)}...` : value
 }


### PR DESCRIPTION
## Summary
- preserve full sanitized command output and file-change diffs in the shared renderer
- stop clipping preformatted renderer blocks and task output passed through Chat SDK
- add regression coverage for long command output, long diffs, and truncation markers

## Validation
- pnpm --filter @centaur/rendering test
- pnpm --filter @centaur/rendering typecheck
- git diff --check