### PR TITLE
feat(chart): add opt-in Tailscale Funnel ingress for the Slackbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ htmlcov/
 # Local-only dev scripts (not committed)
 scripts/local_invest_smoke.sh
 
+# Local-only Helm value overrides (not committed)
+contrib/chart/values.local.yaml
+
 # IDE
 .vscode/
 .idea/

--- a/Justfile
+++ b/Justfile
@@ -106,6 +106,13 @@ deploy:
         --set sandbox.extraEnv.CLAUDE_CODE_AUTH_MODE=${CLAUDE_CODE_AUTH_MODE}
       )
     fi
+    # Layer an optional local-only values file (e.g. Tailscale Funnel ingress) on
+    # top of values.dev.yaml. Kept out of the shared dev values so teammates'
+    # `just up` is unaffected. Appended after -f {{dev_values}} so it wins
+    # (helm applies -f files left-to-right).
+    if [[ -n "${CENTAUR_EXTRA_VALUES:-}" ]]; then
+      extra_args+=(-f "${CENTAUR_EXTRA_VALUES}")
+    fi
     helm upgrade --install {{release}} {{chart}} -n {{namespace}} --create-namespace -f {{dev_values}} ${extra_args[@]+"${extra_args[@]}"}
 
 # Bring up the dev stack; pass `k3s` (just up k3s) to import local images into k3s's containerd.

--- a/contrib/chart/templates/ingress.yaml
+++ b/contrib/chart/templates/ingress.yaml
@@ -13,6 +13,13 @@ spec:
   {{- with .Values.ingress.className }}
   ingressClassName: {{ . }}
   {{- end }}
+  {{- if .Values.ingress.defaultBackend }}
+  defaultBackend:
+    service:
+      name: {{ include "centaur.componentName" (dict "root" . "component" "slackbot") }}
+      port:
+        number: 3001
+  {{- else }}
   rules:
     - {{- if .Values.ingress.host }}
       host: {{ .Values.ingress.host | quote }}
@@ -26,6 +33,7 @@ spec:
                 name: {{ include "centaur.componentName" (dict "root" . "component" "slackbot") }}
                 port:
                   number: 3001
+  {{- end }}
   {{- with .Values.ingress.tls }}
   tls:
 {{ toYaml . | nindent 4 }}

--- a/contrib/chart/values.tailscale-funnel.example.yaml
+++ b/contrib/chart/values.tailscale-funnel.example.yaml
@@ -1,0 +1,32 @@
+# Example overlay: expose the Centaur Slackbot publicly via the Tailscale
+# Kubernetes operator + Funnel, so Slack can POST events to /api/webhooks/slack.
+#
+# Layer it on top of the normal values (it keeps the shared values.dev.yaml clean):
+#   CENTAUR_EXTRA_VALUES=contrib/chart/values.tailscale-funnel.example.yaml just up
+# or with helm directly:
+#   helm upgrade --install centaur contrib/chart -n centaur \
+#     -f contrib/chart/values.dev.yaml \
+#     -f contrib/chart/values.tailscale-funnel.example.yaml
+#
+# Prereqs (see docs: /operate/tailscale-funnel): the Tailscale operator installed
+# in the `tailscale` namespace, your tailnet's HTTPS certificates + MagicDNS
+# enabled, and an ACL `funnel` nodeAttr granted to the operator's proxy tag
+# (default tag:k8s).
+
+ingress:
+  enabled: true
+  className: tailscale
+  defaultBackend: true              # the operator's Funnel Ingress expects a single backend
+  annotations:
+    tailscale.com/funnel: "true"    # public Funnel exposure; omit for tailnet-only
+  tls:
+    - hosts:
+        - centaur-slackbot          # -> https://centaur-slackbot.<your-tailnet>.ts.net
+
+networkPolicy:
+  # Allow the operator's proxy pods (in the `tailscale` namespace) to reach the
+  # Slackbot on :3001. Appended to the chart default of [kube-system]; the
+  # Slackbot NetworkPolicy otherwise admits only the API and workflow-run pods.
+  ingressControllerNamespaces:
+    - kube-system
+    - tailscale

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -247,6 +247,9 @@ postgres:
 ingress:
   enabled: false
   className: ""
+  # When true, render a single spec.defaultBackend instead of host/path rules.
+  # Required by the Tailscale operator's Funnel Ingress; harmless otherwise.
+  defaultBackend: false
   annotations: {}
   host: centaur.local
   tls: []

--- a/docs/pages/mac-mini-setup.mdx
+++ b/docs/pages/mac-mini-setup.mdx
@@ -160,3 +160,6 @@ https://<trycloudflare-host>/api/webhooks/slack
 
 Temporary tunnel URLs usually change when the tunnel restarts, so update the
 Slack Request URL each time or configure a named tunnel/domain.
+
+For a durable, in-cluster alternative that keeps a stable public URL, see
+[Expose the Slackbot with Tailscale Funnel](/operate/tailscale-funnel).

--- a/docs/pages/operate/tailscale-funnel.mdx
+++ b/docs/pages/operate/tailscale-funnel.mdx
@@ -1,0 +1,145 @@
+---
+title: Expose the Slackbot with Tailscale Funnel
+description: Publicly expose Centaur's Slackbot for Slack webhooks using the Tailscale Kubernetes operator and Funnel, with TLS terminated by Tailscale.
+---
+
+# Expose the Slackbot with Tailscale Funnel
+
+Slack delivers events to the Slackbot over public HTTPS (`/api/webhooks/slack`).
+The Slackbot listens on plain HTTP (port 3001) as an in-cluster `ClusterIP`
+service and does not terminate TLS itself. For a durable, in-cluster way to make
+it reachable from Slack, use the [Tailscale Kubernetes operator](https://tailscale.com/kb/1236/kubernetes-operator)
+with [Funnel](https://tailscale.com/kb/1223/funnel): the operator publishes a
+public endpoint at `https://<name>.<tailnet>.ts.net`, terminates TLS with an
+auto-renewed Let's Encrypt certificate, and forwards plain HTTP to the Slackbot.
+
+This is the production-style alternative to the ad-hoc laptop tunnel in
+[Mac Mini-style setup](/mac-mini-setup#6-optional-expose-local-slackbot-with-a-tunnel)
+(`kubectl port-forward` + `cloudflared`/`tailscale funnel`), which is fine for
+quick local testing but ephemeral.
+
+:::warning[The Slackbot has no inbound TLS of its own]
+The chart never provisions a TLS certificate for the Slackbot — it is plain HTTP
+on port 3001 by design. Tailscale Funnel (or any TLS-terminating proxy) owns the
+public certificate.
+:::
+
+## Prerequisites
+
+- Funnel enabled for your tailnet: in the Tailscale admin console DNS page, enable
+  **MagicDNS** and **HTTPS certificates**.
+- A tailnet policy (ACL) that defines the operator tags and grants Funnel to the
+  operator's proxy nodes:
+  ```jsonc
+  {
+    "tagOwners": { "tag:k8s-operator": [], "tag:k8s": ["tag:k8s-operator"] },
+    "nodeAttrs": [ { "target": ["tag:k8s"], "attr": ["funnel"] } ]
+  }
+  ```
+  Target `tag:k8s` (the operator's default proxy tag), **not** `autogroup:member`:
+  tagged proxy nodes are not members, so the default Funnel grant would not cover
+  them and the device would come up tailnet-only.
+- An [OAuth client](https://tailscale.com/kb/1215/oauth-clients) for the operator
+  (scopes `devices:core` and `auth_keys`, owner `tag:k8s-operator`).
+- The Tailscale operator installed in the `tailscale` namespace:
+  ```bash
+  helm repo add tailscale https://pkgs.tailscale.com/helmcharts && helm repo update
+  helm upgrade --install tailscale-operator tailscale/tailscale-operator \
+    -n tailscale --create-namespace \
+    --set-string oauth.clientId=<id> --set-string oauth.clientSecret=<secret> --wait
+  ```
+
+## Configure the chart
+
+Expose the Slackbot with a Tailscale **Funnel Ingress**. A ready-to-use sample
+lives at `contrib/chart/values.tailscale-funnel.example.yaml`:
+
+```yaml
+ingress:
+  enabled: true
+  className: tailscale
+  defaultBackend: true            # the operator's Funnel Ingress expects a single backend
+  annotations:
+    tailscale.com/funnel: "true"  # public Funnel exposure; omit for tailnet-only
+  tls:
+    - hosts:
+        - centaur-slackbot        # -> https://centaur-slackbot.<your-tailnet>.ts.net
+
+networkPolicy:
+  ingressControllerNamespaces:
+    - kube-system
+    - tailscale
+```
+
+What each piece does:
+
+- `ingress.defaultBackend: true` makes the chart emit a single `spec.defaultBackend`
+  (instead of host/path rules) — the shape the Tailscale operator's Funnel Ingress
+  expects.
+- `ingress.className: tailscale` routes the Ingress to the operator.
+- The `tailscale.com/funnel: "true"` annotation makes the endpoint public. Omit it
+  to keep the Slackbot reachable only inside your tailnet.
+- `tls.hosts[0]` sets the device's MagicDNS name (`<name>.<tailnet>.ts.net`).
+- Adding `tailscale` to `networkPolicy.ingressControllerNamespaces` lets the
+  operator's proxy pods reach the Slackbot on port 3001. The Slackbot
+  NetworkPolicy otherwise admits only the API, workflow-run pods, and the listed
+  ingress-controller namespaces (default `kube-system`).
+
+## Deploy
+
+Layer the example file on top of your normal values with the `CENTAUR_EXTRA_VALUES`
+hook, which keeps the shared `values.dev.yaml` untouched:
+
+```bash
+CENTAUR_EXTRA_VALUES=contrib/chart/values.tailscale-funnel.example.yaml just up
+```
+
+Or with Helm directly:
+
+```bash
+helm upgrade --install centaur contrib/chart -n centaur \
+  -f contrib/chart/values.dev.yaml \
+  -f contrib/chart/values.tailscale-funnel.example.yaml
+```
+
+## Point Slack at it
+
+Set the Slack app's Event Subscriptions **Request URL** to:
+
+```text
+https://<name>.<tailnet>.ts.net/api/webhooks/slack
+```
+
+Then finish the Slack app in
+[Deploying in Production → Configure Slack](/deploying-in-production#4-configure-slack):
+subscribe to `app_mention` and the `message.*` events you want, and make sure the
+bot has the `chat:write` scope — the Slackbot delivers replies with Slack's
+streaming API, which requires it.
+
+## Verify
+
+```bash
+kubectl get ingress -n centaur     # ADDRESS resolves to <name>.<tailnet>.ts.net
+kubectl get pods -n tailscale      # operator + a ts-...-slackbot-... proxy, both Running
+```
+
+An unsigned POST should reach the Slackbot and be rejected *by the app* — proof
+that TLS termination, routing, and the NetworkPolicy all work end to end:
+
+```bash
+curl -i -X POST https://<name>.<tailnet>.ts.net/api/webhooks/slack
+# HTTP/2 401  {"ok":false,"error":"missing_signature_headers"}
+```
+
+A `401` from the Slackbot means success: `curl` validated the public Let's Encrypt
+certificate without `-k`. Saving the Request URL in Slack should then verify green.
+
+## Troubleshooting
+
+- **Device appears but Funnel is off (tailnet-only):** the `funnel` nodeAttr is
+  missing or targets `autogroup:member` instead of `tag:k8s`, or HTTPS certificates
+  are not enabled for the tailnet.
+- **Connection hangs or times out:** the Slackbot NetworkPolicy is still blocking
+  the operator's proxy — confirm `tailscale` is in
+  `networkPolicy.ingressControllerNamespaces` and that the namespace carries the
+  `kubernetes.io/metadata.name: tailscale` label (automatic on Kubernetes ≥ 1.22).

--- a/docs/public/md/mac-mini-setup.md
+++ b/docs/public/md/mac-mini-setup.md
@@ -160,3 +160,6 @@ https://<trycloudflare-host>/api/webhooks/slack
 
 Temporary tunnel URLs usually change when the tunnel restarts, so update the
 Slack Request URL each time or configure a named tunnel/domain.
+
+For a durable, in-cluster alternative that keeps a stable public URL, see
+[Expose the Slackbot with Tailscale Funnel](/operate/tailscale-funnel).

--- a/docs/public/md/operate/tailscale-funnel.md
+++ b/docs/public/md/operate/tailscale-funnel.md
@@ -1,0 +1,145 @@
+---
+title: Expose the Slackbot with Tailscale Funnel
+description: Publicly expose Centaur's Slackbot for Slack webhooks using the Tailscale Kubernetes operator and Funnel, with TLS terminated by Tailscale.
+---
+
+# Expose the Slackbot with Tailscale Funnel
+
+Slack delivers events to the Slackbot over public HTTPS (`/api/webhooks/slack`).
+The Slackbot listens on plain HTTP (port 3001) as an in-cluster `ClusterIP`
+service and does not terminate TLS itself. For a durable, in-cluster way to make
+it reachable from Slack, use the [Tailscale Kubernetes operator](https://tailscale.com/kb/1236/kubernetes-operator)
+with [Funnel](https://tailscale.com/kb/1223/funnel): the operator publishes a
+public endpoint at `https://<name>.<tailnet>.ts.net`, terminates TLS with an
+auto-renewed Let's Encrypt certificate, and forwards plain HTTP to the Slackbot.
+
+This is the production-style alternative to the ad-hoc laptop tunnel in
+[Mac Mini-style setup](/mac-mini-setup#6-optional-expose-local-slackbot-with-a-tunnel)
+(`kubectl port-forward` + `cloudflared`/`tailscale funnel`), which is fine for
+quick local testing but ephemeral.
+
+:::warning[The Slackbot has no inbound TLS of its own]
+The chart never provisions a TLS certificate for the Slackbot — it is plain HTTP
+on port 3001 by design. Tailscale Funnel (or any TLS-terminating proxy) owns the
+public certificate.
+:::
+
+## Prerequisites
+
+- Funnel enabled for your tailnet: in the Tailscale admin console DNS page, enable
+  **MagicDNS** and **HTTPS certificates**.
+- A tailnet policy (ACL) that defines the operator tags and grants Funnel to the
+  operator's proxy nodes:
+  ```jsonc
+  {
+    "tagOwners": { "tag:k8s-operator": [], "tag:k8s": ["tag:k8s-operator"] },
+    "nodeAttrs": [ { "target": ["tag:k8s"], "attr": ["funnel"] } ]
+  }
+  ```
+  Target `tag:k8s` (the operator's default proxy tag), **not** `autogroup:member`:
+  tagged proxy nodes are not members, so the default Funnel grant would not cover
+  them and the device would come up tailnet-only.
+- An [OAuth client](https://tailscale.com/kb/1215/oauth-clients) for the operator
+  (scopes `devices:core` and `auth_keys`, owner `tag:k8s-operator`).
+- The Tailscale operator installed in the `tailscale` namespace:
+  ```bash
+  helm repo add tailscale https://pkgs.tailscale.com/helmcharts && helm repo update
+  helm upgrade --install tailscale-operator tailscale/tailscale-operator \
+    -n tailscale --create-namespace \
+    --set-string oauth.clientId=<id> --set-string oauth.clientSecret=<secret> --wait
+  ```
+
+## Configure the chart
+
+Expose the Slackbot with a Tailscale **Funnel Ingress**. A ready-to-use sample
+lives at `contrib/chart/values.tailscale-funnel.example.yaml`:
+
+```yaml
+ingress:
+  enabled: true
+  className: tailscale
+  defaultBackend: true            # the operator's Funnel Ingress expects a single backend
+  annotations:
+    tailscale.com/funnel: "true"  # public Funnel exposure; omit for tailnet-only
+  tls:
+    - hosts:
+        - centaur-slackbot        # -> https://centaur-slackbot.<your-tailnet>.ts.net
+
+networkPolicy:
+  ingressControllerNamespaces:
+    - kube-system
+    - tailscale
+```
+
+What each piece does:
+
+- `ingress.defaultBackend: true` makes the chart emit a single `spec.defaultBackend`
+  (instead of host/path rules) — the shape the Tailscale operator's Funnel Ingress
+  expects.
+- `ingress.className: tailscale` routes the Ingress to the operator.
+- The `tailscale.com/funnel: "true"` annotation makes the endpoint public. Omit it
+  to keep the Slackbot reachable only inside your tailnet.
+- `tls.hosts[0]` sets the device's MagicDNS name (`<name>.<tailnet>.ts.net`).
+- Adding `tailscale` to `networkPolicy.ingressControllerNamespaces` lets the
+  operator's proxy pods reach the Slackbot on port 3001. The Slackbot
+  NetworkPolicy otherwise admits only the API, workflow-run pods, and the listed
+  ingress-controller namespaces (default `kube-system`).
+
+## Deploy
+
+Layer the example file on top of your normal values with the `CENTAUR_EXTRA_VALUES`
+hook, which keeps the shared `values.dev.yaml` untouched:
+
+```bash
+CENTAUR_EXTRA_VALUES=contrib/chart/values.tailscale-funnel.example.yaml just up
+```
+
+Or with Helm directly:
+
+```bash
+helm upgrade --install centaur contrib/chart -n centaur \
+  -f contrib/chart/values.dev.yaml \
+  -f contrib/chart/values.tailscale-funnel.example.yaml
+```
+
+## Point Slack at it
+
+Set the Slack app's Event Subscriptions **Request URL** to:
+
+```text
+https://<name>.<tailnet>.ts.net/api/webhooks/slack
+```
+
+Then finish the Slack app in
+[Deploying in Production → Configure Slack](/deploying-in-production#4-configure-slack):
+subscribe to `app_mention` and the `message.*` events you want, and make sure the
+bot has the `chat:write` scope — the Slackbot delivers replies with Slack's
+streaming API, which requires it.
+
+## Verify
+
+```bash
+kubectl get ingress -n centaur     # ADDRESS resolves to <name>.<tailnet>.ts.net
+kubectl get pods -n tailscale      # operator + a ts-...-slackbot-... proxy, both Running
+```
+
+An unsigned POST should reach the Slackbot and be rejected *by the app* — proof
+that TLS termination, routing, and the NetworkPolicy all work end to end:
+
+```bash
+curl -i -X POST https://<name>.<tailnet>.ts.net/api/webhooks/slack
+# HTTP/2 401  {"ok":false,"error":"missing_signature_headers"}
+```
+
+A `401` from the Slackbot means success: `curl` validated the public Let's Encrypt
+certificate without `-k`. Saving the Request URL in Slack should then verify green.
+
+## Troubleshooting
+
+- **Device appears but Funnel is off (tailnet-only):** the `funnel` nodeAttr is
+  missing or targets `autogroup:member` instead of `tag:k8s`, or HTTPS certificates
+  are not enabled for the tailnet.
+- **Connection hangs or times out:** the Slackbot NetworkPolicy is still blocking
+  the operator's proxy — confirm `tailscale` is in
+  `networkPolicy.ingressControllerNamespaces` and that the namespace carries the
+  `kubernetes.io/metadata.name: tailscale` label (automatic on Kubernetes ≥ 1.22).

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -15,6 +15,7 @@ export const sidebar = [
     text: 'Operate',
     items: [
       { text: 'Slack ETL', link: '/operate/slack-etl' },
+      { text: 'Expose Slackbot with Tailscale Funnel', link: '/operate/tailscale-funnel' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Slack delivers events to the Slackbot over public HTTPS, but the Slackbot is an internal plain-HTTP `ClusterIP` service that intentionally doesn't terminate TLS — so every operator must bring their own ingress. The only documented option today is an ephemeral laptop tunnel (`kubectl port-forward` + `cloudflared`/`ngrok`). This PR adds a small, **opt-in, backward-compatible** chart capability plus documentation for exposing the Slackbot durably via the [Tailscale Kubernetes operator](https://tailscale.com/kb/1236/kubernetes-operator) and [Funnel](https://tailscale.com/kb/1223/funnel), which provides a stable public HTTPS endpoint and terminates TLS with an auto-renewed Let's Encrypt certificate.

## Motivation

- The Slackbot needs a public HTTPS Request URL for Slack Event Subscriptions, but the chart never provisions TLS for it (plain HTTP on `:3001`).
- The existing tunnel guidance is great for quick local testing but ephemeral — URLs rotate on restart.
- Teams running Centaur on their own clusters want a durable, in-cluster, production-style way to expose just the Slackbot, without standing up a full ingress controller + cert-manager.

## What's in this PR

**Chart (narrow, behavior-preserving):**
- `contrib/chart/templates/ingress.yaml`: optional `spec.defaultBackend` rendering, gated on a new `ingress.defaultBackend` value. The Tailscale operator's Funnel Ingress expects a single backend; when the flag is off (default) the template still emits the existing host/path `rules`, so current behavior is unchanged.
- `contrib/chart/values.yaml`: document `ingress.defaultBackend` (default `false`).
- `Justfile`: `deploy` now layers an optional `CENTAUR_EXTRA_VALUES` file on top of `values.dev.yaml`, mirroring the existing env-gated extras (e.g. `OP_CONNECT_CREDENTIALS_FILE`) — keeping environment-specific overrides out of the shared dev values.
- `.gitignore`: ignore a local-only `contrib/chart/values.local.yaml`.

**Docs + example:**
- New guide `docs/pages/operate/tailscale-funnel.mdx` (`/operate/tailscale-funnel`): prerequisites (tailnet HTTPS/MagicDNS, ACL tags + `funnel` nodeAttr, operator install), chart config, deploy, Slack wiring, verification, and troubleshooting.
- `contrib/chart/values.tailscale-funnel.example.yaml`: a copy-pasteable overlay.
- Sidebar entry under **Operate** and a cross-link from the Mac Mini tunnel section to the durable option.

## Backward compatibility

Fully opt-in. `ingress.enabled` stays `false` and `ingress.defaultBackend` defaults to `false`; with the flag off the Ingress template renders exactly as before. No default deployment changes, and `CENTAUR_EXTRA_VALUES` is only consulted when set.

## Usage

```bash
CENTAUR_EXTRA_VALUES=contrib/chart/values.tailscale-funnel.example.yaml just up
```

Then set the Slack Request URL to `https://<name>.<tailnet>.ts.net/api/webhooks/slack`. Full steps are in the new guide.

## Testing

- `helm template` with the example overlay renders the expected Funnel Ingress (`ingressClassName: tailscale`, `tailscale.com/funnel: "true"`, a single `defaultBackend → <release>-slackbot:3001`, and `tls.hosts[0]` as the MagicDNS name), and the Slackbot `NetworkPolicy` admits the operator's `tailscale` namespace on `:3001`.
- `helm lint` passes; the default render (flag off) is byte-for-byte unchanged.
- Validated end-to-end on a local k3s cluster: the operator-managed Funnel served a valid public Let's Encrypt certificate for the `*.ts.net` name, and an unsigned `POST /api/webhooks/slack` returned the Slackbot's own `401 missing_signature_headers` over the public path — confirming TLS termination, routing, and NetworkPolicy end to end. Slack Event Subscriptions then verified and delivered live message turns through the Funnel endpoint.
- Docs `.md` copies regenerated via `docs/scripts/build-md.sh`.

## Notes

No new controllers or chart dependencies — this reuses the chart's existing optional `ingress` template and `networkPolicy.ingressControllerNamespaces` knob. Operating a Tailscale operator/Funnel is the user's choice; nothing here is enabled by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
