### PR TITLE
fix: make overlay dep grep non-fatal under pipefail (#281)

### DIFF
--- a/services/api/entrypoint.sh
+++ b/services/api/entrypoint.sh
@@ -27,7 +27,7 @@ print('\n'.join(sorted(deps)))
     _extra_deps+=$'\n'
   done
   if [[ -n "${_extra_deps}" ]]; then
-    echo "$_extra_deps" | sort -u | grep -v '^$' > /tmp/_extra_deps.txt
+    echo "$_extra_deps" | sort -u | grep -v '^$' > /tmp/_extra_deps.txt || true
     uv pip install -r /tmp/_extra_deps.txt --quiet 2>/dev/null || true
     rm -f /tmp/_extra_deps.txt
   fi


### PR DESCRIPTION
Fixes #281.

`services/api/entrypoint.sh` runs under `set -euo pipefail`. When an overlay tool dir exists but yields zero pip deps, `_extra_deps` is just a newline, so the `[[ -n "${_extra_deps}" ]]` guard passes but `grep -v '^$'` matches nothing and exits 1. With no `|| true`, the script aborts before `exec "$@"` and the api pod CrashLoopBackOffs with empty logs.

One-line guard on the grep, as suggested in the issue:

```diff
-    echo "$_extra_deps" | sort -u | grep -v '^$' > /tmp/_extra_deps.txt
+    echo "$_extra_deps" | sort -u | grep -v '^$' > /tmp/_extra_deps.txt || true
```

No effect on the success path: with real deps `grep` exits 0 and the guard is a no-op; with none, the empty file is already handled by the guarded `uv pip install -r ... || true` on the next line.

Tested: `shellcheck` clean, `bash -n` ok, and an isolated repro of the fragment crashes before / passes after. I couldn't run the full overlay-mount path end-to-end without the cluster.