### PR TITLE
refactor: centralize attachment processing

### DIFF
--- a/services/api/api/attachments/__init__.py
+++ b/services/api/api/attachments/__init__.py
@@ -1,0 +1,14 @@
+"""Shared attachment parsing and storage helpers."""
+
+from api.attachments.models import AttachmentCandidate, AttachmentKind, StoredAttachment
+from api.attachments.processor import AttachmentDecodeError, AttachmentProcessor
+from api.attachments.storage import insert_thread_attachment
+
+__all__ = [
+    "AttachmentCandidate",
+    "AttachmentDecodeError",
+    "AttachmentKind",
+    "AttachmentProcessor",
+    "StoredAttachment",
+    "insert_thread_attachment",
+]

--- a/services/api/api/attachments/models.py
+++ b/services/api/api/attachments/models.py
@@ -1,0 +1,63 @@
+"""Attachment normalization models shared by API and workflow code."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+AttachmentKind = Literal[
+    "image",
+    "document",
+    "text",
+    "archive",
+    "video",
+    "audio",
+    "file",
+    "url",
+]
+
+
+@dataclass(frozen=True)
+class AttachmentCandidate:
+    """Normalized source attachment before any caller-specific storage policy."""
+
+    source: str
+    name: str
+    mime_type: str
+    kind: AttachmentKind = "file"
+    data: bytes | None = None
+    text_content: str | None = None
+    external_id: str | None = None
+    source_url: str | None = None
+    source_path: str | None = None
+    size_bytes: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def effective_size_bytes(self) -> int | None:
+        if self.size_bytes is not None:
+            return self.size_bytes
+        if self.data is not None:
+            return len(self.data)
+        if self.text_content is not None:
+            return len(self.text_content.encode("utf-8"))
+        return None
+
+
+@dataclass(frozen=True)
+class StoredAttachment:
+    """Attachment persisted in the API-owned thread attachment table."""
+
+    id: str
+    thread_key: str
+    message_id: str | None
+    name: str
+    mime_type: str
+    size_bytes: int
+    source: str | None = None
+    source_url: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def download_url(self) -> str:
+        return f"/agent/attachments/{self.id}/download"

--- a/services/api/api/attachments/processor.py
+++ b/services/api/api/attachments/processor.py
@@ -1,0 +1,258 @@
+"""Attachment discovery, classification, and current thread extraction logic."""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+from typing import Any
+from urllib.parse import urlparse
+
+from api.attachments.models import AttachmentCandidate, AttachmentKind, StoredAttachment
+from api.attachments.storage import (
+    attachment_name_from_source_path,
+    insert_thread_attachment,
+    new_attachment_id,
+    safe_attachment_name,
+)
+
+
+class AttachmentDecodeError(ValueError):
+    """Raised when an inline attachment body cannot be decoded."""
+
+
+class AttachmentProcessor:
+    """Normalize source-specific attachment shapes without owning every storage policy."""
+
+    _ARCHIVE_MIME_TYPES = {
+        "application/zip",
+        "application/x-tar",
+        "application/gzip",
+        "application/x-gzip",
+        "application/x-7z-compressed",
+    }
+    _DOCUMENT_MIME_FRAGMENTS = (
+        "document",
+        "spreadsheet",
+        "presentation",
+        "pdf",
+    )
+
+    def classify_mime_type(self, mime_type: str | None, *, name: str | None = None) -> AttachmentKind:
+        resolved = self.normalize_mime_type(mime_type, name=name)
+        if resolved.startswith("image/"):
+            return "image"
+        if resolved.startswith("video/"):
+            return "video"
+        if resolved.startswith("audio/"):
+            return "audio"
+        if resolved.startswith("text/"):
+            return "text"
+        if resolved in self._ARCHIVE_MIME_TYPES:
+            return "archive"
+        if any(fragment in resolved for fragment in self._DOCUMENT_MIME_FRAGMENTS):
+            return "document"
+        if resolved in {"application/json", "application/xml"}:
+            return "text"
+        return "file"
+
+    def normalize_mime_type(self, mime_type: str | None, *, name: str | None = None) -> str:
+        raw = str(mime_type or "").split(";", 1)[0].strip().lower()
+        if raw:
+            return raw
+        guessed = mimetypes.guess_type(name or "")[0]
+        return guessed or "application/octet-stream"
+
+    def detect_url_source(self, url: str) -> dict[str, str] | None:
+        """Return a stable source classification for known attachment/document URLs."""
+
+        parsed = urlparse(str(url or "").strip())
+        host = (parsed.hostname or "").lower()
+        if not parsed.scheme or not host:
+            return None
+        if host in {"docs.google.com", "drive.google.com"}:
+            return {"source": "google_drive_url", "host": host}
+        if host.endswith("docsend.com"):
+            return {"source": "docsend_url", "host": host}
+        if host == "files.slack.com":
+            return {"source": "slack_file_url", "host": host}
+        return {"source": "url", "host": host}
+
+    def candidate_from_inline_part(self, part: dict[str, Any]) -> AttachmentCandidate | None:
+        """Create a candidate from an Anthropic-style base64 content block."""
+
+        source = part.get("source") if isinstance(part, dict) else None
+        if not (
+            isinstance(source, dict)
+            and source.get("type") == "base64"
+            and isinstance(source.get("data"), str)
+        ):
+            return None
+
+        media_type = self.normalize_mime_type(
+            str(source.get("media_type") or "application/octet-stream"),
+            name=part.get("name") if isinstance(part.get("name"), str) else None,
+        )
+        attachment_id = new_attachment_id()
+        source_path = part.get("source_path") if isinstance(part.get("source_path"), str) else None
+        fallback = attachment_name_from_source_path(source_path, attachment_id)
+        name = (
+            str(part.get("name"))
+            if isinstance(part.get("name"), str) and part.get("name")
+            else fallback
+        )
+        try:
+            raw = base64.b64decode(source["data"])
+        except Exception as exc:
+            raise AttachmentDecodeError(f"invalid base64 attachment: {exc}") from exc
+
+        metadata: dict[str, Any] = {}
+        for key in ("slack_file_id", "size", "mime_type"):
+            if key in part:
+                metadata[key] = part[key]
+
+        return AttachmentCandidate(
+            source="inline_base64",
+            external_id=attachment_id,
+            name=name,
+            mime_type=media_type,
+            kind=self.classify_mime_type(media_type, name=name),
+            data=raw,
+            source_path=source_path,
+            size_bytes=len(raw),
+            metadata=metadata,
+        )
+
+    def candidate_from_slack_file_metadata(self, file: dict[str, Any]) -> AttachmentCandidate | None:
+        """Normalize Slack file metadata without fetching or storing file bytes."""
+
+        if not isinstance(file, dict):
+            return None
+        source_url = file.get("url_private_download") or file.get("url_private")
+        name = safe_attachment_name(
+            str(file.get("name") or file.get("title") or file.get("id") or "slack-file"),
+            fallback="slack-file",
+        )
+        mime_type = self.normalize_mime_type(
+            str(file.get("mimetype") or file.get("mime_type") or ""),
+            name=name,
+        )
+        size = file.get("size")
+        return AttachmentCandidate(
+            source="slack_file",
+            external_id=str(file.get("id") or "") or None,
+            name=name,
+            mime_type=mime_type,
+            kind=self.classify_mime_type(mime_type, name=name),
+            source_url=str(source_url) if source_url else None,
+            size_bytes=size if isinstance(size, int) else None,
+            metadata={k: v for k, v in file.items() if k not in {"url_private_download", "url_private"}},
+        )
+
+    def candidate_from_google_doc(
+        self,
+        file: dict[str, Any],
+        *,
+        text_content: str | None = None,
+    ) -> AttachmentCandidate | None:
+        """Normalize Google Drive/Docs metadata without choosing an ETL storage table."""
+
+        if not isinstance(file, dict):
+            return None
+        file_id = str(file.get("id") or "").strip()
+        if not file_id:
+            return None
+        name = safe_attachment_name(str(file.get("name") or file_id), fallback=file_id)
+        mime_type = self.normalize_mime_type(
+            str(file.get("mimeType") or "application/vnd.google-apps.document"),
+            name=name,
+        )
+        return AttachmentCandidate(
+            source="google_doc",
+            external_id=file_id,
+            name=name,
+            mime_type=mime_type,
+            kind="document",
+            text_content=text_content,
+            source_url=str(file.get("webViewLink") or "") or None,
+            metadata=dict(file),
+        )
+
+    def event_ref_for_stored(self, stored: StoredAttachment, *, source_path: str | None = None) -> dict[str, Any]:
+        part: dict[str, Any] = {
+            "type": "attachment_ref",
+            "attachment_id": stored.id,
+            "media_type": stored.mime_type,
+            "name": stored.name,
+        }
+        if source_path:
+            part["source_path"] = source_path
+        return part
+
+    def chat_ref_from_event_part(self, part: dict[str, Any]) -> dict[str, Any] | None:
+        if part.get("type") != "attachment_ref":
+            return None
+        attachment_id = str(part.get("attachment_id") or part.get("id") or "")
+        media_type = str(
+            part.get("media_type") or part.get("mime_type") or "application/octet-stream"
+        )
+        source_path = part.get("source_path") if isinstance(part.get("source_path"), str) else None
+        name = safe_attachment_name(
+            part.get("name") if isinstance(part.get("name"), str) else None,
+            fallback=attachment_name_from_source_path(source_path, attachment_id),
+        )
+        return {
+            "type": "attachment_ref",
+            "id": attachment_id,
+            "name": name,
+            "mime_type": media_type,
+        }
+
+    def event_parts_to_chat_parts(self, parts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        chat_parts: list[dict[str, Any]] = []
+        for part in parts:
+            part_type = part.get("type")
+            if part_type == "text":
+                chat_parts.append({"type": "text", "text": str(part.get("text") or "")})
+            elif part_type == "attachment_ref":
+                chat_parts.append(self.chat_ref_from_event_part(part) or part)
+            else:
+                chat_parts.append(part)
+        return chat_parts
+
+    async def extract_inline_parts(
+        self,
+        conn: Any,
+        *,
+        thread_key: str,
+        chat_message_id: str,
+        parts: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        """Store inline base64 bytes and replace content blocks with attachment refs."""
+
+        transformed: list[dict[str, Any]] = []
+        attachment_ids: list[str] = []
+        for part in parts:
+            candidate = self.candidate_from_inline_part(part)
+            if candidate is None:
+                transformed.append(part)
+                continue
+            if candidate.data is None:
+                transformed.append(part)
+                continue
+            stored = await insert_thread_attachment(
+                conn,
+                thread_key=thread_key,
+                message_id=chat_message_id,
+                name=candidate.name,
+                mime_type=candidate.mime_type,
+                data=candidate.data,
+                attachment_id=candidate.external_id,
+                source=candidate.source,
+                source_url=candidate.source_url,
+                metadata=candidate.metadata,
+            )
+            transformed.append(
+                self.event_ref_for_stored(stored, source_path=candidate.source_path)
+            )
+            attachment_ids.append(stored.id)
+        return transformed, attachment_ids

--- a/services/api/api/attachments/storage.py
+++ b/services/api/api/attachments/storage.py
@@ -1,0 +1,74 @@
+"""Storage helpers for API-owned durable thread attachments."""
+
+from __future__ import annotations
+
+import contextlib
+import pathlib
+import uuid
+from typing import Any
+
+from api.attachments.models import StoredAttachment
+
+
+def new_attachment_id() -> str:
+    return f"att-{uuid.uuid4().hex[:16]}"
+
+
+def attachment_name_from_source_path(source_path: str | None, attachment_id: str) -> str:
+    if not source_path:
+        return f"{attachment_id}.bin"
+    with contextlib.suppress(Exception):
+        parsed = pathlib.PurePosixPath(source_path)
+        if parsed.name:
+            return parsed.name
+    return f"{attachment_id}.bin"
+
+
+def safe_attachment_name(name: str | None, *, fallback: str) -> str:
+    raw = str(name or "").strip()
+    if not raw:
+        return fallback
+    with contextlib.suppress(Exception):
+        parsed = pathlib.PurePosixPath(raw)
+        if parsed.name:
+            return parsed.name
+    return raw
+
+
+async def insert_thread_attachment(
+    conn: Any,
+    *,
+    thread_key: str,
+    message_id: str | None,
+    name: str,
+    mime_type: str,
+    data: bytes,
+    attachment_id: str | None = None,
+    source: str | None = None,
+    source_url: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> StoredAttachment:
+    """Insert bytes into the existing ``attachments`` table."""
+
+    att_id = attachment_id or new_attachment_id()
+    await conn.execute(
+        "INSERT INTO attachments (id, thread_key, message_id, name, mime_type, data) "
+        "VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (id) DO NOTHING",
+        att_id,
+        thread_key,
+        message_id,
+        name,
+        mime_type,
+        data,
+    )
+    return StoredAttachment(
+        id=att_id,
+        thread_key=thread_key,
+        message_id=message_id,
+        name=name,
+        mime_type=mime_type,
+        size_bytes=len(data),
+        source=source,
+        source_url=source_url,
+        metadata=dict(metadata or {}),
+    )

--- a/services/api/api/routers/attachments.py
+++ b/services/api/api/routers/attachments.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import base64
-import uuid
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
 
+from api.attachments.storage import insert_thread_attachment
 from api.deps import enforce_sandbox_thread_scope, verify_api_key
 
 log = structlog.get_logger()
@@ -79,19 +79,23 @@ async def upload_attachment(request: Request):
     except Exception:
         raise HTTPException(status_code=422, detail="data is not valid base64")
 
-    att_id = f"att-{uuid.uuid4().hex[:16]}"
     message_id = body.get("message_id")
     source_url = body.get("source_url")
 
     pool = request.app.state.db_pool
-    await pool.execute(
-        "INSERT INTO attachments (id, thread_key, message_id, name, mime_type, data) "
-        "VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (id) DO NOTHING",
-        att_id, thread_key, message_id, name, mime_type, raw_bytes,
+    stored = await insert_thread_attachment(
+        pool,
+        thread_key=thread_key,
+        message_id=message_id,
+        name=name,
+        mime_type=mime_type,
+        data=raw_bytes,
+        source="direct_upload",
+        source_url=source_url,
     )
     log.info(
         "attachment_uploaded",
-        id=att_id,
+        id=stored.id,
         thread_key=thread_key,
         name=name,
         mime_type=mime_type,
@@ -99,10 +103,10 @@ async def upload_attachment(request: Request):
         source_url=source_url,
     )
     return {
-        "id": att_id,
+        "id": stored.id,
         "name": name,
         "mime_type": mime_type,
-        "download_url": f"/agent/attachments/{att_id}/download",
+        "download_url": stored.download_url,
     }
 
 

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import contextlib
 import datetime as dt
 import hashlib
 import json
 import os
-import pathlib
 import uuid
 from typing import Any
 
@@ -25,6 +23,7 @@ from api.agent import (
     stop_session,
 )
 from api import slackbot_client
+from api.attachments.processor import AttachmentDecodeError, AttachmentProcessor
 from api.harness_config import default_harness
 from api.otel import (
     add_span_event,
@@ -63,6 +62,7 @@ from api.sandbox.harness_protocol import extract_result
 from api.sandbox.registry import get_backend
 
 log = structlog.get_logger()
+_ATTACHMENT_PROCESSOR = AttachmentProcessor()
 
 _SLACKBOT_LIVE_DELIVERY_METADATA_KEY = "slackbot_live_delivery"
 _LEGACY_SLACKBOT_LIVE_DELIVERY_METADATA_KEY = "slackbot" + "_v" + "2_live_delivery"
@@ -378,18 +378,6 @@ async def _merge_execution_metadata(
         canonical_json(metadata),
         execution_id,
     )
-
-
-def _attachment_name_from_source_path(
-    source_path: str | None, attachment_id: str
-) -> str:
-    if not source_path:
-        return f"{attachment_id}.bin"
-    with contextlib.suppress(Exception):
-        parsed = pathlib.PurePosixPath(source_path)
-        if parsed.name:
-            return parsed.name
-    return f"{attachment_id}.bin"
 
 
 def _metadata_platform(metadata: dict[str, Any]) -> str | None:
@@ -763,93 +751,19 @@ async def extract_inline_attachments(
     chat_message_id: str,
     parts: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], list[str]]:
-    transformed: list[dict[str, Any]] = []
-    attachment_ids: list[str] = []
-
-    for part in parts:
-        source = part.get("source") if isinstance(part, dict) else None
-        if (
-            isinstance(source, dict)
-            and source.get("type") == "base64"
-            and isinstance(source.get("data"), str)
-        ):
-            media_type = str(source.get("media_type") or "application/octet-stream")
-            try:
-                raw = base64.b64decode(source["data"])
-            except Exception as exc:
-                raise ControlPlaneError(
-                    "INVALID_BASE64_ATTACHMENT",
-                    f"invalid base64 attachment: {exc}",
-                    422,
-                ) from exc
-            attachment_id = f"att-{uuid.uuid4().hex[:16]}"
-            source_path = (
-                part.get("source_path")
-                if isinstance(part.get("source_path"), str)
-                else None
-            )
-            name = (
-                str(part.get("name"))
-                if isinstance(part.get("name"), str) and part.get("name")
-                else _attachment_name_from_source_path(source_path, attachment_id)
-            )
-            await pool.execute(
-                "INSERT INTO attachments (id, thread_key, message_id, name, mime_type, data) "
-                "VALUES ($1, $2, $3, $4, $5, $6)",
-                attachment_id,
-                thread_key,
-                chat_message_id,
-                name,
-                media_type,
-                raw,
-            )
-            transformed.append(
-                {
-                    "type": "attachment_ref",
-                    "attachment_id": attachment_id,
-                    "media_type": media_type,
-                    "name": name,
-                    **({"source_path": source_path} if source_path else {}),
-                }
-            )
-            attachment_ids.append(attachment_id)
-            continue
-
-        transformed.append(part)
-
-    return transformed, attachment_ids
+    try:
+        return await _ATTACHMENT_PROCESSOR.extract_inline_parts(
+            pool,
+            thread_key=thread_key,
+            chat_message_id=chat_message_id,
+            parts=parts,
+        )
+    except AttachmentDecodeError as exc:
+        raise ControlPlaneError("INVALID_BASE64_ATTACHMENT", str(exc), 422) from exc
 
 
 def event_to_chat_parts(parts: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    chat_parts: list[dict[str, Any]] = []
-    for part in parts:
-        part_type = part.get("type")
-        if part_type == "text":
-            chat_parts.append({"type": "text", "text": str(part.get("text") or "")})
-        elif part_type == "attachment_ref":
-            attachment_id = str(part.get("attachment_id") or "")
-            media_type = str(part.get("media_type") or "application/octet-stream")
-            source_path = (
-                part.get("source_path")
-                if isinstance(part.get("source_path"), str)
-                else None
-            )
-            name = (
-                str(part.get("name"))
-                if isinstance(part.get("name"), str) and part.get("name")
-                else _attachment_name_from_source_path(source_path, attachment_id)
-            )
-            chat_parts.append(
-                {
-                    "type": "attachment_ref",
-                    "id": attachment_id,
-                    "name": name,
-                    "mime_type": media_type,
-                }
-            )
-        else:
-            chat_parts.append(part)
-    return chat_parts
+    return _ATTACHMENT_PROCESSOR.event_parts_to_chat_parts(parts)
 
 
 async def append_message(

--- a/services/api/tests/test_attachments.py
+++ b/services/api/tests/test_attachments.py
@@ -19,8 +19,72 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pytest
 
+from api.attachments.processor import AttachmentProcessor
 from api.runtime_control import extract_inline_attachments, event_to_chat_parts
 from api.sandbox.harness_protocol import messages_to_content_blocks
+
+
+class TestAttachmentProcessor:
+    def test_classifies_common_mime_types(self):
+        processor = AttachmentProcessor()
+
+        assert processor.classify_mime_type("image/png") == "image"
+        assert processor.classify_mime_type("application/pdf") == "document"
+        assert processor.classify_mime_type("text/csv") == "text"
+        assert processor.classify_mime_type("application/zip") == "archive"
+        assert processor.classify_mime_type("video/mp4") == "video"
+
+    def test_detects_known_url_sources(self):
+        processor = AttachmentProcessor()
+
+        assert processor.detect_url_source("https://docs.google.com/document/d/abc") == {
+            "source": "google_drive_url",
+            "host": "docs.google.com",
+        }
+        assert processor.detect_url_source("https://example.docsend.com/view/abc") == {
+            "source": "docsend_url",
+            "host": "example.docsend.com",
+        }
+        assert processor.detect_url_source("https://files.slack.com/files-pri/T-F/x.pdf") == {
+            "source": "slack_file_url",
+            "host": "files.slack.com",
+        }
+
+    def test_normalizes_slack_file_metadata_without_fetching_bytes(self):
+        candidate = AttachmentProcessor().candidate_from_slack_file_metadata(
+            {
+                "id": "F123",
+                "name": "report.pdf",
+                "mimetype": "application/pdf",
+                "size": 1234,
+                "url_private_download": "https://files.slack.com/report.pdf",
+            }
+        )
+
+        assert candidate is not None
+        assert candidate.source == "slack_file"
+        assert candidate.external_id == "F123"
+        assert candidate.name == "report.pdf"
+        assert candidate.kind == "document"
+        assert candidate.size_bytes == 1234
+
+    def test_normalizes_google_doc_metadata_without_storing(self):
+        candidate = AttachmentProcessor().candidate_from_google_doc(
+            {
+                "id": "doc-123",
+                "name": "Investment memo",
+                "mimeType": "application/vnd.google-apps.document",
+                "webViewLink": "https://docs.google.com/document/d/doc-123/edit",
+            },
+            text_content="memo body",
+        )
+
+        assert candidate is not None
+        assert candidate.source == "google_doc"
+        assert candidate.external_id == "doc-123"
+        assert candidate.name == "Investment memo"
+        assert candidate.kind == "document"
+        assert candidate.text_content == "memo body"
 
 
 # ── Unit: harness_protocol attachment_ref handling ──────────────────────────


### PR DESCRIPTION
## Summary
- add `api.attachments` package with normalized attachment models, MIME/URL/source classification, and API-thread storage helpers
- route existing inline base64 extraction and event/chat attachment ref conversion through `AttachmentProcessor`
- reuse the shared storage helper from `/agent/attachments/upload`
- add focused coverage for processor classification plus the existing attachment roundtrip path

## Validation
- `uv run pytest tests/test_attachments.py` from `services/api` (24 passed)
- `uv run ruff check api/attachments api/runtime_control.py api/routers/attachments.py tests/test_attachments.py` from `services/api`
- `uv run python -m compileall -q api/attachments api/runtime_control.py api/routers/attachments.py` from `services/api`
- `just build-one api`
- `just deploy` attempted, but Helm hit an existing field-manager conflict on the Slackbot deployment annotation `checksum/infra-secrets`
- verified locally by rolling only `centaur-centaur-api` to the newly built image and making real in-cluster requests:
  - `/agent/attachments/upload` -> list -> download returned `hello attachment processor`
  - seeded a local active assignment and posted `/agent/message` with inline base64 file content; response returned an `attachment_ids` entry and listing showed the stored `inline.txt` attachment

## Notes
- No ETL workflow integration or schema changes in this PR. This only creates the shared API-side processor and wires the current Slackbot/agent-thread attachment path through it.
