### PR TITLE
fix(slackbotv2): harden api-rs handoff and stream recovery

### DIFF
--- a/services/api-rs/crates/centaur-api-server/Cargo.toml
+++ b/services/api-rs/crates/centaur-api-server/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 axum.workspace = true
 centaur-iron-proxy.workspace = true
 centaur-sandbox-agent-k8s.workspace = true
+centaur-sandbox-core.workspace = true
 centaur-sandbox-local.workspace = true
 centaur-session-core.workspace = true
 centaur-session-runtime.workspace = true
@@ -30,4 +31,3 @@ urlencoding.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
-centaur-sandbox-core.workspace = true

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { Hono } from 'hono'
 import {
   Chat,
@@ -17,6 +18,8 @@ import {
 import {
   collectInitialContext,
   forwardToSessionApi,
+  isRetryableSessionApiError,
+  openSessionEventStream,
   serializeMessage,
   sessionStreamError,
   startingStreamNotification
@@ -62,6 +65,13 @@ type SlackAssistantAdapter = {
   setAssistantTitle?(channelId: string, threadTs: string, title: string): Promise<void>
 }
 
+type SlackbotV2RequestContext = {
+  retryableErrors: unknown[]
+  waitUntil(promise: Promise<unknown>): void
+}
+
+const requestContext = new AsyncLocalStorage<SlackbotV2RequestContext>()
+
 export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   const userName = options.userName ?? 'centaur'
   const logger = options.logger ?? noopLogger
@@ -73,10 +83,11 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     userName,
     logger
   })
+  const state = options.state ?? createDefaultState(options, logger)
   const chat = new Chat({
     userName,
     adapters: { slack },
-    state: options.state ?? createDefaultState(options, logger),
+    state,
     onLockConflict: 'force',
     logger
   })
@@ -86,7 +97,8 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     await thread.subscribe()
     await syncThreadMessageToSession(thread, message, {
       mode: 'execute',
-      options
+      options,
+      state
     })
   })
 
@@ -94,7 +106,8 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     if (!isAllowedSlackMessage(message, options, logger)) return
     await syncThreadMessageToSession(thread, message, {
       mode: message.isMention === true ? 'execute' : 'append',
-      options
+      options,
+      state
     })
   })
 
@@ -105,9 +118,36 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     if (!isAllowedSlackWebhookBody(rawBody, options, logger)) {
       return new globalThis.Response('ok', { status: 200 })
     }
-    const response = await chat.webhooks.slack(c.req.raw, {
+    const awaitHandoff = shouldAwaitSlackHandoff(rawBody)
+    const handoffTasks: Promise<unknown>[] = []
+    const context: SlackbotV2RequestContext = {
+      retryableErrors: [],
       waitUntil: promise => waitUntil(c, promise)
+    }
+    const response = await requestContext.run(context, () => {
+      return chat.webhooks.slack(c.req.raw, {
+        waitUntil: promise => {
+          if (awaitHandoff) {
+            handoffTasks.push(promise)
+          } else {
+            waitUntil(c, promise)
+          }
+        }
+      })
     })
+    if (awaitHandoff && response.ok) {
+      try {
+        await Promise.all(handoffTasks)
+      } catch (error) {
+        if (isRetryableSessionApiError(error)) context.retryableErrors.push(error)
+      }
+      if (context.retryableErrors.length > 0) {
+        traceLog(options, 'slackbotv2_webhook_retry_requested', undefined, {
+          error: errorMessage(context.retryableErrors[0])
+        })
+        return new globalThis.Response('temporary upstream unavailable', { status: 503 })
+      }
+    }
     return new globalThis.Response(await response.text(), {
       headers: response.headers,
       status: response.status
@@ -126,8 +166,8 @@ function createDefaultState(options: SlackbotV2Options, logger: Logger): StateAd
 }
 
 /**
- * Persists a Slack thread update into the session API. In execute mode it also starts and
- * renders a session stream unless another execution is already active for the same thread.
+ * Persists a Slack thread update into the session API. In execute mode the create/append/execute
+ * handoff completes before Slack is acknowledged; SSE rendering continues in background.
  */
 async function syncThreadMessageToSession(
   thread: Thread<SlackbotV2ThreadState>,
@@ -135,15 +175,18 @@ async function syncThreadMessageToSession(
   input: {
     mode: SlackbotV2MessageMode
     options: SlackbotV2Options
+    state: StateAdapter
   }
 ): Promise<void> {
   const traceStartedAtMs = nowMs()
   const state = (await thread.state) ?? {}
   const messageIds = new Set(state.forwardedMessageIds ?? [])
-  const shouldStartExecution = input.mode === 'execute' && state.activeExecution !== true
-  const shouldIncludeContext = shouldStartExecution
+  const executedMessageIds = new Set(state.executedMessageIds ?? [])
+  const shouldStartExecution =
+    input.mode === 'execute' && state.activeExecution !== true && !executedMessageIds.has(message.id)
+  const shouldIncludeContext = shouldStartExecution && state.historyForwarded !== true
   const isDuplicateIncrementalMessage =
-    messageIds.has(message.id) && (!shouldIncludeContext || state.historyForwarded)
+    messageIds.has(message.id) && !shouldStartExecution && !shouldIncludeContext
   const trace: SlackbotV2Trace = {
     includeContext: shouldIncludeContext,
     messageId: message.id,
@@ -172,49 +215,74 @@ async function syncThreadMessageToSession(
   if (shouldIncludeContext && !state.historyForwarded) {
     const contextStartedAtMs = nowMs()
     context = await collectInitialContext(thread, message)
-    for (const item of context) {
-      messageIds.add(item.id)
-    }
     traceLog(input.options, 'slackbotv2_forward_context_collected', trace, {
       message_count: context.length,
       phase_ms: elapsedMs(contextStartedAtMs)
     })
   } else {
-    messageIds.add(serializedMessage.id)
     traceLog(input.options, 'slackbotv2_forward_context_skipped', trace, {
       message_count: 1
     })
   }
 
   let lastEventId = state.lastEventId ?? 0
+  const candidateMessages = context ?? [serializedMessage]
+  const messagesToAppend = candidateMessages.filter(item => !messageIds.has(item.id))
 
   const forwardInput: ForwardSessionInput = {
     afterEventId: lastEventId,
     executeMessage: shouldStartExecution ? serializedMessage : undefined,
-    messages: context ?? [serializedMessage],
+    messages: messagesToAppend,
     onEventId: eventId => {
       lastEventId = Math.max(lastEventId, eventId)
     },
-    openStream: shouldStartExecution,
+    openStream: false,
     threadId: thread.id,
     trace
   }
 
-  const commitForwardedState = async (): Promise<void> => {
+  const commitMessagesAppended = async (): Promise<void> => {
+    const latest = (await thread.state) ?? {}
+    const latestMessageIds = new Set(latest.forwardedMessageIds ?? [])
+    for (const item of messagesToAppend) latestMessageIds.add(item.id)
     await thread.setState({
-      activeExecution: state.activeExecution || shouldStartExecution,
-      forwardedMessageIds: Array.from(messageIds).slice(-1000),
-      historyForwarded: state.historyForwarded || shouldIncludeContext,
+      forwardedMessageIds: Array.from(latestMessageIds).slice(-1000),
+      historyForwarded: latest.historyForwarded || shouldIncludeContext,
       lastEventId
     })
-    traceLog(input.options, 'slackbotv2_forward_state_committed', trace, {
-      forwarded_message_count: Math.min(messageIds.size, 1000)
+    traceLog(input.options, 'slackbotv2_forward_messages_committed', trace, {
+      appended_message_count: messagesToAppend.length,
+      forwarded_message_count: Math.min(latestMessageIds.size, 1000)
+    })
+  }
+
+  const commitExecutionStarted = async (): Promise<void> => {
+    const latest = (await thread.state) ?? {}
+    const latestExecutedMessageIds = new Set(latest.executedMessageIds ?? [])
+    latestExecutedMessageIds.add(serializedMessage.id)
+    await thread.setState({
+      activeExecution: true,
+      executedMessageIds: Array.from(latestExecutedMessageIds).slice(-1000),
+      lastEventId
+    })
+    traceLog(input.options, 'slackbotv2_forward_execution_committed', trace, {
+      executed_message_count: Math.min(latestExecutedMessageIds.size, 1000)
     })
   }
 
   if (!shouldStartExecution) {
-    await forwardToSessionApi(input.options, forwardInput)
-    await commitForwardedState()
+    try {
+      if (messagesToAppend.length > 0) {
+        await forwardToSessionApi(input.options, forwardInput, {
+          onMessagesAppended: commitMessagesAppended
+        })
+      }
+    } catch (error) {
+      if (await requestSlackRetry(input.state, message, error, input.options, trace)) {
+        throw error
+      }
+      throw error
+    }
     traceLog(input.options, 'slackbotv2_forward_complete', trace)
     return
   }
@@ -222,25 +290,68 @@ async function syncThreadMessageToSession(
   try {
     await thread.setState({ ...state, activeExecution: true })
     traceLog(input.options, 'slackbotv2_forward_active_execution_marked', trace)
-    await renderExecutionStream(
+    await forwardToSessionApi(input.options, forwardInput, {
+      onExecutionStarted: commitExecutionStarted,
+      onMessagesAppended: commitMessagesAppended
+    })
+    scheduleExecutionRender(
       thread,
-      executeAndStreamSession(input.options, forwardInput, commitForwardedState),
       serializedMessage,
       input.options,
+      forwardInput,
+      () => lastEventId,
       trace
     )
-    traceLog(input.options, 'slackbotv2_render_complete', trace)
-  } finally {
-    const latest = (await thread.state) ?? {}
-    await thread.setState({
-      ...latest,
-      activeExecution: false,
-      lastEventId: Math.max(latest.lastEventId ?? 0, lastEventId)
-    })
     traceLog(input.options, 'slackbotv2_forward_complete', trace, {
       last_event_id: lastEventId
     })
+  } catch (error) {
+    const latest = (await thread.state) ?? {}
+    await thread.setState({
+      activeExecution: false,
+      lastEventId: Math.max(latest.lastEventId ?? 0, lastEventId)
+    })
+    if (await requestSlackRetry(input.state, message, error, input.options, trace)) {
+      throw error
+    }
+    await renderExecutionStream(thread, streamError(error), serializedMessage, input.options, trace)
+    traceLog(input.options, 'slackbotv2_forward_complete', trace, {
+      latest_active_execution: latest.activeExecution === true,
+      last_event_id: lastEventId
+    })
   }
+}
+
+function scheduleExecutionRender(
+  thread: Thread<SlackbotV2ThreadState>,
+  message: SlackbotV2ApiMessage,
+  options: SlackbotV2Options,
+  input: ForwardSessionInput,
+  getLastEventId: () => number,
+  trace?: SlackbotV2Trace
+): void {
+  const promise = (async () => {
+    try {
+      await renderExecutionStream(
+        thread,
+        streamSessionAfterHandoff(options, input),
+        message,
+        options,
+        trace
+      )
+      traceLog(options, 'slackbotv2_render_complete', trace)
+    } finally {
+      const latest = (await thread.state) ?? {}
+      await thread.setState({
+        activeExecution: false,
+        lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId())
+      })
+      traceLog(options, 'slackbotv2_render_finalized', trace, {
+        last_event_id: getLastEventId()
+      })
+    }
+  })()
+  backgroundWaitUntil(promise)
 }
 
 async function renderExecutionStream(
@@ -268,24 +379,68 @@ async function renderExecutionStream(
   }
 }
 
-async function* executeAndStreamSession(
+async function* streamSessionAfterHandoff(
   options: SlackbotV2Options,
-  input: ForwardSessionInput,
-  onSessionReady: () => Promise<void>
+  input: ForwardSessionInput
 ): AsyncIterable<SlackbotV2RendererSource> {
   yield startingStreamNotification(input.threadId)
   traceLog(options, 'slackbotv2_stream_heartbeat_emitted', input.trace)
 
   try {
-    const stream = await forwardToSessionApi(options, input)
-    await onSessionReady()
-    if (!stream) return
+    const stream = await openSessionEventStream(options, input)
     for await (const event of stream) yield event
   } catch (error) {
     traceLog(options, 'slackbotv2_forward_failed', input.trace, {
       error: errorMessage(error)
     })
     yield sessionStreamError(error)
+  }
+}
+
+async function* streamError(error: unknown): AsyncIterable<SlackbotV2RendererSource> {
+  yield sessionStreamError(error)
+}
+
+async function requestSlackRetry(
+  state: StateAdapter,
+  message: Message,
+  error: unknown,
+  options: SlackbotV2Options,
+  trace?: SlackbotV2Trace
+): Promise<boolean> {
+  if (!isRetryableSessionApiError(error)) return false
+  const context = requestContext.getStore()
+  if (!context) return false
+  context.retryableErrors.push(error)
+  try {
+    await state.delete(`dedupe:slack:${message.id}`)
+  } catch (deleteError) {
+    traceLog(options, 'slackbotv2_webhook_retry_dedupe_clear_failed', trace, {
+      error: errorMessage(deleteError)
+    })
+  }
+  traceLog(options, 'slackbotv2_webhook_retry_marked', trace, {
+    error: errorMessage(error)
+  })
+  return true
+}
+
+function backgroundWaitUntil(promise: Promise<unknown>): void {
+  const context = requestContext.getStore()
+  if (context) {
+    context.waitUntil(promise)
+    return
+  }
+  void promise.catch(() => undefined)
+}
+
+function shouldAwaitSlackHandoff(rawBody: string): boolean {
+  try {
+    const payload = JSON.parse(rawBody) as { event?: { type?: unknown }; type?: unknown }
+    const eventType = payload.event?.type
+    return payload.type === 'event_callback' && (eventType === 'message' || eventType === 'app_mention')
+  } catch {
+    return false
   }
 }
 

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -78,6 +78,8 @@ const RENDER_OBLIGATION_INDEX_KEY = 'slackbotv2:render:index'
 const RENDER_OBLIGATION_INDEX_MAX_LENGTH = 2000
 const RENDER_INDEX_TTL_MS = 30 * 24 * 60 * 60 * 1000
 const RENDER_RECOVERY_LEASE_TTL_MS = 2 * 60 * 1000
+const RENDER_RETRY_INITIAL_DELAY_MS = 250
+const RENDER_RETRY_MAX_DELAY_MS = 5_000
 
 export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   const userName = options.userName ?? 'centaur'
@@ -378,36 +380,76 @@ function scheduleExecutionRender(
   trace?: SlackbotV2Trace
 ): void {
   const promise = (async () => {
-    let rendered = false
-    try {
-      await renderExecutionStream(
+    let attempt = 0
+    while (true) {
+      const result = await renderExecutionAttempt(
         thread,
-        streamSessionAfterHandoff(options, input),
         message,
         options,
+        input,
+        getLastEventId,
         trace
       )
-      rendered = true
-      traceLog(options, 'slackbotv2_render_complete', trace)
-    } catch (error) {
-      traceLog(options, 'slackbotv2_render_failed', trace, {
-        error: errorMessage(error)
+      if (result === 'complete') return
+      const delayMs = renderRetryDelayMs(attempt)
+      attempt += 1
+      traceLog(options, 'slackbotv2_render_retry_scheduled', trace, {
+        retry_delay_ms: delayMs,
+        retry_attempt: attempt
       })
-      throw error
-    } finally {
-      const latest = (await thread.state) ?? {}
-      await thread.setState({
-        activeExecution: false,
-        lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId()),
-        ...(rendered ? { renderObligation: null } : {})
-      })
-      traceLog(options, 'slackbotv2_render_finalized', trace, {
-        obligation_cleared: rendered,
-        last_event_id: getLastEventId()
-      })
+      await sleep(delayMs)
     }
   })()
   backgroundWaitUntil(promise)
+}
+
+async function renderExecutionAttempt(
+  thread: Thread<SlackbotV2ThreadState>,
+  message: SlackbotV2ApiMessage,
+  options: SlackbotV2Options,
+  input: ForwardSessionInput,
+  getLastEventId: () => number,
+  trace?: SlackbotV2Trace
+): Promise<'complete' | 'retry'> {
+  let rendered = false
+  let retry = false
+  try {
+    await renderExecutionStream(
+      thread,
+      streamSessionAfterHandoff(options, input),
+      message,
+      options,
+      trace
+    )
+    rendered = true
+    traceLog(options, 'slackbotv2_render_complete', trace)
+    return 'complete'
+  } catch (error) {
+    if (isRetryableSessionApiError(error)) {
+      retry = true
+      traceLog(options, 'slackbotv2_render_deferred', trace, {
+        error: errorMessage(error),
+        last_event_id: getLastEventId()
+      })
+      return 'retry'
+    }
+    traceLog(options, 'slackbotv2_render_failed', trace, {
+      error: errorMessage(error)
+    })
+    throw error
+  } finally {
+    const latest = (await thread.state) ?? {}
+    await thread.setState({
+      activeExecution: retry,
+      lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId()),
+      ...(rendered ? { renderObligation: null } : {})
+    })
+    traceLog(options, 'slackbotv2_render_finalized', trace, {
+      obligation_cleared: rendered,
+      retry_scheduled: retry,
+      last_event_id: getLastEventId()
+    })
+  }
 }
 
 function scheduleRenderObligationRecovery(
@@ -416,23 +458,47 @@ function scheduleRenderObligationRecovery(
   options: SlackbotV2Options
 ): void {
   backgroundWaitUntil(
-    recoverRenderObligations(chat, state, options).catch(error => {
+    recoverRenderObligationsWithRetry(chat, state, options)
+  )
+}
+
+async function recoverRenderObligationsWithRetry(
+  chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
+  state: StateAdapter,
+  options: SlackbotV2Options
+): Promise<void> {
+  let attempt = 0
+  while (true) {
+    try {
+      const deferredCount = await recoverRenderObligations(chat, state, options)
+      if (deferredCount === 0) return
+      const delayMs = renderRetryDelayMs(attempt)
+      attempt += 1
+      traceLog(options, 'slackbotv2_render_recovery_retry_scheduled', undefined, {
+        deferred_count: deferredCount,
+        retry_delay_ms: delayMs,
+        retry_attempt: attempt
+      })
+      await sleep(delayMs)
+    } catch (error) {
       traceLog(options, 'slackbotv2_render_recovery_failed', undefined, {
         error: errorMessage(error)
       })
-    })
-  )
+      return
+    }
+  }
 }
 
 async function recoverRenderObligations(
   chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
   state: StateAdapter,
   options: SlackbotV2Options
-): Promise<void> {
+): Promise<number> {
   const startedAtMs = nowMs()
   await chat.initialize()
   const indexedThreadIds = await state.getList<string>(RENDER_OBLIGATION_INDEX_KEY)
   const threadIds = Array.from(new Set(indexedThreadIds))
+  let deferredCount = 0
   traceLog(options, 'slackbotv2_render_recovery_scan', undefined, {
     obligation_count: threadIds.length,
     phase_ms: elapsedMs(startedAtMs)
@@ -458,12 +524,15 @@ async function recoverRenderObligations(
     }
 
     try {
-      await recoverRenderObligation(chat, state, options, threadId, obligation)
+      if (await recoverRenderObligation(chat, state, options, threadId, obligation)) {
+        deferredCount += 1
+      }
     } finally {
       const activeLeaseToken = await state.get<string>(renderRecoveryLeaseKey(threadId))
       if (activeLeaseToken === leaseToken) await state.delete(renderRecoveryLeaseKey(threadId))
     }
   }
+  return deferredCount
 }
 
 async function recoverRenderObligation(
@@ -472,7 +541,7 @@ async function recoverRenderObligation(
   options: SlackbotV2Options,
   threadId: string,
   obligation: SlackbotV2RenderObligation
-): Promise<void> {
+): Promise<boolean> {
   const trace: SlackbotV2Trace = {
     includeContext: false,
     messageId: obligation.message.id,
@@ -499,11 +568,20 @@ async function recoverRenderObligation(
   try {
     openedStream = await openSessionEventStream(options, input)
   } catch (error) {
+    const retryable = isRetryableSessionApiError(error)
     traceLog(options, 'slackbotv2_render_recovery_deferred', trace, {
       error: errorMessage(error),
-      last_event_id: lastEventId
+      last_event_id: lastEventId,
+      retryable
     })
-    return
+    if (retryable) return true
+    await renderRecoveredExecutionStream(thread, streamError(error), obligation.message, options, trace)
+    await thread.setState({
+      activeExecution: false,
+      lastEventId,
+      renderObligation: null
+    })
+    return false
   }
 
   let rendered = false
@@ -538,6 +616,7 @@ async function recoverRenderObligation(
       last_event_id: lastEventId
     })
   }
+  return false
 }
 
 async function indexRenderObligation(
@@ -624,18 +703,21 @@ async function* streamSessionAfterHandoff(
   options: SlackbotV2Options,
   input: ForwardSessionInput
 ): AsyncIterable<SlackbotV2RendererSource> {
-  yield startingStreamNotification(input.threadId)
-  traceLog(options, 'slackbotv2_stream_heartbeat_emitted', input.trace)
-
+  let stream: AsyncIterable<SlackbotV2RendererSource>
   try {
-    const stream = await openSessionEventStream(options, input)
-    for await (const event of stream) yield event
+    stream = await openSessionEventStream(options, input)
   } catch (error) {
     traceLog(options, 'slackbotv2_forward_failed', input.trace, {
       error: errorMessage(error)
     })
+    if (isRetryableSessionApiError(error)) throw error
     yield sessionStreamError(error)
+    return
   }
+
+  yield startingStreamNotification(input.threadId)
+  traceLog(options, 'slackbotv2_stream_heartbeat_emitted', input.trace)
+  for await (const event of stream) yield event
 }
 
 async function* streamError(error: unknown): AsyncIterable<SlackbotV2RendererSource> {
@@ -672,6 +754,14 @@ function rendererOptions(thread: Thread, options: SlackbotV2Options): CodexAppSe
       }
     }
   }
+}
+
+function renderRetryDelayMs(attempt: number): number {
+  return Math.min(RENDER_RETRY_INITIAL_DELAY_MS * 2 ** attempt, RENDER_RETRY_MAX_DELAY_MS)
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
 }
 
 async function setAssistantStatus(thread: Thread, status: string): Promise<void> {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -3,12 +3,10 @@ import { randomUUID } from 'node:crypto'
 import { Hono } from 'hono'
 import {
   Chat,
-  Message as ChatMessage,
   StreamingPlan,
-  ThreadImpl,
-  parseMarkdown,
   type Adapter,
   type Logger,
+  type Message as ChatMessage,
   type StateAdapter,
   type Thread
 } from 'chat'
@@ -464,7 +462,7 @@ async function recoverRenderObligation(
     startedAtMs: nowMs(),
     threadId
   }
-  const thread = recoveryThread(chat, state, options, obligation.message)
+  const thread = chat.thread(threadId)
   const threadState = (await thread.state) ?? {}
   let lastEventId = Math.max(threadState.lastEventId ?? 0, obligation.afterEventId)
   const input: ForwardSessionInput = {
@@ -495,7 +493,7 @@ async function recoverRenderObligation(
       activeExecution: true,
       lastEventId
     })
-    await renderExecutionStream(
+    await renderRecoveredExecutionStream(
       thread,
       streamOpenedSession(input, openedStream),
       obligation.message,
@@ -538,42 +536,6 @@ async function indexRenderObligation(
   traceLog(input.options, 'slackbotv2_render_obligation_indexed', input.trace)
 }
 
-function recoveryThread(
-  chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
-  state: StateAdapter,
-  options: SlackbotV2Options,
-  message: SlackbotV2ApiMessage
-): Thread<SlackbotV2ThreadState> {
-  const baseThread = chat.thread(message.threadId)
-  const adapter = baseThread.adapter
-  const currentMessage = new ChatMessage({
-    attachments: [],
-    author: message.author,
-    formatted: parseMarkdown(message.text),
-    id: message.id,
-    isMention: message.isMention,
-    metadata: {
-      dateSent: validDateOrNow(message.timestamp),
-      edited: false
-    },
-    raw: message.raw,
-    text: message.text,
-    threadId: message.threadId
-  })
-  return new ThreadImpl<SlackbotV2ThreadState>({
-    adapter,
-    channelId: adapter.channelIdFromThreadId(message.threadId),
-    channelVisibility: adapter.getChannelVisibility?.(message.threadId) ?? 'unknown',
-    currentMessage,
-    id: message.threadId,
-    initialMessage: currentMessage,
-    isDM: adapter.isDM?.(message.threadId) ?? false,
-    isSubscribedContext: true,
-    logger: options.logger ?? noopLogger,
-    stateAdapter: state
-  })
-}
-
 async function* streamOpenedSession(
   input: Pick<ForwardSessionInput, 'threadId' | 'trace'>,
   stream: AsyncIterable<SlackbotV2RendererSource>
@@ -592,14 +554,10 @@ function canRecoverRenderObligation(value: SlackbotV2RenderObligation): boolean 
     typeof value.afterEventId === 'number' &&
     Boolean(message) &&
     typeof message.id === 'string' &&
+    typeof message.teamId === 'string' &&
     typeof message.text === 'string' &&
     typeof message.threadId === 'string'
   )
-}
-
-function validDateOrNow(value: string): Date {
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? new Date() : date
 }
 
 async function renderExecutionStream(
@@ -625,6 +583,51 @@ async function renderExecutionStream(
   } finally {
     await setAssistantStatus(thread, '')
   }
+}
+
+async function renderRecoveredExecutionStream(
+  thread: Thread,
+  stream: AsyncIterable<SlackbotV2RendererSource>,
+  message: SlackbotV2ApiMessage,
+  options: SlackbotV2Options,
+  trace?: SlackbotV2Trace
+): Promise<void> {
+  const recipient = slackStreamRecipient(message)
+  if (!recipient) {
+    throw new Error('Cannot recover Slack stream without recipient user/team context')
+  }
+  if (!thread.adapter.stream) {
+    throw new Error('Cannot recover Slack stream because adapter streaming is unavailable')
+  }
+
+  const titleStartedAtMs = nowMs()
+  await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
+  await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
+  traceLog(options, 'slackbotv2_render_slack_metadata_set', trace, {
+    phase_ms: elapsedMs(titleStartedAtMs)
+  })
+  try {
+    await thread.adapter.stream(
+      thread.id,
+      codexAppServerToChatSdkStream(stream, rendererOptions(thread, options)),
+      {
+        recipientTeamId: recipient.teamId,
+        recipientUserId: recipient.userId,
+        taskDisplayMode: options.streamTaskDisplayMode ?? 'plan'
+      }
+    )
+  } finally {
+    await setAssistantStatus(thread, '')
+  }
+}
+
+function slackStreamRecipient(
+  message: SlackbotV2ApiMessage
+): { teamId: string; userId: string } | null {
+  const teamId = message.teamId
+  const userId = message.author.userId
+  if (!teamId || !userId) return null
+  return { teamId, userId }
 }
 
 async function* streamSessionAfterHandoff(

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -298,8 +298,21 @@ async function syncThreadMessageToSession(
         })
       }
     } catch (error) {
-      if (await requestSlackRetry(input.state, message, error, input.options, trace)) {
-        throw error
+      if (isRetryableSessionApiError(error)) {
+        const context = requestContext.getStore()
+        if (context) {
+          context.retryableErrors.push(error)
+          try {
+            await input.state.delete(`dedupe:slack:${message.id}`)
+          } catch (deleteError) {
+            traceLog(input.options, 'slackbotv2_webhook_retry_dedupe_clear_failed', trace, {
+              error: errorMessage(deleteError)
+            })
+          }
+          traceLog(input.options, 'slackbotv2_webhook_retry_marked', trace, {
+            error: errorMessage(error)
+          })
+        }
       }
       throw error
     }
@@ -331,8 +344,22 @@ async function syncThreadMessageToSession(
       activeExecution: false,
       lastEventId: Math.max(latest.lastEventId ?? 0, lastEventId)
     })
-    if (await requestSlackRetry(input.state, message, error, input.options, trace)) {
-      throw error
+    if (isRetryableSessionApiError(error)) {
+      const context = requestContext.getStore()
+      if (context) {
+        context.retryableErrors.push(error)
+        try {
+          await input.state.delete(`dedupe:slack:${message.id}`)
+        } catch (deleteError) {
+          traceLog(input.options, 'slackbotv2_webhook_retry_dedupe_clear_failed', trace, {
+            error: errorMessage(deleteError)
+          })
+        }
+        traceLog(input.options, 'slackbotv2_webhook_retry_marked', trace, {
+          error: errorMessage(error)
+        })
+        throw error
+      }
     }
     await renderExecutionStream(thread, streamError(error), serializedMessage, input.options, trace)
     traceLog(input.options, 'slackbotv2_forward_complete', trace, {
@@ -613,30 +640,6 @@ async function* streamSessionAfterHandoff(
 
 async function* streamError(error: unknown): AsyncIterable<SlackbotV2RendererSource> {
   yield sessionStreamError(error)
-}
-
-async function requestSlackRetry(
-  state: StateAdapter,
-  message: ChatMessage,
-  error: unknown,
-  options: SlackbotV2Options,
-  trace?: SlackbotV2Trace
-): Promise<boolean> {
-  if (!isRetryableSessionApiError(error)) return false
-  const context = requestContext.getStore()
-  if (!context) return false
-  context.retryableErrors.push(error)
-  try {
-    await state.delete(`dedupe:slack:${message.id}`)
-  } catch (deleteError) {
-    traceLog(options, 'slackbotv2_webhook_retry_dedupe_clear_failed', trace, {
-      error: errorMessage(deleteError)
-    })
-  }
-  traceLog(options, 'slackbotv2_webhook_retry_marked', trace, {
-    error: errorMessage(error)
-  })
-  return true
 }
 
 function backgroundWaitUntil(promise: Promise<unknown>): void {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -40,7 +40,7 @@ import type {
   SlackbotV2ThreadState,
   SlackbotV2Trace
 } from './types'
-import { elapsedMs, errorMessage, isJsonObject, noopLogger, nowMs, traceLog } from './utils'
+import { elapsedMs, errorMessage, noopLogger, nowMs, traceLog } from './utils'
 
 export type {
   SlackbotV2,
@@ -78,7 +78,7 @@ type SlackbotV2RequestContext = {
 const requestContext = new AsyncLocalStorage<SlackbotV2RequestContext>()
 const RENDER_OBLIGATION_INDEX_KEY = 'slackbotv2:render:index'
 const RENDER_OBLIGATION_INDEX_MAX_LENGTH = 2000
-const RENDER_OBLIGATION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+const RENDER_INDEX_TTL_MS = 30 * 24 * 60 * 60 * 1000
 const RENDER_RECOVERY_LEASE_TTL_MS = 2 * 60 * 1000
 
 export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
@@ -273,17 +273,19 @@ async function syncThreadMessageToSession(
     const latest = (await thread.state) ?? {}
     const latestExecutedMessageIds = new Set(latest.executedMessageIds ?? [])
     latestExecutedMessageIds.add(serializedMessage.id)
-    await persistRenderObligation(input.state, {
-      afterEventId: lastEventId,
-      message: serializedMessage,
-      options: input.options,
-      threadId: thread.id,
-      trace
-    })
     await thread.setState({
       activeExecution: true,
       executedMessageIds: Array.from(latestExecutedMessageIds).slice(-1000),
-      lastEventId
+      lastEventId,
+      renderObligation: {
+        afterEventId: lastEventId,
+        message: serializedMessage
+      }
+    })
+    await indexRenderObligation(input.state, {
+      options: input.options,
+      threadId: thread.id,
+      trace
     })
     traceLog(input.options, 'slackbotv2_forward_execution_committed', trace, {
       executed_message_count: Math.min(latestExecutedMessageIds.size, 1000)
@@ -308,7 +310,7 @@ async function syncThreadMessageToSession(
   }
 
   try {
-    await thread.setState({ ...state, activeExecution: true })
+    await thread.setState({ activeExecution: true })
     traceLog(input.options, 'slackbotv2_forward_active_execution_marked', trace)
     await forwardToSessionApi(input.options, forwardInput, {
       onExecutionStarted: commitExecutionStarted,
@@ -318,7 +320,6 @@ async function syncThreadMessageToSession(
       thread,
       serializedMessage,
       input.options,
-      input.state,
       forwardInput,
       () => lastEventId,
       trace
@@ -347,7 +348,6 @@ function scheduleExecutionRender(
   thread: Thread<SlackbotV2ThreadState>,
   message: SlackbotV2ApiMessage,
   options: SlackbotV2Options,
-  state: StateAdapter,
   input: ForwardSessionInput,
   getLastEventId: () => number,
   trace?: SlackbotV2Trace
@@ -373,9 +373,9 @@ function scheduleExecutionRender(
       const latest = (await thread.state) ?? {}
       await thread.setState({
         activeExecution: false,
-        lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId())
+        lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId()),
+        ...(rendered ? { renderObligation: null } : {})
       })
-      if (rendered) await clearRenderObligation(state, thread.id)
       traceLog(options, 'slackbotv2_render_finalized', trace, {
         obligation_cleared: rendered,
         last_event_id: getLastEventId()
@@ -416,9 +416,11 @@ async function recoverRenderObligations(
   })
 
   for (const threadId of threadIds) {
-    const obligation = await state.get<unknown>(renderObligationKey(threadId))
-    if (!isRenderObligation(obligation)) {
-      if (obligation === null) continue
+    const thread = chat.thread(threadId)
+    const threadState = await thread.state
+    const obligation = threadState?.renderObligation
+    if (!obligation) continue
+    if (!canRecoverRenderObligation(obligation)) {
       traceLog(options, 'slackbotv2_render_recovery_invalid_obligation', undefined, {
         thread_id: threadId
       })
@@ -439,7 +441,7 @@ async function recoverRenderObligations(
     }
 
     try {
-      await recoverRenderObligation(chat, state, options, obligation)
+      await recoverRenderObligation(chat, state, options, threadId, obligation)
     } finally {
       const activeLeaseToken = await state.get<string>(renderRecoveryLeaseKey(threadId))
       if (activeLeaseToken === leaseToken) await state.delete(renderRecoveryLeaseKey(threadId))
@@ -451,6 +453,7 @@ async function recoverRenderObligation(
   chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
   state: StateAdapter,
   options: SlackbotV2Options,
+  threadId: string,
   obligation: SlackbotV2RenderObligation
 ): Promise<void> {
   const trace: SlackbotV2Trace = {
@@ -459,7 +462,7 @@ async function recoverRenderObligation(
     mode: 'execute',
     openStream: true,
     startedAtMs: nowMs(),
-    threadId: obligation.threadId
+    threadId
   }
   const thread = recoveryThread(chat, state, options, obligation.message)
   const threadState = (await thread.state) ?? {}
@@ -471,7 +474,7 @@ async function recoverRenderObligation(
       lastEventId = Math.max(lastEventId, eventId)
     },
     openStream: false,
-    threadId: obligation.threadId,
+    threadId,
     trace
   }
 
@@ -510,9 +513,9 @@ async function recoverRenderObligation(
     const latest = (await thread.state) ?? {}
     await thread.setState({
       activeExecution: false,
-      lastEventId: Math.max(latest.lastEventId ?? 0, lastEventId)
+      lastEventId: Math.max(latest.lastEventId ?? 0, lastEventId),
+      ...(rendered ? { renderObligation: null } : {})
     })
-    if (rendered) await clearRenderObligation(state, obligation.threadId)
     traceLog(options, 'slackbotv2_render_recovery_finalized', trace, {
       obligation_cleared: rendered,
       last_event_id: lastEventId
@@ -520,37 +523,19 @@ async function recoverRenderObligation(
   }
 }
 
-async function persistRenderObligation(
+async function indexRenderObligation(
   state: StateAdapter,
   input: {
-    afterEventId: number
-    message: SlackbotV2ApiMessage
     options: SlackbotV2Options
     threadId: string
     trace?: SlackbotV2Trace
   }
 ): Promise<void> {
-  const now = Date.now()
-  const obligation: SlackbotV2RenderObligation = {
-    afterEventId: input.afterEventId,
-    createdAtMs: now,
-    message: input.message,
-    threadId: input.threadId,
-    updatedAtMs: now,
-    version: 1
-  }
-  await state.set(renderObligationKey(input.threadId), obligation, RENDER_OBLIGATION_TTL_MS)
   await state.appendToList(RENDER_OBLIGATION_INDEX_KEY, input.threadId, {
     maxLength: RENDER_OBLIGATION_INDEX_MAX_LENGTH,
-    ttlMs: RENDER_OBLIGATION_TTL_MS
+    ttlMs: RENDER_INDEX_TTL_MS
   })
-  traceLog(input.options, 'slackbotv2_render_obligation_persisted', input.trace, {
-    after_event_id: input.afterEventId
-  })
-}
-
-async function clearRenderObligation(state: StateAdapter, threadId: string): Promise<void> {
-  await state.delete(renderObligationKey(threadId))
+  traceLog(input.options, 'slackbotv2_render_obligation_indexed', input.trace)
 }
 
 function recoveryThread(
@@ -597,39 +582,18 @@ async function* streamOpenedSession(
   for await (const event of stream) yield event
 }
 
-function renderObligationKey(threadId: string): string {
-  return `slackbotv2:render:${threadId}`
-}
-
 function renderRecoveryLeaseKey(threadId: string): string {
   return `slackbotv2:render:lease:${threadId}`
 }
 
-function isRenderObligation(value: unknown): value is SlackbotV2RenderObligation {
-  if (!isJsonObject(value) || value.version !== 1) return false
+function canRecoverRenderObligation(value: SlackbotV2RenderObligation): boolean {
+  const message = value.message
   return (
     typeof value.afterEventId === 'number' &&
-    typeof value.createdAtMs === 'number' &&
-    typeof value.threadId === 'string' &&
-    typeof value.updatedAtMs === 'number' &&
-    isApiMessage(value.message)
-  )
-}
-
-function isApiMessage(value: unknown): value is SlackbotV2ApiMessage {
-  if (!isJsonObject(value) || !isJsonObject(value.author)) return false
-  return (
-    Array.isArray(value.attachments) &&
-    typeof value.author.fullName === 'string' &&
-    (typeof value.author.isBot === 'boolean' || value.author.isBot === 'unknown') &&
-    typeof value.author.isMe === 'boolean' &&
-    typeof value.author.userId === 'string' &&
-    typeof value.author.userName === 'string' &&
-    typeof value.id === 'string' &&
-    typeof value.isMention === 'boolean' &&
-    typeof value.text === 'string' &&
-    typeof value.threadId === 'string' &&
-    typeof value.timestamp === 'string'
+    Boolean(message) &&
+    typeof message.id === 'string' &&
+    typeof message.text === 'string' &&
+    typeof message.threadId === 'string'
   )
 }
 

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -404,10 +404,8 @@ async function recoverRenderObligations(
 ): Promise<void> {
   const startedAtMs = nowMs()
   await chat.initialize()
-  const indexedThreadIds = await state.getList<unknown>(RENDER_OBLIGATION_INDEX_KEY)
-  const threadIds = Array.from(
-    new Set(indexedThreadIds.filter((threadId): threadId is string => typeof threadId === 'string'))
-  )
+  const indexedThreadIds = await state.getList<string>(RENDER_OBLIGATION_INDEX_KEY)
+  const threadIds = Array.from(new Set(indexedThreadIds))
   traceLog(options, 'slackbotv2_render_recovery_scan', undefined, {
     obligation_count: threadIds.length,
     phase_ms: elapsedMs(startedAtMs)
@@ -418,12 +416,6 @@ async function recoverRenderObligations(
     const threadState = await thread.state
     const obligation = threadState?.renderObligation
     if (!obligation) continue
-    if (!canRecoverRenderObligation(obligation)) {
-      traceLog(options, 'slackbotv2_render_recovery_invalid_obligation', undefined, {
-        thread_id: threadId
-      })
-      continue
-    }
 
     const leaseToken = randomUUID()
     const leaseAcquired = await state.setIfNotExists(
@@ -548,18 +540,6 @@ function renderRecoveryLeaseKey(threadId: string): string {
   return `slackbotv2:render:lease:${threadId}`
 }
 
-function canRecoverRenderObligation(value: SlackbotV2RenderObligation): boolean {
-  const message = value.message
-  return (
-    typeof value.afterEventId === 'number' &&
-    Boolean(message) &&
-    typeof message.id === 'string' &&
-    typeof message.teamId === 'string' &&
-    typeof message.text === 'string' &&
-    typeof message.threadId === 'string'
-  )
-}
-
 async function renderExecutionStream(
   thread: Thread,
   stream: AsyncIterable<SlackbotV2RendererSource>,
@@ -592,14 +572,6 @@ async function renderRecoveredExecutionStream(
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace
 ): Promise<void> {
-  const recipient = slackStreamRecipient(message)
-  if (!recipient) {
-    throw new Error('Cannot recover Slack stream without recipient user/team context')
-  }
-  if (!thread.adapter.stream) {
-    throw new Error('Cannot recover Slack stream because adapter streaming is unavailable')
-  }
-
   const titleStartedAtMs = nowMs()
   await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
   await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
@@ -607,27 +579,18 @@ async function renderRecoveredExecutionStream(
     phase_ms: elapsedMs(titleStartedAtMs)
   })
   try {
-    await thread.adapter.stream(
+    await thread.adapter.stream!(
       thread.id,
       codexAppServerToChatSdkStream(stream, rendererOptions(thread, options)),
       {
-        recipientTeamId: recipient.teamId,
-        recipientUserId: recipient.userId,
+        recipientTeamId: message.teamId,
+        recipientUserId: message.author.userId,
         taskDisplayMode: options.streamTaskDisplayMode ?? 'plan'
       }
     )
   } finally {
     await setAssistantStatus(thread, '')
   }
-}
-
-function slackStreamRecipient(
-  message: SlackbotV2ApiMessage
-): { teamId: string; userId: string } | null {
-  const teamId = message.teamId
-  const userId = message.author.userId
-  if (!teamId || !userId) return null
-  return { teamId, userId }
 }
 
 async function* streamSessionAfterHandoff(

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1,10 +1,14 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
+import { randomUUID } from 'node:crypto'
 import { Hono } from 'hono'
 import {
   Chat,
+  Message as ChatMessage,
   StreamingPlan,
+  ThreadImpl,
+  parseMarkdown,
+  type Adapter,
   type Logger,
-  type Message,
   type StateAdapter,
   type Thread
 } from 'chat'
@@ -31,11 +35,12 @@ import type {
   SlackbotV2ApiMessage,
   SlackbotV2MessageMode,
   SlackbotV2Options,
+  SlackbotV2RenderObligation,
   SlackbotV2RendererSource,
   SlackbotV2ThreadState,
   SlackbotV2Trace
 } from './types'
-import { elapsedMs, errorMessage, noopLogger, nowMs, traceLog } from './utils'
+import { elapsedMs, errorMessage, isJsonObject, noopLogger, nowMs, traceLog } from './utils'
 
 export type {
   SlackbotV2,
@@ -71,6 +76,10 @@ type SlackbotV2RequestContext = {
 }
 
 const requestContext = new AsyncLocalStorage<SlackbotV2RequestContext>()
+const RENDER_OBLIGATION_INDEX_KEY = 'slackbotv2:render:index'
+const RENDER_OBLIGATION_INDEX_MAX_LENGTH = 2000
+const RENDER_OBLIGATION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+const RENDER_RECOVERY_LEASE_TTL_MS = 2 * 60 * 1000
 
 export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   const userName = options.userName ?? 'centaur'
@@ -84,7 +93,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     logger
   })
   const state = options.state ?? createDefaultState(options, logger)
-  const chat = new Chat({
+  const chat = new Chat<{ slack: typeof slack }, SlackbotV2ThreadState>({
     userName,
     adapters: { slack },
     state,
@@ -154,6 +163,10 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     })
   })
 
+  if (options.recoverRenderObligationsOnStart !== false) {
+    scheduleRenderObligationRecovery(chat, state, options)
+  }
+
   return { app, chat }
 }
 
@@ -171,7 +184,7 @@ function createDefaultState(options: SlackbotV2Options, logger: Logger): StateAd
  */
 async function syncThreadMessageToSession(
   thread: Thread<SlackbotV2ThreadState>,
-  message: Message,
+  message: ChatMessage,
   input: {
     mode: SlackbotV2MessageMode
     options: SlackbotV2Options
@@ -260,6 +273,13 @@ async function syncThreadMessageToSession(
     const latest = (await thread.state) ?? {}
     const latestExecutedMessageIds = new Set(latest.executedMessageIds ?? [])
     latestExecutedMessageIds.add(serializedMessage.id)
+    await persistRenderObligation(input.state, {
+      afterEventId: lastEventId,
+      message: serializedMessage,
+      options: input.options,
+      threadId: thread.id,
+      trace
+    })
     await thread.setState({
       activeExecution: true,
       executedMessageIds: Array.from(latestExecutedMessageIds).slice(-1000),
@@ -298,6 +318,7 @@ async function syncThreadMessageToSession(
       thread,
       serializedMessage,
       input.options,
+      input.state,
       forwardInput,
       () => lastEventId,
       trace
@@ -326,11 +347,13 @@ function scheduleExecutionRender(
   thread: Thread<SlackbotV2ThreadState>,
   message: SlackbotV2ApiMessage,
   options: SlackbotV2Options,
+  state: StateAdapter,
   input: ForwardSessionInput,
   getLastEventId: () => number,
   trace?: SlackbotV2Trace
 ): void {
   const promise = (async () => {
+    let rendered = false
     try {
       await renderExecutionStream(
         thread,
@@ -339,19 +362,280 @@ function scheduleExecutionRender(
         options,
         trace
       )
+      rendered = true
       traceLog(options, 'slackbotv2_render_complete', trace)
+    } catch (error) {
+      traceLog(options, 'slackbotv2_render_failed', trace, {
+        error: errorMessage(error)
+      })
+      throw error
     } finally {
       const latest = (await thread.state) ?? {}
       await thread.setState({
         activeExecution: false,
         lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId())
       })
+      if (rendered) await clearRenderObligation(state, thread.id)
       traceLog(options, 'slackbotv2_render_finalized', trace, {
+        obligation_cleared: rendered,
         last_event_id: getLastEventId()
       })
     }
   })()
   backgroundWaitUntil(promise)
+}
+
+function scheduleRenderObligationRecovery(
+  chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
+  state: StateAdapter,
+  options: SlackbotV2Options
+): void {
+  backgroundWaitUntil(
+    recoverRenderObligations(chat, state, options).catch(error => {
+      traceLog(options, 'slackbotv2_render_recovery_failed', undefined, {
+        error: errorMessage(error)
+      })
+    })
+  )
+}
+
+async function recoverRenderObligations(
+  chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
+  state: StateAdapter,
+  options: SlackbotV2Options
+): Promise<void> {
+  const startedAtMs = nowMs()
+  await chat.initialize()
+  const indexedThreadIds = await state.getList<unknown>(RENDER_OBLIGATION_INDEX_KEY)
+  const threadIds = Array.from(
+    new Set(indexedThreadIds.filter((threadId): threadId is string => typeof threadId === 'string'))
+  )
+  traceLog(options, 'slackbotv2_render_recovery_scan', undefined, {
+    obligation_count: threadIds.length,
+    phase_ms: elapsedMs(startedAtMs)
+  })
+
+  for (const threadId of threadIds) {
+    const obligation = await state.get<unknown>(renderObligationKey(threadId))
+    if (!isRenderObligation(obligation)) {
+      if (obligation === null) continue
+      traceLog(options, 'slackbotv2_render_recovery_invalid_obligation', undefined, {
+        thread_id: threadId
+      })
+      continue
+    }
+
+    const leaseToken = randomUUID()
+    const leaseAcquired = await state.setIfNotExists(
+      renderRecoveryLeaseKey(threadId),
+      leaseToken,
+      RENDER_RECOVERY_LEASE_TTL_MS
+    )
+    if (!leaseAcquired) {
+      traceLog(options, 'slackbotv2_render_recovery_lease_skipped', undefined, {
+        thread_id: threadId
+      })
+      continue
+    }
+
+    try {
+      await recoverRenderObligation(chat, state, options, obligation)
+    } finally {
+      const activeLeaseToken = await state.get<string>(renderRecoveryLeaseKey(threadId))
+      if (activeLeaseToken === leaseToken) await state.delete(renderRecoveryLeaseKey(threadId))
+    }
+  }
+}
+
+async function recoverRenderObligation(
+  chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
+  state: StateAdapter,
+  options: SlackbotV2Options,
+  obligation: SlackbotV2RenderObligation
+): Promise<void> {
+  const trace: SlackbotV2Trace = {
+    includeContext: false,
+    messageId: obligation.message.id,
+    mode: 'execute',
+    openStream: true,
+    startedAtMs: nowMs(),
+    threadId: obligation.threadId
+  }
+  const thread = recoveryThread(chat, state, options, obligation.message)
+  const threadState = (await thread.state) ?? {}
+  let lastEventId = Math.max(threadState.lastEventId ?? 0, obligation.afterEventId)
+  const input: ForwardSessionInput = {
+    afterEventId: lastEventId,
+    messages: [],
+    onEventId: eventId => {
+      lastEventId = Math.max(lastEventId, eventId)
+    },
+    openStream: false,
+    threadId: obligation.threadId,
+    trace
+  }
+
+  let openedStream: AsyncIterable<SlackbotV2RendererSource>
+  try {
+    openedStream = await openSessionEventStream(options, input)
+  } catch (error) {
+    traceLog(options, 'slackbotv2_render_recovery_deferred', trace, {
+      error: errorMessage(error),
+      last_event_id: lastEventId
+    })
+    return
+  }
+
+  let rendered = false
+  try {
+    await thread.setState({
+      activeExecution: true,
+      lastEventId
+    })
+    await renderExecutionStream(
+      thread,
+      streamOpenedSession(input, openedStream),
+      obligation.message,
+      options,
+      trace
+    )
+    rendered = true
+    traceLog(options, 'slackbotv2_render_recovery_complete', trace)
+  } catch (error) {
+    traceLog(options, 'slackbotv2_render_recovery_render_failed', trace, {
+      error: errorMessage(error)
+    })
+    throw error
+  } finally {
+    const latest = (await thread.state) ?? {}
+    await thread.setState({
+      activeExecution: false,
+      lastEventId: Math.max(latest.lastEventId ?? 0, lastEventId)
+    })
+    if (rendered) await clearRenderObligation(state, obligation.threadId)
+    traceLog(options, 'slackbotv2_render_recovery_finalized', trace, {
+      obligation_cleared: rendered,
+      last_event_id: lastEventId
+    })
+  }
+}
+
+async function persistRenderObligation(
+  state: StateAdapter,
+  input: {
+    afterEventId: number
+    message: SlackbotV2ApiMessage
+    options: SlackbotV2Options
+    threadId: string
+    trace?: SlackbotV2Trace
+  }
+): Promise<void> {
+  const now = Date.now()
+  const obligation: SlackbotV2RenderObligation = {
+    afterEventId: input.afterEventId,
+    createdAtMs: now,
+    message: input.message,
+    threadId: input.threadId,
+    updatedAtMs: now,
+    version: 1
+  }
+  await state.set(renderObligationKey(input.threadId), obligation, RENDER_OBLIGATION_TTL_MS)
+  await state.appendToList(RENDER_OBLIGATION_INDEX_KEY, input.threadId, {
+    maxLength: RENDER_OBLIGATION_INDEX_MAX_LENGTH,
+    ttlMs: RENDER_OBLIGATION_TTL_MS
+  })
+  traceLog(input.options, 'slackbotv2_render_obligation_persisted', input.trace, {
+    after_event_id: input.afterEventId
+  })
+}
+
+async function clearRenderObligation(state: StateAdapter, threadId: string): Promise<void> {
+  await state.delete(renderObligationKey(threadId))
+}
+
+function recoveryThread(
+  chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
+  state: StateAdapter,
+  options: SlackbotV2Options,
+  message: SlackbotV2ApiMessage
+): Thread<SlackbotV2ThreadState> {
+  const baseThread = chat.thread(message.threadId)
+  const adapter = baseThread.adapter
+  const currentMessage = new ChatMessage({
+    attachments: [],
+    author: message.author,
+    formatted: parseMarkdown(message.text),
+    id: message.id,
+    isMention: message.isMention,
+    metadata: {
+      dateSent: validDateOrNow(message.timestamp),
+      edited: false
+    },
+    raw: message.raw,
+    text: message.text,
+    threadId: message.threadId
+  })
+  return new ThreadImpl<SlackbotV2ThreadState>({
+    adapter,
+    channelId: adapter.channelIdFromThreadId(message.threadId),
+    channelVisibility: adapter.getChannelVisibility?.(message.threadId) ?? 'unknown',
+    currentMessage,
+    id: message.threadId,
+    initialMessage: currentMessage,
+    isDM: adapter.isDM?.(message.threadId) ?? false,
+    isSubscribedContext: true,
+    logger: options.logger ?? noopLogger,
+    stateAdapter: state
+  })
+}
+
+async function* streamOpenedSession(
+  input: Pick<ForwardSessionInput, 'threadId' | 'trace'>,
+  stream: AsyncIterable<SlackbotV2RendererSource>
+): AsyncIterable<SlackbotV2RendererSource> {
+  yield startingStreamNotification(input.threadId)
+  for await (const event of stream) yield event
+}
+
+function renderObligationKey(threadId: string): string {
+  return `slackbotv2:render:${threadId}`
+}
+
+function renderRecoveryLeaseKey(threadId: string): string {
+  return `slackbotv2:render:lease:${threadId}`
+}
+
+function isRenderObligation(value: unknown): value is SlackbotV2RenderObligation {
+  if (!isJsonObject(value) || value.version !== 1) return false
+  return (
+    typeof value.afterEventId === 'number' &&
+    typeof value.createdAtMs === 'number' &&
+    typeof value.threadId === 'string' &&
+    typeof value.updatedAtMs === 'number' &&
+    isApiMessage(value.message)
+  )
+}
+
+function isApiMessage(value: unknown): value is SlackbotV2ApiMessage {
+  if (!isJsonObject(value) || !isJsonObject(value.author)) return false
+  return (
+    Array.isArray(value.attachments) &&
+    typeof value.author.fullName === 'string' &&
+    (typeof value.author.isBot === 'boolean' || value.author.isBot === 'unknown') &&
+    typeof value.author.isMe === 'boolean' &&
+    typeof value.author.userId === 'string' &&
+    typeof value.author.userName === 'string' &&
+    typeof value.id === 'string' &&
+    typeof value.isMention === 'boolean' &&
+    typeof value.text === 'string' &&
+    typeof value.threadId === 'string' &&
+    typeof value.timestamp === 'string'
+  )
+}
+
+function validDateOrNow(value: string): Date {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? new Date() : date
 }
 
 async function renderExecutionStream(
@@ -403,7 +687,7 @@ async function* streamError(error: unknown): AsyncIterable<SlackbotV2RendererSou
 
 async function requestSlackRetry(
   state: StateAdapter,
-  message: Message,
+  message: ChatMessage,
   error: unknown,
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -94,10 +94,24 @@ export async function serializeMessage(message: Message): Promise<SlackbotV2ApiM
     id: message.id,
     isMention: message.isMention === true,
     raw: message.raw,
+    teamId: slackTeamId(message.raw),
     text: message.text,
     threadId: message.threadId,
     timestamp: message.metadata.dateSent.toISOString()
   }
+}
+
+function slackTeamId(raw: unknown): string | undefined {
+  if (!isJsonObject(raw)) return undefined
+  const team = raw.team
+  if (typeof raw.team_id === 'string' && raw.team_id) return raw.team_id
+  if (typeof team === 'string' && team) return team
+  if (isJsonObject(team) && typeof team.id === 'string' && team.id) return team.id
+  const user = raw.user
+  if (isJsonObject(user) && typeof user.team_id === 'string' && user.team_id) {
+    return user.team_id
+  }
+  return undefined
 }
 
 export async function forwardToSessionApi(

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -94,7 +94,7 @@ export async function serializeMessage(message: Message): Promise<SlackbotV2ApiM
     id: message.id,
     isMention: message.isMention === true,
     raw: message.raw,
-    teamId: slackTeamId(message.raw),
+    teamId: slackTeamId(message.raw) as string,
     text: message.text,
     threadId: message.threadId,
     timestamp: message.metadata.dateSent.toISOString()

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -15,6 +15,44 @@ import type {
 } from './types'
 import { elapsedMs, isJsonObject, nowMs, stringValue, toAsyncIterable, traceLog } from './utils'
 
+export class SessionApiError extends Error {
+  readonly action: string
+  readonly body: string
+  readonly retryable: boolean
+  readonly status: number
+  readonly statusText: string
+
+  constructor(input: {
+    action: string
+    body: string
+    retryable: boolean
+    status: number
+    statusText: string
+  }) {
+    const suffix = input.body ? `: ${input.body}` : ''
+    super(
+      `Centaur session ${input.action} failed: ${input.status} ${input.statusText}${suffix}`
+    )
+    this.name = 'SessionApiError'
+    this.action = input.action
+    this.body = input.body
+    this.retryable = input.retryable
+    this.status = input.status
+    this.statusText = input.statusText
+  }
+}
+
+export function isRetryableSessionApiError(error: unknown): boolean {
+  if (error instanceof SessionApiError) return error.retryable
+  if (!(error instanceof Error)) return false
+  return error.name === 'AbortError' || error.name === 'TypeError'
+}
+
+type ForwardSessionApiCallbacks = {
+  onExecutionStarted?(): Promise<void>
+  onMessagesAppended?(): Promise<void>
+}
+
 export async function collectInitialContext(
   thread: { allMessages: AsyncIterable<Message> },
   currentMessage: Message
@@ -64,19 +102,27 @@ export async function serializeMessage(message: Message): Promise<SlackbotV2ApiM
 
 export async function forwardToSessionApi(
   options: SlackbotV2Options,
-  input: ForwardSessionInput
+  input: ForwardSessionInput,
+  callbacks: ForwardSessionApiCallbacks = {}
 ): Promise<AsyncIterable<SlackbotV2RendererSource> | null> {
   const createStartedAtMs = nowMs()
   await createSession(options, input.threadId)
   traceLog(options, 'slackbotv2_session_create_complete', input.trace, {
     phase_ms: elapsedMs(createStartedAtMs)
   })
-  const appendStartedAtMs = nowMs()
-  await appendSessionMessages(options, input.threadId, input.messages)
-  traceLog(options, 'slackbotv2_session_append_complete', input.trace, {
-    message_count: input.messages.length,
-    phase_ms: elapsedMs(appendStartedAtMs)
-  })
+  if (input.messages.length > 0) {
+    const appendStartedAtMs = nowMs()
+    await appendSessionMessages(options, input.threadId, input.messages)
+    traceLog(options, 'slackbotv2_session_append_complete', input.trace, {
+      message_count: input.messages.length,
+      phase_ms: elapsedMs(appendStartedAtMs)
+    })
+    await callbacks.onMessagesAppended?.()
+  } else {
+    traceLog(options, 'slackbotv2_session_append_skipped', input.trace, {
+      message_count: 0
+    })
+  }
   if (!input.executeMessage) return null
 
   const executeStartedAtMs = nowMs()
@@ -84,8 +130,16 @@ export async function forwardToSessionApi(
   traceLog(options, 'slackbotv2_session_execute_complete', input.trace, {
     phase_ms: elapsedMs(executeStartedAtMs)
   })
+  await callbacks.onExecutionStarted?.()
   if (!input.openStream) return null
 
+  return openSessionEventStream(options, input)
+}
+
+export async function openSessionEventStream(
+  options: SlackbotV2Options,
+  input: Pick<ForwardSessionInput, 'afterEventId' | 'onEventId' | 'threadId' | 'trace'>
+): Promise<AsyncIterable<SlackbotV2RendererSource>> {
   const streamStartedAtMs = nowMs()
   const stream = await streamSessionNotifications(
     options,
@@ -219,8 +273,17 @@ async function ensureApiOk(response: Response, action: string): Promise<void> {
   } catch {
     body = ''
   }
-  const suffix = body ? `: ${body}` : ''
-  throw new Error(`Centaur session ${action} failed: ${response.status} ${response.statusText}${suffix}`)
+  throw new SessionApiError({
+    action,
+    body,
+    retryable: isRetryableApiStatus(response.status),
+    status: response.status,
+    statusText: response.statusText
+  })
+}
+
+function isRetryableApiStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500
 }
 
 async function streamSessionNotifications(

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -34,7 +34,7 @@ export type SlackbotV2ApiMessage = {
   id: string
   isMention: boolean
   raw: unknown
-  teamId?: string
+  teamId: string
   text: string
   threadId: string
   timestamp: string

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -77,6 +77,7 @@ export type SlackbotV2Options = {
   logger?: Logger
   maxDurationMs?: number
   postgresUrl?: string
+  recoverRenderObligationsOnStart?: boolean
   signingSecret: string
   slackApiUrl?: string
   state?: StateAdapter
@@ -98,6 +99,15 @@ export type SlackbotV2ThreadState = {
   forwardedMessageIds?: string[]
   historyForwarded?: boolean
   lastEventId?: number
+}
+
+export type SlackbotV2RenderObligation = {
+  afterEventId: number
+  createdAtMs: number
+  message: SlackbotV2ApiMessage
+  threadId: string
+  updatedAtMs: number
+  version: 1
 }
 
 export type SlackbotV2MessageMode = 'append' | 'execute'

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -94,6 +94,7 @@ export type SlackbotV2 = {
 
 export type SlackbotV2ThreadState = {
   activeExecution?: boolean
+  executedMessageIds?: string[]
   forwardedMessageIds?: string[]
   historyForwarded?: boolean
   lastEventId?: number

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -34,6 +34,7 @@ export type SlackbotV2ApiMessage = {
   id: string
   isMention: boolean
   raw: unknown
+  teamId?: string
   text: string
   threadId: string
   timestamp: string

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -99,15 +99,12 @@ export type SlackbotV2ThreadState = {
   forwardedMessageIds?: string[]
   historyForwarded?: boolean
   lastEventId?: number
+  renderObligation?: SlackbotV2RenderObligation | null
 }
 
 export type SlackbotV2RenderObligation = {
   afterEventId: number
-  createdAtMs: number
   message: SlackbotV2ApiMessage
-  threadId: string
-  updatedAtMs: number
-  version: 1
 }
 
 export type SlackbotV2MessageMode = 'append' | 'execute'

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -866,6 +866,7 @@ function apiMessageFromSlackEvent(input: {
       type: input.isMention ? 'app_mention' : 'message',
       user: USER_ID
     },
+    teamId: TEAM_ID,
     text: input.text,
     threadId: input.threadId,
     timestamp: new Date().toISOString()

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -445,15 +445,11 @@ describe('slackbotv2', () => {
       executedMessageIds: [mention.ts],
       forwardedMessageIds: [mention.ts],
       historyForwarded: true,
-      lastEventId: 0
-    })
-    await sharedState.set(`slackbotv2:render:${key}`, {
-      afterEventId: 0,
-      createdAtMs: Date.now(),
-      message,
-      threadId: key,
-      updatedAtMs: Date.now(),
-      version: 1
+      lastEventId: 0,
+      renderObligation: {
+        afterEventId: 0,
+        message
+      }
     })
     await sharedState.appendToList('slackbotv2:render:index', key)
     codexApi.emitOutputLines(key, sampleCodexOutputLines('Recovered request.'))
@@ -472,14 +468,14 @@ describe('slackbotv2', () => {
       parentTs: parent.ts
     })
     expect(await threadText(parent.ts)).toContain('Recovered request.')
-    expect(await sharedState.get(`slackbotv2:render:${key}`)).toBeNull()
     const recoveredThreadState = await sharedState.get<Record<string, unknown>>(
       `thread-state:${key}`
     )
     expect(recoveredThreadState).toEqual(
       expect.objectContaining({
         activeExecution: false,
-        lastEventId: expect.any(Number)
+        lastEventId: expect.any(Number),
+        renderObligation: null
       })
     )
     expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -15,6 +15,7 @@ import {
   createSlackbotV2,
   type SlackbotV2,
   type SlackbotV2AppendMessagesRequest,
+  type SlackbotV2ApiMessage,
   type SlackbotV2CreateSessionRequest,
   type SlackbotV2ExecuteSessionRequest,
   type SlackbotV2SessionMessage
@@ -425,6 +426,65 @@ describe('slackbotv2', () => {
     await Promise.all(waits)
   })
 
+  it('recovers unfinished render obligations from Chat SDK state on startup', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+
+    const parent = await postUserMessage('Context before restart recovery.')
+    const mentionText = `<@${BOT_USER_ID}> recover a completed run`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const key = threadKey(parent.ts)
+    const message = apiMessageFromSlackEvent({
+      isMention: true,
+      text: mentionText,
+      threadId: key,
+      ts: mention.ts
+    })
+    await sharedState.set(`thread-state:${key}`, {
+      activeExecution: true,
+      executedMessageIds: [mention.ts],
+      forwardedMessageIds: [mention.ts],
+      historyForwarded: true,
+      lastEventId: 0
+    })
+    await sharedState.set(`slackbotv2:render:${key}`, {
+      afterEventId: 0,
+      createdAtMs: Date.now(),
+      message,
+      threadId: key,
+      updatedAtMs: Date.now(),
+      version: 1
+    })
+    await sharedState.appendToList('slackbotv2:render:index', key)
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('Recovered request.'))
+
+    bot = createTestBot({ state: sharedState })
+
+    await waitFor(() => codexApi.eventRequests.length === 1, 2000)
+    await waitFor(() => slackApi.calls.some(call => call.method === 'chat.stopStream'), 2000)
+
+    expect(codexApi.creates).toHaveLength(0)
+    expect(codexApi.appends).toHaveLength(0)
+    expect(codexApi.executes).toHaveLength(0)
+    expect(codexApi.eventRequests).toEqual([{ afterEventId: 0, threadKey: key }])
+    expectSlackPlanStreamShape(slackApi.calls, {
+      answers: ['Recovered request.'],
+      parentTs: parent.ts
+    })
+    expect(await threadText(parent.ts)).toContain('Recovered request.')
+    expect(await sharedState.get(`slackbotv2:render:${key}`)).toBeNull()
+    const recoveredThreadState = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${key}`
+    )
+    expect(recoveredThreadState).toEqual(
+      expect.objectContaining({
+        activeExecution: false,
+        lastEventId: expect.any(Number)
+      })
+    )
+    expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)
+  })
+
   it('returns 503 for retryable execute failure and lets Slack retry without duplicate append', async () => {
     codexApi.failNextExecute = true
 
@@ -780,6 +840,40 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function threadKey(threadTs: string): string {
   return `slack:${CHANNEL_ID}:${threadTs}`
+}
+
+function apiMessageFromSlackEvent(input: {
+  isMention: boolean
+  text: string
+  threadId: string
+  ts: string
+}): SlackbotV2ApiMessage {
+  const threadTs = input.threadId.split(':')[2] ?? input.ts
+  return {
+    attachments: [],
+    author: {
+      fullName: 'Test User',
+      isBot: false,
+      isMe: false,
+      userId: USER_ID,
+      userName: 'tester'
+    },
+    id: input.ts,
+    isMention: input.isMention,
+    raw: {
+      channel: CHANNEL_ID,
+      team: TEAM_ID,
+      team_id: TEAM_ID,
+      text: input.text,
+      thread_ts: threadTs,
+      ts: input.ts,
+      type: input.isMention ? 'app_mention' : 'message',
+      user: USER_ID
+    },
+    text: input.text,
+    threadId: input.threadId,
+    timestamp: new Date().toISOString()
+  }
 }
 
 async function postUserMessage(text: string, threadTs?: string): Promise<{ ts: string }> {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -379,85 +379,87 @@ describe('slackbotv2', () => {
     await Promise.all(firstWaits)
   })
 
-  it('starts the Slack stream before a slow session execute returns', async () => {
+  it('waits for a slow session execute before acknowledging Slack and starting the stream', async () => {
     codexApi.autoRespond = false
     const releaseExecute = codexApi.holdNextExecute()
 
     const parent = await postUserMessage('Context before the slow run.')
     const mention = await postUserMessage(`<@${BOT_USER_ID}> start visibly`, parent.ts)
     const waits: Promise<unknown>[] = []
-    const response = await bot.app.request(
-      '/api/webhooks/slack',
-      signedSlackEvent({
-        event_id: 'Ev-slackbotv2-slow-execute',
-        event: {
-          type: 'app_mention',
-          user: USER_ID,
-          channel: CHANNEL_ID,
-          team: TEAM_ID,
-          ts: mention.ts,
-          thread_ts: parent.ts,
-          text: `<@${BOT_USER_ID}> start visibly`
-        }
-      }),
-      {},
-      waitUntilContext(waits)
-    )
+    let responseSettled = false
+    const responsePromise = Promise.resolve(
+      bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: 'Ev-slackbotv2-slow-execute',
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parent.ts,
+            text: `<@${BOT_USER_ID}> start visibly`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+    ).then((response: Response) => {
+      responseSettled = true
+      return response
+    })
 
-    expect(response.status).toBe(200)
     await waitFor(() => codexApi.executes.length === 1)
-    await waitFor(() => slackApi.calls.some(call => call.method === 'chat.startStream'))
+    await sleep(50)
+    expect(responseSettled).toBe(false)
+    expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
     expect(codexApi.eventRequests).toHaveLength(0)
 
     releaseExecute()
+    const response = await responsePromise
+    expect(response.status).toBe(200)
     await waitFor(() => codexApi.eventRequests.length === 1)
     await waitFor(() => codexApi.streamCount === 1)
     codexApi.closeStreams()
     await Promise.all(waits)
   })
 
-  it('refetches full context on a later mention if the initial execute failed', async () => {
+  it('returns 503 for retryable execute failure and lets Slack retry without duplicate append', async () => {
     codexApi.failNextExecute = true
 
     const parent = await postUserMessage('History that must not be lost.')
     const failedMention = await postUserMessage(`<@${BOT_USER_ID}> first try`, parent.ts)
+    const retryableEvent = signedSlackEvent({
+      event_id: 'Ev-slackbotv2-retryable-mention',
+      event: {
+        type: 'app_mention',
+        user: USER_ID,
+        channel: CHANNEL_ID,
+        team: TEAM_ID,
+        ts: failedMention.ts,
+        thread_ts: parent.ts,
+        text: `<@${BOT_USER_ID}> first try`
+      }
+    })
     const failedWaits: Promise<unknown>[] = []
     const failedResponse = await bot.app.request(
       '/api/webhooks/slack',
-      signedSlackEvent({
-        event_id: 'Ev-slackbotv2-failed-mention',
-        event: {
-          type: 'app_mention',
-          user: USER_ID,
-          channel: CHANNEL_ID,
-          team: TEAM_ID,
-          ts: failedMention.ts,
-          thread_ts: parent.ts,
-          text: `<@${BOT_USER_ID}> first try`
-        }
-      }),
+      retryableEvent,
       {},
       waitUntilContext(failedWaits)
     )
-    expect(failedResponse.status).toBe(200)
+    expect(failedResponse.status).toBe(503)
     await Promise.all(failedWaits)
+    expect(codexApi.appends).toHaveLength(1)
+    expect(codexApi.executes).toHaveLength(1)
+    expect(codexApi.eventRequests).toHaveLength(0)
+    expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
 
-    const retryMention = await postUserMessage(`<@${BOT_USER_ID}> retry`, parent.ts)
     const retryWaits: Promise<unknown>[] = []
     const retryResponse = await bot.app.request(
       '/api/webhooks/slack',
-      signedSlackEvent({
-        event_id: 'Ev-slackbotv2-retry-mention',
-        event: {
-          type: 'app_mention',
-          user: USER_ID,
-          channel: CHANNEL_ID,
-          team: TEAM_ID,
-          ts: retryMention.ts,
-          thread_ts: parent.ts,
-          text: `<@${BOT_USER_ID}> retry`
-        }
-      }),
+      retryableEvent,
       {},
       waitUntilContext(retryWaits)
     )
@@ -465,10 +467,12 @@ describe('slackbotv2', () => {
     await Promise.all(retryWaits)
 
     expect(codexApi.executes).toHaveLength(2)
-    const retryContextTexts = sessionMessageTexts(codexApi.appends[1]?.body.messages ?? [])
+    expect(codexApi.appends).toHaveLength(1)
+    const retryContextTexts = sessionMessageTexts(codexApi.appends[0]?.body.messages ?? [])
     expect(retryContextTexts).toContain('History that must not be lost.')
     expect(retryContextTexts.some(text => text.includes('first try'))).toBe(true)
-    expect(retryContextTexts.some(text => text.includes('retry'))).toBe(true)
+    expect(codexApi.eventRequests).toHaveLength(1)
+    expect(await threadText(parent.ts)).toContain('Executed request 2.')
   })
 
   it('keeps v1 external org and trigger-bot allowlist behavior', async () => {
@@ -1656,6 +1660,10 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void
     await new Promise(resolve => setTimeout(resolve, 10))
   }
   throw new Error('Timed out waiting for condition')
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
 }
 
 async function availablePort(preferred: number): Promise<number> {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -481,6 +481,76 @@ describe('slackbotv2', () => {
     expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)
   })
 
+  it('retries retryable event stream open failures after execute', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ state: sharedState })
+    codexApi.autoRespond = false
+    codexApi.failNextEvents = true
+
+    const parent = await postUserMessage('Context before stream retry.')
+    const mentionText = `<@${BOT_USER_ID}> recover after stream open failure`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-stream-open-retry',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: mentionText
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    expect(slackApi.calls.some(call => call.method === 'chat.stopStream')).toBe(false)
+
+    const deferredThreadState = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${key}`
+    )
+    expect(deferredThreadState).toEqual(
+      expect.objectContaining({
+        activeExecution: true,
+        renderObligation: expect.any(Object)
+      })
+    )
+
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('Recovered after stream retry.'))
+    await waitFor(() => codexApi.eventRequests.length >= 2, 3000)
+    await waitFor(() => slackApi.calls.some(call => call.method === 'chat.stopStream'), 3000)
+    await Promise.all(waits)
+
+    expect(codexApi.executes).toHaveLength(1)
+    expect(codexApi.eventRequests).toEqual([
+      { afterEventId: 0, threadKey: key },
+      { afterEventId: 0, threadKey: key }
+    ])
+    expect(await threadText(parent.ts)).toContain('Recovered after stream retry.')
+    const recoveredThreadState = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${key}`
+    )
+    expect(recoveredThreadState).toEqual(
+      expect.objectContaining({
+        activeExecution: false,
+        lastEventId: expect.any(Number),
+        renderObligation: null
+      })
+    )
+    expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)
+  })
+
   it('returns 503 for retryable execute failure and lets Slack retry without duplicate append', async () => {
     codexApi.failNextExecute = true
 
@@ -957,6 +1027,7 @@ type MockSessionApi = {
   emitOutputLines(threadKey: string, lines: string[]): void
   eventRequests: MockSessionEventRequest[]
   executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[]
+  failNextEvents: boolean
   failNextExecute: boolean
   holdNextExecute(): () => void
   reset(): void
@@ -975,6 +1046,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
   let executeHold: Promise<void> | null = null
   let executeHoldRelease: (() => void) | null = null
   let eventId = 0
+  let failNextEvents = false
   let failNextExecute = false
   const port = await availablePort(4063)
   const closeStreams = () => {
@@ -997,11 +1069,17 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       get failNextExecute() {
         return failNextExecute
       },
+      get failNextEvents() {
+        return failNextEvents
+      },
       nextEventId() {
         eventId += 1
         return eventId
       },
       port,
+      setFailNextEvents(value) {
+        failNextEvents = value
+      },
       setFailNextExecute(value) {
         failNextExecute = value
       },
@@ -1030,6 +1108,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       closeStreams()
       autoRespond = true
       eventId = 0
+      failNextEvents = false
       failNextExecute = false
     },
     url: `http://127.0.0.1:${port}`,
@@ -1045,6 +1124,12 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
     },
     set failNextExecute(value: boolean) {
       failNextExecute = value
+    },
+    get failNextEvents() {
+      return failNextEvents
+    },
+    set failNextEvents(value: boolean) {
+      failNextEvents = value
     },
     holdNextExecute() {
       if (executeHoldRelease) throw new Error('execute is already held')
@@ -1093,9 +1178,11 @@ async function handleMockCodexRequest(
     eventRequests: MockSessionEventRequest[]
     executeHold: Promise<void> | null
     executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[]
+    failNextEvents: boolean
     failNextExecute: boolean
     nextEventId(): number
     port: number
+    setFailNextEvents(value: boolean): void
     setFailNextExecute(value: boolean): void
     streams: Set<ServerResponse>
   }
@@ -1129,6 +1216,14 @@ async function handleMockCodexRequest(
   if (endpoint === 'events') {
     const afterEventId = Number.parseInt(url.searchParams.get('after_event_id') ?? '0', 10) || 0
     input.eventRequests.push({ threadKey, afterEventId })
+    if (input.failNextEvents) {
+      input.setFailNextEvents(false)
+      await sendWebResponse(
+        res,
+        new Response('unavailable', { status: 503, statusText: 'Service Unavailable' })
+      )
+      return
+    }
     res.writeHead(200, {
       'cache-control': 'no-cache',
       connection: 'keep-alive',


### PR DESCRIPTION
## Summary
- wait for Slackbot v2's durable api-rs handoff before returning Slack 200 for message/app_mention events
- return 503 on retryable api-rs/network failures so Slack retries the same event
- clear Chat SDK dedupe on retryable failure and persist append/execute progress separately to avoid duplicate appends on retry
- store unfinished Slack stream render obligations on the existing Chat SDK `thread-state:*` record and replay them on Slackbot startup
- keep a small Chat SDK state-list index of candidate thread ids plus short recovery leases so restarted Slackbot instances can reopen api-rs `/events` from the last event id without a separate Slackbot table

## Tests
- bun run --cwd services/slackbotv2 check:types
- bun run --cwd services/slackbotv2 test
- just build-one slackbotv2
- curl -fsS http://127.0.0.1:3002/health
- curl -fsS http://127.0.0.1:8080/healthz

## Notes
- Did not run `just deploy` because the active kubectl context was `prd-centaur-na.tail388b2e.ts.net`; local service health was checked instead.
