### PR TITLE
fix(slackbot): continue active bot threads

### DIFF
--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -583,12 +583,14 @@ async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {
         'slack.thread_ts': normalized.thread_ts,
         'slack.user_id': normalized.user_id,
         'centaur.slackbot.is_mention': normalized.is_mention,
+        'centaur.slackbot.is_thread_reply': normalized.is_thread_reply,
+        'centaur.slackbot.bot_in_thread': normalized.bot_in_thread,
         'centaur.slackbot.part_count': normalized.parts.length
       })
-      if (!normalized.is_mention) {
+      if (!shouldHandoffToCentaur(normalized)) {
         spanAttributes(span, {
           'centaur.slackbot.event_ignored': true,
-          'centaur.slackbot.ignore_reason': 'not_mention'
+          'centaur.slackbot.ignore_reason': 'not_mention_or_active_thread'
         })
         return
       }
@@ -618,6 +620,11 @@ async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {
       }
     }
   )
+}
+
+function shouldHandoffToCentaur(event: NormalizedSlackEvent): boolean {
+  if (event.is_mention) return true
+  return event.is_thread_reply && event.bot_in_thread
 }
 
 const TRIVIAL_ACK_REACTION = 'ok_hand'

--- a/services/slackbot/src/slack/normalize.test.ts
+++ b/services/slackbot/src/slack/normalize.test.ts
@@ -439,6 +439,80 @@ describe('normalizeSlackEnvelope', () => {
     ])
   })
 
+  it('marks unmentioned thread replies as continuations when the bot is already in the thread', async () => {
+    const replies = mock(async () => ({
+      ok: true,
+      messages: [
+        {
+          type: 'message',
+          user: 'U111',
+          channel: 'C123',
+          ts: '1778875060.000100',
+          text: 'Can you explain the architecture?'
+        },
+        {
+          type: 'message',
+          channel: 'C123',
+          subtype: 'bot_message',
+          bot_id: 'B123',
+          bot_profile: { id: 'B123', user_id: 'UBOT' },
+          ts: '1778875065.000100',
+          text: 'Here is the high-level architecture.'
+        },
+        {
+          type: 'message',
+          user: 'U123',
+          channel: 'C123',
+          ts: '1778875070.942789',
+          text: 'go deeper on the sandbox piece'
+        }
+      ]
+    }))
+
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-thread-followup',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'C123',
+          channel_type: 'channel',
+          thread_ts: '1778875060.000100',
+          ts: '1778875070.942789',
+          text: 'go deeper on the sandbox piece'
+        }
+      },
+      botUserId: 'UBOT',
+      botId: 'B123',
+      client: {
+        token: 'xoxb-test-token',
+        conversations: { replies }
+      } as any
+    })
+
+    expect(normalized?.is_mention).toBe(false)
+    expect(normalized?.is_thread_reply).toBe(true)
+    expect(normalized?.bot_in_thread).toBe(true)
+    expect(normalized?.history_messages).toEqual([
+      {
+        message_id: 'slack:T123:C123:1778875060.000100',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Can you explain the architecture?' }],
+        user_id: 'U111',
+        metadata: { platform: 'slack', history_backfill: true }
+      },
+      {
+        message_id: 'slack:T123:C123:1778875065.000100',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Here is the high-level architecture.' }],
+        user_id: 'UBOT',
+        metadata: { platform: 'slack', history_backfill: true }
+      }
+    ])
+  })
+
   it('does not duplicate text when Slack sends both rich_text blocks and event.text', async () => {
     const normalized = await normalizeSlackEnvelope({
       envelope: {

--- a/services/slackbot/src/slack/normalize.ts
+++ b/services/slackbot/src/slack/normalize.ts
@@ -97,7 +97,8 @@ export async function normalizeSlackEnvelope(opts: {
   const isMention =
     event.type === 'app_mention' ||
     Boolean(opts.botUserId && messageMentionsBot(event, opts.botUserId))
-  const historyMessages = isMention
+  const isThreadReply = Boolean(event.thread_ts && event.thread_ts !== event.ts)
+  const historyMessages = isMention || isThreadReply
     ? await collectThreadHistorySafely({
         client: opts.client,
         channel: event.channel,
@@ -108,6 +109,7 @@ export async function normalizeSlackEnvelope(opts: {
         botId: opts.botId
       })
     : []
+  const botInThread = historyMessages.some(message => message.role === 'assistant')
 
   return {
     thread_key: `slack:${teamId}:${event.channel}:${threadTs}`,
@@ -118,6 +120,8 @@ export async function normalizeSlackEnvelope(opts: {
     channel_id: event.channel,
     thread_ts: threadTs,
     is_mention: isMention,
+    is_thread_reply: isThreadReply,
+    bot_in_thread: botInThread,
     parts,
     ...(historyMessages.length ? { history_messages: historyMessages } : {}),
     slack: {

--- a/services/slackbot/src/slack/types.ts
+++ b/services/slackbot/src/slack/types.ts
@@ -29,6 +29,8 @@ export type NormalizedSlackEvent = {
   channel_id: string
   thread_ts: string
   is_mention: boolean
+  is_thread_reply: boolean
+  bot_in_thread: boolean
   parts: NormalizedPart[]
   history_messages?: Array<{
     message_id: string


### PR DESCRIPTION
## Summary
- allow Slackbot to hand off unmentioned thread replies when Centaur has already participated in that thread
- collect thread history for replies so the handoff can detect existing assistant participation and preserve context
- add coverage for the unmentioned active-thread continuation case

## Tests
- `bun test services/slackbot/src/slack/normalize.test.ts services/slackbot/src/index.test.ts`