### PR TITLE
fix(session): make Slack retries idempotent for append and execute

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -86,6 +86,7 @@ async fn execute_session(
         .execute_session(
             &thread_key,
             ExecuteSessionInput {
+                idempotency_key: request.idempotency_key,
                 metadata: request.metadata,
                 input_lines: request.input_lines,
                 idle_timeout_ms: request.idle_timeout_ms,

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -24,6 +24,7 @@ pub struct AppendMessagesResponse {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExecuteSessionRequest {
+    pub idempotency_key: Option<String>,
     pub metadata: Option<Value>,
     #[serde(default)]
     pub input_lines: Vec<String>,

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -213,6 +213,7 @@ pub(crate) async fn append_user_message(
             thread_key,
             AppendMessagesRequest {
                 messages: vec![SessionMessageInput {
+                    client_message_id: None,
                     role: MessageRole::User,
                     parts: vec![json!({"type": "text", "text": text})],
                     metadata: json!({
@@ -236,6 +237,7 @@ pub(crate) async fn execute_input_lines(
         .execute_session(
             thread_key,
             ExecuteSessionRequest {
+                idempotency_key: None,
                 metadata: Some(json!({
                     "source": "centaur-session-cli",
                 })),

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -160,6 +160,8 @@ pub enum MessageRole {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SessionMessageInput {
+    #[serde(default)]
+    pub client_message_id: Option<String>,
     pub role: MessageRole,
     pub parts: Vec<Value>,
     #[serde(default = "empty_object")]
@@ -169,6 +171,7 @@ pub struct SessionMessageInput {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SessionMessage {
     pub message_id: String,
+    pub client_message_id: Option<String>,
     pub thread_key: ThreadKey,
     pub role: MessageRole,
     pub parts: Vec<Value>,
@@ -190,6 +193,7 @@ pub enum ExecutionStatus {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SessionExecution {
     pub execution_id: String,
+    pub idempotency_key: Option<String>,
     pub thread_key: ThreadKey,
     pub status: ExecutionStatus,
     pub metadata: Value,

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -10,7 +10,8 @@ use centaur_sandbox_core::{
 };
 use centaur_sandbox_manager::SandboxManager;
 use centaur_session_core::{
-    HarnessType, Session, SessionEvent, SessionExecution, SessionMessageInput, ThreadKey,
+    ExecutionStatus, HarnessType, Session, SessionEvent, SessionExecution, SessionMessageInput,
+    ThreadKey,
 };
 use centaur_session_sqlx::{
     PgSessionStore, SessionEventListener, SessionStoreError, default_metadata,
@@ -61,6 +62,7 @@ pub enum SandboxWorkloadMode {
 
 #[derive(Debug)]
 pub struct ExecuteSessionInput {
+    pub idempotency_key: Option<String>,
     pub metadata: Option<Value>,
     pub input_lines: Vec<String>,
     pub idle_timeout_ms: Option<u64>,
@@ -127,12 +129,22 @@ impl SessionRuntime {
 
         let execution = self
             .store
-            .create_execution(thread_key, default_metadata(input.metadata))
+            .create_execution(
+                thread_key,
+                input.idempotency_key.as_deref(),
+                default_metadata(input.metadata),
+            )
             .await?;
+        if !execution.created && execution.execution.status != ExecutionStatus::Queued {
+            return Ok(execution.execution);
+        }
         let execution = self
             .store
-            .mark_execution_running(&execution.execution_id)
+            .mark_execution_running(&execution.execution.execution_id)
             .await?;
+        if execution.status != ExecutionStatus::Running {
+            return Ok(execution);
+        }
         let sandbox_id = self
             .ensure_session_sandbox(
                 thread_key,

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0003_session_handoff_idempotency.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0003_session_handoff_idempotency.sql
@@ -1,0 +1,13 @@
+alter table session_messages
+    add column if not exists client_message_id text;
+
+create unique index if not exists session_messages_thread_client_message_idx
+    on session_messages (thread_key, client_message_id)
+    where client_message_id is not null;
+
+alter table session_executions
+    add column if not exists idempotency_key text;
+
+create unique index if not exists session_executions_thread_idempotency_idx
+    on session_executions (thread_key, idempotency_key)
+    where idempotency_key is not null;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -20,6 +20,12 @@ static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
 pub const SESSION_EVENTS_CHANNEL: &str = "centaur_session_events";
 
+#[derive(Clone, Debug)]
+pub struct CreateExecutionResult {
+    pub execution: SessionExecution,
+    pub created: bool,
+}
+
 #[derive(Clone)]
 pub struct PgSessionStore {
     pool: PgPool,
@@ -113,20 +119,26 @@ impl PgSessionStore {
         for message in messages {
             let message_id = prefixed_id("msg");
             let parts = Value::Array(message.parts.clone());
-            sqlx::query(
+            let persisted_message_id = sqlx::query_scalar::<_, String>(
                 r#"
-                insert into session_messages (message_id, thread_key, role, parts, metadata)
-                values ($1, $2, $3, $4, $5)
+                insert into session_messages
+                    (message_id, thread_key, client_message_id, role, parts, metadata)
+                values ($1, $2, $3, $4, $5, $6)
+                on conflict (thread_key, client_message_id)
+                    where client_message_id is not null
+                do update set client_message_id = excluded.client_message_id
+                returning message_id
                 "#,
             )
             .bind(&message_id)
             .bind(thread_key.as_str())
+            .bind(message.client_message_id.as_deref())
             .bind(message.role.as_ref())
             .bind(parts)
             .bind(message.metadata.clone())
-            .execute(&mut *tx)
+            .fetch_one(&mut *tx)
             .await?;
-            message_ids.push(message_id);
+            message_ids.push(persisted_message_id);
         }
 
         tx.commit().await?;
@@ -139,7 +151,7 @@ impl PgSessionStore {
     ) -> Result<Vec<SessionMessage>, SessionStoreError> {
         let rows = sqlx::query_as::<_, SessionMessageRow>(
             r#"
-            select message_id, thread_key, role, parts, metadata, created_at
+            select message_id, client_message_id, thread_key, role, parts, metadata, created_at
             from session_messages
             where thread_key = $1
             order by created_at, message_id
@@ -155,18 +167,35 @@ impl PgSessionStore {
     pub async fn create_execution(
         &self,
         thread_key: &ThreadKey,
+        idempotency_key: Option<&str>,
         metadata: Value,
-    ) -> Result<SessionExecution, SessionStoreError> {
+    ) -> Result<CreateExecutionResult, SessionStoreError> {
         let execution_id = prefixed_id("exe");
-        let row = sqlx::query_as::<_, SessionExecutionRow>(
+        let row = sqlx::query_as::<_, CreateExecutionRow>(
             r#"
-            insert into session_executions (execution_id, thread_key, status, metadata)
-            values ($1, $2, $3, $4)
-            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            insert into session_executions
+                (execution_id, thread_key, idempotency_key, status, metadata)
+            values ($1, $2, $3, $4, $5)
+            on conflict (thread_key, idempotency_key)
+                where idempotency_key is not null
+            do update set idempotency_key = excluded.idempotency_key
+            returning
+                execution_id = $1 as created,
+                execution_id,
+                idempotency_key,
+                thread_key,
+                status,
+                metadata,
+                error,
+                created_at,
+                updated_at,
+                started_at,
+                completed_at
             "#,
         )
         .bind(&execution_id)
         .bind(thread_key.as_str())
+        .bind(idempotency_key)
         .bind(ExecutionStatus::Queued.as_ref())
         .bind(metadata)
         .fetch_one(&self.pool)
@@ -179,18 +208,33 @@ impl PgSessionStore {
         &self,
         execution_id: &str,
     ) -> Result<SessionExecution, SessionStoreError> {
-        let row = sqlx::query_as::<_, SessionExecutionRow>(
+        let maybe_row = sqlx::query_as::<_, SessionExecutionRow>(
             r#"
             update session_executions
             set status = $2, started_at = coalesce(started_at, now()), updated_at = now()
-            where execution_id = $1
-            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            where execution_id = $1 and status = $3
+            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
             "#,
         )
         .bind(execution_id)
         .bind(ExecutionStatus::Running.as_ref())
-        .fetch_one(&self.pool)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .fetch_optional(&self.pool)
         .await?;
+
+        let Some(row) = maybe_row else {
+            let row = sqlx::query_as::<_, SessionExecutionRow>(
+                r#"
+                select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+                from session_executions
+                where execution_id = $1
+                "#,
+            )
+            .bind(execution_id)
+            .fetch_one(&self.pool)
+            .await?;
+            return row.try_into();
+        };
 
         self.set_session_status(&row.thread_key, SessionStatus::Executing)
             .await?;
@@ -206,7 +250,7 @@ impl PgSessionStore {
             update session_executions
             set status = $2, completed_at = coalesce(completed_at, now()), updated_at = now()
             where execution_id = $1
-            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
             "#,
         )
         .bind(execution_id)
@@ -229,7 +273,7 @@ impl PgSessionStore {
             update session_executions
             set status = $2, error = $3, completed_at = coalesce(completed_at, now()), updated_at = now()
             where execution_id = $1
-            returning execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
             "#,
         )
         .bind(execution_id)
@@ -439,6 +483,7 @@ impl TryFrom<SessionRow> for Session {
 #[derive(Debug, FromRow)]
 struct SessionMessageRow {
     message_id: String,
+    client_message_id: Option<String>,
     thread_key: String,
     role: String,
     parts: Value,
@@ -456,6 +501,7 @@ impl TryFrom<SessionMessageRow> for SessionMessage {
         };
         Ok(Self {
             message_id: row.message_id,
+            client_message_id: row.client_message_id,
             thread_key: parse_persisted(row.thread_key)?,
             role: parse_persisted(row.role)?,
             parts,
@@ -468,6 +514,7 @@ impl TryFrom<SessionMessageRow> for SessionMessage {
 #[derive(Debug, FromRow)]
 struct SessionExecutionRow {
     execution_id: String,
+    idempotency_key: Option<String>,
     thread_key: String,
     status: String,
     metadata: Value,
@@ -484,6 +531,7 @@ impl TryFrom<SessionExecutionRow> for SessionExecution {
     fn try_from(row: SessionExecutionRow) -> Result<Self, Self::Error> {
         Ok(Self {
             execution_id: row.execution_id,
+            idempotency_key: row.idempotency_key,
             thread_key: parse_persisted(row.thread_key)?,
             status: parse_persisted(row.status)?,
             metadata: row.metadata,
@@ -492,6 +540,44 @@ impl TryFrom<SessionExecutionRow> for SessionExecution {
             updated_at: row.updated_at,
             started_at: row.started_at,
             completed_at: row.completed_at,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct CreateExecutionRow {
+    created: bool,
+    execution_id: String,
+    idempotency_key: Option<String>,
+    thread_key: String,
+    status: String,
+    metadata: Value,
+    error: Option<String>,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+    started_at: Option<OffsetDateTime>,
+    completed_at: Option<OffsetDateTime>,
+}
+
+impl TryFrom<CreateExecutionRow> for CreateExecutionResult {
+    type Error = SessionStoreError;
+
+    fn try_from(row: CreateExecutionRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            created: row.created,
+            execution: SessionExecutionRow {
+                execution_id: row.execution_id,
+                idempotency_key: row.idempotency_key,
+                thread_key: row.thread_key,
+                status: row.status,
+                metadata: row.metadata,
+                error: row.error,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                started_at: row.started_at,
+                completed_at: row.completed_at,
+            }
+            .try_into()?,
         })
     }
 }

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -31,6 +31,7 @@ import type {
   ForwardSessionInput,
   SlackbotV2,
   SlackbotV2ApiMessage,
+  SlackbotV2ExecuteSessionResponse,
   SlackbotV2MessageMode,
   SlackbotV2Options,
   SlackbotV2RenderObligation,
@@ -48,6 +49,7 @@ export type {
   SlackbotV2AppendMessagesRequest,
   SlackbotV2CreateSessionRequest,
   SlackbotV2ExecuteSessionRequest,
+  SlackbotV2ExecuteSessionResponse,
   SlackbotV2Fetch,
   SlackbotV2Options,
   SlackbotV2SessionMessage,
@@ -269,7 +271,9 @@ async function syncThreadMessageToSession(
     })
   }
 
-  const commitExecutionStarted = async (): Promise<void> => {
+  const commitExecutionStarted = async (
+    execution: SlackbotV2ExecuteSessionResponse
+  ): Promise<void> => {
     const latest = (await thread.state) ?? {}
     const latestExecutedMessageIds = new Set(latest.executedMessageIds ?? [])
     latestExecutedMessageIds.add(serializedMessage.id)
@@ -279,6 +283,7 @@ async function syncThreadMessageToSession(
       lastEventId,
       renderObligation: {
         afterEventId: lastEventId,
+        executionId: execution.execution_id,
         message: serializedMessage
       }
     })
@@ -288,6 +293,7 @@ async function syncThreadMessageToSession(
       trace
     })
     traceLog(input.options, 'slackbotv2_forward_execution_committed', trace, {
+      execution_id: execution.execution_id,
       executed_message_count: Math.min(latestExecutedMessageIds.size, 1000)
     })
   }

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -9,6 +9,7 @@ import type {
   SlackbotV2AppendMessagesRequest,
   SlackbotV2CreateSessionRequest,
   SlackbotV2ExecuteSessionRequest,
+  SlackbotV2ExecuteSessionResponse,
   SlackbotV2Options,
   SlackbotV2RendererSource,
   SlackbotV2SessionMessage
@@ -49,7 +50,7 @@ export function isRetryableSessionApiError(error: unknown): boolean {
 }
 
 type ForwardSessionApiCallbacks = {
-  onExecutionStarted?(): Promise<void>
+  onExecutionStarted?(execution: SlackbotV2ExecuteSessionResponse): Promise<void>
   onMessagesAppended?(): Promise<void>
 }
 
@@ -140,11 +141,12 @@ export async function forwardToSessionApi(
   if (!input.executeMessage) return null
 
   const executeStartedAtMs = nowMs()
-  await executeSession(options, input.threadId, input.executeMessage)
+  const execution = await executeSession(options, input.threadId, input.executeMessage)
   traceLog(options, 'slackbotv2_session_execute_complete', input.trace, {
+    execution_id: execution.execution_id,
     phase_ms: elapsedMs(executeStartedAtMs)
   })
-  await callbacks.onExecutionStarted?.()
+  await callbacks.onExecutionStarted?.(execution)
   if (!input.openStream) return null
 
   return openSessionEventStream(options, input)
@@ -263,9 +265,10 @@ async function executeSession(
   options: SlackbotV2Options,
   threadId: string,
   message: SlackbotV2ApiMessage
-): Promise<void> {
+): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
   const body: SlackbotV2ExecuteSessionRequest = {
+    idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }),
     input_lines: [toCodexInputLine(message, threadId)],
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
@@ -277,6 +280,7 @@ async function executeSession(
     body: JSON.stringify(body)
   })
   await ensureApiOk(response, 'execute session')
+  return (await response.json()) as SlackbotV2ExecuteSessionResponse
 }
 
 async function ensureApiOk(response: Response, action: string): Promise<void> {
@@ -342,6 +346,7 @@ function apiHeaders(options: SlackbotV2Options, jsonBody = true): HeadersInit {
 
 function toSessionMessage(message: SlackbotV2ApiMessage): SlackbotV2SessionMessage {
   return {
+    client_message_id: message.id,
     role: message.author.isMe ? 'assistant' : 'user',
     parts: sessionMessageParts(message),
     metadata: sessionMetadata(message)

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -43,6 +43,7 @@ export type SlackbotV2ApiMessage = {
 export type SlackbotV2SessionMessageRole = 'user' | 'assistant' | 'system' | 'tool'
 
 export type SlackbotV2SessionMessage = {
+  client_message_id?: string
   metadata: JsonObject
   parts: JsonValue[]
   role: SlackbotV2SessionMessageRole
@@ -58,10 +59,18 @@ export type SlackbotV2CreateSessionRequest = {
 }
 
 export type SlackbotV2ExecuteSessionRequest = {
+  idempotency_key?: string
   idle_timeout_ms?: number
   input_lines: string[]
   max_duration_ms?: number
   metadata: JsonObject
+}
+
+export type SlackbotV2ExecuteSessionResponse = {
+  execution_id: string
+  ok: boolean
+  status: string
+  thread_key: string
 }
 
 export type SlackbotV2Fetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
@@ -105,6 +114,7 @@ export type SlackbotV2ThreadState = {
 
 export type SlackbotV2RenderObligation = {
   afterEventId: number
+  executionId: string
   message: SlackbotV2ApiMessage
 }
 

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -176,6 +176,10 @@ describe('slackbotv2', () => {
 
     const firstAppend = codexApi.appends[0]!
     expect(firstAppend.threadKey).toBe(threadKey(parent.ts))
+    expect(firstAppend.body.messages.map(message => message.client_message_id)).toEqual([
+      parent.ts,
+      firstMention.ts
+    ])
     expect(sessionMessageTexts(firstAppend.body.messages)).toContain('The deploy context is above.')
     expect(sessionMessageTexts(firstAppend.body.messages).some(text =>
       text.includes('run with this screenshot')
@@ -196,6 +200,7 @@ describe('slackbotv2', () => {
 
     const firstExecute = codexApi.executes[0]!
     expect(firstExecute.threadKey).toBe(threadKey(parent.ts))
+    expect(firstExecute.body.idempotency_key).toBe(firstMention.ts)
     const firstInputLine = JSON.parse(firstExecute.body.input_lines[0]!) as Record<string, unknown>
     expect(firstInputLine).toEqual(
       expect.objectContaining({
@@ -207,6 +212,7 @@ describe('slackbotv2', () => {
 
     const followUpAppend = codexApi.appends[1]!
     expect(followUpAppend.threadKey).toBe(threadKey(parent.ts))
+    expect(followUpAppend.body.messages[0]?.client_message_id).toBe(followUp.ts)
     expect(sessionMessageTexts(followUpAppend.body.messages)).toEqual([
       'Additional detail for the subscribed thread.'
     ])
@@ -216,6 +222,7 @@ describe('slackbotv2', () => {
       'now execute with the latest'
     )
     const secondExecute = codexApi.executes[1]!
+    expect(secondExecute.body.idempotency_key).toBe(secondMention.ts)
     expect(JSON.stringify(JSON.parse(secondExecute.body.input_lines[0]!))).toContain(
       'now execute with the latest'
     )
@@ -448,6 +455,7 @@ describe('slackbotv2', () => {
       lastEventId: 0,
       renderObligation: {
         afterEventId: 0,
+        executionId: 'exe-recovery',
         message
       }
     })
@@ -598,7 +606,58 @@ describe('slackbotv2', () => {
     expect(retryContextTexts).toContain('History that must not be lost.')
     expect(retryContextTexts.some(text => text.includes('first try'))).toBe(true)
     expect(codexApi.eventRequests).toHaveLength(1)
-    expect(await threadText(parent.ts)).toContain('Executed request 2.')
+    expect(await threadText(parent.ts)).toContain('Executed request 1.')
+  })
+
+  it('reuses an accepted execution when Slack retries after a lost execute response', async () => {
+    codexApi.failNextExecuteAfterAccept = true
+
+    const parent = await postUserMessage('History before response loss.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> first try accepted`, parent.ts)
+    const retryableEvent = signedSlackEvent({
+      event_id: 'Ev-slackbotv2-execute-response-lost',
+      event: {
+        type: 'app_mention',
+        user: USER_ID,
+        channel: CHANNEL_ID,
+        team: TEAM_ID,
+        ts: mention.ts,
+        thread_ts: parent.ts,
+        text: `<@${BOT_USER_ID}> first try accepted`
+      }
+    })
+    const failedWaits: Promise<unknown>[] = []
+    const failedResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      retryableEvent,
+      {},
+      waitUntilContext(failedWaits)
+    )
+    expect(failedResponse.status).toBe(503)
+    await Promise.all(failedWaits)
+    expect(codexApi.executes).toHaveLength(1)
+    expect(codexApi.eventRequests).toHaveLength(0)
+    expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
+
+    const retryWaits: Promise<unknown>[] = []
+    const retryResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      retryableEvent,
+      {},
+      waitUntilContext(retryWaits)
+    )
+    expect(retryResponse.status).toBe(200)
+    await Promise.all(retryWaits)
+
+    expect(codexApi.executes).toHaveLength(2)
+    expect(codexApi.executes.map(execute => execute.body.idempotency_key)).toEqual([
+      mention.ts,
+      mention.ts
+    ])
+    expect(codexApi.appends).toHaveLength(1)
+    expect(codexApi.eventRequests).toHaveLength(1)
+    expect(await threadText(parent.ts)).toContain('Executed request 1.')
+    expect(await threadText(parent.ts)).not.toContain('Executed request 2.')
   })
 
   it('keeps v1 external org and trigger-bot allowlist behavior', async () => {
@@ -1029,6 +1088,7 @@ type MockSessionApi = {
   executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[]
   failNextEvents: boolean
   failNextExecute: boolean
+  failNextExecuteAfterAccept: boolean
   holdNextExecute(): () => void
   reset(): void
   streamCount: number
@@ -1041,6 +1101,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
   const eventRequests: MockSessionEventRequest[] = []
   const events: MockSessionEvent[] = []
   const executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[] = []
+  const idempotentExecutions = new Map<string, string>()
   const streams = new Set<ServerResponse>()
   let autoRespond = true
   let executeHold: Promise<void> | null = null
@@ -1048,6 +1109,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
   let eventId = 0
   let failNextEvents = false
   let failNextExecute = false
+  let failNextExecuteAfterAccept = false
   const port = await availablePort(4063)
   const closeStreams = () => {
     for (const stream of streams) stream.end()
@@ -1069,9 +1131,13 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       get failNextExecute() {
         return failNextExecute
       },
+      get failNextExecuteAfterAccept() {
+        return failNextExecuteAfterAccept
+      },
       get failNextEvents() {
         return failNextEvents
       },
+      idempotentExecutions,
       nextEventId() {
         eventId += 1
         return eventId
@@ -1082,6 +1148,9 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       },
       setFailNextExecute(value) {
         failNextExecute = value
+      },
+      setFailNextExecuteAfterAccept(value) {
+        failNextExecuteAfterAccept = value
       },
       streams
     }).catch(error => {
@@ -1102,6 +1171,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       eventRequests.length = 0
       events.length = 0
       executes.length = 0
+      idempotentExecutions.clear()
       executeHoldRelease?.()
       executeHold = null
       executeHoldRelease = null
@@ -1110,6 +1180,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       eventId = 0
       failNextEvents = false
       failNextExecute = false
+      failNextExecuteAfterAccept = false
     },
     url: `http://127.0.0.1:${port}`,
     closeStreams,
@@ -1124,6 +1195,12 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
     },
     set failNextExecute(value: boolean) {
       failNextExecute = value
+    },
+    get failNextExecuteAfterAccept() {
+      return failNextExecuteAfterAccept
+    },
+    set failNextExecuteAfterAccept(value: boolean) {
+      failNextExecuteAfterAccept = value
     },
     get failNextEvents() {
       return failNextEvents
@@ -1178,12 +1255,15 @@ async function handleMockCodexRequest(
     eventRequests: MockSessionEventRequest[]
     executeHold: Promise<void> | null
     executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[]
+    failNextExecuteAfterAccept: boolean
     failNextEvents: boolean
     failNextExecute: boolean
+    idempotentExecutions: Map<string, string>
     nextEventId(): number
     port: number
     setFailNextEvents(value: boolean): void
     setFailNextExecute(value: boolean): void
+    setFailNextExecuteAfterAccept(value: boolean): void
     streams: Set<ServerResponse>
   }
 ): Promise<void> {
@@ -1255,8 +1335,19 @@ async function handleMockCodexRequest(
     return
   }
   if (input.executeHold) await input.executeHold
-  if (input.autoRespond) {
-    for (const line of sampleCodexOutputLines(`Executed request ${input.executes.length}.`)) {
+  const idempotencyMapKey = body.idempotency_key
+    ? `${threadKey}:${body.idempotency_key}`
+    : undefined
+  const existingExecutionId = idempotencyMapKey
+    ? input.idempotentExecutions.get(idempotencyMapKey)
+    : undefined
+  const executionId =
+    existingExecutionId ?? `exe-${input.idempotentExecutions.size + input.executes.length}`
+  if (idempotencyMapKey && !existingExecutionId) {
+    input.idempotentExecutions.set(idempotencyMapKey, executionId)
+  }
+  if (!existingExecutionId && input.autoRespond) {
+    for (const line of sampleCodexOutputLines(`Executed request ${input.idempotentExecutions.size}.`)) {
       emitMockSessionEvent({
         data: line,
         event: 'session.output.line',
@@ -1267,11 +1358,19 @@ async function handleMockCodexRequest(
       })
     }
   }
+  if (input.failNextExecuteAfterAccept) {
+    input.setFailNextExecuteAfterAccept(false)
+    await sendWebResponse(
+      res,
+      new Response('response lost after accept', { status: 503, statusText: 'Service Unavailable' })
+    )
+    return
+  }
   await sendWebResponse(
     res,
     Response.json({
       ok: true,
-      execution_id: `exe-${input.executes.length}`,
+      execution_id: executionId,
       thread_key: threadKey,
       status: 'completed'
     })


### PR DESCRIPTION
## Summary
- add client message ids and execution idempotency keys to api-rs session persistence
- make duplicate append/execute handoffs return the existing persisted rows instead of creating duplicate work
- have Slackbot v2 send Slack message ids as idempotency keys and store the accepted execution id in render obligations
- add a Slackbot emulator regression for Slack retrying after an accepted execute response is lost

## Testing
- bun run --cwd services/slackbotv2 check:types
- bun run --cwd services/slackbotv2 test
- cargo check -p centaur-session-core -p centaur-session-sqlx -p centaur-session-runtime -p centaur-api-server -p centaur-session-cli
- cargo test -p centaur-session-core -p centaur-api-server -p centaur-session-cli
- just build-one slackbotv2
- just build-one api-rs

Not run: just deploy / local E2E request, because this checkout's Kubernetes context was previously observed as production and I did not mutate a cluster from this PR workflow.