### PR TITLE
chore(sandbox): add thin test image

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -16,6 +16,10 @@ k3s_ctr := env_var_or_default("CENTAUR_K3S_CTR", "sudo k3s ctr")
 #       docker.io:
 #         endpoint: ["http://localhost:5000"]
 registry := env_var_or_default("CENTAUR_LOCAL_REGISTRY", "localhost:5000")
+agent_dockerfile := env_var_or_default("CENTAUR_AGENT_DOCKERFILE", "services/sandbox/Dockerfile")
+agent_build_target := env_var_or_default("CENTAUR_AGENT_BUILD_TARGET", "sandbox")
+agent_image := env_var_or_default("CENTAUR_AGENT_IMAGE", "centaur-agent:latest")
+thin_agent_image := env_var_or_default("CENTAUR_THIN_AGENT_IMAGE", "centaur-agent:thin")
 
 default:
     just --list
@@ -56,6 +60,7 @@ build-one service:
       slackbot) just _build-slackbot ;;
       slackbotv2) just _build-slackbotv2 ;;
       agent|sandbox) just _build-agent ;;
+      agent-thin|sandbox-thin) just _build-agent-thin ;;
       *) echo "unknown service: {{service}}" >&2; exit 2 ;;
     esac
 
@@ -75,7 +80,10 @@ _build-slackbotv2:
     docker build -t centaur-slackbotv2:latest -f services/slackbotv2/Dockerfile .
 
 _build-agent:
-    docker build --target sandbox -t centaur-agent:latest -f services/sandbox/Dockerfile .
+    docker build --target "{{agent_build_target}}" -t "{{agent_image}}" -f "{{agent_dockerfile}}" .
+
+_build-agent-thin:
+    docker build --target sandbox -t "{{thin_agent_image}}" -f services/sandbox/Dockerfile.thin .
 
 # Push locally-built images to the local registry under library/ so k3s pulls
 # them via its docker.io mirror. Used by `just up k3s`. Only changed layers are

--- a/services/api-rs/Justfile
+++ b/services/api-rs/Justfile
@@ -15,6 +15,8 @@ kind_e2e_context := "kind-" + kind_e2e_cluster
 kind_e2e_namespace := "centaur-sandbox-e2e"
 kind_e2e_tmp := "target/e2e"
 kind_e2e_agent_image := "centaur-agent:latest"
+kind_e2e_agent_dockerfile := env_var_or_default("KIND_E2E_AGENT_DOCKERFILE", "services/sandbox/Dockerfile")
+kind_e2e_agent_target := env_var_or_default("KIND_E2E_AGENT_TARGET", "sandbox")
 kind_e2e_iron_proxy_image := "centaur-iron-proxy:latest"
 
 default:
@@ -47,7 +49,7 @@ kind-e2e-up:
     kubectl --context "{{kind_e2e_context}}" -n agent-sandbox-system rollout status deploy/agent-sandbox-controller --timeout=120s
 
 kind-e2e-build-images:
-    cd ../.. && docker build --target sandbox -t "{{kind_e2e_agent_image}}" -f services/sandbox/Dockerfile .
+    cd ../.. && docker build --target "{{kind_e2e_agent_target}}" -t "{{kind_e2e_agent_image}}" -f "{{kind_e2e_agent_dockerfile}}" .
     cd ../.. && docker build -t "{{kind_e2e_iron_proxy_image}}" -f services/iron-proxy/Dockerfile .
 
 kind-e2e-load-images: kind-e2e-up

--- a/services/sandbox/Dockerfile.thin
+++ b/services/sandbox/Dockerfile.thin
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1.7
+
+FROM ubuntu:24.04 AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+ARG CODEX_VERSION=0.130.0
+
+# Minimal runtime for codex-app-server reliability tests. This intentionally
+# omits TeX, Manim, Foundry, browser deps, Amp, and Claude Code.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl fd-find gettext-base git gnupg jq lsb-release \
+      openssh-client openssl procps python3 python3-pip ripgrep sudo unzip \
+      vim-tiny xz-utils \
+    && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
+    && rm -rf /usr/share/doc /usr/share/man /usr/share/info
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /usr/share/doc /usr/share/man /usr/share/info
+
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm install -g --prefer-online --force "@openai/codex@${CODEX_VERSION}" \
+    && find /usr/lib/node_modules -type f \( -name '*.map' -o -name '*.tsbuildinfo' \) -delete \
+    && codex --version | grep -F "${CODEX_VERSION}"
+
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip3 install --break-system-packages --no-compile opentelemetry-proto==1.42.1 \
+    && find /usr/local/lib/python3.12 /usr/lib/python3 -type d -name __pycache__ -prune -exec rm -rf '{}' +
+
+RUN useradd -m -s /bin/bash -u 1001 agent \
+    && echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/agent
+
+USER agent
+WORKDIR /home/agent
+
+ENV PATH="/home/agent/.local/bin:${PATH}"
+
+RUN mkdir -p ~/.codex ~/.claude ~/.config/amp ~/.pi/agent ~/github ~/workspace \
+    && git config --global init.defaultBranch main \
+    && git config --global push.autoSetupRemote true \
+    && git config --global --add safe.directory '*' \
+    && git config --global user.name "Centaur AI" \
+    && git config --global user.email "ai@centaur.local"
+
+FROM runtime AS sandbox
+
+USER root
+RUN rm -f /etc/sudoers.d/agent \
+    && install -d -m 0755 /etc/centaur /opt/centaur
+
+COPY --link centaur_sdk/ /opt/centaur/centaur_sdk/
+COPY --link --chmod=644 services/sandbox/codex-auth.json /etc/centaur/codex-auth.default.json
+COPY --link --chmod=644 services/sandbox/claude-credentials.json /etc/centaur/claude-credentials.default.json
+COPY --link --chmod=755 services/sandbox/call.sh /usr/local/bin/call
+COPY --link --chmod=755 services/sandbox/codex-app-wrapper.py /usr/local/bin/codex-app-wrapper
+COPY --link --chmod=755 services/sandbox/harness_adapter.py /usr/local/bin/harness-adapter
+COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
+COPY --link --chmod=755 services/sandbox/entrypoint.sh /entrypoint.sh
+
+USER agent
+WORKDIR /home/agent
+
+COPY --link --chown=1001:1001 .agents/skills/ /home/agent/.agents/skills/
+COPY --link --chown=1001:1001 harness/ /home/agent/harness/
+COPY --link --chown=1001:1001 services/sandbox/SYSTEM_PROMPT.md /home/agent/AGENTS.md
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["codex-app-wrapper"]


### PR DESCRIPTION
## Summary
- add a separate services/sandbox/Dockerfile.thin for lightweight codex-app-server reliability testing
- wire just build-one sandbox-thin to build centaur-agent:thin
- allow api-rs Kind E2E image builds to override the sandbox Dockerfile via KIND_E2E_AGENT_DOCKERFILE

## Notes
- The thin image keeps the Centaur entrypoint, Codex app wrapper, prompt setup, and required Python OTEL proto dependency.
- It intentionally omits TeX, Manim, Foundry, browser deps, Amp, and Claude Code.
- Local image size was 649MB for centaur-agent:thin vs 5.18GB for centaur-agent:latest on this machine.

## Testing
- just --summary
- just --summary from services/api-rs
- just --dry-run build-one sandbox-thin
- KIND_E2E_AGENT_DOCKERFILE=services/sandbox/Dockerfile.thin just --dry-run kind-e2e-build-images
- just build-one sandbox-thin
- docker run smoke checked codex version, OTEL import, workspace AGENTS.md, and absence of manim/forge/amp/claude
