### PR TITLE
fix(proxy): allow Railway project token header

### DIFF
--- a/services/api/api/iron-proxy.base.yaml
+++ b/services/api/api/iron-proxy.base.yaml
@@ -66,6 +66,7 @@ transforms:
         - "api-access-key"
         - "api-signature"
         - "api-timestamp"
+        - "project-access-token"
         - "fx-access-key"
         - "fx-access-sign"
         - "fx-access-timestamp"

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -883,6 +883,15 @@ def test_render_emits_header_and_gcp_auth_transforms(
     assert entry["rules"] == [{"host": "api.openai.com"}]
 
 
+def test_render_allows_project_access_token_header() -> None:
+    cfg = yaml.safe_load(render_proxy_yaml([]))
+    header_allowlist = next(
+        t for t in cfg["transforms"] if t["name"] == "header_allowlist"
+    )
+
+    assert "project-access-token" in header_allowlist["config"]["headers"]
+
+
 def test_render_replace_secret_emits_query_and_path_locations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1494,7 +1503,10 @@ def test_render_emits_postgres_listeners_with_env_refs(
     ]
     cfg = yaml.safe_load(render_proxy_yaml(secrets))
     listeners = cfg["postgres"]
-    assert [l["name"] for l in listeners] == ["analytics_pg", "database_url"]
+    assert [listener["name"] for listener in listeners] == [
+        "analytics_pg",
+        "database_url",
+    ]
     assert listeners[0]["listen"] == "0.0.0.0:5432"
     assert listeners[1]["listen"] == "0.0.0.0:5433"
     # upstream.dsn uses the secret_ref directly so iron-proxy can resolve it

--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -66,6 +66,7 @@ transforms:
         - "api-access-key"
         - "api-signature"
         - "api-timestamp"
+        - "project-access-token"
         - "fx-access-key"
         - "fx-access-sign"
         - "fx-access-timestamp"


### PR DESCRIPTION
## Summary

- allow iron-proxy to preserve Railway's `Project-Access-Token` header
- keep the change scoped to the exact documented Railway project-token header instead of broadening the auth-header regex
- add a proxy-config regression test for the rendered header allowlist

## Why

Railway project tokens authenticate with `Project-Access-Token`, while account/workspace tokens use `Authorization: Bearer ...`. Without this allowlist entry, the proxy strips the project-token header before the request reaches Railway.

## Test

- `uv run --project services/api pytest services/api/tests/test_proxy_config.py`
