### PR TITLE
Add Rust formatting instruction

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -67,6 +67,9 @@
 |*NEVER run git commit/push inside* ~/github/ — it is read-only. Always use git-branch first.
 |Prefer `rg` (ripgrep) over `grep` for all codebase operations.
 
+[Rust policy]
+|Use `cargo +nightly fmt` to format Rust code.
+
 [Python policy — ALWAYS use uv]
 |ALWAYS use `uv run python` for inline Python and scripts. NEVER invoke `python` or `python3` directly.
 |ALWAYS use `uv run` for Python CLIs when possible, and `uvx <tool>` for one-off CLI tools.


### PR DESCRIPTION
## Summary
- Add a Rust policy directing agents to use `cargo +nightly fmt` for formatting Rust code.

## Testing
- Not run; prompt-only documentation change.

Prompted by: @SuperFluffy