### PR TITLE
feat: add matrixbot backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ pgdata/
 
 # Docker
 services/sandbox/repos/
+.local/
 
 # Agent / AI IDE config
 .agents/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 # Virtual environments
 .venv/
 venv/
+.devenv/
 
 # uv
 uv.lock

--- a/Justfile
+++ b/Justfile
@@ -19,7 +19,7 @@ build:
       just _build-all-sequential
     else
       pids=()
-      for recipe in _build-api _build-iron-proxy _build-slackbot _build-agent; do
+      for recipe in _build-api _build-iron-proxy _build-slackbot _build-matrixbot _build-agent; do
         just "$recipe" &
         pids+=("$!")
       done
@@ -43,9 +43,13 @@ build-one service:
       api) just _build-api ;;
       iron-proxy) just _build-iron-proxy ;;
       slackbot) just _build-slackbot ;;
+      matrixbot) just _build-matrixbot ;;
       agent|sandbox) just _build-agent ;;
       *) echo "unknown service: {{service}}" >&2; exit 2 ;;
     esac
+
+matrixbot-k8s-e2e *args:
+    scripts/local-matrix-k8s-e2e.sh {{args}}
 
 _build-api:
     docker build -t centaur-api:latest -f services/api/Dockerfile .
@@ -55,6 +59,9 @@ _build-iron-proxy:
 
 _build-slackbot:
     docker build -t centaur-slackbot:latest -f services/slackbot/Dockerfile .
+
+_build-matrixbot:
+    docker build -t centaur-matrixbot:latest -f services/matrixbot/Dockerfile .
 
 _build-agent:
     docker build --target sandbox -t centaur-agent:latest -f services/sandbox/Dockerfile .

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -95,6 +95,11 @@ spec:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "slackbot") | nindent 14 }}
 {{- end }}
+{{- if .Values.matrixbot.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "matrixbot") | nindent 14 }}
+{{- end }}
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "iron-proxy") | nindent 14 }}
@@ -217,6 +222,41 @@ spec:
           port: 443
 ---
 {{- end }}
+{{- if .Values.matrixbot.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "matrixbot") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "matrixbot") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "matrixbot") | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 8000
+    - to:
+        - podSelector:
+            matchLabels:
+              centaur.ai/iron-proxy: "true"
+              centaur.ai/sandbox-id: api
+      ports:
+        - protocol: TCP
+          port: {{ .Values.ironProxy.service.proxyPort }}
+    # Matrix sync and message delivery use HTTPS through the configured proxy.
+    - ports:
+        - protocol: TCP
+          port: 443
+---
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -244,6 +284,11 @@ spec:
         - podSelector:
             matchLabels:
               centaur.ai/component: workflow-run
+{{- if .Values.matrixbot.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "matrixbot") | nindent 14 }}
+{{- end }}
 {{- range .Values.runnerAccess.allowedCidrs }}
         - ipBlock:
             cidr: {{ . | quote }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -564,3 +564,132 @@ spec:
           secret:
             secretName: {{ include "centaur.trustedCaSecretName" . }}
 {{- end }}
+---
+{{- if .Values.matrixbot.enabled }}
+{{- if .Values.matrixbot.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "matrixbot-state") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "matrixbot") | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.matrixbot.persistence.size | quote }}
+{{- if .Values.matrixbot.persistence.storageClassName }}
+  storageClassName: {{ .Values.matrixbot.persistence.storageClassName | quote }}
+{{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "matrixbot") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "matrixbot") | nindent 4 }}
+spec:
+  replicas: {{ .Values.matrixbot.replicaCount }}
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "matrixbot") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret-env: {{ toJson (dict "secretManager" .Values.secretManager "firewallCa" .Values.firewall.ca) | sha256sum }}
+        checksum/firewall-ca: {{ toJson .Values.firewall.ca | sha256sum }}
+        checksum/infra-secrets: {{ include "centaur.infraSecretsChecksum" . }}
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "matrixbot") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: matrixbot
+          image: {{ printf "%s:%s" .Values.matrixbot.image.repository .Values.matrixbot.image.tag | quote }}
+          imagePullPolicy: {{ .Values.matrixbot.image.pullPolicy }}
+          env:
+            - name: PORT
+              value: "3002"
+            - name: MATRIX_HOMESERVER_URL
+              value: {{ .Values.matrixbot.homeserverUrl | quote }}
+            - name: MATRIX_USER_ID
+              value: {{ .Values.matrixbot.userId | quote }}
+            - name: MATRIX_DEVICE_ID
+              value: {{ .Values.matrixbot.deviceId | quote }}
+            - name: MATRIX_DEFAULT_HARNESS
+              value: {{ .Values.matrixbot.defaultHarness | quote }}
+            - name: MATRIX_PROCESS_INITIAL_SYNC
+              value: {{ ternary "true" "false" .Values.matrixbot.processInitialSync | quote }}
+            - name: MATRIX_SYNC_TIMEOUT_MS
+              value: {{ .Values.matrixbot.syncTimeoutMs | quote }}
+            - name: MATRIX_POLL_INTERVAL_MS
+              value: {{ .Values.matrixbot.pollIntervalMs | quote }}
+            - name: MATRIX_SYNC_TOKEN_PATH
+              value: {{ .Values.matrixbot.syncTokenPath | quote }}
+            - name: MATRIX_ALLOWED_ROOMS
+              value: {{ .Values.matrixbot.allowedRooms | quote }}
+            - name: MATRIX_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sMATRIX_ACCESS_TOKEN" .Values.secretManager.envPrefix }}
+            - name: MATRIXBOT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sMATRIXBOT_API_KEY" .Values.secretManager.envPrefix }}
+            - name: CENTAUR_API_URL
+              value: {{ printf "http://%s:8000" (include "centaur.componentName" (dict "root" . "component" "api")) | quote }}
+            - name: HTTPS_PROXY
+              value: {{ include "centaur.firewallProxyUrl" . | quote }}
+            - name: HTTP_PROXY
+              value: {{ include "centaur.firewallProxyUrl" . | quote }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /firewall-certs/ca-cert.pem
+            - name: NO_PROXY
+              value: {{ printf "localhost,127.0.0.1,%s,%s,centaur-egress.svc.cluster.local,.centaur-egress.svc.cluster.local" (include "centaur.componentName" (dict "root" . "component" "api")) (include "centaur.firewallNoProxyHosts" .) | quote }}
+            - name: no_proxy
+              value: {{ printf "localhost,127.0.0.1,%s,%s,centaur-egress.svc.cluster.local,.centaur-egress.svc.cluster.local" (include "centaur.componentName" (dict "root" . "component" "api")) (include "centaur.firewallNoProxyHosts" .) | quote }}
+{{- range $name, $value := .Values.matrixbot.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+          ports:
+            - containerPort: 3002
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3002
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3002
+          volumeMounts:
+            - name: firewall-ca
+              mountPath: /firewall-certs
+              readOnly: true
+            - name: matrixbot-state
+              mountPath: /var/lib/centaur-matrixbot
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources:
+{{ toYaml .Values.matrixbot.resources | nindent 12 }}
+      volumes:
+        - name: firewall-ca
+          secret:
+            secretName: {{ include "centaur.trustedCaSecretName" . }}
+        - name: matrixbot-state
+{{- if .Values.matrixbot.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "centaur.componentName" (dict "root" . "component" "matrixbot-state") }}
+{{- else }}
+          emptyDir: {}
+{{- end }}
+{{- end }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -210,6 +210,29 @@
         }
       }
     },
+    "matrixbot": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "homeserverUrl": { "type": "string" },
+        "userId": { "type": "string" },
+        "deviceId": { "type": "string" },
+        "defaultHarness": { "type": "string" },
+        "processInitialSync": { "type": "boolean" },
+        "syncTimeoutMs": { "type": "integer" },
+        "pollIntervalMs": { "type": "integer" },
+        "syncTokenPath": { "type": "string" },
+        "allowedRooms": { "type": "string" },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "size": { "type": "string" },
+            "storageClassName": { "type": "string" }
+          }
+        }
+      }
+    },
     "runnerAccess": {
       "type": "object",
       "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -222,6 +222,29 @@ slackbot:
   extraEnv: {}
   resources: {}
 
+matrixbot:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: centaur-matrixbot
+    tag: latest
+    pullPolicy: Always
+  homeserverUrl: ""
+  userId: ""
+  deviceId: centaur-matrixbot
+  defaultHarness: claude-code
+  processInitialSync: false
+  syncTimeoutMs: 30000
+  pollIntervalMs: 1000
+  syncTokenPath: /var/lib/centaur-matrixbot/sync-token
+  allowedRooms: ""
+  persistence:
+    enabled: false
+    size: 1Gi
+    storageClassName: ""
+  extraEnv: {}
+  resources: {}
+
 postgres:
   enabled: true
   image:

--- a/contrib/scripts/bootstrap-k8s-secrets.sh
+++ b/contrib/scripts/bootstrap-k8s-secrets.sh
@@ -161,6 +161,12 @@ if secret_exists centaur-infra-env; then
   if ! secret_key_present IRON_CONTROL_SECRET_KEY_BASE; then
     patch_data+=("\"IRON_CONTROL_SECRET_KEY_BASE\":\"$(printf '%s%s' "$(rand_hex)" "$(rand_hex)" | base64 | tr -d '\n')\"")
   fi
+  if [[ -n "${MATRIXBOT_API_KEY:-}" ]]; then
+    patch_data+=("\"MATRIXBOT_API_KEY\":\"$(printf '%s' "$MATRIXBOT_API_KEY" | base64 | tr -d '\n')\"")
+  fi
+  if [[ -n "${MATRIX_ACCESS_TOKEN:-}" ]]; then
+    patch_data+=("\"MATRIX_ACCESS_TOKEN\":\"$(printf '%s' "$MATRIX_ACCESS_TOKEN" | base64 | tr -d '\n')\"")
+  fi
   if [[ "${#patch_data[@]}" -gt 0 ]]; then
     patch_json="{\"data\":{$(IFS=,; echo "${patch_data[*]}")}}"
     kubectl -n "$NAMESPACE" patch secret centaur-infra-env --type merge -p "$patch_json" >/dev/null
@@ -202,6 +208,12 @@ else
   fi
   if [[ -n "${LOCAL_DEV_API_KEY:-}" ]]; then
     secret_args+=(--from-literal=LOCAL_DEV_API_KEY="$LOCAL_DEV_API_KEY")
+  fi
+  if [[ -n "${MATRIXBOT_API_KEY:-}" ]]; then
+    secret_args+=(--from-literal=MATRIXBOT_API_KEY="$MATRIXBOT_API_KEY")
+  fi
+  if [[ -n "${MATRIX_ACCESS_TOKEN:-}" ]]; then
+    secret_args+=(--from-literal=MATRIX_ACCESS_TOKEN="$MATRIX_ACCESS_TOKEN")
   fi
   kubectl "${secret_args[@]}" >/dev/null
   echo "Created Secret centaur-infra-env in namespace $NAMESPACE"

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1779460760,
+        "narHash": "sha256-icE9NT38wxcdpozLZa0uS1lTYfuPAYxpIebOQrJBKXo=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "e5f1a41c245ddacb841321026570fa963cedab33",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,44 @@
+{ pkgs, ... }:
+
+{
+  packages = [
+    pkgs.bun
+    pkgs.docker-client
+    pkgs.git
+    pkgs.jujutsu
+    pkgs.kubernetes-helm
+    pkgs.kubectl
+    pkgs.just
+    pkgs.jq
+    pkgs.nodejs_22
+    pkgs.openssl
+    pkgs.postgresql_16
+    pkgs.uv
+  ];
+
+  languages.python = {
+    enable = true;
+    package = pkgs.python311;
+  };
+
+  scripts.api-test.exec = ''
+    if [ -d services/api ]; then
+      cd services/api
+    fi
+    PATH="${pkgs.docker-client}/bin:${pkgs.coreutils}/bin:${pkgs.findutils}/bin:${pkgs.gnugrep}/bin:${pkgs.gnused}/bin:${pkgs.gawk}/bin:${pkgs.gnutar}/bin:${pkgs.gzip}/bin:${pkgs.openssl}/bin:${pkgs.uv}/bin:${pkgs.bash}/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+      ${pkgs.uv}/bin/uv run --python 3.11 pytest "$@"
+  '';
+
+  scripts.api-test-local-pg.exec = ''
+    if [ -d services/api ]; then
+      cd services/api
+    fi
+    ${pkgs.uv}/bin/uv run --python 3.11 pytest "$@"
+  '';
+
+  enterShell = ''
+    export UV_PYTHON=3.11
+    echo "Centaur dev shell: use 'api-test' for API tests with Docker/ParadeDB fallback."
+    echo "Use 'api-test-local-pg' only when local Postgres has required extensions."
+  '';
+}

--- a/docs/plans/2026-05-22-matrix-backend-and-codex-oauth.md
+++ b/docs/plans/2026-05-22-matrix-backend-and-codex-oauth.md
@@ -146,6 +146,54 @@ ROOM_ID=$(scripts/local-matrix.sh create-room)
 scripts/local-matrix.sh send-mention "$ROOM_ID" "reply with exactly PONG"
 ```
 
+Use `scripts/local-matrixbot-smoke.sh` to run the full local Matrixbot loop
+against Synapse and a stub Centaur API. It sends a mention, returns a stubbed
+`PONG` final delivery, and verifies the reply in the Matrix room.
+The stub enforces the durable client protocol:
+`POST /agent/spawn` → `POST /agent/message` → `POST /agent/execute`.
+
+For local Kubernetes testing with the Helm-managed Matrixbot deployment, keep
+the same firewall-proxy path as Slackbot and point Matrixbot at a homeserver
+reachable through standard HTTPS egress:
+
+```bash
+scripts/local-matrix.sh start
+eval "$(scripts/local-matrix.sh env)"
+just up
+
+nix-shell -p kubernetes-helm --run '
+  helm upgrade centaur contrib/chart -n centaur --reuse-values \
+    --set matrixbot.enabled=true \
+    --set matrixbot.homeserverUrl=https://matrix.example.com \
+    --set matrixbot.userId=@centaur:localhost \
+    --set matrixbot.allowedRooms='!roomid:example.com' \
+    --set matrixbot.persistence.enabled=true \
+    --set matrixbot.image.pullPolicy=IfNotPresent
+'
+```
+
+The chart gives Matrixbot the same firewall proxy environment as Slackbot. For
+the disposable local Synapse on `localhost:8008`, use the local smoke script or
+run Matrixbot outside the cluster; do not broaden the production chart's egress
+model just for that test shape.
+
+Set `matrixbot.allowedRooms` to a comma-separated list of Matrix room IDs before
+using real model credentials. Leave it empty only for local experiments. Enable
+`matrixbot.persistence` in deployed environments so the Matrix sync token
+survives pod replacement and the bot does not replay old timeline windows.
+
+For repeatable local E2E without a homelab Kubernetes cluster, use:
+
+```bash
+scripts/local-matrix-k8s-e2e.sh
+```
+
+That script runs Synapse locally, exposes it through a temporary HTTPS
+cloudflared tunnel, deploys Helm-managed Matrixbot into the local Kubernetes
+cluster, sends a Matrix mention, waits for `PONG`, releases the runtime, and
+disables Matrixbot afterward. This keeps the chart's firewall/HTTPS egress shape
+intact while avoiding permanent Matrix infrastructure.
+
 The script stores generated Synapse data under `.local/matrix-synapse`, which is
 ignored by git. It configures a local registration shared secret, creates a bot
 user (`centaur`) and test user (`alice`), disables local-dev rate limits, and
@@ -157,10 +205,13 @@ prints Matrixbot-compatible environment exports. Use
 The first useful slice is a text-only Matrixbot:
 
 - Configuration: homeserver URL, access token, user id, Centaur API URL/key,
-  default harness.
+  default harness, room allowlist, sync token path.
 - Sync loop: receive room message events, ignore own messages, detect mentions.
-- Handoff: call `POST /agent/execute` with `harness: "claude-code"` by default
-  for local testing.
+- Safety: suppress duplicate Matrix event IDs in-process and persist the Matrix
+  sync token when configured.
+- Handoff: use the durable client protocol:
+  `POST /agent/spawn` → `POST /agent/message` → `POST /agent/execute` with
+  `harness: "claude-code"` by default for local testing.
 - Delivery: claim `platform: "matrix"` final-delivery rows and post plain text
   replies into the originating room/thread.
 

--- a/docs/plans/2026-05-22-matrix-backend-and-codex-oauth.md
+++ b/docs/plans/2026-05-22-matrix-backend-and-codex-oauth.md
@@ -1,0 +1,167 @@
+# Matrix Backend and Codex OAuth Design
+
+Status: local draft
+
+## Goals
+
+- Add Matrix as a first-class chat backend without replacing Slack.
+- Preserve the existing durable control-plane API:
+  `spawn -> message -> execute -> events -> final delivery`.
+- Keep Slack behavior stable while making shared backend concerns reusable.
+- Add a path for Codex OAuth or access-token auth without weakening the current
+  API-key-plus-proxy credential boundary.
+
+## Non-Goals
+
+- Do not introduce a broad generic bot framework up front.
+- Do not refactor Slack streaming or rendering unless Matrix needs a shared
+  primitive and the extraction is small.
+- Do not make Codex OAuth the only auth mode. API-key mode must continue to work.
+- Do not mix Matrix support and Codex OAuth in one PR-sized change.
+
+## Current Shape
+
+Slackbot is already a thin client over Centaur's durable API. It normalizes Slack
+events, constructs a `slack:<team>:<channel>:<thread_ts>` thread key, hands the
+turn to the API, then handles final-delivery outbox rows for Slack.
+
+The API and sandbox layers are already platform-neutral for agent execution.
+The platform-specific surface is concentrated in `services/slackbot`, Slack
+delivery metadata, and Slack-specific rendering/status endpoints.
+
+Sandbox harness credentials currently use placeholder environment variables,
+for example `ANTHROPIC_API_KEY=ANTHROPIC_API_KEY`, and iron-proxy replaces those
+placeholders on approved outbound hosts. Codex additionally logs in with
+`codex login --with-api-key` from `CODEX_API_KEY` or `OPENAI_API_KEY`.
+
+## Track 1: Matrix Backend
+
+Add `services/matrixbot` as a sibling service to `services/slackbot`.
+
+Matrixbot should own Matrix-specific concerns:
+
+- Homeserver client configuration and access token handling.
+- Event sync, deduplication, and mention/filter logic.
+- Matrix thread key construction, likely:
+  `matrix:<homeserver_id_or_domain>:<room_id>:<thread_root_or_event_id>`.
+- Converting Matrix messages and attachments into Centaur message parts.
+- Sending final responses back to Matrix rooms or threads.
+
+The first Matrix implementation should use the API convenience path:
+`POST /agent/execute` with `{thread_key, message, harness, delivery}`. This keeps
+the bot small and avoids duplicating the manual spawn/message/execute sequence
+until Matrix needs richer attachment handling or replay behavior.
+
+Final delivery should claim rows with `platform: "matrix"` and a Matrix-specific
+consumer id. Delivery metadata should include enough stable Matrix identifiers to
+post idempotently:
+
+- `room_id`
+- `thread_root_event_id` or fallback parent event id
+- `reply_to_event_id`
+- optional `sender`
+
+Matrix idempotency should not depend only on reading room history. Store a
+Centaur execution id in Matrix event content metadata when possible, and keep
+room-history checks as a best-effort duplicate guard.
+
+## Track 2: Shared Chat Client Utilities
+
+Only extract shared code after Matrixbot proves the duplicated shape.
+
+Good candidates:
+
+- A small Centaur API client for `execute`, final-delivery claim, delivered, and
+  failed.
+- Final-delivery polling loop parameterized by platform and delivery function.
+- Common result-text extraction and chunking.
+- Trace header construction.
+
+Bad candidates:
+
+- A shared event model that tries to erase Slack and Matrix semantics.
+- A generic streaming renderer before Matrix has feature parity requirements.
+- A shared bot runtime that forces Slack and Matrix into one service.
+
+The target shared package can live under `packages/chat-bridge` or inside a
+service-local module until a second service actually imports it.
+
+## Track 3: Codex OAuth / Access-Token Auth
+
+Codex upstream supports ChatGPT OAuth, device auth, API-key auth, and access
+tokens. Centaur currently uses API-key mode because sandbox pods are non-
+interactive and credential injection is mediated by iron-proxy.
+
+Add an explicit Codex auth mode rather than replacing the current behavior:
+
+- `codex_api_key`: current default, uses `OPENAI_API_KEY`/`CODEX_API_KEY` and
+  iron-proxy injection.
+- `codex_access_token`: reads a deployment-scoped or user-scoped access token
+  from the configured secret source and runs
+  `codex login --with-access-token`.
+- `codex_cached_auth`: mounts or materializes a managed `auth.json` into
+  `CODEX_HOME` for deployments that can safely store refreshed Codex login
+  state.
+
+The safest first implementation is `codex_access_token` if a refresh strategy is
+available outside the sandbox. Cached OAuth state is more complex because it
+introduces lifecycle, refresh, revocation, and per-user isolation questions.
+
+Open security decisions:
+
+- Is Codex OAuth deployment-scoped or per-user?
+- Where is refreshable auth state stored?
+- Can a sandbox write refreshed auth state back, or is auth read-only per turn?
+- How does final delivery identify which user credential was used?
+
+## Implementation Order
+
+1. Add local Matrix design and service skeleton.
+2. Implement Matrix inbound text-only mention to Claude/Codex with final reply.
+3. Add Matrix final-delivery polling and idempotency.
+4. Extract a minimal Centaur API/final-delivery helper if duplication is clear.
+5. Add Matrix Helm values and disabled-by-default deployment.
+6. Add Codex auth-mode design and tests.
+7. Implement the smallest non-interactive Codex auth mode beyond API keys.
+
+## Testing Plan
+
+- Unit-test Matrix event normalization, thread key construction, and delivery
+  metadata.
+- Unit-test final-delivery claim/ack/fail behavior with mocked Matrix API calls.
+- Add one API-only integration test that exercises `platform: "matrix"` final
+  delivery rows.
+- For local E2E, run Synapse or another lightweight Matrix homeserver, invite
+  the bot to a room, send a mention, and verify one final response.
+- Keep Slackbot tests unchanged during the initial Matrix service addition.
+
+## Local Matrix Harness
+
+Use `scripts/local-matrix.sh` for a disposable Synapse container:
+
+```bash
+scripts/local-matrix.sh start
+scripts/local-matrix.sh env
+ROOM_ID=$(scripts/local-matrix.sh create-room)
+scripts/local-matrix.sh send-mention "$ROOM_ID" "reply with exactly PONG"
+```
+
+The script stores generated Synapse data under `.local/matrix-synapse`, which is
+ignored by git. It configures a local registration shared secret, creates a bot
+user (`centaur`) and test user (`alice`), disables local-dev rate limits, and
+prints Matrixbot-compatible environment exports. Use
+`scripts/local-matrix.sh reset` to remove the disposable server state.
+
+## First Implementation Slice
+
+The first useful slice is a text-only Matrixbot:
+
+- Configuration: homeserver URL, access token, user id, Centaur API URL/key,
+  default harness.
+- Sync loop: receive room message events, ignore own messages, detect mentions.
+- Handoff: call `POST /agent/execute` with `harness: "claude-code"` by default
+  for local testing.
+- Delivery: claim `platform: "matrix"` final-delivery rows and post plain text
+  replies into the originating room/thread.
+
+This proves the backend shape before touching Slack internals or Codex auth.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "scripts": {
-    "slackbot:delivery-regression": "pnpm --filter slackbot test"
+    "slackbot:delivery-regression": "pnpm --filter slackbot test",
+    "matrixbot:test": "pnpm --filter matrixbot test"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,15 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  services/matrixbot:
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.13
+        version: 1.3.14
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   services/slackbot:
     dependencies:
       '@opentelemetry/api':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/*'
   - 'services/slackbot'
+  - 'services/matrixbot'

--- a/scripts/local-matrix-k8s-e2e.sh
+++ b/scripts/local-matrix-k8s-e2e.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+NAMESPACE="${CENTAUR_NAMESPACE:-centaur}"
+RELEASE="${CENTAUR_RELEASE:-centaur}"
+CHART="${CENTAUR_CHART:-contrib/chart}"
+DEV_VALUES="${CENTAUR_DEV_VALUES:-contrib/chart/values.dev.yaml}"
+E2E_DIR="${MATRIXBOT_K8S_E2E_DIR:-.local/matrixbot-k8s-e2e}"
+MATRIX_USER="${MATRIX_LOCAL_USER:-alice}"
+MATRIX_PASSWORD="${MATRIX_LOCAL_PASSWORD:-alice-local-password}"
+MATRIXBOT_API_KEY="${MATRIXBOT_API_KEY:-aiv2_matrixbot_local}"
+MATRIX_DEFAULT_HARNESS="${MATRIX_DEFAULT_HARNESS:-claude-code}"
+RUN_ID="${MATRIXBOT_K8S_E2E_RUN_ID:-$(date +%s)-$RANDOM}"
+SKIP_BUILD=0
+SKIP_STACK_UP=0
+KEEP_MATRIXBOT=0
+HELM_RELEASE_READY=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/local-matrix-k8s-e2e.sh [--skip-build] [--skip-stack-up] [--keep-matrixbot]
+
+Runs the production-shape Matrix E2E locally:
+  1. starts/reuses local Synapse
+  2. exposes Synapse through a temporary HTTPS cloudflared tunnel
+  3. builds the local matrixbot image unless --skip-build is set
+  4. starts/reuses the local Centaur Helm stack
+  5. deploys Helm-managed matrixbot in-cluster with firewall proxy env
+  6. sends a Matrix mention and waits for a real PONG reply
+  7. releases the Centaur runtime and disables matrixbot unless --keep-matrixbot is set
+
+Requires OP_SERVICE_ACCOUNT_TOKEN and OP_VAULT for Centaur's 1Password-backed
+LLM credential injection. Slack env vars default to local dummy values because
+this test deploys slackbot disabled.
+
+If helm or cloudflared are not installed globally, the script uses nix-shell
+when available.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-build)
+      SKIP_BUILD=1
+      shift
+      ;;
+    --skip-stack-up)
+      SKIP_STACK_UP=1
+      shift
+      ;;
+    --keep-matrixbot)
+      KEEP_MATRIXBOT=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "FATAL: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "FATAL: $name is required in the shell environment" >&2
+    exit 1
+  fi
+}
+
+shell_quote_args() {
+  printf '%q ' "$@"
+}
+
+run_helm() {
+  if command -v helm >/dev/null 2>&1; then
+    helm "$@"
+    return
+  fi
+  if command -v nix-shell >/dev/null 2>&1; then
+    nix-shell -p kubernetes-helm --run "helm $(shell_quote_args "$@")"
+    return
+  fi
+  echo "FATAL: helm not found and nix-shell is unavailable" >&2
+  exit 1
+}
+
+start_cloudflared() {
+  local url="$1"
+  local log_file="$2"
+  if command -v cloudflared >/dev/null 2>&1; then
+    cloudflared tunnel --url "$url" > "$log_file" 2>&1 &
+    TUNNEL_PID="$!"
+    return
+  fi
+  if command -v nix-shell >/dev/null 2>&1; then
+    nix-shell -p cloudflared --run "cloudflared tunnel --url $(printf '%q' "$url")" \
+      > "$log_file" 2>&1 &
+    TUNNEL_PID="$!"
+    return
+  fi
+  echo "FATAL: cloudflared not found and nix-shell is unavailable" >&2
+  exit 1
+}
+
+urlencode() {
+  node -e 'console.log(encodeURIComponent(process.argv[1]))' "$1"
+}
+
+wait_for_tunnel_url() {
+  local log_file="$1"
+  for _ in $(seq 1 120); do
+    local url
+    url="$(grep -Eo 'https://[-a-zA-Z0-9.]+\.trycloudflare\.com' "$log_file" 2>/dev/null | tail -1 || true)"
+    if [[ -n "$url" ]]; then
+      printf '%s\n' "$url"
+      return
+    fi
+    sleep 0.5
+  done
+  echo "FATAL: cloudflared did not publish a trycloudflare URL" >&2
+  tail -100 "$log_file" >&2 || true
+  return 1
+}
+
+wait_http() {
+  local url="$1"
+  local label="$2"
+  for _ in $(seq 1 240); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.5
+  done
+  echo "FATAL: $label did not become ready at $url" >&2
+  return 1
+}
+
+start_synapse_tunnel() {
+  local origin_url="$1"
+  local log_file="$2"
+  for attempt in 1 2 3; do
+    : > "$log_file"
+    start_cloudflared "$origin_url" "$log_file"
+    local tunnel_url
+    if ! tunnel_url="$(wait_for_tunnel_url "$log_file")"; then
+      echo "WARN: cloudflared tunnel attempt $attempt did not publish a URL; retrying" >&2
+      kill "$TUNNEL_PID" >/dev/null 2>&1 || true
+      unset TUNNEL_PID
+      sleep 2
+      continue
+    fi
+    if wait_http "$tunnel_url/_matrix/client/versions" "cloudflared Synapse tunnel"; then
+      printf '%s\n' "$tunnel_url"
+      return
+    fi
+    echo "WARN: cloudflared tunnel attempt $attempt did not become reachable; retrying" >&2
+    kill "$TUNNEL_PID" >/dev/null 2>&1 || true
+    unset TUNNEL_PID
+    sleep 2
+  done
+  echo "FATAL: cloudflared Synapse tunnel did not become reachable after 3 attempts" >&2
+  tail -100 "$log_file" >&2 || true
+  return 1
+}
+
+token_field() {
+  local field="$1"
+  jq -r --arg field "$field" '.[$field]'
+}
+
+api_deploy() {
+  printf '%s-centaur-api' "$RELEASE"
+}
+
+stack_is_up() {
+  kubectl -n "$NAMESPACE" get deploy "$(api_deploy)" >/dev/null 2>&1
+}
+
+helm_release_listed() {
+  run_helm list -n "$NAMESPACE" --all --filter "^$RELEASE$" --short 2>/dev/null \
+    | grep -qx "$RELEASE"
+}
+
+helm_release_deployed() {
+  run_helm list -n "$NAMESPACE" --deployed --filter "^$RELEASE$" --short 2>/dev/null \
+    | grep -qx "$RELEASE"
+}
+
+recover_non_deployed_release() {
+  if ! helm_release_deployed && helm_release_listed; then
+    echo "Removing non-deployed Helm release record for $RELEASE in namespace $NAMESPACE"
+    run_helm uninstall "$RELEASE" -n "$NAMESPACE" >/dev/null || true
+  fi
+}
+
+bootstrap_secrets() {
+  export MATRIXBOT_API_KEY
+  export SLACK_BOT_TOKEN="${SLACK_BOT_TOKEN:-xoxb-local-dummy}"
+  export SLACK_SIGNING_SECRET="${SLACK_SIGNING_SECRET:-local-dummy}"
+  export SLACKBOT_API_KEY="${SLACKBOT_API_KEY:-aiv2_slackbot_dummy}"
+  just bootstrap-secrets
+}
+
+deploy_stack() {
+  run_helm dependency update "$CHART" >/dev/null
+  recover_non_deployed_release
+  run_helm upgrade --install "$RELEASE" "$CHART" \
+    -n "$NAMESPACE" \
+    --create-namespace \
+    -f "$DEV_VALUES" \
+    --set slackbot.enabled=false \
+    --set api.image.pullPolicy=IfNotPresent \
+    --set ironProxy.image.pullPolicy=IfNotPresent \
+    --set sandbox.image.pullPolicy=IfNotPresent \
+    --set postgres.image.pullPolicy=IfNotPresent \
+    --set matrixbot.image.pullPolicy=IfNotPresent
+}
+
+ensure_stack() {
+  bootstrap_secrets
+  if stack_is_up; then
+    HELM_RELEASE_READY=1
+    kubectl -n "$NAMESPACE" rollout status "deploy/$(api_deploy)"
+    return
+  fi
+  if [[ "$SKIP_STACK_UP" == "1" ]]; then
+    echo "FATAL: Centaur stack is not up in namespace $NAMESPACE" >&2
+    exit 1
+  fi
+  if [[ "$SKIP_BUILD" != "1" ]]; then
+    just build
+  fi
+  deploy_stack
+  HELM_RELEASE_READY=1
+  kubectl -n "$NAMESPACE" rollout status "deploy/$(api_deploy)"
+}
+
+deploy_matrixbot() {
+  local homeserver_url="$1"
+  local user_id="$2"
+  local room_id="$3"
+  run_helm upgrade "$RELEASE" "$CHART" \
+    -n "$NAMESPACE" \
+    --reuse-values \
+    --set matrixbot.enabled=true \
+    --set "matrixbot.homeserverUrl=$homeserver_url" \
+    --set "matrixbot.userId=$user_id" \
+    --set "matrixbot.allowedRooms=$room_id" \
+    --set "matrixbot.syncTokenPath=/var/lib/centaur-matrixbot/sync-token-$RUN_ID" \
+    --set matrixbot.persistence.enabled=true \
+    --set matrixbot.image.pullPolicy=IfNotPresent \
+    --set "matrixbot.defaultHarness=$MATRIX_DEFAULT_HARNESS"
+  kubectl -n "$NAMESPACE" rollout status "deploy/$RELEASE-centaur-matrixbot"
+}
+
+disable_matrixbot() {
+  if [[ "$HELM_RELEASE_READY" != "1" ]] && ! helm_release_deployed; then
+    return
+  fi
+  run_helm upgrade "$RELEASE" "$CHART" -n "$NAMESPACE" --reuse-values --set matrixbot.enabled=false >/dev/null || true
+}
+
+wait_for_matrixbot_initial_sync() {
+  for _ in $(seq 1 120); do
+    if kubectl -n "$NAMESPACE" logs "deploy/$RELEASE-centaur-matrixbot" --tail=200 2>/dev/null \
+      | grep -q '"event":"matrix_initial_sync_skipped"'
+    then
+      return
+    fi
+    sleep 0.5
+  done
+  echo "FATAL: in-cluster Matrixbot did not finish initial sync" >&2
+  kubectl -n "$NAMESPACE" logs "deploy/$RELEASE-centaur-matrixbot" --tail=200 >&2 || true
+  return 1
+}
+
+wait_for_pong() {
+  local homeserver="$1"
+  local token="$2"
+  local room_id="$3"
+  local encoded_room_id messages_file
+  encoded_room_id="$(urlencode "$room_id")"
+  messages_file="$E2E_DIR/messages.json"
+  for _ in $(seq 1 180); do
+    curl -fsS "$homeserver/_matrix/client/v3/rooms/$encoded_room_id/messages?dir=b&limit=20" \
+      -H "Authorization: Bearer $token" > "$messages_file"
+    if jq -er --arg bot "$MATRIX_USER_ID" '
+      .chunk[]?
+      | select(.sender == $bot)
+      | .content.body? // empty
+      | select(contains("PONG"))
+    ' "$messages_file" >/dev/null
+    then
+      return
+    fi
+    sleep 1
+  done
+  echo "FATAL: did not observe Matrixbot PONG reply" >&2
+  kubectl -n "$NAMESPACE" logs "deploy/$RELEASE-centaur-matrixbot" --tail=200 >&2 || true
+  return 1
+}
+
+release_thread() {
+  local room_id="$1"
+  local event_id="$2"
+  local thread_key encoded_thread_key
+  thread_key="matrix:$(urlencode "$room_id"):$(urlencode "$event_id")"
+  encoded_thread_key="$(urlencode "$thread_key")"
+  kubectl -n "$NAMESPACE" exec "deploy/$(api_deploy)" -- \
+    curl -fsS -X POST "http://localhost:8000/agent/threads/$encoded_thread_key/release" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $MATRIXBOT_API_KEY" \
+      -d '{}' >/dev/null || true
+}
+
+cleanup() {
+  if [[ -n "${ROOM_ID:-}" && -n "${MENTION_EVENT_ID:-}" ]]; then
+    release_thread "$ROOM_ID" "$MENTION_EVENT_ID"
+  fi
+  if [[ "$KEEP_MATRIXBOT" != "1" ]]; then
+    disable_matrixbot
+  fi
+  if [[ -n "${TUNNEL_PID:-}" ]]; then
+    kill "$TUNNEL_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+main() {
+  require_cmd bun
+  require_cmd curl
+  require_cmd docker
+  require_cmd jq
+  require_cmd just
+  require_cmd kubectl
+  require_cmd node
+  require_env OP_SERVICE_ACCOUNT_TOKEN
+  require_env OP_VAULT
+
+  trap cleanup EXIT
+  mkdir -p "$E2E_DIR"
+
+  scripts/local-matrix.sh start
+  eval "$(scripts/local-matrix.sh env)"
+  export MATRIXBOT_API_KEY
+  export MATRIX_ACCESS_TOKEN
+
+  local user_login user_token tunnel_url send_response
+  user_login="$(scripts/local-matrix.sh ensure-user "$MATRIX_USER" "$MATRIX_PASSWORD")"
+  user_token="$(printf '%s' "$user_login" | token_field access_token)"
+  ROOM_ID="$(scripts/local-matrix.sh create-room "$MATRIX_USER" "$MATRIX_PASSWORD")"
+
+  local matrix_local_port="${MATRIX_LOCAL_PORT:-8008}"
+  tunnel_url="$(start_synapse_tunnel "http://127.0.0.1:$matrix_local_port" "$E2E_DIR/cloudflared.log")"
+
+  if [[ "$SKIP_BUILD" != "1" ]]; then
+    just build-one matrixbot
+  fi
+
+  ensure_stack
+  deploy_matrixbot "$tunnel_url" "$MATRIX_USER_ID" "$ROOM_ID"
+  wait_for_matrixbot_initial_sync
+
+  send_response="$(scripts/local-matrix.sh send-mention "$ROOM_ID" "reply with exactly PONG" )"
+  MENTION_EVENT_ID="$(printf '%s' "$send_response" | token_field event_id)"
+  wait_for_pong "$MATRIX_HOMESERVER_URL" "$user_token" "$ROOM_ID"
+
+  local encoded_room_id messages_file
+  encoded_room_id="$(urlencode "$ROOM_ID")"
+  messages_file="$E2E_DIR/messages.json"
+  curl -fsS "$MATRIX_HOMESERVER_URL/_matrix/client/v3/rooms/$encoded_room_id/messages?dir=b&limit=5" \
+    -H "Authorization: Bearer $user_token" > "$messages_file"
+
+  echo "Matrixbot Kubernetes E2E passed"
+  echo "Tunnel: $tunnel_url"
+  echo "Room: $ROOM_ID"
+  echo "Recent room messages:"
+  jq -r '.chunk[]? | select(.content.body?) | "\(.sender): \(.content.body)"' "$messages_file"
+}
+
+main "$@"

--- a/scripts/local-matrix.sh
+++ b/scripts/local-matrix.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${MATRIX_LOCAL_IMAGE:-matrixdotorg/synapse:latest}"
+CONTAINER="${MATRIX_LOCAL_CONTAINER:-centaur-local-synapse}"
+DATA_DIR="${MATRIX_LOCAL_DATA_DIR:-.local/matrix-synapse}"
+PORT="${MATRIX_LOCAL_PORT:-8008}"
+SERVER_NAME="${MATRIX_LOCAL_SERVER_NAME:-localhost}"
+SHARED_SECRET_FILE="$DATA_DIR/registration_shared_secret"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/local-matrix.sh <command>
+
+Commands:
+  start                       Start a disposable local Synapse container.
+  stop                        Stop the local Synapse container.
+  reset                       Stop Synapse and remove its local data directory.
+  ensure-user USER PASS [--admin]
+                              Register USER if needed, then print login JSON.
+  env [USER] [PASS]           Ensure bot user and print Matrixbot env exports.
+  create-room [USER] [PASS]   Ensure users, create a room, invite/join bot.
+  send-mention ROOM_ID [TEXT] Send a mention from the test user.
+
+Defaults:
+  bot user:  centaur / centaur-local-password
+  test user: alice   / alice-local-password
+
+Environment overrides:
+  MATRIX_LOCAL_IMAGE, MATRIX_LOCAL_CONTAINER, MATRIX_LOCAL_DATA_DIR,
+  MATRIX_LOCAL_PORT, MATRIX_LOCAL_SERVER_NAME
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "FATAL: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+base_url() {
+  printf 'http://localhost:%s' "$PORT"
+}
+
+container_running() {
+  docker inspect -f '{{.State.Running}}' "$CONTAINER" >/dev/null 2>&1
+}
+
+wait_ready() {
+  local url
+  url="$(base_url)/_matrix/client/versions"
+  for _ in $(seq 1 60); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+  echo "FATAL: Synapse did not become ready at $url" >&2
+  docker logs "$CONTAINER" --tail 100 >&2 || true
+  exit 1
+}
+
+ensure_config() {
+  mkdir -p "$DATA_DIR"
+  if [[ ! -f "$DATA_DIR/homeserver.yaml" ]]; then
+    docker run --rm \
+      -v "$PWD/$DATA_DIR:/data" \
+      -e SYNAPSE_SERVER_NAME="$SERVER_NAME" \
+      -e SYNAPSE_REPORT_STATS=no \
+      "$IMAGE" generate >/dev/null
+  fi
+
+  if [[ ! -f "$SHARED_SECRET_FILE" ]]; then
+    openssl rand -hex 32 > "$SHARED_SECRET_FILE"
+  fi
+
+  if ! grep -q '^registration_shared_secret:' "$DATA_DIR/homeserver.yaml"; then
+    {
+      printf '\n'
+      printf 'registration_shared_secret: "%s"\n' "$(cat "$SHARED_SECRET_FILE")"
+      printf 'enable_registration: false\n'
+    } >> "$DATA_DIR/homeserver.yaml"
+  fi
+
+  if ! grep -q '^# Centaur local-dev rate limits' "$DATA_DIR/homeserver.yaml"; then
+    cat >> "$DATA_DIR/homeserver.yaml" <<'EOF'
+
+# Centaur local-dev rate limits
+rc_login:
+  address:
+    per_second: 10000
+    burst_count: 10000
+  account:
+    per_second: 10000
+    burst_count: 10000
+  failed_attempts:
+    per_second: 10000
+    burst_count: 10000
+rc_registration:
+  per_second: 10000
+  burst_count: 10000
+EOF
+  fi
+}
+
+start() {
+  require_cmd docker
+  require_cmd curl
+  require_cmd openssl
+  ensure_config
+
+  if container_running; then
+    wait_ready
+    return
+  fi
+
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  docker run -d \
+    --name "$CONTAINER" \
+    -p "127.0.0.1:$PORT:8008" \
+    -v "$PWD/$DATA_DIR:/data" \
+    "$IMAGE" >/dev/null
+  wait_ready
+  echo "Synapse ready at $(base_url)"
+}
+
+stop() {
+  require_cmd docker
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+}
+
+reset() {
+  stop
+  rm -rf "$DATA_DIR"
+}
+
+login() {
+  local user="$1"
+  local password="$2"
+  curl -fsS -X POST "$(base_url)/_matrix/client/v3/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"type\":\"m.login.password\",\"identifier\":{\"type\":\"m.id.user\",\"user\":\"$user\"},\"password\":\"$password\"}"
+}
+
+ensure_user() {
+  local user="$1"
+  local password="$2"
+  local admin="${3:-}"
+
+  start >/dev/null
+  if login "$user" "$password" >/dev/null 2>&1; then
+    login "$user" "$password"
+    return
+  fi
+
+  local args=(-c /data/homeserver.yaml http://localhost:8008 -u "$user" -p "$password" --exists-ok)
+  if [[ "$admin" == "--admin" ]]; then
+    args+=(-a)
+  else
+    args+=(--no-admin)
+  fi
+  docker exec "$CONTAINER" register_new_matrix_user "${args[@]}" >/dev/null
+  login "$user" "$password"
+}
+
+token_field() {
+  local field="$1"
+  require_cmd jq
+  jq -r --arg field "$field" '.[$field]'
+}
+
+env_exports() {
+  local user="${1:-centaur}"
+  local password="${2:-centaur-local-password}"
+  local login_json
+  login_json="$(ensure_user "$user" "$password")"
+  local token user_id device_id
+  token="$(printf '%s' "$login_json" | token_field access_token)"
+  user_id="$(printf '%s' "$login_json" | token_field user_id)"
+  device_id="$(printf '%s' "$login_json" | token_field device_id)"
+  printf 'export MATRIX_HOMESERVER_URL=%q\n' "$(base_url)"
+  printf 'export MATRIX_ACCESS_TOKEN=%q\n' "$token"
+  printf 'export MATRIX_USER_ID=%q\n' "$user_id"
+  printf 'export MATRIX_DEVICE_ID=%q\n' "$device_id"
+}
+
+create_room() {
+  local user="${1:-alice}"
+  local password="${2:-alice-local-password}"
+  local bot_user="${MATRIX_LOCAL_BOT_USER:-centaur}"
+  local bot_password="${MATRIX_LOCAL_BOT_PASSWORD:-centaur-local-password}"
+  local user_login bot_login user_token bot_token bot_id room_id
+
+  user_login="$(ensure_user "$user" "$password")"
+  bot_login="$(ensure_user "$bot_user" "$bot_password")"
+  user_token="$(printf '%s' "$user_login" | token_field access_token)"
+  bot_token="$(printf '%s' "$bot_login" | token_field access_token)"
+  bot_id="$(printf '%s' "$bot_login" | token_field user_id)"
+
+  room_id="$(
+    curl -fsS -X POST "$(base_url)/_matrix/client/v3/createRoom" \
+      -H "Authorization: Bearer $user_token" \
+      -H "Content-Type: application/json" \
+      -d '{"preset":"private_chat","name":"Centaur local smoke"}' \
+      | token_field room_id
+  )"
+  curl -fsS -X POST "$(base_url)/_matrix/client/v3/rooms/$(urlencode "$room_id")/invite" \
+    -H "Authorization: Bearer $user_token" \
+    -H "Content-Type: application/json" \
+    -d "{\"user_id\":\"$bot_id\"}" >/dev/null
+  curl -fsS -X POST "$(base_url)/_matrix/client/v3/join/$(urlencode "$room_id")" \
+    -H "Authorization: Bearer $bot_token" \
+    -H "Content-Type: application/json" \
+    -d '{}' >/dev/null
+
+  printf '%s\n' "$room_id"
+}
+
+send_mention() {
+  local room_id="$1"
+  local text="${2:-reply with exactly PONG}"
+  local user="${MATRIX_LOCAL_USER:-alice}"
+  local password="${MATRIX_LOCAL_PASSWORD:-alice-local-password}"
+  local bot_id="${MATRIX_LOCAL_BOT_ID:-@centaur:$SERVER_NAME}"
+  local login_json token txn
+  login_json="$(ensure_user "$user" "$password")"
+  token="$(printf '%s' "$login_json" | token_field access_token)"
+  txn="centaur-local-$(date +%s)-$RANDOM"
+  curl -fsS -X PUT "$(base_url)/_matrix/client/v3/rooms/$(urlencode "$room_id")/send/m.room.message/$txn" \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    -d "{\"msgtype\":\"m.text\",\"body\":\"$bot_id $text\",\"m.mentions\":{\"user_ids\":[\"$bot_id\"]}}"
+}
+
+urlencode() {
+  require_cmd node
+  node -e 'console.log(encodeURIComponent(process.argv[1]))' "$1"
+}
+
+case "${1:-}" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  reset)
+    reset
+    ;;
+  ensure-user)
+    shift
+    [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+    ensure_user "$@"
+    ;;
+  env)
+    shift
+    env_exports "$@"
+    ;;
+  create-room)
+    shift
+    create_room "$@"
+    ;;
+  send-mention)
+    shift
+    [[ $# -ge 1 ]] || { usage >&2; exit 2; }
+    send_mention "$@"
+    ;;
+  --help|-h|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/local-matrixbot-smoke.sh
+++ b/scripts/local-matrixbot-smoke.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+SMOKE_DIR="${MATRIXBOT_SMOKE_DIR:-.local/matrixbot-smoke}"
+STUB_PORT="${MATRIXBOT_SMOKE_STUB_PORT:-18080}"
+BOT_PORT="${MATRIXBOT_SMOKE_BOT_PORT:-13002}"
+MATRIX_USER="${MATRIX_LOCAL_USER:-alice}"
+MATRIX_PASSWORD="${MATRIX_LOCAL_PASSWORD:-alice-local-password}"
+BOT_USER_ID="${MATRIX_LOCAL_BOT_ID:-@centaur:${MATRIX_LOCAL_SERVER_NAME:-localhost}}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/local-matrixbot-smoke.sh
+
+Runs a local smoke test for the Matrix backend:
+  1. starts/reuses the local Synapse container
+  2. creates a private room and joins the Matrixbot user
+  3. starts a stub Centaur API
+  4. starts Matrixbot with local Matrix credentials
+  5. sends a Matrix mention and waits for a PONG final-delivery reply
+
+Synapse is left running for reuse. Stop it with:
+  scripts/local-matrix.sh stop
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "FATAL: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+token_field() {
+  local field="$1"
+  jq -r --arg field "$field" '.[$field]'
+}
+
+urlencode() {
+  node -e 'console.log(encodeURIComponent(process.argv[1]))' "$1"
+}
+
+cleanup() {
+  if [[ -n "${MATRIXBOT_PID:-}" ]]; then
+    kill "$MATRIXBOT_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${STUB_PID:-}" ]]; then
+    kill "$STUB_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+wait_http() {
+  local url="$1"
+  local label="$2"
+  for _ in $(seq 1 60); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.25
+  done
+  echo "FATAL: $label did not become ready at $url" >&2
+  return 1
+}
+
+wait_for_bot_initial_sync() {
+  local log_file="$1"
+  for _ in $(seq 1 80); do
+    if grep -q '"event":"matrix_initial_sync_skipped"' "$log_file"; then
+      return
+    fi
+    sleep 0.25
+  done
+  echo "FATAL: Matrixbot did not finish initial sync" >&2
+  tail -100 "$log_file" >&2 || true
+  return 1
+}
+
+wait_for_pong() {
+  local homeserver="$1"
+  local token="$2"
+  local room_id="$3"
+  local encoded_room_id messages_file
+  encoded_room_id="$(urlencode "$room_id")"
+  messages_file="$SMOKE_DIR/messages.json"
+  for _ in $(seq 1 80); do
+    curl -fsS "$homeserver/_matrix/client/v3/rooms/$encoded_room_id/messages?dir=b&limit=20" \
+      -H "Authorization: Bearer $token" > "$messages_file"
+    if jq -er --arg bot "$BOT_USER_ID" '
+      .chunk[]?
+      | select(.sender == $bot)
+      | .content.body? // empty
+      | select(contains("PONG"))
+    ' "$messages_file"
+    then
+      return
+    fi
+    sleep 0.5
+  done
+  echo "FATAL: did not observe Matrixbot PONG reply" >&2
+  return 1
+}
+
+write_stub() {
+  mkdir -p "$SMOKE_DIR"
+  cat > "$SMOKE_DIR/stub-centaur.mjs" <<'EOF'
+const port = Number(process.env.PORT || 18080)
+const assignments = new Map()
+const messages = new Map()
+let delivery = null
+let claimed = false
+let delivered = false
+let executionCounter = 0
+let generationCounter = 0
+
+function json(data, init = {}) {
+  return Response.json(data, init)
+}
+
+function bad(message) {
+  return json({ ok: false, error: message }, { status: 422 })
+}
+
+Bun.serve({
+  port,
+  async fetch(request) {
+    const url = new URL(request.url)
+    const body = request.method === 'POST' ? await request.json().catch(() => ({})) : {}
+
+    if (url.pathname === '/health') return json({ ok: true })
+
+    if (url.pathname === '/agent/spawn' && request.method === 'POST') {
+      if (!body.thread_key) return bad('spawn requires thread_key')
+      if (!body.harness) return bad('spawn requires harness')
+      let assignment = assignments.get(body.thread_key)
+      if (!assignment) {
+        generationCounter += 1
+        assignment = {
+          thread_key: body.thread_key,
+          assignment_generation: generationCounter,
+          harness: body.harness
+        }
+        assignments.set(body.thread_key, assignment)
+      }
+      console.log(JSON.stringify({ event: 'spawn', body }))
+      return json({ ...assignment, runtime_id: 'rtm-smoke', state: 'assigned_idle' })
+    }
+
+    if (url.pathname === '/agent/message' && request.method === 'POST') {
+      if (!body.thread_key) return bad('message requires thread_key')
+      if (!Number.isInteger(body.assignment_generation)) {
+        return bad('message requires assignment_generation')
+      }
+      if (!body.message_id) return bad('message requires message_id')
+      if (!Array.isArray(body.parts) || body.parts.length === 0) {
+        return bad('message requires parts')
+      }
+      const assignment = assignments.get(body.thread_key)
+      if (!assignment || assignment.assignment_generation !== body.assignment_generation) {
+        return bad('message assignment_generation does not match spawned assignment')
+      }
+      messages.set(`${body.thread_key}:${body.assignment_generation}`, body)
+      console.log(JSON.stringify({ event: 'message', body }))
+      return json({ ok: true, message_id: body.message_id })
+    }
+
+    if (url.pathname === '/agent/execute' && request.method === 'POST') {
+      if (body.message) return bad('execute must not use auto-execute message shortcut')
+      if (!body.thread_key) return bad('execute requires thread_key')
+      if (!Number.isInteger(body.assignment_generation)) {
+        return bad('execute requires assignment_generation')
+      }
+      if (!body.execute_id) return bad('execute requires execute_id')
+      const assignment = assignments.get(body.thread_key)
+      if (!assignment || assignment.assignment_generation !== body.assignment_generation) {
+        return bad('execute assignment_generation does not match spawned assignment')
+      }
+      if (!messages.has(`${body.thread_key}:${body.assignment_generation}`)) {
+        return bad('execute requires persisted message first')
+      }
+      executionCounter += 1
+      const executionId = body.execute_id || `matrixbot-smoke-${executionCounter}`
+      delivery = {
+        execution_id: executionId,
+        thread_key: body.thread_key,
+        delivery: body.delivery,
+        final_payload: { result_text: 'PONG' },
+        trace_id: 'matrixbot-smoke'
+      }
+      claimed = false
+      delivered = false
+      console.log(JSON.stringify({ event: 'execute', body }))
+      return json({ ok: true, execution_id: executionId, status: 'queued' })
+    }
+
+    if (url.pathname === '/agent/final-deliveries/claim' && request.method === 'POST') {
+      if (delivery && !claimed && !delivered) {
+        claimed = true
+        console.log(JSON.stringify({ event: 'claim', execution_id: delivery.execution_id, body }))
+        return json({ deliveries: [delivery] })
+      }
+      return json({ deliveries: [] })
+    }
+
+    const deliveredMatch = url.pathname.match(/^\/agent\/final-deliveries\/([^/]+)\/delivered$/)
+    if (deliveredMatch && request.method === 'POST') {
+      delivered = true
+      console.log(JSON.stringify({ event: 'delivered', execution_id: deliveredMatch[1], body }))
+      return json({ ok: true })
+    }
+
+    const failedMatch = url.pathname.match(/^\/agent\/final-deliveries\/([^/]+)\/failed$/)
+    if (failedMatch && request.method === 'POST') {
+      console.log(JSON.stringify({ event: 'failed', execution_id: failedMatch[1], body }))
+      return json({ ok: true })
+    }
+
+    return json({ ok: false, error: 'not_found' }, { status: 404 })
+  }
+})
+
+console.log(JSON.stringify({ event: 'stub_started', port }))
+EOF
+}
+
+main() {
+  if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    return
+  fi
+
+  require_cmd bun
+  require_cmd curl
+  require_cmd jq
+  require_cmd node
+
+  trap cleanup EXIT
+  mkdir -p "$SMOKE_DIR"
+
+  scripts/local-matrix.sh start
+  eval "$(scripts/local-matrix.sh env)"
+
+  local user_login user_token room_id
+  user_login="$(scripts/local-matrix.sh ensure-user "$MATRIX_USER" "$MATRIX_PASSWORD")"
+  user_token="$(printf '%s' "$user_login" | token_field access_token)"
+  room_id="$(scripts/local-matrix.sh create-room "$MATRIX_USER" "$MATRIX_PASSWORD")"
+
+  write_stub
+  PORT="$STUB_PORT" bun "$SMOKE_DIR/stub-centaur.mjs" > "$SMOKE_DIR/stub.log" 2>&1 &
+  STUB_PID="$!"
+  wait_http "http://127.0.0.1:$STUB_PORT/health" "stub Centaur API"
+
+  MATRIX_HOMESERVER_URL="$MATRIX_HOMESERVER_URL" \
+    MATRIX_ACCESS_TOKEN="$MATRIX_ACCESS_TOKEN" \
+    MATRIX_USER_ID="$MATRIX_USER_ID" \
+    MATRIX_DEVICE_ID="$MATRIX_DEVICE_ID" \
+    CENTAUR_API_URL="http://127.0.0.1:$STUB_PORT" \
+    MATRIXBOT_API_KEY="aiv2_matrixbot_smoke" \
+    MATRIX_PROCESS_INITIAL_SYNC=false \
+    MATRIX_SYNC_TIMEOUT_MS=1000 \
+    MATRIX_POLL_INTERVAL_MS=250 \
+    MATRIX_DEFAULT_HARNESS=claude-code \
+    PORT="$BOT_PORT" \
+    bun services/matrixbot/src/index.ts > "$SMOKE_DIR/matrixbot.log" 2>&1 &
+  MATRIXBOT_PID="$!"
+
+  wait_http "http://127.0.0.1:$BOT_PORT/health" "Matrixbot"
+  wait_for_bot_initial_sync "$SMOKE_DIR/matrixbot.log"
+
+  scripts/local-matrix.sh send-mention "$room_id" "reply with exactly PONG" >/dev/null
+  wait_for_pong "$MATRIX_HOMESERVER_URL" "$user_token" "$room_id"
+
+  local encoded_room_id
+  local messages_file="$SMOKE_DIR/messages.json"
+  encoded_room_id="$(urlencode "$room_id")"
+  echo "Matrixbot smoke passed"
+  echo "Room: $room_id"
+  echo "Recent room messages:"
+  curl -fsS "$MATRIX_HOMESERVER_URL/_matrix/client/v3/rooms/$encoded_room_id/messages?dir=b&limit=5" \
+    -H "Authorization: Bearer $user_token" > "$messages_file"
+  jq -r '.chunk[]? | select(.content.body?) | "\(.sender): \(.content.body)"' "$messages_file"
+}
+
+main "$@"

--- a/services/api/api/api_keys.py
+++ b/services/api/api/api_keys.py
@@ -45,6 +45,11 @@ _SERVICE_API_KEYS: tuple[ServiceAPIKeySpec, ...] = (
         scopes=("agent",),
     ),
     ServiceAPIKeySpec(
+        env_var="MATRIXBOT_API_KEY",
+        name="service:matrixbot",
+        scopes=("agent",),
+    ),
+    ServiceAPIKeySpec(
         env_var="LOCAL_DEV_API_KEY",
         name="service:local-dev",
         scopes=("admin", "agent", "threads", "tools:*"),

--- a/services/matrixbot/.env.example
+++ b/services/matrixbot/.env.example
@@ -1,0 +1,14 @@
+PORT=3002
+NODE_ENV="development"
+
+MATRIX_HOMESERVER_URL="https://matrix.example.com"
+MATRIX_ACCESS_TOKEN="syt_..."
+MATRIX_USER_ID="@centaur:example.com"
+MATRIX_DEVICE_ID="centaur-matrixbot"
+MATRIX_DEFAULT_HARNESS="claude-code"
+MATRIX_PROCESS_INITIAL_SYNC="false"
+MATRIX_SYNC_TOKEN_PATH=".local/matrixbot-sync-token"
+MATRIX_ALLOWED_ROOMS="!roomid:example.com"
+
+CENTAUR_API_URL="http://localhost:8000"
+MATRIXBOT_API_KEY="aiv2_..."

--- a/services/matrixbot/Dockerfile
+++ b/services/matrixbot/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:1.3.13-slim
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY services/matrixbot/ ./
+
+EXPOSE 3002
+ENV PORT=3002
+CMD ["bun", "src/index.ts"]

--- a/services/matrixbot/package.json
+++ b/services/matrixbot/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "matrixbot",
+  "version": "0.0.0",
+  "license": "Apache-2.0 OR MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "bun --hot --watch src/index.ts",
+    "test": "bun test src/*.test.ts",
+    "check:types": "bun tsc --project tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.13",
+    "typescript": "^6.0.3"
+  }
+}

--- a/services/matrixbot/src/bot.ts
+++ b/services/matrixbot/src/bot.ts
@@ -1,0 +1,95 @@
+import { executeAgent } from './centaur'
+import type { AppConfig } from './config'
+import { logError, logInfo } from './logging'
+import {
+  joinedTimelineEvents,
+  normalizeMatrixMessage,
+  sync,
+  type MatrixSyncResponse,
+  type NormalizedMatrixMessage
+} from './matrix'
+import { createSyncState, loadSyncToken, rememberEvent, saveSyncToken, type SyncState } from './sync-state'
+
+export function startMatrixSyncLoop(config: AppConfig): void {
+  let state = createSyncState()
+
+  const tick = async () => {
+    try {
+      if (!state.initialized) state = createSyncState(await loadSyncToken(config.matrixSyncTokenPath))
+      const response = await sync(config, state.since)
+      state.since = response.next_batch || state.since
+      await saveSyncToken(config.matrixSyncTokenPath, state.since)
+
+      const messages = messagesFromSyncResponse(config, state, response)
+      if (!state.initialized && !config.matrixProcessInitialSync) {
+        state.initialized = true
+        logInfo('matrix_initial_sync_skipped', { event_count: joinedTimelineEvents(response).length })
+        return
+      }
+      state.initialized = true
+
+      for (const message of messages) {
+        await executeAgent(config, {
+          threadKey: message.threadKey,
+          eventId: message.eventId,
+          message: message.text,
+          harness: config.matrixDefaultHarness,
+          delivery: {
+            platform: 'matrix',
+            room_id: message.roomId,
+            thread_root_event_id: message.threadRootEventId,
+            reply_to_event_id: message.eventId,
+            sender: message.sender
+          },
+          metadata: {
+            matrix: {
+              room_id: message.roomId,
+              event_id: message.eventId,
+              sender: message.sender
+            }
+          }
+        })
+        logInfo('matrix_message_enqueued', {
+          room_id: message.roomId,
+          event_id: message.eventId,
+          thread_key: message.threadKey
+        })
+      }
+    } catch (error) {
+      logError('matrix_sync_failed', error)
+    } finally {
+      setTimeout(tick, config.matrixPollIntervalMs).unref?.()
+    }
+  }
+
+  void tick()
+}
+
+export function messagesFromSyncResponse(
+  config: Pick<AppConfig, 'matrixUserId' | 'matrixAllowedRooms'>,
+  state: SyncState,
+  response: MatrixSyncResponse
+): NormalizedMatrixMessage[] {
+  const messages: NormalizedMatrixMessage[] = []
+  for (const event of joinedTimelineEvents(response)) {
+    const message = normalizeMatrixMessage(event, config)
+    if (!message) continue
+    if (!isAllowedRoom(config, message.roomId)) {
+      logInfo('matrix_room_ignored', { room_id: message.roomId, event_id: message.eventId })
+      continue
+    }
+    if (!rememberEvent(state, message.eventId)) {
+      logInfo('matrix_event_duplicate_ignored', {
+        room_id: message.roomId,
+        event_id: message.eventId
+      })
+      continue
+    }
+    messages.push(message)
+  }
+  return messages
+}
+
+function isAllowedRoom(config: Pick<AppConfig, 'matrixAllowedRooms'>, roomId: string): boolean {
+  return config.matrixAllowedRooms.size === 0 || config.matrixAllowedRooms.has(roomId)
+}

--- a/services/matrixbot/src/centaur.test.ts
+++ b/services/matrixbot/src/centaur.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { executeAgent, extractFinalText } from './centaur'
+import type { AppConfig } from './config'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('extractFinalText', () => {
+  it('uses the first non-empty final payload field', () => {
+    expect(extractFinalText({ result_text: '', final_text: 'done' })).toBe('done')
+  })
+
+  it('returns a fallback when no text was captured', () => {
+    expect(extractFinalText({})).toContain('Execution completed')
+  })
+})
+
+describe('executeAgent', () => {
+  it('runs the durable spawn, message, execute sequence', async () => {
+    const calls: Array<{ path: string; body: any }> = []
+    globalThis.fetch = (async (url: URL | RequestInfo, init?: RequestInit) => {
+      const path = new URL(String(url)).pathname
+      const body = JSON.parse(String(init?.body ?? '{}'))
+      calls.push({ path, body })
+
+      if (path === '/agent/spawn') {
+        return Response.json({
+          thread_key: body.thread_key,
+          assignment_generation: 7,
+          state: 'assigned_idle'
+        })
+      }
+      if (path === '/agent/message') {
+        return Response.json({ ok: true, message_id: body.message_id })
+      }
+      if (path === '/agent/execute') {
+        return Response.json({ ok: true, execution_id: body.execute_id, status: 'queued' })
+      }
+      return Response.json({ error: 'unexpected' }, { status: 404 })
+    }) as typeof fetch
+
+    await executeAgent(config(), {
+      threadKey: 'matrix:room:event',
+      eventId: '$event',
+      message: 'hello',
+      harness: 'claude-code',
+      delivery: {
+        platform: 'matrix',
+        room_id: '!room:localhost',
+        thread_root_event_id: '$event',
+        reply_to_event_id: '$event',
+        sender: '@alice:localhost'
+      },
+      metadata: { matrix: { room_id: '!room:localhost', event_id: '$event' } }
+    })
+
+    expect(calls.map(call => call.path)).toEqual([
+      '/agent/spawn',
+      '/agent/message',
+      '/agent/execute'
+    ])
+    const spawnCall = calls[0]!
+    const messageCall = calls[1]!
+    const executeCall = calls[2]!
+    expect(spawnCall.body).toMatchObject({
+      thread_key: 'matrix:room:event',
+      harness: 'claude-code'
+    })
+    expect(messageCall.body).toMatchObject({
+      thread_key: 'matrix:room:event',
+      assignment_generation: 7,
+      role: 'user',
+      user_id: '@alice:localhost',
+      parts: [{ type: 'text', text: 'hello' }]
+    })
+    expect(executeCall.body).toMatchObject({
+      thread_key: 'matrix:room:event',
+      assignment_generation: 7,
+      harness: 'claude-code',
+      delivery: { platform: 'matrix', room_id: '!room:localhost' }
+    })
+    expect(spawnCall.body.spawn_id).toStartWith('spawn-matrix-')
+    expect(messageCall.body.message_id).toBe(spawnCall.body.spawn_id.replace('spawn-', 'msg-'))
+    expect(executeCall.body.execute_id).toBe(spawnCall.body.spawn_id.replace('spawn-', 'exec-'))
+  })
+})
+
+function config(): AppConfig {
+  return {
+    nodeEnv: 'test',
+    port: 3002,
+    matrixHomeserverUrl: 'http://matrix.local',
+    matrixAccessToken: 'matrix-token',
+    matrixUserId: '@centaur:localhost',
+    matrixDeviceId: 'device',
+    matrixDefaultHarness: 'claude-code',
+    matrixProcessInitialSync: false,
+    matrixSyncTimeoutMs: 1000,
+    matrixPollIntervalMs: 1000,
+    matrixAllowedRooms: new Set(),
+    centaurApiUrl: 'http://centaur.local',
+    centaurApiKey: 'api-key'
+  }
+}

--- a/services/matrixbot/src/centaur.ts
+++ b/services/matrixbot/src/centaur.ts
@@ -1,0 +1,138 @@
+import type { AppConfig } from './config'
+
+export type MatrixDelivery = {
+  platform: 'matrix'
+  room_id: string
+  thread_root_event_id?: string
+  reply_to_event_id?: string
+  sender?: string
+}
+
+export type ExecuteInput = {
+  threadKey: string
+  eventId?: string
+  message: string
+  harness: string
+  delivery: MatrixDelivery
+  metadata?: Record<string, unknown>
+}
+
+export type FinalDelivery = {
+  execution_id: string
+  thread_key: string
+  delivery?: MatrixDelivery
+  final_payload?: Record<string, unknown>
+  trace_id?: string
+  traceparent?: string
+}
+
+const CONSUMER_ID = `matrixbot-${process.pid}`
+
+export async function executeAgent(config: AppConfig, input: ExecuteInput): Promise<unknown> {
+  const turnId = stableTurnId(input)
+  const spawn = await centaur(config, '/agent/spawn', {
+    thread_key: input.threadKey,
+    spawn_id: `spawn-${turnId}`,
+    harness: input.harness
+  })
+  const assignmentGeneration = Number(spawn?.assignment_generation)
+  if (!Number.isInteger(assignmentGeneration)) {
+    throw new Error('Centaur spawn response did not include assignment_generation')
+  }
+
+  await centaur(config, '/agent/message', {
+    thread_key: input.threadKey,
+    assignment_generation: assignmentGeneration,
+    message_id: `msg-${turnId}`,
+    role: 'user',
+    parts: [{ type: 'text', text: input.message }],
+    user_id: input.delivery.sender,
+    metadata: input.metadata ?? {}
+  })
+
+  return centaur(config, '/agent/execute', {
+    thread_key: input.threadKey,
+    assignment_generation: assignmentGeneration,
+    execute_id: `exec-${turnId}`,
+    harness: input.harness,
+    delivery: input.delivery,
+    metadata: input.metadata ?? {}
+  })
+}
+
+export async function claimFinalDeliveries(
+  config: AppConfig,
+  limit = 5
+): Promise<FinalDelivery[]> {
+  const response = await centaur(config, '/agent/final-deliveries/claim', {
+    consumer_id: CONSUMER_ID,
+    platform: 'matrix',
+    limit,
+    lease_seconds: 60
+  })
+  return Array.isArray(response?.deliveries) ? response.deliveries : []
+}
+
+export async function markFinalDelivered(config: AppConfig, executionId: string): Promise<void> {
+  await centaur(config, `/agent/final-deliveries/${executionId}/delivered`, {
+    consumer_id: CONSUMER_ID
+  })
+}
+
+export async function markFinalFailed(
+  config: AppConfig,
+  executionId: string,
+  error: unknown
+): Promise<void> {
+  await centaur(config, `/agent/final-deliveries/${executionId}/failed`, {
+    consumer_id: CONSUMER_ID,
+    error: error instanceof Error ? error.message : String(error),
+    retry_after_seconds: 10
+  })
+}
+
+async function centaur(config: AppConfig, path: string, body: unknown): Promise<any> {
+  const response = await fetch(new URL(path, config.centaurApiUrl), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(config.centaurApiKey ? { Authorization: `Bearer ${config.centaurApiKey}` } : {})
+    },
+    body: JSON.stringify(body)
+  })
+  const text = await response.text()
+  const parsed = text ? JSON.parse(text) : {}
+  if (!response.ok) {
+    throw new Error(parsed?.detail?.message ?? parsed?.detail ?? parsed?.error ?? response.statusText)
+  }
+  return parsed
+}
+
+export function extractFinalText(payload: Record<string, unknown> | undefined): string {
+  const value = firstNonEmpty(
+    payload?.result_text,
+    payload?.result,
+    payload?.text,
+    payload?.final_text,
+    payload?.message
+  )
+  return value || 'Execution completed, but no final text was captured.'
+}
+
+function firstNonEmpty(...values: unknown[]): string {
+  for (const value of values) {
+    const text = value === undefined || value === null ? '' : String(value).trim()
+    if (text) return text
+  }
+  return ''
+}
+
+function stableTurnId(input: ExecuteInput): string {
+  const source = input.eventId || input.delivery.reply_to_event_id || input.threadKey
+  let hash = 0x811c9dc5
+  for (let i = 0; i < source.length; i += 1) {
+    hash ^= source.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return `matrix-${(hash >>> 0).toString(16).padStart(8, '0')}`
+}

--- a/services/matrixbot/src/config.ts
+++ b/services/matrixbot/src/config.ts
@@ -1,0 +1,74 @@
+export type AppConfig = {
+  nodeEnv: string
+  port: number
+  matrixHomeserverUrl: string
+  matrixAccessToken: string
+  matrixUserId: string
+  matrixDeviceId: string
+  matrixDefaultHarness: string
+  matrixProcessInitialSync: boolean
+  matrixSyncTimeoutMs: number
+  matrixPollIntervalMs: number
+  matrixSyncTokenPath?: string
+  matrixAllowedRooms: Set<string>
+  centaurApiUrl: string
+  centaurApiKey?: string
+}
+
+export function loadConfig(env: Record<string, string | undefined> = process.env): AppConfig {
+  return {
+    nodeEnv: env.NODE_ENV ?? 'development',
+    port: positiveInt(env.PORT, 3002),
+    matrixHomeserverUrl: requiredUrl(env.MATRIX_HOMESERVER_URL, 'MATRIX_HOMESERVER_URL'),
+    matrixAccessToken: required(env.MATRIX_ACCESS_TOKEN, 'MATRIX_ACCESS_TOKEN'),
+    matrixUserId: required(env.MATRIX_USER_ID, 'MATRIX_USER_ID'),
+    matrixDeviceId: env.MATRIX_DEVICE_ID || 'centaur-matrixbot',
+    matrixDefaultHarness: env.MATRIX_DEFAULT_HARNESS || 'claude-code',
+    matrixProcessInitialSync: bool(env.MATRIX_PROCESS_INITIAL_SYNC, false),
+    matrixSyncTimeoutMs: positiveInt(env.MATRIX_SYNC_TIMEOUT_MS, 30_000),
+    matrixPollIntervalMs: positiveInt(env.MATRIX_POLL_INTERVAL_MS, 1_000),
+    matrixSyncTokenPath: optional(env.MATRIX_SYNC_TOKEN_PATH),
+    matrixAllowedRooms: csvSet(env.MATRIX_ALLOWED_ROOMS),
+    centaurApiUrl: requiredUrl(env.CENTAUR_API_URL || 'http://localhost:8000', 'CENTAUR_API_URL'),
+    centaurApiKey: env.MATRIXBOT_API_KEY || env.CENTAUR_API_KEY || undefined
+  }
+}
+
+function required(value: string | undefined, name: string): string {
+  if (!value?.trim()) throw new Error(`${name} is required`)
+  return value.trim()
+}
+
+function optional(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed || undefined
+}
+
+function requiredUrl(value: string | undefined, name: string): string {
+  const raw = required(value, name).replace(/\/+$/, '')
+  try {
+    return new URL(raw).toString().replace(/\/+$/, '')
+  } catch {
+    throw new Error(`${name} must be a valid URL`)
+  }
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function bool(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback
+  return /^(1|true|yes|on)$/i.test(value)
+}
+
+function csvSet(value: string | undefined): Set<string> {
+  return new Set(
+    (value ?? '')
+      .split(',')
+      .map(item => item.trim())
+      .filter(Boolean)
+  )
+}

--- a/services/matrixbot/src/final-delivery.test.ts
+++ b/services/matrixbot/src/final-delivery.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { pollFinalDeliveriesOnce } from './final-delivery'
+import type { AppConfig } from './config'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('pollFinalDeliveriesOnce', () => {
+  it('sends Matrix text and marks the delivery delivered', async () => {
+    const calls: Array<{ host: string; path: string; method: string; body: any }> = []
+    globalThis.fetch = (async (url: URL | RequestInfo, init?: RequestInit) => {
+      const parsedUrl = new URL(String(url))
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      calls.push({ host: parsedUrl.host, path: parsedUrl.pathname, method: init?.method ?? 'GET', body })
+
+      if (parsedUrl.pathname === '/agent/final-deliveries/claim') {
+        return Response.json({
+          deliveries: [
+            {
+              execution_id: 'exe_1',
+              thread_key: 'matrix:room:event',
+              delivery: {
+                platform: 'matrix',
+                room_id: '!room:example.com',
+                thread_root_event_id: '$root',
+                reply_to_event_id: '$event'
+              },
+              final_payload: { result_text: 'PONG' }
+            }
+          ]
+        })
+      }
+      if (parsedUrl.pathname.includes('/send/m.room.message/')) {
+        return Response.json({ event_id: '$reply' })
+      }
+      if (parsedUrl.pathname === '/agent/final-deliveries/exe_1/delivered') {
+        return Response.json({ ok: true })
+      }
+      return Response.json({ error: 'unexpected' }, { status: 404 })
+    }) as typeof fetch
+
+    await pollFinalDeliveriesOnce(config())
+
+    expect(calls.map(call => call.path)).toEqual([
+      '/agent/final-deliveries/claim',
+      '/_matrix/client/v3/rooms/!room%3Aexample.com/send/m.room.message/centaur-exe_1-final',
+      '/agent/final-deliveries/exe_1/delivered'
+    ])
+    expect(calls[1]!.body).toMatchObject({
+      msgtype: 'm.text',
+      body: 'PONG',
+      'm.relates_to': {
+        rel_type: 'm.thread',
+        event_id: '$root',
+        'm.in_reply_to': { event_id: '$event' }
+      }
+    })
+  })
+
+  it('marks delivery failed when Matrix send fails', async () => {
+    const calls: Array<{ path: string; body: any }> = []
+    globalThis.fetch = (async (url: URL | RequestInfo, init?: RequestInit) => {
+      const parsedUrl = new URL(String(url))
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      calls.push({ path: parsedUrl.pathname, body })
+
+      if (parsedUrl.pathname === '/agent/final-deliveries/claim') {
+        return Response.json({
+          deliveries: [
+            {
+              execution_id: 'exe_2',
+              thread_key: 'matrix:room:event',
+              delivery: { platform: 'matrix', room_id: '!room:example.com' },
+              final_payload: { result_text: 'PONG' }
+            }
+          ]
+        })
+      }
+      if (parsedUrl.pathname.includes('/send/m.room.message/')) {
+        return Response.json({ error: 'forbidden' }, { status: 403 })
+      }
+      if (parsedUrl.pathname === '/agent/final-deliveries/exe_2/failed') {
+        return Response.json({ ok: true })
+      }
+      return Response.json({ error: 'unexpected' }, { status: 404 })
+    }) as typeof fetch
+
+    await pollFinalDeliveriesOnce(config())
+
+    const failed = calls.find(call => call.path === '/agent/final-deliveries/exe_2/failed')
+    expect(failed?.body.error).toBe('forbidden')
+    expect(failed?.body.retry_after_seconds).toBe(10)
+  })
+
+  it('marks delivery failed when Matrix delivery metadata lacks a room', async () => {
+    const calls: Array<{ path: string; body: any }> = []
+    globalThis.fetch = (async (url: URL | RequestInfo, init?: RequestInit) => {
+      const parsedUrl = new URL(String(url))
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      calls.push({ path: parsedUrl.pathname, body })
+
+      if (parsedUrl.pathname === '/agent/final-deliveries/claim') {
+        return Response.json({
+          deliveries: [
+            {
+              execution_id: 'exe_3',
+              thread_key: 'matrix:room:event',
+              delivery: { platform: 'matrix' },
+              final_payload: { result_text: 'PONG' }
+            }
+          ]
+        })
+      }
+      if (parsedUrl.pathname === '/agent/final-deliveries/exe_3/failed') {
+        return Response.json({ ok: true })
+      }
+      return Response.json({ error: 'unexpected' }, { status: 404 })
+    }) as typeof fetch
+
+    await pollFinalDeliveriesOnce(config())
+
+    expect(calls.map(call => call.path)).toEqual([
+      '/agent/final-deliveries/claim',
+      '/agent/final-deliveries/exe_3/failed'
+    ])
+    expect(calls[1]!.body.error).toBe('missing_matrix_delivery_room')
+  })
+})
+
+function config(): AppConfig {
+  return {
+    nodeEnv: 'test',
+    port: 3002,
+    matrixHomeserverUrl: 'http://matrix.local',
+    matrixAccessToken: 'matrix-token',
+    matrixUserId: '@centaur:localhost',
+    matrixDeviceId: 'device',
+    matrixDefaultHarness: 'claude-code',
+    matrixProcessInitialSync: false,
+    matrixSyncTimeoutMs: 1000,
+    matrixPollIntervalMs: 1000,
+    matrixAllowedRooms: new Set(),
+    centaurApiUrl: 'http://centaur.local',
+    centaurApiKey: 'api-key'
+  }
+}

--- a/services/matrixbot/src/final-delivery.ts
+++ b/services/matrixbot/src/final-delivery.ts
@@ -1,0 +1,49 @@
+import {
+  claimFinalDeliveries,
+  extractFinalText,
+  markFinalDelivered,
+  markFinalFailed,
+  type FinalDelivery
+} from './centaur'
+import type { AppConfig } from './config'
+import { logError } from './logging'
+import { sendTextMessage } from './matrix'
+
+export function startFinalDeliveryPoller(config: AppConfig): void {
+  if (!config.centaurApiKey) return
+  const tick = async () => {
+    try {
+      await pollFinalDeliveriesOnce(config)
+    } catch (error) {
+      logError('final_delivery_poll_failed', error)
+    }
+  }
+  setInterval(tick, 2_000).unref?.()
+  void tick()
+}
+
+export async function pollFinalDeliveriesOnce(config: AppConfig): Promise<void> {
+  const deliveries = await claimFinalDeliveries(config)
+  for (const delivery of deliveries) {
+    try {
+      await deliver(config, delivery)
+      await markFinalDelivered(config, String(delivery.execution_id))
+    } catch (error) {
+      await markFinalFailed(config, String(delivery.execution_id), error).catch(failError =>
+        logError('final_delivery_mark_failed_failed', failError)
+      )
+    }
+  }
+}
+
+async function deliver(config: AppConfig, delivery: FinalDelivery): Promise<void> {
+  const meta = delivery.delivery
+  if (!meta?.room_id) throw new Error('missing_matrix_delivery_room')
+  await sendTextMessage(config, {
+    roomId: meta.room_id,
+    body: extractFinalText(delivery.final_payload),
+    txnId: `centaur-${delivery.execution_id}-final`,
+    threadRootEventId: meta.thread_root_event_id,
+    replyToEventId: meta.reply_to_event_id
+  })
+}

--- a/services/matrixbot/src/index.ts
+++ b/services/matrixbot/src/index.ts
@@ -1,0 +1,35 @@
+import { startMatrixSyncLoop } from './bot'
+import { loadConfig } from './config'
+import { startFinalDeliveryPoller } from './final-delivery'
+import { logError, logInfo } from './logging'
+
+const config = loadConfig()
+
+startMatrixSyncLoop(config)
+startFinalDeliveryPoller(config)
+
+Bun.serve({
+  port: config.port,
+  fetch(request) {
+    const path = new URL(request.url).pathname
+    if (path === '/health' || path === '/health/ready') {
+      return Response.json({
+        ok: true,
+        service: 'matrixbot',
+        commit: process.env.COMMIT_SHA ?? 'local'
+      })
+    }
+    return Response.json({ ok: false, error: 'not_found' }, { status: 404 })
+  },
+  error(error) {
+    logError('http_server_error', error)
+    return Response.json({ ok: false, error: 'internal_error' }, { status: 500 })
+  }
+})
+
+logInfo('matrixbot_started', {
+  port: config.port,
+  homeserver: config.matrixHomeserverUrl,
+  user_id: config.matrixUserId,
+  harness: config.matrixDefaultHarness
+})

--- a/services/matrixbot/src/logging.ts
+++ b/services/matrixbot/src/logging.ts
@@ -1,0 +1,26 @@
+export function logInfo(event: string, fields: Record<string, unknown> = {}): void {
+  log('info', event, fields)
+}
+
+export function logWarn(event: string, fields: Record<string, unknown> = {}): void {
+  log('warning', event, fields)
+}
+
+export function logError(event: string, error: unknown, fields: Record<string, unknown> = {}): void {
+  log('error', event, {
+    ...fields,
+    error: error instanceof Error ? error.message : String(error)
+  })
+}
+
+function log(level: string, event: string, fields: Record<string, unknown>): void {
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      service: 'matrixbot',
+      event,
+      ...fields
+    })
+  )
+}

--- a/services/matrixbot/src/matrix.test.ts
+++ b/services/matrixbot/src/matrix.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { messagesFromSyncResponse } from './bot'
+import { matrixThreadKey, normalizeMatrixMessage } from './matrix'
+import { createSyncState, loadSyncToken, saveSyncToken } from './sync-state'
+
+const config = { matrixUserId: '@centaur:example.com', matrixAllowedRooms: new Set<string>() }
+
+describe('normalizeMatrixMessage', () => {
+  it('normalizes text events that explicitly mention the bot', () => {
+    const message = normalizeMatrixMessage(
+      {
+        type: 'm.room.message',
+        room_id: '!room:example.com',
+        event_id: '$event',
+        sender: '@alice:example.com',
+        content: {
+          msgtype: 'm.text',
+          body: '@centaur:example.com reply with pong',
+          'm.mentions': { user_ids: ['@centaur:example.com'] }
+        }
+      },
+      config
+    )
+
+    expect(message).toEqual({
+      roomId: '!room:example.com',
+      eventId: '$event',
+      sender: '@alice:example.com',
+      text: 'reply with pong',
+      threadRootEventId: '$event',
+      replyToEventId: undefined,
+      threadKey: matrixThreadKey('!room:example.com', '$event')
+    })
+  })
+
+  it('uses Matrix thread relations when present', () => {
+    const message = normalizeMatrixMessage(
+      {
+        type: 'm.room.message',
+        room_id: '!room:example.com',
+        event_id: '$reply',
+        sender: '@alice:example.com',
+        content: {
+          msgtype: 'm.text',
+          body: 'question for @centaur:example.com',
+          'm.relates_to': {
+            rel_type: 'm.thread',
+            event_id: '$root',
+            'm.in_reply_to': { event_id: '$previous' }
+          }
+        }
+      },
+      config
+    )
+
+    expect(message?.threadRootEventId).toBe('$root')
+    expect(message?.replyToEventId).toBe('$previous')
+    expect(message?.threadKey).toBe(matrixThreadKey('!room:example.com', '$root'))
+  })
+
+  it('ignores messages from the bot user', () => {
+    const message = normalizeMatrixMessage(
+      {
+        type: 'm.room.message',
+        room_id: '!room:example.com',
+        event_id: '$event',
+        sender: '@centaur:example.com',
+        content: {
+          msgtype: 'm.text',
+          body: '@centaur:example.com loop'
+        }
+      },
+      config
+    )
+
+    expect(message).toBeNull()
+  })
+})
+
+describe('messagesFromSyncResponse', () => {
+  it('filters rooms outside the allowlist', () => {
+    const state = createSyncState('token')
+    const messages = messagesFromSyncResponse(
+      { matrixUserId: config.matrixUserId, matrixAllowedRooms: new Set(['!allowed:example.com']) },
+      state,
+      {
+        rooms: {
+          join: {
+            '!denied:example.com': {
+              timeline: {
+                events: [
+                  {
+                    type: 'm.room.message',
+                    event_id: '$denied',
+                    sender: '@alice:example.com',
+                    content: {
+                      msgtype: 'm.text',
+                      body: '@centaur:example.com should not run'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    )
+
+    expect(messages).toEqual([])
+  })
+
+  it('suppresses duplicate event IDs within the running process', () => {
+    const state = createSyncState('token')
+    const response = {
+      rooms: {
+        join: {
+          '!room:example.com': {
+            timeline: {
+              events: [
+                {
+                  type: 'm.room.message',
+                  event_id: '$event',
+                  sender: '@alice:example.com',
+                  content: {
+                    msgtype: 'm.text',
+                    body: '@centaur:example.com run once'
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+
+    expect(messagesFromSyncResponse(config, state, response)).toHaveLength(1)
+    expect(messagesFromSyncResponse(config, state, response)).toHaveLength(0)
+  })
+})
+
+describe('sync token persistence', () => {
+  it('round-trips the sync token through an atomic file write', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'matrixbot-sync-'))
+    const path = join(dir, 'sync-token')
+    try {
+      await saveSyncToken(path, 's123')
+      expect(await readFile(path, 'utf8')).toBe('s123\n')
+      expect(await loadSyncToken(path)).toBe('s123')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('treats a missing sync token file as no token', async () => {
+    expect(await loadSyncToken('/tmp/centaur-matrixbot-missing-token')).toBeUndefined()
+  })
+})

--- a/services/matrixbot/src/matrix.ts
+++ b/services/matrixbot/src/matrix.ts
@@ -1,0 +1,178 @@
+import type { AppConfig } from './config'
+
+export type MatrixEvent = {
+  type?: string
+  event_id?: string
+  sender?: string
+  room_id?: string
+  content?: Record<string, unknown>
+}
+
+export type NormalizedMatrixMessage = {
+  roomId: string
+  eventId: string
+  sender: string
+  text: string
+  threadRootEventId: string
+  replyToEventId?: string
+  threadKey: string
+}
+
+export type MatrixSyncResponse = {
+  next_batch?: string
+  rooms?: {
+    join?: Record<
+      string,
+      {
+        timeline?: {
+          events?: MatrixEvent[]
+        }
+      }
+    >
+  }
+}
+
+export async function matrixRequest(
+  config: AppConfig,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<any> {
+  const response = await fetch(new URL(path, config.matrixHomeserverUrl), {
+    method,
+    headers: {
+      Authorization: `Bearer ${config.matrixAccessToken}`,
+      ...(body === undefined ? {} : { 'Content-Type': 'application/json' })
+    },
+    body: body === undefined ? undefined : JSON.stringify(body)
+  })
+  const text = await response.text()
+  const parsed = text ? JSON.parse(text) : {}
+  if (!response.ok) {
+    throw new Error(parsed?.error ?? response.statusText)
+  }
+  return parsed
+}
+
+export async function sync(config: AppConfig, since?: string): Promise<MatrixSyncResponse> {
+  const params = new URLSearchParams({
+    timeout: String(config.matrixSyncTimeoutMs),
+    set_presence: 'offline'
+  })
+  if (since) params.set('since', since)
+  return matrixRequest(config, 'GET', `/_matrix/client/v3/sync?${params.toString()}`)
+}
+
+export async function sendTextMessage(
+  config: AppConfig,
+  opts: {
+    roomId: string
+    body: string
+    txnId: string
+    threadRootEventId?: string
+    replyToEventId?: string
+  }
+): Promise<unknown> {
+  const content: Record<string, unknown> = {
+    msgtype: 'm.text',
+    body: opts.body
+  }
+  if (opts.threadRootEventId) {
+    content['m.relates_to'] = {
+      rel_type: 'm.thread',
+      event_id: opts.threadRootEventId,
+      is_falling_back: true,
+      'm.in_reply_to': {
+        event_id: opts.replyToEventId || opts.threadRootEventId
+      }
+    }
+  }
+  return matrixRequest(
+    config,
+    'PUT',
+    `/_matrix/client/v3/rooms/${encodeURIComponent(opts.roomId)}/send/m.room.message/${encodeURIComponent(
+      opts.txnId
+    )}`,
+    content
+  )
+}
+
+export function joinedTimelineEvents(response: MatrixSyncResponse): MatrixEvent[] {
+  const joined = response.rooms?.join ?? {}
+  const events: MatrixEvent[] = []
+  for (const [roomId, room] of Object.entries(joined)) {
+    for (const event of room.timeline?.events ?? []) {
+      events.push({ ...event, room_id: event.room_id || roomId })
+    }
+  }
+  return events
+}
+
+export function normalizeMatrixMessage(
+  event: MatrixEvent,
+  config: Pick<AppConfig, 'matrixUserId'>
+): NormalizedMatrixMessage | null {
+  if (event.type !== 'm.room.message') return null
+  const roomId = clean(event.room_id)
+  const eventId = clean(event.event_id)
+  const sender = clean(event.sender)
+  if (!roomId || !eventId || !sender || sender === config.matrixUserId) return null
+
+  const content = event.content ?? {}
+  if (clean(content.msgtype) !== 'm.text') return null
+
+  const body = clean(content.body)
+  if (!body || !mentionsBot(content, body, config.matrixUserId)) return null
+
+  const threadRootEventId = threadRoot(content) || eventId
+  const replyToEventId = replyTo(content)
+  return {
+    roomId,
+    eventId,
+    sender,
+    text: stripMention(body, config.matrixUserId),
+    threadRootEventId,
+    replyToEventId,
+    threadKey: matrixThreadKey(roomId, threadRootEventId)
+  }
+}
+
+export function matrixThreadKey(roomId: string, threadRootEventId: string): string {
+  return `matrix:${encodeURIComponent(roomId)}:${encodeURIComponent(threadRootEventId)}`
+}
+
+function mentionsBot(content: Record<string, unknown>, body: string, userId: string): boolean {
+  const mentions = content['m.mentions']
+  if (mentions && typeof mentions === 'object' && !Array.isArray(mentions)) {
+    const userIds = (mentions as Record<string, unknown>).user_ids
+    if (Array.isArray(userIds) && userIds.includes(userId)) return true
+  }
+  return body.includes(userId)
+}
+
+function stripMention(body: string, userId: string): string {
+  return body.replaceAll(userId, '').trim()
+}
+
+function threadRoot(content: Record<string, unknown>): string | null {
+  const relatesTo = relation(content)
+  if (clean(relatesTo?.rel_type) === 'm.thread') return clean(relatesTo?.event_id) || null
+  return null
+}
+
+function replyTo(content: Record<string, unknown>): string | undefined {
+  const relatesTo = relation(content)
+  const reply = relatesTo?.['m.in_reply_to']
+  if (!reply || typeof reply !== 'object' || Array.isArray(reply)) return undefined
+  return clean((reply as Record<string, unknown>).event_id) || undefined
+}
+
+function relation(content: Record<string, unknown>): Record<string, unknown> | null {
+  const relatesTo = content['m.relates_to']
+  if (!relatesTo || typeof relatesTo !== 'object' || Array.isArray(relatesTo)) return null
+  return relatesTo as Record<string, unknown>
+}
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}

--- a/services/matrixbot/src/sync-state.ts
+++ b/services/matrixbot/src/sync-state.ts
@@ -1,0 +1,56 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+export type SyncState = {
+  since?: string
+  initialized: boolean
+  seenEventIds: Set<string>
+}
+
+export function createSyncState(since?: string): SyncState {
+  return {
+    since,
+    initialized: Boolean(since),
+    seenEventIds: new Set()
+  }
+}
+
+export async function loadSyncToken(path: string | undefined): Promise<string | undefined> {
+  if (!path) return undefined
+  try {
+    const token = (await readFile(path, 'utf8')).trim()
+    return token || undefined
+  } catch (error) {
+    if (isNotFound(error)) return undefined
+    throw error
+  }
+}
+
+export async function saveSyncToken(
+  path: string | undefined,
+  token: string | undefined
+): Promise<void> {
+  if (!path || !token) return
+  await mkdir(dirname(path), { recursive: true })
+  const tempPath = `${path}.tmp`
+  await writeFile(tempPath, `${token}\n`, 'utf8')
+  await rename(tempPath, path)
+}
+
+export function rememberEvent(state: SyncState, eventId: string, maxSeen = 2_000): boolean {
+  if (state.seenEventIds.has(eventId)) return false
+  state.seenEventIds.add(eventId)
+  if (state.seenEventIds.size > maxSeen) {
+    const oldest = state.seenEventIds.values().next().value
+    if (oldest) state.seenEventIds.delete(oldest)
+  }
+  return true
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as Error & { code?: string }).code === 'ENOENT'
+  )
+}

--- a/services/matrixbot/tsconfig.json
+++ b/services/matrixbot/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "schema": "https://json.schemastore.org/tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "lib": ["DOM", "ESNext", "DOM.Iterable"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "strictNullChecks": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "moduleResolution": "Bundler",
+    "useDefineForClassFields": true,
+    "allowArbitraryExtensions": true,
+    "noUncheckedIndexedAccess": true,
+    "resolvePackageJsonImports": true,
+    "resolvePackageJsonExports": true,
+    "useUnknownInCatchVariables": true,
+    "allowImportingTsExtensions": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["_", "dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

- add a Matrix bot service that turns Matrix mentions into durable Centaur agent executions
- wire Matrix support into Helm, local scripts, API key seeding, and workspace package config
- add local Matrix and Kubernetes E2E scripts for production-shape Matrix testing

## Verification

- `bun test src/*.test.ts` in `services/matrixbot`: 13 pass
- `bun tsc --project tsconfig.json --noEmit`
- `devenv shell -- helm dependency update contrib/chart`
- `devenv shell -- helm lint contrib/chart -f contrib/chart/values.dev.yaml --set slackbot.enabled=false --set matrixbot.enabled=true --set matrixbot.homeserverUrl=https://matrix.invalid --set matrixbot.userId=@centaur:localhost --set matrixbot.allowedRooms='!room:localhost' --set matrixbot.image.pullPolicy=IfNotPresent`
- `devenv shell -- helm template centaur contrib/chart -n centaur -f contrib/chart/values.dev.yaml --set slackbot.enabled=false --set matrixbot.enabled=true --set matrixbot.homeserverUrl=https://matrix.invalid --set matrixbot.userId=@centaur:localhost --set matrixbot.allowedRooms='!room:localhost' --set matrixbot.image.pullPolicy=IfNotPresent`
- `devenv shell -- just build-one matrixbot`
- `devenv shell -- just build-one api`
- `devenv shell -- just matrixbot-k8s-e2e`

Matrix E2E result:

```text
Matrixbot Kubernetes E2E passed
@centaur:localhost: PONG
```
