### PR TITLE
fix(slackbot): keep streamed answer when a plan block is finalized (Codex answers dropped)

### DIFF
--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -300,14 +300,23 @@ export class AgentSessionRenderer {
     })
     const streamedTextLive =
       Boolean(segment.streamedText.trim()) && segment.streamedText.length < MAX_LIVE_TEXT_CHARS
-    // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.
-    // Only add blocks for content that was not streamed live; live task_update chunks carry
-    // fenced details/output, and the header has already been streamed as the first chunk.
-    const blocks = sanitizeFinalMessagePayload([
-      ...(tasks.length && !segment.planStarted
+    // Slack accumulates appendStream chunks, but stopStream `blocks` REPLACE
+    // the streamed message body. So whenever we emit a composed block layout
+    // (e.g. a plan block), any answer that was streamed live as chunks must be
+    // re-included in the blocks or it is dropped from the final message. This
+    // is what makes plan-emitting harnesses (Codex) lose short answers that
+    // were already streamed: the plan block alone replaces them. Only omit the
+    // answer blocks when we send no blocks at all and the answer was already
+    // streamed live (the accumulated chunks then stand on their own).
+    const planBlocks =
+      tasks.length && !segment.planStarted
         ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)]
-        : []),
-      ...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
+        : []
+    const includeAnswerBlocks =
+      Boolean(answerMarkdown) && (planBlocks.length > 0 || !streamedTextLive)
+    const blocks = sanitizeFinalMessagePayload([
+      ...planBlocks,
+      ...(includeAnswerBlocks ? renderMarkdownBlocks(answerMarkdown) : [])
     ] as AnyBlock[])
     const fallbackText = buildFinalFallbackText({
       title: state.title,


### PR DESCRIPTION
## Problem

When the **Codex** harness produces a final answer, the Slack reply shows only the "Thinking" widget and **no answer text**. The agent completes successfully and the answer is streamed, but it never appears in the closed message. The Claude Code harness is unaffected.

Concretely, the bot message ends up with blocks `[rich_text, plan]` (header + Thinking) and the answer is gone.

## Root cause

Slack streaming is `startStream` → `appendStream` (chunks) → `stopStream` (final `blocks`). The `stopStream` `blocks` **replace** the streamed message body; they do not append to the accumulated chunks.

In `closeTextStream()` (`services/slackbot/src/slack/agent-session.ts`), the answer markdown was only included in the final blocks when it was **not** streamed live:

```ts
...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
```

That is correct only when `stopStream` is called with no blocks (the accumulated stream chunks then stand on their own). But plan-emitting harnesses (Codex always renders a "Thinking" plan block) cause `stopStream` to be called **with** a plan block, which replaces the streamed body and drops the live-streamed answer.

Claude Code does not emit a plan block, so `stopStream` is called with no blocks and its streamed answer survives — which is why only Codex is affected.

## Fix

When we emit any composed blocks (e.g. a plan block), also re-include the answer markdown, since those blocks replace the streamed chunks. Only omit the answer blocks when sending no blocks at all and the answer was already streamed live.

```ts
const planBlocks = tasks.length && !segment.planStarted ? [planBlock(...)] : []
const includeAnswerBlocks =
  Boolean(answerMarkdown) && (planBlocks.length > 0 || !streamedTextLive)
```

## Verification

Verified end-to-end on a live deployment. A Codex Slack reply that previously rendered `[rich_text, plan]` (no answer) now renders `[rich_text, plan, rich_text, table]` with the answer table present.

All existing `agent-session` and `codex-session` tests pass (45 across the two suites). The existing "does not duplicate live plan or streamed answer markdown on finalize" test still passes — its scenario has the plan already streamed (`planStarted=true`), so no plan block is emitted at finalize and the answer is correctly left as the streamed chunks.

I attempted a focused unit regression test, but the exact trigger state (a plan/Thinking block emitted at finalize while the answer streamed live) depends on reasoning-summary publish ordering that was non-trivial to reproduce synthetically at the unit level. Happy to add one with guidance on the preferred test shape.
