### PR TITLE
fix: gate broker credentials to enabled harnesses only

### DIFF
--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -189,6 +189,10 @@ spec:
               value: info
             - name: CENTAUR_DEFAULT_HARNESS
               value: {{ .Values.api.defaultHarness | quote }}
+{{- if .Values.api.enabledHarnesses }}
+            - name: CENTAUR_ENABLED_HARNESSES
+              value: {{ join "," .Values.api.enabledHarnesses | quote }}
+{{- end }}
             - name: TOOL_DIRS
 {{- if .Values.overlay.image.repository }}
               value: {{ printf "/app/tools:%s/tools" .Values.overlay.mountPath | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -112,6 +112,14 @@ api:
     pullPolicy: Always
   executionWorkerEnabled: false
   defaultHarness: codex
+  # Harnesses this deployment can spawn beyond `defaultHarness`. Each entry
+  # joins the set whose harness credentials the API manages (the shared
+  # iron-proxy and, when enabled, iron-token-broker). Leave empty when only
+  # `defaultHarness` is used: handing the broker a brokered credential whose
+  # 1Password items don't exist corrupts its shared SDK client and breaks
+  # token rotation for every credential. Same names/aliases as
+  # `defaultHarness` (amp, claude/claude-code, codex, pi/pi-mono).
+  enabledHarnesses: []
   # The API's worker claims workflow_runs and spawns a per-run sandbox to
   # execute each handler. Disable only if you're running your own claimer.
   workflowWorkerEnabled: true

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -51,6 +51,7 @@ Optional required-by-mode variables:
 | Env var | Set from | Controls |
 | --- | --- | --- |
 | `CENTAUR_DEFAULT_HARNESS` | `api.defaultHarness`. | Default harness for new executions. |
+| `CENTAUR_ENABLED_HARNESSES` | `api.enabledHarnesses` (comma-joined). | Harnesses this deployment can spawn beyond the default. Gates which harness credentials the shared iron-proxy and iron-token-broker manage, so the broker is never handed a brokered credential whose 1Password items are absent (which corrupts its shared SDK client and breaks rotation for every credential). |
 | `CENTAUR_ENVIRONMENT` | `api.extraEnv` or deployment env. | Environment label in traces and telemetry. |
 | `CENTAUR_LOG_LEVEL`, `LOG_LEVEL` | Helm sets `CENTAUR_LOG_LEVEL=info`; override in `api.extraEnv`. | API log level. |
 | `CENTAUR_SERVICE_NAME` | `api.extraEnv`. | Default API log `service` field. |

--- a/services/api/api/harness_config.py
+++ b/services/api/api/harness_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 
 
 _DEFAULT_HARNESS_ALIASES: dict[str, str] = {
@@ -16,3 +17,29 @@ _DEFAULT_HARNESS_ALIASES: dict[str, str] = {
 def default_harness() -> str:
     raw = (os.getenv("CENTAUR_DEFAULT_HARNESS") or "codex").strip().lower()
     return _DEFAULT_HARNESS_ALIASES.get(raw, "codex")
+
+
+def enabled_harnesses() -> frozenset[str]:
+    """Engines whose harness credentials the deployment is allowed to manage.
+
+    Always includes :func:`default_harness`. A deployment that can also spawn
+    other harnesses lists them in ``CENTAUR_ENABLED_HARNESSES`` (comma- or
+    whitespace-separated, accepting the same aliases as
+    ``CENTAUR_DEFAULT_HARNESS``); each named engine joins the set. Names that
+    aren't aliases pass through verbatim so a not-yet-aliased engine still
+    works; unrecognized engines simply match no ``_HARNESS_SECRETS`` entry.
+
+    This is the allowlist :meth:`api.tool_manager.ToolManager.collect_secrets`
+    gates on so the shared API-side iron-proxy and iron-token-broker only
+    manage credentials for harnesses the deployment can actually reach.
+    Advertising a brokered credential whose 1Password items don't exist
+    corrupts iron-token-broker's shared SDK client and breaks rotation for
+    *every* credential, so a deployment must not enable a harness it hasn't
+    provisioned secrets for.
+    """
+    enabled = {default_harness()}
+    raw = os.getenv("CENTAUR_ENABLED_HARNESSES") or ""
+    for token in re.split(r"[,\s]+", raw.strip().lower()):
+        if token:
+            enabled.add(_DEFAULT_HARNESS_ALIASES.get(token, token))
+    return frozenset(enabled)

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -37,6 +37,7 @@ from api.otel import (
 )
 from api.vm_metrics import record_tool_call
 from api.deps import get_key_info, get_sandbox_claims, verify_api_key
+from api.harness_config import enabled_harnesses
 from api import slackbot_client
 from centaur_sdk import ToolContext, reset_tool_context, set_tool_context
 
@@ -2059,17 +2060,30 @@ class ToolManager:
     def collect_secrets(self) -> list[SecretDef]:
         """Return all secrets the deployment manages.
 
-        Base infra + every tool's secrets + the union of every harness
-        credential variant. Used by the shared API-side iron-proxy and by
-        iron-token-broker so the broker manages every brokered credential
-        regardless of which sandboxes are currently running. Per-sandbox
-        proxies should call :meth:`secrets_for_sandbox` instead.
+        Base infra + every tool's secrets + every harness credential variant
+        for the *enabled* harnesses (see
+        :func:`api.harness_config.enabled_harnesses`). Used by the shared
+        API-side iron-proxy and by iron-token-broker so the broker manages
+        every brokered credential a reachable sandbox might use — both auth
+        modes of an enabled engine — regardless of which sandboxes are
+        currently running. Per-sandbox proxies should call
+        :meth:`secrets_for_sandbox` instead.
+
+        The harness loop is gated on the enabled set on purpose: a
+        ``BrokeredTokenSecret`` whose 1Password items are absent corrupts
+        iron-token-broker's shared SDK client and breaks token rotation for
+        *every* credential it manages, so the deployment must not emit a
+        brokered credential for a harness it hasn't provisioned. Harnesses a
+        deployment can spawn beyond ``CENTAUR_DEFAULT_HARNESS`` opt in via
+        ``CENTAUR_ENABLED_HARNESSES``.
         """
         out: list[SecretDef] = list(self._INFRA_SECRETS)
         for lt in self.tools.values():
             out.extend(lt.all_secrets)
-        for harness_set in self._HARNESS_SECRETS.values():
-            out.extend(harness_set)
+        enabled = enabled_harnesses()
+        for (engine, _mode), harness_set in self._HARNESS_SECRETS.items():
+            if engine in enabled:
+                out.extend(harness_set)
         return out
 
     def reload(self) -> dict[str, Any]:

--- a/services/api/tests/test_broker_config.py
+++ b/services/api/tests/test_broker_config.py
@@ -258,16 +258,19 @@ def test_render_broker_yaml_skips_non_brokered_secrets(
     assert [c["id"] for c in cfg["credentials"]] == ["codex"]
 
 
-def test_render_broker_yaml_includes_harness_brokered_secrets(
+def test_render_broker_yaml_includes_enabled_harness_brokered_secrets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ToolManager.collect_secrets feeds the broker reconcile path. Both
-    ``anthropic-claude`` and ``openai-codex`` must appear in the rendered
-    iron-token-broker config so the broker manages them whether or not any
-    sandbox is currently using access_token mode."""
+    """ToolManager.collect_secrets feeds the broker reconcile path. When a
+    deployment enables both harnesses, ``anthropic-claude`` and
+    ``openai-codex`` both appear in the rendered iron-token-broker config so
+    the broker manages them whether or not any sandbox is currently using
+    access_token mode."""
     from api.tool_manager import ToolManager
 
     monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+    monkeypatch.setenv("CENTAUR_ENABLED_HARNESSES", "codex")
     tm = ToolManager.__new__(ToolManager)
     tm.tools = {}
     cfg = yaml.safe_load(render_broker_yaml(tm.collect_secrets()))
@@ -285,3 +288,24 @@ def test_render_broker_yaml_includes_harness_brokered_secrets(
         by_id["openai-codex"]["token_endpoint"]
         == "https://auth.openai.com/oauth/token"
     )
+
+
+def test_render_broker_yaml_omits_unenabled_harness_brokered_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The broker config must not carry a brokered credential for a harness
+    the deployment can't reach. iron-token-broker corrupts its shared
+    1Password SDK client the first time it touches a credential whose vault
+    items are missing, which breaks rotation for *every* credential it
+    manages — so a claude-code-only deployment renders ``anthropic-claude``
+    and omits ``openai-codex`` entirely (the regression this gate fixes)."""
+    from api.tool_manager import ToolManager
+
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+    monkeypatch.delenv("CENTAUR_ENABLED_HARNESSES", raising=False)
+    tm = ToolManager.__new__(ToolManager)
+    tm.tools = {}
+    cfg = yaml.safe_load(render_broker_yaml(tm.collect_secrets()))
+
+    assert {c["id"] for c in cfg["credentials"]} == {"anthropic-claude"}

--- a/services/api/tests/test_harness_config.py
+++ b/services/api/tests/test_harness_config.py
@@ -25,3 +25,51 @@ def test_default_harness_ignores_unknown_values(monkeypatch):
     monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "unknown")
 
     assert default_harness() == "codex"
+
+
+def test_enabled_harnesses_defaults_to_default_harness(monkeypatch):
+    from api.harness_config import enabled_harnesses
+
+    monkeypatch.delenv("CENTAUR_DEFAULT_HARNESS", raising=False)
+    monkeypatch.delenv("CENTAUR_ENABLED_HARNESSES", raising=False)
+    assert enabled_harnesses() == frozenset({"codex"})
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+    assert enabled_harnesses() == frozenset({"claude-code"})
+
+
+def test_enabled_harnesses_adds_explicit_list(monkeypatch):
+    from api.harness_config import enabled_harnesses
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+    monkeypatch.setenv("CENTAUR_ENABLED_HARNESSES", "codex")
+    assert enabled_harnesses() == frozenset({"claude-code", "codex"})
+
+
+def test_enabled_harnesses_normalizes_aliases_and_separators(monkeypatch):
+    from api.harness_config import enabled_harnesses
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+    # Mixed comma/space separators; aliases normalize (claude->claude-code,
+    # pi->pi-mono) so the set matches the _HARNESS_SECRETS engine keys.
+    monkeypatch.setenv("CENTAUR_ENABLED_HARNESSES", "codex,  pi   claude")
+    assert enabled_harnesses() == frozenset({"claude-code", "codex", "pi-mono"})
+
+
+def test_enabled_harnesses_passes_through_unknown_tokens(monkeypatch):
+    from api.harness_config import enabled_harnesses
+
+    monkeypatch.delenv("CENTAUR_DEFAULT_HARNESS", raising=False)
+    monkeypatch.setenv("CENTAUR_ENABLED_HARNESSES", "mystery")
+    # Unknown engines stay verbatim (they match no _HARNESS_SECRETS entry, so
+    # they're inert) rather than being coerced to the default the way
+    # CENTAUR_DEFAULT_HARNESS is.
+    assert enabled_harnesses() == frozenset({"codex", "mystery"})
+
+
+def test_enabled_harnesses_ignores_blank_entries(monkeypatch):
+    from api.harness_config import enabled_harnesses
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+    monkeypatch.setenv("CENTAUR_ENABLED_HARNESSES", "  , ,  ")
+    assert enabled_harnesses() == frozenset({"claude-code"})

--- a/services/api/tests/test_tool_manager.py
+++ b/services/api/tests/test_tool_manager.py
@@ -738,15 +738,58 @@ class TestHarnessSecretSelection:
         assert slack_etl.hosts == ("*.slack.com",)
         assert slack_etl.match_headers == ("Authorization",)
 
-    def test_collect_secrets_returns_union_of_all_harness_variants(self) -> None:
-        """The shared API-side proxy and token broker need every harness
-        credential so they can manage the full set regardless of which mode
-        any individual sandbox is using right now."""
+    def test_collect_secrets_emits_only_enabled_default_harness(
+        self, monkeypatch
+    ) -> None:
+        """A deployment whose only harness is the default emits just that
+        harness's credentials. Both auth-mode variants of the enabled engine
+        appear (the broker manages a credential regardless of the mode a
+        sandbox currently uses), but a harness the deployment can't reach
+        contributes nothing — emitting its brokered credential would poison
+        iron-token-broker's shared SDK client if its vault items are absent."""
+        monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+        monkeypatch.delenv("CENTAUR_ENABLED_HARNESSES", raising=False)
+        tm = ToolManager.__new__(ToolManager)
+        tm.tools = {}
+        names = self._names(tm.collect_secrets())
+        # claude-code: both the api_key and access_token variants.
+        assert "ANTHROPIC_API_KEY" in names
+        assert "anthropic-claude" in names
+        # codex isn't enabled, so none of its credentials are managed.
+        assert "openai-codex" not in names
+        assert "OPENAI_API_KEY" not in names
+        assert "OPENAI_CODEX_ACCOUNT_ID" not in names
+        # Base infra secrets are independent of the harness gate.
+        assert "SLACK_ETL_TOKEN" in names
+
+    def test_collect_secrets_includes_explicitly_enabled_harnesses(
+        self, monkeypatch
+    ) -> None:
+        """Harnesses a deployment can spawn beyond the default opt in via
+        ``CENTAUR_ENABLED_HARNESSES``; their credentials are then managed
+        alongside the default harness's."""
+        monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "claude")
+        monkeypatch.setenv("CENTAUR_ENABLED_HARNESSES", "codex")
         tm = ToolManager.__new__(ToolManager)
         tm.tools = {}
         names = self._names(tm.collect_secrets())
         assert "ANTHROPIC_API_KEY" in names
-        assert "OPENAI_API_KEY" in names
         assert "anthropic-claude" in names
+        assert "OPENAI_API_KEY" in names
         assert "openai-codex" in names
         assert "OPENAI_CODEX_ACCOUNT_ID" in names
+
+    def test_collect_secrets_default_codex_omits_unenabled_claude(
+        self, monkeypatch
+    ) -> None:
+        """The built-in default (codex) with nothing else enabled manages only
+        codex credentials — the claude-code brokered credential is dropped."""
+        monkeypatch.delenv("CENTAUR_DEFAULT_HARNESS", raising=False)
+        monkeypatch.delenv("CENTAUR_ENABLED_HARNESSES", raising=False)
+        tm = ToolManager.__new__(ToolManager)
+        tm.tools = {}
+        names = self._names(tm.collect_secrets())
+        assert "OPENAI_API_KEY" in names
+        assert "openai-codex" in names
+        assert "anthropic-claude" not in names
+        assert "ANTHROPIC_API_KEY" not in names


### PR DESCRIPTION
## Problem

`ToolManager.collect_secrets()` unconditionally appended a `BrokeredTokenSecret` for **every** `(engine, auth_mode)` in `_HARNESS_SECRETS` (`anthropic-claude`, `openai-codex`, …), so the iron-token-broker ConfigMap rendered by `broker_config.render_broker_yaml()` always carried credentials for harnesses a deployment may never run.

iron-token-broker (`ironsh/iron-token-broker:0.0.1-rc.2`) **corrupts its shared 1Password Go-SDK client** the first time it touches a credential whose referenced vault items are missing: the first item op succeeds, then every subsequent op fails with

```
an internal error occurred ... invalid client id
```

which breaks the rotation write path (`Items.Get`/`Items.Put`) for **all** credentials — including the one actually in use. Confirmed empirically: removing the phantom `openai-codex` credential made the broker healthy; re-adding it with missing vault items re-broke it.

The current workaround on the Moonwell deployment is to bootstrap placeholder `OPENAI_CODEX_CLIENT_ID` / `OPENAI_CODEX_BLOB` items in the `ai-agents` vault so resolution succeeds and codex is harmlessly marked unauthenticated.

## Fix

Gate the harness loop in `collect_secrets()` on a new `harness_config.enabled_harnesses()` allowlist:

- `CENTAUR_DEFAULT_HARNESS` is always enabled.
- `CENTAUR_ENABLED_HARNESSES` (comma/whitespace-separated, same aliases as the default) adds any other harnesses the deployment can spawn.

The shared API-side iron-proxy and iron-token-broker now manage credentials only for harnesses the deployment can actually reach, so a credential with missing vault items for an unused harness is never emitted. Both auth-mode variants of each *enabled* engine are still emitted (the broker manages a credential regardless of which mode a sandbox currently uses).

After this lands, the Moonwell deployment can run claude-code-only (default) and delete the placeholder vault items.

## Migration note ⚠️

This changes the set emitted by `collect_secrets()`. Previously every harness credential was managed; now only `CENTAUR_DEFAULT_HARNESS` is, unless `CENTAUR_ENABLED_HARNESSES` lists more. **A deployment that can spawn more than one harness must enumerate them in `CENTAUR_ENABLED_HARNESSES` (`api.enabledHarnesses`)** — otherwise a sandbox spawned on a non-enabled harness in `access_token` mode has no broker credential. (`api_key` mode is unaffected; it doesn't use the broker.)

## Changes

- `harness_config`: add `enabled_harnesses()`.
- `tool_manager`: gate `collect_secrets()` on the enabled set.
- chart: `api.enabledHarnesses` → `CENTAUR_ENABLED_HARNESSES` (rendered only when non-empty); documented in `configuration.md`.
- tests: default-harness-only deployments omit codex creds; explicitly enabled harnesses still emit them; broker config omits unenabled brokered creds; `enabled_harnesses()` parsing.

## Testing

```
uv run pytest tests/test_harness_config.py tests/test_broker_config.py \
  tests/test_tool_manager.py::TestHarnessSecretSelection -q
# 31 passed
```

`helm template` renders `CENTAUR_ENABLED_HARNESSES` only when `api.enabledHarnesses` is non-empty. (One pre-existing, unrelated failure — `test_tool_rest_router_lists_describes_and_invokes_tools`, a 401 auth-env artifact present on `main` too.)

## Upstream

The robust fix is broker-side: iron-token-broker should tolerate a credential whose vault items are missing without poisoning the shared SDK client used by every other credential. Worth reporting to `ironsh/iron-token-broker`; this PR is the deployment-side mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
