### PR TITLE
fix: remove slackbotv2 synthetic starting task

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -23,8 +23,7 @@ import {
   isRetryableSessionApiError,
   openSessionEventStream,
   serializeMessage,
-  sessionStreamError,
-  startingStreamNotification
+  sessionStreamError
 } from './session-api'
 import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from './slack-events'
 import type {
@@ -641,10 +640,9 @@ async function indexRenderObligation(
 }
 
 async function* streamOpenedSession(
-  input: Pick<ForwardSessionInput, 'threadId' | 'trace'>,
+  _input: Pick<ForwardSessionInput, 'threadId' | 'trace'>,
   stream: AsyncIterable<SlackbotV2RendererSource>
 ): AsyncIterable<SlackbotV2RendererSource> {
-  yield startingStreamNotification(input.threadId)
   for await (const event of stream) yield event
 }
 
@@ -721,8 +719,6 @@ async function* streamSessionAfterHandoff(
     return
   }
 
-  yield startingStreamNotification(input.threadId)
-  traceLog(options, 'slackbotv2_stream_heartbeat_emitted', input.trace)
   for await (const event of stream) yield event
 }
 

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -187,24 +187,6 @@ export async function openSessionEventStream(
   return stream
 }
 
-export function startingStreamNotification(threadId: string): JsonObject {
-  return {
-    method: 'item/started',
-    params: {
-      threadId,
-      turnId: 'slackbotv2-starting-turn',
-      startedAtMs: Date.now(),
-      item: {
-        id: 'slackbotv2-starting',
-        memoryCitation: null,
-        phase: 'commentary',
-        text: '',
-        type: 'agentMessage'
-      }
-    }
-  }
-}
-
 export function sessionStreamError(error: unknown): RustSessionStreamEvent {
   return {
     data: { error: error instanceof Error ? error.message : String(error) },

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1088,6 +1088,21 @@ function sampleCodexNotifications(answer: string): ServerNotification[] {
       }
     },
     {
+      method: 'item/started',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        startedAtMs: 4,
+        item: {
+          type: 'agentMessage',
+          id: 'answer-1',
+          text: '',
+          phase: 'final_answer',
+          memoryCitation: null
+        }
+      }
+    },
+    {
       method: 'item/agentMessage/delta',
       params: {
         threadId: 'thread-1',
@@ -2015,15 +2030,7 @@ function expectSlackPlanStreamShape(
     )
     expect(transcript.start.body.ts).toBeUndefined()
     expect(transcript.start.body.markdown_text).toBeUndefined()
-    expect(streamChunks(transcript.start.body.chunks)[0]).toEqual(
-      expect.objectContaining({
-        type: 'task_update',
-        title: 'Thinking',
-        status: 'in_progress'
-      })
-    )
 
-    expect(transcript.appends.length).toBeGreaterThan(0)
     for (const append of transcript.appends) {
       expect(append.body).toEqual(
         expect.objectContaining({


### PR DESCRIPTION
## Summary
- remove the synthetic `slackbotv2-starting` item from opened and recovered Slackbot v2 streams
- stop expecting the fake initial Thinking task in Slack stream emulation
- add the real final-answer `item/started` notification to the Codex emulator fixture

## Test Plan
- `bun test test/chat-sdk-emulate.test.ts`
- `bun tsgo --project tsconfig.json --noEmit`