### PR TITLE
Fix Slack live delivery status and empty fallback

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -1039,7 +1039,7 @@ def _slackbot_streamed_answer_chars(value: Any) -> int:
 def _slackbot_live_delivery_covers_result(result_text: str, streamed_chars: int) -> bool:
     text = result_text.strip()
     if not text:
-        return True
+        return False
     return streamed_chars >= len(text)
 
 
@@ -1950,12 +1950,10 @@ async def _mark_execution_terminal(
             suppress_legacy_delivery = (
                 _has_slackbot_live_delivery(metadata)
                 and not slackbot_live_delivery_failed
-                and (
-                    not result_has_text
-                    or _slackbot_live_delivery_covers_result(
-                        result_text,
-                        slackbot_streamed_answer_chars,
-                    )
+                and result_has_text
+                and _slackbot_live_delivery_covers_result(
+                    result_text,
+                    slackbot_streamed_answer_chars,
                 )
             )
         assignment_row = await pool.fetchrow(

--- a/services/api/tests/test_agent_control_plane.py
+++ b/services/api/tests/test_agent_control_plane.py
@@ -39,7 +39,7 @@ def test_slackbot_streamed_answer_chars_requires_positive_integer_offset():
     assert _slackbot_streamed_answer_chars("25") == 0
     assert _slackbot_streamed_answer_chars(-3) == 0
     assert _slackbot_streamed_answer_chars(25) == 25
-    assert _slackbot_live_delivery_covers_result("", 0) is True
+    assert _slackbot_live_delivery_covers_result("", 0) is False
     assert _slackbot_live_delivery_covers_result("already streamed", 16) is True
     assert _slackbot_live_delivery_covers_result("cut off report", 6) is False
 
@@ -1230,6 +1230,85 @@ async def test_mark_execution_terminal_falls_back_after_cut_off_live_answer(db_p
         final_payload = json.loads(final_payload)
     assert final_payload["result_text"] == result_text
     assert final_payload["slackbot_streamed_answer_chars"] == len(streamed_prefix)
+    ready_events = await db_pool.fetchval(
+        "SELECT COUNT(*) FROM agent_execution_events "
+        "WHERE execution_id = $1 AND event_kind = 'final_delivery_ready'",
+        execution_id,
+    )
+    assert int(ready_events or 0) == 1
+
+
+@pytest.mark.asyncio
+async def test_mark_execution_terminal_falls_back_after_empty_live_answer(db_pool):
+    from api.runtime_control import _mark_execution_terminal
+
+    execution_id = f"exe-{uuid.uuid4().hex[:10]}"
+    thread_key = f"slack:C-test:{uuid.uuid4().hex}"
+    runtime_id = f"rt-{uuid.uuid4().hex[:8]}"
+    await db_pool.execute(
+        "INSERT INTO sandbox_sessions (thread_key, sandbox_id, harness, engine, state) "
+        "VALUES ($1, $2, 'codex', 'codex', 'idle')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_runtime_assignments ("
+        "thread_key, assignment_generation, runtime_id, harness, engine, "
+        "persona_id, prompt_ref, effective_agents_md_sha256, state"
+        ") VALUES ($1, 1, $2, 'codex', 'codex', NULL, 'harness:codex', 'sha', 'active')",
+        thread_key,
+        runtime_id,
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_execution_requests ("
+        "execution_id, thread_key, assignment_generation, execute_id, request_hash, status, "
+        "delivery, metadata, started_at"
+        ") VALUES ($1, $2, 1, 'exec-empty-live', 'hash-empty-live', 'running', "
+        "$3::jsonb, $4::jsonb, NOW())",
+        execution_id,
+        thread_key,
+        json.dumps(
+            {
+                "platform": "slack",
+                "channel": "C-test",
+                "thread_ts": "1779333881.200699",
+            }
+        ),
+        json.dumps(
+            {
+                "slackbot_live_delivery": True,
+                "slackbot_agent_session_id": "sess-empty-live",
+                "slackbot_streamed_answer_chars": 0,
+            }
+        ),
+    )
+    await db_pool.execute(
+        "INSERT INTO agent_final_delivery_outbox (execution_id, thread_key, delivery, state) "
+        "VALUES ($1, $2, '{}'::jsonb, 'awaiting_terminal')",
+        execution_id,
+        thread_key,
+    )
+
+    await _mark_execution_terminal(
+        db_pool,
+        execution_id=execution_id,
+        thread_key=thread_key,
+        status="completed",
+        terminal_reason="completed",
+        result_text="",
+        error_text=None,
+    )
+
+    outbox = await db_pool.fetchrow(
+        "SELECT state, final_payload FROM agent_final_delivery_outbox WHERE execution_id = $1",
+        execution_id,
+    )
+    assert outbox is not None
+    assert outbox["state"] == "pending"
+    final_payload = outbox["final_payload"]
+    if isinstance(final_payload, str):
+        final_payload = json.loads(final_payload)
+    assert final_payload["result_text"] == ""
     ready_events = await db_pool.fetchval(
         "SELECT COUNT(*) FROM agent_execution_events "
         "WHERE execution_id = $1 AND event_kind = 'final_delivery_ready'",

--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -2,6 +2,53 @@ import { describe, expect, it } from 'bun:test'
 import { AgentSessionRenderer, withAgentSessionLock } from './agent-session'
 
 describe('AgentSessionRenderer', () => {
+  it('clears status without opening a blank stream when a session has no visible output', async () => {
+    const calls: Array<{ method: string; params: any }> = []
+    const client = {
+      assistant: {
+        threads: {
+          setStatus: async (params: any) => {
+            calls.push({ method: 'assistant.threads.setStatus', params })
+            return { ok: true }
+          }
+        }
+      },
+      chat: {
+        startStream: async (params: any) => {
+          calls.push({ method: 'chat.startStream', params })
+          return { ok: true, ts: '1778866940.295499' }
+        },
+        appendStream: async (params: any) => {
+          calls.push({ method: 'chat.appendStream', params })
+          return { ok: true }
+        },
+        stopStream: async (params: any) => {
+          calls.push({ method: 'chat.stopStream', params })
+          return { ok: true }
+        },
+        update: async () => ({ ok: true })
+      }
+    }
+
+    const renderer = new AgentSessionRenderer(client as any)
+    const { sessionId } = await renderer.open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+
+    await renderer.done(sessionId)
+
+    expect(calls.map(call => call.method)).toEqual([
+      'assistant.threads.setStatus',
+      'assistant.threads.setStatus'
+    ])
+    expect(calls[0]?.params.status).toBe('Thinking...')
+    expect(calls[1]?.params.status).toBe('')
+  })
+
   it('stops calling assistant.threads.setStatus after the channel returns user_not_found', async () => {
     const setStatusCalls: any[] = []
     const client = {
@@ -101,15 +148,15 @@ describe('AgentSessionRenderer', () => {
         details: '```bash\nsleep 2\n```'
       }
     ])
-    expect(calls.slice(0, 3).map(call => call.method)).toEqual([
+    expect(calls.slice(0, 2).map(call => call.method)).toEqual([
       'assistant.threads.setStatus',
-      'chat.startStream',
-      'assistant.threads.setStatus'
+      'chat.startStream'
     ])
     expect(calls[0]?.params.status).toBe('Thinking...')
     expect(calls[0]?.params.loading_messages).toEqual(['Thinking...'])
-    expect(calls[2]?.params.status).toBe('')
-    expect(calls[2]?.params.loading_messages).toBeUndefined()
+    const statusCalls = calls.filter(call => call.method === 'assistant.threads.setStatus')
+    expect(statusCalls.at(-1)?.params.status).toBe('')
+    expect(statusCalls.at(-1)?.params.loading_messages).toBeUndefined()
 
     const appends = calls.filter(call => call.method === 'chat.appendStream')
     expect(appends[0]?.params.chunks).toEqual([
@@ -171,7 +218,7 @@ describe('AgentSessionRenderer', () => {
 
     expect(calls.map(call => call.method)).toContain('chat.startStream')
     expect(calls.map(call => call.method)).toContain('chat.stopStream')
-    expect(calls.filter(call => call.method === 'assistant.threads.setStatus')).toHaveLength(3)
+    expect(calls.filter(call => call.method === 'assistant.threads.setStatus')).toHaveLength(2)
   })
 
   it('streams task updates with accumulated details and output', async () => {

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -55,6 +55,7 @@ type AgentSessionState = {
   done: boolean
   statusCleared: boolean
   statusUnsupported: boolean
+  statusRefreshTimer?: ReturnType<typeof setInterval>
   segments: Segment[]
 }
 
@@ -107,6 +108,7 @@ function headerBlock(header: string): AnyBlock {
 const sessions = new Map<string, AgentSessionState>()
 const sessionQueues = new Map<string, Promise<void>>()
 const THINKING_STATUS = 'Thinking...'
+const STATUS_REFRESH_INTERVAL_MS = 30_000
 const TEXT_FLUSH_INTERVAL_MS = 250
 const TEXT_FLUSH_CHARS = 1000
 const FIRST_TEXT_FLUSH_CHARS = 1
@@ -125,7 +127,7 @@ export class AgentSessionRenderer {
   async open(input: OpenAgentSessionInput): Promise<{ sessionId: string }> {
     const id = ulid()
     const header = input.header?.trim() || undefined
-    sessions.set(id, {
+    const state = {
       id,
       channel: input.channel,
       parentTs: input.parentTs,
@@ -137,8 +139,11 @@ export class AgentSessionRenderer {
       done: false,
       statusCleared: false,
       statusUnsupported: false
-    })
-    await this.setStatus(id, THINKING_STATUS)
+    }
+    sessions.set(id, state)
+    if (await this.setStatus(id, THINKING_STATUS)) {
+      this.startStatusRefresh(state)
+    }
     return { sessionId: id }
   }
 
@@ -239,6 +244,7 @@ export class AgentSessionRenderer {
       streamedTextChars = streamedTextSourceChars(state)
       closed = true
     } finally {
+      this.stopStatusRefresh(state)
       if (!state.statusCleared) {
         state.statusCleared = await this.setStatus(sessionId, '')
       }
@@ -289,8 +295,6 @@ export class AgentSessionRenderer {
     if (!segment.streamTs && !segment.textParts.length && !segment.tasks.size && !hasFinalText) {
       return
     }
-    await this.ensureStream(state, segment, [])
-    if (!segment.streamTs) return
     const originalTasks = finalTaskSnapshot(segment)
     const tasks = compactFinalTasks(originalTasks)
     const answerSource =
@@ -313,6 +317,12 @@ export class AgentSessionRenderer {
       title: state.title,
       answerMarkdown
     })
+    if (!segment.streamTs) {
+      const initialChunks = markdownToStreamChunks(fallbackText)
+      if (!initialChunks.length) return
+      await this.ensureStream(state, segment, initialChunks)
+    }
+    if (!segment.streamTs) return
     const chunks =
       blocks.length || streamedTextLive ? undefined : markdownToStreamChunks(fallbackText)
     const stopResponse = await this.client.chat.stopStream({
@@ -344,7 +354,6 @@ export class AgentSessionRenderer {
       chunks: effectiveChunks as AnyChunk[]
     })
     if (!response.ok) throw new Error(response.error ?? 'chat.appendStream failed')
-    await this.clearStatusAfterVisibleOutput(state, effectiveChunks)
   }
 
   private async queueText(
@@ -483,7 +492,6 @@ export class AgentSessionRenderer {
       })
       if (!response.ok || !response.ts) throw new Error(response.error ?? 'chat.startStream failed')
       segment.streamTs = response.ts
-      await this.clearStatusAfterVisibleOutput(state, chunks)
     })()
 
     try {
@@ -492,14 +500,6 @@ export class AgentSessionRenderer {
     } finally {
       segment.streamStartPromise = undefined
     }
-  }
-
-  private async clearStatusAfterVisibleOutput(
-    state: AgentSessionState,
-    chunks: SlackStreamChunk[]
-  ): Promise<void> {
-    if (state.statusCleared || !hasVisibleStreamChunks(chunks)) return
-    state.statusCleared = await this.setStatus(state.id, '')
   }
 
   private planPrefix(state: AgentSessionState, segment: Segment): AnyChunk[] {
@@ -520,6 +520,37 @@ export class AgentSessionRenderer {
     if (!header || segment.headerEmitted) return chunks
     segment.headerEmitted = true
     return [markdownChunk(`${headerMarkdown(header)}\n`), ...chunks]
+  }
+
+  private startStatusRefresh(state: AgentSessionState): void {
+    if (state.statusRefreshTimer) return
+    const timer = setInterval(() => {
+      void this.refreshActiveStatus(state)
+    }, STATUS_REFRESH_INTERVAL_MS)
+    timer.unref?.()
+    state.statusRefreshTimer = timer
+  }
+
+  private stopStatusRefresh(state: AgentSessionState): void {
+    if (!state.statusRefreshTimer) return
+    clearInterval(state.statusRefreshTimer)
+    state.statusRefreshTimer = undefined
+  }
+
+  private async refreshActiveStatus(state: AgentSessionState): Promise<void> {
+    if (
+      state.done ||
+      state.statusCleared ||
+      state.statusUnsupported ||
+      !sessions.has(state.id)
+    ) {
+      this.stopStatusRefresh(state)
+      return
+    }
+    const refreshed = await this.setStatus(state.id, THINKING_STATUS)
+    if (!refreshed && state.statusUnsupported) {
+      this.stopStatusRefresh(state)
+    }
   }
 }
 
@@ -714,15 +745,6 @@ function requireSession(id: string): AgentSessionState {
 
 function raiseStreamError(segment: Segment): void {
   if (segment.streamError) throw segment.streamError
-}
-
-function hasVisibleStreamChunks(chunks: SlackStreamChunk[]): boolean {
-  return chunks.some(chunk => {
-    if (chunk.type === 'markdown_text') return Boolean(chunk.text?.trim())
-    if (chunk.type === 'task_update') return Boolean(chunk.title?.trim())
-    if (chunk.type === 'plan_update') return Boolean(chunk.title?.trim())
-    return false
-  })
 }
 
 function safeMarkdownFlush(markdown: string, pendingText: string, streamedText: string): boolean {


### PR DESCRIPTION

# PR Description

## Problem

Long-running Slack sessions could look dead even while Centaur was still running.

The tool/task stream continued internally, but Slack's assistant status was cleared after the first visible streamed output. For long executions, that meant the thread could stop showing an active "Thinking..." state even though tool calls and chain-of-thought style progress were still being processed.

We also found a related blank-delivery edge case. If Slack live delivery was enabled but the model produced zero visible answer characters, the API treated live delivery as already covering the result. That suppressed the durable final-delivery fallback, so a no-output execution could complete without posting a useful fallback message.

## Fix

- Keep Slack assistant status active for the whole agent session.
- Refresh the `Thinking...` status every 30 seconds while the session is active.
- Clear assistant status only when `done()` runs.
- Stop retrying status refreshes if Slack reports that assistant status is unsupported for the channel/thread.
- Avoid opening a blank Slack stream when a session completes with no visible output.
- Change API final-delivery suppression so live Slack delivery only suppresses fallback delivery when there is actual result text and Slack streamed enough visible answer characters to cover it.
- Add regression coverage for both sides:
  - Slackbot renderer does not create blank streams and keeps status behavior sane.
  - API final-delivery fallback is queued when live delivery streamed zero answer characters.

## Relevant Issues Fixed

- Long Slack runs can appear silent/dead after early streamed output because `Thinking...` disappears too soon.
- No-output or failed/no-input executions can skip final fallback delivery when live Slack delivery reported zero streamed answer characters.
- Blank Slack streams can be opened during session close even when there is no visible content to render.

## Test Plan

- `bun test src/*.test.ts src/**/*.test.ts` in `services/slackbot`
- `bun run check:types` in `services/slackbot`
- `/Users/fin-sa/centaur/services/api/.venv/bin/python -m pytest tests/test_agent_control_plane.py -k "slackbot_streamed_answer_chars or live_answer"` in `services/api`
- `/Users/fin-sa/centaur/services/api/.venv/bin/python -m ruff check api/runtime_control.py tests/test_agent_control_plane.py` in `services/api`
