### PR TITLE
fix(api-rs): select idempotency_key in active/latest execution queries

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -210,7 +210,7 @@ impl PgSessionStore {
     ) -> Result<Option<SessionExecution>, SessionStoreError> {
         let row = sqlx::query_as::<_, SessionExecutionRow>(
             r#"
-            select execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
             from session_executions
             where thread_key = $1 and status in ($2, $3)
             order by created_at desc, execution_id desc
@@ -232,7 +232,7 @@ impl PgSessionStore {
     ) -> Result<Option<SessionExecution>, SessionStoreError> {
         let row = sqlx::query_as::<_, SessionExecutionRow>(
             r#"
-            select execution_id, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
             from session_executions
             where thread_key = $1
             order by created_at desc, execution_id desc


### PR DESCRIPTION
`active_execution_for_thread` and `latest_execution_for_thread` map results to `SessionExecutionRow`, which has an `idempotency_key` field (`FromRow` matches by name), but their `SELECT` lists omitted the column. sqlx then fails with `no column found for name: idempotency_key`.

The session stdout pump calls `active_execution_for_thread` for every session, so the pump dies on the first read and never emits output events: the Slack bot opens the event stream and sits at "thinking" forever without posting. The write/RETURNING queries already selected the column; only these two reads were missed when `idempotency_key` was introduced.