### PR TITLE
fix(slackbotv2): render api-rs terminal result text

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -116,6 +116,36 @@ describe('CodexAppServerRendererEventMapper', () => {
     })
   })
 
+  it('hydrates final answer text from Rust execution completion payloads', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+    mapper.process({
+      eventKind: 'session.output.line',
+      data: JSON.stringify({
+        type: 'item.started',
+        item: { id: 'cmd-1', type: 'commandExecution', command: 'true' }
+      })
+    })
+
+    const events = mapper.process({
+      eventKind: 'session.execution_completed',
+      data: {
+        execution_id: 'exe-1',
+        result_text: 'TERMINAL_RESULT_OK'
+      }
+    })
+
+    expect(events).toContainEqual({
+      type: 'renderer.message.delta',
+      delta: 'TERMINAL_RESULT_OK',
+      force: true,
+      planPrefix: true
+    })
+    expect(events.at(-1)).toMatchObject({
+      type: 'renderer.done',
+      answerMarkdown: 'TERMINAL_RESULT_OK'
+    })
+  })
+
   it('maps app-server agent message deltas keyed by turnId', () => {
     const mapper = new CodexAppServerRendererEventMapper()
     const events = mapper.process({

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -96,7 +96,7 @@ export class CodexAppServerRendererEventMapper
 
     const rustMapped = rustSessionEventToServerNotification(source)
     if (rustMapped?.kind === 'failed') return this.fail(rustMapped.error)
-    if (rustMapped?.kind === 'completed') return this.flush()
+    if (rustMapped?.kind === 'completed') return this.complete(rustMapped.resultText)
     if (rustMapped?.kind === 'notification') return this.processNotification(rustMapped.notification)
 
     if (!isRecord(source)) return []
@@ -120,6 +120,20 @@ export class CodexAppServerRendererEventMapper
       threadId: this.state.threadId || undefined
     })
     return out
+  }
+
+  private complete(resultText?: string): RendererEvent[] {
+    if (this.state.done) return []
+    const normalized = resultText?.trim() ?? ''
+    if (normalized && !this.state.answerText.trim()) {
+      const out: RendererEvent[] = []
+      this.state.harnessAnswerText += normalized
+      recomposeBuffers(this.state)
+      this.emitPendingAssistantText(out, { force: true })
+      out.push(...this.flush())
+      return out
+    }
+    return this.flush()
   }
 
   isDone(): boolean {
@@ -593,7 +607,7 @@ async function* renderChatSdkChunks(
 export type RustSessionMappingResult =
   | { kind: 'notification'; notification: ServerNotification }
   | { kind: 'failed'; error: string }
-  | { kind: 'completed' }
+  | { kind: 'completed'; resultText?: string }
   | null
 
 export function rustSessionEventToServerNotification(source: unknown): RustSessionMappingResult {
@@ -634,7 +648,12 @@ export function rustSessionEventToServerNotification(source: unknown): RustSessi
     eventKind === 'session.execution_completed' ||
     eventKind === 'session.execution_cancelled'
   ) {
-    return { kind: 'completed' }
+    const data = isRecord(source.data) ? source.data : source
+    const resultText = terminalResultText(data).trim()
+    return {
+      kind: 'completed',
+      ...(resultText ? { resultText } : {})
+    }
   }
 
   return null

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -571,6 +571,75 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('renders api-rs completion result text when no final answer delta streamed', async () => {
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before a terminal completion.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> complete from terminal payload`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-terminal-result-text',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> complete from terminal payload`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    codexApi.emitOutputLine(
+      threadKey(parent.ts),
+      JSON.stringify({
+        type: 'item.started',
+        item: {
+          id: 'cmd-1',
+          type: 'commandExecution',
+          command: 'true',
+          status: 'inProgress'
+        }
+      })
+    )
+    codexApi.emitOutputLine(
+      threadKey(parent.ts),
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-1',
+          type: 'commandExecution',
+          command: 'true',
+          status: 'completed',
+          aggregatedOutput: ''
+        }
+      })
+    )
+    codexApi.emitSessionEvent(threadKey(parent.ts), 'session.execution_completed', {
+      execution_id: 'exe-terminal-result',
+      status: 'completed',
+      result_text: 'TERMINAL_RESULT_VISIBLE'
+    })
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts).toHaveLength(1)
+    const renderedText = transcripts[0]!.chunks.map(chunkText).filter(Boolean).join('\n')
+    expect(renderedText).toContain('Command execution')
+    expect(renderedText).toContain('TERMINAL_RESULT_VISIBLE')
+    expect(renderedText).not.toContain('Execution completed, but no final text was captured.')
+  })
+
   it('does not duplicate final text when execution completion follows final answer deltas', async () => {
     codexApi.autoRespond = false
 


### PR DESCRIPTION
## Problem

Slackbotv2 currently treats Rust `session.execution_completed` as a pure close signal. If api-rs provides terminal result text on that event and no final-answer delta was streamed, Slack still renders the generic empty-final fallback.

## Fix

- Let the renderer hydrate final answer text from `session.execution_completed.data.result_text`.
- Preserve the no-duplicate path when final-answer deltas already streamed.
- Add Slackbotv2 emulator coverage proving the terminal result becomes visible Slack text.

## Test Plan

- `pnpm --filter @centaur/rendering test -- codex-app-server.test.ts`
- `pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts`
- `pnpm --filter slackbotv2 check:types`
- `git diff --check`
