### PR TITLE
fix(slackbot): stop splicing stale residue into streamed replies

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { AgentSessionRenderer, withAgentSessionLock } from './agent-session'
+import {
+  AgentSessionRenderer,
+  unstreamedMarkdownAfterLivePrefix,
+  withAgentSessionLock
+} from './agent-session'
 
 describe('AgentSessionRenderer', () => {
   it('stops calling assistant.threads.setStatus after the channel returns user_not_found', async () => {
@@ -859,3 +863,39 @@ async function waitUntil(predicate: () => boolean): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 0))
   }
 }
+
+describe('unstreamedMarkdownAfterLivePrefix (long-answer finalize path)', () => {
+  // For long answers (streamed past the live cap) closeTextStream appends only the *unstreamed
+  // remainder* as the final block, because Slack accumulates the live chunks. This helper computes
+  // that remainder. Regression (bug B): when the canonical answer no longer extends the streamed
+  // text, it must NOT fall back to a misaligned char-count slice, which spliced garbled residue.
+
+  it('returns the exact tail when the streamed text is a prefix', () => {
+    expect(
+      unstreamedMarkdownAfterLivePrefix('Hello world. Then the tail.', 'Hello world. ')
+    ).toBe('Then the tail.')
+  })
+
+  it('handles a whitespace-normalized prefix', () => {
+    // Streamed text carries trailing spaces the canonical lacks (markdown normalization).
+    expect(
+      unstreamedMarkdownAfterLivePrefix('Line one\nLine two and the tail', 'Line one   \nLine two')
+    ).toBe('and the tail')
+  })
+
+  it('returns nothing when the streamed text already covers the whole answer', () => {
+    expect(unstreamedMarkdownAfterLivePrefix('Same text.', 'Same text.')).toBe('')
+  })
+
+  it('emits the remainder after the longest common prefix when the answer diverges', () => {
+    // The model reformatted already-streamed content, so the streamed text is no longer a prefix.
+    // The old fallback sliced by the streamed char count -> a misaligned mid-token fragment. The
+    // fix slices at the longest common prefix, yielding a clean continuation with no draft residue.
+    const streamed = 'Here is the answer: the result is 42 (streamed draft).'
+    const canonical = 'Here is the answer: the result is forty-two (reformatted final).'
+    const out = unstreamedMarkdownAfterLivePrefix(canonical, streamed)
+    expect(out).toBe('forty-two (reformatted final).')
+    expect(out).not.toContain('streamed draft')
+    expect(out.startsWith('forty-two')).toBe(true)
+  })
+})

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -650,23 +650,35 @@ function finalMarkdownForFinalBlocks(
   if (opts.includeStreamedText || !segment.streamedText.trim()) {
     return clipText(trimmed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
   }
-  const streamedPrefix = unstreamedMarkdownAfterLivePrefix(markdown, segment.streamedText)
-  if (streamedPrefix !== null) {
-    return clipText(streamedPrefix, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
-  }
-  const unstreamed = markdown.slice(segment.streamedTextSourceChars).trim()
+  const unstreamed = unstreamedMarkdownAfterLivePrefix(markdown, segment.streamedText)
   if (!unstreamed) return ''
   return clipText(unstreamed, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
 }
 
-function unstreamedMarkdownAfterLivePrefix(markdown: string, streamedText: string): string | null {
-  if (!streamedText.trim()) return null
+// Returns the portion of the final answer to append as the composed final block — the answer
+// beyond what was already streamed live. Slack accumulates the live appendStream chunks, so the
+// final block must be the *continuation*, not the whole answer (which would duplicate the streamed
+// prefix). When the streamed text is a (whitespace-normalized) prefix of the answer, this is the
+// exact unstreamed tail. When the model reformatted or rewrote already-streamed content, the
+// streamed text is no longer a clean prefix — rather than a char-count slice (misaligned, which
+// splices garbled residue into long replies), emit the answer beyond the LONGEST COMMON PREFIX
+// with the streamed text: drop what the live stream already showed and render only the genuinely
+// new remainder, accepting a small overlap at the divergence point instead of garbage.
+export function unstreamedMarkdownAfterLivePrefix(markdown: string, streamedText: string): string {
+  if (!streamedText.trim()) return markdown.trim()
   if (markdown.startsWith(streamedText)) return markdown.slice(streamedText.length).trim()
 
   const normalizedMarkdown = normalizeFinalMarkdownPrefix(markdown)
   const normalizedStreamed = normalizeFinalMarkdownPrefix(streamedText)
-  if (!normalizedMarkdown.startsWith(normalizedStreamed)) return null
-  return normalizedMarkdown.slice(normalizedStreamed.length).trim()
+  const commonLen = commonPrefixLength(normalizedMarkdown, normalizedStreamed)
+  return normalizedMarkdown.slice(commonLen).trim()
+}
+
+function commonPrefixLength(a: string, b: string): number {
+  const max = Math.min(a.length, b.length)
+  let i = 0
+  while (i < max && a.charCodeAt(i) === b.charCodeAt(i)) i += 1
+  return i
 }
 
 function normalizeFinalMarkdownPrefix(markdown: string): string {

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -1973,3 +1973,105 @@ function makeFakeSlackClient(
     }
   }
 }
+
+function markdownTextFromStream(calls: Array<{ method: string; params: any }>): string {
+  return calls
+    .filter(call => call.method === 'chat.startStream' || call.method === 'chat.appendStream')
+    .flatMap(call => call.params.chunks ?? [])
+    .filter((chunk: any) => chunk.type === 'markdown_text')
+    .map((chunk: any) => String(chunk.text ?? ''))
+    .join('')
+}
+
+function markdownTextFromStopBlocks(calls: Array<{ method: string; params: any }>): string {
+  const stop = calls.find(call => call.method === 'chat.stopStream')
+  return (stop?.params.blocks ?? [])
+    .filter((block: any) => block.type === 'markdown')
+    .map((block: any) => String(block.text ?? ''))
+    .join('')
+}
+
+describe('CodexSessionRenderer answer-stream divergence', () => {
+  // A tool task makes hasPlan true so answer deltas stream live immediately (rather than waiting
+  // out the pre-stream grace window), and an item.started registers the answer phase so the
+  // agentMessage deltas route to the answer buffer.
+  const TOOL_EVENT = {
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }] }
+  }
+  const ITEM_STARTED = {
+    type: 'item.started',
+    item: { id: 'a1', type: 'agentMessage', phase: 'final_answer' }
+  }
+
+  async function openSession(client: Record<string, unknown>) {
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    return sessionId
+  }
+
+  it('does not splice misaligned canonical residue when item.completed rewrites streamed text', async () => {
+    // Regression: when the recomposed canonical answer no longer EXTENDS what was already streamed
+    // (an item's accumulated deltas replaced by reformatted canonical text), publishPendingAssistantText
+    // used to slice at the stale offset (answerText.slice(streamedAnswerText.length)) and append that
+    // misaligned fragment to the non-retractable Slack stream — the garbled residue users saw. The fix
+    // detects the divergence and freezes the live answer stream, so the coherent already-streamed text
+    // stands and no misaligned canonical fragment reaches the message.
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const sessionId = await openSession(client)
+    const renderer = new CodexSessionRenderer(client as any)
+
+    // CANONICAL deliberately does NOT extend DRAFT (divergence). With the bug, the misaligned
+    // delta CANONICAL.slice(DRAFT.length) leaks the unique tail token 'SENTINEL_ZZZ' into the
+    // delivered message.
+    const DRAFT = 'PROVISIONAL_DRAFT_TEXT'
+    const CANONICAL = 'COMPLETELY_DIFFERENT_CANONICAL_SENTINEL_ZZZ'
+
+    await renderer.event(sessionId, TOOL_EVENT)
+    await renderer.event(sessionId, ITEM_STARTED)
+    await renderer.event(sessionId, { type: 'item.agentMessage.delta', item_id: 'a1', delta: DRAFT })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: { id: 'a1', type: 'agentMessage', phase: 'final_answer', text: CANONICAL }
+    })
+    await renderer.event(sessionId, { type: 'result', text: CANONICAL })
+
+    // The provisional answer streamed live (the divergence scenario is real)...
+    expect(markdownTextFromStream(calls)).toContain('PROVISIONAL_DRAFT_TEXT')
+    // ...and nowhere in the delivered message (live chunks + final blocks) does a misaligned
+    // fragment of the divergent canonical appear.
+    expect(visibleMarkdown(calls)).not.toContain('SENTINEL_ZZZ')
+  })
+
+  it('keeps streaming live (no canonical re-render) when the answer only grows by appending', async () => {
+    // Guard against false-positive divergence: when the canonical answer equals what was streamed,
+    // the live stream is authoritative and must NOT be re-rendered as a final answer block.
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const sessionId = await openSession(client)
+    const renderer = new CodexSessionRenderer(client as any)
+
+    const ANSWER = 'NORMAL-APPEND-CASE-123'
+
+    await renderer.event(sessionId, TOOL_EVENT)
+    await renderer.event(sessionId, ITEM_STARTED)
+    await renderer.event(sessionId, { type: 'item.agentMessage.delta', item_id: 'a1', delta: ANSWER })
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: { id: 'a1', type: 'agentMessage', phase: 'final_answer', text: ANSWER }
+    })
+    await renderer.event(sessionId, { type: 'result', text: ANSWER })
+
+    // Streamed live exactly once, and not duplicated into a final answer block.
+    const streamed = markdownTextFromStream(calls)
+    expect(streamed).toContain('NORMAL-APPEND-CASE-123')
+    expect(countOccurrences(streamed, 'NORMAL-APPEND-CASE-123')).toBe(1)
+    expect(markdownTextFromStopBlocks(calls)).not.toContain('NORMAL-APPEND-CASE-123')
+  })
+})

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -41,6 +41,7 @@ type CodexSessionState = {
   streamedCommentaryText: string
   streamedAnswerText: string
   deliveredAnswerChars: number
+  answerStreamDiverged: boolean
   agentMessagePhase: AgentMessagePhase | null
   agentMessagePhaseByItemId: Map<string, AgentMessagePhase>
   planText: string
@@ -304,6 +305,24 @@ export class CodexSessionRenderer {
     if (!canStream) return
 
     if (state.commentaryText.length > state.streamedCommentaryText.length) return
+    // Live deltas are appended to a Slack stream that cannot be retracted, so streaming is only
+    // safe while the recomposed answer still EXTENDS what we already streamed. recomposeBuffers
+    // can rewrite earlier content (an item's accumulated deltas replaced by reformatted canonical
+    // text on item.completed, or a canonical `assistant` event), making answerText diverge from
+    // streamedAnswerText. Slicing at the now-stale offset would splice garbled residue into the
+    // message, so on divergence we stop streaming the answer: the coherent text already streamed
+    // stands as the final reply, instead of appending a misaligned fragment we cannot take back.
+    if (!state.answerText.startsWith(state.streamedAnswerText)) {
+      if (!state.answerStreamDiverged) {
+        state.answerStreamDiverged = true
+        logInfo('slack_codex_answer_stream_diverged', {
+          agent_session_id: agentSessionId,
+          streamed_answer_chars: state.streamedAnswerText.length,
+          canonical_answer_chars: state.answerText.length
+        })
+      }
+      return
+    }
     if (state.answerText.length <= state.streamedAnswerText.length) return
     const delta = state.answerText.slice(state.streamedAnswerText.length)
     if (!delta) return
@@ -365,6 +384,7 @@ function getState(agentSessionId: string): CodexSessionState {
       streamedCommentaryText: '',
       streamedAnswerText: '',
       deliveredAnswerChars: 0,
+      answerStreamDiverged: false,
       agentMessagePhase: null,
       agentMessagePhaseByItemId: new Map(),
       planText: '',


### PR DESCRIPTION
## Symptom

Slackbot live replies occasionally arrive with garbled, misformatted residue spliced into an otherwise-correct answer — a misaligned fragment of text jammed in, then the real content. Each turn has its own `CodexSessionState`, so it isn't cross-turn buffer reuse; it's an offset bug in the live-reply assembler.

Two related sites both assumed the answer text only grows by **pure append**, while `recomposeBuffers` can **rewrite** already-streamed content (an `item.completed` replaces an item's accumulated deltas with reformatted canonical text, or a canonical `assistant` event). Slack's `appendStream` accumulates and **cannot be retracted**, so any misaligned text becomes permanent.

## Fix 1 — live streaming (`codex-session.ts`)

`publishPendingAssistantText` streamed `answerText.slice(streamedAnswerText.length)`. When the recomposed answer no longer **extends** what was already streamed, that slice is misaligned. Guard it: if `answerText` no longer `startsWith` `streamedAnswerText`, the stream has diverged — **freeze the answer stream** (logging `slack_codex_answer_stream_diverged` once) instead of appending misaligned text. The coherent already-streamed text stands.

## Fix 2 — long-answer finalize path (`agent-session.ts`)

For **long** answers (streamed past the 30k live cap), `closeTextStream` appends only the *unstreamed remainder* as the final composed block (Slack already shows the live chunks). `finalMarkdownForFinalBlocks` computed that remainder, but fell back to `markdown.slice(segment.streamedTextSourceChars)` when the streamed text wasn't a prefix of the canonical answer — a char-count slice that's **misaligned on divergence**, splicing garbled residue into the final block.

`unstreamedMarkdownAfterLivePrefix` now always returns the answer beyond the **longest common (normalized) prefix** with the streamed text: the exact unstreamed tail when the streamed text is a prefix, and a clean continuation (no misaligned slice) when the model reformatted already-streamed content.

Both fixes are Slack-semantics-agnostic — they simply never emit content that can't be cleanly appended to the accumulating stream. (A "re-render the canonical at finalize" approach was rejected: `stopStream` blocks are additive to the `appendStream` chunks — the long-answer path slices off the streamed prefix precisely to avoid re-sending it — so re-rendering would duplicate, not replace.)

## Tests (`*.test.ts`)

- **divergence (streaming):** a divergent `item.completed` no longer leaks a misaligned canonical fragment into the delivered message; the normal append-only path still streams live.
- **finalize remainder:** `unstreamedMarkdownAfterLivePrefix` returns the exact tail for an (optionally whitespace-normalized) prefix, empty when fully covered, and a clean longest-common-prefix continuation on divergence (no mid-token residue).

```
bun test src/*.test.ts src/**/*.test.ts   # 103 pass, 0 fail
bunx tsc --noEmit                          # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
