### PR TITLE
fix(slackbotv2): defer Slack stream until visible output

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -15,6 +15,7 @@ import { createPostgresState } from '@chat-adapter/state-pg'
 import {
   codexAppServerToChatSdkStream,
   type CodexAppServerToChatStreamOptions,
+  type ChatSDKStreamChunk,
   type RendererEvent
 } from '@centaur/rendering'
 import {
@@ -664,9 +665,13 @@ async function renderExecutionStream(
     phase_ms: elapsedMs(titleStartedAtMs)
   })
   try {
+    const visibleStream = await streamAfterFirstChunk(
+      codexAppServerToChatSdkStream(stream, rendererOptions(thread, options))
+    )
+    if (!visibleStream) return
     await thread.post(
       new StreamingPlan(
-        codexAppServerToChatSdkStream(stream, rendererOptions(thread, options)),
+        visibleStream,
         { groupTasks: options.streamTaskDisplayMode ?? 'plan' }
       )
     )
@@ -689,9 +694,13 @@ async function renderRecoveredExecutionStream(
     phase_ms: elapsedMs(titleStartedAtMs)
   })
   try {
+    const visibleStream = await streamAfterFirstChunk(
+      codexAppServerToChatSdkStream(stream, rendererOptions(thread, options))
+    )
+    if (!visibleStream) return
     await thread.adapter.stream!(
       thread.id,
-      codexAppServerToChatSdkStream(stream, rendererOptions(thread, options)),
+      visibleStream,
       {
         recipientTeamId: message.teamId,
         recipientUserId: message.author.userId,
@@ -700,6 +709,25 @@ async function renderRecoveredExecutionStream(
     )
   } finally {
     await setAssistantStatus(thread, '')
+  }
+}
+
+async function streamAfterFirstChunk(
+  stream: AsyncIterable<ChatSDKStreamChunk>
+): Promise<AsyncIterable<ChatSDKStreamChunk> | null> {
+  const iterator = stream[Symbol.asyncIterator]()
+  const first = await iterator.next()
+  if (first.done) return null
+
+  return {
+    async *[Symbol.asyncIterator](): AsyncIterator<ChatSDKStreamChunk> {
+      yield first.value
+      for (;;) {
+        const next = await iterator.next()
+        if (next.done) return
+        yield next.value
+      }
+    }
   }
 }
 

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -640,6 +640,50 @@ describe('slackbotv2', () => {
     expect(renderedText).not.toContain('Execution completed, but no final text was captured.')
   })
 
+  it('does not create an empty Slack stream before the first visible renderer chunk', async () => {
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before a silent execution.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> wait for actual output`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-no-empty-stream-before-output',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> wait for actual output`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+    await sleep(50)
+    expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
+
+    codexApi.emitSessionEvent(threadKey(parent.ts), 'session.execution_completed', {
+      execution_id: 'exe-delayed-visible-output',
+      status: 'completed',
+      result_text: 'DELAYED_VISIBLE_OUTPUT'
+    })
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts).toHaveLength(1)
+    const renderedText = transcripts[0]!.chunks.map(chunkText).filter(Boolean).join('\n')
+    expect(renderedText).toContain('DELAYED_VISIBLE_OUTPUT')
+  })
+
   it('does not duplicate final text when execution completion follows final answer deltas', async () => {
     codexApi.autoRespond = false
 


### PR DESCRIPTION
## Summary
- wait for the first rendered Chat SDK chunk before opening Slack streaming
- keep assistant title/status updates immediate while avoiding blank Slack stream messages
- add a Slackbot v2 emulator regression for silent api-rs executions that only produce terminal result text

## Tests
- pnpm --filter slackbotv2 test
- pnpm --filter slackbotv2 check:types