### PR TITLE
fix(slackbotv2): bound Slack task stream payloads

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -82,6 +82,7 @@ const RENDER_INDEX_TTL_MS = 30 * 24 * 60 * 60 * 1000
 const RENDER_RECOVERY_LEASE_TTL_MS = 2 * 60 * 1000
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
 const RENDER_RETRY_MAX_DELAY_MS = 5_000
+const SLACK_TASK_FIELD_MAX_CHARS = 2_500
 
 export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   const userName = options.userName ?? 'centaur'
@@ -666,7 +667,7 @@ async function renderExecutionStream(
   })
   try {
     const visibleStream = await streamAfterFirstChunk(
-      codexAppServerToChatSdkStream(stream, rendererOptions(thread, options))
+      slackSafeChatSdkStream(codexAppServerToChatSdkStream(stream, rendererOptions(thread, options)))
     )
     if (!visibleStream) return
     await thread.post(
@@ -695,7 +696,7 @@ async function renderRecoveredExecutionStream(
   })
   try {
     const visibleStream = await streamAfterFirstChunk(
-      codexAppServerToChatSdkStream(stream, rendererOptions(thread, options))
+      slackSafeChatSdkStream(codexAppServerToChatSdkStream(stream, rendererOptions(thread, options)))
     )
     if (!visibleStream) return
     await thread.adapter.stream!(
@@ -710,6 +711,31 @@ async function renderRecoveredExecutionStream(
   } finally {
     await setAssistantStatus(thread, '')
   }
+}
+
+async function* slackSafeChatSdkStream(
+  stream: AsyncIterable<ChatSDKStreamChunk>
+): AsyncIterable<ChatSDKStreamChunk> {
+  for await (const chunk of stream) {
+    yield slackSafeChatSdkChunk(chunk)
+  }
+}
+
+function slackSafeChatSdkChunk(chunk: ChatSDKStreamChunk): ChatSDKStreamChunk {
+  if (chunk.type !== 'task_update') return chunk
+  return {
+    ...chunk,
+    ...(chunk.details ? { details: truncateSlackTaskField(chunk.details) } : {}),
+    ...(chunk.output ? { output: truncateSlackTaskField(chunk.output) } : {})
+  }
+}
+
+function truncateSlackTaskField(value: string): string {
+  if (value.length <= SLACK_TASK_FIELD_MAX_CHARS) return value
+  const omitted = value.length - SLACK_TASK_FIELD_MAX_CHARS
+  const suffix = `\n[truncated ${omitted} chars from Slack task output]`
+  const keep = Math.max(0, SLACK_TASK_FIELD_MAX_CHARS - suffix.length)
+  return `${value.slice(0, keep).trimEnd()}${suffix}`
 }
 
 async function streamAfterFirstChunk(

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -755,6 +755,104 @@ describe('slackbotv2', () => {
     ).toHaveLength(1)
   })
 
+  it('truncates large structured task output so final markdown still delivers', async () => {
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before large task output.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> keep final text visible`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-large-task-output',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> keep final text visible`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    const largeOutput = 'large-context-line\n'.repeat(600)
+    codexApi.emitOutputLine(
+      threadKey(parent.ts),
+      JSON.stringify({
+        type: 'item.started',
+        item: {
+          id: 'cmd-large',
+          type: 'commandExecution',
+          command: 'slack thread --json',
+          status: 'inProgress'
+        }
+      })
+    )
+    codexApi.emitOutputLine(
+      threadKey(parent.ts),
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-large',
+          type: 'commandExecution',
+          command: 'slack thread --json',
+          status: 'completed',
+          aggregatedOutput: largeOutput
+        }
+      })
+    )
+    codexApi.emitOutputLine(
+      threadKey(parent.ts),
+      JSON.stringify({
+        type: 'item.started',
+        item: {
+          id: 'answer-large',
+          type: 'agentMessage',
+          text: '',
+          phase: 'final_answer'
+        }
+      })
+    )
+    codexApi.emitOutputLine(
+      threadKey(parent.ts),
+      JSON.stringify({
+        type: 'item.agentMessage.delta',
+        itemId: 'answer-large',
+        delta: 'LARGE_TASK_FINAL_VISIBLE'
+      })
+    )
+    codexApi.emitSessionEvent(threadKey(parent.ts), 'session.execution_completed', {
+      execution_id: 'exe-large-task-output',
+      status: 'completed'
+    })
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts).toHaveLength(1)
+    const taskOutputs = transcripts[0]!.chunks
+      .filter(chunk => chunk.type === 'task_update')
+      .map(chunk => stringField(chunk.output))
+      .filter(Boolean)
+    expect(taskOutputs.some(output => output.includes('[truncated'))).toBe(true)
+    expect(taskOutputs.every(output => output.length <= 2500)).toBe(true)
+    const markdownChunks = transcripts[0]!.chunks.filter(chunk => chunk.type === 'markdown_text')
+    expect(markdownChunks).toEqual([
+      {
+        type: 'markdown_text',
+        text: 'LARGE_TASK_FINAL_VISIBLE'
+      }
+    ])
+  })
+
   it('waits for a slow session execute before acknowledging Slack and starting the stream', async () => {
     codexApi.autoRespond = false
     const releaseExecute = codexApi.holdNextExecute()


### PR DESCRIPTION
## Summary
- truncate Slack structured task details/output before streaming to Slack
- keep generic renderer output unchanged; this is only the Slack transport payload
- add a regression covering large task output followed by final markdown delivery

## Evidence
Fresh staging failures on sha-b0571d1 hit `slackbotv2_render_failed` with `msg_too_long` before final markdown was delivered.

## Tests
- pnpm --filter slackbotv2 test
- pnpm --filter slackbotv2 check:types