### PR TITLE
fix(slackbot): deliver the agent answer once at finalize (not incrementally)

### DIFF
--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -747,7 +747,9 @@ describe('CodexSessionRenderer', () => {
     )
     expect(firstTaskIndex).toBeGreaterThanOrEqual(0)
     expect(contextBlockIndex).toBe(-1)
-    expect(firstTextIndex).toBeGreaterThan(firstTaskIndex)
+    // The answer is delivered once at finalize (not streamed incrementally), so the activity task
+    // has streamed but no answer text has streamed yet before the terminal event.
+    expect(firstTextIndex).toBe(-1)
     expect(thinkingBlockText(calls)).toBe('')
 
     await renderer.event(sessionId, { type: 'turn.completed', result: 'Done.' })
@@ -1973,3 +1975,58 @@ function makeFakeSlackClient(
     }
   }
 }
+
+describe('CodexSessionRenderer answer delivered once at finalize', () => {
+  it('does not stream provisional answer deltas and delivers the canonical answer intact when it diverges', async () => {
+    // Regression for "drops the first ~150 chars and back-fills with a duplicated later slice":
+    // previously provisional answer deltas were streamed live, then at finalize the answer was
+    // sliced at the stale streamedAnswerText offset into a reorganized canonical answer — dropping
+    // the real opening and leaving the already-streamed provisional (a later slice) at the top.
+    // Option B delivers the answer only at finalize from the canonical text, so a divergent
+    // recompose cannot drop or duplicate anything.
+    const calls: Array<{ method: string; params: any }> = []
+    const client = makeFakeSlackClient(calls)
+    const { sessionId } = await new AgentSessionRenderer(client as any).open({
+      channel: 'C123',
+      parentTs: '1778866921.505479',
+      recipientTeamId: 'T123',
+      recipientUserId: 'U123',
+      title: 'Centaur execution'
+    })
+    const renderer = new CodexSessionRenderer(client as any)
+
+    const PROVISIONAL = 'PROVISIONAL first draft.'
+    // Canonical reorganizes: a different real opening, with the provisional text now appearing later.
+    const CANONICAL = 'REAL opening line. PROVISIONAL first draft. Plus more.'
+
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
+    })
+    await renderer.event(sessionId, {
+      type: 'item.agentMessage.delta',
+      itemId: 'msg-1',
+      delta: PROVISIONAL
+    })
+    // A command task makes hasPlan true — under the old behavior the provisional answer would
+    // stream live now; with option B it must not.
+    await renderer.event(sessionId, {
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'call demo ping' }
+    })
+    expect(visibleMarkdown(calls)).not.toContain('PROVISIONAL first draft.')
+
+    // Codex finalizes with a reorganized canonical answer, then the turn completes.
+    await renderer.event(sessionId, {
+      type: 'item.completed',
+      item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: CANONICAL }
+    })
+    await renderer.event(sessionId, { type: 'turn.completed', result: CANONICAL })
+
+    const delivered = visibleMarkdown(calls)
+    // Full canonical answer is delivered contiguously (real opening not dropped)...
+    expect(delivered).toContain(CANONICAL)
+    // ...and the later slice that was streamed provisionally is not duplicated at the top.
+    expect(countOccurrences(delivered, 'PROVISIONAL first draft.')).toBe(1)
+  })
+})

--- a/services/slackbot/src/slack/codex-session.ts
+++ b/services/slackbot/src/slack/codex-session.ts
@@ -304,6 +304,14 @@ export class CodexSessionRenderer {
     if (!canStream) return
 
     if (state.commentaryText.length > state.streamedCommentaryText.length) return
+    // Deliver the assistant answer ONCE, at turn finalize (opts.force) — never stream it
+    // incrementally. Streaming provisional answer deltas into Slack's append-only stream is
+    // unsafe: recompose can reorder or reformat already-streamed content, and the stale slice
+    // offset (streamedAnswerText.length) then drops the real opening and back-fills with a
+    // duplicated later slice. At finalize streamedAnswerText is still empty, so `delta` below is
+    // the whole canonical answer, streamed once from its final text — no divergence is possible.
+    // (Activity/plan/thinking still stream live via publishActivitySummary.)
+    if (!opts.force) return
     if (state.answerText.length <= state.streamedAnswerText.length) return
     const delta = state.answerText.slice(state.streamedAnswerText.length)
     if (!delta) return


### PR DESCRIPTION
## Symptom

Slackbot live replies were consistently mangled: the **first ~150 characters dropped and back-filled with a duplicated later slice**. (An earlier intermittent variant of the same root cause was explored in #414.)

## Root cause

The reply assembler streams provisional answer deltas live in `CodexSessionRenderer.publishPendingAssistantText` via `answerText.slice(streamedAnswerText.length)`, assuming the answer only ever grows by append. But `recomposeBuffers` can **reorder/reformat already-streamed content** (a canonical `item.completed`, multi-item recompose). When the recomposed answer no longer matches what was already streamed, the stale slice offset drops the real opening and leaves the already-streamed provisional text (a later slice) at the top. Slack's `appendStream` is append-only, so the bad content can't be retracted.

## Fix

Deliver the answer **once, at turn finalize**, from the canonical text — never stream it incrementally. Answer streaming is gated on `opts.force`, which only the finalize calls pass; at finalize `streamedAnswerText` is still empty, so the delta is the whole final answer streamed once → no offset arithmetic, no divergence possible. Activity / plan / thinking still stream live.

```ts
if (state.commentaryText.length > state.streamedCommentaryText.length) return
if (!opts.force) return   // answer is delivered once at finalize, from canonical text
if (state.answerText.length <= state.streamedAnswerText.length) return
const delta = state.answerText.slice(state.streamedAnswerText.length)
```

**Trade-off:** the answer appears when the turn completes rather than token-by-token. Chosen over the alternative (`chat.update`-replacing the message at finalize) as the simpler, lower-risk option that doesn't depend on Slack `stopStream`/`update` replace-vs-append semantics.

## Tests

- A divergent `item.completed` no longer drops the opening or duplicates a later slice.
- The answer is not streamed mid-turn even once `hasPlan`/grace would have allowed it (updated the mid-turn-ordering test to match).
- `bun test src/*.test.ts src/**/*.test.ts` → **98 pass, 0 fail**; `bunx tsc --noEmit` → clean.

## Supersedes #414

#414 tried to fix this inside the incremental-streaming math (freeze the stream on divergence). That regressed in production: `answerText` is non-monotonic — it transiently shrinks then grows during recompose — so the guard froze the stream and **truncated** long replies to the pre-divergence fragment. Option B avoids the incremental path entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
