### PR TITLE
fix(slackbotv2): omit task output from Slack streams

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -82,7 +82,7 @@ const RENDER_INDEX_TTL_MS = 30 * 24 * 60 * 60 * 1000
 const RENDER_RECOVERY_LEASE_TTL_MS = 2 * 60 * 1000
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
 const RENDER_RETRY_MAX_DELAY_MS = 5_000
-const SLACK_TASK_FIELD_MAX_CHARS = 2_500
+const SLACK_TASK_DETAILS_MAX_CHARS = 500
 
 export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   const userName = options.userName ?? 'centaur'
@@ -723,18 +723,19 @@ async function* slackSafeChatSdkStream(
 
 function slackSafeChatSdkChunk(chunk: ChatSDKStreamChunk): ChatSDKStreamChunk {
   if (chunk.type !== 'task_update') return chunk
+  const { output: _output, details, ...safeChunk } = chunk
+  void _output
   return {
-    ...chunk,
-    ...(chunk.details ? { details: truncateSlackTaskField(chunk.details) } : {}),
-    ...(chunk.output ? { output: truncateSlackTaskField(chunk.output) } : {})
+    ...safeChunk,
+    ...(details ? { details: truncateSlackTaskField(details) } : {})
   }
 }
 
 function truncateSlackTaskField(value: string): string {
-  if (value.length <= SLACK_TASK_FIELD_MAX_CHARS) return value
-  const omitted = value.length - SLACK_TASK_FIELD_MAX_CHARS
-  const suffix = `\n[truncated ${omitted} chars from Slack task output]`
-  const keep = Math.max(0, SLACK_TASK_FIELD_MAX_CHARS - suffix.length)
+  if (value.length <= SLACK_TASK_DETAILS_MAX_CHARS) return value
+  const omitted = value.length - SLACK_TASK_DETAILS_MAX_CHARS
+  const suffix = `\n[truncated ${omitted} chars from Slack task details]`
+  const keep = Math.max(0, SLACK_TASK_DETAILS_MAX_CHARS - suffix.length)
   return `${value.slice(0, keep).trimEnd()}${suffix}`
 }
 

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -253,7 +253,7 @@ describe('slackbotv2', () => {
     expect(text).toContain('Inspecting the event stream')
     expect(text).toContain('Command execution')
     expect(text).toContain('pnpm test')
-    expect(text).toContain('tests passed')
+    expect(text).not.toContain('tests passed')
     expect(text).toContain('Executed request 1.')
     expect(text).toContain('Executed request 2.')
 
@@ -755,7 +755,7 @@ describe('slackbotv2', () => {
     ).toHaveLength(1)
   })
 
-  it('truncates large structured task output so final markdown still delivers', async () => {
+  it('omits large structured task output so final markdown still delivers', async () => {
     codexApi.autoRespond = false
 
     const parent = await postUserMessage('Context before large task output.')
@@ -785,31 +785,33 @@ describe('slackbotv2', () => {
     await waitFor(() => codexApi.streamCount === 1)
 
     const largeOutput = 'large-context-line\n'.repeat(600)
-    codexApi.emitOutputLine(
-      threadKey(parent.ts),
-      JSON.stringify({
-        type: 'item.started',
-        item: {
-          id: 'cmd-large',
-          type: 'commandExecution',
-          command: 'slack thread --json',
-          status: 'inProgress'
-        }
-      })
-    )
-    codexApi.emitOutputLine(
-      threadKey(parent.ts),
-      JSON.stringify({
-        type: 'item.completed',
-        item: {
-          id: 'cmd-large',
-          type: 'commandExecution',
-          command: 'slack thread --json',
-          status: 'completed',
-          aggregatedOutput: largeOutput
-        }
-      })
-    )
+    for (let index = 0; index < 6; index += 1) {
+      codexApi.emitOutputLine(
+        threadKey(parent.ts),
+        JSON.stringify({
+          type: 'item.started',
+          item: {
+            id: `cmd-large-${index}`,
+            type: 'commandExecution',
+            command: `slack thread --json --page ${index}`,
+            status: 'inProgress'
+          }
+        })
+      )
+      codexApi.emitOutputLine(
+        threadKey(parent.ts),
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: `cmd-large-${index}`,
+            type: 'commandExecution',
+            command: `slack thread --json --page ${index}`,
+            status: 'completed',
+            aggregatedOutput: largeOutput
+          }
+        })
+      )
+    }
     codexApi.emitOutputLine(
       threadKey(parent.ts),
       JSON.stringify({
@@ -838,12 +840,16 @@ describe('slackbotv2', () => {
     await Promise.all(waits)
     const transcripts = slackStreamTranscripts(slackApi.calls)
     expect(transcripts).toHaveLength(1)
-    const taskOutputs = transcripts[0]!.chunks
-      .filter(chunk => chunk.type === 'task_update')
-      .map(chunk => stringField(chunk.output))
-      .filter(Boolean)
-    expect(taskOutputs.some(output => output.includes('[truncated'))).toBe(true)
-    expect(taskOutputs.every(output => output.length <= 2500)).toBe(true)
+    const taskChunks = transcripts[0]!.chunks.filter(chunk => chunk.type === 'task_update')
+    expect(taskChunks).not.toHaveLength(0)
+    expect(taskChunks.every(chunk => stringField(chunk.output) === '')).toBe(true)
+    expect(taskChunks.every(chunk => !chunkText(chunk).includes('large-context-line'))).toBe(true)
+    expect(
+      taskChunks
+        .map(chunk => stringField(chunk.details))
+        .filter(Boolean)
+        .every(details => details.length <= 500)
+    ).toBe(true)
     const markdownChunks = transcripts[0]!.chunks.filter(chunk => chunk.type === 'markdown_text')
     expect(markdownChunks).toEqual([
       {
@@ -2336,14 +2342,11 @@ function expectSlackPlanStreamShape(
         details: expect.stringContaining('pnpm test')
       })
     )
-    expect(progressChunks).toContainEqual(
-      expect.objectContaining({
-        type: 'task_update',
-        id: 'cmd-1',
-        title: '1. Command execution',
-        output: expect.stringContaining('tests passed')
-      })
-    )
+    expect(
+      progressChunks
+        .filter(chunk => chunk.type === 'task_update')
+        .every(chunk => stringField(chunk.output) === '')
+    ).toBe(true)
 
     expect(renderedText).toContain('Implementation plan')
     expect(renderedText).toContain('Inspect App Server events')
@@ -2352,7 +2355,7 @@ function expectSlackPlanStreamShape(
     expect(renderedText).toContain('Inspecting the event stream')
     expect(renderedText).toContain('Command execution')
     expect(renderedText).toContain('pnpm test')
-    expect(renderedText).toContain('tests passed')
+    expect(renderedText).not.toContain('tests passed')
     expect(renderedText.trim().endsWith(answer)).toBe(true)
   }
 }
@@ -2366,7 +2369,7 @@ function expectSlackRenderedReply(text: string, answer: string): void {
   expect(text).toContain('Inspecting the event stream')
   expect(text).toContain('Command execution')
   expect(text).toContain('pnpm test')
-  expect(text).toContain('tests passed')
+  expect(text).not.toContain('tests passed')
   expect(text.trim().endsWith(answer)).toBe(true)
 }
 


### PR DESCRIPTION
## Summary
- omit `task_update.output` before streaming Chat SDK chunks to Slack
- cap Slack task details to 500 chars
- update emulator coverage so multiple huge command outputs cannot enter Slack while final markdown still delivers

## Why
Staging on `sha-8532c20` still reproduced `slack_missing_final` for context-only prompts. The Slackbot v2 logs now show `slackbotv2_render_failed` with Slack `msg_too_long`; the prior 2.5k per-field clamp was not enough because structured task payloads can still exceed Slack adapter/API limits in aggregate before the final markdown chunk is delivered.

Fresh failing examples:
- `exe_e60cfc3a8a1e4cd3958901cf1604d023` / `slack:C0APUQ8U5T9:1780653732.127069`
- `exe_c1c74878052e42fda39870abde70598c` / `slack:C0APUQ8U5T9:1780653761.505139`

## Tests
- `pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts`
- `pnpm --filter slackbotv2 check:types`
- `pnpm --filter slackbotv2 test`