### PR TITLE
fix: preserve final answer for textless turn completion

### DIFF
--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -977,7 +977,7 @@ async fn run_stdout_pump(
 
 #[derive(Default)]
 struct StdoutPumpState {
-    saw_final_answer_by_execution: HashMap<String, bool>,
+    final_answer_text_by_execution: HashMap<String, String>,
     turn_execution_by_id: HashMap<String, String>,
     item_execution_by_id: HashMap<String, String>,
 }
@@ -999,10 +999,10 @@ impl StdoutPumpState {
             }
             if terminal_output(
                 &value,
-                self.saw_final_answer_by_execution
+                self.final_answer_text_by_execution
                     .get(&known_execution_id)
-                    .copied()
-                    .unwrap_or(false),
+                    .map(String::as_str)
+                    .unwrap_or(""),
             )
             .is_some()
             {
@@ -1018,21 +1018,27 @@ impl StdoutPumpState {
 
     fn observe(&mut self, execution_id: &str, line: &str) -> Option<TerminalOutput> {
         let value: Value = serde_json::from_str(line).ok()?;
-        if output_line_carries_final_answer_text(&value) {
-            self.saw_final_answer_by_execution
-                .insert(execution_id.to_owned(), true);
+        if let Some(update) = output_line_final_answer_text(&value) {
+            let text = self
+                .final_answer_text_by_execution
+                .entry(execution_id.to_owned())
+                .or_default();
+            match update {
+                FinalAnswerTextUpdate::Append(delta) => text.push_str(&delta),
+                FinalAnswerTextUpdate::Replace(canonical) => *text = canonical,
+            }
         }
         terminal_output(
             &value,
-            self.saw_final_answer_by_execution
+            self.final_answer_text_by_execution
                 .get(execution_id)
-                .copied()
-                .unwrap_or(false),
+                .map(String::as_str)
+                .unwrap_or(""),
         )
     }
 
     fn forget(&mut self, execution_id: &str) {
-        self.saw_final_answer_by_execution.remove(execution_id);
+        self.final_answer_text_by_execution.remove(execution_id);
         self.turn_execution_by_id
             .retain(|_, mapped_execution_id| mapped_execution_id != execution_id);
         self.item_execution_by_id
@@ -1400,7 +1406,7 @@ fn is_event_stream_attach_race(error: &SessionRuntimeError) -> bool {
     )
 }
 
-fn terminal_output(value: &Value, saw_final_answer_text: bool) -> Option<TerminalOutput> {
+fn terminal_output(value: &Value, prior_final_answer_text: &str) -> Option<TerminalOutput> {
     let method = value.get("method").and_then(Value::as_str);
     let event_type = value.get("type").and_then(Value::as_str);
 
@@ -1413,13 +1419,17 @@ fn terminal_output(value: &Value, saw_final_answer_text: bool) -> Option<Termina
     }
 
     if method == Some("turn/completed") {
-        return Some(completed_turn_terminal_output(value, saw_final_answer_text));
+        return Some(completed_turn_terminal_output(
+            value,
+            prior_final_answer_text,
+        ));
     }
 
     match event_type {
-        Some("turn.completed") => {
-            Some(completed_turn_terminal_output(value, saw_final_answer_text))
-        }
+        Some("turn.completed") => Some(completed_turn_terminal_output(
+            value,
+            prior_final_answer_text,
+        )),
         Some("turn.done") => Some(completed_terminal_output(value, "turn_done")),
         Some("result") => {
             if result_is_failure(value) {
@@ -1434,13 +1444,21 @@ fn terminal_output(value: &Value, saw_final_answer_text: bool) -> Option<Termina
     }
 }
 
-fn completed_turn_terminal_output(value: &Value, saw_final_answer_text: bool) -> TerminalOutput {
+fn completed_turn_terminal_output(value: &Value, prior_final_answer_text: &str) -> TerminalOutput {
     match turn_completion_status(value).as_deref() {
         Some("completed" | "succeeded" | "success") | None => {
-            completed_terminal_output(value, "turn_completed")
+            completed_terminal_output_with_fallback(
+                value,
+                "turn_completed",
+                prior_final_answer_text,
+            )
         }
-        Some(_status) if saw_final_answer_text => {
-            completed_terminal_output(value, "turn_completed")
+        Some(_status) if !prior_final_answer_text.trim().is_empty() => {
+            completed_terminal_output_with_fallback(
+                value,
+                "turn_completed",
+                prior_final_answer_text,
+            )
         }
         Some(status) => TerminalOutput::Failed {
             error: format!("turn completed with status {status} before final answer"),
@@ -1449,7 +1467,20 @@ fn completed_turn_terminal_output(value: &Value, saw_final_answer_text: bool) ->
 }
 
 fn completed_terminal_output(value: &Value, reason: &'static str) -> TerminalOutput {
+    completed_terminal_output_with_fallback(value, reason, "")
+}
+
+fn completed_terminal_output_with_fallback(
+    value: &Value,
+    reason: &'static str,
+    fallback_text: &str,
+) -> TerminalOutput {
     let result_text = terminal_payload_text(value).trim().to_owned();
+    let result_text = if result_text.is_empty() {
+        fallback_text.trim().to_owned()
+    } else {
+        result_text
+    };
     TerminalOutput::Completed {
         reason,
         result_text: (!result_text.is_empty()).then_some(result_text),
@@ -1468,18 +1499,43 @@ fn turn_completion_status(value: &Value) -> Option<String> {
     .next()
 }
 
-fn output_line_carries_final_answer_text(value: &Value) -> bool {
+enum FinalAnswerTextUpdate {
+    Append(String),
+    Replace(String),
+}
+
+fn output_line_final_answer_text(value: &Value) -> Option<FinalAnswerTextUpdate> {
     let method = value.get("method").and_then(Value::as_str);
     let event_type = value.get("type").and_then(Value::as_str);
     if matches!(method, Some("item/agentMessage/delta"))
         || matches!(event_type, Some("item.agentMessage.delta"))
     {
-        return !terminal_payload_text(value).trim().is_empty();
+        let text = terminal_payload_text(value).trim().to_owned();
+        return (!text.is_empty()).then_some(FinalAnswerTextUpdate::Append(text));
     }
     if event_type == Some("assistant") {
-        return !terminal_payload_text(value).trim().is_empty();
+        let text = terminal_payload_text(value).trim().to_owned();
+        return (!text.is_empty()).then_some(FinalAnswerTextUpdate::Replace(text));
     }
-    false
+    if matches!(method, Some("item/completed")) || matches!(event_type, Some("item.completed")) {
+        let item = value
+            .get("item")
+            .or_else(|| value.get("params").and_then(|params| params.get("item")));
+        if let Some(item) = item
+            && matches!(
+                item.get("type").and_then(Value::as_str),
+                Some("agentMessage" | "agent_message")
+            )
+            && matches!(
+                item.get("phase").and_then(Value::as_str),
+                Some("final_answer" | "answer") | None
+            )
+        {
+            let text = terminal_payload_text(item).trim().to_owned();
+            return (!text.is_empty()).then_some(FinalAnswerTextUpdate::Replace(text));
+        }
+    }
+    None
 }
 
 fn turn_ids(value: &Value) -> Vec<String> {
@@ -1936,7 +1992,7 @@ mod tests {
         });
 
         assert_eq!(
-            terminal_output(&event, false),
+            terminal_output(&event, ""),
             Some(TerminalOutput::Completed {
                 reason: "turn_completed",
                 result_text: None
@@ -1955,12 +2011,45 @@ mod tests {
             "params": {"turn": {"id": "turn-1", "status": "completed"}},
         });
 
-        assert!(output_line_carries_final_answer_text(&delta));
+        assert!(matches!(
+            output_line_final_answer_text(&delta),
+            Some(FinalAnswerTextUpdate::Append(_))
+        ));
         assert_eq!(
-            terminal_output(&terminal, true),
+            terminal_output(&terminal, "Final answer"),
             Some(TerminalOutput::Completed {
                 reason: "turn_completed",
-                result_text: None
+                result_text: Some("Final answer".to_owned())
+            })
+        );
+    }
+
+    #[test]
+    fn turn_completed_uses_completed_agent_message_text_when_terminal_is_empty() {
+        let completed = json!({
+            "type": "item.completed",
+            "item": {
+                "id": "msg-final",
+                "type": "agentMessage",
+                "phase": "final_answer",
+                "text": "1. No new findings.\n\n2. No writes were used."
+            }
+        });
+        let terminal = json!({
+            "type": "turn.completed",
+            "turn": {"id": "turn-1", "status": "completed"},
+        });
+
+        let Some(FinalAnswerTextUpdate::Replace(final_text)) =
+            output_line_final_answer_text(&completed)
+        else {
+            panic!("completed agentMessage should replace final answer text")
+        };
+        assert_eq!(
+            terminal_output(&terminal, &final_text),
+            Some(TerminalOutput::Completed {
+                reason: "turn_completed",
+                result_text: Some("1. No new findings.\n\n2. No writes were used.".to_owned())
             })
         );
     }
@@ -1973,7 +2062,7 @@ mod tests {
         });
 
         assert_eq!(
-            terminal_output(&event, false),
+            terminal_output(&event, ""),
             Some(TerminalOutput::Failed {
                 error: "turn completed with status interrupted before final answer".to_owned()
             })
@@ -1988,10 +2077,10 @@ mod tests {
         });
 
         assert_eq!(
-            terminal_output(&event, true),
+            terminal_output(&event, "Final answer"),
             Some(TerminalOutput::Completed {
                 reason: "turn_completed",
-                result_text: None
+                result_text: Some("Final answer".to_owned())
             })
         );
     }
@@ -2004,7 +2093,7 @@ mod tests {
         });
 
         assert_eq!(
-            terminal_output(&event, false),
+            terminal_output(&event, ""),
             Some(TerminalOutput::Completed {
                 reason: "result",
                 result_text: Some("Final answer".to_owned())
@@ -2020,7 +2109,7 @@ mod tests {
         });
 
         assert_eq!(
-            terminal_output(&event, false),
+            terminal_output(&event, ""),
             Some(TerminalOutput::Completed {
                 reason: "turn_done",
                 result_text: Some("Final answer".to_owned())
@@ -2036,7 +2125,7 @@ mod tests {
         });
 
         assert_eq!(
-            terminal_output(&event, false),
+            terminal_output(&event, ""),
             Some(TerminalOutput::Failed {
                 error: "sandbox exited".to_owned()
             })
@@ -2211,6 +2300,30 @@ mod tests {
         );
         assert_eq!(state.execution_for_line(None, delta), None);
         assert_eq!(state.execution_for_line(Some("exe-new"), delta), None);
+    }
+
+    #[test]
+    fn stdout_state_uses_final_agent_message_when_turn_completed_is_textless() {
+        let mut state = StdoutPumpState::default();
+        let started = r#"{"type":"turn.started","turn_id":"turn-1"}"#;
+        let delta = r#"{"type":"item.agentMessage.delta","turnId":"turn-1","itemId":"msg-final","delta":"draft"}"#;
+        let completed = r#"{"type":"item.completed","item":{"id":"msg-final","type":"agentMessage","phase":"final_answer","text":"Final canonical answer."}}"#;
+        let terminal =
+            r#"{"type":"turn.completed","turn":{"id":"turn-1","status":"completed"},"usage":null}"#;
+
+        assert_eq!(
+            state.execution_for_line(Some("exe-1"), started),
+            Some("exe-1".to_owned())
+        );
+        assert_eq!(state.observe("exe-1", delta), None);
+        assert_eq!(state.observe("exe-1", completed), None);
+        assert_eq!(
+            state.observe("exe-1", terminal),
+            Some(TerminalOutput::Completed {
+                reason: "turn_completed",
+                result_text: Some("Final canonical answer.".to_owned())
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
# PR Draft

## Title

```text
fix: preserve final answer for textless Codex turn completion
```

## Body

```markdown
## Summary

- retain per-execution final answer text from Codex `item.agentMessage.delta` events
- replace that buffer with canonical `item.completed` `agentMessage` text for final answers
- use the retained final answer when `turn.completed` is successful but carries no terminal result text
- keep interrupted/textless turns without final-answer text as failures

## Root Cause

Staging reproduced `slack_error_db_completed` in a long-thread follow-up flow. The DB/session stream contained a completed Codex `item.completed` `agentMessage` with final-answer text, immediately followed by a successful `turn.completed` event with no `result`/text field. `centaur-api-rs` finalized the execution from the terminal event only, so final delivery emitted no `result_text` and Slack posted:

`Execution completed, but no final text was captured.`

## Validation

Validated on the local fix branch:

- `cargo fmt -p centaur-session-runtime --check`
- `cargo test -p centaur-session-runtime`
- `cargo test -p centaur-api-server`
- `cargo build --release -p centaur-api-server`

Validated again from a fresh `origin/api-rs-control-plane` worktree by applying the public format patch with `git am`:

- `cargo fmt -p centaur-session-runtime --check`
- `cargo test -p centaur-session-runtime`
- `cargo test -p centaur-api-server`
- `cargo build --release -p centaur-api-server`

Clean worktree release build completed in `5m 34s`.

Validated a third time through the public `authenticated-deploy-prep.sh` helper in local-only mode (`PUSH_BRANCH=0`):

- cloned `origin/api-rs-control-plane`
- applied `0001-fix-preserve-final-answer-for-textless-turn-completion.patch`
- changed only `services/api-rs/crates/centaur-session-runtime/src/lib.rs`
- `cargo fmt -p centaur-session-runtime --check`
- `cargo test -p centaur-session-runtime` (`28` passed)
- `cargo test -p centaur-api-server` (`12` passed)
- `cargo build --release -p centaur-api-server` passed in `5m 31s`
- no push or deploy was performed by the helper

## Branch / Deployment Triage

- The patch applies cleanly to `origin/api-rs-control-plane`.
- The patch conflicts on visible API-RS side branches; see `patch-apply-matrix.md`.
- A scan of `101` fetched `origin/*` refs found no prepared-fix symbols or regression tests; see `remote-ref-fix-scan.md`.
- Public PR/workflow triage found no checked PR or image-publish workflow run containing commit `9572998` or an equivalent API-RS final-answer text retention fix; see `github-pr-workflow-triage.md`.
- Current staging remains on `centaur-api-rs:sha-e391f11`, so post-deploy verification is still blocked.

## Post-Deploy Verification

The image publish workflow is `.github/workflows/publish-images.yml`; it builds `centaur-api-rs` from `services/api-rs/Dockerfile` and publishes `ghcr.io/paradigmxyz/centaur/centaur-api-rs` on `main`, `v*` tags, non-fork PRs, or manual `workflow_dispatch`.

After staging receives a new `centaur-api-rs` image, run:

```bash
RUN_DISCOVERY=1 DISCOVERY_ITERATIONS=20 ./reverify-after-deploy.sh
```

Or to wait for the rollout and then verify:

```bash
POLL_SECONDS=30 MAX_WAIT_SECONDS=1800 RUN_DISCOVERY=1 DISCOVERY_ITERATIONS=20 ./watch-and-reverify.sh
```

The verifier refuses to run against known-bad `sha-e391f11` or before the API deployment is observed and ready.
```

## Artifact References

- Format patch: `0001-fix-preserve-final-answer-for-textless-turn-completion.patch`
- Git bundle: `centaur-api-rs-fix-9572998.bundle`
- Root-cause report: `root-cause-slack-error-db-completed.md`
- Completion audit: `completion-audit.md`
- Completion gate checklist: `completion-gate-checklist.md`
- Authenticated deploy prep: `authenticated-deploy-prep.sh`
- Authenticated deploy prep validation: `authenticated-deploy-prep-validation.md`
- Patch apply matrix: `patch-apply-matrix.md`
- GitHub PR/workflow triage: `github-pr-workflow-triage.md`
- Remote ref fix scan: `remote-ref-fix-scan.md`
- Machine-readable state: `status.json`
