### PR TITLE
fix(slackbotv2): scope session streams to execution

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -126,7 +126,11 @@ async fn stream_events(
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
     let events = state
         .runtime
-        .stream_events(&thread_key, query.after_event_id.unwrap_or(0))
+        .stream_events(
+            &thread_key,
+            query.after_event_id.unwrap_or(0),
+            query.execution_id.as_deref(),
+        )
         .await?;
     let stream = events.map(|result| {
         let sse = match result {

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -40,9 +40,10 @@ pub struct ExecuteSessionResponse {
     pub status: String,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct EventsQuery {
     pub after_event_id: Option<i64>,
+    pub execution_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -102,6 +102,7 @@ struct EventStreamState {
     store: PgSessionStore,
     thread_key: ThreadKey,
     after_event_id: i64,
+    execution_id: Option<String>,
     pending: VecDeque<SessionEvent>,
     listener: SessionEventListener,
     safety_tick: Interval,
@@ -486,6 +487,7 @@ impl SessionRuntime {
         &self,
         thread_key: &ThreadKey,
         after_event_id: i64,
+        execution_id: Option<&str>,
     ) -> Result<
         impl Stream<Item = Result<SessionEvent, SessionRuntimeError>> + use<>,
         SessionRuntimeError,
@@ -502,6 +504,7 @@ impl SessionRuntime {
             self.store.clone(),
             thread_key.clone(),
             after_event_id,
+            execution_id.map(ToOwned::to_owned),
             listener,
         ))
     }
@@ -836,6 +839,7 @@ fn session_event_stream(
     store: PgSessionStore,
     thread_key: ThreadKey,
     after_event_id: i64,
+    execution_id: Option<String>,
     listener: SessionEventListener,
 ) -> impl Stream<Item = Result<SessionEvent, SessionRuntimeError>> {
     stream::unfold(
@@ -843,6 +847,7 @@ fn session_event_stream(
             store,
             thread_key,
             after_event_id,
+            execution_id,
             pending: VecDeque::new(),
             listener,
             safety_tick: {
@@ -866,7 +871,12 @@ fn session_event_stream(
                 }
                 match state
                     .store
-                    .list_events_after(&state.thread_key, state.after_event_id, 100)
+                    .list_events_after(
+                        &state.thread_key,
+                        state.after_event_id,
+                        state.execution_id.as_deref(),
+                        100,
+                    )
                     .await
                 {
                     Ok(events) if events.is_empty() => loop {

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -413,19 +413,23 @@ impl PgSessionStore {
         &self,
         thread_key: &ThreadKey,
         after_event_id: i64,
+        execution_id: Option<&str>,
         limit: i64,
     ) -> Result<Vec<SessionEvent>, SessionStoreError> {
         let rows = sqlx::query_as::<_, SessionEventRow>(
             r#"
             select event_id, thread_key, execution_id, event_type, payload, created_at
             from session_events
-            where thread_key = $1 and event_id > $2
+            where thread_key = $1
+              and event_id > $2
+              and ($3::text is null or execution_id = $3)
             order by event_id
-            limit $3
+            limit $4
             "#,
         )
         .bind(thread_key.as_str())
         .bind(after_event_id)
+        .bind(execution_id)
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -278,6 +278,7 @@ async function syncThreadMessageToSession(
     const latest = (await thread.state) ?? {}
     const latestExecutedMessageIds = new Set(latest.executedMessageIds ?? [])
     latestExecutedMessageIds.add(serializedMessage.id)
+    forwardInput.executionId = execution.execution_id
     await thread.setState({
       activeExecution: true,
       executedMessageIds: Array.from(latestExecutedMessageIds).slice(-1000),
@@ -562,6 +563,7 @@ async function recoverRenderObligation(
   let lastEventId = Math.max(threadState.lastEventId ?? 0, obligation.afterEventId)
   const input: ForwardSessionInput = {
     afterEventId: lastEventId,
+    executionId: obligation.executionId,
     messages: [],
     onEventId: eventId => {
       lastEventId = Math.max(lastEventId, eventId)

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -171,17 +171,19 @@ export async function forwardToSessionApi(
 
 export async function openSessionEventStream(
   options: SlackbotV2Options,
-  input: Pick<ForwardSessionInput, 'afterEventId' | 'onEventId' | 'threadId' | 'trace'>
+  input: Pick<ForwardSessionInput, 'afterEventId' | 'executionId' | 'onEventId' | 'threadId' | 'trace'>
 ): Promise<AsyncIterable<SlackbotV2RendererSource>> {
   const streamStartedAtMs = nowMs()
   const stream = await streamSessionNotifications(
     options,
     input.threadId,
     input.afterEventId,
+    input.executionId,
     input.onEventId
   )
   traceLog(options, 'slackbotv2_session_events_opened', input.trace, {
     after_event_id: input.afterEventId,
+    execution_id: input.executionId,
     phase_ms: elapsedMs(streamStartedAtMs)
   })
   return stream
@@ -307,11 +309,15 @@ async function streamSessionNotifications(
   options: SlackbotV2Options,
   threadId: string,
   afterEventId: number,
+  executionId: string | undefined,
   onEventId: (eventId: number) => void
 ): Promise<AsyncIterable<SlackbotV2RendererSource>> {
   const fetchFn = options.fetch ?? fetch
+  const url = new URL(apiSessionUrl(options.apiUrl, threadId, 'events'))
+  url.searchParams.set('after_event_id', String(afterEventId))
+  if (executionId) url.searchParams.set('execution_id', executionId)
   const response = await fetchFn(
-    `${apiSessionUrl(options.apiUrl, threadId, 'events')}?after_event_id=${afterEventId}`,
+    url.toString(),
     {
       method: 'GET',
       headers: apiHeaders(options, false)

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -133,6 +133,7 @@ export type SlackbotV2Trace = {
 
 export type ForwardSessionInput = {
   afterEventId: number
+  executionId?: string
   executeMessage?: SlackbotV2ApiMessage
   messages: SlackbotV2ApiMessage[]
   onEventId(eventId: number): void

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -942,7 +942,9 @@ describe('slackbotv2', () => {
     expect(codexApi.creates).toHaveLength(0)
     expect(codexApi.appends).toHaveLength(0)
     expect(codexApi.executes).toHaveLength(0)
-    expect(codexApi.eventRequests).toEqual([{ afterEventId: 0, threadKey: key }])
+    expect(codexApi.eventRequests).toEqual([
+      { afterEventId: 0, executionId: 'exe-recovery', threadKey: key }
+    ])
     expectSlackPlanStreamShape(slackApi.calls, {
       answers: ['Recovered request.'],
       parentTs: parent.ts
@@ -1014,8 +1016,8 @@ describe('slackbotv2', () => {
 
     expect(codexApi.executes).toHaveLength(1)
     expect(codexApi.eventRequests).toEqual([
-      { afterEventId: 0, threadKey: key },
-      { afterEventId: 0, threadKey: key }
+      { afterEventId: 0, executionId: 'exe-1', threadKey: key },
+      { afterEventId: 0, executionId: 'exe-1', threadKey: key }
     ])
     expect(await threadText(parent.ts)).toContain('Recovered after stream retry.')
     const recoveredThreadState = await sharedState.get<Record<string, unknown>>(
@@ -1553,12 +1555,14 @@ type MockSessionRequest<T> = {
 
 type MockSessionEventRequest = {
   afterEventId: number
+  executionId?: string
   threadKey: string
 }
 
 type MockSessionEvent = {
   data: string
   event: string
+  executionId?: string
   id: number
   threadKey: string
 }
@@ -1569,9 +1573,9 @@ type MockSessionApi = {
   close(): Promise<void>
   closeStreams(): void
   creates: MockSessionRequest<SlackbotV2CreateSessionRequest>[]
-  emitOutputLine(threadKey: string, line: string): void
-  emitOutputLines(threadKey: string, lines: string[]): void
-  emitSessionEvent(threadKey: string, event: string, data: unknown): void
+  emitOutputLine(threadKey: string, line: string, executionId?: string): void
+  emitOutputLines(threadKey: string, lines: string[], executionId?: string): void
+  emitSessionEvent(threadKey: string, event: string, data: unknown, executionId?: string): void
   eventRequests: MockSessionEventRequest[]
   executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[]
   failNextEvents: boolean
@@ -1711,23 +1715,25 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
     get streamCount() {
       return streams.size
     },
-    emitOutputLine(threadKey: string, line: string) {
+    emitOutputLine(threadKey: string, line: string, executionId?: string) {
       emitMockSessionEvent({
         data: line,
         event: 'session.output.line',
+        executionId,
         events,
         id: ++eventId,
         streams,
         threadKey
       })
     },
-    emitOutputLines(threadKey: string, lines: string[]) {
-      for (const line of lines) api.emitOutputLine(threadKey, line)
+    emitOutputLines(threadKey: string, lines: string[], executionId?: string) {
+      for (const line of lines) api.emitOutputLine(threadKey, line, executionId)
     },
-    emitSessionEvent(threadKey: string, event: string, data: unknown) {
+    emitSessionEvent(threadKey: string, event: string, data: unknown, executionId?: string) {
       emitMockSessionEvent({
         data: typeof data === 'string' ? data : JSON.stringify(data),
         event,
+        executionId,
         events,
         id: ++eventId,
         streams,
@@ -1793,7 +1799,8 @@ async function handleMockCodexRequest(
 
   if (endpoint === 'events') {
     const afterEventId = Number.parseInt(url.searchParams.get('after_event_id') ?? '0', 10) || 0
-    input.eventRequests.push({ threadKey, afterEventId })
+    const executionId = url.searchParams.get('execution_id') || undefined
+    input.eventRequests.push({ threadKey, afterEventId, executionId })
     if (input.failNextEvents) {
       input.setFailNextEvents(false)
       await sendWebResponse(
@@ -1809,7 +1816,13 @@ async function handleMockCodexRequest(
     })
     input.streams.add(res)
     for (const event of input.events) {
-      if (event.threadKey === threadKey && event.id > afterEventId) writeMockSseEvent(res, event)
+      if (
+        event.threadKey === threadKey
+        && event.id > afterEventId
+        && (!executionId || !event.executionId || event.executionId === executionId)
+      ) {
+        writeMockSseEvent(res, event)
+      }
     }
     req.once('close', () => {
       input.streams.delete(res)
@@ -1849,6 +1862,7 @@ async function handleMockCodexRequest(
       emitMockSessionEvent({
         data: line,
         event: 'session.output.line',
+        executionId,
         events: input.events,
         id: input.nextEventId(),
         streams: input.streams,
@@ -1878,6 +1892,7 @@ async function handleMockCodexRequest(
 function emitMockSessionEvent(input: {
   data: string
   event: string
+  executionId?: string
   events: MockSessionEvent[]
   id: number
   streams: Set<ServerResponse>
@@ -1886,6 +1901,7 @@ function emitMockSessionEvent(input: {
   const event: MockSessionEvent = {
     data: input.data,
     event: input.event,
+    executionId: input.executionId,
     id: input.id,
     threadKey: input.threadKey
   }


### PR DESCRIPTION
## Summary
- add optional execution_id filtering to API-RS session event streams
- have Slackbot v2 pass the execution id when rendering live and recovered streams
- update the Slackbot emulator to record execution-scoped stream requests

## Verification
- cargo fmt -p centaur-api-server -p centaur-session-runtime -p centaur-session-sqlx --check
- cargo test -p centaur-session-runtime -p centaur-api-server
- cargo build --release -p centaur-api-server
- pnpm --dir services/slackbotv2 test -- --runInBand chat-sdk-emulate