### PR TITLE
feat(chart,api): allow resource requests/limits for API-managed pods

### DIFF
--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -309,6 +309,46 @@ spec:
               value: {{ .Values.ironProxy.service.managementPort | quote }}
             - name: KUBERNETES_IRON_PROXY_HEALTH_PORT
               value: {{ .Values.ironProxy.service.healthPort | quote }}
+{{- with .Values.ironProxy.apiResources.limits }}
+{{- if .cpu }}
+            - name: KUBERNETES_API_PROXY_CPU_LIMIT
+              value: {{ .cpu | quote }}
+{{- end }}
+{{- if .memory }}
+            - name: KUBERNETES_API_PROXY_MEMORY_LIMIT
+              value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
+{{- with .Values.ironProxy.apiResources.requests }}
+{{- if .cpu }}
+            - name: KUBERNETES_API_PROXY_CPU_REQUEST
+              value: {{ .cpu | quote }}
+{{- end }}
+{{- if .memory }}
+            - name: KUBERNETES_API_PROXY_MEMORY_REQUEST
+              value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
+{{- with .Values.ironProxy.sandboxResources.limits }}
+{{- if .cpu }}
+            - name: KUBERNETES_SANDBOX_PROXY_CPU_LIMIT
+              value: {{ .cpu | quote }}
+{{- end }}
+{{- if .memory }}
+            - name: KUBERNETES_SANDBOX_PROXY_MEMORY_LIMIT
+              value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
+{{- with .Values.ironProxy.sandboxResources.requests }}
+{{- if .cpu }}
+            - name: KUBERNETES_SANDBOX_PROXY_CPU_REQUEST
+              value: {{ .cpu | quote }}
+{{- end }}
+{{- if .memory }}
+            - name: KUBERNETES_SANDBOX_PROXY_MEMORY_REQUEST
+              value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.toolServer.enabled }}
             # Tool-server runs as a sidecar against the API image; uvicorn
             # target is overridden to api.tool_server_app.
@@ -318,12 +358,52 @@ spec:
               value: {{ .Values.api.image.pullPolicy | quote }}
             - name: KUBERNETES_TOOL_SERVER_PORT
               value: {{ .Values.toolServer.port | quote }}
+{{- with .Values.toolServer.resources.limits }}
+{{- if .cpu }}
+            - name: KUBERNETES_TOOL_SERVER_CPU_LIMIT
+              value: {{ .cpu | quote }}
+{{- end }}
+{{- if .memory }}
+            - name: KUBERNETES_TOOL_SERVER_MEMORY_LIMIT
+              value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
+{{- with .Values.toolServer.resources.requests }}
+{{- if .cpu }}
+            - name: KUBERNETES_TOOL_SERVER_CPU_REQUEST
+              value: {{ .cpu | quote }}
+{{- end }}
+{{- if .memory }}
+            - name: KUBERNETES_TOOL_SERVER_MEMORY_REQUEST
+              value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
             # Workflow-run pods reuse the API image and run python -m api.workflow_executor.
             - name: KUBERNETES_WORKFLOW_RUN_IMAGE
               value: {{ printf "%s:%s" .Values.api.image.repository .Values.api.image.tag | quote }}
             - name: KUBERNETES_WORKFLOW_RUN_IMAGE_PULL_POLICY
               value: {{ .Values.api.image.pullPolicy | quote }}
+{{- with .Values.workflowRun.resources.limits }}
+{{- if and .cpu (not (hasKey $apiExtraEnv "KUBERNETES_WORKFLOW_RUN_CPU_LIMIT")) }}
+            - name: KUBERNETES_WORKFLOW_RUN_CPU_LIMIT
+              value: {{ .cpu | quote }}
+{{- end }}
+{{- if and .memory (not (hasKey $apiExtraEnv "KUBERNETES_WORKFLOW_RUN_MEMORY_LIMIT")) }}
+            - name: KUBERNETES_WORKFLOW_RUN_MEMORY_LIMIT
+              value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
+{{- with .Values.workflowRun.resources.requests }}
+{{- if and .cpu (not (hasKey $apiExtraEnv "KUBERNETES_WORKFLOW_RUN_CPU_REQUEST")) }}
+            - name: KUBERNETES_WORKFLOW_RUN_CPU_REQUEST
+              value: {{ .cpu | quote }}
+{{- end }}
+{{- if and .memory (not (hasKey $apiExtraEnv "KUBERNETES_WORKFLOW_RUN_MEMORY_REQUEST")) }}
+            - name: KUBERNETES_WORKFLOW_RUN_MEMORY_REQUEST
+              value: {{ .memory | quote }}
+{{- end }}
+{{- end }}
             - name: FIREWALL_MANAGER_SECRET_SOURCE
               value: {{ .Values.ironProxy.secretSource | quote }}
             - name: FIREWALL_MANAGER_SECRET_TTL

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -31,6 +31,17 @@ ironProxy:
     pgPortRangeEnd: 5471
   secretSource: onepassword
   secretTtl: 10m
+  # Resource requests/limits for iron-proxy Pods, sized independently for the
+  # two kinds of proxy. Empty by default => unconstrained, preserving prior
+  # behavior. Standard k8s resources shape, e.g.:
+  #   apiResources:
+  #     requests: {cpu: 50m, memory: 64Mi}
+  #     limits:   {cpu: 250m, memory: 64Mi}
+  #
+  # The API self-proxy: one long-lived Pod alongside the API.
+  apiResources: {}
+  # Each per-sandbox proxy: one Pod per active sandbox (larger footprint).
+  sandboxResources: {}
 
 # Tool-server sidecar — runs alongside the sandbox container in each sandbox
 # Pod and exposes the same /tools/* surface the API used to. Same image as
@@ -41,6 +52,10 @@ ironProxy:
 toolServer:
   enabled: true
   port: 8001
+  # Resource requests/limits for the tool-server sidecar injected into each
+  # sandbox Pod. Empty by default => unconstrained. Standard k8s resources
+  # shape (see ironProxy.apiResources above).
+  resources: {}
 
 # iron-token-broker — race-free OAuth refresh-token coordinator. Enable when
 # any tool's `oauth_token` secret uses `grant=refresh_token` against an IdP
@@ -173,6 +188,18 @@ sandbox:
     enabled: false
     size: 10Gi
     storageClassName: ""
+  resources:
+    limits: {}
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+# Workflow-run pods run the API image executing `python -m api.workflow_executor`.
+# Sized independently from the sandbox; the defaults mirror it (requests
+# cpu=100m/memory=512Mi here, plus limits cpu=2/memory=4Gi applied by the API
+# when unset) to preserve the prior behavior from when this pod reused the
+# sandbox sizing.
+workflowRun:
   resources:
     limits: {}
     requests:

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -563,7 +563,7 @@ def _build_tool_server_container(
     # 127.0.0.1 would block liveness probes — the kubelet runs on the node
     # and can't see the container's loopback interface — and the resulting
     # probe failures would kill the sidecar.
-    return {
+    container: dict[str, Any] = {
         "name": "tool-server",
         "image": image_ref,
         "imagePullPolicy": _tool_server_image_pull_policy(),
@@ -597,6 +597,10 @@ def _build_tool_server_container(
         },
         "volumeMounts": volume_mounts,
     }
+    tool_server_resources = _tool_server_resources()
+    if tool_server_resources:
+        container["resources"] = tool_server_resources
+    return container
 
 
 def _apply_tool_server_extra_env(env: list[dict[str, Any]], computed_no_proxy: str) -> None:
@@ -692,22 +696,32 @@ def _ensure_kubernetes_env() -> None:
         raise ValueError("AGENT_API_URL is required for kubernetes backend")
 
 
-def _pod_resources() -> dict[str, Any]:
+def _resources_from_env_with_default_limits(
+    prefix: str, *, default_cpu_limit: str, default_memory_limit: str
+) -> dict[str, Any]:
+    """Build a container ``resources`` dict, defaulting *limits* when unset.
+
+    For workloads that have historically run with implicit limits — the sandbox
+    container and the workflow-run pod (both cpu=2/memory=4Gi). An unset CPU/
+    memory limit falls back to the supplied default; an explicitly-empty env
+    value disables that limit. Requests have no default. Reads
+    ``KUBERNETES_<prefix>_{CPU,MEMORY}_{REQUEST,LIMIT}``.
+    """
     limits: dict[str, str] = {}
-    cpu_limit = os.environ.get("KUBERNETES_SANDBOX_CPU_LIMIT")
-    memory_limit = os.environ.get("KUBERNETES_SANDBOX_MEMORY_LIMIT")
+    cpu_limit = os.environ.get(f"KUBERNETES_{prefix}_CPU_LIMIT")
+    memory_limit = os.environ.get(f"KUBERNETES_{prefix}_MEMORY_LIMIT")
     if cpu_limit is None:
-        limits["cpu"] = "2"
+        limits["cpu"] = default_cpu_limit
     elif cpu_limit.strip():
         limits["cpu"] = cpu_limit.strip()
     if memory_limit is None:
-        limits["memory"] = "4Gi"
+        limits["memory"] = default_memory_limit
     elif memory_limit.strip():
         limits["memory"] = memory_limit.strip()
 
     requests: dict[str, str] = {}
-    cpu_request = (os.getenv("KUBERNETES_SANDBOX_CPU_REQUEST") or "").strip()
-    memory_request = (os.getenv("KUBERNETES_SANDBOX_MEMORY_REQUEST") or "").strip()
+    cpu_request = (os.getenv(f"KUBERNETES_{prefix}_CPU_REQUEST") or "").strip()
+    memory_request = (os.getenv(f"KUBERNETES_{prefix}_MEMORY_REQUEST") or "").strip()
     if cpu_request:
         requests["cpu"] = cpu_request
     if memory_request:
@@ -719,6 +733,73 @@ def _pod_resources() -> dict[str, Any]:
     if requests:
         resources["requests"] = requests
     return resources
+
+
+def _pod_resources() -> dict[str, Any]:
+    """Resources for the sandbox agent container (defaults cpu=2/memory=4Gi)."""
+    return _resources_from_env_with_default_limits(
+        "SANDBOX", default_cpu_limit="2", default_memory_limit="4Gi"
+    )
+
+
+def _resources_from_env(prefix: str) -> dict[str, Any]:
+    """Build a container ``resources`` dict from env, applying no defaults.
+
+    Reads ``KUBERNETES_<prefix>_{CPU,MEMORY}_{REQUEST,LIMIT}``. Unlike
+    :func:`_pod_resources` (the sandbox, which defaults to cpu=2/memory=4Gi),
+    an unset value contributes nothing, so the resulting dict is empty when
+    nothing is configured. Callers omit the ``resources`` key entirely in that
+    case, preserving the historical unconstrained behavior for these
+    API-managed containers.
+    """
+    requests: dict[str, str] = {}
+    limits: dict[str, str] = {}
+    cpu_request = (os.getenv(f"KUBERNETES_{prefix}_CPU_REQUEST") or "").strip()
+    memory_request = (os.getenv(f"KUBERNETES_{prefix}_MEMORY_REQUEST") or "").strip()
+    cpu_limit = (os.getenv(f"KUBERNETES_{prefix}_CPU_LIMIT") or "").strip()
+    memory_limit = (os.getenv(f"KUBERNETES_{prefix}_MEMORY_LIMIT") or "").strip()
+    if cpu_request:
+        requests["cpu"] = cpu_request
+    if memory_request:
+        requests["memory"] = memory_request
+    if cpu_limit:
+        limits["cpu"] = cpu_limit
+    if memory_limit:
+        limits["memory"] = memory_limit
+
+    resources: dict[str, Any] = {}
+    if requests:
+        resources["requests"] = requests
+    if limits:
+        resources["limits"] = limits
+    return resources
+
+
+def _api_proxy_resources() -> dict[str, Any]:
+    """Resources for the API self-proxy iron-proxy container."""
+    return _resources_from_env("API_PROXY")
+
+
+def _sandbox_proxy_resources() -> dict[str, Any]:
+    """Resources for each per-sandbox iron-proxy container."""
+    return _resources_from_env("SANDBOX_PROXY")
+
+
+def _tool_server_resources() -> dict[str, Any]:
+    """Resources for the tool-server sidecar injected into sandbox Pods."""
+    return _resources_from_env("TOOL_SERVER")
+
+
+def _workflow_run_resources() -> dict[str, Any]:
+    """Resources for the workflow-run pod.
+
+    Defaults match the sandbox (cpu=2/memory=4Gi), preserving the historical
+    behavior from when this pod reused ``_pod_resources()``, but sized via its
+    own ``KUBERNETES_WORKFLOW_RUN_*`` env so it can be tuned independently.
+    """
+    return _resources_from_env_with_default_limits(
+        "WORKFLOW_RUN", default_cpu_limit="2", default_memory_limit="4Gi"
+    )
 
 
 def _prompt_bundle(persona: str | None) -> str:
@@ -1241,63 +1322,74 @@ class KubernetesExecutorBackend(SandboxBackend):
             )
         if core is not None:
             proxy_ports.append({"containerPort": core["port"], "name": "pg-core"})
+        iron_proxy_container: dict[str, Any] = {
+            "name": "iron-proxy",
+            "image": _proxy_image(),
+            "imagePullPolicy": _proxy_image_pull_policy(),
+            "env": _proxy_iron_env(secret_name, pg_secrets, core=core),
+            "envFrom": env_from,
+            "ports": proxy_ports,
+            "readinessProbe": {
+                "httpGet": {
+                    "path": "/healthz",
+                    "port": _proxy_health_port(),
+                },
+                "periodSeconds": 5,
+                "failureThreshold": 30,
+            },
+            "livenessProbe": {
+                "httpGet": {
+                    "path": "/healthz",
+                    "port": _proxy_health_port(),
+                }
+            },
+            "securityContext": {
+                "allowPrivilegeEscalation": False,
+                "capabilities": {"drop": ["ALL"]},
+                "seccompProfile": {"type": "RuntimeDefault"},
+            },
+            "volumeMounts": [
+                {
+                    "name": "iron-proxy-config-rendered",
+                    "mountPath": "/etc/iron-proxy-rendered",
+                    "readOnly": True,
+                },
+                {
+                    "name": "iron-proxy-config",
+                    "mountPath": "/etc/iron-proxy",
+                },
+                {"name": "iron-proxy-certs", "mountPath": "/certs"},
+                {
+                    "name": "iron-proxy-ca",
+                    "mountPath": "/etc/iron-proxy-ca",
+                    "readOnly": True,
+                },
+            ],
+            # Copy the read-only rendered config into the writable
+            # /etc/iron-proxy mount where the entrypoint expects it.
+            # iron-proxy's entrypoint script writes the CA cert/key
+            # into the same directory.
+            "command": ["/bin/sh", "-ec"],
+            "args": [
+                "cp /etc/iron-proxy-rendered/proxy.yaml /etc/iron-proxy/proxy.yaml && exec /entrypoint.sh"
+            ],
+        }
+        # The API self-proxy and per-sandbox proxies share this spec but are
+        # sized independently: the self-proxy is a single long-lived Pod while
+        # per-sandbox proxies are created one per sandbox.
+        proxy_resources = (
+            _api_proxy_resources()
+            if sandbox_id == _API_PROXY_SANDBOX_ID
+            else _sandbox_proxy_resources()
+        )
+        if proxy_resources:
+            iron_proxy_container["resources"] = proxy_resources
         return {
             "automountServiceAccountToken": False,
             "restartPolicy": restart_policy,
             "imagePullSecrets": _image_pull_secrets(),
             "containers": [
-                {
-                    "name": "iron-proxy",
-                    "image": _proxy_image(),
-                    "imagePullPolicy": _proxy_image_pull_policy(),
-                    "env": _proxy_iron_env(secret_name, pg_secrets, core=core),
-                    "envFrom": env_from,
-                    "ports": proxy_ports,
-                    "readinessProbe": {
-                        "httpGet": {
-                            "path": "/healthz",
-                            "port": _proxy_health_port(),
-                        },
-                        "periodSeconds": 5,
-                        "failureThreshold": 30,
-                    },
-                    "livenessProbe": {
-                        "httpGet": {
-                            "path": "/healthz",
-                            "port": _proxy_health_port(),
-                        }
-                    },
-                    "securityContext": {
-                        "allowPrivilegeEscalation": False,
-                        "capabilities": {"drop": ["ALL"]},
-                        "seccompProfile": {"type": "RuntimeDefault"},
-                    },
-                    "volumeMounts": [
-                        {
-                            "name": "iron-proxy-config-rendered",
-                            "mountPath": "/etc/iron-proxy-rendered",
-                            "readOnly": True,
-                        },
-                        {
-                            "name": "iron-proxy-config",
-                            "mountPath": "/etc/iron-proxy",
-                        },
-                        {"name": "iron-proxy-certs", "mountPath": "/certs"},
-                        {
-                            "name": "iron-proxy-ca",
-                            "mountPath": "/etc/iron-proxy-ca",
-                            "readOnly": True,
-                        },
-                    ],
-                    # Copy the read-only rendered config into the writable
-                    # /etc/iron-proxy mount where the entrypoint expects it.
-                    # iron-proxy's entrypoint script writes the CA cert/key
-                    # into the same directory.
-                    "command": ["/bin/sh", "-ec"],
-                    "args": [
-                        "cp /etc/iron-proxy-rendered/proxy.yaml /etc/iron-proxy/proxy.yaml && exec /entrypoint.sh"
-                    ],
-                },
+                iron_proxy_container,
             ],
             "volumes": [
                 {
@@ -2162,7 +2254,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                 "capabilities": {"drop": ["ALL"]},
                 "seccompProfile": {"type": "RuntimeDefault"},
             },
-            "resources": _pod_resources(),
+            "resources": _workflow_run_resources(),
             "volumeMounts": api_template["volumeMounts"],
         }
 

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -257,6 +257,204 @@ def test_pod_resources_allows_explicitly_empty_memory_limit(
     }
 
 
+def test_resources_from_env_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import _resources_from_env
+
+    for suffix in ("CPU_REQUEST", "MEMORY_REQUEST", "CPU_LIMIT", "MEMORY_LIMIT"):
+        monkeypatch.delenv(f"KUBERNETES_API_PROXY_{suffix}", raising=False)
+
+    assert _resources_from_env("API_PROXY") == {}
+
+
+def test_api_proxy_resources_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from api.sandbox.kubernetes import _api_proxy_resources
+
+    monkeypatch.setenv("KUBERNETES_API_PROXY_CPU_REQUEST", "50m")
+    monkeypatch.setenv("KUBERNETES_API_PROXY_MEMORY_REQUEST", "64Mi")
+    monkeypatch.setenv("KUBERNETES_API_PROXY_CPU_LIMIT", "250m")
+    monkeypatch.setenv("KUBERNETES_API_PROXY_MEMORY_LIMIT", "64Mi")
+
+    assert _api_proxy_resources() == {
+        "requests": {"cpu": "50m", "memory": "64Mi"},
+        "limits": {"cpu": "250m", "memory": "64Mi"},
+    }
+
+
+def test_sandbox_proxy_resources_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from api.sandbox.kubernetes import _sandbox_proxy_resources
+
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_CPU_REQUEST", "100m")
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_MEMORY_REQUEST", "768Mi")
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_CPU_LIMIT", "500m")
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_MEMORY_LIMIT", "768Mi")
+
+    assert _sandbox_proxy_resources() == {
+        "requests": {"cpu": "100m", "memory": "768Mi"},
+        "limits": {"cpu": "500m", "memory": "768Mi"},
+    }
+
+
+def test_workflow_run_resources_defaults_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import _workflow_run_resources
+
+    for suffix in ("CPU_REQUEST", "MEMORY_REQUEST", "CPU_LIMIT", "MEMORY_LIMIT"):
+        monkeypatch.delenv(f"KUBERNETES_WORKFLOW_RUN_{suffix}", raising=False)
+
+    # Defaults match the sandbox so behavior is unchanged from when this pod
+    # reused _pod_resources().
+    assert _workflow_run_resources() == {"limits": {"cpu": "2", "memory": "4Gi"}}
+
+
+def test_workflow_run_resources_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from api.sandbox.kubernetes import _workflow_run_resources
+
+    monkeypatch.setenv("KUBERNETES_WORKFLOW_RUN_CPU_REQUEST", "250m")
+    monkeypatch.setenv("KUBERNETES_WORKFLOW_RUN_MEMORY_REQUEST", "1Gi")
+    monkeypatch.setenv("KUBERNETES_WORKFLOW_RUN_CPU_LIMIT", "1")
+    monkeypatch.setenv("KUBERNETES_WORKFLOW_RUN_MEMORY_LIMIT", "2Gi")
+
+    assert _workflow_run_resources() == {
+        "requests": {"cpu": "250m", "memory": "1Gi"},
+        "limits": {"cpu": "1", "memory": "2Gi"},
+    }
+
+
+def test_workflow_run_resources_allows_explicitly_empty_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import _workflow_run_resources
+
+    # An explicitly-empty limit disables the default instead of falling back.
+    monkeypatch.setenv("KUBERNETES_WORKFLOW_RUN_CPU_LIMIT", "")
+    monkeypatch.setenv("KUBERNETES_WORKFLOW_RUN_MEMORY_LIMIT", "")
+    monkeypatch.setenv("KUBERNETES_WORKFLOW_RUN_CPU_REQUEST", "250m")
+    monkeypatch.delenv("KUBERNETES_WORKFLOW_RUN_MEMORY_REQUEST", raising=False)
+
+    assert _workflow_run_resources() == {"requests": {"cpu": "250m"}}
+
+
+def test_tool_server_resources_partial_memory_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import _tool_server_resources
+
+    for suffix in ("CPU_REQUEST", "MEMORY_REQUEST", "CPU_LIMIT", "MEMORY_LIMIT"):
+        monkeypatch.delenv(f"KUBERNETES_TOOL_SERVER_{suffix}", raising=False)
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_MEMORY_REQUEST", "512Mi")
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_MEMORY_LIMIT", "512Mi")
+
+    assert _tool_server_resources() == {
+        "requests": {"memory": "512Mi"},
+        "limits": {"memory": "512Mi"},
+    }
+
+
+def test_tool_server_container_includes_resources_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import _build_tool_server_container
+
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_IMAGE", "centaur-api:test")
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_CPU_LIMIT", "500m")
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_MEMORY_LIMIT", "512Mi")
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_MEMORY_REQUEST", "512Mi")
+
+    container = _build_tool_server_container(
+        thread_key="slack:C123:123.456",
+        container_name="centaur-sandbox-pod-abc",
+        firewall_host="firewall.internal",
+        api_url="http://api.internal:8000",
+        overlay_mount=None,
+        database_url="postgresql://proxy/ai_v2",
+    )
+
+    assert container["resources"] == {
+        "requests": {"memory": "512Mi"},
+        "limits": {"cpu": "500m", "memory": "512Mi"},
+    }
+
+
+def test_tool_server_container_omits_resources_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.sandbox.kubernetes import _build_tool_server_container
+
+    monkeypatch.setenv("KUBERNETES_TOOL_SERVER_IMAGE", "centaur-api:test")
+    for suffix in ("CPU_REQUEST", "MEMORY_REQUEST", "CPU_LIMIT", "MEMORY_LIMIT"):
+        monkeypatch.delenv(f"KUBERNETES_TOOL_SERVER_{suffix}", raising=False)
+
+    container = _build_tool_server_container(
+        thread_key="slack:C123:123.456",
+        container_name="centaur-sandbox-pod-abc",
+        firewall_host="firewall.internal",
+        api_url="http://api.internal:8000",
+        overlay_mount=None,
+        database_url="postgresql://proxy/ai_v2",
+    )
+
+    assert "resources" not in container
+
+
+def test_sandbox_proxy_pod_spec_includes_resources_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A per-sandbox proxy reads SANDBOX_PROXY_*; API_PROXY_* must not leak in.
+    for suffix in ("CPU_REQUEST", "MEMORY_REQUEST", "CPU_LIMIT", "MEMORY_LIMIT"):
+        monkeypatch.delenv(f"KUBERNETES_API_PROXY_{suffix}", raising=False)
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_CPU_REQUEST", "100m")
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_MEMORY_REQUEST", "768Mi")
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_CPU_LIMIT", "500m")
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_MEMORY_LIMIT", "768Mi")
+
+    backend = KubernetesExecutorBackend()
+    spec = backend._build_proxy_pod_spec("sandbox-id", [], {}, restart_policy="Never")
+
+    container = spec["containers"][0]
+    assert container["name"] == "iron-proxy"
+    assert container["resources"] == {
+        "requests": {"cpu": "100m", "memory": "768Mi"},
+        "limits": {"cpu": "500m", "memory": "768Mi"},
+    }
+
+
+def test_api_proxy_pod_spec_uses_api_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The API self-proxy reads API_PROXY_* and ignores SANDBOX_PROXY_*.
+    from api.sandbox.kubernetes import _API_PROXY_SANDBOX_ID
+
+    monkeypatch.setenv("KUBERNETES_API_PROXY_CPU_REQUEST", "50m")
+    monkeypatch.setenv("KUBERNETES_API_PROXY_MEMORY_REQUEST", "64Mi")
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_CPU_REQUEST", "100m")
+    monkeypatch.setenv("KUBERNETES_SANDBOX_PROXY_MEMORY_REQUEST", "768Mi")
+
+    backend = KubernetesExecutorBackend()
+    spec = backend._build_proxy_pod_spec(
+        _API_PROXY_SANDBOX_ID, [], {}, restart_policy="Always"
+    )
+
+    assert spec["containers"][0]["resources"] == {
+        "requests": {"cpu": "50m", "memory": "64Mi"},
+    }
+
+
+def test_proxy_pod_spec_omits_resources_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for prefix in ("API_PROXY", "SANDBOX_PROXY"):
+        for suffix in ("CPU_REQUEST", "MEMORY_REQUEST", "CPU_LIMIT", "MEMORY_LIMIT"):
+            monkeypatch.delenv(f"KUBERNETES_{prefix}_{suffix}", raising=False)
+
+    backend = KubernetesExecutorBackend()
+    spec = backend._build_proxy_pod_spec("sandbox-id", [], {}, restart_policy="Never")
+
+    assert "resources" not in spec["containers"][0]
+
+
 def test_container_env_includes_firewall_host_for_secret_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

The pods the API creates at runtime — the iron-proxy Pods (the API self-proxy and every per-sandbox proxy), the `tool-server` sidecar, and the workflow-run pod — had no way to set Kubernetes resource requests/limits. The chart exposed no knob and the container specs in `services/api/api/sandbox/kubernetes.py` were hardcoded, so these pods ran with no scheduler reservation or OOM/throttle ceiling (the workflow-run pod only incidentally inherited the sandbox sizing).

This wires per-pod resources through the existing sandbox pattern (chart values → API env → Pod spec), sizing each API-managed container independently:

- **chart values**: `ironProxy.apiResources`, `ironProxy.sandboxResources`, `toolServer.resources`, `workflowRun.resources`.
- **workloads template**: emit `KUBERNETES_{API_PROXY,SANDBOX_PROXY,TOOL_SERVER,WORKFLOW_RUN}_*` resource env from the api Deployment, guarded so unset keys emit nothing.
- **api**: `_resources_from_env()` (no defaults) for the proxies and tool-server; `_resources_from_env_with_default_limits()` for workloads that historically ran with implicit cpu=2/memory=4Gi limits (the sandbox and workflow-run pods). The shared proxy spec selects API vs per-sandbox values by sandbox id.

Behavior is preserved when values are unset: the proxies and tool-server stay unconstrained, and the workflow-run pod keeps its prior sandbox-equivalent sizing.

Fixes #420

## Testing

- `helm template`: each knob renders its `KUBERNETES_*` env independently; partial specs work; unset emits no resource env (and the workflow-run default reproduces the prior sandbox-equivalent sizing).
- `ruff check`: clean.
- `pytest tests/test_sandbox_kubernetes_backend.py`: new full/partial/empty tests for all four knobs pass; existing sandbox/`_pod_resources` tests unchanged.