### PR TITLE
fix: fail sessions on oversized sandbox output

### DIFF
--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -925,7 +925,21 @@ async fn run_stdout_pump(
     );
     let mut output_state = StdoutPumpState::default();
     while let Some(line) = stdout.next().await {
-        let line = line.map_err(codec_error_to_runtime)?;
+        let line = match line {
+            Ok(line) => line,
+            Err(error) => {
+                record_stdout_pump_failure(
+                    &store,
+                    manager,
+                    sandbox_pipes,
+                    &thread_key,
+                    sandbox_id,
+                    stdout_pump_error_message(&error),
+                )
+                .await?;
+                return Ok(());
+            }
+        };
         if let Some(harness_thread_id) = harness_thread_id_from_output_line(&line)
             && let Err(error) = store
                 .update_harness_thread_id(&thread_key, Some(&harness_thread_id))
@@ -982,6 +996,46 @@ async fn run_stdout_pump(
             }),
         )
         .await?;
+    Ok(())
+}
+
+async fn record_stdout_pump_failure(
+    store: &PgSessionStore,
+    manager: Arc<SandboxManager>,
+    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+    error: String,
+) -> Result<(), SessionRuntimeError> {
+    let active_execution = store.active_execution_for_thread(thread_key).await?;
+    let execution_id = active_execution
+        .as_ref()
+        .map(|execution| execution.execution_id.as_str());
+    store
+        .append_event(
+            thread_key,
+            execution_id,
+            "session.stdout_pump_failed",
+            json!({
+                "sandbox_id": sandbox_id,
+                "error": error.as_str(),
+                "max_line_bytes": MAX_SESSION_OUTPUT_LINE_BYTES,
+                "terminalized_execution": execution_id.is_some(),
+            }),
+        )
+        .await?;
+    if let Some(execution) = active_execution {
+        record_terminal_output(
+            store,
+            manager,
+            sandbox_pipes,
+            thread_key,
+            sandbox_id,
+            &execution.execution_id,
+            TerminalOutput::Failed { error },
+        )
+        .await?;
+    }
     Ok(())
 }
 
@@ -1916,6 +1970,15 @@ fn validate_input_lines(lines: &[String]) -> Result<(), SessionRuntimeError> {
     Ok(())
 }
 
+fn stdout_pump_error_message(error: &LinesCodecError) -> String {
+    match error {
+        LinesCodecError::MaxLineLengthExceeded => format!(
+            "sandbox stdout line exceeded maximum length of {MAX_SESSION_OUTPUT_LINE_BYTES} bytes"
+        ),
+        LinesCodecError::Io(error) => format!("sandbox stdout I/O failed: {error}"),
+    }
+}
+
 fn codec_error_to_runtime(error: LinesCodecError) -> SessionRuntimeError {
     SessionRuntimeError::Sandbox(SandboxError::Io(error.to_string()))
 }
@@ -1993,6 +2056,14 @@ mod tests {
     use centaur_session_core::SessionStatus;
     use serde_json::json;
     use time::OffsetDateTime;
+
+    #[test]
+    fn stdout_pump_max_line_error_is_stable() {
+        assert_eq!(
+            stdout_pump_error_message(&LinesCodecError::MaxLineLengthExceeded),
+            "sandbox stdout line exceeded maximum length of 1048576 bytes"
+        );
+    }
 
     #[test]
     fn turn_completed_without_answer_text_is_terminal() {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -859,10 +859,17 @@ function slackSafeChatSdkChunk(chunk: ChatSDKStreamChunk): ChatSDKStreamChunk {
   if (chunk.type !== 'task_update') return chunk
   const { output: _output, details, ...safeChunk } = chunk
   void _output
+  if (isCommandExecutionTask(chunk)) return safeChunk
   return {
     ...safeChunk,
     ...(details ? { details: truncateSlackTaskField(details) } : {})
   }
+}
+
+function isCommandExecutionTask(
+  chunk: Extract<ChatSDKStreamChunk, { type: 'task_update' }>
+): boolean {
+  return chunk.id.startsWith('call_') || chunk.title.toLowerCase().includes('command execution')
 }
 
 function truncateSlackTaskField(value: string): string {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -252,7 +252,7 @@ describe('slackbotv2', () => {
     expect(text).toContain('Checking the command output')
     expect(text).toContain('Inspecting the event stream')
     expect(text).toContain('Command execution')
-    expect(text).toContain('pnpm test')
+    expect(text).not.toContain('pnpm test')
     expect(text).not.toContain('tests passed')
     expect(text).toContain('Executed request 1.')
     expect(text).toContain('Executed request 2.')
@@ -2437,8 +2437,16 @@ function expectSlackPlanStreamShape(
       expect.objectContaining({
         type: 'task_update',
         id: 'cmd-1',
-        title: '1. Command execution',
-        details: expect.stringContaining('pnpm test')
+        title: '1. Command execution'
+      })
+    )
+    const commandChunk = progressChunks.find(
+      chunk => chunk.type === 'task_update' && chunk.id === 'cmd-1'
+    )
+    expect(commandChunk).toBeDefined()
+    expect(commandChunk).toEqual(
+      expect.not.objectContaining({
+        details: expect.any(String)
       })
     )
     expect(
@@ -2453,7 +2461,7 @@ function expectSlackPlanStreamShape(
     expect(renderedText).toContain('Checking the command output')
     expect(renderedText).toContain('Inspecting the event stream')
     expect(renderedText).toContain('Command execution')
-    expect(renderedText).toContain('pnpm test')
+    expect(renderedText).not.toContain('pnpm test')
     expect(renderedText).not.toContain('tests passed')
     expect(renderedText.trim().endsWith(answer)).toBe(true)
   }
@@ -2467,7 +2475,7 @@ function expectSlackRenderedReply(text: string, answer: string): void {
   expect(text).toContain('Checking the command output')
   expect(text).toContain('Inspecting the event stream')
   expect(text).toContain('Command execution')
-  expect(text).toContain('pnpm test')
+  expect(text).not.toContain('pnpm test')
   expect(text).not.toContain('tests passed')
   expect(text.trim().endsWith(answer)).toBe(true)
 }


### PR DESCRIPTION
## Summary
- hide command execution details from Slackbot v2 progress blocks while keeping command task titles visible
- mark the active api-rs session execution failed when the sandbox stdout pump hits the max-line codec limit
- add regression coverage for the stable oversized-line failure message and update Slack render expectations

## Validation
- pnpm --dir services/slackbotv2 test test/chat-sdk-emulate.test.ts
- pnpm --dir services/slackbotv2 run check:types
- cargo test -p centaur-session-runtime