### PR TITLE
feat: update iron-proxy to 0.42.0-rc.8 with single multiplexed pg listener

### DIFF
--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -140,7 +140,7 @@ spec:
         - protocol: TCP
           port: 5432
 {{- end }}
-    # Per-sandbox iron-proxy listeners (HTTP proxy + postgres port range).
+    # Per-sandbox iron-proxy listeners (HTTP proxy + postgres port).
     - to:
         - podSelector:
             matchLabels:
@@ -149,8 +149,7 @@ spec:
         - protocol: TCP
           port: {{ .Values.ironProxy.service.proxyPort }}
         - protocol: TCP
-          port: {{ .Values.ironProxy.service.pgPortRangeStart }}
-          endPort: {{ .Values.ironProxy.service.pgPortRangeEnd }}
+          port: {{ .Values.ironProxy.service.pgPort }}
 {{- if .Values.ironControl.enabled }}
     # iron-control control plane: register principals/roles/grants and per-sandbox proxies.
     - to:
@@ -291,8 +290,7 @@ spec:
         - protocol: TCP
           port: {{ .Values.ironProxy.service.proxyPort }}
         - protocol: TCP
-          port: {{ .Values.ironProxy.service.pgPortRangeStart }}
-          endPort: {{ .Values.ironProxy.service.pgPortRangeEnd }}
+          port: {{ .Values.ironProxy.service.pgPort }}
     - ports:
         - protocol: TCP
           port: 443
@@ -406,8 +404,7 @@ spec:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api") | nindent 14 }}
       ports:
         - protocol: TCP
-          port: {{ .Values.ironProxy.service.pgPortRangeStart }}
-          endPort: {{ .Values.ironProxy.service.pgPortRangeEnd }}
+          port: {{ .Values.ironProxy.service.pgPort }}
   egress:
     - ports:
         - protocol: TCP

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -33,8 +33,7 @@
             "proxyPort": { "type": "integer" },
             "managementPort": { "type": "integer" },
             "healthPort": { "type": "integer" },
-            "pgPortRangeStart": { "type": "integer" },
-            "pgPortRangeEnd": { "type": "integer" }
+            "pgPort": { "type": "integer" }
           }
         },
         "secretSource": { "type": "string" },

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -24,11 +24,10 @@ ironProxy:
     proxyPort: 8080
     managementPort: 9092
     healthPort: 9090
-    # Postgres listener ports. iron-proxy allocates one listener per pg_dsn
-    # secret, starting at pgPortRangeStart and incrementing. NetworkPolicies
-    # allow the whole range so callers can reach any listener.
-    pgPortRangeStart: 5432
-    pgPortRangeEnd: 5471
+    # Postgres listener port. iron-proxy multiplexes every pg_dsn secret through
+    # a single listener (routing by database name); NetworkPolicies allow this
+    # one port so callers can reach it.
+    pgPort: 5432
   secretSource: onepassword
   secretTtl: 10m
 

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -429,6 +429,18 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         config.image_pull_policy = args.agent_image_pull_policy.clone();
         config.ready_timeout = Duration::from_secs(args.ready_timeout_secs);
         config.iron_proxy = args.iron_proxy.to_config()?;
+        if let Some(proxy) = config.iron_proxy.as_mut() {
+            // The k8s backend derives the static sandbox PG DSN catalog from
+            // these fragments (see `pg_sandbox_dsns`); `to_config` only ships
+            // the harness fragment, so add the infra fragment and the
+            // discovered tool fragment (where `pg_dsn` secrets are declared).
+            let mut fragments = vec![args.iron_proxy.infra_fragment()?];
+            if let Some(tool_fragment) = args.discover_tool_proxy_fragment()? {
+                fragments.push(tool_fragment.fragment);
+            }
+            fragments.append(&mut proxy.fragments);
+            proxy.fragments = fragments;
+        }
         config.iron_control = args.iron_control.settings();
         // iron-control is the only proxy mode: a per-sandbox proxy syncs its
         // secrets from the control plane, so configuring iron-proxy without

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use centaur_iron_proxy::{
-    PostgresListener, PostgresUpstream, ProxyFragment, Secret, SecretReplace, Transform,
+    PostgresListener, PostgresUpstream, ProxyFragment, SandboxEnv, Secret, SecretReplace, Transform,
     TransformConfig,
 };
 use serde::Serialize;
@@ -859,6 +859,15 @@ fn postgres_listeners(secrets: &[ToolSecret]) -> Result<Vec<PostgresListener>, T
                     )])?),
                     ..Default::default()
                 }),
+                // Retain the declared DSN env var name + database so api-rs can
+                // bake the sandbox PG DSNs from the static fragment catalog
+                // (see `pg_sandbox_dsns`). This is an api-rs-internal annotation
+                // (`skip_serializing`) and never reaches the proxy.
+                sandbox_env: Some(SandboxEnv {
+                    name: Some(secret.name.clone()),
+                    database: Some(secret.database.clone()),
+                    ..Default::default()
+                }),
                 ..Default::default()
             })
         })
@@ -1011,6 +1020,22 @@ mod tests {
             config.resolve_tool_dirs().unwrap(),
             vec![PathBuf::from("/base"), PathBuf::from("/overlay")]
         );
+    }
+
+    #[test]
+    fn postgres_listeners_retain_sandbox_env_name_and_database() {
+        // api-rs bakes the sandbox PG DSNs from `sandbox_env`, so the listener
+        // must carry the tool's declared env var name and database verbatim.
+        let listeners = postgres_listeners(&[ToolSecret::PgDsn(PgDsnSecret {
+            name: "RESHIFT_DSN".to_owned(),
+            secret_ref: "RESHIFT_DSN".to_owned(),
+            database: "warehouse".to_owned(),
+        })])
+        .unwrap();
+
+        let sandbox_env = listeners[0].sandbox_env.as_ref().unwrap();
+        assert_eq!(sandbox_env.name.as_deref(), Some("RESHIFT_DSN"));
+        assert_eq!(sandbox_env.database.as_deref(), Some("warehouse"));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -394,11 +394,12 @@ pub struct EffectiveReplace {
     pub proxy_value: String,
 }
 
-/// One synced Postgres upstream. iron-control returns the `foreign_id` (the
-/// listener binding key) and the `database` to connect to on both the proxied
-/// and upstream connection. The `dsn`/`role` are proxy-side, so they're not
-/// captured here; api-rs keys the remaining local knobs (port, user, password,
-/// sandbox env var name) off `foreign_id`.
+/// One synced Postgres upstream. iron-control returns the `foreign_id` and the
+/// `database` to connect to on both the proxied and upstream connection; the
+/// proxy multiplexes every upstream through a single listener, routing by
+/// `database`. The `dsn`/`role` are proxy-side, so they're not captured here;
+/// api-rs derives the sandbox DSN env var name from `foreign_id` and assigns the
+/// listener's shared local port and client credential.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct EffectivePgDsn {
     pub foreign_id: String,

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -110,3 +110,27 @@ pub fn placeholder_env(fragments: &[ProxyFragment]) -> BTreeMap<String, String> 
         .map(|value| (value.to_owned(), value.to_owned()))
         .collect()
 }
+
+/// The static catalog of sandbox Postgres DSN env vars declared across
+/// ``fragments``: ``(env_var_name, database)``. The companion of
+/// [`placeholder_env`] for `pg_dsn` secrets — each tool declares the DSN env
+/// var `name` and `database` verbatim in its `pyproject.toml`, so the shape is
+/// fixed at startup (tools don't hot-reload). iron-proxy multiplexes every
+/// upstream through one listener (routing by database), so the DSNs differ only
+/// by database; api-rs stamps the shared per-sandbox host/credential at create.
+/// This lets every sandbox (warm/bootstrap included) be born with the full DSN
+/// set without resolving a principal — the reassignable proxy enforces
+/// per-principal access at runtime. Sorted and deduped for stable env ordering.
+pub fn pg_sandbox_dsns(fragments: &[ProxyFragment]) -> Vec<(String, String)> {
+    let mut dsns: Vec<(String, String)> = fragments
+        .iter()
+        .flat_map(|fragment| &fragment.postgres)
+        .filter_map(|listener| {
+            let sandbox_env = listener.sandbox_env.as_ref()?;
+            Some((sandbox_env.name.clone()?, sandbox_env.database.clone()?))
+        })
+        .collect();
+    dsns.sort();
+    dsns.dedup();
+    dsns
+}

--- a/services/api-rs/crates/centaur-iron-proxy/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/lib.rs
@@ -4,7 +4,9 @@ mod model;
 mod source;
 
 pub use error::{IronProxyConfigError, Result};
-pub use fragment::{harness_auth_fragment, infra_fragment, load_fragment_str, placeholder_env};
+pub use fragment::{
+    harness_auth_fragment, infra_fragment, load_fragment_str, pg_sandbox_dsns, placeholder_env,
+};
 pub use model::{
     PostgresClient, PostgresListener, PostgresUpstream, ProxyFragment, SandboxEnv, Secret,
     SecretReplace, Transform, TransformConfig, pg_foreign_id, pg_sandbox_env_var,

--- a/services/api-rs/crates/centaur-iron-proxy/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/lib.rs
@@ -7,7 +7,7 @@ pub use error::{IronProxyConfigError, Result};
 pub use fragment::{harness_auth_fragment, infra_fragment, load_fragment_str, placeholder_env};
 pub use model::{
     PostgresClient, PostgresListener, PostgresUpstream, ProxyFragment, SandboxEnv, Secret,
-    SecretReplace, Transform, TransformConfig, pg_env_var, pg_foreign_id, pg_sandbox_env_var,
+    SecretReplace, Transform, TransformConfig, pg_foreign_id, pg_sandbox_env_var,
 };
 pub use source::{SourceKind, SourcePolicy};
 

--- a/services/api-rs/crates/centaur-iron-proxy/src/model/mod.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/model/mod.rs
@@ -3,7 +3,7 @@ mod proxy;
 mod transform;
 
 pub use postgres::{
-    PostgresClient, PostgresListener, PostgresUpstream, SandboxEnv, pg_env_var, pg_foreign_id,
+    PostgresClient, PostgresListener, PostgresUpstream, SandboxEnv, pg_foreign_id,
     pg_sandbox_env_var,
 };
 pub use proxy::ProxyFragment;

--- a/services/api-rs/crates/centaur-iron-proxy/src/model/postgres.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/model/postgres.rs
@@ -48,8 +48,8 @@ pub struct SandboxEnv {
 }
 
 /// The iron-control `pg_dsn` secret foreign_id for a listener name. Shared so
-/// the control-plane registration and the managed proxy's `IRON_PROXY_PG_*`
-/// env derive the same key. foreign_id is restricted to `[A-Za-z0-9-._~]`.
+/// the control-plane registration and the sandbox DSN env var derive the same
+/// key. foreign_id is restricted to `[A-Za-z0-9-._~]`.
 pub fn pg_foreign_id(name: &str) -> String {
     let mut slug = String::new();
     let mut prev_dash = false;
@@ -75,15 +75,6 @@ fn normalize_foreign_id(foreign_id: &str) -> String {
             other => other.to_ascii_uppercase(),
         })
         .collect()
-}
-
-/// The managed proxy reads each listener's local config from
-/// `IRON_PROXY_PG_<FOREIGN_ID>_<SUFFIX>` (foreign_id normalized).
-pub fn pg_env_var(foreign_id: &str, suffix: &str) -> String {
-    format!(
-        "IRON_PROXY_PG_{}_{suffix}",
-        normalize_foreign_id(foreign_id)
-    )
 }
 
 /// The sandbox env var that receives a listener's proxied DSN:

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use super::*;
 
 #[test]
@@ -21,6 +19,37 @@ fn harness_auth_fragments_are_baked_in() {
     for name in ["AMP_API_KEY", "GITHUB_TOKEN", "SLACK_BOT_TOKEN"] {
         assert_eq!(placeholders.get(name).map(String::as_str), Some(name));
     }
+}
+
+#[test]
+fn pg_sandbox_dsns_reads_name_and_database_from_fragments() {
+    // A listener with a sandbox_env (the api-rs-internal annotation api-rs
+    // stamps from each tool's declared pg_dsn name/database) is surfaced; a
+    // listener without one (proxy-only) is skipped. Results are sorted/deduped.
+    let fragment = load_fragment_str(
+        r#"
+postgres:
+  - name: reshift_dsn
+    sandbox_env:
+      name: RESHIFT_DSN
+      database: warehouse
+  - name: analytics_dsn
+    sandbox_env:
+      name: ANALYTICS_DSN
+      database: analytics
+  - name: proxy_only
+"#,
+    )
+    .unwrap();
+
+    let dsns = pg_sandbox_dsns(&[fragment.clone(), fragment]);
+    assert_eq!(
+        dsns,
+        vec![
+            ("ANALYTICS_DSN".to_owned(), "analytics".to_owned()),
+            ("RESHIFT_DSN".to_owned(), "warehouse".to_owned()),
+        ]
+    );
 }
 
 #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
-use centaur_iron_proxy::{ProxyFragment, SourceKind, SourcePolicy, pg_sandbox_env_var};
+use centaur_iron_proxy::{ProxyFragment, SourceKind, SourcePolicy, pg_sandbox_dsns};
 use centaur_sandbox_core::{SandboxError, SandboxId, SandboxResult, SandboxSpec};
 use k8s_openapi::api::core::v1::{
     Capabilities, Container, ContainerPort, EmptyDirVolumeSource, EnvFromSource,
@@ -173,8 +173,8 @@ impl AgentSandboxBackend {
                 "iron-proxy sandbox spec is missing its iron-control principal".to_owned(),
             )
         })?;
-        let (pg, replace_placeholders) =
-            self.effective_pg_and_placeholders(&principal_id).await?;
+        let pg = self.resolved_pg_from_fragments();
+        let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
 
         Ok(Some(ResolvedIronProxy {
             proxy_host: iron_proxy_service_name(id),
@@ -186,18 +186,17 @@ impl AgentSandboxBackend {
         }))
     }
 
-    /// Read the principal's effective config from iron-control and derive what
-    /// the sandbox/proxy need for operator-managed secrets: the replace-secret
-    /// placeholders (sandbox env) and the single Postgres listener. The upstream
-    /// DSN/role/database are control-plane-owned; api-rs assigns the local listen
-    /// port, the shared client credential, and each upstream's sandbox DSN env
-    /// var name.
-    async fn effective_pg_and_placeholders(
+    /// Read the principal's effective config from iron-control for the
+    /// replace-secret placeholders set as sandbox env (so tools send the value
+    /// the proxy swaps for the real secret). The Postgres DSN catalog is
+    /// derived statically from fragments instead — see
+    /// [`Self::resolved_pg_from_fragments`].
+    async fn effective_replace_placeholders(
         &self,
         principal: &str,
-    ) -> SandboxResult<(Option<ResolvedPg>, BTreeMap<String, String>)> {
+    ) -> SandboxResult<BTreeMap<String, String>> {
         let Some(iron_control) = self.config.iron_control.as_ref() else {
-            return Ok((None, BTreeMap::new()));
+            return Ok(BTreeMap::new());
         };
         let effective = iron_control
             .client
@@ -207,40 +206,43 @@ impl AgentSandboxBackend {
                 SandboxError::Backend(format!("iron-control effective_config: {err}"))
             })?;
 
-        let replace_placeholders = effective
+        Ok(effective
             .secrets
             .iter()
             .filter_map(|secret| secret.replace.as_ref())
             .map(|replace| replace.proxy_value.trim().to_owned())
             .filter(|value| !value.is_empty() && !value.contains('='))
             .map(|value| (value.clone(), value))
-            .collect();
+            .collect())
+    }
 
-        // iron-control multiplexes every Postgres upstream the principal
-        // resolves to through one listener, routing by database name. The
-        // control plane owns each upstream DSN/role and the connect `database`;
-        // api-rs binds a single local port (PG_LISTENER_PORT) and a single
-        // shared client credential (random per sandbox), and re-derives each
-        // upstream's DSN env var name from foreign_id so it matches what the CLI
-        // registered against. Sorted by foreign_id for stable env ordering.
-        let mut entries: Vec<_> = effective.postgres.iter().collect();
-        entries.sort_by(|a, b| a.foreign_id.cmp(&b.foreign_id));
-        let dsns: Vec<_> = entries
+    /// Build the single Postgres listener from the static fragment catalog
+    /// (every tool's declared `pg_dsn` env var name + database). Unlike the
+    /// per-principal `effective_config` path this needs no principal, so warm
+    /// sandboxes — created under the roleless bootstrap principal — are still
+    /// born with the full DSN set and a live listener; the reassignable proxy
+    /// enforces per-principal access at runtime by routing only the claimed
+    /// principal's granted databases. iron-proxy multiplexes every upstream
+    /// through one listener, so the DSNs differ only by database; api-rs binds a
+    /// single local port and a shared client credential (random per sandbox,
+    /// set on both the proxy CLIENT_PASSWORD and every sandbox DSN). Returns
+    /// `None` when no fragment declares a `pg_dsn`.
+    fn resolved_pg_from_fragments(&self) -> Option<ResolvedPg> {
+        let iron_proxy = self.config.iron_proxy.as_ref()?;
+        let dsns: Vec<ResolvedPgDsn> = pg_sandbox_dsns(&iron_proxy.fragments)
             .into_iter()
-            .map(|entry| ResolvedPgDsn {
-                sandbox_env_name: pg_sandbox_env_var(&entry.foreign_id),
-                database: entry.database.clone(),
+            .map(|(sandbox_env_name, database)| ResolvedPgDsn {
+                sandbox_env_name,
+                database,
             })
             .collect();
-        let pg = (!dsns.is_empty()).then(|| ResolvedPg {
+        (!dsns.is_empty()).then(|| ResolvedPg {
             listen: format!("0.0.0.0:{PG_LISTENER_PORT}"),
             port: PG_LISTENER_PORT,
             user: format!("pg-user-{}", uuid::Uuid::new_v4().simple()),
             password: format!("pg-{}", uuid::Uuid::new_v4().simple()),
             dsns,
-        });
-
-        Ok((pg, replace_placeholders))
+        })
     }
 
     /// Resolve the proxy for a resume, where only the sandbox id is known.
@@ -268,8 +270,8 @@ impl AgentSandboxBackend {
         let Some(principal_id) = principal_id else {
             return Ok(None);
         };
-        let (pg, replace_placeholders) =
-            self.effective_pg_and_placeholders(&principal_id).await?;
+        let pg = self.resolved_pg_from_fragments();
+        let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
         Ok(Some(ResolvedIronProxy {
             proxy_host: iron_proxy_service_name(id),
             proxy_pod_name: new_iron_proxy_pod_name(id),

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
-use centaur_iron_proxy::{ProxyFragment, SourceKind, SourcePolicy, pg_env_var, pg_sandbox_env_var};
+use centaur_iron_proxy::{ProxyFragment, SourceKind, SourcePolicy, pg_sandbox_env_var};
 use centaur_sandbox_core::{SandboxError, SandboxId, SandboxResult, SandboxSpec};
 use k8s_openapi::api::core::v1::{
     Capabilities, Container, ContainerPort, EmptyDirVolumeSource, EnvFromSource,
@@ -41,12 +41,15 @@ const PROXY_TLS_MODE: &str = "mitm";
 const PROXY_TLS_CA_CERT_PATH: &str = "/etc/iron-proxy/ca.crt";
 const PROXY_TLS_CA_KEY_PATH: &str = "/etc/iron-proxy/ca.key";
 const PROXY_LOG_LEVEL: &str = "info";
-// Local listener knobs api-rs assigns per Postgres upstream (the control plane
-// owns the upstream DSN/role/database). Listener ports start here and increment
-// per listener (sorted by foreign_id), matching the chart's pgPortRangeStart;
-// the sandbox connects as PG_SANDBOX_USER with a per-sandbox generated password.
-const PG_LISTENER_PORT_BASE: u16 = 5432;
-const PG_SANDBOX_USER: &str = "app_user";
+// iron-control multiplexes every Postgres upstream through a single listener,
+// routing by database name; the control plane owns each upstream DSN/role/
+// database. api-rs binds one local port (matching the chart's pgPort) and one
+// shared client credential (random per sandbox) the sandbox presents on every
+// DSN. These are the deploy-level env vars iron-proxy reads for that listener.
+const PG_LISTENER_PORT: u16 = 5432;
+const PG_LISTEN_ENV: &str = "IRON_PROXY_PG_LISTEN";
+const PG_CLIENT_USER_ENV: &str = "IRON_PROXY_PG_CLIENT_USER";
+const PG_CLIENT_PASSWORD_ENV: &str = "IRON_PROXY_PG_CLIENT_PASSWORD";
 // Managed iron-proxy instances pick up principal/config changes on their next
 // /proxy/sync poll. Claiming a warm sandbox must not return before the proxy
 // has had a chance to stop serving the bootstrap principal's empty config.
@@ -99,32 +102,43 @@ pub(crate) struct ResolvedIronProxy {
     proxy_port: u16,
     // iron-control principal OID this sandbox's proxy binds to.
     principal_id: String,
-    // Per-listener Postgres config, derived from the principal's effective
-    // config. The upstream DSN/role/database are control-plane-owned; api-rs
-    // assigns the local listen/client knobs (IRON_PROXY_PG_* + the sandbox DSN).
-    pg_listeners: Vec<ResolvedPgListener>,
+    // The single Postgres listener the proxy multiplexes all upstreams through,
+    // derived from the principal's effective config. `None` when the principal
+    // resolves to no Postgres upstreams. The upstream DSN/role/database are
+    // control-plane-owned; api-rs assigns the local listen/client knobs
+    // (IRON_PROXY_PG_* + the per-upstream sandbox DSN env vars).
+    pg: Option<ResolvedPg>,
     // Replace-secret placeholders the operator granted the principal
     // (`proxy_value` -> same), set as sandbox env so tools send the value the
     // proxy swaps. Infra placeholders are set separately from the known set.
     replace_placeholders: BTreeMap<String, String>,
 }
 
+/// The single Postgres listener the proxy multiplexes every upstream through.
+/// iron-control owns each upstream DSN/role/database and routes by database
+/// name; api-rs only assigns the local listen port and the shared client
+/// credential the sandbox presents (random per sandbox).
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct ResolvedPgListener {
-    /// iron-control pg_dsn secret foreign_id; keys the IRON_PROXY_PG_* env.
-    foreign_id: String,
-    /// Local listen address the proxy binds (e.g. ``0.0.0.0:6432``).
+struct ResolvedPg {
+    /// Local listen address the proxy binds (e.g. ``0.0.0.0:5432``).
     listen: String,
     /// Listen port, exposed on the proxy Service and allowed sandbox→proxy.
     port: u16,
-    /// Postgres user the sandbox connects as.
+    /// Shared client user the sandbox connects as (random per sandbox).
     user: String,
-    /// Client password, generated per sandbox; set on both the proxy
-    /// (CLIENT_PASSWORD) and the sandbox DSN so the two agree.
+    /// Shared client password (random per sandbox); set on both the proxy
+    /// (CLIENT_PASSWORD) and every sandbox DSN so the two agree.
     password: String,
+    /// One DSN per upstream, all pointing at this listener and differing only
+    /// by database.
+    dsns: Vec<ResolvedPgDsn>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ResolvedPgDsn {
     /// Sandbox env var that receives the proxied DSN.
     sandbox_env_name: String,
-    /// Database the sandbox connects to (must match the upstream dbname).
+    /// Database the sandbox connects to; iron-proxy routes the listener on it.
     database: String,
 }
 
@@ -159,7 +173,7 @@ impl AgentSandboxBackend {
                 "iron-proxy sandbox spec is missing its iron-control principal".to_owned(),
             )
         })?;
-        let (pg_listeners, replace_placeholders) =
+        let (pg, replace_placeholders) =
             self.effective_pg_and_placeholders(&principal_id).await?;
 
         Ok(Some(ResolvedIronProxy {
@@ -167,23 +181,23 @@ impl AgentSandboxBackend {
             proxy_pod_name: new_iron_proxy_pod_name(id),
             proxy_port: PROXY_TUNNEL_PORT,
             principal_id,
-            pg_listeners,
+            pg,
             replace_placeholders,
         }))
     }
 
     /// Read the principal's effective config from iron-control and derive what
     /// the sandbox/proxy need for operator-managed secrets: the replace-secret
-    /// placeholders (sandbox env) and the Postgres listeners. The upstream
-    /// DSN/role/database are control-plane-owned; api-rs assigns each listener's
-    /// local port (sequential, sorted by foreign_id), user, password, and env
+    /// placeholders (sandbox env) and the single Postgres listener. The upstream
+    /// DSN/role/database are control-plane-owned; api-rs assigns the local listen
+    /// port, the shared client credential, and each upstream's sandbox DSN env
     /// var name.
     async fn effective_pg_and_placeholders(
         &self,
         principal: &str,
-    ) -> SandboxResult<(Vec<ResolvedPgListener>, BTreeMap<String, String>)> {
+    ) -> SandboxResult<(Option<ResolvedPg>, BTreeMap<String, String>)> {
         let Some(iron_control) = self.config.iron_control.as_ref() else {
-            return Ok((Vec::new(), BTreeMap::new()));
+            return Ok((None, BTreeMap::new()));
         };
         let effective = iron_control
             .client
@@ -202,33 +216,31 @@ impl AgentSandboxBackend {
             .map(|value| (value.clone(), value))
             .collect();
 
-        // One listener per Postgres upstream the principal resolves to. The
-        // control plane owns the upstream DSN/role and the connect `database`;
-        // api-rs assigns each listener's local port (sequential from
-        // PG_LISTENER_PORT_BASE, sorted by foreign_id so the assignment is
-        // stable), the sandbox user, a per-sandbox client password, and the DSN
-        // env var name (re-derived from foreign_id so it matches what the CLI
-        // registered against).
+        // iron-control multiplexes every Postgres upstream the principal
+        // resolves to through one listener, routing by database name. The
+        // control plane owns each upstream DSN/role and the connect `database`;
+        // api-rs binds a single local port (PG_LISTENER_PORT) and a single
+        // shared client credential (random per sandbox), and re-derives each
+        // upstream's DSN env var name from foreign_id so it matches what the CLI
+        // registered against. Sorted by foreign_id for stable env ordering.
         let mut entries: Vec<_> = effective.postgres.iter().collect();
         entries.sort_by(|a, b| a.foreign_id.cmp(&b.foreign_id));
-        let pg_listeners = entries
+        let dsns: Vec<_> = entries
             .into_iter()
-            .enumerate()
-            .map(|(offset, entry)| {
-                let port = PG_LISTENER_PORT_BASE + offset as u16;
-                ResolvedPgListener {
-                    foreign_id: entry.foreign_id.clone(),
-                    listen: format!("0.0.0.0:{port}"),
-                    port,
-                    user: PG_SANDBOX_USER.to_owned(),
-                    password: format!("pg-{}", uuid::Uuid::new_v4().simple()),
-                    sandbox_env_name: pg_sandbox_env_var(&entry.foreign_id),
-                    database: entry.database.clone(),
-                }
+            .map(|entry| ResolvedPgDsn {
+                sandbox_env_name: pg_sandbox_env_var(&entry.foreign_id),
+                database: entry.database.clone(),
             })
             .collect();
+        let pg = (!dsns.is_empty()).then(|| ResolvedPg {
+            listen: format!("0.0.0.0:{PG_LISTENER_PORT}"),
+            port: PG_LISTENER_PORT,
+            user: format!("pg-user-{}", uuid::Uuid::new_v4().simple()),
+            password: format!("pg-{}", uuid::Uuid::new_v4().simple()),
+            dsns,
+        });
 
-        Ok((pg_listeners, replace_placeholders))
+        Ok((pg, replace_placeholders))
     }
 
     /// Resolve the proxy for a resume, where only the sandbox id is known.
@@ -256,14 +268,14 @@ impl AgentSandboxBackend {
         let Some(principal_id) = principal_id else {
             return Ok(None);
         };
-        let (pg_listeners, replace_placeholders) =
+        let (pg, replace_placeholders) =
             self.effective_pg_and_placeholders(&principal_id).await?;
         Ok(Some(ResolvedIronProxy {
             proxy_host: iron_proxy_service_name(id),
             proxy_pod_name: new_iron_proxy_pod_name(id),
             proxy_port: PROXY_TUNNEL_PORT,
             principal_id,
-            pg_listeners,
+            pg,
             replace_placeholders,
         }))
     }
@@ -523,14 +535,18 @@ pub(crate) fn apply_proxy_env(spec: &mut SandboxSpec, resolved: &ResolvedIronPro
     for (name, value) in &resolved.replace_placeholders {
         set_missing_env(spec, name, value);
     }
-    // Each Postgres listener reaches the sandbox as a DSN env var pointing at
-    // the proxy's per-listener port; iron-proxy fronts the real upstream.
-    for listener in &resolved.pg_listeners {
-        let dsn = format!(
-            "postgresql://{}:{}@{}:{}/{}",
-            listener.user, listener.password, resolved.proxy_host, listener.port, listener.database,
-        );
-        set_missing_env(spec, &listener.sandbox_env_name, &dsn);
+    // Each Postgres upstream reaches the sandbox as a DSN env var. They all
+    // point at the proxy's single listener with the same shared credential and
+    // differ only by database; iron-proxy routes on the database and fronts the
+    // real upstream.
+    if let Some(pg) = &resolved.pg {
+        for dsn in &pg.dsns {
+            let value = format!(
+                "postgresql://{}:{}@{}:{}/{}",
+                pg.user, pg.password, resolved.proxy_host, pg.port, dsn.database,
+            );
+            set_missing_env(spec, &dsn.sandbox_env_name, &value);
+        }
     }
 }
 
@@ -660,16 +676,17 @@ fn iron_proxy_env_vars(
     for (name, value) in &iron_proxy.extra_env {
         env.insert(name.clone(), env_var(name, value));
     }
-    // Per-listener Postgres local config. The control plane owns the upstream
-    // DSN + role (the pg_dsn secret); the proxy reads these keyed by foreign_id.
-    for listener in &resolved.pg_listeners {
-        for (suffix, value) in [
-            ("LISTEN", listener.listen.as_str()),
-            ("CLIENT_USER", listener.user.as_str()),
-            ("CLIENT_PASSWORD", listener.password.as_str()),
+    // Single-listener Postgres local config. The control plane owns every
+    // upstream DSN + role (the pg_dsn secrets) and multiplexes them through this
+    // one listener; api-rs only supplies the bind address and the shared client
+    // credential the sandbox presents.
+    if let Some(pg) = &resolved.pg {
+        for (name, value) in [
+            (PG_LISTEN_ENV, pg.listen.as_str()),
+            (PG_CLIENT_USER_ENV, pg.user.as_str()),
+            (PG_CLIENT_PASSWORD_ENV, pg.password.as_str()),
         ] {
-            let name = pg_env_var(&listener.foreign_id, suffix);
-            env.insert(name.clone(), env_var(&name, value));
+            env.insert(name.to_owned(), env_var(name, value));
         }
     }
     env.into_values().collect()
@@ -708,8 +725,8 @@ fn iron_proxy_volumes(iron_proxy: &IronProxyConfig) -> Vec<Volume> {
 
 fn build_iron_proxy_service(id: &SandboxId, resolved: &ResolvedIronProxy) -> Service {
     let mut ports = vec![service_port("proxy", resolved.proxy_port)];
-    for listener in &resolved.pg_listeners {
-        ports.push(service_port(format!("pg-{}", listener.port), listener.port));
+    if let Some(pg) = &resolved.pg {
+        ports.push(service_port("pg", pg.port));
     }
     Service {
         metadata: object_meta(iron_proxy_service_name(id), iron_proxy_labels(id)),
@@ -769,12 +786,7 @@ fn build_iron_proxy_network_policies(
 
 fn sandbox_to_proxy_ports(resolved: &ResolvedIronProxy) -> Vec<NetworkPolicyPort> {
     std::iter::once(network_port(resolved.proxy_port))
-        .chain(
-            resolved
-                .pg_listeners
-                .iter()
-                .map(|listener| network_port(listener.port)),
-        )
+        .chain(resolved.pg.as_ref().map(|pg| network_port(pg.port)))
         .collect()
 }
 
@@ -1087,11 +1099,8 @@ fn container_ports(resolved: &ResolvedIronProxy) -> Vec<ContainerPort> {
         container_port("management", PROXY_MANAGEMENT_PORT),
         container_port("health", PROXY_HEALTH_PORT),
     ];
-    for listener in &resolved.pg_listeners {
-        ports.push(container_port(
-            format!("pg-{}", listener.port),
-            listener.port,
-        ));
+    if let Some(pg) = &resolved.pg {
+        ports.push(container_port("pg", pg.port));
     }
     ports
 }

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ironsh/iron-proxy:0.42.0-rc.7@sha256:162a95ba9326580d6a8fdce3a505f7c29e17673cd3e8d45bd4852d9c0df2615c
+FROM ironsh/iron-proxy:0.42.0-rc.8@sha256:0fb21317bdec25321e7215e6538357164ec2df6840649cdbe5ca6922d22ba79e
 
 USER root
 RUN apk add --no-cache curl jq


### PR DESCRIPTION
Updates iron-proxy to 0.42.0-rc.8. PG DSNs are now fully managed by iron-control and multiplexed through a single listener that routes by database name, replacing the per-upstream listener model (each upstream previously got its own sequential port and per-foreign-id `IRON_PROXY_PG_<FOREIGN_ID>_*` env vars).

api-rs now configures a single PG listener on one port with a single random username/password generated per sandbox, passed via the deploy-level `IRON_PROXY_PG_LISTEN`, `IRON_PROXY_PG_CLIENT_USER`, and `IRON_PROXY_PG_CLIENT_PASSWORD` env vars. Each upstream still reaches the sandbox as its own DSN env var, but they all point at the shared listener and credential and differ only by `database`. `database` remains required on pg_dsn secrets (the routing key). The chart's `pgPortRangeStart`/`pgPortRangeEnd` collapse into a single `pgPort`.

Building on that single listener, sandbox PG DSN env vars are now derived from the static tool fragment catalog (each tool's declared `pg_dsn` name + database) instead of the per-principal iron-control effective config. The shape is fixed at startup, so every sandbox — including warm-pool sandboxes created under the roleless bootstrap principal — is born with the full DSN set and a live listener; the reassignable proxy still enforces per-principal access at runtime by routing only the claimed principal's granted databases. This closes the gap where warm sandboxes were claimed with no PG env and no listener, which couldn't be fixed after claim without restarting the pod. To support this, `postgres_listeners` retains the declared DSN env var name/database on the fragment, and infra + tool fragments are now handed to the k8s backend.
