### PR TITLE
fix(slackbotv2): honor plain text render requests

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -708,6 +708,10 @@ async function renderExecutionStream(
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace
 ): Promise<void> {
+  if (isPlainTextOnlyRequest(message.text)) {
+    await renderPlainTextExecutionStream(thread, stream, message, options, trace)
+    return
+  }
   const fallback = new SlackRenderFallback()
   const titleStartedAtMs = nowMs()
   await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
@@ -748,6 +752,10 @@ async function renderRecoveredExecutionStream(
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace
 ): Promise<void> {
+  if (isPlainTextOnlyRequest(message.text)) {
+    await renderPlainTextExecutionStream(thread, stream, message, options, trace)
+    return
+  }
   const fallback = new SlackRenderFallback()
   const titleStartedAtMs = nowMs()
   await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
@@ -779,6 +787,46 @@ async function renderRecoveredExecutionStream(
   } catch (error) {
     if (!isSlackMessageTooLongError(error)) throw error
     await postSlackTooLongFallback(thread, fallback, options, trace)
+  } finally {
+    await setAssistantStatus(thread, '')
+  }
+}
+
+async function renderPlainTextExecutionStream(
+  thread: Thread,
+  stream: AsyncIterable<SlackbotV2RendererSource>,
+  message: SlackbotV2ApiMessage,
+  options: SlackbotV2Options,
+  trace?: SlackbotV2Trace
+): Promise<void> {
+  const fallback = new SlackRenderFallback()
+  const titleStartedAtMs = nowMs()
+  await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
+  await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
+  traceLog(options, 'slackbotv2_render_plain_text_metadata_set', trace, {
+    phase_ms: elapsedMs(titleStartedAtMs)
+  })
+  try {
+    const chatStream = fallback.collectChatSdk(
+      slackSafeChatSdkStream(
+        codexAppServerToChatSdkStream(
+          fallback.collectSource(stream),
+          rendererOptions(thread, options)
+        )
+      )
+    )
+    for await (const _chunk of chatStream) {
+      void _chunk
+    }
+    const text = truncateSlackText(
+      fallback.text() || 'Execution completed, but no final text was captured.',
+      SLACK_FALLBACK_TEXT_MAX_CHARS,
+      'Slack final answer'
+    )
+    traceLog(options, 'slackbotv2_render_plain_text_final', trace, {
+      chars: text.length
+    })
+    await thread.post(text)
   } finally {
     await setAssistantStatus(thread, '')
   }
@@ -870,6 +918,15 @@ function isCommandExecutionTask(
   chunk: Extract<ChatSDKStreamChunk, { type: 'task_update' }>
 ): boolean {
   return chunk.id.startsWith('call_') || chunk.title.toLowerCase().includes('command execution')
+}
+
+function isPlainTextOnlyRequest(text: string): boolean {
+  const normalized = text.toLowerCase()
+  return (
+    /\bplain\s+text\s+only\b/.test(normalized)
+    || /\bno\s+interactive\s+blocks?\b/.test(normalized)
+    || /\bno\s+dashboards?\b/.test(normalized)
+  )
 }
 
 function truncateSlackTaskField(value: string): string {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -924,6 +924,45 @@ describe('slackbotv2', () => {
     ])
   })
 
+  it('honors plain-text-only requests without Slack plan blocks', async () => {
+    const parent = await postUserMessage('Context before a plain text request.')
+    const mention = await postUserMessage(
+      `<@${BOT_USER_ID}> Answer from context only. Plain text only, no interactive blocks or dashboards. Include id plain-text-regression.`,
+      parent.ts
+    )
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-plain-text-only',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> Answer from context only. Plain text only, no interactive blocks or dashboards. Include id plain-text-regression.`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
+    expect(slackApi.calls.some(call => call.method === 'chat.appendStream')).toBe(false)
+    expect(slackApi.calls.some(call => call.method === 'chat.stopStream')).toBe(false)
+
+    const text = await threadText(parent.ts)
+    expect(text).toContain('Executed request 1.')
+    expect(text).not.toContain('Implementation plan')
+    expect(text).not.toContain('Command execution')
+    expect(text).not.toContain('pnpm test')
+  })
+
   it('waits for a slow session execute before acknowledging Slack and starting the stream', async () => {
     codexApi.autoRespond = false
     const releaseExecute = codexApi.holdNextExecute()


### PR DESCRIPTION
## Summary
- detect explicit plain-text/no-interactive render requests in Slackbot v2
- consume the durable renderer stream but post a single final Slack text message instead of a StreamingPlan
- add emulator coverage that verifies no chat stream is started for plain-text-only prompts

## Validation
- pnpm install
- pnpm --dir services/slackbotv2 test test/chat-sdk-emulate.test.ts
- pnpm --dir services/slackbotv2 run check:types