### PR TITLE
Fix SensorTower sales estimates auth

### DIFF
--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -102,7 +102,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `newsapi` | News headlines, article search, and source lists | `NEWSAPI_KEY` |
 | `openfec` | Federal election candidates, committees, contributions, filings, and totals | `DATAGOV_API_KEY` |
 | `plural` | State legislation, legislators, committees, events, and jurisdictions | `PLURAL_API_KEY` |
-| `sensortower` | Mobile app analytics, publisher data, charts, and sales estimates | `SENSOR_TOWER_AUTH_TOKEN` |
+| `sensortower` | Mobile app analytics, publisher data, charts, and sales estimates | `SENSOR_TOWER_AUTH_TOKEN or SENSORTOWER_API_KEY` |
 | `similarweb` | Web traffic, rankings, referrals, keywords, geography, and app data | `SIMILARWEB_API_KEY` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `youtube` | YouTube video, channel, transcript, and search data | `YOUTUBE_API_KEY`, `GOOGLE_API_KEY` |

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -103,7 +103,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `newsapi` | News headlines, article search, and source lists | `NEWSAPI_KEY` |
 | `openfec` | Federal election candidates, committees, contributions, filings, and totals | `DATAGOV_API_KEY` |
 | `plural` | State legislation, legislators, committees, events, and jurisdictions | `PLURAL_API_KEY` |
-| `sensortower` | Mobile app analytics, publisher data, charts, and sales estimates | `SENSOR_TOWER_AUTH_TOKEN` |
+| `sensortower` | Mobile app analytics, publisher data, charts, and sales estimates | `SENSOR_TOWER_AUTH_TOKEN or SENSORTOWER_API_KEY` |
 | `similarweb` | Web traffic, rankings, referrals, keywords, geography, and app data | `SIMILARWEB_API_KEY` |
 | `websearch` | Web search and deep research | `EXA_API_KEY`, `ANTHROPIC_API_KEY` |
 | `youtube` | YouTube video, channel, transcript, and search data | `YOUTUBE_API_KEY`, `GOOGLE_API_KEY` |

--- a/tools/research/sensortower/client.py
+++ b/tools/research/sensortower/client.py
@@ -7,6 +7,18 @@ import httpx
 from centaur_sdk import secret
 
 
+AUTH_TOKEN_SECRET_NAMES = (
+    "SENSOR_TOWER_AUTH_TOKEN",
+    "SENSORTOWER_AUTH_TOKEN",
+    "SENSOR_TOWER_API_KEY",
+    "SENSORTOWER_API_KEY",
+)
+
+
+def _clean_secret(value: str | None) -> str:
+    return (value or "").strip()
+
+
 class SensorTowerClient:
     """Client for SensorTower API.
 
@@ -29,11 +41,18 @@ class SensorTowerClient:
     def _get_auth_token(self) -> str:
         """Get auth token from instance or env var."""
         if self._auth_token:
-            return self._auth_token
-        token = secret("SENSOR_TOWER_AUTH_TOKEN", "") or secret("SENSORTOWER_AUTH_TOKEN", "")
+            return _clean_secret(self._auth_token)
+
+        token = ""
+        for name in AUTH_TOKEN_SECRET_NAMES:
+            token = _clean_secret(secret(name, ""))
+            if token:
+                break
+
         if not token:
             raise RuntimeError(
-                "SENSOR_TOWER_AUTH_TOKEN not set. "
+                "SensorTower auth token not set. Expected one of: "
+                f"{', '.join(AUTH_TOKEN_SECRET_NAMES)}. "
                 "Get your token from https://sensortower.com/users/edit"
             )
         return token

--- a/tools/research/sensortower/pyproject.toml
+++ b/tools/research/sensortower/pyproject.toml
@@ -16,4 +16,9 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "SENSOR_TOWER_AUTH_TOKEN", match_query = true, hosts = ["api.sensortower.com", "app.sensortower.com"]}]
+secrets = [
+    {type = "http", name = "SENSOR_TOWER_AUTH_TOKEN", match_query = true, hosts = ["api.sensortower.com", "app.sensortower.com"]},
+    {type = "http", name = "SENSORTOWER_AUTH_TOKEN", match_query = true, hosts = ["api.sensortower.com", "app.sensortower.com"]},
+    {type = "http", name = "SENSOR_TOWER_API_KEY", match_query = true, hosts = ["api.sensortower.com", "app.sensortower.com"]},
+    {type = "http", name = "SENSORTOWER_API_KEY", match_query = true, hosts = ["api.sensortower.com", "app.sensortower.com"]},
+]

--- a/tools/research/sensortower/test_client.py
+++ b/tools/research/sensortower/test_client.py
@@ -1,0 +1,41 @@
+import httpx
+
+from sensortower import client as sensortower_client
+
+
+def test_sales_estimates_uses_api_key_alias_and_expected_query(monkeypatch):
+    def fake_secret(name: str, default: str = "") -> str:
+        if name == "SENSORTOWER_API_KEY":
+            return "  test-token  "
+        return default
+
+    monkeypatch.setattr(sensortower_client, "secret", fake_secret)
+
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = request.url
+        return httpx.Response(200, json=[{"aid": 6749636760, "cc": "MX", "iu": 4159}])
+
+    client = sensortower_client.SensorTowerClient()
+    client._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    result = client.get_sales_estimates(
+        app_ids=["6749636760"],
+        platform="ios",
+        start_date="2025-12-01",
+        end_date="2026-05-31",
+        countries=["MX"],
+        date_granularity="monthly",
+    )
+
+    assert result == [{"aid": 6749636760, "cc": "MX", "iu": 4159}]
+    assert seen["url"].path == "/v1/ios/sales_report_estimates"
+    assert dict(seen["url"].params) == {
+        "date_granularity": "monthly",
+        "start_date": "2025-12-01",
+        "end_date": "2026-05-31",
+        "app_ids": "6749636760",
+        "countries": "MX",
+        "auth_token": "test-token",
+    }


### PR DESCRIPTION
## Summary
- let SensorTower use common auth token aliases, including SENSORTOWER_API_KEY
- strip token values before adding auth_token query params
- register the aliases in the tool manifest and update docs
- add a focused sales_report_estimates request test

## Verification
- PYTHONPATH=/home/agent/branches/paradigmxyz/centaur:/home/agent/branches/paradigmxyz/centaur/tools/research uv run --no-project --with pytest --with httpx pytest -q /home/agent/branches/paradigmxyz/centaur/tools/research/sensortower/test_client.py
- local SensorTowerClient live call returned the expected six MX monthly rows for app 6749636760 from 2025-12-01 to 2026-05-31