### PR TITLE
fix(websearch): send centaur-websearch User-Agent on free Search MCP requests

### DIFF
--- a/tools/research/websearch/_parallel.py
+++ b/tools/research/websearch/_parallel.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import sys
 import time
 import uuid
 from typing import Any
@@ -35,6 +36,10 @@ MCP_URL = "https://search.parallel.ai/mcp"
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MCP_CLIENT_NAME = "centaur-websearch"
 MCP_CLIENT_VERSION = "0.2.0"
+# Identify free-tier traffic at the HTTP layer. Without this, httpx sends a
+# generic `python-httpx/<ver>` User-Agent and centaur usage is only visible via
+# the JSON-RPC `clientInfo` payload.
+MCP_USER_AGENT = f"{MCP_CLIENT_NAME}/{MCP_CLIENT_VERSION} ({sys.platform})"
 SNIPPET_CHAR_LIMIT = 7000
 
 # Per Parallel docs, Deep Research is "optimized within the `pro` and `ultra`
@@ -553,6 +558,7 @@ class ParallelBackend:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json, text/event-stream",
+            "User-Agent": MCP_USER_AGENT,
         }
         if session_id:
             headers["Mcp-Session-Id"] = session_id

--- a/tools/research/websearch/test_parallel.py
+++ b/tools/research/websearch/test_parallel.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+# `_parallel` uses package-relative imports (`from .models import ...`), so it
+# must be imported as `websearch._parallel` rather than a bare top-level module.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from websearch._parallel import MCP_CLIENT_NAME, ParallelBackend
+
+
+def test_mcp_headers_send_identifiable_user_agent():
+    backend = ParallelBackend(api_key=None)
+
+    headers = backend._mcp_headers(None)
+
+    # Free MCP traffic is identifiable at the HTTP layer, not just via clientInfo.
+    assert headers["User-Agent"].startswith(f"{MCP_CLIENT_NAME}/")
+    # Anonymous free path: no bearer token.
+    assert "Authorization" not in headers
+
+
+def test_mcp_headers_keep_user_agent_with_session_id():
+    backend = ParallelBackend(api_key=None)
+
+    headers = backend._mcp_headers("sess-123")
+
+    assert headers["Mcp-Session-Id"] == "sess-123"
+    assert headers["User-Agent"].startswith(f"{MCP_CLIENT_NAME}/")


### PR DESCRIPTION
## Summary

The Parallel **free Search MCP** path (used when no `PARALLEL_API_KEY` is set — the zero-config default for `search`) set no `User-Agent` header. Since the client uses `httpx`, those requests went out with the default `User-Agent: python-httpx/<version>`, so centaur free-tier traffic was only identifiable via the JSON-RPC `clientInfo` payload, not at the HTTP layer.

This adds a `centaur-websearch/<version> (<platform>)` User-Agent to the MCP request headers (`MCP_USER_AGENT`), so free-tier usage is attributable in HTTP logs (alongside source IP). No other behavior changes: the request stays anonymous (no `Authorization` unless a valid key is held), `clientInfo` is unchanged, and the paid REST path is untouched.

## Changes

- `tools/research/websearch/_parallel.py`: add `MCP_USER_AGENT` and set `User-Agent` in `_mcp_headers()`.
- `tools/research/websearch/test_parallel.py` (new): assert the header is present, with and without a session id, and that the free path stays anonymous.

## Verification

- **Live**: drove the full handshake (`initialize` → `notifications/initialized` → `tools/call web_search`) against `https://search.parallel.ai/mcp` with the new UA — server accepted it and returned live results (anonymous, no key):

```
User-Agent under test: centaur-websearch/0.2.0 (darwin)
HTTP UA accepted; live results: 10
```

- `python -m pytest tools/research/websearch/test_parallel.py` → 2 passed.
- `ruff check` clean on both files; `python -m compileall` OK.
