### PR TITLE
fix(slackbotv2): show command details without output

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -907,17 +907,10 @@ function slackSafeChatSdkChunk(chunk: ChatSDKStreamChunk): ChatSDKStreamChunk {
   if (chunk.type !== 'task_update') return chunk
   const { output: _output, details, ...safeChunk } = chunk
   void _output
-  if (isCommandExecutionTask(chunk)) return safeChunk
   return {
     ...safeChunk,
     ...(details ? { details: truncateSlackTaskField(details) } : {})
   }
-}
-
-function isCommandExecutionTask(
-  chunk: Extract<ChatSDKStreamChunk, { type: 'task_update' }>
-): boolean {
-  return chunk.id.startsWith('call_') || chunk.title.toLowerCase().includes('command execution')
 }
 
 function isPlainTextOnlyRequest(text: string): boolean {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -252,7 +252,7 @@ describe('slackbotv2', () => {
     expect(text).toContain('Checking the command output')
     expect(text).toContain('Inspecting the event stream')
     expect(text).toContain('Command execution')
-    expect(text).not.toContain('pnpm test')
+    expect(text).toContain('pnpm test')
     expect(text).not.toContain('tests passed')
     expect(text).toContain('Executed request 1.')
     expect(text).toContain('Executed request 2.')
@@ -909,6 +909,9 @@ describe('slackbotv2', () => {
     expect(taskChunks).not.toHaveLength(0)
     expect(taskChunks.every(chunk => stringField(chunk.output) === '')).toBe(true)
     expect(taskChunks.every(chunk => !chunkText(chunk).includes('large-context-line'))).toBe(true)
+    expect(taskChunks.some(chunk => chunkText(chunk).includes('slack thread --json --page 0'))).toBe(
+      true
+    )
     expect(
       taskChunks
         .map(chunk => stringField(chunk.details))
@@ -2476,18 +2479,14 @@ function expectSlackPlanStreamShape(
       expect.objectContaining({
         type: 'task_update',
         id: 'cmd-1',
-        title: '1. Command execution'
+        title: '1. Command execution',
+        details: expect.stringContaining('pnpm test')
       })
     )
     const commandChunk = progressChunks.find(
       chunk => chunk.type === 'task_update' && chunk.id === 'cmd-1'
     )
     expect(commandChunk).toBeDefined()
-    expect(commandChunk).toEqual(
-      expect.not.objectContaining({
-        details: expect.any(String)
-      })
-    )
     expect(
       progressChunks
         .filter(chunk => chunk.type === 'task_update')
@@ -2500,7 +2499,7 @@ function expectSlackPlanStreamShape(
     expect(renderedText).toContain('Checking the command output')
     expect(renderedText).toContain('Inspecting the event stream')
     expect(renderedText).toContain('Command execution')
-    expect(renderedText).not.toContain('pnpm test')
+    expect(renderedText).toContain('pnpm test')
     expect(renderedText).not.toContain('tests passed')
     expect(renderedText.trim().endsWith(answer)).toBe(true)
   }
@@ -2514,7 +2513,7 @@ function expectSlackRenderedReply(text: string, answer: string): void {
   expect(text).toContain('Checking the command output')
   expect(text).toContain('Inspecting the event stream')
   expect(text).toContain('Command execution')
-  expect(text).not.toContain('pnpm test')
+  expect(text).toContain('pnpm test')
   expect(text).not.toContain('tests passed')
   expect(text.trim().endsWith(answer)).toBe(true)
 }


### PR DESCRIPTION
## Summary
- keep Slack task stdout/stderr output omitted
- preserve bounded task details so command task cards still show the command being run
- update Slackbot v2 regressions to assert command text is visible while command output remains hidden

## Tests
- bun test services/slackbotv2/test/chat-sdk-emulate.test.ts
- pnpm --filter slackbotv2 check:types