### PR TITLE
fix: keep final Slack answers in stopStream layout

### DIFF
--- a/services/slackbot/src/slack/agent-session.test.ts
+++ b/services/slackbot/src/slack/agent-session.test.ts
@@ -413,7 +413,7 @@ describe('AgentSessionRenderer', () => {
     expect(stop?.params.blocks?.length ?? 0).toBeLessThanOrEqual(50)
   })
 
-  it('does not duplicate live plan or streamed answer markdown on finalize', async () => {
+  it('keeps streamed final answers in the durable stopStream layout', async () => {
     const calls: Array<{ method: string; params: any }> = []
     const client = {
       assistant: {
@@ -460,7 +460,10 @@ describe('AgentSessionRenderer', () => {
     const stop = calls.find(call => call.method === 'chat.stopStream')
     const blocks = stop?.params.blocks ?? []
     expect(blocks.some((block: any) => block.type === 'plan')).toBe(false)
-    expect(blocks.some((block: any) => block.type === 'markdown')).toBe(false)
+    const answerBlocks = blocks.filter(
+      (block: any) => block.type === 'markdown' && block.text.includes('Live answer body.')
+    )
+    expect(answerBlocks).toHaveLength(1)
     expect(stop?.params.chunks).toBeUndefined()
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
     expect(stopStreamFallbackText(stop?.params).trim()).toBe('')

--- a/services/slackbot/src/slack/agent-session.ts
+++ b/services/slackbot/src/slack/agent-session.ts
@@ -295,19 +295,22 @@ export class AgentSessionRenderer {
     const tasks = compactFinalTasks(originalTasks)
     const answerSource =
       state.finalAnswerMarkdown?.trim() || segment.streamedText.trim() || segment.textParts.join('')
-    const answerMarkdown = finalMarkdownForFinalBlocks(answerSource, segment, {
-      includeStreamedText: originalTasks.length >= DURABLE_STREAMED_ANSWER_TASK_THRESHOLD
-    })
+    const explicitFinalAnswer = state.finalAnswerMarkdown?.trim()
+    const answerMarkdown = explicitFinalAnswer
+      ? clipText(explicitFinalAnswer, slackReplyLimits.mixedBodyAndPlan.maxVisibleChars)
+      : finalMarkdownForFinalBlocks(answerSource, segment, {
+          includeStreamedText: originalTasks.length >= DURABLE_STREAMED_ANSWER_TASK_THRESHOLD
+        })
     const streamedTextLive =
       Boolean(segment.streamedText.trim()) && segment.streamedText.length < MAX_LIVE_TEXT_CHARS
-    // Slack accumulates appendStream chunks; stopStream blocks are the composed final layout.
-    // Only add blocks for content that was not streamed live; live task_update chunks carry
-    // fenced details/output, and the header has already been streamed as the first chunk.
+    // chat.stopStream is the durable final layout users see after Slack collapses the
+    // live stream. Always include the final answer in that layout. Relying on
+    // streamed chunks alone can leave a completed message with only the plan card.
     const blocks = sanitizeFinalMessagePayload([
       ...(tasks.length && !segment.planStarted
         ? [planBlock(planTitle(state.title, originalTasks), tasks, EXECUTION_PLAN_ID)]
         : []),
-      ...(!streamedTextLive && answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
+      ...(answerMarkdown ? renderMarkdownBlocks(answerMarkdown) : [])
     ] as AnyBlock[])
     const fallbackText = buildFinalFallbackText({
       title: state.title,
@@ -322,6 +325,31 @@ export class AgentSessionRenderer {
       ...(blocks.length ? { blocks } : {})
     })
     if (!stopResponse.ok) throw new Error(stopResponse.error ?? 'chat.stopStream failed')
+    if (blocks.length) {
+      try {
+        const updateResponse = await this.client.chat.update({
+          channel: state.channel,
+          ts: segment.streamTs,
+          text: fallbackText || ' ',
+          blocks
+        })
+        if (!updateResponse.ok) {
+          logWarn('slack_stream_final_update_failed', {
+            channel_id: state.channel,
+            thread_ts: state.parentTs,
+            stream_ts: segment.streamTs,
+            error: updateResponse.error ?? 'unknown_error'
+          })
+        }
+      } catch (error) {
+        logWarn('slack_stream_final_update_failed', {
+          channel_id: state.channel,
+          thread_ts: state.parentTs,
+          stream_ts: segment.streamTs,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
     segment.closed = true
   }
 

--- a/services/slackbot/src/slack/codex-session.test.ts
+++ b/services/slackbot/src/slack/codex-session.test.ts
@@ -247,7 +247,8 @@ describe('CodexSessionRenderer', () => {
     expect(richTextPlain(cmd?.output)).toContain('one\ntwo')
     expect(calls.filter(call => call.method === 'chat.startStream')).toHaveLength(1)
     expect(calls.some(call => call.method === 'chat.appendStream')).toBe(true)
-    expect(calls.some(call => call.method === 'chat.update')).toBe(false)
+    const finalUpdate = calls.find(call => call.method === 'chat.update')
+    expect(finalUpdate?.params.blocks).toBeTruthy()
   })
 
   it('renders multiple command executions as one visible activity task', async () => {
@@ -1734,7 +1735,10 @@ describe('CodexSessionRenderer', () => {
     const blocks = stop?.params.blocks ?? []
     expect(stop?.params.chunks).toBeUndefined()
     expect(blocks.some((block: any) => block.type === 'context')).toBe(false)
-    expect(blocks.some((block: any) => block.type === 'markdown')).toBe(false)
+    const answerBlocks = blocks.filter(
+      (block: any) => block.type === 'markdown' && block.text.includes('Done: five tools called.')
+    )
+    expect(answerBlocks).toHaveLength(1)
   })
 
   it('treats an unphased terminal agent message after tool use as the final answer', async () => {
@@ -1938,7 +1942,7 @@ function visibleMarkdown(calls: Array<{ method: string; params: any }>): string 
     .filter((block: any) => block.type === 'markdown')
     .map((block: any) => String(block.text ?? ''))
     .join('')
-  return streamed + stopMarkdown
+  return stopMarkdown || streamed
 }
 
 function makeFakeSlackClient(


### PR DESCRIPTION
Fixes a Slack rendering bug where the final `chat.stopStream` layout could omit the answer and leave only activity visible.

When the session has an explicit final answer, render that answer in the durable final block layout. After `stopStream`, update the stream message to that final layout so Slack keeps one authoritative copy of the answer instead of leaving stale live chunks beside the final blocks.

Verification:
- `bun test src/slack/agent-session.test.ts src/slack/codex-session.test.ts`