### PR TITLE
Publish multi-arch images and expose pod scheduling values

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -61,10 +61,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
+        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -98,7 +102,8 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
-          push: ${{ !github.event.pull_request.head.repo.fork }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image }}

--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.49
+version: 0.1.50
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -39,6 +39,21 @@ app.kubernetes.io/component: {{ .component }}
 {{- printf "%s-%s" (include "centaur.fullname" .root) .component | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "centaur.podScheduling" -}}
+{{- with .nodeSelector }}
+nodeSelector:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- with .affinity }}
+affinity:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- with .tolerations }}
+tolerations:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
 {{- define "centaur.secretEnvName" -}}
 {{- required "secretManager.existingSecretName is required" .Values.secretManager.existingSecretName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/contrib/chart/templates/iron-control.yaml
+++ b/contrib/chart/templates/iron-control.yaml
@@ -48,6 +48,7 @@ spec:
       imagePullSecrets:
 {{ toYaml . | nindent 8 }}
       {{- end }}
+{{ include "centaur.podScheduling" .Values.ironControl | nindent 6 }}
       initContainers:
         # Create the dedicated logical DB on the bundled Postgres. Idempotent:
         # guarded by a pg_database existence check, and the CREATE tolerates a

--- a/contrib/chart/templates/token-broker.yaml
+++ b/contrib/chart/templates/token-broker.yaml
@@ -73,6 +73,7 @@ spec:
       imagePullSecrets:
 {{ toYaml . | nindent 8 }}
       {{- end }}
+{{ include "centaur.podScheduling" .Values.tokenBroker | nindent 6 }}
       containers:
         - name: iron-token-broker
           image: {{ printf "%s:%s" .Values.tokenBroker.image.repository .Values.tokenBroker.image.tag | quote }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
 {{ toYaml . | nindent 8 }}
       {{- end }}
+{{ include "centaur.podScheduling" .Values.postgres | nindent 6 }}
       containers:
         - name: postgres
           image: {{ printf "%s:%s" .Values.postgres.image.repository .Values.postgres.image.tag | quote }}
@@ -131,6 +132,7 @@ spec:
       imagePullSecrets:
 {{ toYaml . | nindent 8 }}
       {{- end }}
+{{ include "centaur.podScheduling" .Values.api | nindent 6 }}
 {{- if .Values.overlay.image.repository }}
       initContainers:
         - name: overlay-bootstrap
@@ -303,6 +305,18 @@ spec:
               value: {{ printf "%s:%s" .Values.ironProxy.image.repository .Values.ironProxy.image.tag | quote }}
             - name: KUBERNETES_IRON_PROXY_IMAGE_PULL_POLICY
               value: {{ .Values.ironProxy.image.pullPolicy | quote }}
+{{- if not (hasKey $apiExtraEnv "KUBERNETES_IRON_PROXY_NODE_SELECTOR") }}
+            - name: KUBERNETES_IRON_PROXY_NODE_SELECTOR
+              value: {{ toJson .Values.ironProxy.nodeSelector | quote }}
+{{- end }}
+{{- if not (hasKey $apiExtraEnv "KUBERNETES_IRON_PROXY_AFFINITY") }}
+            - name: KUBERNETES_IRON_PROXY_AFFINITY
+              value: {{ toJson .Values.ironProxy.affinity | quote }}
+{{- end }}
+{{- if not (hasKey $apiExtraEnv "KUBERNETES_IRON_PROXY_TOLERATIONS") }}
+            - name: KUBERNETES_IRON_PROXY_TOLERATIONS
+              value: {{ toJson .Values.ironProxy.tolerations | quote }}
+{{- end }}
             - name: KUBERNETES_IRON_PROXY_PORT
               value: {{ .Values.ironProxy.service.proxyPort | quote }}
             - name: KUBERNETES_IRON_PROXY_MANAGEMENT_PORT
@@ -324,6 +338,18 @@ spec:
               value: {{ printf "%s:%s" .Values.api.image.repository .Values.api.image.tag | quote }}
             - name: KUBERNETES_WORKFLOW_RUN_IMAGE_PULL_POLICY
               value: {{ .Values.api.image.pullPolicy | quote }}
+{{- if not (hasKey $apiExtraEnv "KUBERNETES_WORKFLOW_RUN_NODE_SELECTOR") }}
+            - name: KUBERNETES_WORKFLOW_RUN_NODE_SELECTOR
+              value: {{ toJson .Values.workflowRun.nodeSelector | quote }}
+{{- end }}
+{{- if not (hasKey $apiExtraEnv "KUBERNETES_WORKFLOW_RUN_AFFINITY") }}
+            - name: KUBERNETES_WORKFLOW_RUN_AFFINITY
+              value: {{ toJson .Values.workflowRun.affinity | quote }}
+{{- end }}
+{{- if not (hasKey $apiExtraEnv "KUBERNETES_WORKFLOW_RUN_TOLERATIONS") }}
+            - name: KUBERNETES_WORKFLOW_RUN_TOLERATIONS
+              value: {{ toJson .Values.workflowRun.tolerations | quote }}
+{{- end }}
             - name: FIREWALL_MANAGER_SECRET_SOURCE
               value: {{ .Values.ironProxy.secretSource | quote }}
             - name: FIREWALL_MANAGER_SECRET_TTL
@@ -377,6 +403,18 @@ spec:
 {{- if .Values.sandbox.runtimeClassName }}
             - name: KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME
               value: {{ .Values.sandbox.runtimeClassName | quote }}
+{{- end }}
+{{- if not (hasKey $apiExtraEnv "KUBERNETES_SANDBOX_NODE_SELECTOR") }}
+            - name: KUBERNETES_SANDBOX_NODE_SELECTOR
+              value: {{ toJson .Values.sandbox.nodeSelector | quote }}
+{{- end }}
+{{- if not (hasKey $apiExtraEnv "KUBERNETES_SANDBOX_AFFINITY") }}
+            - name: KUBERNETES_SANDBOX_AFFINITY
+              value: {{ toJson .Values.sandbox.affinity | quote }}
+{{- end }}
+{{- if not (hasKey $apiExtraEnv "KUBERNETES_SANDBOX_TOLERATIONS") }}
+            - name: KUBERNETES_SANDBOX_TOLERATIONS
+              value: {{ toJson .Values.sandbox.tolerations | quote }}
 {{- end }}
 {{- if $reposPath }}
             - name: REPOS_PATH
@@ -494,6 +532,7 @@ spec:
       imagePullSecrets:
 {{ toYaml . | nindent 8 }}
       {{- end }}
+{{ include "centaur.podScheduling" .Values.slackbot | nindent 6 }}
       containers:
         - name: slackbot
           image: {{ printf "%s:%s" .Values.slackbot.image.repository .Values.slackbot.image.tag | quote }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -38,7 +38,36 @@
           }
         },
         "secretSource": { "type": "string" },
-        "secretTtl": { "type": "string" }
+        "secretTtl": { "type": "string" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" }
+      }
+    },
+    "tokenBroker": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string" }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "httpPort": { "type": "integer" },
+            "metricsPort": { "type": "integer" }
+          }
+        },
+        "ttl": { "type": "string" },
+        "resources": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" }
       }
     },
     "toolServer": {
@@ -74,7 +103,10 @@
             "httpPort": { "type": "integer" }
           }
         },
-        "resources": { "type": "object" }
+        "resources": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" }
       }
     },
     "secrets": {
@@ -103,7 +135,10 @@
         "googleDriveSyncIntervalSeconds": { "type": "integer" },
         "googleCalendarEtlEnabled": { "type": "boolean" },
         "googleCalendarSyncIntervalSeconds": { "type": "integer" },
-        "companyContextDocumentsIntervalSeconds": { "type": "integer" }
+        "companyContextDocumentsIntervalSeconds": { "type": "integer" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" }
       }
     },
     "overlay": {
@@ -127,7 +162,18 @@
       "properties": {
         "runtimeClassName": { "type": "string" },
         "reposPath": { "type": "string" },
-        "resources": { "type": "object" }
+        "resources": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" }
+      }
+    },
+    "workflowRun": {
+      "type": "object",
+      "properties": {
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" }
       }
     },
     "repoCache": {
@@ -196,7 +242,10 @@
     "slackbot": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" }
       }
     },
     "postgres": {
@@ -207,7 +256,10 @@
           "properties": {
             "subPath": { "type": "string" }
           }
-        }
+        },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" }
       }
     },
     "runnerAccess": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -31,6 +31,11 @@ ironProxy:
     pgPortRangeEnd: 5471
   secretSource: onepassword
   secretTtl: 10m
+  # Applied by the API to runtime-created iron-proxy Pods and the API proxy
+  # Deployment.
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 # Tool-server sidecar — runs alongside the sandbox container in each sandbox
 # Pod and exposes the same /tools/* surface the API used to. Same image as
@@ -62,6 +67,9 @@ tokenBroker:
   # broker resolver rejects the response.
   ttl: 1m
   resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 # iron-control — Rails control plane for authenticated API access + encrypted
 # secret storage. Off by default; enable per-environment. Uses a dedicated
@@ -88,6 +96,9 @@ ironControl:
   service:
     httpPort: 3000
   resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 # Values for the upstream 1Password Connect subchart
 # (https://github.com/1Password/connect-helm-charts/tree/main/charts/connect).
@@ -150,6 +161,9 @@ api:
   terminationGracePeriodSeconds: 35
   extraEnv: {}
   resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 overlay:
   mountPath: /app/overlay/org
@@ -178,6 +192,16 @@ sandbox:
     requests:
       cpu: 100m
       memory: 512Mi
+  # Applied by the API to runtime-created sandbox Pods.
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+workflowRun:
+  # Applied by the API to runtime-created one-shot workflow execution Pods.
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 repoCache:
   enabled: false
@@ -221,6 +245,9 @@ slackbot:
   runtimeErrorAlertChannel: ""
   extraEnv: {}
   resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 postgres:
   enabled: true
@@ -243,6 +270,9 @@ postgres:
     storageClassName: ""
     subPath: ""
   resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 ingress:
   enabled: false

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -69,6 +69,8 @@ _API_PROXY_SANDBOX_ID = "api"
 # Helm upgrade. The label keeps the chart-side NetworkPolicy selector
 # wired up.
 _TOKEN_BROKER_LABEL = "centaur.ai/iron-token-broker"
+
+
 def _get_rt(session: SandboxSession):
     return runtime_for_session(session)
 
@@ -511,7 +513,10 @@ def _build_tool_server_container(
         {"name": "SSL_CERT_FILE", "value": "/firewall-certs/ca-cert.pem"},
         {"name": "NODE_EXTRA_CA_CERTS", "value": "/firewall-certs/ca-cert.pem"},
         {"name": "CENTAUR_API_URL", "value": api_url},
-        {"name": "CENTAUR_API_KEY", "value": mint_sandbox_token(thread_key, container_name)},
+        {
+            "name": "CENTAUR_API_KEY",
+            "value": mint_sandbox_token(thread_key, container_name),
+        },
         {"name": "TOOL_DIRS", "value": _tool_server_tool_dirs()},
         {"name": "PLUGIN_WATCHER_ENABLED", "value": "0"},
     ]
@@ -599,7 +604,9 @@ def _build_tool_server_container(
     }
 
 
-def _apply_tool_server_extra_env(env: list[dict[str, Any]], computed_no_proxy: str) -> None:
+def _apply_tool_server_extra_env(
+    env: list[dict[str, Any]], computed_no_proxy: str
+) -> None:
     """Let the sidecar see operator sandbox env without breaking its wiring."""
     pinned = {
         "DATABASE_URL",
@@ -719,6 +726,44 @@ def _pod_resources() -> dict[str, Any]:
     if requests:
         resources["requests"] = requests
     return resources
+
+
+def _json_env(name: str, default: Any) -> Any:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{name} must contain valid JSON") from exc
+
+
+def _json_object_env(name: str) -> dict[str, Any]:
+    value = _json_env(name, {})
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be a JSON object")
+    return value
+
+
+def _json_array_env(name: str) -> list[Any]:
+    value = _json_env(name, [])
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a JSON array")
+    return value
+
+
+def _pod_scheduling(prefix: str) -> dict[str, Any]:
+    scheduling: dict[str, Any] = {}
+    node_selector = _json_object_env(f"{prefix}_NODE_SELECTOR")
+    if node_selector:
+        scheduling["nodeSelector"] = node_selector
+    affinity = _json_object_env(f"{prefix}_AFFINITY")
+    if affinity:
+        scheduling["affinity"] = affinity
+    tolerations = _json_array_env(f"{prefix}_TOLERATIONS")
+    if tolerations:
+        scheduling["tolerations"] = tolerations
+    return scheduling
 
 
 def _prompt_bundle(persona: str | None) -> str:
@@ -1241,7 +1286,7 @@ class KubernetesExecutorBackend(SandboxBackend):
             )
         if core is not None:
             proxy_ports.append({"containerPort": core["port"], "name": "pg-core"})
-        return {
+        spec = {
             "automountServiceAccountToken": False,
             "restartPolicy": restart_policy,
             "imagePullSecrets": _image_pull_secrets(),
@@ -1312,6 +1357,8 @@ class KubernetesExecutorBackend(SandboxBackend):
                 },
             ],
         }
+        spec.update(_pod_scheduling("KUBERNETES_IRON_PROXY"))
+        return spec
 
     async def _create_proxy_pod(
         self,
@@ -1660,9 +1707,7 @@ class KubernetesExecutorBackend(SandboxBackend):
                     container_name=pod_name,
                     firewall_host=firewall_host,
                     api_url=os.getenv("AGENT_API_URL", "http://api:8000"),
-                    overlay_mount=(
-                        _SANDBOX_OVERLAY_ROOT if overlay_image else None
-                    ),
+                    overlay_mount=(_SANDBOX_OVERLAY_ROOT if overlay_image else None),
                     database_url=core_pg["dsn"],
                     pg_dsns=sandbox_pg_dsns,
                 )
@@ -1698,6 +1743,7 @@ class KubernetesExecutorBackend(SandboxBackend):
         service_account_name = _service_account_name()
         if service_account_name:
             pod_spec["spec"]["serviceAccountName"] = service_account_name
+        pod_spec["spec"].update(_pod_scheduling("KUBERNETES_SANDBOX"))
 
         await self._delete_existing_workload(pod_name)
         await self._delete_proxy_resources(pod_name)
@@ -2064,9 +2110,7 @@ class KubernetesExecutorBackend(SandboxBackend):
         clones the API container's runtime config — same secrets, same
         ``HTTPS_PROXY`` pointing at the shared API iron-proxy, same CA mount.
         """
-        selector = ",".join(
-            f"{k}={v}" for k, v in _api_pod_match_labels().items()
-        )
+        selector = ",".join(f"{k}={v}" for k, v in _api_pod_match_labels().items())
         pods = await self._core_api().list_namespaced_pod(
             _namespace(), label_selector=selector
         )
@@ -2120,8 +2164,14 @@ class KubernetesExecutorBackend(SandboxBackend):
         # disabling them defensively makes the env unambiguous if a handler
         # imports module-level code that reads these.
         overrides: dict[str, dict[str, Any]] = {
-            "EXECUTION_WORKER_ENABLED": {"name": "EXECUTION_WORKER_ENABLED", "value": "0"},
-            "WORKFLOW_WORKER_ENABLED": {"name": "WORKFLOW_WORKER_ENABLED", "value": "0"},
+            "EXECUTION_WORKER_ENABLED": {
+                "name": "EXECUTION_WORKER_ENABLED",
+                "value": "0",
+            },
+            "WORKFLOW_WORKER_ENABLED": {
+                "name": "WORKFLOW_WORKER_ENABLED",
+                "value": "0",
+            },
             "WARM_POOL_ENABLED": {"name": "WARM_POOL_ENABLED", "value": "0"},
             "PLUGIN_WATCHER_ENABLED": {"name": "PLUGIN_WATCHER_ENABLED", "value": "0"},
             # Already running inside the per-run pod; never recurse.
@@ -2175,9 +2225,12 @@ class KubernetesExecutorBackend(SandboxBackend):
             "containers": [container],
             "volumes": api_template["volumes"],
         }
-        service_account = api_template.get("serviceAccountName") or _service_account_name()
+        service_account = (
+            api_template.get("serviceAccountName") or _service_account_name()
+        )
         if service_account:
             spec["serviceAccountName"] = service_account
+        spec.update(_pod_scheduling("KUBERNETES_WORKFLOW_RUN"))
 
         return {
             "apiVersion": "v1",
@@ -2206,9 +2259,7 @@ class KubernetesExecutorBackend(SandboxBackend):
         await self._ensure_clients()
         pod_name = _workflow_run_pod_name(run_id)
         api_template = await self._load_api_container_template()
-        pod_spec = self._build_workflow_run_pod_spec(
-            run_id, api_template=api_template
-        )
+        pod_spec = self._build_workflow_run_pod_spec(run_id, api_template=api_template)
 
         # If a previous attempt for this run_id left a pod behind, clear it.
         await self._delete_pod(pod_name)
@@ -2228,9 +2279,7 @@ class KubernetesExecutorBackend(SandboxBackend):
         backoff = 0.5
         while True:
             try:
-                pod = await self._core_api().read_namespaced_pod(
-                    pod_name, _namespace()
-                )
+                pod = await self._core_api().read_namespaced_pod(pod_name, _namespace())
             except Exception as exc:
                 if self._is_not_found(exc):
                     return "gone"

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -693,10 +693,7 @@ def test_tool_server_tool_dirs_points_overlay_at_sandbox_mount(
     monkeypatch.delenv("KUBERNETES_TOOL_SERVER_TOOL_DIRS", raising=False)
     monkeypatch.setenv("CENTAUR_OVERLAY_IMAGE", "centaur-overlay:test")
 
-    assert (
-        _tool_server_tool_dirs()
-        == "/app/tools:/home/agent/overlay/org/tools"
-    )
+    assert _tool_server_tool_dirs() == "/app/tools:/home/agent/overlay/org/tools"
 
 
 def test_tool_server_tool_dirs_without_overlay_is_base_only(
@@ -738,6 +735,36 @@ async def test_create_builds_pod_and_prompt_secret(
     monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur-sandbox")
     monkeypatch.setenv("KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME", "gvisor")
     monkeypatch.setenv("KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME", "sandbox-runner")
+    monkeypatch.setenv(
+        "KUBERNETES_SANDBOX_NODE_SELECTOR",
+        json.dumps({"kubernetes.io/arch": "arm64"}),
+    )
+    monkeypatch.setenv(
+        "KUBERNETES_SANDBOX_AFFINITY",
+        json.dumps(
+            {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "pool",
+                                        "operator": "In",
+                                        "values": ["sandboxes"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        ),
+    )
+    monkeypatch.setenv(
+        "KUBERNETES_SANDBOX_TOLERATIONS",
+        json.dumps([{"key": "sandboxes", "operator": "Exists"}]),
+    )
     monkeypatch.setenv("CENTAUR_OVERLAY_IMAGE", "ghcr.io/tempoxyz/centaur-tempo:latest")
     monkeypatch.setenv("CENTAUR_OVERLAY_IMAGE_PULL_POLICY", "Always")
     monkeypatch.setenv("CENTAUR_OVERLAY_IMAGE_SOURCE_PATH", "/overlay")
@@ -791,6 +818,17 @@ async def test_create_builds_pod_and_prompt_secret(
 
     assert pod_body["spec"]["runtimeClassName"] == "gvisor"
     assert pod_body["spec"]["serviceAccountName"] == "sandbox-runner"
+    assert pod_body["spec"]["nodeSelector"] == {"kubernetes.io/arch": "arm64"}
+    assert pod_body["spec"]["affinity"]["nodeAffinity"][
+        "requiredDuringSchedulingIgnoredDuringExecution"
+    ]["nodeSelectorTerms"][0]["matchExpressions"][0] == {
+        "key": "pool",
+        "operator": "In",
+        "values": ["sandboxes"],
+    }
+    assert pod_body["spec"]["tolerations"] == [
+        {"key": "sandboxes", "operator": "Exists"}
+    ]
     assert container["image"] == "centaur-agent:test"
     assert "command" not in container
     assert container["args"] == ["amp-wrapper"]
@@ -878,6 +916,20 @@ async def test_create_builds_per_sandbox_proxy_resources(
     monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur-sandbox")
     monkeypatch.setenv("KUBERNETES_IRON_PROXY_IMAGE", "centaur-iron-proxy:test")
     monkeypatch.setenv(
+        "KUBERNETES_IRON_PROXY_NODE_SELECTOR",
+        json.dumps({"kubernetes.io/arch": "arm64"}),
+    )
+    monkeypatch.setenv(
+        "KUBERNETES_IRON_PROXY_AFFINITY",
+        json.dumps(
+            {"podAntiAffinity": {"preferredDuringSchedulingIgnoredDuringExecution": []}}
+        ),
+    )
+    monkeypatch.setenv(
+        "KUBERNETES_IRON_PROXY_TOLERATIONS",
+        json.dumps([{"key": "proxies", "operator": "Exists"}]),
+    )
+    monkeypatch.setenv(
         "KUBERNETES_FIREWALL_MANAGER_IMAGE", "centaur-firewall-manager:test"
     )
     monkeypatch.setattr(
@@ -933,6 +985,13 @@ async def test_create_builds_per_sandbox_proxy_resources(
     assert [container["name"] for container in proxy_pod["spec"]["containers"]] == [
         "iron-proxy",
     ]
+    assert proxy_pod["spec"]["nodeSelector"] == {"kubernetes.io/arch": "arm64"}
+    assert proxy_pod["spec"]["affinity"] == {
+        "podAntiAffinity": {"preferredDuringSchedulingIgnoredDuringExecution": []}
+    }
+    assert proxy_pod["spec"]["tolerations"] == [
+        {"key": "proxies", "operator": "Exists"}
+    ]
     assert proxy_pod["spec"]["containers"][0]["image"] == "centaur-iron-proxy:test"
     assert proxy_pod["spec"]["containers"][0]["readinessProbe"]["periodSeconds"] == 5
     assert (
@@ -977,6 +1036,44 @@ async def test_create_builds_per_sandbox_proxy_resources(
     )
 
 
+def test_workflow_run_pod_uses_configured_scheduling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = KubernetesExecutorBackend()
+    monkeypatch.setenv(
+        "KUBERNETES_WORKFLOW_RUN_NODE_SELECTOR",
+        json.dumps({"kubernetes.io/arch": "arm64"}),
+    )
+    monkeypatch.setenv(
+        "KUBERNETES_WORKFLOW_RUN_AFFINITY",
+        json.dumps(
+            {"nodeAffinity": {"preferredDuringSchedulingIgnoredDuringExecution": []}}
+        ),
+    )
+    monkeypatch.setenv(
+        "KUBERNETES_WORKFLOW_RUN_TOLERATIONS",
+        json.dumps([{"key": "workflow", "operator": "Exists"}]),
+    )
+
+    pod = backend._build_workflow_run_pod_spec(
+        "run_123",
+        api_template={
+            "env": [],
+            "envFrom": [],
+            "volumeMounts": [],
+            "volumes": [],
+            "imagePullSecrets": [],
+            "serviceAccountName": "centaur-api",
+        },
+    )
+
+    assert pod["spec"]["nodeSelector"] == {"kubernetes.io/arch": "arm64"}
+    assert pod["spec"]["affinity"] == {
+        "nodeAffinity": {"preferredDuringSchedulingIgnoredDuringExecution": []}
+    }
+    assert pod["spec"]["tolerations"] == [{"key": "workflow", "operator": "Exists"}]
+
+
 class FakeAppsApi:
     """Minimal AppsV1Api stand-in. Records create/replace/patch and exposes
     pre-seeded reads via ``deployments_to_read`` (FIFO; Exception items are
@@ -990,9 +1087,7 @@ class FakeAppsApi:
 
     async def read_namespaced_deployment(self, name: str, namespace: str):  # noqa: ANN201, ARG002
         if not self.deployments_to_read:
-            raise AssertionError(
-                f"unexpected read_namespaced_deployment({name})"
-            )
+            raise AssertionError(f"unexpected read_namespaced_deployment({name})")
         item = self.deployments_to_read.pop(0)
         if isinstance(item, Exception):
             raise item
@@ -1020,9 +1115,7 @@ async def test_ensure_token_broker_writes_configmap_and_patches_deployment(
     from api.tool_manager import BrokeredTokenSecret, OAuthFieldSource
 
     monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur")
-    monkeypatch.setenv(
-        "KUBERNETES_TOKEN_BROKER_NAME", "centaur-centaur-token-broker"
-    )
+    monkeypatch.setenv("KUBERNETES_TOKEN_BROKER_NAME", "centaur-centaur-token-broker")
     monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
 
     backend = KubernetesExecutorBackend()
@@ -1083,9 +1176,7 @@ async def test_ensure_token_broker_skips_rollout_when_config_unchanged(
     from api.tool_manager import BrokeredTokenSecret, OAuthFieldSource
 
     monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur")
-    monkeypatch.setenv(
-        "KUBERNETES_TOKEN_BROKER_NAME", "centaur-centaur-token-broker"
-    )
+    monkeypatch.setenv("KUBERNETES_TOKEN_BROKER_NAME", "centaur-centaur-token-broker")
     monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
 
     secrets = [
@@ -1136,9 +1227,7 @@ async def test_ensure_token_broker_tolerates_missing_deployment(
     from api.tool_manager import BrokeredTokenSecret, OAuthFieldSource
 
     monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur")
-    monkeypatch.setenv(
-        "KUBERNETES_TOKEN_BROKER_NAME", "centaur-centaur-token-broker"
-    )
+    monkeypatch.setenv("KUBERNETES_TOKEN_BROKER_NAME", "centaur-centaur-token-broker")
     monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "onepassword")
 
     backend = KubernetesExecutorBackend()
@@ -1205,9 +1294,7 @@ def test_proxy_iron_env_injects_broker_when_url_set(
     )
     env = _proxy_iron_env("centaur-infra-env", [])
     by_name = {e["name"]: e for e in env}
-    assert by_name["IRON_BROKER_URL"]["value"] == (
-        "http://centaur-token-broker:8181"
-    )
+    assert by_name["IRON_BROKER_URL"]["value"] == ("http://centaur-token-broker:8181")
     assert by_name["IRON_BROKER_TOKEN"]["valueFrom"]["secretKeyRef"] == {
         "name": "centaur-infra-env",
         "key": "IRON_BROKER_TOKEN",
@@ -1223,7 +1310,12 @@ def test_tool_server_container_exposes_aws_region_not_credentials(
     monkeypatch.setenv("KUBERNETES_SECRET_ENV_NAME", "centaur-infra-env")
 
     container = _build_tool_server_container(
-        firewall_host="fw", api_url="http://api:8000", overlay_mount=None
+        thread_key="slack:C123:123.456",
+        container_name="centaur-centaur-sandbox-test",
+        firewall_host="fw",
+        api_url="http://api:8000",
+        overlay_mount=None,
+        database_url="postgres://user:pass@fw:5432/centaur",
     )
     by_name = {e["name"]: e for e in container["env"]}
 


### PR DESCRIPTION
## Summary

This makes Centaur friendlier to mixed-architecture Kubernetes clusters.

Today the published Centaur images are built by the default GitHub-hosted runner architecture, so the GHCR tags resolve to linux/amd64 manifests only. In clusters with both amd64 and arm64 nodes, chart-managed pods and API-created runtime pods can land on an incompatible node.

Downstream users can try to work around that by pinning Centaur workloads to amd64 nodes, but that is not a clean or complete solution. Some of the relevant pods are not ordinary chart workloads: the API creates sandbox, iron-proxy, and workflow-run pods at runtime. Pinning those from downstream means carrying chart forks, post-render patches, or extra environment plumbing that mirrors Centaur internals. That workaround is brittle, easy to miss during upgrades, and pushes cluster-scheduling behavior out of the upstream chart/API boundary where operators expect to configure it.

This PR addresses that from both sides:

- publish Centaur images for `linux/amd64` and `linux/arm64` using Buildx + QEMU
- expose standard Helm scheduling values (`nodeSelector`, `affinity`, `tolerations`) for chart-managed workloads
- pass scheduling values through the API for runtime-created `iron-proxy`, sandbox, and workflow-run pods
- validate the runtime scheduling env as JSON before building pod specs

## Details

The publish workflow now configures QEMU before Buildx and sets:

```yaml
platforms: linux/amd64,linux/arm64
```

for the image matrix. That should make these GHCR images publish as multi-platform indexes on future main/tag releases:

- `centaur-api`
- `centaur-slackbot`
- `centaur-agent`
- `centaur-iron-proxy`

The chart now supports scheduling values for:

- `api`
- `slackbot`
- `postgres`
- `tokenBroker`
- `ironControl`
- `ironProxy`
- `sandbox`
- `workflowRun`

For normal chart workloads, those values render directly into the pod template. For runtime-created pods, the chart serializes the values into API env vars:

- `KUBERNETES_IRON_PROXY_NODE_SELECTOR`, `KUBERNETES_IRON_PROXY_AFFINITY`, `KUBERNETES_IRON_PROXY_TOLERATIONS`
- `KUBERNETES_SANDBOX_NODE_SELECTOR`, `KUBERNETES_SANDBOX_AFFINITY`, `KUBERNETES_SANDBOX_TOLERATIONS`
- `KUBERNETES_WORKFLOW_RUN_NODE_SELECTOR`, `KUBERNETES_WORKFLOW_RUN_AFFINITY`, `KUBERNETES_WORKFLOW_RUN_TOLERATIONS`

The Kubernetes backend parses those as JSON and applies them to the generated pod specs. This keeps runtime-created pods configurable through the chart, instead of requiring downstream template forks or post-render patches.

## Testing

- `helm lint contrib/chart`
- `helm template centaur contrib/chart --namespace centaur --set tokenBroker.enabled=true --set ironControl.enabled=true ...` with amd64 `nodeSelector` values for chart workloads and runtime pod values
- `python3 -m json.tool contrib/chart/values.schema.json`
- `uv run ruff format api/sandbox/kubernetes.py tests/test_sandbox_kubernetes_backend.py`
- `uv run ruff check api/sandbox/kubernetes.py tests/test_sandbox_kubernetes_backend.py`
- `uv run pytest tests/test_sandbox_kubernetes_backend.py` (`52 passed`)
