### PR TITLE
fix(sandbox): drop foreign-thread events in codex app-server wrapper

### DIFF
--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -344,6 +344,270 @@ def test_emit_notification_collects_agent_message_delta_output(monkeypatch) -> N
     assert emitted[0]["type"] == "item.agentMessage.delta"
 
 
+def test_emit_notification_suppresses_foreign_thread_turn(monkeypatch) -> None:
+    """A background turn on another thread (the memories agent) must not reach
+    the stream or terminate the durable turn.
+
+    Regression test for the incident: the memories consolidation agent ran in
+    its own thread (confirmed from prod pod logs) and its "What do you want me
+    to work on in /home/agent/.codex/memories?" final answer was relayed to
+    Slack while its turn/completed prematurely ended the user's turn, dropping
+    the real answer.
+    """
+    wrapper = _load_wrapper()
+    emitted: list[dict] = []
+    monkeypatch.setattr(wrapper, "emit", emitted.append)
+
+    wrapper.THREAD_ID = "thread-main"
+    wrapper.THREAD_ID_AUTHORITATIVE = True
+    wrapper.ACTIVE_TURN_ID = "turn-main"
+    wrapper.CURRENT_LLM_OUTPUT_TEXT = ""
+    wrapper.LLM_OUTPUTS_BY_TURN_ID = {}
+
+    foreign = {"threadId": "thread-mem", "turnId": "turn-mem"}
+    assert (
+        wrapper.emit_notification({"method": "turn/started", "params": {**foreign}})
+        is False
+    )
+    assert (
+        wrapper.emit_notification(
+            {
+                "method": "item/agentMessage/delta",
+                "params": {
+                    **foreign,
+                    "itemId": "msg-mem",
+                    "delta": "What do you want me to work on",
+                },
+            }
+        )
+        is False
+    )
+    assert (
+        wrapper.emit_notification(
+            {
+                "method": "item/completed",
+                "params": {
+                    **foreign,
+                    "item": {
+                        "id": "msg-mem",
+                        "type": "agentMessage",
+                        "text": "I only have the environment context, not a task.",
+                        "phase": "final_answer",
+                    },
+                },
+            }
+        )
+        is False
+    )
+    done = wrapper.emit_notification(
+        {"method": "turn/completed", "params": {**foreign, "turn": {"id": "turn-mem"}}}
+    )
+
+    assert done is False
+    assert emitted == []
+    assert wrapper.ACTIVE_TURN_ID == "turn-main"
+    assert wrapper.CURRENT_LLM_OUTPUT_TEXT == ""
+    assert wrapper.LLM_OUTPUTS_BY_TURN_ID == {}
+
+
+def test_emit_notification_relays_primary_thread_turn(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    emitted: list[dict] = []
+    monkeypatch.setattr(wrapper, "emit", emitted.append)
+
+    wrapper.THREAD_ID = "thread-main"
+    wrapper.THREAD_ID_AUTHORITATIVE = True
+    wrapper.ACTIVE_TURN_ID = "turn-main"
+    wrapper.CURRENT_LLM_OUTPUT_TEXT = ""
+    wrapper.LLM_OUTPUTS_BY_TURN_ID = {}
+
+    wrapper.emit_notification(
+        {
+            "method": "item/agentMessage/delta",
+            "params": {
+                "threadId": "thread-main",
+                "turnId": "turn-main",
+                "itemId": "msg-1",
+                "delta": "PONG",
+            },
+        }
+    )
+    done = wrapper.emit_notification(
+        {
+            "method": "turn/completed",
+            "params": {"threadId": "thread-main", "turn": {"id": "turn-main"}},
+        }
+    )
+
+    assert done is True
+    assert [event["type"] for event in emitted] == [
+        "item.agentMessage.delta",
+        "turn.completed",
+    ]
+    assert wrapper.CURRENT_LLM_OUTPUT_TEXT == "PONG"
+    assert wrapper.ACTIVE_TURN_ID is None
+
+
+def test_emit_notification_suppresses_foreign_thread_error(monkeypatch) -> None:
+    """`error` is the protocol's turn-failure path and carries threadId, so a
+    background turn's error must not terminate the durable turn."""
+    wrapper = _load_wrapper()
+    emitted: list[dict] = []
+    monkeypatch.setattr(wrapper, "emit", emitted.append)
+
+    wrapper.THREAD_ID = "thread-main"
+    wrapper.THREAD_ID_AUTHORITATIVE = True
+    wrapper.ACTIVE_TURN_ID = "turn-main"
+
+    done = wrapper.emit_notification(
+        {
+            "method": "error",
+            "params": {
+                "threadId": "thread-mem",
+                "turnId": "turn-mem",
+                "willRetry": False,
+                "error": {"message": "background turn failed"},
+            },
+        }
+    )
+
+    assert done is False
+    assert emitted == []
+    assert wrapper.ACTIVE_TURN_ID == "turn-main"
+
+
+def test_emit_notification_keeps_global_error_terminal(monkeypatch) -> None:
+    """An error without a threadId is process-global and stays terminal."""
+    wrapper = _load_wrapper()
+    emitted: list[dict] = []
+    monkeypatch.setattr(wrapper, "emit", emitted.append)
+
+    wrapper.THREAD_ID = "thread-main"
+    wrapper.ACTIVE_TURN_ID = "turn-main"
+
+    done = wrapper.emit_notification(
+        {"method": "error", "params": {"message": "app-server crashed"}}
+    )
+
+    assert done is True
+    assert [event["type"] for event in emitted] == ["turn.failed"]
+
+
+def test_emit_notification_ignores_foreign_thread_started(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    emitted: list[dict] = []
+    monkeypatch.setattr(wrapper, "emit", emitted.append)
+
+    wrapper.THREAD_ID = None
+    wrapper.emit_notification(
+        {"method": "thread/started", "params": {"thread": {"id": "thread-main"}}}
+    )
+    wrapper.emit_notification(
+        {"method": "thread/started", "params": {"thread": {"id": "thread-mem"}}}
+    )
+
+    assert wrapper.THREAD_ID == "thread-main"
+    assert [event["type"] for event in emitted] == ["thread.started"]
+
+
+def test_emit_notification_fails_open_when_thread_id_not_authoritative(
+    monkeypatch,
+) -> None:
+    """If our own thread id is a uuid fallback (server returned none), the
+    filter must NOT run — otherwise the primary turn's own events, which carry
+    the real thread id, would all be dropped, producing zero output.
+    """
+    wrapper = _load_wrapper()
+    emitted: list[dict] = []
+    monkeypatch.setattr(wrapper, "emit", emitted.append)
+
+    wrapper.THREAD_ID = "00000000-0000-4000-8000-000000000000"  # uuid fallback
+    wrapper.THREAD_ID_AUTHORITATIVE = False
+    wrapper.ACTIVE_TURN_ID = "turn-real"
+    wrapper.CURRENT_LLM_OUTPUT_TEXT = ""
+    wrapper.LLM_OUTPUTS_BY_TURN_ID = {}
+
+    # The real turn's events carry the server's actual thread id, which differs
+    # from our fabricated one. They must still be relayed.
+    wrapper.emit_notification(
+        {
+            "method": "item/agentMessage/delta",
+            "params": {
+                "threadId": "real-server-thread",
+                "turnId": "turn-real",
+                "itemId": "msg-1",
+                "delta": "answer",
+            },
+        }
+    )
+    done = wrapper.emit_notification(
+        {
+            "method": "turn/completed",
+            "params": {"threadId": "real-server-thread", "turn": {"id": "turn-real"}},
+        }
+    )
+
+    assert done is True
+    assert [event["type"] for event in emitted] == [
+        "item.agentMessage.delta",
+        "turn.completed",
+    ]
+    assert wrapper.CURRENT_LLM_OUTPUT_TEXT == "answer"
+
+
+def test_emit_notification_fails_open_without_thread_id(monkeypatch) -> None:
+    """Events that omit threadId keep the original relay behavior."""
+    wrapper = _load_wrapper()
+    emitted: list[dict] = []
+    monkeypatch.setattr(wrapper, "emit", emitted.append)
+
+    wrapper.THREAD_ID = "thread-main"
+    wrapper.THREAD_ID_AUTHORITATIVE = True
+    wrapper.ACTIVE_TURN_ID = None
+    wrapper.CURRENT_LLM_OUTPUT_TEXT = ""
+    wrapper.LLM_OUTPUTS_BY_TURN_ID = {}
+
+    wrapper.emit_notification(
+        {"method": "turn/started", "params": {"turn": {"id": "turn-1"}}}
+    )
+    done = wrapper.emit_notification(
+        {"method": "turn/completed", "params": {"turn": {"id": "turn-1"}}}
+    )
+
+    assert done is True
+    assert [event["type"] for event in emitted] == ["turn.started", "turn.completed"]
+
+
+def test_start_or_resume_thread_marks_server_id_authoritative(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.setattr(wrapper, "emit", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        wrapper, "request", lambda *_a, **_k: {"thread": {"id": "thread-srv"}}
+    )
+
+    wrapper.THREAD_ID = None
+    wrapper.THREAD_ID_AUTHORITATIVE = False
+    wrapper.start_or_resume_thread()
+
+    assert wrapper.THREAD_ID == "thread-srv"
+    assert wrapper.THREAD_ID_AUTHORITATIVE is True
+
+
+def test_start_or_resume_thread_uuid_fallback_not_authoritative(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.delenv("CODEX_CONTINUE_THREAD_ID", raising=False)
+    monkeypatch.delenv("AMP_CONTINUE_THREAD_ID", raising=False)
+    monkeypatch.setattr(wrapper, "emit", lambda *_a, **_k: None)
+    monkeypatch.setattr(wrapper, "request", lambda *_a, **_k: {})  # no thread id
+
+    wrapper.THREAD_ID = None
+    wrapper.THREAD_ID_AUTHORITATIVE = True  # must be cleared by the fallback
+    wrapper.start_or_resume_thread()
+
+    assert wrapper.THREAD_ID  # a uuid was generated for stream labelling
+    assert wrapper.THREAD_ID_AUTHORITATIVE is False
+
+
 def test_main_lazy_starts_app_server_after_input(monkeypatch) -> None:
     wrapper = _load_wrapper()
     requests: list[tuple[str, dict]] = []

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -37,6 +37,9 @@ RESPONSES: dict[int, queue.Queue[dict[str, Any]]] = {}
 EVENTS: queue.Queue[dict[str, Any] | None] = queue.Queue()
 INPUTS: queue.Queue[dict[str, Any] | None] = queue.Queue()
 THREAD_ID: str | None = None
+# True only when THREAD_ID is the real thread id (from the server or a resume
+# id), so it is safe to filter on. See _is_foreign_thread_event.
+THREAD_ID_AUTHORITATIVE = False
 ACTIVE_TURN_ID: str | None = None
 SHUTTING_DOWN = False
 CONFIGURED_OTEL_TRACE_ID: str | None = None
@@ -672,7 +675,7 @@ def configure_trace_context_for_startup(trace_id: str | None) -> None:
 
 
 def start_or_resume_thread() -> str:
-    global THREAD_ID
+    global THREAD_ID, THREAD_ID_AUTHORITATIVE
     if THREAD_ID:
         return THREAD_ID
     resume = (
@@ -688,8 +691,24 @@ def start_or_resume_thread() -> str:
         result = request("thread/start", {"cwd": os.getcwd()}, timeout=60)
     thread = result.get("thread") or {}
     THREAD_ID = str(thread.get("id") or resume or uuid.uuid4())
+    # Authoritative only with a server/resume id; a uuid fallback matches no real
+    # event, so the foreign-thread filter must fail open instead of dropping ours.
+    THREAD_ID_AUTHORITATIVE = bool(thread.get("id") or resume)
     emit({"type": "thread.started", "thread_id": THREAD_ID})
     return THREAD_ID
+
+
+def _is_foreign_thread_event(params: dict[str, Any]) -> bool:
+    """Return True for events from a thread we did not start (e.g. the memories
+    agent, which app-server runs in its own thread on the shared channel).
+
+    Fail open when ``threadId`` is absent or our id is non-authoritative, so we
+    never drop the primary turn's own events.
+    """
+    if not THREAD_ID_AUTHORITATIVE:
+        return False
+    thread_id = str(params.get("threadId") or "")
+    return bool(thread_id and THREAD_ID and thread_id != THREAD_ID)
 
 
 def emit_notification(msg: dict[str, Any]) -> bool:
@@ -700,9 +719,14 @@ def emit_notification(msg: dict[str, Any]) -> bool:
     if method == "thread/started":
         thread = params.get("thread") or {}
         tid = thread.get("id") or params.get("threadId")
-        if tid:
+        # Adopt only the first id; a later foreign thread/started must not clobber it.
+        if tid and THREAD_ID is None:
             THREAD_ID = str(tid)
             emit({"type": "thread.started", "thread_id": THREAD_ID})
+        return False
+
+    # Every event below is scoped to a thread: suppress anything foreign.
+    if _is_foreign_thread_event(params):
         return False
 
     if method == "turn/started":


### PR DESCRIPTION
## What

Scope `codex app-server` notifications to the thread the wrapper started, so background-thread work (notably the memories consolidation agent) can no longer reach the user or end the user's turn.

Fixes #444

## Problem

`codex-app-wrapper.py` relayed every notification from the app-server. The app-server multiplexes concurrent threads/turns onto one stream, and the **memories agent runs in its own thread**. In production this caused:

- the memories agent's "What do you want me to work on in `~/.codex/memories`?" final answer to be shown to the user as the reply, and
- its `turn/completed` to be relayed, which terminated the user's durable turn early and **dropped the real answer**.

See #444 for the full write-up and the (sanitized) log evidence showing the background work on a distinct `threadId`.

## Fix

- `_is_foreign_thread_event(params)` — suppress any notification whose `threadId` differs from ours. Our thread id is known from the `thread/start`/`thread/resume` response before any turn is drained, so the check has no blind window.
- `thread/started` only adopts the **first** thread id; a later foreign `thread/started` cannot clobber ours.
- **Authoritative-id guard.** Making `THREAD_ID` a filter key means a wrong value would drop the primary turn's own events. The existing `thread.get("id") or resume or uuid.uuid4()` fallback can produce an id that matches nothing if the server returns none. We now track whether the id is authoritative (from the server or a resume id) and **fail open** (relay everything) when it is not. Events that omit `threadId` also fail open, for protocol compatibility.

## Why thread-only (scope rationale)

We confirmed from production logs that the discriminator is the **thread** — the memories agent's events carry a different `threadId`, and the thread filter alone suppresses all of them, including the premature terminal. We deliberately did **not** add turn-id-level machinery (per-turn id tracking, stale-terminal guards, etc.): in the reproduced incident those guards would have fired on nothing, and we preferred not to add code for failure modes we have not observed. Happy to revisit if maintainers know of same-thread background-turn cases.

## Testing

`services/api/tests/test_codex_app_wrapper.py` (20 passing), including regressions that fail without this change:

- foreign-thread suppression across the turn lifecycle (`turn/started`, `item/agentMessage/delta`, `item/completed`, `turn/completed`)
- foreign-thread `error` suppressed (does not terminate the user's turn)
- primary-thread events relayed normally; process-global `error` (no `threadId`) still terminal
- non-authoritative `THREAD_ID` (uuid fallback) → filter fails open, primary turn's events relayed
- `start_or_resume_thread` marks server/resume ids authoritative and the uuid fallback non-authoritative

## Out of scope — for maintainer discussion (not in this PR)

To keep this PR focused on the reproduced bug, two adjacent observations are **not** addressed here. We only caught this issue because it surfaced via the memories agent, so before adding speculative handling we'd like your read on whether the wrapper should cover them:

1. **`error` ignores `willRetry`** — any `error` becomes a terminal `turn.failed`, even when `ErrorNotification.willRetry` is true.
2. **`uuid4()` thread-id fallback as identity** — the fabricated id also flows into the emitted `session_id` and `turn/start`'s `threadId`; this PR only makes the new filter fail open in that case.

Both are noted in #444.
