### PR TITLE
feat(api-rs): add telemetry observability

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -4,6 +4,11 @@
 {{- if and .Values.repoCache.enabled (not $reposPath) -}}
 {{- $reposPath = .Values.repoCache.hostPath -}}
 {{- end -}}
+{{- $apiRsMetricsAnnotations := dict -}}
+{{- if .Values.apiRs.metrics.scrapeAnnotations -}}
+{{- $apiRsMetricsAnnotations = dict "prometheus.io/scrape" "true" "prometheus.io/path" .Values.apiRs.metrics.path "prometheus.io/port" (printf "%v" .Values.apiRs.port) -}}
+{{- $apiRsMetricsAnnotations = mergeOverwrite $apiRsMetricsAnnotations (.Values.apiRs.metrics.annotations | default dict) -}}
+{{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -79,6 +84,9 @@ spec:
       annotations:
         checksum/infra-secrets: {{ include "centaur.infraSecretsChecksum" . }}
         checksum/overlay: {{ toJson .Values.overlay | sha256sum }}
+{{- with $apiRsMetricsAnnotations }}
+{{ toYaml . | nindent 8 }}
+{{- end }}
       labels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 8 }}
     spec:
@@ -259,6 +267,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $apiRsName }}
+{{- with $apiRsMetricsAnnotations }}
+  annotations:
+{{ toYaml . | nindent 4 }}
+{{- end }}
   labels:
 {{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
 spec:

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -192,6 +192,26 @@
         }
       }
     },
+    "apiRs": {
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "scrapeAnnotations": { "type": "boolean" },
+            "path": { "type": "string" },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
+        "extraEnv": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
     "slackbot": {
       "type": "object",
       "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -234,6 +234,13 @@ apiRs:
   sandboxWarmPoolReplenishIntervalSecs: 5
   ironProxy:
     mode: enabled
+  metrics:
+    # The Rust API always serves Prometheus text metrics at /metrics. This flag
+    # only controls scrape annotations for Prometheus/VictoriaMetrics-style
+    # discovery.
+    scrapeAnnotations: true
+    path: /metrics
+    annotations: {}
   # 1Password vault the iron-proxy secret source reads from when
   # ironProxy.secretSource is "onepassword". Empty falls back to the binary
   # default ("ai-agents").

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -14,6 +14,8 @@ Use these as the main extension points:
 | --- | --- |
 | `secretManager.existingSecretName` | Required runtime secrets such as database, Slack, sandbox signing, and 1Password credentials. |
 | `api.extraEnv` | API feature flags, worker tuning, retention, observability, and deployment-specific overrides. |
+| `apiRs.extraEnv` | Rust API feature flags, telemetry exporter settings, and deployment-specific overrides. |
+| `apiRs.metrics.*` | Prometheus/VictoriaMetrics scrape metadata for the Rust API `/metrics` endpoint. |
 | `slackbot.extraEnv` | Slackbot HTTP, Slack, feedback, and cross-org behavior. |
 | `sandbox.extraEnv` | Extra variables copied into every sandbox pod through `KUBERNETES_SANDBOX_EXTRA_ENV`. |
 | `overlay.*` | Overlay mount path and overlay image passed to the API and sandboxes. |
@@ -68,6 +70,19 @@ Optional required-by-mode variables:
 | `FINAL_DELIVERY_MAX_ATTEMPTS`, `FINAL_DELIVERY_READY_GRACE_S` | `api.extraEnv`. | Final-delivery retry and claim timing. |
 | `CENTAUR_ENABLE_GCLOUD_BOOTSTRAP`, `GCP_GCLOUD_CREDENTIAL`, `GCLOUD_PROJECT` | `api.extraEnv` or Secret. | Optional gcloud ADC bootstrap in the API container. |
 | `CLAUDE_MODEL`, `CODEX_MODEL` | `api.extraEnv` or request model override. | Harness model selection defaults. |
+
+## API-RS
+
+| Env var or value | Set from | Controls |
+| --- | --- | --- |
+| `RUST_LOG` | Chart sets `info`; override with `apiRs.extraEnv`. | Rust tracing filter for the API-RS binary and crates. |
+| `OTEL_SERVICE_NAME` | `apiRs.extraEnv`; defaults to `centaur-api-rs`. | OpenTelemetry service name used by trace backends. |
+| `CENTAUR_ENVIRONMENT`, `DEPLOY_ENV`, `ENVIRONMENT` | `apiRs.extraEnv` or deployment env. | Deployment environment resource attribute for telemetry. |
+| `OTEL_TRACES_EXPORTER` | `apiRs.extraEnv`. | Set to `otlp` to force OTLP trace export, or `none`/`off` to disable it. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `apiRs.extraEnv`. | Enables OTLP trace export to Tempo, Jaeger, or another OTLP collector. |
+| `apiRs.metrics.scrapeAnnotations` | Helm value, default `true`. | Adds Prometheus scrape annotations to the API-RS Pod template and Service. |
+| `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
+| `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
 
 Execution tuning:
 
@@ -180,6 +195,7 @@ Slack ETL workflows:
 | Env var | Set from | Controls |
 | --- | --- | --- |
 | `VICTORIAMETRICS_URL`, `VICTORIAMETRICS_PUSH_ENABLED` | `api.extraEnv`, `api.victoriaMetricsPushEnabled`. | Push-based API metrics. |
+| `apiRs.metrics.*` | Helm values. | Pull-based scrape metadata for API-RS Prometheus metrics. |
 | `CENTAUR_RETENTION_ATTACHMENTS_TTL_DAYS`, `CENTAUR_RETENTION_TRANSCRIPTS_TTL_DAYS` | `api.extraEnv`. | Attachment/transcript retention TTLs. |
 | `CENTAUR_RETENTION_SWEEP_INTERVAL_SECONDS`, `CENTAUR_RETENTION_BATCH_SIZE`, `CENTAUR_RETENTION_DRY_RUN` | `api.extraEnv`. | Retention sweep cadence, batch size, and dry-run mode. |
 | `TOOL_CALL_TIMEOUT_S`, `TOOL_BINARY_INLINE_MAX_BYTES`, `TOOL_BINARY_PREVIEW_BYTES` | `api.extraEnv`. | Tool execution timeout and binary result handling. |

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -14,6 +14,8 @@ Use these as the main extension points:
 | --- | --- |
 | `secretManager.existingSecretName` | Required runtime secrets such as database, Slack, sandbox signing, and 1Password credentials. |
 | `api.extraEnv` | API feature flags, worker tuning, retention, observability, and deployment-specific overrides. |
+| `apiRs.extraEnv` | Rust API feature flags, telemetry exporter settings, and deployment-specific overrides. |
+| `apiRs.metrics.*` | Prometheus/VictoriaMetrics scrape metadata for the Rust API `/metrics` endpoint. |
 | `slackbot.extraEnv` | Slackbot HTTP, Slack, feedback, and cross-org behavior. |
 | `sandbox.extraEnv` | Extra variables copied into every sandbox pod through `KUBERNETES_SANDBOX_EXTRA_ENV`. |
 | `overlay.*` | Overlay mount path and overlay image passed to the API and sandboxes. |
@@ -67,6 +69,19 @@ Optional required-by-mode variables:
 | `FINAL_DELIVERY_MAX_ATTEMPTS`, `FINAL_DELIVERY_READY_GRACE_S` | `api.extraEnv`. | Final-delivery retry and claim timing. |
 | `CENTAUR_ENABLE_GCLOUD_BOOTSTRAP`, `GCP_GCLOUD_CREDENTIAL`, `GCLOUD_PROJECT` | `api.extraEnv` or Secret. | Optional gcloud ADC bootstrap in the API container. |
 | `CLAUDE_MODEL`, `CODEX_MODEL` | `api.extraEnv` or request model override. | Harness model selection defaults. |
+
+## API-RS
+
+| Env var or value | Set from | Controls |
+| --- | --- | --- |
+| `RUST_LOG` | Chart sets `info`; override with `apiRs.extraEnv`. | Rust tracing filter for the API-RS binary and crates. |
+| `OTEL_SERVICE_NAME` | `apiRs.extraEnv`; defaults to `centaur-api-rs`. | OpenTelemetry service name used by trace backends. |
+| `CENTAUR_ENVIRONMENT`, `DEPLOY_ENV`, `ENVIRONMENT` | `apiRs.extraEnv` or deployment env. | Deployment environment resource attribute for telemetry. |
+| `OTEL_TRACES_EXPORTER` | `apiRs.extraEnv`. | Set to `otlp` to force OTLP trace export, or `none`/`off` to disable it. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `apiRs.extraEnv`. | Enables OTLP trace export to Tempo, Jaeger, or another OTLP collector. |
+| `apiRs.metrics.scrapeAnnotations` | Helm value, default `true`. | Adds Prometheus scrape annotations to the API-RS Pod template and Service. |
+| `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
+| `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
 
 Execution tuning:
 
@@ -175,6 +190,7 @@ Slack ETL workflows:
 | Env var | Set from | Controls |
 | --- | --- | --- |
 | `VICTORIAMETRICS_URL`, `VICTORIAMETRICS_PUSH_ENABLED` | `api.extraEnv`, `api.victoriaMetricsPushEnabled`. | Push-based API metrics. |
+| `apiRs.metrics.*` | Helm values. | Pull-based scrape metadata for API-RS Prometheus metrics. |
 | `CENTAUR_RETENTION_ATTACHMENTS_TTL_DAYS`, `CENTAUR_RETENTION_TRANSCRIPTS_TTL_DAYS` | `api.extraEnv`. | Attachment/transcript retention TTLs. |
 | `CENTAUR_RETENTION_SWEEP_INTERVAL_SECONDS`, `CENTAUR_RETENTION_BATCH_SIZE`, `CENTAUR_RETENTION_DRY_RUN` | `api.extraEnv`. | Retention sweep cadence, batch size, and dry-run mode. |
 | `TOOL_CALL_TIMEOUT_S`, `TOOL_BINARY_INLINE_MAX_BYTES`, `TOOL_BINARY_PREVIEW_BYTES` | `api.extraEnv`. | Tool execution timeout and binary result handling. |

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "centaur-session-core",
  "centaur-session-runtime",
  "centaur-session-sqlx",
+ "centaur-telemetry",
  "clap",
  "eventsource-stream",
  "futures-util",
@@ -285,8 +286,9 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tower",
+ "tower-http",
  "tracing",
- "tracing-subscriber",
  "urlencoding",
 ]
 
@@ -386,6 +388,7 @@ dependencies = [
  "async-trait",
  "centaur-sandbox-core",
  "centaur-session-sqlx",
+ "centaur-telemetry",
  "thiserror",
  "tokio",
  "tracing",
@@ -427,6 +430,7 @@ dependencies = [
  "centaur-sandbox-manager",
  "centaur-session-core",
  "centaur-session-sqlx",
+ "centaur-telemetry",
  "futures-util",
  "serde_json",
  "sha2",
@@ -448,6 +452,22 @@ dependencies = [
  "thiserror",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "centaur-telemetry"
+version = "0.1.0"
+dependencies = [
+ "metrics",
+ "metrics-exporter-prometheus",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -595,6 +615,15 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -828,6 +857,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +899,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -974,6 +1020,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,7 +1098,16 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1605,6 +1681,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,6 +1753,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1810,48 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
+dependencies = [
+ "base64",
+ "evmap",
+ "indexmap",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "metrics",
+ "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rapidhash",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1823,6 +1965,76 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror",
+]
 
 [[package]]
 name = "ordered-float"
@@ -2034,6 +2246,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2420,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2456,15 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2265,6 +2542,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -2490,6 +2768,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2737,6 +3021,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -3412,6 +3702,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3861,6 +4167,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/centaur-session-core",
     "crates/centaur-session-runtime",
     "crates/centaur-session-sqlx",
+    "crates/centaur-telemetry",
 ]
 resolver = "3"
 
@@ -36,6 +37,7 @@ centaur-sandbox-manager = { path = "crates/centaur-sandbox-manager" }
 centaur-session-core = { path = "crates/centaur-session-core" }
 centaur-session-runtime = { path = "crates/centaur-session-runtime" }
 centaur-session-sqlx = { path = "crates/centaur-session-sqlx" }
+centaur-telemetry = { path = "crates/centaur-telemetry" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 crossterm = "0.28"
 eventsource-stream = "0.2.3"
@@ -50,6 +52,11 @@ sha2 = "0.10"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
 ratatui = "0.29"
 rustls = "0.23"
+opentelemetry = "0.32.0"
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["http-proto", "reqwest-blocking-client", "trace"] }
+opentelemetry_sdk = { version = "0.32.1", features = ["trace"] }
+metrics = "0.24.6"
+metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
 sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
 strum = { version = "0.28", features = ["derive"] }
 test-case = "3.3.1"
@@ -58,7 +65,10 @@ time = { version = "0.3", features = ["serde"] }
 tokio = "1"
 tokio-util = "0.7"
 toml = "0.8"
+tower = { version = "0.5", features = ["util"] }
+tower-http = { version = "0.6.11", features = ["trace"] }
 tracing = "0.1"
+tracing-opentelemetry = "0.33.0"
 tracing-subscriber = "0.3"
 urlencoding = "2"
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/services/api-rs/crates/centaur-api-server/Cargo.toml
+++ b/services/api-rs/crates/centaur-api-server/Cargo.toml
@@ -16,6 +16,7 @@ centaur-sandbox-manager.workspace = true
 centaur-session-core.workspace = true
 centaur-session-runtime.workspace = true
 centaur-session-sqlx.workspace = true
+centaur-telemetry.workspace = true
 clap.workspace = true
 eventsource-stream.workspace = true
 futures-util.workspace = true
@@ -29,9 +30,10 @@ sqlx.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal"] }
 toml.workspace = true
+tower-http.workspace = true
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json"] }
 urlencoding.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
+tower.workspace = true

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -15,6 +15,10 @@ mod tests {
     };
 
     use async_trait::async_trait;
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, StatusCode},
+    };
     use centaur_sandbox_core::{
         ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
         SandboxResult, SandboxSpec, SandboxStatus,
@@ -22,6 +26,7 @@ mod tests {
     use centaur_session_runtime::SandboxRuntime;
     use centaur_session_sqlx::PgSessionStore;
     use sqlx::PgPool;
+    use tower::ServiceExt;
 
     use super::build_router_with_runtime;
 
@@ -32,6 +37,52 @@ mod tests {
         let _router = build_router_with_runtime(
             PgSessionStore::new(pool),
             SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_renders_http_request_metrics() {
+        let pool =
+            PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
+        let app = build_router_with_runtime(
+            PgSessionStore::new(pool),
+            SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
+        );
+
+        let app = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(app.status(), StatusCode::OK);
+
+        let pool =
+            PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
+        let app = build_router_with_runtime(
+            PgSessionStore::new(pool),
+            SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body.contains(
+                r#"http_server_requests_total{method="GET",route="/healthz",status="200"}"#
+            )
         );
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -4,18 +4,18 @@ mod tool_discovery;
 use centaur_api_server::build_router_with_session_runtime;
 use centaur_session_runtime::SessionRuntime;
 use centaur_session_sqlx::PgSessionStore;
+use centaur_telemetry::{TelemetryConfig, init_telemetry};
 use clap::Parser;
 use thiserror::Error;
 use tokio::net::TcpListener;
 use tracing::info;
-use tracing_subscriber::{EnvFilter, fmt as tracing_fmt};
 
 use args::Args;
 
 #[tokio::main]
 async fn main() -> Result<(), ServerError> {
     init_crypto_provider();
-    init_tracing();
+    let telemetry = init_telemetry(TelemetryConfig::from_env())?;
 
     let args = Args::parse();
 
@@ -42,16 +42,12 @@ async fn main() -> Result<(), ServerError> {
     axum::serve(listener, build_router_with_session_runtime(runtime))
         .with_graceful_shutdown(shutdown_signal())
         .await?;
+    telemetry.shutdown();
     Ok(())
 }
 
 fn init_crypto_provider() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-}
-
-fn init_tracing() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    tracing_fmt().with_env_filter(filter).json().init();
 }
 
 async fn shutdown_signal() {
@@ -76,6 +72,8 @@ pub(crate) enum ServerError {
     IronControl(#[from] centaur_iron_control::IronControlError),
     #[error(transparent)]
     IronControlRegister(#[from] centaur_iron_control::RegisterError),
+    #[error(transparent)]
+    Telemetry(#[from] centaur_telemetry::TelemetryError),
     #[error(transparent)]
     ToolDiscovery(#[from] tool_discovery::ToolDiscoveryError),
     #[error("iron-proxy requires both firewall CA cert and key Secret names")]

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -1,10 +1,16 @@
-use std::{convert::Infallible, convert::TryFrom};
+use std::{
+    convert::Infallible,
+    convert::TryFrom,
+    time::{Duration, Instant},
+};
 
 use axum::{
     Json, Router,
-    extract::{Path, Query, State},
+    body::Body,
+    extract::{MatchedPath, Path, Query, Request, State},
+    middleware::{self, Next},
     response::{
-        Sse,
+        IntoResponse, Response, Sse,
         sse::{Event, KeepAlive},
     },
     routing::{get, post},
@@ -12,8 +18,14 @@ use axum::{
 use centaur_session_core::{Session, ThreadKey};
 use centaur_session_runtime::{ExecuteSessionInput, SandboxRuntime, SessionRuntime};
 use centaur_session_sqlx::PgSessionStore;
+use centaur_telemetry::{
+    PrometheusHandle, http_status_class, prometheus_handle, record_http_request_finished,
+    record_http_request_started,
+};
 use futures_util::{Stream, StreamExt};
 use serde_json::{Value, json};
+use tower_http::trace::TraceLayer;
+use tracing::Span;
 
 use crate::{
     ApiError,
@@ -26,6 +38,7 @@ use crate::{
 #[derive(Clone)]
 pub struct AppState {
     runtime: SessionRuntime,
+    metrics: PrometheusHandle,
 }
 
 pub fn build_router_with_runtime(store: PgSessionStore, sandbox_runtime: SandboxRuntime) -> Router {
@@ -33,18 +46,95 @@ pub fn build_router_with_runtime(store: PgSessionStore, sandbox_runtime: Sandbox
 }
 
 pub fn build_router_with_session_runtime(runtime: SessionRuntime) -> Router {
+    let metrics_handle =
+        prometheus_handle().expect("failed to initialize Prometheus metrics recorder");
     Router::new()
         .route("/healthz", get(healthz))
+        .route("/metrics", get(metrics))
         .route("/api/session/{thread_key}", post(create_or_get_session))
         .route("/api/session/{thread_key}/messages", post(append_messages))
         .route("/api/session/{thread_key}/execute", post(execute_session))
         .route("/api/session/{thread_key}/events", get(stream_events))
         .route("/api/sandboxes/drain", post(drain_sandboxes))
-        .with_state(AppState { runtime })
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(|request: &Request<Body>| {
+                    let route = matched_route(request);
+                    tracing::info_span!(
+                        "centaur.api_rs.http_request",
+                        "otel.kind" = "server",
+                        "otel.status_code" = tracing::field::Empty,
+                        "http.request.method" = request.method().as_str(),
+                        "http.route" = route.as_str(),
+                        "http.response.status_code" = tracing::field::Empty,
+                    )
+                })
+                .on_request(())
+                .on_response(|response: &Response, latency: Duration, span: &Span| {
+                    let status = response.status();
+                    span.record("http.response.status_code", status.as_u16());
+                    span.record(
+                        "otel.status_code",
+                        if status.is_server_error() {
+                            "ERROR"
+                        } else {
+                            "OK"
+                        },
+                    );
+
+                    tracing::info!(
+                        component = "api_server",
+                        event = "http_request",
+                        status = status.as_u16(),
+                        status_class = http_status_class(status.as_u16()),
+                        duration_ms = (latency.as_secs_f64() * 1000.0),
+                        "http request completed"
+                    );
+                }),
+        )
+        .layer(middleware::from_fn(http_metrics))
+        .with_state(AppState {
+            runtime,
+            metrics: metrics_handle,
+        })
 }
 
 async fn healthz() -> Json<Value> {
     Json(json!({"ok": true}))
+}
+
+async fn metrics(State(state): State<AppState>) -> Response {
+    (
+        [("Content-Type", "text/plain; version=0.0.4; charset=utf-8")],
+        Body::from(state.metrics.render()),
+    )
+        .into_response()
+}
+
+async fn http_metrics(req: Request, next: Next) -> Response {
+    let method = req.method().clone();
+    let route = matched_route(&req);
+
+    if route == "/metrics" {
+        return next.run(req).await;
+    }
+
+    let start = Instant::now();
+    record_http_request_started();
+    let response = next.run(req).await;
+    let status = response.status();
+    let duration = start.elapsed();
+    record_http_request_finished(method.as_str(), route.as_str(), status.as_u16(), duration);
+
+    response
+}
+
+fn matched_route<B>(request: &Request<B>) -> String {
+    request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|path| path.as_str().to_owned())
+        .unwrap_or_else(|| "__unmatched__".to_owned())
 }
 
 async fn create_or_get_session(

--- a/services/api-rs/crates/centaur-sandbox-manager/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-manager/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 [dependencies]
 centaur-sandbox-core.workspace = true
 centaur-session-sqlx.workspace = true
+centaur-telemetry.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 tracing.workspace = true

--- a/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
@@ -4,6 +4,8 @@ use centaur_sandbox_core::{
     DesiredSandboxState, ObservedSandbox, SandboxBackend, SandboxHandle, SandboxId, SandboxIo,
     SandboxResult, SandboxSpec, SandboxStatus,
 };
+use centaur_telemetry::record_sandbox_operation;
+use tracing::{Instrument, error, info, info_span};
 
 use crate::{
     DesiredStateStore, DriftReason, InMemoryDesiredStateStore, ReconcileAction, ReconcileOutcome,
@@ -42,14 +44,99 @@ where
     }
 
     pub async fn create_running(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
-        let handle = self.backend.create(spec.clone()).await?;
-        self.store
-            .set(handle.id.clone(), DesiredSandboxState::Running(spec));
-        Ok(handle)
+        let backend = self.backend.name();
+        let span = info_span!(
+            "centaur.api_rs.sandbox.create",
+            component = "sandbox_manager",
+            event = "sandbox_create",
+            "centaur.sandbox.backend" = backend,
+            "centaur.sandbox_id" = tracing::field::Empty,
+            sandbox_id = tracing::field::Empty,
+        );
+
+        async {
+            info!(
+                component = "sandbox_manager",
+                event = "sandbox_create_started",
+                backend,
+                "creating sandbox"
+            );
+            let handle = match self.backend.create(spec.clone()).await {
+                Ok(handle) => handle,
+                Err(error) => {
+                    record_sandbox_operation(backend, "create", "error");
+                    error!(
+                        component = "sandbox_manager",
+                        event = "sandbox_create_failed",
+                        backend,
+                        %error,
+                        "failed to create sandbox"
+                    );
+                    return Err(error);
+                }
+            };
+            span.record("centaur.sandbox_id", handle.id.as_str());
+            span.record("sandbox_id", handle.id.as_str());
+            self.store
+                .set(handle.id.clone(), DesiredSandboxState::Running(spec));
+            record_sandbox_operation(backend, "create", "success");
+            info!(
+                component = "sandbox_manager",
+                event = "sandbox_create_completed",
+                backend,
+                sandbox_id = %handle.id.as_str(),
+                "sandbox created"
+            );
+            Ok(handle)
+        }
+        .instrument(span.clone())
+        .await
     }
 
     pub async fn open_io(&self, id: &SandboxId) -> SandboxResult<SandboxIo> {
-        self.backend.open_io(id).await
+        let backend = self.backend.name();
+        async {
+            info!(
+                component = "sandbox_manager",
+                event = "sandbox_open_io_started",
+                backend,
+                sandbox_id = %id.as_str(),
+                "opening sandbox I/O"
+            );
+            let io = match self.backend.open_io(id).await {
+                Ok(io) => io,
+                Err(error) => {
+                    record_sandbox_operation(backend, "open_io", "error");
+                    error!(
+                        component = "sandbox_manager",
+                        event = "sandbox_open_io_failed",
+                        backend,
+                        sandbox_id = %id.as_str(),
+                        %error,
+                        "failed to open sandbox I/O"
+                    );
+                    return Err(error);
+                }
+            };
+            record_sandbox_operation(backend, "open_io", "success");
+            info!(
+                component = "sandbox_manager",
+                event = "sandbox_open_io_completed",
+                backend,
+                sandbox_id = %id.as_str(),
+                "sandbox I/O opened"
+            );
+            Ok(io)
+        }
+        .instrument(info_span!(
+            "centaur.api_rs.sandbox.open_io",
+            component = "sandbox_manager",
+            event = "sandbox_open_io",
+            "centaur.sandbox.backend" = backend,
+            "centaur.sandbox_id" = id.as_str(),
+            sandbox_id = %id.as_str(),
+        ))
+        .await
     }
 
     pub async fn status(&self, id: &SandboxId) -> SandboxResult<SandboxStatus> {
@@ -66,7 +153,14 @@ where
     }
 
     pub async fn pause(&self, id: &SandboxId) -> SandboxResult<()> {
-        self.backend.pause(id).await?;
+        let backend = self.backend.name();
+        match self.backend.pause(id).await {
+            Ok(()) => record_sandbox_operation(backend, "pause", "success"),
+            Err(error) => {
+                record_sandbox_operation(backend, "pause", "error");
+                return Err(error);
+            }
+        }
         if let Some(DesiredSandboxState::Running(spec) | DesiredSandboxState::Suspended(spec)) =
             self.store.get(id)
         {
@@ -77,7 +171,14 @@ where
     }
 
     pub async fn resume(&self, id: &SandboxId) -> SandboxResult<()> {
-        self.backend.resume(id).await?;
+        let backend = self.backend.name();
+        match self.backend.resume(id).await {
+            Ok(()) => record_sandbox_operation(backend, "resume", "success"),
+            Err(error) => {
+                record_sandbox_operation(backend, "resume", "error");
+                return Err(error);
+            }
+        }
         if let Some(DesiredSandboxState::Running(spec) | DesiredSandboxState::Suspended(spec)) =
             self.store.get(id)
         {
@@ -88,9 +189,34 @@ where
     }
 
     pub async fn stop(&self, id: &SandboxId) -> SandboxResult<()> {
-        self.backend.stop(id).await?;
-        self.store.set(id.clone(), DesiredSandboxState::Stopped);
-        Ok(())
+        let backend = self.backend.name();
+        async {
+            match self.backend.stop(id).await {
+                Ok(()) => record_sandbox_operation(backend, "stop", "success"),
+                Err(error) => {
+                    record_sandbox_operation(backend, "stop", "error");
+                    return Err(error);
+                }
+            }
+            self.store.set(id.clone(), DesiredSandboxState::Stopped);
+            info!(
+                component = "sandbox_manager",
+                event = "sandbox_stop_completed",
+                backend,
+                sandbox_id = %id.as_str(),
+                "sandbox stopped"
+            );
+            Ok(())
+        }
+        .instrument(info_span!(
+            "centaur.api_rs.sandbox.stop",
+            component = "sandbox_manager",
+            event = "sandbox_stop",
+            "centaur.sandbox.backend" = backend,
+            "centaur.sandbox_id" = id.as_str(),
+            sandbox_id = %id.as_str(),
+        ))
+        .await
     }
 
     pub async fn assign_iron_control_proxy_principal(
@@ -117,18 +243,37 @@ where
         id: &SandboxId,
         plan: ReconcilePlan,
     ) -> SandboxResult<ReconcileOutcome> {
+        let backend = self.backend.name();
         match plan.action {
             ReconcileAction::None => Ok(ReconcileOutcome::Noop),
             ReconcileAction::Pause => {
-                self.backend.pause(id).await?;
+                match self.backend.pause(id).await {
+                    Ok(()) => record_sandbox_operation(backend, "pause", "success"),
+                    Err(error) => {
+                        record_sandbox_operation(backend, "pause", "error");
+                        return Err(error);
+                    }
+                }
                 Ok(ReconcileOutcome::Paused)
             }
             ReconcileAction::Resume => {
-                self.backend.resume(id).await?;
+                match self.backend.resume(id).await {
+                    Ok(()) => record_sandbox_operation(backend, "resume", "success"),
+                    Err(error) => {
+                        record_sandbox_operation(backend, "resume", "error");
+                        return Err(error);
+                    }
+                }
                 Ok(ReconcileOutcome::Resumed)
             }
             ReconcileAction::Stop => {
-                self.backend.stop(id).await?;
+                match self.backend.stop(id).await {
+                    Ok(()) => record_sandbox_operation(backend, "stop", "success"),
+                    Err(error) => {
+                        record_sandbox_operation(backend, "stop", "error");
+                        return Err(error);
+                    }
+                }
                 Ok(ReconcileOutcome::Stopped)
             }
             ReconcileAction::ReportDrift(reason) => Ok(ReconcileOutcome::Drift(reason)),

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -11,6 +11,7 @@ centaur-sandbox-core.workspace = true
 centaur-sandbox-manager.workspace = true
 centaur-session-core.workspace = true
 centaur-session-sqlx.workspace = true
+centaur-telemetry.workspace = true
 futures-util.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -19,6 +19,10 @@ use centaur_session_core::{
 use centaur_session_sqlx::{
     PgSessionStore, SessionEventListener, SessionStoreError, default_metadata,
 };
+use centaur_telemetry::{
+    record_sandbox_warm_pool_claim, record_session_execution_finished,
+    record_session_execution_started,
+};
 use futures_util::{SinkExt, Stream, StreamExt, stream};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -29,7 +33,7 @@ use tokio::{
     time::{Instant, Interval, MissedTickBehavior, interval_at, sleep},
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
-use tracing::warn;
+use tracing::{Instrument, Span, error, info, info_span, warn};
 
 pub const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 
@@ -37,15 +41,18 @@ const MAX_SESSION_OUTPUT_LINE_BYTES: usize = 1024 * 1024;
 const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
+const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 
 type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
+type ExecutionSpanRegistry = Arc<Mutex<HashMap<String, Span>>>;
 
 #[derive(Clone)]
 pub struct SessionRuntime {
     store: PgSessionStore,
     sandbox_runtime: SandboxRuntime,
     sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    execution_spans: ExecutionSpanRegistry,
     iron_control: Option<SessionRegistrar>,
     warm_pool: Option<Arc<WarmPoolManager>>,
 }
@@ -107,6 +114,8 @@ struct EventStreamState {
     listener: SessionEventListener,
     safety_tick: Interval,
     done: bool,
+    emitted_count: u64,
+    span: Span,
 }
 
 impl SessionRuntime {
@@ -115,6 +124,7 @@ impl SessionRuntime {
             store,
             sandbox_runtime,
             sandbox_pipes: Arc::new(Mutex::new(HashMap::new())),
+            execution_spans: Arc::new(Mutex::new(HashMap::new())),
             iron_control: None,
             warm_pool: None,
         }
@@ -162,38 +172,91 @@ impl SessionRuntime {
         persona_id: Option<&str>,
         metadata: Option<Value>,
     ) -> Result<Session, SessionRuntimeError> {
-        // Read slack_user_id before `metadata` is consumed below; it keys the
-        // 1:1 DM principal and is only known here at session creation.
-        let slack_user_id = metadata
-            .as_ref()
-            .and_then(|metadata| metadata.get("slack_user_id"))
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned);
-        let session = self
-            .store
-            .create_or_get_session(
-                thread_key,
-                harness_type,
-                persona_id,
-                default_metadata(metadata),
-            )
-            .await?;
-        if let Some(registrar) = &self.iron_control {
-            // iron-control is the source of truth for the session's egress
-            // proxy: without a registered principal the proxy has no identity
-            // to bind to, so a registration failure must fail session creation
-            // rather than silently boot a sandbox with a non-functional proxy.
-            let principal = registrar
-                .register_session(thread_key.as_str(), slack_user_id.as_deref())
-                .await?;
-            // Persist the principal OID on the session row so a resumed session
-            // can recreate its sandbox after a restart without re-deriving it.
-            return Ok(self
+        let span = info_span!(
+            "centaur.api_rs.session.create_or_get",
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_create_or_get",
+            "centaur.thread_key" = thread_key.as_str(),
+            "centaur.harness_type" = %harness_type,
+            thread_key = %thread_key,
+            harness_type = %harness_type,
+            iron_control_enabled = self.iron_control.is_some(),
+        );
+        let result = async {
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_create_or_get_started",
+                thread_key = %thread_key,
+                harness_type = %harness_type,
+                iron_control_enabled = self.iron_control.is_some(),
+                "creating or loading session"
+            );
+            // Read slack_user_id before `metadata` is consumed below; it keys the
+            // 1:1 DM principal and is only known here at session creation.
+            let slack_user_id = metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("slack_user_id"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            let session = self
                 .store
-                .set_iron_control_principal(thread_key, Some(&principal.id))
-                .await?);
+                .create_or_get_session(
+                    thread_key,
+                    harness_type,
+                    persona_id,
+                    default_metadata(metadata),
+                )
+                .await?;
+            if let Some(registrar) = &self.iron_control {
+                // iron-control is the source of truth for the session's egress
+                // proxy: without a registered principal the proxy has no identity
+                // to bind to, so a registration failure must fail session creation
+                // rather than silently boot a sandbox with a non-functional proxy.
+                let principal = registrar
+                    .register_session(thread_key.as_str(), slack_user_id.as_deref())
+                    .await?;
+                // Persist the principal OID on the session row so a resumed session
+                // can recreate its sandbox after a restart without re-deriving it.
+                let session = self
+                    .store
+                    .set_iron_control_principal(thread_key, Some(&principal.id))
+                    .await?;
+                info!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_create_or_get_completed",
+                    thread_key = %thread_key,
+                    harness_type = %harness_type,
+                    status = %session.status,
+                    iron_control_principal_persisted = true,
+                    "session ready"
+                );
+                return Ok(session);
+            }
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_create_or_get_completed",
+                thread_key = %thread_key,
+                harness_type = %harness_type,
+                status = %session.status,
+                iron_control_principal_persisted = session.iron_control_principal.is_some(),
+                "session ready"
+            );
+            Ok(session)
         }
-        Ok(session)
+        .instrument(span)
+        .await;
+
+        if let Err(error) = &result {
+            error!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_create_or_get_failed",
+                thread_key = %thread_key,
+                harness_type = %harness_type,
+                %error,
+                "failed to create or load session"
+            );
+        }
+        result
     }
 
     pub async fn append_messages(
@@ -201,12 +264,55 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         messages: &[SessionMessageInput],
     ) -> Result<Vec<String>, SessionRuntimeError> {
-        if messages.is_empty() {
-            return Err(SessionRuntimeError::BadRequest(
-                "messages must not be empty".to_owned(),
-            ));
+        let span = info_span!(
+            "centaur.api_rs.session.messages.append",
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_messages_append",
+            "centaur.thread_key" = thread_key.as_str(),
+            thread_key = %thread_key,
+            message_count = messages.len(),
+        );
+        let result = async {
+            if messages.is_empty() {
+                return Err(SessionRuntimeError::BadRequest(
+                    "messages must not be empty".to_owned(),
+                ));
+            }
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_messages_append_started",
+                thread_key = %thread_key,
+                message_count = messages.len(),
+                "appending session messages"
+            );
+            let message_ids = self.store.append_messages(thread_key, messages).await?;
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_messages_append_completed",
+                thread_key = %thread_key,
+                message_count = messages.len(),
+                message_id_count = message_ids.len(),
+                "session messages appended"
+            );
+            Ok(message_ids)
         }
-        let message_ids = self.store.append_messages(thread_key, messages).await?;
+        .instrument(span)
+        .await;
+
+        let message_ids = match result {
+            Ok(message_ids) => message_ids,
+            Err(error) => {
+                error!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_messages_append_failed",
+                    thread_key = %thread_key,
+                    message_count = messages.len(),
+                    %error,
+                    "failed to append session messages"
+                );
+                return Err(error);
+            }
+        };
         self.forward_messages_to_active_execution(thread_key, messages, &message_ids)
             .await;
         Ok(message_ids)
@@ -266,89 +372,191 @@ impl SessionRuntime {
             idle_timeout_ms,
             max_duration_ms,
         } = input;
-        let session = self.store.get_session(thread_key).await?;
-        validate_input_lines(&input_lines)?;
-        let (idle_timeout, max_duration) = duration_options(idle_timeout_ms, max_duration_ms)?;
+        let input_line_count = input_lines.len();
+        let idempotency_key_present = idempotency_key.is_some();
+        let span = info_span!(
+            "centaur.api_rs.session.execute",
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_execute",
+            "centaur.thread_key" = thread_key.as_str(),
+            "centaur.execution_id" = tracing::field::Empty,
+            "centaur.sandbox_id" = tracing::field::Empty,
+            thread_key = %thread_key,
+            execution_id = tracing::field::Empty,
+            sandbox_id = tracing::field::Empty,
+            input_line_count,
+            idempotency_key_present,
+        );
+        let result = async {
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_execute_started",
+                thread_key = %thread_key,
+                input_line_count,
+                idempotency_key_present,
+                "starting session execution"
+            );
+            let session = self.store.get_session(thread_key).await?;
+            let harness_label = session.harness_type.to_string();
+            validate_input_lines(&input_lines)?;
+            let (idle_timeout, max_duration) = duration_options(idle_timeout_ms, max_duration_ms)?;
 
-        let execution = self
-            .store
-            .create_execution(
-                thread_key,
-                idempotency_key.as_deref(),
-                execution_metadata(metadata, idle_timeout_ms, max_duration_ms),
-            )
-            .await?;
-        if !execution.created && execution.execution.status != ExecutionStatus::Queued {
-            return Ok(execution.execution);
-        }
-        let execution = self
-            .store
-            .mark_execution_running(&execution.execution.execution_id)
-            .await?;
-        if execution.status != ExecutionStatus::Running {
-            return Ok(execution);
-        }
-        self.store
-            .append_event(
-                thread_key,
-                Some(&execution.execution_id),
-                "session.execution_started",
-                json!({
-                    "execution_id": execution.execution_id,
-                    "thread_key": thread_key.as_str(),
-                    "input_line_count": input_lines.len(),
-                    "idle_timeout_ms": idle_timeout_ms,
-                    "max_duration_ms": max_duration_ms,
-                }),
-            )
-            .await?;
+            let execution = self
+                .store
+                .create_execution(
+                    thread_key,
+                    idempotency_key.as_deref(),
+                    execution_metadata(metadata, idle_timeout_ms, max_duration_ms),
+                )
+                .await?;
+            span.record(
+                "centaur.execution_id",
+                execution.execution.execution_id.as_str(),
+            );
+            span.record("execution_id", execution.execution.execution_id.as_str());
+            if !execution.created && execution.execution.status != ExecutionStatus::Queued {
+                info!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_execute_idempotent_replay",
+                    thread_key = %thread_key,
+                    execution_id = %execution.execution.execution_id,
+                    status = %execution.execution.status,
+                    "returning existing execution"
+                );
+                return Ok(execution.execution);
+            }
+            let execution = self
+                .store
+                .mark_execution_running(&execution.execution.execution_id)
+                .await?;
+            span.record("centaur.execution_id", execution.execution_id.as_str());
+            span.record("execution_id", execution.execution_id.as_str());
+            if execution.status != ExecutionStatus::Running {
+                info!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_execute_not_running",
+                    thread_key = %thread_key,
+                    execution_id = %execution.execution_id,
+                    status = %execution.status,
+                    "execution is not running after claim"
+                );
+                return Ok(execution);
+            }
+            let execution_trace_span = info_span!(
+                "centaur.api_rs.session.execution",
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_execution",
+                "centaur.thread_key" = thread_key.as_str(),
+                "centaur.execution_id" = execution.execution_id.as_str(),
+                "centaur.sandbox_id" = tracing::field::Empty,
+                thread_key = %thread_key,
+                execution_id = %execution.execution_id,
+                sandbox_id = tracing::field::Empty,
+            );
+            self.execution_spans
+                .lock()
+                .await
+                .insert(execution.execution_id.clone(), execution_trace_span.clone());
+            record_session_execution_started(&harness_label);
+            self.store
+                .append_event(
+                    thread_key,
+                    Some(&execution.execution_id),
+                    "session.execution_started",
+                    json!({
+                        "execution_id": execution.execution_id,
+                        "thread_key": thread_key.as_str(),
+                        "input_line_count": input_line_count,
+                        "idle_timeout_ms": idle_timeout_ms,
+                        "max_duration_ms": max_duration_ms,
+                    }),
+                )
+                .await?;
 
-        let sandbox_id = match self
-            .ensure_session_sandbox(
+            let sandbox_id = match self
+                .ensure_session_sandbox(
+                    thread_key,
+                    session.sandbox_id.as_deref(),
+                    session.iron_control_principal.as_deref(),
+                    &execution.execution_id,
+                )
+                .await
+            {
+                Ok(sandbox_id) => sandbox_id,
+                Err(error) => {
+                    self.record_execution_failure(thread_key, &execution.execution_id, &error)
+                        .await;
+                    return Err(error);
+                }
+            };
+            span.record("centaur.sandbox_id", sandbox_id.as_str());
+            span.record("sandbox_id", sandbox_id.as_str());
+            execution_trace_span.record("centaur.sandbox_id", sandbox_id.as_str());
+            execution_trace_span.record("sandbox_id", sandbox_id.as_str());
+
+            let pipe = match self.ensure_session_pipe(thread_key, &sandbox_id).await {
+                Ok(pipe) => pipe,
+                Err(error) => {
+                    self.record_execution_failure(thread_key, &execution.execution_id, &error)
+                        .await;
+                    return Err(error);
+                }
+            };
+
+            let input_lines = input_lines_with_thread_key(thread_key, &input_lines);
+            if let Err(error) = write_input_lines(
+                &pipe,
+                &input_lines,
                 thread_key,
-                session.sandbox_id.as_deref(),
-                session.iron_control_principal.as_deref(),
                 &execution.execution_id,
+                Some(&sandbox_id),
             )
             .await
-        {
-            Ok(sandbox_id) => sandbox_id,
-            Err(error) => {
+            {
                 self.record_execution_failure(thread_key, &execution.execution_id, &error)
                     .await;
                 return Err(error);
             }
-        };
 
-        let pipe = match self.ensure_session_pipe(thread_key, &sandbox_id).await {
-            Ok(pipe) => pipe,
-            Err(error) => {
-                self.record_execution_failure(thread_key, &execution.execution_id, &error)
-                    .await;
-                return Err(error);
+            if let Some(max_duration) = max_duration {
+                spawn_max_duration_failure(
+                    self.store.clone(),
+                    self.sandbox_runtime.manager.clone(),
+                    self.sandbox_pipes.clone(),
+                    self.execution_spans.clone(),
+                    thread_key.clone(),
+                    execution.execution_id.clone(),
+                    max_duration,
+                    idle_timeout,
+                );
             }
-        };
 
-        let input_lines = input_lines_with_thread_key(thread_key, &input_lines);
-        if let Err(error) = write_input_lines(&pipe, &input_lines).await {
-            self.record_execution_failure(thread_key, &execution.execution_id, &error)
-                .await;
-            return Err(error);
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_execute_completed",
+                thread_key = %thread_key,
+                execution_id = %execution.execution_id,
+                sandbox_id = %sandbox_id,
+                status = %execution.status,
+                completion_reason = "input_accepted",
+                "session execution accepted input"
+            );
+            Ok(execution)
         }
+        .instrument(span.clone())
+        .await;
 
-        if let Some(max_duration) = max_duration {
-            spawn_max_duration_failure(
-                self.store.clone(),
-                self.sandbox_runtime.manager.clone(),
-                self.sandbox_pipes.clone(),
-                thread_key.clone(),
-                execution.execution_id.clone(),
-                max_duration,
-                idle_timeout,
+        if let Err(error) = &result {
+            error!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_execute_failed",
+                thread_key = %thread_key,
+                input_line_count,
+                %error,
+                "session execution failed"
             );
         }
-
-        Ok(execution)
+        result
     }
 
     async fn record_execution_failure(
@@ -357,6 +565,7 @@ impl SessionRuntime {
         execution_id: &str,
         error: &SessionRuntimeError,
     ) {
+        self.execution_spans.lock().await.remove(execution_id);
         let error_message = error.to_string();
         let _ = self
             .store
@@ -371,10 +580,13 @@ impl SessionRuntime {
                 }),
             )
             .await;
-        let _ = self
+        if let Ok(execution) = self
             .store
             .fail_execution(execution_id, &error_message)
-            .await;
+            .await
+        {
+            record_finished_execution_metric(&self.store, thread_key, &execution, "failed").await;
+        }
     }
 
     async fn forward_messages_to_active_execution(
@@ -410,7 +622,15 @@ impl SessionRuntime {
             }
         };
 
-        if let Err(error) = write_input_lines(&pipe, &input_lines).await {
+        if let Err(error) = write_input_lines(
+            &pipe,
+            &input_lines,
+            thread_key,
+            &execution.execution_id,
+            None,
+        )
+        .await
+        {
             self.record_steering_failure(thread_key, &execution.execution_id, error.to_string())
                 .await;
             return;
@@ -498,21 +718,55 @@ impl SessionRuntime {
         impl Stream<Item = Result<SessionEvent, SessionRuntimeError>> + use<>,
         SessionRuntimeError,
     > {
-        let session = self.store.get_session(thread_key).await?;
-        if let Some(sandbox_id) = session.sandbox_id.as_deref() {
-            self.ensure_session_pipe_if_live(thread_key, sandbox_id)
-                .await?;
-        }
-
-        let listener = self.store.listen_session_events().await?;
-
-        Ok(session_event_stream(
-            self.store.clone(),
-            thread_key.clone(),
+        let span = info_span!(
+            "centaur.api_rs.session.events.stream",
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_events_stream",
+            "centaur.thread_key" = thread_key.as_str(),
+            thread_key = %thread_key,
             after_event_id,
-            execution_id.map(ToOwned::to_owned),
-            listener,
-        ))
+            execution_id = execution_id.unwrap_or(""),
+        );
+        let result = async {
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_events_stream_started",
+                thread_key = %thread_key,
+                after_event_id,
+                execution_id = execution_id.unwrap_or(""),
+                "opening session event stream"
+            );
+            let session = self.store.get_session(thread_key).await?;
+            if let Some(sandbox_id) = session.sandbox_id.as_deref() {
+                self.ensure_session_pipe_if_live(thread_key, sandbox_id)
+                    .await?;
+            }
+
+            let listener = self.store.listen_session_events().await?;
+
+            Ok(session_event_stream(
+                self.store.clone(),
+                thread_key.clone(),
+                after_event_id,
+                execution_id.map(ToOwned::to_owned),
+                listener,
+                span.clone(),
+            ))
+        }
+        .instrument(span.clone())
+        .await;
+
+        if let Err(error) = &result {
+            error!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_events_stream_failed",
+                thread_key = %thread_key,
+                after_event_id,
+                %error,
+                "failed to open session event stream"
+            );
+        }
+        result
     }
 
     async fn ensure_session_sandbox(
@@ -522,92 +776,194 @@ impl SessionRuntime {
         iron_control_principal: Option<&str>,
         execution_id: &str,
     ) -> Result<String, SessionRuntimeError> {
-        if let Some(sandbox_id) = existing_sandbox_id {
-            let id = SandboxId::new(sandbox_id);
-            match self.sandbox_runtime.manager.status(&id).await {
-                Ok(status) => match existing_sandbox_action(&status) {
-                    ExistingSandboxAction::Reuse => return Ok(sandbox_id.to_owned()),
-                    ExistingSandboxAction::ResumeOrReplace => {
-                        self.sandbox_pipes.lock().await.remove(sandbox_id);
-                        match self.sandbox_runtime.manager.resume(&id).await {
-                            Ok(()) => {
-                                self.store
-                                    .append_event(
-                                        thread_key,
-                                        Some(execution_id),
-                                        "session.sandbox_resumed",
-                                        json!({
-                                            "execution_id": execution_id,
-                                            "thread_key": thread_key.as_str(),
-                                            "sandbox_id": sandbox_id,
-                                        }),
-                                    )
-                                    .await?;
-                                return Ok(sandbox_id.to_owned());
-                            }
-                            Err(error) => {
-                                warn!(
-                                    %thread_key,
-                                    %execution_id,
-                                    %sandbox_id,
-                                    %error,
-                                    "replacing sandbox after resume failed"
-                                );
-                                self.store
-                                    .append_event(
-                                        thread_key,
-                                        Some(execution_id),
-                                        "session.sandbox_resume_failed",
-                                        json!({
-                                            "execution_id": execution_id,
-                                            "thread_key": thread_key.as_str(),
-                                            "sandbox_id": sandbox_id,
-                                            "error": error.to_string(),
-                                        }),
-                                    )
-                                    .await?;
+        let span = info_span!(
+            "centaur.api_rs.sandbox.ensure",
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "sandbox_ensure",
+            "centaur.thread_key" = thread_key.as_str(),
+            "centaur.execution_id" = execution_id,
+            "centaur.sandbox_id" = tracing::field::Empty,
+            thread_key = %thread_key,
+            execution_id,
+            sandbox_id = tracing::field::Empty,
+            existing_sandbox_id = existing_sandbox_id.unwrap_or(""),
+            iron_control_principal_present = iron_control_principal.is_some(),
+        );
+        let result = async {
+            if let Some(sandbox_id) = existing_sandbox_id {
+                let id = SandboxId::new(sandbox_id);
+                match self.sandbox_runtime.manager.status(&id).await {
+                    Ok(status) => match existing_sandbox_action(&status) {
+                        ExistingSandboxAction::Reuse => {
+                            span.record("centaur.sandbox_id", sandbox_id);
+                            span.record("sandbox_id", sandbox_id);
+                            info!(
+                                component = COMPONENT_SESSION_RUNTIME,
+                                event = "sandbox_ensure_reused",
+                                thread_key = %thread_key,
+                                execution_id,
+                                sandbox_id,
+                                "reusing existing session sandbox"
+                            );
+                            return Ok(sandbox_id.to_owned());
+                        }
+                        ExistingSandboxAction::ResumeOrReplace => {
+                            self.sandbox_pipes.lock().await.remove(sandbox_id);
+                            match self.sandbox_runtime.manager.resume(&id).await {
+                                Ok(()) => {
+                                    span.record("centaur.sandbox_id", sandbox_id);
+                                    span.record("sandbox_id", sandbox_id);
+                                    self.store
+                                        .append_event(
+                                            thread_key,
+                                            Some(execution_id),
+                                            "session.sandbox_resumed",
+                                            json!({
+                                                "execution_id": execution_id,
+                                                "thread_key": thread_key.as_str(),
+                                                "sandbox_id": sandbox_id,
+                                            }),
+                                        )
+                                        .await?;
+                                    info!(
+                                        component = COMPONENT_SESSION_RUNTIME,
+                                        event = "sandbox_ensure_resumed",
+                                        thread_key = %thread_key,
+                                        execution_id,
+                                        sandbox_id,
+                                        "resumed existing session sandbox"
+                                    );
+                                    return Ok(sandbox_id.to_owned());
+                                }
+                                Err(error) => {
+                                    warn!(
+                                        component = COMPONENT_SESSION_RUNTIME,
+                                        event = "sandbox_ensure_resume_failed",
+                                        %thread_key,
+                                        %execution_id,
+                                        %sandbox_id,
+                                        %error,
+                                        "replacing sandbox after resume failed"
+                                    );
+                                    self.store
+                                        .append_event(
+                                            thread_key,
+                                            Some(execution_id),
+                                            "session.sandbox_resume_failed",
+                                            json!({
+                                                "execution_id": execution_id,
+                                                "thread_key": thread_key.as_str(),
+                                                "sandbox_id": sandbox_id,
+                                                "error": error.to_string(),
+                                            }),
+                                        )
+                                        .await?;
+                                }
                             }
                         }
+                        ExistingSandboxAction::Replace => {
+                            info!(
+                                component = COMPONENT_SESSION_RUNTIME,
+                                event = "sandbox_ensure_replacing",
+                                thread_key = %thread_key,
+                                execution_id,
+                                sandbox_id,
+                                status = ?status,
+                                "existing sandbox is not reusable"
+                            );
+                        }
+                    },
+                    Err(SandboxError::NotFound(_)) => {
+                        info!(
+                            component = COMPONENT_SESSION_RUNTIME,
+                            event = "sandbox_ensure_missing",
+                            thread_key = %thread_key,
+                            execution_id,
+                            sandbox_id,
+                            "existing sandbox is missing"
+                        );
                     }
-                    ExistingSandboxAction::Replace => {}
-                },
-                Err(SandboxError::NotFound(_)) => {}
-                Err(error) => return Err(SessionRuntimeError::Sandbox(error)),
+                    Err(error) => return Err(SessionRuntimeError::Sandbox(error)),
+                }
             }
-        }
 
-        if let Some(warm_pool) = &self.warm_pool
-            && let Some(sandbox_id) = warm_pool
-                .claim(thread_key.as_str(), iron_control_principal)
-                .await?
-        {
-            self.store
-                .update_sandbox_id(thread_key, Some(sandbox_id.as_str()))
-                .await?;
-            self.store
-                .append_event(
-                    thread_key,
-                    None,
-                    "session.warm_sandbox_claimed",
-                    json!({
-                        "sandbox_id": sandbox_id.as_str(),
-                        "workload_key": warm_pool.workload_key(),
-                        "iron_control_principal": iron_control_principal,
-                    }),
-                )
-                .await?;
-            return Ok(sandbox_id);
-        }
+            if let Some(warm_pool) = &self.warm_pool {
+                match warm_pool
+                    .claim(thread_key.as_str(), iron_control_principal)
+                    .await
+                {
+                    Ok(Some(sandbox_id)) => {
+                        record_sandbox_warm_pool_claim("hit");
+                        span.record("centaur.sandbox_id", sandbox_id.as_str());
+                        span.record("sandbox_id", sandbox_id.as_str());
+                        self.store
+                            .update_sandbox_id(thread_key, Some(sandbox_id.as_str()))
+                            .await?;
+                        self.store
+                            .append_event(
+                                thread_key,
+                                None,
+                                "session.warm_sandbox_claimed",
+                                json!({
+                                    "sandbox_id": sandbox_id.as_str(),
+                                    "workload_key": warm_pool.workload_key(),
+                                    "iron_control_principal": iron_control_principal,
+                                }),
+                            )
+                            .await?;
+                        info!(
+                            component = COMPONENT_SESSION_RUNTIME,
+                            event = "sandbox_ensure_warm_claimed",
+                            thread_key = %thread_key,
+                            execution_id,
+                            sandbox_id = %sandbox_id,
+                            workload_key = warm_pool.workload_key(),
+                            "claimed warm session sandbox"
+                        );
+                        return Ok(sandbox_id);
+                    }
+                    Ok(None) => record_sandbox_warm_pool_claim("miss"),
+                    Err(error) => {
+                        record_sandbox_warm_pool_claim("error");
+                        return Err(SessionRuntimeError::WarmPool(error));
+                    }
+                }
+            }
 
-        let mut spec = (self.sandbox_runtime.spec_factory)(thread_key, execution_id);
-        if let Some(principal) = iron_control_principal {
-            spec.iron_control_principal = Some(principal.to_owned());
+            let mut spec = (self.sandbox_runtime.spec_factory)(thread_key, execution_id);
+            if let Some(principal) = iron_control_principal {
+                spec.iron_control_principal = Some(principal.to_owned());
+            }
+            let handle = self.sandbox_runtime.manager.create_running(spec).await?;
+            span.record("centaur.sandbox_id", handle.id.as_str());
+            span.record("sandbox_id", handle.id.as_str());
+            self.store
+                .update_sandbox_id(thread_key, Some(handle.id.as_str()))
+                .await?;
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "sandbox_ensure_created",
+                thread_key = %thread_key,
+                execution_id,
+                sandbox_id = %handle.id.as_str(),
+                "created new session sandbox"
+            );
+            Ok(handle.id.into_string())
         }
-        let handle = self.sandbox_runtime.manager.create_running(spec).await?;
-        self.store
-            .update_sandbox_id(thread_key, Some(handle.id.as_str()))
-            .await?;
-        Ok(handle.id.into_string())
+        .instrument(span.clone())
+        .await;
+
+        if let Err(error) = &result {
+            error!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "sandbox_ensure_failed",
+                thread_key = %thread_key,
+                execution_id,
+                %error,
+                "failed to ensure session sandbox"
+            );
+        }
+        result
     }
 
     async fn ensure_session_pipe_if_live(
@@ -636,72 +992,127 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         sandbox_id: &str,
     ) -> Result<SessionPipe, SessionRuntimeError> {
-        if let Some(pipe) = self.sandbox_pipes.lock().await.get(sandbox_id).cloned() {
-            return Ok(pipe);
+        let span = info_span!(
+            "centaur.api_rs.session.pipe.ensure",
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_pipe_ensure",
+            "centaur.thread_key" = thread_key.as_str(),
+            "centaur.sandbox_id" = sandbox_id,
+            thread_key = %thread_key,
+            sandbox_id,
+        );
+        let result = async {
+            if let Some(pipe) = self.sandbox_pipes.lock().await.get(sandbox_id).cloned() {
+                info!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_pipe_reused",
+                    thread_key = %thread_key,
+                    sandbox_id,
+                    "reusing session pipe"
+                );
+                return Ok(pipe);
+            }
+
+            let io = self
+                .sandbox_runtime
+                .manager
+                .open_io(&SandboxId::new(sandbox_id))
+                .await?
+                .into_parts();
+            let pipe = SessionPipe {
+                stdin: Arc::new(Mutex::new(FramedWrite::new(
+                    io.stdin,
+                    LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
+                ))),
+            };
+
+            self.sandbox_pipes
+                .lock()
+                .await
+                .insert(sandbox_id.to_owned(), pipe.clone());
+            let store = self.store.clone();
+            let manager = self.sandbox_runtime.manager.clone();
+            let execution_spans = self.execution_spans.clone();
+            let thread_key = thread_key.clone();
+            let pump_thread_key = thread_key.clone();
+            let pump_key = sandbox_id.to_owned();
+            let sandbox_pipes = self.sandbox_pipes.clone();
+            let stdout = io.stdout;
+            let stderr = io.stderr;
+            let guard = io.guard;
+            let stderr_key = pump_key.clone();
+
+            tokio::spawn(async move {
+                let result = run_stdout_pump(
+                    store.clone(),
+                    manager,
+                    sandbox_pipes.clone(),
+                    execution_spans.clone(),
+                    pump_thread_key.clone(),
+                    &pump_key,
+                    stdout,
+                    guard,
+                )
+                .await;
+                if let Err(error) = result {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_stdout_pump_failed",
+                        thread_key = %pump_thread_key,
+                        sandbox_id = %pump_key,
+                        %error,
+                        "session stdout pump failed"
+                    );
+                    let _ = store
+                        .append_event(
+                            &pump_thread_key,
+                            None,
+                            "session.stdout_pump_failed",
+                            json!({
+                                "sandbox_id": pump_key.as_str(),
+                                "error": error.to_string(),
+                            }),
+                        )
+                        .await;
+                }
+                sandbox_pipes.lock().await.remove(&pump_key);
+            });
+
+            tokio::spawn(async move {
+                if let Err(error) = drain_stderr(stderr).await {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_stderr_drain_failed",
+                        sandbox_id = %stderr_key,
+                        %error,
+                        "session stderr drain failed"
+                    );
+                }
+            });
+
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_pipe_opened",
+                thread_key = %thread_key,
+                sandbox_id,
+                "session pipe opened"
+            );
+            Ok(pipe)
         }
+        .instrument(span.clone())
+        .await;
 
-        let io = self
-            .sandbox_runtime
-            .manager
-            .open_io(&SandboxId::new(sandbox_id))
-            .await?
-            .into_parts();
-        let pipe = SessionPipe {
-            stdin: Arc::new(Mutex::new(FramedWrite::new(
-                io.stdin,
-                LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
-            ))),
-        };
-
-        self.sandbox_pipes
-            .lock()
-            .await
-            .insert(sandbox_id.to_owned(), pipe.clone());
-        let store = self.store.clone();
-        let manager = self.sandbox_runtime.manager.clone();
-        let thread_key = thread_key.clone();
-        let pump_key = sandbox_id.to_owned();
-        let sandbox_pipes = self.sandbox_pipes.clone();
-        let stdout = io.stdout;
-        let stderr = io.stderr;
-        let guard = io.guard;
-        let stderr_key = pump_key.clone();
-
-        tokio::spawn(async move {
-            let result = run_stdout_pump(
-                store.clone(),
-                manager,
-                sandbox_pipes.clone(),
-                thread_key.clone(),
-                &pump_key,
-                stdout,
-                guard,
-            )
-            .await;
-            if let Err(error) = result {
-                warn!(%pump_key, %error, "session stdout pump failed");
-                let _ = store
-                    .append_event(
-                        &thread_key,
-                        None,
-                        "session.stdout_pump_failed",
-                        json!({
-                            "sandbox_id": pump_key.as_str(),
-                            "error": error.to_string(),
-                        }),
-                    )
-                    .await;
-            }
-            sandbox_pipes.lock().await.remove(&pump_key);
-        });
-
-        tokio::spawn(async move {
-            if let Err(error) = drain_stderr(stderr).await {
-                warn!(%stderr_key, %error, "session stderr drain failed");
-            }
-        });
-
-        Ok(pipe)
+        if let Err(error) = &result {
+            error!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_pipe_ensure_failed",
+                thread_key = %thread_key,
+                sandbox_id,
+                %error,
+                "failed to ensure session pipe"
+            );
+        }
+        result
     }
 }
 
@@ -847,6 +1258,7 @@ fn session_event_stream(
     after_event_id: i64,
     execution_id: Option<String>,
     listener: SessionEventListener,
+    span: Span,
 ) -> impl Stream<Item = Result<SessionEvent, SessionRuntimeError>> {
     stream::unfold(
         EventStreamState {
@@ -865,53 +1277,67 @@ fn session_event_stream(
                 tick
             },
             done: false,
+            emitted_count: 0,
+            span,
         },
-        |mut state| async move {
-            loop {
-                if let Some(event) = state.pending.pop_front() {
-                    state.after_event_id = event.event_id;
-                    return Some((Ok(event), state));
-                }
-                if state.done {
-                    return None;
-                }
-                match state
-                    .store
-                    .list_events_after(
-                        &state.thread_key,
-                        state.after_event_id,
-                        state.execution_id.as_deref(),
-                        100,
-                    )
-                    .await
-                {
-                    Ok(events) if events.is_empty() => loop {
-                        tokio::select! {
-                            notification = state.listener.recv() => {
-                                match notification {
-                                    Ok(notification)
-                                        if notification.thread_key == state.thread_key.as_str()
-                                            && notification.event_id > state.after_event_id =>
-                                    {
-                                        break;
-                                    }
-                                    Ok(_) => {}
-                                    Err(error) => {
-                                        state.done = true;
-                                        return Some((Err(SessionRuntimeError::Store(error)), state));
+        |mut state| {
+            let span = state.span.clone();
+            async move {
+                loop {
+                    if let Some(event) = state.pending.pop_front() {
+                        state.after_event_id = event.event_id;
+                        state.emitted_count += 1;
+                        return Some((Ok(event), state));
+                    }
+                    if state.done {
+                        info!(
+                            component = COMPONENT_SESSION_RUNTIME,
+                            event = "session_events_stream_completed",
+                            thread_key = %state.thread_key,
+                            emitted_count = state.emitted_count,
+                            "session event stream completed"
+                        );
+                        return None;
+                    }
+                    match state
+                        .store
+                        .list_events_after(
+                            &state.thread_key,
+                            state.after_event_id,
+                            state.execution_id.as_deref(),
+                            100,
+                        )
+                        .await
+                    {
+                        Ok(events) if events.is_empty() => loop {
+                            tokio::select! {
+                                notification = state.listener.recv() => {
+                                    match notification {
+                                        Ok(notification)
+                                            if notification.thread_key == state.thread_key.as_str()
+                                                && notification.event_id > state.after_event_id =>
+                                        {
+                                            break;
+                                        }
+                                        Ok(_) => {}
+                                        Err(error) => {
+                                            state.done = true;
+                                            return Some((Err(SessionRuntimeError::Store(error)), state));
+                                        }
                                     }
                                 }
+                                _ = state.safety_tick.tick() => break,
                             }
-                            _ = state.safety_tick.tick() => break,
                         }
-                    },
-                    Ok(events) => state.pending = events.into(),
-                    Err(error) => {
-                        state.done = true;
-                        return Some((Err(SessionRuntimeError::Store(error)), state));
+                        Ok(events) => state.pending = events.into(),
+                        Err(error) => {
+                            state.done = true;
+                            return Some((Err(SessionRuntimeError::Store(error)), state));
+                        }
                     }
                 }
             }
+            .instrument(span)
         },
     )
 }
@@ -920,95 +1346,170 @@ async fn run_stdout_pump(
     store: PgSessionStore,
     manager: Arc<SandboxManager>,
     sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    execution_spans: ExecutionSpanRegistry,
     thread_key: ThreadKey,
     sandbox_id: &str,
     stdout: SandboxRead,
     _guard: SandboxIoGuard,
 ) -> Result<(), SessionRuntimeError> {
-    let mut stdout = FramedRead::new(
-        stdout,
-        LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
+    let span = info_span!(
+        "centaur.api_rs.session.stdout_pump",
+        component = COMPONENT_SESSION_RUNTIME,
+        event = "session_stdout_pump",
+        "centaur.thread_key" = thread_key.as_str(),
+        "centaur.sandbox_id" = sandbox_id,
+        thread_key = %thread_key,
+        sandbox_id,
     );
-    let mut output_state = StdoutPumpState::default();
-    while let Some(line) = stdout.next().await {
-        let line = match line {
-            Ok(line) => line,
-            Err(error) => {
-                record_stdout_pump_failure(
-                    &store,
-                    manager,
-                    sandbox_pipes,
-                    &thread_key,
-                    sandbox_id,
-                    stdout_pump_error_message(&error),
-                )
-                .await?;
-                return Ok(());
+    async {
+        let mut stdout = FramedRead::new(
+            stdout,
+            LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
+        );
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_stdout_pump_started",
+            thread_key = %thread_key,
+            sandbox_id,
+            "session stdout pump started"
+        );
+        let mut output_state = StdoutPumpState::default();
+        let mut line_count = 0_u64;
+        while let Some(line) = stdout.next().await {
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    record_stdout_pump_failure(
+                        &store,
+                        manager.clone(),
+                        sandbox_pipes.clone(),
+                        execution_spans.clone(),
+                        &thread_key,
+                        sandbox_id,
+                        stdout_pump_error_message(&error),
+                    )
+                    .await?;
+                    return Ok(());
+                }
+            };
+            line_count += 1;
+            let output_value = serde_json::from_str::<Value>(&line).ok();
+            if let Some(harness_thread_id) = harness_thread_id_from_output_line(&line)
+                && let Err(error) = store
+                    .update_harness_thread_id(&thread_key, Some(&harness_thread_id))
+                    .await
+            {
+                warn!(%thread_key, %harness_thread_id, %error, "failed to persist harness thread id");
             }
-        };
-        if let Some(harness_thread_id) = harness_thread_id_from_output_line(&line)
-            && let Err(error) = store
-                .update_harness_thread_id(&thread_key, Some(&harness_thread_id))
+            let active_execution = store.active_execution_for_thread(&thread_key).await?;
+            let execution_id = active_execution
+                .as_ref()
+                .map(|execution| execution.execution_id.as_str());
+            let Some(output_execution_id) = output_state.execution_for_line(execution_id, &line)
+            else {
+                continue;
+            };
+            let execution_span = execution_spans
+                .lock()
                 .await
-        {
-            warn!(%thread_key, %harness_thread_id, %error, "failed to persist harness thread id");
-        }
-        let active_execution = store.active_execution_for_thread(&thread_key).await?;
-        let execution_id = active_execution
-            .as_ref()
-            .map(|execution| execution.execution_id.as_str());
-        let Some(output_execution_id) = output_state.execution_for_line(execution_id, &line) else {
-            continue;
-        };
-        append_output_line(&store, &thread_key, Some(&output_execution_id), &line).await?;
-        if let Some(execution) = active_execution
-            && execution.execution_id == output_execution_id
-            && let Some(terminal) = output_state.observe(&output_execution_id, &line)
-        {
-            record_terminal_output(
-                &store,
-                manager.clone(),
-                sandbox_pipes.clone(),
+                .get(&output_execution_id)
+                .cloned();
+            let output_span = output_state.stdout_span_for_execution(
+                execution_span.as_ref(),
                 &thread_key,
                 sandbox_id,
                 &output_execution_id,
-                terminal,
+            );
+            append_output_line(&store, &thread_key, Some(&output_execution_id), &line)
+                .instrument(output_span.clone())
+                .await?;
+            if let Some(value) = output_value.as_ref() {
+                output_state.record_codex_app_server_spans(
+                    &output_span,
+                    &thread_key,
+                    sandbox_id,
+                    &output_execution_id,
+                    value,
+                );
+            }
+            if let Some(execution) = active_execution
+                && execution.execution_id == output_execution_id
+                && let Some(terminal) = output_state.observe(&output_execution_id, &line)
+            {
+                record_terminal_output(
+                    &store,
+                    manager.clone(),
+                    sandbox_pipes.clone(),
+                    execution_spans.clone(),
+                    &thread_key,
+                    sandbox_id,
+                    &output_execution_id,
+                    terminal,
+                )
+                .instrument(output_span)
+                .await?;
+                execution_spans.lock().await.remove(&output_execution_id);
+                output_state.forget(&output_execution_id);
+            }
+        }
+        if let Some(execution) = store.active_execution_for_thread(&thread_key).await? {
+            let execution_span = execution_spans
+                .lock()
+                .await
+                .get(&execution.execution_id)
+                .cloned();
+            let output_span = output_state.stdout_span_for_execution(
+                execution_span.as_ref(),
+                &thread_key,
+                sandbox_id,
+                &execution.execution_id,
+            );
+            record_terminal_output(
+                &store,
+                manager,
+                sandbox_pipes,
+                execution_spans.clone(),
+                &thread_key,
+                sandbox_id,
+                &execution.execution_id,
+                TerminalOutput::Failed {
+                    error: "sandbox stdout closed before terminal output".to_owned(),
+                },
+            )
+            .instrument(output_span)
+            .await?;
+            execution_spans.lock().await.remove(&execution.execution_id);
+            output_state.forget(&execution.execution_id);
+        }
+        store
+            .append_event(
+                &thread_key,
+                None,
+                "session.stdout_eof",
+                json!({
+                    "sandbox_id": sandbox_id,
+                }),
             )
             .await?;
-            output_state.forget(&output_execution_id);
-        }
-    }
-    if let Some(execution) = store.active_execution_for_thread(&thread_key).await? {
-        record_terminal_output(
-            &store,
-            manager,
-            sandbox_pipes,
-            &thread_key,
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_stdout_pump_completed",
+            thread_key = %thread_key,
             sandbox_id,
-            &execution.execution_id,
-            TerminalOutput::Failed {
-                error: "sandbox stdout closed before terminal output".to_owned(),
-            },
-        )
-        .await?;
+            output_line_count = line_count,
+            "session stdout pump completed"
+        );
+        Ok(())
     }
-    store
-        .append_event(
-            &thread_key,
-            None,
-            "session.stdout_eof",
-            json!({
-                "sandbox_id": sandbox_id,
-            }),
-        )
-        .await?;
-    Ok(())
+    .instrument(span)
+    .await
 }
 
 async fn record_stdout_pump_failure(
     store: &PgSessionStore,
     manager: Arc<SandboxManager>,
     sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    execution_spans: ExecutionSpanRegistry,
     thread_key: &ThreadKey,
     sandbox_id: &str,
     error: String,
@@ -1035,6 +1536,7 @@ async fn record_stdout_pump_failure(
             store,
             manager,
             sandbox_pipes,
+            execution_spans,
             thread_key,
             sandbox_id,
             &execution.execution_id,
@@ -1050,6 +1552,8 @@ struct StdoutPumpState {
     final_answer_text_by_execution: HashMap<String, String>,
     turn_execution_by_id: HashMap<String, String>,
     item_execution_by_id: HashMap<String, String>,
+    tool_call_by_id: HashMap<String, ToolCallLabels>,
+    stdout_span_by_execution: HashMap<String, Span>,
 }
 
 impl StdoutPumpState {
@@ -1109,10 +1613,51 @@ impl StdoutPumpState {
 
     fn forget(&mut self, execution_id: &str) {
         self.final_answer_text_by_execution.remove(execution_id);
+        let tool_ids_to_forget = self
+            .item_execution_by_id
+            .iter()
+            .filter_map(|(item_id, mapped_execution_id)| {
+                (mapped_execution_id == execution_id).then(|| item_id.clone())
+            })
+            .collect::<Vec<_>>();
         self.turn_execution_by_id
             .retain(|_, mapped_execution_id| mapped_execution_id != execution_id);
         self.item_execution_by_id
             .retain(|_, mapped_execution_id| mapped_execution_id != execution_id);
+        self.stdout_span_by_execution.remove(execution_id);
+        for item_id in tool_ids_to_forget {
+            self.tool_call_by_id.remove(&item_id);
+        }
+    }
+
+    fn stdout_span_for_execution(
+        &mut self,
+        parent: Option<&Span>,
+        thread_key: &ThreadKey,
+        sandbox_id: &str,
+        execution_id: &str,
+    ) -> Span {
+        if let Some(span) = self.stdout_span_by_execution.get(execution_id) {
+            return span.clone();
+        }
+        let span = new_stdout_pump_span(parent, thread_key, sandbox_id, execution_id);
+        self.stdout_span_by_execution
+            .insert(execution_id.to_owned(), span.clone());
+        span
+    }
+
+    fn record_codex_app_server_spans(
+        &mut self,
+        parent: &Span,
+        thread_key: &ThreadKey,
+        sandbox_id: &str,
+        execution_id: &str,
+        value: &Value,
+    ) {
+        record_codex_app_server_event_span(parent, thread_key, sandbox_id, execution_id, value);
+        for event in tool_call_span_events(value, &mut self.tool_call_by_id) {
+            record_codex_app_server_tool_span(parent, thread_key, sandbox_id, execution_id, &event);
+        }
     }
 
     fn known_execution_for_value(&self, value: &Value) -> Option<String> {
@@ -1141,6 +1686,442 @@ impl StdoutPumpState {
     }
 }
 
+fn new_stdout_pump_span(
+    parent: Option<&Span>,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+    execution_id: &str,
+) -> Span {
+    if let Some(parent) = parent {
+        info_span!(
+            parent: parent,
+            "centaur.api_rs.session.stdout_pump",
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_stdout_pump",
+            "centaur.thread_key" = thread_key.as_str(),
+            "centaur.execution_id" = execution_id,
+            "centaur.sandbox_id" = sandbox_id,
+            thread_key = %thread_key,
+            execution_id,
+            sandbox_id,
+        )
+    } else {
+        info_span!(
+            "centaur.api_rs.session.stdout_pump",
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_stdout_pump",
+            "centaur.thread_key" = thread_key.as_str(),
+            "centaur.execution_id" = execution_id,
+            "centaur.sandbox_id" = sandbox_id,
+            thread_key = %thread_key,
+            execution_id,
+            sandbox_id,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ToolCallLabels {
+    kind: String,
+    name: String,
+    method: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct ToolCallSpanEvent {
+    labels: ToolCallLabels,
+    status: &'static str,
+    duration: Option<Duration>,
+}
+
+fn record_codex_app_server_event_span(
+    parent: &Span,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+    execution_id: &str,
+    value: &Value,
+) {
+    let event_type = sandbox_output_event_type(value);
+    let source = sandbox_output_source(value);
+    let item = protocol_item(value);
+    let item_type = item
+        .and_then(|item| string_at_path(item, &["type"]))
+        .unwrap_or_default();
+    let turn_id = turn_ids(value).into_iter().next().unwrap_or_default();
+    let item_id = item_ids(value).into_iter().next().unwrap_or_default();
+
+    let span = info_span!(
+        parent: parent,
+        "centaur.api_rs.codex_app_server.event",
+        component = COMPONENT_SESSION_RUNTIME,
+        event = "codex_app_server_event",
+        "centaur.thread_key" = thread_key.as_str(),
+        "centaur.execution_id" = execution_id,
+        "centaur.sandbox_id" = sandbox_id,
+        "codex_app_server.source" = source,
+        "codex_app_server.event_type" = event_type,
+        "codex_app_server.item_type" = item_type.as_str(),
+        "codex_app_server.turn_id" = turn_id.as_str(),
+        "codex_app_server.item_id" = item_id.as_str(),
+    );
+    let _entered = span.enter();
+}
+
+fn record_codex_app_server_tool_span(
+    parent: &Span,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+    execution_id: &str,
+    event: &ToolCallSpanEvent,
+) {
+    let duration_ms = event
+        .duration
+        .map(|duration| duration.as_secs_f64() * 1000.0);
+    let span = info_span!(
+        parent: parent,
+        "centaur.api_rs.codex_app_server.tool_call",
+        component = COMPONENT_SESSION_RUNTIME,
+        event = "codex_app_server_tool_call",
+        "centaur.thread_key" = thread_key.as_str(),
+        "centaur.execution_id" = execution_id,
+        "centaur.sandbox_id" = sandbox_id,
+        "tool.kind" = event.labels.kind.as_str(),
+        "tool.name" = event.labels.name.as_str(),
+        "tool.method" = event.labels.method.as_str(),
+        "tool.status" = event.status,
+        "tool.duration_ms" = tracing::field::Empty,
+    );
+    if let Some(duration_ms) = duration_ms {
+        span.record("tool.duration_ms", duration_ms);
+    }
+    let _entered = span.enter();
+}
+
+fn sandbox_output_event_type(value: &Value) -> &str {
+    value
+        .get("method")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("type").and_then(Value::as_str))
+        .filter(|event_type| !event_type.trim().is_empty())
+        .unwrap_or("json")
+}
+
+fn sandbox_output_source(value: &Value) -> &str {
+    if value.get("method").and_then(Value::as_str).is_some() {
+        return "codex_app_server";
+    }
+    match value.get("type").and_then(Value::as_str) {
+        Some(event_type)
+            if event_type.starts_with("item.")
+                || event_type.starts_with("turn.")
+                || event_type.starts_with("thread.") =>
+        {
+            "codex_app_server"
+        }
+        Some("system")
+            if value
+                .get("subtype")
+                .and_then(Value::as_str)
+                .is_some_and(|subtype| subtype.starts_with("wrapper_")) =>
+        {
+            "codex_app_server"
+        }
+        Some("assistant" | "user" | "tool") => "harness",
+        Some(_) | None => "sandbox",
+    }
+}
+
+fn tool_call_span_events(
+    value: &Value,
+    known_tool_calls: &mut HashMap<String, ToolCallLabels>,
+) -> Vec<ToolCallSpanEvent> {
+    let mut events = Vec::new();
+    let event_type = sandbox_output_event_type(value);
+
+    if matches!(event_type, "item/started" | "item.started")
+        && let Some(item) = protocol_item(value)
+        && let Some(labels) = tool_labels_from_item(item)
+    {
+        remember_tool_call_labels(item, &labels, known_tool_calls);
+        events.push(ToolCallSpanEvent {
+            labels,
+            status: "started",
+            duration: None,
+        });
+    }
+
+    if matches!(event_type, "item/completed" | "item.completed")
+        && let Some(item) = protocol_item(value)
+    {
+        let item_id = string_at_path(item, &["id"]);
+        let labels = tool_labels_from_item(item).or_else(|| {
+            item_id
+                .as_deref()
+                .and_then(|item_id| known_tool_calls.get(item_id).cloned())
+        });
+        if let Some(labels) = labels {
+            let status = completed_tool_status(item);
+            if let Some(item_id) = item_id {
+                known_tool_calls.remove(&item_id);
+            }
+            events.push(ToolCallSpanEvent {
+                labels,
+                status,
+                duration: duration_from_ms_value(
+                    item.get("durationMs").or_else(|| item.get("duration_ms")),
+                ),
+            });
+        }
+    }
+
+    if matches!(
+        event_type,
+        "item/mcpToolCall/progress" | "item.mcpToolCall.progress"
+    ) {
+        let labels = progress_item_id(value)
+            .and_then(|item_id| known_tool_calls.get(&item_id).cloned())
+            .unwrap_or_else(|| ToolCallLabels {
+                kind: "mcp".to_owned(),
+                name: "unknown".to_owned(),
+                method: "unknown".to_owned(),
+            });
+        events.push(ToolCallSpanEvent {
+            labels,
+            status: "progress",
+            duration: None,
+        });
+    }
+
+    for tool_use in anthropic_tool_uses(value) {
+        let labels = ToolCallLabels {
+            kind: "anthropic".to_owned(),
+            name: string_at_path(tool_use, &["name"]).unwrap_or_else(|| "unknown".to_owned()),
+            method: "call".to_owned(),
+        };
+        if let Some(tool_id) = string_at_path(tool_use, &["id"]) {
+            known_tool_calls.insert(tool_id, labels.clone());
+        }
+        events.push(ToolCallSpanEvent {
+            labels,
+            status: "started",
+            duration: None,
+        });
+    }
+
+    for tool_result in anthropic_tool_results(value) {
+        let labels = string_at_path(tool_result, &["tool_use_id"])
+            .and_then(|tool_use_id| known_tool_calls.remove(&tool_use_id))
+            .unwrap_or_else(|| ToolCallLabels {
+                kind: "anthropic".to_owned(),
+                name: "unknown".to_owned(),
+                method: "call".to_owned(),
+            });
+        events.push(ToolCallSpanEvent {
+            labels,
+            status: if tool_result
+                .get("is_error")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                "failed"
+            } else {
+                "completed"
+            },
+            duration: None,
+        });
+    }
+
+    events
+}
+
+fn protocol_item(value: &Value) -> Option<&Value> {
+    value
+        .get("params")
+        .and_then(|params| params.get("item"))
+        .or_else(|| value.get("item"))
+}
+
+fn tool_labels_from_item(item: &Value) -> Option<ToolCallLabels> {
+    let item_type = string_at_path(item, &["type"])?;
+    match item_type.as_str() {
+        "mcpToolCall" | "mcp_tool_call" => Some(ToolCallLabels {
+            kind: "mcp".to_owned(),
+            name: string_at_path(item, &["tool"]).unwrap_or_else(|| "unknown".to_owned()),
+            method: string_at_path(item, &["server"]).unwrap_or_else(|| "call".to_owned()),
+        }),
+        "dynamicToolCall" | "dynamic_tool_call" => Some(ToolCallLabels {
+            kind: "dynamic".to_owned(),
+            name: string_at_path(item, &["tool"]).unwrap_or_else(|| "unknown".to_owned()),
+            method: string_at_path(item, &["namespace"]).unwrap_or_else(|| "call".to_owned()),
+        }),
+        "collabAgentToolCall" | "collab_agent_tool_call" => Some(ToolCallLabels {
+            kind: "collab_agent".to_owned(),
+            name: string_at_path(item, &["tool"]).unwrap_or_else(|| "agent".to_owned()),
+            method: "call".to_owned(),
+        }),
+        "commandExecution" | "command_execution" => centaur_call_labels_from_command_item(item),
+        _ => None,
+    }
+}
+
+fn remember_tool_call_labels(
+    item: &Value,
+    labels: &ToolCallLabels,
+    known_tool_calls: &mut HashMap<String, ToolCallLabels>,
+) {
+    if let Some(item_id) = string_at_path(item, &["id"]) {
+        known_tool_calls.insert(item_id, labels.clone());
+    }
+}
+
+fn completed_tool_status(item: &Value) -> &'static str {
+    if item
+        .get("success")
+        .and_then(Value::as_bool)
+        .is_some_and(|success| !success)
+        || item.get("error").is_some()
+    {
+        return "failed";
+    }
+
+    if let Some(exit_code) = item.get("exitCode").and_then(Value::as_i64) {
+        return if exit_code == 0 {
+            "completed"
+        } else {
+            "failed"
+        };
+    }
+
+    match item
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("completed")
+    {
+        "failed" | "error" | "cancelled" | "declined" => "failed",
+        "inProgress" | "in_progress" | "running" => "started",
+        _ => "completed",
+    }
+}
+
+fn duration_from_ms_value(value: Option<&Value>) -> Option<Duration> {
+    let millis = value.and_then(|value| {
+        value
+            .as_f64()
+            .or_else(|| value.as_u64().map(|millis| millis as f64))
+            .or_else(|| value.as_i64().map(|millis| millis as f64))
+    })?;
+    if millis.is_finite() && millis >= 0.0 {
+        Some(Duration::from_secs_f64(millis / 1000.0))
+    } else {
+        None
+    }
+}
+
+fn progress_item_id(value: &Value) -> Option<String> {
+    [
+        &["params", "itemId"][..],
+        &["params", "item_id"][..],
+        &["itemId"][..],
+        &["item_id"][..],
+    ]
+    .into_iter()
+    .filter_map(|path| string_at_path(value, path))
+    .next()
+}
+
+fn anthropic_tool_uses(value: &Value) -> Vec<&Value> {
+    if value.get("type").and_then(Value::as_str) != Some("assistant") {
+        return Vec::new();
+    }
+    content_blocks(value)
+        .into_iter()
+        .filter(|part| part.get("type").and_then(Value::as_str) == Some("tool_use"))
+        .collect()
+}
+
+fn anthropic_tool_results(value: &Value) -> Vec<&Value> {
+    if !matches!(
+        value.get("type").and_then(Value::as_str),
+        Some("user" | "tool")
+    ) {
+        return Vec::new();
+    }
+    content_blocks(value)
+        .into_iter()
+        .filter(|part| {
+            part.get("type").and_then(Value::as_str) == Some("tool_result")
+                || part.get("tool_use_id").and_then(Value::as_str).is_some()
+        })
+        .collect()
+}
+
+fn content_blocks(value: &Value) -> Vec<&Value> {
+    value
+        .get("content")
+        .or_else(|| {
+            value
+                .get("message")
+                .and_then(|message| message.get("content"))
+        })
+        .and_then(Value::as_array)
+        .map(|values| values.iter().collect())
+        .unwrap_or_default()
+}
+
+fn centaur_call_labels_from_command_item(item: &Value) -> Option<ToolCallLabels> {
+    let command = string_at_path(item, &["command"])?;
+    let (name, method) = parse_centaur_call_command(&command)?;
+    Some(ToolCallLabels {
+        kind: "centaur_call".to_owned(),
+        name,
+        method,
+    })
+}
+
+fn parse_centaur_call_command(command: &str) -> Option<(String, String)> {
+    let call_start = command
+        .match_indices("call")
+        .find_map(|(index, _)| is_call_command_token(command, index).then_some(index))?;
+    let after_call = command[call_start + "call".len()..]
+        .trim_start_matches(|ch: char| ch.is_whitespace() || ch == '\'' || ch == '"');
+    let mut parts = after_call
+        .split(|ch: char| ch.is_whitespace() || matches!(ch, '\'' | '"' | ';'))
+        .filter(|part| !part.is_empty());
+    let first = parts.next()?;
+    match first {
+        "tools" => Some(("tools".to_owned(), "list".to_owned())),
+        "discover" => Some((
+            parts.next().unwrap_or("unknown").to_owned(),
+            "discover".to_owned(),
+        )),
+        "agent" => Some((
+            "agent".to_owned(),
+            parts.next().unwrap_or("unknown").to_owned(),
+        )),
+        tool => Some((
+            tool.to_owned(),
+            parts.next().unwrap_or("unknown").to_owned(),
+        )),
+    }
+}
+
+fn is_call_command_token(command: &str, index: usize) -> bool {
+    let before = command[..index].chars().next_back();
+    let after = command[index + "call".len()..].chars().next();
+
+    let before_is_boundary = before.is_none_or(|ch| {
+        ch.is_whitespace()
+            || matches!(
+                ch,
+                '\'' | '"' | '`' | ';' | '&' | '|' | '(' | ')' | '{' | '}' | '/'
+            )
+    });
+    let after_is_boundary =
+        after.is_some_and(|ch| ch.is_whitespace() || matches!(ch, '\'' | '"' | ';'));
+
+    before_is_boundary && after_is_boundary
+}
+
 #[derive(Debug, Eq, PartialEq)]
 enum TerminalOutput {
     Completed {
@@ -1156,12 +2137,13 @@ async fn record_terminal_output(
     store: &PgSessionStore,
     manager: Arc<SandboxManager>,
     sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    execution_spans: ExecutionSpanRegistry,
     thread_key: &ThreadKey,
     sandbox_id: &str,
     execution_id: &str,
     terminal: TerminalOutput,
 ) -> Result<(), SessionRuntimeError> {
-    let terminal_execution = match terminal {
+    let (terminal_execution, terminal_status) = match terminal {
         TerminalOutput::Completed {
             reason,
             result_text,
@@ -1187,7 +2169,7 @@ async fn record_terminal_output(
                     payload,
                 )
                 .await?;
-            execution
+            (execution, "completed")
         }
         TerminalOutput::Failed { error } => {
             let Some(execution) = store.fail_execution_if_active(execution_id, &error).await?
@@ -1206,9 +2188,11 @@ async fn record_terminal_output(
                     }),
                 )
                 .await?;
-            execution
+            (execution, "failed")
         }
     };
+    execution_spans.lock().await.remove(execution_id);
+    record_finished_execution_metric(store, thread_key, &terminal_execution, terminal_status).await;
     if let Some(idle_timeout) = idle_timeout_from_execution(&terminal_execution) {
         spawn_idle_pause(
             store.clone(),
@@ -1227,6 +2211,7 @@ fn spawn_max_duration_failure(
     store: PgSessionStore,
     manager: Arc<SandboxManager>,
     sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    execution_spans: ExecutionSpanRegistry,
     thread_key: ThreadKey,
     execution_id: String,
     max_duration: Duration,
@@ -1238,6 +2223,7 @@ fn spawn_max_duration_failure(
             &store,
             manager,
             sandbox_pipes,
+            execution_spans,
             &thread_key,
             &execution_id,
             max_duration,
@@ -1254,6 +2240,7 @@ async fn record_max_duration_failure(
     store: &PgSessionStore,
     manager: Arc<SandboxManager>,
     sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    execution_spans: ExecutionSpanRegistry,
     thread_key: &ThreadKey,
     execution_id: &str,
     max_duration: Duration,
@@ -1264,6 +2251,7 @@ async fn record_max_duration_failure(
     let Some(execution) = store.fail_execution_if_active(execution_id, &error).await? else {
         return Ok(());
     };
+    execution_spans.lock().await.remove(execution_id);
     store
         .append_event(
             thread_key,
@@ -1278,6 +2266,7 @@ async fn record_max_duration_failure(
             }),
         )
         .await?;
+    record_finished_execution_metric(store, thread_key, &execution, "failed").await;
     if let Some(idle_timeout) = idle_timeout.or_else(|| idle_timeout_from_execution(&execution))
         && let Some(sandbox_id) = store.get_session(thread_key).await?.sandbox_id
     {
@@ -1446,6 +2435,28 @@ fn should_pause_idle_sandbox(
 
 fn duration_millis_u64(duration: Duration) -> u64 {
     duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+async fn record_finished_execution_metric(
+    store: &PgSessionStore,
+    thread_key: &ThreadKey,
+    execution: &SessionExecution,
+    status: &'static str,
+) {
+    let harness_label = match store.get_session(thread_key).await {
+        Ok(session) => session.harness_type.to_string(),
+        Err(error) => {
+            warn!(%thread_key, %error, "failed to load session for execution metric labels");
+            "unknown".to_owned()
+        }
+    };
+    record_session_execution_finished(&harness_label, status, execution_duration(execution));
+}
+
+fn execution_duration(execution: &SessionExecution) -> Option<Duration> {
+    let started_at = execution.started_at.unwrap_or(execution.created_at);
+    let completed_at = execution.completed_at?;
+    (completed_at - started_at).try_into().ok()
 }
 
 fn should_attach_session_pipe(status: &SandboxStatus) -> bool {
@@ -1721,12 +2732,41 @@ async fn drain_stderr(mut stderr: SandboxRead) -> Result<(), SessionRuntimeError
 async fn write_input_lines(
     pipe: &SessionPipe,
     input_lines: &[String],
+    thread_key: &ThreadKey,
+    execution_id: &str,
+    sandbox_id: Option<&str>,
 ) -> Result<(), SessionRuntimeError> {
-    let mut stdin = pipe.stdin.lock().await;
-    for line in input_lines {
-        stdin.send(line).await.map_err(codec_error_to_runtime)?;
+    let sandbox_id = sandbox_id.unwrap_or("");
+    let span = info_span!(
+        "centaur.api_rs.sandbox.write_input",
+        component = COMPONENT_SESSION_RUNTIME,
+        event = "sandbox_write_input",
+        "centaur.thread_key" = thread_key.as_str(),
+        "centaur.execution_id" = execution_id,
+        "centaur.sandbox_id" = sandbox_id,
+        thread_key = %thread_key,
+        execution_id,
+        sandbox_id,
+        input_line_count = input_lines.len(),
+    );
+    async {
+        let mut stdin = pipe.stdin.lock().await;
+        for line in input_lines {
+            stdin.send(line).await.map_err(codec_error_to_runtime)?;
+        }
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "sandbox_write_input_completed",
+            thread_key = %thread_key,
+            execution_id,
+            sandbox_id,
+            input_line_count = input_lines.len(),
+            "sandbox input written"
+        );
+        Ok(())
     }
-    Ok(())
+    .instrument(span)
+    .await
 }
 
 fn input_lines_with_thread_key(thread_key: &ThreadKey, input_lines: &[String]) -> Vec<String> {
@@ -2273,6 +3313,210 @@ mod tests {
         assert!(redacted.contains("Authorization: Bearer [REDACTED_TOKEN]"));
         assert!(redacted.contains("CENTAUR_API_KEY=[REDACTED_TOKEN]"));
         assert!(redacted.contains("SLACK_BOT_TOKEN=[REDACTED_TOKEN]"));
+    }
+
+    #[test]
+    fn codex_app_server_event_source_and_type_are_classified() {
+        let app_server = json!({
+            "method": "item/agentMessage/delta",
+            "params": {"turnId": "turn-1", "itemId": "item-1"},
+        });
+        let harness = json!({
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "redacted"}]},
+        });
+        let sandbox = json!({
+            "type": "custom.wrapper.event",
+        });
+
+        assert_eq!(
+            sandbox_output_event_type(&app_server),
+            "item/agentMessage/delta"
+        );
+        assert_eq!(sandbox_output_source(&app_server), "codex_app_server");
+        assert_eq!(sandbox_output_source(&harness), "harness");
+        assert_eq!(sandbox_output_source(&sandbox), "sandbox");
+    }
+
+    #[test]
+    fn codex_app_server_mcp_tool_events_emit_tool_spans() {
+        let started = json!({
+            "method": "item/started",
+            "params": {
+                "item": {
+                    "id": "tool-1",
+                    "type": "mcpToolCall",
+                    "server": "github",
+                    "tool": "list_issues"
+                }
+            }
+        });
+        let progress = json!({
+            "method": "item/mcpToolCall/progress",
+            "params": {"itemId": "tool-1"}
+        });
+        let completed = json!({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "id": "tool-1",
+                    "durationMs": 125
+                }
+            }
+        });
+        let mut known = HashMap::new();
+
+        assert_eq!(
+            tool_call_span_events(&started, &mut known),
+            vec![ToolCallSpanEvent {
+                labels: ToolCallLabels {
+                    kind: "mcp".to_owned(),
+                    name: "list_issues".to_owned(),
+                    method: "github".to_owned(),
+                },
+                status: "started",
+                duration: None,
+            }]
+        );
+        assert_eq!(
+            tool_call_span_events(&progress, &mut known),
+            vec![ToolCallSpanEvent {
+                labels: ToolCallLabels {
+                    kind: "mcp".to_owned(),
+                    name: "list_issues".to_owned(),
+                    method: "github".to_owned(),
+                },
+                status: "progress",
+                duration: None,
+            }]
+        );
+        assert_eq!(
+            tool_call_span_events(&completed, &mut known),
+            vec![ToolCallSpanEvent {
+                labels: ToolCallLabels {
+                    kind: "mcp".to_owned(),
+                    name: "list_issues".to_owned(),
+                    method: "github".to_owned(),
+                },
+                status: "completed",
+                duration: Some(Duration::from_millis(125)),
+            }]
+        );
+        assert!(known.is_empty());
+    }
+
+    #[test]
+    fn command_execution_centaur_call_events_emit_tool_spans() {
+        let started = json!({
+            "type": "item.started",
+            "item": {
+                "id": "cmd-1",
+                "type": "commandExecution",
+                "command": "/bin/bash -lc 'call websearch search {\"query\":\"redacted\"}'"
+            }
+        });
+        let completed = json!({
+            "type": "item.completed",
+            "item": {
+                "id": "cmd-1",
+                "type": "commandExecution",
+                "command": "/usr/local/bin/call discover grafana",
+                "exitCode": 0,
+                "durationMs": 42
+            }
+        });
+        let mut known = HashMap::new();
+
+        assert_eq!(
+            tool_call_span_events(&started, &mut known),
+            vec![ToolCallSpanEvent {
+                labels: ToolCallLabels {
+                    kind: "centaur_call".to_owned(),
+                    name: "websearch".to_owned(),
+                    method: "search".to_owned(),
+                },
+                status: "started",
+                duration: None,
+            }]
+        );
+        assert_eq!(
+            tool_call_span_events(&completed, &mut known),
+            vec![ToolCallSpanEvent {
+                labels: ToolCallLabels {
+                    kind: "centaur_call".to_owned(),
+                    name: "grafana".to_owned(),
+                    method: "discover".to_owned(),
+                },
+                status: "completed",
+                duration: Some(Duration::from_millis(42)),
+            }]
+        );
+    }
+
+    #[test]
+    fn anthropic_tool_use_and_result_events_emit_tool_spans() {
+        let assistant = json!({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "use-1", "name": "todo_write", "input": {"redacted": true}}
+                ]
+            }
+        });
+        let result = json!({
+            "type": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "use-1", "content": "redacted"}
+            ]
+        });
+        let mut known = HashMap::new();
+
+        assert_eq!(
+            tool_call_span_events(&assistant, &mut known),
+            vec![ToolCallSpanEvent {
+                labels: ToolCallLabels {
+                    kind: "anthropic".to_owned(),
+                    name: "todo_write".to_owned(),
+                    method: "call".to_owned(),
+                },
+                status: "started",
+                duration: None,
+            }]
+        );
+        assert_eq!(
+            tool_call_span_events(&result, &mut known),
+            vec![ToolCallSpanEvent {
+                labels: ToolCallLabels {
+                    kind: "anthropic".to_owned(),
+                    name: "todo_write".to_owned(),
+                    method: "call".to_owned(),
+                },
+                status: "completed",
+                duration: None,
+            }]
+        );
+        assert!(known.is_empty());
+    }
+
+    #[test]
+    fn centaur_call_command_parser_matches_only_call_tokens() {
+        assert_eq!(
+            parse_centaur_call_command("call websearch search '{}'"),
+            Some(("websearch".to_owned(), "search".to_owned()))
+        );
+        assert_eq!(
+            parse_centaur_call_command("/bin/bash -lc 'call discover grafana'"),
+            Some(("grafana".to_owned(), "discover".to_owned()))
+        );
+        assert_eq!(
+            parse_centaur_call_command("/usr/local/bin/call agent runtime"),
+            Some(("agent".to_owned(), "runtime".to_owned()))
+        );
+        assert_eq!(
+            parse_centaur_call_command("callback websearch search"),
+            None
+        );
+        assert_eq!(parse_centaur_call_command("recall websearch search"), None);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-telemetry/Cargo.toml
+++ b/services/api-rs/crates/centaur-telemetry/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "centaur-telemetry"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json", "registry"] }

--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -1,0 +1,574 @@
+//! Shared telemetry setup for the Rust Centaur control plane.
+
+use std::{
+    env, fmt as std_fmt,
+    sync::{LazyLock, Mutex},
+    time::Duration,
+};
+
+pub use metrics_exporter_prometheus::PrometheusHandle;
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
+use opentelemetry::trace::{TraceContextExt as _, TracerProvider as _};
+use opentelemetry_sdk::{Resource, trace::SdkTracerProvider};
+use serde_json::Value;
+use thiserror::Error;
+use tracing::{Event, Subscriber};
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+use tracing_subscriber::{
+    EnvFilter, Layer as _,
+    fmt::{
+        self, FmtContext,
+        format::{self as fmt_format, FormatEvent, FormatFields, Writer},
+    },
+    layer::SubscriberExt,
+    registry::LookupSpan,
+    util::SubscriberInitExt,
+};
+
+pub const DEFAULT_SERVICE_NAME: &str = "centaur-api-rs";
+pub const SERVICE_NAMESPACE: &str = "centaur";
+pub const OTEL_SERVICE_NAMESPACE: &str = "service.namespace";
+pub const OTEL_DEPLOYMENT_ENVIRONMENT_NAME: &str = "deployment.environment.name";
+
+pub const FIELD_COMPONENT: &str = "component";
+pub const FIELD_EVENT: &str = "event";
+pub const FIELD_EXECUTION_ID: &str = "execution_id";
+pub const FIELD_SANDBOX_ID: &str = "sandbox_id";
+pub const FIELD_THREAD_KEY: &str = "thread_key";
+
+pub const HTTP_REQUESTS_TOTAL: &str = "http_server_requests_total";
+pub const HTTP_REQUEST_DURATION_SECONDS: &str = "http_server_request_duration_seconds";
+pub const HTTP_REQUESTS_IN_FLIGHT: &str = "http_server_requests_in_flight";
+pub const SESSION_EXECUTIONS_TOTAL: &str = "centaur_session_executions_total";
+pub const SESSION_EXECUTION_DURATION_SECONDS: &str = "centaur_session_execution_duration_seconds";
+pub const SANDBOX_OPERATIONS_TOTAL: &str = "centaur_sandbox_operations_total";
+pub const SANDBOX_WARM_POOL_CLAIMS_TOTAL: &str = "centaur_sandbox_warm_pool_claims_total";
+
+const HTTP_REQUEST_DURATION_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+const SESSION_EXECUTION_DURATION_BUCKETS: &[f64] = &[
+    0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 300.0, 900.0,
+];
+
+static PROMETHEUS_HANDLE: LazyLock<Mutex<Option<PrometheusHandle>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TelemetryConfig {
+    pub service_name: String,
+    pub environment: String,
+    pub rust_log: String,
+    pub traces_exporter: TraceExporter,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TraceExporter {
+    None,
+    Otlp,
+}
+
+#[derive(Debug)]
+pub struct TelemetryGuard {
+    tracer_provider: Option<SdkTracerProvider>,
+}
+
+#[derive(Debug, Error)]
+pub enum TelemetryError {
+    #[error("failed to build Prometheus metrics exporter: {0}")]
+    PrometheusExporter(#[from] metrics_exporter_prometheus::BuildError),
+    #[error("failed to build OTLP trace exporter: {0}")]
+    OtlpExporter(#[from] opentelemetry_otlp::ExporterBuildError),
+    #[error("failed to install global tracing subscriber: {0}")]
+    SetGlobalSubscriber(#[from] tracing_subscriber::util::TryInitError),
+}
+
+impl TelemetryConfig {
+    pub fn from_env() -> Self {
+        let service_name = env::var("OTEL_SERVICE_NAME")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_SERVICE_NAME.to_owned());
+        let environment = first_nonempty_env(&["CENTAUR_ENVIRONMENT", "DEPLOY_ENV", "ENVIRONMENT"])
+            .unwrap_or_else(|| "local".to_owned());
+        let rust_log = env::var("RUST_LOG")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "info".to_owned());
+        let traces_exporter = TraceExporter::from_env();
+
+        Self {
+            service_name,
+            environment,
+            rust_log,
+            traces_exporter,
+        }
+    }
+}
+
+impl TraceExporter {
+    fn from_env() -> Self {
+        let exporter = env::var("OTEL_TRACES_EXPORTER")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
+        let has_endpoint = first_nonempty_env(&[
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+        ])
+        .is_some();
+
+        Self::from_values(&exporter, has_endpoint)
+    }
+
+    fn from_values(exporter: &str, has_endpoint: bool) -> Self {
+        if matches!(exporter, "none" | "false" | "0" | "off") {
+            Self::None
+        } else if exporter == "otlp" || has_endpoint {
+            Self::Otlp
+        } else {
+            Self::None
+        }
+    }
+}
+
+impl TelemetryGuard {
+    pub fn shutdown(mut self) {
+        if let Some(provider) = self.tracer_provider.take() {
+            if let Err(error) = provider.shutdown() {
+                tracing::warn!(%error, "failed to shut down OpenTelemetry tracer provider");
+            }
+        }
+    }
+}
+
+impl Drop for TelemetryGuard {
+    fn drop(&mut self) {
+        if let Some(provider) = self.tracer_provider.take()
+            && let Err(error) = provider.shutdown()
+        {
+            tracing::warn!(%error, "failed to shut down OpenTelemetry tracer provider");
+        }
+    }
+}
+
+pub fn prometheus_handle() -> Result<PrometheusHandle, TelemetryError> {
+    let mut handle = PROMETHEUS_HANDLE
+        .lock()
+        .expect("prometheus handle lock poisoned");
+    if let Some(handle) = handle.as_ref() {
+        return Ok(handle.clone());
+    }
+
+    let new_handle = PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            Matcher::Full(HTTP_REQUEST_DURATION_SECONDS.to_owned()),
+            HTTP_REQUEST_DURATION_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full(SESSION_EXECUTION_DURATION_SECONDS.to_owned()),
+            SESSION_EXECUTION_DURATION_BUCKETS,
+        )?
+        .install_recorder()?;
+    describe_metrics();
+    *handle = Some(new_handle.clone());
+    Ok(new_handle)
+}
+
+pub fn render_metrics() -> Result<String, TelemetryError> {
+    Ok(prometheus_handle()?.render())
+}
+
+pub fn record_http_request_started() {
+    metrics::gauge!(HTTP_REQUESTS_IN_FLIGHT).increment(1.0);
+}
+
+pub fn record_http_request_finished(method: &str, route: &str, status: u16, duration: Duration) {
+    metrics::gauge!(HTTP_REQUESTS_IN_FLIGHT).decrement(1.0);
+    metrics::counter!(
+        HTTP_REQUESTS_TOTAL,
+        "method" => method.to_owned(),
+        "route" => route.to_owned(),
+        "status" => status.to_string(),
+    )
+    .increment(1);
+    metrics::histogram!(
+        HTTP_REQUEST_DURATION_SECONDS,
+        "method" => method.to_owned(),
+        "route" => route.to_owned(),
+        "status_class" => http_status_class(status),
+    )
+    .record(duration.as_secs_f64());
+}
+
+pub fn record_session_execution_started(harness: &str) {
+    metrics::counter!(
+        SESSION_EXECUTIONS_TOTAL,
+        "harness" => normalize_label(harness),
+        "status" => "started",
+    )
+    .increment(1);
+}
+
+pub fn record_session_execution_finished(
+    harness: &str,
+    status: &'static str,
+    duration: Option<Duration>,
+) {
+    metrics::counter!(
+        SESSION_EXECUTIONS_TOTAL,
+        "harness" => normalize_label(harness),
+        "status" => status,
+    )
+    .increment(1);
+    if let Some(duration) = duration {
+        metrics::histogram!(
+            SESSION_EXECUTION_DURATION_SECONDS,
+            "harness" => normalize_label(harness),
+            "status" => status,
+        )
+        .record(duration.as_secs_f64());
+    }
+}
+
+pub fn record_sandbox_operation(backend: &str, operation: &'static str, status: &'static str) {
+    metrics::counter!(
+        SANDBOX_OPERATIONS_TOTAL,
+        "backend" => normalize_label(backend),
+        "operation" => operation,
+        "status" => status,
+    )
+    .increment(1);
+}
+
+pub fn record_sandbox_warm_pool_claim(result: &'static str) {
+    metrics::counter!(
+        SANDBOX_WARM_POOL_CLAIMS_TOTAL,
+        "result" => result,
+    )
+    .increment(1);
+}
+
+pub fn http_status_class(status: u16) -> &'static str {
+    match status / 100 {
+        1 => "1xx",
+        2 => "2xx",
+        3 => "3xx",
+        4 => "4xx",
+        5 => "5xx",
+        _ => "unknown",
+    }
+}
+
+pub fn init_telemetry(config: TelemetryConfig) -> Result<TelemetryGuard, TelemetryError> {
+    let _metrics = prometheus_handle()?;
+    let filter = EnvFilter::try_new(&config.rust_log).unwrap_or_else(|_| EnvFilter::new("info"));
+    let fmt_layer = fmt::layer()
+        .json()
+        .event_format(TraceContextJsonFormatter::new(config.service_name.clone()));
+
+    match config.traces_exporter {
+        TraceExporter::None => {
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(fmt_layer)
+                .try_init()?;
+            Ok(TelemetryGuard {
+                tracer_provider: None,
+            })
+        }
+        TraceExporter::Otlp => {
+            let tracer_provider = build_otlp_tracer_provider(&config)?;
+            let tracer = tracer_provider.tracer(config.service_name.clone());
+            let otel_layer = tracing_opentelemetry::layer()
+                .with_tracer(tracer)
+                .with_filter(
+                    EnvFilter::try_new(&config.rust_log).unwrap_or_else(|_| EnvFilter::new("info")),
+                );
+
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(fmt_layer)
+                .with(otel_layer)
+                .try_init()?;
+
+            Ok(TelemetryGuard {
+                tracer_provider: Some(tracer_provider),
+            })
+        }
+    }
+}
+
+fn describe_metrics() {
+    metrics::describe_counter!(
+        HTTP_REQUESTS_TOTAL,
+        "Total HTTP requests served by the Rust API."
+    );
+    metrics::describe_histogram!(
+        HTTP_REQUEST_DURATION_SECONDS,
+        metrics::Unit::Seconds,
+        "HTTP request latency in seconds for the Rust API."
+    );
+    metrics::describe_gauge!(
+        HTTP_REQUESTS_IN_FLIGHT,
+        "Number of in-flight HTTP requests in the Rust API."
+    );
+    metrics::describe_counter!(
+        SESSION_EXECUTIONS_TOTAL,
+        "Session execution lifecycle events by harness and status."
+    );
+    metrics::describe_histogram!(
+        SESSION_EXECUTION_DURATION_SECONDS,
+        metrics::Unit::Seconds,
+        "Session execution runtime in seconds by harness and terminal status."
+    );
+    metrics::describe_counter!(
+        SANDBOX_OPERATIONS_TOTAL,
+        "Sandbox manager operation attempts by backend, operation, and status."
+    );
+    metrics::describe_counter!(
+        SANDBOX_WARM_POOL_CLAIMS_TOTAL,
+        "Session warm-pool claim attempts by result."
+    );
+}
+
+fn build_otlp_tracer_provider(
+    config: &TelemetryConfig,
+) -> Result<SdkTracerProvider, TelemetryError> {
+    let resource = Resource::builder()
+        .with_service_name(config.service_name.clone())
+        .with_attribute(opentelemetry::KeyValue::new(
+            OTEL_SERVICE_NAMESPACE,
+            SERVICE_NAMESPACE,
+        ))
+        .with_attribute(opentelemetry::KeyValue::new(
+            OTEL_DEPLOYMENT_ENVIRONMENT_NAME,
+            config.environment.clone(),
+        ))
+        .build();
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .build()?;
+
+    Ok(SdkTracerProvider::builder()
+        .with_resource(resource)
+        .with_batch_exporter(exporter)
+        .build())
+}
+
+#[derive(Debug, Clone)]
+struct TraceContextJsonFormatter {
+    inner: fmt_format::Format<fmt_format::Json>,
+    service_name: String,
+}
+
+impl TraceContextJsonFormatter {
+    fn new(service_name: String) -> Self {
+        Self {
+            inner: fmt_format::format().json().with_target(true),
+            service_name,
+        }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for TraceContextJsonFormatter
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std_fmt::Result {
+        let mut formatted = String::new();
+        self.inner
+            .format_event(ctx, Writer::new(&mut formatted), event)?;
+
+        let enriched = inject_log_context(
+            &formatted,
+            &self.service_name,
+            current_trace_context().as_ref(),
+        )
+        .unwrap_or(formatted);
+        writer.write_str(&enriched)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct TraceLogContext {
+    trace_id: String,
+    span_id: String,
+}
+
+fn current_trace_context() -> Option<TraceLogContext> {
+    let context = tracing::Span::current().context();
+    let span_context = context.span().span_context().clone();
+    if !span_context.is_valid() {
+        return None;
+    }
+
+    Some(TraceLogContext {
+        trace_id: span_context.trace_id().to_string(),
+        span_id: span_context.span_id().to_string(),
+    })
+}
+
+fn inject_log_context(
+    log_line: &str,
+    service_name: &str,
+    trace_context: Option<&TraceLogContext>,
+) -> Option<String> {
+    let trimmed = log_line.trim_end_matches('\n');
+    let had_newline = log_line.ends_with('\n');
+    let mut value = serde_json::from_str::<Value>(trimmed).ok()?;
+    let object = value.as_object_mut()?;
+
+    object.insert("service".to_owned(), Value::String(service_name.to_owned()));
+    if let Some(trace_context) = trace_context {
+        object.insert(
+            "trace_id".to_owned(),
+            Value::String(trace_context.trace_id.clone()),
+        );
+        object.insert(
+            "span_id".to_owned(),
+            Value::String(trace_context.span_id.clone()),
+        );
+    }
+
+    let mut enriched = serde_json::to_string(&value).ok()?;
+    if had_newline {
+        enriched.push('\n');
+    }
+    Some(enriched)
+}
+
+fn first_nonempty_env(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        env::var(name)
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn normalize_label(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        "unknown".to_owned()
+    } else {
+        value.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_exporter_defaults_to_none_without_endpoint() {
+        assert_eq!(TraceExporter::from_values("", false), TraceExporter::None);
+    }
+
+    #[test]
+    fn trace_exporter_uses_otlp_when_endpoint_is_present() {
+        assert_eq!(TraceExporter::from_values("", true), TraceExporter::Otlp);
+    }
+
+    #[test]
+    fn trace_exporter_can_be_forced_off() {
+        assert_eq!(
+            TraceExporter::from_values("none", true),
+            TraceExporter::None
+        );
+    }
+
+    #[test]
+    fn prometheus_metrics_render_route_template_labels() {
+        prometheus_handle().unwrap();
+        record_http_request_started();
+        record_http_request_finished(
+            "POST",
+            "/api/session/{thread_key}/execute_test",
+            201,
+            Duration::from_millis(42),
+        );
+
+        let metrics = render_metrics().unwrap();
+
+        assert!(metrics.contains(
+            r#"http_server_requests_total{method="POST",route="/api/session/{thread_key}/execute_test",status="201"}"#
+        ));
+        assert!(metrics.contains(
+            r#"http_server_request_duration_seconds_count{method="POST",route="/api/session/{thread_key}/execute_test",status_class="2xx"}"#
+        ));
+        assert!(metrics.contains("http_server_requests_in_flight 0"));
+    }
+
+    #[test]
+    fn prometheus_metrics_render_domain_metrics() {
+        prometheus_handle().unwrap();
+        record_session_execution_started("codex");
+        record_session_execution_finished("codex", "completed", Some(Duration::from_secs(2)));
+        record_sandbox_operation("local", "create", "success");
+        record_sandbox_warm_pool_claim("hit");
+
+        let metrics = render_metrics().unwrap();
+
+        assert!(
+            metrics
+                .contains(r#"centaur_session_executions_total{harness="codex",status="started"}"#)
+        );
+        assert!(
+            metrics.contains(
+                r#"centaur_session_executions_total{harness="codex",status="completed"}"#
+            )
+        );
+        assert!(metrics.contains(
+            r#"centaur_session_execution_duration_seconds_count{harness="codex",status="completed"}"#
+        ));
+        assert!(metrics.contains(
+            r#"centaur_sandbox_operations_total{backend="local",operation="create",status="success"}"#
+        ));
+        assert!(metrics.contains(r#"centaur_sandbox_warm_pool_claims_total{result="hit"}"#));
+    }
+
+    #[test]
+    fn json_logs_are_enriched_with_service_and_trace_context() {
+        let trace_context = TraceLogContext {
+            trace_id: "0123456789abcdef0123456789abcdef".to_owned(),
+            span_id: "0123456789abcdef".to_owned(),
+        };
+
+        let enriched = inject_log_context(
+            r#"{"timestamp":"2026-06-05T00:00:00Z","level":"INFO","fields":{"message":"ok"}}"#,
+            "centaur-api-rs-test",
+            Some(&trace_context),
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&enriched).unwrap();
+
+        assert_eq!(value["service"], "centaur-api-rs-test");
+        assert_eq!(value["trace_id"], "0123456789abcdef0123456789abcdef");
+        assert_eq!(value["span_id"], "0123456789abcdef");
+        assert_eq!(value["fields"]["message"], "ok");
+    }
+
+    #[test]
+    fn json_log_enrichment_preserves_newline() {
+        let enriched = inject_log_context(
+            "{\"level\":\"INFO\",\"fields\":{}}\n",
+            "centaur-api-rs-test",
+            None,
+        )
+        .unwrap();
+
+        assert!(enriched.ends_with('\n'));
+        assert_eq!(
+            serde_json::from_str::<Value>(&enriched).unwrap()["service"],
+            "centaur-api-rs-test"
+        );
+    }
+}

--- a/services/api-rs/rfcs/0003-telemetry.md
+++ b/services/api-rs/rfcs/0003-telemetry.md
@@ -1,0 +1,296 @@
+# RFC 0003: API-RS Telemetry
+
+Status: Draft
+Owner: TBD
+Target: `services/api-rs`
+
+## Summary
+
+Add a shared telemetry layer for the Rust API control plane that standardizes
+logs, metrics, and traces without leaking HTTP or OpenTelemetry concepts into
+the sandbox abstraction.
+
+The first implementation slice introduces a `centaur-telemetry` crate. The API
+server uses that crate for JSON `tracing` logs by default and optional OTLP trace
+export when an OTLP endpoint is configured. Later slices add HTTP middleware,
+Prometheus/VictoriaMetrics metrics, and domain spans in the session runtime.
+
+## Implementation Status
+
+- Slice 1 is implemented: `centaur-telemetry` initializes JSON logs, optional
+  OTLP tracing, service metadata, shared field constants, and shutdown flushing.
+- Slice 2 is implemented: `centaur-api-server` uses `tower-http` for HTTP
+  request spans, `metrics` plus `metrics-exporter-prometheus` for route-template
+  HTTP metrics, structured request logs, and `/metrics`.
+- Slice 3 is implemented: `centaur-session-runtime` and
+  `centaur-sandbox-manager` emit domain spans and structured logs for session
+  create, message append, execute, sandbox ensure/create/open/stop, input
+  writes, stdout pumping, and event-stream setup.
+- Slice 4 is implemented: `centaur-session-runtime` and
+  `centaur-sandbox-manager` emit bounded Prometheus domain metrics for session
+  execution lifecycle, execution duration, sandbox backend operations, and
+  warm-pool claim results.
+- Metrics scrape readiness is implemented: the Helm chart emits Prometheus
+  scrape annotations for `api-rs` by default. Dashboard and Grafana provisioning
+  artifacts are intentionally not checked in with this slice.
+- Codex app-server event spans are implemented: parsed sandbox stdout JSON
+  emits `centaur.api_rs.codex_app_server.event` spans, and recognized tool-call
+  envelopes emit `centaur.api_rs.codex_app_server.tool_call` spans with bounded
+  tool identity and status attributes only.
+- Process-local trace continuity is implemented for spawned stdout work:
+  `centaur.api_rs.session.execution` is created when an execution is claimed,
+  kept active until terminal state, and used as the parent for stdout-pump,
+  codex app-server event, and tool-call spans emitted by the background pump.
+
+## Goals
+
+- Emit single-line structured logs from all Rust API binaries and library
+  crates through `tracing`.
+- Keep JSON stdout logs as the default local and production log path.
+- Support optional OTLP trace export through standard `OTEL_*` environment
+  variables.
+- Centralize service metadata, environment parsing, field names, and shutdown
+  flushing in one crate.
+- Add metrics with bounded labels only. Runtime identifiers belong in logs and
+  spans, not metric labels.
+- Preserve the current crate boundaries: HTTP telemetry belongs in
+  `centaur-api-server`; session and sandbox spans belong in their owning crates;
+  sandbox core traits stay byte-oriented and backend-neutral.
+
+## Non-goals
+
+- Replacing the Python API telemetry implementation.
+- Exporting OpenTelemetry logs in the first slice.
+- Adding tool, workflow, final delivery, or Slack-specific telemetry to
+  `api-rs` before those concepts exist there.
+- Adding high-cardinality labels such as `thread_key`, `execution_id`,
+  `sandbox_id`, or `user_id` to metrics.
+- Making sandbox traits aware of HTTP routes, request IDs, or OpenTelemetry
+  carrier formats.
+
+## Existing State
+
+`centaur-api-server` currently initializes JSON logs directly in `main.rs`.
+There is no shared telemetry crate, HTTP request middleware, `/metrics`
+endpoint, OpenTelemetry setup, or shared field contract.
+
+The durable runtime boundaries already exist:
+
+- `POST /api/session/{thread_key}`
+- `POST /api/session/{thread_key}/messages`
+- `POST /api/session/{thread_key}/execute`
+- `GET /api/session/{thread_key}/events`
+- `SessionRuntime::execute_session`
+- `SessionRuntime::ensure_session_sandbox`
+- `SandboxManager` lifecycle and I/O operations
+- `PgSessionStore` session, execution, and event persistence
+
+Those are the boundaries telemetry should describe.
+
+## Proposed Workspace Layout
+
+```text
+services/api-rs/
+  crates/
+    centaur-telemetry/
+      src/lib.rs
+    centaur-api-server/
+    centaur-session-runtime/
+    centaur-session-sqlx/
+    centaur-sandbox-manager/
+```
+
+## Telemetry Crate
+
+`centaur-telemetry` owns:
+
+- `TelemetryConfig`
+- `init_telemetry`
+- `TelemetryGuard`
+- service/resource attributes
+- shared structured field names
+- exporter selection
+- shutdown flushing
+
+Configuration comes from:
+
+| Env var | Purpose |
+| ------- | ------- |
+| `RUST_LOG` | Rust tracing filter, default `info` |
+| `OTEL_SERVICE_NAME` | Service name, default `centaur-api-rs` |
+| `CENTAUR_ENVIRONMENT` | Deployment environment |
+| `DEPLOY_ENV` | Environment fallback |
+| `ENVIRONMENT` | Environment fallback |
+| `OTEL_TRACES_EXPORTER` | `otlp` or explicit off values |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Enables OTLP trace export when set |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Trace-specific OTLP endpoint |
+
+The default with no OTLP endpoint is JSON logs only. That keeps local execution
+simple and avoids noisy exporter failures in tests.
+
+## Logs
+
+Logs should use `tracing` fields instead of interpolated strings. The common
+fields are:
+
+| Field | Use |
+| ----- | --- |
+| `service` | Stable service name, when not already carried as resource metadata |
+| `component` | Crate or subsystem, for example `session_runtime` |
+| `event` | Machine-readable event name |
+| `thread_key` | Thread/session identity for logs and spans only |
+| `execution_id` | Execution identity for logs and spans only |
+| `sandbox_id` | Sandbox identity for logs and spans only |
+
+Do not log:
+
+- auth headers
+- API keys
+- environment values that may contain secrets
+- message text or raw message parts
+- sandbox stdout lines
+- raw metadata blobs
+
+## Metrics
+
+Metrics should be exported from `/metrics` in Prometheus text format first,
+because that matches the existing Centaur/VictoriaMetrics operational model.
+OTLP metrics can be added later behind the same telemetry crate.
+
+Initial metric set:
+
+| Metric | Labels |
+| ------ | ------ |
+| `http_server_requests_total` | `method`, `route`, `status` |
+| `http_server_request_duration_seconds` | `method`, `route`, `status_class` |
+| `http_server_requests_in_flight` | none |
+| `centaur_session_executions_total` | `harness`, `status` |
+| `centaur_session_execution_duration_seconds` | `harness`, `status` |
+| `centaur_sandbox_operations_total` | `backend`, `operation`, `status` |
+| `centaur_sandbox_warm_pool_claims_total` | `result` |
+
+Label rules:
+
+- Use route templates, not concrete paths.
+- Keep labels low-cardinality and finite.
+- Never label metrics with `thread_key`, `execution_id`, `sandbox_id`, or
+  `user_id`.
+
+## Traces
+
+Trace spans should follow OpenTelemetry semantic conventions where they apply,
+especially HTTP server spans. Centaur-specific attributes should use the
+`centaur.*` namespace.
+
+Initial span set:
+
+| Span | Owner |
+| ---- | ----- |
+| `centaur.api_rs.http_request` | `centaur-api-server` middleware |
+| `centaur.api_rs.session.create_or_get` | `centaur-session-runtime` |
+| `centaur.api_rs.session.messages.append` | `centaur-session-runtime` |
+| `centaur.api_rs.session.execute` | `centaur-session-runtime` |
+| `centaur.api_rs.session.execution` | `centaur-session-runtime` |
+| `centaur.api_rs.sandbox.ensure` | `centaur-session-runtime` |
+| `centaur.api_rs.sandbox.create` | `centaur-sandbox-manager` |
+| `centaur.api_rs.sandbox.open_io` | `centaur-sandbox-manager` |
+| `centaur.api_rs.sandbox.write_input` | `centaur-session-runtime` |
+| `centaur.api_rs.session.stdout_pump` | `centaur-session-runtime` |
+| `centaur.api_rs.session.events.stream` | `centaur-session-runtime` |
+| `centaur.api_rs.codex_app_server.event` | `centaur-session-runtime` |
+| `centaur.api_rs.codex_app_server.tool_call` | `centaur-session-runtime` |
+
+Spans may carry:
+
+- `centaur.thread_key`
+- `centaur.execution_id`
+- `centaur.sandbox_id`
+- `centaur.harness_type`
+- `centaur.sandbox.backend`
+- `centaur.session.event_type`
+- `codex_app_server.source`
+- `codex_app_server.event_type`
+- `codex_app_server.item_type`
+- `tool.kind`
+- `tool.name`
+- `tool.method`
+- `tool.status`
+
+They must not carry message text, stdout lines, raw metadata, or secrets.
+Tool-call spans must not carry tool arguments, command output, tool results, or
+prompt content.
+
+## Trace Continuity
+
+The Rust API should preserve one trace tree per execution where possible.
+The current implementation explicitly propagates trace context across spawned
+stdout-pump work by keeping a process-local execution span registry keyed by
+`execution_id`.
+
+Trace context needs to be persisted or explicitly propagated before spawning
+background work. The stdout pump now uses the registered execution span as the
+parent for `centaur.api_rs.session.stdout_pump`,
+`centaur.api_rs.codex_app_server.event`, and
+`centaur.api_rs.codex_app_server.tool_call`.
+
+Cross-process continuity after an API restart remains future work. If `api-rs`
+needs that, reuse `thread_traces(thread_key, trace_id, root_span_id)` when
+available or add equivalent columns to `sessions`.
+
+## Implementation Plan
+
+1. Add `centaur-telemetry`.
+   - Add the workspace crate.
+   - Move JSON tracing initialization out of `centaur-api-server`.
+   - Add optional OTLP trace export.
+   - Add `TelemetryGuard` shutdown flushing.
+   - Add tests for environment-driven exporter selection.
+
+2. Add HTTP telemetry.
+   - Add `tower-http` request tracing.
+   - Add request logs, route-template metrics, and HTTP server spans.
+   - Add `/metrics`.
+
+3. Add runtime spans and logs.
+   - Instrument session create, append, execute, stream, sandbox ensure, pipe
+     open, input write, stdout pump, and terminal states.
+   - Keep payload content out of telemetry.
+
+4. Add metrics registry and domain metrics.
+   - Use the shared `metrics` facade and Prometheus exporter for counters,
+     histograms, and text exposition.
+   - Add session execution lifecycle, execution duration, sandbox operation,
+     and warm-pool claim metrics with bounded labels.
+
+5. Add metric scrape readiness.
+   - Add Helm scrape annotations for the `api-rs` `/metrics` endpoint.
+   - Document the external Prometheus/VictoriaMetrics and Tempo/Jaeger
+     requirements.
+   - Document the logs datasource requirement and trace ID correlation contract.
+
+6. Add trace continuity.
+   - Propagate context into background tasks.
+   - Keep execution spans active until terminal state.
+   - Reuse `thread_traces` when available for cross-process continuity.
+   - Persist root trace/span context if restart continuity is required.
+
+7. Verify locally.
+   - Run Rust unit tests.
+   - Start `centaur-api-server` locally.
+   - Exercise create, messages, execute, and events endpoints.
+   - Verify JSON logs include `trace_id` and `span_id` when emitted inside a
+     span.
+   - With an OTLP endpoint configured, verify a trace arrives in the target
+     backend.
+   - With a logs backend configured, verify a log trace ID opens the same trace
+     in Grafana/Jaeger.
+
+## Acceptance Criteria
+
+- API-RS still starts with no telemetry-specific environment variables.
+- Logs remain single-line JSON by default.
+- Setting `OTEL_EXPORTER_OTLP_ENDPOINT` enables trace export.
+- Dropping the telemetry guard flushes pending spans.
+- Metrics labels stay bounded.
+- No telemetry path records message text, stdout lines, raw metadata, secrets,
+  or auth headers.

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -794,10 +794,11 @@ def drain_until_turn_done() -> None:
 def handle_input(turn_input: dict[str, Any]) -> None:
     global ACTIVE_TURN_ID, CURRENT_LLM_INPUT_TEXT, CURRENT_LLM_OUTPUT_TEXT
     global CURRENT_TRACE_METADATA
-    if turn_input.get("type") == "interrupt":
+    input_type = turn_input.get("type")
+    if input_type == "interrupt":
         interrupt_active_turn()
         return
-    if turn_input.get("type") != "user":
+    if input_type not in {"user", "turn.start"}:
         return
 
     thread_key = str(turn_input.get("thread_key") or "").strip()


### PR DESCRIPTION
## Summary
- add a shared `centaur-telemetry` crate for JSON logs, Prometheus metrics, and OTLP trace export in api-rs
- instrument api-rs HTTP, sandbox manager operations, session lifecycle, execution windows, stdout pumps, Codex app-server events, and first-party tool-call spans
- add Helm scrape annotation wiring plus configuration/RFC coverage
- accept `turn.start` in the Codex app wrapper so documented API-to-sandbox input starts Codex app-server turns

## Validation
- `cargo test -p centaur-session-runtime`
- `cargo build -p centaur-api-server`
- `python3 -m py_compile services/sandbox/codex-app-wrapper.py`
- `helm template centaur contrib/chart --namespace centaur >/tmp/centaur-api-rs-helm-template.yaml`
- `git diff --cached --check`
- `pnpm install --frozen-lockfile`
- `bun test test` in `services/slackbotv2`
- post-rebase local api-rs smoke on `127.0.0.1:18180` with local mock sandbox: create session -> append message -> execute -> SSE replay included `session.execution_completed` with `result_text: "PONG 1"`

## Live Observability Evidence
Pre-rebase local live validation exported full api-rs/Codex/Slackbot traces through Jaeger/Loki/Prometheus. After rebase, the local mock smoke verified the updated API binary and migrations on the rebased tree.
