### PR TITLE
fix: allow linked-thread sandbox attachment downloads

### DIFF
--- a/services/api/api/routers/attachments.py
+++ b/services/api/api/routers/attachments.py
@@ -9,7 +9,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
 
 from api.attachments.storage import insert_thread_attachment
-from api.deps import enforce_sandbox_thread_scope, verify_api_key
+from api.deps import (
+    enforce_sandbox_thread_scope,
+    get_sandbox_claims,
+    sandbox_cross_thread_reads_allowed,
+    verify_api_key,
+)
 
 log = structlog.get_logger()
 
@@ -132,12 +137,17 @@ async def download_attachment(
     # cross-thread reads are enabled (the default) — a thread link is the
     # capability to view its attachments.
     enforce_sandbox_thread_scope(request, row["thread_key"], write=False)
-    # An explicit thread_key constrains the read to that thread, for callers
-    # whose key is not a sandbox token (so the check above does not apply).
+    # An explicit thread_key constrains the read to that thread for privileged
+    # service callers. Sandbox tokens already passed the read policy above; if
+    # cross-thread reads are enabled, do not let a helper-appended current
+    # thread_key re-tighten a legitimate linked-thread attachment download.
     if thread_key is not None and row["thread_key"] != thread_key:
-        raise HTTPException(
-            status_code=403, detail="Attachment does not belong to the requested thread"
-        )
+        claims = get_sandbox_claims(request)
+        if claims is None or not sandbox_cross_thread_reads_allowed():
+            raise HTTPException(
+                status_code=403,
+                detail="Attachment does not belong to the requested thread",
+            )
     return Response(
         content=row["data"],
         media_type=row["mime_type"],

--- a/services/api/tests/test_attachments.py
+++ b/services/api/tests/test_attachments.py
@@ -763,6 +763,16 @@ async def test_download_attachment_allows_cross_thread_reads_by_default(monkeypa
     assert resp.status_code == 200
     assert resp.body == SAMPLE_PNG
 
+    # Sandbox token scoped to another thread with a helper-appended current
+    # thread_key still serves the bytes when cross-thread reads are enabled.
+    resp = await download_attachment(
+        _request({"thread_key": "test:other-thread"}),
+        "att-x",
+        thread_key="test:other-thread",
+    )
+    assert resp.status_code == 200
+    assert resp.body == SAMPLE_PNG
+
     # Sandbox token scoped to the owning thread → serves the bytes
     resp = await download_attachment(
         _request({"thread_key": "test:owner-thread"}), "att-x"
@@ -775,7 +785,7 @@ async def test_download_attachment_allows_cross_thread_reads_by_default(monkeypa
     assert resp.status_code == 200
 
     # Explicit thread_key must match the attachment's thread, regardless of
-    # token type (used by privileged callers acting for an agent).
+    # non-sandbox token type (used by privileged callers acting for an agent).
     with pytest.raises(HTTPException) as excinfo:
         await download_attachment(
             _request(None), "att-x", thread_key="test:other-thread"
@@ -820,6 +830,16 @@ async def test_download_attachment_enforces_thread_scope_when_reads_locked(monke
     with pytest.raises(HTTPException) as excinfo:
         await download_attachment(
             _request({"thread_key": "test:other-thread"}), "att-x"
+        )
+    assert excinfo.value.status_code == 403
+
+    # The explicit thread_key bypass stays locked down when cross-thread reads
+    # are disabled.
+    with pytest.raises(HTTPException) as excinfo:
+        await download_attachment(
+            _request({"thread_key": "test:other-thread"}),
+            "att-x",
+            thread_key="test:other-thread",
         )
     assert excinfo.value.status_code == 403
 


### PR DESCRIPTION
## Summary
- allow sandbox-token attachment downloads with a helper-appended current thread_key when cross-thread reads are enabled
- preserve the explicit thread_key guard for privileged/service-key callers and when SANDBOX_CROSS_THREAD_READS is disabled
- add regression coverage for thread B reading thread A attachments with ?thread_key=B

## Validation
- uv run pytest tests/test_attachments.py -k 'download_attachment_allows_cross_thread_reads_by_default or download_attachment_enforces_thread_scope_when_reads_locked'
- uv run ruff check api/routers/attachments.py tests/test_attachments.py
- just build-one api
- just deploy
- kubectl rollout restart -n centaur deploy/centaur-centaur-api && kubectl rollout status -n centaur deploy/centaur-centaur-api --timeout=180s
- In-cluster E2E: uploaded as thread A sandbox token, downloaded as thread B sandbox token with ?thread_key=B; got status=200 body=probe
