### PR TITLE
feat: add opencode as a selectable harness

### DIFF
--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -52,7 +52,8 @@ Optional required-by-mode variables:
 
 | Env var | Set from | Controls |
 | --- | --- | --- |
-| `CENTAUR_DEFAULT_HARNESS` | `api.defaultHarness`. | Default harness for new executions. |
+| `CENTAUR_DEFAULT_HARNESS` | `api.defaultHarness`. | Default harness for new executions (`codex`, `claude-code`, `amp`, `opencode`, `pi-mono`). |
+| `OPENCODE_PROVIDER`, `OPENCODE_MODEL`, `OPENCODE_AUTH_MODE`, `OPENCODE_BASE_URL` | `sandbox.extraEnv`. | opencode provider/model selection and the credential family iron-proxy injects (`anthropic` default, or `openai`). |
 | `CENTAUR_ENVIRONMENT` | `api.extraEnv` or deployment env. | Environment label in traces and telemetry. |
 | `CENTAUR_LOG_LEVEL`, `LOG_LEVEL` | Helm sets `CENTAUR_LOG_LEVEL=info`; override in `api.extraEnv`. | API log level. |
 | `CENTAUR_SERVICE_NAME` | `api.extraEnv`. | Default API log `service` field. |

--- a/docs/public/md/what-is-centaur.md
+++ b/docs/public/md/what-is-centaur.md
@@ -17,7 +17,7 @@ That makes Centaur a better fit for team workflows than an in-memory chat loop. 
 
 ## Isolated Sandboxes
 
-Each conversation is assigned to a Kubernetes sandbox pod that runs the selected harness, such as Amp, Claude Code, or Codex. The API owns runtime assignment, execution serialization, cancellation, recovery, and release.
+Each conversation is assigned to a Kubernetes sandbox pod that runs the selected harness, such as Amp, Claude Code, Codex, or opencode. The API owns runtime assignment, execution serialization, cancellation, recovery, and release.
 
 Sandboxes speak a stable Anthropic-style message format with the API. Harness-specific quirks stay inside the sandbox adapter, so clients do not need to know how each CLI handles text, images, files, or interrupts.
 

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -24,6 +24,11 @@ pub fn harness_auth_fragment(engine: &str, auth_mode: &str) -> Result<Option<Pro
         ("codex", "access_token") => CODEX_ACCESS_TOKEN_FRAGMENT,
         ("claude-code", "api_key") => CLAUDE_CODE_API_KEY_FRAGMENT,
         ("claude-code", "access_token") => CLAUDE_CODE_ACCESS_TOKEN_FRAGMENT,
+        // opencode is provider-agnostic; OPENCODE_AUTH_MODE selects the
+        // provider family. The default (api_key) and explicit anthropic both
+        // rewrite the Anthropic key; openai targets api.openai.com.
+        ("opencode", "api_key" | "anthropic") => CLAUDE_CODE_API_KEY_FRAGMENT,
+        ("opencode", "openai") => CODEX_API_KEY_FRAGMENT,
         _ => return Ok(None),
     };
     load_fragment_str(yaml).map(Some)

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -14,6 +14,29 @@ fn harness_auth_fragments_are_baked_in() {
 
     assert!(harness_auth_fragment("codex", "bogus").unwrap().is_none());
 
+    // opencode reuses the provider-family fragments: the default (api_key) and
+    // "anthropic" rewrite the Anthropic key; "openai" targets api.openai.com.
+    let opencode_default = harness_auth_fragment("opencode", "api_key")
+        .unwrap()
+        .unwrap();
+    let opencode_anthropic = harness_auth_fragment("opencode", "anthropic")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        placeholder_env(&[opencode_default]).get("ANTHROPIC_API_KEY"),
+        Some(&"ANTHROPIC_API_KEY".to_owned())
+    );
+    assert_eq!(
+        placeholder_env(&[opencode_anthropic]).get("ANTHROPIC_API_KEY"),
+        Some(&"ANTHROPIC_API_KEY".to_owned())
+    );
+    assert!(
+        harness_auth_fragment("opencode", "openai")
+            .unwrap()
+            .is_some()
+    );
+    assert!(harness_auth_fragment("opencode", "bogus").unwrap().is_none());
+
     let infra = infra_fragment().unwrap();
     let placeholders = placeholder_env(&[infra]);
     for name in ["AMP_API_KEY", "GITHUB_TOKEN", "SLACK_BOT_TOKEN"] {

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -574,6 +574,8 @@ enum HarnessTypeArg {
     Amp,
     #[value(name = "claudecode")]
     ClaudeCode,
+    #[value(name = "opencode")]
+    OpenCode,
 }
 
 impl From<HarnessTypeArg> for HarnessType {
@@ -582,6 +584,7 @@ impl From<HarnessTypeArg> for HarnessType {
             HarnessTypeArg::Codex => Self::Codex,
             HarnessTypeArg::Amp => Self::Amp,
             HarnessTypeArg::ClaudeCode => Self::ClaudeCode,
+            HarnessTypeArg::OpenCode => Self::OpenCode,
         }
     }
 }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -124,6 +124,7 @@ pub enum HarnessType {
     Codex,
     Amp,
     ClaudeCode,
+    OpenCode,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
@@ -257,6 +258,10 @@ mod tests {
             HarnessType::from_str("claudecode").unwrap(),
             HarnessType::ClaudeCode
         );
+        assert_eq!(
+            HarnessType::from_str("opencode").unwrap(),
+            HarnessType::OpenCode
+        );
     }
 
     #[test]
@@ -264,6 +269,10 @@ mod tests {
         assert_eq!(
             serde_json::to_value(HarnessType::ClaudeCode).unwrap(),
             serde_json::json!("claudecode")
+        );
+        assert_eq!(
+            serde_json::to_value(HarnessType::OpenCode).unwrap(),
+            serde_json::json!("opencode")
         );
         assert_eq!(
             serde_json::from_value::<HarnessType>(serde_json::json!("codex")).unwrap(),

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0007_session_opencode_harness.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0007_session_opencode_harness.sql
@@ -1,0 +1,7 @@
+-- Allow the opencode harness as a supported session harness_type.
+alter table sessions
+    drop constraint if exists sessions_harness_type_supported;
+
+alter table sessions
+    add constraint sessions_harness_type_supported
+    check (harness_type in ('codex', 'amp', 'claudecode', 'opencode'));

--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -98,7 +98,7 @@ _VALID_STDOUT_EVENT_TYPES = frozenset(
     }
 )
 
-_ENGINE_HARNESSES = {"amp", "claude-code", "codex", "pi-mono"}
+_ENGINE_HARNESSES = {"amp", "claude-code", "codex", "opencode", "pi-mono"}
 _REUSABLE_DB_STATES = {"running", "idle", "delivering", "error", "suspended"}
 
 IDLE_TTL_S = int(os.getenv("IDLE_TTL_S", "86400"))  # 24 hours

--- a/services/api/api/harness_config.py
+++ b/services/api/api/harness_config.py
@@ -8,6 +8,8 @@ _DEFAULT_HARNESS_ALIASES: dict[str, str] = {
     "claude": "claude-code",
     "claude-code": "claude-code",
     "codex": "codex",
+    "oc": "opencode",
+    "opencode": "opencode",
     "pi": "pi-mono",
     "pi-mono": "pi-mono",
 }

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -260,6 +260,8 @@ def _engine_model_label(
         return _resolve_codex_model_label(explicit or None)
     if engine_name == "amp":
         return f"amp-{explicit}" if explicit else "amp"
+    if engine_name == "opencode":
+        return f"opencode-{explicit}" if explicit else "opencode"
     if explicit:
         return explicit
     return engine_name or "centaur"

--- a/services/api/api/sandbox/config.py
+++ b/services/api/api/sandbox/config.py
@@ -23,6 +23,9 @@ _HARNESS_STUB_KEYS = (
     "OPENAI_API_KEY",
     "AMP_API_KEY",
     "GITHUB_TOKEN",
+    # Generic placeholder for opencode custom providers whose apiKey points at
+    # OPENCODE_API_KEY; iron-proxy rewrites it to the real credential on the wire.
+    "OPENCODE_API_KEY",
 )
 
 _SANDBOX_PASSTHROUGH_ENV_KEYS = (
@@ -161,6 +164,8 @@ def build_harness_cmd(engine: str, model: str | None = None) -> list[str]:
         return ["codex-app-wrapper"]
     if engine == "claude-code":
         return ["claude-app-wrapper"]
+    if engine == "opencode":
+        return ["opencode-app-wrapper"]
     return ["sleep", "infinity"]
 
 

--- a/services/api/api/sandbox/harness_protocol.py
+++ b/services/api/api/sandbox/harness_protocol.py
@@ -38,7 +38,7 @@ def is_turn_done(engine: str, event: dict) -> bool:
         if "restarting (" in error_msg and "giving up" not in error_msg:
             return False
         return True
-    if engine in ("amp", "claude-code"):
+    if engine in ("amp", "claude-code", "opencode"):
         if t == "result":
             return True
         if t == "assistant":
@@ -75,7 +75,7 @@ def extract_result(engine: str, event: dict) -> str | None:
             if isinstance(text, str) and text:
                 return text
         return _extract_error_message(event) or None
-    if engine in ("amp", "claude-code"):
+    if engine in ("amp", "claude-code", "opencode"):
         if t == "result":
             result = event.get("result")
             if isinstance(result, str) and result:
@@ -115,7 +115,7 @@ def extract_result(engine: str, event: dict) -> str | None:
 def extract_thread_id(engine: str, event: dict) -> str | None:
     """Return the harness thread/session id from *event*, or ``None``."""
     t = event.get("type", "")
-    if engine in ("amp", "claude-code"):
+    if engine in ("amp", "claude-code", "opencode"):
         if t == "system" and event.get("subtype") == "init":
             return event.get("session_id") or None
         if t == "assistant":

--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -1499,6 +1499,10 @@ class KubernetesExecutorBackend(SandboxBackend):
             env.append(f"CLAUDE_MODEL={model}")
         if engine == "claude-code" and resume_thread_id:
             env.append(f"CLAUDE_CONTINUE_SESSION_ID={resume_thread_id}")
+        if engine == "opencode" and model:
+            env.append(f"OPENCODE_MODEL={model}")
+        if engine == "opencode" and resume_thread_id:
+            env.append(f"OPENCODE_CONTINUE_SESSION_ID={resume_thread_id}")
         if persona:
             env.append(f"AGENT_PERSONA={persona}")
         if repo:

--- a/services/api/api/sandbox/normalize.py
+++ b/services/api/api/sandbox/normalize.py
@@ -844,7 +844,7 @@ def _normalize_pi_event(event: dict) -> list[dict]:
 # Main dispatcher
 # ---------------------------------------------------------------------------
 
-_ENGINE_HARNESSES = {"amp", "claude-code", "codex", "pi-mono"}
+_ENGINE_HARNESSES = {"amp", "claude-code", "codex", "opencode", "pi-mono"}
 
 
 def normalize_harness_event(engine: str, event: dict) -> list[dict]:

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -1934,6 +1934,34 @@ class ToolManager:
                 inject_header="chatgpt-account-id",
             ),
         ),
+        # opencode is provider-agnostic; OPENCODE_AUTH_MODE selects which
+        # provider family's credential iron-proxy injects. The default
+        # (unset -> "api_key") and the explicit "anthropic" both target the
+        # Anthropic provider; "openai" targets api.openai.com.
+        ("opencode", "api_key"): (
+            HttpSecret(
+                name="ANTHROPIC_API_KEY",
+                secret_ref="ANTHROPIC_API_KEY",
+                hosts=("api.anthropic.com",),
+                match_headers=("X-Api-Key",),
+            ),
+        ),
+        ("opencode", "anthropic"): (
+            HttpSecret(
+                name="ANTHROPIC_API_KEY",
+                secret_ref="ANTHROPIC_API_KEY",
+                hosts=("api.anthropic.com",),
+                match_headers=("X-Api-Key",),
+            ),
+        ),
+        ("opencode", "openai"): (
+            HttpSecret(
+                name="OPENAI_API_KEY",
+                secret_ref="OPENAI_API_KEY",
+                hosts=("api.openai.com",),
+                match_headers=("Authorization",),
+            ),
+        ),
     }
 
     # Maps an engine to the env-var name (in ``sandbox.extraEnv``) that
@@ -1942,6 +1970,7 @@ class ToolManager:
     _HARNESS_AUTH_MODE_ENV: ClassVar[dict[str, str]] = {
         "claude-code": "CLAUDE_CODE_AUTH_MODE",
         "codex": "CODEX_AUTH_MODE",
+        "opencode": "OPENCODE_AUTH_MODE",
     }
 
     @classmethod

--- a/services/api/api/warm_pool.py
+++ b/services/api/api/warm_pool.py
@@ -94,7 +94,9 @@ async def _spawn_warm_container() -> WarmContainer | None:
     if not backend.supports_warm_pool:
         return None
     engine = (
-        POOL_HARNESS if POOL_HARNESS in {"amp", "claude-code", "codex"} else "codex"
+        POOL_HARNESS
+        if POOL_HARNESS in {"amp", "claude-code", "codex", "opencode"}
+        else "codex"
     )
 
     placeholder_key = f"warm-{int(time.time() * 1000)}-{id(asyncio.current_task())}"

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -942,7 +942,7 @@ class _ToolProxy:
 # ── Agent-turn helper (domain logic, NOT on the context) ──────────────
 
 
-_EXECUTION_HARNESSES = frozenset({"amp", "claude-code", "codex", "pi-mono"})
+_EXECUTION_HARNESSES = frozenset({"amp", "claude-code", "codex", "opencode", "pi-mono"})
 
 
 async def _compute_agent_session_title(

--- a/services/api/api/workflows/slack_thread_turn.py
+++ b/services/api/api/workflows/slack_thread_turn.py
@@ -12,10 +12,11 @@ from api.workflow_engine import Delivery, WorkflowContext
 
 WORKFLOW_NAME = "slack_thread_turn"
 
-_EXECUTION_HARNESSES = frozenset({"amp", "claude-code", "codex", "pi-mono"})
+_EXECUTION_HARNESSES = frozenset({"amp", "claude-code", "codex", "opencode", "pi-mono"})
 _PROMPT_FLAG_ALIASES = {
     "claude": "claude-code",
     "pi": "pi-mono",
+    "oc": "opencode",
 }
 _PROMPT_FLAG_SKIP = frozenset({"engine", "model", "opus", "sonnet", "haiku"})
 _PROMPT_FLAG_VALUE_SKIP = frozenset({"engine", "model"})

--- a/services/api/tests/test_harness_config.py
+++ b/services/api/tests/test_harness_config.py
@@ -25,3 +25,19 @@ def test_default_harness_ignores_unknown_values(monkeypatch):
     monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "unknown")
 
     assert default_harness() == "codex"
+
+
+def test_default_harness_supports_opencode_alias(monkeypatch):
+    from api.harness_config import default_harness
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "opencode")
+    assert default_harness() == "opencode"
+
+    monkeypatch.setenv("CENTAUR_DEFAULT_HARNESS", "oc")
+    assert default_harness() == "opencode"
+
+
+def test_build_harness_cmd_opencode():
+    from api.sandbox.config import build_harness_cmd
+
+    assert build_harness_cmd("opencode") == ["opencode-app-wrapper"]

--- a/services/api/tests/test_harness_protocol.py
+++ b/services/api/tests/test_harness_protocol.py
@@ -457,3 +457,22 @@ class TestMessagesToContentBlocks:
             {"type": "text", "text": "first"},
             {"type": "text", "text": "second"},
         ]
+
+
+class TestOpenCode:
+    """opencode reuses the claude-code wire shapes emitted by its wrapper."""
+
+    def test_result_signals_turn_done(self):
+        event = {"type": "result", "subtype": "success", "result": "all done"}
+        assert is_turn_done("opencode", event) is True
+
+    def test_error_signals_turn_done(self):
+        assert is_turn_done("opencode", {"type": "error", "message": "boom"}) is True
+
+    def test_extract_result_from_result_event(self):
+        event = {"type": "result", "subtype": "success", "result": "the answer"}
+        assert extract_result("opencode", event) == "the answer"
+
+    def test_extract_thread_id_from_init(self):
+        event = {"type": "system", "subtype": "init", "session_id": "ses_abc123"}
+        assert extract_thread_id("opencode", event) == "ses_abc123"

--- a/services/api/tests/test_normalize.py
+++ b/services/api/tests/test_normalize.py
@@ -221,3 +221,35 @@ class TestAutoDetect:
     def test_detect_amp_fallback(self):
         result = normalize_harness_event("", {"type": "result", "result": "ok"})
         assert result == [{"type": "result", "text": "ok"}]
+
+
+class TestOpenCode:
+    """opencode routes through the amp-like normalizer (wrapper emits that shape)."""
+
+    def test_result_event(self):
+        result = normalize_harness_event(
+            "opencode", {"type": "result", "subtype": "success", "result": "done"}
+        )
+        assert result == [{"type": "result", "text": "done"}]
+
+    def test_system_init(self):
+        result = normalize_harness_event(
+            "opencode",
+            {"type": "system", "subtype": "init", "session_id": "ses_1"},
+        )
+        assert result == [
+            {"type": "system", "subtype": "init", "session_id": "ses_1"}
+        ]
+
+    def test_stream_text_delta(self):
+        evt = {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "hi"},
+            },
+        }
+        result = normalize_harness_event("opencode", evt)
+        assert result == [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}}
+        ]

--- a/services/api/tests/test_tool_manager.py
+++ b/services/api/tests/test_tool_manager.py
@@ -718,6 +718,22 @@ class TestHarnessSecretSelection:
         assert "ANTHROPIC_API_KEY" in names
         assert "anthropic-claude" not in names
 
+    def test_opencode_defaults_to_anthropic(self) -> None:
+        tm = ToolManager.__new__(ToolManager)
+        tm.tools = {}
+        names = self._names(tm.secrets_for_sandbox("opencode", {}))
+        assert "ANTHROPIC_API_KEY" in names
+        assert "OPENAI_API_KEY" not in names
+
+    def test_opencode_openai_mode_swaps_provider(self) -> None:
+        tm = ToolManager.__new__(ToolManager)
+        tm.tools = {}
+        names = self._names(
+            tm.secrets_for_sandbox("opencode", {"OPENCODE_AUTH_MODE": "openai"})
+        )
+        assert "OPENAI_API_KEY" in names
+        assert "ANTHROPIC_API_KEY" not in names
+
     def test_unknown_engine_gets_no_harness_extras(self) -> None:
         tm = ToolManager.__new__(ToolManager)
         tm.tools = {}

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -55,6 +55,7 @@ RUN useradd -m -s /bin/bash -u 1001 agent \
 ARG CLAUDE_CODE_VERSION=2.1.154
 ARG CODEX_VERSION=0.130.0
 ARG PI_CODING_AGENT_VERSION=0.67.2
+ARG OPENCODE_VERSION=1.16.2
 ARG NUSHELL_VERSION=0.112.2
 ARG KUBECTL_VERSION=v1.34.2
 
@@ -93,10 +94,12 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
       "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
       "@openai/codex@${CODEX_VERSION}" \
       "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \
+      "opencode-ai@${OPENCODE_VERSION}" \
       agent-browser@0.26.0 \
     && find /usr/lib/node_modules -type f \( -name '*.map' -o -name '*.tsbuildinfo' \) -delete \
     && claude --version | grep -F "${CLAUDE_CODE_VERSION}" \
-    && codex --version | grep -F "${CODEX_VERSION}"
+    && codex --version | grep -F "${CODEX_VERSION}" \
+    && opencode --version | grep -F "${OPENCODE_VERSION}"
 
 # ── agent-browser system deps (must run as root before USER agent) ───────────
 # Chrome for Testing doesn't provide Linux ARM64 builds; fall back to system chromium
@@ -198,6 +201,7 @@ COPY --link --chmod=755 services/sandbox/md2docx.py /usr/local/bin/md2docx
 COPY --link --chmod=755 services/sandbox/amp-wrapper.py /usr/local/bin/amp-wrapper
 COPY --link --chmod=755 services/sandbox/codex-app-wrapper.py /usr/local/bin/codex-app-wrapper
 COPY --link --chmod=755 services/sandbox/claude-app-wrapper.py /usr/local/bin/claude-app-wrapper
+COPY --link --chmod=755 services/sandbox/opencode-app-wrapper.py /usr/local/bin/opencode-app-wrapper
 COPY --link --chmod=755 services/sandbox/harness_adapter.py /usr/local/bin/harness-adapter
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
 COPY --link --chmod=755 services/sandbox/install_tool_shims.py /usr/local/bin/install-tool-shims

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -50,12 +50,17 @@ if [ -n "${TOOL_DIRS:-}" ]; then
 fi
 
 if [ -d "$STATE_DIR" ] && [ -w "$STATE_DIR" ]; then
-    mkdir -p "$STATE_DIR/workspace" "$STATE_DIR/uploads" "$STATE_DIR/branches" "$STATE_DIR/codex" "$STATE_DIR/claude"
+    mkdir -p "$STATE_DIR/workspace" "$STATE_DIR/uploads" "$STATE_DIR/branches" "$STATE_DIR/codex" "$STATE_DIR/claude" "$STATE_DIR/opencode"
     rm -rf "$HOME_DIR/.codex" "$HOME_DIR/.claude" "$HOME_DIR/uploads" "$HOME_DIR/branches"
     ln -s "$STATE_DIR/codex" "$HOME_DIR/.codex"
     ln -s "$STATE_DIR/claude" "$HOME_DIR/.claude"
     ln -s "$STATE_DIR/uploads" "$HOME_DIR/uploads"
     ln -s "$STATE_DIR/branches" "$HOME_DIR/branches"
+    # opencode stores session history under its XDG data dir; persist it so
+    # OPENCODE_CONTINUE_SESSION_ID can resume across warm-pool claims.
+    mkdir -p "$HOME_DIR/.local/share"
+    rm -rf "$HOME_DIR/.local/share/opencode"
+    ln -s "$STATE_DIR/opencode" "$HOME_DIR/.local/share/opencode"
     export CENTAUR_PERSISTENT_STATE=1
 fi
 
@@ -177,6 +182,78 @@ case "$CLAUDE_CODE_AUTH_MODE" in
         exit 1
         ;;
 esac
+
+# ── opencode settings ────────────────────────────────────────────────────────
+# opencode is provider-agnostic: the model provider and model are fully
+# configurable through env vars, which the entrypoint renders into the global
+# opencode.json. Authentication mirrors the codex/claude stub-key model — the
+# provider's apiKey points at a placeholder env var that iron-proxy rewrites to
+# the real credential on the wire (selected by OPENCODE_AUTH_MODE).
+#
+#   OPENCODE_PROVIDER    provider id (default: anthropic)
+#   OPENCODE_MODEL       bare model id (default: claude-opus-4-8)
+#   OPENCODE_AUTH_MODE   anthropic | openai | api_key (default: anthropic)
+#   OPENCODE_BASE_URL    optional custom OpenAI-compatible base URL
+#   OPENCODE_PROVIDER_NPM optional AI-SDK adapter package for custom providers
+#   OPENCODE_API_KEY_ENV optional override of the placeholder env var name
+mkdir -p "$HOME_DIR/.config/opencode"
+OPENCODE_PROVIDER="${OPENCODE_PROVIDER:-anthropic}"
+OPENCODE_MODEL="${OPENCODE_MODEL:-claude-opus-4-8}"
+OPENCODE_AUTH_MODE="${OPENCODE_AUTH_MODE:-anthropic}"
+# Default the placeholder env var to the provider family's stub key.
+if [ -z "${OPENCODE_API_KEY_ENV:-}" ]; then
+    case "$OPENCODE_AUTH_MODE" in
+        openai) OPENCODE_API_KEY_ENV="OPENAI_API_KEY" ;;
+        *) OPENCODE_API_KEY_ENV="ANTHROPIC_API_KEY" ;;
+    esac
+fi
+export OPENCODE_PROVIDER OPENCODE_MODEL OPENCODE_AUTH_MODE OPENCODE_API_KEY_ENV
+# The wrapper and the local server must share a password so loopback requests
+# authenticate regardless of the server's default policy.
+if [ -z "${OPENCODE_SERVER_PASSWORD:-}" ]; then
+    OPENCODE_SERVER_PASSWORD="$(head -c 24 /dev/urandom | base64 | tr -d '/+=')"
+fi
+export OPENCODE_SERVER_PASSWORD
+OPENCODE_PROVIDER="$OPENCODE_PROVIDER" \
+OPENCODE_MODEL="$OPENCODE_MODEL" \
+OPENCODE_BASE_URL="${OPENCODE_BASE_URL:-}" \
+OPENCODE_PROVIDER_NPM="${OPENCODE_PROVIDER_NPM:-}" \
+OPENCODE_API_KEY_ENV="$OPENCODE_API_KEY_ENV" \
+python3 - "$HOME_DIR/.config/opencode/opencode.json" <<'PYEOF'
+import json
+import os
+import sys
+
+provider = os.environ["OPENCODE_PROVIDER"]
+model = os.environ["OPENCODE_MODEL"]
+base_url = os.environ.get("OPENCODE_BASE_URL", "").strip()
+npm = os.environ.get("OPENCODE_PROVIDER_NPM", "").strip()
+key_env = os.environ["OPENCODE_API_KEY_ENV"]
+
+options = {"apiKey": "{env:%s}" % key_env}
+if base_url:
+    options["baseURL"] = base_url
+
+provider_block = {"options": options}
+if npm:
+    provider_block["npm"] = npm
+
+# model may already be provider-qualified ("anthropic/claude-..."); only prefix
+# the provider when it is a bare model id.
+qualified_model = model if "/" in model else f"{provider}/{model}"
+
+config = {
+    "$schema": "https://opencode.ai/config.json",
+    "model": qualified_model,
+    "provider": {provider: provider_block},
+    # Non-interactive sandbox: never prompt, never auto-update.
+    "autoupdate": False,
+}
+
+with open(sys.argv[1], "w") as f:
+    json.dump(config, f, indent=2)
+    f.write("\n")
+PYEOF
 
 # ── Pi-mono settings ─────────────────────────────────────────────────────────
 mkdir -p "$HOME_DIR/.pi/agent/extensions"

--- a/services/sandbox/harness_adapter.py
+++ b/services/sandbox/harness_adapter.py
@@ -28,10 +28,17 @@ class ClaudeCodeAdapter(HarnessAdapter):
     pass
 
 
+class OpenCodeAdapter(HarnessAdapter):
+    # opencode reads ``AGENTS.md`` natively from the workspace root, so no
+    # prompt-file rewriting is needed (same as Codex).
+    pass
+
+
 ADAPTERS = {
     "amp-wrapper": AmpAdapter,
     "codex-app-wrapper": CodexAdapter,
     "claude-app-wrapper": ClaudeCodeAdapter,
+    "opencode-app-wrapper": OpenCodeAdapter,
 }
 
 

--- a/services/sandbox/opencode-app-wrapper.py
+++ b/services/sandbox/opencode-app-wrapper.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Centaur NDJSON bridge for the opencode CLI.
+
+opencode exposes a headless HTTP server (``opencode serve``) with an OpenAPI
+surface and a global Server-Sent-Events stream, rather than a stdin/stdout
+app-server like codex. This wrapper spans that gap so opencode speaks the same
+NDJSON dialect Centaur already consumes from the codex/claude wrappers:
+
+* It boots ``opencode serve`` bound to loopback, waits for readiness, and opens
+  one persistent session.
+* Centaur's Anthropic-shaped envelopes (``{"type":"user","message":{...}}``
+  plus ``interrupt``) arrive on stdin. Each user turn is delivered with a
+  **synchronous** ``POST /session/:id/message`` whose response carries the
+  finished assistant message — that return is the authoritative end-of-turn
+  signal, so there is no ambiguity about which ``session.idle`` belongs to us.
+* The global ``GET /event`` stream is used only for live streaming: text and
+  reasoning deltas for our session are re-emitted as Anthropic ``stream_event``
+  deltas and tool calls as ``content_block_start`` blocks, exactly the shapes
+  the claude/amp normalizer already understands.
+* ``SIGUSR1`` and ``{"type":"interrupt"}`` abort the active turn via
+  ``POST /session/:id/abort``.
+
+The emitted events deliberately mirror the claude-code wire format so the API
+control plane can treat the ``opencode`` engine as claude-like (see
+``api/sandbox/harness_protocol.py`` and ``api/sandbox/normalize.py``). The
+model and provider are configured entirely through ``opencode.json`` /
+``OPENCODE_CONFIG_CONTENT`` written by the entrypoint, so no per-message model
+override is sent here.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import queue
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+DEFAULT_PORT = 4096
+SERVER_READY_TIMEOUT_S = 60.0
+# Watchdog for a single turn's synchronous message POST. opencode turns can run
+# for many minutes (large refactors, deep tool loops); this is a generous
+# ceiling, not a quality budget.
+TURN_TIMEOUT_S = float(os.environ.get("OPENCODE_TURN_TIMEOUT_SECONDS") or 1800)
+
+SERVER: subprocess.Popen[str] | None = None
+SESSION_ID: str = ""
+SHUTTING_DOWN = False
+TURN_LOCK = threading.Lock()
+TURN_ACTIVE = threading.Event()
+# User turns are queued by the stdin reader; interrupts are dispatched inline by
+# that thread so they cancel a turn that is blocked on its synchronous POST.
+USER_TURNS: queue.Queue[dict[str, Any] | None] = queue.Queue()
+
+# Tracks how much of each streamed text/reasoning part has already been emitted,
+# so we forward only the new suffix when opencode reports cumulative text.
+_PART_EMITTED_LEN: dict[str, int] = {}
+_TOOL_STARTED: set[str] = set()
+_STREAM_LOCK = threading.Lock()
+
+
+def emit(payload: dict[str, Any]) -> None:
+    sys.stdout.write(
+        json.dumps(payload, separators=(",", ":"), ensure_ascii=False) + "\n"
+    )
+    sys.stdout.flush()
+
+
+# ── HTTP helpers (stdlib only — the sandbox has no `requests`) ────────────────
+
+
+def _base_url() -> str:
+    port = int(os.environ.get("OPENCODE_SERVER_PORT") or DEFAULT_PORT)
+    return f"http://127.0.0.1:{port}"
+
+
+def _auth_header() -> dict[str, str]:
+    password = os.environ.get("OPENCODE_SERVER_PASSWORD")
+    if not password:
+        return {}
+    username = os.environ.get("OPENCODE_SERVER_USERNAME") or "opencode"
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def _request(
+    method: str,
+    path: str,
+    body: dict[str, Any] | None = None,
+    *,
+    timeout: float,
+) -> Any:
+    url = f"{_base_url()}{path}"
+    data = (
+        json.dumps(body, separators=(",", ":")).encode() if body is not None else None
+    )
+    headers = {"Accept": "application/json", **_auth_header()}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    # The local server must never be reached through the egress proxy.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    with opener.open(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8", "replace")
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def _wait_for_server() -> None:
+    deadline = time.monotonic() + SERVER_READY_TIMEOUT_S
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        if SERVER is not None and SERVER.poll() is not None:
+            raise RuntimeError(
+                f"opencode serve exited early with code {SERVER.returncode}"
+            )
+        try:
+            _request("GET", "/global/health", timeout=3.0)
+            return
+        except (urllib.error.URLError, OSError, socket.timeout) as exc:
+            last_err = exc
+            time.sleep(0.25)
+    raise RuntimeError(f"opencode server not ready in {SERVER_READY_TIMEOUT_S}s: {last_err}")
+
+
+def _create_or_resume_session() -> str:
+    resume = (os.environ.get("OPENCODE_CONTINUE_SESSION_ID") or "").strip()
+    if resume:
+        try:
+            session = _request("GET", f"/session/{resume}", timeout=10.0)
+            if isinstance(session, dict) and session.get("id"):
+                return str(session["id"])
+        except (urllib.error.URLError, OSError, socket.timeout):
+            pass  # fall through to a fresh session
+    session = _request("POST", "/session", body={}, timeout=30.0)
+    if not isinstance(session, dict) or not session.get("id"):
+        raise RuntimeError(f"unexpected /session response: {session!r}")
+    return str(session["id"])
+
+
+# ── SSE event stream → Anthropic-shaped streaming deltas ──────────────────────
+
+
+def _emit_text_delta(part: dict[str, Any], delta: str | None) -> None:
+    part_id = str(part.get("id") or "")
+    text = part.get("text")
+    if not isinstance(text, str):
+        return
+    chunk = delta if isinstance(delta, str) and delta else ""
+    if not chunk:
+        with _STREAM_LOCK:
+            seen = _PART_EMITTED_LEN.get(part_id, 0)
+            if len(text) <= seen:
+                return
+            chunk = text[seen:]
+            _PART_EMITTED_LEN[part_id] = len(text)
+    else:
+        with _STREAM_LOCK:
+            _PART_EMITTED_LEN[part_id] = len(text)
+    if not chunk:
+        return
+    emit(
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": chunk},
+            },
+        }
+    )
+
+
+def _emit_reasoning_delta(part: dict[str, Any], delta: str | None) -> None:
+    part_id = f"reasoning:{part.get('id') or ''}"
+    text = part.get("text")
+    if not isinstance(text, str):
+        return
+    chunk = delta if isinstance(delta, str) and delta else ""
+    if not chunk:
+        with _STREAM_LOCK:
+            seen = _PART_EMITTED_LEN.get(part_id, 0)
+            if len(text) <= seen:
+                return
+            chunk = text[seen:]
+            _PART_EMITTED_LEN[part_id] = len(text)
+    else:
+        with _STREAM_LOCK:
+            _PART_EMITTED_LEN[part_id] = len(text)
+    if not chunk:
+        return
+    emit(
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "thinking_delta", "thinking": chunk},
+            },
+        }
+    )
+
+
+def _emit_tool_start(part: dict[str, Any]) -> None:
+    call_id = str(part.get("callID") or part.get("id") or "")
+    if not call_id:
+        return
+    with _STREAM_LOCK:
+        if call_id in _TOOL_STARTED:
+            return
+        _TOOL_STARTED.add(call_id)
+    state = part.get("state") if isinstance(part.get("state"), dict) else {}
+    tool_input = state.get("input") if isinstance(state.get("input"), dict) else {}
+    emit(
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "content_block": {
+                    "type": "tool_use",
+                    "id": call_id,
+                    "name": str(part.get("tool") or "tool"),
+                    "input": tool_input,
+                },
+            },
+        }
+    )
+
+
+def _handle_stream_event(event: dict[str, Any]) -> None:
+    etype = event.get("type")
+    props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+    if etype == "message.part.updated":
+        part = props.get("part") if isinstance(props.get("part"), dict) else {}
+        if part.get("sessionID") != SESSION_ID:
+            return  # subagent / unrelated session
+        ptype = part.get("type")
+        if ptype == "text":
+            _emit_text_delta(part, props.get("delta"))
+        elif ptype == "reasoning":
+            _emit_reasoning_delta(part, props.get("delta"))
+        elif ptype == "tool":
+            _emit_tool_start(part)
+    elif etype == "session.error" and props.get("sessionID") in (SESSION_ID, None):
+        err = props.get("error")
+        message = _error_message(err)
+        if message:
+            emit({"type": "error", "message": message})
+
+
+def _sse_reader() -> None:
+    """Stream the global event bus, forwarding our session's deltas."""
+    backoff = 0.5
+    while not SHUTTING_DOWN:
+        try:
+            req = urllib.request.Request(
+                f"{_base_url()}/event",
+                headers={"Accept": "text/event-stream", **_auth_header()},
+                method="GET",
+            )
+            opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+            with opener.open(req, timeout=None) as resp:
+                backoff = 0.5
+                for raw in resp:
+                    if SHUTTING_DOWN:
+                        return
+                    line = raw.decode("utf-8", "replace").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    payload = line[len("data:") :].strip()
+                    if not payload:
+                        continue
+                    try:
+                        event = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(event, dict):
+                        try:
+                            _handle_stream_event(event)
+                        except Exception as exc:  # never let streaming kill the turn
+                            emit({"type": "system", "subtype": "stream_error", "message": str(exc)})
+        except (urllib.error.URLError, OSError, socket.timeout):
+            if SHUTTING_DOWN:
+                return
+            time.sleep(backoff)
+            backoff = min(backoff * 2, 5.0)
+
+
+# ── Turn handling ─────────────────────────────────────────────────────────────
+
+
+def _error_message(err: Any) -> str:
+    if isinstance(err, str):
+        return err
+    if isinstance(err, dict):
+        data = err.get("data") if isinstance(err.get("data"), dict) else {}
+        return (
+            str(data.get("message"))
+            if data.get("message")
+            else str(err.get("name") or err.get("message") or "opencode error")
+        )
+    return ""
+
+
+def _final_text_from_message(response: Any) -> str:
+    """Pull the assistant text from a /session/:id/message response."""
+    if not isinstance(response, dict):
+        return ""
+    parts = response.get("parts")
+    if not isinstance(parts, list):
+        return ""
+    texts = [
+        p.get("text", "")
+        for p in parts
+        if isinstance(p, dict) and p.get("type") == "text" and p.get("text")
+    ]
+    return texts[-1] if texts else ""
+
+
+def _content_to_text(blocks: list[Any]) -> str:
+    out: list[str] = []
+    for block in blocks:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str):
+                out.append(text)
+    return "\n".join(t for t in out if t).strip()
+
+
+def handle_user_turn(turn_input: dict[str, Any]) -> None:
+    message = turn_input.get("message")
+    if not isinstance(message, dict):
+        return
+    blocks = message.get("content")
+    if not isinstance(blocks, list) or not blocks:
+        return
+    text = _content_to_text(blocks)
+    if not text:
+        return
+
+    with TURN_LOCK:
+        TURN_ACTIVE.set()
+        with _STREAM_LOCK:
+            _PART_EMITTED_LEN.clear()
+            _TOOL_STARTED.clear()
+        try:
+            response = _request(
+                "POST",
+                f"/session/{SESSION_ID}/message",
+                body={"parts": [{"type": "text", "text": text}]},
+                timeout=TURN_TIMEOUT_S,
+            )
+            result_text = _final_text_from_message(response)
+            emit(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": result_text,
+                }
+            )
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")[:1000] if exc.fp else ""
+            _emit_turn_error(f"opencode HTTP {exc.code}: {detail or exc.reason}")
+        except (urllib.error.URLError, OSError, socket.timeout) as exc:
+            _emit_turn_error(f"opencode request failed: {exc}")
+        finally:
+            TURN_ACTIVE.clear()
+
+
+def _emit_turn_error(message: str) -> None:
+    emit({"type": "error", "message": message})
+    emit(
+        {
+            "type": "result",
+            "subtype": "error",
+            "is_error": True,
+            "result": message,
+        }
+    )
+
+
+def interrupt_active_turn(*_args: object) -> None:
+    if not TURN_ACTIVE.is_set() or not SESSION_ID:
+        return
+    try:
+        _request("POST", f"/session/{SESSION_ID}/abort", body={}, timeout=10.0)
+    except (urllib.error.URLError, OSError, socket.timeout) as exc:
+        emit({"type": "error", "message": f"interrupt failed: {exc}"})
+
+
+# ── Process lifecycle ─────────────────────────────────────────────────────────
+
+
+def _build_serve_cmd() -> list[str]:
+    port = int(os.environ.get("OPENCODE_SERVER_PORT") or DEFAULT_PORT)
+    return ["opencode", "serve", "--hostname", "127.0.0.1", "--port", str(port)]
+
+
+def exit_wrapper(*_args: object) -> None:
+    global SHUTTING_DOWN
+    SHUTTING_DOWN = True
+    if SERVER and SERVER.poll() is None:
+        try:
+            os.killpg(os.getpgid(SERVER.pid), signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
+def _stdin_reader() -> None:
+    """Read Centaur envelopes off stdin.
+
+    Interrupts are dispatched here so they cancel a turn that is currently
+    blocked on its synchronous message POST; user turns are queued for the main
+    thread to run one at a time.
+    """
+    for raw in sys.stdin:
+        if SHUTTING_DOWN:
+            break
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            emit({"type": "error", "message": "invalid stdin JSON"})
+            continue
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "interrupt":
+            interrupt_active_turn()
+        elif item.get("type") == "user":
+            USER_TURNS.put(item)
+    USER_TURNS.put(None)
+
+
+def main() -> None:
+    global SERVER, SESSION_ID
+    signal.signal(signal.SIGTERM, exit_wrapper)
+    signal.signal(signal.SIGINT, exit_wrapper)
+    signal.signal(signal.SIGUSR1, interrupt_active_turn)
+
+    emit({"type": "system", "subtype": "wrapper_heartbeat", "phase": "startup"})
+
+    SERVER = subprocess.Popen(
+        _build_serve_cmd(),
+        stdin=subprocess.DEVNULL,
+        stdout=sys.stderr,
+        stderr=sys.stderr,
+        text=True,
+        cwd=os.getcwd(),
+        start_new_session=True,
+    )
+
+    try:
+        _wait_for_server()
+        SESSION_ID = _create_or_resume_session()
+    except Exception as exc:
+        emit({"type": "error", "message": f"opencode startup failed: {exc}"})
+        emit(
+            {
+                "type": "result",
+                "subtype": "error",
+                "is_error": True,
+                "result": f"opencode startup failed: {exc}",
+            }
+        )
+        exit_wrapper()
+        return
+
+    threading.Thread(target=_sse_reader, daemon=True).start()
+    threading.Thread(target=_stdin_reader, daemon=True).start()
+    emit(
+        {
+            "type": "system",
+            "subtype": "wrapper_heartbeat",
+            "phase": "app_server_started",
+        }
+    )
+    emit({"type": "system", "subtype": "init", "session_id": SESSION_ID})
+
+    while not SHUTTING_DOWN:
+        item = USER_TURNS.get()
+        if item is None:
+            break
+        try:
+            handle_user_turn(item)
+        except Exception as exc:
+            _emit_turn_error(f"wrapper error: {exc}")
+
+    exit_wrapper()
+    if SERVER:
+        try:
+            SERVER.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            SERVER.kill()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds opencode as a harness option alongside the existing ones. It runs as its own sandbox process that translates between Centaur's turn protocol and opencode's headless server, so conversations can be driven by opencode the same way they already can by the others.

The model provider and model are fully configurable, and provider credentials are attached the same way they are for the other harnesses — at the proxy boundary, so no real keys ever live inside the sandbox.

Worth a smoke test against a live build before rollout, since the message and event shapes were validated against the pinned version's docs rather than a running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)