### PR TITLE
feat(api-rs): CloudWatch tool aws_auth via iron-control

### DIFF
--- a/contrib/scripts/bootstrap-k8s-secrets.sh
+++ b/contrib/scripts/bootstrap-k8s-secrets.sh
@@ -23,6 +23,12 @@ Optional local-dev admin key:
                                (envFrom centaur-infra-env). Re-run with --force
                                or kubectl patch to rotate.
 
+Optional repo-cache GitHub token:
+  GITHUB_TOKEN                 added to centaur-infra-env when present; the
+                               repo-cache DaemonSet reads it (repoCache.githubToken
+                               -> existingSecretName) to clone tool/overlay repos.
+                               Updated on every run when set, so it rotates.
+
 Optional iron-control bootstrap (consumed when ironControl.enabled=true):
   IRON_CONTROL_DATABASE_URL    overrides the derived DSN (default points at the
                                bundled Postgres server with no database path, so
@@ -123,6 +129,11 @@ if secret_exists centaur-infra-env; then
   if [[ -n "${LOCAL_DEV_API_KEY:-}" ]]; then
     patch_data+=("\"LOCAL_DEV_API_KEY\":\"$(printf '%s' "$LOCAL_DEV_API_KEY" | base64 | tr -d '\n')\"")
   fi
+  # GITHUB_TOKEN for the repo-cache DaemonSet. Set whenever present so it can be
+  # rotated; harmless when repoCache is disabled.
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    patch_data+=("\"GITHUB_TOKEN\":\"$(printf '%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')\"")
+  fi
   # iron-control keys: top up only when absent so we never rotate them out from
   # under a running pod (its ActiveRecord-encrypted data would become
   # undecryptable). Generated values mirror the create path.
@@ -202,6 +213,9 @@ else
   fi
   if [[ -n "${LOCAL_DEV_API_KEY:-}" ]]; then
     secret_args+=(--from-literal=LOCAL_DEV_API_KEY="$LOCAL_DEV_API_KEY")
+  fi
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    secret_args+=(--from-literal=GITHUB_TOKEN="$GITHUB_TOKEN")
   fi
   kubectl "${secret_args[@]}" >/dev/null
   echo "Created Secret centaur-infra-env in namespace $NAMESPACE"

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -361,6 +361,7 @@ enum ToolSecret {
     OAuthToken(OAuthTokenSecret),
     GcpAuth(GcpAuthSecret),
     PgDsn(PgDsnSecret),
+    AwsAuth(AwsAuthSecret),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -417,6 +418,24 @@ struct PgDsnSecret {
     database: String,
 }
 
+/// A `type = "aws_auth"` secret. The in-sandbox AWS SDK signs each request with
+/// throwaway placeholder credentials (`access_key_id_ref`/`secret_access_key_ref`
+/// and the optional `session_token_ref`); iron-proxy's `aws_auth` transform reads
+/// the region/service from the inbound signature scope and re-signs with the real
+/// keys resolved from those refs. `allowed_regions`/`allowed_services` scope which
+/// the proxy will sign for; `hosts` become the request rules. Mirrors the
+/// `centaur-perms` parser so both producers agree on the metadata.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct AwsAuthSecret {
+    name: String,
+    hosts: Vec<String>,
+    access_key_id_ref: String,
+    secret_access_key_ref: String,
+    session_token_ref: Option<String>,
+    allowed_regions: Vec<String>,
+    allowed_services: Vec<String>,
+}
+
 fn parse_secret_list(
     value: Option<&TomlValue>,
     default_hosts: &[String],
@@ -468,6 +487,7 @@ fn parse_secret(
         "oauth_token" => parse_oauth_token_secret(table, name),
         "gcp_auth" => parse_gcp_auth_secret(table, name, secret_ref),
         "pg_dsn" => parse_pg_dsn_secret(table, name, secret_ref),
+        "aws_auth" => parse_aws_auth_secret(table, name),
         "brokered_token" | "hmac_sign" => Err(ToolDiscoveryError::Invalid(format!(
             "api-rs iron-control tool discovery does not yet support secret type {:?}",
             optional_str(table, "type").unwrap_or("unknown")
@@ -604,6 +624,33 @@ fn parse_pg_dsn_secret(
     }))
 }
 
+fn parse_aws_auth_secret(
+    table: &toml::Table,
+    name: String,
+) -> Result<ToolSecret, ToolDiscoveryError> {
+    // `hosts` is required (no tool-level fallback, matching the centaur-perms
+    // loader); the credential refs are placeholders the proxy re-signs with.
+    let hosts = required_string_array(table.get("hosts"), "hosts")?;
+    let access_key_id_ref = required_str(table, "access_key_id")?.to_owned();
+    let secret_access_key_ref = required_str(table, "secret_access_key")?.to_owned();
+    let session_token_ref = match table.get("session_token") {
+        None => None,
+        Some(_) => Some(required_str(table, "session_token")?.to_owned()),
+    };
+    let allowed_regions = optional_string_array(table.get("allowed_regions"))?.unwrap_or_default();
+    let allowed_services =
+        optional_string_array(table.get("allowed_services"))?.unwrap_or_default();
+    Ok(ToolSecret::AwsAuth(AwsAuthSecret {
+        name,
+        hosts,
+        access_key_id_ref,
+        secret_access_key_ref,
+        session_token_ref,
+        allowed_regions,
+        allowed_services,
+    }))
+}
+
 fn parse_oauth_fields(
     value: Option<&TomlValue>,
     secret_name: &str,
@@ -647,6 +694,7 @@ fn fragment_from_secrets(secrets: Vec<ToolSecret>) -> Result<ProxyFragment, Tool
         fragment.transforms.push(transform);
     }
     fragment.transforms.extend(gcp_auth_transforms(&secrets)?);
+    fragment.transforms.extend(aws_auth_transforms(&secrets)?);
     if let Some(transform) = oauth_token_transform(&secrets)? {
         fragment.transforms.push(transform);
     }
@@ -781,6 +829,74 @@ fn gcp_auth_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDis
         config.insert("rules".to_owned(), yaml_value(host_rules(hosts)?)?);
         transforms.push(Transform {
             name: "gcp_auth".to_owned(),
+            config: TransformConfig {
+                extra: config,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+    }
+    Ok(transforms)
+}
+
+fn aws_auth_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDiscoveryError> {
+    // Group by credential identity (the placeholder refs) and union the host
+    // rules + region/service scoping across tools that share the same keys, so
+    // iron-control derives one stable `aws_auth` secret per credential (keyed on
+    // the access-key placeholder) instead of colliding foreign_ids. Mirrors the
+    // dedup `gcp_auth_transforms` does by secret_ref.
+    type AwsCredKey = (String, String, Option<String>);
+    let mut by_cred =
+        BTreeMap::<AwsCredKey, (BTreeSet<String>, BTreeSet<String>, BTreeSet<String>)>::new();
+    for secret in secrets {
+        let ToolSecret::AwsAuth(secret) = secret else {
+            continue;
+        };
+        let entry = by_cred
+            .entry((
+                secret.access_key_id_ref.clone(),
+                secret.secret_access_key_ref.clone(),
+                secret.session_token_ref.clone(),
+            ))
+            .or_default();
+        entry.0.extend(secret.hosts.iter().cloned());
+        entry.1.extend(secret.allowed_regions.iter().cloned());
+        entry.2.extend(secret.allowed_services.iter().cloned());
+    }
+    let mut transforms = Vec::new();
+    for ((access_key_id_ref, secret_access_key_ref, session_token_ref), (hosts, regions, services)) in
+        by_cred
+    {
+        let mut config = BTreeMap::new();
+        config.insert(
+            "access_key_id".to_owned(),
+            yaml_map([("placeholder", yaml_string(&access_key_id_ref))])?,
+        );
+        config.insert(
+            "secret_access_key".to_owned(),
+            yaml_map([("placeholder", yaml_string(&secret_access_key_ref))])?,
+        );
+        if let Some(session_token_ref) = &session_token_ref {
+            config.insert(
+                "session_token".to_owned(),
+                yaml_map([("placeholder", yaml_string(session_token_ref))])?,
+            );
+        }
+        if !regions.is_empty() {
+            config.insert(
+                "allowed_regions".to_owned(),
+                yaml_value(regions.into_iter().collect::<Vec<_>>())?,
+            );
+        }
+        if !services.is_empty() {
+            config.insert(
+                "allowed_services".to_owned(),
+                yaml_value(services.into_iter().collect::<Vec<_>>())?,
+            );
+        }
+        config.insert("rules".to_owned(), yaml_value(host_rules(hosts)?)?);
+        transforms.push(Transform {
+            name: "aws_auth".to_owned(),
             config: TransformConfig {
                 extra: config,
                 ..Default::default()
@@ -1086,6 +1202,73 @@ secrets = [
         assert_eq!(
             discovered.fragment.transforms[1].name,
             "oauth_token".to_owned()
+        );
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn discovers_aws_auth_tool_as_transform() {
+        let temp = temp_dir("api-rs-tools-aws");
+        let base = temp.join("base");
+        // Mirrors tools/infra/cloudwatch/pyproject.toml.
+        write_tool(
+            &base.join("infra").join("cloudwatch"),
+            r#"
+[project]
+description = "cloudwatch"
+
+[tool.centaur]
+hosts = ["logs.*.amazonaws.com", "monitoring.*.amazonaws.com"]
+secrets = [
+  { type = "aws_auth", name = "cloudwatch", access_key_id = "AWS_ACCESS_KEY_ID", secret_access_key = "AWS_SECRET_ACCESS_KEY", hosts = ["logs.*.amazonaws.com", "monitoring.*.amazonaws.com"], allowed_services = ["logs", "monitoring"] },
+]
+"#,
+        );
+
+        let discovered = discover_tool_proxy_fragment(&[base.clone()]).unwrap();
+
+        // The tool is kept (not dropped) and contributes exactly one aws_auth
+        // transform in the shape iron-control's translator consumes.
+        assert_eq!(discovered.tool_count, 1);
+        assert_eq!(discovered.secret_count, 1);
+        let transform = discovered
+            .fragment
+            .transforms
+            .iter()
+            .find(|transform| transform.name == "aws_auth")
+            .expect("aws_auth transform present");
+        let config = &transform.config.extra;
+        assert_eq!(
+            config["access_key_id"]["placeholder"].as_str(),
+            Some("AWS_ACCESS_KEY_ID")
+        );
+        assert_eq!(
+            config["secret_access_key"]["placeholder"].as_str(),
+            Some("AWS_SECRET_ACCESS_KEY")
+        );
+        assert!(!config.contains_key("session_token"));
+        assert!(!config.contains_key("allowed_regions"));
+        assert_eq!(
+            config["allowed_services"]
+                .as_sequence()
+                .unwrap()
+                .iter()
+                .filter_map(YamlValue::as_str)
+                .collect::<Vec<_>>(),
+            vec!["logs", "monitoring"]
+        );
+        assert_eq!(config["rules"].as_sequence().unwrap().len(), 2);
+
+        // The sandbox AWS SDK gets seeded placeholder credentials to sign with.
+        let placeholders = centaur_iron_proxy::placeholder_env(&[discovered.fragment.clone()]);
+        assert_eq!(
+            placeholders.get("AWS_ACCESS_KEY_ID").map(String::as_str),
+            Some("AWS_ACCESS_KEY_ID")
+        );
+        assert_eq!(
+            placeholders.get("AWS_SECRET_ACCESS_KEY").map(String::as_str),
+            Some("AWS_SECRET_ACCESS_KEY")
         );
 
         let _ = fs::remove_dir_all(temp);

--- a/services/api-rs/crates/centaur-iron-control/src/client.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/client.rs
@@ -13,10 +13,10 @@ use serde_json::{Value, json};
 
 use crate::error::{IronControlError, Result};
 use crate::models::{
-    BrokerCredentialInput, BrokerCredentialRecord, DataEnvelope, EffectiveConfig,
-    GcpAuthSecretInput, Grant, GrantSecret, Grantee, HmacSecretInput, IdentityInput,
-    OAuthTokenSecretInput, PgDsnSecretInput, Principal, Proxy, ProxyInput, Role, SecretRecord,
-    StaticSecretInput,
+    AwsAuthSecretInput, BrokerCredentialInput, BrokerCredentialRecord, DataEnvelope,
+    EffectiveConfig, GcpAuthSecretInput, Grant, GrantSecret, Grantee, HmacSecretInput,
+    IdentityInput, OAuthTokenSecretInput, PgDsnSecretInput, Principal, Proxy, ProxyInput, Role,
+    SecretRecord, StaticSecretInput,
 };
 
 const API_PREFIX: &str = "/api/v1";
@@ -265,10 +265,21 @@ impl IronControlClient {
         .await
     }
 
+    /// Upsert an AWS auth secret by ``foreign_id``.
+    pub async fn upsert_aws_auth_secret(&self, input: &AwsAuthSecretInput) -> Result<SecretRecord> {
+        self.write(
+            Method::PUT,
+            &upsert_path("aws_auth_secrets", &input.foreign_id),
+            input,
+        )
+        .await
+    }
+
     /// Fetch a secret's identity (id, ``foreign_id``, ``name``) by OID. The
     /// ``collection`` is the resource path segment for the secret's type
     /// (``static_secrets``, ``oauth_token_secrets``, ``gcp_auth_secrets``,
-    /// ``pg_dsn_secrets``, ``hmac_secrets``) — see [`Grant::secret_target`].
+    /// ``pg_dsn_secrets``, ``hmac_secrets``, ``aws_auth_secrets``) — see
+    /// [`Grant::secret_target`].
     pub async fn get_secret(&self, collection: &str, oid: &str) -> Result<SecretRecord> {
         let path = format!("{API_PREFIX}/{collection}/{}", urlencoding::encode(oid));
         let resp = self.send(Method::GET, &path, None::<&Value>).await?;
@@ -328,14 +339,19 @@ impl IronControlClient {
         namespace: &str,
         labels: &[(String, String)],
     ) -> Result<Vec<BrokerCredentialRecord>> {
-        self.list_collection("broker_credentials", namespace, labels).await
+        self.list_collection("broker_credentials", namespace, labels)
+            .await
     }
 
     /// Fetch a broker credential's full resource object (every field
     /// iron-control returns; secret material is never echoed) by OID (``bcr_``)
     /// or ``foreign_id``. Returned as a raw [`Value`] so callers can render the
     /// read-only health fields without modeling them all.
-    pub async fn get_broker_credential_detail(&self, namespace: &str, ident: &str) -> Result<Value> {
+    pub async fn get_broker_credential_detail(
+        &self,
+        namespace: &str,
+        ident: &str,
+    ) -> Result<Value> {
         let path = resource_path("broker_credentials", "bcr_", namespace, ident, "");
         let resp = self.send(Method::GET, &path, None::<&Value>).await?;
         decode_data(resp, Method::GET, &path).await
@@ -481,6 +497,7 @@ fn grant_body(grantee: &Grantee, secret: &GrantSecret) -> Value {
         GrantSecret::OAuthToken(id) => ("oauth_token_secret_id", id),
         GrantSecret::PgDsn(id) => ("pg_dsn_secret_id", id),
         GrantSecret::Hmac(id) => ("hmac_secret_id", id),
+        GrantSecret::AwsAuth(id) => ("aws_auth_secret_id", id),
     };
     map.insert(key.to_owned(), json!(id));
     Value::Object(map)
@@ -581,6 +598,45 @@ mod tests {
             body,
             json!({ "role_id": "role_infra", "oauth_token_secret_id": "ots_slack" })
         );
+    }
+
+    #[test]
+    fn grant_body_role_aws_auth() {
+        let body = grant_body(
+            &Grantee::Role("role_cw".to_owned()),
+            &GrantSecret::AwsAuth("aas_cloudwatch".to_owned()),
+        );
+        assert_eq!(
+            body,
+            json!({ "role_id": "role_cw", "aws_auth_secret_id": "aas_cloudwatch" })
+        );
+    }
+
+    #[test]
+    fn aws_auth_input_serializes_sources_and_scopes() {
+        let input = AwsAuthSecretInput {
+            namespace: "default".to_owned(),
+            foreign_id: "tool-cloudwatch-aws-cloudwatch".to_owned(),
+            name: Some("AWS Auth (tool-cloudwatch)".to_owned()),
+            description: None,
+            labels: std::collections::BTreeMap::new(),
+            access_key_id: SecretSource::env("AWS_ACCESS_KEY_ID"),
+            secret_access_key: SecretSource::env("AWS_SECRET_ACCESS_KEY"),
+            session_token: None,
+            allowed_regions: vec![],
+            allowed_services: vec!["logs".to_owned(), "monitoring".to_owned()],
+            rules: vec![RequestRule::host("logs.us-east-1.amazonaws.com")],
+        };
+        let body = serde_json::to_value(&input).unwrap();
+        assert_eq!(
+            body["access_key_id"],
+            json!({ "source_type": "env", "config": { "var": "AWS_ACCESS_KEY_ID" } })
+        );
+        assert_eq!(body["allowed_services"], json!(["logs", "monitoring"]));
+        // Omitted optionals don't serialize.
+        assert!(body.get("session_token").is_none());
+        assert!(body.get("allowed_regions").is_none());
+        assert!(body.get("description").is_none());
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -17,9 +17,9 @@ mod util;
 pub use client::IronControlClient;
 pub use error::{IronControlError, Result};
 pub use models::{
-    BrokerCredentialInput, BrokerCredentialRecord, EffectiveConfig, EffectivePgDsn,
-    EffectiveReplace, EffectiveSecret, GcpAuthSecretInput, Grant, GrantSecret, Grantee,
-    HmacSecretHeader, HmacSecretInput, IdentityInput, InjectConfig, OAuthTokenSecretInput,
+    AwsAuthSecretInput, BrokerCredentialInput, BrokerCredentialRecord, EffectiveConfig,
+    EffectivePgDsn, EffectiveReplace, EffectiveSecret, GcpAuthSecretInput, Grant, GrantSecret,
+    Grantee, HmacSecretHeader, HmacSecretInput, IdentityInput, InjectConfig, OAuthTokenSecretInput,
     PgDsnSecretInput, Principal, Proxy, ProxyInput, ReplaceConfig, RequestRule, Role, SECRET_TYPES,
     SecretRecord, SecretSource, StaticSecretInput,
 };

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -3,7 +3,7 @@
 //! iron-control wraps every request and single-resource response in a
 //! ``{ "data": ... }`` envelope; [`DataEnvelope`] handles both directions.
 //! Object IDs are typed-prefix strings (``prn_``, ``role_``, ``ssr_``,
-//! ``gas_``, ``ots_``, ``hms_``, ``bcr_``, ``grant_``, ``prx_``). Resources with a ``foreign_id``
+//! ``gas_``, ``ots_``, ``hms_``, ``aas_``, ``bcr_``, ``grant_``, ``prx_``). Resources with a ``foreign_id``
 //! support upsert: a PUT whose path segment is a ``foreign_id`` (not an OID)
 //! creates the resource if absent and updates it otherwise.
 
@@ -72,7 +72,10 @@ impl SecretSource {
     /// whose current access token iron-control delivers inline. When
     /// ``credential_id`` is a ``foreign_id`` (rather than a ``bcr_`` OID),
     /// ``credential_namespace`` is required so iron-control can resolve it.
-    pub fn token_broker(credential_id: impl Into<String>, credential_namespace: impl Into<String>) -> Self {
+    pub fn token_broker(
+        credential_id: impl Into<String>,
+        credential_namespace: impl Into<String>,
+    ) -> Self {
         Self {
             source_type: "token_broker".to_owned(),
             secret: None,
@@ -210,6 +213,41 @@ pub struct GcpAuthSecretInput {
     pub keyfile: Option<SecretSource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credentials_provider: Option<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<RequestRule>,
+}
+
+// ---------------------------------------------------------------------------
+// AWS auth secrets
+// ---------------------------------------------------------------------------
+
+/// Request body for ``POST``/``PUT /api/v1/aws_auth_secrets``. iron-proxy
+/// re-signs outbound AWS SigV4 requests: the tool signs each request with
+/// throwaway placeholder credentials, and iron-proxy reads the region/service
+/// from the inbound signature's credential scope, strips the signature, and
+/// re-signs with the real keys it resolves from ``access_key_id`` /
+/// ``secret_access_key`` (and optional ``session_token`` for STS). The real keys
+/// never reach the sandbox. ``allowed_regions`` / ``allowed_services`` scope
+/// which regions/services the proxy will sign for (empty = unscoped).
+// Not `Eq`: holds `SecretSource` values (arbitrary `Value` config).
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct AwsAuthSecretInput {
+    pub namespace: String,
+    pub foreign_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
+    pub access_key_id: SecretSource,
+    pub secret_access_key: SecretSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_token: Option<SecretSource>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_regions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_services: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rules: Vec<RequestRule>,
 }
@@ -439,6 +477,7 @@ pub const SECRET_TYPES: &[(&str, &str, &str)] = &[
     ("gcp_auth", "gcp_auth_secrets", "gas_"),
     ("pg_dsn", "pg_dsn_secrets", "pgs_"),
     ("hmac", "hmac_secrets", "hms_"),
+    ("aws_auth", "aws_auth_secrets", "aas_"),
 ];
 
 // ---------------------------------------------------------------------------
@@ -460,6 +499,7 @@ pub enum GrantSecret {
     OAuthToken(String),
     PgDsn(String),
     Hmac(String),
+    AwsAuth(String),
 }
 
 impl GrantSecret {
@@ -476,6 +516,7 @@ impl GrantSecret {
             "gcp_auth" => Self::GcpAuth(id),
             "pg_dsn" => Self::PgDsn(id),
             "hmac" => Self::Hmac(id),
+            "aws_auth" => Self::AwsAuth(id),
             _ => return None,
         })
     }
@@ -501,6 +542,8 @@ pub struct Grant {
     pub pg_dsn_secret_id: Option<String>,
     #[serde(default)]
     pub hmac_secret_id: Option<String>,
+    #[serde(default)]
+    pub aws_auth_secret_id: Option<String>,
 }
 
 impl Grant {
@@ -512,6 +555,7 @@ impl Grant {
             .or(self.gcp_auth_secret_id.as_deref())
             .or(self.pg_dsn_secret_id.as_deref())
             .or(self.hmac_secret_id.as_deref())
+            .or(self.aws_auth_secret_id.as_deref())
     }
 
     /// The granted secret's ``(type label, REST collection, OID)``, whichever
@@ -528,6 +572,8 @@ impl Grant {
             Some(("pg_dsn", "pg_dsn_secrets", id))
         } else if let Some(id) = &self.hmac_secret_id {
             Some(("hmac", "hmac_secrets", id))
+        } else if let Some(id) = &self.aws_auth_secret_id {
+            Some(("aws_auth", "aws_auth_secrets", id))
         } else {
             None
         }

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -23,9 +23,9 @@ use serde_yaml::Value as YamlValue;
 use crate::client::IronControlClient;
 use crate::error::IronControlError;
 use crate::models::{
-    GcpAuthSecretInput, GrantSecret, Grantee, HmacSecretInput, IdentityInput, InjectConfig,
-    OAuthTokenSecretInput, PgDsnSecretInput, ReplaceConfig, RequestRule, SecretSource,
-    StaticSecretInput,
+    AwsAuthSecretInput, GcpAuthSecretInput, GrantSecret, Grantee, HmacSecretInput, IdentityInput,
+    InjectConfig, OAuthTokenSecretInput, PgDsnSecretInput, ReplaceConfig, RequestRule,
+    SecretSource, StaticSecretInput,
 };
 use crate::util::{managed_labels, slugify};
 
@@ -64,6 +64,7 @@ pub enum SecretInput {
     GcpAuth(GcpAuthSecretInput),
     PgDsn(PgDsnSecretInput),
     Hmac(HmacSecretInput),
+    AwsAuth(AwsAuthSecretInput),
 }
 
 /// A fragment transform iron-control cannot represent, or a malformed entry.
@@ -152,6 +153,9 @@ pub async fn grant_inputs_to_role(
             SecretInput::Hmac(input) => {
                 GrantSecret::Hmac(client.upsert_hmac_secret(&input).await?.id)
             }
+            SecretInput::AwsAuth(input) => {
+                GrantSecret::AwsAuth(client.upsert_aws_auth_secret(&input).await?.id)
+            }
         };
         let grant = client
             .create_grant(&Grantee::Role(role_oid.to_owned()), &secret)
@@ -166,10 +170,11 @@ pub async fn grant_inputs_to_role(
 /// Only the transform shapes Centaur uses are translated: the ``secrets``
 /// transform (replace and inject, including ``token_broker`` sources),
 /// ``oauth_token``, and ``gcp_auth``. Postgres listeners translate to
-/// ``pg_dsn`` secrets (one per listener). ``hmac_sign`` errors out here: it is
-/// represented in iron-control (see [`HmacSecretInput`]), but only the infra
-/// and harness fragments flow through this fragment translator and neither
-/// signs requests — tool ``hmac_sign`` secrets are operator-managed via the
+/// ``pg_dsn`` secrets (one per listener). ``hmac_sign`` and ``aws_auth`` error
+/// out here: both are represented in iron-control (see [`HmacSecretInput`],
+/// [`AwsAuthSecretInput`]), but only the infra and harness fragments flow
+/// through this fragment translator and none sign/re-sign requests — tool
+/// ``hmac_sign`` and ``aws_auth`` secrets are operator-managed via the
 /// ``centaur-perms`` CLI, which parses ``pyproject.toml`` directly.
 pub fn secret_inputs_from_fragment(
     namespace: &str,
@@ -217,6 +222,14 @@ pub fn secret_inputs_from_fragment(
                 // Tool hmac_sign secrets are registered via the centaur-perms CLI.
                 return Err(TranslateError::Unsupported {
                     what: "hmac_sign request signing in an infra/harness fragment".to_owned(),
+                });
+            }
+            "aws_auth" => {
+                // Representable in iron-control, but never reached: only infra/
+                // harness fragments come through here and none re-sign AWS SigV4.
+                // Tool aws_auth secrets are registered via the centaur-perms CLI.
+                return Err(TranslateError::Unsupported {
+                    what: "aws_auth request signing in an infra/harness fragment".to_owned(),
                 });
             }
             // Base-config transforms (allowlist, header_allowlist) and any
@@ -930,6 +943,22 @@ postgres:
             r#"
 transforms:
   - name: hmac_sign
+    config:
+      extra: {}
+"#,
+        )
+        .unwrap();
+        let err =
+            secret_inputs_from_fragment("default", "tool-x", &fragment, &env_policy()).unwrap_err();
+        assert!(matches!(err, TranslateError::Unsupported { .. }));
+    }
+
+    #[test]
+    fn aws_auth_is_unsupported() {
+        let fragment = load_fragment_str(
+            r#"
+transforms:
+  - name: aws_auth
     config:
       extra: {}
 "#,

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -169,12 +169,11 @@ pub async fn grant_inputs_to_role(
 ///
 /// Only the transform shapes Centaur uses are translated: the ``secrets``
 /// transform (replace and inject, including ``token_broker`` sources),
-/// ``oauth_token``, and ``gcp_auth``. Postgres listeners translate to
-/// ``pg_dsn`` secrets (one per listener). ``hmac_sign`` and ``aws_auth`` error
-/// out here: both are represented in iron-control (see [`HmacSecretInput`],
-/// [`AwsAuthSecretInput`]), but only the infra and harness fragments flow
-/// through this fragment translator and none sign/re-sign requests — tool
-/// ``hmac_sign`` and ``aws_auth`` secrets are operator-managed via the
+/// ``oauth_token``, ``gcp_auth``, and ``aws_auth``. Postgres listeners translate
+/// to ``pg_dsn`` secrets (one per listener). ``hmac_sign`` errors out here: it
+/// is represented in iron-control (see [`HmacSecretInput`]), but only the infra
+/// and harness fragments flow through this fragment translator and none sign
+/// requests — tool ``hmac_sign`` secrets are operator-managed via the
 /// ``centaur-perms`` CLI, which parses ``pyproject.toml`` directly.
 pub fn secret_inputs_from_fragment(
     namespace: &str,
@@ -225,12 +224,10 @@ pub fn secret_inputs_from_fragment(
                 });
             }
             "aws_auth" => {
-                // Representable in iron-control, but never reached: only infra/
-                // harness fragments come through here and none re-sign AWS SigV4.
-                // Tool aws_auth secrets are registered via the centaur-perms CLI.
-                return Err(TranslateError::Unsupported {
-                    what: "aws_auth request signing in an infra/harness fragment".to_owned(),
-                });
+                let mut input =
+                    aws_auth_from_transform(namespace, role_foreign_id, transform, policy)?;
+                input.foreign_id = unique_foreign_id(input.foreign_id, &mut used_foreign_ids);
+                inputs.push(SecretInput::AwsAuth(input));
             }
             // Base-config transforms (allowlist, header_allowlist) and any
             // future unmanaged entries carry no secrets to register.
@@ -708,6 +705,71 @@ fn gcp_auth_from_transform(
 }
 
 // ---------------------------------------------------------------------------
+// AWS auth secrets
+// ---------------------------------------------------------------------------
+
+/// Translate an ``aws_auth`` transform into an [`AwsAuthSecretInput`]. The
+/// credential refs (``access_key_id``/``secret_access_key`` and the optional
+/// ``session_token``) are placeholders resolved through the deployment
+/// [`SourcePolicy`], like the ``gcp_auth`` keyfile; ``allowed_regions`` /
+/// ``allowed_services`` scope which the proxy signs for, and ``rules`` mirror the
+/// shared request-rule shape. The ``foreign_id`` keys on the access-key
+/// placeholder so the same credential set is one stable secret.
+fn aws_auth_from_transform(
+    namespace: &str,
+    role: &str,
+    transform: &centaur_iron_proxy::Transform,
+    policy: &SourcePolicy,
+) -> Result<AwsAuthSecretInput, TranslateError> {
+    let config = &transform.config.extra;
+    let access_key_id_value = config
+        .get("access_key_id")
+        .ok_or_else(|| malformed(role, "aws_auth missing access_key_id"))?;
+    let (access_key_id, placeholder) =
+        aws_source(role, "access_key_id", access_key_id_value, policy)?;
+    let secret_access_key_value = config
+        .get("secret_access_key")
+        .ok_or_else(|| malformed(role, "aws_auth missing secret_access_key"))?;
+    let (secret_access_key, _) =
+        aws_source(role, "secret_access_key", secret_access_key_value, policy)?;
+    let session_token = config
+        .get("session_token")
+        .map(|value| aws_source(role, "session_token", value, policy).map(|(source, _)| source))
+        .transpose()?;
+    Ok(AwsAuthSecretInput {
+        namespace: namespace.to_owned(),
+        foreign_id: format!("{role}-aws-{}", slugify(&placeholder)),
+        name: Some(format!("AWS Auth ({role})")),
+        description: None,
+        labels: managed_labels(),
+        access_key_id,
+        secret_access_key,
+        session_token,
+        allowed_regions: yaml_string_array(config.get("allowed_regions")),
+        allowed_services: yaml_string_array(config.get("allowed_services")),
+        rules: rules_from_values(role, &sequence(config.get("rules")))?,
+    })
+}
+
+/// Resolve one ``aws_auth`` credential ref — a ``{placeholder: NAME}`` mapping or
+/// a bare ``NAME`` string — into its [`SecretSource`], returning the placeholder
+/// too so the caller can derive the secret's ``foreign_id``.
+fn aws_source(
+    role: &str,
+    field: &str,
+    value: &YamlValue,
+    policy: &SourcePolicy,
+) -> Result<(SecretSource, String), TranslateError> {
+    let placeholder = yaml_str(value, "placeholder")
+        .or_else(|| value.as_str())
+        .ok_or_else(|| malformed(role, &format!("aws_auth {field} must be a placeholder")))?;
+    Ok((
+        source_from_placeholder(policy, placeholder, None),
+        placeholder.to_owned(),
+    ))
+}
+
+// ---------------------------------------------------------------------------
 // serde_yaml helpers and slugging
 // ---------------------------------------------------------------------------
 
@@ -954,19 +1016,91 @@ transforms:
     }
 
     #[test]
-    fn aws_auth_is_unsupported() {
+    fn translates_aws_auth_transform() {
         let fragment = load_fragment_str(
             r#"
 transforms:
   - name: aws_auth
     config:
-      extra: {}
+      access_key_id: { placeholder: AWS_ACCESS_KEY_ID }
+      secret_access_key: { placeholder: AWS_SECRET_ACCESS_KEY }
+      allowed_services: [logs, monitoring]
+      rules:
+        - { host: logs.us-east-1.amazonaws.com }
+        - { host: monitoring.us-east-1.amazonaws.com }
+"#,
+        )
+        .unwrap();
+        let inputs =
+            secret_inputs_from_fragment("default", "infra", &fragment, &env_policy()).unwrap();
+        let SecretInput::AwsAuth(input) = &inputs[0] else {
+            panic!("expected an aws_auth secret");
+        };
+        assert_eq!(input.foreign_id, "infra-aws-aws-access-key-id");
+        assert_eq!(input.name.as_deref(), Some("AWS Auth (infra)"));
+        assert_eq!(input.access_key_id.source_type, "env");
+        assert_eq!(
+            input.access_key_id.config,
+            json!({ "var": "AWS_ACCESS_KEY_ID" })
+        );
+        assert_eq!(
+            input.secret_access_key.config,
+            json!({ "var": "AWS_SECRET_ACCESS_KEY" })
+        );
+        assert!(input.session_token.is_none());
+        assert_eq!(
+            input.allowed_services,
+            vec!["logs".to_owned(), "monitoring".to_owned()]
+        );
+        assert!(input.allowed_regions.is_empty());
+        assert_eq!(input.rules.len(), 2);
+        assert_eq!(
+            input.rules[0].host.as_deref(),
+            Some("logs.us-east-1.amazonaws.com")
+        );
+    }
+
+    #[test]
+    fn translates_aws_auth_with_session_token() {
+        let fragment = load_fragment_str(
+            r#"
+transforms:
+  - name: aws_auth
+    config:
+      access_key_id: { placeholder: AWS_ACCESS_KEY_ID }
+      secret_access_key: { placeholder: AWS_SECRET_ACCESS_KEY }
+      session_token: { placeholder: AWS_SESSION_TOKEN }
+      allowed_regions: [us-west-2]
+      rules:
+        - { host: logs.us-west-2.amazonaws.com }
+"#,
+        )
+        .unwrap();
+        let inputs =
+            secret_inputs_from_fragment("default", "infra", &fragment, &env_policy()).unwrap();
+        let SecretInput::AwsAuth(input) = &inputs[0] else {
+            panic!("expected an aws_auth secret");
+        };
+        let session = input.session_token.as_ref().unwrap();
+        assert_eq!(session.config, json!({ "var": "AWS_SESSION_TOKEN" }));
+        assert_eq!(input.allowed_regions, vec!["us-west-2".to_owned()]);
+    }
+
+    #[test]
+    fn aws_auth_missing_access_key_is_malformed() {
+        let fragment = load_fragment_str(
+            r#"
+transforms:
+  - name: aws_auth
+    config:
+      secret_access_key: { placeholder: AWS_SECRET_ACCESS_KEY }
+      rules: [{ host: logs.us-east-1.amazonaws.com }]
 "#,
         )
         .unwrap();
         let err =
-            secret_inputs_from_fragment("default", "tool-x", &fragment, &env_policy()).unwrap_err();
-        assert!(matches!(err, TranslateError::Unsupported { .. }));
+            secret_inputs_from_fragment("default", "infra", &fragment, &env_policy()).unwrap_err();
+        assert!(matches!(err, TranslateError::Malformed { .. }), "{err:?}");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -100,7 +100,7 @@ fn normalize_auth_mode(value: &str) -> String {
 }
 
 pub fn placeholder_env(fragments: &[ProxyFragment]) -> BTreeMap<String, String> {
-    fragments
+    let mut env: BTreeMap<String, String> = fragments
         .iter()
         .flat_map(|fragment| &fragment.transforms)
         .filter(|transform| transform.is_secrets())
@@ -108,7 +108,42 @@ pub fn placeholder_env(fragments: &[ProxyFragment]) -> BTreeMap<String, String> 
         .filter_map(|secret| secret.proxy_value())
         .filter(|value| !value.is_empty() && !value.contains('='))
         .map(|value| (value.to_owned(), value.to_owned()))
-        .collect()
+        .collect();
+    // The `aws_auth` transform re-signs at the proxy, but the in-sandbox AWS SDK
+    // still needs credentials in its environment to produce the inbound SigV4
+    // signature. Seed each declared placeholder ref (var name == value, the same
+    // convention the secrets transform uses) so the SDK signs with throwaway
+    // values the proxy strips and replaces with the real keys.
+    for transform in fragments
+        .iter()
+        .flat_map(|fragment| &fragment.transforms)
+        .filter(|transform| transform.name == "aws_auth")
+    {
+        for field in ["access_key_id", "secret_access_key", "session_token"] {
+            if let Some(name) = transform
+                .config
+                .extra
+                .get(field)
+                .and_then(placeholder_ref)
+                .filter(|value| !value.is_empty() && !value.contains('='))
+            {
+                env.entry(name.clone()).or_insert(name);
+            }
+        }
+    }
+    env
+}
+
+/// Extract a `{placeholder: NAME}` ref (or a bare `NAME` string) from an
+/// `aws_auth` credential field, matching how iron-control's translator reads it.
+fn placeholder_ref(value: &serde_yaml::Value) -> Option<String> {
+    value
+        .as_mapping()
+        .and_then(|mapping| mapping.get(serde_yaml::Value::from("placeholder")))
+        .and_then(serde_yaml::Value::as_str)
+        .or_else(|| value.as_str())
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 /// The static catalog of sandbox Postgres DSN env vars declared across

--- a/services/api-rs/crates/centaur-perms/src/main.rs
+++ b/services/api-rs/crates/centaur-perms/src/main.rs
@@ -125,7 +125,7 @@ enum SecretsCmd {
 
 #[derive(Args, Debug)]
 struct SecretSelector {
-    /// Secret OID (`ssr_`/`ots_`/`gas_`/`pgs_`/`hms_`) or `foreign_id`. A
+    /// Secret OID (`ssr_`/`ots_`/`gas_`/`pgs_`/`hms_`/`aas_`) or `foreign_id`. A
     /// `foreign_id` is resolved by trying each secret type in turn.
     secret: String,
 }
@@ -769,7 +769,11 @@ fn print_secrets(rows: &[(&str, Option<String>, String, String)], namespace: &st
 // broker credentials
 // ---------------------------------------------------------------------------
 
-async fn broker_create(cli: &Cli, client: &IronControlClient, args: &BrokerCreateArgs) -> Result<()> {
+async fn broker_create(
+    cli: &Cli,
+    client: &IronControlClient,
+    args: &BrokerCreateArgs,
+) -> Result<()> {
     let token_endpoint_headers = args
         .token_endpoint_headers
         .iter()
@@ -797,20 +801,32 @@ async fn broker_create(cli: &Cli, client: &IronControlClient, args: &BrokerCreat
         "broker credential {} ({}) upserted{}",
         record.foreign_id.as_deref().unwrap_or(&args.foreign_id),
         record.id,
-        record.status.as_deref().map(|s| format!(" — status {s}")).unwrap_or_default(),
+        record
+            .status
+            .as_deref()
+            .map(|s| format!(" — status {s}"))
+            .unwrap_or_default(),
     );
     Ok(())
 }
 
 async fn broker_list(cli: &Cli, client: &IronControlClient, args: &FilterArgs) -> Result<()> {
     let labels = filter_labels(args)?;
-    let mut found = client.list_broker_credentials(&cli.namespace, &labels).await?;
+    let mut found = client
+        .list_broker_credentials(&cli.namespace, &labels)
+        .await?;
     apply_filter(&mut found, args.filter.as_deref(), |c| {
-        (c.foreign_id.clone().unwrap_or_default(), c.name.clone().unwrap_or_default())
+        (
+            c.foreign_id.clone().unwrap_or_default(),
+            c.name.clone().unwrap_or_default(),
+        )
     });
     found.sort_by(|a, b| a.foreign_id.cmp(&b.foreign_id));
     if found.is_empty() {
-        println!("no broker credentials found in namespace {:?}", cli.namespace);
+        println!(
+            "no broker credentials found in namespace {:?}",
+            cli.namespace
+        );
         return Ok(());
     }
     let width = found
@@ -833,14 +849,18 @@ async fn broker_list(cli: &Cli, client: &IronControlClient, args: &FilterArgs) -
 }
 
 async fn broker_show(cli: &Cli, client: &IronControlClient, args: &BrokerSelector) -> Result<()> {
-    let detail = client.get_broker_credential_detail(&cli.namespace, &args.credential).await?;
+    let detail = client
+        .get_broker_credential_detail(&cli.namespace, &args.credential)
+        .await?;
     println!("broker credential: {}", args.credential);
     println!("{}", serde_json::to_string_pretty(&detail)?);
     Ok(())
 }
 
 async fn broker_delete(cli: &Cli, client: &IronControlClient, args: &BrokerSelector) -> Result<()> {
-    client.delete_broker_credential(&cli.namespace, &args.credential).await?;
+    client
+        .delete_broker_credential(&cli.namespace, &args.credential)
+        .await?;
     println!("broker credential {}: deleted", args.credential);
     Ok(())
 }
@@ -961,7 +981,9 @@ async fn revoke_secrets(
 fn grant_secret_from_oid(oid: &str) -> Result<GrantSecret> {
     match GrantSecret::from_oid(oid) {
         Some(secret) => Ok(secret),
-        None => bail!("--secret expects a secret OID (ssr_/ots_/gas_/pgs_/hms_), got {oid:?}"),
+        None => {
+            bail!("--secret expects a secret OID (ssr_/ots_/gas_/pgs_/hms_/aas_), got {oid:?}")
+        }
     }
 }
 

--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -33,6 +33,10 @@ fn secret_type_routes_by_oid_prefix() {
     );
     assert_eq!(secret_type_for_oid("pgs_4").map(|t| t.0), Some("pg_dsn"));
     assert_eq!(secret_type_for_oid("hms_5").map(|t| t.0), Some("hmac"));
+    assert_eq!(
+        secret_type_for_oid("aas_6").map(|t| t.1),
+        Some("aws_auth_secrets")
+    );
     // A bare foreign_id is not an OID — callers fall back to lookup.
     assert!(secret_type_for_oid("falconx-hmac").is_none());
 }
@@ -257,6 +261,79 @@ fn hmac_requires_hosts() {
     );
 }
 
+const CLOUDWATCH_AWS: &str = r#"{ type = "aws_auth", name = "cloudwatch", access_key_id = "AWS_ACCESS_KEY_ID", secret_access_key = "AWS_SECRET_ACCESS_KEY", hosts = ["logs.*.amazonaws.com", "monitoring.*.amazonaws.com"], allowed_services = ["logs", "monitoring"] }"#;
+
+#[test]
+fn parses_aws_auth_secret() {
+    let parsed = tools::parse_secret(&entry(CLOUDWATCH_AWS), &[]).unwrap();
+    let ParsedSecret::AwsAuth(aws) = parsed else {
+        panic!("expected aws_auth")
+    };
+    assert_eq!(aws.name, "cloudwatch");
+    assert_eq!(
+        aws.hosts,
+        vec![
+            "logs.*.amazonaws.com".to_owned(),
+            "monitoring.*.amazonaws.com".to_owned()
+        ]
+    );
+    assert_eq!(aws.access_key_id_ref, "AWS_ACCESS_KEY_ID");
+    assert_eq!(aws.secret_access_key_ref, "AWS_SECRET_ACCESS_KEY");
+    assert_eq!(aws.session_token_ref, None);
+    assert_eq!(
+        aws.allowed_services,
+        vec!["logs".to_owned(), "monitoring".to_owned()]
+    );
+    assert!(aws.allowed_regions.is_empty());
+}
+
+#[test]
+fn parses_aws_auth_with_session_token_and_regions() {
+    let parsed = tools::parse_secret(
+        &entry(
+            r#"{ type = "aws_auth", name = "cw", access_key_id = "AKID", secret_access_key = "SAK", session_token = "STS_TOKEN", hosts = ["logs.us-east-1.amazonaws.com"], allowed_regions = ["us-east-1"] }"#,
+        ),
+        &[],
+    )
+    .unwrap();
+    let ParsedSecret::AwsAuth(aws) = parsed else {
+        panic!("expected aws_auth")
+    };
+    assert_eq!(aws.session_token_ref.as_deref(), Some("STS_TOKEN"));
+    assert_eq!(aws.allowed_regions, vec!["us-east-1".to_owned()]);
+}
+
+#[test]
+fn aws_auth_requires_access_key_id() {
+    let err = tools::parse_secret(
+        &entry(
+            r#"{ type = "aws_auth", name = "X", secret_access_key = "SAK", hosts = ["logs.amazonaws.com"] }"#,
+        ),
+        &[],
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("requires a non-empty 'access_key_id'"),
+        "{err}"
+    );
+}
+
+#[test]
+fn aws_auth_requires_hosts() {
+    let err = tools::parse_secret(
+        &entry(
+            r#"{ type = "aws_auth", name = "X", access_key_id = "AKID", secret_access_key = "SAK" }"#,
+        ),
+        &[],
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("'hosts' must be a non-empty"),
+        "{err}"
+    );
+}
+
 #[test]
 fn parses_pg_dsn_secret() {
     let parsed = tools::parse_secret(
@@ -310,7 +387,9 @@ fn translates_http_replace_to_static_input() {
         .unwrap(),
     ];
     let out = translate::translate("default", "tool-slack", &secrets, &SourcePolicy::env());
-    let SecretInput::Static(input) = &out.inputs[0] else { panic!("expected static") };
+    let SecretInput::Static(input) = &out.inputs[0] else {
+        panic!("expected static")
+    };
     assert_eq!(input.foreign_id, "tool-slack-slack-bot-token");
     assert_eq!(input.name, "SLACK_BOT_TOKEN");
     let replace = input.replace_config.as_ref().unwrap();
@@ -386,7 +465,9 @@ fn translates_pg_dsn_to_input_with_roundtrip_foreign_id() {
         .unwrap(),
     ];
     let out = translate::translate("default", "tool-reshift", &secrets, &SourcePolicy::env());
-    let SecretInput::PgDsn(input) = &out.inputs[0] else { panic!("expected pg_dsn") };
+    let SecretInput::PgDsn(input) = &out.inputs[0] else {
+        panic!("expected pg_dsn")
+    };
     // The foreign_id is not role-prefixed: it must round-trip back to the
     // sandbox DSN env var (`RESHIFT_DSN`) that api-rs derives from it.
     assert_eq!(input.foreign_id, "reshift");
@@ -404,7 +485,9 @@ fn translates_pg_dsn_to_input_with_roundtrip_foreign_id() {
 fn translates_hmac_to_input() {
     let secrets = vec![tools::parse_secret(&entry(FALCONX_HMAC), &[]).unwrap()];
     let out = translate::translate("default", "tool-falconx", &secrets, &SourcePolicy::env());
-    let SecretInput::Hmac(input) = &out.inputs[0] else { panic!("expected hmac") };
+    let SecretInput::Hmac(input) = &out.inputs[0] else {
+        panic!("expected hmac")
+    };
     assert_eq!(input.foreign_id, "tool-falconx-hmac-falconx-p1");
     assert_eq!(input.name, "FALCONX_P1");
     assert_eq!(input.signature_algorithm, "sha256");
@@ -431,6 +514,62 @@ fn translates_hmac_to_input() {
 }
 
 #[test]
+fn translates_aws_auth_to_input() {
+    let secrets = vec![tools::parse_secret(&entry(CLOUDWATCH_AWS), &[]).unwrap()];
+    let out = translate::translate("default", "tool-cloudwatch", &secrets, &SourcePolicy::env());
+    let SecretInput::AwsAuth(input) = &out.inputs[0] else {
+        panic!("expected aws_auth")
+    };
+    assert_eq!(input.foreign_id, "tool-cloudwatch-aws-cloudwatch");
+    assert_eq!(input.name.as_deref(), Some("AWS Auth (tool-cloudwatch)"));
+    // Credential refs resolve via the deployment source policy (env here).
+    assert_eq!(input.access_key_id.source_type, "env");
+    assert_eq!(
+        input.access_key_id.config,
+        serde_json::json!({ "var": "AWS_ACCESS_KEY_ID" })
+    );
+    assert_eq!(
+        input.secret_access_key.config,
+        serde_json::json!({ "var": "AWS_SECRET_ACCESS_KEY" })
+    );
+    assert!(input.session_token.is_none());
+    assert_eq!(
+        input.allowed_services,
+        vec!["logs".to_owned(), "monitoring".to_owned()]
+    );
+    assert!(input.allowed_regions.is_empty());
+    let hosts: Vec<_> = input
+        .rules
+        .iter()
+        .filter_map(|r| r.host.as_deref())
+        .collect();
+    assert_eq!(
+        hosts,
+        vec!["logs.*.amazonaws.com", "monitoring.*.amazonaws.com"]
+    );
+}
+
+#[test]
+fn translates_aws_auth_session_token_through_policy() {
+    let secrets = vec![
+        tools::parse_secret(
+            &entry(
+                r#"{ type = "aws_auth", name = "cw", access_key_id = "AKID", secret_access_key = "SAK", session_token = "STS_TOKEN", hosts = ["logs.us-east-1.amazonaws.com"] }"#,
+            ),
+            &[],
+        )
+        .unwrap(),
+    ];
+    let out = translate::translate("default", "tool-cw", &secrets, &SourcePolicy::env());
+    let SecretInput::AwsAuth(input) = &out.inputs[0] else {
+        panic!("expected aws_auth")
+    };
+    let session = input.session_token.as_ref().unwrap();
+    assert_eq!(session.source_type, "env");
+    assert_eq!(session.config, serde_json::json!({ "var": "STS_TOKEN" }));
+}
+
+#[test]
 fn translates_brokered_token_to_token_broker_static_secret() {
     let secrets = vec![
         tools::parse_secret(
@@ -440,7 +579,9 @@ fn translates_brokered_token_to_token_broker_static_secret() {
         .unwrap(),
     ];
     let out = translate::translate("default", "tool-codex", &secrets, &SourcePolicy::env());
-    let SecretInput::Static(input) = &out.inputs[0] else { panic!("expected static") };
+    let SecretInput::Static(input) = &out.inputs[0] else {
+        panic!("expected static")
+    };
     assert_eq!(input.foreign_id, "tool-codex-openai-codex");
     assert_eq!(input.name, "openai-codex");
     // Sourced from the broker credential (created out of band), not env/1password.
@@ -614,7 +755,12 @@ fn real_slack_tool_parses_and_translates() {
     };
     let manifest = tools::find_tool(&[tools_dir], "slack").unwrap();
     assert_eq!(manifest.name, "slack");
-    let out = translate::translate("default", "tool-slack", &manifest.all_secrets().cloned().collect::<Vec<_>>(), &SourcePolicy::env());
+    let out = translate::translate(
+        "default",
+        "tool-slack",
+        &manifest.all_secrets().cloned().collect::<Vec<_>>(),
+        &SourcePolicy::env(),
+    );
     assert!(
         out.inputs.iter().any(
             |i| matches!(i, SecretInput::Static(s) if s.foreign_id == "tool-slack-slack-bot-token")

--- a/services/api-rs/crates/centaur-perms/src/tools.rs
+++ b/services/api-rs/crates/centaur-perms/src/tools.rs
@@ -180,6 +180,25 @@ pub struct BrokerTokenSecret {
     pub inject_formatter: String,
 }
 
+/// A `type = "aws_auth"` secret: AWS SigV4 re-signing handled by iron-proxy's
+/// `aws_auth` transform. The tool's AWS SDK signs each request with throwaway
+/// *placeholder* credentials; iron-proxy reads the region/service from the
+/// inbound signature's credential scope, strips it, and re-signs with the real
+/// credentials resolved from `access_key_id_ref`/`secret_access_key_ref` (and
+/// optional `session_token_ref` for STS). The real keys never reach the sandbox.
+/// `allowed_regions`/`allowed_services` scope which regions/services the proxy
+/// will sign for; `hosts` becomes the iron-control request rules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AwsAuthSecret {
+    pub name: String,
+    pub hosts: Vec<String>,
+    pub access_key_id_ref: String,
+    pub secret_access_key_ref: String,
+    pub session_token_ref: Option<String>,
+    pub allowed_regions: Vec<String>,
+    pub allowed_services: Vec<String>,
+}
+
 /// One parsed `[tool.centaur]` secret entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParsedSecret {
@@ -189,6 +208,7 @@ pub enum ParsedSecret {
     PgDsn(PgDsnSecret),
     Hmac(HmacSignSecret),
     BrokerToken(BrokerTokenSecret),
+    AwsAuth(AwsAuthSecret),
 }
 
 impl ParsedSecret {
@@ -201,6 +221,7 @@ impl ParsedSecret {
             ParsedSecret::PgDsn(s) => &s.name,
             ParsedSecret::Hmac(s) => &s.name,
             ParsedSecret::BrokerToken(s) => &s.name,
+            ParsedSecret::AwsAuth(s) => &s.name,
         }
     }
 }
@@ -401,9 +422,12 @@ pub fn parse_secret(entry: &Value, default_hosts: &[String]) -> Result<ParsedSec
             &secret_ref,
         )?)),
         "hmac_sign" => Ok(ParsedSecret::Hmac(parse_hmac(table, &name)?)),
-        "brokered_token" => {
-            Ok(ParsedSecret::BrokerToken(parse_broker_token(table, &name, default_hosts)?))
-        }
+        "brokered_token" => Ok(ParsedSecret::BrokerToken(parse_broker_token(
+            table,
+            &name,
+            default_hosts,
+        )?)),
+        "aws_auth" => Ok(ParsedSecret::AwsAuth(parse_aws(table, &name)?)),
         other => bail!("unknown secret type {other:?} for secret {name:?}"),
     }
 }
@@ -623,6 +647,59 @@ fn parse_hmac(table: &toml::Table, name: &str) -> Result<HmacSignSecret> {
         timestamp_format,
         allow_chunked_body,
     })
+}
+
+/// Port of the `aws_auth` branch of `_parse_secret`. `hosts` is required (no
+/// tool-level fallback, matching the Python loader), `access_key_id` and
+/// `secret_access_key` are required non-empty credential refs, `session_token`
+/// is an optional ref, and `allowed_regions`/`allowed_services` are optional
+/// scoping arrays of non-empty strings.
+fn parse_aws(table: &toml::Table, name: &str) -> Result<AwsAuthSecret> {
+    let hosts = non_empty_str_array(table.get("hosts")).ok_or_else(|| {
+        eyre!("aws_auth entry {name:?} 'hosts' must be a non-empty array of non-empty strings")
+    })?;
+    let access_key_id_ref = opt_str(table, "access_key_id")
+        .ok_or_else(|| eyre!("aws_auth entry {name:?} requires a non-empty 'access_key_id'"))?;
+    let secret_access_key_ref = opt_str(table, "secret_access_key")
+        .ok_or_else(|| eyre!("aws_auth entry {name:?} requires a non-empty 'secret_access_key'"))?;
+    let session_token_ref = match table.get("session_token") {
+        None => None,
+        Some(_) => Some(opt_str(table, "session_token").ok_or_else(|| {
+            eyre!("aws_auth entry {name:?} 'session_token' must be a non-empty string")
+        })?),
+    };
+    let allowed_regions = aws_str_array(table.get("allowed_regions"), name, "allowed_regions")?;
+    let allowed_services = aws_str_array(table.get("allowed_services"), name, "allowed_services")?;
+    Ok(AwsAuthSecret {
+        name: name.to_owned(),
+        hosts,
+        access_key_id_ref,
+        secret_access_key_ref,
+        session_token_ref,
+        allowed_regions,
+        allowed_services,
+    })
+}
+
+/// An optional `aws_auth` scoping array: absent yields `[]`, present must be an
+/// array of non-empty strings.
+fn aws_str_array(value: Option<&Value>, name: &str, key: &str) -> Result<Vec<String>> {
+    let Some(value) = value else {
+        return Ok(vec![]);
+    };
+    let arr = value.as_array().ok_or_else(|| {
+        eyre!("aws_auth entry {name:?} {key:?} must be an array of non-empty strings")
+    })?;
+    arr.iter()
+        .map(|item| {
+            item.as_str()
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+                .ok_or_else(|| {
+                    eyre!("aws_auth entry {name:?} {key:?} must be an array of non-empty strings")
+                })
+        })
+        .collect()
 }
 
 /// The default injection for a `brokered_token` secret: the broker's current

--- a/services/api-rs/crates/centaur-perms/src/translate.rs
+++ b/services/api-rs/crates/centaur-perms/src/translate.rs
@@ -10,16 +10,16 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use centaur_iron_control::{
-    GcpAuthSecretInput, HmacSecretHeader, HmacSecretInput, InjectConfig, OAuthTokenSecretInput,
-    PgDsnSecretInput, ReplaceConfig, RequestRule, SecretInput, SecretSource, StaticSecretInput,
-    gcp_auth_scopes_or_default, managed_labels, slugify, source_from_placeholder,
-    unique_foreign_id,
+    AwsAuthSecretInput, GcpAuthSecretInput, HmacSecretHeader, HmacSecretInput, InjectConfig,
+    OAuthTokenSecretInput, PgDsnSecretInput, ReplaceConfig, RequestRule, SecretInput, SecretSource,
+    StaticSecretInput, gcp_auth_scopes_or_default, managed_labels, slugify,
+    source_from_placeholder, unique_foreign_id,
 };
 use centaur_iron_proxy::SourcePolicy;
 
 use crate::tools::{
-    BrokerTokenSecret, FieldSource, GcpAuthSecret, HmacSignSecret, HttpSecret, OAuthTokenSecret,
-    ParsedSecret, PgDsnSecret, SecretMode,
+    AwsAuthSecret, BrokerTokenSecret, FieldSource, GcpAuthSecret, HmacSignSecret, HttpSecret,
+    OAuthTokenSecret, ParsedSecret, PgDsnSecret, SecretMode,
 };
 
 /// The result of translating a tool's secrets: the iron-control inputs to upsert.
@@ -89,6 +89,15 @@ pub fn translate(
                     namespace,
                     role_foreign_id,
                     broker,
+                    &mut used,
+                )));
+            }
+            ParsedSecret::AwsAuth(aws) => {
+                out.inputs.push(SecretInput::AwsAuth(aws_input(
+                    namespace,
+                    role_foreign_id,
+                    aws,
+                    policy,
                     &mut used,
                 )));
             }
@@ -249,6 +258,37 @@ fn hmac_input(
             .collect(),
         credentials: field_sources(&hmac.credentials, policy),
         rules: rules_from_hosts(&hmac.hosts),
+    }
+}
+
+/// Translate an `aws_auth` secret into an [`AwsAuthSecretInput`]. iron-control
+/// delivers each granted AWS auth secret to iron-proxy as its own `aws_auth`
+/// transform with its own rules (like a `gcp_auth`/`hmac_sign` secret), so the
+/// `foreign_id` is role-prefixed and deduped (`{role}-aws-{slug}`). The
+/// credential refs resolve through the deployment's [`SourcePolicy`] like every
+/// other secret source.
+fn aws_input(
+    namespace: &str,
+    role: &str,
+    aws: &AwsAuthSecret,
+    policy: &SourcePolicy,
+    used: &mut BTreeSet<String>,
+) -> AwsAuthSecretInput {
+    AwsAuthSecretInput {
+        namespace: namespace.to_owned(),
+        foreign_id: unique_foreign_id(format!("{role}-aws-{}", slugify(&aws.name)), used),
+        name: Some(format!("AWS Auth ({role})")),
+        description: None,
+        labels: managed_labels(),
+        access_key_id: source_from_placeholder(policy, &aws.access_key_id_ref, None),
+        secret_access_key: source_from_placeholder(policy, &aws.secret_access_key_ref, None),
+        session_token: aws
+            .session_token_ref
+            .as_ref()
+            .map(|r| source_from_placeholder(policy, r, None)),
+        allowed_regions: aws.allowed_regions.clone(),
+        allowed_services: aws.allowed_services.clone(),
+        rules: rules_from_hosts(&aws.hosts),
     }
 }
 

--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -78,6 +78,15 @@ transforms:
         - "x-as-user-email"
         - "/^x-codex-.*$/"
         - "/^x-openai-.*$/"
+        # AWS SigV4 request headers (x-amz-target, x-amz-date,
+        # x-amz-content-sha256, x-amz-security-token) for the aws_auth transform.
+        - "/^x-amz-.*$/"
+        # AWS SDK headers that the SDK signer folds into the SigV4 signed-headers
+        # set (amz-sdk-request, amz-sdk-invocation-id, and x-amzn-query-mode for
+        # CloudWatch's query-JSON protocol). aws_auth signs them, so they must
+        # survive egress filtering or AWS rejects with InvalidSignatureException.
+        - "/^amz-sdk-.*$/"
+        - "/^x-amzn-.*$/"
         - "/^x-[a-z0-9-]*(api-key|apikey|secret|token|auth|key)$/"
 
 log:

--- a/tools/infra/cloudwatch/.env.example
+++ b/tools/infra/cloudwatch/.env.example
@@ -1,0 +1,16 @@
+# The real AWS credentials are resolved by iron-proxy (via the secrets backend
+# / 1Password), NOT by this tool — boto3 signs with placeholders and iron-proxy
+# re-signs on the wire. Store a read-only CloudWatch IAM user's keys under the
+# names below in your secrets backend, the same way as other tool credentials.
+# Scope the IAM policy tightly — read-only CloudWatch Logs + Metrics only, e.g.:
+#   logs:DescribeLogGroups, logs:FilterLogEvents, logs:GetLogEvents,
+#   logs:StartQuery, logs:GetQueryResults, logs:StopQuery,
+#   cloudwatch:ListMetrics, cloudwatch:GetMetricData,
+#   cloudwatch:DescribeAlarms, cloudwatch:DescribeAlarmHistory
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+
+# Region the log groups / metrics live in. NOT a secret — this is the only AWS
+# value the tool process itself reads (to pick the endpoint + signing scope).
+# Defaults to us-east-1 if unset.
+AWS_REGION=us-east-1

--- a/tools/infra/cloudwatch/client.py
+++ b/tools/infra/cloudwatch/client.py
@@ -1,0 +1,376 @@
+"""AWS CloudWatch client for read-only logs, metrics, and alarms.
+
+Mirrors the useful read-only surface of the AWS CloudWatch MCP server using
+boto3: browse log groups, tail/filter log events, run CloudWatch Logs Insights
+queries, list metrics and pull metric data, and inspect alarms.
+
+AWS auth rides iron-proxy's ``aws_auth`` transform (declared in pyproject.toml):
+boto3 signs each request with throwaway *placeholder* credentials, and iron-proxy
+reads the region/service from the signature scope, strips it, and re-signs with
+the real read-only IAM keys it resolves from the secrets backend. The real keys
+never enter this process — the SigV4 analogue of the ``secrets`` placeholder
+swap. Only the region is a real value: boto3 needs it to pick the endpoint host
+and credential scope, and it isn't a secret.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+_DEFAULT_REGION = "us-east-1"
+
+# boto3 must sign with *some* credentials; iron-proxy's aws_auth transform
+# discards this signature and re-signs with the real keys, so the value is
+# irrelevant beyond being non-empty.
+_PLACEHOLDER_CREDENTIAL = "iron-proxy-resigns-this"
+
+
+class CloudWatchClient:
+    """Read-only client for CloudWatch Logs and Metrics (boto3, SigV4).
+
+    boto3 signs with placeholder credentials; iron-proxy's ``aws_auth`` transform
+    re-signs with the real read-only IAM keys (resolved from the secrets backend),
+    so credentials never reach this process. The region comes from ``AWS_REGION``
+    (a non-secret), defaulting to ``us-east-1``. boto3 clients are built lazily on
+    first use so tool discovery never needs network access.
+    """
+
+    def __init__(self, region: str | None = None):
+        self._region = region
+        self.__logs: Any = None
+        self.__cw: Any = None
+
+    # -- boto3 plumbing (lazy) ----------------------------------------------
+
+    @property
+    def region(self) -> str:
+        # Region is non-secret config, read straight from the env (not secret(),
+        # whose server-mode StubBackend returns the key name as a placeholder
+        # rather than the default). Defaults to us-east-1 when unset.
+        return self._region or os.getenv("AWS_REGION") or _DEFAULT_REGION  # noqa: TID251
+
+    def _session(self) -> Any:
+        import boto3  # lazy: keeps import cheap and tests boto3-free
+
+        # Placeholder credentials — iron-proxy re-signs on the wire. Passed
+        # explicitly so boto3 never reaches for IMDS / ambient AWS config.
+        return boto3.session.Session(
+            aws_access_key_id=_PLACEHOLDER_CREDENTIAL,
+            aws_secret_access_key=_PLACEHOLDER_CREDENTIAL,
+            region_name=self.region,
+        )
+
+    def _logs(self) -> Any:
+        if self.__logs is None:
+            self.__logs = self._session().client("logs")
+        return self.__logs
+
+    def _cw(self) -> Any:
+        if self.__cw is None:
+            self.__cw = self._session().client("cloudwatch")
+        return self.__cw
+
+    @staticmethod
+    def _call(fn: Any, **kwargs: Any) -> dict:
+        """Invoke a boto3 call, dropping None args and normalizing errors."""
+        clean = {k: v for k, v in kwargs.items() if v is not None}
+        try:
+            return fn(**clean)
+        except Exception as exc:  # botocore.ClientError et al.
+            raise RuntimeError(f"CloudWatch API error: {exc}") from exc
+
+    # -- Logs: groups & events ----------------------------------------------
+
+    def list_log_groups(
+        self,
+        name_prefix: str | None = None,
+        limit: int = 50,
+    ) -> list[dict]:
+        """List CloudWatch log groups, optionally filtered by name prefix.
+
+        Use this to discover log group names for filter_log_events / start_query.
+
+        Args:
+            name_prefix: Only return groups whose name starts with this string.
+            limit: Max groups to return (1-50).
+        """
+        resp = self._call(
+            self._logs().describe_log_groups,
+            logGroupNamePrefix=name_prefix,
+            limit=max(1, min(limit, 50)),
+        )
+        return _clean(resp.get("logGroups", []))
+
+    def filter_log_events(
+        self,
+        log_group_name: str,
+        filter_pattern: str | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        limit: int = 100,
+    ) -> dict:
+        """Search log events in a group within a time window.
+
+        The workhorse for grepping logs. ``filter_pattern`` uses CloudWatch Logs
+        filter syntax (e.g. 'ERROR', '"timeout"', '{ $.level = "error" }').
+
+        Args:
+            log_group_name: Exact log group name (see list_log_groups).
+            filter_pattern: CloudWatch Logs filter pattern. Omit to return all events.
+            start_time: ISO-8601 timestamp or epoch (s/ms). Defaults to 1h before end.
+            end_time: ISO-8601 timestamp or epoch (s/ms). Defaults to now.
+            limit: Max events to return (1-10000).
+        """
+        start_ms, end_ms = _resolve_window_ms(start_time, end_time)
+        resp = self._call(
+            self._logs().filter_log_events,
+            logGroupName=log_group_name,
+            filterPattern=filter_pattern,
+            startTime=start_ms,
+            endTime=end_ms,
+            limit=max(1, min(limit, 10000)),
+        )
+        return {
+            "events": _clean(resp.get("events", [])),
+            "searched_log_streams": _clean(resp.get("searchedLogStreams", [])),
+        }
+
+    # -- Logs Insights -------------------------------------------------------
+
+    def start_query(
+        self,
+        log_group_names: list[str] | str,
+        query_string: str,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        limit: int = 100,
+    ) -> dict:
+        """Start a CloudWatch Logs Insights query. Returns a query_id to poll.
+
+        Logs Insights is asynchronous: call this to start, then poll
+        get_query_results with the returned query_id until status is Complete.
+
+        Args:
+            log_group_names: One name or a list of log group names to query.
+            query_string: Logs Insights query, e.g.
+                'fields @timestamp, @message | filter @message like /ERROR/ | sort @timestamp desc'.
+            start_time: ISO-8601 timestamp or epoch (s/ms). Defaults to 1h before end.
+            end_time: ISO-8601 timestamp or epoch (s/ms). Defaults to now.
+            limit: Max rows the query may return (1-10000).
+        """
+        names = [log_group_names] if isinstance(log_group_names, str) else list(log_group_names)
+        start_ms, end_ms = _resolve_window_ms(start_time, end_time)
+        resp = self._call(
+            self._logs().start_query,
+            logGroupNames=names,
+            queryString=query_string,
+            startTime=start_ms // 1000,  # Insights wants epoch seconds
+            endTime=end_ms // 1000,
+            limit=max(1, min(limit, 10000)),
+        )
+        return _clean(resp)
+
+    def get_query_results(self, query_id: str) -> dict:
+        """Get results/status for a Logs Insights query started with start_query.
+
+        Status is one of Scheduled, Running, Complete, Failed, Cancelled, Timeout.
+        Poll until status is Complete (or terminal) before trusting the results.
+
+        Args:
+            query_id: The query_id returned by start_query.
+        """
+        resp = self._call(self._logs().get_query_results, queryId=query_id)
+        return _clean(resp)
+
+    def stop_query(self, query_id: str) -> dict:
+        """Stop a running Logs Insights query.
+
+        Args:
+            query_id: The query_id returned by start_query.
+        """
+        return _clean(self._call(self._logs().stop_query, queryId=query_id))
+
+    # -- Metrics -------------------------------------------------------------
+
+    def list_metrics(
+        self,
+        namespace: str | None = None,
+        metric_name: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """List available metrics, optionally filtered by namespace/name.
+
+        Use to discover the namespace, metric name, and dimensions to pass to
+        get_metric_data.
+
+        Args:
+            namespace: e.g. 'AWS/EC2', 'AWS/Lambda', or a custom namespace.
+            metric_name: e.g. 'CPUUtilization', 'Errors'.
+            limit: Max metrics to return (results are truncated client-side).
+        """
+        resp = self._call(
+            self._cw().list_metrics,
+            Namespace=namespace,
+            MetricName=metric_name,
+        )
+        return _clean(resp.get("Metrics", []))[: max(1, limit)]
+
+    def get_metric_data(
+        self,
+        namespace: str,
+        metric_name: str,
+        dimensions: dict[str, str] | None = None,
+        stat: str = "Average",
+        period: int = 300,
+        start_time: str | None = None,
+        end_time: str | None = None,
+    ) -> dict:
+        """Fetch time-series data points for a single metric.
+
+        Args:
+            namespace: Metric namespace, e.g. 'AWS/Lambda'.
+            metric_name: Metric name, e.g. 'Errors'.
+            dimensions: Dimension name→value map, e.g. {'FunctionName': 'my-fn'}.
+            stat: Statistic — Average, Sum, Minimum, Maximum, SampleCount, or p99 etc.
+            period: Granularity in seconds (must be a multiple of 60).
+            start_time: ISO-8601 timestamp or epoch (s/ms). Defaults to 1h before end.
+            end_time: ISO-8601 timestamp or epoch (s/ms). Defaults to now.
+        """
+        start_dt, end_dt = _resolve_window_dt(start_time, end_time)
+        dims = [{"Name": k, "Value": v} for k, v in (dimensions or {}).items()]
+        resp = self._call(
+            self._cw().get_metric_data,
+            MetricDataQueries=[
+                {
+                    "Id": "m1",
+                    "MetricStat": {
+                        "Metric": {
+                            "Namespace": namespace,
+                            "MetricName": metric_name,
+                            "Dimensions": dims,
+                        },
+                        "Period": period,
+                        "Stat": stat,
+                    },
+                    "ReturnData": True,
+                }
+            ],
+            StartTime=start_dt,
+            EndTime=end_dt,
+        )
+        return _clean(resp.get("MetricDataResults", []))
+
+    # -- Alarms --------------------------------------------------------------
+
+    def describe_alarms(
+        self,
+        state_value: str | None = None,
+        alarm_name_prefix: str | None = None,
+        limit: int = 50,
+    ) -> list[dict]:
+        """List metric alarms, optionally filtered by state and name prefix.
+
+        Pass state_value='ALARM' to see only currently-firing alarms.
+
+        Args:
+            state_value: 'OK', 'ALARM', or 'INSUFFICIENT_DATA'.
+            alarm_name_prefix: Only alarms whose name starts with this string.
+            limit: Max alarms to return (1-100).
+        """
+        resp = self._call(
+            self._cw().describe_alarms,
+            StateValue=state_value,
+            AlarmNamePrefix=alarm_name_prefix,
+            MaxRecords=max(1, min(limit, 100)),
+        )
+        return _clean(resp.get("MetricAlarms", []))
+
+    def get_alarm_history(
+        self,
+        alarm_name: str | None = None,
+        limit: int = 50,
+    ) -> list[dict]:
+        """Get state-change history for an alarm (or all alarms).
+
+        Args:
+            alarm_name: Restrict to one alarm. Omit for history across all alarms.
+            limit: Max history items to return (1-100).
+        """
+        resp = self._call(
+            self._cw().describe_alarm_history,
+            AlarmName=alarm_name,
+            MaxRecords=max(1, min(limit, 100)),
+        )
+        return _clean(resp.get("AlarmHistoryItems", []))
+
+    # -- Lifecycle -----------------------------------------------------------
+
+    def close(self):
+        self.__logs = None
+        self.__cw = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+# -- Helpers -----------------------------------------------------------------
+
+
+def _to_epoch_ms(value: str | int | float | None) -> int | None:
+    """Coerce an ISO-8601 string or epoch (seconds or millis) to epoch millis."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        # Heuristic: values past ~2001 in seconds are < 1e12; millis are larger.
+        return int(value if value > 1_000_000_000_000 else value * 1000)
+    text = str(value).strip().replace("Z", "+00:00")
+    dt = datetime.fromisoformat(text)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return int(dt.timestamp() * 1000)
+
+
+def _resolve_window_ms(start: str | None, end: str | None) -> tuple[int, int]:
+    """Resolve a (start, end) window to epoch millis, defaulting to the last hour."""
+    end_ms = _to_epoch_ms(end)
+    if end_ms is None:
+        end_ms = int(datetime.now(UTC).timestamp() * 1000)
+    start_ms = _to_epoch_ms(start)
+    if start_ms is None:
+        start_ms = end_ms - int(timedelta(hours=1).total_seconds() * 1000)
+    return start_ms, end_ms
+
+
+def _resolve_window_dt(start: str | None, end: str | None) -> tuple[datetime, datetime]:
+    """Resolve a (start, end) window to tz-aware datetimes (CloudWatch metrics API)."""
+    start_ms, end_ms = _resolve_window_ms(start, end)
+    return (
+        datetime.fromtimestamp(start_ms / 1000, tz=UTC),
+        datetime.fromtimestamp(end_ms / 1000, tz=UTC),
+    )
+
+
+def _clean(obj: Any) -> Any:
+    """Make a boto3 response JSON-serializable.
+
+    Converts datetimes to ISO-8601, decodes bytes, and strips the boilerplate
+    ``ResponseMetadata`` envelope so it doesn't bloat the agent's context.
+    """
+    if isinstance(obj, dict):
+        return {k: _clean(v) for k, v in obj.items() if k != "ResponseMetadata"}
+    if isinstance(obj, (list, tuple)):
+        return [_clean(v) for v in obj]
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, (bytes, bytearray)):
+        return bytes(obj).decode("utf-8", "replace")
+    return obj
+
+
+def _client() -> CloudWatchClient:
+    return CloudWatchClient()

--- a/tools/infra/cloudwatch/pyproject.toml
+++ b/tools/infra/cloudwatch/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "cloudwatch"
+description = "AWS CloudWatch — Logs Insights queries, log events, metrics, and alarms (read-only)"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "boto3>=1.34",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+
+# AWS SigV4 rides iron-proxy's `aws_auth` transform: boto3 signs each request
+# with throwaway placeholder credentials, and iron-proxy re-signs it with the
+# real read-only IAM keys it resolves from `access_key_id`/`secret_access_key`
+# (stored in the secrets backend like any other tool credential). The real keys
+# never enter the tool process — same placeholder-swap model as the `secrets`
+# transform, just for SigV4. Scope the IAM user to read-only CloudWatch.
+[tool.centaur]
+module = "client.py"
+hosts = ["logs.*.amazonaws.com", "monitoring.*.amazonaws.com"]
+secrets = [
+    { type = "aws_auth", name = "cloudwatch", access_key_id = "AWS_ACCESS_KEY_ID", secret_access_key = "AWS_SECRET_ACCESS_KEY", hosts = [
+        "logs.*.amazonaws.com",
+        "monitoring.*.amazonaws.com",
+    ], allowed_services = [
+        "logs",
+        "monitoring",
+    ] },
+]

--- a/tools/infra/cloudwatch/test_client.py
+++ b/tools/infra/cloudwatch/test_client.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+spec = importlib.util.spec_from_file_location(
+    "cloudwatch_client", Path(__file__).with_name("client.py")
+)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+CloudWatchClient = module.CloudWatchClient
+
+
+class FakeBotoClient:
+    """Records boto3 calls and returns canned responses, no network or boto3."""
+
+    def __init__(self, responses: dict[str, Any] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.responses = responses or {}
+
+    def __getattr__(self, name: str):
+        def _method(**kwargs: Any) -> Any:
+            self.calls.append({"op": name, "kwargs": kwargs})
+            return self.responses.get(name, {})
+
+        return _method
+
+
+class RecordingCloudWatchClient(CloudWatchClient):
+    """Swaps boto3 logs/cloudwatch clients for recording fakes."""
+
+    def __init__(self, **responses: Any) -> None:
+        super().__init__(region="us-west-2")
+        self.logs = FakeBotoClient(responses)
+        self.cw = FakeBotoClient(responses)
+
+    def _logs(self) -> Any:
+        return self.logs
+
+    def _cw(self) -> Any:
+        return self.cw
+
+
+def test_list_log_groups_clamps_limit_and_drops_none() -> None:
+    client = RecordingCloudWatchClient(describe_log_groups={"logGroups": [{"logGroupName": "/x"}]})
+
+    out = client.list_log_groups(limit=999)
+
+    assert out == [{"logGroupName": "/x"}]
+    call = client.logs.calls[-1]
+    assert call["op"] == "describe_log_groups"
+    assert call["kwargs"] == {"limit": 50}  # clamped, name_prefix=None dropped
+
+
+def test_filter_log_events_defaults_to_last_hour() -> None:
+    client = RecordingCloudWatchClient()
+
+    client.filter_log_events("/aws/lambda/fn", end_time="2026-05-28T12:00:00Z")
+
+    kwargs = client.logs.calls[-1]["kwargs"]
+    assert kwargs["logGroupName"] == "/aws/lambda/fn"
+    assert kwargs["endTime"] == int(datetime(2026, 5, 28, 12, tzinfo=UTC).timestamp() * 1000)
+    assert kwargs["startTime"] == kwargs["endTime"] - 3_600_000
+    assert "filterPattern" not in kwargs  # None dropped
+
+
+def test_filter_log_events_passes_pattern_and_clamps_limit() -> None:
+    client = RecordingCloudWatchClient()
+
+    client.filter_log_events("/g", filter_pattern="ERROR", limit=99999)
+
+    kwargs = client.logs.calls[-1]["kwargs"]
+    assert kwargs["filterPattern"] == "ERROR"
+    assert kwargs["limit"] == 10000
+
+
+def test_start_query_normalizes_names_and_uses_epoch_seconds() -> None:
+    client = RecordingCloudWatchClient(start_query={"queryId": "q-1"})
+
+    out = client.start_query(
+        "/only-one",
+        "fields @message",
+        start_time="2026-05-28T11:00:00Z",
+        end_time="2026-05-28T12:00:00Z",
+    )
+
+    assert out == {"queryId": "q-1"}
+    kwargs = client.logs.calls[-1]["kwargs"]
+    assert kwargs["logGroupNames"] == ["/only-one"]
+    assert kwargs["startTime"] == int(datetime(2026, 5, 28, 11, tzinfo=UTC).timestamp())
+    assert kwargs["endTime"] == int(datetime(2026, 5, 28, 12, tzinfo=UTC).timestamp())
+
+
+def test_get_metric_data_builds_single_query() -> None:
+    client = RecordingCloudWatchClient(get_metric_data={"MetricDataResults": [{"Id": "m1"}]})
+
+    out = client.get_metric_data(
+        "AWS/Lambda",
+        "Errors",
+        dimensions={"FunctionName": "fn"},
+        stat="Sum",
+        period=60,
+        start_time="2026-05-28T11:00:00Z",
+        end_time="2026-05-28T12:00:00Z",
+    )
+
+    assert out == [{"Id": "m1"}]
+    kwargs = client.cw.calls[-1]["kwargs"]
+    q = kwargs["MetricDataQueries"][0]
+    assert q["MetricStat"]["Metric"]["Namespace"] == "AWS/Lambda"
+    assert q["MetricStat"]["Metric"]["Dimensions"] == [{"Name": "FunctionName", "Value": "fn"}]
+    assert q["MetricStat"]["Stat"] == "Sum"
+    assert q["MetricStat"]["Period"] == 60
+    assert kwargs["StartTime"] == datetime(2026, 5, 28, 11, tzinfo=UTC)
+    assert kwargs["EndTime"] == datetime(2026, 5, 28, 12, tzinfo=UTC)
+
+
+def test_describe_alarms_filters_active() -> None:
+    client = RecordingCloudWatchClient(describe_alarms={"MetricAlarms": [{"AlarmName": "a"}]})
+
+    out = client.describe_alarms(state_value="ALARM")
+
+    assert out == [{"AlarmName": "a"}]
+    kwargs = client.cw.calls[-1]["kwargs"]
+    assert kwargs["StateValue"] == "ALARM"
+    assert kwargs["MaxRecords"] == 50
+    assert "AlarmNamePrefix" not in kwargs
+
+
+def test_clean_strips_metadata_and_serializes_datetimes() -> None:
+    cleaned = module._clean(
+        {
+            "ResponseMetadata": {"RequestId": "abc"},
+            "MetricAlarms": [{"StateUpdatedTimestamp": datetime(2026, 5, 28, tzinfo=UTC)}],
+        }
+    )
+
+    assert "ResponseMetadata" not in cleaned
+    assert cleaned["MetricAlarms"][0]["StateUpdatedTimestamp"] == "2026-05-28T00:00:00+00:00"
+
+
+def test_to_epoch_ms_handles_seconds_and_millis() -> None:
+    assert module._to_epoch_ms(1_700_000_000) == 1_700_000_000_000  # seconds → ms
+    assert module._to_epoch_ms(1_700_000_000_000) == 1_700_000_000_000  # already ms
+    assert module._to_epoch_ms(None) is None
+
+
+def test_api_errors_are_wrapped() -> None:
+    client = RecordingCloudWatchClient()
+
+    def boom(**_: Any):
+        raise ValueError("AccessDenied")
+
+    client.logs.describe_log_groups = boom  # type: ignore[assignment]
+
+    try:
+        client.list_log_groups()
+    except RuntimeError as exc:
+        assert "CloudWatch API error" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")


### PR DESCRIPTION
Reimplements PR #449's AWS auth support in the Rust api-rs / iron-control control plane instead of the Python `services/api`, which api-rs is replacing.

Adds an `aws_auth` credential type to `centaur-iron-control` (new `AwsAuthSecretInput` model, `aws_auth_secrets` upsert client, `aas_` grant wiring) and to the `centaur-perms` tool-config path, so a tool declaring `type = "aws_auth"` in its pyproject gets a re-signing secret registered in iron-control and granted to its role. iron-proxy re-signs SigV4 requests the tool signed with placeholder credentials, so the real read-only IAM keys never reach the sandbox.

Keeps the CloudWatch tool and the iron-proxy SigV4 header allowlist from #449; drops the Python `services/api` changes. AWS_REGION is non-secret and reaches the sandbox via `passthrough_env`.

Supersedes #449.