### PR TITLE
fix(slackbotv2): pin Slack stream continuation fix

### DIFF
--- a/patches/@chat-adapter__slack@4.30.0.patch
+++ b/patches/@chat-adapter__slack@4.30.0.patch
@@ -1,0 +1,340 @@
+diff --git a/dist/index.js b/dist/index.js
+index 53a35e40d7dc03dea57f965325728761467ad7c7..49bb6c8b5a5361663a1a3160ec9d0e8172180e1e 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -31,6 +31,122 @@ import {
+   toModalElement,
+   toPlainText
+ } from "chat";
++var STREAM_BUFFER_SIZE = 256;
++var STREAM_SEGMENT_LIMIT = 11500;
++var STREAM_CHUNK_LIMIT = 256;
++var STREAM_FENCE_RESERVE = 64;
++var FENCE_PATTERN = /^(`{3,}|~{3,})/;
++var Fence = class {
++  constructor() {
++    this.buffer = "";
++  }
++  get closing() {
++    return this.value ? `\n${this.value.marker}` : void 0;
++  }
++  get opening() {
++    return this.value ? `${this.value.opening}\n` : void 0;
++  }
++  finish() {
++    if (this.buffer) {
++      this.track(this.buffer);
++      this.buffer = "";
++    }
++  }
++  push(text) {
++    const lines = `${this.buffer}${text}`.split("\n");
++    this.buffer = lines.pop() ?? "";
++    for (const line of lines) {
++      this.track(line);
++    }
++  }
++  track(line) {
++    const trimmed = line.trimStart();
++    const match = FENCE_PATTERN.exec(trimmed);
++    if (!match) {
++      return;
++    }
++    const marker = match[1];
++    if (!this.value) {
++      this.value = {
++        marker,
++        opening: trimmed
++      };
++    } else if (marker[0] === this.value.marker[0] && marker.length >= this.value.marker.length) {
++      this.value = void 0;
++    }
++  }
++};
++function splitText(text, limit) {
++  if (text.length <= limit) {
++    return [text];
++  }
++  const chunks = [];
++  let offset = 0;
++  let remaining = Math.ceil(text.length / limit);
++  while (offset < text.length) {
++    const left = text.length - offset;
++    if (left <= limit) {
++      chunks.push(text.slice(offset));
++      break;
++    }
++    const target = Math.min(limit, Math.ceil(left / Math.max(remaining, 1)));
++    const minimum = Math.max(1, Math.floor(target * 0.75));
++    let end = offset + target;
++    const window = text.slice(offset, end);
++    const boundary = Math.max(window.lastIndexOf("\n"), window.lastIndexOf(" "));
++    if (boundary >= minimum) {
++      end = offset + boundary + 1;
++    }
++    const lastCode = text.charCodeAt(end - 1);
++    if (lastCode >= 55296 && lastCode <= 56319) {
++      end += end - offset === 1 ? 1 : -1;
++    }
++    chunks.push(text.slice(offset, end));
++    offset = end;
++    remaining = Math.max(1, remaining - 1);
++  }
++  return chunks;
++}
++function truncateText(text, limit) {
++  if (text.length <= limit) {
++    return text;
++  }
++  let end = limit - 3;
++  const lastCode = text.charCodeAt(end - 1);
++  if (lastCode >= 55296 && lastCode <= 56319) {
++    end -= 1;
++  }
++  return `${text.slice(0, end)}...`;
++}
++function taskId(id, index) {
++  if (index === 0) {
++    return truncateText(id, STREAM_CHUNK_LIMIT);
++  }
++  const suffix = `:part:${index + 1}`;
++  return `${truncateText(id, STREAM_CHUNK_LIMIT - suffix.length)}${suffix}`;
++}
++function taskTitle(title, index, total) {
++  if (total === 1) {
++    return truncateText(title, STREAM_CHUNK_LIMIT);
++  }
++  const suffix = ` (${index + 1}/${total})`;
++  return `${truncateText(title, STREAM_CHUNK_LIMIT - suffix.length)}${suffix}`;
++}
++function splitTask(chunk, previous) {
++  const sources = chunk.sources;
++  const details = chunk.details ? splitText(chunk.details, STREAM_CHUNK_LIMIT) : [];
++  const output = chunk.output ? splitText(chunk.output, STREAM_CHUNK_LIMIT) : [];
++  const total = Math.max(previous, details.length, output.length, 1);
++  return Array.from({ length: total }, (_, index) => ({
++    ...details[index] ? { details: details[index] } : {},
++    id: taskId(chunk.id, index),
++    ...output[index] ? { output: output[index] } : {},
++    ...index === 0 && sources !== void 0 ? { sources } : {},
++    status: chunk.status,
++    title: taskTitle(chunk.title, index, total),
++    type: "task_update"
++  }));
++}
+ 
+ // src/cards.ts
+ import {
+@@ -3434,24 +3550,91 @@ var SlackAdapter = class _SlackAdapter {
+     }
+     this.logger.debug("Slack: starting stream", { channel, threadTs });
+     const token = await this.getToken();
+-    const streamer = this._client.chatStream({
+-      channel,
+-      thread_ts: threadTs,
+-      recipient_user_id: options.recipientUserId,
+-      recipient_team_id: options.recipientTeamId,
+-      ...options.taskDisplayMode && {
+-        task_display_mode: options.taskDisplayMode
+-      }
++    const createSegment = () => ({
++      hasContent: false,
++      length: 0,
++      stopped: false,
++      streamer: this._client.chatStream({
++        channel,
++        thread_ts: threadTs,
++        recipient_user_id: options.recipientUserId,
++        recipient_team_id: options.recipientTeamId,
++        ...options.taskDisplayMode && {
++          task_display_mode: options.taskDisplayMode
++        },
++        buffer_size: STREAM_BUFFER_SIZE
++      })
+     });
++    let current = createSegment();
++    let structured;
++    let lastResult;
+     let lastAppended = "";
++    const taskParts = /* @__PURE__ */ new Map();
++    const fence = new Fence();
+     const renderer = new StreamingMarkdownRenderer({
+       wrapTablesForAppend: false
+     });
++    const stopSegment = async (segment, blocks, force = false) => {
++      if (segment.stopped || !(segment.hasContent || force)) {
++        return void 0;
++      }
++      const result = await segment.streamer.stop({
++        token,
++        ...blocks ? { blocks } : {}
++      });
++      segment.stopped = true;
++      return result;
++    };
++    const rotateSegment = async (closing, opening) => {
++      if (closing) {
++        await current.streamer.append({ markdown_text: closing, token });
++        current.hasContent = true;
++        current.length += closing.length;
++      }
++      if (current !== structured) {
++        await stopSegment(current);
++      }
++      current = createSegment();
++      if (opening) {
++        await current.streamer.append({ markdown_text: opening, token });
++        current.hasContent = true;
++        current.length += opening.length;
++      }
++    };
+     const flushMarkdownDelta = async (delta) => {
+       if (delta.length === 0) {
+         return;
+       }
+-      await streamer.append({ markdown_text: delta, token });
++      let remaining = delta;
++      while (remaining.length > 0) {
++        if (current.length === STREAM_SEGMENT_LIMIT) {
++          await rotateSegment(fence.closing, fence.opening);
++        }
++        const available = STREAM_SEGMENT_LIMIT - current.length;
++        const first = remaining.codePointAt(0);
++        const width = first !== void 0 && first > 65535 ? 2 : 1;
++        if (available < width) {
++          await rotateSegment(fence.closing, fence.opening);
++          continue;
++        }
++        if (remaining.length > available && available <= STREAM_FENCE_RESERVE + width) {
++          await rotateSegment(fence.closing, fence.opening);
++          continue;
++        }
++        const limit = remaining.length > available ? Math.max(width, available - STREAM_FENCE_RESERVE) : available;
++        const [text] = splitText(remaining, limit);
++        if (!text) {
++          break;
++        }
++        await current.streamer.append({ markdown_text: text, token });
++        current.hasContent = true;
++        current.length += text.length;
++        fence.push(text);
++        remaining = remaining.slice(text.length);
++        if (remaining.length > 0) {
++          await rotateSegment(fence.closing, fence.opening);
++        }
++      }
+     };
+     let structuredChunksSupported = true;
+     const sendStructuredChunk = async (chunk) => {
+@@ -3463,7 +3646,20 @@ var SlackAdapter = class _SlackAdapter {
+       await flushMarkdownDelta(delta);
+       lastAppended = committable;
+       try {
+-        await streamer.append({ chunks: [chunk], token });
++        structured ??= current;
++        const chunks = chunk.type === "task_update" ? splitTask(chunk, taskParts.get(chunk.id) ?? 0) : [
++          {
++            ...chunk,
++            title: truncateText(chunk.title, STREAM_CHUNK_LIMIT)
++          }
++        ];
++        if (chunk.type === "task_update") {
++          taskParts.set(chunk.id, chunks.length);
++        }
++        for (const normalized of chunks) {
++          await structured.streamer.append({ chunks: [normalized], token });
++          structured.hasContent = true;
++        }
+       } catch (error) {
+         structuredChunksSupported = false;
+         this.logger.warn(
+@@ -3479,31 +3675,70 @@ var SlackAdapter = class _SlackAdapter {
+       await flushMarkdownDelta(delta);
+       lastAppended = committable;
+     };
+-    for await (const chunk of textStream) {
+-      if (typeof chunk === "string") {
+-        await pushTextAndFlush(chunk);
+-      } else if (chunk.type === "markdown_text") {
+-        await pushTextAndFlush(chunk.text);
+-      } else {
+-        await sendStructuredChunk(chunk);
++    try {
++      for await (const chunk of textStream) {
++        if (typeof chunk === "string") {
++          await pushTextAndFlush(chunk);
++        } else if (chunk.type === "markdown_text") {
++          await pushTextAndFlush(chunk.text);
++        } else {
++          await sendStructuredChunk(chunk);
++        }
++      }
++      renderer.finish();
++      const finalCommittable = renderer.getCommittableText();
++      const finalDelta = finalCommittable.slice(lastAppended.length);
++      await flushMarkdownDelta(finalDelta);
++      fence.finish();
++      if (fence.closing) {
++        await current.streamer.append({
++          markdown_text: fence.closing,
++          token
++        });
++        current.hasContent = true;
++        current.length += fence.closing.length;
++      }
++      if (structured && structured !== current) {
++        await stopSegment(structured);
++      }
++      lastResult = await stopSegment(
++        current,
++        options?.stopBlocks,
++        true
++      );
++    } catch (error) {
++      const segments = /* @__PURE__ */ new Set([structured, current]);
++      fence.finish();
++      for (const segment of segments) {
++        if (!segment?.hasContent) {
++          continue;
++        }
++        try {
++          if (segment === current && fence.closing) {
++            await segment.streamer.append({
++              markdown_text: fence.closing,
++              token
++            });
++            segment.length += fence.closing.length;
++          }
++          await stopSegment(segment);
++        } catch (stopError) {
++          this.logger.warn("Slack: failed to stop partial stream", {
++            error: stopError
++          });
++        }
+       }
++      throw error;
+     }
+-    renderer.finish();
+-    const finalCommittable = renderer.getCommittableText();
+-    const finalDelta = finalCommittable.slice(lastAppended.length);
+-    await flushMarkdownDelta(finalDelta);
+-    const result = await streamer.stop({
+-      token,
+-      ...options?.stopBlocks ? {
+-        blocks: options.stopBlocks
+-      } : {}
+-    });
+-    const messageTs = result.message?.ts ?? result.ts;
++    if (!lastResult) {
++      throw new NetworkError("slack", "Slack stream returned no result");
++    }
++    const messageTs = lastResult.message?.ts ?? lastResult.ts;
+     this.logger.debug("Slack: stream complete", { messageId: messageTs });
+     return {
+       id: messageTs,
+       threadId,
+-      raw: result
++      raw: lastResult
+     };
+   }
+   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@chat-adapter/slack@4.30.0':
+    hash: 060f005e1f0de4defd4612913bd7c2b82bd3b2b54086ca51d0a45f382624f59d
+    path: patches/@chat-adapter__slack@4.30.0.patch
+
 importers:
 
   .: {}
@@ -129,7 +134,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.30.0
-        version: 4.30.0(zod@4.4.3)
+        version: 4.30.0(patch_hash=060f005e1f0de4defd4612913bd7c2b82bd3b2b54086ca51d0a45f382624f59d)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
@@ -1554,7 +1559,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.30.0(zod@4.4.3)':
+  '@chat-adapter/slack@4.30.0(patch_hash=060f005e1f0de4defd4612913bd7c2b82bd3b2b54086ca51d0a45f382624f59d)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.30.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,7 @@
 packages:
-  - 'packages/*'
-  - 'services/slackbot'
-  - 'services/slackbotv2'
+  - packages/*
+  - services/slackbot
+  - services/slackbotv2
+
+patchedDependencies:
+  '@chat-adapter/slack@4.30.0': patches/@chat-adapter__slack@4.30.0.patch

--- a/services/slackbot/Dockerfile
+++ b/services/slackbot/Dockerfile
@@ -6,6 +6,7 @@ ENV NODE_ENV=production
 RUN bun install -g pnpm@10.28.1
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches/ patches/
 COPY services/slackbot/package.json services/slackbot/package.json
 RUN pnpm install --filter slackbot --prod --frozen-lockfile
 

--- a/services/slackbotv2/Dockerfile
+++ b/services/slackbotv2/Dockerfile
@@ -9,6 +9,7 @@ RUN bun install -g pnpm@10.28.1
 # depends on the @centaur/* workspace packages, so they must be present for
 # pnpm to link the `workspace:*` ranges.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches/ patches/
 COPY packages/ packages/
 COPY services/slackbotv2/package.json services/slackbotv2/package.json
 RUN pnpm install --filter slackbotv2 --prod --frozen-lockfile

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -705,6 +705,51 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('continues oversized final answers across Slack stream replies', async () => {
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before a long final answer.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> write a long visible answer`, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-stream-continuation',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> write a long visible answer`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    const answer = `STREAM_CONTINUATION_START ${'x'.repeat(14_000)} STREAM_CONTINUATION_END`
+    codexApi.emitOutputLines(key, sampleCodexOutputLines(answer))
+    codexApi.emitSessionEvent(key, 'session.execution_completed', {
+      execution_id: 'exe-stream-continuation',
+      status: 'completed',
+      result_text: answer
+    })
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts.length).toBeGreaterThan(1)
+    expect(await threadText(parent.ts)).toContain('STREAM_CONTINUATION_START')
+    expect(await threadText(parent.ts)).toContain('STREAM_CONTINUATION_END')
+  })
+
   it('does not create an empty Slack stream before the first visible renderer chunk', async () => {
     codexApi.autoRespond = false
 


### PR DESCRIPTION
## Summary
- pin the effective @chat-adapter/slack behavior to the Slack stream continuation fix from vercel/chat#601 via pnpm patchedDependencies
- copy the patch into the slackbotv2 Docker dependency layer so production image builds can apply it
- add a Slackbot v2 emulator regression test proving oversized final answers continue across Slack stream replies

Raw git subdirectory pinning was not installable because the Chat SDK PR package still resolves internal packages with workspace:* dependencies, and pkg.pr.new artifacts were unavailable for the PR commit. This keeps the dependency version at 4.30.0 while pinning the needed adapter code path.

Closes the replacement path for the now-closed Centaur pagination PR #452.

## Validation
- pnpm --filter slackbotv2 check:types
- pnpm --filter slackbotv2 test
- just build-one slackbotv2

Local Centaur deploy smoke was not run because the local centaur namespace deployments are currently unready/scaled down; the affected image build and Slackbot v2 emulator coverage passed.