### PR TITLE
fix(chart): repo-cache temp dir broken by k8s $$ collapse

### DIFF
--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -70,7 +70,13 @@ spec:
                 repo="$1"
                 repo_url="https://github.com/${repo}.git"
                 target="/cache/${repo}"
-                tmp="${target}.tmp.$$"
+                # Deterministic temp name. This script runs as a Kubernetes
+                # container command, and Kubernetes collapses a doubled dollar
+                # sign to a single one during its own $(VAR) expansion before
+                # bash sees it, so a PID-based suffix is neither unique nor
+                # valid. Sync is sequential per pod, so a fixed name plus the
+                # rm -rf below is enough.
+                tmp="${target}.tmp"
 
                 mkdir -p "$(dirname "$target")"
                 if git -C "$target" rev-parse --git-dir >/dev/null 2>&1; then
@@ -87,7 +93,9 @@ spec:
                   git -C "$target" clean -fd
                 else
                   echo "Cloning $repo"
-                  rm -rf "$tmp" "$target"
+                  # Also sweep any stale "${target}.tmp.*" dirs left by the
+                  # previous PID-suffix scheme so they don't accumulate on disk.
+                  rm -rf "${target}".tmp* "$target"
                   git clone --quiet "$repo_url" "$tmp"
                   git -C "$tmp" config gc.auto 0
                   mv "$tmp" "$target"


### PR DESCRIPTION
The repo-cache sync used a PID-suffixed temp dir (`${target}.tmp.$$`), but Kubernetes runs $(VAR) expansion on container commands and collapses a doubled dollar sign to a single one before bash sees it. The suffix became a constant literal, so temp names were not unique and the `mv` failed with "cannot move ... to a subdirectory of itself", leaving repos unsynced.

This uses a deterministic temp name and sweeps any stale `${target}.tmp.*` dirs before cloning. Sync is sequential per pod, so a fixed name is safe, and existing corrupt caches self-heal on the next run.