### PR TITLE
fix(slackbotv2): continue large task streams

### DIFF
--- a/patches/@chat-adapter__slack@4.30.0.patch
+++ b/patches/@chat-adapter__slack@4.30.0.patch
@@ -1,14 +1,15 @@
 diff --git a/dist/index.js b/dist/index.js
-index 53a35e40d7dc03dea57f965325728761467ad7c7..49bb6c8b5a5361663a1a3160ec9d0e8172180e1e 100644
+index 53a35e4..8fc9ebd 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -31,6 +31,122 @@ import {
+@@ -31,6 +31,123 @@ import {
    toModalElement,
    toPlainText
  } from "chat";
 +var STREAM_BUFFER_SIZE = 256;
 +var STREAM_SEGMENT_LIMIT = 11500;
 +var STREAM_CHUNK_LIMIT = 256;
++var STREAM_STRUCTURED_CHUNK_LIMIT = 45;
 +var STREAM_FENCE_RESERVE = 64;
 +var FENCE_PATTERN = /^(`{3,}|~{3,})/;
 +var Fence = class {
@@ -125,7 +126,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..49bb6c8b5a5361663a1a3160ec9d0e81
  
  // src/cards.ts
  import {
-@@ -3434,24 +3550,91 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3434,24 +3551,89 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -141,6 +142,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..49bb6c8b5a5361663a1a3160ec9d0e81
 +      hasContent: false,
 +      length: 0,
 +      stopped: false,
++      structuredChunks: 0,
 +      streamer: this._client.chatStream({
 +        channel,
 +        thread_ts: threadTs,
@@ -153,7 +155,6 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..49bb6c8b5a5361663a1a3160ec9d0e81
 +      })
      });
 +    let current = createSegment();
-+    let structured;
 +    let lastResult;
      let lastAppended = "";
 +    const taskParts = /* @__PURE__ */ new Map();
@@ -178,9 +179,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..49bb6c8b5a5361663a1a3160ec9d0e81
 +        current.hasContent = true;
 +        current.length += closing.length;
 +      }
-+      if (current !== structured) {
-+        await stopSegment(current);
-+      }
++      await stopSegment(current);
 +      current = createSegment();
 +      if (opening) {
 +        await current.streamer.append({ markdown_text: opening, token });
@@ -226,12 +225,11 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..49bb6c8b5a5361663a1a3160ec9d0e81
      };
      let structuredChunksSupported = true;
      const sendStructuredChunk = async (chunk) => {
-@@ -3463,7 +3646,20 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3463,7 +3645,23 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
 -        await streamer.append({ chunks: [chunk], token });
-+        structured ??= current;
 +        const chunks = chunk.type === "task_update" ? splitTask(chunk, taskParts.get(chunk.id) ?? 0) : [
 +          {
 +            ...chunk,
@@ -242,13 +240,17 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..49bb6c8b5a5361663a1a3160ec9d0e81
 +          taskParts.set(chunk.id, chunks.length);
 +        }
 +        for (const normalized of chunks) {
-+          await structured.streamer.append({ chunks: [normalized], token });
-+          structured.hasContent = true;
++          if (current.structuredChunks >= STREAM_STRUCTURED_CHUNK_LIMIT) {
++            await rotateSegment(fence.closing, fence.opening);
++          }
++          await current.streamer.append({ chunks: [normalized], token });
++          current.hasContent = true;
++          current.structuredChunks += 1;
 +        }
        } catch (error) {
          structuredChunksSupported = false;
          this.logger.warn(
-@@ -3479,31 +3675,70 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3479,31 +3677,67 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
      };
@@ -282,16 +284,13 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..49bb6c8b5a5361663a1a3160ec9d0e81
 +        current.hasContent = true;
 +        current.length += fence.closing.length;
 +      }
-+      if (structured && structured !== current) {
-+        await stopSegment(structured);
-+      }
 +      lastResult = await stopSegment(
 +        current,
 +        options?.stopBlocks,
 +        true
 +      );
 +    } catch (error) {
-+      const segments = /* @__PURE__ */ new Set([structured, current]);
++      const segments = /* @__PURE__ */ new Set([current]);
 +      fence.finish();
 +      for (const segment of segments) {
 +        if (!segment?.hasContent) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@chat-adapter/slack@4.30.0':
-    hash: 060f005e1f0de4defd4612913bd7c2b82bd3b2b54086ca51d0a45f382624f59d
+    hash: d0bf9c24275f57166a636ee40732ce679b7dcc8b37f3df003c9604e279372a6b
     path: patches/@chat-adapter__slack@4.30.0.patch
 
 importers:
@@ -134,7 +134,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.30.0
-        version: 4.30.0(patch_hash=060f005e1f0de4defd4612913bd7c2b82bd3b2b54086ca51d0a45f382624f59d)(zod@4.4.3)
+        version: 4.30.0(patch_hash=d0bf9c24275f57166a636ee40732ce679b7dcc8b37f3df003c9604e279372a6b)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
@@ -1559,7 +1559,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.30.0(patch_hash=060f005e1f0de4defd4612913bd7c2b82bd3b2b54086ca51d0a45f382624f59d)(zod@4.4.3)':
+  '@chat-adapter/slack@4.30.0(patch_hash=d0bf9c24275f57166a636ee40732ce679b7dcc8b37f3df003c9604e279372a6b)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.30.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -750,6 +750,66 @@ describe('slackbotv2', () => {
     expect(await threadText(parent.ts)).toContain('STREAM_CONTINUATION_END')
   })
 
+  it('continues large task streams across Slack stream replies', async () => {
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before many tool steps.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> run many small steps`, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-task-stream-continuation',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> run many small steps`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    for (let index = 1; index <= 60; index += 1) {
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: `cmd-${index}`,
+            type: 'commandExecution',
+            command: `printf step-${index}`,
+            status: 'completed',
+            aggregatedOutput: ''
+          }
+        })
+      )
+    }
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('TASK_STREAM_CONTINUATION_OK'))
+    codexApi.emitSessionEvent(key, 'session.execution_completed', {
+      execution_id: 'exe-task-stream-continuation',
+      status: 'completed',
+      result_text: 'TASK_STREAM_CONTINUATION_OK'
+    })
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts.length).toBeGreaterThan(1)
+    expect(transcripts.flatMap(transcript => transcript.chunks).filter(chunk => chunk.type === 'task_update').length)
+      .toBeGreaterThan(50)
+    expect(await threadText(parent.ts)).toContain('TASK_STREAM_CONTINUATION_OK')
+  })
+
   it('does not create an empty Slack stream before the first visible renderer chunk', async () => {
     codexApi.autoRespond = false
 


### PR DESCRIPTION
## Summary
- update the pinned Chat SDK Slack adapter patch so structured task/plan chunks rotate onto continuation stream replies after 45 chunks
- keep existing markdown continuation behavior and final-answer delivery on the active stream segment
- add a Slackbot v2 emulator regression for more than 50 task updates

## Validation
- pnpm --filter slackbotv2 check:types
- pnpm --filter slackbotv2 test
- just build-one slackbotv2
- just build-one slackbot