### PR TITLE
Make claude-fable-5 the default --claude model

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -216,17 +216,18 @@ def _agent_session_title(
 
 # ── Per-message header (rendered italic at the top of every assistant message) ──
 
-_DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
+_DEFAULT_CLAUDE_MODEL = "claude-fable-5"
 
 _CLAUDE_MODEL_ALIASES: dict[str, str] = {
-    "opus": _DEFAULT_CLAUDE_MODEL,
+    "fable": "claude-fable-5",
+    "opus": "claude-opus-4-8",
     "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5",
 }
 
 
 def _resolve_claude_model_label(model: str | None) -> str:
-    raw = (model or os.getenv("CLAUDE_MODEL") or "opus").strip().lower()
+    raw = (model or os.getenv("CLAUDE_MODEL") or _DEFAULT_CLAUDE_MODEL).strip().lower()
     if raw.startswith("claude-"):
         return raw
     return _CLAUDE_MODEL_ALIASES.get(raw, raw or _DEFAULT_CLAUDE_MODEL)

--- a/services/api/tests/test_claude_app_wrapper.py
+++ b/services/api/tests/test_claude_app_wrapper.py
@@ -40,7 +40,7 @@ def test_build_claude_cmd_defaults(monkeypatch) -> None:
     assert "--include-hook-events" not in cmd
     assert "--append-system-prompt-file" not in cmd
     assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "claude-opus-4-8"
+    assert cmd[cmd.index("--model") + 1] == "claude-fable-5"
     assert "--resume" not in cmd
 
 

--- a/services/api/tests/test_workflow_engine_title.py
+++ b/services/api/tests/test_workflow_engine_title.py
@@ -138,7 +138,7 @@ async def test_title_handles_non_dict_active_assignment(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_header_uses_base_when_no_persona_paradigm_claude(monkeypatch):
-    """Paradigm + no persona + claude-code → ``base · claude-opus-4-8``."""
+    """Paradigm + no persona + claude-code → ``base · claude-fable-5``."""
     get_active = AsyncMock(return_value={"persona_id": None, "harness": "claude-code", "engine": "claude-code"})
     monkeypatch.setattr(workflow_engine, "get_active_assignment", get_active)
     monkeypatch.delenv("CLAUDE_MODEL", raising=False)
@@ -147,7 +147,7 @@ async def test_header_uses_base_when_no_persona_paradigm_claude(monkeypatch):
     header = await workflow_engine._compute_agent_session_header(
         pool=object(), thread_key="slack:T:C:1.0", selector=selector,
     )
-    assert header == "base · claude-opus-4-8"
+    assert header == "base · claude-fable-5"
 
 
 @pytest.mark.asyncio

--- a/services/sandbox/claude-app-wrapper.py
+++ b/services/sandbox/claude-app-wrapper.py
@@ -27,7 +27,7 @@ import sys
 import threading
 from typing import Any
 
-DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
+DEFAULT_CLAUDE_MODEL = "claude-fable-5"
 
 APP: subprocess.Popen[str] | None = None
 WRITE_LOCK = threading.Lock()


### PR DESCRIPTION
## What

Switches the `--claude` (claude-code) harness default model from `claude-opus-4-8` to **`claude-fable-5`** (Claude Fable 5 — Anthropic's most capable widely released model).

Requested in Slack: make the `--claude` default Fable.

## Changes

- `services/sandbox/claude-app-wrapper.py` — `DEFAULT_CLAUDE_MODEL` → `claude-fable-5`. This is the actual model passed to `claude --model` when no `CLAUDE_MODEL` is set (the default path).
- `services/api/api/runtime_control.py` — `_DEFAULT_CLAUDE_MODEL` → `claude-fable-5` and the no-model header-label fallback now resolves to the default. Added a `fable` alias; **decoupled the `opus` alias so it still maps to `claude-opus-4-8`** (so `--opus` keeps working as an explicit opt-back).
- Updated the two tests that pinned the old default (`test_claude_app_wrapper.py`, `test_workflow_engine_title.py`).

## Scope notes

- Only the **no-flag default** changes. Explicit selectors (`--opus`, `--sonnet`, `--haiku`) are untouched.
- `entrypoint.sh`'s `claude-sonnet-4-20250514` belongs to the separate Pi-mono agent, not `--claude`; left as-is.

## Test

`pytest tests/test_claude_app_wrapper.py tests/test_workflow_engine_title.py` → 28 passed.