### PR TITLE
Make Claude Fable 5 the default Claude model

### DIFF
--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -253,7 +253,7 @@ def _agent_session_title(
 _DEFAULT_CLAUDE_MODEL = "claude-fable-5"
 
 _CLAUDE_MODEL_ALIASES: dict[str, str] = {
-    "fable": "claude-fable-5",
+    "fable": _DEFAULT_CLAUDE_MODEL,
     "opus": "claude-opus-4-8",
     "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5",


### PR DESCRIPTION
## What

Switches the no-flag `claude-code` default model from `claude-opus-4-8` to **`claude-fable-5`** — Anthropic's newly-released Mythos-class GA model.

## Changes
- `services/sandbox/claude-app-wrapper.py`: `DEFAULT_CLAUDE_MODEL → claude-fable-5` — the functional default the `claude` CLI runs with when `CLAUDE_MODEL` is unset.
- `services/api/api/runtime_control.py`: per-message header default → `fable`; added a `fable` alias and **kept `opus → claude-opus-4-8`** as an explicit opt-back. `--sonnet`/`--haiku` aliases untouched.
- Updated the 2 tests that pinned the old default.

## Scope
Only the no-flag default changes. `--opus`, `--sonnet`, `--haiku` are unaffected; `--opus` remains the way to pin Opus 4.8.

## Tests
`pytest tests/test_claude_app_wrapper.py tests/test_workflow_engine_title.py` → 28 passed.