### PR TITLE
fix(slackbotv2): avoid paging open task cards

### DIFF
--- a/patches/@chat-adapter__slack@4.30.0.patch
+++ b/patches/@chat-adapter__slack@4.30.0.patch
@@ -2,7 +2,7 @@ diff --git a/dist/index.js b/dist/index.js
 index 53a35e4..8fc9ebd 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -31,6 +31,123 @@ import {
+@@ -31,6 +31,126 @@ import {
    toModalElement,
    toPlainText
  } from "chat";
@@ -12,6 +12,9 @@ index 53a35e4..8fc9ebd 100644
 +var STREAM_STRUCTURED_CHUNK_LIMIT = 45;
 +var STREAM_FENCE_RESERVE = 64;
 +var FENCE_PATTERN = /^(`{3,}|~{3,})/;
++function isOpenTaskStatus(status) {
++  return status === "pending" || status === "in_progress";
++}
 +var Fence = class {
 +  constructor() {
 +    this.buffer = "";
@@ -126,7 +129,7 @@ index 53a35e4..8fc9ebd 100644
  
  // src/cards.ts
  import {
-@@ -3434,24 +3551,89 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3434,24 +3551,101 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -141,6 +144,7 @@ index 53a35e4..8fc9ebd 100644
 +    const createSegment = () => ({
 +      hasContent: false,
 +      length: 0,
++      openTasks: /* @__PURE__ */ new Set(),
 +      stopped: false,
 +      structuredChunks: 0,
 +      streamer: this._client.chatStream({
@@ -187,6 +191,17 @@ index 53a35e4..8fc9ebd 100644
 +        current.length += opening.length;
 +      }
 +    };
++    const shouldRotateSegment = () => current.structuredChunks >= STREAM_STRUCTURED_CHUNK_LIMIT && current.openTasks.size === 0;
++    const rememberTaskStatus = (chunk) => {
++      if (chunk.type !== "task_update") {
++        return;
++      }
++      if (isOpenTaskStatus(chunk.status)) {
++        current.openTasks.add(chunk.id);
++      } else {
++        current.openTasks.delete(chunk.id);
++      }
++    };
      const flushMarkdownDelta = async (delta) => {
        if (delta.length === 0) {
          return;
@@ -225,7 +240,7 @@ index 53a35e4..8fc9ebd 100644
      };
      let structuredChunksSupported = true;
      const sendStructuredChunk = async (chunk) => {
-@@ -3463,7 +3645,23 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3463,7 +3645,24 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
@@ -240,12 +255,13 @@ index 53a35e4..8fc9ebd 100644
 +          taskParts.set(chunk.id, chunks.length);
 +        }
 +        for (const normalized of chunks) {
-+          if (current.structuredChunks >= STREAM_STRUCTURED_CHUNK_LIMIT) {
++          if (shouldRotateSegment()) {
 +            await rotateSegment(fence.closing, fence.opening);
 +          }
 +          await current.streamer.append({ chunks: [normalized], token });
 +          current.hasContent = true;
 +          current.structuredChunks += 1;
++          rememberTaskStatus(normalized);
 +        }
        } catch (error) {
          structuredChunksSupported = false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@chat-adapter/slack@4.30.0':
-    hash: d0bf9c24275f57166a636ee40732ce679b7dcc8b37f3df003c9604e279372a6b
+    hash: a589c631f4abbabc9aea713d0bc4efa959a1926636132b02356b3b4bb777dd51
     path: patches/@chat-adapter__slack@4.30.0.patch
 
 importers:
@@ -134,7 +134,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.30.0
-        version: 4.30.0(patch_hash=d0bf9c24275f57166a636ee40732ce679b7dcc8b37f3df003c9604e279372a6b)(zod@4.4.3)
+        version: 4.30.0(patch_hash=a589c631f4abbabc9aea713d0bc4efa959a1926636132b02356b3b4bb777dd51)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
@@ -1559,7 +1559,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.30.0(patch_hash=d0bf9c24275f57166a636ee40732ce679b7dcc8b37f3df003c9604e279372a6b)(zod@4.4.3)':
+  '@chat-adapter/slack@4.30.0(patch_hash=a589c631f4abbabc9aea713d0bc4efa959a1926636132b02356b3b4bb777dd51)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.30.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -813,6 +813,123 @@ describe('slackbotv2', () => {
     expect(await threadText(parent.ts)).toContain('TASK_STREAM_CONTINUATION_OK')
   })
 
+  it('does not seal a Slack stream continuation while task cards are still open', async () => {
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before a task boundary page.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> run steps with one slow command`, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-open-task-stream-continuation',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> run steps with one slow command`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    for (let index = 1; index <= 43; index += 1) {
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: `cmd-before-${index}`,
+            type: 'commandExecution',
+            command: `printf before-${index}`,
+            status: 'completed',
+            aggregatedOutput: ''
+          }
+        })
+      )
+    }
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.started',
+        item: {
+          id: 'cmd-open',
+          type: 'commandExecution',
+          command: 'sleep 1 && true',
+          status: 'inProgress'
+        }
+      })
+    )
+    for (let index = 1; index <= 8; index += 1) {
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: `cmd-during-${index}`,
+            type: 'commandExecution',
+            command: `printf during-${index}`,
+            status: 'completed',
+            aggregatedOutput: ''
+          }
+        })
+      )
+    }
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-open',
+          type: 'commandExecution',
+          command: 'sleep 1 && true',
+          status: 'completed',
+          aggregatedOutput: ''
+        }
+      })
+    )
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('OPEN_TASK_PAGE_OK'))
+    codexApi.emitSessionEvent(key, 'session.execution_completed', {
+      execution_id: 'exe-open-task-page',
+      status: 'completed',
+      result_text: 'OPEN_TASK_PAGE_OK'
+    })
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts.length).toBeGreaterThan(1)
+
+    const transcriptWithOpenTask = transcripts.find(transcript =>
+      transcript.chunks.some(chunk => chunk.type === 'task_update' && chunk.id === 'cmd-open')
+    )
+    expect(transcriptWithOpenTask).toBeDefined()
+    expect(transcriptWithOpenTask!.chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'task_update',
+        id: 'cmd-open',
+        status: 'in_progress'
+      })
+    )
+    expect(transcriptWithOpenTask!.chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'task_update',
+        id: 'cmd-open',
+        status: 'complete'
+      })
+    )
+    expect(await threadText(parent.ts)).toContain('OPEN_TASK_PAGE_OK')
+  })
+
   it('does not create an empty Slack stream before the first visible renderer chunk', async () => {
     codexApi.autoRespond = false
 


### PR DESCRIPTION
## Summary
- track open `task_update` cards inside each Slack stream continuation segment
- defer structured-chunk pagination until the current segment has no pending/in-progress tasks
- add emulator coverage for a continuation boundary hit while a task is still open

## Why
Slack renders a sealed native plan stream with still-open task cards as `Something went wrong`. The API execution and sandbox commands can still complete successfully, but the earlier continuation page is immutable after `chat.stopStream`. This keeps rotation between terminal task states instead of splitting an in-progress task from its completion update.

## Validation
- `pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts`
- `pnpm --filter slackbotv2 test`
- `pnpm --filter slackbotv2 check:types`
- `just build-one slackbotv2`