### PR TITLE
Add Slack DM sending support

### DIFF
--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -16,7 +16,7 @@ stderr_console = Console(stderr=True)
 
 @app.command()
 def send(
-    channel: str = typer.Argument(..., help="Channel name (with or without #)"),
+    channel: str = typer.Argument(..., help="Channel name, channel ID, or Slack user ID"),
     message: str = typer.Argument(..., help="Message text to send"),
     thread: str = typer.Option(None, "--thread", "-t", help="Thread timestamp to reply to"),
     no_attribution: bool = typer.Option(
@@ -25,11 +25,12 @@ def send(
         help="Skip auto-adding requester attribution (from SLACK_REQUESTER_ID)",
     ),
 ):
-    """Send a message to a channel.
+    """Send a message to a channel or Slack user DM.
 
     Examples:
         slack send "#eng-ai" "Hello from the CLI!"
         slack send eng-ai "Reply in thread" --thread 1234567890.123456
+        slack send U12345678 "Direct follow-up"
     """
     from .client import send_message
 
@@ -38,6 +39,32 @@ def send(
         console.print("[green]✓ Message sent[/]")
         console.print(f"[dim]{result['permalink']}[/]")
     except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def dm(
+    user_id: str = typer.Argument(..., help="Slack user ID, e.g. U12345678"),
+    message: str = typer.Argument(..., help="Message text to send"),
+    no_attribution: bool = typer.Option(
+        False,
+        "--no-attribution",
+        help="Skip auto-adding requester attribution (from SLACK_REQUESTER_ID)",
+    ),
+):
+    """Send a direct message to a Slack user.
+
+    Examples:
+        slack dm U12345678 "Remember to update the CRM"
+    """
+    from .client import send_dm
+
+    try:
+        result = send_dm(user_id, message, no_attribution=no_attribution)
+        console.print("[green]✓ DM sent[/]")
+        console.print(f"[dim]{result['permalink']}[/]")
+    except (RuntimeError, ValueError) as e:
         console.print(f"[red]Error: {e}[/]")
         raise typer.Exit(1)
 

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -92,6 +92,7 @@ class SlackClient:
     _DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
     _NUMERIC_TS_RE = re.compile(r"^\d+(?:\.\d+)?$")
     _CHANNEL_ID_RE = re.compile(r"^[CGD][A-Z0-9]+$")
+    _USER_ID_RE = re.compile(r"^[UW][A-Z0-9]+$")
     _AUTH_ERROR_CODES: ClassVar[frozenset[str]] = frozenset(
         {
             "account_inactive",
@@ -169,6 +170,17 @@ class SlackClient:
     def _looks_like_channel_id(self, channel: str) -> bool:
         """Return whether a channel reference is already a Slack conversation ID."""
         return bool(self._CHANNEL_ID_RE.fullmatch(self._clean_channel_ref(channel).upper()))
+
+    def _clean_user_ref(self, user_id: str) -> str:
+        """Normalize plain and mention-form Slack user IDs."""
+        raw = str(user_id).strip()
+        if raw.startswith("<@") and raw.endswith(">"):
+            raw = raw[2:-1].split("|", 1)[0]
+        return raw.strip()
+
+    def _looks_like_user_id(self, user_id: str) -> bool:
+        """Return whether a value is a Slack user ID."""
+        return bool(self._USER_ID_RE.fullmatch(self._clean_user_ref(user_id).upper()))
 
     def _raise_slack_api_error(
         self,
@@ -380,6 +392,35 @@ class SlackClient:
             if ch["name"] == name:
                 return ch["id"]
         raise RuntimeError(f"Channel '{channel}' not found or bot not a member")
+
+    def _open_dm_channel(self, user_id: str) -> str:
+        """Open or reuse a one-on-one DM channel with a Slack user."""
+        normalized = self._clean_user_ref(user_id).upper()
+        if not self._looks_like_user_id(normalized):
+            raise ValueError("user_id must be a Slack user ID like U123 or <@U123>")
+        try:
+            response = self._retry_on_ratelimit(
+                self._client.conversations_open,
+                users=normalized,
+                method_key="conversations.open",
+            )
+        except SlackApiError as e:
+            self._raise_slack_api_error(
+                e,
+                slack_method="conversations.open",
+                access_path="bot_token",
+                requested_channel=normalized,
+            )
+        channel_id = response.get("channel", {}).get("id")
+        if not channel_id:
+            raise RuntimeError("Slack API error: conversations.open returned no channel id")
+        return str(channel_id)
+
+    def _resolve_message_destination(self, channel: str) -> str:
+        """Resolve a send_message destination from channel, channel ID, or user ID."""
+        if self._looks_like_user_id(channel):
+            return self._open_dm_channel(channel)
+        return self._resolve_channel(channel)
 
     def _resolve_mentions(self, text: str, user_cache: dict[str, str]) -> str:
         """Replace <@USER_ID> mentions with @username using cached lookups only."""
@@ -1380,10 +1421,10 @@ class SlackClient:
         unfurl_links: bool | None = None,
         unfurl_media: bool | None = None,
     ) -> dict:
-        """Send a message to a channel.
+        """Send a message to a channel or Slack user DM.
 
         Args:
-            channel: Channel name (with or without #) or channel ID
+            channel: Channel name (with or without #), channel ID, or Slack user ID
             text: Message text to send
             thread_ts: Optional thread timestamp to reply in thread
             no_attribution: If True, skip adding requester attribution
@@ -1394,7 +1435,7 @@ class SlackClient:
         Returns:
             Dict with channel, ts, permalink
         """
-        channel_id = self._resolve_channel(channel)
+        channel_id = self._resolve_message_destination(channel)
 
         message_text = text
         if not no_attribution:
@@ -1420,6 +1461,37 @@ class SlackClient:
             }
         except SlackApiError as e:
             raise RuntimeError(f"Slack API error: {e.response['error']}") from e
+
+    def send_dm(
+        self,
+        user_id: str,
+        text: str,
+        no_attribution: bool = False,
+        blocks: list | None = None,
+        unfurl_links: bool | None = None,
+        unfurl_media: bool | None = None,
+    ) -> dict:
+        """Send a direct message to a Slack user.
+
+        Args:
+            user_id: Slack user ID, e.g. U123 or <@U123>
+            text: Message text to send
+            no_attribution: If True, skip adding requester attribution
+            blocks: Optional Slack Block Kit blocks for rich formatting
+            unfurl_links: Override Slack's link unfurl behavior for this message
+            unfurl_media: Override Slack's media unfurl behavior for this message
+
+        Returns:
+            Dict with channel, ts, permalink
+        """
+        return self.send_message(
+            user_id,
+            text,
+            no_attribution=no_attribution,
+            blocks=blocks,
+            unfurl_links=unfurl_links,
+            unfurl_media=unfurl_media,
+        )
 
     def _current_slack_destination(self) -> tuple[str | None, str | None]:
         """Return the active Slack channel/thread from the tool context, if any.
@@ -2146,6 +2218,10 @@ def get_user_email(*args, **kwargs):
 
 def send_message(*args, **kwargs):
     return _client().send_message(*args, **kwargs)
+
+
+def send_dm(*args, **kwargs):
+    return _client().send_dm(*args, **kwargs)
 
 
 def upload_file(*args, **kwargs):

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -25,6 +25,8 @@ class _FakeWebClient:
         self.history_pages: list[dict] = []
         self.reply_calls: list[dict] = []
         self.reply_pages: list[dict] = []
+        self.open_calls: list[dict] = []
+        self.open_response: dict = {"channel": {"id": "D123"}}
         self.users_calls: list[dict] = []
         self.users_pages: list[dict] = []
         self.list_calls: list[dict] = []
@@ -56,6 +58,10 @@ class _FakeWebClient:
     def conversations_replies(self, **kwargs):
         self.reply_calls.append(kwargs)
         return self.reply_pages.pop(0)
+
+    def conversations_open(self, **kwargs):
+        self.open_calls.append(kwargs)
+        return self.open_response
 
     def users_list(self, **kwargs):
         self.users_calls.append(kwargs)
@@ -161,6 +167,30 @@ def test_send_message_omits_unfurl_flags_by_default() -> None:
     assert fake_web_client.last_kwargs is not None
     assert "unfurl_links" not in fake_web_client.last_kwargs
     assert "unfurl_media" not in fake_web_client.last_kwargs
+
+
+def test_send_message_opens_dm_for_user_id_destination() -> None:
+    client, fake_web_client = _make_client()
+
+    result = client.send_message("<@U123ABC>", "hello", no_attribution=True)
+
+    assert fake_web_client.open_calls == [{"users": "U123ABC"}]
+    assert fake_web_client.last_kwargs is not None
+    assert fake_web_client.last_kwargs["channel"] == "D123"
+    assert fake_web_client.last_kwargs["text"] == "hello"
+    assert result["channel"] == "D123"
+    assert result["permalink"] == "https://slack.com/archives/D123/p123456"
+
+
+def test_send_dm_opens_dm_and_posts_message() -> None:
+    client, fake_web_client = _make_client()
+
+    client.send_dm("U234ABC", "hello", no_attribution=True, unfurl_links=False)
+
+    assert fake_web_client.open_calls == [{"users": "U234ABC"}]
+    assert fake_web_client.last_kwargs is not None
+    assert fake_web_client.last_kwargs["channel"] == "D123"
+    assert fake_web_client.last_kwargs["unfurl_links"] is False
 
 
 def test_retry_on_ratelimit_honors_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add Slack DM resolution via conversations.open for user ID destinations
- expose a first-class send_dm Slack tool wrapper and CLI command
- cover DM sending in Slack client tests

## Tests
- PYTHONPATH=/home/agent/branches/paradigmxyz/centaur/tools/productivity:/home/agent/branches/paradigmxyz/centaur uv run --with pytest --with slack-sdk --with typer --with python-dotenv --with rich --with structlog pytest slack/tests/test_client.py

Prompted by: @Zygimantass