### PR TITLE
fix(slackbotv2): page Slack plans by visible tasks

### DIFF
--- a/patches/@chat-adapter__slack@4.30.0.patch
+++ b/patches/@chat-adapter__slack@4.30.0.patch
@@ -9,7 +9,7 @@ index 53a35e4..8fc9ebd 100644
 +var STREAM_BUFFER_SIZE = 256;
 +var STREAM_SEGMENT_LIMIT = 11500;
 +var STREAM_CHUNK_LIMIT = 256;
-+var STREAM_STRUCTURED_CHUNK_LIMIT = 45;
++var STREAM_TASK_LIMIT = 48;
 +var STREAM_FENCE_RESERVE = 64;
 +var FENCE_PATTERN = /^(`{3,}|~{3,})/;
 +function isOpenTaskStatus(status) {
@@ -129,7 +129,7 @@ index 53a35e4..8fc9ebd 100644
  
  // src/cards.ts
  import {
-@@ -3434,24 +3551,101 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3434,24 +3551,102 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -146,7 +146,7 @@ index 53a35e4..8fc9ebd 100644
 +      length: 0,
 +      openTasks: /* @__PURE__ */ new Set(),
 +      stopped: false,
-+      structuredChunks: 0,
++      visibleTasks: /* @__PURE__ */ new Set(),
 +      streamer: this._client.chatStream({
 +        channel,
 +        thread_ts: threadTs,
@@ -191,11 +191,12 @@ index 53a35e4..8fc9ebd 100644
 +        current.length += opening.length;
 +      }
 +    };
-+    const shouldRotateSegment = () => current.structuredChunks >= STREAM_STRUCTURED_CHUNK_LIMIT && current.openTasks.size === 0;
++    const shouldRotateSegment = () => current.visibleTasks.size >= STREAM_TASK_LIMIT && current.openTasks.size === 0;
 +    const rememberTaskStatus = (chunk) => {
 +      if (chunk.type !== "task_update") {
 +        return;
 +      }
++      current.visibleTasks.add(chunk.id);
 +      if (isOpenTaskStatus(chunk.status)) {
 +        current.openTasks.add(chunk.id);
 +      } else {
@@ -240,7 +241,7 @@ index 53a35e4..8fc9ebd 100644
      };
      let structuredChunksSupported = true;
      const sendStructuredChunk = async (chunk) => {
-@@ -3463,7 +3645,24 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3463,7 +3645,23 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
@@ -260,7 +261,6 @@ index 53a35e4..8fc9ebd 100644
 +          }
 +          await current.streamer.append({ chunks: [normalized], token });
 +          current.hasContent = true;
-+          current.structuredChunks += 1;
 +          rememberTaskStatus(normalized);
 +        }
        } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@chat-adapter/slack@4.30.0':
-    hash: a589c631f4abbabc9aea713d0bc4efa959a1926636132b02356b3b4bb777dd51
+    hash: cb7455cf7c0d31f8bfce4fe16fcaf203261f5c1b642c856cf2a9a294bd4050fa
     path: patches/@chat-adapter__slack@4.30.0.patch
 
 importers:
@@ -134,7 +134,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.30.0
-        version: 4.30.0(patch_hash=a589c631f4abbabc9aea713d0bc4efa959a1926636132b02356b3b4bb777dd51)(zod@4.4.3)
+        version: 4.30.0(patch_hash=cb7455cf7c0d31f8bfce4fe16fcaf203261f5c1b642c856cf2a9a294bd4050fa)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
@@ -1559,7 +1559,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.30.0(patch_hash=a589c631f4abbabc9aea713d0bc4efa959a1926636132b02356b3b4bb777dd51)(zod@4.4.3)':
+  '@chat-adapter/slack@4.30.0(patch_hash=cb7455cf7c0d31f8bfce4fe16fcaf203261f5c1b642c856cf2a9a294bd4050fa)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.30.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -787,6 +787,18 @@ describe('slackbotv2', () => {
       codexApi.emitOutputLine(
         key,
         JSON.stringify({
+          type: 'item.started',
+          item: {
+            id: `cmd-${index}`,
+            type: 'commandExecution',
+            command: `printf step-${index}`,
+            status: 'inProgress'
+          }
+        })
+      )
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
           type: 'item.completed',
           item: {
             id: `cmd-${index}`,
@@ -810,6 +822,13 @@ describe('slackbotv2', () => {
     expect(transcripts.length).toBeGreaterThan(1)
     expect(transcripts.flatMap(transcript => transcript.chunks).filter(chunk => chunk.type === 'task_update').length)
       .toBeGreaterThan(50)
+    expect(
+      new Set(
+        transcripts[0]!.chunks
+          .filter(chunk => chunk.type === 'task_update')
+          .map(chunk => stringField(chunk.id))
+      ).size
+    ).toBe(48)
     expect(await threadText(parent.ts)).toContain('TASK_STREAM_CONTINUATION_OK')
   })
 
@@ -843,7 +862,7 @@ describe('slackbotv2', () => {
     await waitFor(() => codexApi.eventRequests.length === 1)
     await waitFor(() => codexApi.streamCount === 1)
 
-    for (let index = 1; index <= 43; index += 1) {
+    for (let index = 1; index <= 47; index += 1) {
       codexApi.emitOutputLine(
         key,
         JSON.stringify({
@@ -870,7 +889,7 @@ describe('slackbotv2', () => {
         }
       })
     )
-    for (let index = 1; index <= 8; index += 1) {
+    for (let index = 1; index <= 3; index += 1) {
       codexApi.emitOutputLine(
         key,
         JSON.stringify({
@@ -893,6 +912,19 @@ describe('slackbotv2', () => {
           id: 'cmd-open',
           type: 'commandExecution',
           command: 'sleep 1 && true',
+          status: 'completed',
+          aggregatedOutput: ''
+        }
+      })
+    )
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-after-open',
+          type: 'commandExecution',
+          command: 'printf after-open',
           status: 'completed',
           aggregatedOutput: ''
         }


### PR DESCRIPTION
## Summary
- page Slack native plan streams by distinct visible task cards instead of raw task update chunks
- keep the visible task soft cap at 48 cards per stream page
- preserve the existing guard that avoids sealing a page while tasks are still open

## Why
The old cap counted every structured chunk. A command can emit `in_progress` and `complete` task updates, and thinking/details can emit additional updates, so the 45-chunk cap could produce only ~12 visible task cards in Slack. This makes the limit match what users see: visible task cards.

## Current limits after this PR
- visible plan/task cards per stream page: 48
- markdown segment budget per stream page: 11,500 chars
- task title/details chunk split: 256 chars in the Chat SDK adapter patch
- Slack task details are trimmed to 500 chars before reaching Chat SDK
- renderer task body cap before Slackbot trimming: 3,000 chars
- final plain fallback cap: 35,000 chars

## Validation
- `pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts`
- `pnpm --filter slackbotv2 test`
- `pnpm --filter slackbotv2 check:types`
- `just build-one slackbotv2`