### PR TITLE
fix(api): respawn unresumable suspended sandboxes and dedupe runtime-failure posts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,6 @@ jobs:
           bun test \
             src/centaur/handoff.test.ts \
             src/slack/normalize.test.ts \
+            src/slack/home.test.ts \
+            src/index.test.ts \
             src/centaur/final-delivery.test.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Centaur — Developer Guide
 
+## Fork tracking (Tavus)
+
+This repo is Tavus's fork of [paradigmxyz/centaur](https://github.com/paradigmxyz/centaur).
+**Every PR against this fork must add one line to [FORK.md](FORK.md)** — the PR's head
+commit hash, a one-line description, and the PR URL — so we always know exactly how
+this fork differs from upstream. No exceptions; reviewers should block PRs that skip it.
+
 ## Quick Start
 
 ### 1. Clone and configure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,9 +276,11 @@ For tool changes: tools hot-reload, so just verify via `curl -X POST http://loca
 ## Local-First Testing — Never Touch the Deploy Box
 
 **All testing and E2E validation MUST happen on the local Kubernetes stack** (`just up` on this machine).
-The deploy box is **production**. Changes reach it via `git push` → GitHub Actions auto-deploy. The only reasons to SSH into it are:
+The deploy box is **production**. Do not assume `git push` deployed anything unless
+you can see the relevant GitHub Actions run or the running deployment's image/commit
+changed. The only reasons to SSH into it are:
 - Checking logs (`kubectl logs`, VictoriaLogs queries) for debugging production issues
-- Emergency manual intervention — **only when the user explicitly asks**
+- Emergency manual intervention or deployment — **only when the user explicitly asks**
 
 For E2E testing, always:
 1. `just build-one <service>` locally
@@ -286,6 +288,88 @@ For E2E testing, always:
 3. Run curl commands against `localhost` through `kubectl exec -n centaur deploy/centaur-centaur-api -- curl ...`
 4. Verify results locally
 5. Only then commit, push, and let CI/CD handle production
+
+### Deploying to `samuel-a100`
+
+`samuel-a100` is a shared production host. It also runs a request-handler preview
+stack in Docker, so keep Centaur isolated in the existing k3s namespace and do not
+stop or repurpose non-Centaur containers. The Centaur checkout is:
+
+```bash
+ssh samuel-a100
+cd ~/projects/centaur
+```
+
+The host checkout may have `origin` pointed at upstream `paradigmxyz/centaur`; fetch
+Tavus explicitly before deploying Tavus fork commits:
+
+```bash
+git remote add tavus git@github.com:Tavus-Engineering/centaur.git 2>/dev/null || true
+git fetch tavus main
+git checkout -B tavus-main <tavus-commit-sha>
+```
+
+k3s and Helm need the k3s kubeconfig explicitly:
+
+```bash
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+```
+
+For a Slackbot-only deploy, build a unique immutable local image tag, import it into
+k3s containerd, then update the Helm release while preserving all existing values:
+
+```bash
+SHA=$(git rev-parse --short HEAD)
+docker build -t "centaur-slackbot-tavus:fork-${SHA}" -f services/slackbot/Dockerfile .
+docker save "centaur-slackbot-tavus:fork-${SHA}" | sudo k3s ctr images import -
+
+helm upgrade centaur contrib/chart -n centaur --reuse-values \
+  --set slackbot.image.repository=centaur-slackbot-tavus \
+  --set slackbot.image.tag="fork-${SHA}"
+
+kubectl -n centaur rollout status deploy/centaur-centaur-slackbot --timeout=180s
+kubectl -n centaur get deploy centaur-centaur-slackbot \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+Smoke-test the Slackbot from inside the running pod, so the existing signing secret
+is used without printing it. For App Home changes, send a signed `app_home_opened`
+event and then verify `slack_app_home_published` appears in Slackbot logs:
+
+```bash
+EVENT_ID="Ev-home-smoke-${SHA}-$(date +%s)"
+kubectl -n centaur exec deploy/centaur-centaur-slackbot -- env EVENT_ID="$EVENT_ID" bun -e '
+import { createHmac } from "node:crypto";
+const payload = JSON.stringify({
+  type: "event_callback",
+  event_id: process.env.EVENT_ID,
+  team_id: "T8G3FLPSM",
+  event: {
+    type: "app_home_opened",
+    user: "U0AQJ5GNT4P",
+    channel: "DHOME",
+    tab: "home",
+    event_ts: `${Date.now() / 1000}`
+  }
+});
+const ts = Math.floor(Date.now() / 1000).toString();
+const sig = "v0=" + createHmac("sha256", process.env.SLACK_SIGNING_SECRET)
+  .update(`v0:${ts}:${payload}`)
+  .digest("hex");
+const response = await fetch("http://127.0.0.1:3001/api/webhooks/slack", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "X-Slack-Request-Timestamp": ts,
+    "X-Slack-Signature": sig
+  },
+  body: payload
+});
+console.log(JSON.stringify({ event_id: process.env.EVENT_ID, status: response.status, body: await response.json() }));
+'
+
+kubectl -n centaur logs deploy/centaur-centaur-slackbot --since=5m | grep -A6 -B2 "$EVENT_ID"
+```
 
 ## Code Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Centaur (Tavus fork)
+
+Read [AGENTS.md](AGENTS.md) for the full developer guide.
+
+**Fork rule:** this is Tavus's fork of paradigmxyz/centaur. Every PR must add one
+line to [FORK.md](FORK.md) (head commit hash · one-line description · PR URL) so the
+divergence from upstream stays fully enumerated. See "Fork tracking" in AGENTS.md.

--- a/FORK.md
+++ b/FORK.md
@@ -14,3 +14,4 @@ line in the PR that syncs it back.
 | 06128dc9 | api: select harness from bare claude/codex words in Slack turns (selectors, not wake words) | [#4](https://github.com/Tavus-Engineering/centaur/pull/4) |
 | 24025565 | add FORK.md divergence tracking + AGENTS.md/CLAUDE.md policy | [#5](https://github.com/Tavus-Engineering/centaur/pull/5) |
 | 24f6cebb | slack: read non-member public channels/threads via SLACK_SEARCH_TOKEN user-token fallback | [#6](https://github.com/Tavus-Engineering/centaur/pull/6) |
+| 33213991 | sandbox: auto-raise codex reasoning effort to high for code/debug turns (heuristic on first message) | [#7](https://github.com/Tavus-Engineering/centaur/pull/7) |

--- a/FORK.md
+++ b/FORK.md
@@ -15,3 +15,4 @@ line in the PR that syncs it back.
 | 24025565 | add FORK.md divergence tracking + AGENTS.md/CLAUDE.md policy | [#5](https://github.com/Tavus-Engineering/centaur/pull/5) |
 | 24f6cebb | slack: read non-member public channels/threads via SLACK_SEARCH_TOKEN user-token fallback | [#6](https://github.com/Tavus-Engineering/centaur/pull/6) |
 | 33213991 | sandbox: auto-raise codex reasoning effort to high for code/debug turns (heuristic on first message) | [#7](https://github.com/Tavus-Engineering/centaur/pull/7) |
+| ff489b5b | pylon tool: read issue threads (get_issue_context/messages/threads, issue-ref normalization) | [#8](https://github.com/Tavus-Engineering/centaur/pull/8) |

--- a/FORK.md
+++ b/FORK.md
@@ -12,4 +12,4 @@ line in the PR that syncs it back.
 |---|---|---|
 | 555ec005 | slackbot: reply to DMs and joined threads without a mention | [#2](https://github.com/Tavus-Engineering/centaur/pull/2) |
 | 06128dc9 | api: select harness from bare claude/codex words in Slack turns (selectors, not wake words) | [#4](https://github.com/Tavus-Engineering/centaur/pull/4) |
-| – | add FORK.md divergence tracking + AGENTS.md/CLAUDE.md policy | [#5](https://github.com/Tavus-Engineering/centaur/pull/5) |
+| 24025565 | add FORK.md divergence tracking + AGENTS.md/CLAUDE.md policy | [#5](https://github.com/Tavus-Engineering/centaur/pull/5) |

--- a/FORK.md
+++ b/FORK.md
@@ -17,3 +17,4 @@ line in the PR that syncs it back.
 | 33213991 | sandbox: auto-raise codex reasoning effort to high for code/debug turns (heuristic on first message) | [#7](https://github.com/Tavus-Engineering/centaur/pull/7) |
 | ff489b5b | pylon tool: read issue threads (get_issue_context/messages/threads, issue-ref normalization) | [#8](https://github.com/Tavus-Engineering/centaur/pull/8) |
 | dde06b4c | cost controls: reuse unthreaded DM runtimes, shorten idle TTL, and use gpt-5.5 medium without fast mode | [#9](https://github.com/Tavus-Engineering/centaur/pull/9) |
+| 1385fbfa | slackbot: ignore inaccessible DM events before agent handoff | [#10](https://github.com/Tavus-Engineering/centaur/pull/10) |

--- a/FORK.md
+++ b/FORK.md
@@ -18,3 +18,4 @@ line in the PR that syncs it back.
 | ff489b5b | pylon tool: read issue threads (get_issue_context/messages/threads, issue-ref normalization) | [#8](https://github.com/Tavus-Engineering/centaur/pull/8) |
 | dde06b4c | cost controls: reuse unthreaded DM runtimes, shorten idle TTL, and use gpt-5.5 medium without fast mode | [#9](https://github.com/Tavus-Engineering/centaur/pull/9) |
 | 1385fbfa | slackbot: ignore inaccessible DM events before agent handoff | [#10](https://github.com/Tavus-Engineering/centaur/pull/10) |
+| 5a598aae | api: respawn unresumable suspended sandboxes (pod backend) + post runtime-start failures once per thread | [#11](https://github.com/Tavus-Engineering/centaur/pull/11) |

--- a/FORK.md
+++ b/FORK.md
@@ -16,3 +16,4 @@ line in the PR that syncs it back.
 | 24f6cebb | slack: read non-member public channels/threads via SLACK_SEARCH_TOKEN user-token fallback | [#6](https://github.com/Tavus-Engineering/centaur/pull/6) |
 | 33213991 | sandbox: auto-raise codex reasoning effort to high for code/debug turns (heuristic on first message) | [#7](https://github.com/Tavus-Engineering/centaur/pull/7) |
 | ff489b5b | pylon tool: read issue threads (get_issue_context/messages/threads, issue-ref normalization) | [#8](https://github.com/Tavus-Engineering/centaur/pull/8) |
+| dde06b4c | cost controls: reuse unthreaded DM runtimes, shorten idle TTL, and use gpt-5.5 medium without fast mode | [#9](https://github.com/Tavus-Engineering/centaur/pull/9) |

--- a/FORK.md
+++ b/FORK.md
@@ -13,3 +13,4 @@ line in the PR that syncs it back.
 | 555ec005 | slackbot: reply to DMs and joined threads without a mention | [#2](https://github.com/Tavus-Engineering/centaur/pull/2) |
 | 06128dc9 | api: select harness from bare claude/codex words in Slack turns (selectors, not wake words) | [#4](https://github.com/Tavus-Engineering/centaur/pull/4) |
 | 24025565 | add FORK.md divergence tracking + AGENTS.md/CLAUDE.md policy | [#5](https://github.com/Tavus-Engineering/centaur/pull/5) |
+| 24f6cebb | slack: read non-member public channels/threads via SLACK_SEARCH_TOKEN user-token fallback | [#6](https://github.com/Tavus-Engineering/centaur/pull/6) |

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,15 @@
+# Fork changes
+
+This is Tavus's fork of [paradigmxyz/centaur](https://github.com/paradigmxyz/centaur).
+This file is the single source of truth for how this fork differs from upstream.
+
+**Rule: every PR merged into this fork adds exactly one line to the table below**
+— the PR's head commit hash, a one-line description of the change, and the PR URL.
+Add the line as part of the PR itself. If a change is later upstreamed, remove its
+line in the PR that syncs it back.
+
+| Commit | Change | PR |
+|---|---|---|
+| 555ec005 | slackbot: reply to DMs and joined threads without a mention | [#2](https://github.com/Tavus-Engineering/centaur/pull/2) |
+| 06128dc9 | api: select harness from bare claude/codex words in Slack turns (selectors, not wake words) | [#4](https://github.com/Tavus-Engineering/centaur/pull/4) |
+| – | add FORK.md divergence tracking + AGENTS.md/CLAUDE.md policy | [#5](https://github.com/Tavus-Engineering/centaur/pull/5) |

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -189,6 +189,10 @@ spec:
               value: info
             - name: CENTAUR_DEFAULT_HARNESS
               value: {{ .Values.api.defaultHarness | quote }}
+{{- if not (hasKey $apiExtraEnv "IDLE_TTL_S") }}
+            - name: IDLE_TTL_S
+              value: {{ .Values.api.idleTtlSeconds | quote }}
+{{- end }}
             - name: TOOL_DIRS
 {{- if .Values.overlay.image.repository }}
               value: {{ printf "/app/tools:%s/tools" .Values.overlay.mountPath | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -112,6 +112,7 @@ api:
     pullPolicy: Always
   executionWorkerEnabled: false
   defaultHarness: codex
+  idleTtlSeconds: 900
   # The API's worker claims workflow_runs and spawns a per-run sandbox to
   # execute each handler. Disable only if you're running your own claimer.
   workflowWorkerEnabled: true

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -160,11 +160,13 @@ https://<your-host>/api/webhooks/slack
 In your Slack app's **Event Subscriptions** settings, set the Request URL to the
 Slackbot webhook URL above.
 
-Subscribe to the `app_mention` bot event. For a minimal channel-mention test,
-the app also needs Bot Token Scopes that let it read mentions and write replies,
-for example `app_mentions:read` and `chat:write`. If you enable DM events such
-as `message.im`, Slack will also require direct-message scopes such as
-`im:history`.
+Subscribe to the `app_mention` bot event. If you enable the App Home tab, also
+turn on **Features > App Home > Home Tab** and subscribe to the `app_home_opened`
+bot event so the Slackbot can publish the Watch Agent Home view. For a minimal
+channel-mention test, the app also needs Bot Token Scopes that let it read
+mentions and write replies, for example `app_mentions:read` and `chat:write`. If
+you enable DM events such as `message.im`, Slack will also require
+direct-message scopes such as `im:history`.
 
 Message events also unlock mention-free replies: with `message.im` enabled the
 bot answers DMs directly, and with `message.channels` (plus `channels:history`)

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -166,6 +166,12 @@ for example `app_mentions:read` and `chat:write`. If you enable DM events such
 as `message.im`, Slack will also require direct-message scopes such as
 `im:history`.
 
+Message events also unlock mention-free replies: with `message.im` enabled the
+bot answers DMs directly, and with `message.channels` (plus `channels:history`)
+it follows up in any thread where it has already replied, without needing
+another mention. If you subscribe to `app_mention` only, the bot responds to
+explicit mentions and nothing else.
+
 Save changes and reinstall the app.
 
 ## 7. Try Slack mentions

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -81,7 +81,7 @@ Execution tuning:
 | `EXECUTION_RECONCILE_STARTUP_LIMIT` | `api.extraEnv`. | Max interrupted executions recovered at startup. |
 | `EXECUTION_STREAM_EOF_RETRY_DELAY_S` | `api.extraEnv`. | Delay before retrying interrupted sandbox streams. |
 | `THREAD_FAILURE_LOOP_WINDOW_S`, `THREAD_FAILURE_LOOP_THRESHOLD` | `api.extraEnv`. | Repeated thread failure detection. |
-| `IDLE_TTL_S`, `SUSPENDED_RETENTION_S`, `MAX_ACTIVE_SANDBOX_SESSIONS` | `api.extraEnv`. | Sandbox cleanup limits. |
+| `IDLE_TTL_S`, `SUSPENDED_RETENTION_S`, `MAX_ACTIVE_SANDBOX_SESSIONS` | `api.idleTtlSeconds` or `api.extraEnv`. | Sandbox cleanup limits. |
 | `STREAM_EOF_REATTACH_MAX`, `STREAM_EOF_REATTACH_BACKOFF_S` | `api.extraEnv`. | Stream reattach retry behavior. |
 | `SANDBOX_CROSS_THREAD_READS` | `api.extraEnv`. | Lets a sandbox token read any thread it has the key for (messages, status, attachments). Defaults to enabled. Set to `0` to confine reads to the token's own thread. Writes are always confined regardless. |
 

--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -48,6 +48,20 @@ These are broadly useful across most deployments and are good candidates to conf
 | `attio` | CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
 | `pylon` | Support issues, accounts, contacts, teams, tags, and users | `PYLON_API_KEY` |
 
+### Pylon issue threads
+
+Centaur exposes Pylon through REST tool methods. In a sandbox, use `call discover
+pylon` and then call method names with JSON arguments:
+
+```bash
+call pylon get_issue_context '{"issue_id":"16412"}'
+```
+
+Use `get_issue_context` when a user references a support thread such as `Pylon
+Issue #16412`; it returns the issue details, messages, and internal threads.
+Avoid CLI-style calls like `call pylon issue 16412` — `issue` is a local Typer
+command, not a REST tool method.
+
 ## Communications
 
 | Tool | Use | API key / credential |

--- a/docs/public/md/quickstart.md
+++ b/docs/public/md/quickstart.md
@@ -160,11 +160,13 @@ https://<your-host>/api/webhooks/slack
 In your Slack app's **Event Subscriptions** settings, set the Request URL to the
 Slackbot webhook URL above.
 
-Subscribe to the `app_mention` bot event. For a minimal channel-mention test,
-the app also needs Bot Token Scopes that let it read mentions and write replies,
-for example `app_mentions:read` and `chat:write`. If you enable DM events such
-as `message.im`, Slack will also require direct-message scopes such as
-`im:history`.
+Subscribe to the `app_mention` bot event. If you enable the App Home tab, also
+turn on **Features > App Home > Home Tab** and subscribe to the `app_home_opened`
+bot event so the Slackbot can publish the Watch Agent Home view. For a minimal
+channel-mention test, the app also needs Bot Token Scopes that let it read
+mentions and write replies, for example `app_mentions:read` and `chat:write`. If
+you enable DM events such as `message.im`, Slack will also require
+direct-message scopes such as `im:history`.
 
 Message events also unlock mention-free replies: with `message.im` enabled the
 bot answers DMs directly, and with `message.channels` (plus `channels:history`)

--- a/docs/public/md/quickstart.md
+++ b/docs/public/md/quickstart.md
@@ -166,6 +166,12 @@ for example `app_mentions:read` and `chat:write`. If you enable DM events such
 as `message.im`, Slack will also require direct-message scopes such as
 `im:history`.
 
+Message events also unlock mention-free replies: with `message.im` enabled the
+bot answers DMs directly, and with `message.channels` (plus `channels:history`)
+it follows up in any thread where it has already replied, without needing
+another mention. If you subscribe to `app_mention` only, the bot responds to
+explicit mentions and nothing else.
+
 Save changes and reinstall the app.
 
 ## 7. Try Slack mentions

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -80,7 +80,7 @@ Execution tuning:
 | `EXECUTION_RECONCILE_STARTUP_LIMIT` | `api.extraEnv`. | Max interrupted executions recovered at startup. |
 | `EXECUTION_STREAM_EOF_RETRY_DELAY_S` | `api.extraEnv`. | Delay before retrying interrupted sandbox streams. |
 | `THREAD_FAILURE_LOOP_WINDOW_S`, `THREAD_FAILURE_LOOP_THRESHOLD` | `api.extraEnv`. | Repeated thread failure detection. |
-| `IDLE_TTL_S`, `SUSPENDED_RETENTION_S`, `MAX_ACTIVE_SANDBOX_SESSIONS` | `api.extraEnv`. | Sandbox cleanup limits. |
+| `IDLE_TTL_S`, `SUSPENDED_RETENTION_S`, `MAX_ACTIVE_SANDBOX_SESSIONS` | `api.idleTtlSeconds` or `api.extraEnv`. | Sandbox cleanup limits. |
 | `STREAM_EOF_REATTACH_MAX`, `STREAM_EOF_REATTACH_BACKOFF_S` | `api.extraEnv`. | Stream reattach retry behavior. |
 | `SANDBOX_CROSS_THREAD_READS` | `api.extraEnv`. | Lets a sandbox token read any thread it has the key for (messages, status, attachments). Defaults to enabled. Set to `0` to confine reads to the token's own thread. Writes are always confined regardless. |
 

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -48,6 +48,20 @@ These are broadly useful across most deployments and are good candidates to conf
 | `attio` | CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
 | `pylon` | Support issues, accounts, contacts, teams, tags, and users | `PYLON_API_KEY` |
 
+### Pylon issue threads
+
+Centaur exposes Pylon through REST tool methods. In a sandbox, use `call discover
+pylon` and then call method names with JSON arguments:
+
+```bash
+call pylon get_issue_context '{"issue_id":"16412"}'
+```
+
+Use `get_issue_context` when a user references a support thread such as `Pylon
+Issue #16412`; it returns the issue details, messages, and internal threads.
+Avoid CLI-style calls like `call pylon issue 16412` — `issue` is a local Typer
+command, not a REST tool method.
+
 ## Communications
 
 | Tool | Use | API key / credential |

--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -1,15 +1,15 @@
 model = "gpt-5.5"
-model_reasoning_effort = "low"
+model_reasoning_effort = "medium"
 personality = "pragmatic"
 model_verbosity = "low"
-service_tier = "fast"
+service_tier = "default"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 suppress_unstable_features_warning = true
 
 [features]
 goals = true
-fast_mode = true
+fast_mode = false
 memories = true
 hooks = true
 enable_fanout = false
@@ -17,11 +17,11 @@ runtime_metrics = true
 
 [features.multi_agent_v2]
 enabled = true
-max_concurrent_threads_per_session = 6
+max_concurrent_threads_per_session = 2
 
 [agents]
-max_depth = 2
-job_max_runtime_seconds = 1800
+max_depth = 1
+job_max_runtime_seconds = 900
 
 [tools]
 view_image = true

--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -101,7 +101,7 @@ _VALID_STDOUT_EVENT_TYPES = frozenset(
 _ENGINE_HARNESSES = {"amp", "claude-code", "codex", "pi-mono"}
 _REUSABLE_DB_STATES = {"running", "idle", "delivering", "error", "suspended"}
 
-IDLE_TTL_S = int(os.getenv("IDLE_TTL_S", "86400"))  # 24 hours
+IDLE_TTL_S = int(os.getenv("IDLE_TTL_S", "900"))  # 15 minutes
 SUSPENDED_RETENTION_S = int(os.getenv("SUSPENDED_RETENTION_S", str(7 * 24 * 60 * 60)))
 MAX_ACTIVE_SANDBOX_SESSIONS = int(os.getenv("MAX_ACTIVE_SANDBOX_SESSIONS", "45"))
 STREAM_EOF_REATTACH_MAX = int(os.getenv("STREAM_EOF_REATTACH_MAX", "6"))

--- a/services/api/api/agent.py
+++ b/services/api/api/agent.py
@@ -861,16 +861,18 @@ async def get_or_spawn(
                     _get_runtime(session.sandbox_id)
                     return session
                 except Exception as exc:
+                    # Backends without real suspend support (e.g. the pod
+                    # controller, where pause deletes the pod and resume is a
+                    # no-op) can never bring a suspended sandbox back. Fall
+                    # through to the gone-container path and respawn with the
+                    # preserved agent_thread_id instead of failing the turn.
                     log.warning(
-                        "suspended_session_resume_failed",
+                        "suspended_session_resume_failed_respawning",
                         thread_key=thread_key,
                         sandbox=session.sandbox_id[:12],
                         error=str(exc),
                         exc_info=True,
                     )
-                    raise RuntimeError(
-                        f"failed to resume suspended sandbox: {session.sandbox_id}"
-                    ) from exc
             # Container is gone — save agent_thread_id and cursor for resume, clean up row
             old_agent_thread_id = session.agent_thread_id
             old_last_delivered_id = session.last_delivered_id

--- a/services/api/api/runtime_control.py
+++ b/services/api/api/runtime_control.py
@@ -414,16 +414,27 @@ def _deployment_environment() -> str:
 def _slack_thread_metadata(thread_key: str) -> dict[str, str]:
     # Slack thread keys are slack:<team>:<channel>:<thread_ts>; the older
     # slack:<channel>:<thread_ts> form is still accepted for compatibility.
+    # Unthreaded DMs use slack:<team>:<D-channel>:<D-channel> so they can reuse
+    # one runtime without pretending the channel id is a Slack timestamp.
     parts = thread_key.split(":")
     if parts[0] != "slack":
         return {}
     if len(parts) == 4:
+        if parts[2].startswith("D") and parts[3] == parts[2]:
+            return {
+                "slack_team_id": parts[1],
+                "slack_channel_id": parts[2],
+            }
         return {
             "slack_team_id": parts[1],
             "slack_channel_id": parts[2],
             "slack_thread_ts": parts[3],
         }
     if len(parts) == 3:
+        if parts[1].startswith("D") and parts[2] == parts[1]:
+            return {
+                "slack_channel_id": parts[1],
+            }
         return {
             "slack_channel_id": parts[1],
             "slack_thread_ts": parts[2],
@@ -477,6 +488,11 @@ def _execution_laminar_metadata(
     )
     if channel and not metadata.get("slack_channel_id"):
         metadata["slack_channel_id"] = channel
+    thread_ts = (
+        delivery.get("thread_ts") if isinstance(delivery.get("thread_ts"), str) else None
+    )
+    if thread_ts:
+        metadata["slack_thread_ts"] = thread_ts
     return metadata
 
 

--- a/services/api/api/tool_manager.py
+++ b/services/api/api/tool_manager.py
@@ -1169,17 +1169,18 @@ async def _capture_live_slack_send(
         return None
 
     thread_key = str(sandbox_claims.get("thread_key") or "")
-    parts = thread_key.split(":")
-    if len(parts) < 4 or parts[0] != "slack":
+    destination = _slack_destination_from_thread_key(thread_key)
+    if destination is None:
         return None
-    active_channel = parts[2]
-    active_thread_ts = parts[3]
+    active_channel, active_thread_ts, is_stable_dm = destination
     requested_channel = str(args.get("channel") or args.get("channel_id") or "").lstrip("#")
     requested_thread_ts = str(args.get("thread_ts") or "")
     channel_is_id = bool(re.match(r"^[CDG][A-Z0-9]+$", requested_channel))
     if channel_is_id and requested_channel != active_channel:
         return None
-    if requested_thread_ts and requested_thread_ts != active_thread_ts:
+    if requested_thread_ts and active_thread_ts and requested_thread_ts != active_thread_ts:
+        return None
+    if requested_thread_ts and active_thread_ts is None and not is_stable_dm:
         return None
 
     text = str(args.get("text") or args.get("message") or "").strip()
@@ -1217,8 +1218,20 @@ async def _capture_live_slack_send(
         "captured": True,
         "message": "Captured into the active Slackbot live reply; no separate Slack message was posted.",
         "channel": active_channel,
-        "thread_ts": active_thread_ts,
+        "thread_ts": requested_thread_ts or active_thread_ts or "",
     }
+
+
+def _slack_destination_from_thread_key(thread_key: str) -> tuple[str, str | None, bool] | None:
+    parts = thread_key.split(":")
+    if len(parts) < 4 or parts[0] != "slack":
+        return None
+    channel = parts[2]
+    thread_ts = ":".join(parts[3:])
+    if not channel or not thread_ts:
+        return None
+    is_stable_dm = channel.startswith("D") and thread_ts == channel
+    return channel, None if is_stable_dm else thread_ts, is_stable_dm
 
 
 async def _extract_tool_attachment(

--- a/services/api/api/vm_metrics.py
+++ b/services/api/api/vm_metrics.py
@@ -790,7 +790,7 @@ async def refresh_runtime_metrics(pool: Pool) -> None:
         "SELECT COUNT(*) FROM agent_runtime_assignments "
         "WHERE state = 'active' "
         "  AND updated_at < NOW() - make_interval(secs => $1::double precision)",
-        float(os.getenv("IDLE_TTL_S", "86400")),
+        float(os.getenv("IDLE_TTL_S", "900")),
     )
     RUNTIME_ASSIGNMENTS_STALE_ACTIVE.set(int(stale_active or 0))
 

--- a/services/api/api/workflow_engine.py
+++ b/services/api/api/workflow_engine.py
@@ -66,6 +66,29 @@ log = structlog.get_logger()
 
 T = TypeVar("T")
 
+# Threads that already received a runtime-start failure message, keyed by
+# thread_key with the failure text and post time. A persistent spawn failure
+# would otherwise post the same error to the thread on every incoming message.
+_RUNTIME_FAILURE_NOTICE_TTL_S = 24 * 60 * 60
+_runtime_failure_notices: dict[str, tuple[str, float]] = {}
+
+
+def _should_post_runtime_failure(thread_key: str, error_text: str) -> bool:
+    """True if this thread hasn't been told about this spawn failure yet.
+
+    Deduped per (thread, error text) so a thread is notified once per distinct
+    failure rather than on every message while the failure persists.
+    """
+    now = time.monotonic()
+    for key, (_, posted_at) in list(_runtime_failure_notices.items()):
+        if now - posted_at > _RUNTIME_FAILURE_NOTICE_TTL_S:
+            _runtime_failure_notices.pop(key, None)
+    prior = _runtime_failure_notices.get(thread_key)
+    if prior is not None and prior[0] == error_text:
+        return False
+    _runtime_failure_notices[thread_key] = (error_text, now)
+    return True
+
 
 # ── Typed helpers ─────────────────────────────────────────────────────────
 
@@ -1229,26 +1252,35 @@ async def do_agent_turn(
                 agents_md_override=agents_md_override,
             )
         except Exception as exc:
-            try:
-                failure_session_id = await slackbot_client.open_agent_session(
-                    delivery=effective_delivery,
-                    metadata=effective_metadata,
-                    thread_key=effective_thread_key,
-                    title="Centaur",
-                    header=None,
-                )
-                if failure_session_id:
-                    await slackbot_client.session_text(
-                        failure_session_id,
-                        f"Failed to start the runtime: {exc}",
+            failure_text = f"Failed to start the runtime: {exc}"
+            if _should_post_runtime_failure(effective_thread_key, failure_text):
+                try:
+                    failure_session_id = await slackbot_client.open_agent_session(
+                        delivery=effective_delivery,
+                        metadata=effective_metadata,
+                        thread_key=effective_thread_key,
+                        title="Centaur",
+                        header=None,
                     )
-                    await slackbot_client.session_done(failure_session_id)
-            except Exception:
-                log.warning(
-                    "workflow_spawn_failure_session_failed",
+                    if failure_session_id:
+                        await slackbot_client.session_text(
+                            failure_session_id,
+                            failure_text,
+                        )
+                        await slackbot_client.session_done(failure_session_id)
+                except Exception:
+                    log.warning(
+                        "workflow_spawn_failure_session_failed",
+                        workflow_run_id=ctx.run_id,
+                        thread_key=effective_thread_key,
+                        exc_info=True,
+                    )
+            else:
+                log.info(
+                    "workflow_spawn_failure_notice_suppressed",
                     workflow_run_id=ctx.run_id,
                     thread_key=effective_thread_key,
-                    exc_info=True,
+                    error=str(exc),
                 )
             raise
         ag = int(spawn["assignment_generation"])

--- a/services/api/api/workflows/slack_thread_turn.py
+++ b/services/api/api/workflows/slack_thread_turn.py
@@ -26,7 +26,10 @@ _PROMPT_FLAG_RE = re.compile(
 # Bare engine names select a harness without flag syntax ("claude, review
 # this PR"). Only the unambiguous engine words participate \u2014 "amp" and "pi"
 # collide with ordinary English too often. Unlike flags, bare words are left
-# in the message text.
+# in the message text. They are selectors, not triggers: this parser only
+# runs on turns the slackbot already addressed to the bot (a mention, a DM,
+# or a follow-up in a thread the bot participates in), so a bystander channel
+# message containing "claude" never wakes the bot or reaches this code.
 _BARE_HARNESS_WORD_RE = re.compile(r"\b(claude|codex)\b", re.IGNORECASE)
 _BARE_PERSONA_PROMPT = (
     "Briefly introduce yourself using your active persona instructions and ask what "

--- a/services/api/api/workflows/slack_thread_turn.py
+++ b/services/api/api/workflows/slack_thread_turn.py
@@ -23,6 +23,11 @@ _PROMPT_FLAG_RE = re.compile(
     r"(^|\s)(`?)(--|[\u2013\u2014])([a-z][a-z0-9-]*)(?=\s|`|$)",
     re.IGNORECASE,
 )
+# Bare engine names select a harness without flag syntax ("claude, review
+# this PR"). Only the unambiguous engine words participate \u2014 "amp" and "pi"
+# collide with ordinary English too often. Unlike flags, bare words are left
+# in the message text.
+_BARE_HARNESS_WORD_RE = re.compile(r"\b(claude|codex)\b", re.IGNORECASE)
 _BARE_PERSONA_PROMPT = (
     "Briefly introduce yourself using your active persona instructions and ask what "
     "we should work on."
@@ -181,6 +186,11 @@ def _extract_prompt_selection_from_text(
             persona = classified_persona
 
     cleaned = _strip_ranges(text, ranges) if ranges else text.strip()
+    if harness is None:
+        bare = _BARE_HARNESS_WORD_RE.search(cleaned)
+        if bare:
+            word = bare.group(1).lower()
+            harness = _PROMPT_FLAG_ALIASES.get(word, word)
     return harness, persona, cleaned
 
 

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -459,7 +459,7 @@ def test_reasoning_effort_bumps_on_code_work(monkeypatch) -> None:
         "",
     ]
     for text in code_work:
-        assert wrapper._reasoning_effort_for_text(text) == "high", text
+        assert wrapper._reasoning_effort_for_text(text) == "medium", text
     for text in everyday:
         assert wrapper._reasoning_effort_for_text(text) is None, text
 

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -435,3 +435,45 @@ def test_main_lazy_starts_app_server_after_input(monkeypatch) -> None:
     )
     assert {"type": "thread.started", "thread_id": "thread-123"} in emitted
     assert {"type": "turn.completed"} in emitted
+
+
+def test_reasoning_effort_bumps_on_code_work(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.delenv("CENTAUR_CODEX_DYNAMIC_EFFORT", raising=False)
+    monkeypatch.delenv("CENTAUR_CODEX_EFFORT", raising=False)
+    monkeypatch.delenv("CENTAUR_CODEX_EFFORT_HIGH", raising=False)
+
+    code_work = [
+        "investigate conversation cf47d2dadd0a1406, two recording webhooks",
+        "why is request-handler publishing duplicate events?",
+        "fix the bug in daily_service.py",
+        "what voice id is set on persona pb700592f1b6",
+        "look at the signoz logs for this error",
+        "open a PR for that",
+    ]
+    everyday = [
+        "hey, how are you?",
+        "summarize the #general channel for me",
+        "what is our refund policy in coda",
+        "thanks!",
+        "",
+    ]
+    for text in code_work:
+        assert wrapper._reasoning_effort_for_text(text) == "high", text
+    for text in everyday:
+        assert wrapper._reasoning_effort_for_text(text) is None, text
+
+
+def test_reasoning_effort_respects_env_controls(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    # hard override forces a value regardless of content
+    monkeypatch.setenv("CENTAUR_CODEX_EFFORT", "medium")
+    assert wrapper._reasoning_effort_for_text("hey there") == "medium"
+    monkeypatch.delenv("CENTAUR_CODEX_EFFORT", raising=False)
+    # disabled => never bump
+    monkeypatch.setenv("CENTAUR_CODEX_DYNAMIC_EFFORT", "0")
+    assert wrapper._reasoning_effort_for_text("fix the bug in app.py") is None
+    monkeypatch.setenv("CENTAUR_CODEX_DYNAMIC_EFFORT", "1")
+    # custom high value
+    monkeypatch.setenv("CENTAUR_CODEX_EFFORT_HIGH", "xhigh")
+    assert wrapper._reasoning_effort_for_text("fix the bug in app.py") == "xhigh"

--- a/services/api/tests/test_sandbox_entrypoint.py
+++ b/services/api/tests/test_sandbox_entrypoint.py
@@ -17,7 +17,7 @@ def _write_codex_harness_config(home: Path) -> Path:
         "\n".join(
             [
                 'model = "gpt-5.5"',
-                'model_reasoning_effort = "low"',
+                'model_reasoning_effort = "medium"',
                 'plan_mode_reasoning_effort = "high"',
                 'approval_policy = "on-request"',
                 'approvals_reviewer = "user"',
@@ -26,7 +26,7 @@ def _write_codex_harness_config(home: Path) -> Path:
                 'sandbox_mode = "workspace-write"',
                 "check_for_update_on_startup = true",
                 "suppress_unstable_features_warning = true",
-                'service_tier = "fast"',
+                'service_tier = "default"',
                 "",
                 "[tools]",
                 "view_image = true",
@@ -43,11 +43,11 @@ def _write_codex_harness_config(home: Path) -> Path:
                 "",
                 "[features.multi_agent_v2]",
                 "enabled = true",
-                "max_concurrent_threads_per_session = 6",
+                "max_concurrent_threads_per_session = 2",
                 "",
                 "[agents]",
-                "max_depth = 2",
-                "job_max_runtime_seconds = 1800",
+                "max_depth = 1",
+                "job_max_runtime_seconds = 900",
                 "",
             ]
         )
@@ -103,12 +103,12 @@ def test_sandbox_entrypoint_bootstraps_mock_google_adc(tmp_path: Path) -> None:
 
     codex_config = (home / ".codex" / "config.toml").read_text()
     assert 'model = "gpt-5.5"' in codex_config
-    assert 'model_reasoning_effort = "low"' in codex_config
+    assert 'model_reasoning_effort = "medium"' in codex_config
     assert 'plan_mode_reasoning_effort = "high"' in codex_config
     assert 'approval_policy = "on-request"' in codex_config
     assert 'sandbox_mode = "workspace-write"' in codex_config
-    assert 'service_tier = "fast"' in codex_config
-    assert "max_concurrent_threads_per_session = 6" in codex_config
+    assert 'service_tier = "default"' in codex_config
+    assert "max_concurrent_threads_per_session = 2" in codex_config
 
 
 def test_sandbox_entrypoint_installs_codex_harness_config(tmp_path: Path) -> None:

--- a/services/api/tests/test_slack_thread_metadata.py
+++ b/services/api/tests/test_slack_thread_metadata.py
@@ -23,5 +23,12 @@ def test_legacy_thread_key_without_team() -> None:
     }
 
 
+def test_stable_dm_thread_key_is_channel_scoped() -> None:
+    assert _slack_thread_metadata("slack:T0AQQ46PL4C:D0B0XS7BLA3:D0B0XS7BLA3") == {
+        "slack_team_id": "T0AQQ46PL4C",
+        "slack_channel_id": "D0B0XS7BLA3",
+    }
+
+
 def test_non_slack_thread_key() -> None:
     assert _slack_thread_metadata("task:do-something-123") == {}

--- a/services/api/tests/test_tool_manager.py
+++ b/services/api/tests/test_tool_manager.py
@@ -17,6 +17,7 @@ from api.tool_manager import (  # noqa: E402
     _describe_method_docstring,
     _friendly_type_name,
     _normalize_for_serialization,
+    _slack_destination_from_thread_key,
     _tool_arg_validation_error,
     _to_toon,
     ToolManager,
@@ -73,6 +74,20 @@ class TestDescribeMethodDocstring:
         out = _describe_method_docstring(doc)
         assert len(out) <= 1200
         assert out.endswith("\u2026")
+
+
+class TestSlackThreadKeyParsing:
+    def test_team_scoped_thread_key_has_channel_and_thread(self):
+        assert _slack_destination_from_thread_key(
+            "slack:T123:C123:1778883099.579529"
+        ) == ("C123", "1778883099.579529", False)
+
+    def test_stable_dm_thread_key_is_channel_scoped(self):
+        assert _slack_destination_from_thread_key("slack:T123:D123:D123") == (
+            "D123",
+            None,
+            True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -414,6 +414,18 @@ def test_recovery_command_paraphrases_are_recognized():
         ("please use --opus and review this", None, None, "please use and review this"),
         ("please use --model opus and review this", None, None, "please use and review this"),
         ("please use `--model opus` and review this", None, None, "please use and review this"),
+        # Bare engine words select a harness and stay in the text.
+        ("claude review this PR", "claude-code", None, "claude review this PR"),
+        ("use codex for this one", "codex", None, "use codex for this one"),
+        ("CLAUDE, what do you think?", "claude-code", None, "CLAUDE, what do you think?"),
+        # First bare word wins when both appear.
+        ("claude not codex please", "claude-code", None, "claude not codex please"),
+        # Explicit flags take precedence over bare words.
+        ("--codex but ask claude later", "codex", None, "but ask claude later"),
+        # Substrings of larger words do not match.
+        ("claudette runs the codexes", None, None, "claudette runs the codexes"),
+        # Bare engine words compose with persona flags.
+        ("--invest claude review this", "claude-code", "invest", "claude review this"),
     ],
 )
 def test_prompt_selection_extraction_handles_slack_flag_shapes(

--- a/services/api/tests/test_workflows.py
+++ b/services/api/tests/test_workflows.py
@@ -2532,3 +2532,19 @@ async def test_wait_for_workflow_returns_completed_child_after_deadline(db_pool)
     assert child["run_id"] == child_run_id
     assert child["status"] == "completed"
     assert child["output_json"] == {"ok": True}
+
+
+def test_runtime_failure_notice_posted_once_per_thread():
+    from api import workflow_engine
+
+    workflow_engine._runtime_failure_notices.clear()
+    thread = "slack:T1:C1:123.456"
+    err = "Failed to start the runtime: failed to resume suspended sandbox: sb-1"
+
+    assert workflow_engine._should_post_runtime_failure(thread, err) is True
+    assert workflow_engine._should_post_runtime_failure(thread, err) is False
+    # A different failure on the same thread is announced again.
+    assert workflow_engine._should_post_runtime_failure(thread, "other error") is True
+    # Other threads are independent.
+    assert workflow_engine._should_post_runtime_failure("slack:T1:C2:9.9", err) is True
+    workflow_engine._runtime_failure_notices.clear()

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -219,6 +219,7 @@
 |  call twitter search_tweets '{"query":"ethereum","max_results":20}'
 |  call linear search_issues '{"query":"bug in auth"}'
 |  call notion search '{"query":"meeting notes"}'
+|  call pylon get_issue_context '{"issue_id":"16412"}'  # issue + messages + internal threads
 |  call vlogs errors '{"service":"api"}'
 
 [Tool discovery — discover before you call]

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -13,6 +13,7 @@ import json
 import os
 from pathlib import Path
 import queue
+import re
 import signal
 import subprocess
 import sys
@@ -43,6 +44,51 @@ CONFIGURED_OTEL_TRACE_ID: str | None = None
 CONFIGURED_TRACE_CONTEXT_ID: str | None = None
 APP_INITIALIZED = False
 CURRENT_TRACEPARENT: str | None = None
+
+# Dynamic reasoning effort: keep the config.toml default (cheap) for everyday
+# chat, but launch codex at a higher effort when the first turn of a session
+# looks like code / debugging / investigation work. Effort is fixed at
+# app-server launch, so this is decided once from the first message and holds
+# for the thread. Controls (env):
+#   CENTAUR_CODEX_DYNAMIC_EFFORT  on by default; set 0/false/off to disable
+#   CENTAUR_CODEX_EFFORT_HIGH     effort to use when code work is detected (default "high")
+#   CENTAUR_CODEX_EFFORT          hard override: force this effort, skip the heuristic
+_CODE_WORK_RE = re.compile(
+    r"""(
+        \bc[0-9a-f]{15}\b                                   # conversation_id
+      | \b[pr][0-9a-f]{11}\b                                # persona_id / replica_id
+      | \b(investigate|debug|root[\s-]*cause|traceback|stack[\s-]*trace
+            |stacktrace|regression|repro)\w*
+      | \b(why|what|how)\b.{0,40}\b(fail|failing|failed|broke|broken|breaking
+            |error|erroring|crash|crashing|hang|hanging|slow|timeout|timing)\w*
+      | \b(fix|patch|bug|pull[\s-]*request|diff|stack\s*trace)\b
+      | \bPR\b
+      | \b(request-handler|realtime-replica|developer-portal|tavus-api
+            |tavus-operator|billing-service|avatar-service|tavus-lambdas
+            |llm-helpers|phoenix-2-pro|sparrow-one|template-video|centaur)\b
+      | \b(signoz|cloudwatch|webhook|stack\s*trace|exception)\b
+      | \.(py|ts|tsx|js|jsx|go|rs|sql|sh)\b                 # source file extensions
+      | \bcode\b
+    )""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _reasoning_effort_for_text(text: str) -> str | None:
+    """Pick a reasoning-effort override for a session from its first message.
+
+    Returns the effort string to pass to ``codex -c model_reasoning_effort=…``,
+    or ``None`` to leave the config.toml default in place.
+    """
+    if (os.environ.get("CENTAUR_CODEX_DYNAMIC_EFFORT", "1").strip().lower()
+            in ("0", "false", "no", "off")):
+        return None
+    forced = (os.environ.get("CENTAUR_CODEX_EFFORT") or "").strip()
+    if forced:
+        return forced
+    if text and _CODE_WORK_RE.search(text):
+        return (os.environ.get("CENTAUR_CODEX_EFFORT_HIGH") or "high").strip()
+    return None
 OTEL_PROXY: ThreadingHTTPServer | None = None
 OTEL_PROXY_TARGET_ENDPOINT: str | None = None
 OTEL_PROXY_SPAN_PREFIX = "codex."
@@ -103,7 +149,7 @@ def notify(method: str, params: dict[str, Any] | None = None) -> None:
     send_raw({"method": method, "params": params or {}})
 
 
-def start_app_server() -> None:
+def start_app_server(reasoning_effort: str | None = None) -> None:
     global APP, APP_INITIALIZED
     if APP is not None and APP.poll() is None and APP_INITIALIZED:
         return
@@ -111,13 +157,19 @@ def start_app_server() -> None:
         APP = None
         APP_INITIALIZED = False
 
+    cmd = ["codex", "app-server"]
+    if reasoning_effort:
+        cmd += ["-c", f"model_reasoning_effort={reasoning_effort}"]
+        emit(
+            {
+                "type": "system",
+                "subtype": "codex_reasoning_effort",
+                "effort": reasoning_effort,
+            }
+        )
+    cmd += ["--listen", "stdio://"]
     APP = subprocess.Popen(
-        [
-            "codex",
-            "app-server",
-            "--listen",
-            "stdio://",
-        ],
+        cmd,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=sys.stderr,
@@ -808,9 +860,14 @@ def handle_input(turn_input: dict[str, Any]) -> None:
         turn_input.get("thread_key"),
     )
     CURRENT_TRACE_METADATA = trace_metadata_from_input(turn_input)
-    start_app_server()
-    thread_id = start_or_resume_thread()
     items = input_items(turn_input)
+    # Decide reasoning effort from this turn's text. Only the first turn of a
+    # session actually launches the app-server, so this fixes effort per thread.
+    first_text = "\n".join(
+        str(item.get("text") or "") for item in items if item.get("type") == "text"
+    )
+    start_app_server(_reasoning_effort_for_text(first_text))
+    thread_id = start_or_resume_thread()
     CURRENT_LLM_INPUT_TEXT = "\n".join(
         str(item.get("text") or "") for item in items if item.get("type") == "text"
     ).strip()

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -51,7 +51,7 @@ CURRENT_TRACEPARENT: str | None = None
 # app-server launch, so this is decided once from the first message and holds
 # for the thread. Controls (env):
 #   CENTAUR_CODEX_DYNAMIC_EFFORT  on by default; set 0/false/off to disable
-#   CENTAUR_CODEX_EFFORT_HIGH     effort to use when code work is detected (default "high")
+#   CENTAUR_CODEX_EFFORT_HIGH     effort to use when code work is detected (default "medium")
 #   CENTAUR_CODEX_EFFORT          hard override: force this effort, skip the heuristic
 _CODE_WORK_RE = re.compile(
     r"""(
@@ -87,7 +87,7 @@ def _reasoning_effort_for_text(text: str) -> str | None:
     if forced:
         return forced
     if text and _CODE_WORK_RE.search(text):
-        return (os.environ.get("CENTAUR_CODEX_EFFORT_HIGH") or "high").strip()
+        return (os.environ.get("CENTAUR_CODEX_EFFORT_HIGH") or "medium").strip()
     return None
 OTEL_PROXY: ThreadingHTTPServer | None = None
 OTEL_PROXY_TARGET_ENDPOINT: str | None = None

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -383,10 +383,16 @@ function targetFromDelivery(delivery: any): {
   const threadKey = String(delivery.thread_key ?? "");
   const parts = threadKey.split(":");
   if (parts[0] === "slack" && parts.length >= 4) {
+    const teamId = parts[1];
+    const channel = parts[2];
+    const threadTs = parts.slice(3).join(":");
+    if (!teamId || !channel) return {};
     return {
-      teamId: parts[1],
-      channel: parts[2],
-      threadTs: parts.slice(3).join(":"),
+      teamId,
+      channel,
+      ...(channel.startsWith("D") && threadTs === channel
+        ? {}
+        : { threadTs }),
     };
   }
   return {};

--- a/services/slackbot/src/centaur/handoff.test.ts
+++ b/services/slackbot/src/centaur/handoff.test.ts
@@ -38,6 +38,7 @@ describe('CentaurHandoff', () => {
         channel_id: 'C123',
         thread_ts: '1778883099.579529',
         is_mention: true,
+        is_addressed: true,
         parts: [{ type: 'text', text: 'hello' }],
         slack: {
           event_id: 'Ev-envelope-one',
@@ -89,6 +90,7 @@ describe('CentaurHandoff', () => {
         channel_id: 'C123',
         thread_ts: '1778883099.579529',
         is_mention: true,
+        is_addressed: true,
         parts: [
           { type: 'text', text: 'review this' },
           {
@@ -153,6 +155,7 @@ describe('CentaurHandoff', () => {
         channel_id: 'C123',
         thread_ts: '1778883099.579529',
         is_mention: true,
+        is_addressed: true,
         parts: [{ type: 'text', text: 'hello' }],
         slack: {
           event_ts: '1778883100.000000',

--- a/services/slackbot/src/index.test.ts
+++ b/services/slackbot/src/index.test.ts
@@ -11,11 +11,79 @@ afterEach(() => {
 })
 
 describe('Slack event HTTP dedupe', () => {
+  it('publishes the Watch Agent Home tab when App Home is opened', async () => {
+    process.env.SLACK_SIGNING_SECRET = 'test-signing-secret'
+    process.env.SLACK_BOT_TOKEN = 'xoxb-home-test'
+    delete process.env.SLACKBOT_API_KEY
+    delete process.env.CENTAUR_API_KEY
+
+    const slackCalls: Array<{ path: string; body: Record<string, unknown> }> = []
+    const slackApi = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url)
+        const body = await slackApiBody(request)
+        slackCalls.push({ path: url.pathname, body })
+        if (url.pathname === '/api/auth.test') {
+          return Response.json({ ok: true, user_id: 'UBOT', bot_id: 'BBOT' })
+        }
+        if (url.pathname === '/api/views.publish') {
+          return Response.json({ ok: true, view: { id: 'VHOME' } })
+        }
+        return Response.json({ ok: false, error: 'unexpected_slack_method' }, { status: 404 })
+      }
+    })
+    process.env.SLACK_API_URL = `http://127.0.0.1:${slackApi.port}/api/`
+
+    try {
+      const { app } = await import(`./index.ts?app_home=${Date.now()}`)
+      const body = JSON.stringify({
+        type: 'event_callback',
+        event_id: 'Ev-home-opened',
+        team_id: 'T123',
+        event: {
+          type: 'app_home_opened',
+          user: 'UHOME',
+          channel: 'DHOME',
+          tab: 'home',
+          event_ts: '1778883099.579531'
+        }
+      })
+      const waits: Promise<unknown>[] = []
+      const response = await app.request(
+        '/api/webhooks/slack',
+        signedJsonRequest(body, process.env.SLACK_SIGNING_SECRET),
+        {},
+        {
+          waitUntil: (promise: Promise<unknown>) => {
+            waits.push(promise)
+          }
+        } as any
+      )
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ ok: true })
+      await Promise.allSettled(waits)
+
+      const publish = slackCalls.find(call => call.path === '/api/views.publish')
+      expect(publish?.body.user_id).toBe('UHOME')
+      const view = publish?.body.view as Record<string, unknown> | undefined
+      expect(view?.type).toBe('home')
+      expect(JSON.stringify(view?.blocks)).toContain('Watch Agent')
+      expect(JSON.stringify(view?.blocks)).toContain('tavus-context')
+    } finally {
+      await slackApi.stop()
+    }
+  })
+
   it('creates Linear issues from configured feedback slash commands', async () => {
     process.env.SLACK_SIGNING_SECRET = 'test-signing-secret'
     process.env.LINEAR_API_KEY = 'lin-test-key'
     process.env.SLACK_FEEDBACK_LINEAR_TEAM_ID = 'team-feedback'
     process.env.SLACK_FEEDBACK_LINEAR_PROJECT_ID = 'project-feedback'
+    delete process.env.SLACK_BOT_TOKEN
+    delete process.env.SLACKBOT_API_KEY
+    delete process.env.CENTAUR_API_KEY
 
     const originalFetch = globalThis.fetch
     const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
@@ -248,5 +316,29 @@ function signedJsonRequest(body: string, signingSecret: string): RequestInit {
       'x-slack-signature': signature
     },
     body
+  }
+}
+
+async function slackApiBody(request: Request): Promise<Record<string, unknown>> {
+  const contentType = request.headers.get('content-type') ?? ''
+  const text = await request.text()
+  if (contentType.includes('application/json')) {
+    return JSON.parse(text || '{}') as Record<string, unknown>
+  }
+  return Object.fromEntries(
+    Array.from(new URLSearchParams(text).entries()).map(([key, value]) => [
+      key,
+      parseMaybeJson(value)
+    ])
+  )
+}
+
+function parseMaybeJson(value: string): unknown {
+  const trimmed = value.trim()
+  if (!trimmed || !['{', '['].includes(trimmed[0] ?? '')) return value
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return value
   }
 }

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -21,6 +21,7 @@ import { authorizeSlackOrg } from './slack/authorization'
 import { CodexSessionRenderer, hasActiveCodexSession } from './slack/codex-session'
 import { EventDeduper, slackDedupKey } from './slack/dedup'
 import { duplicateSlackAlertText, type DuplicateSlackEventDetails } from './slack/duplicate-alert'
+import { publishWatchAgentHome } from './slack/home'
 import { EnvSlackInstallationStore, SlackClientResolver } from './slack/installations'
 import { normalizeSlackEnvelope } from './slack/normalize'
 import { markdownToStreamChunks } from './slack/render'
@@ -57,6 +58,8 @@ void resolver
 type Variables = {
   slackRawBody: string
 }
+
+type SlackbotSpanAttributes = Parameters<typeof spanAttributes>[1]
 
 type WaitUntilContext = {
   waitUntil(promise: Promise<unknown>): void
@@ -559,6 +562,11 @@ async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {
         return
       }
 
+      if (rawEvent.type === 'app_home_opened') {
+        await handleAppHomeOpened(envelope, rawEvent, attrs => spanAttributes(span, attrs))
+        return
+      }
+
       const { client, installation } = await resolver.resolve({
         teamId: envelope.team_id,
         enterpriseId: envelope.enterprise_id
@@ -619,6 +627,49 @@ async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {
       }
     }
   )
+}
+
+async function handleAppHomeOpened(
+  envelope: SlackEnvelope,
+  event: Record<string, unknown>,
+  setSpanAttributes: (attrs: SlackbotSpanAttributes) => void
+): Promise<void> {
+  const userId = typeof event.user === 'string' ? event.user : ''
+  const tab = typeof event.tab === 'string' ? event.tab : undefined
+  if (tab && tab !== 'home') {
+    setSpanAttributes({
+      'centaur.slackbot.event_ignored': true,
+      'centaur.slackbot.ignore_reason': 'non_home_app_tab',
+      'slack.app_home_tab': tab
+    })
+    return
+  }
+  if (!userId) {
+    setSpanAttributes({
+      'centaur.slackbot.event_ignored': true,
+      'centaur.slackbot.ignore_reason': 'missing_app_home_user'
+    })
+    logWarn('slack_app_home_opened_missing_user', {
+      team_id: envelope.team_id,
+      event_id: envelope.event_id
+    })
+    return
+  }
+
+  const { client } = await resolver.resolve({
+    teamId: envelope.team_id,
+    enterpriseId: envelope.enterprise_id
+  })
+  await publishWatchAgentHome(client, userId)
+  setSpanAttributes({
+    'centaur.slackbot.event_action': 'publish_app_home',
+    'slack.user_id': userId
+  })
+  logInfo('slack_app_home_published', {
+    team_id: envelope.team_id,
+    event_id: envelope.event_id,
+    user_id: userId
+  })
 }
 
 const TRIVIAL_ACK_REACTION = 'ok_hand'

--- a/services/slackbot/src/index.ts
+++ b/services/slackbot/src/index.ts
@@ -583,12 +583,13 @@ async function processSlackEvent(envelope: SlackEnvelope): Promise<void> {
         'slack.thread_ts': normalized.thread_ts,
         'slack.user_id': normalized.user_id,
         'centaur.slackbot.is_mention': normalized.is_mention,
+        'centaur.slackbot.is_addressed': normalized.is_addressed,
         'centaur.slackbot.part_count': normalized.parts.length
       })
-      if (!normalized.is_mention) {
+      if (!normalized.is_addressed) {
         spanAttributes(span, {
           'centaur.slackbot.event_ignored': true,
-          'centaur.slackbot.ignore_reason': 'not_mention'
+          'centaur.slackbot.ignore_reason': 'not_addressed'
         })
         return
       }

--- a/services/slackbot/src/slack/home.test.ts
+++ b/services/slackbot/src/slack/home.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test'
+import { buildWatchAgentHomeView } from './home'
+
+describe('Watch Agent Home view', () => {
+  it('builds a Slack Home tab with the expected capability sections', () => {
+    const view = buildWatchAgentHomeView()
+    const body = JSON.stringify(view.blocks)
+
+    expect(view.type).toBe('home')
+    expect(view.callback_id).toBe('watch_agent_home_v1')
+    expect(view.blocks.length).toBeLessThanOrEqual(100)
+    expect(body).toContain('Watch Agent')
+    expect(body).toContain('Connected Systems')
+    expect(body).toContain('CLI And Harnesses')
+    expect(body).toContain('tavus-context')
+    expect(body).toContain('tavus-investigate-conversation')
+    expect(body).toContain('signoz-generating-queries')
+    expect(body).toContain('Sample Prompts')
+  })
+})

--- a/services/slackbot/src/slack/home.ts
+++ b/services/slackbot/src/slack/home.ts
@@ -1,0 +1,140 @@
+import type { AnyBlock, HomeView } from '@slack/types'
+import type { WebClient } from '@slack/web-api'
+
+const CALLBACK_ID = 'watch_agent_home_v1'
+
+export function buildWatchAgentHomeView(): HomeView {
+  return {
+    type: 'home',
+    callback_id: CALLBACK_ID,
+    blocks: [
+      header('Watch Agent'),
+      section(
+        '*Centaur-powered Tavus engineering agent*\n' +
+          'Use this app in DMs or mention it in a channel thread when you want a persistent AI teammate that can read context, inspect code, query observability, and run Centaur workflows.'
+      ),
+      context(
+        'Live tools can differ by deployment and overlay. Ask `what tools are live right now?` for an exact inventory before relying on a specific connector.'
+      ),
+      divider(),
+      header('What It Can Do'),
+      fields([
+        '*Investigate Tavus incidents*\nTrace CVI conversations, personas, transcripts, realtime-replica, request-handler, worker logs, and CloudWatch/SigNoz evidence.',
+        '*Review and ship code*\nRead Tavus repos, review branches/PRs, run focused tests, commit/push approved changes, and watch CI when asked.',
+        '*Find internal context*\nSearch across code, PRs, issues, Slack decisions, Linear projects, docs, and Coda-backed context where configured.',
+        '*Operate Centaur*\nRun local stack QA, inspect agent executions, check VictoriaLogs/VictoriaMetrics, and debug Slackbot delivery paths.',
+        '*Build tools and workflows*\nCreate tool plugins, durable workflows, dashboards, alerts, saved views, and recurring agent loops.',
+        '*Synthesize updates*\nDraft Linear status posts, weekly all-hands rollups, RCA summaries, QA reports, and comparison artifacts.'
+      ]),
+      divider(),
+      header('Connected Systems'),
+      fields([
+        '*MCP and connector-style systems*\nTavus CLI/MCP, SigNoz, Slack, Coda, GitHub, Linear, AWS, Google Workspace, Notion, Figma, and deployment-specific tool overlays.',
+        '*Centaur API tools*\nUse `call tools` for the live list, then `call discover <tool>` before invoking methods. Tool calls route through Centaur auth and audit logging.',
+        '*Observability*\nVictoriaLogs, VictoriaMetrics, SigNoz queries, dashboard/alert workflows, execution timelines, tool analytics, and prompt/model analytics.',
+        '*Repository access*\nMounted Tavus repos, GitHub API, local code search, PR metadata, issue context, CI checks, and deployment notes.'
+      ]),
+      divider(),
+      header('CLI And Harnesses'),
+      fields([
+        '*Harness selectors*\nDefault is Codex. Add `--codex`, `--amp`, `--claude`, or `--pi` when you want a specific runtime.',
+        '*Repo and shell tools*\n`git`, `gh`, `rg`, `fd`, `jq`, `uv`, `node`, `bun`, `pnpm`, `rust`, `forge`, `cast`, `anvil`, `tmux`, `cmake`, and protobuf tooling.',
+        '*Centaur helper*\nInside the sandbox, API tools are called with `call <tool> <method> <json>`. Legacy `call search` and `call sql` shorthands are not used.',
+        '*Durable workflows*\nAsk for recurring checks or long-running tasks; Centaur can run child workflows and report back after sleeps, events, or agent turns.'
+      ]),
+      divider(),
+      header('Tavus Skills'),
+      section(
+        [
+          '`tavus-context` - cross-system Tavus research across GitHub, Linear, Slack, and docs.',
+          '`tavus-repos` - map Tavus repos, services, env vars, webhooks, and ownership boundaries.',
+          '`tavus-investigate-conversation` - RCA a CVI conversation from config, traces, logs, and code.',
+          '`tavus-investigate-persona` - inspect persona config, tools, guardrails, and behavior.',
+          '`tavus-weekly-rollup` - summarize merged PRs across Tavus engineering repos.',
+          '`linear-sync` - draft and post M/W/F Linear project status updates.',
+          '`commit-pr` - preflight, commit, push, open/update a PR, and watch CI.',
+          '`install-tools` - repair or verify Tavus CLIs and MCP servers.'
+        ].join('\n')
+      ),
+      header('Centaur And SigNoz Skills'),
+      section(
+        [
+          '`qa`, `dogfood`, `auth-failure-log-triage`, `creating-tools`, `learning-synthesis`, `improve-gap-task`.',
+          '`signoz-generating-queries`, `signoz-investigating-alerts`, `signoz-creating-dashboards`, `signoz-creating-alerts`, `signoz-setting-up-observability`, plus dashboard, alert, view, docs, MCP setup, and ClickHouse-query helpers.'
+        ].join('\n')
+      ),
+      divider(),
+      header('Sample Prompts'),
+      section(
+        [
+          '- `Investigate conversation c123. Why did the user hear silence? Include RQH, realtime-replica, SigNoz, and CloudWatch evidence.`',
+          '- `What tools and personas are live in this Watch Agent deployment right now?`',
+          '- `Review PR 123 in request-handler against main and tell me if it is merge-ready.`',
+          '- `Run Centaur QA locally and give me failures with exact repro steps.`',
+          '- `Find the full Tavus context for why we changed persona tool ownership.`',
+          '- `Create a weekly all-hands rollup of merged Tavus engineering PRs.`',
+          '- `Query p95 latency and error rate for realtime-replica over the last hour.`',
+          '- `Look up persona p123, list attached tools, and explain likely behavior risks.`'
+        ].join('\n')
+      ),
+      divider(),
+      context(
+        'Tip: mention Watch Agent in a channel for shared work, or use the Messages tab for a private one-on-one thread.'
+      )
+    ]
+  }
+}
+
+export async function publishWatchAgentHome(client: WebClient, userId: string): Promise<unknown> {
+  return client.views.publish({
+    user_id: userId,
+    view: buildWatchAgentHomeView()
+  })
+}
+
+function header(text: string): AnyBlock {
+  return {
+    type: 'header',
+    text: {
+      type: 'plain_text',
+      text,
+      emoji: false
+    }
+  }
+}
+
+function section(text: string): AnyBlock {
+  return {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text
+    }
+  }
+}
+
+function fields(items: string[]): AnyBlock {
+  return {
+    type: 'section',
+    fields: items.map(text => ({
+      type: 'mrkdwn',
+      text
+    }))
+  }
+}
+
+function context(text: string): AnyBlock {
+  return {
+    type: 'context',
+    elements: [
+      {
+        type: 'mrkdwn',
+        text
+      }
+    ]
+  }
+}
+
+function divider(): AnyBlock {
+  return { type: 'divider' }
+}

--- a/services/slackbot/src/slack/normalize.test.ts
+++ b/services/slackbot/src/slack/normalize.test.ts
@@ -583,6 +583,7 @@ describe('normalizeSlackEnvelope', () => {
   })
 
   it('treats a DM without a mention as addressed', async () => {
+    const info = mock(async () => ({ ok: true }))
     const normalized = await normalizeSlackEnvelope({
       envelope: {
         type: 'event_callback',
@@ -598,13 +599,44 @@ describe('normalizeSlackEnvelope', () => {
         }
       },
       botUserId: 'UBOT',
-      client
+      client: {
+        token: 'xoxb-test-token',
+        conversations: { replies: mock(async () => ({ ok: true, messages: [] })), info }
+      } as any
     })
 
+    expect(info).toHaveBeenCalledWith({ channel: 'D123' })
     expect(normalized?.is_mention).toBe(false)
     expect(normalized?.is_addressed).toBe(true)
     expect(normalized?.thread_key).toBe('slack:T123:D123:D123')
     expect(normalized?.thread_ts).toBe('1778875070.942789')
+  })
+
+  it('ignores DM events when the bot cannot access the channel', async () => {
+    const info = mock(async () => ({ ok: false, error: 'channel_not_found' }))
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-dm-channel-not-found',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'D123',
+          channel_type: 'im',
+          ts: '1778875070.942789',
+          text: 'this should not spawn an agent'
+        }
+      },
+      botUserId: 'UBOT',
+      client: {
+        token: 'xoxb-test-token',
+        conversations: { replies: mock(async () => ({ ok: true, messages: [] })), info }
+      } as any
+    })
+
+    expect(info).toHaveBeenCalledWith({ channel: 'D123' })
+    expect(normalized).toBeNull()
   })
 
   it('reuses one thread key for unthreaded messages in the same DM', async () => {

--- a/services/slackbot/src/slack/normalize.test.ts
+++ b/services/slackbot/src/slack/normalize.test.ts
@@ -603,6 +603,73 @@ describe('normalizeSlackEnvelope', () => {
 
     expect(normalized?.is_mention).toBe(false)
     expect(normalized?.is_addressed).toBe(true)
+    expect(normalized?.thread_key).toBe('slack:T123:D123:D123')
+    expect(normalized?.thread_ts).toBe('1778875070.942789')
+  })
+
+  it('reuses one thread key for unthreaded messages in the same DM', async () => {
+    const first = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-dm-one',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'D123',
+          channel_type: 'im',
+          ts: '1778875070.000001',
+          text: 'first'
+        }
+      },
+      botUserId: 'UBOT',
+      client
+    })
+    const second = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-dm-two',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'D123',
+          channel_type: 'im',
+          ts: '1778875075.000002',
+          text: 'second'
+        }
+      },
+      botUserId: 'UBOT',
+      client
+    })
+
+    expect(first?.thread_key).toBe('slack:T123:D123:D123')
+    expect(second?.thread_key).toBe(first?.thread_key)
+    expect(second?.thread_ts).toBe('1778875075.000002')
+  })
+
+  it('keeps real Slack thread timestamps for threaded DM replies', async () => {
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-dm-thread',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'D123',
+          channel_type: 'im',
+          thread_ts: '1778875000.000001',
+          ts: '1778875075.000002',
+          text: 'thread reply'
+        }
+      },
+      botUserId: 'UBOT',
+      client
+    })
+
+    expect(normalized?.thread_key).toBe('slack:T123:D123:1778875000.000001')
+    expect(normalized?.thread_ts).toBe('1778875000.000001')
   })
 
   it('treats a thread reply as addressed when the bot already replied in the thread', async () => {

--- a/services/slackbot/src/slack/normalize.test.ts
+++ b/services/slackbot/src/slack/normalize.test.ts
@@ -212,7 +212,10 @@ describe('normalizeSlackEnvelope', () => {
               elements: [
                 {
                   type: 'rich_text_quote',
-                  elements: [{ type: 'user', user_id: 'UBOT' }, { type: 'text', text: ' help' }]
+                  elements: [
+                    { type: 'user', user_id: 'UBOT' },
+                    { type: 'text', text: ' help' }
+                  ]
                 },
                 {
                   type: 'rich_text_section',
@@ -577,5 +580,140 @@ describe('normalizeSlackEnvelope', () => {
     expect(normalized?.is_mention).toBe(true)
     expect(normalized?.parts).toEqual([{ type: 'text', text: '--invest pick this up' }])
     expect(normalized?.history_messages).toBeUndefined()
+  })
+
+  it('treats a DM without a mention as addressed', async () => {
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-dm-no-mention',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'D123',
+          channel_type: 'im',
+          ts: '1778875070.942789',
+          text: 'what tools do you have access to?'
+        }
+      },
+      botUserId: 'UBOT',
+      client
+    })
+
+    expect(normalized?.is_mention).toBe(false)
+    expect(normalized?.is_addressed).toBe(true)
+  })
+
+  it('treats a thread reply as addressed when the bot already replied in the thread', async () => {
+    const replies = mock(async () => ({
+      ok: true,
+      messages: [
+        {
+          type: 'message',
+          user: 'U123',
+          ts: '1778875060.000100',
+          text: '<@UBOT> can you look into this?'
+        },
+        {
+          type: 'message',
+          user: 'UBOT',
+          ts: '1778875065.000200',
+          text: 'Looking now.'
+        }
+      ]
+    }))
+
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-thread-follow-up',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'C123',
+          channel_type: 'channel',
+          thread_ts: '1778875060.000100',
+          ts: '1778875070.942789',
+          text: 'any update?'
+        }
+      },
+      botUserId: 'UBOT',
+      client: {
+        token: 'xoxb-test-token',
+        conversations: { replies }
+      } as any
+    })
+
+    expect(normalized?.is_mention).toBe(false)
+    expect(normalized?.is_addressed).toBe(true)
+    expect(normalized?.history_messages).toHaveLength(2)
+  })
+
+  it('does not treat a thread reply as addressed when the bot never replied in the thread', async () => {
+    const replies = mock(async () => ({
+      ok: true,
+      messages: [
+        {
+          type: 'message',
+          user: 'U456',
+          ts: '1778875060.000100',
+          text: 'kicking off a discussion'
+        }
+      ]
+    }))
+
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-thread-bystander',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'C123',
+          channel_type: 'channel',
+          thread_ts: '1778875060.000100',
+          ts: '1778875070.942789',
+          text: 'agreed'
+        }
+      },
+      botUserId: 'UBOT',
+      client: {
+        token: 'xoxb-test-token',
+        conversations: { replies }
+      } as any
+    })
+
+    expect(normalized?.is_mention).toBe(false)
+    expect(normalized?.is_addressed).toBe(false)
+  })
+
+  it('does not treat a top-level channel message without a mention as addressed', async () => {
+    const replies = mock(async () => ({ ok: true, messages: [] }))
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-channel-top-level',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'C123',
+          channel_type: 'channel',
+          ts: '1778875070.942789',
+          text: 'unrelated chatter'
+        }
+      },
+      botUserId: 'UBOT',
+      client: {
+        token: 'xoxb-test-token',
+        conversations: { replies }
+      } as any
+    })
+
+    expect(normalized?.is_addressed).toBe(false)
+    expect(replies).not.toHaveBeenCalled()
   })
 })

--- a/services/slackbot/src/slack/normalize.test.ts
+++ b/services/slackbot/src/slack/normalize.test.ts
@@ -716,4 +716,32 @@ describe('normalizeSlackEnvelope', () => {
     expect(normalized?.is_addressed).toBe(false)
     expect(replies).not.toHaveBeenCalled()
   })
+
+  it('does not treat bare engine words as a wake word', async () => {
+    const replies = mock(async () => ({ ok: true, messages: [] }))
+    const normalized = await normalizeSlackEnvelope({
+      envelope: {
+        type: 'event_callback',
+        team_id: 'T123',
+        event_id: 'Ev-bare-engine-word',
+        event: {
+          type: 'message',
+          user: 'U123',
+          channel: 'C123',
+          channel_type: 'channel',
+          ts: '1778875070.942789',
+          text: 'claude and codex are getting pretty good these days'
+        }
+      },
+      botUserId: 'UBOT',
+      client: {
+        token: 'xoxb-test-token',
+        conversations: { replies }
+      } as any
+    })
+
+    expect(normalized?.is_mention).toBe(false)
+    expect(normalized?.is_addressed).toBe(false)
+    expect(replies).not.toHaveBeenCalled()
+  })
 })

--- a/services/slackbot/src/slack/normalize.ts
+++ b/services/slackbot/src/slack/normalize.ts
@@ -85,7 +85,6 @@ export async function normalizeSlackEnvelope(opts: {
   const teamId = opts.envelope.team_id ?? event.team
   if (!teamId) return null
 
-  const threadTs = event.thread_ts ?? event.ts
   const textPart = slackMessageText(event, opts.botUserId)
   const parts: NormalizedPart[] = []
   if (textPart) parts.push({ type: 'text', text: textPart })
@@ -98,6 +97,8 @@ export async function normalizeSlackEnvelope(opts: {
     event.type === 'app_mention' ||
     Boolean(opts.botUserId && messageMentionsBot(event, opts.botUserId))
   const isDm = event.channel_type === 'im'
+  const threadTs = event.thread_ts ?? event.ts
+  const threadKeyTs = isDm && !event.thread_ts ? event.channel : threadTs
   const isThreadReply = Boolean(event.thread_ts) && event.thread_ts !== event.ts
   const historyMessages =
     isMention || isDm || isThreadReply
@@ -115,7 +116,7 @@ export async function normalizeSlackEnvelope(opts: {
   const isAddressed = isMention || isDm || (isThreadReply && botInThread)
 
   return {
-    thread_key: `slack:${teamId}:${event.channel}:${threadTs}`,
+    thread_key: `slack:${teamId}:${event.channel}:${threadKeyTs}`,
     message_id: `slack:${teamId}:${event.channel}:${event.ts}`,
     team_id: teamId,
     recipient_team_id: recipientSlackTeamId(event) ?? teamId,

--- a/services/slackbot/src/slack/normalize.ts
+++ b/services/slackbot/src/slack/normalize.ts
@@ -97,6 +97,7 @@ export async function normalizeSlackEnvelope(opts: {
     event.type === 'app_mention' ||
     Boolean(opts.botUserId && messageMentionsBot(event, opts.botUserId))
   const isDm = event.channel_type === 'im'
+  if (isDm && !(await canAccessConversation(opts.client, event.channel))) return null
   const threadTs = event.thread_ts ?? event.ts
   const threadKeyTs = isDm && !event.thread_ts ? event.channel : threadTs
   const isThreadReply = Boolean(event.thread_ts) && event.thread_ts !== event.ts
@@ -138,6 +139,31 @@ export async function normalizeSlackEnvelope(opts: {
       app_id: event.app_id ?? event.bot_profile?.app_id,
       bot_user_id: event.bot_profile?.user_id
     }
+  }
+}
+
+async function canAccessConversation(client: WebClient, channel: string): Promise<boolean> {
+  const conversations = client.conversations as unknown as {
+    info?: (args: { channel: string }) => Promise<{ ok?: boolean; error?: string }>
+  }
+  if (typeof conversations.info !== 'function') return true
+
+  try {
+    const response = await conversations.info({ channel })
+    if (response?.ok === false) {
+      logWarn('slack_conversation_access_denied', {
+        channel,
+        error: response.error ?? 'unknown_error'
+      })
+      return false
+    }
+    return true
+  } catch (error) {
+    logWarn('slack_conversation_access_check_failed', {
+      channel,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return false
   }
 }
 

--- a/services/slackbot/src/slack/normalize.ts
+++ b/services/slackbot/src/slack/normalize.ts
@@ -97,17 +97,22 @@ export async function normalizeSlackEnvelope(opts: {
   const isMention =
     event.type === 'app_mention' ||
     Boolean(opts.botUserId && messageMentionsBot(event, opts.botUserId))
-  const historyMessages = isMention
-    ? await collectThreadHistorySafely({
-        client: opts.client,
-        channel: event.channel,
-        threadTs,
-        currentTs: event.ts,
-        teamId,
-        botUserId: opts.botUserId,
-        botId: opts.botId
-      })
-    : []
+  const isDm = event.channel_type === 'im'
+  const isThreadReply = Boolean(event.thread_ts) && event.thread_ts !== event.ts
+  const historyMessages =
+    isMention || isDm || isThreadReply
+      ? await collectThreadHistorySafely({
+          client: opts.client,
+          channel: event.channel,
+          threadTs,
+          currentTs: event.ts,
+          teamId,
+          botUserId: opts.botUserId,
+          botId: opts.botId
+        })
+      : []
+  const botInThread = historyMessages.some(message => message.role === 'assistant')
+  const isAddressed = isMention || isDm || (isThreadReply && botInThread)
 
   return {
     thread_key: `slack:${teamId}:${event.channel}:${threadTs}`,
@@ -118,6 +123,7 @@ export async function normalizeSlackEnvelope(opts: {
     channel_id: event.channel,
     thread_ts: threadTs,
     is_mention: isMention,
+    is_addressed: isAddressed,
     parts,
     ...(historyMessages.length ? { history_messages: historyMessages } : {}),
     slack: {

--- a/services/slackbot/src/slack/trivial-ack.test.ts
+++ b/services/slackbot/src/slack/trivial-ack.test.ts
@@ -61,6 +61,7 @@ function baseEvent(overrides: Partial<NormalizedSlackEvent> = {}): NormalizedSla
     channel_id: 'C',
     thread_ts: '1.0',
     is_mention: true,
+    is_addressed: true,
     parts: [{ type: 'text', text: 'thanks!' }],
     history_messages: [
       {
@@ -129,7 +130,11 @@ describe('shouldAckWithReaction', () => {
     ).toBe(false)
   })
 
-  it('does not ack a non-mention message', () => {
-    expect(shouldAckWithReaction(baseEvent({ is_mention: false }))).toBe(false)
+  it('does not ack a message that is not addressed to the bot', () => {
+    expect(shouldAckWithReaction(baseEvent({ is_mention: false, is_addressed: false }))).toBe(false)
+  })
+
+  it('acks an addressed follow-up even without a mention', () => {
+    expect(shouldAckWithReaction(baseEvent({ is_mention: false, is_addressed: true }))).toBe(true)
   })
 })

--- a/services/slackbot/src/slack/trivial-ack.ts
+++ b/services/slackbot/src/slack/trivial-ack.ts
@@ -43,10 +43,10 @@ export function isTrivialAck(text: string): boolean {
   return Boolean(normalized) && ACK_PHRASES.has(normalized)
 }
 
-// Mentions inside an existing thread that already has an assistant reply, with
+// Messages inside an existing thread that already has an assistant reply, with
 // a short whitelisted ack as the only part, get a reaction instead of a spawn.
 export function shouldAckWithReaction(event: NormalizedSlackEvent): boolean {
-  if (!event.is_mention) return false
+  if (!event.is_addressed) return false
   if (event.parts.length !== 1) return false
   const part = event.parts[0]
   if (!part || part.type !== 'text') return false

--- a/services/slackbot/src/slack/types.ts
+++ b/services/slackbot/src/slack/types.ts
@@ -29,6 +29,7 @@ export type NormalizedSlackEvent = {
   channel_id: string
   thread_ts: string
   is_mention: boolean
+  is_addressed: boolean
   parts: NormalizedPart[]
   history_messages?: Array<{
     message_id: string

--- a/tools/business/pylon/README.md
+++ b/tools/business/pylon/README.md
@@ -1,0 +1,46 @@
+# Pylon
+
+Pylon is exposed to Centaur agents as a REST tool, not as an MCP server and not
+as the local Typer CLI. In a sandbox, inspect and call it with the `call` helper:
+
+```bash
+call discover pylon
+call pylon get_issue_context '{"issue_id":"16412"}'
+```
+
+Use `get_issue_context` as the first call when a user references a support
+thread such as `Pylon Issue #16412`. It returns:
+
+- `issue`: the issue metadata and body from `GET /issues/{id}`
+- `messages`: customer-facing messages, replies, and internal notes from
+  `GET /issues/{id}/messages`
+- `threads`: internal issue threads from `GET /issues/{id}/threads`
+
+Pylon accepts issue numbers for `GET /issues/{id}`, but the messages and threads
+endpoints are documented around the canonical issue ID. The client resolves
+numeric refs first, so these all work:
+
+```bash
+call pylon get_issue_context '{"issue_id":"16412"}'
+call pylon get_issue_context '{"issue_id":"#16412"}'
+call pylon get_issue_context '{"issue_id":"https://app.usepylon.com/issues/16412"}'
+```
+
+Do not call CLI commands through the API helper:
+
+```bash
+# Wrong in a sandbox: "issue" is a CLI command, not a tool method.
+call pylon issue 16412
+
+# Correct in a sandbox.
+call pylon get_issue '{"issue_id":"16412"}'
+call pylon get_issue_messages '{"issue_id":"16412"}'
+```
+
+For local standalone use after installing the tool package:
+
+```bash
+pylon issue-context 16412 --json
+pylon issue-messages 16412 --json
+pylon issue-threads 16412 --json
+```

--- a/tools/business/pylon/cli.py
+++ b/tools/business/pylon/cli.py
@@ -3,13 +3,13 @@
 import json
 import sys
 
+import typer
 from dotenv import load_dotenv
+from rich.console import Console
+
+from centaur_sdk import Table
 
 load_dotenv()
-
-import typer
-from rich.console import Console
-from centaur_sdk import Table
 
 app = typer.Typer(name="pylon", help="Pylon CLI for AI agents")
 console = Console()
@@ -33,7 +33,7 @@ def me():
         console.print(f"[dim]ID: {data.get('id', 'N/A')}[/]")
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 @app.command()
@@ -56,7 +56,7 @@ def issues(
         results = client.list_issues(days=days)
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if state:
         results = [i for i in results if i.get("state", "").lower() == state.lower()]
@@ -119,7 +119,7 @@ def issue(
         result = client.get_issue(issue_id)
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if json_output:
         print(json.dumps(result, indent=2, ensure_ascii=False), file=sys.stdout)
@@ -148,6 +148,127 @@ def issue(
 
     console.print(f"\n[bold]Created:[/] {result.get('created_at', 'N/A')}")
     console.print(f"[bold]Updated:[/] {result.get('updated_at', 'N/A')}")
+
+
+@app.command()
+def issue_context(
+    issue_id: str = typer.Argument(..., help="Issue ID, number, #number, or Pylon issue URL"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Get issue details, messages, and internal threads.
+
+    Examples:
+        pylon issue-context 16412
+        pylon issue-context "#16412" --json
+    """
+    client = _get_client()
+
+    try:
+        result = client.get_issue_context(issue_id)
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if json_output:
+        print(json.dumps(result, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
+
+    issue_data = result.get("issue", {})
+    messages = result.get("messages", [])
+    threads = result.get("threads", [])
+
+    console.print(
+        f"\n[bold cyan]#{issue_data.get('number', 'N/A')}[/] {issue_data.get('title', '')}"
+    )
+    console.print(f"[dim]ID: {issue_data.get('id', 'N/A')}[/]")
+    console.print(f"[bold]State:[/] {issue_data.get('state', 'N/A')}")
+    console.print(f"[bold]Messages:[/] {len(messages)}")
+    console.print(f"[bold]Internal threads:[/] {len(threads)}")
+
+    body_html = issue_data.get("body_html")
+    if body_html:
+        console.print("\n[bold]Body HTML:[/]")
+        console.print(body_html)
+
+    if messages:
+        console.print("\n[bold]Recent messages:[/]")
+        for message in messages[-5:]:
+            author = message.get("author") or {}
+            author_name = author.get("name") or author.get("email") or "Unknown"
+            body = message.get("body_html") or message.get("body") or ""
+            console.print(f"[cyan]{author_name}[/]: {body[:500]}")
+
+
+@app.command()
+def issue_messages(
+    issue_id: str = typer.Argument(..., help="Issue ID, number, #number, or Pylon issue URL"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Get all messages on an issue.
+
+    Examples:
+        pylon issue-messages 16412
+        pylon issue-messages "#16412" --json
+    """
+    client = _get_client()
+
+    try:
+        result = client.get_issue_messages(issue_id)
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if json_output:
+        print(json.dumps(result, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
+
+    if not result:
+        console.print("[yellow]No messages found.[/]")
+        raise typer.Exit()
+
+    for message in result:
+        author = message.get("author") or {}
+        author_name = author.get("name") or author.get("email") or "Unknown"
+        body = message.get("body_html") or message.get("body") or ""
+        console.print(f"\n[bold cyan]{author_name}[/]")
+        console.print(body)
+
+
+@app.command()
+def issue_threads(
+    issue_id: str = typer.Argument(..., help="Issue ID, number, #number, or Pylon issue URL"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Get all internal threads on an issue.
+
+    Examples:
+        pylon issue-threads 16412
+        pylon issue-threads "#16412" --json
+    """
+    client = _get_client()
+
+    try:
+        result = client.get_issue_threads(issue_id)
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if json_output:
+        print(json.dumps(result, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
+
+    if not result:
+        console.print("[yellow]No threads found.[/]")
+        raise typer.Exit()
+
+    table = Table(title=f"Threads ({len(result)})")
+    table.add_column("Name", style="cyan", max_width=40)
+    table.add_column("ID", style="dim", max_width=40)
+
+    for thread in result:
+        table.add_row(thread.get("name", ""), thread.get("id", ""))
+
+    console.print(table)
 
 
 @app.command()
@@ -187,7 +308,7 @@ def issue_create(
         console.print(f"[dim]ID: {result.get('id')}[/]")
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 @app.command()
@@ -222,7 +343,7 @@ def issue_update(
         console.print(f"[green]✓ Updated issue #{result.get('number', 'N/A')}[/]")
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 @app.command()
@@ -259,7 +380,7 @@ def issue_search(
         result = client.search_issues(filter_obj, limit=limit)
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     issues_data = result.get("data", [])
 
@@ -307,7 +428,7 @@ def accounts(
         result = client.list_accounts(limit=limit)
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     accounts_data = result.get("data", [])
 
@@ -353,7 +474,7 @@ def account(
         result = client.get_account(account_id)
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if json_output:
         print(json.dumps(result, indent=2, ensure_ascii=False), file=sys.stdout)
@@ -404,7 +525,7 @@ def account_create(
         console.print(f"[dim]ID: {result.get('id')}[/]")
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 @app.command()
@@ -424,7 +545,7 @@ def contacts(
         results = client.list_contacts()
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if query:
         query_lower = query.lower()
@@ -468,7 +589,7 @@ def contact(
         result = client.get_contact(contact_id)
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if json_output:
         print(json.dumps(result, indent=2, ensure_ascii=False), file=sys.stdout)
@@ -493,7 +614,7 @@ def users(
         results = client.list_users()
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if query:
         query_lower = query.lower()
@@ -531,7 +652,7 @@ def teams():
         results = client.list_teams()
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if not results:
         console.print("[yellow]No teams found.[/]")
@@ -560,7 +681,7 @@ def tags(
         results = client.list_tags()
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if object_type:
         results = [t for t in results if t.get("object_type", "").lower() == object_type.lower()]

--- a/tools/business/pylon/client.py
+++ b/tools/business/pylon/client.py
@@ -1,12 +1,35 @@
 """Pylon API client."""
 
-from datetime import datetime, timedelta, timezone
+import re
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
+
 from centaur_sdk import secret
 
 BASE_URL = "https://api.usepylon.com"
+
+
+def _clean_issue_ref(issue_ref: str) -> str:
+    """Normalize issue numbers, #numbers, and Pylon issue URLs for API paths."""
+    ref = str(issue_ref).strip()
+    if not ref:
+        raise ValueError("issue_id must not be empty")
+
+    issue_path_match = re.search(r"/issues/([^/?#]+)", ref)
+    if issue_path_match:
+        return issue_path_match.group(1)
+
+    hash_match = re.search(r"#([A-Za-z0-9_-]+)", ref)
+    if hash_match:
+        return hash_match.group(1)
+
+    prefix_match = re.search(r"\bissue\s+([A-Za-z0-9_-]+)\b", ref, flags=re.IGNORECASE)
+    if prefix_match:
+        return prefix_match.group(1)
+
+    return ref.removeprefix("#").strip()
 
 
 class PylonClient:
@@ -47,6 +70,14 @@ class PylonClient:
 
             return response.json()
 
+    def _canonical_issue_id(self, issue_id: str) -> str:
+        """Return the canonical Pylon issue ID for child issue endpoints."""
+        ref = _clean_issue_ref(issue_id)
+        if ref.isdigit():
+            issue = self.get_issue(ref)
+            return str(issue.get("id") or ref)
+        return ref
+
     def get_me(self) -> dict:
         """Get details of the organization associated with the API token."""
         return self._request("GET", "/me")
@@ -68,9 +99,9 @@ class PylonClient:
             List of issue dicts
         """
         if not end_time:
-            end_time = datetime.now(timezone.utc).isoformat()
+            end_time = datetime.now(UTC).isoformat()
         if not start_time:
-            start_dt = datetime.now(timezone.utc) - timedelta(days=days)
+            start_dt = datetime.now(UTC) - timedelta(days=days)
             start_time = start_dt.isoformat()
 
         response = self._request(
@@ -79,9 +110,58 @@ class PylonClient:
         return response.get("data", [])
 
     def get_issue(self, issue_id: str) -> dict:
-        """Get an issue by its ID or number."""
+        """Get an issue by its ID, number, #number, or Pylon issue URL.
+
+        This returns the issue metadata and body. To read the actual customer/internal
+        conversation, use get_issue_context or get_issue_messages instead.
+        """
+        issue_id = _clean_issue_ref(issue_id)
         response = self._request("GET", f"/issues/{issue_id}")
         return response.get("data", {})
+
+    def get_issue_messages(self, issue_id: str) -> list[dict]:
+        """Get all messages for a Pylon issue.
+
+        Use this when a user asks to read a Pylon thread. Pylon's issue detail
+        endpoint accepts an issue number, but the messages endpoint is documented
+        around the canonical issue ID; this method resolves numeric refs first.
+        """
+        canonical_id = self._canonical_issue_id(issue_id)
+        response = self._request("GET", f"/issues/{canonical_id}/messages")
+        return response.get("data", [])
+
+    def get_issue_threads(self, issue_id: str) -> list[dict]:
+        """Get all internal threads for a Pylon issue.
+
+        Use this with get_issue_messages when investigating support context. Numeric
+        issue refs like "16412" or "#16412" are resolved to the canonical Pylon ID.
+        """
+        canonical_id = self._canonical_issue_id(issue_id)
+        response = self._request("GET", f"/issues/{canonical_id}/threads")
+        return response.get("data", [])
+
+    def get_issue_context(
+        self,
+        issue_id: str,
+        include_messages: bool = True,
+        include_threads: bool = True,
+    ) -> dict[str, Any]:
+        """Read the useful context for a Pylon issue or thread in one call.
+
+        Best first call when a user references "Pylon Issue #16412" or asks to
+        access a Pylon thread. Returns issue details plus messages and internal
+        threads by default.
+        """
+        issue = self.get_issue(issue_id)
+        canonical_id = str(issue.get("id") or _clean_issue_ref(issue_id))
+        result: dict[str, Any] = {"issue": issue}
+        if include_messages:
+            messages_response = self._request("GET", f"/issues/{canonical_id}/messages")
+            result["messages"] = messages_response.get("data", [])
+        if include_threads:
+            threads_response = self._request("GET", f"/issues/{canonical_id}/threads")
+            result["threads"] = threads_response.get("data", [])
+        return result
 
     def search_issues(
         self,

--- a/tools/business/pylon/pyproject.toml
+++ b/tools/business/pylon/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylon"
-description = "Pylon CLI for AI agents - support issues, accounts, contacts"
+description = "Pylon CLI for AI agents - support issues, messages, threads, accounts, contacts"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/business/pylon/test_client.py
+++ b/tools/business/pylon/test_client.py
@@ -1,0 +1,69 @@
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+_CLIENT_PATH = Path(__file__).with_name("client.py")
+_SPEC = importlib.util.spec_from_file_location("pylon_client", _CLIENT_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_pylon_client = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_pylon_client)
+PylonClient = _pylon_client.PylonClient
+
+
+class FakePylonClient(PylonClient):
+    def __init__(self):
+        super().__init__(api_key="test")
+        self.requests: list[tuple[str, str, dict[str, Any]]] = []
+
+    def _request(self, method: str, endpoint: str, **kwargs) -> dict:
+        self.requests.append((method, endpoint, kwargs))
+        if endpoint == "/issues/16412":
+            return {"data": {"id": "iss_canonical", "number": 16412, "title": "Recording issue"}}
+        if endpoint == "/issues/iss_canonical":
+            return {"data": {"id": "iss_canonical", "number": 16412, "title": "Recording issue"}}
+        if endpoint == "/issues/iss_canonical/messages":
+            return {"data": [{"id": "msg_1", "body_html": "<p>Customer report</p>"}]}
+        if endpoint == "/issues/iss_canonical/threads":
+            return {"data": [{"id": "thr_1", "name": "Internal notes"}]}
+        raise AssertionError(f"unexpected request: {method} {endpoint}")
+
+
+def test_get_issue_context_resolves_issue_number_for_messages_and_threads():
+    client = FakePylonClient()
+
+    result = client.get_issue_context("#16412")
+
+    assert result == {
+        "issue": {"id": "iss_canonical", "number": 16412, "title": "Recording issue"},
+        "messages": [{"id": "msg_1", "body_html": "<p>Customer report</p>"}],
+        "threads": [{"id": "thr_1", "name": "Internal notes"}],
+    }
+    assert [request[:2] for request in client.requests] == [
+        ("GET", "/issues/16412"),
+        ("GET", "/issues/iss_canonical/messages"),
+        ("GET", "/issues/iss_canonical/threads"),
+    ]
+
+
+def test_get_issue_messages_accepts_pylon_issue_url():
+    client = FakePylonClient()
+
+    result = client.get_issue_messages("https://app.usepylon.com/issues/16412?foo=bar")
+
+    assert result == [{"id": "msg_1", "body_html": "<p>Customer report</p>"}]
+    assert [request[:2] for request in client.requests] == [
+        ("GET", "/issues/16412"),
+        ("GET", "/issues/iss_canonical/messages"),
+    ]
+
+
+def test_get_issue_messages_uses_canonical_id_directly():
+    client = FakePylonClient()
+
+    result = client.get_issue_messages("iss_canonical")
+
+    assert result == [{"id": "msg_1", "body_html": "<p>Customer report</p>"}]
+    assert [request[:2] for request in client.requests] == [
+        ("GET", "/issues/iss_canonical/messages"),
+    ]

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -103,6 +103,16 @@ class SlackClient:
             "token_revoked",
         }
     )
+    # Bot tokens can only read history/replies for channels the bot has joined;
+    # a non-member public channel returns one of these. When a user token is
+    # configured (SLACK_SEARCH_TOKEN) we retry the read with it so the agent
+    # can read public channels it hasn't been invited to.
+    _NOT_A_MEMBER_CODES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "not_in_channel",
+            "channel_not_found",
+        }
+    )
 
     def __init__(
         self,
@@ -369,6 +379,42 @@ class SlackClient:
 
         return items, next_cursor, bool(next_cursor)
 
+    def _has_user_token(self) -> bool:
+        """True when a distinct user (search) token is configured for reads."""
+        return bool(self.search_token) and self._search_client is not self._client
+
+    def _collect_pages_with_user_fallback(
+        self,
+        make_fetch_page: Callable[[WebClient], Callable[[str | None, int], dict[str, Any]]],
+        *,
+        result_key: str,
+        limit: int,
+        cursor: str | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None, bool]:
+        """Collect cursor pages on the bot token, falling back to the user token.
+
+        The bot token is tried first so member channels keep working unchanged.
+        On ``not_in_channel`` / ``channel_not_found`` — the signature of a public
+        channel the bot has not joined — the read is retried with the user token
+        (which reads as the installing user) when one is configured.
+        """
+        try:
+            return self._collect_cursor_pages(
+                make_fetch_page(self._client),
+                result_key=result_key,
+                limit=limit,
+                cursor=cursor,
+            )
+        except SlackApiError as error:
+            if self._has_user_token() and self._slack_error_code(error) in self._NOT_A_MEMBER_CODES:
+                return self._collect_cursor_pages(
+                    make_fetch_page(self._search_client),
+                    result_key=result_key,
+                    limit=limit,
+                    cursor=cursor,
+                )
+            raise
+
     def _resolve_channel(self, channel: str) -> str:
         """Resolve a channel name to its ID using cached channel list."""
         normalized = self._clean_channel_ref(channel)
@@ -379,7 +425,41 @@ class SlackClient:
         for ch in channels:
             if ch["name"] == name:
                 return ch["id"]
+        # The bot only lists channels it has joined. With a user token we can
+        # resolve a public channel the bot isn't in (reads escalate to it too).
+        resolved = self._resolve_channel_via_user_token(name)
+        if resolved:
+            return resolved
         raise RuntimeError(f"Channel '{channel}' not found or bot not a member")
+
+    def _resolve_channel_via_user_token(self, name: str) -> str | None:
+        """Resolve a public/private channel name to its ID using the user token.
+
+        ``conversations.list`` is an O(workspace) scan, so this only runs as a
+        fallback after the bot's own membership list misses, and only when a
+        user token is configured. Capped to avoid an unbounded scan.
+        """
+        if not self._has_user_token():
+            return None
+        cursor: str | None = None
+        for _ in range(20):  # cap: ~20 pages * 1000 = 20k channels
+            try:
+                response = self._retry_on_ratelimit(
+                    self._search_client.conversations_list,
+                    types="public_channel,private_channel",
+                    limit=1000,
+                    cursor=cursor,
+                    exclude_archived=True,
+                )
+            except SlackApiError:
+                return None
+            for ch in response.get("channels", []) or []:
+                if ch.get("name") == name:
+                    return ch["id"]
+            cursor = (response.get("response_metadata", {}) or {}).get("next_cursor") or None
+            if not cursor:
+                break
+        return None
 
     def _resolve_mentions(self, text: str, user_cache: dict[str, str]) -> str:
         """Replace <@USER_ID> mentions with @username using cached lookups only."""
@@ -880,28 +960,33 @@ class SlackClient:
 
         requested_limit = max(1, min(int(limit), self._MAX_PAGE_SIZE))
 
-        def fetch_page(next_cursor: str | None, batch_limit: int) -> dict[str, Any]:
-            kwargs: dict[str, Any] = {
-                "channel": channel_id,
-                "limit": batch_limit,
-            }
-            if next_cursor:
-                kwargs["cursor"] = next_cursor
-            if normalized_oldest is not None:
-                kwargs["oldest"] = normalized_oldest
-            if normalized_latest is not None:
-                kwargs["latest"] = normalized_latest
-            if normalized_oldest is not None or normalized_latest is not None:
-                kwargs["inclusive"] = inclusive
-            return self._retry_on_ratelimit(
-                self._client.conversations_history,
-                method_key="conversations.history",
-                **kwargs,
-            )
+        def make_fetch_page(
+            api_client: WebClient,
+        ) -> Callable[[str | None, int], dict[str, Any]]:
+            def fetch_page(next_cursor: str | None, batch_limit: int) -> dict[str, Any]:
+                kwargs: dict[str, Any] = {
+                    "channel": channel_id,
+                    "limit": batch_limit,
+                }
+                if next_cursor:
+                    kwargs["cursor"] = next_cursor
+                if normalized_oldest is not None:
+                    kwargs["oldest"] = normalized_oldest
+                if normalized_latest is not None:
+                    kwargs["latest"] = normalized_latest
+                if normalized_oldest is not None or normalized_latest is not None:
+                    kwargs["inclusive"] = inclusive
+                return self._retry_on_ratelimit(
+                    api_client.conversations_history,
+                    method_key="conversations.history",
+                    **kwargs,
+                )
+
+            return fetch_page
 
         try:
-            raw_messages, next_cursor, has_more = self._collect_cursor_pages(
-                fetch_page,
+            raw_messages, next_cursor, has_more = self._collect_pages_with_user_fallback(
+                make_fetch_page,
                 result_key="messages",
                 limit=requested_limit,
                 cursor=cursor,
@@ -973,28 +1058,33 @@ class SlackClient:
 
         requested_limit = max(1, min(int(limit), self._MAX_PAGE_SIZE))
 
-        def fetch_page(next_cursor: str | None, batch_limit: int) -> dict[str, Any]:
-            kwargs: dict[str, Any] = {
-                "channel": channel_id,
-                "ts": normalized_thread_ts,
-                "limit": batch_limit,
-                "inclusive": inclusive,
-            }
-            if next_cursor:
-                kwargs["cursor"] = next_cursor
-            if normalized_oldest is not None:
-                kwargs["oldest"] = normalized_oldest
-            if normalized_latest is not None:
-                kwargs["latest"] = normalized_latest
-            return self._retry_on_ratelimit(
-                self._client.conversations_replies,
-                method_key="conversations.replies",
-                **kwargs,
-            )
+        def make_fetch_page(
+            api_client: WebClient,
+        ) -> Callable[[str | None, int], dict[str, Any]]:
+            def fetch_page(next_cursor: str | None, batch_limit: int) -> dict[str, Any]:
+                kwargs: dict[str, Any] = {
+                    "channel": channel_id,
+                    "ts": normalized_thread_ts,
+                    "limit": batch_limit,
+                    "inclusive": inclusive,
+                }
+                if next_cursor:
+                    kwargs["cursor"] = next_cursor
+                if normalized_oldest is not None:
+                    kwargs["oldest"] = normalized_oldest
+                if normalized_latest is not None:
+                    kwargs["latest"] = normalized_latest
+                return self._retry_on_ratelimit(
+                    api_client.conversations_replies,
+                    method_key="conversations.replies",
+                    **kwargs,
+                )
+
+            return fetch_page
 
         try:
-            raw_messages, next_cursor, has_more = self._collect_cursor_pages(
-                fetch_page,
+            raw_messages, next_cursor, has_more = self._collect_pages_with_user_fallback(
+                make_fetch_page,
                 result_key="messages",
                 limit=requested_limit,
                 cursor=cursor,

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1514,9 +1514,11 @@ class SlackClient:
     def _current_slack_destination(self) -> tuple[str | None, str | None]:
         """Return the active Slack channel/thread from the tool context, if any.
 
-        Slack thread keys are ``slack:<team>:<channel>:<thread_ts>`` (the format
-        the slackbot emits). The older ``slack:<channel>:<thread_ts>`` form is
-        still accepted for backwards compatibility.
+        Slack thread keys are ``slack:<team>:<channel>:<thread_ts>``. Unthreaded
+        DMs use ``slack:<team>:<D-channel>:<D-channel>`` to reuse one runtime; in
+        that case only the channel can be inferred from the key. The older
+        ``slack:<channel>:<thread_ts>`` form is still accepted for backwards
+        compatibility.
         """
         try:
             thread_key = get_tool_context().thread_key or ""
@@ -1531,6 +1533,8 @@ class SlackClient:
             channel, thread_ts = parts[1], parts[2]
         else:
             return None, None
+        if channel.startswith("D") and thread_ts == channel:
+            return channel, None
         if channel and thread_ts:
             return channel, thread_ts
         return None, None

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -606,6 +606,25 @@ def test_upload_file_infers_destination_from_team_scoped_thread_key() -> None:
     assert fake_web_client.last_kwargs["thread_ts"] == "1780035646.228899"
 
 
+def test_upload_file_infers_stable_dm_channel_without_fake_thread_ts() -> None:
+    client, fake_web_client = _make_client()
+    client._resolve_channel = lambda channel: channel  # type: ignore[method-assign]
+    token = set_tool_context(
+        ToolContext(
+            name="slack",
+            thread_key="slack:T0AQQ46PL4C:D0B0XS7BLA3:D0B0XS7BLA3",
+        ),
+    )
+    try:
+        client.upload_file(content_base64="dGVzdA==", filename="random_data.csv")
+    finally:
+        reset_tool_context(token)
+
+    assert fake_web_client.last_kwargs is not None
+    assert fake_web_client.last_kwargs["channel"] == "D0B0XS7BLA3"
+    assert "thread_ts" not in fake_web_client.last_kwargs
+
+
 def test_upload_file_uploads_once_and_returns_when_share_lands(monkeypatch) -> None:
     """The stripped path does a single upload and verifies via files.info; no
     retry, no orphan deletion."""

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -121,6 +121,7 @@ def _make_client() -> tuple[SlackClient, _FakeWebClient]:
     fake_web_client = _FakeWebClient()
     client._client = fake_web_client
     client._search_client = fake_web_client
+    client.search_token = ""
     client._user_cache = {}
     client._ratelimit_deadlines = {}
     client._resolve_channel = lambda channel: "C123"  # type: ignore[method-assign]
@@ -985,3 +986,77 @@ def test_list_users_paginates_and_skips_deleted_by_default() -> None:
         {"limit": 10},
         {"limit": 9, "cursor": "cursor-2"},
     ]
+
+
+def _make_client_with_user_token() -> tuple[SlackClient, _FakeWebClient, _FakeWebClient]:
+    """Client with distinct bot and user (search) token clients."""
+    client = SlackClient.__new__(SlackClient)
+    bot = _FakeWebClient()
+    user = _FakeWebClient()
+    client._client = bot
+    client._search_client = user
+    client.search_token = "xoxp-test"
+    client._user_cache = {}
+    client._ratelimit_deadlines = {}
+    client._resolve_channel = lambda channel: "C999"  # type: ignore[method-assign]
+    client._get_user_cache = lambda: {}  # type: ignore[method-assign]
+    return client, bot, user
+
+
+def test_thread_replies_fall_back_to_user_token_when_bot_not_in_channel() -> None:
+    client, bot, user = _make_client_with_user_token()
+
+    def bot_not_in_channel(**_kwargs):
+        raise _make_slack_error(error="not_in_channel", status_code=403)
+
+    bot.conversations_replies = bot_not_in_channel  # type: ignore[method-assign]
+    user.reply_pages = [
+        {
+            "messages": [{"user": "U1", "text": "from a channel the bot is not in", "ts": "1.0"}],
+            "response_metadata": {"next_cursor": ""},
+        }
+    ]
+
+    result = client.get_thread_replies_page("C999", "1.0")
+
+    assert result["count"] == 1
+    assert result["messages"][0]["text"] == "from a channel the bot is not in"
+    assert len(user.reply_calls) == 1
+
+
+def test_channel_history_falls_back_to_user_token_when_bot_not_in_channel() -> None:
+    client, bot, user = _make_client_with_user_token()
+
+    def bot_not_in_channel(**_kwargs):
+        raise _make_slack_error(error="not_in_channel", status_code=403)
+
+    bot.conversations_history = bot_not_in_channel  # type: ignore[method-assign]
+    user.history_pages = [
+        {
+            "messages": [{"user": "U1", "text": "public channel message", "ts": "2.0"}],
+            "response_metadata": {"next_cursor": ""},
+        }
+    ]
+
+    result = client.get_channel_history_page("C999", limit=5)
+
+    assert result["count"] == 1
+    assert result["messages"][0]["text"] == "public channel message"
+    assert len(user.history_calls) == 1
+
+
+def test_no_user_token_means_not_in_channel_still_raises() -> None:
+    # When bot and search clients are the same (no user token), the error
+    # surfaces as a structured auth failure rather than silently retrying.
+    client, fake_web_client = _make_client()
+    client.search_token = ""
+    client._get_user_cache = lambda: {}  # type: ignore[method-assign]
+
+    def fail(**_kwargs):
+        raise _make_slack_error(error="not_in_channel", status_code=403)
+
+    fake_web_client.conversations_replies = fail  # type: ignore[method-assign]
+
+    # Without a user token the read is not retried; the failure surfaces.
+    with pytest.raises((SlackApiError, SlackAuthError)):
+        client.get_thread_replies_page("C999", "1.0")


### PR DESCRIPTION
## Why

The Watch Agent spammed a customer-investigation thread in #product-eng with `Failed to start the runtime: failed to resume suspended sandbox: ...` on every message (reported by Ari, 2026-06-09). Root cause chain:

1. PR #9 (cost controls) cut `IDLE_TTL_S` from 24h to 15min, so sessions get suspended after any short lull.
2. The deployed sandbox controller is `KUBERNETES_SANDBOX_CONTROLLER=pod`, whose `pause_by_id` falls back to `stop_by_id` (deletes the pod) and whose `resume_by_id` is the base-class **no-op**. A 'suspended' session can never come back.
3. `get_or_spawn` raised on the failed resume and left the DB row in `suspended`, so **every** subsequent message in the thread re-failed and re-posted the error. 39 sessions are currently stuck in `suspended` on samuel-a100.

## What

- `get_or_spawn`: on suspended-resume failure, log and fall through to the gone-container path — preserve `agent_thread_id`/cursors, delete the row, respawn. Stuck rows self-heal on the next message.
- `workflow_engine`: post `Failed to start the runtime` at most once per thread per distinct error (24h in-process TTL); suppressed repeats are logged as `workflow_spawn_failure_notice_suppressed`.
- Test for the dedupe helper.

## Testing

- `uv run pytest tests/test_agent_control_plane.py tests/test_workflows.py` — same pass/fail set as clean `main` (the failures there are pre-existing DB-fixture flakes); new test passes.
- `uv run ruff check` clean on touched files.

FORK.md updated per fork policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)