### PR TITLE
fix(slackbotv2): accept Slack events route

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { randomUUID } from 'node:crypto'
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import {
   Chat,
   StreamingPlan,
@@ -129,7 +129,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
 
   const app = new Hono()
   app.get('/health', c => c.json({ ok: true, service: 'slackbotv2' }))
-  app.post('/api/webhooks/slack', async c => {
+  const handleSlackWebhook = async (c: Context) => {
     const rawBody = await c.req.raw.clone().text()
     if (!isAllowedSlackWebhookBody(rawBody, options, logger)) {
       return new globalThis.Response('ok', { status: 200 })
@@ -168,7 +168,9 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
       headers: response.headers,
       status: response.status
     })
-  })
+  }
+  app.post('/api/webhooks/slack', handleSlackWebhook)
+  app.post('/api/slack/events', handleSlackWebhook)
 
   if (options.recoverRenderObligationsOnStart !== false) {
     scheduleRenderObligationRecovery(chat, state, options)

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -80,6 +80,34 @@ afterAll(async () => {
 })
 
 describe('slackbotv2', () => {
+  it('accepts Slack events on the legacy route', async () => {
+    const parent = await postUserMessage('Legacy route context.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> use the legacy route`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/slack/events',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-legacy-route',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> use the legacy route`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+    expect(codexApi.executes).toHaveLength(1)
+    expect(codexApi.executes[0]?.threadKey).toBe(threadKey(parent.ts))
+  })
+
   it('syncs thread context, forwards subscribed messages, and renders execute streams', async () => {
     const parent = await postUserMessage('The deploy context is above.')
     const firstMention = await postUserMessage(


### PR DESCRIPTION
## Summary
- mount the Slackbot v2 webhook handler on both `/api/webhooks/slack` and `/api/slack/events`
- add a signed Slack event regression test for the legacy Slack Events API path

## Tests
- `bun run check:types` in `services/slackbotv2`
- `bun test test` in `services/slackbotv2`