### PR TITLE
fix: P0 review fixes for the Rust control plane (#344 review)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -118,6 +118,8 @@ jobs:
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache
             type=gha,scope=${{ matrix.image }}
+          # Fork PRs run with a read-only GITHUB_TOKEN: exporting the registry
+          # cache would fail the build, so only export it when we can push.
           cache-to: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache,mode=max
+            ${{ !github.event.pull_request.head.repo.fork && format('type=registry,ref={0}/{1}/{2}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAMESPACE, matrix.image) || '' }}
             type=gha,mode=max,scope=${{ matrix.image }}

--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { CodexAppServerRendererEventMapper, codexAppServerToChatSdkStream } from './codex-app-server'
+import {
+  CodexAppServerRendererEventMapper,
+  codexAppServerToChatSdkStream,
+  codexAppServerToRendererEvents
+} from './codex-app-server'
 import type { RendererTaskBlock } from './types'
 
 describe('CodexAppServerRendererEventMapper', () => {
@@ -497,3 +501,25 @@ async function collect<T>(source: AsyncIterable<T>): Promise<T[]> {
 async function* toAsyncIterable<T>(source: Iterable<T>): AsyncIterable<T> {
   for (const item of source) yield item
 }
+
+describe('codexAppServerToRendererEvents', () => {
+  it('flushes buffered answer text and emits renderer.done when the source ends without a terminal event', () => {
+    const events = codexAppServerToRendererEvents([
+      {
+        type: 'item.started',
+        item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
+      },
+      {
+        type: 'item.agentMessage.delta',
+        itemId: 'msg-1',
+        delta: 'Final answer text.'
+      }
+    ])
+
+    const done = events.find(event => event.type === 'renderer.done')
+    expect(done).toMatchObject({
+      type: 'renderer.done',
+      answerMarkdown: 'Final answer text.'
+    })
+  })
+})

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -567,7 +567,11 @@ export function codexAppServerToRendererEvents(
   sources: Array<ServerNotification | RustSessionStreamEvent | unknown>
 ): RendererEvent[] {
   const mapper = new CodexAppServerRendererEventMapper()
-  return sources.flatMap(source => mapper.process(source))
+  const events = sources.flatMap(source => mapper.process(source))
+  // Flush buffered answer text and emit renderer.done for sources that end
+  // without a terminal event. No-op when a terminal event already completed
+  // the stream.
+  return events.concat(mapper.flush())
 }
 
 export async function* codexAppServerToChatSdkStream(

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -458,6 +458,12 @@ fn parse_secret(
 ) -> Result<ToolSecret, ToolDiscoveryError> {
     if let Some(name) = value.as_str() {
         let name = nonempty(name, "secret name")?.to_owned();
+        if default_hosts.is_empty() {
+            return Err(ToolDiscoveryError::Invalid(format!(
+                "secret entry {name:?} requires the tool to declare non-empty top-level \
+                 'hosts'; a secret without hosts would be unscoped in iron-proxy"
+            )));
+        }
         return Ok(ToolSecret::Http(HttpSecret {
             name: name.clone(),
             secret_ref: name.clone(),
@@ -506,6 +512,13 @@ fn parse_http_secret(
 ) -> Result<ToolSecret, ToolDiscoveryError> {
     let hosts =
         optional_string_array(table.get("hosts"))?.unwrap_or_else(|| default_hosts.to_vec());
+    if hosts.is_empty() || hosts.iter().any(String::is_empty) {
+        return Err(ToolDiscoveryError::Invalid(format!(
+            "HTTP secret {name:?} 'hosts' must be a non-empty array of non-empty strings \
+             (entry-level or tool-level); a secret without hosts would be unscoped in \
+             iron-proxy"
+        )));
+    }
     let mode = optional_str(table, "mode").unwrap_or("replace");
     match mode {
         "replace" => {

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -503,6 +503,18 @@ pub enum GrantSecret {
 }
 
 impl GrantSecret {
+    /// The wrapped secret OID, whichever secret type it is.
+    pub fn oid(&self) -> &str {
+        match self {
+            Self::Static(id)
+            | Self::GcpAuth(id)
+            | Self::OAuthToken(id)
+            | Self::PgDsn(id)
+            | Self::Hmac(id)
+            | Self::AwsAuth(id) => id,
+        }
+    }
+
     /// Route an OID to its grant variant by prefix (see [`SECRET_TYPES`]).
     /// `None` when the OID matches no known secret type.
     pub fn from_oid(oid: &str) -> Option<Self> {

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -125,16 +125,18 @@ pub async fn register_role(
 }
 
 /// Upsert each secret in ``inputs`` and grant it to the role identified by
-/// ``role_oid``, returning the created grant OIDs in input order. Idempotent
-/// when the inputs carry stable ``foreign_id``s (re-running re-upserts and
-/// re-grants). This is the wire-driving half of [`register_role`], factored out
-/// so callers that build [`SecretInput`]s from a source other than an
-/// iron-proxy fragment (e.g. a tool's ``pyproject.toml``) can reuse it.
+/// ``role_oid``, returning the grant OIDs in input order. Idempotent when the
+/// inputs carry stable ``foreign_id``s: re-running re-upserts each secret and
+/// reuses the role's existing grant for it instead of posting a duplicate.
+/// This is the wire-driving half of [`register_role`], factored out so callers
+/// that build [`SecretInput`]s from a source other than an iron-proxy fragment
+/// (e.g. a tool's ``pyproject.toml``) can reuse it.
 pub async fn grant_inputs_to_role(
     client: &IronControlClient,
     role_oid: &str,
     inputs: Vec<SecretInput>,
 ) -> Result<Vec<String>, IronControlError> {
+    let existing = client.list_role_grants(role_oid).await?;
     let mut grant_ids = Vec::with_capacity(inputs.len());
     for input in inputs {
         let secret = match input {
@@ -157,6 +159,13 @@ pub async fn grant_inputs_to_role(
                 GrantSecret::AwsAuth(client.upsert_aws_auth_secret(&input).await?.id)
             }
         };
+        if let Some(grant) = existing
+            .iter()
+            .find(|grant| grant.secret_id() == Some(secret.oid()))
+        {
+            grant_ids.push(grant.id.clone());
+            continue;
+        }
         let grant = client
             .create_grant(&Grantee::Role(role_oid.to_owned()), &secret)
             .await?;

--- a/services/api-rs/crates/centaur-perms/src/tools.rs
+++ b/services/api-rs/crates/centaur-perms/src/tools.rs
@@ -376,6 +376,12 @@ pub fn parse_secret(entry: &Value, default_hosts: &[String]) -> Result<ParsedSec
         if s.is_empty() {
             bail!("secret entry string must be non-empty");
         }
+        if default_hosts.is_empty() {
+            bail!(
+                "secret entry {s:?} requires the tool to declare non-empty top-level \
+                 'hosts'; a secret without hosts would be unscoped in iron-proxy"
+            );
+        }
         return Ok(ParsedSecret::Http(HttpSecret {
             name: s.to_owned(),
             secret_ref: s.to_owned(),
@@ -449,7 +455,15 @@ fn parse_http(
             "HTTP secret {name:?} has unknown mode {other:?} (expected 'replace' or 'inject')"
         ),
     };
-    let hosts = str_array(table.get("hosts")).unwrap_or_else(|| default_hosts.to_vec());
+    let hosts = match non_empty_str_array(table.get("hosts")) {
+        Some(hosts) => hosts,
+        None if !default_hosts.is_empty() => default_hosts.to_vec(),
+        None => bail!(
+            "HTTP secret {name:?} 'hosts' must be a non-empty array of non-empty strings \
+             (or the tool must declare top-level hosts); a secret without hosts would be \
+             unscoped in iron-proxy"
+        ),
+    };
 
     match mode {
         SecretMode::Replace => {

--- a/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
@@ -75,7 +75,11 @@ impl WarmPoolManager {
 
             let id = SandboxId::new(sandbox_id.as_str());
             let failure = match self.manager.status(&id).await {
-                Ok(SandboxStatus::Running | SandboxStatus::Created) => {
+                // Only `Running` accepts `open_io`. `Created` means the
+                // runtime regressed after the replenisher saw it running
+                // (backends wait for readiness before returning from create),
+                // so claiming it would fail at I/O attach.
+                Ok(SandboxStatus::Running) => {
                     if let Some(principal_id) = iron_control_principal
                         && let Err(error) = self
                             .manager

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -425,20 +425,25 @@ impl SessionRuntime {
                 );
                 return Ok(execution.execution);
             }
-            let execution = self
+            let claim = self
                 .store
                 .mark_execution_running(&execution.execution.execution_id)
                 .await?;
+            let execution = claim.execution;
             span.record("centaur.execution_id", execution.execution_id.as_str());
             span.record("execution_id", execution.execution_id.as_str());
-            if execution.status != ExecutionStatus::Running {
+            if !claim.claimed {
+                // A concurrent request with the same idempotency key claimed
+                // the execution first (or it already reached a terminal
+                // state). Do not drive it again — return the current row so
+                // the caller can attach to the event stream.
                 info!(
                     component = COMPONENT_SESSION_RUNTIME,
-                    event = "session_execute_not_running",
+                    event = "session_execute_not_claimed",
                     thread_key = %thread_key,
                     execution_id = %execution.execution_id,
                     status = %execution.status,
-                    "execution is not running after claim"
+                    "execution was already claimed or terminal"
                 );
                 return Ok(execution);
             }

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0009_absurd_await_event_task_guard.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0009_absurd_await_event_task_guard.sql
@@ -1,0 +1,197 @@
+-- await_event trusted the caller-provided (task_id, run_id) pair: it loaded the
+-- run row but never verified the run belongs to p_task_id, so a mismatched call
+-- could attach a wait/checkpoint from one task's run onto another task and put
+-- the wrong task to sleep. Reject mismatches like get_task_checkpoint_states
+-- already does.
+
+create or replace function absurd.await_event (
+  p_queue_name text,
+  p_task_id uuid,
+  p_run_id uuid,
+  p_step_name text,
+  p_event_name text,
+  p_timeout integer default null
+)
+  returns table (
+    should_suspend boolean,
+    payload jsonb
+  )
+  language plpgsql
+as $$
+declare
+  v_run_state text;
+  v_existing_payload jsonb;
+  v_event_payload jsonb;
+  v_checkpoint_payload jsonb;
+  v_resolved_payload jsonb;
+  v_timeout_at timestamptz;
+  v_available_at timestamptz;
+  v_now timestamptz := absurd.current_time();
+  v_task_state text;
+  v_wake_event text;
+  v_run_task_id uuid;
+begin
+  if p_event_name is null or length(trim(p_event_name)) = 0 then
+    raise exception 'event_name must be provided';
+  end if;
+
+  if p_timeout is not null then
+    if p_timeout < 0 then
+      raise exception 'timeout must be non-negative';
+    end if;
+    v_timeout_at := v_now + (p_timeout::double precision * interval '1 second');
+  end if;
+
+  v_available_at := coalesce(v_timeout_at, 'infinity'::timestamptz);
+
+  execute format(
+    'select state
+       from absurd.%I
+      where task_id = $1
+        and checkpoint_name = $2',
+    'c_' || p_queue_name
+  )
+  into v_checkpoint_payload
+  using p_task_id, p_step_name;
+
+  if v_checkpoint_payload is not null then
+    return query select false, v_checkpoint_payload;
+    return;
+  end if;
+
+  -- Ensure a row exists for this event so we can take a row-level lock.
+  --
+  -- We use payload IS NULL as the sentinel for "not emitted yet".  emit_event
+  -- always writes a non-NULL payload (at minimum JSON null).
+  --
+  -- Lock ordering is important to avoid deadlocks: await_event locks the event
+  -- row first (FOR SHARE) and then the run row (FOR UPDATE).  emit_event
+  -- naturally locks the event row via its UPSERT before touching waits/runs.
+  execute format(
+    'insert into absurd.%I (event_name, payload, emitted_at)
+     values ($1, null, ''epoch''::timestamptz)
+     on conflict (event_name) do nothing',
+    'e_' || p_queue_name
+  ) using p_event_name;
+
+  execute format(
+    'select 1
+       from absurd.%I
+      where event_name = $1
+      for share',
+    'e_' || p_queue_name
+  ) using p_event_name;
+
+  execute format(
+    'select r.state, r.event_payload, r.wake_event, t.state, r.task_id
+       from absurd.%I r
+       join absurd.%I t on t.task_id = r.task_id
+      where r.run_id = $1
+      for update',
+    'r_' || p_queue_name,
+    't_' || p_queue_name
+  )
+  into v_run_state, v_existing_payload, v_wake_event, v_task_state, v_run_task_id
+  using p_run_id;
+
+  if v_run_state is null then
+    raise exception 'Run "%" not found while awaiting event', p_run_id;
+  end if;
+
+  if v_run_task_id <> p_task_id then
+    raise exception 'Run "%" does not belong to task "%" in queue "%"', p_run_id, p_task_id, p_queue_name;
+  end if;
+
+  if v_task_state = 'cancelled' then
+    raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+  end if;
+
+  execute format(
+    'select payload
+       from absurd.%I
+      where event_name = $1',
+    'e_' || p_queue_name
+  )
+  into v_event_payload
+  using p_event_name;
+
+  if v_existing_payload is not null then
+    execute format(
+      'update absurd.%I
+          set event_payload = null
+        where run_id = $1',
+      'r_' || p_queue_name
+    ) using p_run_id;
+
+    if v_event_payload is not null and v_event_payload = v_existing_payload then
+      v_resolved_payload := v_existing_payload;
+    end if;
+  end if;
+
+  if v_run_state <> 'running' then
+    raise exception 'Run "%" must be running to await events', p_run_id;
+  end if;
+
+  if v_resolved_payload is null and v_event_payload is not null then
+    v_resolved_payload := v_event_payload;
+  end if;
+
+  if v_resolved_payload is not null then
+    execute format(
+      'insert into absurd.%I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
+       values ($1, $2, $3, ''committed'', $4, $5)
+       on conflict (task_id, checkpoint_name)
+       do update set state = excluded.state,
+                     status = excluded.status,
+                     owner_run_id = excluded.owner_run_id,
+                     updated_at = excluded.updated_at',
+      'c_' || p_queue_name
+    ) using p_task_id, p_step_name, v_resolved_payload, p_run_id, v_now;
+    return query select false, v_resolved_payload;
+    return;
+  end if;
+
+  -- Detect if we resumed due to timeout: wake_event matches and payload is null
+  if v_resolved_payload is null and v_wake_event = p_event_name and v_existing_payload is null then
+    -- Resumed due to timeout; don't re-sleep and don't create a new wait
+    execute format(
+      'update absurd.%I set wake_event = null where run_id = $1',
+      'r_' || p_queue_name
+    ) using p_run_id;
+    return query select false, null::jsonb;
+    return;
+  end if;
+
+  execute format(
+    'insert into absurd.%I (task_id, run_id, step_name, event_name, timeout_at, created_at)
+     values ($1, $2, $3, $4, $5, $6)
+     on conflict (run_id, step_name)
+     do update set event_name = excluded.event_name,
+                   timeout_at = excluded.timeout_at,
+                   created_at = excluded.created_at',
+    'w_' || p_queue_name
+  ) using p_task_id, p_run_id, p_step_name, p_event_name, v_timeout_at, v_now;
+
+  execute format(
+    'update absurd.%I
+        set state = ''sleeping'',
+            claimed_by = null,
+            claim_expires_at = null,
+            available_at = $3,
+            wake_event = $2,
+            event_payload = null
+      where run_id = $1',
+    'r_' || p_queue_name
+  ) using p_run_id, p_event_name, v_available_at;
+
+  execute format(
+    'update absurd.%I
+        set state = ''sleeping''
+      where task_id = $1',
+    't_' || p_queue_name
+  ) using p_task_id;
+
+  return query select true, null::jsonb;
+  return;
+end;
+$$;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -26,6 +26,15 @@ pub struct CreateExecutionResult {
     pub created: bool,
 }
 
+#[derive(Clone, Debug)]
+pub struct ClaimExecutionResult {
+    pub execution: SessionExecution,
+    /// True only when this call transitioned the execution from `queued` to
+    /// `running`. False means another request already claimed it (or it is
+    /// terminal), so the caller must not drive the execution.
+    pub claimed: bool,
+}
+
 #[derive(Clone)]
 pub struct PgSessionStore {
     pool: PgPool,
@@ -258,7 +267,7 @@ impl PgSessionStore {
     pub async fn mark_execution_running(
         &self,
         execution_id: &str,
-    ) -> Result<SessionExecution, SessionStoreError> {
+    ) -> Result<ClaimExecutionResult, SessionStoreError> {
         let maybe_row = sqlx::query_as::<_, SessionExecutionRow>(
             r#"
             update session_executions
@@ -274,6 +283,9 @@ impl PgSessionStore {
         .await?;
 
         let Some(row) = maybe_row else {
+            // The execution was not queued: a concurrent request already
+            // claimed it or it reached a terminal state. Report the current
+            // row without taking ownership.
             let row = sqlx::query_as::<_, SessionExecutionRow>(
                 r#"
                 select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
@@ -284,12 +296,18 @@ impl PgSessionStore {
             .bind(execution_id)
             .fetch_one(&self.pool)
             .await?;
-            return row.try_into();
+            return Ok(ClaimExecutionResult {
+                execution: row.try_into()?,
+                claimed: false,
+            });
         };
 
         self.set_session_status(&row.thread_key, SessionStatus::Executing)
             .await?;
-        row.try_into()
+        Ok(ClaimExecutionResult {
+            execution: row.try_into()?,
+            claimed: true,
+        })
     }
 
     pub async fn complete_execution(

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -562,31 +562,42 @@ async function recoverRenderObligations(
   })
 
   for (const threadId of threadIds) {
-    const thread = chat.thread(threadId)
-    const threadState = await thread.state
-    const obligation = threadState?.renderObligation
-    if (!obligation) continue
+    try {
+      const thread = chat.thread(threadId)
+      const threadState = await thread.state
+      const obligation = threadState?.renderObligation
+      if (!obligation) continue
 
-    const leaseToken = randomUUID()
-    const leaseAcquired = await state.setIfNotExists(
-      renderRecoveryLeaseKey(threadId),
-      leaseToken,
-      RENDER_RECOVERY_LEASE_TTL_MS
-    )
-    if (!leaseAcquired) {
-      traceLog(options, 'slackbotv2_render_recovery_lease_skipped', undefined, {
+      const leaseToken = randomUUID()
+      const leaseAcquired = await state.setIfNotExists(
+        renderRecoveryLeaseKey(threadId),
+        leaseToken,
+        RENDER_RECOVERY_LEASE_TTL_MS
+      )
+      if (!leaseAcquired) {
+        traceLog(options, 'slackbotv2_render_recovery_lease_skipped', undefined, {
+          thread_id: threadId
+        })
+        continue
+      }
+
+      try {
+        if (await recoverRenderObligation(chat, state, options, threadId, obligation)) {
+          deferredCount += 1
+        }
+      } finally {
+        const activeLeaseToken = await state.get<string>(renderRecoveryLeaseKey(threadId))
+        if (activeLeaseToken === leaseToken) await state.delete(renderRecoveryLeaseKey(threadId))
+      }
+    } catch (error) {
+      // One thread's corrupt state or failed render must not abort the scan:
+      // log it, count it as deferred so a later pass retries it, and keep
+      // recovering the remaining threads.
+      deferredCount += 1
+      traceLog(options, 'slackbotv2_render_recovery_thread_failed', undefined, {
+        error: errorMessage(error),
         thread_id: threadId
       })
-      continue
-    }
-
-    try {
-      if (await recoverRenderObligation(chat, state, options, threadId, obligation)) {
-        deferredCount += 1
-      }
-    } finally {
-      const activeLeaseToken = await state.get<string>(renderRecoveryLeaseKey(threadId))
-      if (activeLeaseToken === leaseToken) await state.delete(renderRecoveryLeaseKey(threadId))
     }
   }
   return deferredCount

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -197,6 +197,9 @@ export function sessionStreamError(error: unknown): RustSessionStreamEvent {
   }
 }
 
+/** Largest attachment we are willing to buffer in memory and inline as base64. */
+export const MAX_INLINE_ATTACHMENT_BYTES = 100 * 1024 * 1024
+
 async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2ApiAttachment> {
   const serialized: SlackbotV2ApiAttachment = {
     fetchMetadata: attachment.fetchMetadata,
@@ -209,9 +212,20 @@ async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2Ap
     width: attachment.width
   }
 
+  if (typeof attachment.size === 'number' && attachment.size > MAX_INLINE_ATTACHMENT_BYTES) {
+    serialized.fetchError = attachmentTooLargeError(attachment.size)
+    return serialized
+  }
+
   try {
     const data = attachment.data ?? (await attachment.fetchData?.())
     if (data) {
+      // Re-check the actual byte count: Slack size metadata can be absent.
+      const byteLength = Buffer.isBuffer(data) ? data.length : data.size
+      if (byteLength > MAX_INLINE_ATTACHMENT_BYTES) {
+        serialized.fetchError = attachmentTooLargeError(byteLength)
+        return serialized
+      }
       serialized.dataBase64 = await bytesToBase64(data)
     }
   } catch (error) {
@@ -219,6 +233,10 @@ async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2Ap
   }
 
   return serialized
+}
+
+function attachmentTooLargeError(bytes: number): string {
+  return `attachment too large to inline (${bytes} bytes > ${MAX_INLINE_ATTACHMENT_BYTES} byte limit)`
 }
 
 async function bytesToBase64(data: Buffer | Blob): Promise<string> {


### PR DESCRIPTION
Fixes the low-effort/high-reward (P0) findings from the code review of #344, one commit per finding.

## Correctness

- **Execution claim race** — `mark_execution_running` treated an already-`running` row as a successful claim, so a concurrent request with the same idempotency key could send the same input to the sandbox twice. It now returns a `claimed` flag set only by the actual `queued→running` transition, and the runtime only drives the execution when it owns the claim.
- **`absurd.await_event` task/run mismatch** — the function never verified `p_run_id` belongs to `p_task_id`, so a mismatched call could attach one task's run to another task's wait/checkpoint and put the wrong task to sleep. Added the same guard `get_task_checkpoint_states` already had. Shipped as **migration 0009** (`create or replace`) rather than editing 0007, since 0007 is applied in live environments and sqlx validates migration checksums.
- **Warm pool handed out not-ready sandboxes** — `Created` sandboxes (not ready for byte I/O) were claimable and failed later at `open_io`. Since backends wait for readiness before the replenisher records a sandbox, `Created` at claim time means the runtime regressed: it is now marked failed and the next one is tried.
- **Grant idempotency** — `grant_inputs_to_role` documented idempotency but always POSTed a new grant; re-running `centaur-perms … grant` or startup role registration duplicated grants or conflicted. It now reuses the role's existing grant per secret.

## Security

- **Empty hosts ⇒ unscoped secret** — an HTTP tool secret parsed with an empty `hosts` list emitted an empty iron-control `rules` array, leaving the credential host-unlimited. Both manifest parsers (`centaur-perms` and the api-server tool-discovery mirror) now fail closed, matching the existing `brokered_token` behavior.
  - ⚠️ `tools/infra/grafana/pyproject.toml` declares `hosts = []` and is the one in-repo tool relying on the old behavior: it is now warn-skipped at discovery and errors in `centaur-perms` until real hosts are declared. Someone who knows the deployment's Grafana/VictoriaMetrics hostnames should add them.

## Bot / rendering

- **Lost final answers** — `codexAppServerToRendererEvents` never called `mapper.flush()`, so finite sources ending without a terminal event lost buffered answer text and never got `renderer.done`. Now flushes like the streaming variant (regression test included, verified red-without-fix).
- **Unbounded attachment buffering** — Slack attachments were downloaded into memory and base64-inlined with no limit. Now capped at 100 MiB, checked against Slack's `size` metadata before downloading and re-checked on actual bytes; oversized attachments degrade via the existing `fetchError` channel.
- **Recovery scan aborted on first failure** — one corrupt obligation or render error stopped startup recovery for all remaining threads until the next restart. Each thread is now isolated, logged (`slackbotv2_render_recovery_thread_failed`), and deferred to the capped-backoff retry loop.

## CI

- **Fork PR builds failed at cache export** — `cache-to: type=registry` pushes a cache manifest to GHCR even with `push: false`, and fork PRs run with a read-only token. The registry cache export is now gated on the same not-a-fork predicate as `push`.

## Verification

- `cargo check` / `cargo test` on all touched crates (135 tests), `cargo fmt --check`, no new clippy warnings
- `bun test` + `tsc --noEmit` for `packages/rendering` (18) and `services/slackbotv2` (22)
- Migrations 0001→0009 applied to a disposable Postgres 16; functional smoke test of the new guard: mismatched (task, run) raises `does not belong`, matched pair passes the guard and fails on the pre-existing `must be running` check
- `actionlint` on the workflow change
