### PR TITLE
fix(api-rs): raise stdout cap and disable service links

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -488,6 +488,7 @@ fn build_agent_sandbox(
         "containers": [container],
         "restartPolicy": "Never",
         "automountServiceAccountToken": false,
+        "enableServiceLinks": false,
     });
     insert_optional(
         &mut pod_spec,
@@ -731,6 +732,10 @@ mod tests {
             1
         );
         let container = &sandbox.spec.pod_template.spec.containers[0];
+        assert_eq!(
+            sandbox.spec.pod_template.spec.enable_service_links,
+            Some(false)
+        );
         assert_eq!(container.image.as_deref(), Some("centaur-agent:latest"));
         assert_eq!(container.stdin, Some(true));
         assert_eq!(container.volume_mounts.as_ref().unwrap().len(), 2);

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -37,7 +37,7 @@ use tracing::{Instrument, Span, error, info, info_span, warn};
 
 pub const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 
-const MAX_SESSION_OUTPUT_LINE_BYTES: usize = 1024 * 1024;
+const MAX_SESSION_OUTPUT_LINE_BYTES: usize = 8 * 1024 * 1024;
 const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
@@ -3121,7 +3121,7 @@ mod tests {
     fn stdout_pump_max_line_error_is_stable() {
         assert_eq!(
             stdout_pump_error_message(&LinesCodecError::MaxLineLengthExceeded),
-            "sandbox stdout line exceeded maximum length of 1048576 bytes"
+            "sandbox stdout line exceeded maximum length of 8388608 bytes"
         );
     }
 


### PR DESCRIPTION
## Summary
- raise the API-RS sandbox stdout NDJSON line cap from 1 MiB to 8 MiB
- set `enableServiceLinks: false` on generated Agent Sandbox pod specs
- update tests for the new cap and pod spec field

## Tests
- `cargo fmt`
- `cargo test -p centaur-sandbox-agent-k8s builds_agent_sandbox_spec_with_state_volume_and_limits`
- `cargo test -p centaur-session-runtime`