### PR TITLE
fix: keep sandbox bootstrap noise out of the harness stdout stream

### DIFF
--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -226,7 +226,9 @@ def main() -> int:
     index_path = bin_dir / ".centaur-tools.json"
     index_path.write_text(json.dumps(list(scripts.values()), indent=2, sort_keys=True) + "\n")
     _write_catalog(bin_dir / "centaur-tools", index_path, pythonpath)
-    print(f"installed {len(scripts)} Centaur tool CLI shims into {bin_dir}")
+    # stdout is reserved for harness JSONL output (the session stdout pump streams
+    # it to clients); write bootstrap notices to stderr so they never pollute it.
+    print(f"installed {len(scripts)} Centaur tool CLI shims into {bin_dir}", file=sys.stderr)
     return 0
 
 

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -570,7 +570,9 @@ function isTerminalCodexOutputLine(line: string): boolean {
   try {
     payload = JSON.parse(line)
   } catch {
-    return true
+    // Non-JSON stdout lines (e.g. sandbox bootstrap notices) are noise, not a
+    // signal that the turn finished; treating them as terminal drops the answer.
+    return false
   }
   if (!isJsonObject(payload)) return false
 

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -332,6 +332,42 @@ describe('slackbotv2', () => {
     })
   })
 
+  it('ignores non-JSON sandbox bootstrap output lines instead of ending the stream', async () => {
+    codexApi.autoRespond = false
+
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> answer after bootstrap noise`)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-bootstrap-noise',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> answer after bootstrap noise`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+
+    const key = threadKey(mention.ts)
+    codexApi.emitOutputLine(key, 'installed 62 Centaur tool CLI shims into /home/agent/.local/bin')
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('Answer despite bootstrap noise.'))
+
+    await Promise.all(waits)
+    expect(slackApi.calls.some(call => call.method === 'chat.stopStream')).toBe(true)
+    expect(await threadText(mention.ts)).toContain('Answer despite bootstrap noise.')
+    expect(await threadText(mention.ts)).not.toContain(
+      'Execution completed, but no final text was captured.'
+    )
+  })
+
   it('forwards subscribed messages to /messages without executing during a stream', async () => {
     codexApi.autoRespond = false
 


### PR DESCRIPTION
## Problem

On prd-centaur-na, mentions answered from a **fresh** sandbox finalize in Slack as
`Execution completed, but no final text was captured.` while the agent's real answer
streams afterwards and is dropped.

Incident: https://tempoxyz.slack.com/archives/C0A99L9RLHZ/p1781101314839669?thread_ts=1781098991.854579&cid=C0A99L9RLHZ
(execution `exe_9b90bf5c492c4946bcc284d250aaac0c`, sandbox `asbx-1781101306199-9`, 2026-06-10 14:21 UTC)

## Root cause

1. `services/sandbox/entrypoint.sh` runs `install-tool-shims`, which printed
   `installed 62 Centaur tool CLI shims into /home/agent/.local/bin` to **stdout** — the
   same pipe the session stdout pump streams as `session.output.line` events
   (it was event 27757, the first output line of the execution).
2. slackbotv2's `isTerminalCodexOutputLine` treats any JSON-unparseable line as terminal
   (`catch { return true }`), so the bootstrap notice ended the render stream ~4s after
   input was written, before any codex output. The codex answer (events 27758–29162)
   arrived after the render obligation was already cleared.

Warm-pool sandboxes flush entrypoint output before attach, which is why only
fresh-sandbox turns failed.

## Fix

- `install_tool_shims.py`: write the bootstrap notice to stderr; stdout stays pure harness JSONL
- slackbotv2: non-JSON output lines are noise, not terminal
- regression test: emits the exact bootstrap line before codex output and asserts the
  answer is still delivered (fails against the old `return true` behavior)

`services/slackbotv2`: 23/23 tests pass.