### PR TITLE
fix(proxy): allow Datadog API-key auth headers

### DIFF
--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -66,6 +66,8 @@ transforms:
         - "api-access-key"
         - "api-signature"
         - "api-timestamp"
+        - "dd-api-key"
+        - "dd-application-key"
         - "fx-access-key"
         - "fx-access-sign"
         - "fx-access-timestamp"


### PR DESCRIPTION
## Summary

Add `dd-api-key` / `dd-application-key` to iron-proxy's `header_allowlist` so agent tools can authenticate to the Datadog REST API through the per-sandbox proxy.

## Why

Datadog authenticates with two headers — `DD-API-KEY` (org API key) and `DD-APPLICATION-KEY` (application key); it does not accept `Authorization: Bearer <api_key>` for static-key auth. Because neither `dd-`-prefixed header is on iron-proxy's `header_allowlist` (and they don't match the `^x-…(api-key|token|auth|key)$` catch-all), the proxy strips them before egress, so a Datadog tool's requests reach `api.datadoghq.com` unauthenticated and 403. This mirrors the existing per-tool header additions (`x-as-user-email`, etc.).

## Rebased / ported

This PR originally also edited the legacy `services/api` Python proxy renderer and its `test_proxy_config.py`. Both were **removed upstream** when the Python `api` service was deleted (#521), so the rebase dropped them. The change now lands solely in `services/iron-proxy/iron-proxy.yaml` — the base proxy config baked into the iron-proxy image (`Dockerfile` → `proxy.yaml.default`) and the only place `header_allowlist` is defined in the repo. The allowlist is now static YAML (no renderer), so the old render-test is obsolete.