### PR TITLE
fix: stop silent Slack answer loss - segment budget, pump reattach, file uploads

### DIFF
--- a/patches/@chat-adapter__slack@4.30.0.patch
+++ b/patches/@chat-adapter__slack@4.30.0.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/index.js b/dist/index.js
-index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e984b25ba93 100644
+index 53a35e40d7dc03dea57f965325728761467ad7c7..f9f5a201e661a5234fd5cd479d8475ca9bfacccd 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -31,6 +31,123 @@ import {
+@@ -31,6 +31,148 @@ import {
    toModalElement,
    toPlainText
  } from "chat";
@@ -11,6 +11,8 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +var STREAM_CHUNK_LIMIT = 256;
 +var STREAM_TASK_LIMIT = 50;
 +var STREAM_FENCE_RESERVE = 64;
++var STREAM_CARD_OVERHEAD = 64;
++var STREAM_PLAN_SIZE_KEY = "\0plan";
 +var FENCE_PATTERN = /^(`{3,}|~{3,})/;
 +var Fence = class {
 +  constructor() {
@@ -123,10 +125,33 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +    type: "task_update"
 +  }));
 +}
++function estimateStructuredChunkSize(chunk) {
++  let size = STREAM_CARD_OVERHEAD;
++  if (typeof chunk.id === "string") {
++    size += chunk.id.length;
++  }
++  if (typeof chunk.title === "string") {
++    size += chunk.title.length;
++  }
++  if (typeof chunk.details === "string") {
++    size += chunk.details.length;
++  }
++  if (typeof chunk.output === "string") {
++    size += chunk.output.length;
++  }
++  if (chunk.sources !== void 0) {
++    try {
++      size += JSON.stringify(chunk.sources).length;
++    } catch {
++      size += STREAM_CHUNK_LIMIT;
++    }
++  }
++  return size;
++}
  
  // src/cards.ts
  import {
-@@ -3434,26 +3551,122 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3434,26 +3576,130 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -140,6 +165,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 -      }
 +    const createSegment = () => ({
 +      cards: 0,
++      chunkSizes: /* @__PURE__ */ new Map(),
 +      hasContent: false,
 +      length: 0,
 +      stopped: false,
@@ -199,7 +225,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 -      await streamer.append({ markdown_text: delta, token });
 +      let remaining = delta;
 +      while (remaining.length > 0) {
-+        if (current.length === STREAM_SEGMENT_LIMIT) {
++        if (current.length >= STREAM_SEGMENT_LIMIT) {
 +          await rotateSegment(fence.closing, fence.opening);
 +        }
 +        const available = STREAM_SEGMENT_LIMIT - current.length;
@@ -229,24 +255,31 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +      }
      };
      let structuredChunksSupported = true;
-+    const appendStructuredChunk = async (segment, chunk) => {
++    const appendStructuredChunk = async (segment, chunk, sizeKey) => {
 +      await segment.streamer.append({ chunks: [chunk], token });
 +      segment.hasContent = true;
++      const size = estimateStructuredChunkSize(chunk);
++      const prior = segment.chunkSizes.get(sizeKey) ?? 0;
++      if (size > prior) {
++        segment.length += size - prior;
++        segment.chunkSizes.set(sizeKey, size);
++      }
 +    };
 +    const createStructuredSegment = async () => {
 +      current = createSegment();
 +      structured.add(current);
 +      if (plan) {
-+        await appendStructuredChunk(current, plan);
++        await appendStructuredChunk(current, plan, STREAM_PLAN_SIZE_KEY);
 +      }
 +      return current;
 +    };
-+    const getTaskSegment = async (id) => {
++    const getTaskSegment = async (id, size) => {
 +      const existing = taskSegments.get(id);
 +      if (existing) {
 +        return existing;
 +      }
-+      if (current.cards >= STREAM_TASK_LIMIT) {
++      const overflowing = current.hasContent && current.length + size > STREAM_SEGMENT_LIMIT;
++      if (current.cards >= STREAM_TASK_LIMIT || overflowing) {
 +        await createStructuredSegment();
 +      } else {
 +        structured.add(current);
@@ -258,7 +291,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
      const sendStructuredChunk = async (chunk) => {
        if (!structuredChunksSupported) {
          return;
-@@ -3463,7 +3676,25 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3463,7 +3709,25 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
@@ -272,20 +305,20 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +            structured.add(current);
 +          }
 +          for (const segment of structured) {
-+            await appendStructuredChunk(segment, plan);
++            await appendStructuredChunk(segment, plan, STREAM_PLAN_SIZE_KEY);
 +          }
 +          return;
 +        }
 +        const chunks = splitTask(chunk, taskParts.get(chunk.id) ?? 0);
 +        taskParts.set(chunk.id, chunks.length);
 +        for (const normalized of chunks) {
-+          const segment = await getTaskSegment(normalized.id);
-+          await appendStructuredChunk(segment, normalized);
++          const segment = await getTaskSegment(normalized.id, estimateStructuredChunkSize(normalized));
++          await appendStructuredChunk(segment, normalized, normalized.id);
 +        }
        } catch (error) {
          structuredChunksSupported = false;
          this.logger.warn(
-@@ -3479,31 +3710,72 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3479,31 +3743,75 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
      };
@@ -305,7 +338,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +        } else {
 +          await sendStructuredChunk(chunk);
 +        }
-       }
++      }
 +      renderer.finish();
 +      const finalCommittable = renderer.getCommittableText();
 +      const finalDelta = finalCommittable.slice(lastAppended.length);
@@ -318,6 +351,9 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +        });
 +        current.hasContent = true;
 +        current.length += fence.closing.length;
++      }
++      if (options?.stopBlocks && current.hasContent && current.length + JSON.stringify(options.stopBlocks).length > STREAM_SEGMENT_LIMIT) {
++        await rotateSegment(void 0, void 0);
 +      }
 +      for (const segment of structured) {
 +        if (segment !== current) {
@@ -350,7 +386,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +            error: stopError
 +          });
 +        }
-+      }
+       }
 +      throw error;
      }
 -    renderer.finish();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@chat-adapter/slack@4.30.0':
-    hash: 3d0b198070971a99f7e1536863ea700cc3723c828e4fdedccc9b98e68db2fbe4
+    hash: 833a969ecaa76a41f85dc5cde536c5259c2206f41721461d9b4e94b24f623032
     path: patches/@chat-adapter__slack@4.30.0.patch
 
 importers:
@@ -134,7 +134,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.30.0
-        version: 4.30.0(patch_hash=3d0b198070971a99f7e1536863ea700cc3723c828e4fdedccc9b98e68db2fbe4)(zod@4.4.3)
+        version: 4.30.0(patch_hash=833a969ecaa76a41f85dc5cde536c5259c2206f41721461d9b4e94b24f623032)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
@@ -1559,7 +1559,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.30.0(patch_hash=3d0b198070971a99f7e1536863ea700cc3723c828e4fdedccc9b98e68db2fbe4)(zod@4.4.3)':
+  '@chat-adapter/slack@4.30.0(patch_hash=833a969ecaa76a41f85dc5cde536c5259c2206f41721461d9b4e94b24f623032)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.30.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
 name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",
@@ -466,6 +467,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -67,8 +67,26 @@ fn init_crypto_provider() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 
+/// Resolves on SIGINT or SIGTERM. Kubernetes stops pods with SIGTERM; as PID 1
+/// the process would otherwise ignore it and every rollout would end in an
+/// abrupt SIGKILL after the grace period, killing in-flight work mid-write.
 async fn shutdown_signal() {
-    let _ = tokio::signal::ctrl_c().await;
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let Ok(mut sigterm) = signal(SignalKind::terminate()) else {
+            let _ = tokio::signal::ctrl_c().await;
+            return;
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 #[derive(Debug, Error)]

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -21,4 +21,7 @@ tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 time.workspace = true
+tokio = { workspace = true, features = ["io-util", "macros", "rt-multi-thread", "sync", "time"] }
+uuid.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -41,17 +41,27 @@ const MAX_SESSION_OUTPUT_LINE_BYTES: usize = 8 * 1024 * 1024;
 const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
+const SESSION_PIPE_MAX_REATTACH_ATTEMPTS: u32 = 3;
+const SESSION_PIPE_REATTACH_DELAY: Duration = Duration::from_millis(500);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 
 type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
 type ExecutionSpanRegistry = Arc<Mutex<HashMap<String, Span>>>;
+type SessionPipeMap = Arc<Mutex<HashMap<String, SessionPipe>>>;
+/// Per-sandbox locks serializing `open_io` so concurrent attach attempts
+/// (execute, SSE attach, steering, pump reattach) cannot open competing
+/// attach streams that interfere with each other. Entries are never removed:
+/// they are tiny, bounded by the sandboxes this process touches, and removal
+/// would reintroduce the open race it exists to prevent.
+type SessionPipeOpenLocks = Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>;
 
 #[derive(Clone)]
 pub struct SessionRuntime {
     store: PgSessionStore,
     sandbox_runtime: SandboxRuntime,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    sandbox_pipes: SessionPipeMap,
+    pipe_open_locks: SessionPipeOpenLocks,
     execution_spans: ExecutionSpanRegistry,
     iron_control: Option<SessionRegistrar>,
     warm_pool: Option<Arc<WarmPoolManager>>,
@@ -124,6 +134,7 @@ impl SessionRuntime {
             store,
             sandbox_runtime,
             sandbox_pipes: Arc::new(Mutex::new(HashMap::new())),
+            pipe_open_locks: Arc::new(Mutex::new(HashMap::new())),
             execution_spans: Arc::new(Mutex::new(HashMap::new())),
             iron_control: None,
             warm_pool: None,
@@ -1018,81 +1029,46 @@ impl SessionRuntime {
                 return Ok(pipe);
             }
 
+            // Serialize opens per sandbox: concurrent callers (execute, SSE
+            // attach, steering) must not race `open_io` for the same sandbox,
+            // since competing k8s attach streams disrupt each other.
+            let open_lock = self.pipe_open_lock(sandbox_id).await;
+            let _open_guard = open_lock.lock().await;
+            if let Some(pipe) = self.sandbox_pipes.lock().await.get(sandbox_id).cloned() {
+                info!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_pipe_reused",
+                    thread_key = %thread_key,
+                    sandbox_id,
+                    "reusing session pipe"
+                );
+                return Ok(pipe);
+            }
+
             let io = self
                 .sandbox_runtime
                 .manager
                 .open_io(&SandboxId::new(sandbox_id))
                 .await?
                 .into_parts();
-            let pipe = SessionPipe {
-                stdin: Arc::new(Mutex::new(FramedWrite::new(
-                    io.stdin,
-                    LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
-                ))),
-            };
+            let pipe = session_pipe_from_stdin(io.stdin);
 
             self.sandbox_pipes
                 .lock()
                 .await
                 .insert(sandbox_id.to_owned(), pipe.clone());
-            let store = self.store.clone();
-            let manager = self.sandbox_runtime.manager.clone();
-            let execution_spans = self.execution_spans.clone();
-            let thread_key = thread_key.clone();
-            let pump_thread_key = thread_key.clone();
-            let pump_key = sandbox_id.to_owned();
-            let sandbox_pipes = self.sandbox_pipes.clone();
-            let stdout = io.stdout;
-            let stderr = io.stderr;
-            let guard = io.guard;
-            let stderr_key = pump_key.clone();
-
-            tokio::spawn(async move {
-                let result = run_stdout_pump(
-                    store.clone(),
-                    manager,
-                    sandbox_pipes.clone(),
-                    execution_spans.clone(),
-                    pump_thread_key.clone(),
-                    &pump_key,
-                    stdout,
-                    guard,
-                )
-                .await;
-                if let Err(error) = result {
-                    warn!(
-                        component = COMPONENT_SESSION_RUNTIME,
-                        event = "session_stdout_pump_failed",
-                        thread_key = %pump_thread_key,
-                        sandbox_id = %pump_key,
-                        %error,
-                        "session stdout pump failed"
-                    );
-                    let _ = store
-                        .append_event(
-                            &pump_thread_key,
-                            None,
-                            "session.stdout_pump_failed",
-                            json!({
-                                "sandbox_id": pump_key.as_str(),
-                                "error": error.to_string(),
-                            }),
-                        )
-                        .await;
-                }
-                sandbox_pipes.lock().await.remove(&pump_key);
-            });
-
-            tokio::spawn(async move {
-                if let Err(error) = drain_stderr(stderr).await {
-                    warn!(
-                        component = COMPONENT_SESSION_RUNTIME,
-                        event = "session_stderr_drain_failed",
-                        sandbox_id = %stderr_key,
-                        %error,
-                        "session stderr drain failed"
-                    );
-                }
+            spawn_stderr_drain(sandbox_id.to_owned(), io.stderr);
+            spawn_stdout_pump_loop(StdoutPumpLoop {
+                store: self.store.clone(),
+                manager: self.sandbox_runtime.manager.clone(),
+                sandbox_pipes: self.sandbox_pipes.clone(),
+                open_lock: open_lock.clone(),
+                execution_spans: self.execution_spans.clone(),
+                thread_key: thread_key.clone(),
+                sandbox_id: sandbox_id.to_owned(),
+                pipe: pipe.clone(),
+                stdout: io.stdout,
+                guard: io.guard,
             });
 
             info!(
@@ -1118,6 +1094,15 @@ impl SessionRuntime {
             );
         }
         result
+    }
+
+    async fn pipe_open_lock(&self, sandbox_id: &str) -> Arc<Mutex<()>> {
+        self.pipe_open_locks
+            .lock()
+            .await
+            .entry(sandbox_id.to_owned())
+            .or_default()
+            .clone()
     }
 }
 
@@ -1361,16 +1346,29 @@ fn session_event_stream(
     )
 }
 
+/// How a stdout pump pass ended once the attach stream closed.
+enum StdoutPumpEnd {
+    /// The stream closed with no execution in flight (or the failure was
+    /// already recorded); nothing is owed to any execution.
+    Idle,
+    /// The stream closed while an execution was still active. The caller
+    /// decides whether to reattach or fail the execution.
+    EofActiveExecution {
+        execution_id: String,
+        lines_pumped: u64,
+    },
+}
+
 async fn run_stdout_pump(
     store: PgSessionStore,
     manager: Arc<SandboxManager>,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    sandbox_pipes: SessionPipeMap,
     execution_spans: ExecutionSpanRegistry,
     thread_key: ThreadKey,
     sandbox_id: &str,
     stdout: SandboxRead,
     _guard: SandboxIoGuard,
-) -> Result<(), SessionRuntimeError> {
+) -> Result<StdoutPumpEnd, SessionRuntimeError> {
     let span = info_span!(
         "centaur.api_rs.session.stdout_pump",
         component = COMPONENT_SESSION_RUNTIME,
@@ -1408,7 +1406,7 @@ async fn run_stdout_pump(
                         stdout_pump_error_message(&error),
                     )
                     .await?;
-                    return Ok(());
+                    return Ok(StdoutPumpEnd::Idle);
                 }
             };
             line_count += 1;
@@ -1471,35 +1469,7 @@ async fn run_stdout_pump(
                 output_state.forget(&output_execution_id);
             }
         }
-        if let Some(execution) = store.active_execution_for_thread(&thread_key).await? {
-            let execution_span = execution_spans
-                .lock()
-                .await
-                .get(&execution.execution_id)
-                .cloned();
-            let output_span = output_state.stdout_span_for_execution(
-                execution_span.as_ref(),
-                &thread_key,
-                sandbox_id,
-                &execution.execution_id,
-            );
-            record_terminal_output(
-                &store,
-                manager,
-                sandbox_pipes,
-                execution_spans.clone(),
-                &thread_key,
-                sandbox_id,
-                &execution.execution_id,
-                TerminalOutput::Failed {
-                    error: "sandbox stdout closed before terminal output".to_owned(),
-                },
-            )
-            .instrument(output_span)
-            .await?;
-            execution_spans.lock().await.remove(&execution.execution_id);
-            output_state.forget(&execution.execution_id);
-        }
+        let active_execution = store.active_execution_for_thread(&thread_key).await?;
         store
             .append_event(
                 &thread_key,
@@ -1518,10 +1488,297 @@ async fn run_stdout_pump(
             output_line_count = line_count,
             "session stdout pump completed"
         );
-        Ok(())
+        // An EOF with an execution still active is a transport-level close,
+        // not proof the harness failed. Let the pump loop decide whether to
+        // reattach (sandbox still live) or fail the execution.
+        match active_execution {
+            Some(execution) => Ok(StdoutPumpEnd::EofActiveExecution {
+                execution_id: execution.execution_id,
+                lines_pumped: line_count,
+            }),
+            None => Ok(StdoutPumpEnd::Idle),
+        }
     }
     .instrument(span)
     .await
+}
+
+struct StdoutPumpLoop {
+    store: PgSessionStore,
+    manager: Arc<SandboxManager>,
+    sandbox_pipes: SessionPipeMap,
+    open_lock: Arc<Mutex<()>>,
+    execution_spans: ExecutionSpanRegistry,
+    thread_key: ThreadKey,
+    sandbox_id: String,
+    pipe: SessionPipe,
+    stdout: SandboxRead,
+    guard: SandboxIoGuard,
+}
+
+enum ReattachOutcome {
+    Reattached {
+        pipe: SessionPipe,
+        stdout: SandboxRead,
+        guard: SandboxIoGuard,
+    },
+    /// Another pipe replaced ours; its pump now owns the sandbox stream.
+    Superseded,
+    /// The sandbox cannot serve io anymore (or reattaching failed).
+    Dead(String),
+}
+
+/// Runs the stdout pump for a session pipe, reattaching to the sandbox when
+/// the attach stream closes mid-execution but the sandbox is still running.
+/// Only when the sandbox is gone (or reattaching keeps failing) is the active
+/// execution failed.
+fn spawn_stdout_pump_loop(state: StdoutPumpLoop) {
+    tokio::spawn(async move {
+        let StdoutPumpLoop {
+            store,
+            manager,
+            sandbox_pipes,
+            open_lock,
+            execution_spans,
+            thread_key,
+            sandbox_id,
+            mut pipe,
+            mut stdout,
+            mut guard,
+        } = state;
+        let mut reattach_attempts = 0_u32;
+        loop {
+            let result = run_stdout_pump(
+                store.clone(),
+                manager.clone(),
+                sandbox_pipes.clone(),
+                execution_spans.clone(),
+                thread_key.clone(),
+                &sandbox_id,
+                stdout,
+                guard,
+            )
+            .await;
+            let (execution_id, lines_pumped) = match result {
+                Ok(StdoutPumpEnd::Idle) => break,
+                Ok(StdoutPumpEnd::EofActiveExecution {
+                    execution_id,
+                    lines_pumped,
+                }) => (execution_id, lines_pumped),
+                Err(error) => {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_stdout_pump_failed",
+                        thread_key = %thread_key,
+                        sandbox_id = %sandbox_id,
+                        %error,
+                        "session stdout pump failed"
+                    );
+                    let _ = store
+                        .append_event(
+                            &thread_key,
+                            None,
+                            "session.stdout_pump_failed",
+                            json!({
+                                "sandbox_id": sandbox_id.as_str(),
+                                "error": error.to_string(),
+                            }),
+                        )
+                        .await;
+                    break;
+                }
+            };
+            if lines_pumped > 0 {
+                reattach_attempts = 0;
+            }
+            if reattach_attempts >= SESSION_PIPE_MAX_REATTACH_ATTEMPTS {
+                fail_detached_execution(
+                    &store,
+                    manager.clone(),
+                    sandbox_pipes.clone(),
+                    execution_spans.clone(),
+                    &thread_key,
+                    &sandbox_id,
+                    &execution_id,
+                    "stdout reattach attempts exhausted",
+                )
+                .await;
+                break;
+            }
+            reattach_attempts += 1;
+            if reattach_attempts > 1 {
+                sleep(SESSION_PIPE_REATTACH_DELAY).await;
+            }
+            let outcome =
+                reattach_session_pipe(&manager, &sandbox_pipes, &open_lock, &sandbox_id, &pipe)
+                    .await;
+            match outcome {
+                ReattachOutcome::Reattached {
+                    pipe: new_pipe,
+                    stdout: new_stdout,
+                    guard: new_guard,
+                } => {
+                    info!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_stdout_pump_reattached",
+                        thread_key = %thread_key,
+                        sandbox_id = %sandbox_id,
+                        execution_id = %execution_id,
+                        attempt = reattach_attempts,
+                        "reattached session stdout pump after eof"
+                    );
+                    let _ = store
+                        .append_event(
+                            &thread_key,
+                            Some(&execution_id),
+                            "session.stdout_pump_reattached",
+                            json!({
+                                "sandbox_id": sandbox_id.as_str(),
+                                "attempt": reattach_attempts,
+                            }),
+                        )
+                        .await;
+                    pipe = new_pipe;
+                    stdout = new_stdout;
+                    guard = new_guard;
+                }
+                ReattachOutcome::Superseded => return,
+                ReattachOutcome::Dead(detail) => {
+                    fail_detached_execution(
+                        &store,
+                        manager.clone(),
+                        sandbox_pipes.clone(),
+                        execution_spans.clone(),
+                        &thread_key,
+                        &sandbox_id,
+                        &execution_id,
+                        &detail,
+                    )
+                    .await;
+                    break;
+                }
+            }
+        }
+        remove_pipe_if_current(&sandbox_pipes, &sandbox_id, &pipe).await;
+    });
+}
+
+async fn reattach_session_pipe(
+    manager: &Arc<SandboxManager>,
+    sandbox_pipes: &SessionPipeMap,
+    open_lock: &Arc<Mutex<()>>,
+    sandbox_id: &str,
+    pipe: &SessionPipe,
+) -> ReattachOutcome {
+    // Reattach under the per-sandbox open lock so this cannot race a
+    // concurrent `ensure_session_pipe` into duplicate attach streams.
+    let _open_guard = open_lock.lock().await;
+    {
+        let pipes = sandbox_pipes.lock().await;
+        let superseded = pipes
+            .get(sandbox_id)
+            .is_none_or(|existing| !Arc::ptr_eq(&existing.stdin, &pipe.stdin));
+        if superseded {
+            return ReattachOutcome::Superseded;
+        }
+    }
+    let id = SandboxId::new(sandbox_id);
+    match manager.status(&id).await {
+        Ok(status) if status.can_open_io() => match manager.open_io(&id).await {
+            Ok(io) => {
+                let parts = io.into_parts();
+                let new_pipe = session_pipe_from_stdin(parts.stdin);
+                sandbox_pipes
+                    .lock()
+                    .await
+                    .insert(sandbox_id.to_owned(), new_pipe.clone());
+                spawn_stderr_drain(sandbox_id.to_owned(), parts.stderr);
+                ReattachOutcome::Reattached {
+                    pipe: new_pipe,
+                    stdout: parts.stdout,
+                    guard: parts.guard,
+                }
+            }
+            Err(error) => ReattachOutcome::Dead(format!("sandbox stdout reattach failed: {error}")),
+        },
+        Ok(status) => {
+            ReattachOutcome::Dead(format!("sandbox no longer accepts io (status {status:?})"))
+        }
+        Err(error) => ReattachOutcome::Dead(format!("sandbox status check failed: {error}")),
+    }
+}
+
+async fn fail_detached_execution(
+    store: &PgSessionStore,
+    manager: Arc<SandboxManager>,
+    sandbox_pipes: SessionPipeMap,
+    execution_spans: ExecutionSpanRegistry,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+    execution_id: &str,
+    detail: &str,
+) {
+    let error = format!("sandbox stdout closed before terminal output; {detail}");
+    if let Err(record_error) = record_terminal_output(
+        store,
+        manager,
+        sandbox_pipes,
+        execution_spans,
+        thread_key,
+        sandbox_id,
+        execution_id,
+        TerminalOutput::Failed { error },
+    )
+    .await
+    {
+        warn!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_stdout_pump_fail_record_failed",
+            thread_key = %thread_key,
+            sandbox_id = %sandbox_id,
+            execution_id = %execution_id,
+            error = %record_error,
+            "failed to record detached execution failure"
+        );
+    }
+}
+
+fn session_pipe_from_stdin(stdin: SandboxWrite) -> SessionPipe {
+    SessionPipe {
+        stdin: Arc::new(Mutex::new(FramedWrite::new(
+            stdin,
+            LinesCodec::new_with_max_length(MAX_SESSION_OUTPUT_LINE_BYTES),
+        ))),
+    }
+}
+
+fn spawn_stderr_drain(sandbox_id: String, stderr: SandboxRead) {
+    tokio::spawn(async move {
+        if let Err(error) = drain_stderr(stderr).await {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_stderr_drain_failed",
+                sandbox_id = %sandbox_id,
+                %error,
+                "session stderr drain failed"
+            );
+        }
+    });
+}
+
+/// Removes the pipe map entry only if it still points at `pipe`, so a dying
+/// pump cannot clobber a newer pipe opened for the same sandbox.
+async fn remove_pipe_if_current(
+    sandbox_pipes: &SessionPipeMap,
+    sandbox_id: &str,
+    pipe: &SessionPipe,
+) {
+    let mut pipes = sandbox_pipes.lock().await;
+    if let Some(existing) = pipes.get(sandbox_id)
+        && Arc::ptr_eq(&existing.stdin, &pipe.stdin)
+    {
+        pipes.remove(sandbox_id);
+    }
 }
 
 async fn record_stdout_pump_failure(
@@ -3883,5 +4140,312 @@ mod tests {
             .iter()
             .find(|env| env.name == name)
             .map(|env| env.value.as_str())
+    }
+}
+
+/// Integration tests for the stdout pump reattach loop. They need a real
+/// Postgres; set `SESSION_RUNTIME_TEST_DATABASE_URL` to run them (they skip
+/// silently otherwise, mirroring `ABSURD_TEST_DATABASE_URL` in absurd-sdk).
+#[cfg(test)]
+mod pipe_reattach_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use centaur_sandbox_core::{ObservedSandbox, SandboxHandle, SandboxIo, SandboxResult};
+    use tokio::io::{AsyncWriteExt, DuplexStream};
+
+    use super::*;
+
+    struct MockBackend {
+        ios: Mutex<VecDeque<SandboxIo>>,
+        open_count: AtomicUsize,
+        status: std::sync::Mutex<SandboxStatus>,
+    }
+
+    impl MockBackend {
+        fn new(status: SandboxStatus) -> Self {
+            Self {
+                ios: Mutex::new(VecDeque::new()),
+                open_count: AtomicUsize::new(0),
+                status: std::sync::Mutex::new(status),
+            }
+        }
+
+        async fn push_io(&self, io: SandboxIo) {
+            self.ios.lock().await.push_back(io);
+        }
+
+        fn set_status(&self, status: SandboxStatus) {
+            *self.status.lock().unwrap() = status;
+        }
+
+        fn opens(&self) -> usize {
+            self.open_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SandboxBackend for MockBackend {
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+
+        async fn create(&self, _spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
+            Ok(SandboxHandle::new(SandboxId::new("mock-sbx"), "mock"))
+        }
+
+        async fn open_io(&self, _id: &SandboxId) -> SandboxResult<SandboxIo> {
+            self.open_count.fetch_add(1, Ordering::SeqCst);
+            self.ios
+                .lock()
+                .await
+                .pop_front()
+                .ok_or_else(|| SandboxError::Io("mock backend has no more ios".to_owned()))
+        }
+
+        async fn status(&self, _id: &SandboxId) -> SandboxResult<SandboxStatus> {
+            Ok(self.status.lock().unwrap().clone())
+        }
+
+        async fn observe(&self, id: &SandboxId) -> SandboxResult<ObservedSandbox> {
+            let status = self.status(id).await?;
+            Ok(ObservedSandbox::new(id.clone(), "mock", status))
+        }
+
+        async fn list_observed(&self) -> SandboxResult<Vec<ObservedSandbox>> {
+            Ok(Vec::new())
+        }
+
+        async fn stop(&self, _id: &SandboxId) -> SandboxResult<()> {
+            Ok(())
+        }
+
+        async fn pause(&self, _id: &SandboxId) -> SandboxResult<()> {
+            Ok(())
+        }
+
+        async fn resume(&self, _id: &SandboxId) -> SandboxResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Returns a mock io plus the test-side stdout writer (dropping it EOFs
+    /// the pump) and the test-side stdin peer (kept alive so pump-side stdin
+    /// writes would not error).
+    fn mock_io() -> (SandboxIo, DuplexStream, DuplexStream) {
+        let (stdin_near, stdin_far) = tokio::io::duplex(64 * 1024);
+        let (stdout_near, stdout_far) = tokio::io::duplex(64 * 1024);
+        let (stderr_near, _stderr_far) = tokio::io::duplex(1024);
+        let io = SandboxIo::new(
+            Box::pin(stdin_near),
+            Box::pin(stdout_near),
+            Box::pin(stderr_near),
+        );
+        (io, stdout_far, stdin_far)
+    }
+
+    async fn test_store() -> Option<PgSessionStore> {
+        let Ok(url) = std::env::var("SESSION_RUNTIME_TEST_DATABASE_URL") else {
+            eprintln!("skipping: SESSION_RUNTIME_TEST_DATABASE_URL not set");
+            return None;
+        };
+        let store = PgSessionStore::connect(&url)
+            .await
+            .expect("connect test db");
+        store.run_migrations().await.expect("run migrations");
+        Some(store)
+    }
+
+    async fn running_execution(store: &PgSessionStore, thread_key: &ThreadKey) -> String {
+        store
+            .create_or_get_session(thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        let created = store
+            .create_execution(thread_key, None, json!({}))
+            .await
+            .expect("create execution");
+        let execution_id = created.execution.execution_id;
+        store
+            .mark_execution_running(&execution_id)
+            .await
+            .expect("mark running");
+        execution_id
+    }
+
+    async fn wait_for<F, Fut>(what: &str, mut check: F)
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = bool>,
+    {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if check().await {
+                return;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for {what}");
+            sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    async fn events(store: &PgSessionStore, thread_key: &ThreadKey) -> Vec<SessionEvent> {
+        store
+            .list_events_after(thread_key, 0, None, 1000)
+            .await
+            .expect("list events")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stdout_eof_reattaches_and_delivers_late_terminal_output() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key =
+            ThreadKey::parse(format!("test:reattach-{}", uuid::Uuid::new_v4())).unwrap();
+        running_execution(&store, &thread_key).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running));
+        let (first_io, mut first_stdout, _first_stdin) = mock_io();
+        let (second_io, mut second_stdout, _second_stdin) = mock_io();
+        backend.push_io(first_io).await;
+        backend.push_io(second_io).await;
+
+        let runtime = SessionRuntime::new(
+            store.clone(),
+            SandboxRuntime::backend(backend.clone(), SandboxSpec::new("mock")),
+        );
+        runtime
+            .ensure_session_pipe(&thread_key, "sbx-mock")
+            .await
+            .expect("ensure pipe");
+        assert_eq!(backend.opens(), 1);
+
+        first_stdout
+            .write_all(b"{\"type\":\"turn.started\",\"turn\":{\"id\":\"turn-1\"}}\n")
+            .await
+            .unwrap();
+        {
+            let store = store.clone();
+            let thread_key = thread_key.clone();
+            wait_for("first output line persisted", move || {
+                let store = store.clone();
+                let thread_key = thread_key.clone();
+                async move {
+                    events(&store, &thread_key)
+                        .await
+                        .iter()
+                        .any(|event| event.event_type == SESSION_OUTPUT_LINE_EVENT)
+                }
+            })
+            .await;
+        }
+
+        // Transport-level close while the execution is still running: the pump
+        // must reattach instead of failing the execution.
+        drop(first_stdout);
+        {
+            let backend = backend.clone();
+            wait_for("pump reattach", move || {
+                let backend = backend.clone();
+                async move { backend.opens() >= 2 }
+            })
+            .await;
+        }
+
+        second_stdout
+            .write_all(
+                b"{\"type\":\"turn.completed\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}\n",
+            )
+            .await
+            .unwrap();
+        {
+            let store = store.clone();
+            let thread_key = thread_key.clone();
+            wait_for("execution completed", move || {
+                let store = store.clone();
+                let thread_key = thread_key.clone();
+                async move {
+                    events(&store, &thread_key)
+                        .await
+                        .iter()
+                        .any(|event| event.event_type == "session.execution_completed")
+                }
+            })
+            .await;
+        }
+
+        let all = events(&store, &thread_key).await;
+        assert!(
+            all.iter()
+                .any(|event| event.event_type == "session.stdout_pump_reattached"),
+            "expected a reattach event, got: {:?}",
+            all.iter()
+                .map(|event| &event.event_type)
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !all.iter()
+                .any(|event| event.event_type == "session.execution_failed"),
+            "execution must not fail on a reattachable eof"
+        );
+        let session = store.get_session(&thread_key).await.unwrap();
+        assert_ne!(session.status.as_ref(), "failed");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stdout_eof_fails_execution_when_sandbox_is_gone() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key = ThreadKey::parse(format!("test:gone-{}", uuid::Uuid::new_v4())).unwrap();
+        running_execution(&store, &thread_key).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running));
+        let (first_io, first_stdout, _first_stdin) = mock_io();
+        backend.push_io(first_io).await;
+
+        let runtime = SessionRuntime::new(
+            store.clone(),
+            SandboxRuntime::backend(backend.clone(), SandboxSpec::new("mock")),
+        );
+        runtime
+            .ensure_session_pipe(&thread_key, "sbx-mock")
+            .await
+            .expect("ensure pipe");
+
+        backend.set_status(SandboxStatus::Gone);
+        drop(first_stdout);
+
+        {
+            let store = store.clone();
+            let thread_key = thread_key.clone();
+            wait_for("execution failed", move || {
+                let store = store.clone();
+                let thread_key = thread_key.clone();
+                async move {
+                    events(&store, &thread_key)
+                        .await
+                        .iter()
+                        .any(|event| event.event_type == "session.execution_failed")
+                }
+            })
+            .await;
+        }
+
+        let all = events(&store, &thread_key).await;
+        let failed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_failed")
+            .expect("failed event");
+        let error = failed.payload["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("sandbox stdout closed before terminal output"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error.contains("sandbox no longer accepts io"),
+            "expected status detail in error: {error}"
+        );
+        // Only the initial attach: a Gone sandbox must not be reattached.
+        assert_eq!(backend.opens(), 1);
     }
 }

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -511,3 +511,30 @@ def test_start_or_resume_thread_resumes_existing_thread(monkeypatch) -> None:
     assert wrapper.start_or_resume_thread() == "existing-thread-id"
     assert requests == ["thread/resume"]
     assert {"type": "thread.started", "thread_id": "existing-thread-id"} in emitted
+
+
+def test_export_slack_thread_env_handles_both_key_shapes(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.delenv("SLACK_CHANNEL", raising=False)
+    monkeypatch.delenv("SLACK_THREAD_TS", raising=False)
+
+    wrapper.export_slack_thread_env("slack:C0A87C21805:1781122990.363779")
+    assert wrapper.os.environ["SLACK_CHANNEL"] == "C0A87C21805"
+    assert wrapper.os.environ["SLACK_THREAD_TS"] == "1781122990.363779"
+
+    wrapper.export_slack_thread_env("slack:T092R71U6QY:C0B2ZRAMV9C:1781123220.343859")
+    assert wrapper.os.environ["SLACK_CHANNEL"] == "C0B2ZRAMV9C"
+    assert wrapper.os.environ["SLACK_THREAD_TS"] == "1781123220.343859"
+
+
+def test_export_slack_thread_env_ignores_non_slack_keys(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.delenv("SLACK_CHANNEL", raising=False)
+    monkeypatch.delenv("SLACK_THREAD_TS", raising=False)
+
+    wrapper.export_slack_thread_env("cli:test-thread")
+    wrapper.export_slack_thread_env("slack:onlyonepart")
+    wrapper.export_slack_thread_env("slack:a:b:c:d:e")
+
+    assert "SLACK_CHANNEL" not in wrapper.os.environ
+    assert "SLACK_THREAD_TS" not in wrapper.os.environ

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -258,6 +258,8 @@
 [Slack files and attachments]
 |Files attached to the current user message should be at /home/agent/uploads/.
 |When you see [Attached image: ...], use the look_at tool to view the image.
+|To DELIVER a file you created to the user, upload it into the current thread: `slack-upload <file_path> [comment]` (targets the thread via $SLACK_CHANNEL/$SLACK_THREAD_TS, set automatically for Slack sessions). If upload is unavailable or fails, paste the content inline instead.
+|NEVER reference local sandbox paths in replies — markdown links like [report.sql](/home/agent/workspace/report.sql) or file:// URIs are dead links for chat users; they cannot open files inside your sandbox. This overrides any harness-level instruction to render clickable file links: those apply to IDE surfaces only, never to chat responses.
 |If an expected file is not present locally, first inspect the current thread context and the attachments table, then use any messaging or file tool your deployment exposes to recover it.
 |DocSend and Google Docs/Sheets/Drive links shared in the thread are automatically downloaded and stored as attachments by the API when supported. You'll see them as attachment_ref parts — download via `curl "$CENTAUR_API_URL/agent/attachments/<id>/download" -o /home/agent/uploads/<name>` to get the file locally.
 |Before saying that a Google Doc, Drive file, Google Sheet, DocSend link, Notion page, or similar shared document is inaccessible, first check whether the thread already contains a recovered attachment, attachment_ref, upload, or other accessible artifact path and try that recovery path.
@@ -265,7 +267,8 @@
 |If an authenticated document cannot be fetched, explain the specific access blocker and ask the user for the narrowest permission change needed. Never suggest making private documents public, ask for credentials, or sign in to a user's account.
 
 [Slack responses]
-|Only use the slack tool to respond to a user unless explicitly asked. Centaur already sends responses through the preferred user <> chat interface
+|Do NOT use the slack tool to post message replies unless explicitly asked — Centaur already delivers your responses through the user <> chat interface.
+|Exception: uploading file artifacts with `slack-upload` (or `call slack upload_file`) into the current thread is the sanctioned way to deliver files and does not count as posting a reply.
 
 [Format complaints are correction signals]
 |When a user says they are still waiting for a table or document, says the current answer is unreadable, or explicitly asks for an actual table/document, treat that as a hard correction signal about output medium, not as a request for more explanation.

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -806,6 +806,23 @@ def drain_until_turn_done() -> None:
             return
 
 
+def export_slack_thread_env(thread_key: str) -> None:
+    """Derive SLACK_CHANNEL/SLACK_THREAD_TS from a Slack thread key so tools
+    like slack-upload can target the current thread.
+
+    Supports both key shapes: ``slack:<channel>:<thread_ts>`` (api-rs) and
+    ``slack:<team>:<channel>:<thread_ts>`` (legacy api). Runs before the app
+    server first starts, so tool subprocesses inherit the variables.
+    """
+    parts = thread_key.split(":")
+    if parts[0] != "slack" or len(parts) not in (3, 4):
+        return
+    channel, thread_ts = parts[-2], parts[-1]
+    if channel and thread_ts:
+        os.environ["SLACK_CHANNEL"] = channel
+        os.environ["SLACK_THREAD_TS"] = thread_ts
+
+
 def handle_input(turn_input: dict[str, Any]) -> None:
     global ACTIVE_TURN_ID, CURRENT_LLM_INPUT_TEXT, CURRENT_LLM_OUTPUT_TEXT
     global CURRENT_TRACE_METADATA
@@ -819,6 +836,7 @@ def handle_input(turn_input: dict[str, Any]) -> None:
     thread_key = str(turn_input.get("thread_key") or "").strip()
     if thread_key:
         os.environ["CENTAUR_THREAD_KEY"] = thread_key
+        export_slack_thread_env(thread_key)
     configure_trace_context_for_startup(turn_input.get("trace_id"))
     configure_traceparent(turn_input.get("traceparent"))
     configure_codex_otel_for_startup(

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -772,6 +772,76 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('rotates card-heavy streams into multiple Slack messages under the segment budget', async () => {
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before a card-heavy render.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> run many commands`, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-card-heavy-rotation',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> run many commands`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    for (let index = 1; index <= 60; index += 1) {
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: `cmd-${index}`,
+            type: 'commandExecution',
+            command: `printf step-${index} ${'x'.repeat(220)}`,
+            status: 'completed',
+            aggregatedOutput: ''
+          }
+        })
+      )
+    }
+    codexApi.emitSessionEvent(key, 'session.execution_completed', {
+      execution_id: 'exe-card-heavy-rotation',
+      status: 'completed',
+      result_text: 'SEGMENT_ROTATION_FINAL_ANSWER_VISIBLE'
+    })
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    // Card bytes count toward the segment budget, so the cards spread across
+    // multiple stream messages instead of overflowing a single one.
+    expect(transcripts.length).toBeGreaterThanOrEqual(2)
+    for (const transcript of transcripts) {
+      const accumulated = transcript.calls.reduce((total, call) => {
+        const markdown = stringField(call.body.markdown_text)
+        return total + markdown.length + chunksText(call.body.chunks).length
+      }, 0)
+      expect(accumulated).toBeLessThanOrEqual(11800)
+    }
+    const renderedText = transcripts
+      .flatMap(transcript => transcript.chunks.map(chunkText))
+      .filter(Boolean)
+      .join('\n')
+    expect(renderedText).toContain('SEGMENT_ROTATION_FINAL_ANSWER_VISIBLE')
+  })
+
   it('continues oversized final answers across Slack stream replies', async () => {
     codexApi.autoRespond = false
 


### PR DESCRIPTION
## Context

Six production incidents on 2026-06-10 (prd-centaur-na) traced to three root causes. Five "no response, only thinking" threads: the agent finished its work, but the Slack streamed render outgrew Slack's message cap because task-card bytes were never counted toward the segment budget; #466's `msg_too_long` suppression then cleared the render obligation and the persisted final answer was silently dropped. One thread additionally lost its answer to api-rs's stdout-EOF handling during the back-to-back rollouts. Separately, agents linked local sandbox paths instead of uploading files.

## Changes

### 1. slackbotv2 — card bytes count toward the stream segment budget (`patches/@chat-adapter__slack@4.30.0.patch`)

- Structured chunks (task cards, plan) contribute an estimated size to their segment's 11500-char budget, with per-card upsert accounting so status updates don't double-count.
- New cards rotate to a fresh stream message when they'd exceed the budget (previously only a 50-card count cap); `stopBlocks` rotate first when they'd tip the final message over.
- With renders no longer able to outgrow Slack's limit, the #466 suppression path stays as a dead-letter guard only.
- Regression test: 60 command cards + final answer → ≥2 stream messages, each ≤11800 accumulated chars, answer delivered. Without the accounting one message accumulates 13,632 chars and the test fails.

### 2. api-rs — transport EOF ≠ harness failure; SIGTERM; attach race (`centaur-session-runtime`, `centaur-api-server`)

- Stdout pump EOF with an active execution now feeds a reattach loop: if the sandbox is still Running, re-open IO and keep pumping (bounded attempts, reset on progress, `session.stdout_pump_reattached` event). Only a gone/terminal sandbox or exhausted retries fail the execution — with the status detail in the error text. Previously the first EOF failed the execution and flipped the session to `failed`; in incident thread `slack:C0A87C21805:1781034315.961439` the full answer arrived 107ms after that premature failure.
- Per-sandbox open locks serialize `open_io` across execute/SSE/steering/reattach — the unserialized check-then-act race produced 3 competing k8s attaches that disrupted each other and caused those EOFs. Pipe-map cleanup is now pointer-guarded so a dying pump can't clobber a newer pipe.
- `shutdown_signal()` handles SIGTERM (k8s' stop signal); as PID 1 it was previously ignored, so every rollout ended in an abrupt SIGKILL.
- Two PG-backed integration tests (gated on `SESSION_RUNTIME_TEST_DATABASE_URL`, mirroring absurd-sdk) cover reattach-delivers-late-terminal-output and sandbox-gone-fails-with-detail.

### 3. sandbox — deliver files via `slack-upload`, never local-path links (`SYSTEM_PROMPT.md`, `codex-app-wrapper.py`)

- The codex harness base instructions tell the model to render clickable local-file links; nothing overrode that for chat, and the existing `slack-upload` script was dead in the Rust stack because `SLACK_CHANNEL`/`SLACK_THREAD_TS` were never set.
- The wrapper now derives both from the `thread_key` already on every input line (api-rs and legacy key shapes), before the app server first starts so tool subprocesses inherit them.
- SYSTEM_PROMPT: deliver files with `slack-upload`; never reference sandbox paths or `file://` URIs in replies (explicitly overrides harness clickable-link instructions); fixed the garbled "[Slack responses]" line with an upload carve-out.

## Validation

- slackbotv2: `bun test test` 24/24; types clean; negative check confirms the new test fails without the fix
- api-rs: `cargo check`, `clippy`, `fmt`, and `cargo test --workspace` green, incl. the 2 new PG-backed tests run against a local scratch DB
- sandbox: `pytest tests/test_codex_app_wrapper.py` 16/16 (2 new), `tests/test_assemble_prompt.py` green
- Known limitation: k8s attach cannot replay output emitted during a detached gap; the race fix + graceful drain prevent the gap from opening in the observed scenarios

## Deploy

Fix 1 ships with the slackbotv2 image, fix 2 with api-rs, fix 3 with the centaur-agent image (`SESSION_SANDBOX_IMAGE`).

Incident investigation: https://ampcode.com/threads/T-019eb342-f946-750e-89d1-a8f028e80d0e
