### PR TITLE
fix(harness-server): phase Claude agent messages so Slack renders one reply

### DIFF
--- a/crates/harness-server/Cargo.lock
+++ b/crates/harness-server/Cargo.lock
@@ -1541,6 +1541,7 @@ dependencies = [
  "allocative",
  "clap",
  "codex-app-server-protocol",
+ "codex-protocol",
  "codex-utils-absolute-path",
  "serde",
  "serde_json",

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -12,6 +12,11 @@ path = "src/main.rs"
 allocative = "=0.3.4"
 clap = { version = "4.5", features = ["derive"] }
 codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "e93dc98a48d597df322436ffe8d03bfd7ec63b3b", package = "codex-app-server-protocol" }
+# Already a transitive dep of codex-app-server-protocol; made direct because
+# `MessagePhase` (the type of `ThreadItem::AgentMessage.phase`) is defined in
+# codex_protocol::models and not re-exported by codex-app-server-protocol.
+# Keep the rev in lockstep with the other codex crates.
+codex-protocol = { git = "https://github.com/openai/codex", rev = "e93dc98a48d597df322436ffe8d03bfd7ec63b3b", package = "codex-protocol" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "e93dc98a48d597df322436ffe8d03bfd7ec63b3b", package = "codex-utils-absolute-path" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/harness-server/src/anthropic.rs
+++ b/crates/harness-server/src/anthropic.rs
@@ -45,6 +45,22 @@ impl AnthropicStreamEvent {
     pub fn parse_json_line(line: &str) -> Result<Self> {
         Ok(serde_json::from_str(line)?)
     }
+
+    /// The authoritative end-of-message stop reason, carried by the raw
+    /// `message_delta` stream event (`tool_use`, `end_turn`, ...). The per-block
+    /// `assistant` events leave `stop_reason` null, so this is the only in-stream
+    /// signal of whether a message is interim commentary or the final answer.
+    pub fn message_stop_reason(&self) -> Option<&str> {
+        match self {
+            Self::StreamEvent {
+                event:
+                    AnthropicRawStreamEvent::MessageDelta {
+                        delta: Some(delta), ..
+                    },
+            } => delta.stop_reason.as_deref(),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -65,9 +81,18 @@ pub enum AnthropicRawStreamEvent {
         index: usize,
     },
     MessageStop,
-    MessageDelta,
+    MessageDelta {
+        #[serde(default)]
+        delta: Option<AnthropicMessageDeltaBody>,
+    },
     #[serde(other)]
     Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnthropicMessageDeltaBody {
+    #[serde(default)]
+    pub stop_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -158,7 +183,7 @@ impl AnthropicEventNormalizer {
                 self.content_blocks.clear();
                 NormalizedEvent::Ignored
             }
-            AnthropicRawStreamEvent::MessageDelta | AnthropicRawStreamEvent::Unknown => {
+            AnthropicRawStreamEvent::MessageDelta { .. } | AnthropicRawStreamEvent::Unknown => {
                 NormalizedEvent::Ignored
             }
         }

--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -6,19 +6,195 @@ use codex_app_server_protocol::UserInput;
 use serde_json::json;
 
 use crate::{
-    HarnessKind, HarnessServer, NormalizedEvent, Result, ThreadState,
+    HarnessKind, HarnessServer, NormalizedContent, NormalizedEvent, Result, ThreadState,
     anthropic::{AnthropicEventNormalizer, AnthropicStreamEvent},
     command_from_override, user_input_to_anthropic_content,
 };
 
 const DEFAULT_CLAUDE_MODEL: &str = "claude-opus-4-8";
 
+/// Defers agent text until the owning message's fate is known, so agentMessage
+/// items can be emitted with an authoritative stop reason. Claude's per-block
+/// `assistant` events leave `stop_reason` null, and downstream renderers treat
+/// unphased messages as the final answer, so completing each text block as it
+/// arrives makes every interim message render as an extra reply. Text is held
+/// until a `message_delta` stop reason, a `tool_use` in the same message, a tool
+/// result, a newer message, or the terminal `result` settles whether the text was
+/// commentary (`tool_use`) or the final answer (`end_turn`). Flushing replays the
+/// original delta chunks after an `AgentMessageStarted` carrying the stop reason,
+/// so the item starts with the right phase and native chunking is preserved.
+#[derive(Debug, Default)]
+pub struct ClaudeEventNormalizer {
+    inner: AnthropicEventNormalizer,
+    pending: Vec<PendingAgentMessage>,
+}
+
+#[derive(Debug)]
+struct PendingAgentMessage {
+    item_id: String,
+    chunks: Vec<String>,
+    canonical: Option<String>,
+}
+
+impl PendingAgentMessage {
+    fn text(&self) -> String {
+        self.canonical
+            .clone()
+            .unwrap_or_else(|| self.chunks.concat())
+    }
+}
+
+impl ClaudeEventNormalizer {
+    pub fn normalize(&mut self, event: AnthropicStreamEvent) -> Vec<NormalizedEvent> {
+        let message_stop_reason = event.message_stop_reason().map(str::to_string);
+        let normalized = self.inner.normalize(event);
+        let mut out = Vec::new();
+        if let Some(stop_reason) = message_stop_reason {
+            self.flush_pending(Some(stop_reason), &mut out);
+        }
+
+        match normalized {
+            NormalizedEvent::AgentTextDelta { item_id, delta } => {
+                self.flush_other_messages(&item_id, &mut out);
+                self.pending_for(item_id).chunks.push(delta);
+            }
+            NormalizedEvent::AssistantMessage {
+                partial: false,
+                stop_reason,
+                content,
+            } => self.defer_assistant_message(stop_reason, content, &mut out),
+            NormalizedEvent::ToolResults(results) => {
+                self.flush_pending(Some("tool_use".to_string()), &mut out);
+                out.push(NormalizedEvent::ToolResults(results));
+            }
+            event @ NormalizedEvent::Result { .. } => {
+                self.flush_pending(Some("end_turn".to_string()), &mut out);
+                out.push(event);
+            }
+            event @ NormalizedEvent::Error { .. } => {
+                self.flush_pending(None, &mut out);
+                out.push(event);
+            }
+            NormalizedEvent::Ignored => {}
+            event => out.push(event),
+        }
+        out
+    }
+
+    fn defer_assistant_message(
+        &mut self,
+        stop_reason: Option<String>,
+        content: Vec<NormalizedContent>,
+        out: &mut Vec<NormalizedEvent>,
+    ) {
+        let mut passthrough = Vec::new();
+        let mut has_tool_use = false;
+        for part in content {
+            match part {
+                NormalizedContent::AgentText { item_id, text } => {
+                    self.flush_other_messages(&item_id, out);
+                    self.pending_for(item_id).canonical = Some(text);
+                }
+                part @ NormalizedContent::ToolUse { .. } => {
+                    has_tool_use = true;
+                    passthrough.push(part);
+                }
+                part @ NormalizedContent::ReasoningText { .. } => passthrough.push(part),
+            }
+        }
+        if has_tool_use {
+            self.flush_pending(Some("tool_use".to_string()), out);
+        }
+        if let Some(stop_reason) = stop_reason {
+            self.flush_pending(Some(stop_reason), out);
+        }
+        if !passthrough.is_empty() {
+            out.push(NormalizedEvent::AssistantMessage {
+                partial: false,
+                stop_reason: None,
+                content: passthrough,
+            });
+        }
+    }
+
+    fn pending_for(&mut self, item_id: String) -> &mut PendingAgentMessage {
+        if let Some(index) = self
+            .pending
+            .iter()
+            .position(|message| message.item_id == item_id)
+        {
+            return &mut self.pending[index];
+        }
+        self.pending.push(PendingAgentMessage {
+            item_id,
+            chunks: Vec::new(),
+            canonical: None,
+        });
+        self.pending.last_mut().expect("just pushed")
+    }
+
+    /// Text from an older message still pending when a newer message produces
+    /// text means the older message ended mid-turn: commentary.
+    fn flush_other_messages(&mut self, current_item_id: &str, out: &mut Vec<NormalizedEvent>) {
+        if self
+            .pending
+            .iter()
+            .all(|message| message.item_id == current_item_id)
+        {
+            return;
+        }
+        let (current, others) = std::mem::take(&mut self.pending)
+            .into_iter()
+            .partition(|message| message.item_id == current_item_id);
+        self.pending = current;
+        flush_messages(others, Some("tool_use".to_string()), out);
+    }
+
+    fn flush_pending(&mut self, stop_reason: Option<String>, out: &mut Vec<NormalizedEvent>) {
+        flush_messages(std::mem::take(&mut self.pending), stop_reason, out);
+    }
+}
+
+fn flush_messages(
+    pending: Vec<PendingAgentMessage>,
+    stop_reason: Option<String>,
+    out: &mut Vec<NormalizedEvent>,
+) {
+    for message in pending {
+        let text = message.text();
+        if text.is_empty() {
+            continue;
+        }
+        out.push(NormalizedEvent::AgentMessageStarted {
+            item_id: message.item_id.clone(),
+            stop_reason: stop_reason.clone(),
+        });
+        out.extend(
+            message
+                .chunks
+                .into_iter()
+                .map(|delta| NormalizedEvent::AgentTextDelta {
+                    item_id: message.item_id.clone(),
+                    delta,
+                }),
+        );
+        out.push(NormalizedEvent::AssistantMessage {
+            partial: false,
+            stop_reason: stop_reason.clone(),
+            content: vec![NormalizedContent::AgentText {
+                item_id: message.item_id,
+                text,
+            }],
+        });
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct ClaudeCodeHarness;
 
 impl HarnessServer for ClaudeCodeHarness {
     type Event = AnthropicStreamEvent;
-    type EventNormalizer = AnthropicEventNormalizer;
+    type EventNormalizer = ClaudeEventNormalizer;
 
     fn kind(&self) -> HarnessKind {
         HarnessKind::ClaudeCode
@@ -90,18 +266,253 @@ impl HarnessServer for ClaudeCodeHarness {
         normalizer: &mut Self::EventNormalizer,
         event: Self::Event,
     ) -> Result<Vec<NormalizedEvent>> {
-        Ok(vec![normalizer.normalize(event)])
+        Ok(normalizer.normalize(event))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use codex_app_server_protocol::UserInput;
-    use serde_json::Value;
+    use serde_json::{Value, json};
 
-    use crate::HarnessServer;
+    use crate::{HarnessServer, NormalizedContent, NormalizedEvent};
 
-    use super::ClaudeCodeHarness;
+    use super::{ClaudeCodeHarness, ClaudeEventNormalizer};
+
+    fn normalize(normalizer: &mut ClaudeEventNormalizer, event: Value) -> Vec<NormalizedEvent> {
+        normalizer.normalize(serde_json::from_value(event).unwrap())
+    }
+
+    fn agent_texts(events: &[NormalizedEvent]) -> Vec<(Option<String>, String)> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                NormalizedEvent::AssistantMessage {
+                    partial: false,
+                    stop_reason,
+                    content,
+                } => {
+                    let text = content
+                        .iter()
+                        .filter_map(|part| match part {
+                            NormalizedContent::AgentText { text, .. } => Some(text.as_str()),
+                            _ => None,
+                        })
+                        .collect::<String>();
+                    (!text.is_empty()).then(|| (stop_reason.clone(), text))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn defers_streamed_text_until_message_delta_settles_stop_reason() {
+        let mut normalizer = ClaudeEventNormalizer::default();
+
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "message_start", "message": {"id": "msg_1", "stop_reason": null, "content": []}}}),
+        );
+        assert!(events.is_empty());
+
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}}),
+        );
+        assert!(events.is_empty());
+
+        // Text deltas are buffered, not forwarded.
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Let me check."}}}),
+        );
+        assert!(events.is_empty());
+
+        // The per-block assistant event records canonical text but stays deferred.
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "assistant", "message": {"id": "msg_1", "stop_reason": null, "content": [{"type": "text", "text": "Let me check."}]}}),
+        );
+        assert!(events.is_empty());
+
+        // The tool_use block settles the message as commentary.
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "assistant", "message": {"id": "msg_1", "stop_reason": null, "content": [{"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "echo hello"}}]}}),
+        );
+        assert_eq!(
+            agent_texts(&events),
+            vec![(Some("tool_use".to_string()), "Let me check.".to_string())]
+        );
+        assert!(matches!(
+            events.last(),
+            Some(NormalizedEvent::AssistantMessage { content, .. })
+                if matches!(content.as_slice(), [NormalizedContent::ToolUse { .. }])
+        ));
+
+        // message_delta arrives after the blocks; nothing left to flush.
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "message_delta", "delta": {"stop_reason": "tool_use"}}}),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn final_message_flushes_as_end_turn_on_message_delta() {
+        let mut normalizer = ClaudeEventNormalizer::default();
+        normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "message_start", "message": {"id": "msg_2", "stop_reason": null, "content": []}}}),
+        );
+        normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}}),
+        );
+        normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "DONE"}}}),
+        );
+        normalize(
+            &mut normalizer,
+            json!({"type": "assistant", "message": {"id": "msg_2", "stop_reason": null, "content": [{"type": "text", "text": "DONE"}]}}),
+        );
+
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}}),
+        );
+        assert_eq!(
+            agent_texts(&events),
+            vec![(Some("end_turn".to_string()), "DONE".to_string())]
+        );
+    }
+
+    #[test]
+    fn pending_text_flushes_as_final_answer_when_result_arrives_first() {
+        let mut normalizer = ClaudeEventNormalizer::default();
+        normalize(
+            &mut normalizer,
+            json!({"type": "assistant", "message": {"id": "msg_1", "stop_reason": null, "content": [{"type": "text", "text": "final answer"}]}}),
+        );
+
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "result", "subtype": "success", "result": "final answer"}),
+        );
+        assert_eq!(
+            agent_texts(&events),
+            vec![(Some("end_turn".to_string()), "final answer".to_string())]
+        );
+        assert!(matches!(
+            events.last(),
+            Some(NormalizedEvent::Result { error: None })
+        ));
+    }
+
+    #[test]
+    fn tool_result_flushes_pending_text_as_commentary() {
+        let mut normalizer = ClaudeEventNormalizer::default();
+        normalize(
+            &mut normalizer,
+            json!({"type": "assistant", "message": {"id": "msg_1", "stop_reason": null, "content": [{"type": "text", "text": "Let me check."}]}}),
+        );
+
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": "toolu_1", "content": "ok", "is_error": false}]}}),
+        );
+        assert_eq!(
+            agent_texts(&events),
+            vec![(Some("tool_use".to_string()), "Let me check.".to_string())]
+        );
+        assert!(matches!(
+            events.last(),
+            Some(NormalizedEvent::ToolResults(results)) if results.len() == 1
+        ));
+    }
+
+    #[test]
+    fn newer_message_text_flushes_older_pending_message_as_commentary() {
+        let mut normalizer = ClaudeEventNormalizer::default();
+        normalize(
+            &mut normalizer,
+            json!({"type": "assistant", "message": {"id": "msg_1", "stop_reason": null, "content": [{"type": "text", "text": "first"}]}}),
+        );
+
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "assistant", "message": {"id": "msg_2", "stop_reason": null, "content": [{"type": "text", "text": "second"}]}}),
+        );
+        assert_eq!(
+            agent_texts(&events),
+            vec![(Some("tool_use".to_string()), "first".to_string())]
+        );
+
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "result", "subtype": "success", "result": "second"}),
+        );
+        assert_eq!(
+            agent_texts(&events),
+            vec![(Some("end_turn".to_string()), "second".to_string())]
+        );
+    }
+
+    #[test]
+    fn flush_replays_original_delta_chunks_behind_phased_item_start() {
+        let mut normalizer = ClaudeEventNormalizer::default();
+        normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "message_start", "message": {"id": "msg_1", "stop_reason": null, "content": []}}}),
+        );
+        normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}}),
+        );
+        for chunk in ["hel", "lo ", "world"] {
+            normalize(
+                &mut normalizer,
+                json!({"type": "stream_event", "event": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": chunk}}}),
+            );
+        }
+
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "stream_event", "event": {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}}),
+        );
+        assert!(matches!(
+            &events[0],
+            NormalizedEvent::AgentMessageStarted { item_id, stop_reason: Some(reason) }
+                if item_id == "msg_1" && reason == "end_turn"
+        ));
+        let deltas: Vec<&str> = events
+            .iter()
+            .filter_map(|event| match event {
+                NormalizedEvent::AgentTextDelta { delta, .. } => Some(delta.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(deltas, vec!["hel", "lo ", "world"]);
+        assert_eq!(
+            agent_texts(&events),
+            vec![(Some("end_turn".to_string()), "hello world".to_string())]
+        );
+    }
+
+    #[test]
+    fn explicit_assistant_stop_reason_flushes_immediately() {
+        let mut normalizer = ClaudeEventNormalizer::default();
+        let events = normalize(
+            &mut normalizer,
+            json!({"type": "assistant", "message": {"id": "msg_1", "stop_reason": "end_turn", "content": [{"type": "text", "text": "hello"}]}}),
+        );
+        assert_eq!(
+            agent_texts(&events),
+            vec![(Some("end_turn".to_string()), "hello".to_string())]
+        );
+    }
 
     #[test]
     fn steer_stdin_uses_claude_streaming_user_message_shape() {

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -93,6 +93,12 @@ pub enum NormalizedEvent {
     SessionStarted {
         session_id: Option<String>,
     },
+    /// Announces an agent message before its text deltas so the item starts with
+    /// the phase implied by `stop_reason` (deltas carry no phase of their own).
+    AgentMessageStarted {
+        item_id: String,
+        stop_reason: Option<String>,
+    },
     AssistantMessage {
         partial: bool,
         stop_reason: Option<String>,

--- a/crates/harness-server/src/turn.rs
+++ b/crates/harness-server/src/turn.rs
@@ -8,6 +8,7 @@ use codex_app_server_protocol::{
     Turn, TurnCompletedNotification, TurnError, TurnItemsView, TurnStartedNotification, TurnStatus,
     UserInput,
 };
+use codex_protocol::models::MessagePhase;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde_json::Value;
 
@@ -150,13 +151,23 @@ impl CodexTurnNormalizer {
 
         match event {
             NormalizedEvent::SessionStarted { .. } => {}
-            NormalizedEvent::AssistantMessage {
-                partial, content, ..
+            NormalizedEvent::AgentMessageStarted {
+                item_id,
+                stop_reason,
             } => {
+                let phase = phase_from_stop_reason(stop_reason.as_deref());
+                self.start_agent_message_item(item_id, phase, &mut out);
+            }
+            NormalizedEvent::AssistantMessage {
+                partial,
+                stop_reason,
+                content,
+            } => {
+                let phase = phase_from_stop_reason(stop_reason.as_deref());
                 for item in content {
                     match item {
                         NormalizedContent::AgentText { item_id, text } => {
-                            self.emit_agent_text(item_id, text, *partial, &mut out);
+                            self.emit_agent_text(item_id, text, *partial, phase.clone(), &mut out);
                         }
                         NormalizedContent::ReasoningText { item_id, text } => {
                             self.emit_reasoning_text(item_id, text, *partial, &mut out);
@@ -312,23 +323,34 @@ impl CodexTurnNormalizer {
         })
     }
 
+    fn start_agent_message_item(
+        &mut self,
+        item_id: &str,
+        phase: Option<MessagePhase>,
+        out: &mut Vec<ServerNotification>,
+    ) {
+        if self.started_items.contains_key(item_id) {
+            return;
+        }
+        let item = ThreadItem::AgentMessage {
+            id: item_id.to_string(),
+            text: String::new(),
+            phase,
+            memory_citation: None,
+        };
+        self.started_items.insert(item_id.to_string(), item.clone());
+        out.push(self.item_started(item));
+    }
+
     fn emit_agent_text(
         &mut self,
         item_id: &str,
         text: &str,
         partial: bool,
+        phase: Option<MessagePhase>,
         out: &mut Vec<ServerNotification>,
     ) {
-        if !self.started_items.contains_key(item_id) {
-            let item = ThreadItem::AgentMessage {
-                id: item_id.to_string(),
-                text: String::new(),
-                phase: None,
-                memory_citation: None,
-            };
-            self.started_items.insert(item_id.to_string(), item.clone());
-            out.push(self.item_started(item));
-        }
+        self.start_agent_message_item(item_id, phase.clone(), out);
 
         let previous = self
             .text_by_item_id
@@ -355,7 +377,7 @@ impl CodexTurnNormalizer {
             let item = ThreadItem::AgentMessage {
                 id: item_id.to_string(),
                 text: final_text,
-                phase: None,
+                phase,
                 memory_citation: None,
             };
             self.completed_items.push(item.clone());
@@ -372,16 +394,7 @@ impl CodexTurnNormalizer {
         if delta.is_empty() {
             return;
         }
-        if !self.started_items.contains_key(item_id) {
-            let item = ThreadItem::AgentMessage {
-                id: item_id.to_string(),
-                text: String::new(),
-                phase: None,
-                memory_citation: None,
-            };
-            self.started_items.insert(item_id.to_string(), item.clone());
-            out.push(self.item_started(item));
-        }
+        self.start_agent_message_item(item_id, None, out);
         out.push(ServerNotification::AgentMessageDelta(
             AgentMessageDeltaNotification {
                 thread_id: self.thread_id.clone(),
@@ -672,6 +685,18 @@ impl CodexTurnNormalizer {
     }
 }
 
+/// Classifies an assistant message by its stop reason: `tool_use` means more
+/// work follows in the same turn (commentary), while `end_turn`/`stop_sequence`
+/// terminate the turn (final answer). Unknown reasons stay unphased so
+/// downstream keeps its compatibility behavior.
+fn phase_from_stop_reason(stop_reason: Option<&str>) -> Option<MessagePhase> {
+    match stop_reason {
+        Some("tool_use") => Some(MessagePhase::Commentary),
+        Some("end_turn" | "stop_sequence") => Some(MessagePhase::FinalAnswer),
+        _ => None,
+    }
+}
+
 fn tool_projection(tool: &str, arguments: &Value) -> ToolProjection {
     if matches!(tool, "Bash" | "shell_command")
         && let Some(command) = arguments.get("command").and_then(Value::as_str)
@@ -846,6 +871,50 @@ mod tests {
         assert_eq!(params["threadId"], "claude-session-1");
         assert_eq!(params["item"]["type"], "agentMessage");
         assert_eq!(params["item"]["text"], "final answer");
+    }
+
+    #[test]
+    fn stop_reason_projects_agent_message_phase() {
+        let mut normalizer = normalizer();
+        let events = process_anthropic(
+            &mut normalizer,
+            json!({
+                "type": "assistant",
+                "is_partial": false,
+                "message": {
+                    "id": "msg_1",
+                    "stop_reason": "tool_use",
+                    "content": [{"type": "text", "text": "Let me check."}]
+                }
+            }),
+        );
+        let started = notification_to_jsonrpc(&events[2]).unwrap().params.unwrap();
+        assert_eq!(started["item"]["type"], "agentMessage");
+        assert_eq!(started["item"]["phase"], "commentary");
+        let completed = notification_to_jsonrpc(&events[4]).unwrap().params.unwrap();
+        assert_eq!(completed["item"]["phase"], "commentary");
+
+        let events = process_anthropic(
+            &mut normalizer,
+            json!({
+                "type": "assistant",
+                "is_partial": false,
+                "message": {
+                    "id": "msg_2",
+                    "stop_reason": "end_turn",
+                    "content": [{"type": "text", "text": "DONE"}]
+                }
+            }),
+        );
+        let completed = events
+            .iter()
+            .find_map(|event| {
+                let rpc = notification_to_jsonrpc(event).unwrap();
+                (rpc.method == "item/completed").then(|| rpc.params.unwrap())
+            })
+            .expect("final text should complete an item");
+        assert_eq!(completed["item"]["phase"], "final_answer");
+        assert_eq!(completed["item"]["text"], "DONE");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On the PR-463 dogfood deployment, Codex renders a single reply on Slack but Claude renders multiple.

Claude turns with tool use emit several assistant messages ("Let me check..." → tool call → "DONE"). The common bridge (`CodexTurnNormalizer`) completed each one as an agentMessage item with `phase: null`. Downstream renderers (`packages/rendering/src/codex-app-server.ts`, slackbot) default **unphased** items to `final_answer`, so every interim message accumulated in the Slack answer buffer alongside the real answer. Codex tags its items `commentary`/`final_answer` natively, which is why it renders one reply.

Reproduced locally by driving one real blocks-mode turn per harness and replaying the notification stream through the downstream buffer classification:

- **Claude (before)**: both agentMessage items `phase=null` → answer buffer = `Let me check.DONE` (2 segments)
- **Codex**: `Let me check.` tagged `commentary`, answer = `DONE` (1 segment)

## Fix

Claude's per-block `assistant` events carry `stop_reason: null`; the only in-stream phase signal is the `message_delta` stream event at message end (`tool_use` = more work follows, `end_turn` = final answer), which the bridge previously discarded. Since downstream per-item buffers are append-only, the phase must be known before `item/started` is emitted.

- `anthropic.rs`: parse `message_delta.delta.stop_reason`.
- `claude.rs`: new `ClaudeEventNormalizer` defers agent text until the owning message's fate is settled — by a `message_delta` stop reason, a `tool_use` block in the same message, a tool result, a newer message, or the terminal `result`. Flushing replays the original delta chunks behind an item start that carries the stop reason, so native chunking is preserved.
- `turn.rs`: map `stop_reason` → `MessagePhase` (`tool_use` → `commentary`, `end_turn`/`stop_sequence` → `final_answer`) and stamp it on agentMessage `item/started`/`item/completed`.

After the fix, the Claude stream renders identically to Codex: commentary phased out of the reply, single `final_answer` segment.

Trade-off: Claude's answer text now reaches consumers in a burst at message end rather than mid-generation (the phase is unknowable until then). Chunk boundaries are preserved.

## Testing

- 24 lib tests + 7 fake-harness integration tests pass (6 new normalizer tests, 1 new phase-projection test).
- `real_claude_code_long_streaming_is_anchored_to_native_cli` (ignored, runs real `claude`) passes — streaming is not collapsed into one delta.
- Verified end-to-end against the real `claude` CLI: a tool-using turn now produces `phase=commentary` for the preamble and `phase=final_answer` for the answer; the emulated Slack answer buffer contains only the final answer.

Amp is unaffected: its normalizer path is unchanged, and it only gains correct phases when its events carry stop reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)