### PR TITLE
feat(slackbot): bring back --claude/--amp/--codex and --model overrides

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -98,6 +98,7 @@ pub(crate) fn run_codex_blocks_server() -> Result<()> {
             Ok(BlocksCommand::User {
                 input,
                 client_user_message_id,
+                model,
             }) => {
                 if let Err(error) = run_codex_user_turn(
                     &mut codex,
@@ -106,6 +107,7 @@ pub(crate) fn run_codex_blocks_server() -> Result<()> {
                     &mut thread_id,
                     input,
                     client_user_message_id,
+                    model,
                 ) {
                     let fallback_thread_id = thread_id.as_deref().unwrap_or("codex");
                     eprintln!("Codex blocks turn failed: {error:#}");
@@ -139,6 +141,7 @@ fn run_codex_user_turn<W: Write>(
     thread_id: &mut Option<String>,
     input: Vec<UserInput>,
     client_user_message_id: Option<String>,
+    model: Option<String>,
 ) -> Result<()> {
     if thread_id.is_none() {
         *thread_id = Some(start_or_resume_thread(codex, stdout, request_id)?);
@@ -154,6 +157,9 @@ fn run_codex_user_turn<W: Write>(
     });
     if let Some(client_user_message_id) = client_user_message_id {
         params["clientUserMessageId"] = Value::String(client_user_message_id);
+    }
+    if let Some(model) = model {
+        params["model"] = Value::String(model);
     }
 
     let turn_request_id = next_request_id(request_id);

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -87,7 +87,11 @@ pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()>
             Ok(BlocksCommand::User {
                 input,
                 client_user_message_id,
+                model,
             }) => {
+                if let Some(model) = model {
+                    state.model = model;
+                }
                 if let Err(error) = run_blocks_turn(
                     harness,
                     &mut state,
@@ -186,6 +190,7 @@ pub(crate) enum BlocksCommand {
     User {
         input: Vec<UserInput>,
         client_user_message_id: Option<String>,
+        model: Option<String>,
     },
     Interrupt,
 }
@@ -202,6 +207,8 @@ struct BlocksLine {
     text: Option<String>,
     #[serde(default)]
     client_user_message_id: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -255,6 +262,10 @@ pub(crate) fn parse_blocks_line(line: &str) -> Result<BlocksCommand> {
                 client_user_message_id: parsed
                     .client_user_message_id
                     .or_else(|| parsed.message.and_then(|message| message.id)),
+                model: parsed
+                    .model
+                    .map(|model| model.trim().to_owned())
+                    .filter(|model| !model.is_empty()),
             })
         }
         "interrupt" => Ok(BlocksCommand::Interrupt),
@@ -799,4 +810,29 @@ pub(crate) fn write_blocks_error<W: Write>(
             }
         }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_blocks_user_line_with_model_override() {
+        let line = r#"{"type":"user","thread_key":"web:t1","model":"claude-sonnet-4-6","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#;
+        let BlocksCommand::User { model, input, .. } = parse_blocks_line(line).expect("parses")
+        else {
+            panic!("expected user command");
+        };
+        assert_eq!(model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(input.len(), 1);
+    }
+
+    #[test]
+    fn ignores_blank_model_on_blocks_user_line() {
+        let line = r#"{"type":"user","model":"  ","text":"hi"}"#;
+        let BlocksCommand::User { model, .. } = parse_blocks_line(line).expect("parses") else {
+            panic!("expected user command");
+        };
+        assert_eq!(model, None);
+    }
 }

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -60,10 +60,23 @@ impl IntoResponse for ApiError {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
         };
-        let body = Json(json!({
+        let mut body = json!({
             "ok": false,
             "error": self.to_string(),
-        }));
-        (status, body).into_response()
+        });
+        // Structured conflict details let clients (e.g. the slackbot) recover by
+        // retrying with the session's existing harness instead of parsing the
+        // human-readable message.
+        if let Self::Runtime(SessionRuntimeError::Store(SessionStoreError::HarnessConflict {
+            existing,
+            requested,
+            ..
+        })) = &self
+        {
+            body["code"] = json!("harness_conflict");
+            body["existing_harness"] = json!(existing);
+            body["requested_harness"] = json!(requested);
+        }
+        (status, Json(body)).into_response()
     }
 }

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -27,6 +27,7 @@ import {
   serializeMessage,
   sessionStreamError
 } from './session-api'
+import { extractMessageOverrides } from './overrides'
 import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from './slack-events'
 import type {
   ForwardSessionInput,
@@ -268,6 +269,14 @@ async function syncThreadMessageToSession(
 
   const serializeStartedAtMs = nowMs()
   const serializedMessage = await serializeMessage(message)
+  const overrides = extractMessageOverrides(serializedMessage.text)
+  serializedMessage.text = overrides.cleanedText
+  if (overrides.harnessType || overrides.model) {
+    traceLog(input.options, 'slackbotv2_forward_overrides_parsed', trace, {
+      harness_type: overrides.harnessType,
+      model: overrides.model
+    })
+  }
   traceLog(input.options, 'slackbotv2_forward_message_serialized', trace, {
     attachment_count: serializedMessage.attachments.length,
     phase_ms: elapsedMs(serializeStartedAtMs)
@@ -277,6 +286,11 @@ async function syncThreadMessageToSession(
   if (shouldIncludeContext && !state.historyForwarded) {
     const contextStartedAtMs = nowMs()
     context = await collectInitialContext(thread, message)
+    // collectInitialContext re-serializes the current message; mirror the
+    // flag-stripped text on that copy too.
+    for (const item of context) {
+      if (item.id === serializedMessage.id) item.text = serializedMessage.text
+    }
     traceLog(input.options, 'slackbotv2_forward_context_collected', trace, {
       message_count: context.length,
       phase_ms: elapsedMs(contextStartedAtMs)
@@ -294,7 +308,9 @@ async function syncThreadMessageToSession(
   const forwardInput: ForwardSessionInput = {
     afterEventId: lastEventId,
     executeMessage: shouldStartExecution ? serializedMessage : undefined,
+    harnessType: overrides.harnessType,
     messages: messagesToAppend,
+    model: overrides.model,
     onEventId: eventId => {
       lastEventId = Math.max(lastEventId, eventId)
     },

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -1,0 +1,74 @@
+/**
+ * Inline message directives, restored from the v1 slackbot:
+ *   --claude | --claude-code | --amp | --codex   pick the harness for the thread
+ *   --model <name> (or --model=<name>)           pick the model within that harness
+ *   --opus | --sonnet | --haiku                  model shortcuts (imply claude-code)
+ *
+ * Flags are stripped from the text before it reaches the agent. The harness
+ * applies at session creation (the API pins a thread to one harness); the model
+ * applies per turn via the blocks-protocol `model` field.
+ */
+
+export type MessageOverrides = {
+  cleanedText: string
+  harnessType?: string
+  model?: string
+}
+
+// Flag name -> HarnessType wire value (serde lowercase of the Rust enum).
+const HARNESS_FLAGS: Record<string, string> = {
+  amp: 'amp',
+  claude: 'claudecode',
+  'claude-code': 'claudecode',
+  claudecode: 'claudecode',
+  codex: 'codex'
+}
+
+const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> = {
+  haiku: { harnessType: 'claudecode', model: 'claude-haiku-4-5' },
+  opus: { harnessType: 'claudecode', model: 'claude-opus-4-8' },
+  sonnet: { harnessType: 'claudecode', model: 'claude-sonnet-4-6' }
+}
+
+const MODEL_FLAG_PATTERN = /(?:^|\s)--model[=\s]+([A-Za-z0-9._/-]+)(?=\s|$)/i
+
+export function extractMessageOverrides(text: string): MessageOverrides {
+  let cleaned = text
+  let harnessType: string | undefined
+  let model: string | undefined
+
+  const modelMatch = MODEL_FLAG_PATTERN.exec(cleaned)
+  if (modelMatch) {
+    model = modelMatch[1]
+    cleaned = stripMatch(cleaned, modelMatch)
+  }
+
+  for (const [flag, harness] of Object.entries(HARNESS_FLAGS)) {
+    const match = flagPattern(flag).exec(cleaned)
+    if (!match) continue
+    harnessType = harness
+    cleaned = stripMatch(cleaned, match)
+  }
+
+  for (const [flag, shortcut] of Object.entries(MODEL_SHORTCUTS)) {
+    const match = flagPattern(flag).exec(cleaned)
+    if (!match) continue
+    model ??= shortcut.model
+    harnessType ??= shortcut.harnessType
+    cleaned = stripMatch(cleaned, match)
+  }
+
+  return {
+    cleanedText: cleaned === text ? text : cleaned.trim(),
+    harnessType,
+    model
+  }
+}
+
+function flagPattern(flag: string): RegExp {
+  return new RegExp(`(?:^|\\s)--${flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|$)`, 'i')
+}
+
+function stripMatch(text: string, match: RegExpExecArray): string {
+  return `${text.slice(0, match.index)}${text.slice(match.index + match[0].length)}`
+}

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -138,7 +138,7 @@ export async function forwardToSessionApi(
   callbacks: ForwardSessionApiCallbacks = {}
 ): Promise<AsyncIterable<SlackbotV2RendererSource> | null> {
   const createStartedAtMs = nowMs()
-  await createSession(options, input.threadId)
+  await createSession(options, input.threadId, input.harnessType)
   traceLog(options, 'slackbotv2_session_create_complete', input.trace, {
     phase_ms: elapsedMs(createStartedAtMs)
   })
@@ -158,7 +158,7 @@ export async function forwardToSessionApi(
   if (!input.executeMessage) return null
 
   const executeStartedAtMs = nowMs()
-  const execution = await executeSession(options, input.threadId, input.executeMessage)
+  const execution = await executeSession(options, input.threadId, input.executeMessage, input.model)
   traceLog(options, 'slackbotv2_session_execute_complete', input.trace, {
     execution_id: execution.execution_id,
     phase_ms: elapsedMs(executeStartedAtMs)
@@ -245,22 +245,74 @@ async function bytesToBase64(data: Buffer | Blob): Promise<string> {
   return Buffer.from(bytes).toString('base64')
 }
 
-async function createSession(options: SlackbotV2Options, threadId: string): Promise<void> {
+const DEFAULT_HARNESS_TYPE = 'codex'
+
+async function createSession(
+  options: SlackbotV2Options,
+  threadId: string,
+  harnessType?: string
+): Promise<void> {
+  const requested = harnessType ?? DEFAULT_HARNESS_TYPE
+  const response = await postCreateSession(options, threadId, requested)
+  if (response.ok) return
+
+  let body = ''
+  try {
+    body = await response.text()
+  } catch {
+    body = ''
+  }
+  // A thread is pinned to the harness it was created with; the API rejects a
+  // differing harness_type with 409. A mid-thread --claude/--amp/--codex (or a
+  // plain message on a thread created with a non-default harness) lands here:
+  // keep the thread alive on its existing harness instead of failing the message.
+  const existing = response.status === 409 ? existingHarnessFromConflict(body) : undefined
+  if (existing && existing !== requested) {
+    const retry = await postCreateSession(options, threadId, existing)
+    await ensureApiOk(retry, 'create session')
+    return
+  }
+  throw new SessionApiError({
+    action: 'create session',
+    body,
+    retryable: isRetryableApiStatus(response.status),
+    status: response.status,
+    statusText: response.statusText
+  })
+}
+
+async function postCreateSession(
+  options: SlackbotV2Options,
+  threadId: string,
+  harnessType: string
+): Promise<Response> {
   const fetchFn = options.fetch ?? fetch
   const body: SlackbotV2CreateSessionRequest = {
-    harness_type: 'codex',
+    harness_type: harnessType,
     metadata: {
       source: 'slackbotv2',
       platform: 'slack',
       thread_id: threadId
     }
   }
-  const response = await fetchFn(apiSessionUrl(options.apiUrl, threadId), {
+  return fetchFn(apiSessionUrl(options.apiUrl, threadId), {
     method: 'POST',
     headers: apiHeaders(options),
     body: JSON.stringify(body)
   })
-  await ensureApiOk(response, 'create session')
+}
+
+function existingHarnessFromConflict(body: string): string | undefined {
+  try {
+    const payload = JSON.parse(body)
+    if (isJsonObject(payload)) {
+      const existing = stringValue(payload.existing_harness)
+      if (existing) return existing
+    }
+  } catch {
+    // fall through to message parsing
+  }
+  return /already exists with harness_type ([A-Za-z0-9_-]+)/.exec(body)?.[1]
 }
 
 async function appendSessionMessages(
@@ -283,13 +335,14 @@ async function appendSessionMessages(
 async function executeSession(
   options: SlackbotV2Options,
   threadId: string,
-  message: SlackbotV2ApiMessage
+  message: SlackbotV2ApiMessage,
+  model?: string
 ): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
   const body: SlackbotV2ExecuteSessionRequest = {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }),
-    input_lines: [toCodexInputLine(message, threadId)],
+    input_lines: [toCodexInputLine(message, threadId, model)],
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
   }
@@ -404,11 +457,12 @@ function sessionMetadata(
   }
 }
 
-function toCodexInputLine(message: SlackbotV2ApiMessage, threadId: string): string {
+function toCodexInputLine(message: SlackbotV2ApiMessage, threadId: string, model?: string): string {
   return JSON.stringify({
     type: 'user',
     thread_key: threadId,
     trace_metadata: sessionMetadata(message, { action: 'execute' }),
+    ...(model ? { model } : {}),
     message: {
       role: 'user',
       content: codexInputContent(message)

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -135,7 +135,11 @@ export type ForwardSessionInput = {
   afterEventId: number
   executionId?: string
   executeMessage?: SlackbotV2ApiMessage
+  /** Harness override parsed from message flags (--claude/--amp/--codex). */
+  harnessType?: string
   messages: SlackbotV2ApiMessage[]
+  /** Per-turn model override parsed from message flags (--model/--opus/...). */
+  model?: string
   onEventId(eventId: number): void
   openStream: boolean
   threadId: string

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import { extractMessageOverrides } from '../src/overrides'
+
+describe('extractMessageOverrides', () => {
+  test('returns text untouched without flags', () => {
+    const result = extractMessageOverrides('review this PR --not-a-known-flag stays')
+    expect(result).toEqual({
+      cleanedText: 'review this PR --not-a-known-flag stays',
+      harnessType: undefined,
+      model: undefined
+    })
+  })
+
+  test('parses harness flags', () => {
+    expect(extractMessageOverrides('--claude review this')).toEqual({
+      cleanedText: 'review this',
+      harnessType: 'claudecode',
+      model: undefined
+    })
+    expect(extractMessageOverrides('--claude-code review this').harnessType).toBe('claudecode')
+    expect(extractMessageOverrides('--amp review this').harnessType).toBe('amp')
+    expect(extractMessageOverrides('--codex review this').harnessType).toBe('codex')
+  })
+
+  test('parses harness flag anywhere in the message', () => {
+    expect(extractMessageOverrides('review this --amp please')).toEqual({
+      cleanedText: 'review this please',
+      harnessType: 'amp',
+      model: undefined
+    })
+  })
+
+  test('is case-insensitive', () => {
+    expect(extractMessageOverrides('--Claude review').harnessType).toBe('claudecode')
+  })
+
+  test('parses --model with space or equals', () => {
+    expect(extractMessageOverrides('--claude --model claude-sonnet-4-6 fix it')).toEqual({
+      cleanedText: 'fix it',
+      harnessType: 'claudecode',
+      model: 'claude-sonnet-4-6'
+    })
+    expect(extractMessageOverrides('--codex --model=gpt-5.2 fix it')).toEqual({
+      cleanedText: 'fix it',
+      harnessType: 'codex',
+      model: 'gpt-5.2'
+    })
+  })
+
+  test('model shortcuts set model and imply claude-code', () => {
+    expect(extractMessageOverrides('--opus fix it')).toEqual({
+      cleanedText: 'fix it',
+      harnessType: 'claudecode',
+      model: 'claude-opus-4-8'
+    })
+    expect(extractMessageOverrides('--sonnet fix it').model).toBe('claude-sonnet-4-6')
+    expect(extractMessageOverrides('--haiku fix it').model).toBe('claude-haiku-4-5')
+  })
+
+  test('explicit flags win over shortcut implications', () => {
+    expect(extractMessageOverrides('--codex --opus fix it')).toEqual({
+      cleanedText: 'fix it',
+      harnessType: 'codex',
+      model: 'claude-opus-4-8'
+    })
+    expect(extractMessageOverrides('--sonnet --model claude-opus-4-8 fix it').model).toBe(
+      'claude-opus-4-8'
+    )
+  })
+
+  test('does not match flags embedded in words or longer flags', () => {
+    expect(extractMessageOverrides('run pre--claude task').harnessType).toBeUndefined()
+    expect(extractMessageOverrides('--claudette hi').harnessType).toBeUndefined()
+    expect(extractMessageOverrides('--ampere hi').harnessType).toBeUndefined()
+  })
+
+  test('flag-only message cleans to empty text', () => {
+    expect(extractMessageOverrides('--claude')).toEqual({
+      cleanedText: '',
+      harnessType: 'claudecode',
+      model: undefined
+    })
+  })
+
+  test('--model without a value is left untouched', () => {
+    expect(extractMessageOverrides('what does --model do?')).toEqual({
+      cleanedText: 'what does --model do?',
+      harnessType: undefined,
+      model: undefined
+    })
+  })
+})

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test'
+import { forwardToSessionApi } from '../src/session-api'
+import type {
+  ForwardSessionInput,
+  SlackbotV2ApiMessage,
+  SlackbotV2Options
+} from '../src/types'
+
+type RecordedRequest = {
+  body: unknown
+  url: string
+}
+
+function apiMessage(text: string): SlackbotV2ApiMessage {
+  return {
+    attachments: [],
+    author: {
+      fullName: 'Test User',
+      isBot: false,
+      isMe: false,
+      userId: 'U1',
+      userName: 'test'
+    },
+    id: '1700000000.000100',
+    isMention: true,
+    raw: {},
+    teamId: 'T1',
+    text,
+    threadId: 'slack:C1:1700000000.000100',
+    timestamp: '2026-06-10T00:00:00.000Z'
+  }
+}
+
+function forwardInput(
+  message: SlackbotV2ApiMessage,
+  overrides: Partial<ForwardSessionInput> = {}
+): ForwardSessionInput {
+  return {
+    afterEventId: 0,
+    executeMessage: message,
+    messages: [message],
+    onEventId: () => undefined,
+    openStream: false,
+    threadId: message.threadId,
+    ...overrides
+  }
+}
+
+function fakeApi(responses: { createSession?: Array<{ body?: unknown; status: number }> } = {}) {
+  const requests: RecordedRequest[] = []
+  const createResponses = [...(responses.createSession ?? [])]
+  const fetchFn = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = String(input)
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined
+    requests.push({ body, url })
+    if (url.endsWith('/execute')) {
+      return Response.json({
+        execution_id: 'exec-1',
+        ok: true,
+        status: 'running',
+        thread_key: 'slack:C1:1700000000.000100'
+      })
+    }
+    if (!url.endsWith('/messages') && createResponses.length > 0) {
+      const next = createResponses.shift()!
+      return Response.json(next.body ?? { ok: next.status < 400 }, { status: next.status })
+    }
+    return Response.json({ ok: true })
+  }
+  return { fetchFn, requests }
+}
+
+function options(fetchFn: SlackbotV2Options['fetch']): SlackbotV2Options {
+  return {
+    apiUrl: 'http://api.test',
+    botToken: 'xoxb-test',
+    fetch: fetchFn,
+    signingSecret: 'secret'
+  }
+}
+
+describe('forwardToSessionApi overrides', () => {
+  test('creates session with default codex harness', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
+    const create = requests.find(request => request.url.endsWith('.000100'))
+    expect((create?.body as { harness_type?: string }).harness_type).toBe('codex')
+  })
+
+  test('creates session with parsed harness override', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('review this'), { harnessType: 'claudecode' })
+    )
+    const create = requests.find(request => request.url.endsWith('.000100'))
+    expect((create?.body as { harness_type?: string }).harness_type).toBe('claudecode')
+  })
+
+  test('includes model override on the execute input line', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('review this'), {
+        harnessType: 'claudecode',
+        model: 'claude-sonnet-4-6'
+      })
+    )
+    const execute = requests.find(request => request.url.endsWith('/execute'))
+    const inputLines = (execute?.body as { input_lines: string[] }).input_lines
+    expect(inputLines).toHaveLength(1)
+    const line = JSON.parse(inputLines[0]!)
+    expect(line.model).toBe('claude-sonnet-4-6')
+    expect(line.message.content).toEqual([{ type: 'text', text: 'review this' }])
+  })
+
+  test('omits model field when no override is set', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
+    const execute = requests.find(request => request.url.endsWith('/execute'))
+    const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
+    expect('model' in line).toBe(false)
+  })
+
+  test('retries session creation with existing harness on 409 conflict', async () => {
+    const { fetchFn, requests } = fakeApi({
+      createSession: [
+        {
+          body: {
+            code: 'harness_conflict',
+            error:
+              'session slack:C1:1700000000.000100 already exists with harness_type codex, requested claudecode',
+            existing_harness: 'codex',
+            ok: false,
+            requested_harness: 'claudecode'
+          },
+          status: 409
+        },
+        { status: 200 }
+      ]
+    })
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('review this'), { harnessType: 'claudecode' })
+    )
+    const creates = requests.filter(request => request.url.endsWith('.000100'))
+    expect(creates.map(request => (request.body as { harness_type: string }).harness_type)).toEqual(
+      ['claudecode', 'codex']
+    )
+    expect(requests.some(request => request.url.endsWith('/execute'))).toBe(true)
+  })
+
+  test('recovers existing harness from the error message when fields are absent', async () => {
+    const { fetchFn, requests } = fakeApi({
+      createSession: [
+        {
+          body: {
+            error:
+              'session slack:C1:1700000000.000100 already exists with harness_type amp, requested codex',
+            ok: false
+          },
+          status: 409
+        },
+        { status: 200 }
+      ]
+    })
+    await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
+    const creates = requests.filter(request => request.url.endsWith('.000100'))
+    expect(creates.map(request => (request.body as { harness_type: string }).harness_type)).toEqual(
+      ['codex', 'amp']
+    )
+  })
+
+  test('surfaces non-conflict create failures', async () => {
+    const { fetchFn } = fakeApi({
+      createSession: [{ body: { error: 'boom', ok: false }, status: 500 }]
+    })
+    await expect(
+      forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
+    ).rejects.toThrow('create session failed: 500')
+  })
+})


### PR DESCRIPTION
Restores the v1 slackbot's inline directives on the new Rust API harness stack.

## Usage

```
@centaur --claude --model claude-sonnet-4-6 review this PR
@centaur --amp fix the build
@centaur --opus summarize this thread
```

- `--claude` / `--claude-code` / `--amp` / `--codex` pick the harness for the thread (applies at session creation).
- `--model <name>` (or `--model=<name>`) picks the model within that harness, per turn — mid-thread model switches work.
- `--opus` / `--sonnet` / `--haiku` are shortcuts for the full Claude model IDs and imply the claude-code harness; explicit flags win over implications.
- Flags are stripped from the text before it reaches the agent (and from the thread title).

## Changes

**slackbotv2**
- New `src/overrides.ts` flag parser; wired through `syncThreadMessageToSession` → `createSession` (`harness_type`) and `executeSession` (top-level `model` on the input line).
- Sessions are pinned to the harness they were created with, so `createSession` now recovers from the API's 409 harness conflict by retrying with the existing harness. Without this, every plain message on a `--claude` thread would fail, since the bot used to hardcode `codex` on every create. A mid-thread harness flag is gracefully ignored rather than killing the message.

**centaur-api-server**
- The 409 `HarnessConflict` response gains structured `existing_harness` / `requested_harness` fields (with a message-regex fallback on the client) so the bot doesn't have to scrape the human-readable error.

**harness-server**
- Applies the `model` blocks-field plumbing from d1bdebc5 (`claude/mid-thread-model`), byte-identical so the eventual merge is clean: claude/amp apply it to per-turn CLI state, codex forwards it in `turn/start`.

## Testing

- slackbotv2: 40/40 `bun test` (17 new: parser unit tests + wire-format tests covering harness in the create body, model on the input line, 409-retry recovery, error propagation); `check:types` clean.
- Rust: `cargo test` in harness-server (includes the cherry-picked model-parsing tests); `cargo check`/clippy clean for `centaur-api-server` (remaining warnings pre-date this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)