### PR TITLE
chore: default harness-server claude model to claude-fable-5

### DIFF
--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -11,7 +11,7 @@ use crate::{
     command_from_override, user_input_to_anthropic_content,
 };
 
-const DEFAULT_CLAUDE_MODEL: &str = "claude-opus-4-8";
+const DEFAULT_CLAUDE_MODEL: &str = "claude-fable-5";
 
 /// Defers agent text until the owning message's fate is known, so agentMessage
 /// items can be emitted with an authoritative stop reason. Claude's per-block


### PR DESCRIPTION
## Summary

Aligns the Rust harness-server's default Claude model with the API's intended default by changing `DEFAULT_CLAUDE_MODEL` in `crates/harness-server/src/claude.rs` from `claude-opus-4-8` to `claude-fable-5`. This constant feeds `default_model()`, which is passed as the `--model` argument to the Claude Code CLI.

Stacked on top of #463 (base branch `codex/harness-server-rust-over-api-rs`).

## ⚠️ Risk / action required before merge

`claude-fable-5` is **not** a currently-served Anthropic model ID (the live family is Opus 4.8 / Sonnet 4.6 / Haiku 4.5). Unlike the `claude-fable-5` value already in `services/api/api/runtime_control.py`, which is **display-only** (it feeds the italic per-message header, not the invocation), this change alters the **actual model invocation**. Until `claude-fable-5` is live, this default will cause Claude harness turns to fail at runtime.

Requested explicitly with the understanding that it will be tested before relying on it. Do not merge until the model ID is confirmed served.

## Validation

- `cargo +nightly fmt --manifest-path crates/harness-server/Cargo.toml -- --check`

## Notes

Requester GitHub mapping was unavailable in session context, so no `Prompted by` line is included.
