### PR TITLE
fix(harness-server): own the Claude model in the in-image harness config

### DIFF
--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -11,8 +11,6 @@ use crate::{
     command_from_override, user_input_to_anthropic_content,
 };
 
-const DEFAULT_CLAUDE_MODEL: &str = "claude-opus-4-8";
-
 /// Defers agent text until the owning message's fate is known, so agentMessage
 /// items can be emitted with an authoritative stop reason. Claude's per-block
 /// `assistant` events leave `stop_reason` null, and downstream renderers treat
@@ -204,8 +202,13 @@ impl HarnessServer for ClaudeCodeHarness {
         "claude-code"
     }
 
+    /// Empty when no explicit override exists: the model is owned by the
+    /// in-image harness config (harness/claude/settings.json), mirroring how
+    /// codex reads harness/codex/config.toml. An empty model means
+    /// `command_for_turn` omits `--model` so the CLI falls through to
+    /// settings.json.
     fn default_model(&self) -> String {
-        env::var("CLAUDE_MODEL").unwrap_or_else(|_| DEFAULT_CLAUDE_MODEL.to_string())
+        env::var("CLAUDE_MODEL").unwrap_or_default()
     }
 
     fn default_model_provider(&self) -> &'static str {
@@ -230,9 +233,10 @@ impl HarnessServer for ClaudeCodeHarness {
             "--dangerously-skip-permissions",
             "--permission-mode",
             "bypassPermissions",
-            "--model",
-            &state.model,
         ]);
+        if !state.model.is_empty() {
+            command.args(["--model", &state.model]);
+        }
         if PathBuf::from("AGENTS.md").is_file() {
             command.args(["--append-system-prompt-file", "AGENTS.md"]);
         }

--- a/harness/claude/settings.json
+++ b/harness/claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "claude-fable-5",
   "permissions": {
     "defaultMode": "bypassPermissions",
     "additionalDirectories": [


### PR DESCRIPTION
## Summary

Follow-up to #481, replacing it. Targets `codex/harness-server-rust-over-api-rs` (same as #481) since the change lives in `crates/harness-server`.

Instead of editing harness-server's hard-coded `DEFAULT_CLAUDE_MODEL`, make the claude-code harness resolve its model the way codex already does: from the harness config baked into the sandbox image. There is no control-plane or env plumbing for the codex model — `harness/codex/config.toml` owns it (`model = "gpt-5.5"`) and the entrypoint copies it to `~/.codex/config.toml`. Claude now works the same way.

## Root cause

- `harness-server claude-code` (blocks mode) forced `--model` on every CLI invocation, resolving it as `thread/start` param → `CLAUDE_MODEL` env → baked-in constant. Nothing in the deployment sets the param or the env var, so the stale constant (`claude-opus-4-8`) always won — and because `--model` beats settings.json, the in-image harness config could never own the model the way codex's config.toml does.
- Verified with a stub `claude` CLI: the env override mechanism itself works fine; it just never received a value, and the forced `--model` made the constant the de-facto default.

## Changes

- `harness/claude/settings.json`: `"model": "claude-fable-5"` — the single source of truth, symmetric with `harness/codex/config.toml` (matches main's fable-5 default from #461/#462).
- `crates/harness-server/src/claude.rs`: drop the `DEFAULT_CLAUDE_MODEL` constant; only pass `--model` when explicitly provided (`thread/start` param or `CLAUDE_MODEL` env), letting the CLI fall through to settings.json otherwise. The env var remains as an explicit per-deployment override.

## Validation

- `cargo test --manifest-path crates/harness-server/Cargo.toml` (31 passed)
- `cargo fmt --manifest-path crates/harness-server/Cargo.toml -- --check`
- Stub-CLI runs: `CLAUDE_MODEL=claude-sonnet-4-6` → `--model claude-sonnet-4-6`; env unset → no `--model` flag (settings.json owns it)

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
