### PR TITLE
fix(chart): make repo-cache readiness use sync sentinel

### DIFF
--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -69,6 +69,12 @@ spec:
               git config --global --add safe.directory '*'
               git config --global init.defaultBranch main
               umask 022
+              ready_file=/cache/.repo-cache-ready
+              ready_tmp="${ready_file}.tmp"
+
+              repository_fingerprint() {
+                printf 'repositories=%s\nrepository_refs=%s\n' "$REPOSITORIES" "$REPOSITORY_REFS"
+              }
 
               repo_ref() {
                 local repo="$1"
@@ -142,11 +148,22 @@ spec:
               }
 
               while true; do
+                sync_ok=1
                 for repo in $REPOSITORIES; do
                   if ! sync_repo "$repo"; then
                     echo "Failed to sync $repo" >&2
+                    sync_ok=0
                   fi
                 done
+                if [ "$sync_ok" = "1" ]; then
+                  {
+                    repository_fingerprint
+                    printf 'synced_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  } > "$ready_tmp"
+                  mv "$ready_tmp" "$ready_file"
+                else
+                  rm -f "$ready_tmp" "$ready_file"
+                fi
                 sleep "$SYNC_INTERVAL_SECONDS"
               done
           env:
@@ -164,11 +181,17 @@ spec:
                 - /bin/bash
                 - -ec
                 - |
+                  ready_file=/cache/.repo-cache-ready
+                  expected="$(printf 'repositories=%s\nrepository_refs=%s\n' "$REPOSITORIES" "$REPOSITORY_REFS")"
+                  actual="$(sed -n '1,2p' "$ready_file" 2>/dev/null || true)"
+                  [ "$actual" = "$expected" ] || exit 1
                   for repo in $REPOSITORIES; do
-                    git -C "/cache/$repo" rev-parse --git-dir >/dev/null 2>&1 || exit 1
+                    [ -d "/cache/$repo/.git" ] || exit 1
                   done
-            initialDelaySeconds: 10
-            periodSeconds: 30
+            initialDelaySeconds: {{ .Values.repoCache.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.repoCache.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.repoCache.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.repoCache.readinessProbe.failureThreshold }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -163,6 +163,15 @@
           "type": "array",
           "items": { "type": "integer" }
         },
+        "readinessProbe": {
+          "type": "object",
+          "properties": {
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" },
+            "timeoutSeconds": { "type": "integer" },
+            "failureThreshold": { "type": "integer" }
+          }
+        },
         "nodeSelector": { "type": "object" },
         "tolerations": { "type": "array" },
         "affinity": { "type": "object" },

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -219,6 +219,11 @@ repoCache:
     token: ""
   egressPorts:
     - 443
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Summary
- write an atomic repo-cache readiness sentinel after a full successful sync pass
- make readiness validate the sentinel fingerprint and repo directories instead of running git for every repo
- add explicit repoCache readiness probe knobs so Kubernetes does not use the 1s default timeout

## Validation
- helm dependency build contrib/chart
- helm template centaur contrib/chart --set repoCache.enabled=true ... --show-only templates/repo-cache.yaml
- helm lint contrib/chart --set repoCache.enabled=true --set repoCache.githubToken.token=dummy --set repoCache.repositories={tempoxyz/tempo,paradigmxyz/centaur}
- local bash sentinel simulation for ready, missing repo, and stale fingerprint cases

## Live evidence
- centaur-system repo-cache on bose has valid repos but the current git-based readiness probe takes ~1.96-1.99s, exceeding Kubernetes default timeoutSeconds=1
- the sentinel/directory probe avoids per-repo git process work in the kubelet readiness path