### PR TITLE
feat(slackbotv2): conflate render streams for slow Slack consumers

### DIFF
--- a/services/slackbotv2/src/conflate.ts
+++ b/services/slackbotv2/src/conflate.ts
@@ -1,0 +1,110 @@
+import type { ChatSDKStreamChunk } from '@centaur/rendering'
+
+type TaskChunk = Extract<ChatSDKStreamChunk, { type: 'task_update' }>
+type PlanChunk = Extract<ChatSDKStreamChunk, { type: 'plan_update' }>
+
+/**
+ * Conflates a Chat SDK chunk stream for a slow consumer.
+ *
+ * Slack rendering pays one rate-limited API call per chunk, while a busy
+ * execution can emit tens of thousands of chunks. Without conflation the
+ * consumer replays every intermediate state and a large turn can take longer
+ * to render than to run. This wrapper drains the source eagerly into a
+ * pending snapshot while the consumer is busy:
+ *
+ * - `markdown_text` deltas are concatenated into one pending chunk (markdown
+ *   is append-only content, so merging loses nothing),
+ * - `task_update`s are keyed by id and merged per field, newest value
+ *   winning. Updates often omit `details`/`output` to mean "unchanged" (the
+ *   chunk schema cannot express clearing a field), so absent fields inherit
+ *   the pending value instead of dropping content the consumer never sent,
+ * - `plan_update` keeps only the latest title.
+ *
+ * Each consumer pull yields one pending item (plan first, then tasks in
+ * first-seen order, then markdown), so the Slack call count is bounded by
+ * distinct cards plus markdown volume instead of by source event count.
+ * When the consumer keeps up, pending holds at most one item and the stream
+ * behaves exactly like the unwrapped source.
+ */
+export async function* conflateChatSdkStream(
+  source: AsyncIterable<ChatSDKStreamChunk>
+): AsyncIterable<ChatSDKStreamChunk> {
+  const iterator = source[Symbol.asyncIterator]()
+  // Map.set on an existing key keeps its insertion position, so cards stay
+  // in first-seen order even when they update while pending.
+  const pendingTasks = new Map<string, TaskChunk>()
+  let pendingPlan: PlanChunk | undefined
+  let pendingMarkdown = ''
+  let sourceDone = false
+  let sourceFailed = false
+  let sourceError: unknown
+  let aborted = false
+  let wake: (() => void) | undefined
+
+  const pump = (async () => {
+    try {
+      while (!aborted) {
+        const result = await iterator.next()
+        if (result.done) return
+        const chunk = result.value
+        if (chunk.type === 'markdown_text') {
+          pendingMarkdown += chunk.text
+        } else if (chunk.type === 'plan_update') {
+          pendingPlan = chunk
+        } else {
+          const pending = pendingTasks.get(chunk.id)
+          pendingTasks.set(chunk.id, pending ? { ...pending, ...chunk } : chunk)
+        }
+        wake?.()
+      }
+    } catch (error) {
+      sourceFailed = true
+      sourceError = error
+    } finally {
+      sourceDone = true
+      wake?.()
+    }
+  })()
+
+  try {
+    while (true) {
+      if (pendingPlan) {
+        const plan = pendingPlan
+        pendingPlan = undefined
+        yield plan
+        continue
+      }
+      const nextTask = pendingTasks.entries().next()
+      if (!nextTask.done) {
+        const [id, task] = nextTask.value
+        pendingTasks.delete(id)
+        yield task
+        continue
+      }
+      if (pendingMarkdown) {
+        const text = pendingMarkdown
+        pendingMarkdown = ''
+        yield { type: 'markdown_text', text }
+        continue
+      }
+      // Run-to-completion guarantees the pump cannot fold between the checks
+      // above and the await below, so no wakeup can be lost.
+      if (sourceFailed) throw sourceError
+      if (sourceDone) return
+      await new Promise<void>(resolve => {
+        wake = resolve
+      })
+      wake = undefined
+    }
+  } finally {
+    // Consumer finished or abandoned the stream: stop pumping and cancel the
+    // source so a live SSE is not held open. Do not await either - a silent
+    // source can keep a pending next() unsettled indefinitely.
+    aborted = true
+    wake = undefined
+    void pump.catch(() => undefined)
+    if (!sourceDone) {
+      void Promise.resolve(iterator.return?.()).catch(() => undefined)
+    }
+  }
+}

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -19,6 +19,7 @@ import {
   type ChatSDKStreamChunk,
   type RendererEvent
 } from '@centaur/rendering'
+import { conflateChatSdkStream } from './conflate'
 import {
   collectInitialContext,
   forwardToSessionApi,
@@ -733,10 +734,12 @@ async function renderExecutionStream(
   })
   try {
     const visibleStream = await streamAfterFirstChunk(
-      slackSafeChatSdkStream(
-        codexAppServerToChatSdkStream(
-          stream,
-          rendererOptions(thread, options)
+      conflateChatSdkStream(
+        slackSafeChatSdkStream(
+          codexAppServerToChatSdkStream(
+            stream,
+            rendererOptions(thread, options)
+          )
         )
       )
     )
@@ -774,10 +777,12 @@ async function renderRecoveredExecutionStream(
   })
   try {
     const visibleStream = await streamAfterFirstChunk(
-      slackSafeChatSdkStream(
-        codexAppServerToChatSdkStream(
-          stream,
-          rendererOptions(thread, options)
+      conflateChatSdkStream(
+        slackSafeChatSdkStream(
+          codexAppServerToChatSdkStream(
+            stream,
+            rendererOptions(thread, options)
+          )
         )
       )
     )

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -817,6 +817,97 @@ describe('slackbotv2', () => {
     expect(await threadText(parent.ts)).toContain('STREAM_CONTINUATION_END')
   })
 
+  it('conflates rapid task updates instead of one Slack call per event', async () => {
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before a chatty command.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> run the chatty command`, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-conflated-render',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> run the chatty command`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.started',
+        item: {
+          id: 'cmd-chatty',
+          type: 'commandExecution',
+          command: 'stream-much-output',
+          status: 'inProgress'
+        }
+      })
+    )
+    const updateCount = 400
+    for (let index = 1; index <= updateCount; index += 1) {
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.commandExecution.outputDelta',
+          itemId: 'cmd-chatty',
+          delta: `line-${index}\n`
+        })
+      )
+    }
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-chatty',
+          type: 'commandExecution',
+          command: 'stream-much-output',
+          status: 'completed',
+          aggregatedOutput: ''
+        }
+      })
+    )
+    codexApi.emitSessionEvent(key, 'session.execution_completed', {
+      execution_id: 'exe-conflated-render',
+      status: 'completed',
+      result_text: 'CONFLATED_RENDER_OK'
+    })
+
+    await Promise.all(waits)
+    const chattyChunkSends = slackApi.calls.reduce((total, call) => {
+      return (
+        total +
+        streamChunks(call.body.chunks).filter(chunk => chunk.id === 'cmd-chatty').length
+      )
+    }, 0)
+    // Without conflation every output delta becomes its own Slack append
+    // (~400 chunk sends for this card). Conflation folds updates that arrive
+    // while a Slack call is in flight, so the card is sent far fewer times.
+    expect(chattyChunkSends).toBeGreaterThan(0)
+    expect(chattyChunkSends).toBeLessThan(100)
+    const renderedText = slackStreamTranscripts(slackApi.calls)
+      .flatMap(transcript => transcript.chunks.map(chunkText))
+      .filter(Boolean)
+      .join('\n')
+    expect(renderedText).toContain('CONFLATED_RENDER_OK')
+  })
+
   it('continues large task streams across Slack stream replies', async () => {
     codexApi.autoRespond = false
 
@@ -952,6 +1043,16 @@ describe('slackbotv2', () => {
           status: 'inProgress'
         }
       })
+    )
+    // Conflation collapses unsent intermediate states, so wait until the open
+    // task has actually reached Slack before completing it - this test is
+    // about segments staying open while a card is in progress.
+    await waitFor(() =>
+      slackApi.calls.some(call =>
+        streamChunks(call.body.chunks).some(
+          chunk => chunk.id === 'cmd-open' && chunk.status === 'in_progress'
+        )
+      )
     )
     for (let index = 1; index <= 3; index += 1) {
       codexApi.emitOutputLine(
@@ -2762,30 +2863,15 @@ function expectSlackPlanStreamShape(
     expect(progressChunks).toContainEqual(
       expect.objectContaining({ type: 'plan_update', title: 'Implementation plan' })
     )
+    // Conflation may merge intermediate states into the final card update
+    // when the consumer is behind, so only assert the terminal status per
+    // card here; content presence is asserted on the aggregate text below.
     expect(progressChunks).toContainEqual(
       expect.objectContaining({
         type: 'task_update',
         id: 'thinking-commentary-1',
         title: 'Thinking',
-        status: 'in_progress',
-      })
-    )
-    expect(progressChunks).toContainEqual(
-      expect.objectContaining({
-        type: 'task_update',
-        id: 'thinking-commentary-1',
-        title: 'Thinking',
-        status: 'complete',
-        details: expect.stringContaining('Checking the command output')
-      })
-    )
-    expect(progressChunks).toContainEqual(
-      expect.objectContaining({
-        type: 'task_update',
-        id: 'reasoning-1',
-        title: 'Thinking',
-        status: 'in_progress',
-        details: expect.stringContaining('Inspecting the event stream')
+        status: 'complete'
       })
     )
     expect(progressChunks).toContainEqual(

--- a/services/slackbotv2/test/conflate.test.ts
+++ b/services/slackbotv2/test/conflate.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'bun:test'
+import type { ChatSDKStreamChunk } from '@centaur/rendering'
+import { conflateChatSdkStream } from '../src/conflate'
+
+type ManualSource = {
+  iterable: AsyncIterable<ChatSDKStreamChunk>
+  push(chunk: ChatSDKStreamChunk): void
+  end(): void
+  fail(error: Error): void
+  readonly returnCalled: boolean
+}
+
+function manualSource(): ManualSource {
+  const queue: ChatSDKStreamChunk[] = []
+  let closed = false
+  let failure: Error | undefined
+  let notify: (() => void) | undefined
+  let returnCalled = false
+
+  const iterator: AsyncIterator<ChatSDKStreamChunk> = {
+    async next() {
+      while (true) {
+        const chunk = queue.shift()
+        if (chunk) return { done: false, value: chunk }
+        if (failure) throw failure
+        if (closed) return { done: true, value: undefined }
+        await new Promise<void>(resolve => {
+          notify = resolve
+        })
+        notify = undefined
+      }
+    },
+    async return() {
+      returnCalled = true
+      closed = true
+      notify?.()
+      return { done: true, value: undefined }
+    }
+  }
+
+  return {
+    iterable: { [Symbol.asyncIterator]: () => iterator },
+    push(chunk) {
+      queue.push(chunk)
+      notify?.()
+    },
+    end() {
+      closed = true
+      notify?.()
+    },
+    fail(error) {
+      failure = error
+      notify?.()
+    },
+    get returnCalled() {
+      return returnCalled
+    }
+  }
+}
+
+/** Lets the pump drain everything currently queued in the source. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 20; i += 1) await Promise.resolve()
+}
+
+function task(
+  id: string,
+  status: 'pending' | 'in_progress' | 'complete',
+  details?: string
+): ChatSDKStreamChunk {
+  return { type: 'task_update', id, title: `Task ${id}`, status, ...(details ? { details } : {}) }
+}
+
+function markdown(text: string): ChatSDKStreamChunk {
+  return { type: 'markdown_text', text }
+}
+
+describe('conflateChatSdkStream', () => {
+  it('collapses task updates and concatenates markdown while the consumer is busy', async () => {
+    const source = manualSource()
+    const stream = conflateChatSdkStream(source.iterable)[Symbol.asyncIterator]()
+
+    source.push(task('a', 'pending'))
+    const first = await stream.next()
+    expect(first.value).toEqual(task('a', 'pending'))
+
+    // Consumer is "busy": everything below folds into the pending snapshot.
+    source.push(task('a', 'in_progress', 'running step 1'))
+    source.push(markdown('Hello '))
+    source.push(task('a', 'complete'))
+    source.push(markdown('world'))
+    source.push(task('b', 'complete'))
+    source.push({ type: 'plan_update', title: 'The plan' })
+    await settle()
+
+    expect((await stream.next()).value).toEqual({ type: 'plan_update', title: 'The plan' })
+    // Latest status wins; details from the intermediate update survive the
+    // merge because the completion chunk omitted them ("unchanged").
+    expect((await stream.next()).value).toEqual(task('a', 'complete', 'running step 1'))
+    expect((await stream.next()).value).toEqual(task('b', 'complete'))
+    expect((await stream.next()).value).toEqual(markdown('Hello world'))
+
+    source.end()
+    expect((await stream.next()).done).toBe(true)
+  })
+
+  it('merges task fields so omitted details inherit the pending value', async () => {
+    const source = manualSource()
+    const stream = conflateChatSdkStream(source.iterable)[Symbol.asyncIterator]()
+
+    source.push(markdown('start'))
+    expect((await stream.next()).value).toEqual(markdown('start'))
+
+    source.push(task('a', 'in_progress', 'first details'))
+    source.push(task('a', 'in_progress', 'second details'))
+    source.push(task('a', 'complete'))
+    await settle()
+
+    expect((await stream.next()).value).toEqual(task('a', 'complete', 'second details'))
+    source.end()
+    expect((await stream.next()).done).toBe(true)
+  })
+
+  it('passes chunks through unchanged when the consumer keeps up', async () => {
+    const source = manualSource()
+    const stream = conflateChatSdkStream(source.iterable)[Symbol.asyncIterator]()
+    const chunks: ChatSDKStreamChunk[] = [
+      task('a', 'pending'),
+      markdown('first'),
+      task('a', 'complete'),
+      markdown('second')
+    ]
+
+    for (const chunk of chunks) {
+      source.push(chunk)
+      expect((await stream.next()).value).toEqual(chunk)
+    }
+    source.end()
+    expect((await stream.next()).done).toBe(true)
+  })
+
+  it('keeps tasks in first-seen order when an earlier task updates later', async () => {
+    const source = manualSource()
+    const stream = conflateChatSdkStream(source.iterable)[Symbol.asyncIterator]()
+
+    // Prime the pump so the chunks below all fold while the consumer is busy.
+    source.push(markdown('start'))
+    expect((await stream.next()).value).toEqual(markdown('start'))
+
+    source.push(task('a', 'in_progress'))
+    source.push(task('b', 'pending'))
+    source.push(task('a', 'complete'))
+    await settle()
+
+    expect((await stream.next()).value).toEqual(task('a', 'complete'))
+    expect((await stream.next()).value).toEqual(task('b', 'pending'))
+    source.end()
+    expect((await stream.next()).done).toBe(true)
+  })
+
+  it('drains pending chunks before surfacing a source failure', async () => {
+    const source = manualSource()
+    const stream = conflateChatSdkStream(source.iterable)[Symbol.asyncIterator]()
+
+    source.push(markdown('partial answer'))
+    source.fail(new Error('sse exploded'))
+    await settle()
+
+    expect((await stream.next()).value).toEqual(markdown('partial answer'))
+    expect(stream.next()).rejects.toThrow('sse exploded')
+  })
+
+  it('cancels the source when the consumer abandons the stream', async () => {
+    const source = manualSource()
+    const stream = conflateChatSdkStream(source.iterable)[Symbol.asyncIterator]()
+
+    source.push(task('a', 'pending'))
+    await stream.next()
+    await stream.return?.(undefined)
+    await settle()
+
+    expect(source.returnCalled).toBe(true)
+  })
+})


### PR DESCRIPTION
## Context

Incident on 2026-06-11 (thread `slack:C0A87C21805:1781171006.081809`): the harness finished a 10,453-event turn in 59s with the full answer persisted, but the Slack render was still grinding **36 minutes later** when the 10:19 deploy killed the pod. Rendering pays one rate-limited Slack API call per chunk and replays every intermediate state, so render time scales with event count, not content size. The unfinished render left `activeExecution` stuck true, so follow-up mentions in the thread were appended but never executed.

## Change

Wrap the render chunk stream in a conflator (`conflateChatSdkStream`) that drains the SSE eagerly into a pending snapshot while the Slack consumer is busy:

- **markdown deltas** concatenate into one pending chunk (append-only content, merging loses nothing),
- **task updates** merge per field keyed by card id, newest value winning — updates omit `details`/`output` to mean "unchanged" (the chunk schema cannot express clearing a field), so absent fields inherit the pending value instead of dropping content the consumer never sent,
- **plan updates** keep the latest title.

Each consumer pull yields one pending item (plan, then cards in first-seen order, then markdown), so the Slack call count is bounded by **distinct cards + markdown volume** instead of source event count. When Slack keeps up, pending never accumulates and behavior is identical to today. Slack upserts cards in place, so intermediate states a slow consumer hasn't posted yet would be overwritten by the next update anyway — skipping them changes nothing user-visible.

Wired into both `renderExecutionStream` and `renderRecoveredExecutionStream`. The plain-text path already posts once at the end and needs no conflation.

## Validation

- 6 deterministic unit tests for the conflator (collapse, per-field merge, first-seen order, pass-through when keeping up, failure propagation after draining, source cancellation on abandon).
- New emulate regression test: 400 output deltas to one card → **402 chunk sends without conflation, a handful with it** (verified by temporarily bypassing the conflator: the test fails with `Received: 402`).
- Existing tests that asserted specific intermediate card states now assert terminal state + aggregate content (intermediates are timing-dependent under conflation by design); the open-segment continuation test synchronizes on `in_progress` reaching Slack before completing the card, preserving its original intent.
- `bun test test`: 30/30; `tsgo --noEmit` clean.

## What this does not fix (follow-ups)

Conflation makes the hang class very unlikely but two backstops from the same incident remain open: a render deadline/watchdog (Slack outage → infinite retry still possible) and recovery hardening (serial obligation scan currently wedges forever on a zombie `running` execution whose SSE never yields; ~189 obligations are queued behind it in prod).

Incident investigation: https://ampcode.com/threads/T-019eb342-f946-750e-89d1-a8f028e80d0e
