### PR TITLE
feat(tools): add tenderly tool

### DIFF
--- a/tools/crypto/tenderly/__init__.py
+++ b/tools/crypto/tenderly/__init__.py
@@ -1,0 +1,1 @@
+"""Tenderly simulation, tracing, and Virtual TestNet API."""

--- a/tools/crypto/tenderly/cli.py
+++ b/tools/crypto/tenderly/cli.py
@@ -1,0 +1,600 @@
+"""CLI for Tenderly simulation, tracing, and Virtual TestNets."""
+
+import json
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from .client import (
+    TenderlyClient,
+    error_path,
+    extract_call_trace,
+    find_failures,
+    flatten_call_trace,
+    trace_skeleton,
+)
+
+app = typer.Typer(
+    name="tenderly",
+    help="Tenderly CLI for transaction simulation, tracing, and Virtual TestNets",
+)
+vnet_app = typer.Typer(name="vnet", help="Manage and interact with Virtual TestNets")
+app.add_typer(vnet_app)
+console = Console()
+
+SHOW_CHOICES = "summary, trace, skeleton, events, state, assets, balances, failures, error-path, json"
+
+
+def print_rows(rows: list[dict], output: str) -> None:
+    """Print a list of dicts as JSON or a rich table."""
+    if output == "json":
+        print(json.dumps(rows, indent=2, default=str))
+        return
+    if not rows:
+        console.print("[yellow]No results.[/]")
+        return
+    table = Table()
+    for col in rows[0].keys():
+        table.add_column(str(col), overflow="fold")
+    for row in rows:
+        table.add_row(*[str(v) for v in row.values()])
+    console.print(table)
+
+
+def _events(result: dict) -> list[dict]:
+    """Extract decoded events from a simulate/trace response."""
+    transaction = result.get("transaction") or {}
+    info = transaction.get("transaction_info") or {}
+    logs = info.get("logs") or result.get("logs") or []
+    events = []
+    for log in logs:
+        raw = log.get("raw") or {}
+        events.append(
+            {
+                "name": log.get("name") or "(unknown)",
+                "contract": raw.get("address", ""),
+                "inputs": ", ".join(
+                    f"{i.get('soltype', {}).get('name', '?')}={i.get('value')}"
+                    for i in log.get("inputs") or []
+                ),
+            }
+        )
+    return events
+
+
+def _state_changes(result: dict) -> list[dict]:
+    """Extract storage diffs from a simulate/trace response."""
+    transaction = result.get("transaction") or {}
+    info = transaction.get("transaction_info") or {}
+    diffs = info.get("state_diff") or result.get("state_diff") or []
+    changes = []
+    for diff in diffs:
+        raw_entries = diff.get("raw") or [{}]
+        for raw in raw_entries:
+            changes.append(
+                {
+                    "contract": diff.get("address") or raw.get("address", ""),
+                    "variable": diff.get("soltype", {}).get("name", "")
+                    if diff.get("soltype")
+                    else "",
+                    "key": raw.get("key", ""),
+                    "before": diff.get("original", raw.get("original", "")),
+                    "after": diff.get("dirty", raw.get("dirty", "")),
+                }
+            )
+    return changes
+
+
+def _asset_changes(result: dict) -> list[dict]:
+    """Extract asset transfers from a simulate/trace response."""
+    transaction = result.get("transaction") or {}
+    info = transaction.get("transaction_info") or {}
+    assets = info.get("asset_changes") or result.get("asset_changes") or []
+    return [
+        {
+            "type": change.get("type", ""),
+            "from": change.get("from", ""),
+            "to": change.get("to", ""),
+            "amount": change.get("amount", ""),
+            "token": (change.get("token_info") or {}).get("symbol", ""),
+            "usd": change.get("dollar_value", ""),
+        }
+        for change in assets
+    ]
+
+
+def _balance_changes(result: dict) -> list[dict]:
+    """Extract net balance changes from a simulate/trace response."""
+    transaction = result.get("transaction") or {}
+    info = transaction.get("transaction_info") or {}
+    diffs = info.get("balance_diff") or result.get("balance_diff") or []
+    return [
+        {
+            "address": diff.get("address", ""),
+            "before": diff.get("original", ""),
+            "after": diff.get("dirty", ""),
+            "is_miner": diff.get("is_miner", False),
+        }
+        for diff in diffs
+    ]
+
+
+def _print_result_view(result: dict, show: str) -> None:
+    """Render the requested view of a simulate/trace response."""
+    if show == "json":
+        print(json.dumps(result, indent=2, default=str))
+        return
+
+    root = extract_call_trace(result)
+    if show == "trace":
+        print_rows(flatten_call_trace(root), "table")
+    elif show == "skeleton":
+        print_rows(trace_skeleton(root), "table")
+    elif show == "events":
+        print_rows(_events(result), "table")
+    elif show == "state":
+        print_rows(_state_changes(result), "table")
+    elif show == "assets":
+        print_rows(_asset_changes(result), "table")
+    elif show == "balances":
+        print_rows(_balance_changes(result), "table")
+    elif show == "failures":
+        print_rows(find_failures(root), "table")
+    elif show == "error-path":
+        print_rows(error_path(root), "table")
+    else:
+        transaction = result.get("transaction") or {}
+        status = transaction.get("status", result.get("status"))
+        status_text = "[green]Success[/]" if status else "[red]Reverted[/]"
+        console.print(f"[bold]Status:[/] {status_text}")
+        console.print(f"[bold]Gas used:[/] {transaction.get('gas_used', 'N/A')}")
+        if transaction.get("block_number"):
+            console.print(f"[bold]Block:[/] {transaction.get('block_number')}")
+        error = transaction.get("error_message") or (root or {}).get("error")
+        if error:
+            console.print(f"[bold]Error:[/] [red]{error}[/]")
+        failures = find_failures(root)
+        if failures:
+            console.print(f"[bold]Failed calls:[/] {len(failures)} (use --show failures)")
+        simulation = result.get("simulation") or {}
+        if simulation.get("id"):
+            console.print(f"[bold]Simulation ID:[/] {simulation['id']}")
+
+
+@app.command()
+def whoami():
+    """Show the authenticated Tenderly user."""
+    try:
+        with TenderlyClient() as client:
+            user = client.get_user()
+            print(json.dumps(user, indent=2, default=str))
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def projects(
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table, json"),
+):
+    """List Tenderly projects for the configured account."""
+    try:
+        with TenderlyClient() as client:
+            rows = [
+                {
+                    "name": p.get("name", ""),
+                    "slug": p.get("slug", ""),
+                    "id": p.get("id", ""),
+                }
+                for p in client.list_projects()
+            ]
+            print_rows(rows, output)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def networks(
+    search: str = typer.Option(None, "--search", "-s", help="Filter by name or chain ID"),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table, json"),
+):
+    """List public EVM networks supported by Tenderly."""
+    try:
+        with TenderlyClient() as client:
+            nets = client.get_networks()
+            rows = [
+                {
+                    "id": n.get("id", ""),
+                    "name": n.get("name", ""),
+                    "slug": n.get("slug", ""),
+                    "native_currency": (n.get("native_currency") or {}).get("symbol", "")
+                    if isinstance(n.get("native_currency"), dict)
+                    else n.get("native_currency", ""),
+                }
+                for n in nets
+            ]
+            if search:
+                needle = search.lower()
+                rows = [
+                    r
+                    for r in rows
+                    if needle in str(r["name"]).lower()
+                    or needle in str(r["slug"]).lower()
+                    or needle == str(r["id"])
+                ]
+            print_rows(rows, output)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def contract(
+    address: str = typer.Argument(..., help="Contract address (0x...)"),
+    network: str = typer.Option("1", "--network", "-n", help="Network ID (e.g. 1, 10, 8453)"),
+    abi: bool = typer.Option(False, "--abi", help="Print only the contract ABI"),
+):
+    """Get metadata (name, ABI, compiler) for a verified contract."""
+    try:
+        with TenderlyClient() as client:
+            data = client.get_contract(network, address)
+            if abi:
+                contract_data = data.get("data") or data
+                abi_data = contract_data.get("abi") or []
+                print(json.dumps(abi_data, indent=2, default=str))
+            else:
+                print(json.dumps(data, indent=2, default=str))
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def simulate(
+    from_address: str = typer.Option(..., "--from", "-f", help="Sender address"),
+    to_address: str = typer.Option(..., "--to", "-t", help="Target contract address"),
+    input_data: str = typer.Option("0x", "--input", "-i", help="Calldata (0x...)"),
+    value: int = typer.Option(0, "--value", "-v", help="Native value in wei"),
+    gas: int = typer.Option(8_000_000, "--gas", "-g", help="Gas limit"),
+    network: str = typer.Option("1", "--network", "-n", help="Network ID"),
+    block: int = typer.Option(None, "--block", "-b", help="Block number (default latest)"),
+    save: bool = typer.Option(False, "--save", help="Persist the simulation in Tenderly"),
+    show: str = typer.Option("summary", "--show", help=f"View: {SHOW_CHOICES}"),
+):
+    """Simulate a transaction on a public network without spending gas."""
+    try:
+        with TenderlyClient() as client:
+            result = client.simulate(
+                network_id=network,
+                from_address=from_address,
+                to_address=to_address,
+                input_data=input_data,
+                value=value,
+                gas=gas,
+                block_number=block,
+                save=save,
+            )
+            _print_result_view(result, show)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def trace(
+    tx_hash: str = typer.Argument(..., help="Transaction hash (0x...)"),
+    network: str = typer.Option("1", "--network", "-n", help="Network ID"),
+    show: str = typer.Option("summary", "--show", help=f"View: {SHOW_CHOICES}"),
+):
+    """Trace an on-chain transaction with decoded calls, events, and state diffs."""
+    try:
+        with TenderlyClient() as client:
+            result = client.trace_transaction(network, tx_hash)
+            _print_result_view(result, show)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+# --- Virtual TestNets ---
+
+
+def _vnet_row(vnet: dict) -> dict:
+    fork = vnet.get("fork_config") or {}
+    return {
+        "id": vnet.get("id", ""),
+        "slug": vnet.get("slug", ""),
+        "network": fork.get("network_id", ""),
+        "block": fork.get("block_number", ""),
+        "status": vnet.get("status", ""),
+    }
+
+
+@vnet_app.command("create")
+def vnet_create(
+    slug: str = typer.Argument(..., help="Slug for the new Virtual TestNet"),
+    network: str = typer.Option("1", "--network", "-n", help="Network ID to fork"),
+    name: str = typer.Option(None, "--name", help="Display name (defaults to slug)"),
+    block: str = typer.Option("latest", "--block", "-b", help="Fork block number or 'latest'"),
+    chain_id: int = typer.Option(None, "--chain-id", help="Custom chain ID for the vnet"),
+):
+    """Create a Virtual TestNet by forking a public network."""
+    try:
+        with TenderlyClient() as client:
+            block_number = int(block) if block != "latest" else "latest"
+            vnet = client.create_vnet(
+                network_id=network,
+                slug=slug,
+                display_name=name,
+                block_number=block_number,
+                chain_id=chain_id,
+            )
+            print(json.dumps(vnet, indent=2, default=str))
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("list")
+def vnet_list(
+    page: int = typer.Option(1, "--page", help="Page number"),
+    per_page: int = typer.Option(20, "--per-page", help="Results per page"),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table, json"),
+):
+    """List Virtual TestNets in the project."""
+    try:
+        with TenderlyClient() as client:
+            vnets = client.list_vnets(page=page, per_page=per_page)
+            if output == "json":
+                print(json.dumps(vnets, indent=2, default=str))
+            else:
+                print_rows([_vnet_row(v) for v in vnets], output)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("get")
+def vnet_get(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+):
+    """Get full details of a Virtual TestNet, including RPC URLs."""
+    try:
+        with TenderlyClient() as client:
+            print(json.dumps(client.get_vnet(vnet_id), indent=2, default=str))
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("delete")
+def vnet_delete(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+):
+    """Delete a Virtual TestNet."""
+    try:
+        with TenderlyClient() as client:
+            client.delete_vnet(vnet_id)
+            console.print(f"[green]Deleted vnet {vnet_id}.[/]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("txs")
+def vnet_txs(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    page: int = typer.Option(1, "--page", help="Page number"),
+    per_page: int = typer.Option(20, "--per-page", help="Results per page"),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table, json"),
+):
+    """List transactions executed on a Virtual TestNet."""
+    try:
+        with TenderlyClient() as client:
+            txs = client.list_vnet_transactions(vnet_id, page=page, per_page=per_page)
+            if output == "json":
+                print(json.dumps(txs, indent=2, default=str))
+            else:
+                rows = [
+                    {
+                        "hash": tx.get("tx_hash") or tx.get("hash", ""),
+                        "from": tx.get("from", ""),
+                        "to": tx.get("to", ""),
+                        "status": tx.get("status", ""),
+                        "block": tx.get("block_number", ""),
+                    }
+                    for tx in txs
+                ]
+                print_rows(rows, output)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("send")
+def vnet_send(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    from_address: str = typer.Option(..., "--from", "-f", help="Sender (impersonated, no key needed)"),
+    to_address: str = typer.Option(..., "--to", "-t", help="Target address"),
+    input_data: str = typer.Option("0x", "--input", "-i", help="Calldata (0x...)"),
+    value: int = typer.Option(0, "--value", "-v", help="Native value in wei"),
+    gas: int = typer.Option(None, "--gas", "-g", help="Gas limit"),
+):
+    """Send an unsigned (impersonated) transaction on a Virtual TestNet."""
+    try:
+        with TenderlyClient() as client:
+            tx_hash = client.send_vnet_transaction(
+                vnet_id,
+                from_address=from_address,
+                to_address=to_address,
+                input_data=input_data,
+                value=value,
+                gas=gas,
+            )
+            console.print(f"[green]Sent:[/] {tx_hash}")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("simulate")
+def vnet_simulate(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    from_address: str = typer.Option(..., "--from", "-f", help="Sender address"),
+    to_address: str = typer.Option(..., "--to", "-t", help="Target address"),
+    input_data: str = typer.Option("0x", "--input", "-i", help="Calldata (0x...)"),
+    value: int = typer.Option(0, "--value", "-v", help="Native value in wei"),
+    gas: int = typer.Option(8_000_000, "--gas", "-g", help="Gas limit"),
+    show: str = typer.Option("summary", "--show", help=f"View: {SHOW_CHOICES}"),
+):
+    """Simulate a transaction on a Virtual TestNet without changing its state."""
+    try:
+        with TenderlyClient() as client:
+            result = client.simulate_vnet_transaction(
+                vnet_id,
+                from_address=from_address,
+                to_address=to_address,
+                input_data=input_data,
+                value=value,
+                gas=gas,
+            )
+            _print_result_view(result, show)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("call")
+def vnet_call(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    to_address: str = typer.Option(..., "--to", "-t", help="Contract address"),
+    input_data: str = typer.Option(..., "--input", "-i", help="Calldata (0x...)"),
+    from_address: str = typer.Option(None, "--from", "-f", help="Caller address"),
+):
+    """Execute a read-only eth_call on a Virtual TestNet."""
+    try:
+        with TenderlyClient() as client:
+            result = client.vnet_call(
+                vnet_id, to_address, input_data, from_address=from_address
+            )
+            print(result)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("fund")
+def vnet_fund(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    addresses: str = typer.Argument(..., help="Comma-separated addresses to fund"),
+    amount: float = typer.Option(10.0, "--amount", "-a", help="Amount in native token (e.g. ETH)"),
+):
+    """Set the native balance of one or more accounts."""
+    try:
+        with TenderlyClient() as client:
+            addr_list = [a.strip() for a in addresses.split(",")]
+            wei = int(amount * 10**18)
+            client.set_balance(vnet_id, addr_list, wei)
+            console.print(f"[green]Set balance of {len(addr_list)} account(s) to {amount}.[/]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("erc20")
+def vnet_erc20(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    token: str = typer.Option(..., "--token", help="ERC-20 token contract address"),
+    wallet: str = typer.Option(..., "--wallet", "-w", help="Wallet address"),
+    amount: int = typer.Option(..., "--amount", "-a", help="Amount in token base units"),
+):
+    """Set the ERC-20 token balance of a wallet."""
+    try:
+        with TenderlyClient() as client:
+            client.set_erc20_balance(vnet_id, token, wallet, amount)
+            console.print(f"[green]Set {token} balance of {wallet} to {amount}.[/]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("storage")
+def vnet_storage(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    contract: str = typer.Option(..., "--contract", "-c", help="Contract address"),
+    slot: str = typer.Option(..., "--slot", "-s", help="Storage slot (0x...)"),
+    value: str = typer.Option(..., "--value", "-v", help="32-byte value (0x...)"),
+):
+    """Write a raw value to a contract storage slot."""
+    try:
+        with TenderlyClient() as client:
+            client.set_storage_at(vnet_id, contract, slot, value)
+            console.print(f"[green]Wrote slot {slot} on {contract}.[/]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("snapshot")
+def vnet_snapshot(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+):
+    """Save the current Virtual TestNet state and print the snapshot ID."""
+    try:
+        with TenderlyClient() as client:
+            snapshot_id = client.snapshot(vnet_id)
+            console.print(f"[green]Snapshot:[/] {snapshot_id}")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("revert")
+def vnet_revert(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    snapshot_id: str = typer.Argument(..., help="Snapshot ID from 'tenderly vnet snapshot'"),
+):
+    """Restore a Virtual TestNet to a previously saved snapshot."""
+    try:
+        with TenderlyClient() as client:
+            client.revert(vnet_id, snapshot_id)
+            console.print(f"[green]Reverted to snapshot {snapshot_id}.[/]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("increase-time")
+def vnet_increase_time(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    seconds: int = typer.Argument(..., help="Seconds to advance the clock"),
+):
+    """Advance the Virtual TestNet clock."""
+    try:
+        with TenderlyClient() as client:
+            client.increase_time(vnet_id, seconds)
+            console.print(f"[green]Advanced time by {seconds}s.[/]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+@vnet_app.command("mine")
+def vnet_mine(
+    vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
+    blocks: int = typer.Option(1, "--blocks", "-b", help="Number of blocks to mine"),
+):
+    """Mine one or more blocks on a Virtual TestNet."""
+    try:
+        with TenderlyClient() as client:
+            client.mine_blocks(vnet_id, blocks)
+            console.print(f"[green]Mined {blocks} block(s).[/]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/crypto/tenderly/client.py
+++ b/tools/crypto/tenderly/client.py
@@ -1,0 +1,489 @@
+"""Tenderly API client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from centaur_sdk import secret
+
+API_BASE = "https://api.tenderly.co/api/v1"
+
+
+class TenderlyClient:
+    """Client for the Tenderly API and Virtual TestNet RPC endpoints."""
+
+    def __init__(
+        self,
+        access_key: str | None = None,
+        account: str | None = None,
+        project: str | None = None,
+        timeout: float = 60.0,
+    ):
+        self.access_key = access_key
+        self.account = account
+        self.project = project
+        self.timeout = timeout
+        self._http: httpx.Client | None = None
+        self._vnet_rpc_cache: dict[str, dict] = {}
+
+    def _get_access_key(self) -> str:
+        """Get access key from env var."""
+        if self.access_key:
+            return self.access_key
+        key = secret("TENDERLY_ACCESS_KEY", "")
+        if key:
+            return key
+        raise RuntimeError("TENDERLY_ACCESS_KEY not set.")
+
+    def _get_account(self) -> str:
+        """Get account slug from env var."""
+        account = self.account or secret("TENDERLY_ACCOUNT_SLUG", "")
+        if account:
+            return account
+        raise RuntimeError("TENDERLY_ACCOUNT_SLUG not set.")
+
+    def _get_project(self) -> str:
+        """Get project slug from env var."""
+        project = self.project or secret("TENDERLY_PROJECT_SLUG", "")
+        if project:
+            return project
+        raise RuntimeError("TENDERLY_PROJECT_SLUG not set.")
+
+    def _project_path(self) -> str:
+        return f"/account/{self._get_account()}/project/{self._get_project()}"
+
+    @property
+    def http(self) -> httpx.Client:
+        """Get or create the HTTP client."""
+        if self._http is None:
+            self._http = httpx.Client(
+                headers={"Content-Type": "application/json"},
+                timeout=self.timeout,
+            )
+        return self._http
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        if self._http is not None:
+            self._http.close()
+            self._http = None
+
+    def __enter__(self) -> TenderlyClient:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        json: dict | None = None,
+        params: dict | None = None,
+    ) -> Any:
+        """Make an authenticated request against the Tenderly API."""
+        response = self.http.request(
+            method,
+            f"{API_BASE}{path}",
+            json=json,
+            params=params,
+            headers={"X-Access-Key": self._get_access_key()},
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Tenderly API error: {response.status_code} - {response.text}"
+            )
+        if not response.content:
+            return None
+        return response.json()
+
+    # --- Account & networks ---
+
+    def get_user(self) -> dict:
+        """Get info about the authenticated user."""
+        return self._request("GET", "/user")
+
+    def list_projects(self) -> list[dict]:
+        """List projects for the configured account."""
+        result = self._request("GET", f"/account/{self._get_account()}/projects")
+        return result.get("projects", []) if isinstance(result, dict) else result
+
+    def get_networks(self) -> list[dict]:
+        """List public EVM networks supported by Tenderly."""
+        result = self._request("GET", "/public-networks")
+        return result if isinstance(result, list) else result.get("networks", [])
+
+    # --- Contracts ---
+
+    def get_contract(self, network_id: str, address: str) -> dict:
+        """Get metadata (name, ABI, compiler) for a verified contract."""
+        return self._request(
+            "GET", f"/public-contract/{network_id}/{address.lower()}"
+        )
+
+    # --- Simulation ---
+
+    def simulate(
+        self,
+        network_id: str,
+        from_address: str,
+        to_address: str,
+        input_data: str = "0x",
+        value: int = 0,
+        gas: int = 8_000_000,
+        gas_price: int | None = None,
+        block_number: int | None = None,
+        simulation_type: str = "full",
+        state_objects: dict | None = None,
+        save: bool = False,
+    ) -> dict:
+        """Simulate a transaction on a public network."""
+        payload: dict[str, Any] = {
+            "network_id": str(network_id),
+            "from": from_address,
+            "to": to_address,
+            "input": input_data,
+            "value": value,
+            "gas": gas,
+            "simulation_type": simulation_type,
+            "save": save,
+            "save_if_fails": save,
+        }
+        if gas_price is not None:
+            payload["gas_price"] = str(gas_price)
+        if block_number is not None:
+            payload["block_number"] = block_number
+        if state_objects:
+            payload["state_objects"] = state_objects
+        return self._request("POST", f"{self._project_path()}/simulate", json=payload)
+
+    def simulate_bundle(self, simulations: list[dict]) -> dict:
+        """Simulate a bundle of transactions executed sequentially."""
+        return self._request(
+            "POST",
+            f"{self._project_path()}/simulate-bundle",
+            json={"simulations": simulations},
+        )
+
+    # --- Tracing ---
+
+    def trace_transaction(self, network_id: str, tx_hash: str) -> dict:
+        """Get the decoded execution trace of an on-chain transaction."""
+        return self._request("GET", f"/public-contract/{network_id}/trace/{tx_hash}")
+
+    # --- Virtual TestNets ---
+
+    def create_vnet(
+        self,
+        network_id: str,
+        slug: str,
+        display_name: str | None = None,
+        block_number: int | str = "latest",
+        chain_id: int | None = None,
+    ) -> dict:
+        """Create a Virtual TestNet by forking a public network."""
+        payload: dict[str, Any] = {
+            "slug": slug,
+            "display_name": display_name or slug,
+            "fork_config": {
+                "network_id": int(network_id),
+                "block_number": block_number,
+            },
+            "virtual_network_config": {
+                "chain_config": {
+                    "chain_id": chain_id if chain_id is not None else int(network_id),
+                },
+            },
+            "sync_state_config": {"enabled": False},
+            "explorer_page_config": {
+                "enabled": False,
+                "verification_visibility": "bytecode",
+            },
+        }
+        return self._request("POST", f"{self._project_path()}/vnets", json=payload)
+
+    def list_vnets(self, page: int = 1, per_page: int = 20) -> list[dict]:
+        """List Virtual TestNets in the project."""
+        result = self._request(
+            "GET",
+            f"{self._project_path()}/vnets",
+            params={"page": page, "perPage": per_page},
+        )
+        return result if isinstance(result, list) else result.get("vnets", [])
+
+    def get_vnet(self, vnet_id: str) -> dict:
+        """Get full details of a Virtual TestNet."""
+        return self._request("GET", f"{self._project_path()}/vnets/{vnet_id}")
+
+    def delete_vnet(self, vnet_id: str) -> None:
+        """Delete a Virtual TestNet."""
+        self._request("DELETE", f"{self._project_path()}/vnets/{vnet_id}")
+
+    def list_vnet_transactions(
+        self, vnet_id: str, page: int = 1, per_page: int = 20
+    ) -> list[dict]:
+        """List transactions executed on a Virtual TestNet."""
+        result = self._request(
+            "GET",
+            f"{self._project_path()}/vnets/{vnet_id}/transactions",
+            params={"page": page, "perPage": per_page},
+        )
+        return result if isinstance(result, list) else result.get("transactions", [])
+
+    def simulate_vnet_transaction(
+        self,
+        vnet_id: str,
+        from_address: str,
+        to_address: str,
+        input_data: str = "0x",
+        value: int = 0,
+        gas: int = 8_000_000,
+        block_number: int | None = None,
+    ) -> dict:
+        """Simulate a transaction on a Virtual TestNet without changing state."""
+        callargs: dict[str, Any] = {
+            "from": from_address,
+            "to": to_address,
+            "data": input_data,
+            "value": hex(value),
+            "gas": hex(gas),
+        }
+        payload: dict[str, Any] = {"callArgs": callargs}
+        if block_number is not None:
+            payload["blockNumber"] = hex(block_number)
+        return self._request(
+            "POST",
+            f"{self._project_path()}/vnets/{vnet_id}/transactions/simulate",
+            json=payload,
+        )
+
+    # --- Virtual TestNet RPC ---
+
+    def get_vnet_rpc_url(self, vnet_id: str, admin: bool = True) -> str:
+        """Get the (admin) RPC URL for a Virtual TestNet."""
+        vnet = self._vnet_rpc_cache.get(vnet_id) or self.get_vnet(vnet_id)
+        self._vnet_rpc_cache[vnet_id] = vnet
+        rpcs = vnet.get("rpcs", [])
+        wanted = "Admin RPC" if admin else "Public RPC"
+        for rpc in rpcs:
+            if rpc.get("name") == wanted:
+                return rpc["url"]
+        if rpcs:
+            return rpcs[0]["url"]
+        raise RuntimeError(f"No RPC endpoints found for vnet {vnet_id}.")
+
+    def vnet_rpc(self, vnet_id: str, method: str, params: list | None = None) -> Any:
+        """Make a JSON-RPC call against a Virtual TestNet's admin RPC."""
+        url = self.get_vnet_rpc_url(vnet_id, admin=True)
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params or [],
+            "id": 1,
+        }
+        response = self.http.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json()
+        if "error" in result:
+            raise RuntimeError(f"RPC error: {result['error']}")
+        return result.get("result")
+
+    def send_vnet_transaction(
+        self,
+        vnet_id: str,
+        from_address: str,
+        to_address: str,
+        input_data: str = "0x",
+        value: int = 0,
+        gas: int | None = None,
+    ) -> str:
+        """Send an unsigned (impersonated) transaction on a Virtual TestNet."""
+        tx: dict[str, Any] = {
+            "from": from_address,
+            "to": to_address,
+            "data": input_data,
+            "value": hex(value),
+        }
+        if gas is not None:
+            tx["gas"] = hex(gas)
+        return self.vnet_rpc(vnet_id, "eth_sendTransaction", [tx])
+
+    def vnet_call(
+        self,
+        vnet_id: str,
+        to_address: str,
+        input_data: str,
+        from_address: str | None = None,
+        block: str = "latest",
+    ) -> str:
+        """Execute a read-only eth_call on a Virtual TestNet."""
+        call: dict[str, Any] = {"to": to_address, "data": input_data}
+        if from_address:
+            call["from"] = from_address
+        return self.vnet_rpc(vnet_id, "eth_call", [call, block])
+
+    def set_balance(self, vnet_id: str, addresses: list[str], amount_wei: int) -> Any:
+        """Set the native balance of one or more accounts."""
+        return self.vnet_rpc(
+            vnet_id, "tenderly_setBalance", [addresses, hex(amount_wei)]
+        )
+
+    def set_erc20_balance(
+        self, vnet_id: str, token: str, wallet: str, amount: int
+    ) -> Any:
+        """Set the ERC-20 token balance of a wallet."""
+        return self.vnet_rpc(
+            vnet_id, "tenderly_setErc20Balance", [token, wallet, hex(amount)]
+        )
+
+    def set_storage_at(self, vnet_id: str, contract: str, slot: str, value: str) -> Any:
+        """Write a raw value to a contract storage slot."""
+        return self.vnet_rpc(vnet_id, "tenderly_setStorageAt", [contract, slot, value])
+
+    def snapshot(self, vnet_id: str) -> str:
+        """Save the current Virtual TestNet state and return a snapshot ID."""
+        return self.vnet_rpc(vnet_id, "evm_snapshot")
+
+    def revert(self, vnet_id: str, snapshot_id: str) -> Any:
+        """Restore a Virtual TestNet to a previously saved snapshot."""
+        return self.vnet_rpc(vnet_id, "evm_revert", [snapshot_id])
+
+    def increase_time(self, vnet_id: str, seconds: int) -> Any:
+        """Advance the Virtual TestNet clock by the given number of seconds."""
+        return self.vnet_rpc(vnet_id, "evm_increaseTime", [hex(seconds)])
+
+    def mine_blocks(self, vnet_id: str, blocks: int = 1) -> Any:
+        """Mine one or more blocks on a Virtual TestNet."""
+        if blocks == 1:
+            return self.vnet_rpc(vnet_id, "evm_mine")
+        return self.vnet_rpc(vnet_id, "evm_increaseBlocks", [hex(blocks)])
+
+
+# --- Trace navigation helpers ---
+
+
+def extract_call_trace(result: dict) -> dict | None:
+    """Pull the root call trace node out of a simulate/trace response."""
+    if not isinstance(result, dict):
+        return None
+    if "call_trace" in result:
+        trace = result["call_trace"]
+        return trace[0] if isinstance(trace, list) and trace else trace
+    transaction = result.get("transaction", {})
+    info = transaction.get("transaction_info", {}) if transaction else {}
+    trace = info.get("call_trace")
+    if isinstance(trace, list):
+        return trace[0] if trace else None
+    return trace
+
+
+def _call_label(node: dict) -> str:
+    """Human-readable label for a call trace node."""
+    name = node.get("function_name") or (node.get("input") or "")[:10] or "fallback"
+    target = node.get("contract_name") or node.get("to") or ""
+    return f"{target}.{name}" if target else name
+
+
+def flatten_call_trace(node: dict | None, depth: int = 0) -> list[dict]:
+    """Flatten a nested call trace into a depth-annotated list."""
+    if not node:
+        return []
+    flat = [
+        {
+            "depth": depth,
+            "type": node.get("call_type") or node.get("type", "CALL"),
+            "label": _call_label(node),
+            "from": node.get("from", ""),
+            "to": node.get("to", ""),
+            "gas_used": node.get("gas_used", 0),
+            "error": node.get("error") or node.get("error_reason") or "",
+        }
+    ]
+    for child in node.get("calls") or []:
+        flat.extend(flatten_call_trace(child, depth + 1))
+    return flat
+
+
+def trace_skeleton(node: dict | None, max_depth: int = 3) -> list[dict]:
+    """Compressed call tree: only nodes up to max_depth, with child counts."""
+    skeleton = []
+    for entry_node, depth in _walk(node):
+        if depth > max_depth:
+            continue
+        children = entry_node.get("calls") or []
+        skeleton.append(
+            {
+                "depth": depth,
+                "label": _call_label(entry_node),
+                "gas_used": entry_node.get("gas_used", 0),
+                "error": entry_node.get("error") or "",
+                "children": len(children),
+                "truncated": depth == max_depth and len(children) > 0,
+            }
+        )
+    return skeleton
+
+
+def find_failures(node: dict | None) -> list[dict]:
+    """Find all errored calls anywhere in a trace."""
+    return [
+        {
+            "depth": depth,
+            "label": _call_label(entry_node),
+            "from": entry_node.get("from", ""),
+            "to": entry_node.get("to", ""),
+            "error": entry_node.get("error") or entry_node.get("error_reason") or "",
+        }
+        for entry_node, depth in _walk(node)
+        if entry_node.get("error") or entry_node.get("error_reason")
+    ]
+
+
+def error_path(node: dict | None) -> list[dict]:
+    """Blame chain from the root call to the deepest errored call."""
+    if not node or not (node.get("error") or node.get("error_reason")):
+        return []
+    path = [
+        {
+            "depth": 0,
+            "label": _call_label(node),
+            "error": node.get("error") or node.get("error_reason") or "",
+        }
+    ]
+    current = node
+    depth = 0
+    while True:
+        errored_children = [
+            child
+            for child in current.get("calls") or []
+            if child.get("error") or child.get("error_reason")
+        ]
+        if not errored_children:
+            return path
+        current = errored_children[-1]
+        depth += 1
+        path.append(
+            {
+                "depth": depth,
+                "label": _call_label(current),
+                "error": current.get("error") or current.get("error_reason") or "",
+            }
+        )
+
+
+def _walk(node: dict | None, depth: int = 0):
+    """Yield (node, depth) pairs over a nested call trace."""
+    if not node:
+        return
+    yield node, depth
+    for child in node.get("calls") or []:
+        yield from _walk(child, depth + 1)
+
+
+def _client() -> TenderlyClient:
+    access_key = secret("TENDERLY_ACCESS_KEY", "")
+    if not access_key:
+        raise RuntimeError("TENDERLY_ACCESS_KEY not set.")
+    return TenderlyClient(access_key=access_key)

--- a/tools/crypto/tenderly/pyproject.toml
+++ b/tools/crypto/tenderly/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "tenderly"
+description = "Tenderly CLI for transaction simulation, tracing, and Virtual TestNets"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27.0",
+    "typer>=0.12.0",
+    "rich>=13.0.0",
+]
+
+[project.scripts]
+tenderly = "centaur_tool_tenderly.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_tenderly"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+
+[tool.centaur]
+module = "client.py"
+secrets = [
+    {type = "http", name = "TENDERLY_ACCESS_KEY", match_headers = ["X-Access-Key"], hosts = ["api.tenderly.co"]},
+    {type = "http", name = "TENDERLY_ACCOUNT_SLUG", match_path = true, hosts = ["api.tenderly.co"]},
+    {type = "http", name = "TENDERLY_PROJECT_SLUG", match_path = true, hosts = ["api.tenderly.co"]},
+]

--- a/tools/crypto/tenderly/tests/test_client.py
+++ b/tools/crypto/tenderly/tests/test_client.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from tenderly.client import (
+    TenderlyClient,
+    error_path,
+    extract_call_trace,
+    find_failures,
+    flatten_call_trace,
+    trace_skeleton,
+)
+
+
+def make_client(handler) -> TenderlyClient:
+    client = TenderlyClient(access_key="test-key", account="acct", project="proj")
+    client._http = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def test_simulate_posts_payload_with_auth() -> None:
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["access_key"] = request.headers.get("X-Access-Key")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"transaction": {"status": True, "gas_used": 21000}}
+        )
+
+    client = make_client(handler)
+    result = client.simulate(
+        network_id="1",
+        from_address="0xabc",
+        to_address="0xdef",
+        input_data="0x1234",
+        value=5,
+        gas=1_000_000,
+        block_number=42,
+    )
+
+    assert captured["url"] == (
+        "https://api.tenderly.co/api/v1/account/acct/project/proj/simulate"
+    )
+    assert captured["access_key"] == "test-key"
+    assert captured["body"]["network_id"] == "1"
+    assert captured["body"]["from"] == "0xabc"
+    assert captured["body"]["to"] == "0xdef"
+    assert captured["body"]["input"] == "0x1234"
+    assert captured["body"]["value"] == 5
+    assert captured["body"]["gas"] == 1_000_000
+    assert captured["body"]["block_number"] == 42
+    assert captured["body"]["simulation_type"] == "full"
+    assert result["transaction"]["status"] is True
+
+
+def test_simulate_omits_optional_fields() -> None:
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={})
+
+    client = make_client(handler)
+    client.simulate(network_id="1", from_address="0xabc", to_address="0xdef")
+
+    assert "block_number" not in captured["body"]
+    assert "gas_price" not in captured["body"]
+    assert "state_objects" not in captured["body"]
+
+
+def test_api_error_raises_runtime_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="invalid simulation")
+
+    client = make_client(handler)
+    with pytest.raises(RuntimeError, match="400 - invalid simulation"):
+        client.simulate(network_id="1", from_address="0xabc", to_address="0xdef")
+
+
+def test_get_contract_lowercases_address() -> None:
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={"contract_name": "WETH9"})
+
+    client = make_client(handler)
+    client.get_contract("1", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+
+    assert captured["url"] == (
+        "https://api.tenderly.co/api/v1/public-contract/1/"
+        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    )
+
+
+def test_get_networks_handles_list_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[{"id": "1", "name": "Mainnet"}])
+
+    client = make_client(handler)
+    assert client.get_networks() == [{"id": "1", "name": "Mainnet"}]
+
+
+def test_create_vnet_payload() -> None:
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"id": "vnet-1", "slug": "my-fork"})
+
+    client = make_client(handler)
+    vnet = client.create_vnet(network_id="8453", slug="my-fork", chain_id=73571)
+
+    assert captured["url"].endswith("/account/acct/project/proj/vnets")
+    assert captured["body"]["slug"] == "my-fork"
+    assert captured["body"]["display_name"] == "my-fork"
+    assert captured["body"]["fork_config"] == {
+        "network_id": 8453,
+        "block_number": "latest",
+    }
+    assert (
+        captured["body"]["virtual_network_config"]["chain_config"]["chain_id"] == 73571
+    )
+    assert vnet["id"] == "vnet-1"
+
+
+def test_vnet_rpc_uses_admin_rpc_and_hex_encodes() -> None:
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "api.tenderly.co":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "vnet-1",
+                    "rpcs": [
+                        {"name": "Public RPC", "url": "https://virtual.mainnet.rpc.tenderly.co/pub"},
+                        {"name": "Admin RPC", "url": "https://virtual.mainnet.rpc.tenderly.co/admin"},
+                    ],
+                },
+            )
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": "0x1"})
+
+    client = make_client(handler)
+    client.set_balance("vnet-1", ["0xabc"], 10**18)
+
+    assert captured["url"] == "https://virtual.mainnet.rpc.tenderly.co/admin"
+    assert captured["body"]["method"] == "tenderly_setBalance"
+    assert captured["body"]["params"] == [["0xabc"], hex(10**18)]
+
+
+def test_vnet_rpc_error_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "api.tenderly.co":
+            return httpx.Response(
+                200,
+                json={"id": "vnet-1", "rpcs": [{"name": "Admin RPC", "url": "https://rpc.test/x"}]},
+            )
+        return httpx.Response(
+            200, json={"jsonrpc": "2.0", "id": 1, "error": {"message": "boom"}}
+        )
+
+    client = make_client(handler)
+    with pytest.raises(RuntimeError, match="RPC error"):
+        client.snapshot("vnet-1")
+
+
+SAMPLE_TRACE = {
+    "contract_name": "Router",
+    "function_name": "swap",
+    "from": "0xaaa",
+    "to": "0xbbb",
+    "gas_used": 100,
+    "calls": [
+        {
+            "contract_name": "Token",
+            "function_name": "transfer",
+            "gas_used": 40,
+            "calls": [],
+        },
+        {
+            "contract_name": "Pool",
+            "function_name": "mint",
+            "gas_used": 50,
+            "error": "execution reverted",
+            "calls": [
+                {
+                    "contract_name": "Token",
+                    "function_name": "transferFrom",
+                    "gas_used": 10,
+                    "error": "ERC20: insufficient allowance",
+                    "calls": [],
+                }
+            ],
+        },
+    ],
+}
+
+
+def test_flatten_call_trace_depths_and_labels() -> None:
+    flat = flatten_call_trace(SAMPLE_TRACE)
+
+    assert [(f["depth"], f["label"]) for f in flat] == [
+        (0, "Router.swap"),
+        (1, "Token.transfer"),
+        (1, "Pool.mint"),
+        (2, "Token.transferFrom"),
+    ]
+
+
+def test_find_failures_collects_all_errors() -> None:
+    failures = find_failures(SAMPLE_TRACE)
+
+    assert len(failures) == 2
+    assert failures[0]["label"] == "Pool.mint"
+    assert failures[1]["error"] == "ERC20: insufficient allowance"
+
+
+def test_error_path_requires_root_error() -> None:
+    assert error_path(SAMPLE_TRACE) == []
+
+
+def test_error_path_follows_blame_chain() -> None:
+    errored_root = {**SAMPLE_TRACE, "error": "execution reverted"}
+    path = error_path(errored_root)
+
+    assert [p["label"] for p in path] == ["Router.swap", "Pool.mint", "Token.transferFrom"]
+    assert path[-1]["error"] == "ERC20: insufficient allowance"
+
+
+def test_trace_skeleton_truncates_at_max_depth() -> None:
+    skeleton = trace_skeleton(SAMPLE_TRACE, max_depth=1)
+
+    assert [s["label"] for s in skeleton] == ["Router.swap", "Token.transfer", "Pool.mint"]
+    truncated = [s for s in skeleton if s["truncated"]]
+    assert len(truncated) == 1
+    assert truncated[0]["label"] == "Pool.mint"
+
+
+def test_extract_call_trace_from_simulation_response() -> None:
+    result = {
+        "transaction": {"transaction_info": {"call_trace": SAMPLE_TRACE}},
+    }
+    assert extract_call_trace(result)["function_name"] == "swap"
+
+
+def test_extract_call_trace_from_trace_response_list() -> None:
+    result = {"call_trace": [SAMPLE_TRACE]}
+    assert extract_call_trace(result)["function_name"] == "swap"


### PR DESCRIPTION
Adds a new crypto tool that mirrors what the Tenderly MCP server offers: gasless transaction simulation, decoded traces of on-chain transactions, and full Virtual TestNet management (forking networks, impersonated sends, balance and storage cheatcodes, snapshots, time travel). Big traces can be viewed as summaries, skeletons, failure lists, or blame chains so agents don't have to wade through the raw output.

Needs the Tenderly access key and account/project slugs provisioned in the secrets backend before it works in sandboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)