### PR TITLE
feat: adopt orphaned executions and unwedge render recovery

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
  "centaur-iron-proxy",
  "centaur-sandbox-core",
  "clap",
+ "jiff",
  "k8s-openapi",
  "kube",
  "serde",
@@ -453,6 +454,7 @@ dependencies = [
 name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",
@@ -467,6 +469,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1594,10 +1597,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-link",
 ]
 
 [[package]]
@@ -1609,6 +1614,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -61,6 +61,7 @@ base64 = "0.22"
 futures-util = { version = "0.3", features = ["sink"] }
 hmac = "0.12"
 hex = "0.4"
+jiff = "0.2"
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -54,6 +54,14 @@ async fn main() -> Result<(), ServerError> {
         .await?,
     );
 
+    // Adopt executions orphaned by the previous process (deploy/crash):
+    // recover finished turns from recorded sandbox output, re-attach still
+    // running sandboxes, and fail the rest so their threads unwedge.
+    let adoption_runtime = runtime.clone();
+    tokio::spawn(async move {
+        adoption_runtime.adopt_orphaned_executions().await;
+    });
+
     let listener = TcpListener::bind(args.server.bind_addr).await?;
     info!(bind_addr = %args.server.bind_addr, "starting centaur api-rs server");
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/Cargo.toml
@@ -12,6 +12,7 @@ centaur-iron-control.workspace = true
 centaur-iron-proxy.workspace = true
 centaur-sandbox-core.workspace = true
 clap.workspace = true
+jiff.workspace = true
 k8s-openapi.workspace = true
 kube = { workspace = true, features = ["derive", "ws"] }
 serde.workspace = true

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -16,7 +16,9 @@ use centaur_sandbox_core::{
     SandboxResult, SandboxSpec, SandboxStatus,
 };
 use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
-use kube::api::{AttachParams, DeleteParams, ListParams, Patch, PatchParams, PostParams};
+use kube::api::{
+    AttachParams, DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams,
+};
 use kube::{Api, Client, Error};
 use serde_json::{Value, json};
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -313,6 +315,32 @@ impl SandboxBackend for AgentSandboxBackend {
 
     async fn open_io(&self, id: &SandboxId) -> SandboxResult<SandboxIo> {
         self.attach_io(id).await
+    }
+
+    /// Replays the workload container's stdout from the kubelet's log files.
+    /// Unlike an attach stream, this includes output emitted while no reader
+    /// was attached, which is what makes orphaned-execution adoption possible.
+    async fn read_output_since(
+        &self,
+        id: &SandboxId,
+        since: Option<std::time::SystemTime>,
+    ) -> SandboxResult<Vec<String>> {
+        let mut params = LogParams {
+            container: Some(self.config.container_name.clone()),
+            ..LogParams::default()
+        };
+        if let Some(since) = since {
+            params.since_time = Some(
+                jiff::Timestamp::try_from(since)
+                    .map_err(|error| SandboxError::io_source("invalid log since time", error))?,
+            );
+        }
+        let text = self
+            .pods()
+            .logs(id.as_str(), &params)
+            .await
+            .map_err(|err| map_kube_error("read sandbox pod logs", err))?;
+        Ok(text.lines().map(str::to_owned).collect())
     }
 
     async fn status(&self, id: &SandboxId) -> SandboxResult<SandboxStatus> {

--- a/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
@@ -20,6 +20,24 @@ pub trait SandboxBackend: Send + Sync {
     /// Open owned stdin/stdout/stderr handles for a running sandbox.
     async fn open_io(&self, id: &SandboxId) -> SandboxResult<SandboxIo>;
 
+    /// Read the sandbox workload's recorded stdout history since `since`.
+    ///
+    /// Live io streams only deliver output from attach time forward; output
+    /// emitted while no reader was attached (for example across a control
+    /// plane restart) is otherwise lost. Backends whose runtime records the
+    /// workload's stdout (such as Kubernetes pod logs) can replay it here so
+    /// orphaned executions can be adopted instead of failed.
+    async fn read_output_since(
+        &self,
+        _id: &SandboxId,
+        _since: Option<std::time::SystemTime>,
+    ) -> SandboxResult<Vec<String>> {
+        Err(crate::SandboxError::Unsupported {
+            backend: self.name(),
+            operation: "read_output_since",
+        })
+    }
+
     /// Return the portable, cheap lifecycle status for a sandbox.
     async fn status(&self, id: &SandboxId) -> SandboxResult<SandboxStatus>;
 

--- a/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
@@ -143,6 +143,16 @@ where
         self.backend.status(id).await
     }
 
+    /// Read the sandbox workload's recorded stdout history since `since`.
+    /// Backends without recorded output return `SandboxError::Unsupported`.
+    pub async fn read_output_since(
+        &self,
+        id: &SandboxId,
+        since: Option<std::time::SystemTime>,
+    ) -> SandboxResult<Vec<String>> {
+        self.backend.read_output_since(id, since).await
+    }
+
     pub async fn observe(&self, id: &SandboxId) -> SandboxResult<ObservedSandbox> {
         self.backend.observe(id).await
     }

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -21,7 +21,10 @@ tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 time.workspace = true
+tokio = { workspace = true, features = ["io-util", "macros", "rt-multi-thread", "sync", "time"] }
+uuid.workspace = true
 
 [lints]
 workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
-    time::Duration,
+    time::{Duration, SystemTime},
 };
 
 use centaur_iron_control::SessionRegistrar;
@@ -1129,6 +1129,223 @@ impl SessionRuntime {
             );
         }
         result
+    }
+
+    /// Reconciles executions left `queued`/`running` by a previous control
+    /// plane process. Execution rows never time out on their own: the only
+    /// writer of a terminal status is the process that was watching the
+    /// sandbox, so a kill mid-turn leaves the row active forever, wedging the
+    /// thread (the one-active-execution index blocks new executes) and any
+    /// event-stream consumer waiting for a terminal event.
+    ///
+    /// Adoption order of preference:
+    /// 1. The sandbox already finished the turn while nobody was attached:
+    ///    recover the terminal outcome from the backend's recorded output.
+    /// 2. The sandbox is still running the turn: re-attach the stdout pump
+    ///    and re-arm the remaining max-duration deadline.
+    /// 3. The sandbox is gone: record the failure honestly.
+    pub async fn adopt_orphaned_executions(&self) {
+        let executions = match self.store.list_active_executions().await {
+            Ok(executions) => executions,
+            Err(error) => {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "execution_adoption_scan_failed",
+                    %error,
+                    "failed to list orphaned executions"
+                );
+                return;
+            }
+        };
+        if executions.is_empty() {
+            return;
+        }
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "execution_adoption_scan",
+            orphan_count = executions.len(),
+            "adopting executions orphaned by a previous control plane process"
+        );
+        for execution in executions {
+            if let Err(error) = self.adopt_orphaned_execution(&execution).await {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "execution_adoption_failed",
+                    thread_key = %execution.thread_key,
+                    execution_id = %execution.execution_id,
+                    %error,
+                    "failed to adopt orphaned execution; will retry on next startup"
+                );
+            }
+        }
+    }
+
+    async fn adopt_orphaned_execution(
+        &self,
+        execution: &SessionExecution,
+    ) -> Result<(), SessionRuntimeError> {
+        let thread_key = &execution.thread_key;
+        let execution_id = execution.execution_id.as_str();
+        if execution.status == ExecutionStatus::Queued {
+            // Input is only written after an execution is marked running, so
+            // a queued orphan never reached the harness: nothing can come.
+            self.fail_orphaned_execution(
+                thread_key,
+                execution_id,
+                "",
+                "orphaned before input was sent",
+            )
+            .await;
+            return Ok(());
+        }
+        let session = self.store.get_session(thread_key).await?;
+        let Some(sandbox_id) = session.sandbox_id.as_deref() else {
+            self.fail_orphaned_execution(
+                thread_key,
+                execution_id,
+                "",
+                "orphaned with no sandbox assigned",
+            )
+            .await;
+            return Ok(());
+        };
+        let id = SandboxId::new(sandbox_id);
+        let status = match self.sandbox_runtime.manager.status(&id).await {
+            Ok(status) => status,
+            Err(SandboxError::NotFound(_)) => SandboxStatus::Gone,
+            // Transient status failures must not fail a possibly live
+            // execution; surface the error and retry on the next startup.
+            Err(error) => return Err(SessionRuntimeError::Sandbox(error)),
+        };
+        if !status.can_open_io() {
+            self.fail_orphaned_execution(
+                thread_key,
+                execution_id,
+                sandbox_id,
+                &format!("sandbox no longer accepts io (status {status:?})"),
+            )
+            .await;
+            return Ok(());
+        }
+
+        // The turn may have finished while no control plane was attached. An
+        // attach stream cannot replay that output, but the backend's recorded
+        // history (pod logs) can.
+        let since = execution.started_at.unwrap_or(execution.created_at);
+        let lines = match self
+            .sandbox_runtime
+            .manager
+            .read_output_since(&id, Some(SystemTime::from(since)))
+            .await
+        {
+            Ok(lines) => lines,
+            Err(SandboxError::Unsupported { .. }) => Vec::new(),
+            Err(error) => {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "execution_adoption_log_read_failed",
+                    thread_key = %thread_key,
+                    execution_id,
+                    sandbox_id,
+                    %error,
+                    "failed to read recorded sandbox output; adopting live"
+                );
+                Vec::new()
+            }
+        };
+        if let Some(terminal) = terminal_output_from_lines(&lines) {
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "execution_adopted",
+                thread_key = %thread_key,
+                execution_id,
+                sandbox_id,
+                mode = "recorded_output",
+                "adopted orphaned execution from recorded sandbox output"
+            );
+            let _ = self
+                .store
+                .append_event(
+                    thread_key,
+                    Some(execution_id),
+                    "session.execution_adopted",
+                    json!({ "sandbox_id": sandbox_id, "mode": "recorded_output" }),
+                )
+                .await;
+            record_terminal_output(
+                &self.context(),
+                thread_key,
+                sandbox_id,
+                execution_id,
+                terminal,
+            )
+            .await?;
+            return Ok(());
+        }
+
+        // No terminal in the recorded output: treat the turn as still in
+        // flight. Re-attach the stdout pump and re-arm the remaining
+        // max-duration budget so an adopted-but-silent turn stays bounded.
+        self.ensure_session_pipe(thread_key, sandbox_id).await?;
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "execution_adopted",
+            thread_key = %thread_key,
+            execution_id,
+            sandbox_id,
+            mode = "live_attach",
+            "adopted orphaned execution with a live sandbox attach"
+        );
+        let _ = self
+            .store
+            .append_event(
+                thread_key,
+                Some(execution_id),
+                "session.execution_adopted",
+                json!({ "sandbox_id": sandbox_id, "mode": "live_attach" }),
+            )
+            .await;
+        if let Some(max_duration) = max_duration_from_execution(execution) {
+            let elapsed = SystemTime::now()
+                .duration_since(SystemTime::from(since))
+                .unwrap_or_default();
+            spawn_max_duration_failure(
+                self.context(),
+                thread_key.clone(),
+                execution.execution_id.clone(),
+                max_duration.saturating_sub(elapsed),
+                idle_timeout_from_execution(execution),
+            );
+        }
+        Ok(())
+    }
+
+    async fn fail_orphaned_execution(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: &str,
+        sandbox_id: &str,
+        detail: &str,
+    ) {
+        let error = format!("execution orphaned by control plane restart; {detail}");
+        if let Err(record_error) = record_terminal_output(
+            &self.context(),
+            thread_key,
+            sandbox_id,
+            execution_id,
+            TerminalOutput::Failed { error },
+        )
+        .await
+        {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "execution_adoption_fail_record_failed",
+                thread_key = %thread_key,
+                execution_id,
+                error = %record_error,
+                "failed to record orphaned execution failure"
+            );
+        }
     }
 }
 
@@ -3080,6 +3297,36 @@ fn idle_timeout_from_execution(execution: &SessionExecution) -> Option<Duration>
         .and_then(|value| nonzero_duration_millis(value).ok())
 }
 
+fn max_duration_from_execution(execution: &SessionExecution) -> Option<Duration> {
+    execution
+        .metadata
+        .get("max_duration_ms")
+        .and_then(Value::as_u64)
+        .and_then(|value| nonzero_duration_millis(value).ok())
+}
+
+/// Folds recorded sandbox output the same way the live stdout pump does,
+/// returning the first terminal outcome (with its accumulated final answer)
+/// if the recorded history already contains the end of the turn.
+fn terminal_output_from_lines(lines: &[String]) -> Option<TerminalOutput> {
+    let mut final_answer_text = String::new();
+    for line in lines {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if let Some(update) = output_line_final_answer_text(&value) {
+            match update {
+                FinalAnswerTextUpdate::Append(delta) => final_answer_text.push_str(&delta),
+                FinalAnswerTextUpdate::Replace(canonical) => final_answer_text = canonical,
+            }
+        }
+        if let Some(terminal) = terminal_output(&value, &final_answer_text) {
+            return Some(terminal);
+        }
+    }
+    None
+}
+
 #[derive(Debug, Error)]
 pub enum SessionRuntimeError {
     #[error("{0}")]
@@ -3862,5 +4109,324 @@ mod tests {
             .iter()
             .find(|env| env.name == name)
             .map(|env| env.value.as_str())
+    }
+}
+
+/// Integration tests for orphaned-execution adoption. They need a real
+/// Postgres; set `SESSION_RUNTIME_TEST_DATABASE_URL` to run them (they skip
+/// silently otherwise, mirroring `ABSURD_TEST_DATABASE_URL` in absurd-sdk).
+#[cfg(test)]
+mod adoption_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use centaur_sandbox_core::{ObservedSandbox, SandboxHandle, SandboxIo, SandboxResult};
+    use tokio::io::{AsyncWriteExt, DuplexStream};
+
+    use super::*;
+
+    /// The adoption scan is database-wide, so concurrently running tests
+    /// would adopt each other's executions. Serialize the module; every test
+    /// fully terminalizes its own executions before releasing the lock.
+    static TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
+    struct MockBackend {
+        ios: Mutex<VecDeque<SandboxIo>>,
+        recorded_output: Vec<String>,
+        open_count: AtomicUsize,
+        status: std::sync::Mutex<SandboxStatus>,
+    }
+
+    impl MockBackend {
+        fn new(status: SandboxStatus, recorded_output: Vec<String>) -> Self {
+            Self {
+                ios: Mutex::new(VecDeque::new()),
+                recorded_output,
+                open_count: AtomicUsize::new(0),
+                status: std::sync::Mutex::new(status),
+            }
+        }
+
+        async fn push_io(&self, io: SandboxIo) {
+            self.ios.lock().await.push_back(io);
+        }
+
+        fn opens(&self) -> usize {
+            self.open_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SandboxBackend for MockBackend {
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+
+        async fn create(&self, _spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
+            Ok(SandboxHandle::new(SandboxId::new("mock-sbx"), "mock"))
+        }
+
+        async fn open_io(&self, _id: &SandboxId) -> SandboxResult<SandboxIo> {
+            self.open_count.fetch_add(1, Ordering::SeqCst);
+            self.ios
+                .lock()
+                .await
+                .pop_front()
+                .ok_or_else(|| SandboxError::io("mock backend has no more ios"))
+        }
+
+        async fn read_output_since(
+            &self,
+            _id: &SandboxId,
+            _since: Option<SystemTime>,
+        ) -> SandboxResult<Vec<String>> {
+            Ok(self.recorded_output.clone())
+        }
+
+        async fn status(&self, _id: &SandboxId) -> SandboxResult<SandboxStatus> {
+            Ok(self.status.lock().unwrap().clone())
+        }
+
+        async fn observe(&self, id: &SandboxId) -> SandboxResult<ObservedSandbox> {
+            let status = self.status(id).await?;
+            Ok(ObservedSandbox::new(id.clone(), "mock", status))
+        }
+
+        async fn list_observed(&self) -> SandboxResult<Vec<ObservedSandbox>> {
+            Ok(Vec::new())
+        }
+
+        async fn stop(&self, _id: &SandboxId) -> SandboxResult<()> {
+            Ok(())
+        }
+
+        async fn pause(&self, _id: &SandboxId) -> SandboxResult<()> {
+            Ok(())
+        }
+
+        async fn resume(&self, _id: &SandboxId) -> SandboxResult<()> {
+            Ok(())
+        }
+    }
+
+    fn mock_io() -> (SandboxIo, DuplexStream, DuplexStream) {
+        let (stdin_near, stdin_far) = tokio::io::duplex(64 * 1024);
+        let (stdout_near, stdout_far) = tokio::io::duplex(64 * 1024);
+        let (stderr_near, _stderr_far) = tokio::io::duplex(1024);
+        let io = SandboxIo::new(
+            Box::pin(stdin_near),
+            Box::pin(stdout_near),
+            Box::pin(stderr_near),
+        );
+        (io, stdout_far, stdin_far)
+    }
+
+    async fn test_store() -> Option<PgSessionStore> {
+        let Ok(url) = std::env::var("SESSION_RUNTIME_TEST_DATABASE_URL") else {
+            eprintln!("skipping: SESSION_RUNTIME_TEST_DATABASE_URL not set");
+            return None;
+        };
+        let store = PgSessionStore::connect(&url)
+            .await
+            .expect("connect test db");
+        store.run_migrations().await.expect("run migrations");
+        Some(store)
+    }
+
+    async fn orphaned_execution(
+        store: &PgSessionStore,
+        thread_key: &ThreadKey,
+        sandbox_id: Option<&str>,
+        running: bool,
+    ) -> String {
+        store
+            .create_or_get_session(thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        if sandbox_id.is_some() {
+            store
+                .update_sandbox_id(thread_key, sandbox_id)
+                .await
+                .expect("set sandbox id");
+        }
+        let created = store
+            .create_execution(thread_key, None, json!({}))
+            .await
+            .expect("create execution");
+        let execution_id = created.execution.execution_id;
+        if running {
+            store
+                .mark_execution_running(&execution_id)
+                .await
+                .expect("mark running");
+        }
+        execution_id
+    }
+
+    async fn wait_for_event(store: &PgSessionStore, thread_key: &ThreadKey, event_type: &str) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let events = store
+                .list_events_after(thread_key, 0, None, 1000)
+                .await
+                .expect("list events");
+            if events.iter().any(|event| event.event_type == event_type) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {event_type}"
+            );
+            sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    async fn events(store: &PgSessionStore, thread_key: &ThreadKey) -> Vec<SessionEvent> {
+        store
+            .list_events_after(thread_key, 0, None, 1000)
+            .await
+            .expect("list events")
+    }
+
+    fn runtime_with(store: &PgSessionStore, backend: Arc<MockBackend>) -> SessionRuntime {
+        SessionRuntime::new(
+            store.clone(),
+            SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn adopts_finished_turn_from_recorded_sandbox_output() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-logs-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+
+        let backend = Arc::new(MockBackend::new(
+            SandboxStatus::Running,
+            vec![
+                json!({"type": "item.completed", "item": {"id": "msg-1", "type": "agentMessage", "text": "Done: pushed commit abc123.", "phase": "final_answer"}}).to_string(),
+                json!({"type": "turn.completed", "turn": {"id": "turn-1", "status": "completed"}}).to_string(),
+            ],
+        ));
+        let runtime = runtime_with(&store, backend.clone());
+        runtime.adopt_orphaned_executions().await;
+
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
+        let all = events(&store, &thread_key).await;
+        assert!(
+            all.iter()
+                .any(|event| event.event_type == "session.execution_adopted"),
+            "expected an adoption event"
+        );
+        let completed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_completed")
+            .expect("completed event");
+        assert_eq!(
+            completed.payload["result_text"].as_str(),
+            Some("Done: pushed commit abc123.")
+        );
+        // The terminal came from recorded output; no live attach was needed.
+        assert_eq!(backend.opens(), 0);
+        let session = store.get_session(&thread_key).await.unwrap();
+        assert_ne!(session.status.as_ref(), "failed");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn adopts_live_when_recorded_output_has_no_terminal() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-live-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, mut stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+
+        let runtime = runtime_with(&store, backend.clone());
+        runtime.adopt_orphaned_executions().await;
+        assert_eq!(backend.opens(), 1);
+
+        stdout
+            .write_all(
+                b"{\"type\":\"turn.completed\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\"}}\n",
+            )
+            .await
+            .unwrap();
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
+        let all = events(&store, &thread_key).await;
+        assert!(
+            all.iter().any(|event| {
+                event.event_type == "session.execution_adopted"
+                    && event.payload["mode"] == json!("live_attach")
+            }),
+            "expected a live adoption event"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fails_orphans_whose_sandbox_is_gone() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-gone-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Gone, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        runtime.adopt_orphaned_executions().await;
+
+        wait_for_event(&store, &thread_key, "session.execution_failed").await;
+        let all = events(&store, &thread_key).await;
+        let failed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_failed")
+            .expect("failed event");
+        let error = failed.payload["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("execution orphaned by control plane restart"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error.contains("sandbox no longer accepts io"),
+            "expected status detail: {error}"
+        );
+        assert_eq!(backend.opens(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fails_queued_orphans_that_never_received_input() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-queued-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        runtime.adopt_orphaned_executions().await;
+
+        wait_for_event(&store, &thread_key, "session.execution_failed").await;
+        let all = events(&store, &thread_key).await;
+        let failed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_failed")
+            .expect("failed event");
+        let error = failed.payload["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("orphaned before input was sent"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(backend.opens(), 0);
     }
 }

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -245,6 +245,25 @@ impl PgSessionStore {
         row.map(TryInto::try_into).transpose()
     }
 
+    /// Lists every execution still marked queued or running. Used at startup
+    /// to adopt executions orphaned by a previous control plane process.
+    pub async fn list_active_executions(&self) -> Result<Vec<SessionExecution>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            from session_executions
+            where status in ($1, $2)
+            order by created_at, execution_id
+            "#,
+        )
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
     pub async fn latest_execution_for_thread(
         &self,
         thread_key: &ThreadKey,

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -82,6 +82,8 @@ const RENDER_OBLIGATION_INDEX_KEY = 'slackbotv2:render:index'
 const RENDER_OBLIGATION_INDEX_MAX_LENGTH = 2000
 const RENDER_INDEX_TTL_MS = 30 * 24 * 60 * 60 * 1000
 const RENDER_RECOVERY_LEASE_TTL_MS = 2 * 60 * 1000
+const RENDER_RECOVERY_THREAD_TIMEOUT_MS = 2 * 60 * 1000
+const RENDER_RECOVERY_MAX_THREAD_FAILURES = 5
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
 const RENDER_RETRY_MAX_DELAY_MS = 5_000
 const SLACK_TASK_DETAILS_MAX_CHARS = 500
@@ -525,10 +527,11 @@ async function recoverRenderObligationsWithRetry(
   // Wait for Postgres before scanning for obligations. This is also what warms the
   // shared pool at startup, so transient connect failures don't wedge the bot.
   await ensureStateConnected(state, options)
+  const failureCounts = new Map<string, number>()
   let attempt = 0
   while (true) {
     try {
-      const deferredCount = await recoverRenderObligations(chat, state, options)
+      const deferredCount = await recoverRenderObligations(chat, state, options, failureCounts)
       if (deferredCount === 0) return
       const delayMs = renderRetryDelayMs(attempt)
       attempt += 1
@@ -550,12 +553,14 @@ async function recoverRenderObligationsWithRetry(
 async function recoverRenderObligations(
   chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
   state: StateAdapter,
-  options: SlackbotV2Options
+  options: SlackbotV2Options,
+  failureCounts: Map<string, number>
 ): Promise<number> {
   const startedAtMs = nowMs()
   await chat.initialize()
   const indexedThreadIds = await state.getList<string>(RENDER_OBLIGATION_INDEX_KEY)
   const threadIds = Array.from(new Set(indexedThreadIds))
+  const timeoutMs = options.renderRecoveryThreadTimeoutMs ?? RENDER_RECOVERY_THREAD_TIMEOUT_MS
   let deferredCount = 0
   traceLog(options, 'slackbotv2_render_recovery_scan', undefined, {
     obligation_count: threadIds.length,
@@ -569,6 +574,22 @@ async function recoverRenderObligations(
       const obligation = threadState?.renderObligation
       if (!obligation) continue
 
+      // An obligation that keeps failing non-retryably (for example corrupt
+      // state that can never address a Slack thread) must not poison the
+      // retry loop forever: give up on it and unwedge the thread.
+      if ((failureCounts.get(threadId) ?? 0) >= RENDER_RECOVERY_MAX_THREAD_FAILURES) {
+        traceLog(options, 'slackbotv2_render_recovery_abandoned', undefined, {
+          failure_count: failureCounts.get(threadId),
+          thread_id: threadId
+        })
+        await thread.setState({
+          activeExecution: false,
+          lastEventId: threadState?.lastEventId ?? 0,
+          renderObligation: null
+        })
+        continue
+      }
+
       const leaseToken = randomUUID()
       const leaseAcquired = await state.setIfNotExists(
         renderRecoveryLeaseKey(threadId),
@@ -576,27 +597,56 @@ async function recoverRenderObligations(
         RENDER_RECOVERY_LEASE_TTL_MS
       )
       if (!leaseAcquired) {
+        // Another holder (or a lease from a crashed pass, pending TTL expiry)
+        // owns this thread. Count it as deferred so the retry loop keeps
+        // running until the obligation is actually resolved.
+        deferredCount += 1
         traceLog(options, 'slackbotv2_render_recovery_lease_skipped', undefined, {
           thread_id: threadId
         })
         continue
       }
-
-      try {
-        if (await recoverRenderObligation(chat, state, options, threadId, obligation)) {
-          deferredCount += 1
-        }
-      } finally {
+      const releaseLease = async (): Promise<void> => {
         const activeLeaseToken = await state.get<string>(renderRecoveryLeaseKey(threadId))
         if (activeLeaseToken === leaseToken) await state.delete(renderRecoveryLeaseKey(threadId))
       }
+
+      // A single hung recovery (for example an event stream that never
+      // produces a chunk) must not block every obligation queued behind it.
+      // Race a deadline; on timeout move on and leave the attempt running
+      // detached - it may still finish and clear the obligation, which is why
+      // the lease is kept so a later pass does not start a duplicate render.
+      const recovery = recoverRenderObligation(chat, state, options, threadId, obligation)
+      let outcome: { timedOut: true } | { timedOut: false; deferred: boolean }
+      try {
+        outcome = await Promise.race([
+          recovery.then(deferred => ({ timedOut: false as const, deferred })),
+          sleep(timeoutMs).then(() => ({ timedOut: true as const }))
+        ])
+      } catch (error) {
+        await releaseLease()
+        throw error
+      }
+      if (outcome.timedOut) {
+        void recovery.catch(() => undefined)
+        deferredCount += 1
+        traceLog(options, 'slackbotv2_render_recovery_thread_timeout', undefined, {
+          thread_id: threadId,
+          timeout_ms: timeoutMs
+        })
+        continue
+      }
+      await releaseLease()
+      if (outcome.deferred) deferredCount += 1
     } catch (error) {
       // One thread's corrupt state or failed render must not abort the scan:
-      // log it, count it as deferred so a later pass retries it, and keep
-      // recovering the remaining threads.
+      // log it, count it as deferred so a later pass retries it (up to the
+      // failure budget above), and keep recovering the remaining threads.
+      failureCounts.set(threadId, (failureCounts.get(threadId) ?? 0) + 1)
       deferredCount += 1
       traceLog(options, 'slackbotv2_render_recovery_thread_failed', undefined, {
         error: errorMessage(error),
+        failure_count: failureCounts.get(threadId),
         thread_id: threadId
       })
     }

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -88,6 +88,8 @@ export type SlackbotV2Options = {
   maxDurationMs?: number
   postgresUrl?: string
   recoverRenderObligationsOnStart?: boolean
+  /** Per-thread deadline for one recovery attempt during the startup scan. */
+  renderRecoveryThreadTimeoutMs?: number
   signingSecret: string
   slackApiUrl?: string
   state?: StateAdapter

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1492,6 +1492,125 @@ describe('slackbotv2', () => {
     expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)
   })
 
+  it('does not let one hung recovery block the obligations queued behind it', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+
+    // Thread A's execution has no events at all (a zombie: its SSE opens and
+    // never yields a chunk), so its recovery hangs until the per-thread
+    // deadline. Thread B is fully renderable and indexed behind A.
+    const hungKey = threadKey('1781100000.000001')
+    const hungMessage = apiMessageFromSlackEvent({
+      isMention: true,
+      text: `<@${BOT_USER_ID}> hung recovery`,
+      threadId: hungKey,
+      ts: '1781100000.000002'
+    })
+    await sharedState.set(`thread-state:${hungKey}`, {
+      activeExecution: true,
+      executedMessageIds: [hungMessage.id],
+      forwardedMessageIds: [hungMessage.id],
+      historyForwarded: true,
+      lastEventId: 0,
+      renderObligation: {
+        afterEventId: 0,
+        executionId: 'exe-hung-recovery',
+        message: hungMessage
+      }
+    })
+    await sharedState.appendToList('slackbotv2:render:index', hungKey)
+
+    const parent = await postUserMessage('Context before queued recovery.')
+    const mentionText = `<@${BOT_USER_ID}> recover behind a zombie`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const key = threadKey(parent.ts)
+    const message = apiMessageFromSlackEvent({
+      isMention: true,
+      text: mentionText,
+      threadId: key,
+      ts: mention.ts
+    })
+    await sharedState.set(`thread-state:${key}`, {
+      activeExecution: true,
+      executedMessageIds: [mention.ts],
+      forwardedMessageIds: [mention.ts],
+      historyForwarded: true,
+      lastEventId: 0,
+      renderObligation: {
+        afterEventId: 0,
+        executionId: 'exe-behind-zombie',
+        message
+      }
+    })
+    await sharedState.appendToList('slackbotv2:render:index', key)
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('Recovered behind the zombie.'))
+
+    bot = createTestBot({ state: sharedState, renderRecoveryThreadTimeoutMs: 200 })
+
+    await waitFor(async () => {
+      const recovered = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+      return recovered?.renderObligation === null
+    }, 5000)
+    expect(await threadText(parent.ts)).toContain('Recovered behind the zombie.')
+    const recoveredState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+    expect(recoveredState).toEqual(
+      expect.objectContaining({ activeExecution: false, renderObligation: null })
+    )
+    // The hung thread stays pending (deferred), not failed or cleared.
+    const hungState = await sharedState.get<Record<string, unknown>>(`thread-state:${hungKey}`)
+    expect(hungState).toEqual(
+      expect.objectContaining({
+        renderObligation: expect.objectContaining({ executionId: 'exe-hung-recovery' })
+      })
+    )
+  })
+
+  it('abandons an obligation after repeated non-retryable recovery failures', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+
+    // A corrupt thread id without a thread ts: the Slack adapter rejects it
+    // on every recovery attempt, mirroring the production obligation that
+    // poisoned the scan forever.
+    const corruptKey = `slack:${CHANNEL_ID}:`
+    const corruptMessage = apiMessageFromSlackEvent({
+      isMention: true,
+      text: `<@${BOT_USER_ID}> recover the corrupt thread`,
+      threadId: corruptKey,
+      ts: '1781100001.000001'
+    })
+    await sharedState.set(`thread-state:${corruptKey}`, {
+      activeExecution: true,
+      executedMessageIds: [corruptMessage.id],
+      forwardedMessageIds: [corruptMessage.id],
+      historyForwarded: true,
+      lastEventId: 0,
+      renderObligation: {
+        afterEventId: 0,
+        executionId: 'exe-corrupt-thread',
+        message: corruptMessage
+      }
+    })
+    await sharedState.appendToList('slackbotv2:render:index', corruptKey)
+    codexApi.emitOutputLines(corruptKey, sampleCodexOutputLines('Unreachable answer.'))
+
+    bot = createTestBot({ state: sharedState })
+
+    await waitFor(async () => {
+      const threadState = await sharedState.get<Record<string, unknown>>(
+        `thread-state:${corruptKey}`
+      )
+      return threadState?.renderObligation === null
+    }, 10_000)
+    const abandonedState = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${corruptKey}`
+    )
+    expect(abandonedState).toEqual(
+      expect.objectContaining({ activeExecution: false, renderObligation: null })
+    )
+    // Five failing passes with backoff take several seconds.
+  }, 15_000)
+
   it('retries retryable event stream open failures after execute', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
@@ -3000,10 +3119,13 @@ function parseMaybeJson(value: string): unknown {
   }
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 1000
+): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
-    if (predicate()) return
+    if (await predicate()) return
     await new Promise(resolve => setTimeout(resolve, 10))
   }
   throw new Error('Timed out waiting for condition')


### PR DESCRIPTION
## Context

Follow-up to #484, from the same 2026-06-11 incident. Two durable-state bugs remained:

1. **Zombie executions**: execution rows never time out — the only writer of a terminal status is the api-rs process watching the sandbox, so a kill mid-turn (deploys) leaves the row `running` forever. The thread wedges (the one-active-execution unique index blocks new executes) and every event-stream consumer waits for a terminal event that will never come. The production zombie (`exe_4efb8d2a…`) had been "running" for 17 hours while its sandbox was still alive and its finished answer (*"Done: pushed commit 5ca8c99 to PR #432…"*) sat unread in the pod logs.
2. **Recovery wedge**: slackbotv2's startup obligation scan is serial and fully awaits each re-render, so the zombie's never-yielding SSE hung the scan indefinitely — ~180 undelivered answers starved behind it (plus a corrupt obligation with an empty thread ts that failed on every pass forever).

## Changes

### api-rs — adopt orphaned executions at startup (`adopt_orphaned_executions`)

Adopt, don't fail:
1. **Turn finished while nobody was attached** → recover the terminal outcome + final answer from the backend's recorded output. k8s attach streams only deliver from attach-time forward, but the kubelet's pod logs retain what was missed: new `SandboxBackend::read_output_since` (default `Unsupported`), implemented for the k8s backend via the pod-logs API, folded through the same terminal-detection logic as the live pump.
2. **Turn still in flight** (sandbox Running, no terminal in logs) → re-attach the stdout pump and re-arm the remaining `max_duration` budget from execution metadata.
3. **Sandbox gone / queued orphan that never received input** → record the failure honestly (`execution orphaned by control plane restart; …`), which unwedges the thread.

Emits `session.execution_adopted` events (`mode: recorded_output | live_attach`) for observability.

### slackbotv2 — recovery scan can no longer wedge

- **Per-thread deadline** (`renderRecoveryThreadTimeoutMs`, default 2 min): on timeout, defer and move on; the attempt keeps running detached with its lease held so a later pass can't start a duplicate render alongside it.
- **Lease-skips count as deferred** so the retry loop keeps running until obligations actually resolve (previously a crashed pass's lease silently dropped threads until the next pod restart).
- **Failure budget** (5 non-retryable failures) abandons undeliverable obligations — like the production `slack:D0B2Y8AC50X:` (empty thread ts) that poisoned every pass — and clears their state.

With both halves: adoption terminalizes zombies → their SSEs deliver terminal events → recovery drains the backlog; and even before adoption runs, one bad thread can only cost the scan its timeout instead of everything behind it.

## Validation

- Rust: full workspace green incl. 4 new Postgres-gated adoption tests (`SESSION_RUNTIME_TEST_DATABASE_URL` pattern). The headline test reproduces the production zombie exactly: running row + alive sandbox + answer only in recorded logs → execution completes **with the answer**, zero live attaches. Also covered: live re-attach when logs have no terminal, sandbox-gone failure with status detail, queued-orphan failure. `cargo fmt`/`clippy` clean.
- slackbotv2: 32/32 (`bun test test`), types clean. New tests: a renderable obligation queued behind a hung zombie is delivered despite the hang (zombie stays pending, not clobbered); a corrupt obligation is abandoned after repeated failures and its thread unwedged.

## Notes

- Stacked on #484 (includes its conflation commit); merge that first.
- Heads-up: there is concurrent in-progress work in the shared dev worktree refactoring `SandboxError` (`Io(String)` → struct variants with sources). This PR builds against the committed tip's tuple form; when that refactor lands, the merge touchpoints are the two `SandboxError::Io(...)` constructions in `read_output_since` and the test mock (the refactor's helper forms drop in directly).

Incident investigation: https://ampcode.com/threads/T-019eb342-f946-750e-89d1-a8f028e80d0e
