### PR TITLE
fix(slackbot): route final delivery to Slack Connect team

### DIFF
--- a/services/slackbot/src/centaur/final-delivery.test.ts
+++ b/services/slackbot/src/centaur/final-delivery.test.ts
@@ -162,6 +162,7 @@ describe("final delivery polling", () => {
       expect((postMessage?.params as any)?.text).toBe(
         "done [once](https://example.com) with **bold** text",
       );
+      expect((postMessage?.params as any)?.recipient_team_id).toBe("T123");
       expect((postMessage?.params as any)?.blocks).toEqual([
         {
           type: "markdown",

--- a/services/slackbot/src/centaur/final-delivery.ts
+++ b/services/slackbot/src/centaur/final-delivery.ts
@@ -148,6 +148,7 @@ async function deliver(
     threadTs,
     executionId(delivery),
     config.SLACK_TEAM_ID,
+    recipientTeamId(meta),
     chunks,
   );
 }
@@ -156,12 +157,20 @@ function executionId(delivery: any): string {
   return String(delivery?.execution_id ?? "");
 }
 
+function recipientTeamId(delivery: any): string | undefined {
+  const value = String(
+    delivery?.recipient_team_id ?? delivery?.team_id ?? "",
+  ).trim();
+  return value || undefined;
+}
+
 async function postFollowups(
   client: WebClient,
   channel: string,
   threadTs: string,
   executionId: string,
   teamId: string | undefined,
+  recipientTeamId: string | undefined,
   chunks: string[],
 ): Promise<void> {
   const posted = await withSpan(
@@ -190,6 +199,7 @@ async function postFollowups(
         client.chat.postMessage({
           channel,
           thread_ts: threadTs,
+          ...(recipientTeamId ? { recipient_team_id: recipientTeamId } : {}),
           text: renderedChunk,
           blocks: renderMarkdownBlocks(renderedChunk),
           unfurl_links: false,


### PR DESCRIPTION
## Summary
- Pass preserved Slack Connect recipient team into final-delivery fallback/aggregate chat.postMessage calls
- Keep normal Slack posts unchanged when no recipient team is present
- Add regression coverage for recipient_team_id on final delivery posts

## Test
- bun test src/centaur/final-delivery.test.ts
- bun test src/*.test.ts src/**/*.test.ts