### PR TITLE
fix(api-rs): Rust CI gate, constant-time webhook auth, error-chain hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,35 @@ jobs:
             tests/test_agent_control_plane.py::test_worker_stops_session_when_cancel_requested_mid_stream \
             tests/test_agent_control_plane.py::test_worker_maps_amp_user_cancelled_error_to_cancelled
 
+  rust-api:
+    name: Rust API fmt, clippy, and tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: services/api-rs
+
+      - name: Format
+        working-directory: services/api-rs
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        working-directory: services/api-rs
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test
+        working-directory: services/api-rs
+        run: cargo test --workspace
+
   slackbot-targeted-tests:
     name: Slackbot interface and delivery tests
     runs-on: ubuntu-latest

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "sqlx",
+ "subtle",
  "thiserror",
  "tokio",
  "toml",

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -24,6 +24,14 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/paradigmxyz/centaur"
 
+# Workspace-wide lint policy. CI runs `cargo clippy --workspace --all-targets
+# -- -D warnings`, so every warn-level lint below (and every default clippy
+# warning) is a hard failure there while staying a warning locally.
+[workspace.lints.clippy]
+dbg_macro = "warn"
+todo = "warn"
+unimplemented = "warn"
+
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1"
@@ -69,6 +77,7 @@ metrics = "0.24.6"
 metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
 sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
 strum = { version = "0.28", features = ["derive"] }
+subtle = "2"
 test-case = "3.3.1"
 thiserror = "2"
 time = { version = "0.3", features = ["serde", "serde-well-known"] }

--- a/services/api-rs/crates/absurd-sdk/Cargo.toml
+++ b/services/api-rs/crates/absurd-sdk/Cargo.toml
@@ -24,3 +24,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/absurd-sdk/src/lib.rs
+++ b/services/api-rs/crates/absurd-sdk/src/lib.rs
@@ -39,6 +39,11 @@ const UNKNOWN_TASK_DEFER_JITTER_SECONDS: u64 = 15;
 pub enum Error {
     #[error("{0}")]
     InvalidOptions(String),
+    /// A task handler failed with an application-level error. The boxed
+    /// error keeps the full `source()` chain intact instead of flattening
+    /// it to a string.
+    #[error(transparent)]
+    TaskFailed(Box<dyn std::error::Error + Send + Sync>),
     #[error("queue name must be provided")]
     MissingQueueName,
     #[error("queue name {name:?} is too long (max {max} bytes)")]
@@ -1929,6 +1934,18 @@ fn map_task_state_error(err: sqlx::Error) -> Error {
 }
 
 fn serialize_error(err: &Error) -> Value {
+    // Persist the full source chain: the failure payload is often the only
+    // forensic artifact of a failed run.
+    let mut message = err.to_string();
+    let mut source = std::error::Error::source(err);
+    while let Some(cause) = source {
+        let rendered = cause.to_string();
+        if !message.contains(&rendered) {
+            message.push_str(": ");
+            message.push_str(&rendered);
+        }
+        source = cause.source();
+    }
     json!({
         "name": match err {
             Error::Timeout(_) => "TimeoutError",
@@ -1937,7 +1954,7 @@ fn serialize_error(err: &Error) -> Value {
             Error::Suspend => "SuspendTask",
             _ => "Error",
         },
-        "message": err.to_string(),
+        "message": message,
     })
 }
 

--- a/services/api-rs/crates/centaur-api-server/Cargo.toml
+++ b/services/api-rs/crates/centaur-api-server/Cargo.toml
@@ -31,6 +31,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
+subtle.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal"] }
@@ -42,3 +43,6 @@ urlencoding.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 tower.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -22,6 +22,10 @@ pub enum ApiError {
     MethodNotAllowed(String),
     #[error("{0}")]
     PayloadTooLarge(String),
+    /// Server-side misconfiguration or invariant failure. The message is
+    /// logged but never returned to the client.
+    #[error("{0}")]
+    Internal(String),
     #[error(transparent)]
     Runtime(#[from] SessionRuntimeError),
     #[error(transparent)]
@@ -56,14 +60,43 @@ impl IntoResponse for ApiError {
             })) => StatusCode::CONFLICT,
             Self::Workflow(WorkflowRuntimeError::BadRequest(_)) => StatusCode::BAD_REQUEST,
             Self::Workflow(WorkflowRuntimeError::NotFound(_)) => StatusCode::NOT_FOUND,
-            Self::Runtime(_) | Self::Workflow(_) | Self::Serialize(_) => {
+            Self::Workflow(WorkflowRuntimeError::Upstream(_)) => StatusCode::BAD_GATEWAY,
+            Self::Internal(_) | Self::Runtime(_) | Self::Workflow(_) | Self::Serialize(_) => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
         };
+        // 5xx error details are server-side faults: log them for operators but
+        // never echo internals (SQL text, hostnames, config refs) to clients.
+        let message = if status.is_server_error() {
+            tracing::error!(
+                status = status.as_u16(),
+                error = %error_chain(&self),
+                "API request failed"
+            );
+            "internal server error".to_owned()
+        } else {
+            self.to_string()
+        };
         let body = Json(json!({
             "ok": false,
-            "error": self.to_string(),
+            "error": message,
         }));
         (status, body).into_response()
     }
+}
+
+/// Render an error and its full `source()` chain as a single string. Causes
+/// already rendered into an ancestor's message are skipped.
+pub(crate) fn error_chain(error: &dyn std::error::Error) -> String {
+    let mut message = error.to_string();
+    let mut source = error.source();
+    while let Some(cause) = source {
+        let rendered = cause.to_string();
+        if !message.contains(&rendered) {
+            message.push_str(": ");
+            message.push_str(&rendered);
+        }
+        source = cause.source();
+    }
+    message
 }

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -271,12 +271,22 @@ async fn stream_events(
             query.execution_id.as_deref(),
         )
         .await?;
-    let stream = events.map(|result| {
+    let stream = events.map(move |result| {
+        // Stream failures are server-side faults: log the details, send the
+        // client an opaque stream-error event.
+        let opaque = |error: &dyn std::error::Error| {
+            tracing::error!(
+                thread_key = %thread_key,
+                error = %crate::error::error_chain(error),
+                "session event stream failed"
+            );
+            stream_error_sse("event stream failed")
+        };
         let sse = match result {
             Ok(event) => SessionSseEvent::try_from(event)
                 .map(Event::from)
-                .unwrap_or_else(|error| stream_error_sse(error.to_string())),
-            Err(error) => stream_error_sse(error.to_string()),
+                .unwrap_or_else(|error| opaque(&error)),
+            Err(error) => opaque(&error),
         };
         Ok(sse)
     });
@@ -444,10 +454,10 @@ fn parse_webhook_body(headers: &HeaderMap, raw_body: &[u8]) -> Result<Value, Api
             .map_err(|_| ApiError::BadRequest("invalid JSON webhook body".to_owned())),
         "application/x-www-form-urlencoded" => {
             let form = parse_form(std::str::from_utf8(raw_body).unwrap_or_default());
-            if let Some(Value::String(payload)) = form.get("payload") {
-                if let Ok(value) = serde_json::from_str(payload) {
-                    return Ok(value);
-                }
+            if let Some(Value::String(payload)) = form.get("payload")
+                && let Ok(value) = serde_json::from_str(payload)
+            {
+                return Ok(value);
             }
             Ok(Value::Object(form.into_iter().collect()))
         }
@@ -541,7 +551,9 @@ fn verify_webhook_auth(
         WorkflowWebhookAuth::None => Ok(()),
         WorkflowWebhookAuth::Bearer { secret_ref } => {
             let expected = env::var(secret_ref).map_err(|_| {
-                ApiError::BadRequest("webhook auth secret is not configured".to_owned())
+                ApiError::Internal(format!(
+                    "webhook auth secret {secret_ref} is not configured"
+                ))
             })?;
             let Some(actual) = header_value(headers, "Authorization") else {
                 return Err(ApiError::Unauthorized("missing bearer token".to_owned()));
@@ -551,7 +563,7 @@ fn verify_webhook_auth(
                 .or_else(|| actual.strip_prefix("bearer "))
                 .unwrap_or(actual.as_str())
                 .trim();
-            if actual == expected.trim() {
+            if constant_time_eq(actual.as_bytes(), expected.trim().as_bytes()) {
                 Ok(())
             } else {
                 Err(ApiError::Unauthorized("invalid bearer token".to_owned()))
@@ -595,25 +607,38 @@ fn verify_hmac_signature(
             "missing webhook signature".to_owned(),
         ));
     };
-    let secret = env::var(secret_ref)
-        .map_err(|_| ApiError::BadRequest("webhook auth secret is not configured".to_owned()))?;
+    let secret = env::var(secret_ref).map_err(|_| {
+        ApiError::Internal(format!(
+            "webhook auth secret {secret_ref} is not configured"
+        ))
+    })?;
+    let invalid = || ApiError::Unauthorized("invalid webhook signature".to_owned());
+    let presented = signature
+        .trim()
+        .strip_prefix(signature_prefix)
+        .ok_or_else(invalid)?;
+    let presented = match encoding {
+        "base64" => general_purpose::STANDARD
+            .decode(presented)
+            .map_err(|_| invalid())?,
+        _ => hex::decode(presented).map_err(|_| invalid())?,
+    };
     let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).map_err(|_| {
-        ApiError::BadRequest("webhook auth secret is not valid HMAC key material".to_owned())
+        ApiError::Internal(format!(
+            "webhook auth secret {secret_ref} is not valid HMAC key material"
+        ))
     })?;
     mac.update(raw_body);
-    let digest = mac.finalize().into_bytes();
-    let encoded = match encoding {
-        "base64" => general_purpose::STANDARD.encode(digest),
-        _ => hex::encode(digest),
-    };
-    let expected = format!("{signature_prefix}{encoded}");
-    if signature.trim() == expected {
-        Ok(())
-    } else {
-        Err(ApiError::Unauthorized(
-            "invalid webhook signature".to_owned(),
-        ))
-    }
+    // `verify_slice` is a constant-time comparison.
+    mac.verify_slice(&presented).map_err(|_| invalid())
+}
+
+/// Compare two byte strings in constant time (modulo length, which is not
+/// secret here).
+fn constant_time_eq(actual: &[u8], expected: &[u8]) -> bool {
+    use subtle::ConstantTimeEq;
+
+    actual.ct_eq(expected).into()
 }
 
 fn signature_header_name(auth: &WorkflowWebhookAuth) -> Option<&str> {
@@ -715,5 +740,99 @@ mod webhook_tests {
             raw_body,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn verifies_uppercase_hex_hmac_signature() {
+        let raw_body = br#"{"hello":"signed"}"#;
+        let secret_ref = "CENTRAUR_TEST_WEBHOOK_SECRET_UPPER";
+        unsafe {
+            env::set_var(secret_ref, "test-webhook-secret");
+        }
+        let mut mac = Hmac::<Sha256>::new_from_slice(b"test-webhook-secret").unwrap();
+        mac.update(raw_body);
+        let signature = format!(
+            "sha256={}",
+            hex::encode(mac.finalize().into_bytes()).to_uppercase()
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("x-test-signature", signature.parse().unwrap());
+        verify_hmac_signature(
+            "X-Test-Signature",
+            "sha256=",
+            "hex",
+            secret_ref,
+            &headers,
+            raw_body,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn verifies_base64_hmac_signature() {
+        let raw_body = br#"{"hello":"signed"}"#;
+        let secret_ref = "CENTRAUR_TEST_WEBHOOK_SECRET_B64";
+        unsafe {
+            env::set_var(secret_ref, "test-webhook-secret");
+        }
+        let mut mac = Hmac::<Sha256>::new_from_slice(b"test-webhook-secret").unwrap();
+        mac.update(raw_body);
+        let signature = general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        let mut headers = HeaderMap::new();
+        headers.insert("x-test-signature", signature.parse().unwrap());
+        verify_hmac_signature(
+            "X-Test-Signature",
+            "",
+            "base64",
+            secret_ref,
+            &headers,
+            raw_body,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_hmac_signature() {
+        let secret_ref = "CENTRAUR_TEST_WEBHOOK_SECRET_REJECT";
+        unsafe {
+            env::set_var(secret_ref, "test-webhook-secret");
+        }
+        let mut headers = HeaderMap::new();
+        for bad_signature in [
+            // Valid hex, wrong digest.
+            format!("sha256={}", hex::encode([0_u8; 32])),
+            // Missing prefix.
+            hex::encode([0_u8; 32]),
+            // Not decodable.
+            "sha256=not-hex".to_owned(),
+        ] {
+            headers.insert("x-test-signature", bad_signature.parse().unwrap());
+            let error = verify_hmac_signature(
+                "X-Test-Signature",
+                "sha256=",
+                "hex",
+                secret_ref,
+                &headers,
+                br#"{"hello":"signed"}"#,
+            )
+            .unwrap_err();
+            assert!(matches!(error, ApiError::Unauthorized(_)));
+        }
+    }
+
+    #[test]
+    fn missing_webhook_secret_is_internal_error() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-test-signature", "sha256=00".parse().unwrap());
+        let error = verify_hmac_signature(
+            "X-Test-Signature",
+            "sha256=",
+            "hex",
+            "CENTRAUR_TEST_WEBHOOK_SECRET_UNSET",
+            &headers,
+            b"{}",
+        )
+        .unwrap_err();
+        assert!(matches!(error, ApiError::Internal(_)));
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -1241,7 +1241,7 @@ secrets = [
 "#,
         );
 
-        let discovered = discover_tool_proxy_fragment(&[base.clone()]).unwrap();
+        let discovered = discover_tool_proxy_fragment(std::slice::from_ref(&base)).unwrap();
 
         // The tool is kept (not dropped) and contributes exactly one aws_auth
         // transform in the shape iron-control's translator consumes.
@@ -1276,7 +1276,8 @@ secrets = [
         assert_eq!(config["rules"].as_sequence().unwrap().len(), 2);
 
         // The sandbox AWS SDK gets seeded placeholder credentials to sign with.
-        let placeholders = centaur_iron_proxy::placeholder_env(&[discovered.fragment.clone()]);
+        let placeholders =
+            centaur_iron_proxy::placeholder_env(std::slice::from_ref(&discovered.fragment));
         assert_eq!(
             placeholders.get("AWS_ACCESS_KEY_ID").map(String::as_str),
             Some("AWS_ACCESS_KEY_ID")

--- a/services/api-rs/crates/centaur-iron-control/Cargo.toml
+++ b/services/api-rs/crates/centaur-iron-control/Cargo.toml
@@ -13,3 +13,6 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true
 urlencoding.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-iron-proxy/Cargo.toml
+++ b/services/api-rs/crates/centaur-iron-proxy/Cargo.toml
@@ -10,3 +10,6 @@ serde.workspace = true
 serde_yaml.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-perms/Cargo.toml
+++ b/services/api-rs/crates/centaur-perms/Cargo.toml
@@ -17,3 +17,6 @@ eyre.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/Cargo.toml
@@ -18,3 +18,6 @@ serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "rt-multi-thread", "sync", "time"] }
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -202,9 +202,7 @@ impl AgentSandboxBackend {
             .client
             .effective_config(&iron_control.namespace, principal)
             .await
-            .map_err(|err| {
-                SandboxError::Backend(format!("iron-control effective_config: {err}"))
-            })?;
+            .map_err(|err| SandboxError::backend_source("iron-control effective_config", err))?;
 
         Ok(effective
             .secrets
@@ -325,16 +323,16 @@ impl AgentSandboxBackend {
         resolved: &ResolvedIronProxy,
     ) -> SandboxResult<ProxySyncEnv> {
         let iron_control = self.config.iron_control.as_ref().ok_or_else(|| {
-            SandboxError::Backend("iron-proxy requires iron-control to be configured".to_owned())
+            SandboxError::backend("iron-proxy requires iron-control to be configured")
         })?;
         let proxy = iron_control
             .client
             .create_proxy(id.as_str(), &resolved.principal_id)
             .await
-            .map_err(|err| SandboxError::Backend(format!("iron-control create proxy: {err}")))?;
-        let token = proxy.token.ok_or_else(|| {
-            SandboxError::Backend("iron-control create proxy returned no token".to_owned())
-        })?;
+            .map_err(|err| SandboxError::backend_source("iron-control create proxy", err))?;
+        let token = proxy
+            .token
+            .ok_or_else(|| SandboxError::backend("iron-control create proxy returned no token"))?;
         self.proxy_ids
             .lock()
             .await
@@ -379,16 +377,16 @@ impl AgentSandboxBackend {
         id: &SandboxId,
         principal_id: &str,
     ) -> SandboxResult<()> {
-        let iron_control =
-            self.config
-                .iron_control
-                .as_ref()
-                .ok_or_else(|| SandboxError::Unsupported {
-                    backend: crate::BACKEND_NAME,
-                    operation: "assign_iron_control_proxy_principal",
-                })?;
+        let iron_control = self
+            .config
+            .iron_control
+            .as_ref()
+            .ok_or(SandboxError::Unsupported {
+                backend: crate::BACKEND_NAME,
+                operation: "assign_iron_control_proxy_principal",
+            })?;
         let proxy_id = self.proxy_id_for_sandbox(id).await?.ok_or_else(|| {
-            SandboxError::Backend(format!(
+            SandboxError::backend(format!(
                 "iron-control proxy id for sandbox {} was not found",
                 id.as_str()
             ))
@@ -397,7 +395,7 @@ impl AgentSandboxBackend {
             .client
             .assign_proxy_principal(&proxy_id, principal_id)
             .await
-            .map_err(|err| SandboxError::Backend(format!("iron-control assign proxy: {err}")))?;
+            .map_err(|err| SandboxError::backend_source("iron-control assign proxy", err))?;
         self.proxy_ids
             .lock()
             .await

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -169,7 +169,7 @@ impl AgentSandboxBackend {
     pub async fn try_default(namespace: impl Into<String>) -> SandboxResult<Self> {
         let client = Client::try_default()
             .await
-            .map_err(|err| SandboxError::Backend(format!("create kube client: {err}")))?;
+            .map_err(|err| SandboxError::backend_source("create kube client", err))?;
         Ok(Self::new(client, AgentSandboxConfig::new(namespace)))
     }
 
@@ -277,11 +277,9 @@ impl AgentSandboxBackend {
         let stderr = attached
             .stderr()
             .map(|stream| Box::pin(stream) as Pin<Box<dyn AsyncRead + Send>>);
-        let stdin = stdin.ok_or_else(|| SandboxError::Io("stdin was not attached".to_owned()))?;
-        let stdout =
-            stdout.ok_or_else(|| SandboxError::Io("stdout was not attached".to_owned()))?;
-        let stderr =
-            stderr.ok_or_else(|| SandboxError::Io("stderr was not attached".to_owned()))?;
+        let stdin = stdin.ok_or_else(|| SandboxError::io("stdin was not attached"))?;
+        let stdout = stdout.ok_or_else(|| SandboxError::io("stdout was not attached"))?;
+        let stderr = stderr.ok_or_else(|| SandboxError::io("stderr was not attached"))?;
         // Keep kube's attach process alive as long as the returned streams are in use.
         Ok(SandboxIo::with_guard(stdin, stdout, stderr, attached))
     }
@@ -806,7 +804,7 @@ fn map_kube_error(operation: &str, err: Error) -> SandboxError {
     if is_not_found(&err) {
         SandboxError::NotFound(operation.to_owned())
     } else {
-        SandboxError::Backend(format!("{operation}: {err}"))
+        SandboxError::backend_source(operation, err)
     }
 }
 

--- a/services/api-rs/crates/centaur-sandbox-core/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-core/Cargo.toml
@@ -10,3 +10,6 @@ async-trait.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-util"] }
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-sandbox-core/src/error.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/error.rs
@@ -1,6 +1,12 @@
+use std::fmt::Display;
+
 use thiserror::Error;
 
 pub type SandboxResult<T> = Result<T, SandboxError>;
+
+/// Boxed error used to carry backend-specific failure causes across the
+/// backend-neutral [`SandboxError`] boundary without flattening the chain.
+pub type BoxedError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[derive(Debug, Error)]
 pub enum SandboxError {
@@ -16,12 +22,59 @@ pub enum SandboxError {
     #[error("sandbox is not ready: {0}")]
     NotReady(String),
 
-    #[error("sandbox I/O failed: {0}")]
-    Io(String),
+    #[error("sandbox I/O failed: {context}")]
+    Io {
+        context: String,
+        #[source]
+        source: Option<BoxedError>,
+    },
 
-    #[error("backend operation failed: {0}")]
-    Backend(String),
+    #[error("backend operation failed: {context}")]
+    Backend {
+        context: String,
+        #[source]
+        source: Option<BoxedError>,
+    },
 
     #[error("invalid sandbox spec: {0}")]
     InvalidSpec(String),
+}
+
+impl SandboxError {
+    /// I/O failure with only a descriptive context.
+    pub fn io(context: impl Into<String>) -> Self {
+        Self::Io {
+            context: context.into(),
+            source: None,
+        }
+    }
+
+    /// I/O failure preserving the underlying error as `source()`. The cause
+    /// is also rendered into the context so `Display` keeps the full story.
+    pub fn io_source(context: impl Display, source: impl Into<BoxedError>) -> Self {
+        let source = source.into();
+        Self::Io {
+            context: format!("{context}: {source}"),
+            source: Some(source),
+        }
+    }
+
+    /// Backend failure with only a descriptive context.
+    pub fn backend(context: impl Into<String>) -> Self {
+        Self::Backend {
+            context: context.into(),
+            source: None,
+        }
+    }
+
+    /// Backend failure preserving the underlying error as `source()`. The
+    /// cause is also rendered into the context so `Display` keeps the full
+    /// story.
+    pub fn backend_source(context: impl Display, source: impl Into<BoxedError>) -> Self {
+        let source = source.into();
+        Self::Backend {
+            context: format!("{context}: {source}"),
+            source: Some(source),
+        }
+    }
 }

--- a/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
@@ -11,7 +11,7 @@ mod lifecycle;
 mod spec;
 
 pub use backend::SandboxBackend;
-pub use error::{SandboxError, SandboxResult};
+pub use error::{BoxedError, SandboxError, SandboxResult};
 pub use io::{SandboxIo, SandboxIoGuard, SandboxIoParts, SandboxRead, SandboxWrite};
 pub use lifecycle::{
     DesiredSandboxState, ObservedSandbox, SandboxHandle, SandboxId, SandboxStatus,

--- a/services/api-rs/crates/centaur-sandbox-e2e/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-e2e/Cargo.toml
@@ -14,3 +14,6 @@ clap.workspace = true
 kube.workspace = true
 test-case.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "rt-multi-thread", "time"] }
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-sandbox-local/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-local/Cargo.toml
@@ -14,3 +14,6 @@ tokio = { workspace = true, features = ["io-util", "process", "sync", "time"] }
 [dev-dependencies]
 centaur-sandbox-manager = { path = "../centaur-sandbox-manager" }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
@@ -84,9 +84,9 @@ impl SandboxBackend for LocalSandboxBackend {
             command.env(&env.name, &env.value);
         }
 
-        let mut child = command.spawn().map_err(|err| {
-            SandboxError::Backend(format!("failed to spawn local sandbox: {err}"))
-        })?;
+        let mut child = command
+            .spawn()
+            .map_err(|err| SandboxError::backend_source("failed to spawn local sandbox", err))?;
 
         let stdin = child.stdin.take();
         let stdout = child.stdout.take();
@@ -123,15 +123,15 @@ impl SandboxBackend for LocalSandboxBackend {
         let stdin = sandbox
             .stdin
             .take()
-            .ok_or_else(|| SandboxError::Io("stdin is already open or closed".to_owned()))?;
+            .ok_or_else(|| SandboxError::io("stdin is already open or closed"))?;
         let stdout = sandbox
             .stdout
             .take()
-            .ok_or_else(|| SandboxError::Io("stdout is already open or closed".to_owned()))?;
+            .ok_or_else(|| SandboxError::io("stdout is already open or closed"))?;
         let stderr = sandbox
             .stderr
             .take()
-            .ok_or_else(|| SandboxError::Io("stderr is already open or closed".to_owned()))?;
+            .ok_or_else(|| SandboxError::io("stderr is already open or closed"))?;
         Ok(SandboxIo::new(
             Box::pin(stdin) as SandboxWrite,
             Box::pin(stdout) as SandboxRead,
@@ -219,7 +219,7 @@ async fn refresh_status(sandbox: &mut LocalSandbox) -> SandboxResult<SandboxStat
     match sandbox
         .child
         .try_wait()
-        .map_err(|err| SandboxError::Backend(format!("failed to poll local sandbox: {err}")))?
+        .map_err(|err| SandboxError::backend_source("failed to poll local sandbox", err))?
     {
         Some(_) => {
             sandbox.status = SandboxStatus::Stopped;
@@ -248,12 +248,12 @@ async fn send_signal(child: &Child, signal: &str) -> SandboxResult<()> {
         .arg(pid.to_string())
         .status()
         .await
-        .map_err(|err| SandboxError::Backend(format!("failed to send SIG{signal}: {err}")))?;
+        .map_err(|err| SandboxError::backend_source(format!("failed to send SIG{signal}"), err))?;
 
     if status.success() {
         Ok(())
     } else {
-        Err(SandboxError::Backend(format!(
+        Err(SandboxError::backend(format!(
             "kill -{signal} {pid} exited with {status}"
         )))
     }

--- a/services/api-rs/crates/centaur-sandbox-manager/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-manager/Cargo.toml
@@ -16,3 +16,6 @@ tracing.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-sandbox-manager/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/lib.rs
@@ -106,7 +106,7 @@ mod tests {
 
         let err = manager.pause(&"sandbox-1".into()).await.unwrap_err();
 
-        assert!(matches!(err, SandboxError::Backend(_)));
+        assert!(matches!(err, SandboxError::Backend { .. }));
         assert!(matches!(
             manager.desired_state(&"sandbox-1".into()),
             Some(DesiredSandboxState::Running(_))
@@ -226,7 +226,7 @@ mod tests {
                 .expect("fail operation lock poisoned")
                 .contains(&operation)
             {
-                return Err(SandboxError::Backend(format!(
+                return Err(SandboxError::backend(format!(
                     "injected {operation} failure"
                 )));
             }

--- a/services/api-rs/crates/centaur-session-cli/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-cli/Cargo.toml
@@ -16,3 +16,6 @@ ratatui.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-session-core/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-core/Cargo.toml
@@ -11,3 +11,6 @@ serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 time.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -22,3 +22,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 time.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -105,6 +105,16 @@ struct SessionPipe {
     stdin: Arc<Mutex<SessionInputSink>>,
 }
 
+/// Shared handles threaded through background session tasks (stdout pump,
+/// terminal-output recording, max-duration failure, idle pause).
+#[derive(Clone)]
+struct RuntimeContext {
+    store: PgSessionStore,
+    manager: Arc<SandboxManager>,
+    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    execution_spans: ExecutionSpanRegistry,
+}
+
 struct EventStreamState {
     store: PgSessionStore,
     thread_key: ThreadKey,
@@ -127,6 +137,15 @@ impl SessionRuntime {
             execution_spans: Arc::new(Mutex::new(HashMap::new())),
             iron_control: None,
             warm_pool: None,
+        }
+    }
+
+    fn context(&self) -> RuntimeContext {
+        RuntimeContext {
+            store: self.store.clone(),
+            manager: self.sandbox_runtime.manager.clone(),
+            sandbox_pipes: self.sandbox_pipes.clone(),
+            execution_spans: self.execution_spans.clone(),
         }
     }
 
@@ -525,10 +544,7 @@ impl SessionRuntime {
 
             if let Some(max_duration) = max_duration {
                 spawn_max_duration_failure(
-                    self.store.clone(),
-                    self.sandbox_runtime.manager.clone(),
-                    self.sandbox_pipes.clone(),
-                    self.execution_spans.clone(),
+                    self.context(),
                     thread_key.clone(),
                     execution.execution_id.clone(),
                     max_duration,
@@ -1035,13 +1051,10 @@ impl SessionRuntime {
                 .lock()
                 .await
                 .insert(sandbox_id.to_owned(), pipe.clone());
-            let store = self.store.clone();
-            let manager = self.sandbox_runtime.manager.clone();
-            let execution_spans = self.execution_spans.clone();
+            let ctx = self.context();
             let thread_key = thread_key.clone();
             let pump_thread_key = thread_key.clone();
             let pump_key = sandbox_id.to_owned();
-            let sandbox_pipes = self.sandbox_pipes.clone();
             let stdout = io.stdout;
             let stderr = io.stderr;
             let guard = io.guard;
@@ -1049,10 +1062,7 @@ impl SessionRuntime {
 
             tokio::spawn(async move {
                 let result = run_stdout_pump(
-                    store.clone(),
-                    manager,
-                    sandbox_pipes.clone(),
-                    execution_spans.clone(),
+                    ctx.clone(),
                     pump_thread_key.clone(),
                     &pump_key,
                     stdout,
@@ -1068,7 +1078,8 @@ impl SessionRuntime {
                         %error,
                         "session stdout pump failed"
                     );
-                    let _ = store
+                    let _ = ctx
+                        .store
                         .append_event(
                             &pump_thread_key,
                             None,
@@ -1080,7 +1091,7 @@ impl SessionRuntime {
                         )
                         .await;
                 }
-                sandbox_pipes.lock().await.remove(&pump_key);
+                ctx.sandbox_pipes.lock().await.remove(&pump_key);
             });
 
             tokio::spawn(async move {
@@ -1362,10 +1373,7 @@ fn session_event_stream(
 }
 
 async fn run_stdout_pump(
-    store: PgSessionStore,
-    manager: Arc<SandboxManager>,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
-    execution_spans: ExecutionSpanRegistry,
+    ctx: RuntimeContext,
     thread_key: ThreadKey,
     sandbox_id: &str,
     stdout: SandboxRead,
@@ -1399,10 +1407,7 @@ async fn run_stdout_pump(
                 Ok(line) => line,
                 Err(error) => {
                     record_stdout_pump_failure(
-                        &store,
-                        manager.clone(),
-                        sandbox_pipes.clone(),
-                        execution_spans.clone(),
+                        &ctx,
                         &thread_key,
                         sandbox_id,
                         stdout_pump_error_message(&error),
@@ -1414,13 +1419,14 @@ async fn run_stdout_pump(
             line_count += 1;
             let output_value = serde_json::from_str::<Value>(&line).ok();
             if let Some(harness_thread_id) = harness_thread_id_from_output_line(&line)
-                && let Err(error) = store
+                && let Err(error) = ctx
+                    .store
                     .update_harness_thread_id(&thread_key, Some(&harness_thread_id))
                     .await
             {
                 warn!(%thread_key, %harness_thread_id, %error, "failed to persist harness thread id");
             }
-            let active_execution = store.active_execution_for_thread(&thread_key).await?;
+            let active_execution = ctx.store.active_execution_for_thread(&thread_key).await?;
             let execution_id = active_execution
                 .as_ref()
                 .map(|execution| execution.execution_id.as_str());
@@ -1428,7 +1434,8 @@ async fn run_stdout_pump(
             else {
                 continue;
             };
-            let execution_span = execution_spans
+            let execution_span = ctx
+                .execution_spans
                 .lock()
                 .await
                 .get(&output_execution_id)
@@ -1439,7 +1446,7 @@ async fn run_stdout_pump(
                 sandbox_id,
                 &output_execution_id,
             );
-            append_output_line(&store, &thread_key, Some(&output_execution_id), &line)
+            append_output_line(&ctx.store, &thread_key, Some(&output_execution_id), &line)
                 .instrument(output_span.clone())
                 .await?;
             if let Some(value) = output_value.as_ref() {
@@ -1456,10 +1463,7 @@ async fn run_stdout_pump(
                 && let Some(terminal) = output_state.observe(&output_execution_id, &line)
             {
                 record_terminal_output(
-                    &store,
-                    manager.clone(),
-                    sandbox_pipes.clone(),
-                    execution_spans.clone(),
+                    &ctx,
                     &thread_key,
                     sandbox_id,
                     &output_execution_id,
@@ -1467,12 +1471,13 @@ async fn run_stdout_pump(
                 )
                 .instrument(output_span)
                 .await?;
-                execution_spans.lock().await.remove(&output_execution_id);
+                ctx.execution_spans.lock().await.remove(&output_execution_id);
                 output_state.forget(&output_execution_id);
             }
         }
-        if let Some(execution) = store.active_execution_for_thread(&thread_key).await? {
-            let execution_span = execution_spans
+        if let Some(execution) = ctx.store.active_execution_for_thread(&thread_key).await? {
+            let execution_span = ctx
+                .execution_spans
                 .lock()
                 .await
                 .get(&execution.execution_id)
@@ -1484,10 +1489,7 @@ async fn run_stdout_pump(
                 &execution.execution_id,
             );
             record_terminal_output(
-                &store,
-                manager,
-                sandbox_pipes,
-                execution_spans.clone(),
+                &ctx,
                 &thread_key,
                 sandbox_id,
                 &execution.execution_id,
@@ -1497,10 +1499,10 @@ async fn run_stdout_pump(
             )
             .instrument(output_span)
             .await?;
-            execution_spans.lock().await.remove(&execution.execution_id);
+            ctx.execution_spans.lock().await.remove(&execution.execution_id);
             output_state.forget(&execution.execution_id);
         }
-        store
+        ctx.store
             .append_event(
                 &thread_key,
                 None,
@@ -1525,19 +1527,16 @@ async fn run_stdout_pump(
 }
 
 async fn record_stdout_pump_failure(
-    store: &PgSessionStore,
-    manager: Arc<SandboxManager>,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
-    execution_spans: ExecutionSpanRegistry,
+    ctx: &RuntimeContext,
     thread_key: &ThreadKey,
     sandbox_id: &str,
     error: String,
 ) -> Result<(), SessionRuntimeError> {
-    let active_execution = store.active_execution_for_thread(thread_key).await?;
+    let active_execution = ctx.store.active_execution_for_thread(thread_key).await?;
     let execution_id = active_execution
         .as_ref()
         .map(|execution| execution.execution_id.as_str());
-    store
+    ctx.store
         .append_event(
             thread_key,
             execution_id,
@@ -1552,10 +1551,7 @@ async fn record_stdout_pump_failure(
         .await?;
     if let Some(execution) = active_execution {
         record_terminal_output(
-            store,
-            manager,
-            sandbox_pipes,
-            execution_spans,
+            ctx,
             thread_key,
             sandbox_id,
             &execution.execution_id,
@@ -1635,9 +1631,8 @@ impl StdoutPumpState {
         let tool_ids_to_forget = self
             .item_execution_by_id
             .iter()
-            .filter_map(|(item_id, mapped_execution_id)| {
-                (mapped_execution_id == execution_id).then(|| item_id.clone())
-            })
+            .filter(|&(_item_id, mapped_execution_id)| mapped_execution_id == execution_id)
+            .map(|(item_id, _mapped_execution_id)| item_id.clone())
             .collect::<Vec<_>>();
         self.turn_execution_by_id
             .retain(|_, mapped_execution_id| mapped_execution_id != execution_id);
@@ -2153,10 +2148,7 @@ enum TerminalOutput {
 }
 
 async fn record_terminal_output(
-    store: &PgSessionStore,
-    manager: Arc<SandboxManager>,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
-    execution_spans: ExecutionSpanRegistry,
+    ctx: &RuntimeContext,
     thread_key: &ThreadKey,
     sandbox_id: &str,
     execution_id: &str,
@@ -2167,7 +2159,8 @@ async fn record_terminal_output(
             reason,
             result_text,
         } => {
-            let Some(execution) = store.complete_execution_if_active(execution_id).await? else {
+            let Some(execution) = ctx.store.complete_execution_if_active(execution_id).await?
+            else {
                 return Ok(());
             };
             let mut payload = json!({
@@ -2180,7 +2173,7 @@ async fn record_terminal_output(
             {
                 object.insert("result_text".to_owned(), json!(result_text));
             }
-            store
+            ctx.store
                 .append_event(
                     thread_key,
                     Some(execution_id),
@@ -2191,11 +2184,14 @@ async fn record_terminal_output(
             (execution, "completed")
         }
         TerminalOutput::Failed { error } => {
-            let Some(execution) = store.fail_execution_if_active(execution_id, &error).await?
+            let Some(execution) = ctx
+                .store
+                .fail_execution_if_active(execution_id, &error)
+                .await?
             else {
                 return Ok(());
             };
-            store
+            ctx.store
                 .append_event(
                     thread_key,
                     Some(execution_id),
@@ -2210,13 +2206,12 @@ async fn record_terminal_output(
             (execution, "failed")
         }
     };
-    execution_spans.lock().await.remove(execution_id);
-    record_finished_execution_metric(store, thread_key, &terminal_execution, terminal_status).await;
+    ctx.execution_spans.lock().await.remove(execution_id);
+    record_finished_execution_metric(&ctx.store, thread_key, &terminal_execution, terminal_status)
+        .await;
     if let Some(idle_timeout) = idle_timeout_from_execution(&terminal_execution) {
         spawn_idle_pause(
-            store.clone(),
-            manager,
-            sandbox_pipes,
+            ctx.clone(),
             thread_key.clone(),
             terminal_execution.execution_id,
             sandbox_id.to_owned(),
@@ -2227,10 +2222,7 @@ async fn record_terminal_output(
 }
 
 fn spawn_max_duration_failure(
-    store: PgSessionStore,
-    manager: Arc<SandboxManager>,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
-    execution_spans: ExecutionSpanRegistry,
+    ctx: RuntimeContext,
     thread_key: ThreadKey,
     execution_id: String,
     max_duration: Duration,
@@ -2239,10 +2231,7 @@ fn spawn_max_duration_failure(
     tokio::spawn(async move {
         sleep(max_duration).await;
         if let Err(error) = record_max_duration_failure(
-            &store,
-            manager,
-            sandbox_pipes,
-            execution_spans,
+            &ctx,
             &thread_key,
             &execution_id,
             max_duration,
@@ -2256,10 +2245,7 @@ fn spawn_max_duration_failure(
 }
 
 async fn record_max_duration_failure(
-    store: &PgSessionStore,
-    manager: Arc<SandboxManager>,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
-    execution_spans: ExecutionSpanRegistry,
+    ctx: &RuntimeContext,
     thread_key: &ThreadKey,
     execution_id: &str,
     max_duration: Duration,
@@ -2267,11 +2253,15 @@ async fn record_max_duration_failure(
 ) -> Result<(), SessionRuntimeError> {
     let max_duration_ms = duration_millis_u64(max_duration);
     let error = format!("execution exceeded max_duration_ms={max_duration_ms}");
-    let Some(execution) = store.fail_execution_if_active(execution_id, &error).await? else {
+    let Some(execution) = ctx
+        .store
+        .fail_execution_if_active(execution_id, &error)
+        .await?
+    else {
         return Ok(());
     };
-    execution_spans.lock().await.remove(execution_id);
-    store
+    ctx.execution_spans.lock().await.remove(execution_id);
+    ctx.store
         .append_event(
             thread_key,
             Some(execution_id),
@@ -2285,14 +2275,12 @@ async fn record_max_duration_failure(
             }),
         )
         .await?;
-    record_finished_execution_metric(store, thread_key, &execution, "failed").await;
+    record_finished_execution_metric(&ctx.store, thread_key, &execution, "failed").await;
     if let Some(idle_timeout) = idle_timeout.or_else(|| idle_timeout_from_execution(&execution))
-        && let Some(sandbox_id) = store.get_session(thread_key).await?.sandbox_id
+        && let Some(sandbox_id) = ctx.store.get_session(thread_key).await?.sandbox_id
     {
         spawn_idle_pause(
-            store.clone(),
-            manager,
-            sandbox_pipes,
+            ctx.clone(),
             thread_key.clone(),
             execution_id.to_owned(),
             sandbox_id,
@@ -2303,9 +2291,7 @@ async fn record_max_duration_failure(
 }
 
 fn spawn_idle_pause(
-    store: PgSessionStore,
-    manager: Arc<SandboxManager>,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    ctx: RuntimeContext,
     thread_key: ThreadKey,
     execution_id: String,
     sandbox_id: String,
@@ -2313,16 +2299,8 @@ fn spawn_idle_pause(
 ) {
     tokio::spawn(async move {
         sleep(idle_timeout).await;
-        if let Err(error) = record_idle_pause(
-            &store,
-            manager,
-            sandbox_pipes,
-            &thread_key,
-            &execution_id,
-            &sandbox_id,
-            idle_timeout,
-        )
-        .await
+        if let Err(error) =
+            record_idle_pause(&ctx, &thread_key, &execution_id, &sandbox_id, idle_timeout).await
         {
             warn!(%thread_key, %execution_id, %sandbox_id, %error, "idle pause task failed");
         }
@@ -2330,16 +2308,14 @@ fn spawn_idle_pause(
 }
 
 async fn record_idle_pause(
-    store: &PgSessionStore,
-    manager: Arc<SandboxManager>,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    ctx: &RuntimeContext,
     thread_key: &ThreadKey,
     execution_id: &str,
     sandbox_id: &str,
     idle_timeout: Duration,
 ) -> Result<(), SessionRuntimeError> {
-    let latest_execution = store.latest_execution_for_thread(thread_key).await?;
-    let session = store.get_session(thread_key).await?;
+    let latest_execution = ctx.store.latest_execution_for_thread(thread_key).await?;
+    let session = ctx.store.get_session(thread_key).await?;
     if !should_pause_idle_sandbox(
         &session,
         latest_execution.as_ref(),
@@ -2350,7 +2326,7 @@ async fn record_idle_pause(
     }
 
     let id = SandboxId::new(sandbox_id);
-    match manager.status(&id).await {
+    match ctx.manager.status(&id).await {
         Ok(SandboxStatus::Suspended | SandboxStatus::Stopped | SandboxStatus::Gone) => {
             return Ok(());
         }
@@ -2359,7 +2335,7 @@ async fn record_idle_pause(
         Err(SandboxError::NotFound(_)) => return Ok(()),
         Err(error) => {
             record_idle_pause_failure(
-                store,
+                &ctx.store,
                 thread_key,
                 execution_id,
                 sandbox_id,
@@ -2371,10 +2347,10 @@ async fn record_idle_pause(
         }
     }
 
-    sandbox_pipes.lock().await.remove(sandbox_id);
-    match manager.pause(&id).await {
+    ctx.sandbox_pipes.lock().await.remove(sandbox_id);
+    match ctx.manager.pause(&id).await {
         Ok(()) => {
-            store
+            ctx.store
                 .append_event(
                     thread_key,
                     Some(execution_id),
@@ -2391,7 +2367,7 @@ async fn record_idle_pause(
         }
         Err(error) => {
             record_idle_pause_failure(
-                store,
+                &ctx.store,
                 thread_key,
                 execution_id,
                 sandbox_id,
@@ -2743,7 +2719,7 @@ async fn drain_stderr(mut stderr: SandboxRead) -> Result<(), SessionRuntimeError
     io::copy(&mut stderr, &mut io::sink())
         .await
         .map_err(|err| {
-            SessionRuntimeError::Sandbox(SandboxError::Io(format!("drain stderr: {err}")))
+            SessionRuntimeError::Sandbox(SandboxError::io_source("drain stderr", err))
         })?;
     Ok(())
 }
@@ -3045,7 +3021,11 @@ fn stdout_pump_error_message(error: &LinesCodecError) -> String {
 }
 
 fn codec_error_to_runtime(error: LinesCodecError) -> SessionRuntimeError {
-    SessionRuntimeError::Sandbox(SandboxError::Io(error.to_string()))
+    let context = error.to_string();
+    SessionRuntimeError::Sandbox(SandboxError::Io {
+        context,
+        source: Some(Box::new(error)),
+    })
 }
 
 fn duration_options(
@@ -3615,8 +3595,7 @@ mod tests {
     fn event_stream_tolerates_not_ready_attach_race() {
         let not_ready =
             SessionRuntimeError::Sandbox(SandboxError::NotReady("sandbox paused".to_owned()));
-        let backend_error =
-            SessionRuntimeError::Sandbox(SandboxError::Backend("api failed".to_owned()));
+        let backend_error = SessionRuntimeError::Sandbox(SandboxError::backend("api failed"));
 
         assert!(is_event_stream_attach_race(&not_ready));
         assert!(!is_event_stream_attach_race(&backend_error));
@@ -3627,7 +3606,7 @@ mod tests {
         let not_ready =
             SessionRuntimeError::Sandbox(SandboxError::NotReady("sandbox starting".to_owned()));
         let not_found = SessionRuntimeError::Sandbox(SandboxError::NotFound("asbx-1".to_owned()));
-        let io = SessionRuntimeError::Sandbox(SandboxError::Io("stdin closed".to_owned()));
+        let io = SessionRuntimeError::Sandbox(SandboxError::io("stdin closed"));
         let store = SessionRuntimeError::Store(SessionStoreError::NotFound {
             thread_key: "cli:test".to_owned(),
         });

--- a/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
@@ -13,3 +13,6 @@ sqlx.workspace = true
 thiserror.workspace = true
 time.workspace = true
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-telemetry/Cargo.toml
+++ b/services/api-rs/crates/centaur-telemetry/Cargo.toml
@@ -16,3 +16,6 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json", "registry"] }
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -134,10 +134,10 @@ impl TraceExporter {
 
 impl TelemetryGuard {
     pub fn shutdown(mut self) {
-        if let Some(provider) = self.tracer_provider.take() {
-            if let Err(error) = provider.shutdown() {
-                tracing::warn!(%error, "failed to shut down OpenTelemetry tracer provider");
-            }
+        if let Some(provider) = self.tracer_provider.take()
+            && let Err(error) = provider.shutdown()
+        {
+            tracing::warn!(%error, "failed to shut down OpenTelemetry tracer provider");
         }
     }
 }

--- a/services/api-rs/crates/centaur-workflows/Cargo.toml
+++ b/services/api-rs/crates/centaur-workflows/Cargo.toml
@@ -24,3 +24,6 @@ time.workspace = true
 tokio = { workspace = true, features = ["io-util", "process"] }
 tracing.workspace = true
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -138,7 +138,9 @@ pub struct WorkflowWebhookSpec {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[derive(Default)]
 pub enum WorkflowWebhookAuth {
+    #[default]
     None,
     Hmac {
         secret_ref: String,
@@ -157,12 +159,6 @@ pub enum WorkflowWebhookAuth {
     Bearer {
         secret_ref: String,
     },
-}
-
-impl Default for WorkflowWebhookAuth {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -422,16 +418,8 @@ impl WorkflowRuntime {
     pub async fn list_runs(&self, limit: i64) -> Result<Vec<WorkflowRun>, WorkflowRuntimeError> {
         let limit = limit.clamp(1, 200);
         let mut runs = Vec::new();
-        runs.extend(
-            self.list_runs_for_queue(WORKFLOW_QUEUE, limit)
-                .await?
-                .into_iter(),
-        );
-        runs.extend(
-            self.list_runs_for_queue(WORKFLOW_ETL_QUEUE, limit)
-                .await?
-                .into_iter(),
-        );
+        runs.extend(self.list_runs_for_queue(WORKFLOW_QUEUE, limit).await?);
+        runs.extend(self.list_runs_for_queue(WORKFLOW_ETL_QUEUE, limit).await?);
         runs.sort_by(|a, b| {
             b.created_at
                 .cmp(&a.created_at)
@@ -589,7 +577,7 @@ fn absurd_queue_tables(
             "absurd.t_centaur_workflow_schedules",
             "absurd.r_centaur_workflow_schedules",
         )),
-        other => Err(WorkflowRuntimeError::BadRequest(format!(
+        other => Err(WorkflowRuntimeError::Internal(format!(
             "unknown workflow queue {other:?}"
         ))),
     }
@@ -862,21 +850,21 @@ fn workflow_schedule_input(
         metadata.insert("workflow_name".to_owned(), json!(workflow_name));
         metadata.insert("no_delivery".to_owned(), json!(no_delivery));
     }
-    if let Some(thread_key) = object.get("thread_key").and_then(Value::as_str) {
-        if !thread_key.trim().is_empty() {
-            input.insert("thread_key".to_owned(), json!(thread_key.trim()));
-            if !input.contains_key("delivery") {
-                if let Some((channel, thread_ts)) = split_slack_thread_key(thread_key.trim()) {
-                    input.insert(
-                        "delivery".to_owned(),
-                        json!({
-                            "platform": "slack",
-                            "channel": channel,
-                            "thread_ts": thread_ts,
-                        }),
-                    );
-                }
-            }
+    if let Some(thread_key) = object.get("thread_key").and_then(Value::as_str)
+        && !thread_key.trim().is_empty()
+    {
+        input.insert("thread_key".to_owned(), json!(thread_key.trim()));
+        if !input.contains_key("delivery")
+            && let Some((channel, thread_ts)) = split_slack_thread_key(thread_key.trim())
+        {
+            input.insert(
+                "delivery".to_owned(),
+                json!({
+                    "platform": "slack",
+                    "channel": channel,
+                    "thread_ts": thread_ts,
+                }),
+            );
         }
     }
     if let Some(slack_channel) = object.get("slack_channel").and_then(Value::as_str) {
@@ -1025,20 +1013,23 @@ async fn discover_python_workflow_metadata() -> Result<PythonWorkflowMetadata, W
     }
 
     let mut child = command.spawn().map_err(|error| {
-        WorkflowRuntimeError::BadRequest(format!(
+        WorkflowRuntimeError::Internal(format!(
             "failed to spawn Python workflow host {}: {error}",
             host_path.display()
         ))
     })?;
-    let mut stdin = child.stdin.take().ok_or_else(|| {
-        WorkflowRuntimeError::BadRequest("workflow host stdin missing".to_owned())
-    })?;
-    let stdout = child.stdout.take().ok_or_else(|| {
-        WorkflowRuntimeError::BadRequest("workflow host stdout missing".to_owned())
-    })?;
-    let stderr = child.stderr.take().ok_or_else(|| {
-        WorkflowRuntimeError::BadRequest("workflow host stderr missing".to_owned())
-    })?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| WorkflowRuntimeError::Internal("workflow host stdin missing".to_owned()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| WorkflowRuntimeError::Internal("workflow host stdout missing".to_owned()))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| WorkflowRuntimeError::Internal("workflow host stderr missing".to_owned()))?;
     let stderr_task = tokio::spawn(async move {
         let mut lines = BufReader::new(stderr).lines();
         let mut collected = Vec::new();
@@ -1080,7 +1071,7 @@ async fn discover_python_workflow_metadata() -> Result<PythonWorkflowMetadata, W
             }
             Some("host.error") | Some("workflow.error") => {
                 let stderr = stderr_task.await.unwrap_or_default();
-                return Err(WorkflowRuntimeError::BadRequest(format!(
+                return Err(WorkflowRuntimeError::Internal(format!(
                     "Python workflow discovery error: {}{}{}",
                     message
                         .get("message")
@@ -1091,7 +1082,7 @@ async fn discover_python_workflow_metadata() -> Result<PythonWorkflowMetadata, W
                 )));
             }
             other => {
-                return Err(WorkflowRuntimeError::BadRequest(format!(
+                return Err(WorkflowRuntimeError::Internal(format!(
                     "unexpected Python workflow discovery message type {other:?}: {message}"
                 )));
             }
@@ -1100,7 +1091,7 @@ async fn discover_python_workflow_metadata() -> Result<PythonWorkflowMetadata, W
 
     let status = child.wait().await?;
     let stderr = stderr_task.await.unwrap_or_default();
-    Err(WorkflowRuntimeError::BadRequest(format!(
+    Err(WorkflowRuntimeError::Internal(format!(
         "Python workflow host exited before workflow.discovery: status={status}, stderr={stderr}"
     )))
 }
@@ -1341,17 +1332,21 @@ async fn run_centaur_workflow(
                         });
                         run_agent_session_turn(
                             session_runtime,
-                            thread_key,
-                            harness_type,
-                            None,
-                            vec![json!({"type": "text", "text": prompt})],
-                            client_message_id.clone(),
-                            metadata.clone(),
-                            metadata.clone(),
-                            metadata,
-                            format!("absurd-workflow-agent-turn:{client_message_id}"),
-                            idle_timeout_ms,
-                            max_duration_ms,
+                            AgentTurnRequest {
+                                thread_key,
+                                harness_type,
+                                persona_id: None,
+                                parts: vec![json!({"type": "text", "text": prompt})],
+                                client_message_id: client_message_id.clone(),
+                                session_metadata: metadata.clone(),
+                                message_metadata: metadata.clone(),
+                                execution_metadata: metadata,
+                                execution_idempotency_key: format!(
+                                    "absurd-workflow-agent-turn:{client_message_id}"
+                                ),
+                                idle_timeout_ms,
+                                max_duration_ms,
+                            },
                         )
                         .await
                         .map_err(absurd_error)
@@ -1473,20 +1468,23 @@ async fn run_python_workflow_host_local(
     }
 
     let mut child = command.spawn().map_err(|error| {
-        WorkflowRuntimeError::BadRequest(format!(
+        WorkflowRuntimeError::Internal(format!(
             "failed to spawn Python workflow host {}: {error}",
             host_path.display()
         ))
     })?;
-    let mut stdin = child.stdin.take().ok_or_else(|| {
-        WorkflowRuntimeError::BadRequest("workflow host stdin missing".to_owned())
-    })?;
-    let stdout = child.stdout.take().ok_or_else(|| {
-        WorkflowRuntimeError::BadRequest("workflow host stdout missing".to_owned())
-    })?;
-    let stderr = child.stderr.take().ok_or_else(|| {
-        WorkflowRuntimeError::BadRequest("workflow host stderr missing".to_owned())
-    })?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| WorkflowRuntimeError::Internal("workflow host stdin missing".to_owned()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| WorkflowRuntimeError::Internal("workflow host stdout missing".to_owned()))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| WorkflowRuntimeError::Internal("workflow host stderr missing".to_owned()))?;
     let stderr_task = tokio::spawn(async move {
         let mut lines = BufReader::new(stderr).lines();
         let mut collected = Vec::new();
@@ -1522,7 +1520,7 @@ async fn run_python_workflow_host_local(
             }
             Some("workflow.error") | Some("host.error") => {
                 let stderr = stderr_task.await.unwrap_or_default();
-                return Err(WorkflowRuntimeError::BadRequest(format!(
+                return Err(WorkflowRuntimeError::Internal(format!(
                     "Python workflow host error: {}{}{}",
                     message
                         .get("message")
@@ -1551,7 +1549,7 @@ async fn run_python_workflow_host_local(
                 write_host_message(&mut stdin, &response).await?;
             }
             other => {
-                return Err(WorkflowRuntimeError::BadRequest(format!(
+                return Err(WorkflowRuntimeError::Internal(format!(
                     "unexpected Python workflow host message type {other:?}: {message}"
                 )));
             }
@@ -1560,7 +1558,7 @@ async fn run_python_workflow_host_local(
 
     let status = child.wait().await?;
     let stderr = stderr_task.await.unwrap_or_default();
-    Err(WorkflowRuntimeError::BadRequest(format!(
+    Err(WorkflowRuntimeError::Internal(format!(
         "Python workflow host exited before workflow.result: status={status}, stderr={stderr}"
     )))
 }
@@ -1651,7 +1649,7 @@ where
             }
             Some("workflow.error") | Some("host.error") => {
                 let stderr = stderr_task.await.unwrap_or_default();
-                return Err(WorkflowRuntimeError::BadRequest(format!(
+                return Err(WorkflowRuntimeError::Internal(format!(
                     "Python workflow host error: {}{}{}",
                     message
                         .get("message")
@@ -1680,7 +1678,7 @@ where
                 write_host_message(stdin, &response).await?;
             }
             other => {
-                return Err(WorkflowRuntimeError::BadRequest(format!(
+                return Err(WorkflowRuntimeError::Internal(format!(
                     "unexpected Python workflow host message type {other:?}: {message}"
                 )));
             }
@@ -1688,7 +1686,7 @@ where
     }
 
     let stderr = stderr_task.await.unwrap_or_default();
-    Err(WorkflowRuntimeError::BadRequest(format!(
+    Err(WorkflowRuntimeError::Internal(format!(
         "Python workflow host exited before workflow.result: stderr={stderr}"
     )))
 }
@@ -1874,17 +1872,19 @@ async fn run_python_agent_turn(
         .unwrap_or_else(|| format!("absurd-workflow-agent-turn:{client_message_id}"));
     let result = run_agent_session_turn(
         session_runtime,
-        thread_key,
-        harness_type,
-        persona_id,
-        parts,
-        client_message_id,
-        session_metadata,
-        message_metadata,
-        execution_metadata,
-        execution_idempotency_key,
-        idle_timeout_ms,
-        max_duration_ms,
+        AgentTurnRequest {
+            thread_key,
+            harness_type,
+            persona_id,
+            parts,
+            client_message_id,
+            session_metadata,
+            message_metadata,
+            execution_metadata,
+            execution_idempotency_key,
+            idle_timeout_ms,
+            max_duration_ms,
+        },
     )
     .await?;
     serde_json::to_value(result).map_err(WorkflowRuntimeError::from)
@@ -2117,7 +2117,7 @@ async fn send_slack_message(token: &str, payload: Value) -> Result<Value, Workfl
         .json()
         .await?;
     if response.get("ok").and_then(Value::as_bool) != Some(true) {
-        return Err(WorkflowRuntimeError::BadRequest(format!(
+        return Err(WorkflowRuntimeError::Upstream(format!(
             "Slack chat.postMessage failed: {}",
             response
                 .get("error")
@@ -2143,8 +2143,7 @@ fn slack_post_result_from_response(channel: &str, response: Value) -> SlackPostR
     }
 }
 
-async fn run_agent_session_turn(
-    session_runtime: SessionRuntime,
+struct AgentTurnRequest {
     thread_key: String,
     harness_type: HarnessType,
     persona_id: Option<String>,
@@ -2156,7 +2155,25 @@ async fn run_agent_session_turn(
     execution_idempotency_key: String,
     idle_timeout_ms: u64,
     max_duration_ms: u64,
+}
+
+async fn run_agent_session_turn(
+    session_runtime: SessionRuntime,
+    turn: AgentTurnRequest,
 ) -> Result<AgentTurnResult, WorkflowRuntimeError> {
+    let AgentTurnRequest {
+        thread_key,
+        harness_type,
+        persona_id,
+        parts,
+        client_message_id,
+        session_metadata,
+        message_metadata,
+        execution_metadata,
+        execution_idempotency_key,
+        idle_timeout_ms,
+        max_duration_ms,
+    } = turn;
     let thread_key = ThreadKey::parse(thread_key)?;
     session_runtime
         .create_or_get_session(
@@ -2227,7 +2244,7 @@ async fn run_agent_session_turn(
                     result_text: result_text_from_output_lines(&output_lines),
                     output_lines,
                 };
-                return Err(WorkflowRuntimeError::BadRequest(format!(
+                return Err(WorkflowRuntimeError::Upstream(format!(
                     "agent turn {} for thread {} ended with {}",
                     result.execution_id, result.thread_key, result.status
                 )));
@@ -2236,7 +2253,7 @@ async fn run_agent_session_turn(
         }
     }
 
-    Err(WorkflowRuntimeError::BadRequest(
+    Err(WorkflowRuntimeError::Upstream(
         "session event stream ended before terminal execution event".to_owned(),
     ))
 }
@@ -2279,15 +2296,25 @@ fn workflow_run_from_row(row: sqlx::postgres::PgRow) -> Result<WorkflowRun, Work
 }
 
 fn absurd_error(error: WorkflowRuntimeError) -> absurd::Error {
-    absurd::Error::InvalidOptions(error.to_string())
+    absurd::Error::TaskFailed(Box::new(error))
 }
 
 #[derive(Debug, Error)]
 pub enum WorkflowRuntimeError {
+    /// The caller supplied an invalid request or workflow configuration.
+    /// Maps to HTTP 400.
     #[error("{0}")]
     BadRequest(String),
     #[error("workflow run not found: {0}")]
     NotFound(String),
+    /// Server-side failure (workflow host spawn/protocol, internal dispatch).
+    /// Maps to HTTP 500.
+    #[error("{0}")]
+    Internal(String),
+    /// An upstream dependency (Slack, agent session) failed. Maps to
+    /// HTTP 502.
+    #[error("{0}")]
+    Upstream(String),
     #[error(transparent)]
     Absurd(#[from] absurd::Error),
     #[error(transparent)]


### PR DESCRIPTION
Hardening from a workspace-wide review of `services/api-rs` (clippy + manual staff-level audit). Three parts:

## 1. Rust CI gate + workspace lint policy

The Rust workspace previously had **no CI at all** — no build, no tests, no lints. This adds:

- A `rust-api` CI job: `cargo fmt --all --check` → `cargo clippy --workspace --all-targets -- -D warnings` → `cargo test --workspace` (SHA-pinned actions, `rust-cache` scoped to `services/api-rs`). The suite is hermetic: e2e tests are `#[ignore]`d and DB tests are env-gated, so no services are needed in CI.
- `[workspace.lints]` in the root manifest (`dbg_macro`/`todo`/`unimplemented` as warn — hard failures in CI via `-D warnings`), wired into every crate with `[lints] workspace = true`.
- Fixes for all 16 pre-existing clippy warnings so the gate starts green. The `too_many_arguments` clusters got real refactors instead of `#[allow]`s:
  - session-runtime background tasks (stdout pump, terminal output, max-duration, idle pause) share a `RuntimeContext` struct instead of threading 4 handles positionally through 7 functions
  - `run_agent_session_turn` takes an `AgentTurnRequest` struct instead of 12 positional args (including three adjacent `Value` params that could silently transpose)

## 2. Constant-time webhook auth + 5xx hygiene

- `verify_hmac_signature` now **decodes** the presented signature and verifies with `Mac::verify_slice` (constant-time) instead of hex-encoding the digest and `==`-comparing strings. Uppercase hex signatures now verify as a side effect.
- Bearer token comparison uses `subtle::ConstantTimeEq` (already in the dep tree transitively; now a direct dep).
- A missing or invalid webhook secret returns **500** (new `ApiError::Internal`) instead of a 400 that blamed the caller and confirmed config state to unauthenticated probers. This matches the Python API, which already returns 500 here.
- 5xx response bodies and SSE stream errors no longer leak internals (sqlx/kube error text, hostnames, config refs). The full error chain is logged server-side; clients get an opaque message. 4xx messages are unchanged.

## 3. Error-chain preservation (the stringification funnels)

- **`SandboxError`**: `Io(String)`/`Backend(String)` became struct variants with `#[source] Option<BoxedError>` plus `io`/`io_source`/`backend`/`backend_source` constructors. Display strings are byte-identical to before — every existing `%error` log line keeps its content — but the structured source chain now survives for chain-walking consumers (e.g. the new 5xx logging).
- **`absurd::Error`**: new `TaskFailed(Box<dyn Error + Send + Sync>)` (transparent). Workflow failures are no longer mislabeled `InvalidOptions` with the chain destroyed, and `serialize_error` walks `source()` into the persisted failure payload — the only forensic artifact of a failed run.
- **`WorkflowRuntimeError`**: new `Internal` (→ 500) and `Upstream` (→ 502) variants. ~20 server-side failure sites reclassified off `BadRequest`: Python host spawn/protocol/exit failures and queue dispatch are `Internal`; Slack API and agent-turn failures are `Upstream`. Server faults stop surfacing as 400s and become visible to 5xx alerting.

## Behavior changes for reviewers

- Clients that previously saw raw error text in 500 bodies now get `"internal server error"`; key on status codes instead (nothing in-tree parses those strings).
- Webhook with misconfigured secret: 400 → 500.
- Slack/agent-turn workflow failures: 400 → 502 if surfaced over HTTP.

## Validation

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ (zero warnings)
- `cargo test --workspace` ✓ — 190 passed, 0 failed
- New tests: uppercase-hex / base64 / wrong-digest / missing-prefix / undecodable HMAC signatures, and missing-secret-is-`Internal`.
