### PR TITLE
Refresh tools and workflows from repo cache

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -4,6 +4,11 @@
 {{- if and .Values.repoCache.enabled (not $reposPath) -}}
 {{- $reposPath = .Values.repoCache.hostPath -}}
 {{- end -}}
+{{- $toolsUseRepoCache := and .Values.repoCache.enabled .Values.toolServer.enabled .Values.toolServer.repo -}}
+{{- $workflowDirs := "/app/workflows" -}}
+{{- if $toolsUseRepoCache -}}
+{{- $workflowDirs = printf "%s/%s/workflows" .Values.repoCache.hostPath .Values.toolServer.repo -}}
+{{- end -}}
 {{- $apiRsMetricsAnnotations := dict -}}
 {{- if .Values.apiRs.metrics.scrapeAnnotations -}}
 {{- $apiRsMetricsAnnotations = dict "prometheus.io/scrape" "true" "prometheus.io/path" .Values.apiRs.metrics.path "prometheus.io/port" (printf "%v" .Values.apiRs.port) -}}
@@ -97,25 +102,6 @@ spec:
       imagePullSecrets:
 {{ toYaml . | nindent 8 }}
       {{- end }}
-{{- if .Values.overlay.image.repository }}
-      initContainers:
-        - name: overlay-bootstrap
-          image: {{ printf "%s:%s" .Values.overlay.image.repository .Values.overlay.image.tag | quote }}
-          imagePullPolicy: {{ .Values.overlay.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -ec
-            - |
-              src={{ .Values.overlay.image.sourcePath | quote }}
-              target={{ .Values.overlay.mountPath | quote }}
-              mkdir -p "$target"
-              cp -R "$src"/. "$target"/
-          volumeMounts:
-            - name: overlay-root
-              mountPath: {{ dir .Values.overlay.mountPath | quote }}
-          securityContext:
-{{ toYaml .Values.containerSecurityContext | nindent 12 }}
-{{- end }}
       containers:
         - name: api-rs
           image: {{ printf "%s:%s" .Values.apiRs.image.repository .Values.apiRs.image.tag | quote }}
@@ -133,28 +119,12 @@ spec:
             - name: RUST_LOG
               value: info
             - name: TOOL_DIRS
-{{- if .Values.overlay.image.repository }}
-              value: {{ printf "/app/tools:%s/tools" .Values.overlay.mountPath | quote }}
-{{- else }}
               value: /app/tools
-{{- end }}
             - name: WORKFLOW_DIRS
-{{- if .Values.overlay.image.repository }}
-              value: {{ printf "/app/workflows:%s/workflows" .Values.overlay.mountPath | quote }}
-{{- else }}
-              value: /app/workflows
-{{- end }}
-{{- if or .Values.overlay.systemPrompt .Values.overlay.image.repository }}
+              value: {{ $workflowDirs | quote }}
+{{- if .Values.overlay.systemPrompt }}
             - name: CENTAUR_OVERLAY_DIR
               value: {{ .Values.overlay.mountPath | quote }}
-{{- end }}
-{{- if .Values.overlay.image.repository }}
-            - name: CENTAUR_OVERLAY_IMAGE
-              value: {{ printf "%s:%s" .Values.overlay.image.repository .Values.overlay.image.tag | quote }}
-            - name: CENTAUR_OVERLAY_IMAGE_PULL_POLICY
-              value: {{ .Values.overlay.image.pullPolicy | quote }}
-            - name: CENTAUR_OVERLAY_IMAGE_SOURCE_PATH
-              value: {{ .Values.overlay.image.sourcePath | quote }}
 {{- end }}
             - name: SESSION_SANDBOX_BACKEND
               value: {{ .Values.apiRs.sandboxBackend | quote }}
@@ -239,12 +209,10 @@ spec:
 {{- if not .Values.toolServer.repo }}
 {{- fail "toolServer.repo (owner/name) must be set when toolServer.enabled=true" }}
 {{- end }}
-            # Base tools are git-cloned into each sandbox at boot by a
-            # tools-bootstrap init container (the repo-cache architecture, without
-            # the shared node cache), so adding a tool is a push to the repo, not
-            # an api-rs image rebuild. api-rs still discovers its own /app/tools to
-            # grant proxy creds, so pin toolServer.ref to the tool set that image
-            # carries to avoid drift between granted creds and installed tools.
+            # Base tools are copied from repo-cache into each sandbox at boot by
+            # a tools-bootstrap init container, so adding a tool is a push to the
+            # repo, not an api-rs image rebuild. api-rs reads the same repo-cache
+            # mount for tool-secret discovery and refreshes grants in-process.
             - name: KUBERNETES_TOOLS_REPO
               value: {{ .Values.toolServer.repo | quote }}
 {{- if .Values.toolServer.ref }}
@@ -253,11 +221,15 @@ spec:
 {{- end }}
             - name: KUBERNETES_TOOLS_SUBDIR
               value: {{ .Values.toolServer.subdir | quote }}
+{{- if $toolsUseRepoCache }}
+            - name: KUBERNETES_TOOLS_REPO_CACHE_PATH
+              value: {{ .Values.repoCache.hostPath | quote }}
+{{- end }}
             - name: KUBERNETES_TOOLS_RUNNER_IMAGE
               value: {{ printf "%s:%s" (default .Values.sandbox.image.repository .Values.toolServer.runnerImage.repository) (default .Values.sandbox.image.tag .Values.toolServer.runnerImage.tag) | quote }}
             - name: KUBERNETES_TOOLS_RUNNER_IMAGE_PULL_POLICY
               value: {{ default .Values.sandbox.image.pullPolicy .Values.toolServer.runnerImage.pullPolicy | quote }}
-{{- if .Values.toolServer.githubToken.existingSecretName }}
+{{- if and .Values.toolServer.githubToken.existingSecretName (not $toolsUseRepoCache) }}
             - name: KUBERNETES_TOOLS_GITHUB_TOKEN_SECRET
               value: {{ .Values.toolServer.githubToken.existingSecretName | quote }}
             - name: KUBERNETES_TOOLS_GITHUB_TOKEN_SECRET_KEY
@@ -303,15 +275,18 @@ spec:
 {{ toYaml .Values.containerSecurityContext | nindent 12 }}
           resources:
 {{ toYaml .Values.apiRs.resources | nindent 12 }}
-{{- if .Values.overlay.image.repository }}
+{{- if $toolsUseRepoCache }}
           volumeMounts:
-            - name: overlay-root
-              mountPath: {{ dir .Values.overlay.mountPath | quote }}
+            - name: repo-cache
+              mountPath: {{ .Values.repoCache.hostPath | quote }}
+              readOnly: true
 {{- end }}
-{{- if .Values.overlay.image.repository }}
+{{- if $toolsUseRepoCache }}
       volumes:
-        - name: overlay-root
-          emptyDir: {}
+        - name: repo-cache
+          hostPath:
+            path: {{ .Values.repoCache.hostPath | quote }}
+            type: DirectoryOrCreate
 {{- end }}
 ---
 apiVersion: v1

--- a/contrib/chart/templates/overlay-configmap.yaml
+++ b/contrib/chart/templates/overlay-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.overlay.systemPrompt (not .Values.overlay.image.repository) }}
+{{- if .Values.overlay.systemPrompt }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/contrib/chart/templates/repo-cache-secret.yaml
+++ b/contrib/chart/templates/repo-cache-secret.yaml
@@ -1,8 +1,5 @@
 {{- if .Values.repoCache.enabled }}
-{{- if and (not .Values.repoCache.githubToken.existingSecretName) (not .Values.repoCache.githubToken.token) }}
-{{- fail "repoCache.githubToken.token or repoCache.githubToken.existingSecretName is required when repoCache.enabled=true" }}
-{{- end }}
-{{- if not .Values.repoCache.githubToken.existingSecretName }}
+{{- if and .Values.repoCache.githubToken.token (not .Values.repoCache.githubToken.existingSecretName) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -1,13 +1,23 @@
 {{- if .Values.repoCache.enabled }}
-{{- if not .Values.repoCache.repositories }}
-{{- fail "repoCache.repositories must contain at least one owner/repo entry when repoCache.enabled=true" }}
+{{- $repoCacheRepositories := list -}}
+{{- range .Values.repoCache.repositories }}
+{{- $repoCacheRepositories = append $repoCacheRepositories . -}}
 {{- end }}
+{{- if and .Values.toolServer.enabled .Values.toolServer.repo }}
+{{- $repoCacheRepositories = append $repoCacheRepositories .Values.toolServer.repo -}}
+{{- end }}
+{{- $repoCacheRepositories = uniq $repoCacheRepositories -}}
+{{- if $repoCacheRepositories }}
+{{- $repoCacheHasGithubToken := or .Values.repoCache.githubToken.existingSecretName .Values.repoCache.githubToken.token -}}
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
 {{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
 {{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
 {{- $repoCacheRepositoryRefs := list -}}
 {{- range $repo, $ref := .Values.repoCache.repositoryRefs }}
 {{- $repoCacheRepositoryRefs = append $repoCacheRepositoryRefs (printf "%s=%s" $repo $ref) -}}
+{{- end }}
+{{- if and .Values.toolServer.enabled .Values.toolServer.repo .Values.toolServer.ref (not (hasKey .Values.repoCache.repositoryRefs .Values.toolServer.repo)) }}
+{{- $repoCacheRepositoryRefs = append $repoCacheRepositoryRefs (printf "%s=%s" .Values.toolServer.repo .Values.toolServer.ref) -}}
 {{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -51,11 +61,7 @@ spec:
             - |
               set -o pipefail
               token_file=/github-token/token
-              if [ ! -s "$token_file" ]; then
-                echo "GitHub token file is missing or empty: $token_file" >&2
-                exit 1
-              fi
-
+              if [ -s "$token_file" ]; then
               cat > /tmp/git-askpass <<'EOF'
               #!/bin/sh
               case "$1" in
@@ -66,6 +72,7 @@ spec:
               EOF
               chmod 0700 /tmp/git-askpass
               export GIT_ASKPASS=/tmp/git-askpass
+              fi
               git config --global --add safe.directory '*'
               git config --global init.defaultBranch main
               umask 022
@@ -151,7 +158,7 @@ spec:
               done
           env:
             - name: REPOSITORIES
-              value: {{ join " " .Values.repoCache.repositories | quote }}
+              value: {{ join " " $repoCacheRepositories | quote }}
             - name: REPOSITORY_REFS
               value: {{ join " " $repoCacheRepositoryRefs | quote }}
             - name: SYNC_INTERVAL_SECONDS
@@ -183,14 +190,17 @@ spec:
           volumeMounts:
             - name: repo-cache
               mountPath: /cache
+{{- if $repoCacheHasGithubToken }}
             - name: github-token
               mountPath: /github-token
               readOnly: true
+{{- end }}
       volumes:
         - name: repo-cache
           hostPath:
             path: {{ .Values.repoCache.hostPath | quote }}
             type: DirectoryOrCreate
+{{- if $repoCacheHasGithubToken }}
         - name: github-token
           secret:
             secretName: {{ include "centaur.repoCacheGithubTokenSecretName" . }}
@@ -198,4 +208,6 @@ spec:
             items:
               - key: {{ .Values.repoCache.githubToken.secretKey | quote }}
                 path: token
+{{- end }}
+{{- end }}
 {{- end }}

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -132,25 +132,6 @@ spec:
       imagePullSecrets:
 {{ toYaml . | nindent 8 }}
       {{- end }}
-{{- if .Values.overlay.image.repository }}
-      initContainers:
-        - name: overlay-bootstrap
-          image: {{ printf "%s:%s" .Values.overlay.image.repository .Values.overlay.image.tag | quote }}
-          imagePullPolicy: {{ .Values.overlay.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -ec
-            - |
-              src={{ .Values.overlay.image.sourcePath | quote }}
-              target={{ .Values.overlay.mountPath | quote }}
-              mkdir -p "$target"
-              cp -R "$src"/. "$target"/
-          volumeMounts:
-            - name: overlay-root
-              mountPath: {{ dir .Values.overlay.mountPath | quote }}
-          securityContext:
-{{ toYaml .Values.containerSecurityContext | nindent 12 }}
-{{- end }}
       containers:
         - name: api
           image: {{ printf "%s:%s" .Values.api.image.repository .Values.api.image.tag | quote }}
@@ -191,28 +172,12 @@ spec:
             - name: CENTAUR_DEFAULT_HARNESS
               value: {{ .Values.api.defaultHarness | quote }}
             - name: TOOL_DIRS
-{{- if .Values.overlay.image.repository }}
-              value: {{ printf "/app/tools:%s/tools" .Values.overlay.mountPath | quote }}
-{{- else }}
               value: /app/tools
-{{- end }}
             - name: WORKFLOW_DIRS
-{{- if .Values.overlay.image.repository }}
-              value: {{ printf "/app/workflows:%s/workflows" .Values.overlay.mountPath | quote }}
-{{- else }}
               value: /app/workflows
-{{- end }}
-{{- if or .Values.overlay.systemPrompt .Values.overlay.image.repository }}
+{{- if .Values.overlay.systemPrompt }}
             - name: CENTAUR_OVERLAY_DIR
               value: {{ .Values.overlay.mountPath | quote }}
-{{- end }}
-{{- if .Values.overlay.image.repository }}
-            - name: CENTAUR_OVERLAY_IMAGE
-              value: {{ printf "%s:%s" .Values.overlay.image.repository .Values.overlay.image.tag | quote }}
-            - name: CENTAUR_OVERLAY_IMAGE_PULL_POLICY
-              value: {{ .Values.overlay.image.pullPolicy | quote }}
-            - name: CENTAUR_OVERLAY_IMAGE_SOURCE_PATH
-              value: {{ .Values.overlay.image.sourcePath | quote }}
 {{- end }}
             - name: AGENT_API_URL
               value: {{ printf "http://%s:8000" (include "centaur.componentName" (dict "root" . "component" "api")) | quote }}
@@ -438,11 +403,7 @@ spec:
             - name: firewall-ca
               mountPath: /firewall-certs
               readOnly: true
-{{- if .Values.overlay.image.repository }}
-            - name: overlay-root
-              mountPath: {{ dir .Values.overlay.mountPath | quote }}
-              readOnly: true
-{{- else if .Values.overlay.systemPrompt }}
+{{- if .Values.overlay.systemPrompt }}
             - name: overlay
               mountPath: {{ .Values.overlay.mountPath | quote }}
               readOnly: true
@@ -455,10 +416,7 @@ spec:
         - name: firewall-ca
           secret:
             secretName: {{ include "centaur.trustedCaSecretName" . }}
-{{- if .Values.overlay.image.repository }}
-        - name: overlay-root
-          emptyDir: {}
-{{- else if .Values.overlay.systemPrompt }}
+{{- if .Values.overlay.systemPrompt }}
         - name: overlay
           configMap:
             name: {{ include "centaur.componentName" (dict "root" . "component" "overlay") }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -109,16 +109,7 @@
       "type": "object",
       "properties": {
         "mountPath": { "type": "string" },
-        "systemPrompt": { "type": "string" },
-        "image": {
-          "type": "object",
-          "properties": {
-            "repository": { "type": "string" },
-            "tag": { "type": "string" },
-            "pullPolicy": { "type": "string" },
-            "sourcePath": { "type": "string" }
-          }
-        }
+        "systemPrompt": { "type": "string" }
       }
     },
     "sandbox": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -31,10 +31,9 @@ ironProxy:
   secretSource: onepassword
   secretTtl: 10m
 
-# Base tools delivery for api-rs sandboxes. When enabled, a tools-bootstrap init
-# container git-clones `repo` at `ref` into each sandbox's /app/tools (the
-# repo-cache architecture — clone a repo into a pre-provisioned dir — without the
-# shared node cache), so adding a tool is a push to the repo, not an image
+# Base tools delivery for api-rs sandboxes. When enabled, repo-cache keeps `repo`
+# fresh on each node and a tools-bootstrap init container copies `subdir` into
+# each sandbox's /app/tools, so adding a tool is a push to the repo, not an image
 # rebuild. `port` is legacy (the deprecated tool-server sidecar) and unused here.
 toolServer:
   enabled: true
@@ -54,9 +53,8 @@ toolServer:
     repository: ""
     tag: ""
     pullPolicy: ""
-  # GitHub token for private-repo clones (fed to git via GIT_ASKPASS). Leave the
-  # secret name empty for public repos; point it at the repo-cache token secret
-  # to reuse the same credential.
+  # GitHub token for direct private-repo clones when repoCache.enabled=false.
+  # With the default repo-cache path, configure repoCache.githubToken instead.
   githubToken:
     existingSecretName: ""
     secretKey: token
@@ -168,11 +166,6 @@ api:
 overlay:
   mountPath: /app/overlay/org
   systemPrompt: ""
-  image:
-    repository: ""
-    tag: ""
-    pullPolicy: IfNotPresent
-    sourcePath: /overlay
 
 sandbox:
   controller: pod
@@ -204,8 +197,10 @@ sandbox:
       memory: 512Mi
 
 repoCache:
-  enabled: false
+  enabled: true
   hostPath: /var/lib/centaur/repos
+  # Additional repos to cache. toolServer.repo is cached automatically when the
+  # tool server is enabled.
   repositories: []
   repositoryRefs: {}
   syncIntervalSeconds: 300
@@ -214,6 +209,7 @@ repoCache:
     tag: ""
     pullPolicy: ""
   githubToken:
+    # Optional for public repos; required for private repos.
     existingSecretName: ""
     secretKey: token
     token: ""

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1,11 +1,15 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    env,
+    env, fs,
     net::SocketAddr,
     path::PathBuf,
+    process::Command,
     sync::Arc,
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 use centaur_api_server::SandboxRuntime;
 use centaur_iron_control::{
@@ -18,14 +22,14 @@ use centaur_sandbox_agent_k8s::{
     AgentSandboxBackend, AgentSandboxConfig, GitHubTokenRef, IronControlSettings, IronProxyConfig,
     ToolsConfig,
 };
-use centaur_sandbox_core::{Mount, MountKind, OverlayImage, SandboxSpec};
+use centaur_sandbox_core::{Mount, MountKind, SandboxSpec};
 use centaur_sandbox_local::LocalSandboxBackend;
 use centaur_sandbox_manager::WarmPoolConfig;
 use centaur_session_core::HarnessType;
 use centaur_session_runtime::SandboxWorkloadMode;
 use centaur_workflows::WorkflowHostSandboxRuntime;
 use clap::{Args as ClapArgs, Parser, ValueEnum};
-use tracing::info;
+use tracing::{error, info};
 
 use crate::{
     ServerError,
@@ -56,6 +60,12 @@ impl Args {
         self.sandbox.iron_control_runtime().await
     }
 
+    pub(crate) fn iron_control_tool_reconciler(
+        &self,
+    ) -> Result<Option<IronControlToolReconciler>, ServerError> {
+        self.sandbox.iron_control_tool_reconciler()
+    }
+
     pub(crate) fn warm_pool_config(&self) -> Option<WarmPoolConfig> {
         self.sandbox.warm_pool_config()
     }
@@ -74,6 +84,273 @@ pub(crate) struct IronControlRuntime {
     pub(crate) registrar: SessionRegistrar,
     pub(crate) warm_pool_bootstrap_principal: String,
     pub(crate) workflow_host_principal: String,
+}
+
+pub(crate) struct IronControlToolReconciler {
+    client: IronControlClient,
+    namespace: String,
+    source_policy: SourcePolicy,
+    base_infra_fragment: ProxyFragment,
+    tool_dirs: Vec<PathBuf>,
+    tool_git_source: Option<ToolGitSource>,
+    interval: Duration,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ToolGitSource {
+    repo: String,
+    git_ref: Option<String>,
+    source_subdir: String,
+    cache_dir: PathBuf,
+    repo_cache_path: Option<String>,
+}
+
+impl IronControlToolReconciler {
+    pub(crate) async fn run(self) {
+        let mut interval = tokio::time::interval(self.interval);
+        // The startup path already registered once; wait a full period so this
+        // task only handles post-start git/volume updates.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if let Err(error) = self.reconcile_once().await {
+                error!(%error, "failed to reconcile iron-control tool secrets");
+            }
+        }
+    }
+
+    async fn reconcile_once(&self) -> Result<(), ServerError> {
+        let tool_dirs = self.tool_dirs()?;
+        let tool_fragment = self.discover_tool_proxy_fragment()?;
+        let mut infra = self.base_infra_fragment.clone();
+        if let Some(tool_fragment) = &tool_fragment {
+            merge_fragment(&mut infra, tool_fragment.fragment.clone());
+        }
+        let role_id = register_role(
+            &self.client,
+            &self.namespace,
+            &RoleSpec::infra(),
+            &infra,
+            &self.source_policy,
+        )
+        .await?;
+        info!(
+            role_id,
+            tool_dirs = ?tool_dirs,
+            tool_count = tool_fragment
+                .as_ref()
+                .map_or(0, |fragment| fragment.tool_count),
+            secret_count = tool_fragment
+                .as_ref()
+                .map_or(0, |fragment| fragment.secret_count),
+            "reconciled iron-control tool secrets"
+        );
+        Ok(())
+    }
+
+    fn discover_tool_proxy_fragment(
+        &self,
+    ) -> Result<Option<DiscoveredToolProxyFragment>, ServerError> {
+        let tool_dirs = self.tool_dirs()?;
+        let discovered = discover_tool_proxy_fragment(&tool_dirs)?;
+        if discovered.secret_count == 0 {
+            return Ok(None);
+        }
+        Ok(Some(discovered))
+    }
+
+    fn tool_dirs(&self) -> Result<Vec<PathBuf>, ServerError> {
+        if let Some(source) = &self.tool_git_source {
+            source.sync()?;
+            let tools_dir = source.tools_dir();
+            if source.repo_cache_path.is_some() && !tools_dir.is_dir() {
+                return Ok(Vec::new());
+            }
+            return Ok(vec![tools_dir]);
+        }
+        Ok(self.tool_dirs.clone())
+    }
+}
+
+impl ToolGitSource {
+    fn from_config(tools: &ToolsConfig) -> Self {
+        Self {
+            repo: tools.repo.clone(),
+            git_ref: tools.git_ref.clone(),
+            source_subdir: tools.source_subdir.clone(),
+            cache_dir: env::temp_dir()
+                .join("centaur-api-rs-tools")
+                .join(slug_path_component(&tools.repo)),
+            repo_cache_path: tools.repo_cache_path.clone(),
+        }
+    }
+
+    fn tools_dir(&self) -> PathBuf {
+        if let Some(repo_cache_path) = &self.repo_cache_path {
+            return PathBuf::from(repo_cache_path)
+                .join(&self.repo)
+                .join(&self.source_subdir);
+        }
+        self.cache_dir.join(&self.source_subdir)
+    }
+
+    fn sync(&self) -> Result<(), ServerError> {
+        if self.repo_cache_path.is_some() {
+            return Ok(());
+        }
+        static TOOL_PROXY_GIT_SYNC: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = TOOL_PROXY_GIT_SYNC
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.sync_locked()
+    }
+
+    fn sync_locked(&self) -> Result<(), ServerError> {
+        let repo_url = format!("https://github.com/{}.git", self.repo);
+        if !self.cache_dir.join(".git").is_dir() {
+            if self.cache_dir.exists() {
+                fs::remove_dir_all(&self.cache_dir)?;
+            }
+            if let Some(parent) = self.cache_dir.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            run_git(
+                Command::new("git")
+                    .arg("clone")
+                    .arg("--quiet")
+                    .arg("--filter=blob:none")
+                    .arg("--no-checkout")
+                    .arg(&repo_url)
+                    .arg(&self.cache_dir),
+                "clone api-rs tools repo",
+            )?;
+            run_git(
+                Command::new("git")
+                    .arg("-C")
+                    .arg(&self.cache_dir)
+                    .arg("sparse-checkout")
+                    .arg("set")
+                    .arg(&self.source_subdir),
+                "configure api-rs tools sparse checkout",
+            )?;
+        }
+
+        match &self.git_ref {
+            Some(git_ref) => {
+                run_git(
+                    Command::new("git")
+                        .arg("-C")
+                        .arg(&self.cache_dir)
+                        .arg("-c")
+                        .arg("gc.auto=0")
+                        .arg("fetch")
+                        .arg("--quiet")
+                        .arg("origin")
+                        .arg(git_ref),
+                    "fetch api-rs tools ref",
+                )?;
+                run_git(
+                    Command::new("git")
+                        .arg("-C")
+                        .arg(&self.cache_dir)
+                        .arg("checkout")
+                        .arg("--quiet")
+                        .arg("--detach")
+                        .arg("FETCH_HEAD"),
+                    "checkout api-rs tools ref",
+                )?;
+            }
+            None => {
+                run_git(
+                    Command::new("git")
+                        .arg("-C")
+                        .arg(&self.cache_dir)
+                        .arg("checkout")
+                        .arg("--quiet"),
+                    "checkout api-rs tools default branch",
+                )?;
+                run_git(
+                    Command::new("git")
+                        .arg("-C")
+                        .arg(&self.cache_dir)
+                        .arg("pull")
+                        .arg("--ff-only")
+                        .arg("--quiet"),
+                    "pull api-rs tools default branch",
+                )?;
+            }
+        }
+
+        if !self.tools_dir().is_dir() {
+            return Err(ServerError::ToolSource(format!(
+                "configured tools subdir does not exist after sync: {}",
+                self.tools_dir().display()
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn run_git(command: &mut Command, operation: &str) -> Result<(), ServerError> {
+    command.env("GIT_TERMINAL_PROMPT", "0");
+    let askpass = configure_git_askpass(command)?;
+    let output = command.output()?;
+    if let Some(path) = askpass {
+        let _ = fs::remove_file(path);
+    }
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(ServerError::ToolSource(format!(
+        "{operation} failed with status {}: {}",
+        output.status,
+        stderr.trim()
+    )))
+}
+
+fn configure_git_askpass(command: &mut Command) -> Result<Option<PathBuf>, ServerError> {
+    let token = env::var("GITHUB_TOKEN")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let token_file = env::var("CENTAUR_TOOLS_GITHUB_TOKEN_FILE")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let Some(password_command) = token
+        .map(|token| format!("echo {}", shell_quote(&token)))
+        .or_else(|| token_file.map(|path| format!("cat {}", shell_quote(&path))))
+    else {
+        return Ok(None);
+    };
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let path = env::temp_dir().join(format!(
+        "centaur-api-rs-git-askpass-{}-{nonce}.sh",
+        std::process::id()
+    ));
+    fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\ncase \"$1\" in\n  *Username*) echo x-access-token;;\n  *Password*) {password_command};;\n  *) echo;;\nesac\n"
+        ),
+    )?;
+    #[cfg(unix)]
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o700))?;
+    command.env("GIT_ASKPASS", &path);
+    Ok(Some(path))
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r#"'\''"#))
+}
+
+fn slug_path_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect()
 }
 
 #[derive(Debug, ClapArgs)]
@@ -226,6 +503,12 @@ struct SandboxArgs {
     workflow_host_command: Option<String>,
     #[command(flatten)]
     tools_source: ToolsArgs,
+    #[arg(
+        long = "tool-proxy-reconcile-interval-secs",
+        env = "TOOL_PROXY_RECONCILE_INTERVAL_SECS",
+        default_value_t = 60
+    )]
+    tool_proxy_reconcile_interval_secs: u64,
 }
 
 impl SandboxArgs {
@@ -272,6 +555,34 @@ impl SandboxArgs {
             registrar: SessionRegistrar::new(client, namespace, role_ids),
             warm_pool_bootstrap_principal: bootstrap.id,
             workflow_host_principal: workflow_host.id,
+        }))
+    }
+
+    /// Background registration for git/volume-backed tool updates. The startup
+    /// registrar grants every principal the stable infra role; re-upserting that
+    /// role here adds newly discovered tool secrets to existing and future
+    /// principals without restarting api-rs or sandboxes.
+    fn iron_control_tool_reconciler(
+        &self,
+    ) -> Result<Option<IronControlToolReconciler>, ServerError> {
+        let Some(client) = self.iron_control.client() else {
+            return Ok(None);
+        };
+        if self.tool_proxy_reconcile_interval_secs == 0 {
+            return Ok(None);
+        }
+        Ok(Some(IronControlToolReconciler {
+            client,
+            namespace: self.iron_control.namespace.clone(),
+            source_policy: self.iron_proxy.source_policy(),
+            base_infra_fragment: self.iron_proxy.infra_fragment()?,
+            tool_dirs: self.tools.resolve_tool_dirs()?,
+            tool_git_source: self
+                .tools_source
+                .to_config()
+                .as_ref()
+                .map(ToolGitSource::from_config),
+            interval: Duration::from_secs(self.tool_proxy_reconcile_interval_secs),
         }))
     }
 
@@ -388,9 +699,6 @@ impl SandboxArgs {
                     .read_only(),
                 );
             }
-            if let Some(overlay) = overlay_image_from_env() {
-                spec = spec.overlay_image(overlay);
-            }
         }
         for (name, value) in self.workflow_host_env_template()? {
             upsert_spec_env(&mut spec, name, value);
@@ -402,13 +710,10 @@ impl SandboxArgs {
     }
 
     fn agent_k8s_workflow_dirs(&self) -> String {
-        if matches!(self.backend, SandboxBackendKind::AgentK8s)
-            && env::var_os("CENTAUR_OVERLAY_IMAGE").is_some()
-        {
-            "/opt/centaur/workflows:/opt/centaur/overlay/workflows".to_owned()
-        } else {
-            "/opt/centaur/workflows".to_owned()
+        if let Some(repo) = clean_optional_value(self.tools_source.repo.as_deref()) {
+            return format!("{SANDBOX_REPOS_MOUNT_PATH}/{repo}/workflows");
         }
+        "/opt/centaur/workflows".to_owned()
     }
 
     fn default_workflow_host_path(&self) -> String {
@@ -594,7 +899,7 @@ impl SandboxArgs {
     fn discover_tool_proxy_fragment(
         &self,
     ) -> Result<Option<DiscoveredToolProxyFragment>, ServerError> {
-        let tool_dirs = self.tools.resolve_tool_dirs()?;
+        let tool_dirs = self.tool_proxy_dirs()?;
         let discovered = discover_tool_proxy_fragment(&tool_dirs)?;
         if discovered.secret_count == 0 {
             return Ok(None);
@@ -605,6 +910,15 @@ impl SandboxArgs {
             "api-rs tool proxy fragment enabled"
         );
         Ok(Some(discovered))
+    }
+
+    fn tool_proxy_dirs(&self) -> Result<Vec<PathBuf>, ServerError> {
+        if let Some(tools) = self.tools_source.to_config() {
+            let source = ToolGitSource::from_config(&tools);
+            source.sync()?;
+            return Ok(vec![source.tools_dir()]);
+        }
+        self.tools.resolve_tool_dirs()
     }
 
     fn warm_pool_config(&self) -> Option<WarmPoolConfig> {
@@ -672,10 +986,6 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         }
         config.iron_control = args.iron_control.settings();
         config.tools = args.tools_source.to_config();
-        // The same org overlay (and the same CENTAUR_OVERLAY_* env the chart
-        // already sets) serves every sandbox; workflow hosts set it spec-level
-        // via `workflow_host_spec`, which then takes precedence in the backend.
-        config.overlay = overlay_image_from_env();
         // iron-control is the only proxy mode: a per-sandbox proxy syncs its
         // secrets from the control plane, so configuring iron-proxy without
         // iron-control would produce a non-functional proxy. Fail fast.
@@ -741,6 +1051,14 @@ struct ToolsArgs {
         default_value = "token"
     )]
     github_token_secret_key: String,
+    // Optional mounted repo-cache root. When present, sandboxes and api-rs copy
+    // tools from `<path>/<repo>/<subdir>` instead of fetching GitHub directly.
+    #[arg(
+        id = "tools_repo_cache_path",
+        long = "kubernetes-tools-repo-cache-path",
+        env = "KUBERNETES_TOOLS_REPO_CACHE_PATH"
+    )]
+    repo_cache_path: Option<String>,
 }
 
 impl ToolsArgs {
@@ -761,6 +1079,7 @@ impl ToolsArgs {
                     .unwrap_or_else(|| "token".to_owned()),
             });
         }
+        config.repo_cache_path = clean_optional_value(self.repo_cache_path.as_deref());
         Some(config)
     }
 }
@@ -1070,20 +1389,6 @@ fn default_workflow_host_path() -> String {
         .to_string()
 }
 
-/// The org overlay image, from the `CENTAUR_OVERLAY_*` env the chart sets.
-/// Shared by workflow-host specs and the agent-sandbox backend default — every
-/// sandbox mounts the same overlay tree at the same path.
-fn overlay_image_from_env() -> Option<OverlayImage> {
-    let image = env::var("CENTAUR_OVERLAY_IMAGE").ok()?;
-    let source_path =
-        env::var("CENTAUR_OVERLAY_IMAGE_SOURCE_PATH").unwrap_or_else(|_| "/overlay".to_owned());
-    let mut overlay = OverlayImage::new(image, source_path, "/opt/centaur/overlay");
-    if let Ok(image_pull_policy) = env::var("CENTAUR_OVERLAY_IMAGE_PULL_POLICY") {
-        overlay = overlay.image_pull_policy(image_pull_policy);
-    }
-    Some(overlay)
-}
-
 fn harness_fragment_engine_name(engine: &HarnessType) -> &'static str {
     match engine {
         HarnessType::Codex => "codex",
@@ -1149,42 +1454,6 @@ fn parse_label_selector_arg(value: &str) -> Result<BTreeMap<String, String>, Str
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // Process env is global: tests that set CENTAUR_OVERLAY_* via EnvGuard must
-    // not interleave, or one test observes another's values.
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        ENV_MUTEX
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-
-    struct EnvGuard {
-        name: &'static str,
-        old_value: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(name: &'static str, value: &str) -> Self {
-            let old_value = env::var(name).ok();
-            unsafe {
-                env::set_var(name, value);
-            }
-            Self { name, old_value }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                match &self.old_value {
-                    Some(value) => env::set_var(self.name, value),
-                    None => env::remove_var(self.name),
-                }
-            }
-        }
-    }
 
     #[test]
     fn parses_session_sandbox_flags() {
@@ -1268,11 +1537,7 @@ mod tests {
     }
 
     #[test]
-    fn tools_and_overlay_config_read_from_flags() {
-        // The overlay rides the same CENTAUR_OVERLAY_* env the workflow host
-        // reads — one overlay convention for every sandbox.
-        let _env_lock = env_lock();
-        let _overlay_image = EnvGuard::set("CENTAUR_OVERLAY_IMAGE", "centaur-overlay:test");
+    fn tools_config_read_from_flags() {
         let args = Args::try_parse_from([
             "centaur-api-server",
             "--database-url",
@@ -1287,6 +1552,8 @@ mod tests {
             "main",
             "--kubernetes-tools-runner-image",
             "centaur-agent:test",
+            "--kubernetes-tools-repo-cache-path",
+            "/var/lib/centaur/repos",
             "--kubernetes-tools-github-token-secret",
             "centaur-repo-cache-github-token",
         ])
@@ -1297,47 +1564,13 @@ mod tests {
         assert_eq!(tools.git_ref.as_deref(), Some("main"));
         assert_eq!(tools.source_subdir, "tools");
         assert_eq!(tools.image, "centaur-agent:test");
+        assert_eq!(
+            tools.repo_cache_path.as_deref(),
+            Some("/var/lib/centaur/repos")
+        );
         let token = tools.github_token.expect("token should be Some");
         assert_eq!(token.secret_name, "centaur-repo-cache-github-token");
         assert_eq!(token.secret_key, "token");
-        let overlay = config.overlay.expect("overlay should be Some");
-        assert_eq!(overlay.image, "centaur-overlay:test");
-        assert_eq!(overlay.mount_path, "/opt/centaur/overlay");
-    }
-
-    #[test]
-    fn agent_k8s_workflow_host_mounts_overlay_workflows() {
-        let _env_lock = env_lock();
-        let _overlay_image = EnvGuard::set("CENTAUR_OVERLAY_IMAGE", "ghcr.io/example/overlay:test");
-        let _overlay_pull_policy = EnvGuard::set("CENTAUR_OVERLAY_IMAGE_PULL_POLICY", "Always");
-        let _overlay_source_path = EnvGuard::set("CENTAUR_OVERLAY_IMAGE_SOURCE_PATH", "/overlay");
-        let _workflow_dirs =
-            EnvGuard::set("WORKFLOW_DIRS", "/app/workflows:/app/overlay/workflows");
-        let args = Args::try_parse_from([
-            "centaur-api-server",
-            "--database-url",
-            "postgres://postgres:postgres@localhost/centaur",
-            "--session-sandbox-backend",
-            "agent-k8s",
-            "--kubernetes-sandbox-iron-proxy-mode",
-            "disabled",
-        ])
-        .unwrap();
-
-        let spec = args.sandbox.workflow_host_spec(None).unwrap();
-
-        assert_eq!(
-            spec.env
-                .iter()
-                .find(|env| env.name == "WORKFLOW_DIRS")
-                .map(|env| env.value.as_str()),
-            Some("/opt/centaur/workflows:/opt/centaur/overlay/workflows")
-        );
-        let overlay = spec.overlay.as_ref().expect("overlay image configured");
-        assert_eq!(overlay.image, "ghcr.io/example/overlay:test");
-        assert_eq!(overlay.source_path, "/overlay");
-        assert_eq!(overlay.mount_path, "/opt/centaur/overlay");
-        assert_eq!(overlay.image_pull_policy.as_deref(), Some("Always"));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -34,6 +34,10 @@ async fn main() -> Result<(), ServerError> {
         workflow_host_principal = Some(iron_control.workflow_host_principal);
         runtime = runtime.with_iron_control(iron_control.registrar);
     }
+    if let Some(reconciler) = args.iron_control_tool_reconciler()? {
+        info!("iron-control tool secret reconciliation enabled");
+        tokio::spawn(reconciler.run());
+    }
     if let Some(mut config) = args.warm_pool_config() {
         config.bootstrap_iron_control_principal = warm_pool_bootstrap_principal.clone();
         runtime = runtime.with_warm_pool(config);
@@ -95,6 +99,8 @@ pub(crate) enum ServerError {
     Telemetry(#[from] centaur_telemetry::TelemetryError),
     #[error(transparent)]
     ToolDiscovery(#[from] tool_discovery::ToolDiscoveryError),
+    #[error("tool source error: {0}")]
+    ToolSource(String),
     #[error("iron-proxy requires both firewall CA cert and key Secret names")]
     MissingIronProxyCaSecret,
     #[error("{0}")]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -12,8 +12,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use centaur_iron_control::IronControlClient;
 use centaur_sandbox_core::{
-    MountKind, ObservedSandbox, OverlayImage, SandboxBackend, SandboxError, SandboxHandle,
-    SandboxId, SandboxIo, SandboxResult, SandboxSpec, SandboxStatus,
+    MountKind, ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
+    SandboxResult, SandboxSpec, SandboxStatus,
 };
 use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
 use kube::api::{AttachParams, DeleteParams, ListParams, Patch, PatchParams, PostParams};
@@ -59,11 +59,6 @@ pub struct AgentSandboxConfig {
     /// git-clones the tools repo into the agent's `/app/tools`, and `TOOL_DIRS`
     /// is set so the agent's shim installer finds them.
     pub tools: Option<ToolsConfig>,
-    /// When set, the org overlay tree (tools, workflows, skills, system-prompt
-    /// overlay) is mounted into every sandbox this backend creates, via the same
-    /// spec-level [`OverlayImage`] plumbing workflow-host sandboxes use. A
-    /// spec-level overlay takes precedence over this default.
-    pub overlay: Option<OverlayImage>,
     pub ready_timeout: Duration,
 }
 
@@ -95,7 +90,6 @@ impl AgentSandboxConfig {
             iron_proxy: None,
             iron_control: None,
             tools: None,
-            overlay: None,
             ready_timeout: Duration::from_secs(60),
         }
     }
@@ -117,11 +111,6 @@ impl AgentSandboxConfig {
 
     pub fn tools(mut self, tools: ToolsConfig) -> Self {
         self.tools = Some(tools);
-        self
-    }
-
-    pub fn overlay(mut self, overlay: OverlayImage) -> Self {
-        self.overlay = Some(overlay);
         self
     }
 }
@@ -474,21 +463,16 @@ fn build_agent_sandbox(
         "args",
         (!spec.args.is_empty()).then(|| spec.args.clone()),
     );
-    // One overlay per sandbox: a spec-level overlay (workflow hosts) wins over
-    // the backend-wide default, so the two never stack into duplicate
-    // `overlay-bootstrap`/`overlay-root` names.
-    let overlay = spec.overlay.as_ref().or(config.overlay.as_ref());
-
-    // Agent container env: spec env + tools/overlay wiring (deduped). `TOOL_DIRS`
+    // Agent container env: spec env + tools wiring (deduped). `TOOL_DIRS`
     // is set deterministically here (not via passthrough) so it always matches
-    // the paths the bootstrap init containers actually populate in this pod.
+    // the path the bootstrap init container actually populates in this pod.
     let mut agent_env: Vec<(String, String)> = spec
         .env
         .iter()
         .map(|env| (env.name.clone(), env.value.clone()))
         .collect();
-    if config.tools.is_some() || overlay.is_some() {
-        for (name, value) in tools::agent_env(overlay) {
+    if config.tools.is_some() {
+        for (name, value) in tools::agent_env(config.tools.as_ref()) {
             upsert_env(&mut agent_env, &name, value);
         }
     }
@@ -506,7 +490,7 @@ fn build_agent_sandbox(
     insert_optional(&mut container, "resources", resources_json(spec));
 
     let (mut volumes, mut volume_mounts) = mount_json(spec);
-    let mut init_containers = overlay_json(overlay, &mut volumes, &mut volume_mounts);
+    let mut init_containers = Vec::new();
     if let Some(state_volume) = &config.state_volume {
         volume_mounts.push(json!({
             "name": "state",
@@ -518,9 +502,10 @@ fn build_agent_sandbox(
         volumes.push(iron_proxy::sandbox_ca_volume_json(iron_proxy));
     }
     // Tool sources are bootstrapped into an emptyDir by an init container and
-    // mounted read-only into the agent at the same path `TOOL_DIRS` points at.
+    // mounted into the agent at the same path `TOOL_DIRS` points at. The mount is
+    // writable so `centaur-tools refresh` can fetch and republish the tree.
     if config.tools.is_some() {
-        volume_mounts.extend(tools::agent_volume_mounts_json(config.tools.is_some()));
+        volume_mounts.extend(tools::agent_volume_mounts_json(config.tools.as_ref()));
         volumes.extend(tools::volumes_json(config.tools.as_ref()));
     }
     insert_optional(
@@ -529,8 +514,7 @@ fn build_agent_sandbox(
         (!volume_mounts.is_empty()).then_some(volume_mounts),
     );
 
-    // tools-bootstrap git-clones the tools repo into /app/tools (the overlay's
-    // own overlay-bootstrap init container came from `overlay_json` above).
+    // tools-bootstrap publishes the tools repo into /app/tools.
     if let Some(tools) = &config.tools {
         // The sandbox NetworkPolicy only allows egress to the per-sandbox proxy
         // (plus api-rs and DNS), so when iron-proxy is on the clone must ride it.
@@ -558,7 +542,7 @@ fn build_agent_sandbox(
         "automountServiceAccountToken": false,
         "enableServiceLinks": false,
     });
-    if config.tools.is_some() || overlay.is_some() {
+    if config.tools.is_some() {
         pod_spec["securityContext"] = tools::pod_security_context_json();
     }
     insert_optional(
@@ -615,86 +599,6 @@ fn build_agent_sandbox(
     sandbox.metadata.labels = Some(labels);
     sandbox.metadata.annotations = Some(annotations);
     Ok(sandbox)
-}
-
-// The overlay's `SYSTEM_PROMPT.md` is staged by the init container into a tiny
-// shared volume and surfaced to the agent at `$HOME/AGENTS_OVERLAY.md`, which
-// the sandbox entrypoint appends to the base prompt.
-const OVERLAY_PROMPT_VOLUME: &str = "overlay-prompt";
-const OVERLAY_PROMPT_DIR: &str = "/overlay-prompt";
-const OVERLAY_PROMPT_FILE: &str = "AGENTS_OVERLAY.md";
-const AGENT_OVERLAY_PROMPT_PATH: &str = "/home/agent/AGENTS_OVERLAY.md";
-const OVERLAY_SYSTEM_PROMPT_REL: &str = "services/sandbox/SYSTEM_PROMPT.md";
-
-/// The shared overlay plumbing: an `overlay-bootstrap` init container copies the
-/// overlay image's tree into the `overlay-root` emptyDir mounted read-only into
-/// the main container at `mount_path`, and stages the overlay's
-/// `SYSTEM_PROMPT.md` as `$HOME/AGENTS_OVERLAY.md`.
-fn overlay_json(
-    overlay: Option<&OverlayImage>,
-    volumes: &mut Vec<Value>,
-    volume_mounts: &mut Vec<Value>,
-) -> Vec<Value> {
-    let Some(overlay) = overlay else {
-        return Vec::new();
-    };
-
-    let volume_name = "overlay-root";
-    let init_mount_path = "/centaur-overlay-target";
-    volumes.push(json!({
-        "name": volume_name,
-        "emptyDir": {},
-    }));
-    volumes.push(json!({
-        "name": OVERLAY_PROMPT_VOLUME,
-        "emptyDir": {},
-    }));
-    volume_mounts.push(json!({
-        "name": volume_name,
-        "mountPath": overlay.mount_path,
-        "readOnly": true,
-    }));
-    volume_mounts.push(json!({
-        "name": OVERLAY_PROMPT_VOLUME,
-        "mountPath": AGENT_OVERLAY_PROMPT_PATH,
-        "subPath": OVERLAY_PROMPT_FILE,
-        "readOnly": true,
-    }));
-
-    let mut init_container = json!({
-        "name": "overlay-bootstrap",
-        "image": overlay.image,
-        "command": ["/bin/sh", "-ec"],
-        "args": [format!(
-            "src={}; target={}; mkdir -p \"$target\"; cp -R \"$src\"/. \"$target\"/; \
-             if [ -f \"$target/{OVERLAY_SYSTEM_PROMPT_REL}\" ]; then \
-             cp \"$target/{OVERLAY_SYSTEM_PROMPT_REL}\" '{OVERLAY_PROMPT_DIR}/{OVERLAY_PROMPT_FILE}'; \
-             else : > '{OVERLAY_PROMPT_DIR}/{OVERLAY_PROMPT_FILE}'; fi",
-            shell_quote(&overlay.source_path),
-            shell_quote(init_mount_path),
-        )],
-        "volumeMounts": [
-            {
-                "name": volume_name,
-                "mountPath": init_mount_path,
-            },
-            {
-                "name": OVERLAY_PROMPT_VOLUME,
-                "mountPath": OVERLAY_PROMPT_DIR,
-            },
-        ],
-        "securityContext": tools::security_context_json(),
-    });
-    insert_optional(
-        &mut init_container,
-        "imagePullPolicy",
-        overlay.image_pull_policy.clone(),
-    );
-    vec![init_container]
-}
-
-fn shell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', r#"'\''"#))
 }
 
 fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
@@ -810,7 +714,7 @@ fn map_kube_error(operation: &str, err: Error) -> SandboxError {
 
 #[cfg(test)]
 mod tests {
-    use centaur_sandbox_core::{OverlayImage, ResourceLimits, SandboxSpec};
+    use centaur_sandbox_core::{ResourceLimits, SandboxSpec};
     use k8s_openapi::api::core::v1::{PodCondition, PodStatus};
 
     use super::*;
@@ -854,141 +758,6 @@ mod tests {
         assert_eq!(container.stdin, Some(true));
         assert_eq!(container.volume_mounts.as_ref().unwrap().len(), 2);
         assert!(container.resources.as_ref().unwrap().limits.is_some());
-    }
-
-    #[test]
-    fn builds_agent_sandbox_spec_with_overlay_image() {
-        let spec = SandboxSpec::new("centaur-agent:latest").overlay_image(
-            OverlayImage::new(
-                "ghcr.io/example/centaur-overlay:test",
-                "/overlay",
-                "/opt/centaur/overlay",
-            )
-            .image_pull_policy("Always"),
-        );
-        let mut config = AgentSandboxConfig::new("centaur");
-        config.image_pull_secrets = vec!["github-access-token-read-packages".to_owned()];
-
-        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
-
-        let pod_spec = &sandbox.spec.pod_template.spec;
-        let init = &pod_spec.init_containers.as_ref().unwrap()[0];
-        assert_eq!(init.name, "overlay-bootstrap");
-        assert_eq!(
-            init.image.as_deref(),
-            Some("ghcr.io/example/centaur-overlay:test")
-        );
-        assert_eq!(init.image_pull_policy.as_deref(), Some("Always"));
-        assert!(
-            init.args
-                .as_ref()
-                .unwrap()
-                .iter()
-                .any(|arg| arg.contains("src='/overlay'"))
-        );
-        assert!(
-            pod_spec
-                .volumes
-                .as_ref()
-                .unwrap()
-                .iter()
-                .any(|volume| volume.name == "overlay-root")
-        );
-        assert_eq!(
-            pod_spec.image_pull_secrets.as_ref().unwrap()[0]
-                .name
-                .as_deref(),
-            Some("github-access-token-read-packages")
-        );
-        let container = &pod_spec.containers[0];
-        let overlay_mount = container
-            .volume_mounts
-            .as_ref()
-            .unwrap()
-            .iter()
-            .find(|mount| mount.name == "overlay-root")
-            .expect("main container overlay mount");
-        assert_eq!(overlay_mount.mount_path, "/opt/centaur/overlay");
-        assert_eq!(overlay_mount.read_only, Some(true));
-    }
-
-    #[test]
-    fn builds_agent_sandbox_spec_with_overlay_without_tools() {
-        let spec = SandboxSpec::new("centaur-agent:latest");
-        let config = AgentSandboxConfig::new("centaur").overlay(OverlayImage::new(
-            "overlay:test",
-            "/overlay",
-            "/opt/centaur/overlay",
-        ));
-
-        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
-        let pod_spec = &sandbox.spec.pod_template.spec;
-        let container = &pod_spec.containers[0];
-
-        let env = container.env.as_ref().unwrap();
-        assert!(env.iter().any(|env| {
-            env.name == "TOOL_DIRS"
-                && env.value.as_deref() == Some("/app/tools:/opt/centaur/overlay/tools")
-        }));
-        assert!(env.iter().any(|env| {
-            env.name == "CENTAUR_OVERLAY_DIR"
-                && env.value.as_deref() == Some("/opt/centaur/overlay")
-        }));
-
-        let volumes = pod_spec.volumes.as_ref().unwrap();
-        assert!(
-            volumes
-                .iter()
-                .any(|volume| { volume.name == "overlay-root" && volume.empty_dir.is_some() })
-        );
-        assert!(
-            volumes
-                .iter()
-                .any(|volume| { volume.name == "overlay-prompt" && volume.empty_dir.is_some() })
-        );
-        assert!(!volumes.iter().any(|volume| volume.name == "tools-root"));
-
-        let mounts = container.volume_mounts.as_ref().unwrap();
-        assert!(mounts.iter().any(|mount| mount.name == "overlay-root"));
-        assert!(mounts.iter().any(|mount| mount.name == "overlay-prompt"));
-
-        let init_containers = pod_spec.init_containers.as_ref().unwrap();
-        assert_eq!(init_containers.len(), 1);
-        assert_eq!(init_containers[0].name, "overlay-bootstrap");
-    }
-
-    #[test]
-    fn spec_level_overlay_wins_over_backend_default() {
-        // A workflow-host spec carries its own overlay while the backend has a
-        // default — the two must collapse into ONE overlay-bootstrap/overlay-root
-        // pair (duplicate names are an invalid pod), with the spec's winning.
-        let spec = SandboxSpec::new("centaur-agent:latest").overlay_image(OverlayImage::new(
-            "overlay:spec",
-            "/overlay",
-            "/opt/centaur/overlay",
-        ));
-        let config = AgentSandboxConfig::new("centaur").overlay(OverlayImage::new(
-            "overlay:config",
-            "/overlay",
-            "/opt/centaur/overlay",
-        ));
-
-        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
-        let pod_spec = &sandbox.spec.pod_template.spec;
-
-        let init_containers = pod_spec.init_containers.as_ref().unwrap();
-        assert_eq!(init_containers.len(), 1);
-        assert_eq!(init_containers[0].name, "overlay-bootstrap");
-        assert_eq!(init_containers[0].image.as_deref(), Some("overlay:spec"));
-
-        let overlay_volumes = pod_spec
-            .volumes
-            .as_ref()
-            .unwrap()
-            .iter()
-            .filter(|volume| volume.name == "overlay-root")
-            .count();
-        assert_eq!(overlay_volumes, 1);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
@@ -1,4 +1,4 @@
-//! Tool sources + gerard overlay wiring for agent sandboxes.
+//! Tool sources for agent sandboxes.
 //!
 //! api-rs serves no `/tools` HTTP registry and the agent's `call <tool>` HTTP
 //! registry is deprecated upstream (control-plane-only). Instead the agent
@@ -12,29 +12,23 @@
 //! trees api-rs's own `tool_discovery` scans, so the creds api-rs grants match
 //! the tools the agent installs:
 //!
-//! * a `tools-bootstrap` init container git-clones the tools repo at a pinned
-//!   ref and copies its `source_subdir` into an emptyDir mounted at `/app/tools`
-//!   — the same repo-cache architecture (clone a repo into a pre-provisioned
-//!   directory, no Dockerfile rebuild to add a tool) without sharing the
-//!   repo-cache DaemonSet's node-level cache;
-//! * the org overlay rides the shared spec-level [`OverlayImage`] plumbing
-//!   (`overlay_json` in `lib.rs`, the same mechanism and `/opt/centaur/overlay`
-//!   mount workflow-host sandboxes use), which also stages the overlay's
-//!   `SYSTEM_PROMPT.md` as `$HOME/AGENTS_OVERLAY.md` for the sandbox entrypoint
-//!   to append to the base prompt.
-//!
-//! `TOOL_DIRS` is set explicitly on the agent env to `/app/tools` (or
-//! `/app/tools:<mount_path>/tools` when the overlay is configured), pointing at
-//! the paths the init containers populate in this pod.
+//! * a `tools-bootstrap` init container copies the tools repo's `source_subdir`
+//!   from the repo-cache DaemonSet's node-level cache when configured, otherwise
+//!   it git-clones the tools repo at a pinned ref into an emptyDir mounted at
+//!   `/app/tools`;
+//! `TOOL_DIRS` is set explicitly on the agent env to `/app/tools`, pointing at
+//! the path the init container populates in this pod. The copied tools tree keeps
+//! source metadata in a hidden file so `centaur-tools refresh` can either re-copy
+//! from repo-cache or fetch the configured ref, then reinstall shims without
+//! restarting the pod.
 
-use centaur_sandbox_core::OverlayImage;
 use serde_json::{Value, json};
 
 const AGENT_UID: i64 = 1001;
 
 /// Base tools path inside both the api-rs pod and the agent sandbox.
 pub(crate) const BASE_TOOL_DIR: &str = "/app/tools";
-/// emptyDir the `tools-bootstrap` init container clones the tools tree into.
+/// emptyDir the `tools-bootstrap` init container publishes the tools tree into.
 const TOOLS_VOLUME: &str = "tools-root";
 /// Staging path where `tools-bootstrap` mounts the tools emptyDir. The agent
 /// container mounts the same volume read-only at `BASE_TOOL_DIR`.
@@ -43,6 +37,8 @@ const TOOLS_BOOTSTRAP_DIR: &str = "/tools-bootstrap";
 const GITHUB_TOKEN_VOLUME: &str = "tools-github-token";
 const GITHUB_TOKEN_DIR: &str = "/tools-github-token";
 const GITHUB_TOKEN_FILE: &str = "token";
+const GITHUB_TOKEN_FILE_PATH: &str = "/tools-github-token/token";
+const REPO_CACHE_VOLUME: &str = "tools-repo-cache";
 
 /// Git source for the base tools tree. When set, every sandbox gets a
 /// `tools-bootstrap` init container that clones `repo` at `git_ref` and copies
@@ -61,6 +57,10 @@ pub struct ToolsConfig {
     pub image_pull_policy: Option<String>,
     /// GitHub token secret for private-repo clones. `None` => unauthenticated clone.
     pub github_token: Option<GitHubTokenRef>,
+    /// Optional repo-cache root path mounted from the host. When set,
+    /// tools-bootstrap copies from `<repo_cache_path>/<repo>/<source_subdir>` and
+    /// `centaur-tools refresh` re-copies from the same cache instead of fetching.
+    pub repo_cache_path: Option<String>,
 }
 
 /// A Kubernetes Secret key holding a GitHub token, fed to `git` via `GIT_ASKPASS`.
@@ -79,6 +79,7 @@ impl ToolsConfig {
             image: image.into(),
             image_pull_policy: None,
             github_token: None,
+            repo_cache_path: None,
         }
     }
 }
@@ -101,21 +102,22 @@ pub(crate) fn pod_security_context_json() -> Value {
     })
 }
 
-/// `TOOL_DIRS` for the agent: base tools plus the overlay's tools when present.
-/// Matches the value the api-rs Deployment computes for its own `TOOL_DIRS`.
-pub(crate) fn agent_tool_dirs(overlay: Option<&OverlayImage>) -> String {
-    match overlay {
-        Some(overlay) => format!("{BASE_TOOL_DIR}:{}/tools", overlay.mount_path),
-        None => BASE_TOOL_DIR.to_owned(),
-    }
+/// `TOOL_DIRS` for the agent. Matches the path tools-bootstrap populates.
+pub(crate) fn agent_tool_dirs() -> String {
+    BASE_TOOL_DIR.to_owned()
 }
 
-/// Agent env added for tools/overlay wiring: `TOOL_DIRS` (always) and
-/// `CENTAUR_OVERLAY_DIR` (when the overlay is configured).
-pub(crate) fn agent_env(overlay: Option<&OverlayImage>) -> Vec<(String, String)> {
-    let mut env = vec![("TOOL_DIRS".to_owned(), agent_tool_dirs(overlay))];
-    if let Some(overlay) = overlay {
-        env.push(("CENTAUR_OVERLAY_DIR".to_owned(), overlay.mount_path.clone()));
+/// Agent env added for tools wiring.
+pub(crate) fn agent_env(tools: Option<&ToolsConfig>) -> Vec<(String, String)> {
+    let mut env = vec![("TOOL_DIRS".to_owned(), agent_tool_dirs())];
+    if tools
+        .and_then(|tools| tools.github_token.as_ref())
+        .is_some()
+    {
+        env.push((
+            "CENTAUR_TOOLS_GITHUB_TOKEN_FILE".to_owned(),
+            GITHUB_TOKEN_FILE_PATH.to_owned(),
+        ));
     }
     env
 }
@@ -134,9 +136,10 @@ pub(crate) struct CloneProxy {
     pub ca_volume_mount: Value,
 }
 
-/// The `tools-bootstrap` init container: clones `repo` at `git_ref` (sparse, on
+/// The `tools-bootstrap` init container: copies `repo`'s `source_subdir` from
+/// repo-cache when configured, otherwise clones `repo` at `git_ref` (sparse, on
 /// `source_subdir`) and copies that subtree into the shared `tools-root` emptyDir
-/// the agent mounts read-only at `/app/tools`. With a `CloneProxy`, the clone
+/// the agent mounts at `/app/tools`. With a `CloneProxy`, the clone fallback
 /// rides the per-sandbox iron-proxy like all other sandbox egress.
 pub(crate) fn tools_init_container_json(
     tools: &ToolsConfig,
@@ -144,6 +147,20 @@ pub(crate) fn tools_init_container_json(
 ) -> Value {
     let repo_url = format!("https://github.com/{}.git", tools.repo);
     let subdir = &tools.source_subdir;
+    let repo_cache_repo_path = tools.repo_cache_path.as_ref().map(|path| {
+        format!(
+            "{}/{}",
+            path.trim_end_matches('/'),
+            tools.repo.trim_start_matches('/')
+        )
+    });
+    let metadata = json!({
+        "source_subdir": subdir,
+        "git_ref": tools.git_ref.as_deref(),
+        "source": if repo_cache_repo_path.is_some() { "repo_cache" } else { "git" },
+        "repo_cache_repo_path": repo_cache_repo_path.as_deref(),
+    })
+    .to_string();
 
     let proxy_exports = match clone_proxy {
         Some(proxy) => format!(
@@ -175,10 +192,10 @@ pub(crate) fn tools_init_container_json(
     // without one we check out the cloned default branch.
     let checkout = match &tools.git_ref {
         Some(git_ref) => format!(
-            "git -C \"$src\" -c gc.auto=0 fetch --quiet origin \"{git_ref}\" && \
-             git -C \"$src\" checkout --quiet --detach FETCH_HEAD"
+            "git -C \"$source\" -c gc.auto=0 fetch --quiet origin \"{git_ref}\" && \
+             git -C \"$source\" checkout --quiet --detach FETCH_HEAD"
         ),
-        None => "git -C \"$src\" checkout --quiet".to_owned(),
+        None => "git -C \"$source\" checkout --quiet".to_owned(),
     };
 
     // The per-sandbox proxy is created in the same reconcile as the Sandbox and
@@ -187,6 +204,34 @@ pub(crate) fn tools_init_container_json(
     // clone must retry through the connection-refused window rather than die.
     // repo/ref/subdir are operator config, but quote them anyway so a stray
     // space or metacharacter breaks loudly in git instead of in the shell.
+    let publish_script = if let Some(repo_cache_repo_path) = &repo_cache_repo_path {
+        format!(
+            "attempt=0\n\
+             cache_repo=\"{repo_cache_repo_path}\"\n\
+             until [ -d \"$cache_repo/.git\" ] && [ -d \"$cache_repo/{subdir}\" ]; do\n\
+             attempt=$((attempt + 1))\n\
+             if [ \"$attempt\" -ge 30 ]; then echo \"tools repo-cache entry unavailable after $attempt attempts: $cache_repo/{subdir}\" >&2; exit 1; fi\n\
+             sleep 2\n\
+             done\n\
+             find \"$target\" -mindepth 1 -maxdepth 1 ! -name '.centaur-tools-source.json' -exec rm -rf {{}} +\n\
+             cp -R \"$cache_repo/{subdir}/.\" \"$target\"/"
+        )
+    } else {
+        format!(
+            "source=\"$target/.centaur-source\"\n\
+             rm -rf \"$source\"\n\
+             until git clone --quiet --filter=blob:none --no-checkout \"{repo_url}\" \"$source\" && \
+             git -C \"$source\" sparse-checkout set \"{subdir}\" && \
+             {checkout}; do\n\
+             attempt=$((attempt + 1))\n\
+             if [ \"$attempt\" -ge 30 ]; then echo \"tools clone failed after $attempt attempts\" >&2; exit 1; fi\n\
+             rm -rf \"$source\"\n\
+             sleep 2\n\
+             done\n\
+             find \"$target\" -mindepth 1 -maxdepth 1 ! -name '.centaur-source' ! -name '.centaur-tools-source.json' -exec rm -rf {{}} +\n\
+             cp -R \"$source/{subdir}/.\" \"$target\"/"
+        )
+    };
     let script = format!(
         "set -e\n\
          {proxy_exports}\
@@ -194,18 +239,12 @@ pub(crate) fn tools_init_container_json(
          export GIT_TERMINAL_PROMPT=0\n\
          git config --global --add safe.directory '*'\n\
          attempt=0\n\
-         until src=\"$(mktemp -d)\" && \
-         git clone --quiet --filter=blob:none --no-checkout \"{repo_url}\" \"$src\" && \
-         git -C \"$src\" sparse-checkout set \"{subdir}\" && \
-         {checkout}; do\n\
-         attempt=$((attempt + 1))\n\
-         if [ \"$attempt\" -ge 30 ]; then echo \"tools clone failed after $attempt attempts\" >&2; exit 1; fi\n\
-         rm -rf \"$src\"\n\
-         sleep 2\n\
-         done\n\
          target=\"{TOOLS_BOOTSTRAP_DIR}\"\n\
          mkdir -p \"$target\"\n\
-         cp -R \"$src/{subdir}/.\" \"$target\"/"
+         {publish_script}\n\
+         cat > \"$target/.centaur-tools-source.json\" <<'CENTAUR_TOOLS_METADATA'\n\
+{metadata}\n\
+CENTAUR_TOOLS_METADATA"
     );
 
     let mut volume_mounts = vec![json!({"name": TOOLS_VOLUME, "mountPath": TOOLS_BOOTSTRAP_DIR})];
@@ -218,6 +257,13 @@ pub(crate) fn tools_init_container_json(
     }
     if let Some(proxy) = clone_proxy {
         volume_mounts.push(proxy.ca_volume_mount.clone());
+    }
+    if let Some(repo_cache_path) = &tools.repo_cache_path {
+        volume_mounts.push(json!({
+            "name": REPO_CACHE_VOLUME,
+            "mountPath": repo_cache_path,
+            "readOnly": true,
+        }));
     }
 
     let mut container = json!({
@@ -248,18 +294,42 @@ pub(crate) fn volumes_json(tools: Option<&ToolsConfig>) -> Vec<Value> {
                 },
             }));
         }
+        if let Some(repo_cache_path) = &tools.repo_cache_path {
+            volumes.push(json!({
+                "name": REPO_CACHE_VOLUME,
+                "hostPath": {
+                    "path": repo_cache_path,
+                    "type": "DirectoryOrCreate",
+                },
+            }));
+        }
     }
     volumes
 }
 
-/// Volume mounts added to the AGENT container: the base tools tree at
-/// `/app/tools`. (Overlay mounts ride the shared spec-level overlay plumbing.)
-pub(crate) fn agent_volume_mounts_json(tools: bool) -> Vec<Value> {
-    if tools {
-        vec![json!({"name": TOOLS_VOLUME, "mountPath": BASE_TOOL_DIR, "readOnly": true})]
-    } else {
-        Vec::new()
+/// Volume mounts added to the AGENT container: the tools tree at `/app/tools`.
+/// It is writable so `centaur-tools refresh` can publish a freshly fetched tree
+/// into the same emptyDir and reinstall shims without restarting the pod.
+pub(crate) fn agent_volume_mounts_json(tools: Option<&ToolsConfig>) -> Vec<Value> {
+    let Some(tools) = tools else {
+        return Vec::new();
+    };
+    let mut mounts = vec![json!({"name": TOOLS_VOLUME, "mountPath": BASE_TOOL_DIR})];
+    if tools.github_token.is_some() {
+        mounts.push(json!({
+            "name": GITHUB_TOKEN_VOLUME,
+            "mountPath": GITHUB_TOKEN_DIR,
+            "readOnly": true,
+        }));
     }
+    if let Some(repo_cache_path) = &tools.repo_cache_path {
+        mounts.push(json!({
+            "name": REPO_CACHE_VOLUME,
+            "mountPath": repo_cache_path,
+            "readOnly": true,
+        }));
+    }
+    mounts
 }
 
 #[cfg(test)]
@@ -267,30 +337,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn tool_dirs_include_overlay_tools_at_its_mount_path() {
-        assert_eq!(agent_tool_dirs(None), "/app/tools");
-        let overlay = OverlayImage::new("centaur-overlay:test", "/overlay", "/opt/centaur/overlay");
-        assert_eq!(
-            agent_tool_dirs(Some(&overlay)),
-            "/app/tools:/opt/centaur/overlay/tools"
-        );
+    fn tool_dirs_point_at_bootstrapped_tools() {
+        assert_eq!(agent_tool_dirs(), "/app/tools");
     }
 
     #[test]
-    fn agent_env_sets_tool_dirs_and_overlay_dir() {
+    fn agent_env_sets_tool_dirs() {
         let env = agent_env(None);
         assert_eq!(env, vec![("TOOL_DIRS".to_owned(), "/app/tools".to_owned())]);
-
-        let overlay = OverlayImage::new("centaur-overlay:test", "/overlay", "/opt/centaur/overlay");
-        let env = agent_env(Some(&overlay));
-        assert!(env.contains(&(
-            "TOOL_DIRS".to_owned(),
-            "/app/tools:/opt/centaur/overlay/tools".to_owned()
-        )));
-        assert!(env.contains(&(
-            "CENTAUR_OVERLAY_DIR".to_owned(),
-            "/opt/centaur/overlay".to_owned()
-        )));
     }
 
     #[test]
@@ -306,7 +360,9 @@ mod tests {
         ));
         assert!(script.contains("sparse-checkout set \"tools\""));
         assert!(script.contains("fetch --quiet origin \"main\""));
-        assert!(script.contains("cp -R \"$src/tools/.\" \"$target\"/"));
+        assert!(script.contains("source=\"$target/.centaur-source\""));
+        assert!(script.contains("cp -R \"$source/tools/.\" \"$target\"/"));
+        assert!(script.contains(".centaur-tools-source.json"));
         // No token configured => no askpass, single (tools) volume mount.
         assert!(!script.contains("GIT_ASKPASS"));
         assert_eq!(c["volumeMounts"].as_array().unwrap().len(), 1);
@@ -325,7 +381,7 @@ mod tests {
             .as_str()
             .unwrap()
             .to_owned();
-        assert!(script.contains("until src=\"$(mktemp -d)\""));
+        assert!(script.contains("until git clone"));
         assert!(script.contains("checkout --quiet --detach FETCH_HEAD; do"));
         assert!(script.contains("if [ \"$attempt\" -ge 30 ]"));
         assert!(script.contains("sleep 2"));
@@ -369,8 +425,39 @@ mod tests {
             .unwrap()
             .to_owned();
         // Default branch: plain checkout, no explicit ref fetch.
-        assert!(script.contains("git -C \"$src\" checkout --quiet; do"));
+        assert!(script.contains("git -C \"$source\" checkout --quiet; do"));
         assert!(!script.contains("fetch --quiet origin"));
+    }
+
+    #[test]
+    fn tools_init_can_copy_from_repo_cache() {
+        let mut tools = ToolsConfig::new("paradigmxyz/centaur", "centaur-agent:test");
+        tools.repo_cache_path = Some("/var/lib/centaur/repos".to_owned());
+
+        let c = tools_init_container_json(&tools, None);
+        let script = c["command"][2].as_str().unwrap();
+        assert!(script.contains("cache_repo=\"/var/lib/centaur/repos/paradigmxyz/centaur\""));
+        assert!(script.contains("cp -R \"$cache_repo/tools/.\" \"$target\"/"));
+        assert!(script.contains("\"source\":\"repo_cache\""));
+        assert!(!script.contains("git clone"));
+        assert!(c["volumeMounts"].as_array().unwrap().iter().any(|mount| {
+            mount["name"] == REPO_CACHE_VOLUME
+                && mount["mountPath"] == "/var/lib/centaur/repos"
+                && mount["readOnly"] == true
+        }));
+
+        let volumes = volumes_json(Some(&tools));
+        assert!(volumes.iter().any(|volume| {
+            volume["name"] == REPO_CACHE_VOLUME
+                && volume["hostPath"]["path"] == "/var/lib/centaur/repos"
+                && volume["hostPath"]["type"] == "DirectoryOrCreate"
+        }));
+        let mounts = agent_volume_mounts_json(Some(&tools));
+        assert!(mounts.iter().any(|mount| {
+            mount["name"] == REPO_CACHE_VOLUME
+                && mount["mountPath"] == "/var/lib/centaur/repos"
+                && mount["readOnly"] == true
+        }));
     }
 
     #[test]
@@ -415,12 +502,33 @@ mod tests {
     }
 
     #[test]
-    fn agent_mounts_tools_read_only() {
-        let mounts = agent_volume_mounts_json(true);
+    fn agent_mounts_tools_writable_for_refresh() {
+        let tools = ToolsConfig::new("paradigmxyz/centaur", "centaur-agent:test");
+        let mounts = agent_volume_mounts_json(Some(&tools));
         assert_eq!(mounts.len(), 1);
         assert_eq!(mounts[0]["mountPath"], "/app/tools");
-        assert_eq!(mounts[0]["readOnly"], true);
+        assert!(mounts[0].get("readOnly").is_none());
 
-        assert!(agent_volume_mounts_json(false).is_empty());
+        assert!(agent_volume_mounts_json(None).is_empty());
+    }
+
+    #[test]
+    fn agent_mounts_token_for_private_repo_refresh() {
+        let mut tools = ToolsConfig::new("paradigmxyz/centaur", "centaur-agent:test");
+        tools.github_token = Some(GitHubTokenRef {
+            secret_name: "centaur-repo-cache-github-token".to_owned(),
+            secret_key: "token".to_owned(),
+        });
+
+        let env = agent_env(Some(&tools));
+        assert!(env.contains(&(
+            "CENTAUR_TOOLS_GITHUB_TOKEN_FILE".to_owned(),
+            "/tools-github-token/token".to_owned()
+        )));
+        let mounts = agent_volume_mounts_json(Some(&tools));
+        assert_eq!(mounts.len(), 2);
+        assert!(mounts.iter().any(|mount| {
+            mount["mountPath"] == "/tools-github-token" && mount["readOnly"] == true
+        }));
     }
 }

--- a/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
@@ -16,4 +16,4 @@ pub use io::{SandboxIo, SandboxIoGuard, SandboxIoParts, SandboxRead, SandboxWrit
 pub use lifecycle::{
     DesiredSandboxState, ObservedSandbox, SandboxHandle, SandboxId, SandboxStatus,
 };
-pub use spec::{EnvVar, Mount, MountKind, OverlayImage, ResourceLimits, SandboxSpec};
+pub use spec::{EnvVar, Mount, MountKind, ResourceLimits, SandboxSpec};

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -5,8 +5,6 @@ pub struct SandboxSpec {
     pub image: String,
     #[serde(default)]
     pub labels: std::collections::BTreeMap<String, String>,
-    #[serde(default)]
-    pub overlay: Option<OverlayImage>,
     pub command: Option<Vec<String>>,
     pub args: Vec<String>,
     pub env: Vec<EnvVar>,
@@ -25,7 +23,6 @@ impl SandboxSpec {
         Self {
             image: image.into(),
             labels: std::collections::BTreeMap::new(),
-            overlay: None,
             command: None,
             args: Vec::new(),
             env: Vec::new(),
@@ -43,11 +40,6 @@ impl SandboxSpec {
 
     pub fn label(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.labels.insert(name.into(), value.into());
-        self
-    }
-
-    pub fn overlay_image(mut self, overlay: OverlayImage) -> Self {
-        self.overlay = Some(overlay);
         self
     }
 
@@ -78,34 +70,6 @@ impl SandboxSpec {
 
     pub fn resources(mut self, resources: ResourceLimits) -> Self {
         self.resources = Some(resources);
-        self
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct OverlayImage {
-    pub image: String,
-    pub source_path: String,
-    pub mount_path: String,
-    pub image_pull_policy: Option<String>,
-}
-
-impl OverlayImage {
-    pub fn new(
-        image: impl Into<String>,
-        source_path: impl Into<String>,
-        mount_path: impl Into<String>,
-    ) -> Self {
-        Self {
-            image: image.into(),
-            source_path: source_path.into(),
-            mount_path: mount_path.into(),
-            image_pull_policy: None,
-        }
-    }
-
-    pub fn image_pull_policy(mut self, image_pull_policy: impl Into<String>) -> Self {
-        self.image_pull_policy = Some(image_pull_policy.into());
         self
     }
 }

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -1,4 +1,11 @@
-use std::{collections::BTreeMap, env, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    env,
+    path::PathBuf,
+    str::FromStr,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 use absurd::{
     Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy, SpawnOptions, StepHandle,
@@ -38,6 +45,8 @@ const DEFAULT_AGENT_IDLE_TIMEOUT_MS: u64 = 60_000;
 const DEFAULT_AGENT_MAX_DURATION_MS: u64 = 30 * 60 * 1_000;
 const WORKFLOW_HOST_CLAIM_EXTENSION: Duration = Duration::from_secs(5 * 60);
 const WORKFLOW_HOST_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
+const WORKFLOW_RECONCILE_INTERVAL_SECS_ENV: &str = "WORKFLOW_RECONCILE_INTERVAL_SECS";
+const DEFAULT_WORKFLOW_RECONCILE_INTERVAL_SECS: u64 = 60;
 
 struct WorkflowTaskHeartbeatGuard {
     task: JoinHandle<()>,
@@ -60,8 +69,8 @@ struct WorkflowRuntimeInner {
     _worker: Worker,
     _etl_worker: Worker,
     _schedule_worker: Worker,
-    webhook_registry: BTreeMap<String, RegisteredWorkflowWebhook>,
-    schedule_registry: Arc<BTreeMap<String, RegisteredWorkflowSchedule>>,
+    webhook_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowWebhook>>>,
+    schedule_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
 }
 
 #[derive(Clone)]
@@ -285,7 +294,8 @@ impl WorkflowRuntime {
                 warn!(%error, "python workflow discovery failed");
                 PythonWorkflowMetadata::default()
             });
-        let schedule_registry = Arc::new(build_schedule_registry(&discovery)?);
+        let schedule_registry = Arc::new(RwLock::new(build_schedule_registry(&discovery)?));
+        let webhook_registry = Arc::new(RwLock::new(build_webhook_registry(&discovery)?));
 
         let task_session_runtime = session_runtime.clone();
         let task_workflow_host_sandbox = workflow_host_sandbox.clone();
@@ -325,7 +335,11 @@ impl WorkflowRuntime {
                 }
             },
         )?;
-        reconcile_schedules(&schedule_client, &schedule_registry).await?;
+        let startup_schedules = schedule_registry
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        reconcile_schedules(&schedule_client, &startup_schedules).await?;
 
         let worker = client.start_worker(WorkerOptions {
             worker_id: Some("centaur-api-rs-workflow-worker".to_owned()),
@@ -367,6 +381,15 @@ impl WorkflowRuntime {
             "started absurd workflow schedule worker"
         );
 
+        if let Some(interval) = workflow_reconcile_interval() {
+            spawn_workflow_metadata_reconciler(
+                schedule_client.clone(),
+                webhook_registry.clone(),
+                schedule_registry.clone(),
+                interval,
+            );
+        }
+
         Ok(Self {
             inner: Arc::new(WorkflowRuntimeInner {
                 client,
@@ -374,7 +397,7 @@ impl WorkflowRuntime {
                 _worker: worker,
                 _etl_worker: etl_worker,
                 _schedule_worker: schedule_worker,
-                webhook_registry: build_webhook_registry(&discovery)?,
+                webhook_registry,
                 schedule_registry,
             }),
         })
@@ -530,15 +553,32 @@ impl WorkflowRuntime {
     }
 
     pub fn get_webhook(&self, slug: &str) -> Option<RegisteredWorkflowWebhook> {
-        self.inner.webhook_registry.get(slug).cloned()
+        self.inner
+            .webhook_registry
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(slug)
+            .cloned()
     }
 
     pub fn list_webhooks(&self) -> Vec<RegisteredWorkflowWebhook> {
-        self.inner.webhook_registry.values().cloned().collect()
+        self.inner
+            .webhook_registry
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values()
+            .cloned()
+            .collect()
     }
 
     pub fn list_schedules(&self) -> Vec<RegisteredWorkflowSchedule> {
-        self.inner.schedule_registry.values().cloned().collect()
+        self.inner
+            .schedule_registry
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values()
+            .cloned()
+            .collect()
     }
 
     fn client_for_workflow(&self, workflow_name: &str) -> &Client {
@@ -1113,21 +1153,109 @@ async fn reconcile_schedules(
     Ok(())
 }
 
+fn workflow_reconcile_interval() -> Option<Duration> {
+    let seconds = env::var(WORKFLOW_RECONCILE_INTERVAL_SECS_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_WORKFLOW_RECONCILE_INTERVAL_SECS);
+    (seconds > 0).then(|| Duration::from_secs(seconds))
+}
+
+fn spawn_workflow_metadata_reconciler(
+    schedule_client: Client,
+    webhook_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowWebhook>>>,
+    schedule_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
+    interval: Duration,
+) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // Startup discovery already ran; wait one full period before refreshing.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            if let Err(error) = reconcile_workflow_metadata_once(
+                &schedule_client,
+                &webhook_registry,
+                &schedule_registry,
+            )
+            .await
+            {
+                warn!(%error, "failed to reconcile workflow metadata");
+            }
+        }
+    });
+}
+
+async fn reconcile_workflow_metadata_once(
+    schedule_client: &Client,
+    webhook_registry: &Arc<RwLock<BTreeMap<String, RegisteredWorkflowWebhook>>>,
+    schedule_registry: &Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
+) -> Result<(), WorkflowRuntimeError> {
+    let discovery = discover_python_workflow_metadata().await?;
+    let next_webhooks = build_webhook_registry(&discovery)?;
+    let next_schedules = build_schedule_registry(&discovery)?;
+    {
+        let mut webhooks = webhook_registry
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *webhooks = next_webhooks;
+    }
+    {
+        let mut schedules = schedule_registry
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *schedules = next_schedules.clone();
+    }
+    reconcile_schedules(schedule_client, &next_schedules).await?;
+    info!(
+        webhook_count = discovery.webhooks.len(),
+        schedule_count = discovery.schedules.len(),
+        "reconciled workflow metadata"
+    );
+    Ok(())
+}
+
 async fn run_schedule_tick(
     input: ScheduleTickInput,
     ctx: TaskContext,
     schedule_client: Client,
     workflow_client: Client,
     etl_client: Client,
-    schedules: Arc<BTreeMap<String, RegisteredWorkflowSchedule>>,
+    schedules: Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
 ) -> Result<Value, absurd::Error> {
-    let schedule = schedules.get(&input.schedule_id).ok_or_else(|| {
-        absurd::Error::InvalidOptions(format!(
-            "unknown workflow schedule_id {:?}",
-            input.schedule_id
-        ))
-    })?;
     ctx.sleep_until("schedule_tick", input.scheduled_at).await?;
+    let schedule = match schedules
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&input.schedule_id)
+        .cloned()
+    {
+        Some(schedule) if schedule.enabled => schedule,
+        Some(schedule) => {
+            info!(
+                schedule_id = %schedule.schedule_id,
+                "skipping disabled workflow schedule tick"
+            );
+            return Ok(json!({
+                "schedule_id": schedule.schedule_id,
+                "scheduled_at": input.scheduled_at.to_rfc3339(),
+                "skipped": true,
+                "reason": "disabled",
+            }));
+        }
+        None => {
+            info!(
+                schedule_id = %input.schedule_id,
+                "skipping removed workflow schedule tick"
+            );
+            return Ok(json!({
+                "schedule_id": input.schedule_id,
+                "scheduled_at": input.scheduled_at.to_rfc3339(),
+                "skipped": true,
+                "reason": "removed",
+            }));
+        }
+    };
     let fire_key = format!(
         "schedule:{}:{}",
         schedule.schedule_id,
@@ -1151,8 +1279,8 @@ async fn run_schedule_tick(
             },
         )
         .await?;
-    let next_run_at = next_schedule_time(schedule, Utc::now()).map_err(absurd_error)?;
-    spawn_schedule_tick(&schedule_client, schedule, next_run_at)
+    let next_run_at = next_schedule_time(&schedule, Utc::now()).map_err(absurd_error)?;
+    spawn_schedule_tick(&schedule_client, &schedule, next_run_at)
         .await
         .map_err(absurd_error)?;
     Ok(json!({

--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -7,13 +7,111 @@ import json
 import os
 from pathlib import Path
 import shlex
+import shutil
 import stat
+import subprocess
 import sys
+import tempfile
 import tomllib
 
 
 def _split_paths(value: str) -> list[Path]:
     return [Path(part) for part in value.split(":") if part]
+
+
+def _git_env() -> tuple[dict[str, str], tempfile.TemporaryDirectory[str] | None]:
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    token_file = os.environ.get("CENTAUR_TOOLS_GITHUB_TOKEN_FILE")
+    if not token_file:
+        return env, None
+    temp_dir = tempfile.TemporaryDirectory(prefix="centaur-tools-askpass-")
+    askpass = Path(temp_dir.name) / "askpass.sh"
+    askpass.write_text(
+        "#!/bin/sh\n"
+        "case \"$1\" in\n"
+        "  *Username*) echo x-access-token;;\n"
+        f"  *Password*) cat {shlex.quote(token_file)};;\n"
+        "  *) echo;;\n"
+        "esac\n"
+    )
+    askpass.chmod(0o700)
+    env["GIT_ASKPASS"] = str(askpass)
+    return env, temp_dir
+
+
+def _publish_tools(tool_dir: Path, published: Path) -> None:
+    if not published.is_dir():
+        raise RuntimeError(f"refreshed tools subdir does not exist: {published}")
+
+    for child in tool_dir.iterdir():
+        if child.name in {".centaur-source", ".centaur-tools-source.json"}:
+            continue
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+    for child in published.iterdir():
+        target = tool_dir / child.name
+        if child.is_dir() and not child.is_symlink():
+            shutil.copytree(child, target, symlinks=True)
+        else:
+            shutil.copy2(child, target, follow_symlinks=False)
+
+
+def _refresh_tool_dir(tool_dir: Path) -> bool:
+    source = tool_dir / ".centaur-source"
+    metadata_path = tool_dir / ".centaur-tools-source.json"
+    if not metadata_path.is_file():
+        return False
+
+    metadata = json.loads(metadata_path.read_text())
+    subdir = metadata.get("source_subdir") or "tools"
+    if metadata.get("source") == "repo_cache":
+        repo_cache_repo_path = metadata.get("repo_cache_repo_path")
+        if not repo_cache_repo_path:
+            raise RuntimeError(f"repo-cache tools metadata is missing repo_cache_repo_path: {metadata_path}")
+        _publish_tools(tool_dir, Path(repo_cache_repo_path) / subdir)
+        return True
+
+    if not source.is_dir():
+        return False
+
+    git_ref = metadata.get("git_ref")
+    env, temp_dir = _git_env()
+    try:
+        if git_ref:
+            subprocess.run(
+                ["git", "-C", str(source), "-c", "gc.auto=0", "fetch", "--quiet", "origin", str(git_ref)],
+                check=True,
+                env=env,
+            )
+            subprocess.run(
+                ["git", "-C", str(source), "checkout", "--quiet", "--detach", "FETCH_HEAD"],
+                check=True,
+                env=env,
+            )
+        else:
+            subprocess.run(
+                ["git", "-C", str(source), "pull", "--ff-only", "--quiet"],
+                check=True,
+                env=env,
+            )
+    finally:
+        if temp_dir is not None:
+            temp_dir.cleanup()
+
+    _publish_tools(tool_dir, source / subdir)
+    return True
+
+
+def _refresh_tool_dirs(tool_dirs: list[Path]) -> int:
+    refreshed = 0
+    for tool_dir in tool_dirs:
+        if _refresh_tool_dir(tool_dir):
+            refreshed += 1
+    return refreshed
 
 
 def _discover_scripts(tool_dirs: list[Path]) -> dict[str, dict[str, str]]:
@@ -22,7 +120,10 @@ def _discover_scripts(tool_dirs: list[Path]) -> dict[str, dict[str, str]]:
         if not tool_dir.is_dir():
             continue
         for pyproject in sorted(tool_dir.rglob("pyproject.toml")):
-            if any(part in {".git", ".venv", "__pycache__"} for part in pyproject.parts):
+            if any(
+                part in {".centaur-source", ".git", ".venv", "__pycache__"}
+                for part in pyproject.parts
+            ):
                 continue
             try:
                 data = tomllib.loads(pyproject.read_text())
@@ -91,28 +192,38 @@ def load():
 
 
 def usage():
-    print("usage: centaur-tools [list|json|which <name>|run <name> [args...]|call <name> <method> [json]]", file=sys.stderr)
+    print("usage: centaur-tools [list|json|refresh|which <name>|run <name> [args...]|call <name> <method> [json]]", file=sys.stderr)
     return 2
 
 
 CALL_RUNNER = r'''
 import asyncio
+import importlib
 import importlib.util
 import inspect
 import json
 from pathlib import Path
 import sys
 
-module_path = Path(sys.argv[1])
-method = sys.argv[2]
-payload = json.loads(sys.argv[3])
+project_dir = Path(sys.argv[1])
+client_module = sys.argv[2]
+method = sys.argv[3]
+payload = json.loads(sys.argv[4])
 
-spec = importlib.util.spec_from_file_location("_centaur_tool_client", module_path)
-if spec is None or spec.loader is None:
-    raise RuntimeError(f"cannot load client module from {{module_path}}")
-module = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = module
-spec.loader.exec_module(module)
+module_path = project_dir / client_module
+package_name = project_dir.name.replace("-", "_")
+if (project_dir / "__init__.py").is_file() and package_name.isidentifier() and module_path.suffix == ".py":
+    parent = str(project_dir.parent)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+    module = importlib.import_module(f"{{package_name}}.{{module_path.stem}}")
+else:
+    spec = importlib.util.spec_from_file_location("_centaur_tool_client", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load client module from {{module_path}}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
 
 target = getattr(module, method, None)
 if target is None and hasattr(module, "_client"):
@@ -134,7 +245,7 @@ print(json.dumps(result, default=str, separators=(",", ":")))
 
 def call_tool(tool, method, payload):
     project_dir = Path(tool["project_dir"])
-    module_path = project_dir / tool.get("client_module", "client.py")
+    client_module = tool.get("client_module", "client.py")
     env = os.environ.copy()
     if PYTHONPATH_VALUE:
         if env.get("PYTHONPATH"):
@@ -149,7 +260,8 @@ def call_tool(tool, method, payload):
             "python",
             "-c",
             CALL_RUNNER,
-            str(module_path),
+            str(project_dir),
+            client_module,
             method,
             json.dumps(payload, separators=(",", ":")),
         ],
@@ -162,6 +274,8 @@ def call_tool(tool, method, payload):
 
 def main(argv):
     command = argv[1] if len(argv) > 1 else "list"
+    if command == "refresh":
+        return subprocess.call(["install-tool-shims", "--refresh"])
     tools = load()
     by_name = {{tool["name"]: tool for tool in tools}}
     if command == "list":
@@ -212,13 +326,24 @@ if __name__ == "__main__":
     _write_executable(path, content)
 
 
-def main() -> int:
+def main(argv: list[str]) -> int:
+    refresh = "--refresh" in argv[1:]
     tool_dirs = _split_paths(os.environ.get("TOOL_DIRS", ""))
     bin_dir = Path(os.environ.get("CENTAUR_TOOL_BIN_DIR", str(Path.home() / ".local/bin")))
     bin_dir.mkdir(parents=True, exist_ok=True)
 
+    if refresh:
+        refreshed = _refresh_tool_dirs(tool_dirs)
+        print(f"refreshed {refreshed} Centaur tool source dirs", file=sys.stderr)
+
     scripts = _discover_scripts(tool_dirs)
-    pythonpath = os.environ.get("CENTAUR_TOOL_PYTHONPATH", "")
+    pythonpath_parts = [
+        part for part in os.environ.get("CENTAUR_TOOL_PYTHONPATH", "").split(os.pathsep) if part
+    ]
+    sdk_parent = Path("/opt/centaur")
+    if (sdk_parent / "centaur_sdk").is_dir() and str(sdk_parent) not in pythonpath_parts:
+        pythonpath_parts.append(str(sdk_parent))
+    pythonpath = os.pathsep.join(pythonpath_parts)
 
     for name, script in scripts.items():
         _write_tool_shim(bin_dir / name, script, pythonpath)
@@ -233,4 +358,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- make repo-cache the default source for sandbox tools and api-rs tool discovery
- support centaur-tools refresh from the live repo-cache checkout
- add in-process workflow metadata reconciliation for webhooks and schedules
- remove overlay image chart wiring and values/schema

## Validation
- cargo fmt --all --manifest-path services/api-rs/Cargo.toml
- cargo test --manifest-path services/api-rs/Cargo.toml -p centaur-workflows -p centaur-api-server -p centaur-sandbox-agent-k8s
- helm template centaur contrib/chart
- helm template centaur contrib/chart --set toolServer.enabled=false
- checked rendered manifests contain no overlay image refs
- git diff --check on touched files
