### PR TITLE
fix(api-rs): wire harness OTLP export so Laminar traces carry cost

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.49
+version: 0.1.50
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -201,6 +201,19 @@ spec:
               value: {{ .Values.sandbox.codexAuthMode | quote }}
             - name: CLAUDE_CODE_AUTH_MODE
               value: {{ .Values.sandbox.claudeCodeAuthMode | quote }}
+{{- $sandboxEnvList := list }}
+{{- range $k, $v := .Values.sandbox.extraEnv }}
+{{- $sandboxEnvList = append $sandboxEnvList (dict "name" $k "value" ($v | toString)) }}
+{{- end }}
+{{- if and $sandboxEnvList (not (hasKey .Values.apiRs.extraEnv "SESSION_SANDBOX_EXTRA_ENV")) }}
+            # Operator sandbox env (sandbox.extraEnv), applied to every codex
+            # sandbox api-rs creates. Carries the harness OTLP trace wiring
+            # (endpoint, service name, NO_PROXY extras) that codex needs to
+            # export usage/cost spans. Same contract as the Python control
+            # plane's KUBERNETES_SANDBOX_EXTRA_ENV.
+            - name: SESSION_SANDBOX_EXTRA_ENV
+              value: {{ $sandboxEnvList | toJson | quote }}
+{{- end }}
 {{- if .Values.ironControl.enabled }}
             # iron-control control plane: principals/roles/grants + per-sandbox
             # proxy sync. When unset, the api-rs falls back to the rendered

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -160,6 +160,18 @@ spec:
         - protocol: TCP
           port: {{ .Values.ironControl.service.httpPort }}
 {{- end }}
+{{- if .Values.networkPolicy.otlpEgress.enabled }}
+    # OTLP trace export (e.g. Laminar). The collector lives in another
+    # namespace; without this rule api-rs's own spans die with
+    # BatchSpanProcessor "network error" export failures.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ required "networkPolicy.otlpEgress.namespace is required when networkPolicy.otlpEgress.enabled" .Values.networkPolicy.otlpEgress.namespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.otlpEgress.port }}
+{{- end }}
     - ports:
         - protocol: TCP
           port: 443

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -374,6 +374,16 @@ networkPolicy:
   # the egress rule must allow it. Defaults to 6443 (k3s, kubeadm). Set to 443
   # on clusters whose API server endpoint already listens on 443.
   apiServerPort: 6443
+  # Egress to an in-cluster OTLP trace collector (e.g. Laminar) in another
+  # namespace. api-rs needs this to export its own spans; sandboxes get their
+  # equivalent per-sandbox rule from api-rs, derived from the OTLP endpoint in
+  # sandbox.extraEnv. The collector's own namespace must also admit ingress
+  # from this namespace's pods.
+  otlpEgress:
+    enabled: false
+    # kubernetes.io/metadata.name of the collector's namespace, e.g. "laminar".
+    namespace: ""
+    port: 8000
 
 podSecurityContext:
   fsGroupChangePolicy: OnRootMismatch

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3121,6 +3122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4093,6 +4100,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -90,4 +90,4 @@ tracing = "0.1"
 tracing-opentelemetry = "0.33.0"
 tracing-subscriber = "0.3"
 urlencoding = "2"
-uuid = { version = "1", features = ["serde", "v4"] }
+uuid = { version = "1", features = ["serde", "v4", "v5"] }

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -20,7 +20,7 @@ use centaur_iron_proxy::{
 };
 use centaur_sandbox_agent_k8s::{
     AgentSandboxBackend, AgentSandboxConfig, GitHubTokenRef, IronControlSettings, IronProxyConfig,
-    ToolSource, ToolsConfig,
+    OtlpEgressTarget, ToolSource, ToolsConfig,
 };
 use centaur_sandbox_core::{Mount, MountKind, SandboxSpec};
 use centaur_sandbox_local::LocalSandboxBackend;
@@ -29,7 +29,7 @@ use centaur_session_core::HarnessType;
 use centaur_session_runtime::SandboxWorkloadMode;
 use centaur_workflows::WorkflowHostSandboxRuntime;
 use clap::{Args as ClapArgs, Parser, ValueEnum};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::{
     ServerError,
@@ -507,6 +507,13 @@ struct SandboxArgs {
         value_delimiter = ','
     )]
     passthrough_env: Vec<String>,
+    /// Operator-supplied sandbox env as a JSON list of `{"name","value"}`
+    /// objects — the chart renders `sandbox.extraEnv` into this (the same
+    /// contract as the Python control plane's `KUBERNETES_SANDBOX_EXTRA_ENV`).
+    /// Carries the harness OTLP wiring (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`,
+    /// `OTEL_SERVICE_NAME`, NO_PROXY extras) into every codex sandbox.
+    #[arg(long = "session-sandbox-extra-env", env = "SESSION_SANDBOX_EXTRA_ENV")]
+    extra_env_json: Option<String>,
     #[command(flatten)]
     tools: ToolDiscoveryArgs,
     #[command(flatten)]
@@ -863,7 +870,106 @@ impl SandboxArgs {
             }
         }
 
+        // Operator extra env wins over template defaults (same precedence as
+        // the Python control plane). Proxy wiring stays safe: the backend's
+        // `apply_proxy_env` overrides the pinned proxy vars at create time and
+        // merges NO_PROXY instead of replacing it.
+        for (name, value) in self.sandbox_extra_env() {
+            if let Some((_, existing_value)) = envs
+                .iter_mut()
+                .find(|(existing_name, _)| existing_name == &name)
+            {
+                *existing_value = value;
+            } else {
+                envs.push((name, value));
+            }
+        }
+
         Ok(envs)
+    }
+
+    /// `SESSION_SANDBOX_EXTRA_ENV` parsed as a JSON list of `{"name","value"}`
+    /// objects. Invalid JSON or shapes are ignored (with a warning) rather than
+    /// failing startup, matching the Python control plane's behavior.
+    fn sandbox_extra_env(&self) -> Vec<(String, String)> {
+        let Some(raw) = self
+            .extra_env_json
+            .as_deref()
+            .map(str::trim)
+            .filter(|raw| !raw.is_empty())
+        else {
+            return Vec::new();
+        };
+        let parsed: serde_json::Value = match serde_json::from_str(raw) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                warn!(%error, "SESSION_SANDBOX_EXTRA_ENV is not valid JSON; ignoring");
+                return Vec::new();
+            }
+        };
+        let Some(items) = parsed.as_array() else {
+            warn!("SESSION_SANDBOX_EXTRA_ENV is not a JSON array; ignoring");
+            return Vec::new();
+        };
+        items
+            .iter()
+            .filter_map(|item| {
+                let name = item.get("name")?.as_str()?.trim();
+                if name.is_empty() || name.contains('=') {
+                    return None;
+                }
+                let value = match item.get("value") {
+                    None | Some(serde_json::Value::Null) => String::new(),
+                    Some(serde_json::Value::String(value)) => value.clone(),
+                    Some(other) => other.to_string(),
+                };
+                Some((name.to_owned(), value))
+            })
+            .collect()
+    }
+
+    /// Per-sandbox OTLP egress NetworkPolicy target, derived from the OTLP
+    /// endpoint the codex sandbox env will carry. Only in-cluster service DNS
+    /// endpoints (`<service>.<namespace>.svc[...]`) map to a namespace
+    /// selector; anything else gets no rule and a warning, because a silently
+    /// missing rule means harness usage/cost spans never reach the collector.
+    fn sandbox_otlp_egress_target(&self) -> Result<Option<OtlpEgressTarget>, ServerError> {
+        if !matches!(self.workload, SandboxWorkloadKind::CodexAppServer) {
+            return Ok(None);
+        }
+        let envs = self.codex_app_server_env_template()?;
+        let endpoint = [
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+        ]
+        .into_iter()
+        .find_map(|key| {
+            envs.iter()
+                .find(|(name, value)| name == key && !value.trim().is_empty())
+                .map(|(_, value)| value.trim().to_owned())
+        });
+        let Some(endpoint) = endpoint else {
+            return Ok(None);
+        };
+        match parse_otlp_egress_target(&endpoint) {
+            Some(target) => {
+                info!(
+                    namespace = %target.namespace,
+                    port = target.port,
+                    endpoint = %endpoint,
+                    "sandbox OTLP egress enabled"
+                );
+                Ok(Some(target))
+            }
+            None => {
+                warn!(
+                    endpoint = %endpoint,
+                    "sandbox OTLP endpoint is not an in-cluster service DNS name; \
+                     no sandbox egress NetworkPolicy rule will be created for it"
+                );
+                Ok(None)
+            }
+        }
     }
 
     fn workflow_host_env_template(&self) -> Result<Vec<(String, String)>, ServerError> {
@@ -1017,6 +1123,10 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         }
         config.iron_control = args.iron_control.settings();
         config.tools = args.tools_source.to_config();
+        // Direct harness OTLP export (codex usage/cost spans) needs a hole in
+        // the per-sandbox egress NetworkPolicy; derived from the sandbox's own
+        // OTLP endpoint env so there is a single source of truth.
+        config.otlp_egress = args.sandbox_otlp_egress_target()?;
         // iron-control is the only proxy mode: a per-sandbox proxy syncs its
         // secrets from the control plane, so configuring iron-proxy without
         // iron-control would produce a non-functional proxy. Fail fast.
@@ -1494,6 +1604,32 @@ fn parse_host_port(value: &str) -> Option<u16> {
     value.rsplit_once(':')?.1.parse().ok()
 }
 
+/// Map an OTLP endpoint URL onto a NetworkPolicy egress target. Only
+/// in-cluster service DNS hosts (`<service>.<namespace>.svc[.<cluster-domain>]`)
+/// are mapped; the namespace label is the policy's `kubernetes.io/metadata.name`
+/// selector. Ports default by scheme when absent.
+fn parse_otlp_egress_target(endpoint: &str) -> Option<OtlpEgressTarget> {
+    let trimmed = endpoint.trim();
+    let (scheme, rest) = trimmed.split_once("://").unwrap_or(("http", trimmed));
+    let authority = rest.split('/').next()?.trim();
+    let host_port = authority
+        .rsplit_once('@')
+        .map(|(_, host_port)| host_port)
+        .unwrap_or(authority);
+    let (host, port) = match host_port.rsplit_once(':') {
+        Some((host, port)) => (host, port.parse().ok()?),
+        None => (host_port, if scheme == "https" { 443 } else { 80 }),
+    };
+    let labels: Vec<&str> = host.split('.').collect();
+    if labels.len() < 3 || labels[2] != "svc" || labels[0].is_empty() || labels[1].is_empty() {
+        return None;
+    }
+    Some(OtlpEgressTarget {
+        namespace: labels[1].to_owned(),
+        port,
+    })
+}
+
 fn clean_optional_value(value: Option<&str>) -> Option<String> {
     non_empty(value).map(ToOwned::to_owned)
 }
@@ -1727,6 +1863,151 @@ mod tests {
         assert!(
             env.iter()
                 .any(|(name, value)| name == "OPENAI_API_KEY" && value == "OPENAI_API_KEY")
+        );
+    }
+
+    #[test]
+    fn codex_app_server_env_template_applies_extra_env_last() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-workload",
+            "codex-app-server",
+            "--session-sandbox-extra-env",
+            r#"[
+                {"name":"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT","value":"http://laminar-app-server.laminar.svc.cluster.local:8000/v1/traces"},
+                {"name":"OTEL_SERVICE_NAME","value":"codex"},
+                {"name":"CODEX_AUTH_MODE","value":"chatgpt"},
+                {"name":"NULL_VALUE"},
+                {"name":"  ","value":"skipped"},
+                {"name":"BAD=NAME","value":"skipped"}
+            ]"#,
+        ])
+        .unwrap();
+
+        let env = args.sandbox.codex_app_server_env_template().unwrap();
+        let value = |key: &str| {
+            env.iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value.as_str())
+        };
+
+        assert_eq!(
+            value("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"),
+            Some("http://laminar-app-server.laminar.svc.cluster.local:8000/v1/traces")
+        );
+        assert_eq!(value("OTEL_SERVICE_NAME"), Some("codex"));
+        // Operator extra env overrides template defaults.
+        assert_eq!(value("CODEX_AUTH_MODE"), Some("chatgpt"));
+        // Null values become empty strings; invalid names are dropped.
+        assert_eq!(value("NULL_VALUE"), Some(""));
+        assert!(!env.iter().any(|(name, _)| name == "BAD=NAME"));
+        // No duplicate entries for overridden names.
+        assert_eq!(
+            env.iter()
+                .filter(|(name, _)| name == "CODEX_AUTH_MODE")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn sandbox_extra_env_ignores_invalid_json() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-extra-env",
+            "not-json",
+        ])
+        .unwrap();
+
+        assert!(args.sandbox.sandbox_extra_env().is_empty());
+    }
+
+    #[test]
+    fn sandbox_otlp_egress_target_derived_from_extra_env_endpoint() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-workload",
+            "codex-app-server",
+            "--session-sandbox-extra-env",
+            r#"[{"name":"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT","value":"http://laminar-app-server.laminar.svc.cluster.local:8000/v1/traces"}]"#,
+        ])
+        .unwrap();
+
+        assert_eq!(
+            args.sandbox.sandbox_otlp_egress_target().unwrap(),
+            Some(OtlpEgressTarget {
+                namespace: "laminar".to_owned(),
+                port: 8000,
+            })
+        );
+    }
+
+    #[test]
+    fn sandbox_otlp_egress_target_absent_without_endpoint_or_for_mock_workload() {
+        let without_endpoint = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-workload",
+            "codex-app-server",
+        ])
+        .unwrap();
+        assert_eq!(
+            without_endpoint
+                .sandbox
+                .sandbox_otlp_egress_target()
+                .unwrap(),
+            None
+        );
+
+        let mock = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-extra-env",
+            r#"[{"name":"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT","value":"http://laminar-app-server.laminar.svc.cluster.local:8000/v1/traces"}]"#,
+        ])
+        .unwrap();
+        assert_eq!(mock.sandbox.sandbox_otlp_egress_target().unwrap(), None);
+    }
+
+    #[test]
+    fn parse_otlp_egress_target_accepts_only_in_cluster_service_dns() {
+        assert_eq!(
+            parse_otlp_egress_target(
+                "http://laminar-app-server.laminar.svc.cluster.local:8000/v1/traces"
+            ),
+            Some(OtlpEgressTarget {
+                namespace: "laminar".to_owned(),
+                port: 8000,
+            })
+        );
+        assert_eq!(
+            parse_otlp_egress_target("http://collector.observability.svc:4318"),
+            Some(OtlpEgressTarget {
+                namespace: "observability".to_owned(),
+                port: 4318,
+            })
+        );
+        assert_eq!(
+            parse_otlp_egress_target("https://collector.observability.svc.cluster.local"),
+            Some(OtlpEgressTarget {
+                namespace: "observability".to_owned(),
+                port: 443,
+            })
+        );
+        // External hosts and bare service names never map to a namespace rule.
+        assert_eq!(parse_otlp_egress_target("https://api.honeycomb.io"), None);
+        assert_eq!(parse_otlp_egress_target("http://laminar:8000"), None);
+        assert_eq!(
+            parse_otlp_egress_target("http://laminar-app-server.laminar:8000"),
+            None
         );
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -717,18 +717,18 @@ impl SandboxArgs {
                 spec = spec.env(name, value);
             }
         }
-        if matches!(self.backend, SandboxBackendKind::AgentK8s) {
-            if let Some(repos_path) = clean_optional_value(self.repos_path.as_deref()) {
-                spec = spec.mount(
-                    Mount::new(
-                        MountKind::Bind {
-                            source_path: repos_path,
-                        },
-                        SANDBOX_REPOS_MOUNT_PATH,
-                    )
-                    .read_only(),
-                );
-            }
+        if matches!(self.backend, SandboxBackendKind::AgentK8s)
+            && let Some(repos_path) = clean_optional_value(self.repos_path.as_deref())
+        {
+            spec = spec.mount(
+                Mount::new(
+                    MountKind::Bind {
+                        source_path: repos_path,
+                    },
+                    SANDBOX_REPOS_MOUNT_PATH,
+                )
+                .read_only(),
+            );
         }
         for (name, value) in self.workflow_host_env_template()? {
             upsert_spec_env(&mut spec, name, value);

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -40,6 +40,17 @@ use crate::{
 
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
 
+/// OTLP env always forwarded from the api-rs process into codex sandboxes,
+/// mirroring the Python control plane's `_SANDBOX_PASSTHROUGH_ENV_KEYS`. The
+/// wrapper inside the sandbox reads these to configure codex's trace export
+/// (endpoint, Laminar ingest auth header, resource attributes).
+const SANDBOX_OTLP_PASSTHROUGH_ENV_KEYS: [&str; 4] = [
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_RESOURCE_ATTRIBUTES",
+];
+
 #[derive(Debug, Parser)]
 #[command(about = "Run the Centaur API Rust session control plane")]
 pub(crate) struct Args {
@@ -851,6 +862,21 @@ impl SandboxArgs {
                 .any(|(existing, _)| existing == "OPENAI_API_KEY")
         {
             envs.push(("OPENAI_API_KEY".to_owned(), "OPENAI_API_KEY".to_owned()));
+        }
+
+        // OTLP trace wiring rides from this process into every sandbox (the
+        // same hardcoded set the Python control plane forwarded). The harness
+        // wrapper needs the endpoint + auth header to configure codex's OTLP
+        // export — codex's `session_task.turn` spans carry the token usage
+        // Laminar prices into cost. The headers value is a secret (Laminar
+        // ingest key, ideally ingest-only): it reaches the api-rs process via
+        // the chart's secret envFrom, never via values.
+        for name in SANDBOX_OTLP_PASSTHROUGH_ENV_KEYS {
+            if let Some(value) = clean_optional_value(env::var(name).ok().as_deref())
+                && !envs.iter().any(|(existing, _)| existing == name)
+            {
+                envs.push((name.to_owned(), value));
+            }
         }
 
         for name in &self.passthrough_env {
@@ -1949,23 +1975,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_otlp_egress_target_absent_without_endpoint_or_for_mock_workload() {
-        let without_endpoint = Args::try_parse_from([
-            "centaur-api-server",
-            "--database-url",
-            "postgres://postgres:postgres@localhost/centaur",
-            "--session-sandbox-workload",
-            "codex-app-server",
-        ])
-        .unwrap();
-        assert_eq!(
-            without_endpoint
-                .sandbox
-                .sandbox_otlp_egress_target()
-                .unwrap(),
-            None
-        );
-
+    fn sandbox_otlp_egress_target_absent_for_mock_workload() {
         let mock = Args::try_parse_from([
             "centaur-api-server",
             "--database-url",
@@ -1975,6 +1985,67 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(mock.sandbox.sandbox_otlp_egress_target().unwrap(), None);
+    }
+
+    /// The only test that mutates the process-level OTLP env keys: keeps all
+    /// assertions that depend on their presence or absence sequential so
+    /// parallel tests never race on them.
+    #[test]
+    fn codex_app_server_env_template_forwards_process_otlp_env() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-workload",
+            "codex-app-server",
+        ])
+        .unwrap();
+
+        unsafe {
+            for key in SANDBOX_OTLP_PASSTHROUGH_ENV_KEYS {
+                env::remove_var(key);
+            }
+        }
+        let envs = args.sandbox.codex_app_server_env_template().unwrap();
+        assert!(!envs.iter().any(|(name, _)| name.starts_with("OTEL_")));
+        assert_eq!(args.sandbox.sandbox_otlp_egress_target().unwrap(), None);
+
+        unsafe {
+            env::set_var(
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                "http://laminar-app-server.laminar.svc.cluster.local:8000/v1/traces",
+            );
+            env::set_var("OTEL_EXPORTER_OTLP_HEADERS", "authorization=Bearer test");
+        }
+        let envs = args.sandbox.codex_app_server_env_template().unwrap();
+        let value = |key: &str| {
+            envs.iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value.as_str())
+        };
+        // The harness wrapper reads these to configure codex's OTLP export
+        // (endpoint + Laminar ingest auth header).
+        assert_eq!(
+            value("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"),
+            Some("http://laminar-app-server.laminar.svc.cluster.local:8000/v1/traces")
+        );
+        assert_eq!(
+            value("OTEL_EXPORTER_OTLP_HEADERS"),
+            Some("authorization=Bearer test")
+        );
+        // The egress target derives from the same forwarded endpoint.
+        assert_eq!(
+            args.sandbox.sandbox_otlp_egress_target().unwrap(),
+            Some(OtlpEgressTarget {
+                namespace: "laminar".to_owned(),
+                port: 8000,
+            })
+        );
+        unsafe {
+            for key in SANDBOX_OTLP_PASSTHROUGH_ENV_KEYS {
+                env::remove_var(key);
+            }
+        }
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -20,8 +20,8 @@ use serde_json::{Value, json};
 use tokio::time::{Instant, sleep};
 
 use crate::{
-    AgentSandboxBackend, MANAGED_BY_LABEL, MANAGED_BY_VALUE, SANDBOX_ID_LABEL, is_not_found,
-    map_kube_error,
+    AgentSandboxBackend, MANAGED_BY_LABEL, MANAGED_BY_VALUE, OtlpEgressTarget, SANDBOX_ID_LABEL,
+    is_not_found, map_kube_error,
 };
 
 const IRON_PROXY_LABEL: &str = "centaur.ai/iron-proxy";
@@ -298,7 +298,13 @@ impl AgentSandboxBackend {
             .await
             .map_err(|err| map_kube_error("create iron-proxy service", err))?;
         let control_port = url_port(&sync.control_url).unwrap_or(443);
-        for policy in build_iron_proxy_network_policies(id, resolved, iron_proxy, control_port) {
+        for policy in build_iron_proxy_network_policies(
+            id,
+            resolved,
+            iron_proxy,
+            control_port,
+            self.config.otlp_egress.as_ref(),
+        ) {
             self.network_policies()
                 .create(&PostParams::default(), &policy)
                 .await
@@ -518,7 +524,11 @@ impl AgentSandboxBackend {
 }
 
 pub(crate) fn apply_proxy_env(spec: &mut SandboxSpec, resolved: &ResolvedIronProxy) {
-    let no_proxy_extra = current_env_values(spec, ["NO_PROXY", "no_proxy"]);
+    let mut no_proxy_extra = current_env_values(spec, ["NO_PROXY", "no_proxy"]);
+    // The harness exports OTLP traces (usage/cost spans) straight to the
+    // collector; routing them through iron-proxy fails (plain-HTTP forwards
+    // are rejected), so the endpoint host always bypasses the proxy.
+    no_proxy_extra.extend(otlp_endpoint_hosts(spec));
     let api_host = env_value(spec, "CENTAUR_API_URL").and_then(host_from_url);
     for (name, value) in proxy_env(
         &resolved.proxy_host,
@@ -743,8 +753,29 @@ fn build_iron_proxy_network_policies(
     resolved: &ResolvedIronProxy,
     iron_proxy: &IronProxyConfig,
     control_port: u16,
+    otlp_egress: Option<&OtlpEgressTarget>,
 ) -> Vec<NetworkPolicy> {
     let sandbox_to_proxy_ports = sandbox_to_proxy_ports(resolved);
+    let mut sandbox_egress = vec![
+        egress_to(
+            vec![pod_peer(iron_proxy_labels(id))],
+            sandbox_to_proxy_ports.clone(),
+        ),
+        egress_to(
+            vec![pod_peer(iron_proxy.api_pod_labels.clone())],
+            vec![network_port(8000), network_port(8080)],
+        ),
+        dns_egress_rule(),
+    ];
+    if let Some(target) = otlp_egress {
+        // Direct harness OTLP export (codex usage/cost spans). The collector
+        // lives outside this namespace, so the sandbox bypasses iron-proxy for
+        // this one destination (the endpoint host also rides NO_PROXY).
+        sandbox_egress.push(egress_to(
+            vec![namespace_peer(&target.namespace)],
+            vec![network_port(target.port)],
+        ));
+    }
     vec![
         NetworkPolicy {
             metadata: object_meta(
@@ -754,17 +785,7 @@ fn build_iron_proxy_network_policies(
             spec: Some(NetworkPolicySpec {
                 pod_selector: Some(label_selector(sandbox_labels(id))),
                 policy_types: Some(vec!["Egress".to_owned()]),
-                egress: Some(vec![
-                    egress_to(
-                        vec![pod_peer(iron_proxy_labels(id))],
-                        sandbox_to_proxy_ports.clone(),
-                    ),
-                    egress_to(
-                        vec![pod_peer(iron_proxy.api_pod_labels.clone())],
-                        vec![network_port(8000), network_port(8080)],
-                    ),
-                    dns_egress_rule(),
-                ]),
+                egress: Some(sandbox_egress),
                 ..Default::default()
             }),
         },
@@ -827,15 +848,19 @@ fn proxy_egress_rules(
 
 fn dns_egress_rule() -> NetworkPolicyEgressRule {
     egress_to(
-        vec![NetworkPolicyPeer {
-            namespace_selector: Some(label_selector(BTreeMap::from([(
-                "kubernetes.io/metadata.name".to_owned(),
-                "kube-system".to_owned(),
-            )]))),
-            ..Default::default()
-        }],
+        vec![namespace_peer("kube-system")],
         vec![udp_port(53), network_port(53)],
     )
+}
+
+fn namespace_peer(namespace: &str) -> NetworkPolicyPeer {
+    NetworkPolicyPeer {
+        namespace_selector: Some(label_selector(BTreeMap::from([(
+            "kubernetes.io/metadata.name".to_owned(),
+            namespace.to_owned(),
+        )]))),
+        ..Default::default()
+    }
 }
 
 fn proxy_env(
@@ -927,6 +952,19 @@ fn current_env_values<const N: usize>(spec: &SandboxSpec, names: [&str; N]) -> V
         .into_iter()
         .filter_map(|name| env_value(spec, name))
         .collect()
+}
+
+/// Hosts of the spec's OTLP exporter endpoints, mirrored into NO_PROXY (same
+/// contract as the Python control plane's `_sandbox_otel_endpoint_hosts`).
+fn otlp_endpoint_hosts(spec: &SandboxSpec) -> Vec<String> {
+    [
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+    ]
+    .into_iter()
+    .filter_map(|name| env_value(spec, name))
+    .filter_map(host_from_url)
+    .collect()
 }
 
 /// The authority (`[user@]host[:port]`) of a URL or bare `host:port`, with any
@@ -1141,4 +1179,109 @@ fn unique_suffix() -> String {
         .unwrap_or_default()
         .as_millis();
     format!("{millis}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolved() -> ResolvedIronProxy {
+        ResolvedIronProxy {
+            proxy_host: "asbx-test-iron-proxy".to_owned(),
+            proxy_pod_name: "asbx-test-iron-proxy-1".to_owned(),
+            proxy_port: 8080,
+            principal_id: "principal".to_owned(),
+            pg: None,
+            replace_placeholders: BTreeMap::new(),
+        }
+    }
+
+    fn rule_allows_namespace_port(
+        rule: &NetworkPolicyEgressRule,
+        namespace: &str,
+        port: u16,
+    ) -> bool {
+        rule.to.as_ref().is_some_and(|peers| {
+            peers.iter().any(|peer| {
+                peer.namespace_selector.as_ref().is_some_and(|selector| {
+                    selector.match_labels.as_ref().is_some_and(|labels| {
+                        labels
+                            .get("kubernetes.io/metadata.name")
+                            .map(String::as_str)
+                            == Some(namespace)
+                    })
+                })
+            })
+        }) && rule.ports.as_ref().is_some_and(|ports| {
+            ports
+                .iter()
+                .any(|policy_port| policy_port.port == Some(IntOrString::Int(i32::from(port))))
+        })
+    }
+
+    #[test]
+    fn sandbox_egress_policy_allows_otlp_collector_when_configured() {
+        let id = SandboxId::new("asbx-test");
+        let iron_proxy = IronProxyConfig::new("proxy:test", "ca-cert", "ca-key");
+        let target = OtlpEgressTarget {
+            namespace: "laminar".to_owned(),
+            port: 8000,
+        };
+
+        let policies =
+            build_iron_proxy_network_policies(&id, &resolved(), &iron_proxy, 3000, Some(&target));
+        let sandbox_egress = policies[0]
+            .spec
+            .as_ref()
+            .unwrap()
+            .egress
+            .as_ref()
+            .unwrap()
+            .clone();
+        assert!(
+            sandbox_egress
+                .iter()
+                .any(|rule| rule_allows_namespace_port(rule, "laminar", 8000))
+        );
+
+        let policies = build_iron_proxy_network_policies(&id, &resolved(), &iron_proxy, 3000, None);
+        let sandbox_egress = policies[0]
+            .spec
+            .as_ref()
+            .unwrap()
+            .egress
+            .as_ref()
+            .unwrap()
+            .clone();
+        assert!(
+            !sandbox_egress
+                .iter()
+                .any(|rule| rule_allows_namespace_port(rule, "laminar", 8000))
+        );
+    }
+
+    #[test]
+    fn apply_proxy_env_adds_otlp_endpoint_host_to_no_proxy() {
+        let mut spec = SandboxSpec::new("centaur-agent:latest").env(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "http://laminar-app-server.laminar.svc.cluster.local:8000/v1/traces",
+        );
+
+        apply_proxy_env(&mut spec, &resolved());
+
+        for name in ["NO_PROXY", "no_proxy"] {
+            let value = spec
+                .env
+                .iter()
+                .find(|env| env.name == name)
+                .map(|env| env.value.clone())
+                .unwrap();
+            assert!(
+                value
+                    .split(',')
+                    .any(|host| host == "laminar-app-server.laminar.svc.cluster.local"),
+                "{name} should contain the OTLP endpoint host: {value}"
+            );
+        }
+    }
 }

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -59,7 +59,21 @@ pub struct AgentSandboxConfig {
     /// git-clones the tools repo into the agent's `/app/tools`, and `TOOL_DIRS`
     /// is set so the agent's shim installer finds them.
     pub tools: Option<ToolsConfig>,
+    /// In-cluster OTLP collector (e.g. Laminar) the sandbox exports harness
+    /// traces to directly. The per-sandbox egress NetworkPolicy denies all
+    /// destinations except the proxy/control plane, so without this rule the
+    /// harness's usage/cost spans never leave the pod.
+    pub otlp_egress: Option<OtlpEgressTarget>,
     pub ready_timeout: Duration,
+}
+
+/// Destination of the sandbox's direct OTLP export, expressed as the target
+/// namespace (matched by `kubernetes.io/metadata.name`) and port of the
+/// collector service.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OtlpEgressTarget {
+    pub namespace: String,
+    pub port: u16,
 }
 
 /// iron-control coordinates for sync-mode egress proxies. When set, a sandbox
@@ -90,6 +104,7 @@ impl AgentSandboxConfig {
             iron_proxy: None,
             iron_control: None,
             tools: None,
+            otlp_egress: None,
             ready_timeout: Duration::from_secs(60),
         }
     }

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
@@ -16,6 +16,7 @@
 //!   from the repo-cache DaemonSet's node-level cache when configured, otherwise
 //!   it git-clones the tools repo at a pinned ref into an emptyDir mounted at
 //!   `/app/tools`;
+//!
 //! `TOOL_DIRS` is set explicitly on the agent env to `/app/tools`, pointing at
 //! the path the init container populates in this pod. The copied tools tree keeps
 //! source metadata in a hidden file so `centaur-tools refresh` can either re-copy

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "sync", "time"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 time.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -527,7 +527,8 @@ impl SessionRuntime {
                 }
             };
 
-            let input_lines = input_lines_with_thread_key(thread_key, &input_lines);
+            let trace = SessionTraceContext::new(thread_key, Some(&execution_trace_span));
+            let input_lines = input_lines_with_session_context(thread_key, &trace, &input_lines);
             if let Err(error) = write_input_lines(
                 &pipe,
                 &input_lines,
@@ -630,6 +631,17 @@ impl SessionRuntime {
         }) else {
             return;
         };
+
+        // Steering joins the active execution's trace so harness spans for the
+        // steered turn stay in the same tree.
+        let execution_span = self
+            .execution_spans
+            .lock()
+            .await
+            .get(&execution.execution_id)
+            .cloned();
+        let trace = SessionTraceContext::new(thread_key, execution_span.as_ref());
+        let input_lines = input_lines_with_session_context(thread_key, &trace, &input_lines);
 
         let pipe = match self
             .wait_for_active_steering_pipe(thread_key, &execution.execution_id)
@@ -2764,14 +2776,56 @@ async fn write_input_lines(
     .await
 }
 
-fn input_lines_with_thread_key(thread_key: &ThreadKey, input_lines: &[String]) -> Vec<String> {
+/// Trace identity injected into sandbox stdin lines so the harness wrapper
+/// (codex-app-wrapper) can configure its OTLP export. Without a `trace_id` or
+/// `traceparent` on the first turn the wrapper never writes codex's `[otel]`
+/// config, codex exports no `session_task.turn` spans, and Laminar has no
+/// token usage to price into cost.
+#[derive(Clone, Debug)]
+struct SessionTraceContext {
+    /// Stable per-thread trace id, derived from the thread key (UUIDv5) so it
+    /// needs no persisted state and survives API restarts.
+    trace_id: String,
+    /// W3C traceparent of the current execution span, when the OpenTelemetry
+    /// layer is active. Lets harness spans join the execution's trace.
+    traceparent: Option<String>,
+}
+
+impl SessionTraceContext {
+    fn new(thread_key: &ThreadKey, execution_span: Option<&Span>) -> Self {
+        Self {
+            trace_id: thread_trace_id(thread_key),
+            traceparent: execution_span.and_then(centaur_telemetry::traceparent_for_span),
+        }
+    }
+}
+
+/// Deterministic per-thread trace id: one trace identity per thread without a
+/// `thread_traces` table (derive, don't store).
+fn thread_trace_id(thread_key: &ThreadKey) -> String {
+    uuid::Uuid::new_v5(
+        &uuid::Uuid::NAMESPACE_URL,
+        format!("centaur:thread:{}", thread_key.as_str()).as_bytes(),
+    )
+    .to_string()
+}
+
+fn input_lines_with_session_context(
+    thread_key: &ThreadKey,
+    trace: &SessionTraceContext,
+    input_lines: &[String],
+) -> Vec<String> {
     input_lines
         .iter()
-        .map(|line| input_line_with_thread_key(thread_key, line))
+        .map(|line| input_line_with_session_context(thread_key, trace, line))
         .collect()
 }
 
-fn input_line_with_thread_key(thread_key: &ThreadKey, line: &str) -> String {
+fn input_line_with_session_context(
+    thread_key: &ThreadKey,
+    trace: &SessionTraceContext,
+    line: &str,
+) -> String {
     let Ok(mut value) = serde_json::from_str::<Value>(line) else {
         return line.to_owned();
     };
@@ -2780,6 +2834,12 @@ fn input_line_with_thread_key(thread_key: &ThreadKey, line: &str) -> String {
     };
     map.entry("thread_key")
         .or_insert_with(|| Value::String(thread_key.as_str().to_owned()));
+    map.entry("trace_id")
+        .or_insert_with(|| Value::String(trace.trace_id.clone()));
+    if let Some(traceparent) = &trace.traceparent {
+        map.entry("traceparent")
+            .or_insert_with(|| Value::String(traceparent.clone()));
+    }
     serde_json::to_string(&value).unwrap_or_else(|_| line.to_owned())
 }
 
@@ -3796,28 +3856,56 @@ mod tests {
     }
 
     #[test]
-    fn input_line_with_thread_key_enriches_json_objects() {
+    fn input_line_with_session_context_enriches_json_objects() {
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+        let trace = SessionTraceContext::new(&thread_key, None);
 
-        let line = input_line_with_thread_key(&thread_key, r#"{"type":"user"}"#);
+        let line = input_line_with_session_context(&thread_key, &trace, r#"{"type":"user"}"#);
         let value: Value = serde_json::from_str(&line).unwrap();
 
         assert_eq!(value["type"], "user");
         assert_eq!(value["thread_key"], thread_key.as_str());
+        assert_eq!(value["trace_id"], trace.trace_id);
+        // Without an OpenTelemetry layer there is no traceparent to forward.
+        assert!(value.get("traceparent").is_none());
     }
 
     #[test]
-    fn input_line_with_thread_key_preserves_existing_thread_key_and_non_json() {
+    fn input_line_with_session_context_preserves_existing_fields_and_non_json() {
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+        let trace = SessionTraceContext {
+            trace_id: thread_trace_id(&thread_key),
+            traceparent: Some("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01".to_owned()),
+        };
 
-        let line = input_line_with_thread_key(
+        let line = input_line_with_session_context(
             &thread_key,
-            r#"{"type":"user","thread_key":"chat:existing"}"#,
+            &trace,
+            r#"{"type":"user","thread_key":"chat:existing","trace_id":"caller-trace"}"#,
         );
         let value: Value = serde_json::from_str(&line).unwrap();
 
         assert_eq!(value["thread_key"], "chat:existing");
-        assert_eq!(input_line_with_thread_key(&thread_key, "raw"), "raw");
+        assert_eq!(value["trace_id"], "caller-trace");
+        assert_eq!(
+            value["traceparent"],
+            "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+        );
+        assert_eq!(
+            input_line_with_session_context(&thread_key, &trace, "raw"),
+            "raw"
+        );
+    }
+
+    #[test]
+    fn thread_trace_id_is_deterministic_per_thread() {
+        let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+        let other = ThreadKey::parse("chat:C456:1780000000.000000").unwrap();
+
+        assert_eq!(thread_trace_id(&thread_key), thread_trace_id(&thread_key));
+        assert_ne!(thread_trace_id(&thread_key), thread_trace_id(&other));
+        // The wrapper parses this with uuid.UUID(...): must stay a canonical UUID.
+        assert!(uuid::Uuid::parse_str(&thread_trace_id(&thread_key)).is_ok());
     }
 
     fn session_with_sandbox(sandbox_id: &str) -> Session {

--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -260,6 +260,23 @@ pub fn http_status_class(status: u16) -> &'static str {
     }
 }
 
+/// W3C `traceparent` for a tracing span, when the OpenTelemetry layer is
+/// installed and the span carries a valid trace context. The sampled flag is
+/// always `01`: downstream harness exporters (codex OTLP) must keep emitting
+/// usage/cost spans regardless of any upstream sampling decision.
+pub fn traceparent_for_span(span: &tracing::Span) -> Option<String> {
+    let context = span.context();
+    let span_context = context.span().span_context().clone();
+    if !span_context.is_valid() {
+        return None;
+    }
+    Some(format!(
+        "00-{}-{}-01",
+        span_context.trace_id(),
+        span_context.span_id()
+    ))
+}
+
 pub fn init_telemetry(config: TelemetryConfig) -> Result<TelemetryGuard, TelemetryError> {
     let _metrics = prometheus_handle()?;
     let filter = EnvFilter::try_new(&config.rust_log).unwrap_or_else(|_| EnvFilter::new("info"));

--- a/services/api-rs/rfcs/0003-telemetry.md
+++ b/services/api-rs/rfcs/0003-telemetry.md
@@ -41,6 +41,17 @@ Prometheus/VictoriaMetrics metrics, and domain spans in the session runtime.
   `centaur.api_rs.session.execution` is created when an execution is claimed,
   kept active until terminal state, and used as the parent for stdout-pump,
   codex app-server event, and tool-call spans emitted by the background pump.
+- Harness trace export wiring is implemented: every sandbox stdin line carries
+  `thread_key`, a deterministic per-thread `trace_id` (UUIDv5 of the thread
+  key — no `thread_traces` table), and the execution span's `traceparent`, so
+  codex-app-wrapper can configure codex's OTLP export and the harness's
+  `session_task.turn` spans (token usage that Laminar prices into cost) join
+  the execution trace. Operator sandbox env (`SESSION_SANDBOX_EXTRA_ENV`,
+  rendered from the chart's `sandbox.extraEnv`) carries the OTLP endpoint into
+  each sandbox; the endpoint host is auto-merged into the sandbox `NO_PROXY`,
+  and the per-sandbox egress NetworkPolicy gets a namespace-scoped rule for
+  in-cluster collector endpoints. The chart's `networkPolicy.otlpEgress`
+  values open the matching api-rs egress for its own OTLP export.
 
 ## Goals
 

--- a/services/api-rs/rfcs/0003-telemetry.md
+++ b/services/api-rs/rfcs/0003-telemetry.md
@@ -46,12 +46,17 @@ Prometheus/VictoriaMetrics metrics, and domain spans in the session runtime.
   key — no `thread_traces` table), and the execution span's `traceparent`, so
   codex-app-wrapper can configure codex's OTLP export and the harness's
   `session_task.turn` spans (token usage that Laminar prices into cost) join
-  the execution trace. Operator sandbox env (`SESSION_SANDBOX_EXTRA_ENV`,
-  rendered from the chart's `sandbox.extraEnv`) carries the OTLP endpoint into
-  each sandbox; the endpoint host is auto-merged into the sandbox `NO_PROXY`,
-  and the per-sandbox egress NetworkPolicy gets a namespace-scoped rule for
-  in-cluster collector endpoints. The chart's `networkPolicy.otlpEgress`
-  values open the matching api-rs egress for its own OTLP export.
+  the execution trace. The api-rs process's own OTLP env
+  (`OTEL_EXPORTER_OTLP_{ENDPOINT,TRACES_ENDPOINT,HEADERS}` and
+  `OTEL_RESOURCE_ATTRIBUTES`) is always forwarded into codex sandboxes —
+  the same hardcoded passthrough set the Python control plane used — so the
+  Laminar ingest key flows secret → api-rs env → sandbox without touching
+  values. Operator sandbox env (`SESSION_SANDBOX_EXTRA_ENV`, rendered from the
+  chart's `sandbox.extraEnv`) layers on top; the endpoint host is auto-merged
+  into the sandbox `NO_PROXY`, and the per-sandbox egress NetworkPolicy gets a
+  namespace-scoped rule for in-cluster collector endpoints. The chart's
+  `networkPolicy.otlpEgress` values open the matching api-rs egress for its
+  own OTLP export on installs without a broader CNI policy.
 
 ## Goals
 


### PR DESCRIPTION
## Problem

Since the Jun 10 cutover to the Rust control plane, Laminar traces contain **no cost** — in fact no spans arrive at all (project's newest span: `2026-06-10 14:11 UTC`).

Cost only ever came from **`codex.session_task.turn` spans** ($8,567 lifetime, the only `span_type=LLM` rows): codex exports OTLP inside the sandbox, `codex-app-wrapper`'s prefix proxy normalizes token usage into `gen_ai.usage.*`, Laminar prices it.

## Root causes (all verified live in prd-centaur-na)

1. **The Laminar ingest credential was never in IaC.** Laminar's `/v1/traces` requires `Authorization: Bearer <project API key>` (key `centaur-production-otlp`, created May 27; lmnr stores only its SHA3-256 hash). `OTEL_EXPORTER_OTLP_HEADERS` appears nowhere — not in the chart, not in `prd-centaur-infra` values (git history confirms), not in `centaur-secret-env`, not in ArgoCD parameter overrides. The pre-cutover deployments carried it as an **unrecorded hot-patch**; sandboxes inherited it via the Python control plane's hardcoded `_SANDBOX_PASSTHROUGH_ENV_KEYS`. The cutover replaced the Deployments and the patch evaporated. Laminar's access log shows the flip at `2026-06-10 14:11`: old api-rs pod `…13.69` getting 200s, new pod `…11.34` getting 401s — and **11,803/11,803 OTLP POSTs in the last 24h are 401s**. (The Rust exporter surfaces this as a misleading `BatchSpanProcessor … network error`.)
2. **Sandboxes lost their OTLP wiring entirely in the Rust path**: no OTEL env reaches sandbox pods, and stdin lines carry only `thread_key` — the wrapper needs `trace_id`/`traceparent` + endpoint before it writes codex's `[otel]` config, so codex exports nothing.
3. **Per-sandbox egress is blocked by label drift**: the existing `centaur-sandbox-laminar` CiliumNetworkPolicy grants Laminar egress to pods labeled `centaur.ai/managed: "true"` (the Python label); the Rust backend labels pods `centaur.ai/managed-by: api-rs`, which matches nothing. Verified: a pod with the old label reaches Laminar today (200); an asbx pod times out. (api-rs itself is fine — the `centaur-laminar` CNP was updated at cutover to include `api-rs`, and a debug container in the api-rs pod netns reaches Laminar: `/health` 200.)

## Fix

- **args.rs**: always forward the api-rs process's `OTEL_EXPORTER_OTLP_{ENDPOINT,TRACES_ENDPOINT,HEADERS}` + `OTEL_RESOURCE_ATTRIBUTES` into codex sandbox env (Python `_SANDBOX_PASSTHROUGH_ENV_KEYS` parity). The ingest key flows **secret → api-rs `envFrom` → sandbox → wrapper → codex exporter config** without ever entering Helm values. Also: parse `SESSION_SANDBOX_EXTRA_ENV` (rendered from `sandbox.extraEnv`, operator wins) and derive the per-sandbox OTLP egress NetworkPolicy target from the sandbox's own endpoint when it's in-cluster service DNS.
- **session-runtime**: every stdin line (execute + steering) carries `thread_key`, a deterministic per-thread `trace_id` (UUIDv5 of thread key — derive-don't-store replacement for Python's `thread_traces` row), and the execution span's W3C `traceparent` (always sampled).
- **agent-k8s**: namespace-scoped Laminar egress rule on the per-sandbox egress policy (self-contained — no dependency on the `centaur.ai/managed` label contract; resume-safe), and the OTLP endpoint host is auto-merged into sandbox `NO_PROXY` so exports bypass iron-proxy (plain-HTTP via the proxy 405s).
- **chart**: render `sandbox.extraEnv` → `SESSION_SANDBOX_EXTRA_ENV`; optional `networkPolicy.otlpEgress` egress block for installs that rely purely on the chart's KNPs (prd does **not** need it — the existing `centaur-laminar` CNP already covers api-rs). Default render is byte-identical (apart from the chart version label). Chart 0.1.50.
- Also repairs `clippy -D warnings` on the base branch (broken by a direct push; no CI gates PRs to this branch).

`opentelemetry-otlp` 0.32 reads `OTEL_EXPORTER_OTLP_HEADERS` from the process env for the HTTP exporter (verified in upstream source), so api-rs's own export needs zero code change once the env var exists.

## Validation

`cargo fmt --check` / `clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` green; `helm lint` + template render checks (defaults byte-identical; otlp values render correctly). Live-verified the network paths in prd with ephemeral pods: api-rs→Laminar open (200/401-auth-only), old-label sandbox identity open, new asbx identity blocked (fixed by the per-sandbox rule here).

## Rollout (after merge + image/chart deploy)

1. **Mint a new Laminar project API key** (Settings → API keys in the Laminar UI, prefer ingest-only; the old key's plaintext is unrecoverable by design) and add `OTEL_EXPORTER_OTLP_HEADERS: authorization=Bearer <key>` to the `centaur-secret-env` secret (1Password source). `envFrom` already injects it into api-rs; this PR propagates it to sandboxes. **This is the single missing credential** — without it everything still 401s.
2. Recycle pre-fix sandboxes (incl. warm pool) — existing pods lack the env/policies; the warm-pool workload key changes automatically, but live session sandboxes stay dark until replaced.
3. No Laminar-side CNP change needed (verified live). `networkPolicy.otlpEgress` not needed in prd (existing `centaur-laminar` CNP covers api-rs).
