### PR TITLE
Add repo-cache extra tool sources

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -5,9 +5,17 @@
 {{- $reposPath = .Values.repoCache.hostPath -}}
 {{- end -}}
 {{- $toolsUseRepoCache := and .Values.repoCache.enabled .Values.toolServer.enabled .Values.toolServer.repo -}}
+{{- $toolDirs := list "/app/tools" -}}
 {{- $workflowDirs := "/app/workflows" -}}
 {{- if $toolsUseRepoCache -}}
-{{- $workflowDirs = printf "%s/%s/workflows" .Values.repoCache.hostPath .Values.toolServer.repo -}}
+{{- $toolDirs = list (printf "%s/%s/%s" .Values.repoCache.hostPath .Values.toolServer.repo .Values.toolServer.subdir) -}}
+{{- $workflowDirList := list (printf "%s/%s/workflows" .Values.repoCache.hostPath .Values.toolServer.repo) -}}
+{{- range .Values.toolServer.extraSources }}
+{{- $sourceSubdir := default "tools" .subdir -}}
+{{- $toolDirs = append $toolDirs (printf "%s/%s/%s" $.Values.repoCache.hostPath .repo $sourceSubdir) -}}
+{{- $workflowDirList = append $workflowDirList (printf "%s/%s/workflows" $.Values.repoCache.hostPath .repo) -}}
+{{- end -}}
+{{- $workflowDirs = join ":" $workflowDirList -}}
 {{- end -}}
 {{- $apiRsMetricsAnnotations := dict -}}
 {{- if .Values.apiRs.metrics.scrapeAnnotations -}}
@@ -119,7 +127,7 @@ spec:
             - name: RUST_LOG
               value: info
             - name: TOOL_DIRS
-              value: /app/tools
+              value: {{ join ":" $toolDirs | quote }}
             - name: WORKFLOW_DIRS
               value: {{ $workflowDirs | quote }}
 {{- if .Values.overlay.systemPrompt }}
@@ -221,6 +229,10 @@ spec:
 {{- end }}
             - name: KUBERNETES_TOOLS_SUBDIR
               value: {{ .Values.toolServer.subdir | quote }}
+{{- with .Values.toolServer.extraSources }}
+            - name: KUBERNETES_TOOLS_EXTRA_SOURCES
+              value: {{ toJson . | quote }}
+{{- end }}
 {{- if $toolsUseRepoCache }}
             - name: KUBERNETES_TOOLS_REPO_CACHE_PATH
               value: {{ .Values.repoCache.hostPath | quote }}

--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -5,6 +5,9 @@
 {{- end }}
 {{- if and .Values.toolServer.enabled .Values.toolServer.repo }}
 {{- $repoCacheRepositories = append $repoCacheRepositories .Values.toolServer.repo -}}
+{{- range .Values.toolServer.extraSources }}
+{{- $repoCacheRepositories = append $repoCacheRepositories .repo -}}
+{{- end }}
 {{- end }}
 {{- $repoCacheRepositories = uniq $repoCacheRepositories -}}
 {{- if $repoCacheRepositories }}
@@ -18,6 +21,11 @@
 {{- end }}
 {{- if and .Values.toolServer.enabled .Values.toolServer.repo .Values.toolServer.ref (not (hasKey .Values.repoCache.repositoryRefs .Values.toolServer.repo)) }}
 {{- $repoCacheRepositoryRefs = append $repoCacheRepositoryRefs (printf "%s=%s" .Values.toolServer.repo .Values.toolServer.ref) -}}
+{{- end }}
+{{- range .Values.toolServer.extraSources }}
+{{- if and .ref (not (hasKey $.Values.repoCache.repositoryRefs .repo)) }}
+{{- $repoCacheRepositoryRefs = append $repoCacheRepositoryRefs (printf "%s=%s" .repo .ref) -}}
+{{- end }}
 {{- end }}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -44,7 +44,22 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
-        "port": { "type": "integer" }
+        "port": { "type": "integer" },
+        "repo": { "type": "string" },
+        "ref": { "type": "string" },
+        "subdir": { "type": "string" },
+        "extraSources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "repo": { "type": "string" },
+              "ref": { "type": "string" },
+              "subdir": { "type": "string" }
+            },
+            "required": ["repo"]
+          }
+        }
       }
     },
     "ironControl": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -47,6 +47,13 @@ toolServer:
   ref: ""
   # Subdirectory in the repo holding the tools tree (mounted at /app/tools).
   subdir: tools
+  # Additional repo/subdir sources copied after the base tools source. Later
+  # sources shadow earlier ones when tool directory names collide. These repos
+  # are cached automatically when repoCache.enabled=true.
+  extraSources: []
+  # - repo: tempoxyz/centaur-tempo
+  #   ref: ""
+  #   subdir: tools
   # Git-capable image the clone init container runs in; empty fields fall back to
   # sandbox.image (which carries git).
   runnerImage:

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -20,7 +20,7 @@ use centaur_iron_proxy::{
 };
 use centaur_sandbox_agent_k8s::{
     AgentSandboxBackend, AgentSandboxConfig, GitHubTokenRef, IronControlSettings, IronProxyConfig,
-    ToolsConfig,
+    ToolSource, ToolsConfig,
 };
 use centaur_sandbox_core::{Mount, MountKind, SandboxSpec};
 use centaur_sandbox_local::LocalSandboxBackend;
@@ -92,7 +92,7 @@ pub(crate) struct IronControlToolReconciler {
     source_policy: SourcePolicy,
     base_infra_fragment: ProxyFragment,
     tool_dirs: Vec<PathBuf>,
-    tool_git_source: Option<ToolGitSource>,
+    tool_git_sources: Vec<ToolGitSource>,
     interval: Duration,
 }
 
@@ -160,28 +160,50 @@ impl IronControlToolReconciler {
     }
 
     fn tool_dirs(&self) -> Result<Vec<PathBuf>, ServerError> {
-        if let Some(source) = &self.tool_git_source {
-            source.sync()?;
-            let tools_dir = source.tools_dir();
-            if source.repo_cache_path.is_some() && !tools_dir.is_dir() {
-                return Ok(Vec::new());
+        if !self.tool_git_sources.is_empty() {
+            let mut dirs = Vec::with_capacity(self.tool_git_sources.len());
+            for source in &self.tool_git_sources {
+                source.sync()?;
+                let tools_dir = source.tools_dir();
+                if source.repo_cache_path.is_some() && !tools_dir.is_dir() {
+                    continue;
+                }
+                dirs.push(tools_dir);
             }
-            return Ok(vec![tools_dir]);
+            return Ok(dirs);
         }
         Ok(self.tool_dirs.clone())
     }
 }
 
 impl ToolGitSource {
-    fn from_config(tools: &ToolsConfig) -> Self {
+    fn from_config(tools: &ToolsConfig) -> Vec<Self> {
+        let mut sources = vec![Self::from_source(
+            &ToolSource {
+                repo: tools.repo.clone(),
+                git_ref: tools.git_ref.clone(),
+                source_subdir: tools.source_subdir.clone(),
+            },
+            tools.repo_cache_path.clone(),
+        )];
+        sources.extend(
+            tools
+                .extra_sources
+                .iter()
+                .map(|source| Self::from_source(source, tools.repo_cache_path.clone())),
+        );
+        sources
+    }
+
+    fn from_source(source: &ToolSource, repo_cache_path: Option<String>) -> Self {
         Self {
-            repo: tools.repo.clone(),
-            git_ref: tools.git_ref.clone(),
-            source_subdir: tools.source_subdir.clone(),
+            repo: source.repo.clone(),
+            git_ref: source.git_ref.clone(),
+            source_subdir: source.source_subdir.clone(),
             cache_dir: env::temp_dir()
                 .join("centaur-api-rs-tools")
-                .join(slug_path_component(&tools.repo)),
-            repo_cache_path: tools.repo_cache_path.clone(),
+                .join(slug_path_component(&source.repo)),
+            repo_cache_path,
         }
     }
 
@@ -577,11 +599,12 @@ impl SandboxArgs {
             source_policy: self.iron_proxy.source_policy(),
             base_infra_fragment: self.iron_proxy.infra_fragment()?,
             tool_dirs: self.tools.resolve_tool_dirs()?,
-            tool_git_source: self
+            tool_git_sources: self
                 .tools_source
                 .to_config()
                 .as_ref()
-                .map(ToolGitSource::from_config),
+                .map(ToolGitSource::from_config)
+                .unwrap_or_default(),
             interval: Duration::from_secs(self.tool_proxy_reconcile_interval_secs),
         }))
     }
@@ -914,9 +937,17 @@ impl SandboxArgs {
 
     fn tool_proxy_dirs(&self) -> Result<Vec<PathBuf>, ServerError> {
         if let Some(tools) = self.tools_source.to_config() {
-            let source = ToolGitSource::from_config(&tools);
-            source.sync()?;
-            return Ok(vec![source.tools_dir()]);
+            let sources = ToolGitSource::from_config(&tools);
+            let mut dirs = Vec::with_capacity(sources.len());
+            for source in sources {
+                source.sync()?;
+                let tools_dir = source.tools_dir();
+                if source.repo_cache_path.is_some() && !tools_dir.is_dir() {
+                    continue;
+                }
+                dirs.push(tools_dir);
+            }
+            return Ok(dirs);
         }
         self.tools.resolve_tool_dirs()
     }
@@ -1059,6 +1090,12 @@ struct ToolsArgs {
         env = "KUBERNETES_TOOLS_REPO_CACHE_PATH"
     )]
     repo_cache_path: Option<String>,
+    #[arg(
+        id = "tools_extra_sources",
+        long = "kubernetes-tools-extra-sources",
+        env = "KUBERNETES_TOOLS_EXTRA_SOURCES"
+    )]
+    extra_sources: Option<String>,
 }
 
 impl ToolsArgs {
@@ -1080,7 +1117,46 @@ impl ToolsArgs {
             });
         }
         config.repo_cache_path = clean_optional_value(self.repo_cache_path.as_deref());
+        if let Some(value) = clean_optional_value(self.extra_sources.as_deref()) {
+            match serde_json::from_str::<Vec<ToolSourceArg>>(&value) {
+                Ok(sources) => {
+                    config.extra_sources = sources
+                        .into_iter()
+                        .filter_map(ToolSourceArg::into_source)
+                        .collect();
+                }
+                Err(err) => {
+                    tracing::warn!(error = %err, "invalid KUBERNETES_TOOLS_EXTRA_SOURCES; ignoring extra tool sources");
+                }
+            }
+        }
         Some(config)
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ToolSourceArg {
+    repo: String,
+    #[serde(default, rename = "ref")]
+    git_ref: Option<String>,
+    #[serde(default)]
+    subdir: Option<String>,
+}
+
+impl ToolSourceArg {
+    fn into_source(self) -> Option<ToolSource> {
+        Some(ToolSource {
+            repo: clean_optional_value(Some(self.repo.as_str()))?,
+            git_ref: self
+                .git_ref
+                .as_deref()
+                .and_then(|value| clean_optional_value(Some(value))),
+            source_subdir: self
+                .subdir
+                .as_deref()
+                .and_then(|value| clean_optional_value(Some(value)))
+                .unwrap_or_else(|| "tools".to_owned()),
+        })
     }
 }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -25,7 +25,7 @@ use tokio::time::{Instant, sleep};
 
 pub use generated::agents_x_k8s_io as crd;
 pub use iron_proxy::IronProxyConfig;
-pub use tools::{GitHubTokenRef, ToolsConfig};
+pub use tools::{GitHubTokenRef, ToolSource, ToolsConfig};
 
 pub mod generated;
 mod iron_proxy;

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
@@ -61,6 +61,17 @@ pub struct ToolsConfig {
     /// tools-bootstrap copies from `<repo_cache_path>/<repo>/<source_subdir>` and
     /// `centaur-tools refresh` re-copies from the same cache instead of fetching.
     pub repo_cache_path: Option<String>,
+    /// Additional tool sources copied after the base tree. Later sources shadow
+    /// earlier ones when they contain the same tool directory name.
+    pub extra_sources: Vec<ToolSource>,
+}
+
+/// One repo/subdir tools source copied into `/app/tools`.
+#[derive(Clone, Debug)]
+pub struct ToolSource {
+    pub repo: String,
+    pub git_ref: Option<String>,
+    pub source_subdir: String,
 }
 
 /// A Kubernetes Secret key holding a GitHub token, fed to `git` via `GIT_ASKPASS`.
@@ -80,7 +91,18 @@ impl ToolsConfig {
             image_pull_policy: None,
             github_token: None,
             repo_cache_path: None,
+            extra_sources: Vec::new(),
         }
+    }
+
+    fn sources(&self) -> Vec<ToolSource> {
+        let mut sources = vec![ToolSource {
+            repo: self.repo.clone(),
+            git_ref: self.git_ref.clone(),
+            source_subdir: self.source_subdir.clone(),
+        }];
+        sources.extend(self.extra_sources.clone());
+        sources
     }
 }
 
@@ -145,22 +167,7 @@ pub(crate) fn tools_init_container_json(
     tools: &ToolsConfig,
     clone_proxy: Option<&CloneProxy>,
 ) -> Value {
-    let repo_url = format!("https://github.com/{}.git", tools.repo);
-    let subdir = &tools.source_subdir;
-    let repo_cache_repo_path = tools.repo_cache_path.as_ref().map(|path| {
-        format!(
-            "{}/{}",
-            path.trim_end_matches('/'),
-            tools.repo.trim_start_matches('/')
-        )
-    });
-    let metadata = json!({
-        "source_subdir": subdir,
-        "git_ref": tools.git_ref.as_deref(),
-        "source": if repo_cache_repo_path.is_some() { "repo_cache" } else { "git" },
-        "repo_cache_repo_path": repo_cache_repo_path.as_deref(),
-    })
-    .to_string();
+    let sources = tools.sources();
 
     let proxy_exports = match clone_proxy {
         Some(proxy) => format!(
@@ -187,61 +194,99 @@ pub(crate) fn tools_init_container_json(
         String::new()
     };
 
-    // `--filter=blob:none --no-checkout` + sparse-checkout fetches only the tools
-    // subtree's blobs. With a ref we fetch it explicitly (branch/tag/sha);
-    // without one we check out the cloned default branch.
-    let checkout = match &tools.git_ref {
-        Some(git_ref) => format!(
-            "git -C \"$source\" -c gc.auto=0 fetch --quiet origin \"{git_ref}\" && \
-             git -C \"$source\" checkout --quiet --detach FETCH_HEAD"
-        ),
-        None => "git -C \"$source\" checkout --quiet".to_owned(),
-    };
-
     // The per-sandbox proxy is created in the same reconcile as the Sandbox and
     // may not be accepting connections when this init container first runs — and
     // an init failure is terminal for the Sandbox (no kubelet retry), so the
     // clone must retry through the connection-refused window rather than die.
     // repo/ref/subdir are operator config, but quote them anyway so a stray
     // space or metacharacter breaks loudly in git instead of in the shell.
-    let publish_script = if let Some(repo_cache_repo_path) = &repo_cache_repo_path {
-        format!(
-            "attempt=0\n\
-             cache_repo=\"{repo_cache_repo_path}\"\n\
-             until [ -d \"$cache_repo/.git\" ] && [ -d \"$cache_repo/{subdir}\" ]; do\n\
-             attempt=$((attempt + 1))\n\
-             if [ \"$attempt\" -ge 30 ]; then echo \"tools repo-cache entry unavailable after $attempt attempts: $cache_repo/{subdir}\" >&2; exit 1; fi\n\
-             sleep 2\n\
-             done\n\
-             find \"$target\" -mindepth 1 -maxdepth 1 ! -name '.centaur-tools-source.json' -exec rm -rf {{}} +\n\
-             cp -R \"$cache_repo/{subdir}/.\" \"$target\"/"
-        )
-    } else {
-        format!(
-            "source=\"$target/.centaur-source\"\n\
-             rm -rf \"$source\"\n\
-             until git clone --quiet --filter=blob:none --no-checkout \"{repo_url}\" \"$source\" && \
-             git -C \"$source\" sparse-checkout set \"{subdir}\" && \
-             {checkout}; do\n\
-             attempt=$((attempt + 1))\n\
-             if [ \"$attempt\" -ge 30 ]; then echo \"tools clone failed after $attempt attempts\" >&2; exit 1; fi\n\
-             rm -rf \"$source\"\n\
-             sleep 2\n\
-             done\n\
-             find \"$target\" -mindepth 1 -maxdepth 1 ! -name '.centaur-source' ! -name '.centaur-tools-source.json' -exec rm -rf {{}} +\n\
-             cp -R \"$source/{subdir}/.\" \"$target\"/"
-        )
-    };
+    let mut publish_steps = String::from(
+        "find \"$target\" -mindepth 1 -maxdepth 1 ! -name '.centaur-source*' ! -name '.centaur-tools-source.json' -exec rm -rf {} +\n",
+    );
+    let mut metadata_sources = Vec::new();
+    for (index, source) in sources.iter().enumerate() {
+        let subdir = &source.source_subdir;
+        if let Some(repo_cache_path) = &tools.repo_cache_path {
+            let repo_cache_repo_path = format!(
+                "{}/{}",
+                repo_cache_path.trim_end_matches('/'),
+                source.repo.trim_start_matches('/')
+            );
+            publish_steps.push_str(&format!(
+                "attempt=0\n\
+                 cache_repo=\"{repo_cache_repo_path}\"\n\
+                 until [ -d \"$cache_repo/.git\" ] && [ -d \"$cache_repo/{subdir}\" ]; do\n\
+                 attempt=$((attempt + 1))\n\
+                 if [ \"$attempt\" -ge 30 ]; then echo \"tools repo-cache entry unavailable after $attempt attempts: $cache_repo/{subdir}\" >&2; exit 1; fi\n\
+                 sleep 2\n\
+                 done\n\
+                 cp -R \"$cache_repo/{subdir}/.\" \"$target\"/\n"
+            ));
+            metadata_sources.push(json!({
+                "repo": source.repo,
+                "source_subdir": subdir,
+                "git_ref": source.git_ref.as_deref(),
+                "source": "repo_cache",
+                "repo_cache_repo_path": repo_cache_repo_path,
+            }));
+        } else {
+            let repo_url = format!("https://github.com/{}.git", source.repo);
+            let source_path = if index == 0 {
+                "$target/.centaur-source".to_owned()
+            } else {
+                format!("$target/.centaur-source-{index}")
+            };
+            let checkout = match &source.git_ref {
+                Some(git_ref) => format!(
+                    "git -C \"$source\" -c gc.auto=0 fetch --quiet origin \"{git_ref}\" && \
+                     git -C \"$source\" checkout --quiet --detach FETCH_HEAD"
+                ),
+                None => "git -C \"$source\" checkout --quiet".to_owned(),
+            };
+            publish_steps.push_str(&format!(
+                "source=\"{source_path}\"\n\
+                 rm -rf \"$source\"\n\
+                 attempt=0\n\
+                 until git clone --quiet --filter=blob:none --no-checkout \"{repo_url}\" \"$source\" && \
+                 git -C \"$source\" sparse-checkout set \"{subdir}\" && \
+                 {checkout}; do\n\
+                 attempt=$((attempt + 1))\n\
+                 if [ \"$attempt\" -ge 30 ]; then echo \"tools clone failed after $attempt attempts\" >&2; exit 1; fi\n\
+                 rm -rf \"$source\"\n\
+                 sleep 2\n\
+                 done\n\
+                 cp -R \"$source/{subdir}/.\" \"$target\"/\n"
+            ));
+            metadata_sources.push(json!({
+                "repo": source.repo,
+                "source_subdir": subdir,
+                "git_ref": source.git_ref.as_deref(),
+                "source": "git",
+                "source_path": source_path.replace("$target", TOOLS_BOOTSTRAP_DIR),
+            }));
+        }
+    }
+    let first_metadata = metadata_sources
+        .first()
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let metadata = json!({
+        "source_subdir": first_metadata.get("source_subdir").and_then(Value::as_str),
+        "git_ref": first_metadata.get("git_ref").and_then(Value::as_str),
+        "source": first_metadata.get("source").and_then(Value::as_str),
+        "repo_cache_repo_path": first_metadata.get("repo_cache_repo_path").and_then(Value::as_str),
+        "sources": metadata_sources,
+    })
+    .to_string();
     let script = format!(
         "set -e\n\
          {proxy_exports}\
          {askpass}\
          export GIT_TERMINAL_PROMPT=0\n\
          git config --global --add safe.directory '*'\n\
-         attempt=0\n\
          target=\"{TOOLS_BOOTSTRAP_DIR}\"\n\
          mkdir -p \"$target\"\n\
-         {publish_script}\n\
+         {publish_steps}\n\
          cat > \"$target/.centaur-tools-source.json\" <<'CENTAUR_TOOLS_METADATA'\n\
 {metadata}\n\
 CENTAUR_TOOLS_METADATA"

--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -40,24 +40,78 @@ def _git_env() -> tuple[dict[str, str], tempfile.TemporaryDirectory[str] | None]
     return env, temp_dir
 
 
-def _publish_tools(tool_dir: Path, published: Path) -> None:
-    if not published.is_dir():
-        raise RuntimeError(f"refreshed tools subdir does not exist: {published}")
-
+def _clear_published_tools(tool_dir: Path) -> None:
     for child in tool_dir.iterdir():
-        if child.name in {".centaur-source", ".centaur-tools-source.json"}:
+        if child.name in {".centaur-source", ".centaur-tools-source.json"} or child.name.startswith(
+            ".centaur-source-"
+        ):
             continue
         if child.is_dir() and not child.is_symlink():
             shutil.rmtree(child)
         else:
             child.unlink()
 
+
+def _copy_published_tools(tool_dir: Path, published: Path) -> None:
+    if not published.is_dir():
+        raise RuntimeError(f"refreshed tools subdir does not exist: {published}")
+
     for child in published.iterdir():
         target = tool_dir / child.name
+        if target.exists() or target.is_symlink():
+            if target.is_dir() and not target.is_symlink():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
         if child.is_dir() and not child.is_symlink():
             shutil.copytree(child, target, symlinks=True)
         else:
             shutil.copy2(child, target, follow_symlinks=False)
+
+
+def _publish_tools(tool_dir: Path, published: Path) -> None:
+    _clear_published_tools(tool_dir)
+    _copy_published_tools(tool_dir, published)
+
+
+def _refresh_source(tool_dir: Path, source_metadata: dict[str, object]) -> None:
+    subdir = str(source_metadata.get("source_subdir") or "tools")
+    if source_metadata.get("source") == "repo_cache":
+        repo_cache_repo_path = source_metadata.get("repo_cache_repo_path")
+        if not repo_cache_repo_path:
+            raise RuntimeError("repo-cache tools metadata is missing repo_cache_repo_path")
+        _copy_published_tools(tool_dir, Path(str(repo_cache_repo_path)) / subdir)
+        return
+
+    source_path = Path(str(source_metadata.get("source_path") or tool_dir / ".centaur-source"))
+    if not source_path.is_dir():
+        raise RuntimeError(f"git tools source does not exist: {source_path}")
+
+    git_ref = source_metadata.get("git_ref")
+    env, temp_dir = _git_env()
+    try:
+        if git_ref:
+            subprocess.run(
+                ["git", "-C", str(source_path), "-c", "gc.auto=0", "fetch", "--quiet", "origin", str(git_ref)],
+                check=True,
+                env=env,
+            )
+            subprocess.run(
+                ["git", "-C", str(source_path), "checkout", "--quiet", "--detach", "FETCH_HEAD"],
+                check=True,
+                env=env,
+            )
+        else:
+            subprocess.run(
+                ["git", "-C", str(source_path), "pull", "--ff-only", "--quiet"],
+                check=True,
+                env=env,
+            )
+    finally:
+        if temp_dir is not None:
+            temp_dir.cleanup()
+
+    _copy_published_tools(tool_dir, source_path / subdir)
 
 
 def _refresh_tool_dir(tool_dir: Path) -> bool:
@@ -67,6 +121,15 @@ def _refresh_tool_dir(tool_dir: Path) -> bool:
         return False
 
     metadata = json.loads(metadata_path.read_text())
+    sources = metadata.get("sources")
+    if isinstance(sources, list) and sources:
+        _clear_published_tools(tool_dir)
+        for source_metadata in sources:
+            if not isinstance(source_metadata, dict):
+                raise RuntimeError(f"invalid tools source metadata in {metadata_path}: {source_metadata!r}")
+            _refresh_source(tool_dir, source_metadata)
+        return True
+
     subdir = metadata.get("source_subdir") or "tools"
     if metadata.get("source") == "repo_cache":
         repo_cache_repo_path = metadata.get("repo_cache_repo_path")


### PR DESCRIPTION
## Summary
- add toolServer.extraSources chart support for repo-cache-backed overlay tool/workflow repos
- have api-rs scan all configured repo-cache tool dirs for iron-control tool-secret reconciliation
- have tools-bootstrap and centaur-tools refresh copy multiple sources in order, with later sources shadowing earlier ones

This lets staging/prod configure tempoxyz/centaur-tempo as a repo-cache source instead of relying on overlay images.

## Validation
- cargo fmt --all --manifest-path services/api-rs/Cargo.toml
- cargo test --manifest-path services/api-rs/Cargo.toml -p centaur-api-server -p centaur-sandbox-agent-k8s
- python3 -m py_compile services/sandbox/install_tool_shims.py
- helm template centaur contrib/chart
- helm template centaur contrib/chart --set 'toolServer.extraSources[0].repo=tempoxyz/centaur-tempo'
- git diff --check on touched files
- rg overlay image refs under contrib/chart services/api-rs services/sandbox