### PR TITLE
feat: surface api-rs runtime identity

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -29,6 +29,8 @@ use centaur_session_core::HarnessType;
 use centaur_session_runtime::SandboxWorkloadMode;
 use centaur_workflows::WorkflowHostSandboxRuntime;
 use clap::{Args as ClapArgs, Parser, ValueEnum};
+use serde_json::json;
+use sha2::{Digest, Sha256};
 use tracing::{error, info};
 
 use crate::{
@@ -783,7 +785,8 @@ impl SandboxArgs {
                 let mut workload = SandboxWorkloadMode::codex_app_server(
                     image,
                     self.codex_app_server_env_template()?,
-                );
+                )
+                .overlay_hash(self.tools_source.overlay_hash());
                 if let Some(repos_path) = clean_optional_value(self.repos_path.as_deref()) {
                     workload = workload.mount(
                         Mount::new(
@@ -1131,6 +1134,31 @@ impl ToolsArgs {
             }
         }
         Some(config)
+    }
+
+    fn overlay_hash(&self) -> Option<String> {
+        let repo = clean_optional_value(self.repo.as_deref())?;
+        let git_ref = clean_optional_value(self.git_ref.as_deref());
+        let source_subdir = clean_optional_value(Some(self.source_subdir.as_str()))
+            .unwrap_or_else(|| "tools".to_owned());
+        let extra_sources = clean_optional_value(self.extra_sources.as_deref());
+        if let (Some(git_ref), None) = (&git_ref, &extra_sources)
+            && clean_optional_value(self.repo_cache_path.as_deref()).is_none()
+            && is_sha_like_ref(git_ref)
+        {
+            return Some(git_ref.clone());
+        }
+        let descriptor = json!({
+            "repo": repo,
+            "git_ref": git_ref,
+            "source_subdir": source_subdir,
+            "repo_cache_path": clean_optional_value(self.repo_cache_path.as_deref()),
+            "extra_sources": extra_sources,
+        });
+        let encoded =
+            serde_json::to_vec(&descriptor).expect("tool source descriptor should serialize");
+        let digest = Sha256::digest(encoded);
+        Some(format!("sha256:{digest:x}"))
     }
 }
 
@@ -1498,6 +1526,14 @@ fn clean_optional_value(value: Option<&str>) -> Option<String> {
     non_empty(value).map(ToOwned::to_owned)
 }
 
+fn is_sha_like_ref(value: &str) -> bool {
+    let value = value
+        .strip_prefix("sha-")
+        .or_else(|| value.strip_prefix("sha_"))
+        .unwrap_or(value);
+    (7..=64).contains(&value.len()) && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
 fn upsert_spec_env(spec: &mut SandboxSpec, name: String, value: String) {
     if let Some(existing) = spec.env.iter_mut().find(|env| env.name == name) {
         existing.value = value;
@@ -1647,6 +1683,35 @@ mod tests {
         let token = tools.github_token.expect("token should be Some");
         assert_eq!(token.secret_name, "centaur-repo-cache-github-token");
         assert_eq!(token.secret_key, "token");
+        assert!(
+            args.sandbox
+                .tools_source
+                .overlay_hash()
+                .is_some_and(|hash| hash.starts_with("sha256:"))
+        );
+    }
+
+    #[test]
+    fn tools_overlay_hash_hashes_layered_source_descriptors() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--kubernetes-tools-repo",
+            "paradigmxyz/centaur",
+            "--kubernetes-tools-ref",
+            "main",
+            "--kubernetes-tools-runner-image",
+            "centaur-agent:test",
+            "--kubernetes-tools-extra-sources",
+            r#"[{"repo":"tempoxyz/centaur-tempo","ref":"abc1234","subdir":"tools"}]"#,
+        ])
+        .unwrap();
+
+        let hash = args.sandbox.tools_source.overlay_hash().unwrap();
+
+        assert!(hash.starts_with("sha256:"));
+        assert_ne!(hash, "main");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -234,11 +234,28 @@ async fn execute_session(
             },
         )
         .await?;
+    tracing::info!(
+        component = "api_server",
+        event = "session_execute_response",
+        thread_key = %execution.thread_key,
+        execution_id = %execution.execution_id,
+        status = %execution.status,
+        base_image_hash = execution.base_image_hash.as_deref().unwrap_or(""),
+        overlay_hash = execution.overlay_hash.as_deref().unwrap_or(""),
+        model = execution.model.as_deref().unwrap_or(""),
+        harness_run_id = execution.harness_run_id.as_deref().unwrap_or(""),
+        "session execution response ready"
+    );
     Ok(Json(ExecuteSessionResponse {
         ok: true,
         execution_id: execution.execution_id,
         thread_key: execution.thread_key,
         status: execution.status.to_string(),
+        base_image_ref: execution.base_image_ref,
+        base_image_hash: execution.base_image_hash,
+        overlay_hash: execution.overlay_hash,
+        model: execution.model,
+        harness_run_id: execution.harness_run_id,
     }))
 }
 

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -39,6 +39,11 @@ pub struct ExecuteSessionResponse {
     pub execution_id: String,
     pub thread_key: ThreadKey,
     pub status: String,
+    pub base_image_ref: Option<String>,
+    pub base_image_hash: Option<String>,
+    pub overlay_hash: Option<String>,
+    pub model: Option<String>,
+    pub harness_run_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -586,12 +586,33 @@ fn build_agent_sandbox(
     );
 
     let mut annotations = config.annotations.clone();
+    insert_annotation(
+        &mut annotations,
+        "centaur.ai/base-image-ref",
+        spec.runtime_identity.base_image_ref.as_deref(),
+    );
+    insert_annotation(
+        &mut annotations,
+        "centaur.ai/base-image-hash",
+        spec.runtime_identity.base_image_hash.as_deref(),
+    );
+    insert_annotation(
+        &mut annotations,
+        "centaur.ai/overlay-hash",
+        spec.runtime_identity.overlay_hash.as_deref(),
+    );
+    insert_annotation(
+        &mut annotations,
+        "centaur.ai/model",
+        spec.runtime_identity.model.as_deref(),
+    );
     if let Some(principal) = &spec.iron_control_principal {
         annotations.insert(
             IRON_CONTROL_PRINCIPAL_ANNOTATION.to_owned(),
             principal.clone(),
         );
     }
+    agent_spec["podTemplate"]["metadata"]["annotations"] = json!(annotations.clone());
 
     let crd_spec = serde_json::from_value(agent_spec)
         .map_err(|err| SandboxError::InvalidSpec(format!("invalid Agent Sandbox spec: {err}")))?;
@@ -632,6 +653,12 @@ fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
         });
     }
     (volumes, mounts)
+}
+
+fn insert_annotation(annotations: &mut BTreeMap<String, String>, name: &str, value: Option<&str>) {
+    if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+        annotations.insert(name.to_owned(), value.to_owned());
+    }
 }
 
 fn resources_json(spec: &SandboxSpec) -> Option<Value> {
@@ -721,7 +748,14 @@ mod tests {
 
     #[test]
     fn builds_agent_sandbox_spec_with_state_volume_and_limits() {
-        let spec = SandboxSpec::new("centaur-agent:latest")
+        let spec = SandboxSpec::new("centaur-agent:sha-deadbeef")
+            .runtime_identity(
+                centaur_sandbox_core::SandboxRuntimeIdentity::from_base_image(
+                    "centaur-agent:sha-deadbeef",
+                )
+                .overlay_hash(Some("overlay-sha".to_owned()))
+                .model(Some("gpt-5".to_owned())),
+            )
             .command(["/bin/sh", "-lc"])
             .args(["cat"])
             .env("CENTAUR_API_URL", "http://api:8000")
@@ -754,10 +788,30 @@ mod tests {
             sandbox.spec.pod_template.spec.enable_service_links,
             Some(false)
         );
-        assert_eq!(container.image.as_deref(), Some("centaur-agent:latest"));
+        assert_eq!(
+            container.image.as_deref(),
+            Some("centaur-agent:sha-deadbeef")
+        );
         assert_eq!(container.stdin, Some(true));
         assert_eq!(container.volume_mounts.as_ref().unwrap().len(), 2);
         assert!(container.resources.as_ref().unwrap().limits.is_some());
+        let annotations = sandbox.metadata.annotations.as_ref().unwrap();
+        assert_eq!(
+            annotations
+                .get("centaur.ai/base-image-hash")
+                .map(String::as_str),
+            Some("sha-deadbeef")
+        );
+        assert_eq!(
+            annotations
+                .get("centaur.ai/overlay-hash")
+                .map(String::as_str),
+            Some("overlay-sha")
+        );
+        assert_eq!(
+            annotations.get("centaur.ai/model").map(String::as_str),
+            Some("gpt-5")
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
@@ -16,4 +16,6 @@ pub use io::{SandboxIo, SandboxIoGuard, SandboxIoParts, SandboxRead, SandboxWrit
 pub use lifecycle::{
     DesiredSandboxState, ObservedSandbox, SandboxHandle, SandboxId, SandboxStatus,
 };
-pub use spec::{EnvVar, Mount, MountKind, ResourceLimits, SandboxSpec};
+pub use spec::{
+    EnvVar, Mount, MountKind, ResourceLimits, SandboxRuntimeIdentity, SandboxSpec, image_ref_hash,
+};

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -16,12 +16,19 @@ pub struct SandboxSpec {
     /// proxy for the sandbox instead of rendering a static proxy config.
     #[serde(default)]
     pub iron_control_principal: Option<String>,
+    /// Operator-facing runtime identity stamped by the control plane. This is
+    /// not used by backends for scheduling; it lets API responses, logs, and
+    /// pod annotations identify what ran.
+    #[serde(default)]
+    pub runtime_identity: SandboxRuntimeIdentity,
 }
 
 impl SandboxSpec {
     pub fn new(image: impl Into<String>) -> Self {
+        let image = image.into();
         Self {
-            image: image.into(),
+            runtime_identity: SandboxRuntimeIdentity::from_base_image(&image),
+            image,
             labels: std::collections::BTreeMap::new(),
             command: None,
             args: Vec::new(),
@@ -70,6 +77,44 @@ impl SandboxSpec {
 
     pub fn resources(mut self, resources: ResourceLimits) -> Self {
         self.resources = Some(resources);
+        self
+    }
+
+    pub fn runtime_identity(mut self, identity: SandboxRuntimeIdentity) -> Self {
+        self.runtime_identity = identity;
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SandboxRuntimeIdentity {
+    #[serde(default)]
+    pub base_image_ref: Option<String>,
+    #[serde(default)]
+    pub base_image_hash: Option<String>,
+    #[serde(default)]
+    pub overlay_hash: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+impl SandboxRuntimeIdentity {
+    pub fn from_base_image(image_ref: &str) -> Self {
+        Self {
+            base_image_ref: non_empty(image_ref),
+            base_image_hash: image_ref_hash(image_ref),
+            overlay_hash: None,
+            model: None,
+        }
+    }
+
+    pub fn overlay_hash(mut self, value: Option<String>) -> Self {
+        self.overlay_hash = value.and_then(|value| non_empty(&value));
+        self
+    }
+
+    pub fn model(mut self, value: Option<String>) -> Self {
+        self.model = value.and_then(|value| non_empty(&value));
         self
     }
 }
@@ -146,5 +191,67 @@ impl ResourceLimits {
 impl Default for ResourceLimits {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub fn image_ref_hash(image_ref: &str) -> Option<String> {
+    let image_ref = image_ref.trim();
+    if image_ref.is_empty() {
+        return None;
+    }
+    if let Some((_, digest)) = image_ref.rsplit_once('@') {
+        return non_empty(digest);
+    }
+    let tail = image_ref.rsplit('/').next().unwrap_or(image_ref);
+    let (_, tag) = tail.rsplit_once(':')?;
+    let tag = tag.trim();
+    if is_sha_like_tag(tag) || tag.to_ascii_lowercase().contains("sha-") {
+        return Some(tag.to_owned());
+    }
+    None
+}
+
+fn is_sha_like_tag(value: &str) -> bool {
+    let value = value
+        .strip_prefix("sha-")
+        .or_else(|| value.strip_prefix("sha_"))
+        .unwrap_or(value);
+    (7..=64).contains(&value.len()) && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SandboxSpec, image_ref_hash};
+
+    #[test]
+    fn extracts_image_hash_from_digest_or_sha_tag() {
+        assert_eq!(
+            image_ref_hash("ghcr.io/org/agent@sha256:abc123"),
+            Some("sha256:abc123".to_owned())
+        );
+        assert_eq!(
+            image_ref_hash("ghcr.io/org/agent:sha-deadbeef"),
+            Some("sha-deadbeef".to_owned())
+        );
+        assert_eq!(image_ref_hash("ghcr.io/org/agent:latest"), None);
+    }
+
+    #[test]
+    fn sandbox_spec_defaults_base_runtime_identity_from_image() {
+        let spec = SandboxSpec::new("ghcr.io/org/agent:sha-deadbeef");
+
+        assert_eq!(
+            spec.runtime_identity.base_image_ref.as_deref(),
+            Some("ghcr.io/org/agent:sha-deadbeef")
+        );
+        assert_eq!(
+            spec.runtime_identity.base_image_hash.as_deref(),
+            Some("sha-deadbeef")
+        );
     }
 }

--- a/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
@@ -1,6 +1,8 @@
 use std::{sync::Arc, time::Duration};
 
-use centaur_sandbox_core::{SandboxError, SandboxId, SandboxSpec, SandboxStatus};
+use centaur_sandbox_core::{
+    SandboxError, SandboxId, SandboxRuntimeIdentity, SandboxSpec, SandboxStatus,
+};
 use centaur_session_sqlx::{PgSessionStore, SessionStoreError};
 use thiserror::Error;
 use tokio::time::{MissedTickBehavior, interval};
@@ -43,6 +45,10 @@ impl WarmPoolManager {
 
     pub fn workload_key(&self) -> &str {
         &self.workload_key
+    }
+
+    pub fn runtime_identity(&self) -> SandboxRuntimeIdentity {
+        (self.spec_factory)().runtime_identity
     }
 
     pub fn spawn_replenisher(self: Arc<Self>) {

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -200,12 +200,25 @@ pub struct SessionExecution {
     pub idempotency_key: Option<String>,
     pub thread_key: ThreadKey,
     pub status: ExecutionStatus,
+    pub base_image_ref: Option<String>,
+    pub base_image_hash: Option<String>,
+    pub overlay_hash: Option<String>,
+    pub model: Option<String>,
+    pub harness_run_id: Option<String>,
     pub metadata: Value,
     pub error: Option<String>,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
     pub started_at: Option<OffsetDateTime>,
     pub completed_at: Option<OffsetDateTime>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionRuntimeIdentity {
+    pub base_image_ref: Option<String>,
+    pub base_image_hash: Option<String>,
+    pub overlay_hash: Option<String>,
+    pub model: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -6,15 +6,15 @@ use std::{
 
 use centaur_iron_control::SessionRegistrar;
 use centaur_sandbox_core::{
-    Mount, SandboxBackend, SandboxError, SandboxId, SandboxIoGuard, SandboxRead, SandboxSpec,
-    SandboxStatus, SandboxWrite,
+    Mount, SandboxBackend, SandboxError, SandboxId, SandboxIoGuard, SandboxRead,
+    SandboxRuntimeIdentity, SandboxSpec, SandboxStatus, SandboxWrite,
 };
 use centaur_sandbox_manager::{
     SandboxManager, WarmPoolConfig, WarmPoolError, WarmPoolManager, WarmSandboxSpecFactory,
 };
 use centaur_session_core::{
-    ExecutionStatus, HarnessType, MessageRole, Session, SessionEvent, SessionExecution,
-    SessionMessageInput, ThreadKey,
+    ExecutionRuntimeIdentity, ExecutionStatus, HarnessType, MessageRole, Session, SessionEvent,
+    SessionExecution, SessionMessageInput, ThreadKey,
 };
 use centaur_session_sqlx::{
     PgSessionStore, SessionEventListener, SessionStoreError, default_metadata,
@@ -69,11 +69,13 @@ pub struct SandboxRuntime {
 pub enum SandboxWorkloadMode {
     MockAppServer {
         image: String,
+        runtime_identity: SandboxRuntimeIdentity,
     },
     CodexAppServer {
         image: String,
         env: Vec<(String, String)>,
         mounts: Vec<Mount>,
+        runtime_identity: SandboxRuntimeIdentity,
     },
 }
 
@@ -400,9 +402,15 @@ impl SessionRuntime {
             "centaur.thread_key" = thread_key.as_str(),
             "centaur.execution_id" = tracing::field::Empty,
             "centaur.sandbox_id" = tracing::field::Empty,
+            "centaur.base_image_hash" = tracing::field::Empty,
+            "centaur.overlay_hash" = tracing::field::Empty,
+            "centaur.model" = tracing::field::Empty,
             thread_key = %thread_key,
             execution_id = tracing::field::Empty,
             sandbox_id = tracing::field::Empty,
+            base_image_hash = tracing::field::Empty,
+            overlay_hash = tracing::field::Empty,
+            model = tracing::field::Empty,
             input_line_count,
             idempotency_key_present,
         );
@@ -420,7 +428,7 @@ impl SessionRuntime {
             validate_input_lines(&input_lines)?;
             let (idle_timeout, max_duration) = duration_options(idle_timeout_ms, max_duration_ms)?;
 
-            let execution = self
+            let create_result = self
                 .store
                 .create_execution(
                     thread_key,
@@ -428,25 +436,63 @@ impl SessionRuntime {
                     execution_metadata(metadata, idle_timeout_ms, max_duration_ms),
                 )
                 .await?;
-            span.record(
-                "centaur.execution_id",
-                execution.execution.execution_id.as_str(),
+            let runtime_identity = identity_with_model_fallback(
+                self.sandbox_runtime
+                    .runtime_identity(thread_key, &create_result.execution.execution_id),
+                &session.harness_type,
             );
-            span.record("execution_id", execution.execution.execution_id.as_str());
-            if !execution.created && execution.execution.status != ExecutionStatus::Queued {
+            let execution_created = create_result.created;
+            let execution_needs_identity = create_result.execution.status
+                == ExecutionStatus::Queued
+                && execution_runtime_identity_missing(&create_result.execution, &runtime_identity);
+            let execution = if execution_created || execution_needs_identity {
+                self.store
+                    .update_execution_runtime_identity(
+                        &create_result.execution.execution_id,
+                        &runtime_identity,
+                    )
+                    .await?
+            } else {
+                create_result.execution
+            };
+            span.record("centaur.execution_id", execution.execution_id.as_str());
+            span.record("execution_id", execution.execution_id.as_str());
+            span.record(
+                "centaur.base_image_hash",
+                execution.base_image_hash.as_deref().unwrap_or(""),
+            );
+            span.record(
+                "centaur.overlay_hash",
+                execution.overlay_hash.as_deref().unwrap_or(""),
+            );
+            span.record("centaur.model", execution.model.as_deref().unwrap_or(""));
+            span.record(
+                "base_image_hash",
+                execution.base_image_hash.as_deref().unwrap_or(""),
+            );
+            span.record(
+                "overlay_hash",
+                execution.overlay_hash.as_deref().unwrap_or(""),
+            );
+            span.record("model", execution.model.as_deref().unwrap_or(""));
+            if !execution_created && execution.status != ExecutionStatus::Queued {
                 info!(
                     component = COMPONENT_SESSION_RUNTIME,
                     event = "session_execute_idempotent_replay",
                     thread_key = %thread_key,
-                    execution_id = %execution.execution.execution_id,
-                    status = %execution.execution.status,
+                    execution_id = %execution.execution_id,
+                    status = %execution.status,
+                    base_image_hash = execution.base_image_hash.as_deref().unwrap_or(""),
+                    overlay_hash = execution.overlay_hash.as_deref().unwrap_or(""),
+                    model = execution.model.as_deref().unwrap_or(""),
+                    harness_run_id = execution.harness_run_id.as_deref().unwrap_or(""),
                     "returning existing execution"
                 );
-                return Ok(execution.execution);
+                return Ok(execution);
             }
             let claim = self
                 .store
-                .mark_execution_running(&execution.execution.execution_id)
+                .mark_execution_running(&execution.execution_id)
                 .await?;
             let execution = claim.execution;
             span.record("centaur.execution_id", execution.execution_id.as_str());
@@ -473,9 +519,15 @@ impl SessionRuntime {
                 "centaur.thread_key" = thread_key.as_str(),
                 "centaur.execution_id" = execution.execution_id.as_str(),
                 "centaur.sandbox_id" = tracing::field::Empty,
+                "centaur.base_image_hash" = execution.base_image_hash.as_deref().unwrap_or(""),
+                "centaur.overlay_hash" = execution.overlay_hash.as_deref().unwrap_or(""),
+                "centaur.model" = execution.model.as_deref().unwrap_or(""),
                 thread_key = %thread_key,
                 execution_id = %execution.execution_id,
                 sandbox_id = tracing::field::Empty,
+                base_image_hash = execution.base_image_hash.as_deref().unwrap_or(""),
+                overlay_hash = execution.overlay_hash.as_deref().unwrap_or(""),
+                model = execution.model.as_deref().unwrap_or(""),
             );
             self.execution_spans
                 .lock()
@@ -493,6 +545,10 @@ impl SessionRuntime {
                         "input_line_count": input_line_count,
                         "idle_timeout_ms": idle_timeout_ms,
                         "max_duration_ms": max_duration_ms,
+                        "base_image_ref": execution.base_image_ref.clone(),
+                        "base_image_hash": execution.base_image_hash.clone(),
+                        "overlay_hash": execution.overlay_hash.clone(),
+                        "model": execution.model.clone(),
                     }),
                 )
                 .await?;
@@ -559,6 +615,9 @@ impl SessionRuntime {
                 execution_id = %execution.execution_id,
                 sandbox_id = %sandbox_id,
                 status = %execution.status,
+                base_image_hash = execution.base_image_hash.as_deref().unwrap_or(""),
+                overlay_hash = execution.overlay_hash.as_deref().unwrap_or(""),
+                model = execution.model.as_deref().unwrap_or(""),
                 completion_reason = "input_accepted",
                 "session execution accepted input"
             );
@@ -588,6 +647,32 @@ impl SessionRuntime {
     ) {
         self.execution_spans.lock().await.remove(execution_id);
         let error_message = error.to_string();
+        if let Ok(execution) = self
+            .store
+            .fail_execution(execution_id, &error_message)
+            .await
+        {
+            let _ = self
+                .store
+                .append_event(
+                    thread_key,
+                    Some(execution_id),
+                    "session.execution_failed",
+                    json!({
+                        "execution_id": execution_id,
+                        "thread_key": thread_key.as_str(),
+                        "error": error_message,
+                        "base_image_ref": execution.base_image_ref.clone(),
+                        "base_image_hash": execution.base_image_hash.clone(),
+                        "overlay_hash": execution.overlay_hash.clone(),
+                        "model": execution.model.clone(),
+                        "harness_run_id": execution.harness_run_id.clone(),
+                    }),
+                )
+                .await;
+            record_finished_execution_metric(&self.store, thread_key, &execution, "failed").await;
+            return;
+        }
         let _ = self
             .store
             .append_event(
@@ -601,13 +686,6 @@ impl SessionRuntime {
                 }),
             )
             .await;
-        if let Ok(execution) = self
-            .store
-            .fail_execution(execution_id, &error_message)
-            .await
-        {
-            record_finished_execution_metric(&self.store, thread_key, &execution, "failed").await;
-        }
     }
 
     async fn forward_messages_to_active_execution(
@@ -914,6 +992,8 @@ impl SessionRuntime {
                     .await
                 {
                     Ok(Some(sandbox_id)) => {
+                        let identity =
+                            execution_identity_from_sandbox_identity(&warm_pool.runtime_identity());
                         record_sandbox_warm_pool_claim("hit");
                         span.record("centaur.sandbox_id", sandbox_id.as_str());
                         span.record("sandbox_id", sandbox_id.as_str());
@@ -929,6 +1009,10 @@ impl SessionRuntime {
                                     "sandbox_id": sandbox_id.as_str(),
                                     "workload_key": warm_pool.workload_key(),
                                     "iron_control_principal": iron_control_principal,
+                                    "base_image_ref": identity.base_image_ref.clone(),
+                                    "base_image_hash": identity.base_image_hash.clone(),
+                                    "overlay_hash": identity.overlay_hash.clone(),
+                                    "model": identity.model.clone(),
                                 }),
                             )
                             .await?;
@@ -939,6 +1023,9 @@ impl SessionRuntime {
                             execution_id,
                             sandbox_id = %sandbox_id,
                             workload_key = warm_pool.workload_key(),
+                            base_image_hash = identity.base_image_hash.as_deref().unwrap_or(""),
+                            overlay_hash = identity.overlay_hash.as_deref().unwrap_or(""),
+                            model = identity.model.as_deref().unwrap_or(""),
                             "claimed warm session sandbox"
                         );
                         return Ok(sandbox_id);
@@ -955,6 +1042,7 @@ impl SessionRuntime {
             if let Some(principal) = iron_control_principal {
                 spec.iron_control_principal = Some(principal.to_owned());
             }
+            let identity = execution_identity_from_sandbox_identity(&spec.runtime_identity);
             let handle = self.sandbox_runtime.manager.create_running(spec).await?;
             span.record("centaur.sandbox_id", handle.id.as_str());
             span.record("sandbox_id", handle.id.as_str());
@@ -967,6 +1055,9 @@ impl SessionRuntime {
                 thread_key = %thread_key,
                 execution_id,
                 sandbox_id = %handle.id.as_str(),
+                base_image_hash = identity.base_image_hash.as_deref().unwrap_or(""),
+                overlay_hash = identity.overlay_hash.as_deref().unwrap_or(""),
+                model = identity.model.as_deref().unwrap_or(""),
                 "created new session sandbox"
             );
             Ok(handle.id.into_string())
@@ -1196,12 +1287,24 @@ impl SandboxRuntime {
             workload_key: Some(workload_key),
         }
     }
+
+    fn runtime_identity(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: &str,
+    ) -> ExecutionRuntimeIdentity {
+        execution_identity_from_sandbox_identity(
+            &(self.spec_factory)(thread_key, execution_id).runtime_identity,
+        )
+    }
 }
 
 impl SandboxWorkloadMode {
     pub fn mock_app_server(image: impl Into<String>) -> Self {
+        let image = image.into();
         Self::MockAppServer {
-            image: image.into(),
+            runtime_identity: SandboxRuntimeIdentity::from_base_image(&image),
+            image,
         }
     }
 
@@ -1209,9 +1312,13 @@ impl SandboxWorkloadMode {
         image: impl Into<String>,
         env: impl IntoIterator<Item = (String, String)>,
     ) -> Self {
+        let image = image.into();
+        let env = env.into_iter().collect::<Vec<_>>();
         Self::CodexAppServer {
-            image: image.into(),
-            env: env.into_iter().collect(),
+            runtime_identity: SandboxRuntimeIdentity::from_base_image(&image)
+                .model(model_from_env_pairs(&env)),
+            image,
+            env,
             mounts: Vec::new(),
         }
     }
@@ -1220,6 +1327,20 @@ impl SandboxWorkloadMode {
         match &mut self {
             Self::MockAppServer { .. } => {}
             Self::CodexAppServer { mounts, .. } => mounts.push(mount),
+        }
+        self
+    }
+
+    pub fn overlay_hash(mut self, overlay_hash: Option<String>) -> Self {
+        match &mut self {
+            Self::MockAppServer {
+                runtime_identity, ..
+            }
+            | Self::CodexAppServer {
+                runtime_identity, ..
+            } => {
+                runtime_identity.overlay_hash = overlay_hash.and_then(|value| non_empty(&value));
+            }
         }
         self
     }
@@ -1234,11 +1355,20 @@ impl SandboxWorkloadMode {
 
     fn spec_with_thread_key(&self, thread_key: Option<&ThreadKey>) -> SandboxSpec {
         match self {
-            Self::MockAppServer { image } => SandboxSpec::new(image)
+            Self::MockAppServer {
+                image,
+                runtime_identity,
+            } => SandboxSpec::new(image)
+                .runtime_identity(runtime_identity.clone())
                 .command(["/bin/sh", "-lc"])
                 .args([mock_app_server_script()]),
-            Self::CodexAppServer { image, env, mounts } => {
-                let mut spec = SandboxSpec::new(image);
+            Self::CodexAppServer {
+                image,
+                env,
+                mounts,
+                runtime_identity,
+            } => {
+                let mut spec = SandboxSpec::new(image).runtime_identity(runtime_identity.clone());
                 if let Some(thread_key) = thread_key {
                     spec = spec.env("CENTAUR_THREAD_KEY", thread_key.as_str());
                 }
@@ -1258,6 +1388,62 @@ fn sandbox_spec_key(spec: &SandboxSpec) -> String {
     let encoded = serde_json::to_vec(spec).expect("sandbox specs should serialize");
     let digest = Sha256::digest(encoded);
     format!("sandbox-spec-sha256:{digest:x}")
+}
+
+fn execution_identity_from_sandbox_identity(
+    identity: &SandboxRuntimeIdentity,
+) -> ExecutionRuntimeIdentity {
+    ExecutionRuntimeIdentity {
+        base_image_ref: identity.base_image_ref.clone(),
+        base_image_hash: identity.base_image_hash.clone(),
+        overlay_hash: identity.overlay_hash.clone(),
+        model: identity.model.clone(),
+    }
+}
+
+fn identity_with_model_fallback(
+    mut identity: ExecutionRuntimeIdentity,
+    harness_type: &HarnessType,
+) -> ExecutionRuntimeIdentity {
+    if identity.model.is_none() {
+        identity.model = model_from_harness_env(harness_type);
+    }
+    identity
+}
+
+fn execution_runtime_identity_missing(
+    execution: &SessionExecution,
+    identity: &ExecutionRuntimeIdentity,
+) -> bool {
+    execution.base_image_ref.is_none()
+        || execution.base_image_hash.is_none()
+        || (identity.overlay_hash.is_some() && execution.overlay_hash.is_none())
+        || (identity.model.is_some() && execution.model.is_none())
+}
+
+fn model_from_env_pairs(env: &[(String, String)]) -> Option<String> {
+    for name in ["CODEX_MODEL", "CLAUDE_MODEL", "AMP_MODEL"] {
+        if let Some((_, value)) = env.iter().find(|(env_name, _)| env_name == name)
+            && let Some(value) = non_empty(value)
+        {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn model_from_harness_env(harness_type: &HarnessType) -> Option<String> {
+    let name = match harness_type {
+        HarnessType::Codex => "CODEX_MODEL",
+        HarnessType::ClaudeCode => "CLAUDE_MODEL",
+        HarnessType::Amp => "AMP_MODEL",
+    };
+    std::env::var(name).ok().and_then(|value| non_empty(&value))
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_owned())
 }
 
 fn mock_app_server_script() -> &'static str {
@@ -1418,18 +1604,45 @@ async fn run_stdout_pump(
             };
             line_count += 1;
             let output_value = serde_json::from_str::<Value>(&line).ok();
-            if let Some(harness_thread_id) = harness_thread_id_from_output_line(&line)
-                && let Err(error) = ctx
-                    .store
-                    .update_harness_thread_id(&thread_key, Some(&harness_thread_id))
-                    .await
-            {
-                warn!(%thread_key, %harness_thread_id, %error, "failed to persist harness thread id");
-            }
+            let observed_harness_run_id = harness_thread_id_from_output_line(&line);
             let active_execution = ctx.store.active_execution_for_thread(&thread_key).await?;
             let execution_id = active_execution
                 .as_ref()
                 .map(|execution| execution.execution_id.as_str());
+            if let Some(harness_run_id) = observed_harness_run_id.as_deref()
+                && let Some(execution_id) = execution_id
+            {
+                if let Err(error) = ctx
+                    .store
+                    .update_harness_thread_id(&thread_key, Some(harness_run_id))
+                    .await
+                {
+                    warn!(%thread_key, harness_run_id, %error, "failed to persist session harness run id");
+                }
+                match ctx
+                    .store
+                    .update_execution_harness_run_id(execution_id, Some(harness_run_id))
+                    .await
+                {
+                    Ok(execution) => {
+                        info!(
+                            component = COMPONENT_SESSION_RUNTIME,
+                            event = "session_harness_run_observed",
+                            thread_key = %thread_key,
+                            execution_id,
+                            sandbox_id,
+                            harness_run_id,
+                            base_image_hash = execution.base_image_hash.as_deref().unwrap_or(""),
+                            overlay_hash = execution.overlay_hash.as_deref().unwrap_or(""),
+                            model = execution.model.as_deref().unwrap_or(""),
+                            "observed harness run id"
+                        );
+                    }
+                    Err(error) => {
+                        warn!(%thread_key, execution_id, harness_run_id, %error, "failed to persist execution harness run id");
+                    }
+                }
+            }
             let Some(output_execution_id) = output_state.execution_for_line(execution_id, &line)
             else {
                 continue;
@@ -2167,6 +2380,11 @@ async fn record_terminal_output(
                 "execution_id": execution_id,
                 "thread_key": thread_key.as_str(),
                 "completion_reason": reason,
+                "base_image_ref": execution.base_image_ref.clone(),
+                "base_image_hash": execution.base_image_hash.clone(),
+                "overlay_hash": execution.overlay_hash.clone(),
+                "model": execution.model.clone(),
+                "harness_run_id": execution.harness_run_id.clone(),
             });
             if let (Some(result_text), Some(object)) =
                 (result_text.as_deref(), payload.as_object_mut())
@@ -2200,6 +2418,11 @@ async fn record_terminal_output(
                         "execution_id": execution_id,
                         "thread_key": thread_key.as_str(),
                         "error": error.as_str(),
+                        "base_image_ref": execution.base_image_ref.clone(),
+                        "base_image_hash": execution.base_image_hash.clone(),
+                        "overlay_hash": execution.overlay_hash.clone(),
+                        "model": execution.model.clone(),
+                        "harness_run_id": execution.harness_run_id.clone(),
                     }),
                 )
                 .await?;
@@ -2272,6 +2495,11 @@ async fn record_max_duration_failure(
                 "error": error,
                 "reason": "max_duration_exceeded",
                 "max_duration_ms": max_duration_ms,
+                "base_image_ref": execution.base_image_ref.clone(),
+                "base_image_hash": execution.base_image_hash.clone(),
+                "overlay_hash": execution.overlay_hash.clone(),
+                "model": execution.model.clone(),
+                "harness_run_id": execution.harness_run_id.clone(),
             }),
         )
         .await?;
@@ -3777,6 +4005,32 @@ mod tests {
     }
 
     #[test]
+    fn codex_workload_carries_runtime_identity() {
+        let workload = SandboxWorkloadMode::codex_app_server(
+            "ghcr.io/org/centaur-agent:sha-deadbeef",
+            [("CODEX_MODEL".to_owned(), "gpt-5".to_owned())],
+        )
+        .overlay_hash(Some("overlay-sha".to_owned()));
+        let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+
+        let spec = workload.spec(&thread_key);
+
+        assert_eq!(
+            spec.runtime_identity.base_image_ref.as_deref(),
+            Some("ghcr.io/org/centaur-agent:sha-deadbeef")
+        );
+        assert_eq!(
+            spec.runtime_identity.base_image_hash.as_deref(),
+            Some("sha-deadbeef")
+        );
+        assert_eq!(
+            spec.runtime_identity.overlay_hash.as_deref(),
+            Some("overlay-sha")
+        );
+        assert_eq!(spec.runtime_identity.model.as_deref(), Some("gpt-5"));
+    }
+
+    #[test]
     fn warm_workload_key_ignores_claimed_thread_key() {
         let workload = SandboxWorkloadMode::codex_app_server(
             "centaur-agent:latest",
@@ -3848,6 +4102,11 @@ mod tests {
             idempotency_key: None,
             thread_key,
             status,
+            base_image_ref: None,
+            base_image_hash: None,
+            overlay_hash: None,
+            model: None,
+            harness_run_id: None,
             metadata,
             error: None,
             created_at: now,

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0010_session_runtime_identity.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0010_session_runtime_identity.sql
@@ -1,0 +1,6 @@
+alter table session_executions
+    add column if not exists base_image_ref text,
+    add column if not exists base_image_hash text,
+    add column if not exists overlay_hash text,
+    add column if not exists model text,
+    add column if not exists harness_run_id text;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -3,8 +3,8 @@
 use std::str::FromStr;
 
 use centaur_session_core::{
-    ExecutionStatus, HarnessType, Session, SessionEvent, SessionExecution, SessionMessage,
-    SessionMessageInput, SessionStatus, ThreadKey, empty_object,
+    ExecutionRuntimeIdentity, ExecutionStatus, HarnessType, Session, SessionEvent,
+    SessionExecution, SessionMessage, SessionMessageInput, SessionStatus, ThreadKey, empty_object,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -204,6 +204,11 @@ impl PgSessionStore {
                 idempotency_key,
                 thread_key,
                 status,
+                base_image_ref,
+                base_image_hash,
+                overlay_hash,
+                model,
+                harness_run_id,
                 metadata,
                 error,
                 created_at,
@@ -229,7 +234,7 @@ impl PgSessionStore {
     ) -> Result<Option<SessionExecution>, SessionStoreError> {
         let row = sqlx::query_as::<_, SessionExecutionRow>(
             r#"
-            select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            select execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
             from session_executions
             where thread_key = $1 and status in ($2, $3)
             order by created_at desc, execution_id desc
@@ -251,7 +256,7 @@ impl PgSessionStore {
     ) -> Result<Option<SessionExecution>, SessionStoreError> {
         let row = sqlx::query_as::<_, SessionExecutionRow>(
             r#"
-            select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            select execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
             from session_executions
             where thread_key = $1
             order by created_at desc, execution_id desc
@@ -274,7 +279,7 @@ impl PgSessionStore {
             update session_executions
             set status = $2, started_at = coalesce(started_at, now()), updated_at = now()
             where execution_id = $1 and status = $3
-            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            returning execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
             "#,
         )
         .bind(execution_id)
@@ -289,7 +294,7 @@ impl PgSessionStore {
             // row without taking ownership.
             let row = sqlx::query_as::<_, SessionExecutionRow>(
                 r#"
-                select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+                select execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
                 from session_executions
                 where execution_id = $1
                 "#,
@@ -311,6 +316,56 @@ impl PgSessionStore {
         })
     }
 
+    pub async fn update_execution_runtime_identity(
+        &self,
+        execution_id: &str,
+        identity: &ExecutionRuntimeIdentity,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set
+                base_image_ref = $2,
+                base_image_hash = $3,
+                overlay_hash = $4,
+                model = $5,
+                updated_at = now()
+            where execution_id = $1
+            returning execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(identity.base_image_ref.as_deref())
+        .bind(identity.base_image_hash.as_deref())
+        .bind(identity.overlay_hash.as_deref())
+        .bind(identity.model.as_deref())
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn update_execution_harness_run_id(
+        &self,
+        execution_id: &str,
+        harness_run_id: Option<&str>,
+    ) -> Result<SessionExecution, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set harness_run_id = $2, updated_at = now()
+            where execution_id = $1
+            returning execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(harness_run_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
     pub async fn complete_execution(
         &self,
         execution_id: &str,
@@ -320,7 +375,7 @@ impl PgSessionStore {
             update session_executions
             set status = $2, completed_at = coalesce(completed_at, now()), updated_at = now()
             where execution_id = $1
-            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            returning execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
             "#,
         )
         .bind(execution_id)
@@ -342,7 +397,7 @@ impl PgSessionStore {
             update session_executions
             set status = $2, completed_at = coalesce(completed_at, now()), updated_at = now()
             where execution_id = $1 and status in ($3, $4)
-            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            returning execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
             "#,
         )
         .bind(execution_id)
@@ -370,7 +425,7 @@ impl PgSessionStore {
             update session_executions
             set status = $2, error = $3, completed_at = coalesce(completed_at, now()), updated_at = now()
             where execution_id = $1
-            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            returning execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
             "#,
         )
         .bind(execution_id)
@@ -394,7 +449,7 @@ impl PgSessionStore {
             update session_executions
             set status = $2, error = $3, completed_at = coalesce(completed_at, now()), updated_at = now()
             where execution_id = $1 and status in ($4, $5)
-            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            returning execution_id, idempotency_key, thread_key, status, base_image_ref, base_image_hash, overlay_hash, model, harness_run_id, metadata, error, created_at, updated_at, started_at, completed_at
             "#,
         )
         .bind(execution_id)
@@ -767,6 +822,11 @@ struct SessionExecutionRow {
     idempotency_key: Option<String>,
     thread_key: String,
     status: String,
+    base_image_ref: Option<String>,
+    base_image_hash: Option<String>,
+    overlay_hash: Option<String>,
+    model: Option<String>,
+    harness_run_id: Option<String>,
     metadata: Value,
     error: Option<String>,
     created_at: OffsetDateTime,
@@ -784,6 +844,11 @@ impl TryFrom<SessionExecutionRow> for SessionExecution {
             idempotency_key: row.idempotency_key,
             thread_key: parse_persisted(row.thread_key)?,
             status: parse_persisted(row.status)?,
+            base_image_ref: row.base_image_ref,
+            base_image_hash: row.base_image_hash,
+            overlay_hash: row.overlay_hash,
+            model: row.model,
+            harness_run_id: row.harness_run_id,
             metadata: row.metadata,
             error: row.error,
             created_at: row.created_at,
@@ -801,6 +866,11 @@ struct CreateExecutionRow {
     idempotency_key: Option<String>,
     thread_key: String,
     status: String,
+    base_image_ref: Option<String>,
+    base_image_hash: Option<String>,
+    overlay_hash: Option<String>,
+    model: Option<String>,
+    harness_run_id: Option<String>,
     metadata: Value,
     error: Option<String>,
     created_at: OffsetDateTime,
@@ -820,6 +890,11 @@ impl TryFrom<CreateExecutionRow> for CreateExecutionResult {
                 idempotency_key: row.idempotency_key,
                 thread_key: row.thread_key,
                 status: row.status,
+                base_image_ref: row.base_image_ref,
+                base_image_hash: row.base_image_hash,
+                overlay_hash: row.overlay_hash,
+                model: row.model,
+                harness_run_id: row.harness_run_id,
                 metadata: row.metadata,
                 error: row.error,
                 created_at: row.created_at,


### PR DESCRIPTION
## Summary
- Persist runtime identity on api-rs session executions: base image ref/hash,
  tool-source overlay hash, model, and harness run id.
- Expose the same identity through execute responses, session events,
  structured logs/spans, and sandbox annotations.
- Derive base image hash from the sandbox image ref and overlay hash from
  configured api-rs tool sources.

## Testing
- `cargo check -p centaur-sandbox-core -p centaur-sandbox-agent-k8s -p centaur-sandbox-manager -p centaur-session-core -p centaur-session-sqlx -p centaur-session-runtime -p centaur-api-server`
- `cargo test -p centaur-sandbox-core -p centaur-sandbox-agent-k8s -p centaur-session-runtime -p centaur-api-server`
- `cargo test -p centaur-session-sqlx`
- `just build-one api-rs`

Local deploy note: `just deploy` completed the Helm upgrade, but the rebuilt
api-rs pod exited during startup with
`UnsupportedConfig("iron-proxy requires iron-control: set IRON_CONTROL_URL and IRON_CONTROL_API_KEY")`.
I rolled the local deployment back and confirmed the previous api-rs pod is
healthy again.
