### PR TITLE
fix(sandbox): report stopped when the agent container terminates so executions don't reclaim-loop

### DIFF
--- a/services/api/api/sandbox/kubernetes.py
+++ b/services/api/api/sandbox/kubernetes.py
@@ -53,6 +53,23 @@ _READY_TIMEOUT_S = int(os.getenv("KUBERNETES_SANDBOX_READY_TIMEOUT_S", "60"))
 _ATTACH_LOG_TAIL_LINES = int(os.getenv("KUBERNETES_ATTACH_LOG_TAIL_LINES", "200"))
 _CONTAINER_NAME = "sandbox"
 _AGENT_UID = 1001
+
+
+def _agent_container_terminated(pod: Any) -> bool:
+    """True when the sandbox (agent) container has terminated.
+
+    The pod's ``phase`` stays ``Running`` as long as any container is alive, so
+    a crashed/OOMKilled agent container is hidden by the surviving per-sandbox
+    tool-server sidecar. This inspects the agent container's own state so the
+    caller can stop treating such a session as live.
+    """
+    statuses = getattr(getattr(pod, "status", None), "container_statuses", None) or []
+    for container_status in statuses:
+        if getattr(container_status, "name", None) != _CONTAINER_NAME:
+            continue
+        state = getattr(container_status, "state", None)
+        return getattr(state, "terminated", None) is not None
+    return False
 _SANDBOX_OVERLAY_ROOT = "/home/agent/overlay"
 _SANDBOX_OVERLAY_DIR = f"{_SANDBOX_OVERLAY_ROOT}/org"
 # Writable dir the tool-server sidecar installs overlay tool deps into. The
@@ -1900,6 +1917,15 @@ class KubernetesExecutorBackend(SandboxBackend):
             return "stopped"
         phase = (pod.status.phase or "").lower()
         if phase == "running":
+            # Pod phase stays "Running" while *any* container runs, so a
+            # crashed or OOMKilled agent container is masked by the surviving
+            # per-sandbox tool-server sidecar. Report "stopped" when the agent
+            # container itself has terminated, so callers finalize the
+            # execution (failed) instead of reconnecting to a dead container's
+            # stdout forever — a stream that EOFs immediately on every attach,
+            # which otherwise reclaim-loops until the hard deadline.
+            if _agent_container_terminated(pod):
+                return "stopped"
             return "running"
         if phase == "pending":
             return "created"

--- a/services/api/tests/test_sandbox_kubernetes_backend.py
+++ b/services/api/tests/test_sandbox_kubernetes_backend.py
@@ -2171,3 +2171,57 @@ async def test_create_isolates_codex_api_key_from_claude_sandbox(
     proxy_yaml = fake_core.created_configmaps[0][1]["data"]["proxy.yaml"]
     assert "OPENAI_API_KEY" in proxy_yaml
     assert "ANTHROPIC_API_KEY" not in proxy_yaml
+
+
+def _status_pod(*, phase: str, sandbox_terminated: bool) -> SimpleNamespace:
+    terminated = (
+        SimpleNamespace(reason="OOMKilled", exit_code=137)
+        if sandbox_terminated
+        else None
+    )
+    return SimpleNamespace(
+        metadata=SimpleNamespace(deletion_timestamp=None),
+        status=SimpleNamespace(
+            phase=phase,
+            container_statuses=[
+                SimpleNamespace(
+                    name="sandbox", state=SimpleNamespace(terminated=terminated)
+                ),
+                SimpleNamespace(
+                    name="tool-server", state=SimpleNamespace(terminated=None)
+                ),
+            ],
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_reports_stopped_when_agent_container_terminated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pod whose sandbox container OOMKilled must not read as ``running``.
+
+    The pod phase stays ``Running`` because the per-sandbox tool-server sidecar
+    survives the agent container's OOM kill. Reporting ``running`` makes the
+    execution worker reclaim-loop on a stream that EOFs immediately on every
+    reattach (dead container's stdout) until the hard deadline, instead of
+    finalizing the execution as failed.
+    """
+    from api.sandbox.kubernetes import KubernetesExecutorBackend
+
+    monkeypatch.setenv("KUBERNETES_NAMESPACE", "centaur")
+    backend = KubernetesExecutorBackend()
+
+    async def _noop() -> None:
+        return None
+
+    monkeypatch.setattr(backend, "_ensure_clients", _noop)
+    fake_core = FakeCoreApi()
+    backend._core = fake_core  # type: ignore[attr-defined]
+
+    fake_core.pods_to_read = [_status_pod(phase="Running", sandbox_terminated=True)]
+    assert await backend.status_by_id("sandbox-x") == "stopped"
+
+    # Control: agent container still alive → genuinely running.
+    fake_core.pods_to_read = [_status_pod(phase="Running", sandbox_terminated=False)]
+    assert await backend.status_by_id("sandbox-x") == "running"


### PR DESCRIPTION
## Problem

When a sandbox's agent container is OOMKilled (or otherwise terminates) mid-turn, the execution gets stuck in an endless reclaim loop until the hard deadline and the user never gets a response.

## Root cause

`KubernetesExecutorBackend.status_by_id` derives session status from the **pod phase** alone. The phase stays `Running` as long as *any* container runs — and each sandbox pod has a per-sandbox `tool-server` sidecar that survives the agent container's death. So after the `sandbox` container is OOMKilled (exit 137), `status_by_id` still returns `running`.

The execution stream consumer (`runtime_control`) then sees the dead container's stdout stream EOF, checks `backend.status(...)`, gets `running`, and sets the execution back to `retry_wait` expecting a reattach to recover. But every reattach to the dead container's stdout EOFs immediately, so it loops — `execute_claimed` roughly every 60s — until the hard-deadline reaper terminalizes it. No failure is ever surfaced to the user.

Observed in a deployed GKE cluster: a memory-heavy build OOM-killed the sandbox container; the attach stream closed (`{"status":"Success"}`) at the exact instant of the OOM kill; `podPhase=Running` (sidecar still alive) → reclaim loop for the entire deadline window.

## Fix

`status_by_id` now inspects the agent (`sandbox`) container's own state. If that container has terminated, it returns `stopped` even when the pod phase is `Running`, so the stream-EOF path finalizes the execution (failed) instead of reclaim-looping on a dead container's stdout.

## Testing

- Added `test_status_by_id_reports_stopped_when_agent_container_terminated` — OOMKilled agent container + `Running` pod phase → `stopped`; live agent container → `running`. Passing (`uv run pytest tests/test_sandbox_kubernetes_backend.py`); `ruff check` clean.
- Root cause reproduced live (a real monorepo build OOM-killed the sandbox container at its memory limit); this change finalizes such executions cleanly instead of looping.
