### PR TITLE
fix(api-rs): raise session body limits

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -20,7 +20,7 @@ mod tests {
     use async_trait::async_trait;
     use axum::{
         body::{Body, to_bytes},
-        http::{Request, StatusCode},
+        http::{Request, StatusCode, header},
     };
     use centaur_sandbox_core::{
         ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
@@ -87,6 +87,59 @@ mod tests {
                 r#"http_server_requests_total{method="GET",route="/healthz",status="200"}"#
             )
         );
+    }
+
+    #[tokio::test]
+    async fn append_messages_accepts_payloads_larger_than_axum_default_limit() {
+        let pool =
+            PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
+        let app = build_router_with_runtime(
+            PgSessionStore::new(pool),
+            SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
+        );
+        let body = format!(
+            r#"{{"messages":[],"padding":"{}"}}"#,
+            "x".repeat(3 * 1024 * 1024)
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/session/slack%3AC123%3A123.456/messages")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn execute_accepts_payloads_larger_than_axum_default_limit() {
+        let pool =
+            PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
+        let app = build_router_with_runtime(
+            PgSessionStore::new(pool),
+            SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
+        );
+        let body = format!(r#"{{"input_lines":["{}"]"#, "x".repeat(3 * 1024 * 1024));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/session/slack%3AC123%3A123.456/execute")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[derive(Default)]

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -9,7 +9,7 @@ use std::{
 use axum::{
     Json, Router,
     body::{Body, Bytes},
-    extract::{MatchedPath, Path, Query, Request, State},
+    extract::{DefaultBodyLimit, MatchedPath, Path, Query, Request, State},
     http::{HeaderMap, Method, StatusCode, Uri},
     middleware::{self, Next},
     response::{
@@ -54,6 +54,7 @@ pub struct AppState {
 }
 
 const MAX_WEBHOOK_BODY_BYTES: usize = 1024 * 1024;
+const MAX_SESSION_JSON_BODY_BYTES: usize = 256 * 1024 * 1024;
 const REDACTED_WEBHOOK_HEADERS: &[&str] = &[
     "authorization",
     "cookie",
@@ -84,8 +85,14 @@ pub fn build_router_with_session_and_workflow_runtime(
         .route("/healthz", get(healthz))
         .route("/metrics", get(metrics))
         .route("/api/session/{thread_key}", post(create_or_get_session))
-        .route("/api/session/{thread_key}/messages", post(append_messages))
-        .route("/api/session/{thread_key}/execute", post(execute_session))
+        .route(
+            "/api/session/{thread_key}/messages",
+            post(append_messages).layer(DefaultBodyLimit::max(MAX_SESSION_JSON_BODY_BYTES)),
+        )
+        .route(
+            "/api/session/{thread_key}/execute",
+            post(execute_session).layer(DefaultBodyLimit::max(MAX_SESSION_JSON_BODY_BYTES)),
+        )
         .route("/api/session/{thread_key}/events", get(stream_events))
         .route("/api/sandboxes/drain", post(drain_sandboxes))
         .route(


### PR DESCRIPTION
## Summary
- raises the Rust API JSON body limit for session message append and execute routes
- keeps the larger limit route-scoped instead of changing webhook or metrics behavior
- adds regression coverage for requests larger than Axum's default body cap

## Root cause
Slackbot v2 can inline attachment data into session message and execute JSON payloads, but the Rust API routes were still using Axum's default JSON body limit. Attachment-bearing requests could fail before reaching the handler with `413 Payload Too Large`.

## Validation
- `cargo test -p centaur-api-server`
- `just build-one api-rs`

No additional local rollout testing was run after splitting this into a separate PR.