### PR TITLE
Inject host-scoped header secrets

### DIFF
--- a/services/api/api/proxy_config.py
+++ b/services/api/api/proxy_config.py
@@ -103,6 +103,13 @@ def _build_source(secret_ref: str) -> dict[str, str]:
     return {"type": "env", "var": secret_ref}
 
 
+def _default_inject_formatter(header: str) -> str:
+    """Return the conventional full header value for an injected raw secret."""
+    if header.lower() in {"authorization", "proxy-authorization"}:
+        return "Bearer {{.Value}}"
+    return ""
+
+
 # Per-sandbox listener that lets a co-located tool-server sidecar reach the
 # core Centaur DB through the proxy (sandboxes are denied direct Postgres
 # egress). Unlike tool ``pg_dsn`` listeners, its upstream is always resolved
@@ -138,7 +145,9 @@ def assign_pg_listen_ports(secrets: list[SecretDef]) -> dict[str, int]:
     return {name: PG_LISTEN_PORT_BASE + idx for idx, name in enumerate(names)}
 
 
-def _secret_action_block(secret: HttpSecret) -> tuple[str, dict[str, Any]]:
+def _secret_action_block(
+    secret: HttpSecret, host_set: set[str] | None = None
+) -> tuple[str, dict[str, Any]]:
     """Return the ``replace``/``inject`` block iron-proxy expects for *secret*.
 
     Replace mode emits the ``proxy_value`` placeholder plus the scan locations
@@ -146,6 +155,20 @@ def _secret_action_block(secret: HttpSecret) -> tuple[str, dict[str, Any]]:
     Inject mode emits the target iron-proxy writes itself — a header (with an
     optional Go-template ``formatter``) or a query parameter.
     """
+    if (
+        secret.mode is SecretMode.REPLACE
+        and (host_set if host_set is not None else secret.hosts)
+        and secret.match_headers
+        and not secret.match_path
+        and not secret.match_query
+    ):
+        if len(secret.match_headers) == 1:
+            block = {"header": secret.match_headers[0]}
+            formatter = _default_inject_formatter(secret.match_headers[0])
+            if formatter:
+                block["formatter"] = formatter
+            return "inject", block
+
     if secret.mode is SecretMode.REPLACE:
         block: dict[str, Any] = {
             "proxy_value": secret.replacer,
@@ -186,7 +209,7 @@ def _build_secret_transform(
 
     entries: list[dict[str, Any]] = []
     for secret, host_set in sorted(by_secret.items(), key=lambda kv: astuple(kv[0])):
-        action, block = _secret_action_block(secret)
+        action, block = _secret_action_block(secret, host_set)
         entries.append(
             {
                 "source": _build_source(secret.secret_ref),

--- a/services/api/tests/test_proxy_config.py
+++ b/services/api/tests/test_proxy_config.py
@@ -876,12 +876,52 @@ def test_render_emits_header_and_gcp_auth_transforms(
     assert names == ["allowlist", "secrets", "gcp_auth", "header_allowlist"]
     secrets_block = next(t for t in cfg["transforms"] if t["name"] == "secrets")
     entry = secrets_block["config"]["secrets"][0]
-    assert "inject" not in entry
-    assert entry["replace"]["proxy_value"] == "OPENAI_API_KEY"
-    assert entry["replace"]["match_headers"] == ["Authorization"]
-    assert "match_path" not in entry["replace"]
-    assert "match_query" not in entry["replace"]
+    assert "replace" not in entry
+    assert entry["inject"] == {
+        "header": "Authorization",
+        "formatter": "Bearer {{.Value}}",
+    }
     assert entry["rules"] == [{"host": "api.openai.com"}]
+
+
+def test_render_host_scoped_header_secret_injects_raw_non_auth_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    secrets = [
+        HttpSecret(
+            "VENDOR_API_KEY",
+            "VENDOR_API_KEY",
+            hosts=("api.vendor.com",),
+            match_headers=("X-Api-Key",),
+        ),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    secrets_block = next(t for t in cfg["transforms"] if t["name"] == "secrets")
+    entry = secrets_block["config"]["secrets"][0]
+    assert "replace" not in entry
+    assert entry["inject"] == {"header": "X-Api-Key"}
+    assert entry["rules"] == [{"host": "api.vendor.com"}]
+
+
+def test_render_unhosted_header_secret_keeps_legacy_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FIREWALL_MANAGER_SECRET_SOURCE", "env")
+    secrets = [
+        HttpSecret(
+            "LEGACY_API_KEY",
+            "LEGACY_API_KEY",
+            match_headers=("Authorization",),
+        ),
+    ]
+    cfg = yaml.safe_load(render_proxy_yaml(secrets))
+    secrets_block = next(t for t in cfg["transforms"] if t["name"] == "secrets")
+    entry = secrets_block["config"]["secrets"][0]
+    assert "inject" not in entry
+    assert entry["replace"]["proxy_value"] == "LEGACY_API_KEY"
+    assert entry["replace"]["match_headers"] == ["Authorization"]
+    assert entry["rules"] == []
 
 
 def test_render_replace_secret_emits_query_and_path_locations(
@@ -1495,7 +1535,10 @@ def test_render_emits_postgres_listeners_with_env_refs(
     ]
     cfg = yaml.safe_load(render_proxy_yaml(secrets))
     listeners = cfg["postgres"]
-    assert [l["name"] for l in listeners] == ["analytics_pg", "database_url"]
+    assert [listener["name"] for listener in listeners] == [
+        "analytics_pg",
+        "database_url",
+    ]
     assert listeners[0]["listen"] == "0.0.0.0:5432"
     assert listeners[1]["listen"] == "0.0.0.0:5433"
     # upstream.dsn uses the secret_ref directly so iron-proxy can resolve it


### PR DESCRIPTION
## Summary
- Render host-scoped, header-only HTTP secrets as iron-proxy injected headers instead of placeholder replacement.
- Preserve replacement mode for unhosted legacy secrets and query/path placeholder secrets.
- Default injected Authorization/Proxy-Authorization values to Bearer formatting.

## Tests
- uv run pytest tests/test_proxy_config.py
- uv run ruff check api/proxy_config.py tests/test_proxy_config.py