### PR TITLE
build(sandbox): bake pnpm 10.9.0 into the agent image

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -58,6 +58,12 @@ ARG CODEX_VERSION=0.139.0
 ARG PI_CODING_AGENT_VERSION=0.67.2
 ARG NUSHELL_VERSION=0.112.2
 ARG KUBECTL_VERSION=v1.34.2
+# Bootstrap pnpm for agents working in JS monorepos. The exact baked version
+# doesn't constrain repos: when a repo's `packageManager` field declares a
+# different version, pnpm downloads and runs that one (v11 `pmOnFail=download`
+# default; `manage-package-manager-versions` in v10) over the same registry
+# egress a dependency install already needs.
+ARG PNPM_VERSION=11.5.3
 
 # ── kubectl ──────────────────────────────────────────────────────────────────
 RUN set -eux; \
@@ -94,10 +100,12 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
       "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
       "@openai/codex@${CODEX_VERSION}" \
       "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \
+      "pnpm@${PNPM_VERSION}" \
       agent-browser@0.26.0 \
     && find /usr/lib/node_modules -type f \( -name '*.map' -o -name '*.tsbuildinfo' \) -delete \
     && claude --version | grep -F "${CLAUDE_CODE_VERSION}" \
-    && codex --version | grep -F "${CODEX_VERSION}"
+    && codex --version | grep -F "${CODEX_VERSION}" \
+    && pnpm --version | grep -F "${PNPM_VERSION}"
 
 # ── agent-browser system deps (must run as root before USER agent) ───────────
 # Chrome for Testing doesn't provide Linux ARM64 builds; fall back to system chromium


### PR DESCRIPTION
Agents working in pnpm-based repos can't install dependencies or run tests today — `pnpm: command not found` — so review and CI-fix workflows either skip verification or fail outright.

Install pnpm in the existing global npm CLI layer, mirroring the other pinned CLIs, with the same `--version` build check.

The baked version doesn't constrain repos: when a repo's `packageManager` field declares a different version, pnpm downloads and runs the declared one ([v11 `pmOnFail=download` default](https://pnpm.io/blog/releases/11.0), `manage-package-manager-versions` in v10) over the same registry egress a dependency install already needs — so any repo's pin keeps working regardless of what's baked.