### PR TITLE
fix(slackbotv2): survive Slack stream expiry and guarantee final-answer delivery

### DIFF
--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -87,10 +87,12 @@ spec:
             httpGet:
               path: /health
               port: 3001
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: 3001
+            timeoutSeconds: 5
           securityContext:
 {{ toYaml .Values.containerSecurityContext | nindent 12 }}
           resources:

--- a/patches/@chat-adapter__slack@4.30.0.patch
+++ b/patches/@chat-adapter__slack@4.30.0.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/index.js b/dist/index.js
-index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e984b25ba93 100644
+index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22eed819d8e 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -31,6 +31,123 @@ import {
+@@ -31,6 +31,176 @@ import {
    toModalElement,
    toPlainText
  } from "chat";
@@ -11,6 +11,59 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +var STREAM_CHUNK_LIMIT = 256;
 +var STREAM_TASK_LIMIT = 50;
 +var STREAM_FENCE_RESERVE = 64;
++// Slack hard-expires a streaming message ~300s after chat.startStream
++// (measured in production: appends fail with message_not_in_streaming_state
++// at ~303-304s). Rotate segments well before that so long renders survive.
++function streamSegmentMaxAgeMs() {
++  const value = Number(process.env.SLACK_STREAM_SEGMENT_MAX_AGE_MS ?? "");
++  return Number.isFinite(value) && value > 0 ? value : 24e4;
++}
++// Structured task chunks do not count toward the markdown segment limit, so
++// a plan card accumulating many task cards can push the message past Slack's
++// size cap (msg_too_long). Budget the per-segment structured content too.
++function streamSegmentTaskCharBudget() {
++  const value = Number(process.env.SLACK_STREAM_SEGMENT_TASK_CHAR_BUDGET ?? "");
++  return Number.isFinite(value) && value > 0 ? value : 16e3;
++}
++function slackStreamErrorCode(error) {
++  if (!error || typeof error !== "object") {
++    return typeof error === "string" ? error : "";
++  }
++  if (typeof error.error === "string") {
++    return error.error;
++  }
++  const data = error.data;
++  if (data && typeof data === "object" && typeof data.error === "string") {
++    return data.error;
++  }
++  if (typeof error.message === "string") {
++    return error.message;
++  }
++  return "";
++}
++function isSlackStreamDeliveryError(error) {
++  const code = slackStreamErrorCode(error);
++  return code.includes("msg_too_long") || code.includes("msg_blocks_too_long") || code.includes("message_not_in_streaming_state");
++}
++function annotateSlackAnswerLost(error, lost) {
++  if (!error || typeof error !== "object" && typeof error !== "function") {
++    return;
++  }
++  try {
++    error.slackAnswerLost = lost;
++  } catch {
++  }
++}
++function slackAnswerLostAnnotation(error) {
++  if (!error || typeof error !== "object" && typeof error !== "function") {
++    return void 0;
++  }
++  const value = error.slackAnswerLost;
++  return typeof value === "boolean" ? value : void 0;
++}
++function taskChunkChars(chunk) {
++  return (typeof chunk.title === "string" ? chunk.title.length : 0) + (typeof chunk.details === "string" ? chunk.details.length : 0) + (typeof chunk.output === "string" ? chunk.output.length : 0) + 64;
++}
 +var FENCE_PATTERN = /^(`{3,}|~{3,})/;
 +var Fence = class {
 +  constructor() {
@@ -126,7 +179,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
  
  // src/cards.ts
  import {
-@@ -3434,26 +3551,122 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3434,26 +3604,210 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -142,7 +195,10 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +      cards: 0,
 +      hasContent: false,
 +      length: 0,
++      startedAt: Date.now(),
 +      stopped: false,
++      taskChars: /* @__PURE__ */ new Map(),
++      taskCharsTotal: 0,
 +      streamer: this._client.chatStream({
 +        channel,
 +        thread_ts: threadTs,
@@ -157,6 +213,8 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +    let current = createSegment();
 +    const structured = /* @__PURE__ */ new Set();
 +    let lastResult;
++    let provisionalResult;
++    let sourceConsumed = false;
      let lastAppended = "";
 +    let plan;
 +    const taskParts = /* @__PURE__ */ new Map();
@@ -165,6 +223,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
      const renderer = new StreamingMarkdownRenderer({
        wrapTablesForAppend: false
      });
++    const isExpired = (segment) => Date.now() - segment.startedAt >= streamSegmentMaxAgeMs();
 +    const stopSegment = async (segment, blocks, force = false) => {
 +      if (segment.stopped || !(segment.hasContent || force)) {
 +        return void 0;
@@ -174,7 +233,38 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +        ...blocks ? { blocks } : {}
 +      });
 +      segment.stopped = true;
++      if (result) {
++        provisionalResult = result;
++      }
 +      return result;
++    };
++    const unmapSegment = (segment) => {
++      structured.delete(segment);
++      for (const [id, taskSegment] of taskSegments) {
++        if (taskSegment === segment) {
++          taskSegments.delete(id);
++        }
++      }
++    };
++    const retireSegment = async (segment, reason) => {
++      try {
++        await stopSegment(segment);
++        unmapSegment(segment);
++      } catch (stopError) {
++        if (segment.length > 0) {
++          // Markdown-bearing content may be part of the final answer. Mark
++          // the error so outer catch handlers (including the structured-chunk
++          // degrade path) cannot swallow it: the bot must run its durable
++          // final-answer fallback.
++          annotateSlackAnswerLost(stopError, true);
++          throw stopError;
++        }
++        unmapSegment(segment);
++        this.logger.warn("Slack: failed to stop rotated progress stream segment", {
++          reason,
++          error: stopError
++        });
++      }
 +    };
 +    const rotateSegment = async (closing, opening) => {
 +      if (closing) {
@@ -192,6 +282,31 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +        current.length += opening.length;
 +      }
 +    };
++    const rotateCurrentForAge = async () => {
++      const closing = fence.closing;
++      const opening = fence.opening;
++      if (closing && current.hasContent && !current.stopped) {
++        try {
++          await current.streamer.append({ markdown_text: closing, token });
++          current.length += closing.length;
++        } catch (closeError) {
++          this.logger.warn("Slack: failed to close fence on aged stream segment", {
++            error: closeError
++          });
++        }
++      }
++      if (structured.has(current)) {
++        await retireSegment(current, "age");
++      } else {
++        await stopSegment(current);
++      }
++      current = createSegment();
++      if (opening) {
++        await current.streamer.append({ markdown_text: opening, token });
++        current.hasContent = true;
++        current.length += opening.length;
++      }
++    };
      const flushMarkdownDelta = async (delta) => {
        if (delta.length === 0) {
          return;
@@ -199,6 +314,9 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 -      await streamer.append({ markdown_text: delta, token });
 +      let remaining = delta;
 +      while (remaining.length > 0) {
++        if (isExpired(current)) {
++          await rotateCurrentForAge();
++        }
 +        if (current.length === STREAM_SEGMENT_LIMIT) {
 +          await rotateSegment(fence.closing, fence.opening);
 +        }
@@ -232,6 +350,15 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +    const appendStructuredChunk = async (segment, chunk) => {
 +      await segment.streamer.append({ chunks: [chunk], token });
 +      segment.hasContent = true;
++      if (chunk.type === "task_update" || chunk.type === "plan_update") {
++        const key = chunk.type === "plan_update" ? "@plan" : chunk.id;
++        const size = taskChunkChars(chunk);
++        const previous = segment.taskChars.get(key) ?? 0;
++        if (size > previous) {
++          segment.taskCharsTotal += size - previous;
++          segment.taskChars.set(key, size);
++        }
++      }
 +    };
 +    const createStructuredSegment = async () => {
 +      current = createSegment();
@@ -241,12 +368,26 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +      }
 +      return current;
 +    };
-+    const getTaskSegment = async (id) => {
++    const getTaskSegment = async (id, chunkChars) => {
 +      const existing = taskSegments.get(id);
 +      if (existing) {
-+        return existing;
++        if (isExpired(existing)) {
++          await retireSegment(existing, "age");
++        } else if (!existing.stopped) {
++          const previous = existing.taskChars.get(id) ?? 0;
++          const projected = existing.taskCharsTotal - previous + Math.max(previous, chunkChars);
++          if (projected <= streamSegmentTaskCharBudget()) {
++            return existing;
++          }
++          taskSegments.delete(id);
++        } else {
++          taskSegments.delete(id);
++        }
 +      }
-+      if (current.cards >= STREAM_TASK_LIMIT) {
++      if (isExpired(current)) {
++        await rotateCurrentForAge();
++      }
++      if (current.cards >= STREAM_TASK_LIMIT || current.taskCharsTotal + chunkChars > streamSegmentTaskCharBudget()) {
 +        await createStructuredSegment();
 +      } else {
 +        structured.add(current);
@@ -258,7 +399,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
      const sendStructuredChunk = async (chunk) => {
        if (!structuredChunksSupported) {
          return;
-@@ -3463,7 +3676,25 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3463,8 +3817,45 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
@@ -268,24 +409,44 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +            ...chunk,
 +            title: truncateText(chunk.title, STREAM_CHUNK_LIMIT)
 +          };
-+          if (structured.size === 0) {
-+            structured.add(current);
-+          }
-+          for (const segment of structured) {
++          for (const segment of Array.from(structured)) {
++            if (segment.stopped) {
++              structured.delete(segment);
++              continue;
++            }
++            if (isExpired(segment)) {
++              if (segment === current) {
++                await rotateCurrentForAge();
++              } else {
++                await retireSegment(segment, "age");
++              }
++              continue;
++            }
 +            await appendStructuredChunk(segment, plan);
++          }
++          if (structured.size === 0) {
++            if (isExpired(current)) {
++              await rotateCurrentForAge();
++            }
++            structured.add(current);
++            await appendStructuredChunk(current, plan);
 +          }
 +          return;
 +        }
 +        const chunks = splitTask(chunk, taskParts.get(chunk.id) ?? 0);
 +        taskParts.set(chunk.id, chunks.length);
 +        for (const normalized of chunks) {
-+          const segment = await getTaskSegment(normalized.id);
++          const segment = await getTaskSegment(normalized.id, taskChunkChars(normalized));
 +          await appendStructuredChunk(segment, normalized);
 +        }
        } catch (error) {
++        if (isSlackStreamDeliveryError(error) || slackAnswerLostAnnotation(error) === true) {
++          throw error;
++        }
          structuredChunksSupported = false;
          this.logger.warn(
-@@ -3479,31 +3710,72 @@ var SlackAdapter = class _SlackAdapter {
+           "Structured streaming chunk failed, falling back to text-only streaming. Ensure your Slack app manifest includes assistant_view, assistant:write scope, and @slack/web-api >= 7.14.0",
+@@ -3479,31 +3870,91 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
      };
@@ -305,13 +466,14 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +        } else {
 +          await sendStructuredChunk(chunk);
 +        }
-       }
++      }
 +      renderer.finish();
 +      const finalCommittable = renderer.getCommittableText();
 +      const finalDelta = finalCommittable.slice(lastAppended.length);
 +      await flushMarkdownDelta(finalDelta);
++      sourceConsumed = true;
 +      fence.finish();
-+      if (fence.closing) {
++      if (fence.closing && !current.stopped) {
 +        await current.streamer.append({
 +          markdown_text: fence.closing,
 +          token
@@ -319,38 +481,56 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..3e63db3d328688a104cf408ff97f8e98
 +        current.hasContent = true;
 +        current.length += fence.closing.length;
 +      }
-+      for (const segment of structured) {
-+        if (segment !== current) {
-+          await stopSegment(segment);
-+        }
-+      }
 +      lastResult = await stopSegment(
 +        current,
 +        options?.stopBlocks,
-+        true
-+      );
-+    } catch (error) {
-+      const segments = /* @__PURE__ */ new Set([...structured, current]);
-+      fence.finish();
-+      for (const segment of segments) {
-+        if (!segment.hasContent) {
++        !provisionalResult
++      ) ?? provisionalResult;
++      for (const segment of Array.from(structured)) {
++        if (segment === current || segment.stopped) {
 +          continue;
 +        }
 +        try {
-+          if (segment === current && fence.closing) {
++          await stopSegment(segment);
++        } catch (stopError) {
++          if (segment.length > 0) {
++            throw stopError;
++          }
++          this.logger.warn("Slack: failed to stop progress stream segment", {
++            error: stopError
++          });
++        }
++      }
++    } catch (error) {
++      const segments = /* @__PURE__ */ new Set([...structured, current]);
++      fence.finish();
++      let answerStopFailed = false;
++      for (const segment of segments) {
++        if (!segment.hasContent || segment.stopped) {
++          continue;
++        }
++        if (segment === current && fence.closing) {
++          try {
 +            await segment.streamer.append({
 +              markdown_text: fence.closing,
 +              token
 +            });
 +            segment.length += fence.closing.length;
++          } catch {
 +          }
++        }
++        try {
 +          await stopSegment(segment);
 +        } catch (stopError) {
++          if (segment.length > 0 || segment === current) {
++            answerStopFailed = true;
++          }
 +          this.logger.warn("Slack: failed to stop partial stream", {
 +            error: stopError
 +          });
 +        }
-+      }
+       }
++      annotateSlackAnswerLost(error, !sourceConsumed || answerStopFailed);
 +      throw error;
      }
 -    renderer.finish();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@chat-adapter/slack@4.30.0':
-    hash: 3d0b198070971a99f7e1536863ea700cc3723c828e4fdedccc9b98e68db2fbe4
+    hash: 3969edeaa8632fe39c4f2a10d6c3505e86aa4eb1cb970fb86eacca4f5deea5ca
     path: patches/@chat-adapter__slack@4.30.0.patch
 
 importers:
@@ -134,7 +134,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.30.0
-        version: 4.30.0(patch_hash=3d0b198070971a99f7e1536863ea700cc3723c828e4fdedccc9b98e68db2fbe4)(zod@4.4.3)
+        version: 4.30.0(patch_hash=3969edeaa8632fe39c4f2a10d6c3505e86aa4eb1cb970fb86eacca4f5deea5ca)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
@@ -1559,7 +1559,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.30.0(patch_hash=3d0b198070971a99f7e1536863ea700cc3723c828e4fdedccc9b98e68db2fbe4)(zod@4.4.3)':
+  '@chat-adapter/slack@4.30.0(patch_hash=3969edeaa8632fe39c4f2a10d6c3505e86aa4eb1cb970fb86eacca4f5deea5ca)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.30.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -420,7 +420,15 @@ async function syncThreadMessageToSession(
         throw error
       }
     }
-    await renderExecutionStream(thread, streamError(error), serializedMessage, input.options, trace)
+    try {
+      await renderExecutionStream(thread, streamError(error), serializedMessage, input.options, trace)
+    } catch (renderError) {
+      // The error notice is best-effort; a Slack render failure here must not
+      // mask the original forward failure.
+      traceLog(input.options, 'slackbotv2_forward_error_notice_render_failed', trace, {
+        error: errorMessage(renderError)
+      })
+    }
     traceLog(input.options, 'slackbotv2_forward_complete', trace, {
       latest_active_execution: latest.activeExecution === true,
       last_event_id: lastEventId
@@ -470,6 +478,7 @@ async function renderExecutionAttempt(
 ): Promise<'complete' | 'retry'> {
   let rendered = false
   let retry = false
+  let fallbackLastEventId = 0
   try {
     await renderExecutionStream(
       thread,
@@ -482,7 +491,12 @@ async function renderExecutionAttempt(
     traceLog(options, 'slackbotv2_render_complete', trace)
     return 'complete'
   } catch (error) {
-    if (isRetryableSessionApiError(error)) {
+    // Check the Slack adapter's delivery annotation before retryability:
+    // Slack network failures can surface as TypeError/AbortError, which would
+    // otherwise be misclassified as retryable session API errors and re-render
+    // the whole stream instead of posting the durable final answer.
+    const answerLost = slackAnswerLost(error)
+    if (answerLost === undefined && isRetryableSessionApiError(error)) {
       retry = true
       traceLog(options, 'slackbotv2_render_deferred', trace, {
         error: errorMessage(error),
@@ -490,15 +504,41 @@ async function renderExecutionAttempt(
       })
       return 'retry'
     }
+    if (answerLost === false) {
+      // The Slack stream broke only after the final answer became visible
+      // (for example a progress-card stop failed). Reposting would duplicate
+      // the answer, so record the failure and finish.
+      rendered = true
+      traceLog(options, 'slackbotv2_render_failed_answer_visible', trace, {
+        error: errorMessage(error)
+      })
+      return 'complete'
+    }
     traceLog(options, 'slackbotv2_render_failed', trace, {
-      error: errorMessage(error)
+      error: errorMessage(error),
+      slack_answer_lost: answerLost ?? 'unknown'
     })
+    const fallback = await renderFallbackFinalAnswer(
+      thread,
+      options,
+      {
+        afterEventId: input.afterEventId,
+        executionId: input.executionId,
+        threadId: input.threadId
+      },
+      trace
+    )
+    if (fallback) {
+      rendered = true
+      fallbackLastEventId = fallback.lastEventId
+      return 'complete'
+    }
     throw error
   } finally {
     const latest = (await thread.state) ?? {}
     await thread.setState({
       activeExecution: retry,
-      lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId()),
+      lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId(), fallbackLastEventId),
       ...(rendered ? { renderObligation: null } : {})
     })
     traceLog(options, 'slackbotv2_render_finalized', trace, {
@@ -506,6 +546,96 @@ async function renderExecutionAttempt(
       retry_scheduled: retry,
       last_event_id: getLastEventId()
     })
+  }
+}
+
+/**
+ * Reads the delivery annotation the Slack chat adapter attaches to streaming
+ * errors. `false` means the stream's final answer was confirmed visible before
+ * the failure; `true` means it was definitely not; `undefined` means the error
+ * did not come through the adapter's streaming path.
+ */
+function slackAnswerLost(error: unknown): boolean | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const value = (error as { slackAnswerLost?: unknown }).slackAnswerLost
+  return typeof value === 'boolean' ? value : undefined
+}
+
+const FALLBACK_OPEN_MAX_ATTEMPTS = 4
+
+/**
+ * Delivers the durable final answer as a plain thread post after the live
+ * Slack streaming render failed. Replays the session event stream from the
+ * execution's starting position (the control plane keeps the events durably,
+ * so the terminal result is replayable even when the failed render already
+ * consumed it), drains it without making Slack calls, and posts the terminal
+ * result text once. Slack streaming is best-effort; this is the delivery
+ * guarantee. Returns null when nothing could be delivered.
+ */
+async function renderFallbackFinalAnswer(
+  thread: Thread,
+  options: SlackbotV2Options,
+  source: { afterEventId: number; executionId?: string; threadId: string },
+  trace?: SlackbotV2Trace
+): Promise<{ lastEventId: number } | null> {
+  const startedAtMs = nowMs()
+  let lastEventId = source.afterEventId
+  try {
+    let stream: AsyncIterable<SlackbotV2RendererSource> | undefined
+    for (let attempt = 0; ; attempt++) {
+      try {
+        stream = await openSessionEventStream(options, {
+          afterEventId: source.afterEventId,
+          executionId: source.executionId,
+          onEventId: eventId => {
+            lastEventId = Math.max(lastEventId, eventId)
+          },
+          threadId: source.threadId,
+          trace
+        })
+        break
+      } catch (error) {
+        if (!isRetryableSessionApiError(error) || attempt + 1 >= FALLBACK_OPEN_MAX_ATTEMPTS) {
+          throw error
+        }
+        await sleep(renderRetryDelayMs(attempt))
+      }
+    }
+    const fallback = new SlackRenderFallback()
+    const chatStream = fallback.collectChatSdk(
+      slackSafeChatSdkStream(
+        codexAppServerToChatSdkStream(
+          fallback.collectSource(stream),
+          fallbackRendererOptions(options)
+        )
+      )
+    )
+    for await (const _chunk of chatStream) {
+      void _chunk
+    }
+    const text = fallback.text()
+    if (!text) {
+      traceLog(options, 'slackbotv2_render_fallback_empty', trace, {
+        last_event_id: lastEventId,
+        phase_ms: elapsedMs(startedAtMs)
+      })
+      return null
+    }
+    await thread.post(
+      truncateSlackText(text, SLACK_FALLBACK_TEXT_MAX_CHARS, 'Slack final answer')
+    )
+    traceLog(options, 'slackbotv2_render_fallback_complete', trace, {
+      chars: text.length,
+      last_event_id: lastEventId,
+      phase_ms: elapsedMs(startedAtMs)
+    })
+    return { lastEventId }
+  } catch (error) {
+    traceLog(options, 'slackbotv2_render_fallback_failed', trace, {
+      error: errorMessage(error),
+      phase_ms: elapsedMs(startedAtMs)
+    })
+    return null
   }
 }
 
@@ -670,10 +800,13 @@ async function recoverRenderObligation(
     threadId
   }
   const thread = chat.thread(threadId)
-  const threadState = (await thread.state) ?? {}
-  let lastEventId = Math.max(threadState.lastEventId ?? 0, obligation.afterEventId)
+  // Replay from the obligation's starting position, not the thread's
+  // lastEventId: the failed render may have consumed events (including the
+  // terminal result) past which a resumed stream would never see the final
+  // answer again. Session events are durable, so a full replay is safe.
+  let lastEventId = obligation.afterEventId
   const input: ForwardSessionInput = {
-    afterEventId: lastEventId,
+    afterEventId: obligation.afterEventId,
     executionId: obligation.executionId,
     messages: [],
     onEventId: eventId => {
@@ -720,10 +853,33 @@ async function recoverRenderObligation(
     rendered = true
     traceLog(options, 'slackbotv2_render_recovery_complete', trace)
   } catch (error) {
-    traceLog(options, 'slackbotv2_render_recovery_render_failed', trace, {
-      error: errorMessage(error)
-    })
-    throw error
+    const answerLost = slackAnswerLost(error)
+    if (answerLost === false) {
+      // The recovered stream broke only after the final answer became
+      // visible; reposting would duplicate it.
+      rendered = true
+      traceLog(options, 'slackbotv2_render_recovery_failed_answer_visible', trace, {
+        error: errorMessage(error)
+      })
+    } else {
+      traceLog(options, 'slackbotv2_render_recovery_render_failed', trace, {
+        error: errorMessage(error),
+        slack_answer_lost: answerLost ?? 'unknown'
+      })
+      const fallback = await renderFallbackFinalAnswer(
+        thread,
+        options,
+        {
+          afterEventId: obligation.afterEventId,
+          executionId: obligation.executionId,
+          threadId
+        },
+        trace
+      )
+      if (!fallback) throw error
+      rendered = true
+      lastEventId = Math.max(lastEventId, fallback.lastEventId)
+    }
   } finally {
     const latest = (await thread.state) ?? {}
     await thread.setState({
@@ -800,9 +956,6 @@ async function renderExecutionStream(
         { groupTasks: options.streamTaskDisplayMode ?? 'plan' }
       )
     )
-  } catch (error) {
-    if (!isSlackMessageTooLongError(error)) throw error
-    suppressSlackTooLongRender(error, options, trace)
   } finally {
     await setAssistantStatus(thread, '')
   }
@@ -846,9 +999,6 @@ async function renderRecoveredExecutionStream(
         taskDisplayMode: options.streamTaskDisplayMode ?? 'plan'
       }
     )
-  } catch (error) {
-    if (!isSlackMessageTooLongError(error)) throw error
-    suppressSlackTooLongRender(error, options, trace)
   } finally {
     await setAssistantStatus(thread, '')
   }
@@ -940,16 +1090,6 @@ class SlackRenderFallback {
   }
 }
 
-function suppressSlackTooLongRender(
-  error: unknown,
-  options: SlackbotV2Options,
-  trace?: SlackbotV2Trace
-): void {
-  traceLog(options, 'slackbotv2_render_too_long_suppressed', trace, {
-    error: errorMessage(error)
-  })
-}
-
 async function* slackSafeChatSdkStream(
   stream: AsyncIterable<ChatSDKStreamChunk>
 ): AsyncIterable<ChatSDKStreamChunk> {
@@ -1029,21 +1169,6 @@ function terminalResultText(event: unknown): string {
   return ''
 }
 
-function isSlackMessageTooLongError(error: unknown): boolean {
-  if (error instanceof Error && isSlackTooLongCode(error.message)) return true
-  if (!error || typeof error !== 'object') return false
-  const fields = error as Record<string, unknown>
-  if (typeof fields.error === 'string' && isSlackTooLongCode(fields.error)) return true
-  const data = fields.data
-  if (!data || typeof data !== 'object') return false
-  const dataError = (data as Record<string, unknown>).error
-  return typeof dataError === 'string' && isSlackTooLongCode(dataError)
-}
-
-function isSlackTooLongCode(value: string): boolean {
-  return value.includes('msg_too_long') || value.includes('msg_blocks_too_long')
-}
-
 async function* streamSessionAfterHandoff(
   options: SlackbotV2Options,
   input: ForwardSessionInput
@@ -1094,6 +1219,25 @@ function rendererOptions(thread: Thread, options: SlackbotV2Options): CodexAppSe
       await mapper?.onRendererEvent?.(event)
       if (event.type === 'renderer.title.update') {
         await setAssistantTitle(thread, event.title)
+      }
+    }
+  }
+}
+
+/**
+ * Renderer options for the final-answer fallback drain: no Slack side effects
+ * (no assistant title updates) and renderer hooks must not be able to fail
+ * the delivery.
+ */
+function fallbackRendererOptions(options: SlackbotV2Options): CodexAppServerToChatStreamOptions {
+  const mapper = options.mapper
+  return {
+    ...mapper,
+    async onRendererEvent(event: RendererEvent) {
+      try {
+        await mapper?.onRendererEvent?.(event)
+      } catch {
+        // Fallback delivery must not depend on renderer side-effect hooks.
       }
     }
   }

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -5,6 +5,17 @@ const apiUrl = stringEnv('CENTAUR_API_URL', 'http://127.0.0.1:8080')
 const botToken = requiredEnv('SLACK_BOT_TOKEN')
 const signingSecret = requiredEnv('SLACK_SIGNING_SECRET')
 
+// Default to info: the chat adapter logs entire raw Slack webhook bodies at
+// debug, and JSON-serializing those multi-hundred-KB payloads on the hot path
+// blocks the event loop long enough to fail the 1s liveness probe.
+const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const
+const minLogLevel: (typeof LOG_LEVELS)[number] = (() => {
+  const value = optionalEnv('SLACKBOTV2_LOG_LEVEL')?.toLowerCase()
+  return (LOG_LEVELS as readonly string[]).includes(value ?? '')
+    ? (value as (typeof LOG_LEVELS)[number])
+    : 'info'
+})()
+
 const consoleLogger = {
   debug: (message: string, data?: unknown) => log('debug', message, data),
   info: (message: string, data?: unknown) => log('info', message, data),
@@ -80,7 +91,8 @@ function optionalNumberEnv(name: string): number | undefined {
   return parsed
 }
 
-function log(level: string, message: string, data?: unknown): void {
+function log(level: (typeof LOG_LEVELS)[number], message: string, data?: unknown): void {
+  if (LOG_LEVELS.indexOf(level) < LOG_LEVELS.indexOf(minLogLevel)) return
   console.log(
     JSON.stringify({
       level,

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -28,6 +28,8 @@ const BOT_USER_ID = 'U000000001'
 const USER_ID = 'USLACKBOTV2USER'
 const TEAM_ID = 'T000000001'
 const CHANNEL_ID = 'C000000001'
+/** How real Slack renders a streamed message whose stream broke or was never stopped. */
+const BROKEN_STREAM_TEXT = ':warning: Something went wrong'
 
 let emulator: Emulator
 let slackApi: PatchedSlackApi
@@ -704,12 +706,14 @@ describe('slackbotv2', () => {
     expect(renderedText).not.toContain('Execution completed, but no final text was captured.')
   })
 
-  it('does not post a duplicate final-answer fallback when Slack rejects the stream as too long', async () => {
+  it('reposts the durable final answer exactly once when Slack rejects the stream stop as too long', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
     bot = createTestBot({ state: sharedState })
     codexApi.autoRespond = false
-    slackApi.failStreamStopsLongerThan(120)
+    // Every stop fails: the streamed message never finalizes, so its content
+    // breaks in real Slack. The bot must repost the durable answer once.
+    slackApi.failStreamStopsLongerThan(10)
 
     const parent = await postUserMessage('Context before an oversized Slack render.')
     const mention = await postUserMessage(`<@${BOT_USER_ID}> generate noisy progress`, parent.ts)
@@ -718,7 +722,7 @@ describe('slackbotv2', () => {
     const response = await bot.app.request(
       '/api/webhooks/slack',
       signedSlackEvent({
-        event_id: 'Ev-slackbotv2-msg-too-long-suppressed',
+        event_id: 'Ev-slackbotv2-msg-too-long-fallback',
         event: {
           type: 'app_mention',
           user: USER_ID,
@@ -752,19 +756,317 @@ describe('slackbotv2', () => {
       })
     )
     codexApi.emitSessionEvent(key, 'session.execution_completed', {
-      execution_id: 'exe-msg-too-long-suppressed',
+      execution_id: 'exe-msg-too-long-fallback',
       status: 'completed',
       result_text: 'TOO_LONG_FALLBACK_VISIBLE'
     })
 
     await Promise.all(waits)
     expect(slackApi.calls.some(call => call.method === 'chat.stopStream')).toBe(true)
-    const visibleFinalReplies = (await threadTexts(parent.ts)).filter(text =>
+    const texts = await threadTexts(parent.ts)
+    // The streamed message broke ("Something went wrong"), so the durable
+    // final answer must be reposted - exactly once, never duplicated.
+    expect(texts.some(text => text.includes(BROKEN_STREAM_TEXT))).toBe(true)
+    const visibleFinalReplies = texts.filter(text =>
       text.includes('TOO_LONG_FALLBACK_VISIBLE')
     )
     expect(visibleFinalReplies).toHaveLength(1)
     const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
     expect(threadState).toEqual(
+      expect.objectContaining({
+        activeExecution: false,
+        renderObligation: null
+      })
+    )
+  })
+
+  it('reposts the durable final answer when the Slack stream expires mid-render', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ state: sharedState })
+    codexApi.autoRespond = false
+    // The first append succeeds, then Slack expires the streaming message
+    // (production: ~300s after chat.startStream) and every further append
+    // fails. The final answer has not reached Slack at that point.
+    slackApi.failStreamAppendsAfter(1, 'message_not_in_streaming_state')
+
+    const parent = await postUserMessage('Context before a stream expiry.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> run something long`, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-stream-expired-fallback',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> run something long`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-long',
+          type: 'commandExecution',
+          command: 'sleep 600',
+          status: 'completed',
+          aggregatedOutput: 'done'
+        }
+      })
+    )
+    codexApi.emitSessionEvent(key, 'session.execution_completed', {
+      execution_id: 'exe-stream-expired',
+      status: 'completed',
+      result_text: 'EXPIRED_STREAM_FALLBACK_VISIBLE'
+    })
+
+    await Promise.all(waits)
+    const texts = await threadTexts(parent.ts)
+    const visibleFinalReplies = texts.filter(text =>
+      text.includes('EXPIRED_STREAM_FALLBACK_VISIBLE')
+    )
+    expect(visibleFinalReplies).toHaveLength(1)
+    const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+    expect(threadState).toEqual(
+      expect.objectContaining({
+        activeExecution: false,
+        renderObligation: null
+      })
+    )
+  })
+
+  it('rotates Slack stream segments before they reach the streaming age limit', async () => {
+    process.env.SLACK_STREAM_SEGMENT_MAX_AGE_MS = '120'
+    try {
+      codexApi.autoRespond = false
+
+      const parent = await postUserMessage('Context before a slow render.')
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> work slowly`, parent.ts)
+      const key = threadKey(parent.ts)
+      const waits: Promise<unknown>[] = []
+      const response = await bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: 'Ev-slackbotv2-age-rotation',
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parent.ts,
+            text: `<@${BOT_USER_ID}> work slowly`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+
+      expect(response.status).toBe(200)
+      await waitFor(() => codexApi.executes.length === 1)
+      await waitFor(() => codexApi.eventRequests.length === 1)
+      await waitFor(() => codexApi.streamCount === 1)
+
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: 'cmd-slow-1',
+            type: 'commandExecution',
+            // Large enough to flush the Slack SDK's client-side stream buffer
+            // so the first segment demonstrably carries content.
+            command: `sleep 1 # ${'x'.repeat(300)}`,
+            status: 'completed',
+            aggregatedOutput: 'first'
+          }
+        })
+      )
+      // Wait for the first segment to age past the rotation threshold, then
+      // keep streaming: the adapter must continue in a fresh stream message.
+      await waitFor(() => slackApi.calls.some(call => call.method === 'chat.startStream'))
+      await new Promise(resolve => setTimeout(resolve, 250))
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: 'cmd-slow-2',
+            type: 'commandExecution',
+            command: 'sleep 2',
+            status: 'completed',
+            aggregatedOutput: 'second'
+          }
+        })
+      )
+      codexApi.emitSessionEvent(key, 'session.execution_completed', {
+        execution_id: 'exe-age-rotation',
+        status: 'completed',
+        result_text: 'AGE_ROTATION_ANSWER_VISIBLE'
+      })
+
+      await Promise.all(waits)
+      const starts = slackApi.calls.filter(call => call.method === 'chat.startStream')
+      expect(starts.length).toBeGreaterThanOrEqual(2)
+      const startTs = new Set(
+        starts.map(call => call.streamTs).filter((ts): ts is string => Boolean(ts))
+      )
+      const stopTs = new Set(
+        slackApi.calls
+          .filter(call => call.method === 'chat.stopStream')
+          .map(call => stringField(call.body.ts))
+      )
+      for (const ts of startTs) {
+        expect(stopTs.has(ts)).toBe(true)
+      }
+      const texts = await threadTexts(parent.ts)
+      expect(texts.some(text => text.includes(BROKEN_STREAM_TEXT))).toBe(false)
+      const visibleFinalReplies = texts.filter(text =>
+        text.includes('AGE_ROTATION_ANSWER_VISIBLE')
+      )
+      expect(visibleFinalReplies).toHaveLength(1)
+    } finally {
+      delete process.env.SLACK_STREAM_SEGMENT_MAX_AGE_MS
+    }
+  })
+
+  it('rotates structured plan segments before they exceed the task char budget', async () => {
+    process.env.SLACK_STREAM_SEGMENT_TASK_CHAR_BUDGET = '400'
+    try {
+      codexApi.autoRespond = false
+
+      const parent = await postUserMessage('Context before a card-heavy render.')
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> run many steps`, parent.ts)
+      const key = threadKey(parent.ts)
+      const waits: Promise<unknown>[] = []
+      const response = await bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: 'Ev-slackbotv2-budget-rotation',
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parent.ts,
+            text: `<@${BOT_USER_ID}> run many steps`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+
+      expect(response.status).toBe(200)
+      await waitFor(() => codexApi.executes.length === 1)
+      await waitFor(() => codexApi.eventRequests.length === 1)
+      await waitFor(() => codexApi.streamCount === 1)
+
+      for (let index = 1; index <= 3; index++) {
+        codexApi.emitOutputLine(
+          key,
+          JSON.stringify({
+            type: 'item.completed',
+            item: {
+              id: `cmd-budget-${index}`,
+              type: 'commandExecution',
+              command: `step-${index} ${'x'.repeat(200)}`,
+              status: 'completed',
+              aggregatedOutput: 'ok'
+            }
+          })
+        )
+        // Let the renderer flush each card before emitting the next so the
+        // budget accounting sees them as separate appends. The first flush of
+        // a segment arrives as chat.startStream, later ones as appendStream.
+        await waitFor(
+          () =>
+            slackApi.calls.filter(
+              call => call.method === 'chat.appendStream' || call.method === 'chat.startStream'
+            ).length >= index
+        )
+      }
+      codexApi.emitSessionEvent(key, 'session.execution_completed', {
+        execution_id: 'exe-budget-rotation',
+        status: 'completed',
+        result_text: 'BUDGET_ROTATION_ANSWER_VISIBLE'
+      })
+
+      await Promise.all(waits)
+      const starts = slackApi.calls.filter(call => call.method === 'chat.startStream')
+      expect(starts.length).toBeGreaterThanOrEqual(2)
+      const texts = await threadTexts(parent.ts)
+      expect(texts.some(text => text.includes(BROKEN_STREAM_TEXT))).toBe(false)
+      const visibleFinalReplies = texts.filter(text =>
+        text.includes('BUDGET_ROTATION_ANSWER_VISIBLE')
+      )
+      expect(visibleFinalReplies).toHaveLength(1)
+    } finally {
+      delete process.env.SLACK_STREAM_SEGMENT_TASK_CHAR_BUDGET
+    }
+  })
+
+  it('recovers the final answer when thread state already advanced past the terminal event', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+
+    const parent = await postUserMessage('Context before restart recovery past terminal.')
+    const mentionText = `<@${BOT_USER_ID}> recover a consumed run`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const key = threadKey(parent.ts)
+    const message = apiMessageFromSlackEvent({
+      isMention: true,
+      text: mentionText,
+      threadId: key,
+      ts: mention.ts
+    })
+    // The crashed render consumed the whole stream (lastEventId advanced past
+    // the terminal event) but the answer never reached Slack. Recovery must
+    // replay from the obligation's starting position, not lastEventId.
+    await sharedState.set(`thread-state:${key}`, {
+      activeExecution: true,
+      executedMessageIds: [mention.ts],
+      forwardedMessageIds: [mention.ts],
+      historyForwarded: true,
+      lastEventId: 999999,
+      renderObligation: {
+        afterEventId: 0,
+        executionId: 'exe-recovery-consumed',
+        message
+      }
+    })
+    await sharedState.appendToList('slackbotv2:render:index', key)
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('Recovered consumed answer.'))
+
+    bot = createTestBot({ state: sharedState })
+
+    await waitFor(() => codexApi.eventRequests.length === 1, 2000)
+    await waitFor(() => slackApi.calls.some(call => call.method === 'chat.stopStream'), 2000)
+
+    expect(codexApi.eventRequests).toEqual([
+      { afterEventId: 0, executionId: 'exe-recovery-consumed', threadKey: key }
+    ])
+    expect(await threadText(parent.ts)).toContain('Recovered consumed answer.')
+    const recoveredThreadState = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${key}`
+    )
+    expect(recoveredThreadState).toEqual(
       expect.objectContaining({
         activeExecution: false,
         renderObligation: null
@@ -2570,6 +2872,7 @@ type PatchedSlackApi = {
   calls: StreamCall[]
   close(): Promise<void>
   failRepliesWithThreadNotFound(channel: string, ts: string): void
+  failStreamAppendsAfter(count: number, error: string): void
   failStreamStopsLongerThan(maxChars: number): void
   reset(): void
   url: string
@@ -2606,10 +2909,12 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
   const calls: StreamCall[] = []
   const threadNotFoundReplies = new Set<string>()
   let maxStreamStopChars: number | null = null
+  const appendFailure: { error: string; remaining: number } = { error: '', remaining: -1 }
   const streams = new Map<string, StreamRecord>()
   const port = await availablePort(4053)
   const server = createServer((req, res) => {
     void handlePatchedSlackRequest(req, res, {
+      appendFailure,
       calls,
       maxStreamStopChars,
       port,
@@ -2628,12 +2933,18 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
     failRepliesWithThreadNotFound(channel: string, ts: string) {
       threadNotFoundReplies.add(slackReplyKey(channel, ts))
     },
+    failStreamAppendsAfter(count: number, error: string) {
+      appendFailure.remaining = count
+      appendFailure.error = error
+    },
     failStreamStopsLongerThan(maxChars: number) {
       maxStreamStopChars = maxChars
     },
     reset() {
       calls.length = 0
       maxStreamStopChars = null
+      appendFailure.remaining = -1
+      appendFailure.error = ''
       threadNotFoundReplies.clear()
       streams.clear()
     },
@@ -2645,6 +2956,7 @@ async function handlePatchedSlackRequest(
   req: IncomingMessage,
   res: ServerResponse,
   input: {
+    appendFailure: { error: string; remaining: number }
     calls: StreamCall[]
     maxStreamStopChars: number | null
     port: number
@@ -2689,7 +3001,7 @@ async function handlePatchedSlackRequest(
   if (path === '/api/chat.appendStream') {
     await sendWebResponse(
       res,
-      await appendStream(input.upstreamUrl, request, input.streams, input.calls)
+      await appendStream(input.upstreamUrl, request, input.streams, input.calls, input.appendFailure)
     )
     return
   }
@@ -2816,12 +3128,24 @@ async function appendStream(
   emulatorUrl: string,
   request: Request,
   streams: Map<string, StreamRecord>,
-  calls: StreamCall[]
+  calls: StreamCall[],
+  appendFailure: { error: string; remaining: number }
 ): Promise<Response> {
   const body = await requestBody(request)
   const channel = stringField(body.channel)
   const ts = stringField(body.ts)
   calls.push({ method: 'chat.appendStream', body, streamTs: ts })
+  if (appendFailure.remaining === 0) {
+    // The stream broke server-side: real Slack renders the message as
+    // "Something went wrong" and drops the streamed content.
+    await postSlack(emulatorUrl, request, '/api/chat.update', {
+      channel,
+      ts,
+      text: BROKEN_STREAM_TEXT
+    })
+    return Response.json({ ok: false, error: appendFailure.error })
+  }
+  if (appendFailure.remaining > 0) appendFailure.remaining -= 1
   const record = streams.get(streamKey(channel, ts)) ?? { channel, ts, text: '' }
   record.text += streamBodyText(body)
   streams.set(streamKey(channel, ts), record)
@@ -2848,6 +3172,13 @@ async function stopStream(
   const record = streams.get(key) ?? { channel, ts, text: '' }
   const text = [record.text, streamBodyText(body)].filter(part => part.trim()).join('\n')
   if (maxStreamStopChars !== null && text.length > maxStreamStopChars) {
+    // A stream that is never stopped breaks in real Slack: the message shows
+    // "Something went wrong" instead of the streamed content.
+    await postSlack(emulatorUrl, request, '/api/chat.update', {
+      channel,
+      ts,
+      text: BROKEN_STREAM_TEXT
+    })
     return Response.json({ ok: false, error: 'msg_too_long' })
   }
   await postSlack(emulatorUrl, request, '/api/chat.update', {


### PR DESCRIPTION
## Problem

Five user-reported "Something went wrong" threads in `prd-centaur-na` today (17:29–18:37 UTC). In **all five, the agent succeeded**: executions `completed`, full answers durably stored in `session_executions` / `session_events`. The Slack delivery layer lost them. Two distinct failure modes:

**1. Slack hard-expires streaming messages ~300s after `chat.startStream`** (measured 303s/304s/304s in prod). Renders lag behind execution because appends are rate-limited; once expired, every append/stop fails with `message_not_in_streaming_state`, the bot logged `render_failed` and threw — answer never posted (bugs in threads `1781201798.438709`, `1781198978.127569`, `1781198965.221389`). One failing render hit the wall even though its execution finished in 107s — the Slack append backlog alone was 3.4 min.

**2. `msg_too_long` from oversized plan cards.** Structured task chunks never counted toward segment rotation (only the 11.5k markdown budget existed), so card-heavy turns exceeded Slack's message cap mid-stream or on stop. Since #466 that error was *suppressed* and counted as rendered — the answer was silently dropped (threads `1781202966.588339`, `1781202092.450689`).

24h impact: **54** `msg_too_long` stop failures + **17** `message_not_in_streaming_state` vs 459 successful renders (~15%).

Separately, the slackbotv2 pod was liveness-killed 4×/8h: the chat adapter logs entire raw Slack webhook bodies (50KB+ each) at debug through an unfiltered console logger, stalling the event loop past the 1s probe timeout.

## Fix

Slack streaming is now **best-effort**; the durable session result is the **delivery guarantee**.

### Adapter patch (`patches/@chat-adapter__slack@4.30.0.patch`)
- **Time-based segment rotation**: every live segment (markdown and plan-card) is stopped and replaced before the ~300s Slack streaming lifetime (`SLACK_STREAM_SEGMENT_MAX_AGE_MS`, default 240s, env-overridable for tests). Long renders now continue across stream messages instead of dying.
- **Structured-content budget**: per-segment task-chunk char accounting (`SLACK_STREAM_SEGMENT_TASK_CHAR_BUDGET`, default 16k) rotates plan cards before they can hit `msg_too_long`.
- **`slackAnswerLost` annotation** on thrown stream errors: `false` only when the source stream was fully consumed and the answer-bearing segments stopped cleanly. The answer segment is stopped *before* progress segments so a progress-card failure can't block answer delivery.
- Delivery-impacting Slack errors (`msg_too_long`, `msg_blocks_too_long`, `message_not_in_streaming_state`) and annotated errors are **rethrown** from the structured-append path instead of silently degrading to text-only.

### slackbotv2
- **Durable final-answer fallback**: on any render failure where the answer isn't confirmed visible, replay the session SSE from the execution's start position (events are durable; the terminal `result_text` is replayable even if the failed render already consumed it), drain without Slack calls, and post the final text once. Annotation `false` ⇒ skip the repost — preserves #466's no-duplicate intent.
- Annotation is checked **before** `isRetryableSessionApiError` so Slack network errors (`TypeError`/`AbortError`) can't enter the infinite re-render retry loop.
- **Recovery** replays from `obligation.afterEventId` instead of `max(lastEventId, …)`, which could skip the terminal event after a failed render; recovery also gets the same fallback.
- `msg_too_long` suppression removed.

### Ops
- Console logger defaults to `info` (`SLACKBOTV2_LOG_LEVEL` to override) — kills the raw-webhook-body debug serialization stalls.
- Chart probes get `timeoutSeconds: 5` (was the 1s default).

## Tests

The #466 regression test had become **vacuous** (output-stripping landed later; stream text was 89 chars vs the 120-char failure threshold, so the stop never failed — verified empirically). The emulator now models real Slack (a never-stopped stream renders "Something went wrong" and drops content), and the suite gains real fault-injection coverage:

- stop rejected as too long → broken stream + durable answer reposted **exactly once**, obligation cleared
- stream expires mid-render (`message_not_in_streaming_state` on append) → answer reposted exactly once
- age-based rotation (tiny env threshold) → ≥2 stream messages, every started stream stopped, answer once, nothing broken
- task-char budget rotation → ≥2 stream messages, answer once
- recovery when `lastEventId` already advanced past the terminal event → replays from obligation start, answer delivered

`bun test` 36/36 pass (repeated runs), `tsgo` clean, `pnpm install --frozen-lockfile` clean, `helm template` renders the probe change.

## Notes
- Fallback delivery is **at-least-once**: if the state commit fails after a successful fallback post, restart recovery may repost. Exactly-once would need a durable delivery marker; not justified yet.
- The annotation-`false` partial-failure path (early progress-segment stop fails, answer segment stops fine → no repost) is covered by code review but not by a dedicated e2e test; forcing that exact sequence through the emulator requires per-ts stop targeting.
- slackbotv2 tests aren't wired into CI (`ci.yml` only runs the legacy `services/slackbot` targeted tests) — worth a follow-up.

Investigation evidence (DB rows, VictoriaLogs queries, Laminar timing) in the Amp thread.
