### PR TITLE
chore(chart): carry repo-cache sync-sentinel readiness onto api-rs-control-plane

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.50
+version: 0.1.51
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -84,6 +84,12 @@ spec:
               git config --global --add safe.directory '*'
               git config --global init.defaultBranch main
               umask 022
+              ready_file=/cache/.repo-cache-ready
+              ready_tmp="${ready_file}.tmp"
+
+              repository_fingerprint() {
+                printf 'repositories=%s\nrepository_refs=%s\n' "$REPOSITORIES" "$REPOSITORY_REFS"
+              }
 
               repo_ref() {
                 local repo="$1"
@@ -157,11 +163,22 @@ spec:
               }
 
               while true; do
+                sync_ok=1
                 for repo in $REPOSITORIES; do
                   if ! sync_repo "$repo"; then
                     echo "Failed to sync $repo" >&2
+                    sync_ok=0
                   fi
                 done
+                if [ "$sync_ok" = "1" ]; then
+                  {
+                    repository_fingerprint
+                    printf 'synced_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  } > "$ready_tmp"
+                  mv "$ready_tmp" "$ready_file"
+                else
+                  rm -f "$ready_tmp" "$ready_file"
+                fi
                 sleep "$SYNC_INTERVAL_SECONDS"
               done
           env:
@@ -179,11 +196,17 @@ spec:
                 - /bin/bash
                 - -ec
                 - |
+                  ready_file=/cache/.repo-cache-ready
+                  expected="$(printf 'repositories=%s\nrepository_refs=%s\n' "$REPOSITORIES" "$REPOSITORY_REFS")"
+                  actual="$(sed -n '1,2p' "$ready_file" 2>/dev/null || true)"
+                  [ "$actual" = "$expected" ] || exit 1
                   for repo in $REPOSITORIES; do
-                    git -C "/cache/$repo" rev-parse --git-dir >/dev/null 2>&1 || exit 1
+                    [ -d "/cache/$repo/.git" ] || exit 1
                   done
-            initialDelaySeconds: 10
-            periodSeconds: 30
+            initialDelaySeconds: {{ .Values.repoCache.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.repoCache.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.repoCache.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.repoCache.readinessProbe.failureThreshold }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -169,6 +169,15 @@
           "type": "array",
           "items": { "type": "integer" }
         },
+        "readinessProbe": {
+          "type": "object",
+          "properties": {
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" },
+            "timeoutSeconds": { "type": "integer" },
+            "failureThreshold": { "type": "integer" }
+          }
+        },
         "nodeSelector": { "type": "object" },
         "tolerations": { "type": "array" },
         "affinity": { "type": "object" },

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -222,6 +222,11 @@ repoCache:
     token: ""
   egressPorts:
     - 443
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Cherry-picks the repo-cache readiness sentinel fix (90c125c6, currently deployed in prod via the chart pin but only existing on `fix/repo-cache-readiness-sentinel`) onto the branch, composed with the new repo-list/tool-source logic. Chart 0.1.51.

**Why this blocks the OTLP cost rollout:** api-rs images at/after the overlay-removal commit (41d36d64) — which includes #492 — resolve tools from the repo-cache mount and otherwise shell out to `git`, which isn't in the image (`Io(NotFound)` crash at startup, reproduced in prod and rolled back). So the image can only move forward together with the chart pin, and the chart pin can only move forward without regressing the sentinel fix once this lands.

After merge, prod deploy = move the ArgoCD chart `targetRevision` and `apiRs.image.tag` to this PR's merge sha together (tempoxyz/prd-centaur-infra#351 tracks the image side).