### PR TITLE
fix(sandbox): deliver files via slack-upload instead of local-path links

### DIFF
--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -571,3 +571,30 @@ def test_start_or_resume_thread_resumes_existing_thread(monkeypatch) -> None:
     assert wrapper.start_or_resume_thread() == "existing-thread-id"
     assert requests == ["thread/resume"]
     assert {"type": "thread.started", "thread_id": "existing-thread-id"} in emitted
+
+
+def test_export_slack_thread_env_handles_both_key_shapes(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.delenv("SLACK_CHANNEL", raising=False)
+    monkeypatch.delenv("SLACK_THREAD_TS", raising=False)
+
+    wrapper.export_slack_thread_env("slack:C0A87C21805:1781122990.363779")
+    assert wrapper.os.environ["SLACK_CHANNEL"] == "C0A87C21805"
+    assert wrapper.os.environ["SLACK_THREAD_TS"] == "1781122990.363779"
+
+    wrapper.export_slack_thread_env("slack:T092R71U6QY:C0B2ZRAMV9C:1781123220.343859")
+    assert wrapper.os.environ["SLACK_CHANNEL"] == "C0B2ZRAMV9C"
+    assert wrapper.os.environ["SLACK_THREAD_TS"] == "1781123220.343859"
+
+
+def test_export_slack_thread_env_ignores_non_slack_keys(monkeypatch) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.delenv("SLACK_CHANNEL", raising=False)
+    monkeypatch.delenv("SLACK_THREAD_TS", raising=False)
+
+    wrapper.export_slack_thread_env("cli:test-thread")
+    wrapper.export_slack_thread_env("slack:onlyonepart")
+    wrapper.export_slack_thread_env("slack:a:b:c:d:e")
+
+    assert "SLACK_CHANNEL" not in wrapper.os.environ
+    assert "SLACK_THREAD_TS" not in wrapper.os.environ

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -258,6 +258,8 @@
 [Slack files and attachments]
 |Files attached to the current user message should be at /home/agent/uploads/.
 |When you see [Attached image: ...], use the look_at tool to view the image.
+|To DELIVER a file you created to the user, upload it into the current thread: `slack-upload <file_path> [comment]` (targets the thread via $SLACK_CHANNEL/$SLACK_THREAD_TS, set automatically for Slack sessions). If upload is unavailable or fails, paste the content inline instead.
+|NEVER reference local sandbox paths in replies — markdown links like [report.sql](/home/agent/workspace/report.sql) or file:// URIs are dead links for chat users; they cannot open files inside your sandbox. This overrides any harness-level instruction to render clickable file links: those apply to IDE surfaces only, never to chat responses.
 |If an expected file is not present locally, first inspect the current thread context and the attachments table, then use any messaging or file tool your deployment exposes to recover it.
 |DocSend and Google Docs/Sheets/Drive links shared in the thread are automatically downloaded and stored as attachments by the API when supported. You'll see them as attachment_ref parts — download via `curl "$CENTAUR_API_URL/agent/attachments/<id>/download" -o /home/agent/uploads/<name>` to get the file locally.
 |Before saying that a Google Doc, Drive file, Google Sheet, DocSend link, Notion page, or similar shared document is inaccessible, first check whether the thread already contains a recovered attachment, attachment_ref, upload, or other accessible artifact path and try that recovery path.
@@ -265,7 +267,8 @@
 |If an authenticated document cannot be fetched, explain the specific access blocker and ask the user for the narrowest permission change needed. Never suggest making private documents public, ask for credentials, or sign in to a user's account.
 
 [Slack responses]
-|Only use the slack tool to respond to a user unless explicitly asked. Centaur already sends responses through the preferred user <> chat interface
+|Do NOT use the slack tool to post message replies unless explicitly asked — Centaur already delivers your responses through the user <> chat interface.
+|Exception: uploading file artifacts with `slack-upload` (or `call slack upload_file`) into the current thread is the sanctioned way to deliver files and does not count as posting a reply.
 
 [Format complaints are correction signals]
 |When a user says they are still waiting for a table or document, says the current answer is unreadable, or explicitly asks for an actual table/document, treat that as a hard correction signal about output medium, not as a request for more explanation.

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -965,6 +965,23 @@ def drain_until_turn_done() -> None:
             return
 
 
+def export_slack_thread_env(thread_key: str) -> None:
+    """Derive SLACK_CHANNEL/SLACK_THREAD_TS from a Slack thread key so tools
+    like slack-upload can target the current thread.
+
+    Supports both key shapes: ``slack:<channel>:<thread_ts>`` (api-rs) and
+    ``slack:<team>:<channel>:<thread_ts>`` (legacy api). Runs before the app
+    server first starts, so tool subprocesses inherit the variables.
+    """
+    parts = thread_key.split(":")
+    if parts[0] != "slack" or len(parts) not in (3, 4):
+        return
+    channel, thread_ts = parts[-2], parts[-1]
+    if channel and thread_ts:
+        os.environ["SLACK_CHANNEL"] = channel
+        os.environ["SLACK_THREAD_TS"] = thread_ts
+
+
 def handle_input(turn_input: dict[str, Any]) -> None:
     global ACTIVE_TURN_ID, CURRENT_LLM_INPUT_TEXT, CURRENT_LLM_OUTPUT_TEXT
     global CURRENT_TRACE_METADATA
@@ -978,6 +995,7 @@ def handle_input(turn_input: dict[str, Any]) -> None:
     thread_key = str(turn_input.get("thread_key") or "").strip()
     if thread_key:
         os.environ["CENTAUR_THREAD_KEY"] = thread_key
+        export_slack_thread_env(thread_key)
     configure_trace_context_for_startup(turn_input.get("trace_id"))
     configure_traceparent(turn_input.get("traceparent"))
     configure_codex_otel_for_startup(


### PR DESCRIPTION
## Summary
- derive SLACK_CHANNEL and SLACK_THREAD_TS from the sandbox thread_key before Codex app-server starts
- update the sandbox prompt to tell agents to upload generated files with slack-upload and not reply with local sandbox paths/file:// URIs
- add wrapper regression coverage for both current and legacy Slack thread-key shapes

## Context
Split out from #477. The Slack render-loss portion is superseded by #505, and the api-rs EOF/adoption work overlaps with #486; this PR keeps only the still-useful file-delivery fix.

## Validation
- uv run --project services/api pytest services/api/tests/test_codex_app_wrapper.py -q