### PR TITLE
feat(slackbotv2): native feedback buttons on final answers

### DIFF
--- a/services/slackbotv2/src/feedback.ts
+++ b/services/slackbotv2/src/feedback.ts
@@ -1,0 +1,194 @@
+import type { ActionEvent, Logger, ModalSubmitEvent } from 'chat'
+
+/** action_id on the feedback_buttons element of the final answer message. */
+export const FEEDBACK_ACTION_ID = 'centaur_feedback'
+/** callback_id of the free-text details modal opened from a 👎. */
+export const FEEDBACK_MODAL_CALLBACK_ID = 'centaur_feedback_submit'
+/** Slack caps plain_text_input max_length at 3000 characters. */
+const FEEDBACK_MESSAGE_MAX_LENGTH = 3000
+/** Slack expects interaction acks within 3 seconds. */
+const FEEDBACK_API_TIMEOUT_MS = 2500
+
+type FeedbackChat = {
+  onAction(actionId: string, handler: (event: ActionEvent) => Promise<void>): void
+  onModalSubmit(callbackId: string, handler: (event: ModalSubmitEvent) => Promise<void>): void
+}
+
+export type FeedbackOptions = {
+  apiKey?: string
+  apiUrl: string
+  logger: Logger
+}
+
+type FeedbackContext = {
+  channel_id?: string
+  message_ts?: string
+  team_id?: string
+  thread_ts?: string
+}
+
+/**
+ * Blocks appended to the final streamed answer via Slack's `chat.stopStream`
+ * (`StreamingPlan.endWith` / adapter `stopBlocks`). `feedback_buttons` renders
+ * as Slack's native subtle 👍/👎 affordance on the message — no extra OAuth
+ * scope and no app reinstall required, unlike shortcuts.
+ */
+export function feedbackEndBlocks(): unknown[] {
+  return [
+    {
+      type: 'context_actions',
+      elements: [
+        {
+          type: 'feedback_buttons',
+          action_id: FEEDBACK_ACTION_ID,
+          positive_button: {
+            text: { type: 'plain_text', text: 'Good response' },
+            accessibility_label: 'Mark this response as good',
+            value: 'positive'
+          },
+          negative_button: {
+            text: { type: 'plain_text', text: 'Bad response' },
+            accessibility_label: 'Mark this response as bad and add details',
+            value: 'negative'
+          }
+        }
+      ]
+    }
+  ]
+}
+
+/**
+ * Wires the feedback flow: 👍 stores a one-tap positive record, 👎 opens a
+ * free-text modal whose submission is stored via the Centaur feedback API.
+ */
+export function registerFeedbackHandlers(chat: FeedbackChat, options: FeedbackOptions): void {
+  chat.onAction(FEEDBACK_ACTION_ID, async event => {
+    const sentiment = event.value === 'negative' ? 'negative' : 'positive'
+    const context = feedbackContext(event)
+    if (sentiment === 'negative' && (await openFeedbackModal(event, context, options))) return
+    // Positive feedback is one tap; a negative tap only lands here when the
+    // modal could not be opened, so the bare sentiment is still recorded.
+    await storeFeedback(options, {
+      source: 'slackbotv2_feedback_button',
+      message: sentiment === 'positive' ? '+1' : '-1',
+      user_id: event.user.userId,
+      channel_id: context.channel_id,
+      thread_ts: context.thread_ts,
+      metadata: { sentiment, slack: context }
+    })
+  })
+
+  chat.onModalSubmit(FEEDBACK_MODAL_CALLBACK_ID, async event => {
+    const message = event.values.message?.trim()
+    if (!message) return
+    const context = parseFeedbackContext(event.privateMetadata)
+    await storeFeedback(options, {
+      source: 'slackbotv2_feedback_modal',
+      message,
+      user_id: event.user.userId,
+      channel_id: context.channel_id,
+      thread_ts: context.thread_ts,
+      metadata: { sentiment: 'negative', slack: context }
+    })
+  })
+}
+
+async function openFeedbackModal(
+  event: ActionEvent,
+  context: FeedbackContext,
+  options: FeedbackOptions
+): Promise<boolean> {
+  try {
+    const result = await event.openModal({
+      type: 'modal',
+      callbackId: FEEDBACK_MODAL_CALLBACK_ID,
+      title: 'Feedback',
+      submitLabel: 'Send',
+      privateMetadata: JSON.stringify(context),
+      children: [
+        {
+          type: 'text_input',
+          id: 'message',
+          label: 'What went wrong?',
+          multiline: true,
+          maxLength: FEEDBACK_MESSAGE_MAX_LENGTH,
+          placeholder: 'Tell us what to improve'
+        }
+      ]
+    })
+    return Boolean(result)
+  } catch (error) {
+    options.logger.warn('slackbotv2_feedback_modal_open_failed', { error: String(error) })
+    return false
+  }
+}
+
+function feedbackContext(event: ActionEvent): FeedbackContext {
+  const raw = (event.raw ?? {}) as {
+    channel?: { id?: string }
+    container?: { channel_id?: string; message_ts?: string; thread_ts?: string }
+    message?: { thread_ts?: string; ts?: string }
+    team?: { id?: string }
+  }
+  const messageTs = raw.message?.ts ?? raw.container?.message_ts
+  return pruneContext({
+    channel_id: raw.channel?.id ?? raw.container?.channel_id,
+    message_ts: messageTs,
+    team_id: raw.team?.id,
+    thread_ts: raw.message?.thread_ts ?? raw.container?.thread_ts ?? messageTs
+  })
+}
+
+function parseFeedbackContext(privateMetadata: string | undefined): FeedbackContext {
+  if (!privateMetadata) return {}
+  try {
+    const parsed: unknown = JSON.parse(privateMetadata)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    return pruneContext(
+      Object.fromEntries(
+        Object.entries(parsed).filter(([, value]) => typeof value === 'string')
+      ) as FeedbackContext
+    )
+  } catch {
+    return {}
+  }
+}
+
+function pruneContext(context: FeedbackContext): FeedbackContext {
+  return Object.fromEntries(
+    Object.entries(context).filter(([, value]) => Boolean(value))
+  ) as FeedbackContext
+}
+
+async function storeFeedback(
+  options: FeedbackOptions,
+  body: {
+    channel_id?: string
+    message: string
+    metadata: Record<string, unknown>
+    source: string
+    thread_ts?: string
+    user_id?: string
+  }
+): Promise<void> {
+  const apiKey = options.apiKey ?? process.env.SLACKBOT_API_KEY ?? process.env.CENTAUR_API_KEY
+  try {
+    const response = await fetch(new URL('/api/feedback', options.apiUrl), {
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+        ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {})
+      },
+      method: 'POST',
+      signal: AbortSignal.timeout(FEEDBACK_API_TIMEOUT_MS)
+    })
+    if (!response.ok) {
+      throw new Error(`feedback API returned ${response.status}`)
+    }
+  } catch (error) {
+    options.logger.warn('slackbotv2_feedback_store_failed', {
+      error: String(error),
+      source: body.source
+    })
+  }
+}

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -20,6 +20,7 @@ import {
   type RendererEvent
 } from '@centaur/rendering'
 import { conflateChatSdkStream } from './conflate'
+import { feedbackEndBlocks, registerFeedbackHandlers } from './feedback'
 import {
   collectInitialContext,
   forwardToSessionApi,
@@ -108,6 +109,12 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     adapters: { slack },
     state,
     onLockConflict: 'force',
+    logger
+  })
+
+  registerFeedbackHandlers(chat, {
+    apiKey: options.apiKey,
+    apiUrl: options.apiUrl,
     logger
   })
 
@@ -953,7 +960,10 @@ async function renderExecutionStream(
     await thread.post(
       new StreamingPlan(
         visibleStream,
-        { groupTasks: options.streamTaskDisplayMode ?? 'plan' }
+        {
+          endWith: feedbackEndBlocks(),
+          groupTasks: options.streamTaskDisplayMode ?? 'plan'
+        }
       )
     )
   } finally {
@@ -996,6 +1006,7 @@ async function renderRecoveredExecutionStream(
       {
         recipientTeamId: message.teamId,
         recipientUserId: message.author.userId,
+        stopBlocks: feedbackEndBlocks(),
         taskDisplayMode: options.streamTaskDisplayMode ?? 'plan'
       }
     )

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -110,6 +110,106 @@ describe('slackbotv2', () => {
     expect(codexApi.executes[0]?.threadKey).toBe(threadKey(parent.ts))
   })
 
+  it('stores one-tap positive feedback from the native feedback buttons', async () => {
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackInteraction({
+        type: 'block_actions',
+        team: { id: TEAM_ID },
+        user: { id: USER_ID, username: 'tester', name: 'Test User' },
+        channel: { id: CHANNEL_ID },
+        message: { ts: '1700000001.000200', thread_ts: '1700000001.000100' },
+        trigger_id: 'trigger-positive',
+        actions: [{ action_id: 'centaur_feedback', type: 'feedback_buttons', value: 'positive' }]
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+    expect(slackApi.calls.filter(call => call.method === 'views.open')).toHaveLength(0)
+    expect(codexApi.feedbacks).toHaveLength(1)
+    expect(codexApi.feedbacks[0]).toMatchObject({
+      source: 'slackbotv2_feedback_button',
+      message: '+1',
+      user_id: USER_ID,
+      channel_id: CHANNEL_ID,
+      thread_ts: '1700000001.000100',
+      metadata: { sentiment: 'positive' }
+    })
+  })
+
+  it('opens the details modal on negative feedback and stores the submission', async () => {
+    const waits: Promise<unknown>[] = []
+    const actionResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackInteraction({
+        type: 'block_actions',
+        team: { id: TEAM_ID },
+        user: { id: USER_ID, username: 'tester', name: 'Test User' },
+        channel: { id: CHANNEL_ID },
+        message: { ts: '1700000002.000200', thread_ts: '1700000002.000100' },
+        trigger_id: 'trigger-negative',
+        actions: [{ action_id: 'centaur_feedback', type: 'feedback_buttons', value: 'negative' }]
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(actionResponse.status).toBe(200)
+    await Promise.all(waits)
+    expect(codexApi.feedbacks).toHaveLength(0)
+    const opens = slackApi.calls.filter(call => call.method === 'views.open')
+    expect(opens).toHaveLength(1)
+    const view = opens[0]?.body.view as {
+      blocks?: Array<{ block_id?: string }>
+      callback_id?: string
+      private_metadata?: string
+    }
+    expect(view?.blocks?.[0]?.block_id).toBe('message')
+
+    const submitWaits: Promise<unknown>[] = []
+    const submitResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackInteraction({
+        type: 'view_submission',
+        team: { id: TEAM_ID },
+        user: { id: USER_ID, username: 'tester', name: 'Test User' },
+        view: {
+          id: 'V0TESTVIEW',
+          callback_id: view?.callback_id,
+          private_metadata: view?.private_metadata,
+          state: {
+            values: {
+              message: {
+                message: {
+                  type: 'plain_text_input',
+                  value: '  The answer missed the point.  '
+                }
+              }
+            }
+          }
+        }
+      }),
+      {},
+      waitUntilContext(submitWaits)
+    )
+
+    expect(submitResponse.status).toBe(200)
+    await Promise.all(submitWaits)
+    expect(codexApi.feedbacks).toHaveLength(1)
+    expect(codexApi.feedbacks[0]).toMatchObject({
+      source: 'slackbotv2_feedback_modal',
+      message: 'The answer missed the point.',
+      user_id: USER_ID,
+      channel_id: CHANNEL_ID,
+      thread_ts: '1700000002.000100',
+      metadata: { sentiment: 'negative' }
+    })
+  })
+
   it('syncs thread context, forwards subscribed messages, and renders execute streams', async () => {
     const parent = await postUserMessage('The deploy context is above.')
     const firstMention = await postUserMessage(
@@ -364,6 +464,9 @@ describe('slackbotv2', () => {
 
     await Promise.all(waits)
     expect(slackApi.calls.some(call => call.method === 'chat.stopStream')).toBe(true)
+    const stops = slackApi.calls.filter(call => call.method === 'chat.stopStream')
+    const stopBlocks = stops.flatMap(call => (call.body.blocks as Array<{ type?: string }>) ?? [])
+    expect(stopBlocks.some(block => block.type === 'context_actions')).toBe(true)
     expect(await threadText(mention.ts)).toContain('Answer despite bootstrap noise.')
     expect(await threadText(mention.ts)).not.toContain(
       'Execution completed, but no final text was captured.'
@@ -2488,6 +2591,23 @@ function signedSlackEvent(input: {
   }
 }
 
+function signedSlackInteraction(payload: Record<string, unknown>): RequestInit {
+  const timestamp = Math.floor(Date.now() / 1000)
+  const body = `payload=${encodeURIComponent(JSON.stringify(payload))}`
+  const signature = createHmac('sha256', SIGNING_SECRET)
+    .update(`v0:${timestamp}:${body}`)
+    .digest('hex')
+  return {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      'x-slack-request-timestamp': String(timestamp),
+      'x-slack-signature': `v0=${signature}`
+    },
+    body
+  }
+}
+
 function waitUntilContext(waits: Promise<unknown>[]) {
   return {
     waitUntil(promise: Promise<unknown>) {
@@ -2517,6 +2637,15 @@ type MockSessionEvent = {
   threadKey: string
 }
 
+type MockFeedbackRequest = {
+  channel_id?: string
+  message: string
+  metadata?: { sentiment?: string; slack?: Record<string, string> }
+  source: string
+  thread_ts?: string
+  user_id?: string
+}
+
 type MockSessionApi = {
   appends: MockSessionRequest<SlackbotV2AppendMessagesRequest>[]
   autoRespond: boolean
@@ -2531,6 +2660,7 @@ type MockSessionApi = {
   failNextEvents: boolean
   failNextExecute: boolean
   failNextExecuteAfterAccept: boolean
+  feedbacks: MockFeedbackRequest[]
   holdNextExecute(): () => void
   reset(): void
   streamCount: number
@@ -2543,6 +2673,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
   const eventRequests: MockSessionEventRequest[] = []
   const events: MockSessionEvent[] = []
   const executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[] = []
+  const feedbacks: MockFeedbackRequest[] = []
   const idempotentExecutions = new Map<string, string>()
   const streams = new Set<ServerResponse>()
   let autoRespond = true
@@ -2564,6 +2695,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       events,
       eventRequests,
       executes,
+      feedbacks,
       get autoRespond() {
         return autoRespond
       },
@@ -2607,12 +2739,14 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
     creates,
     eventRequests,
     executes,
+    feedbacks,
     reset() {
       appends.length = 0
       creates.length = 0
       eventRequests.length = 0
       events.length = 0
       executes.length = 0
+      feedbacks.length = 0
       idempotentExecutions.clear()
       executeHoldRelease?.()
       executeHold = null
@@ -2712,6 +2846,7 @@ async function handleMockCodexRequest(
     failNextExecuteAfterAccept: boolean
     failNextEvents: boolean
     failNextExecute: boolean
+    feedbacks: MockFeedbackRequest[]
     idempotentExecutions: Map<string, string>
     nextEventId(): number
     port: number
@@ -2722,6 +2857,12 @@ async function handleMockCodexRequest(
   }
 ): Promise<void> {
   const url = new URL(req.url ?? '/', `http://127.0.0.1:${input.port}`)
+  if (url.pathname === '/api/feedback') {
+    const request = await nodeRequestToWebRequest(req, url)
+    input.feedbacks.push((await request.json()) as MockFeedbackRequest)
+    await sendWebResponse(res, Response.json({ ok: true, feedback_id: 'fbk_test' }))
+    return
+  }
   const match = /^\/api\/session\/([^/]+)(?:\/(messages|execute|events))?$/.exec(url.pathname)
   if (!match?.[1]) {
     await sendWebResponse(res, new Response('not found', { status: 404 }))
@@ -2886,6 +3027,7 @@ type StreamCall = {
     | 'chat.startStream'
     | 'chat.appendStream'
     | 'chat.stopStream'
+    | 'views.open'
   streamTs?: string
 }
 
@@ -2979,6 +3121,12 @@ async function handlePatchedSlackRequest(
   }
 
   const path = normalizeApiPath(url.pathname)
+  if (path === '/api/views.open') {
+    const body = await requestBody(request)
+    input.calls.push({ method: 'views.open', body })
+    await sendWebResponse(res, Response.json({ ok: true, view: { id: 'V0TESTVIEW' } }))
+    return
+  }
   if (path === '/api/assistant.threads.setStatus') {
     const body = await requestBody(request)
     input.calls.push({ method: 'assistant.threads.setStatus', body })


### PR DESCRIPTION
## Summary

Replaces the message-shortcut feedback entry point (required the `commands` scope + app reinstall) with **Slack's native `feedback_buttons` element** in a `context_actions` block — the same subtle 👍/👎 hover affordance Slack AI uses. `block_actions` require no extra OAuth scope; interactivity is already enabled on both apps.

Important context: both staging and prod route Slack traffic to **slackbotv2** (`centaur-staging.tehq.net` and `centaur.tehq.net` HTTPRoutes → `centaur-slackbotv2`), so the v1 modal flow from #500 never serves traffic. This implements the flow in the live service.

## How

- `feedbackEndBlocks()` appended to the final streamed answer via `chat.stopStream` (Chat SDK `StreamingPlan.endWith` on the live path, adapter `stopBlocks` on the recovery path — both supported by the patched `@chat-adapter/slack@4.30`)
- 👍 → one-tap positive record via `POST /api/feedback` (shipped in #500)
- 👎 → free-text modal via Chat SDK `ActionEvent.openModal`; `chat.onModalSubmit` stores the submission with channel/thread/team context round-tripped through `private_metadata`
- Store failures are logged, never thrown into the webhook path; feedback API calls use a 2.5s timeout inside Slack's 3s ack window

## Verification

- `tsgo` typecheck ✅
- 38/38 emulator tests ✅, including new ones:
  - one-tap positive stores immediately (no modal)
  - negative opens the modal (captured `views.open`, asserted field ids), and a `view_submission` echoing the adapter-encoded `callback_id`/`private_metadata` round-trips into a stored record
  - the execute-stream test now asserts `chat.stopStream` carries the `context_actions` block

## Needs live-Slack verification after deploy

1. `chat.stopStream` accepting `context_actions`/`feedback_buttons` blocks (docs say Messages surface; the emulator accepts them, real Slack should be confirmed in staging)
2. The exact `block_actions` payload shape for `feedback_buttons` taps (assumed the tapped button's `value` arrives as `action.value`)

The stg-ai/ai app manifests are being reverted to drop the now-unneeded shortcut + `commands` scope (interactivity stays).