### PR TITLE
feat(tools): inject host-scoped HTTP secrets instead of replace

### DIFF
--- a/tools/business/ashby/pyproject.toml
+++ b/tools/business/ashby/pyproject.toml
@@ -27,4 +27,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "ASHBY_API_KEY", match_headers = ["Authorization"], hosts = ["api.ashbyhq.com"]}]
+secrets = [{type = "http", name = "ASHBY_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = 'Basic {{ base64 .Value ":" }}', hosts = ["api.ashbyhq.com"]}]

--- a/tools/business/attio/pyproject.toml
+++ b/tools/business/attio/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "ATTIO_API_KEY", match_headers = ["Authorization"], hosts = ["api.attio.com"]}]
+secrets = [{type = "http", name = "ATTIO_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.attio.com"]}]

--- a/tools/business/pylon/pyproject.toml
+++ b/tools/business/pylon/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "PYLON_API_KEY", match_headers = ["Authorization"], hosts = ["api.usepylon.com"]}]
+secrets = [{type = "http", name = "PYLON_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.usepylon.com"]}]

--- a/tools/comms/discord/pyproject.toml
+++ b/tools/comms/discord/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "DISCORD_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["discord.com"]}]
+secrets = [{type = "http", name = "DISCORD_BOT_TOKEN", mode = "inject", inject_header = "Authorization", hosts = ["discord.com"]}]

--- a/tools/comms/twitter/pyproject.toml
+++ b/tools/comms/twitter/pyproject.toml
@@ -28,4 +28,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "SYNOPTIC_API_KEY", match_headers = ["x-api-key"], hosts = ["api.synoptic.com"]}]
+secrets = [{type = "http", name = "SYNOPTIC_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["api.synoptic.com"]}]

--- a/tools/crypto/allium/pyproject.toml
+++ b/tools/crypto/allium/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "ALLIUM_API_KEY", match_headers = ["X-API-KEY"], hosts = ["api.allium.so", "mcp.allium.so"]}]
+secrets = [{type = "http", name = "ALLIUM_API_KEY", mode = "inject", inject_header = "X-API-KEY", hosts = ["api.allium.so", "mcp.allium.so"]}]

--- a/tools/crypto/arkham/pyproject.toml
+++ b/tools/crypto/arkham/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "ARKHAM_API_KEY", match_headers = ["API-Key"], hosts = ["api.arkm.com"]}]
+secrets = [{type = "http", name = "ARKHAM_API_KEY", mode = "inject", inject_header = "API-Key", hosts = ["api.arkm.com"]}]

--- a/tools/crypto/coingecko/pyproject.toml
+++ b/tools/crypto/coingecko/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "COINGECKO_API_KEY", match_headers = ["x-cg-pro-api-key"], hosts = ["pro-api.coingecko.com"]}]
+secrets = [{type = "http", name = "COINGECKO_API_KEY", mode = "inject", inject_header = "x-cg-pro-api-key", hosts = ["pro-api.coingecko.com"]}]

--- a/tools/crypto/coinmetrics/pyproject.toml
+++ b/tools/crypto/coinmetrics/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "COINMETRICS_API_KEY", match_query = true, hosts = ["api.coinmetrics.io"]}]
+secrets = [{type = "http", name = "COINMETRICS_API_KEY", mode = "inject", inject_query_param = "api_key", hosts = ["api.coinmetrics.io"]}]

--- a/tools/crypto/databento/pyproject.toml
+++ b/tools/crypto/databento/pyproject.toml
@@ -25,4 +25,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "DATABENTO_API_KEY", match_headers = ["Authorization"], hosts = ["hist.databento.com"]}]
+secrets = [{type = "http", name = "DATABENTO_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = 'Basic {{ base64 .Value ":" }}', hosts = ["hist.databento.com"]}]

--- a/tools/crypto/debank/pyproject.toml
+++ b/tools/crypto/debank/pyproject.toml
@@ -25,4 +25,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "DEBANK_API_KEY", match_headers = ["AccessKey"], hosts = ["pro-openapi.debank.com"]}]
+secrets = [{type = "http", name = "DEBANK_API_KEY", mode = "inject", inject_header = "AccessKey", hosts = ["pro-openapi.debank.com"]}]

--- a/tools/crypto/dune/pyproject.toml
+++ b/tools/crypto/dune/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "DUNE_API_KEY", match_headers = ["X-Dune-API-Key"], hosts = ["api.dune.com"]}]
+secrets = [{type = "http", name = "DUNE_API_KEY", mode = "inject", inject_header = "X-Dune-API-Key", hosts = ["api.dune.com"]}]

--- a/tools/crypto/eodhd/pyproject.toml
+++ b/tools/crypto/eodhd/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "EODHD_API_KEY", match_query = true, hosts = ["eodhd.com"]}]
+secrets = [{type = "http", name = "EODHD_API_KEY", mode = "inject", inject_query_param = "api_token", hosts = ["eodhd.com"]}]

--- a/tools/crypto/etherscan/pyproject.toml
+++ b/tools/crypto/etherscan/pyproject.toml
@@ -16,4 +16,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "ETHERSCAN_API_KEY", match_query = true, hosts = ["api.etherscan.io"]}]
+secrets = [{type = "http", name = "ETHERSCAN_API_KEY", mode = "inject", inject_query_param = "apikey", hosts = ["api.etherscan.io"]}]

--- a/tools/crypto/messari/pyproject.toml
+++ b/tools/crypto/messari/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "MESSARI_API_KEY", match_headers = ["x-messari-api-key"], hosts = ["api.messari.io"]}]
+secrets = [{type = "http", name = "MESSARI_API_KEY", mode = "inject", inject_header = "x-messari-api-key", hosts = ["api.messari.io"]}]

--- a/tools/crypto/nansen/pyproject.toml
+++ b/tools/crypto/nansen/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "NANSEN_API_KEY", match_headers = ["apikey"], hosts = ["api.nansen.ai"]}]
+secrets = [{type = "http", name = "NANSEN_API_KEY", mode = "inject", inject_header = "apiKey", hosts = ["api.nansen.ai"]}]

--- a/tools/crypto/snapshot/pyproject.toml
+++ b/tools/crypto/snapshot/pyproject.toml
@@ -16,4 +16,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "SNAPSHOT_API_KEY", match_headers = ["x-api-key"], hosts = ["hub.snapshot.org"]}]
+secrets = [{type = "http", name = "SNAPSHOT_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["hub.snapshot.org"]}]

--- a/tools/crypto/tally/pyproject.toml
+++ b/tools/crypto/tally/pyproject.toml
@@ -16,4 +16,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "TALLY_API_KEY", match_headers = ["Api-Key"], hosts = ["api.tally.xyz"]}]
+secrets = [{type = "http", name = "TALLY_API_KEY", mode = "inject", inject_header = "Api-Key", hosts = ["api.tally.xyz"]}]

--- a/tools/crypto/token-terminal/pyproject.toml
+++ b/tools/crypto/token-terminal/pyproject.toml
@@ -16,4 +16,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "TOKEN_TERMINAL_API_KEY", match_headers = ["authorization"], hosts = ["api.tokenterminal.com"]}]
+secrets = [{type = "http", name = "TOKEN_TERMINAL_API_KEY", mode = "inject", inject_header = "authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.tokenterminal.com"]}]

--- a/tools/crypto/tokenomist/pyproject.toml
+++ b/tools/crypto/tokenomist/pyproject.toml
@@ -16,4 +16,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "TOKENOMIST_API_KEY", match_headers = ["x-api-key"], hosts = ["api.tokenomist.ai"]}]
+secrets = [{type = "http", name = "TOKENOMIST_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["api.tokenomist.ai"]}]

--- a/tools/infra/posthog/pyproject.toml
+++ b/tools/infra/posthog/pyproject.toml
@@ -27,6 +27,6 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "POSTHOG_API_KEY", match_headers = ["Authorization"], hosts = ["us.posthog.com"]},
+    {type = "http", name = "POSTHOG_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["us.posthog.com"]},
     {type = "http", name = "POSTHOG_PROJECT_ID", match_path = true, hosts = ["us.posthog.com"]},
 ]

--- a/tools/media/nano-banana/pyproject.toml
+++ b/tools/media/nano-banana/pyproject.toml
@@ -29,5 +29,5 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "GOOGLE_API_KEY", match_headers = ["x-goog-api-key"], hosts = ["generativelanguage.googleapis.com"]},
+    {type = "http", name = "GOOGLE_API_KEY", mode = "inject", inject_header = "x-goog-api-key", hosts = ["generativelanguage.googleapis.com"]},
 ]

--- a/tools/media/veo3/pyproject.toml
+++ b/tools/media/veo3/pyproject.toml
@@ -27,5 +27,5 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "GOOGLE_API_KEY", match_headers = ["x-goog-api-key"], hosts = ["generativelanguage.googleapis.com"]},
+    {type = "http", name = "GOOGLE_API_KEY", mode = "inject", inject_header = "x-goog-api-key", hosts = ["generativelanguage.googleapis.com"]},
 ]

--- a/tools/productivity/airtable/pyproject.toml
+++ b/tools/productivity/airtable/pyproject.toml
@@ -26,5 +26,5 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "AIRTABLE_API_KEY", match_headers = ["Authorization"], hosts = ["api.airtable.com"]},
+    {type = "http", name = "AIRTABLE_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.airtable.com"]},
 ]

--- a/tools/productivity/composio/pyproject.toml
+++ b/tools/productivity/composio/pyproject.toml
@@ -17,5 +17,5 @@ packages = ["."]
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "COMPOSIO_API_KEY", match_headers = ["x-api-key"], hosts = ["backend.composio.dev"]},
+    {type = "http", name = "COMPOSIO_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["backend.composio.dev"]},
 ]

--- a/tools/productivity/figma/pyproject.toml
+++ b/tools/productivity/figma/pyproject.toml
@@ -26,5 +26,5 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "FIGMA_ACCESS_TOKEN", match_headers = ["X-Figma-Token"], hosts = ["api.figma.com"]},
+    {type = "http", name = "FIGMA_ACCESS_TOKEN", mode = "inject", inject_header = "X-Figma-Token", hosts = ["api.figma.com"]},
 ]

--- a/tools/productivity/granola/pyproject.toml
+++ b/tools/productivity/granola/pyproject.toml
@@ -26,5 +26,5 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "GRANOLA_API_KEY", match_headers = ["Authorization"], hosts = ["public-api.granola.ai"]},
+    {type = "http", name = "GRANOLA_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["public-api.granola.ai"]},
 ]

--- a/tools/productivity/linear/pyproject.toml
+++ b/tools/productivity/linear/pyproject.toml
@@ -27,5 +27,5 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "LINEAR_API_KEY", match_headers = ["Authorization"], hosts = ["api.linear.app", "uploads.linear.app"]},
+    {type = "http", name = "LINEAR_API_KEY", mode = "inject", inject_header = "Authorization", hosts = ["api.linear.app", "uploads.linear.app"]},
 ]

--- a/tools/productivity/notion/pyproject.toml
+++ b/tools/productivity/notion/pyproject.toml
@@ -27,5 +27,5 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "NOTION_API_KEY", match_headers = ["Authorization"], hosts = ["api.notion.com"]},
+    {type = "http", name = "NOTION_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.notion.com"]},
 ]

--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -28,8 +28,8 @@ packages = ["."]
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
+    {type = "http", name = "SLACK_BOT_TOKEN", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["slack.com"]},
 ]
 optional_secrets = [
-    {type = "http", name = "SLACK_SEARCH_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
+    {type = "http", name = "SLACK_SEARCH_TOKEN", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["slack.com"]},
 ]

--- a/tools/research/archiver/pyproject.toml
+++ b/tools/research/archiver/pyproject.toml
@@ -29,6 +29,6 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "REDUCTO_API_KEY", match_headers = ["Authorization"], hosts = ["platform.reducto.ai"]},
+    {type = "http", name = "REDUCTO_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["platform.reducto.ai"]},
     {type = "http", name = "BROWSER_USE_API_KEY", match_query = true, hosts = ["connect.browser-use.com"]},
 ]

--- a/tools/research/congress/pyproject.toml
+++ b/tools/research/congress/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "DATAGOV_API_KEY", match_query = true, hosts = ["api.congress.gov"]}]
+secrets = [{type = "http", name = "DATAGOV_API_KEY", mode = "inject", inject_query_param = "api_key", hosts = ["api.congress.gov"]}]

--- a/tools/research/crunchbase/pyproject.toml
+++ b/tools/research/crunchbase/pyproject.toml
@@ -25,4 +25,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "CRUNCHBASE_API_KEY", match_headers = ["X-cb-user-key"], hosts = ["api.crunchbase.com"]}]
+secrets = [{type = "http", name = "CRUNCHBASE_API_KEY", mode = "inject", inject_header = "X-cb-user-key", hosts = ["api.crunchbase.com"]}]

--- a/tools/research/harmonic/pyproject.toml
+++ b/tools/research/harmonic/pyproject.toml
@@ -25,4 +25,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "HARMONIC_API_KEY", match_headers = ["apikey"], hosts = ["api.harmonic.ai"]}]
+secrets = [{type = "http", name = "HARMONIC_API_KEY", mode = "inject", inject_header = "apikey", hosts = ["api.harmonic.ai"]}]

--- a/tools/research/legistorm/pyproject.toml
+++ b/tools/research/legistorm/pyproject.toml
@@ -26,5 +26,5 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 hosts = ["api.legistorm.com"]
-secrets = [{type = "http", name = "LEGISTORM_API_KEY", match_headers = ["X-Api-Key"], hosts = ["api.legistorm.com"]}]
+secrets = [{type = "http", name = "LEGISTORM_API_KEY", mode = "inject", inject_header = "X-Api-Key", hosts = ["api.legistorm.com"]}]
 optional_secrets = ["LEGISTORM_ISSUES_ENDPOINT"]

--- a/tools/research/listennotes/pyproject.toml
+++ b/tools/research/listennotes/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "LISTENNOTES_KEY", match_headers = ["X-ListenAPI-Key"], hosts = ["listen-api.listennotes.com"]}]
+secrets = [{type = "http", name = "LISTENNOTES_KEY", mode = "inject", inject_header = "X-ListenAPI-Key", hosts = ["listen-api.listennotes.com"]}]

--- a/tools/research/newsapi/pyproject.toml
+++ b/tools/research/newsapi/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "NEWSAPI_KEY", match_headers = ["X-Api-Key"], hosts = ["newsapi.org"]}]
+secrets = [{type = "http", name = "NEWSAPI_KEY", mode = "inject", inject_header = "X-Api-Key", hosts = ["newsapi.org"]}]

--- a/tools/research/openfec/pyproject.toml
+++ b/tools/research/openfec/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "DATAGOV_API_KEY", match_query = true, hosts = ["api.open.fec.gov"]}]
+secrets = [{type = "http", name = "DATAGOV_API_KEY", mode = "inject", inject_query_param = "api_key", hosts = ["api.open.fec.gov"]}]

--- a/tools/research/plural/pyproject.toml
+++ b/tools/research/plural/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "PLURAL_API_KEY", match_headers = ["X-API-KEY"], hosts = ["v3.openstates.org"]}]
+secrets = [{type = "http", name = "PLURAL_API_KEY", mode = "inject", inject_header = "X-API-KEY", hosts = ["v3.openstates.org"]}]

--- a/tools/research/sensortower/pyproject.toml
+++ b/tools/research/sensortower/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "SENSOR_TOWER_AUTH_TOKEN", match_query = true, hosts = ["api.sensortower.com", "app.sensortower.com"]}]
+secrets = [{type = "http", name = "SENSOR_TOWER_AUTH_TOKEN", mode = "inject", inject_query_param = "auth_token", hosts = ["api.sensortower.com", "app.sensortower.com"]}]

--- a/tools/research/similarweb/pyproject.toml
+++ b/tools/research/similarweb/pyproject.toml
@@ -26,4 +26,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "SIMILARWEB_API_KEY", match_query = true, hosts = ["api.similarweb.com"]}]
+secrets = [{type = "http", name = "SIMILARWEB_API_KEY", mode = "inject", inject_query_param = "api_key", hosts = ["api.similarweb.com"]}]

--- a/tools/research/websearch/pyproject.toml
+++ b/tools/research/websearch/pyproject.toml
@@ -34,7 +34,7 @@ module = "client.py"
 # Set ANTHROPIC_API_KEY to enable the Claude-backed synthesis pipeline on
 # top of search results (reviewer → writer → citation repair).
 optional_secrets = [
-    {type = "http", name = "PARALLEL_API_KEY", match_headers = ["x-api-key", "Authorization"], hosts = ["api.parallel.ai", "search.parallel.ai"]},
-    {type = "http", name = "ANTHROPIC_API_KEY", match_headers = ["x-api-key"], hosts = ["api.anthropic.com"]},
+    {type = "http", name = "PARALLEL_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.parallel.ai", "search.parallel.ai"]},
+    {type = "http", name = "ANTHROPIC_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["api.anthropic.com"]},
 ]
 hosts = ["api.parallel.ai", "search.parallel.ai"]

--- a/tools/research/youtube/pyproject.toml
+++ b/tools/research/youtube/pyproject.toml
@@ -27,6 +27,6 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "YOUTUBE_API_KEY", match_query = true, hosts = ["www.googleapis.com"]},
-    {type = "http", name = "GOOGLE_API_KEY", match_query = true, hosts = ["www.googleapis.com"]},
+    {type = "http", name = "YOUTUBE_API_KEY", mode = "inject", inject_query_param = "key", hosts = ["www.googleapis.com"]},
+    {type = "http", name = "GOOGLE_API_KEY", mode = "inject", inject_query_param = "key", hosts = ["www.googleapis.com"]},
 ]


### PR DESCRIPTION
Flips every host-scoped tool HTTP secret from `replace` to `inject` mode (35 tools, 43 entries). iron-proxy now sets the credential on the request itself at the network boundary, overwriting the StubBackend key-name stub the tool builds its header/query with, so the real secret never reaches the tool. No bootstrap or client changes needed — the SDK stub keeps clients working and the control plane already maps inject to iron-control's `inject_config`.

Left on `replace` where inject can't apply: path-embedded keys (telegram, alchemy, defillama, posthog project id), grafana (no scoped host), and standard-metrics (client-side OAuth exchange — wants an `oauth_token` secret as a follow-up).