### PR TITLE
[codex] fix Slackbot v2 large attachment input

### DIFF
--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -56,6 +56,8 @@ LLM_INPUTS_BY_TURN_ID: dict[str, str] = {}
 LLM_OUTPUTS_BY_TURN_ID: dict[str, str] = {}
 CURRENT_TRACE_METADATA: dict[str, Any] = {}
 TRACE_METADATA_BY_TURN_ID: dict[str, dict[str, Any]] = {}
+ATTACHMENT_UPLOADS: dict[str, dict[str, Any]] = {}
+STAGED_ATTACHMENTS: dict[str, dict[str, Any]] = {}
 
 LAMINAR_METADATA_PREFIX = "lmnr.association.properties.metadata."
 DATA_URL_PREFIX = "data:"
@@ -227,6 +229,35 @@ def input_items_from_image_block(block: dict[str, Any]) -> list[dict[str, Any]]:
 def input_items_from_attachment_block(block: dict[str, Any]) -> list[dict[str, Any]]:
     name = str(block.get("name") or "attachment")
     mime_type = optional_string(block.get("mimeType"))
+    local_path = optional_string(block.get("localPath")) or optional_string(block.get("path"))
+    if local_path:
+        path = Path(local_path)
+        if path.exists():
+            return local_file_items(
+                path,
+                mime_type,
+                is_image=optional_string(block.get("attachment_type")) == "image",
+            )
+
+    staged_attachment_id = optional_string(block.get("stagedAttachmentId"))
+    if staged_attachment_id:
+        staged = STAGED_ATTACHMENTS.get(staged_attachment_id)
+        if staged:
+            path = Path(str(staged.get("path") or ""))
+            if path.exists():
+                return local_file_items(
+                    path,
+                    optional_string(staged.get("mimeType")) or mime_type,
+                    is_image=optional_string(staged.get("attachmentType"))
+                    == "image",
+                )
+        return [
+            {
+                "type": "text",
+                "text": f"[Attachment was not staged successfully: {name}]",
+            }
+        ]
+
     data_base64 = optional_string(block.get("dataBase64"))
     if data_base64:
         path = materialize_base64(data_base64, name, mime_type)
@@ -298,6 +329,46 @@ def write_upload_bytes(data: bytes, name: str, mime_type: str | None) -> Path:
     path = unique_upload_path(name, mime_type)
     path.write_bytes(data)
     return path
+
+
+def handle_attachment_chunk(chunk_input: dict[str, Any]) -> None:
+    attachment_id = optional_string(chunk_input.get("attachmentId"))
+    if not attachment_id:
+        emit({"type": "error", "message": "attachment chunk missing attachmentId"})
+        return
+    name = str(chunk_input.get("name") or "attachment")
+    mime_type = optional_string(chunk_input.get("mimeType"))
+    upload = ATTACHMENT_UPLOADS.get(attachment_id)
+    if upload is None:
+        UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+        path = unique_upload_path(name, mime_type)
+        upload = {
+            "path": path,
+            "name": name,
+            "mimeType": mime_type,
+            "attachmentType": optional_string(chunk_input.get("attachmentType")),
+        }
+        ATTACHMENT_UPLOADS[attachment_id] = upload
+
+    data_base64 = optional_string(chunk_input.get("dataBase64"))
+    if data_base64:
+        try:
+            data = base64.b64decode(data_base64, validate=True)
+        except (binascii.Error, ValueError):
+            ATTACHMENT_UPLOADS.pop(attachment_id, None)
+            emit(
+                {
+                    "type": "error",
+                    "message": f"invalid attachment chunk for {attachment_id}",
+                }
+            )
+            return
+        with Path(upload["path"]).open("ab") as file:
+            file.write(data)
+
+    if bool(chunk_input.get("final")):
+        STAGED_ATTACHMENTS[attachment_id] = upload
+        ATTACHMENT_UPLOADS.pop(attachment_id, None)
 
 
 def unique_upload_path(name: str, mime_type: str | None) -> Path:
@@ -988,6 +1059,9 @@ def handle_input(turn_input: dict[str, Any]) -> None:
     input_type = turn_input.get("type")
     if input_type == "interrupt":
         interrupt_active_turn()
+        return
+    if input_type == "attachment.chunk":
+        handle_attachment_chunk(turn_input)
         return
     if input_type not in {"user", "turn.start"}:
         return

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -199,6 +199,8 @@ export function sessionStreamError(error: unknown): RustSessionStreamEvent {
 
 /** Largest attachment we are willing to buffer in memory and inline as base64. */
 export const MAX_INLINE_ATTACHMENT_BYTES = 100 * 1024 * 1024
+const MAX_CODEX_INPUT_LINE_CHARS = 900 * 1024
+const STAGED_ATTACHMENT_CHUNK_CHARS = 700 * 1024
 
 async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2ApiAttachment> {
   const serialized: SlackbotV2ApiAttachment = {
@@ -342,7 +344,7 @@ async function executeSession(
   const body: SlackbotV2ExecuteSessionRequest = {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }),
-    input_lines: [toCodexInputLine(message, threadId, model)],
+    input_lines: toCodexInputLines(message, threadId, model),
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
   }
@@ -435,9 +437,21 @@ function sessionMessageParts(message: SlackbotV2ApiMessage): JsonValue[] {
     parts.push({ type: 'text', text: message.text })
   }
   for (const attachment of message.attachments) {
-    parts.push({ ...attachment, attachment_type: attachment.type, type: 'attachment' })
+    parts.push(sessionAttachmentPart(attachment))
   }
   return parts.length > 0 ? parts : [{ type: 'text', text: '' }]
+}
+
+function sessionAttachmentPart(attachment: SlackbotV2ApiAttachment): JsonObject {
+  const part: JsonObject = { ...attachment, attachment_type: attachment.type, type: 'attachment' }
+  if (
+    typeof attachment.dataBase64 === 'string'
+    && attachment.dataBase64.length > MAX_CODEX_INPUT_LINE_CHARS
+  ) {
+    delete part.dataBase64
+    part.dataBase64Omitted = `${attachment.dataBase64.length} base64 chars omitted from stored session message`
+  }
+  return part
 }
 
 function sessionMetadata(
@@ -457,7 +471,36 @@ function sessionMetadata(
   }
 }
 
-function toCodexInputLine(message: SlackbotV2ApiMessage, threadId: string, model?: string): string {
+function toCodexInputLines(
+  message: SlackbotV2ApiMessage,
+  threadId: string,
+  model?: string
+): string[] {
+  const staged = new Map<SlackbotV2ApiAttachment, string>()
+  const lines: string[] = []
+  for (const attachment of message.attachments) {
+    if (!attachment.dataBase64) continue
+    const inlineLine = toCodexInputLineWithStaged(message, threadId, staged, model)
+    if (
+      inlineLine.length <= MAX_CODEX_INPUT_LINE_CHARS
+      && attachment.dataBase64.length <= MAX_CODEX_INPUT_LINE_CHARS
+    ) {
+      continue
+    }
+    const stagedAttachmentId = `att-${message.id}-${staged.size + 1}`
+    staged.set(attachment, stagedAttachmentId)
+    lines.push(...stagedAttachmentInputLines(attachment, stagedAttachmentId))
+  }
+  lines.push(toCodexInputLineWithStaged(message, threadId, staged, model))
+  return lines
+}
+
+function toCodexInputLineWithStaged(
+  message: SlackbotV2ApiMessage,
+  threadId: string,
+  staged: Map<SlackbotV2ApiAttachment, string>,
+  model?: string
+): string {
   return JSON.stringify({
     type: 'user',
     thread_key: threadId,
@@ -465,23 +508,63 @@ function toCodexInputLine(message: SlackbotV2ApiMessage, threadId: string, model
     ...(model ? { model } : {}),
     message: {
       role: 'user',
-      content: codexInputContent(message)
+      content: codexInputContent(message, staged)
     }
   })
 }
 
-function codexInputContent(message: SlackbotV2ApiMessage): JsonValue[] {
+function stagedAttachmentInputLines(
+  attachment: SlackbotV2ApiAttachment,
+  stagedAttachmentId: string
+): string[] {
+  const dataBase64 = attachment.dataBase64
+  if (!dataBase64) return []
+  const lines: string[] = []
+  const chunkSize = STAGED_ATTACHMENT_CHUNK_CHARS - (STAGED_ATTACHMENT_CHUNK_CHARS % 4)
+  for (let offset = 0, index = 0; offset < dataBase64.length; offset += chunkSize, index += 1) {
+    const chunk = dataBase64.slice(offset, offset + chunkSize)
+    lines.push(JSON.stringify({
+      type: 'attachment.chunk',
+      attachmentId: stagedAttachmentId,
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      attachmentType: attachment.type,
+      chunkIndex: index,
+      final: offset + chunkSize >= dataBase64.length,
+      dataBase64: chunk
+    }))
+  }
+  return lines
+}
+
+function codexInputContent(
+  message: SlackbotV2ApiMessage,
+  staged: Map<SlackbotV2ApiAttachment, string> = new Map()
+): JsonValue[] {
   const content: JsonValue[] = []
   if (message.text.trim()) {
     content.push({ type: 'text', text: message.text })
   }
   for (const attachment of message.attachments) {
-    content.push(codexAttachmentInput(attachment))
+    content.push(codexAttachmentInput(attachment, staged.get(attachment)))
   }
   return content.length > 0 ? content : [{ type: 'text', text: 'continue' }]
 }
 
-function codexAttachmentInput(attachment: SlackbotV2ApiAttachment): JsonValue {
+function codexAttachmentInput(
+  attachment: SlackbotV2ApiAttachment,
+  stagedAttachmentId?: string
+): JsonValue {
+  if (stagedAttachmentId) {
+    return {
+      type: 'attachment',
+      attachment_type: attachment.type,
+      stagedAttachmentId,
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      size: attachment.size
+    }
+  }
   const dataUrl =
     attachment.dataBase64 && attachment.mimeType
       ? `data:${attachment.mimeType};base64,${attachment.dataBase64}`
@@ -492,6 +575,16 @@ function codexAttachmentInput(attachment: SlackbotV2ApiAttachment): JsonValue {
       url: dataUrl ?? attachment.url,
       detail: 'auto',
       name: attachment.name
+    }
+  }
+  if (attachment.dataBase64) {
+    return {
+      type: 'attachment',
+      attachment_type: attachment.type,
+      dataBase64: attachment.dataBase64,
+      mimeType: attachment.mimeType,
+      name: attachment.name,
+      size: attachment.size
     }
   }
   return {
@@ -506,8 +599,7 @@ function attachmentDescription(attachment: SlackbotV2ApiAttachment): string {
     `type=${attachment.type}`,
     attachment.mimeType ? `mime=${attachment.mimeType}` : undefined,
     attachment.url ? `url=${attachment.url}` : undefined,
-    // TODO: Upload files through POST /session/{thread_key}/attachments and pass refs here.
-    attachment.dataBase64 ? `base64=${attachment.dataBase64}` : undefined,
+    attachment.dataBase64Omitted ? `content=${attachment.dataBase64Omitted}` : undefined,
     attachment.fetchError ? `fetch_error=${attachment.fetchError}` : undefined
   ].filter(Boolean)
   return `[Slack attachment: ${fields.join(' ')}]`

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -17,6 +17,7 @@ export type SlackbotV2ApiAuthor = {
 
 export type SlackbotV2ApiAttachment = {
   dataBase64?: string
+  dataBase64Omitted?: string
   fetchError?: string
   fetchMetadata?: Record<string, string>
   height?: number

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -395,6 +395,70 @@ describe('slackbotv2', () => {
     expectSlackRenderedReply(renderedReplies[1]!, 'Executed request 2.')
   })
 
+  it('stages large Slack file attachments without exceeding session input line limits', async () => {
+    const parent = await postUserMessage('Context before the video upload.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> inspect this mp4`, parent.ts)
+    const fileUrl = `${slackApi.url}/files/large-upload.mp4`
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-large-mp4',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> inspect this mp4`,
+          files: [
+            {
+              id: 'F-large-mp4',
+              mimetype: 'video/mp4',
+              name: 'large-upload.mp4',
+              size: 2 * 1024 * 1024,
+              url_private: fileUrl
+            }
+          ]
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    const appendedAttachment = codexApi.appends[0]!.body.messages
+      .flatMap(message => message.parts)
+      .find(part => isRecord(part) && part.type === 'attachment')
+    expect(appendedAttachment).toEqual(
+      expect.objectContaining({
+        attachment_type: 'video',
+        dataBase64Omitted: expect.stringContaining('base64 chars omitted'),
+        mimeType: 'video/mp4',
+        name: 'large-upload.mp4'
+      })
+    )
+    expect(appendedAttachment).not.toHaveProperty('dataBase64')
+
+    const inputLines = codexApi.executes[0]!.body.input_lines
+    expect(inputLines.length).toBeGreaterThan(1)
+    for (const line of inputLines) {
+      expect(line.length).toBeLessThanOrEqual(1048576)
+    }
+
+    const chunkInputs = inputLines.slice(0, -1).map(line => JSON.parse(line))
+    expect(chunkInputs.every(input => input.type === 'attachment.chunk')).toBe(true)
+    expect(chunkInputs.at(-1)).toEqual(expect.objectContaining({ final: true }))
+
+    const turnInput = JSON.parse(inputLines.at(-1)!) as Record<string, unknown>
+    const serializedTurn = JSON.stringify(turnInput)
+    expect(serializedTurn).toContain('"stagedAttachmentId"')
+    expect(serializedTurn).not.toContain('dataBase64')
+  })
+
   it('executes a root app mention when Slack has no thread history yet', async () => {
     const mention = await postUserMessage(`<@${BOT_USER_ID}> answer from a new root message`)
     slackApi.failRepliesWithThreadNotFound(CHANNEL_ID, mention.ts)
@@ -3130,6 +3194,19 @@ async function handlePatchedSlackRequest(
       res,
       new Response('captured-image', {
         headers: { 'content-type': 'image/png' }
+      })
+    )
+    return
+  }
+
+  if (
+    url.pathname.endsWith('/files/large-upload.mp4')
+    || url.pathname.endsWith('/large-upload.mp4')
+  ) {
+    await sendWebResponse(
+      res,
+      new Response(new Uint8Array(2 * 1024 * 1024), {
+        headers: { 'content-type': 'video/mp4' }
       })
     )
     return


### PR DESCRIPTION
## Summary
- split large Slackbot v2 attachment payloads into bounded `attachment.chunk` session input lines
- reassemble staged attachment chunks inside `codex-app-wrapper` before starting the Codex turn
- avoid persisting giant base64 strings in session message history while keeping small inline images working as before
- add a Slackbot v2 regression test for a large MP4-shaped attachment

## Root cause
Slackbot v2 fetched Slack file bytes and placed the full base64 payload into a single `/api/session/{thread_key}/execute` input line. The Rust session runtime rejects input lines over 1,048,576 characters before the sandbox wrapper can materialize the attachment as a file. Large MP4 uploads therefore failed before reaching Codex.

## Validation
- `pnpm --filter slackbotv2 check:types`
- `bun test test/chat-sdk-emulate.test.ts -t "stages large Slack file attachments"`
- `python3 -m py_compile services/sandbox/codex-app-wrapper.py`
- `just build-one slackbotv2`
- `just build-one sandbox`
- `just deploy`

## Notes
The branch has been rebased onto `main`; the PR now stays scoped to the four-file large-attachment fix.

The full `bun test test/chat-sdk-emulate.test.ts` suite had two stream-rotation failures before this rebase as well: `rotates Slack stream segments before they reach the streaming age limit` and `rotates structured plan segments before they exceed the task char budget`. Local deployed API-RS E2E was blocked by local iron-control configuration: `iron-proxy requires iron-control: set IRON_CONTROL_URL and IRON_CONTROL_API_KEY`.
