### PR TITLE
feat(sandbox): source the org overlay prompt from CENTAUR_OVERLAY_DIR

### DIFF
--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -289,6 +289,15 @@ fi
 if [ -f "$HOME_DIR/AGENTS_OVERLAY.md" ] && [ -f "$TARGET_PROMPT" ]; then
     printf '\n\n---\n\n' >> "$TARGET_PROMPT"
     cat "$HOME_DIR/AGENTS_OVERLAY.md" >> "$TARGET_PROMPT"
+# Repo-cache-era org prompt: with overlay images gone, point CENTAUR_OVERLAY_DIR
+# at the org repo's clone under the repos mount (e.g. ~/github/<owner>/<repo>)
+# and its SYSTEM_PROMPT.md is appended here, same contract the overlay-bootstrap
+# init container used to fulfil by staging $HOME/AGENTS_OVERLAY.md.
+elif [ -n "${CENTAUR_OVERLAY_DIR:-}" ] \
+    && [ -f "${CENTAUR_OVERLAY_DIR}/services/sandbox/SYSTEM_PROMPT.md" ] \
+    && [ -f "$TARGET_PROMPT" ]; then
+    printf '\n\n---\n\n' >> "$TARGET_PROMPT"
+    cat "${CENTAUR_OVERLAY_DIR}/services/sandbox/SYSTEM_PROMPT.md" >> "$TARGET_PROMPT"
 fi
 
 # Persona prompt injection is done by the API when it writes AGENTS_BASE.md.


### PR DESCRIPTION
Now that overlay images are gone, the sandbox entrypoint can pull the org's system prompt straight from its repo-cache clone — same contract the old overlay-bootstrap init container fulfilled. No behavior change unless the new env var is set.

Split out of #512.