### PR TITLE
feat: --codex/--claude restart threads on the requested harness; --model picks the model inside it

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.58
+version: 0.1.59
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -169,6 +169,10 @@ spec:
               value: {{ .Values.apiRs.sandboxBackend | quote }}
             - name: SESSION_SANDBOX_WORKLOAD
               value: {{ .Values.apiRs.sandboxWorkload | quote }}
+            # Default harness for warm sandboxes. Per-session sandboxes run
+            # their session's harness regardless (pinned via container args).
+            - name: SESSION_SANDBOX_HARNESS
+              value: {{ .Values.sandbox.harnessEngine | quote }}
             - name: SESSION_SANDBOX_READY_TIMEOUT_SECS
               value: {{ .Values.apiRs.sandboxReadyTimeoutSecs | quote }}
             - name: SESSION_SANDBOX_WARM_POOL_SIZE

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -32,6 +32,10 @@ spec:
               value: "3001"
             - name: CENTAUR_API_URL
               value: {{ printf "http://%s:%v" $apiRsName .Values.apiRs.port | quote }}
+            # New threads without an explicit --claude/--amp/--codex flag run
+            # the deployment's default harness.
+            - name: SLACKBOTV2_DEFAULT_HARNESS
+              value: {{ .Values.sandbox.harnessEngine | quote }}
             - name: SLACK_BOT_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -193,9 +193,13 @@ sandbox:
   #                  subscription token (proxy injects the brokered credential).
   codexAuthMode: api_key
   claudeCodeAuthMode: api_key
-  # Which harness the sandbox runs: codex | amp | claudecode. Selects the
-  # iron-proxy auth fragment api-rs registers and must agree with the sandbox
-  # image's default CMD (services/sandbox/Dockerfile).
+  # The deployment's default harness: codex | amp | claudecode. Decides what
+  # warm sandboxes boot (SESSION_SANDBOX_HARNESS) and which harness auth
+  # fragment is required at startup (the other harnesses' fragments are
+  # registered too when available, so per-session --claude/--amp/--codex
+  # overrides keep working credentials). Per-session sandboxes always run
+  # their session's harness via container args; the sandbox image CMD only
+  # matters for containers started outside api-rs.
   harnessEngine: codex
   extraEnv: {}
   stateVolume:

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1639,7 +1639,11 @@ impl IronProxyHarnessArgs {
     /// credentials through the proxy.
     fn fragments(&self) -> Result<Vec<ProxyFragment>, ServerError> {
         let mut fragments = vec![self.fragment()?];
-        for engine in [HarnessType::Codex, HarnessType::ClaudeCode, HarnessType::Amp] {
+        for engine in [
+            HarnessType::Codex,
+            HarnessType::ClaudeCode,
+            HarnessType::Amp,
+        ] {
             if engine == self.engine {
                 continue;
             }

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -462,6 +462,16 @@ struct SandboxArgs {
         default_value = "mock"
     )]
     workload: SandboxWorkloadKind,
+    /// The default harness for warm sandboxes. Per-session sandboxes always
+    /// run their session's harness (pinned via container args); this only
+    /// decides what the warm pool boots ahead of time. Defaults to codex
+    /// to match the sandbox image's CMD.
+    #[arg(
+        long = "session-sandbox-harness",
+        env = "SESSION_SANDBOX_HARNESS",
+        default_value = "codex"
+    )]
+    default_harness: HarnessType,
     #[arg(
         long = "session-sandbox-k8s-namespace",
         alias = "kubernetes-namespace",
@@ -845,6 +855,7 @@ impl SandboxArgs {
                 let mut workload = SandboxWorkloadMode::codex_app_server(
                     image,
                     self.codex_app_server_env_template()?,
+                    self.default_harness.clone(),
                 );
                 if let Some(repos_path) = clean_optional_value(self.repos_path.as_deref()) {
                     workload = workload.mount(
@@ -1416,12 +1427,12 @@ impl IronProxyArgs {
         let (ca_cert_secret_name, ca_key_secret_name) =
             ca.ok_or(ServerError::MissingIronProxyCaSecret)?;
 
-        let harness_fragment = self.harness.fragment()?;
+        let harness_fragments = self.harness.fragments()?;
         let mut config =
             IronProxyConfig::new(self.image.clone(), ca_cert_secret_name, ca_key_secret_name);
         config.image_pull_policy = self.image_pull_policy.clone();
         self.source.apply_to_config(&mut config);
-        config.fragments = vec![harness_fragment];
+        config.fragments = harness_fragments;
         config.env_from_secret_names = self.env_from_secret_names();
         if let Some(labels) = self
             .api_pod_label_selector
@@ -1451,12 +1462,14 @@ impl IronProxyArgs {
         Ok(vec![(RoleSpec::infra(), infra)])
     }
 
-    /// The full infra fragment: the shared infra secrets plus the harness auth
-    /// (also infra), selected by auth mode. Discovered tool secrets are folded
-    /// into the same infra role at registration time.
+    /// The full infra fragment: the shared infra secrets plus every available
+    /// harness auth fragment (also infra), selected by auth mode. Discovered
+    /// tool secrets are folded into the same infra role at registration time.
     fn infra_fragment(&self) -> Result<ProxyFragment, ServerError> {
         let mut infra = infra_fragment()?;
-        merge_fragment(&mut infra, self.harness.fragment()?);
+        for fragment in self.harness.fragments()? {
+            merge_fragment(&mut infra, fragment);
+        }
         Ok(infra)
     }
 
@@ -1617,6 +1630,27 @@ impl IronProxyHarnessArgs {
                 "no harness auth fragment for engine {engine} auth-mode {auth_mode}"
             ))
         })
+    }
+
+    /// Every harness auth fragment to register. The configured engine's
+    /// fragment is required (startup fails without it, as before); the other
+    /// engines' fragments are added when their engine/auth-mode pair has one,
+    /// so sessions restarted onto another harness still get working
+    /// credentials through the proxy.
+    fn fragments(&self) -> Result<Vec<ProxyFragment>, ServerError> {
+        let mut fragments = vec![self.fragment()?];
+        for engine in [HarnessType::Codex, HarnessType::ClaudeCode, HarnessType::Amp] {
+            if engine == self.engine {
+                continue;
+            }
+            let auth_mode = harness_auth_mode_env(&engine).unwrap_or_else(|| "api_key".to_owned());
+            if let Some(fragment) =
+                harness_auth_fragment(harness_fragment_engine_name(&engine), &auth_mode)?
+            {
+                fragments.push(fragment);
+            }
+        }
+        Ok(fragments)
     }
 }
 
@@ -2389,10 +2423,14 @@ mod tests {
         .unwrap();
 
         let workload = args.sandbox.container_workload_mode().unwrap();
-        let SandboxWorkloadMode::CodexAppServer { mounts, .. } = workload else {
+        let SandboxWorkloadMode::CodexAppServer {
+            harness, mounts, ..
+        } = workload
+        else {
             panic!("expected codex app server workload");
         };
 
+        assert_eq!(harness, HarnessType::Codex);
         assert!(mounts.iter().any(|mount| {
             mount.target_path == SANDBOX_REPOS_MOUNT_PATH
                 && mount.read_only

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -19,8 +19,10 @@ use axum::{
     routing::{any, get, post},
 };
 use base64::{Engine as _, engine::general_purpose};
-use centaur_session_core::{Session, ThreadKey};
-use centaur_session_runtime::{ExecuteSessionInput, SandboxRuntime, SessionRuntime};
+use centaur_session_core::ThreadKey;
+use centaur_session_runtime::{
+    ExecuteSessionInput, HarnessConflictPolicy, SandboxRuntime, SessionRuntime,
+};
 use centaur_session_sqlx::PgSessionStore;
 use centaur_telemetry::{
     PrometheusHandle, http_status_class, prometheus_handle, record_http_request_finished,
@@ -40,9 +42,9 @@ use tracing::Span;
 use crate::{
     ApiError,
     types::{
-        AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest,
+        AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
         EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
-        ListWorkflowRunsQuery, SessionSseEvent, stream_error_sse,
+        ListWorkflowRunsQuery, OnHarnessConflict, SessionSseEvent, stream_error_sse,
     },
 };
 
@@ -192,18 +194,26 @@ async fn create_or_get_session(
     State(state): State<AppState>,
     Path(raw_thread_key): Path<String>,
     Json(request): Json<CreateSessionRequest>,
-) -> Result<Json<Session>, ApiError> {
+) -> Result<Json<CreateSessionResponse>, ApiError> {
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
-    let session = state
+    let on_harness_conflict = match request.on_harness_conflict {
+        Some(OnHarnessConflict::Restart) => HarnessConflictPolicy::Restart,
+        Some(OnHarnessConflict::Reject) | None => HarnessConflictPolicy::Reject,
+    };
+    let outcome = state
         .runtime
         .create_or_get_session(
             &thread_key,
             &request.harness_type,
             request.persona_id.as_deref(),
             request.metadata,
+            on_harness_conflict,
         )
         .await?;
-    Ok(Json(session))
+    Ok(Json(CreateSessionResponse {
+        session: outcome.session,
+        harness_switched: outcome.harness_switched,
+    }))
 }
 
 async fn append_messages(

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -1,5 +1,5 @@
 use axum::response::sse::Event;
-use centaur_session_core::{HarnessType, SessionEvent, SessionMessageInput, ThreadKey};
+use centaur_session_core::{HarnessType, Session, SessionEvent, SessionMessageInput, ThreadKey};
 use centaur_session_runtime::SESSION_OUTPUT_LINE_EVENT;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -10,6 +10,27 @@ pub struct CreateSessionRequest {
     pub harness_type: HarnessType,
     pub persona_id: Option<String>,
     pub metadata: Option<Value>,
+    /// What to do when the session already exists on a different harness.
+    /// Omitted or `reject`: fail with 409. `restart`: stop the old sandbox and
+    /// restart the thread on the requested harness (the new harness starts
+    /// with no conversational memory).
+    #[serde(default)]
+    pub on_harness_conflict: Option<OnHarnessConflict>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum OnHarnessConflict {
+    Reject,
+    Restart,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CreateSessionResponse {
+    #[serde(flatten)]
+    pub session: Session,
+    /// True when this request restarted the thread onto a different harness.
+    pub harness_switched: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -107,6 +107,7 @@ async fn main() -> Result<()> {
                 metadata: Some(json!({
                     "source": "centaur-session-cli",
                 })),
+                on_harness_conflict: None,
             },
         )
         .await

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -44,7 +44,7 @@ const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 
-type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
+type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str, &HarnessType) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
 type ExecutionSpanRegistry = Arc<Mutex<HashMap<String, Span>>>;
 
@@ -64,6 +64,9 @@ pub struct SandboxRuntime {
     spec_factory: SandboxSpecFactory,
     warm_spec_factory: Option<WarmSandboxSpecFactory>,
     workload_key: Option<String>,
+    /// The harness warm sandboxes boot with. A warm claim is only valid for a
+    /// session on the same harness; other sessions get a cold sandbox.
+    warm_harness: Option<HarnessType>,
 }
 
 #[derive(Clone, Debug)]
@@ -75,7 +78,30 @@ pub enum SandboxWorkloadMode {
         image: String,
         env: Vec<(String, String)>,
         mounts: Vec<Mount>,
+        /// The harness used for warm sandboxes and as the workload default.
+        /// Per-session sandboxes run the session's own harness.
+        harness: HarnessType,
     },
+}
+
+/// What to do when a session already exists with a different harness.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HarnessConflictPolicy {
+    /// Fail with [`SessionStoreError::HarnessConflict`] (the default).
+    Reject,
+    /// Restart the thread on the requested harness: stop the old sandbox,
+    /// clear the harness thread state, and switch the session row over. The
+    /// new harness starts with no conversational memory.
+    Restart,
+}
+
+/// Result of [`SessionRuntime::create_or_get_session`].
+#[derive(Clone, Debug)]
+pub struct CreateOrGetSessionOutcome {
+    pub session: Session,
+    /// True when the session was restarted onto a different harness because
+    /// the request asked for [`HarnessConflictPolicy::Restart`].
+    pub harness_switched: bool,
 }
 
 /// Outcome of [`SessionRuntime::drain`]: the sandboxes that were stopped and
@@ -201,7 +227,8 @@ impl SessionRuntime {
         harness_type: &HarnessType,
         persona_id: Option<&str>,
         metadata: Option<Value>,
-    ) -> Result<Session, SessionRuntimeError> {
+        on_harness_conflict: HarnessConflictPolicy,
+    ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
         let span = info_span!(
             "centaur.api_rs.session.create_or_get",
             component = COMPONENT_SESSION_RUNTIME,
@@ -228,7 +255,8 @@ impl SessionRuntime {
                 .and_then(|metadata| metadata.get("slack_user_id"))
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned);
-            let session = self
+            let mut harness_switched = false;
+            let session = match self
                 .store
                 .create_or_get_session(
                     thread_key,
@@ -236,7 +264,20 @@ impl SessionRuntime {
                     persona_id,
                     default_metadata(metadata),
                 )
-                .await?;
+                .await
+            {
+                Ok(session) => session,
+                Err(SessionStoreError::HarnessConflict { existing, .. })
+                    if on_harness_conflict == HarnessConflictPolicy::Restart =>
+                {
+                    let session = self
+                        .restart_session_on_harness(thread_key, harness_type, &existing)
+                        .await?;
+                    harness_switched = true;
+                    session
+                }
+                Err(error) => return Err(error.into()),
+            };
             if let Some(registrar) = &self.iron_control {
                 // iron-control is the source of truth for the session's egress
                 // proxy: without a registered principal the proxy has no identity
@@ -258,9 +299,13 @@ impl SessionRuntime {
                     harness_type = %harness_type,
                     status = %session.status,
                     iron_control_principal_persisted = true,
+                    harness_switched,
                     "session ready"
                 );
-                return Ok(session);
+                return Ok(CreateOrGetSessionOutcome {
+                    session,
+                    harness_switched,
+                });
             }
             info!(
                 component = COMPONENT_SESSION_RUNTIME,
@@ -269,9 +314,13 @@ impl SessionRuntime {
                 harness_type = %harness_type,
                 status = %session.status,
                 iron_control_principal_persisted = session.iron_control_principal.is_some(),
+                harness_switched,
                 "session ready"
             );
-            Ok(session)
+            Ok(CreateOrGetSessionOutcome {
+                session,
+                harness_switched,
+            })
         }
         .instrument(span)
         .await;
@@ -287,6 +336,60 @@ impl SessionRuntime {
             );
         }
         result
+    }
+
+    /// Restart an existing session on a different harness: stop its sandbox
+    /// (killing any in-flight execution), clear the harness thread state, and
+    /// flip the session row to the requested harness. Stored messages and
+    /// events are preserved for the record, but the new harness boots with no
+    /// conversational memory — callers that want continuity must re-send
+    /// context with the next turn.
+    async fn restart_session_on_harness(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        previous_harness: &str,
+    ) -> Result<Session, SessionRuntimeError> {
+        let previous = self.store.get_session(thread_key).await?;
+        if let Some(sandbox_id) = previous.sandbox_id.as_deref() {
+            self.sandbox_pipes.lock().await.remove(sandbox_id);
+            match self
+                .sandbox_runtime
+                .manager
+                .stop(&SandboxId::new(sandbox_id))
+                .await
+            {
+                Ok(()) | Err(SandboxError::NotFound(_)) => {}
+                Err(error) => return Err(SessionRuntimeError::Sandbox(error)),
+            }
+        }
+        let session = self
+            .store
+            .switch_session_harness(thread_key, harness_type)
+            .await?;
+        self.store
+            .append_event(
+                thread_key,
+                None,
+                "session.harness_switched",
+                json!({
+                    "thread_key": thread_key.as_str(),
+                    "from_harness": previous_harness,
+                    "to_harness": harness_type.as_ref(),
+                    "stopped_sandbox_id": previous.sandbox_id,
+                }),
+            )
+            .await?;
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_harness_switched",
+            thread_key = %thread_key,
+            from_harness = previous_harness,
+            to_harness = %harness_type,
+            stopped_sandbox_id = previous.sandbox_id.as_deref().unwrap_or(""),
+            "restarted session on a new harness"
+        );
+        Ok(session)
     }
 
     pub async fn append_messages(
@@ -511,6 +614,7 @@ impl SessionRuntime {
             let sandbox_id = match self
                 .ensure_session_sandbox(
                     thread_key,
+                    &session.harness_type,
                     session.sandbox_id.as_deref(),
                     session.iron_control_principal.as_deref(),
                     &execution.execution_id,
@@ -816,6 +920,7 @@ impl SessionRuntime {
     async fn ensure_session_sandbox(
         &self,
         thread_key: &ThreadKey,
+        harness_type: &HarnessType,
         existing_sandbox_id: Option<&str>,
         iron_control_principal: Option<&str>,
         execution_id: &str,
@@ -931,7 +1036,17 @@ impl SessionRuntime {
                 }
             }
 
-            if let Some(warm_pool) = &self.warm_pool {
+            // Warm sandboxes are pre-booted with the workload's default
+            // harness; a session on any other harness needs a cold sandbox.
+            let warm_harness_matches = self
+                .sandbox_runtime
+                .warm_harness
+                .as_ref()
+                .is_none_or(|warm| warm == harness_type);
+            if !warm_harness_matches && self.warm_pool.is_some() {
+                record_sandbox_warm_pool_claim("harness_mismatch");
+            }
+            if let Some(warm_pool) = self.warm_pool.as_ref().filter(|_| warm_harness_matches) {
                 match warm_pool
                     .claim(thread_key.as_str(), iron_control_principal)
                     .await
@@ -974,7 +1089,8 @@ impl SessionRuntime {
                 }
             }
 
-            let mut spec = (self.sandbox_runtime.spec_factory)(thread_key, execution_id);
+            let mut spec =
+                (self.sandbox_runtime.spec_factory)(thread_key, execution_id, harness_type);
             if let Some(principal) = iron_control_principal {
                 spec.iron_control_principal = Some(principal.to_owned());
             }
@@ -1389,7 +1505,10 @@ impl SandboxRuntime {
 
     pub fn backend(backend: Arc<dyn SandboxBackend>, spec: SandboxSpec) -> Self {
         let warm_spec = spec.clone();
-        let spec_factory = move |_thread_key: &ThreadKey, _execution_id: &str| spec.clone();
+        let spec_factory =
+            move |_thread_key: &ThreadKey, _execution_id: &str, _harness: &HarnessType| {
+                spec.clone()
+            };
         let warm_spec_factory = move || warm_spec.clone();
         Self::backend_with_warm_spec_factory(backend, spec_factory, warm_spec_factory)
     }
@@ -1398,23 +1517,27 @@ impl SandboxRuntime {
         backend: Arc<dyn SandboxBackend>,
         workload: SandboxWorkloadMode,
     ) -> Self {
+        let warm_harness = workload.default_harness();
         let warm_workload = workload.clone();
-        Self::backend_with_warm_spec_factory(
+        let mut runtime = Self::backend_with_warm_spec_factory(
             backend,
-            move |thread_key, _execution_id| workload.spec(thread_key),
+            move |thread_key, _execution_id, harness| workload.spec(thread_key, harness),
             move || warm_workload.warm_spec(),
-        )
+        );
+        runtime.warm_harness = warm_harness;
+        runtime
     }
 
     pub fn backend_with_spec_factory<F>(backend: Arc<dyn SandboxBackend>, spec_factory: F) -> Self
     where
-        F: Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync + 'static,
+        F: Fn(&ThreadKey, &str, &HarnessType) -> SandboxSpec + Send + Sync + 'static,
     {
         Self {
             manager: Arc::new(SandboxManager::new(backend)),
             spec_factory: Arc::new(spec_factory),
             warm_spec_factory: None,
             workload_key: None,
+            warm_harness: None,
         }
     }
 
@@ -1424,7 +1547,7 @@ impl SandboxRuntime {
         warm_spec_factory: W,
     ) -> Self
     where
-        F: Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync + 'static,
+        F: Fn(&ThreadKey, &str, &HarnessType) -> SandboxSpec + Send + Sync + 'static,
         W: Fn() -> SandboxSpec + Send + Sync + 'static,
     {
         let warm_spec_factory: WarmSandboxSpecFactory = Arc::new(warm_spec_factory);
@@ -1434,6 +1557,7 @@ impl SandboxRuntime {
             spec_factory: Arc::new(spec_factory),
             warm_spec_factory: Some(warm_spec_factory),
             workload_key: Some(workload_key),
+            warm_harness: None,
         }
     }
 }
@@ -1448,11 +1572,13 @@ impl SandboxWorkloadMode {
     pub fn codex_app_server(
         image: impl Into<String>,
         env: impl IntoIterator<Item = (String, String)>,
+        harness: HarnessType,
     ) -> Self {
         Self::CodexAppServer {
             image: image.into(),
             env: env.into_iter().collect(),
             mounts: Vec::new(),
+            harness,
         }
     }
 
@@ -1464,21 +1590,37 @@ impl SandboxWorkloadMode {
         self
     }
 
-    fn spec(&self, thread_key: &ThreadKey) -> SandboxSpec {
-        self.spec_with_thread_key(Some(thread_key))
+    fn default_harness(&self) -> Option<HarnessType> {
+        match self {
+            Self::MockAppServer { .. } => None,
+            Self::CodexAppServer { harness, .. } => Some(harness.clone()),
+        }
+    }
+
+    fn spec(&self, thread_key: &ThreadKey, harness: &HarnessType) -> SandboxSpec {
+        self.spec_for(Some(thread_key), harness)
     }
 
     fn warm_spec(&self) -> SandboxSpec {
-        self.spec_with_thread_key(None)
+        match self {
+            Self::MockAppServer { .. } => self.spec_for(None, &HarnessType::Codex),
+            Self::CodexAppServer { harness, .. } => self.spec_for(None, harness),
+        }
     }
 
-    fn spec_with_thread_key(&self, thread_key: Option<&ThreadKey>) -> SandboxSpec {
+    fn spec_for(&self, thread_key: Option<&ThreadKey>, harness: &HarnessType) -> SandboxSpec {
         match self {
             Self::MockAppServer { image } => SandboxSpec::new(image)
                 .command(["/bin/sh", "-lc"])
                 .args([mock_app_server_script()]),
-            Self::CodexAppServer { image, env, mounts } => {
-                let mut spec = SandboxSpec::new(image);
+            Self::CodexAppServer {
+                image, env, mounts, ..
+            } => {
+                // Pin the harness via container args (the image entrypoint is
+                // kept) so the sandbox runs the session's harness rather than
+                // whatever the image CMD defaults to.
+                let mut spec = SandboxSpec::new(image)
+                    .args(["harness-server", harness_server_subcommand(harness)]);
                 if let Some(thread_key) = thread_key {
                     spec = spec.env("CENTAUR_THREAD_KEY", thread_key.as_str());
                 }
@@ -1491,6 +1633,16 @@ impl SandboxWorkloadMode {
                 spec
             }
         }
+    }
+}
+
+/// The harness-server CLI subcommand for a harness type
+/// (see crates/harness-server/src/main.rs).
+fn harness_server_subcommand(harness: &HarnessType) -> &'static str {
+    match harness {
+        HarnessType::Codex => "codex",
+        HarnessType::ClaudeCode => "claude-code",
+        HarnessType::Amp => "amp",
     }
 }
 
@@ -4028,6 +4180,7 @@ mod tests {
         let workload = SandboxWorkloadMode::codex_app_server(
             "centaur-agent:latest",
             [("CENTAUR_API_URL".to_owned(), "http://api:8000".to_owned())],
+            HarnessType::Codex,
         )
         .mount(
             Mount::new(
@@ -4040,7 +4193,7 @@ mod tests {
         );
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
 
-        let spec = workload.spec(&thread_key);
+        let spec = workload.spec(&thread_key, &HarnessType::Codex);
 
         assert_eq!(spec.mounts.len(), 1);
         assert_eq!(spec.mounts[0].target_path, "/home/agent/github");
@@ -4055,10 +4208,14 @@ mod tests {
 
     #[test]
     fn codex_workload_does_not_inject_stale_continue_thread_id() {
-        let workload = SandboxWorkloadMode::codex_app_server("centaur-agent:latest", Vec::new());
+        let workload = SandboxWorkloadMode::codex_app_server(
+            "centaur-agent:latest",
+            Vec::new(),
+            HarnessType::Codex,
+        );
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
 
-        let spec = workload.spec(&thread_key);
+        let spec = workload.spec(&thread_key, &HarnessType::Codex);
 
         assert_eq!(
             spec.env
@@ -4081,10 +4238,11 @@ mod tests {
         let workload = SandboxWorkloadMode::codex_app_server(
             "centaur-agent:latest",
             [("CENTAUR_API_URL".to_owned(), "http://api:8000".to_owned())],
+            HarnessType::Codex,
         );
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
 
-        let claimed_spec = workload.spec(&thread_key);
+        let claimed_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode);
         let warm_spec = workload.warm_spec();
 
         assert_eq!(
@@ -4099,17 +4257,60 @@ mod tests {
         let workload = SandboxWorkloadMode::codex_app_server(
             "centaur-agent:latest",
             [("CENTAUR_API_URL".to_owned(), "http://api:8000".to_owned())],
+            HarnessType::Codex,
         );
         let first_thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
         let second_thread_key = ThreadKey::parse("chat:C456:1780000000.000001").unwrap();
 
         assert_ne!(
-            sandbox_spec_key(&workload.spec(&first_thread_key)),
-            sandbox_spec_key(&workload.spec(&second_thread_key))
+            sandbox_spec_key(&workload.spec(&first_thread_key, &HarnessType::ClaudeCode)),
+            sandbox_spec_key(&workload.spec(&second_thread_key, &HarnessType::ClaudeCode))
         );
         assert_eq!(
             sandbox_spec_key(&workload.warm_spec()),
             sandbox_spec_key(&workload.warm_spec())
+        );
+    }
+
+    #[test]
+    fn codex_workload_pins_harness_via_container_args() {
+        let workload = SandboxWorkloadMode::codex_app_server(
+            "centaur-agent:latest",
+            Vec::new(),
+            HarnessType::Codex,
+        );
+        let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+
+        let codex_spec = workload.spec(&thread_key, &HarnessType::Codex);
+        let claude_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode);
+        let amp_spec = workload.spec(&thread_key, &HarnessType::Amp);
+
+        assert_eq!(codex_spec.args, vec!["harness-server", "codex"]);
+        assert_eq!(claude_spec.args, vec!["harness-server", "claude-code"]);
+        assert_eq!(amp_spec.args, vec!["harness-server", "amp"]);
+        // The image entrypoint must be preserved: only CMD is overridden.
+        assert_eq!(codex_spec.command, None);
+    }
+
+    #[test]
+    fn warm_spec_uses_workload_default_harness() {
+        let workload = SandboxWorkloadMode::codex_app_server(
+            "centaur-agent:latest",
+            Vec::new(),
+            HarnessType::Codex,
+        );
+
+        assert_eq!(
+            workload.warm_spec().args,
+            vec!["harness-server", "codex"],
+            "warm sandboxes boot the configured default harness"
+        );
+        // A session on a different harness produces a different spec, so a
+        // warm claim for it would hand over the wrong harness.
+        let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+        assert_eq!(
+            workload.spec(&thread_key, &HarnessType::ClaudeCode).args,
+            vec!["harness-server", "claude-code"]
         );
     }
 

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -505,6 +505,38 @@ impl PgSessionStore {
         row.try_into()
     }
 
+    /// Move an existing session onto a different harness. Clears the sandbox
+    /// and harness thread state (they belong to the old harness) and resets
+    /// the session to idle; messages and events are preserved.
+    pub async fn switch_session_harness(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+    ) -> Result<Session, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            update sessions
+            set harness_type = $2,
+                harness_thread_id = null,
+                sandbox_id = null,
+                status = $3,
+                updated_at = now()
+            where thread_key = $1
+            returning thread_key, sandbox_id, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(harness_type.as_ref())
+        .bind(SessionStatus::Idle.as_ref())
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| SessionStoreError::NotFound {
+            thread_key: thread_key.as_str().to_owned(),
+        })?;
+
+        row.try_into()
+    }
+
     pub async fn set_iron_control_principal(
         &self,
         thread_key: &ThreadKey,

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -14,7 +14,8 @@ use absurd::{
 use centaur_sandbox_core::SandboxSpec;
 use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
 use centaur_session_runtime::{
-    ExecuteSessionInput, SESSION_OUTPUT_LINE_EVENT, SandboxRuntime, SessionRuntime,
+    ExecuteSessionInput, HarnessConflictPolicy, SESSION_OUTPUT_LINE_EVENT, SandboxRuntime,
+    SessionRuntime,
 };
 use centaur_session_sqlx::PgSessionStore;
 use chrono::{DateTime, Utc};
@@ -2536,6 +2537,7 @@ async fn run_agent_session_turn(
             &harness_type,
             persona_id.as_deref(),
             Some(session_metadata),
+            HarnessConflictPolicy::Reject,
         )
         .await?;
     session_runtime

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -24,6 +24,7 @@ import { conflateChatSdkStream } from './conflate'
 import {
   collectInitialContext,
   forwardToSessionApi,
+  harnessRestartPreamble,
   isRetryableSessionApiError,
   openSessionEventStream,
   serializeMessage,
@@ -320,7 +321,9 @@ async function syncThreadMessageToSession(
     executeContextMessages:
       shouldStartExecution && shouldIncludeContext ? candidateMessages : undefined,
     executeMessage: shouldStartExecution ? serializedMessage : undefined,
-    harnessType: overrides.harnessType,
+    // A harness override only applies when this message starts an execution;
+    // restarting the thread out from under an active execution would kill it.
+    harnessType: shouldStartExecution ? overrides.harnessType : undefined,
     messages: messagesToAppend,
     model: overrides.model,
     onEventId: eventId => {
@@ -329,6 +332,17 @@ async function syncThreadMessageToSession(
     openStream: false,
     threadId: thread.id,
     trace
+  }
+
+  // The previous harness's conversation state dies with its sandbox on a
+  // restart, so re-feed the Slack thread transcript with this turn.
+  const handleSessionRestarted = async (): Promise<void> => {
+    const history = context ?? (await collectInitialContext(thread, message))
+    forwardInput.contextPreamble = harnessRestartPreamble(history, serializedMessage.id)
+    traceLog(input.options, 'slackbotv2_forward_restart_context_built', trace, {
+      history_message_count: history.length,
+      preamble_chars: forwardInput.contextPreamble?.length ?? 0
+    })
   }
 
   const commitMessagesAppended = async (): Promise<void> => {
@@ -419,7 +433,8 @@ async function syncThreadMessageToSession(
     traceLog(input.options, 'slackbotv2_forward_active_execution_marked', trace)
     await forwardToSessionApi(input.options, forwardInput, {
       onExecutionStarted: commitExecutionStarted,
-      onMessagesAppended: commitMessagesAppended
+      onMessagesAppended: commitMessagesAppended,
+      onSessionRestarted: handleSessionRestarted
     })
     scheduleExecutionRender(
       thread,

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -2,11 +2,14 @@
  * Inline message directives, restored from the v1 slackbot:
  *   --claude | --claude-code | --amp | --codex   pick the harness for the thread
  *   --model <name> (or --model=<name>)           pick the model within that harness
- *   --opus | --sonnet | --haiku                  model shortcuts (imply claude-code)
+ *   --fable | --opus | --sonnet | --haiku        model shortcuts (imply claude-code)
  *
  * Flags are stripped from the text before it reaches the agent. The harness
- * applies at session creation (the API pins a thread to one harness); the model
- * applies per turn via the blocks-protocol `model` field.
+ * applies at session creation — an explicit harness flag on a thread pinned to
+ * another harness restarts the thread on the requested one. The model applies
+ * per turn via the blocks-protocol `model` field; `--model` accepts either a
+ * full model id (claude-sonnet-4-6, gpt-5.2, …), an amp mode (deep/fast), or a
+ * Claude alias (fable/opus/sonnet/haiku) which expands to the full id.
  */
 
 export type MessageOverrides = {
@@ -24,11 +27,22 @@ const HARNESS_FLAGS: Record<string, string> = {
   codex: 'codex'
 }
 
-const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> = {
-  haiku: { harnessType: 'claudecode', model: 'claude-haiku-4-5' },
-  opus: { harnessType: 'claudecode', model: 'claude-opus-4-8' },
-  sonnet: { harnessType: 'claudecode', model: 'claude-sonnet-4-6' }
+// Claude model aliases, usable both as bare flags (--opus) and as --model
+// values (--model opus). Bare-flag form also implies the claude-code harness.
+const CLAUDE_MODEL_ALIASES: Record<string, string> = {
+  fable: 'claude-fable-5',
+  haiku: 'claude-haiku-4-5',
+  opus: 'claude-opus-4-8',
+  sonnet: 'claude-sonnet-4-6'
 }
+
+const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> =
+  Object.fromEntries(
+    Object.entries(CLAUDE_MODEL_ALIASES).map(([alias, model]) => [
+      alias,
+      { harnessType: 'claudecode', model }
+    ])
+  )
 
 const MODEL_FLAG_PATTERN = /(?:^|\s)--model[=\s]+([A-Za-z0-9._/-]+)(?=\s|$)/i
 
@@ -39,7 +53,8 @@ export function extractMessageOverrides(text: string): MessageOverrides {
 
   const modelMatch = MODEL_FLAG_PATTERN.exec(cleaned)
   if (modelMatch) {
-    model = modelMatch[1]
+    const value = modelMatch[1]!
+    model = CLAUDE_MODEL_ALIASES[value.toLowerCase()] ?? value
     cleaned = stripMatch(cleaned, modelMatch)
   }
 

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -30,6 +30,7 @@ const options: SlackbotV2Options = {
   assistantStatus: optionalEnv('SLACKBOTV2_ASSISTANT_STATUS'),
   botToken,
   botUserId: optionalEnv('SLACK_BOT_USER_ID'),
+  defaultHarnessType: optionalEnv('SLACKBOTV2_DEFAULT_HARNESS'),
   idleTimeoutMs: optionalNumberEnv('SESSION_IDLE_TIMEOUT_MS'),
   maxDurationMs: optionalNumberEnv('SESSION_MAX_DURATION_MS'),
   postgresUrl:

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -52,6 +52,13 @@ export function isRetryableSessionApiError(error: unknown): boolean {
 type ForwardSessionApiCallbacks = {
   onExecutionStarted?(execution: SlackbotV2ExecuteSessionResponse): Promise<void>
   onMessagesAppended?(): Promise<void>
+  /**
+   * Fires when session creation restarted the thread onto a new harness
+   * (explicit --claude/--amp/--codex on a thread pinned to another harness).
+   * Runs before append/execute, so the callback may set
+   * `input.contextPreamble` to re-feed thread history to the fresh harness.
+   */
+  onSessionRestarted?(): Promise<void>
 }
 
 export async function collectInitialContext(
@@ -143,10 +150,19 @@ export async function forwardToSessionApi(
   callbacks: ForwardSessionApiCallbacks = {}
 ): Promise<AsyncIterable<SlackbotV2RendererSource> | null> {
   const createStartedAtMs = nowMs()
-  await createSession(options, input.threadId, input.harnessType, sessionRequesterMessage(input))
+  const created = await createSession(
+    options,
+    input.threadId,
+    input.harnessType,
+    sessionRequesterMessage(input)
+  )
   traceLog(options, 'slackbotv2_session_create_complete', input.trace, {
+    harness_switched: created.harnessSwitched,
     phase_ms: elapsedMs(createStartedAtMs)
   })
+  if (created.harnessSwitched) {
+    await callbacks.onSessionRestarted?.()
+  }
   if (input.messages.length > 0) {
     const appendStartedAtMs = nowMs()
     await appendSessionMessages(options, input.threadId, input.messages, !input.executeMessage)
@@ -168,7 +184,8 @@ export async function forwardToSessionApi(
     input.threadId,
     input.executeMessage,
     input.model,
-    input.executeContextMessages
+    input.executeContextMessages,
+    input.contextPreamble
   )
   traceLog(options, 'slackbotv2_session_execute_complete', input.trace, {
     execution_id: execution.execution_id,
@@ -198,6 +215,40 @@ export async function openSessionEventStream(
     phase_ms: elapsedMs(streamStartedAtMs)
   })
   return stream
+}
+
+const RESTART_CONTEXT_MAX_CHARS = 24_000
+
+/**
+ * Transcript of the Slack thread, fed to a freshly restarted harness as a
+ * context preamble (the old harness's conversation state dies with its
+ * sandbox). The current message is excluded — it rides in the same input line
+ * as the actual user turn.
+ */
+export function harnessRestartPreamble(
+  history: SlackbotV2ApiMessage[],
+  currentMessageId: string
+): string | undefined {
+  const lines: string[] = []
+  for (const item of history) {
+    if (item.id === currentMessageId) continue
+    const text = item.text.trim()
+    if (!text) continue
+    const author = item.author.isMe
+      ? 'assistant'
+      : item.author.userName || item.author.fullName || 'user'
+    lines.push(`[${author}]: ${text}`)
+  }
+  if (lines.length === 0) return undefined
+  let transcript = lines.join('\n')
+  if (transcript.length > RESTART_CONTEXT_MAX_CHARS) {
+    transcript = `…(earlier messages truncated)\n${transcript.slice(-RESTART_CONTEXT_MAX_CHARS)}`
+  }
+  return (
+    'This Slack thread was just restarted on a different agent harness, so the previous '
+    + 'agent\'s working state is gone. Transcript of the thread so far, for context:\n'
+    + transcript
+  )
 }
 
 export function sessionStreamError(error: unknown): RustSessionStreamEvent {
@@ -283,15 +334,30 @@ export function clearRequesterIdentityCacheForTests(): void {
   requesterIdentityCache.clear()
 }
 
+type CreateSessionOutcome = {
+  /** The API restarted the thread onto the requested harness. */
+  harnessSwitched: boolean
+}
+
 async function createSession(
   options: SlackbotV2Options,
   threadId: string,
   harnessType?: string,
   message?: SlackbotV2ApiMessage
-): Promise<void> {
-  const requested = harnessType ?? DEFAULT_HARNESS_TYPE
-  const response = await postCreateSession(options, threadId, requested, message)
-  if (response.ok) return
+): Promise<CreateSessionOutcome> {
+  const requested = harnessType ?? options.defaultHarnessType ?? DEFAULT_HARNESS_TYPE
+  // An explicit --claude/--amp/--codex restarts a thread pinned to another
+  // harness; the implicit default never forces a switch.
+  const response = await postCreateSession(
+    options,
+    threadId,
+    requested,
+    message,
+    harnessType ? 'restart' : undefined
+  )
+  if (response.ok) {
+    return { harnessSwitched: await harnessSwitchedFromResponse(response) }
+  }
 
   let body = ''
   try {
@@ -300,14 +366,14 @@ async function createSession(
     body = ''
   }
   // A thread is pinned to the harness it was created with; the API rejects a
-  // differing harness_type with 409. A mid-thread --claude/--amp/--codex (or a
-  // plain message on a thread created with a non-default harness) lands here:
-  // keep the thread alive on its existing harness instead of failing the message.
+  // differing harness_type with 409. A plain message on a thread created with
+  // a non-default harness lands here: keep the thread alive on its existing
+  // harness instead of failing the message.
   const existing = response.status === 409 ? existingHarnessFromConflict(body) : undefined
   if (existing && existing !== requested) {
     const retry = await postCreateSession(options, threadId, existing, message)
     await ensureApiOk(retry, 'create session')
-    return
+    return { harnessSwitched: false }
   }
   throw new SessionApiError({
     action: 'create session',
@@ -322,7 +388,8 @@ async function postCreateSession(
   options: SlackbotV2Options,
   threadId: string,
   harnessType: string,
-  message?: SlackbotV2ApiMessage
+  message?: SlackbotV2ApiMessage,
+  onHarnessConflict?: 'reject' | 'restart'
 ): Promise<Response> {
   const fetchFn = options.fetch ?? fetch
   const body: SlackbotV2CreateSessionRequest = {
@@ -332,13 +399,23 @@ async function postCreateSession(
       platform: 'slack',
       thread_id: threadId,
       ...sessionRequesterMetadata(message)
-    }
+    },
+    ...(onHarnessConflict ? { on_harness_conflict: onHarnessConflict } : {})
   }
   return fetchFn(apiSessionUrl(options.apiUrl, threadId), {
     method: 'POST',
     headers: apiHeaders(options),
     body: JSON.stringify(body)
   })
+}
+
+async function harnessSwitchedFromResponse(response: Response): Promise<boolean> {
+  try {
+    const payload = await response.json()
+    return isJsonObject(payload) && payload.harness_switched === true
+  } catch {
+    return false
+  }
 }
 
 function existingHarnessFromConflict(body: string): string | undefined {
@@ -620,14 +697,22 @@ async function executeSession(
   threadId: string,
   message: SlackbotV2ApiMessage,
   model?: string,
-  contextMessages?: SlackbotV2ApiMessage[]
+  contextMessages?: SlackbotV2ApiMessage[],
+  contextPreamble?: string
 ): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
   const requesterIdentity = await resolveRequesterIdentity(options, message)
   const body: SlackbotV2ExecuteSessionRequest = {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),
-    input_lines: toCodexInputLines(message, threadId, model, requesterIdentity, contextMessages),
+    input_lines: toCodexInputLines(
+      message,
+      threadId,
+      model,
+      requesterIdentity,
+      contextMessages,
+      contextPreamble
+    ),
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
   }
@@ -776,7 +861,8 @@ function toCodexInputLines(
   threadId: string,
   model?: string,
   requesterIdentity?: RequesterIdentity,
-  contextMessages?: SlackbotV2ApiMessage[]
+  contextMessages?: SlackbotV2ApiMessage[],
+  contextPreamble?: string
 ): string[] {
   const staged = new Map<SlackbotV2ApiAttachment, string>()
   const lines: string[] = []
@@ -788,7 +874,8 @@ function toCodexInputLines(
       staged,
       model,
       requesterIdentity,
-      contextMessages
+      contextMessages,
+      contextPreamble
     )
     if (
       inlineLine.length <= MAX_CODEX_INPUT_LINE_CHARS
@@ -807,7 +894,8 @@ function toCodexInputLines(
       staged,
       model,
       requesterIdentity,
-      contextMessages
+      contextMessages,
+      contextPreamble
     )
   )
   return lines
@@ -819,7 +907,8 @@ function toCodexInputLineWithStaged(
   staged: Map<SlackbotV2ApiAttachment, string>,
   model?: string,
   requesterIdentity?: RequesterIdentity,
-  contextMessages?: SlackbotV2ApiMessage[]
+  contextMessages?: SlackbotV2ApiMessage[],
+  contextPreamble?: string
 ): string {
   return JSON.stringify({
     type: 'user',
@@ -828,7 +917,13 @@ function toCodexInputLineWithStaged(
     ...(model ? { model } : {}),
     message: {
       role: 'user',
-      content: codexInputContent(message, staged, requesterIdentity, contextMessages)
+      content: codexInputContent(
+        message,
+        staged,
+        requesterIdentity,
+        contextMessages,
+        contextPreamble
+      )
     }
   })
 }
@@ -907,16 +1002,21 @@ function codexInputContent(
   message: SlackbotV2ApiMessage,
   staged: Map<SlackbotV2ApiAttachment, string> = new Map(),
   requesterIdentity?: RequesterIdentity,
-  contextMessages?: SlackbotV2ApiMessage[]
+  contextMessages?: SlackbotV2ApiMessage[],
+  contextPreamble?: string
 ): JsonValue[] {
   const content: JsonValue[] = []
   const requesterContext = requesterIdentityContext(requesterIdentity)
   if (requesterContext) {
     content.push({ type: 'text', text: requesterContext })
   }
-  const threadContext = slackThreadContext(message, contextMessages)
-  if (threadContext) {
-    content.push({ type: 'text', text: threadContext })
+  if (contextPreamble?.trim()) {
+    content.push({ type: 'text', text: contextPreamble })
+  } else {
+    const threadContext = slackThreadContext(message, contextMessages)
+    if (threadContext) {
+      content.push({ type: 'text', text: threadContext })
+    }
   }
   if (message.text.trim()) {
     content.push({ type: 'text', text: message.text })

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -57,6 +57,8 @@ export type SlackbotV2AppendMessagesRequest = {
 export type SlackbotV2CreateSessionRequest = {
   harness_type: string
   metadata: JsonObject
+  /** 'restart': switch the thread to harness_type if it's pinned to another harness. */
+  on_harness_conflict?: 'reject' | 'restart'
 }
 
 export type SlackbotV2ExecuteSessionRequest = {
@@ -83,6 +85,11 @@ export type SlackbotV2Options = {
   assistantStatus?: string
   botToken: string
   botUserId?: string
+  /**
+   * Harness for new threads when no --claude/--amp/--codex flag is given
+   * (HarnessType wire value: codex | amp | claudecode). Defaults to codex.
+   */
+  defaultHarnessType?: string
   fetch?: SlackbotV2Fetch
   idleTimeoutMs?: number
   logger?: Logger
@@ -137,6 +144,12 @@ export type SlackbotV2Trace = {
 export type ForwardSessionInput = {
   afterEventId: number
   executeContextMessages?: SlackbotV2ApiMessage[]
+  /**
+   * Prepended to the execute message content as a text part. Set when a
+   * harness restart discards the previous harness's conversation state so the
+   * new harness still sees the thread history.
+   */
+  contextPreamble?: string
   executionId?: string
   executeMessage?: SlackbotV2ApiMessage
   /** Harness override parsed from message flags (--claude/--amp/--codex). */

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -55,6 +55,22 @@ describe('extractMessageOverrides', () => {
     })
     expect(extractMessageOverrides('--sonnet fix it').model).toBe('claude-sonnet-4-6')
     expect(extractMessageOverrides('--haiku fix it').model).toBe('claude-haiku-4-5')
+    expect(extractMessageOverrides('--fable fix it').model).toBe('claude-fable-5')
+  })
+
+  test('--model expands claude aliases to full model ids', () => {
+    expect(extractMessageOverrides('--claude --model opus go')).toEqual({
+      cleanedText: 'go',
+      harnessType: 'claudecode',
+      model: 'claude-opus-4-8'
+    })
+    expect(extractMessageOverrides('--model Sonnet go').model).toBe('claude-sonnet-4-6')
+    expect(extractMessageOverrides('--model fable go').model).toBe('claude-fable-5')
+  })
+
+  test('--model passes non-alias values through verbatim', () => {
+    expect(extractMessageOverrides('--codex --model gpt-5.2-codex go').model).toBe('gpt-5.2-codex')
+    expect(extractMessageOverrides('--amp --model fast go').model).toBe('fast')
   })
 
   test('explicit flags win over shortcut implications', () => {

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { forwardToSessionApi } from '../src/session-api'
+import { forwardToSessionApi, harnessRestartPreamble } from '../src/session-api'
 import type {
   ForwardSessionInput,
   SlackbotV2ApiMessage,
@@ -179,5 +179,101 @@ describe('forwardToSessionApi overrides', () => {
     await expect(
       forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
     ).rejects.toThrow('create session failed: 500')
+  })
+})
+
+describe('forwardToSessionApi harness restart', () => {
+  test('explicit harness override requests restart on conflict', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('switch me'), { harnessType: 'codex' })
+    )
+    const create = requests.find(request => request.url.endsWith('.000100'))
+    expect((create?.body as { on_harness_conflict?: string }).on_harness_conflict).toBe('restart')
+  })
+
+  test('default create does not request restart', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
+    const create = requests.find(request => request.url.endsWith('.000100'))
+    expect('on_harness_conflict' in (create?.body as object)).toBe(false)
+  })
+
+  test('harness_switched response fires onSessionRestarted and prepends the preamble', async () => {
+    const { fetchFn, requests } = fakeApi({
+      createSession: [{ body: { ok: true, harness_switched: true }, status: 200 }]
+    })
+    const message = apiMessage('continue with codex')
+    const input = forwardInput(message, { harnessType: 'codex' })
+    let restarted = false
+    await forwardToSessionApi(options(fetchFn), input, {
+      onSessionRestarted: async () => {
+        restarted = true
+        input.contextPreamble = harnessRestartPreamble(
+          [
+            { ...message, id: '1700000000.000001', text: 'earlier question' },
+            {
+              ...message,
+              author: { ...message.author, isMe: true, userName: 'centaur' },
+              id: '1700000000.000002',
+              text: 'earlier answer'
+            },
+            message
+          ],
+          message.id
+        )
+      }
+    })
+    expect(restarted).toBe(true)
+    const execute = requests.find(request => request.url.endsWith('/execute'))
+    const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
+    const [requesterContext, preamble, current] = line.message.content
+    expect(requesterContext.type).toBe('text')
+    expect(requesterContext.text).toContain('# Requester Context')
+    expect(requesterContext.text).not.toContain('restarted on a different agent harness')
+    expect(preamble.type).toBe('text')
+    expect(preamble.text).toContain('restarted on a different agent harness')
+    expect(preamble.text).toContain('[test]: earlier question')
+    expect(preamble.text).toContain('[assistant]: earlier answer')
+    expect(preamble.text).not.toContain('continue with codex')
+    expect(current).toEqual({ type: 'text', text: 'continue with codex' })
+  })
+
+  test('no restart leaves the execute line without a preamble', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const input = forwardInput(apiMessage('plain message'), { harnessType: 'codex' })
+    let restarted = false
+    await forwardToSessionApi(options(fetchFn), input, {
+      onSessionRestarted: async () => {
+        restarted = true
+      }
+    })
+    expect(restarted).toBe(false)
+    const execute = requests.find(request => request.url.endsWith('/execute'))
+    const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
+    expect(line.message.content[0].text).toContain('# Requester Context')
+    expect(line.message.content[0].text).not.toContain('restarted on a different agent harness')
+    expect(line.message.content.at(-1)).toEqual({ type: 'text', text: 'plain message' })
+  })
+})
+
+describe('harnessRestartPreamble', () => {
+  const base = apiMessage('current')
+
+  test('returns undefined when there is no prior history', () => {
+    expect(harnessRestartPreamble([base], base.id)).toBeUndefined()
+  })
+
+  test('truncates very long transcripts from the front', () => {
+    const history = [
+      { ...base, id: 'old.1', text: 'x'.repeat(30_000) },
+      { ...base, id: 'old.2', text: 'most recent line' },
+      base
+    ]
+    const preamble = harnessRestartPreamble(history, base.id)!
+    expect(preamble).toContain('…(earlier messages truncated)')
+    expect(preamble).toContain('most recent line')
+    expect(preamble.length).toBeLessThan(26_000)
   })
 })


### PR DESCRIPTION
On the new Rust API stack, `--codex` on a Claude thread (and vice versa) now **restarts the thread on the requested harness**, and `--model` selects a model **inside** that harness. Follow-up to the slackbot override flags, which parsed correctly but had no effect on what actually ran (the sandbox always booted the image CMD's harness — see thread logs from the PR-463 preview).

## What changed

**Harness actually follows the session (api-rs)**
- `ensure_session_sandbox` now passes `session.harness_type` into the sandbox spec factory; the `CodexAppServer` workload pins `args: ["harness-server", codex|claude-code|amp]` on the container (image entrypoint preserved). The image CMD no longer decides the harness.
- Warm sandboxes boot the deployment default (`SESSION_SANDBOX_HARNESS`, chart value `sandbox.harnessEngine`) and are only claimed by sessions on that harness; other harnesses get a cold sandbox (`harness_mismatch` is recorded on the warm-pool claim metric).

**Restart on harness switch (api-rs)**
- `POST /api/session/{thread_key}` accepts `on_harness_conflict: "restart"`. On a pinned-thread conflict the runtime stops the old sandbox (any in-flight execution dies with it), clears `harness_thread_id`/`sandbox_id`, flips the session row (messages/events preserved), appends a `session.harness_switched` event, and returns `harness_switched: true`.
- Default behavior (absent/`reject`) is the existing 409.

**Slackbot (slackbotv2)**
- An explicit `--claude`/`--amp`/`--codex` requests `on_harness_conflict: restart` — but only on messages that start an execution, so an active run is never killed by a passing mention. Plain messages keep the existing 409 fallback and never force a switch.
- On a switch, the bot rebuilds the Slack thread transcript and prepends it as a context preamble text part on the same turn — the new harness starts with no conversational memory otherwise. Capped at 24k chars, truncated from the front.
- `--model` expands Claude aliases (`fable`/`opus`/`sonnet`/`haiku` → full ids) and passes everything else verbatim (`gpt-5.2`, amp `deep`/`fast`). `--fable` joins the bare shortcuts. Previously `--model opus` sent the literal string `opus`.
- The no-flag default harness is now `SLACKBOTV2_DEFAULT_HARNESS` (chart wires it to `sandbox.harnessEngine`) instead of hardcoded `codex` — without this, the spec-threading change would have silently flipped default threads from the claude-code dogfood back to codex.

**Iron-proxy**
- Registers every harness auth fragment that has credentials (configured engine's fragment remains required at startup), so a thread restarted onto the other harness still authenticates through the proxy. Placeholder env now carries all fragments' keys.

## Usage

```
@centaur --codex try this with codex instead     ← restarts the thread on codex
@centaur --claude --model sonnet now with claude ← back to claude-code on sonnet
@centaur --model gpt-5.2 continue                ← per-turn model, same harness
```

## Testing
- api-rs: full workspace `cargo test` green (incl. new specs: harness pinned via args, warm spec uses default harness); clippy clean on touched files.
- slackbotv2: 62/64 `bun test` (2 failures are pre-existing on main — Slack stream rotation tests); typecheck clean. New tests: restart requested only for explicit flags, `harness_switched` fires the restart callback and the preamble lands as the first content part, `--model` alias expansion/passthrough, preamble truncation.
- `helm template` renders the new `SESSION_SANDBOX_HARNESS` / `SLACKBOTV2_DEFAULT_HARNESS` envs from `sandbox.harnessEngine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)