### PR TITLE
feat(chart): add opt-in ingress for iron-control

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.51
+version: 0.1.52
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/iron-control-ingress.yaml
+++ b/contrib/chart/templates/iron-control-ingress.yaml
@@ -1,28 +1,46 @@
-{{- if and .Values.ironControl.enabled .Values.ironControl.tailscaleIngress.enabled }}
-{{- $hostname := required "ironControl.tailscaleIngress.hostname is required when ironControl.tailscaleIngress.enabled (a single DNS label, e.g. iron-control)" .Values.ironControl.tailscaleIngress.hostname }}
-# Tailnet ingress for iron-control via the Tailscale Kubernetes operator
-# (installed separately). The operator only honors a single backend, so this
-# renders spec.defaultBackend rather than host/path rules; tls.hosts carries
-# the single label the operator names the device after (it serves at
-# <hostname>.<tailnet>.ts.net).
+{{- if and .Values.ironControl.enabled .Values.ironControl.ingress.enabled }}
+# Optional Ingress for iron-control; the controller (Tailscale operator,
+# Cloudflare, ingress-nginx, ...) is installed separately and selected via
+# ironControl.ingress.className. defaultBackend renders the single-backend
+# form some controllers (the Tailscale operator) require instead of host/path
+# rules.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "centaur.ironControlName" . }}
   labels:
 {{ include "centaur.componentLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
-  {{- with .Values.ironControl.tailscaleIngress.annotations }}
+  {{- with .Values.ironControl.ingress.annotations }}
   annotations:
 {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: tailscale
+  {{- with .Values.ironControl.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ironControl.ingress.defaultBackend }}
   defaultBackend:
     service:
       name: {{ include "centaur.ironControlName" . }}
       port:
         number: {{ .Values.ironControl.service.httpPort }}
+  {{- else }}
+  rules:
+    - {{- if .Values.ironControl.ingress.host }}
+      host: {{ .Values.ironControl.ingress.host | quote }}
+      {{- end }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "centaur.ironControlName" . }}
+                port:
+                  number: {{ .Values.ironControl.service.httpPort }}
+  {{- end }}
+  {{- with .Values.ironControl.ingress.tls }}
   tls:
-    - hosts:
-        - {{ $hostname | quote }}
+{{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/contrib/chart/templates/iron-control-ingress.yaml
+++ b/contrib/chart/templates/iron-control-ingress.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.ironControl.enabled .Values.ironControl.tailscaleIngress.enabled }}
+{{- $hostname := required "ironControl.tailscaleIngress.hostname is required when ironControl.tailscaleIngress.enabled (a single DNS label, e.g. iron-control)" .Values.ironControl.tailscaleIngress.hostname }}
+# Tailnet ingress for iron-control via the Tailscale Kubernetes operator
+# (installed separately). The operator only honors a single backend, so this
+# renders spec.defaultBackend rather than host/path rules; tls.hosts carries
+# the single label the operator names the device after (it serves at
+# <hostname>.<tailnet>.ts.net).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "centaur.ironControlName" . }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "iron-control") | nindent 4 }}
+  {{- with .Values.ironControl.tailscaleIngress.annotations }}
+  annotations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: {{ include "centaur.ironControlName" . }}
+      port:
+        number: {{ .Values.ironControl.service.httpPort }}
+  tls:
+    - hosts:
+        - {{ $hostname | quote }}
+{{- end }}

--- a/contrib/chart/templates/iron-control.yaml
+++ b/contrib/chart/templates/iron-control.yaml
@@ -218,11 +218,14 @@ spec:
         - podSelector:
             matchLabels:
               centaur.ai/iron-proxy: "true"
-{{- if .Values.ironControl.tailscaleIngress.enabled }}
-        # Tailscale operator proxy pods forwarding tailnet ingress traffic.
+{{- if .Values.ironControl.ingress.enabled }}
+        # Ingress controller pods (Tailscale operator, Cloudflare, ...)
+        # forwarding external traffic to iron-control.
+{{- range default .Values.networkPolicy.ingressControllerNamespaces .Values.networkPolicy.ingressSourceNamespaces }}
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.ironControl.tailscaleIngress.operatorNamespace }}
+              kubernetes.io/metadata.name: {{ . | quote }}
+{{- end }}
 {{- end }}
       ports:
         - protocol: TCP

--- a/contrib/chart/templates/iron-control.yaml
+++ b/contrib/chart/templates/iron-control.yaml
@@ -218,6 +218,12 @@ spec:
         - podSelector:
             matchLabels:
               centaur.ai/iron-proxy: "true"
+{{- if .Values.ironControl.tailscaleIngress.enabled }}
+        # Tailscale operator proxy pods forwarding tailnet ingress traffic.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.ironControl.tailscaleIngress.operatorNamespace }}
+{{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.ironControl.service.httpPort }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -92,24 +92,29 @@ ironControl:
     name: iron_control_production
   service:
     httpPort: 3000
-  # Optional tailnet-only ingress via the Tailscale Kubernetes operator
-  # (installed separately; see docs/operate/tailscale-funnel for operator
-  # setup). Renders an Ingress with className "tailscale" and a single
-  # defaultBackend, which the operator turns into a Tailscale device serving
-  # iron-control at `hostname`. Tailnet-only by default; add the
-  # `tailscale.com/funnel: "true"` annotation to expose via Funnel.
-  tailscaleIngress:
+  # Optional Ingress for iron-control. Bring your own controller — Tailscale
+  # operator, Cloudflare, ingress-nginx, etc. — via className + annotations +
+  # tls. Mirrors the top-level `ingress` block (which is wired to the
+  # Slackbot). Add the controller's namespace to
+  # networkPolicy.ingressControllerNamespaces so its pods can reach
+  # iron-control; the iron-control NetworkPolicy admits those namespaces when
+  # this is enabled.
+  #
+  # Tailscale operator example (serves https://iron-control.<tailnet>.ts.net):
+  #   className: tailscale
+  #   defaultBackend: true
+  #   tls: [{hosts: [iron-control]}]
+  ingress:
     enabled: false
-    # Single DNS label the operator names the Tailscale device after, placed in
-    # the Ingress tls.hosts — e.g. "iron-control" serves
-    # https://iron-control.<tailnet>.ts.net. REQUIRED when enabled. MagicDNS +
-    # HTTPS certificates must be enabled on the tailnet.
-    hostname: ""
-    # Namespace the Tailscale operator runs its proxy pods in. The iron-control
-    # NetworkPolicy admits ingress from this namespace so tailnet traffic can
-    # reach the pod.
-    operatorNamespace: tailscale
+    className: ""
     annotations: {}
+    # When true, render a single spec.defaultBackend instead of host/path
+    # rules. Required by the Tailscale operator; harmless otherwise.
+    defaultBackend: false
+    # Host for the path rule when not using defaultBackend; empty matches any
+    # host.
+    host: ""
+    tls: []
   resources: {}
   # Solid Queue worker (`bin/jobs`) that runs iron-control's background jobs —
   # most importantly the broker-credential OAuth refresh loop that mints and

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -92,6 +92,24 @@ ironControl:
     name: iron_control_production
   service:
     httpPort: 3000
+  # Optional tailnet-only ingress via the Tailscale Kubernetes operator
+  # (installed separately; see docs/operate/tailscale-funnel for operator
+  # setup). Renders an Ingress with className "tailscale" and a single
+  # defaultBackend, which the operator turns into a Tailscale device serving
+  # iron-control at `hostname`. Tailnet-only by default; add the
+  # `tailscale.com/funnel: "true"` annotation to expose via Funnel.
+  tailscaleIngress:
+    enabled: false
+    # Single DNS label the operator names the Tailscale device after, placed in
+    # the Ingress tls.hosts — e.g. "iron-control" serves
+    # https://iron-control.<tailnet>.ts.net. REQUIRED when enabled. MagicDNS +
+    # HTTPS certificates must be enabled on the tailnet.
+    hostname: ""
+    # Namespace the Tailscale operator runs its proxy pods in. The iron-control
+    # NetworkPolicy admits ingress from this namespace so tailnet traffic can
+    # reach the pod.
+    operatorNamespace: tailscale
+    annotations: {}
   resources: {}
   # Solid Queue worker (`bin/jobs`) that runs iron-control's background jobs —
   # most importantly the broker-credential OAuth refresh loop that mints and


### PR DESCRIPTION
Adds an optional, controller-agnostic Ingress for iron-control. A new `ironControl.ingress` values block mirrors the top-level `ingress` block (which is wired to the Slackbot): configurable `className`, `annotations`, `host`/path rules or a single `defaultBackend` (the form the Tailscale operator expects), and a `tls` passthrough, so Tailscale, Cloudflare, ingress-nginx, etc. all work without chart changes. When enabled, the iron-control NetworkPolicy also admits ingress from `networkPolicy.ingressControllerNamespaces` so the controller's pods can reach the pod. Disabled by default; chart version bumped to 0.1.52.

Verified end to end with the Tailscale operator (`className: tailscale`, `defaultBackend: true`, `tls: [{hosts: [iron-control]}]`): the operator provisions the device and serves iron-control at `https://iron-control.<tailnet>.ts.net` with a valid Let's Encrypt cert. The Cloudflare/nginx-style `host` + path-rule rendering is verified via `helm template`.