### PR TITLE
fix(slackbotv2): stop the recovery sweep from duplicating live renders

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -84,6 +84,7 @@ const RENDER_OBLIGATION_INDEX_KEY = 'slackbotv2:render:index'
 const RENDER_OBLIGATION_INDEX_MAX_LENGTH = 2000
 const RENDER_INDEX_TTL_MS = 30 * 24 * 60 * 60 * 1000
 const RENDER_RECOVERY_LEASE_TTL_MS = 2 * 60 * 1000
+const RENDER_LEASE_REFRESH_INTERVAL_MS = 60 * 1000
 const RENDER_RECOVERY_THREAD_TIMEOUT_MS = 2 * 60 * 1000
 const RENDER_RECOVERY_MAX_THREAD_FAILURES = 5
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
@@ -312,6 +313,7 @@ async function syncThreadMessageToSession(
   }
 
   let lastEventId = state.lastEventId ?? 0
+  const renderLease: { release: (() => Promise<void>) | null } = { release: null }
   const candidateMessages = context ?? [serializedMessage]
   const messagesToAppend = candidateMessages.filter(item => !messageIds.has(item.id))
 
@@ -351,6 +353,16 @@ async function syncThreadMessageToSession(
     const latestExecutedMessageIds = new Set(latest.executedMessageIds ?? [])
     latestExecutedMessageIds.add(serializedMessage.id)
     forwardInput.executionId = execution.execution_id
+    // Take the render lease before the obligation becomes visible so a
+    // concurrent recovery sweep never claims it while this process is about
+    // to render it live.
+    try {
+      renderLease.release = await acquireRenderLease(input.state, thread.id)
+    } catch (error) {
+      traceLog(input.options, 'slackbotv2_render_lease_acquire_failed', trace, {
+        error: errorMessage(error)
+      })
+    }
     await thread.setState({
       activeExecution: true,
       executedMessageIds: Array.from(latestExecutedMessageIds).slice(-1000),
@@ -415,12 +427,16 @@ async function syncThreadMessageToSession(
       input.options,
       forwardInput,
       () => lastEventId,
+      renderLease,
       trace
     )
     traceLog(input.options, 'slackbotv2_forward_complete', trace, {
       last_event_id: lastEventId
     })
   } catch (error) {
+    // The live render is not happening; let the recovery sweep claim the
+    // obligation (if one was committed) as soon as it scans.
+    await renderLease.release?.()
     const latest = (await thread.state) ?? {}
     await thread.setState({
       activeExecution: false,
@@ -465,27 +481,32 @@ function scheduleExecutionRender(
   options: SlackbotV2Options,
   input: ForwardSessionInput,
   getLastEventId: () => number,
+  renderLease: { release: (() => Promise<void>) | null },
   trace?: SlackbotV2Trace
 ): void {
   const promise = (async () => {
-    let attempt = 0
-    while (true) {
-      const result = await renderExecutionAttempt(
-        thread,
-        message,
-        options,
-        input,
-        getLastEventId,
-        trace
-      )
-      if (result === 'complete') return
-      const delayMs = renderRetryDelayMs(attempt)
-      attempt += 1
-      traceLog(options, 'slackbotv2_render_retry_scheduled', trace, {
-        retry_delay_ms: delayMs,
-        retry_attempt: attempt
-      })
-      await sleep(delayMs)
+    try {
+      let attempt = 0
+      while (true) {
+        const result = await renderExecutionAttempt(
+          thread,
+          message,
+          options,
+          input,
+          getLastEventId,
+          trace
+        )
+        if (result === 'complete') return
+        const delayMs = renderRetryDelayMs(attempt)
+        attempt += 1
+        traceLog(options, 'slackbotv2_render_retry_scheduled', trace, {
+          retry_delay_ms: delayMs,
+          retry_attempt: attempt
+        })
+        await sleep(delayMs)
+      }
+    } finally {
+      await renderLease.release?.()
     }
   })()
   backgroundWaitUntil(promise)
@@ -783,7 +804,13 @@ async function recoverRenderObligations(
       if (outcome.timedOut) {
         void recovery.catch(() => undefined)
         deferredCount += 1
+        // Count timeouts toward the abandonment budget: an obligation whose
+        // recovery hangs on every claim (for example an event stream that
+        // never yields) would otherwise keep the sweep loop spinning forever,
+        // racing every live render in the process.
+        failureCounts.set(threadId, (failureCounts.get(threadId) ?? 0) + 1)
         traceLog(options, 'slackbotv2_render_recovery_thread_timeout', undefined, {
+          failure_count: failureCounts.get(threadId),
           thread_id: threadId,
           timeout_ms: timeoutMs
         })
@@ -942,6 +969,40 @@ async function* streamOpenedSession(
 
 function renderRecoveryLeaseKey(threadId: string): string {
   return `slackbotv2:render:lease:${threadId}`
+}
+
+/**
+ * Holds the per-thread render lease for the duration of a live render so the
+ * recovery sweep cannot claim the just-indexed obligation and post a
+ * duplicate answer (it lease-skips instead). The TTL keeps this crash-safe:
+ * if the pod dies mid-render the lease expires and recovery takes over. The
+ * lease is refreshed while the render runs because agent turns routinely
+ * outlive a single TTL window.
+ */
+async function acquireRenderLease(
+  state: StateAdapter,
+  threadId: string
+): Promise<() => Promise<void>> {
+  const key = renderRecoveryLeaseKey(threadId)
+  const token = randomUUID()
+  await state.set(key, token, RENDER_RECOVERY_LEASE_TTL_MS)
+  const refresh = setInterval(() => {
+    void state
+      .get<string>(key)
+      .then(current =>
+        current === token ? state.set(key, token, RENDER_RECOVERY_LEASE_TTL_MS) : undefined
+      )
+      .catch(() => undefined)
+  }, RENDER_LEASE_REFRESH_INTERVAL_MS)
+  return async () => {
+    clearInterval(refresh)
+    try {
+      const current = await state.get<string>(key)
+      if (current === token) await state.delete(key)
+    } catch {
+      // Best effort: TTL expiry is the backstop.
+    }
+  }
 }
 
 async function renderExecutionStream(

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -2034,6 +2034,87 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('does not duplicate the live render while the recovery sweep is cycling', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+
+    // A zombie obligation (its event stream never yields) keeps the recovery
+    // sweep loop cycling with short claim timeouts, so sweep passes land
+    // while the live render below is still streaming. Without the live
+    // render holding the per-thread lease, a pass claims the just-indexed
+    // obligation and posts the same answer twice.
+    const zombieKey = threadKey('1781200000.000001')
+    const zombieMessage = apiMessageFromSlackEvent({
+      isMention: true,
+      text: `<@${BOT_USER_ID}> zombie`,
+      threadId: zombieKey,
+      ts: '1781200000.000002'
+    })
+    await sharedState.set(`thread-state:${zombieKey}`, {
+      activeExecution: true,
+      executedMessageIds: [zombieMessage.id],
+      forwardedMessageIds: [zombieMessage.id],
+      historyForwarded: true,
+      lastEventId: 0,
+      renderObligation: {
+        afterEventId: 0,
+        executionId: 'exe-sweep-zombie',
+        message: zombieMessage
+      }
+    })
+    await sharedState.appendToList('slackbotv2:render:index', zombieKey)
+
+    codexApi.autoRespond = false
+    bot = createTestBot({ state: sharedState, renderRecoveryThreadTimeoutMs: 100 })
+
+    const parent = await postUserMessage('Context before sweep race.')
+    const mentionText = `<@${BOT_USER_ID}> race the sweep`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-sweep-race',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: mentionText
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+
+    const key = threadKey(parent.ts)
+    await waitFor(() => codexApi.executes.length === 1, 2000)
+    const outputLines = sampleCodexOutputLines('Single answer despite the sweep.')
+    // Everything except turn/completed: the live render stays in-flight...
+    codexApi.emitOutputLines(key, outputLines.slice(0, -1))
+    // ...long enough for several sweep passes to scan the live obligation.
+    await sleep(1200)
+    codexApi.emitOutputLines(key, outputLines.slice(-1))
+    await Promise.all(waits)
+    await waitFor(() => slackApi.calls.some(call => call.method === 'chat.stopStream'), 3000)
+    await waitFor(async () => {
+      const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+      return threadState?.renderObligation === null
+    }, 3000)
+
+    // Exactly one renderer consumed the execution and exactly one Slack
+    // stream was started for the live thread.
+    expect(codexApi.eventRequests.filter(request => request.threadKey === key)).toHaveLength(1)
+    const startsForThread = slackApi.calls.filter(
+      call => call.method === 'chat.startStream' && call.body.thread_ts === parent.ts
+    )
+    expect(startsForThread).toHaveLength(1)
+    expect(await threadText(parent.ts)).toContain('Single answer despite the sweep.')
+  })
+
   it('abandons an obligation after repeated non-retryable recovery failures', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()


### PR DESCRIPTION
## Symptom

stgai posted the same answer twice, 20ms apart ([thread](https://tempoxyz.slack.com/archives/C0A87C21805/p1781251762068989)). Initially suspected to be the feedback-buttons PR (#508) — it isn't; both copies just made it obvious by each carrying the feedback block.

## Root cause

The #505 recovery sweep races live renders:

1. `commitExecutionStarted` publishes the render obligation **before** the live render starts, and the live renderer **never holds the per-thread recovery lease**.
2. The sweep claims any obligation whose lease is free — including one the live renderer is about to (or already does) stream.
3. The only protection was timing: the sweep normally exits at startup. But staging has **zombie obligations** (event streams that never yield → 2min claim timeout → deferred → retry forever), so the sweep loop has been cycling continuously since pod start (`render_recovery_lease_skipped` every ~250ms–5s in the logs). A pass landed 600ms into a live render → claimed the fresh obligation → both renderers consumed the execution → twin Slack replies.

Evidence: two `session_events_opened` 400ms apart, `render_recovery_complete` at 08:09:40.032 vs `render_complete` at 08:09:40.057, and twin messages `1781251779.657959`/`.678299`.

## Fix

- **Live renders hold the recovery lease**: acquired before the obligation is written, refreshed while streaming (agent turns outlive the 2-min TTL), released when the render settles (including the forward-failure path, where releasing immediately is what lets recovery take over). Crash-safe: pod death → TTL expiry → recovery claims. Also covers the rolling-update window where an old pod is still rendering while the new pod's sweep starts.
- **Claim timeouts count toward the existing abandonment budget** (5): permanently-hung obligations get abandoned instead of keeping the sweep spinning forever — this also drains staging's current zombie set (~6 threads).

## Verification

- New regression test reproduces the race deterministically: zombie obligation keeps the sweep cycling while a live render is held in-flight mid-stream. **Without the fix: 2 event streams + 2 Slack streams for one execution. With it: 1 + 1, lease-skipped.**
- Ran the new test against the unfixed code to confirm it fails for exactly the production reason (`eventRequests` length 2)
- `tsgo` ✅, full slackbotv2 suite 57/57 ✅ (incl. the existing hung-zombie test, which still asserts deferral — lease-skips don't count toward the budget)