### PR TITLE
fix(api-rs): reap orphaned sandboxes and backstop lost idle pauses

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -26,7 +26,7 @@ use centaur_sandbox_core::{Mount, MountKind, SandboxSpec};
 use centaur_sandbox_local::LocalSandboxBackend;
 use centaur_sandbox_manager::WarmPoolConfig;
 use centaur_session_core::HarnessType;
-use centaur_session_runtime::SandboxWorkloadMode;
+use centaur_session_runtime::{SandboxJanitorConfig, SandboxWorkloadMode};
 use centaur_workflows::WorkflowHostSandboxRuntime;
 use clap::{Args as ClapArgs, Parser, ValueEnum};
 use tracing::{error, info, warn};
@@ -79,6 +79,10 @@ impl Args {
 
     pub(crate) fn warm_pool_config(&self) -> Option<WarmPoolConfig> {
         self.sandbox.warm_pool_config()
+    }
+
+    pub(crate) fn sandbox_janitor_config(&self) -> Option<SandboxJanitorConfig> {
+        self.sandbox.sandbox_janitor_config()
     }
 
     pub(crate) async fn workflow_host_sandbox_runtime(
@@ -497,6 +501,23 @@ struct SandboxArgs {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     warm_pool_replenish_interval_secs: u64,
+    /// Seconds between sandbox janitor passes; 0 disables the janitor. The
+    /// interval doubles as the orphan grace period.
+    #[arg(
+        long = "session-sandbox-janitor-interval-secs",
+        env = "SESSION_SANDBOX_JANITOR_INTERVAL_SECS",
+        default_value_t = 300
+    )]
+    sandbox_janitor_interval_secs: u64,
+    /// Idle-pause backstop in seconds for sessions whose per-execution idle
+    /// timer was lost (e.g. across a control-plane restart); 0 disables the
+    /// idle arm while keeping the orphan sweep.
+    #[arg(
+        long = "session-sandbox-janitor-idle-backstop-secs",
+        env = "SESSION_SANDBOX_JANITOR_IDLE_BACKSTOP_SECS",
+        default_value_t = 21_600
+    )]
+    sandbox_janitor_idle_backstop_secs: u64,
     #[arg(
         long = "session-sandbox-k8s-context",
         alias = "kubernetes-context",
@@ -1089,6 +1110,14 @@ impl SandboxArgs {
             target_size: self.warm_pool_size,
             replenish_interval: Duration::from_secs(self.warm_pool_replenish_interval_secs),
             bootstrap_iron_control_principal: None,
+        })
+    }
+
+    fn sandbox_janitor_config(&self) -> Option<SandboxJanitorConfig> {
+        (self.sandbox_janitor_interval_secs > 0).then(|| SandboxJanitorConfig {
+            interval: Duration::from_secs(self.sandbox_janitor_interval_secs),
+            idle_backstop: (self.sandbox_janitor_idle_backstop_secs > 0)
+                .then(|| Duration::from_secs(self.sandbox_janitor_idle_backstop_secs)),
         })
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -42,6 +42,14 @@ async fn main() -> Result<(), ServerError> {
         config.bootstrap_iron_control_principal = warm_pool_bootstrap_principal.clone();
         runtime = runtime.with_warm_pool(config);
     }
+    if let Some(config) = args.sandbox_janitor_config() {
+        info!(
+            interval_secs = config.interval.as_secs(),
+            idle_backstop_secs = config.idle_backstop.map(|d| d.as_secs()),
+            "sandbox janitor enabled"
+        );
+        tokio::spawn(runtime.clone().run_sandbox_janitor(config));
+    }
     let workflow_host_sandbox = args
         .workflow_host_sandbox_runtime(workflow_host_principal.as_deref())
         .await?;

--- a/services/api-rs/crates/centaur-session-runtime/src/janitor.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/janitor.rs
@@ -1,0 +1,299 @@
+//! Periodic sandbox janitor.
+//!
+//! Two leak classes survive every other lifecycle mechanism:
+//!
+//! 1. Backend sandboxes with no `sessions.sandbox_id` or warm-pool reference.
+//!    Desired state lives in process memory, so a control-plane restart (or a
+//!    create/register race) leaves running sandboxes nothing will ever stop.
+//! 2. Sessions whose idle pause never fired because the per-execution timer
+//!    task (`spawn_idle_pause`) died with the process.
+//!
+//! The janitor closes both: it pauses sessions idle past a backstop TTL and
+//! stops sandboxes that stay unreferenced across two consecutive passes. The
+//! two-pass confirmation replaces a timestamp grace so freshly created
+//! sandboxes that have not registered yet are never reaped.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use centaur_sandbox_core::{ObservedSandbox, SandboxId, SandboxStatus};
+use centaur_session_core::ThreadKey;
+use tracing::{info, warn};
+
+use crate::{RuntimeContext, SessionRuntime, SessionRuntimeError, record_idle_pause};
+
+/// Configuration for [`SessionRuntime::run_sandbox_janitor`].
+#[derive(Clone, Debug)]
+pub struct SandboxJanitorConfig {
+    /// Time between janitor passes. Doubles as the orphan grace period: an
+    /// unreferenced sandbox is only stopped after staying unreferenced for a
+    /// full interval, so this must exceed the worst-case gap between a
+    /// sandbox turning `Running` and its reference landing in the store
+    /// (i.e. the readiness wait inside `create_running`).
+    pub interval: Duration,
+    /// Pause sandboxes whose latest execution finished at least this long ago
+    /// and have no active execution. Backstop for lost idle-pause timers;
+    /// `None` disables the idle arm.
+    pub idle_backstop: Option<Duration>,
+}
+
+impl SessionRuntime {
+    /// Run the sandbox janitor until the process exits.
+    ///
+    /// Spawn with `tokio::spawn(runtime.clone().run_sandbox_janitor(config))`.
+    pub async fn run_sandbox_janitor(self, config: SandboxJanitorConfig) {
+        let ctx = self.context();
+        let mut pending: HashSet<String> = HashSet::new();
+        let mut interval = tokio::time::interval(config.interval);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Skip the immediate tick so startup creations register before the
+        // first pass marks anything as pending.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            janitor_tick(&ctx, config.idle_backstop, &mut pending).await;
+        }
+    }
+}
+
+async fn janitor_tick(
+    ctx: &RuntimeContext,
+    idle_backstop: Option<Duration>,
+    pending: &mut HashSet<String>,
+) {
+    // The arms are independent; an idle-arm failure must not starve the
+    // orphan sweep (and vice versa).
+    if let Some(backstop) = idle_backstop
+        && let Err(error) = pause_idle_sessions(ctx, backstop).await
+    {
+        warn!(
+            component = "sandbox_janitor",
+            event = "idle_backstop_pass_failed",
+            %error,
+            "idle backstop pass failed"
+        );
+    }
+    if let Err(error) = reap_orphan_sandboxes(ctx, pending).await {
+        warn!(
+            component = "sandbox_janitor",
+            event = "orphan_sweep_pass_failed",
+            %error,
+            "orphan sweep pass failed"
+        );
+    }
+}
+
+/// Pause sandboxes for sessions idle past the backstop TTL.
+///
+/// Reuses [`record_idle_pause`], which re-validates the latest execution and
+/// sandbox status before acting, so racing a live turn is safe: the guard
+/// refuses when the execution is no longer the latest or the sandbox is not
+/// running.
+async fn pause_idle_sessions(
+    ctx: &RuntimeContext,
+    backstop: Duration,
+) -> Result<(), SessionRuntimeError> {
+    let idle = ctx.store.list_idle_sandbox_sessions(backstop).await?;
+    for session in idle {
+        let thread_key = match ThreadKey::parse(session.thread_key.clone()) {
+            Ok(thread_key) => thread_key,
+            Err(error) => {
+                warn!(
+                    component = "sandbox_janitor",
+                    event = "idle_backstop_thread_key_invalid",
+                    thread_key = %session.thread_key,
+                    %error,
+                    "skipping idle session with unparseable thread key"
+                );
+                continue;
+            }
+        };
+        if let Err(error) = record_idle_pause(
+            ctx,
+            &thread_key,
+            &session.execution_id,
+            &session.sandbox_id,
+            backstop,
+        )
+        .await
+        {
+            warn!(
+                component = "sandbox_janitor",
+                event = "idle_backstop_pause_failed",
+                thread_key = %thread_key,
+                sandbox_id = %session.sandbox_id,
+                %error,
+                "idle backstop failed to pause sandbox; will retry next pass"
+            );
+        } else {
+            info!(
+                component = "sandbox_janitor",
+                event = "idle_backstop_paused",
+                thread_key = %thread_key,
+                sandbox_id = %session.sandbox_id,
+                "idle backstop paused sandbox"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Stop backend sandboxes that stayed unreferenced for two consecutive passes.
+async fn reap_orphan_sandboxes(
+    ctx: &RuntimeContext,
+    pending: &mut HashSet<String>,
+) -> Result<(), SessionRuntimeError> {
+    let observed = ctx.manager.list_observed().await?;
+    let referenced: HashSet<String> = ctx
+        .store
+        .list_referenced_sandbox_ids()
+        .await?
+        .into_iter()
+        .collect();
+    let (reap_now, next_pending) = orphan_reap_candidates(&observed, &referenced, pending);
+    *pending = next_pending;
+    for id in reap_now {
+        match ctx.manager.stop(&id).await {
+            Ok(()) => {
+                ctx.sandbox_pipes.lock().await.remove(id.as_str());
+                info!(
+                    component = "sandbox_janitor",
+                    event = "orphan_sandbox_reaped",
+                    sandbox_id = %id.as_str(),
+                    "stopped sandbox with no session or warm-pool reference"
+                );
+            }
+            Err(error) => {
+                // Keep it pending so the next pass retries the stop.
+                pending.insert(id.as_str().to_owned());
+                warn!(
+                    component = "sandbox_janitor",
+                    event = "orphan_sandbox_reap_failed",
+                    sandbox_id = %id.as_str(),
+                    %error,
+                    "failed to stop orphan sandbox; will retry next pass"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Pure selection: which observed sandboxes to stop now, and which to mark
+/// pending for the next pass.
+///
+/// A sandbox is stopped only when it is running or suspended, unreferenced,
+/// and was already unreferenced on the previous pass (`pending`). Anything
+/// newly unreferenced goes into the returned pending set instead, giving
+/// in-flight creations a full interval to register their reference; `Created`
+/// (still scheduling/pulling) is skipped outright because creation can
+/// legitimately outlast an interval before `create_running` returns.
+fn orphan_reap_candidates(
+    observed: &[ObservedSandbox],
+    referenced: &HashSet<String>,
+    pending: &HashSet<String>,
+) -> (Vec<SandboxId>, HashSet<String>) {
+    let mut reap_now = Vec::new();
+    let mut next_pending = HashSet::new();
+    for sandbox in observed {
+        if sandbox.status.is_terminal() || matches!(sandbox.status, SandboxStatus::Created) {
+            continue;
+        }
+        let id = sandbox.id.as_str();
+        if referenced.contains(id) {
+            continue;
+        }
+        if pending.contains(id) {
+            reap_now.push(sandbox.id.clone());
+        } else {
+            next_pending.insert(id.to_owned());
+        }
+    }
+    (reap_now, next_pending)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn observed(id: &str, status: SandboxStatus) -> ObservedSandbox {
+        ObservedSandbox::new(id, "test", status)
+    }
+
+    fn set(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|id| (*id).to_owned()).collect()
+    }
+
+    #[test]
+    fn newly_unreferenced_sandbox_is_marked_pending_not_reaped() {
+        let sandboxes = [observed("sb-1", SandboxStatus::Running)];
+
+        let (reap, pending) = orphan_reap_candidates(&sandboxes, &set(&[]), &set(&[]));
+
+        assert!(reap.is_empty());
+        assert_eq!(pending, set(&["sb-1"]));
+    }
+
+    #[test]
+    fn sandbox_unreferenced_for_two_passes_is_reaped() {
+        let sandboxes = [observed("sb-1", SandboxStatus::Running)];
+
+        let (reap, pending) = orphan_reap_candidates(&sandboxes, &set(&[]), &set(&["sb-1"]));
+
+        assert_eq!(
+            reap.iter().map(SandboxId::as_str).collect::<Vec<_>>(),
+            ["sb-1"]
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn referenced_sandbox_is_never_reaped_even_when_pending() {
+        let sandboxes = [observed("sb-1", SandboxStatus::Running)];
+
+        let (reap, pending) = orphan_reap_candidates(&sandboxes, &set(&["sb-1"]), &set(&["sb-1"]));
+
+        assert!(reap.is_empty());
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn terminal_sandboxes_are_ignored() {
+        let sandboxes = [
+            observed("sb-stopped", SandboxStatus::Stopped),
+            observed("sb-gone", SandboxStatus::Gone),
+        ];
+
+        let (reap, pending) = orphan_reap_candidates(&sandboxes, &set(&[]), &set(&[]));
+
+        assert!(reap.is_empty());
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn suspended_unreferenced_sandbox_is_reaped() {
+        let sandboxes = [observed("sb-1", SandboxStatus::Suspended)];
+
+        let (reap, _) = orphan_reap_candidates(&sandboxes, &set(&[]), &set(&["sb-1"]));
+
+        assert_eq!(reap.len(), 1);
+    }
+
+    #[test]
+    fn created_sandbox_is_never_reaped_or_marked_pending() {
+        let sandboxes = [observed("sb-new", SandboxStatus::Created)];
+
+        let (reap, pending) = orphan_reap_candidates(&sandboxes, &set(&[]), &set(&["sb-new"]));
+
+        assert!(reap.is_empty());
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn pending_entry_for_vanished_sandbox_is_dropped() {
+        let (reap, pending) = orphan_reap_candidates(&[], &set(&[]), &set(&["sb-old"]));
+
+        assert!(reap.is_empty());
+        assert!(pending.is_empty());
+    }
+}

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1,3 +1,7 @@
+mod janitor;
+
+pub use janitor::SandboxJanitorConfig;
+
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
@@ -109,11 +113,11 @@ struct SessionPipe {
 /// Shared handles threaded through background session tasks (stdout pump,
 /// terminal-output recording, max-duration failure, idle pause).
 #[derive(Clone)]
-struct RuntimeContext {
-    store: PgSessionStore,
-    manager: Arc<SandboxManager>,
-    sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
-    execution_spans: ExecutionSpanRegistry,
+pub(crate) struct RuntimeContext {
+    pub(crate) store: PgSessionStore,
+    pub(crate) manager: Arc<SandboxManager>,
+    pub(crate) sandbox_pipes: Arc<Mutex<HashMap<String, SessionPipe>>>,
+    pub(crate) execution_spans: ExecutionSpanRegistry,
 }
 
 struct EventStreamState {
@@ -141,7 +145,7 @@ impl SessionRuntime {
         }
     }
 
-    fn context(&self) -> RuntimeContext {
+    pub(crate) fn context(&self) -> RuntimeContext {
         RuntimeContext {
             store: self.store.clone(),
             manager: self.sandbox_runtime.manager.clone(),
@@ -2544,7 +2548,7 @@ fn spawn_idle_pause(
     });
 }
 
-async fn record_idle_pause(
+pub(crate) async fn record_idle_pause(
     ctx: &RuntimeContext,
     thread_key: &ThreadKey,
     execution_id: &str,

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -637,6 +637,66 @@ impl PgSessionStore {
         Ok(())
     }
 
+    /// Sandbox ids the control plane still references: any session's current
+    /// sandbox plus ready/claimed warm-pool entries. Sandboxes the backend
+    /// reports that are absent from this set are orphans (insert races,
+    /// crashed processes, historical teardown failures) and have nothing left
+    /// to reap them except the janitor.
+    pub async fn list_referenced_sandbox_ids(&self) -> Result<Vec<String>, SessionStoreError> {
+        let ids = sqlx::query_scalar::<_, String>(
+            r#"
+            select sandbox_id from sessions where sandbox_id is not null
+            union
+            select sandbox_id from session_warm_sandboxes where status in ('ready', 'claimed')
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(ids)
+    }
+
+    /// Sessions whose sandbox should be idle-paused by the janitor backstop:
+    /// the latest execution is terminal and finished before the cutoff, and no
+    /// active execution exists. This catches sandboxes whose in-process idle
+    /// timer died with a control-plane restart.
+    pub async fn list_idle_sandbox_sessions(
+        &self,
+        idle: std::time::Duration,
+    ) -> Result<Vec<IdleSandboxSession>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, (String, String, String)>(
+            r#"
+            select s.thread_key, s.sandbox_id, e.execution_id
+            from sessions s
+            join lateral (
+                select execution_id, status, coalesce(completed_at, updated_at) as finished_at
+                from session_executions
+                where thread_key = s.thread_key
+                order by created_at desc, execution_id desc
+                limit 1
+            ) e on true
+            where s.sandbox_id is not null
+              and e.status in ($1, $2, $3)
+              and e.finished_at < now() - make_interval(secs => $4::double precision)
+            "#,
+        )
+        .bind(ExecutionStatus::Completed.as_ref())
+        .bind(ExecutionStatus::Failed.as_ref())
+        .bind(ExecutionStatus::Cancelled.as_ref())
+        .bind(idle.as_secs_f64())
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(
+                |(thread_key, sandbox_id, execution_id)| IdleSandboxSession {
+                    thread_key,
+                    sandbox_id,
+                    execution_id,
+                },
+            )
+            .collect())
+    }
+
     pub async fn update_harness_thread_id(
         &self,
         thread_key: &ThreadKey,
@@ -987,6 +1047,14 @@ fn prefixed_id(prefix: &str) -> String {
 
 pub fn default_metadata(metadata: Option<Value>) -> Value {
     metadata.unwrap_or_else(empty_object)
+}
+
+/// A session eligible for the janitor's idle-pause backstop.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IdleSandboxSession {
+    pub thread_key: String,
+    pub sandbox_id: String,
+    pub execution_id: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Sandbox desired state lives in process memory (`InMemoryDesiredStateStore`) and idle pauses are per-execution `tokio::spawn(sleep(...))` timers. A control-plane restart (deploy, crash, OOM-kill) therefore permanently orphans every live sandbox: the pods keep running, nothing references them, and no code path will ever stop them. `list_observed()` exists on the backend trait but is only reachable through the manual `drain` admin route.

We hit the end state of this in production-like use on a single-node cluster: dozens of unreferenced 512Mi sandbox pods accumulated until memory requests reached ~99% of allocatable, after which every new `agent_turn` failed with `sandbox readiness timed out after 60s`. The same failure class is reported in #172 (thread sandboxes never garbage-collect — which proposes exactly the periodic reconciler implemented here) and #171 (warm pods orphaned across restarts). #349 fixes the warm-pool slice of this on the legacy Python side; this PR covers all session sandboxes on the api-rs side.

## Fix

Add a periodic sandbox janitor to `centaur-session-runtime`, spawned from `main.rs` beside the existing background tasks. Two independent arms per tick:

- **Orphan sweep** — diff `backend.list_observed()` against the durable references in Postgres (`sessions.sandbox_id` ∪ `ready`/`claimed` rows in `session_warm_sandboxes`); `stop()` anything running/suspended that nothing references. Safety: a sandbox must be unreferenced on **two consecutive passes** before it is stopped (in-flight creations get a full interval to register), `Created`-status sandboxes are never touched (creation can legitimately outlast an interval while pulling images), and failed stops stay pending and retry next pass.
- **Idle backstop** — pause sessions whose latest execution is terminal, older than a TTL, with no active execution, via the existing `record_idle_pause` (which re-validates the latest execution and sandbox status, so racing a live turn is safe). This restores idle-pausing for sessions whose in-process timer died with a restart — the sandbox-pod analogue of what #486 did for executions.

Configuration (both env-tunable, additive, no behavior change when disabled):

- `--session-sandbox-janitor-interval-secs` (default 300, `0` disables the janitor)
- `--session-sandbox-janitor-idle-backstop-secs` (default 21600, `0` disables the idle arm)

No schema migration; the two new store queries are read-only.

## Verification

- `cargo fmt`; `cargo clippy --all-targets -- -D warnings` clean on the three touched crates
- `cargo test -p centaur-session-runtime -p centaur-session-sqlx -p centaur-sandbox-manager` green, including 7 new unit tests on the pure reap-selection logic (pending→reap progression, referenced rescue, terminal/`Created` skip, vanished-pending cleanup)
- Known gap, stated openly: the two SQL queries have no DB-backed test — the crate currently has no Postgres test harness; happy to add one if you have a preferred shape.

A Python-side equivalent of this fix (reconciler pod sweep + retry-on-failed-teardown in `agent.py`) has been running on our deployment since the incident; we can contribute that too if the legacy path's lifetime warrants it.

Refs #172, #171. Complements #349.