### PR TITLE
ci: build arm64 docker images

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -39,15 +39,15 @@ jobs:
   # Build each image natively per platform (amd64 on x64 runners, arm64 on
   # arm runners — no QEMU emulation), push by digest, and hand the digests
   # to the merge job below which assembles the multi-arch manifest.
-  # arm64 is only built for release publishes (main pushes, tags, manual
-  # dispatch) — PR builds stay amd64-only to keep iteration fast.
+  # arm64 is only built on pushes to main and release tags — PR and manual
+  # dispatch builds stay amd64-only to keep iteration fast.
   build:
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         service: [api-rs, slackbotv2, agent, iron-proxy]
-        platform: ${{ github.event_name == 'pull_request' && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64", "linux/arm64"]') }}
+        platform: ${{ github.event_name == 'push' && fromJSON('["linux/amd64", "linux/arm64"]') || fromJSON('["linux/amd64"]') }}
         include:
           - service: api-rs
             image: centaur-api-rs

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -102,6 +107,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ !github.event.pull_request.head.repo.fork }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -39,13 +39,15 @@ jobs:
   # Build each image natively per platform (amd64 on x64 runners, arm64 on
   # arm runners — no QEMU emulation), push by digest, and hand the digests
   # to the merge job below which assembles the multi-arch manifest.
+  # arm64 is only built for release publishes (main pushes, tags, manual
+  # dispatch) — PR builds stay amd64-only to keep iteration fast.
   build:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         service: [api-rs, slackbotv2, agent, iron-proxy]
-        platform: [linux/amd64, linux/arm64]
+        platform: ${{ github.event_name == 'pull_request' && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64", "linux/arm64"]') }}
         include:
           - service: api-rs
             image: centaur-api-rs
@@ -63,18 +65,17 @@ jobs:
             image: centaur-iron-proxy
             dockerfile: services/iron-proxy/Dockerfile
             target: ""
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            arch: amd64
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            arch: arm64
 
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+
+      - name: Derive platform slug
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_SLUG=${platform//\//-}" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -97,7 +98,7 @@ jobs:
         env:
           DOCKER_METADATA_PR_HEAD_SHA: true
 
-      - name: Build and push ${{ matrix.image }} (${{ matrix.arch }})
+      - name: Build and push ${{ matrix.image }} (${{ matrix.platform }})
         id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -113,13 +114,13 @@ jobs:
           build-args: |
             RUST_BUILD_PROFILE=${{ env.RUST_BUILD_PROFILE }}
           cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache-${{ matrix.arch }}
-            type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache-${{ env.PLATFORM_SLUG }}
+            type=gha,scope=${{ matrix.image }}-${{ env.PLATFORM_SLUG }}
           # Fork PRs run with a read-only GITHUB_TOKEN: exporting the registry
           # cache would fail the build, so only export it when we can push.
           cache-to: |
-            ${{ !github.event.pull_request.head.repo.fork && format('type=registry,ref={0}/{1}/{2}:buildcache-{3},mode=max', env.REGISTRY, env.IMAGE_NAMESPACE, matrix.image, matrix.arch) || '' }}
-            type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}
+            ${{ !github.event.pull_request.head.repo.fork && format('type=registry,ref={0}/{1}/{2}:buildcache-{3},mode=max', env.REGISTRY, env.IMAGE_NAMESPACE, matrix.image, env.PLATFORM_SLUG) || '' }}
+            type=gha,mode=max,scope=${{ matrix.image }}-${{ env.PLATFORM_SLUG }}
 
       - name: Export digest
         if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -132,7 +133,7 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: digests-${{ matrix.image }}-${{ matrix.arch }}
+          name: digests-${{ matrix.image }}-${{ env.PLATFORM_SLUG }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -36,11 +36,16 @@ env:
   RUST_BUILD_PROFILE: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && 'debug' || 'release' }}
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  # Build each image natively per platform (amd64 on x64 runners, arm64 on
+  # arm runners — no QEMU emulation), push by digest, and hand the digests
+  # to the merge job below which assembles the multi-arch manifest.
+  build:
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        service: [api-rs, slackbotv2, agent, iron-proxy]
+        platform: [linux/amd64, linux/arm64]
         include:
           - service: api-rs
             image: centaur-api-rs
@@ -58,6 +63,12 @@ jobs:
             image: centaur-iron-proxy
             dockerfile: services/iron-proxy/Dockerfile
             target: ""
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: Checkout
@@ -65,10 +76,87 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
-          platforms: arm64
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata for ${{ matrix.image }}
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.image }}
+            org.opencontainers.image.source=${{ env.IMAGE_SOURCE }}
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
+
+      - name: Build and push ${{ matrix.image }} (${{ matrix.arch }})
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Tags are applied by the merge job on the multi-arch manifest;
+          # per-arch builds are pushed by digest only. Fork PRs run with a
+          # read-only GITHUB_TOKEN, so they build without pushing.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=${{ !github.event.pull_request.head.repo.fork }}
+          build-args: |
+            RUST_BUILD_PROFILE=${{ env.RUST_BUILD_PROFILE }}
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache-${{ matrix.arch }}
+            type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          # Fork PRs run with a read-only GITHUB_TOKEN: exporting the registry
+          # cache would fail the build, so only export it when we can push.
+          cache-to: |
+            ${{ !github.event.pull_request.head.repo.fork && format('type=registry,ref={0}/{1}/{2}:buildcache-{3},mode=max', env.REGISTRY, env.IMAGE_NAMESPACE, matrix.image, matrix.arch) || '' }}
+            type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}
+
+      - name: Export digest
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.image }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: centaur-api-rs
+          - image: centaur-slackbotv2
+          - image: centaur-agent
+          - image: centaur-iron-proxy
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digests-${{ matrix.image }}-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -101,23 +189,13 @@ jobs:
         env:
           DOCKER_METADATA_PR_HEAD_SHA: true
 
-      - name: Build and push ${{ matrix.image }}
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.target }}
-          platforms: linux/amd64,linux/arm64
-          push: ${{ !github.event.pull_request.head.repo.fork }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            RUST_BUILD_PROFILE=${{ env.RUST_BUILD_PROFILE }}
-          cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:buildcache
-            type=gha,scope=${{ matrix.image }}
-          # Fork PRs run with a read-only GITHUB_TOKEN: exporting the registry
-          # cache would fail the build, so only export it when we can push.
-          cache-to: |
-            ${{ !github.event.pull_request.head.repo.fork && format('type=registry,ref={0}/{1}/{2}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAMESPACE, matrix.image) || '' }}
-            type=gha,mode=max,scope=${{ matrix.image }}
+      - name: Create multi-arch manifest for ${{ matrix.image }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Port of #370 by @OisinKyne onto the current publish-images workflow — all credit to him for the original idea and change.

## Problem to be solved

Running centaur on ARM hosts (e.g. a Mac with k3d) currently requires building all four images locally, since CI only publishes amd64.

## Proposed solution

Instead of QEMU emulation (which the original PR flagged as slow), arm64 builds run natively on GitHub's ARM runners:

- **build** job: `service × platform` matrix (8 jobs) — amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`. Each build pushes by digest only and uploads the digest as an artifact. Build caches (registry + GHA) are scoped per arch.
- **merge** job: per image, downloads the two digests and assembles the multi-arch manifest with `docker buildx imagetools create`, applying the same tag set as before via metadata-action.

Fork PRs keep the existing behavior: build without pushing (merge job is skipped).

Validated with actionlint.

Closes #370

Co-authored-by: Oisín Kyne <OisinKyne@users.noreply.github.com>