### PR TITLE
[codex] durable agent boxes and harness multiplexer

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -41,7 +41,7 @@ rules:
     verbs: ["create", "delete", "get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["delete", "get", "list", "watch"]
+    verbs: ["create", "delete", "get", "list", "watch"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["create", "delete", "get", "list", "watch"]
@@ -143,6 +143,14 @@ spec:
               value: {{ .Values.apiRs.codeModeMcp.timeoutSeconds | quote }}
             - name: CODEMODE_MAX_CONCURRENCY
               value: {{ .Values.apiRs.codeModeMcp.maxConcurrency | quote }}
+            - name: CODEMODE_BOX_PROFILE_ID
+              value: {{ .Values.apiRs.codeModeMcp.boxProfileId | quote }}
+            - name: CODEMODE_BOX_PROFILE_DISPLAY_NAME
+              value: {{ .Values.apiRs.codeModeMcp.boxProfileDisplayName | quote }}
+{{- if .Values.apiRs.codeModeMcp.boxProfileDistributionRef }}
+            - name: CODEMODE_BOX_PROFILE_DISTRIBUTION_REF
+              value: {{ .Values.apiRs.codeModeMcp.boxProfileDistributionRef | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.overlay.systemPrompt }}
             - name: CENTAUR_OVERLAY_DIR
@@ -158,6 +166,16 @@ spec:
               value: {{ .Values.apiRs.sandboxWarmPoolSize | quote }}
             - name: SESSION_SANDBOX_WARM_POOL_REPLENISH_INTERVAL_SECS
               value: {{ .Values.apiRs.sandboxWarmPoolReplenishIntervalSecs | quote }}
+            - name: SESSION_SANDBOX_STATE_VOLUME_ENABLED
+              value: {{ .Values.sandbox.stateVolume.enabled | quote }}
+            - name: SESSION_SANDBOX_STATE_VOLUME_MOUNT_PATH
+              value: {{ .Values.sandbox.stateVolume.mountPath | quote }}
+            - name: SESSION_SANDBOX_STATE_VOLUME_SIZE
+              value: {{ .Values.sandbox.stateVolume.size | quote }}
+{{- if .Values.sandbox.stateVolume.storageClassName }}
+            - name: SESSION_SANDBOX_STATE_VOLUME_STORAGE_CLASS_NAME
+              value: {{ .Values.sandbox.stateVolume.storageClassName | quote }}
+{{- end }}
             - name: SESSION_SANDBOX_K8S_NAMESPACE
               value: {{ .Release.Namespace | quote }}
             - name: SESSION_SANDBOX_IMAGE

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -149,6 +149,7 @@ sandbox:
   extraEnv: {}
   stateVolume:
     enabled: false
+    mountPath: /home/agent/state
     size: 10Gi
     storageClassName: ""
   resources:
@@ -243,9 +244,8 @@ apiRs:
     periodSeconds: 10
     timeoutSeconds: 5
   terminationGracePeriodSeconds: 35
-  # Code Mode MCP is served by api-rs at /mcp. Scripts execute in Centaur
-  # sandboxes via harness-server codemode-exec, so Kubernetes mode uses the
-  # normal per-sandbox iron-proxy and principal binding path.
+  # Code Mode MCP is served by api-rs at /mcp. Scripts execute in durable
+  # principal-owned Centaur boxes through harness-server multiplexer.
   codeModeMcp:
     enabled: false
     bootstrap: true
@@ -253,6 +253,9 @@ apiRs:
     maxOutputBytes: 10000
     timeoutSeconds: 120
     maxConcurrency: 8
+    boxProfileId: codemode-default
+    boxProfileDisplayName: Code Mode
+    boxProfileDistributionRef: ""
   extraEnv: {}
   resources: {}
 

--- a/crates/harness-server/src/codemode.rs
+++ b/crates/harness-server/src/codemode.rs
@@ -41,9 +41,17 @@ struct ExecResponse {
 }
 
 #[derive(Debug)]
-struct RunOutput {
-    output: String,
-    is_error: bool,
+pub(crate) struct CodeModeRunInput {
+    pub(crate) script: String,
+    pub(crate) timeout_seconds: Option<u64>,
+    pub(crate) max_output_bytes: Option<usize>,
+    pub(crate) principal: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CodeModeRunOutput {
+    pub(crate) output: String,
+    pub(crate) is_error: bool,
 }
 
 pub fn default_proxy_dir() -> PathBuf {
@@ -101,31 +109,45 @@ pub fn run_codemode_exec_server(config: CodeModeExecConfig) -> Result<()> {
 }
 
 fn handle_request(config: &CodeModeExecConfig, request: ExecRequest) -> ExecResponse {
+    let output = run_codemode(
+        config,
+        CodeModeRunInput {
+            script: request.script,
+            timeout_seconds: request.timeout_seconds,
+            max_output_bytes: request.max_output_bytes,
+            principal: request.principal,
+        },
+    );
+    ExecResponse {
+        id: request.id,
+        output: output.output,
+        is_error: output.is_error,
+    }
+}
+
+pub(crate) fn run_codemode(
+    config: &CodeModeExecConfig,
+    request: CodeModeRunInput,
+) -> CodeModeRunOutput {
     let principal = request
         .principal
-        .clone()
         .or_else(|| env::var("CENTAUR_CODEMODE_PRINCIPAL").ok())
         .unwrap_or_else(|| "unknown-principal".to_owned());
     let timeout = request
         .timeout_seconds
         .map_or(config.default_timeout, Duration::from_secs);
     let max_output_bytes = request.max_output_bytes.unwrap_or(config.max_output_bytes);
-    let output = run_script(
+    run_script(
         config,
         &request.script,
         timeout,
         max_output_bytes,
         &principal,
     )
-    .unwrap_or_else(|error| RunOutput {
+    .unwrap_or_else(|error| CodeModeRunOutput {
         output: format!("error: {error}"),
         is_error: true,
-    });
-    ExecResponse {
-        id: request.id,
-        output: output.output,
-        is_error: output.is_error,
-    }
+    })
 }
 
 fn run_script(
@@ -134,7 +156,7 @@ fn run_script(
     timeout: Duration,
     max_output_bytes: usize,
     principal: &str,
-) -> Result<RunOutput> {
+) -> Result<CodeModeRunOutput> {
     let id = Uuid::new_v4();
     let script_path = env::temp_dir().join(format!("codemode-{id}.py"));
     let stdout_path = env::temp_dir().join(format!("codemode-{id}.stdout"));
@@ -169,7 +191,7 @@ fn run_script(
                 failed.then(|| status.code().unwrap_or(-1)),
             );
             cleanup_paths([&script_path, &stdout_path, &stderr_path]);
-            return Ok(RunOutput {
+            return Ok(CodeModeRunOutput {
                 output,
                 is_error: failed,
             });
@@ -183,7 +205,7 @@ fn run_script(
     let _ = child.kill();
     let _ = child.wait();
     cleanup_paths([&script_path, &stdout_path, &stderr_path]);
-    Ok(RunOutput {
+    Ok(CodeModeRunOutput {
         output: format!("error: script timed out after {}s", timeout.as_secs()),
         is_error: true,
     })

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod claude;
 pub mod codemode;
 pub mod codex;
 mod error;
+pub mod multiplexer;
 mod server;
 mod traits;
 mod turn;
@@ -15,6 +16,10 @@ pub use codemode::{
     CodeModeExecConfig, default_env_dir, default_proxy_dir, run_codemode_exec_server,
 };
 pub use error::{HarnessServerError, Result};
+pub use multiplexer::{
+    HarnessProcessKind, MultiplexerCommand, MultiplexerConfig, MultiplexerEvent,
+    MultiplexerEventKind, MultiplexerRequest, run_multiplexer_server,
+};
 pub use server::{run_blocks_server, run_harness_server, run_validate_jsonrpc, server_for};
 pub use traits::{
     AppServerNormalizer, AppServerRuntime, HarnessKind, HarnessServer, NormalizedContent,

--- a/crates/harness-server/src/main.rs
+++ b/crates/harness-server/src/main.rs
@@ -1,7 +1,8 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use harness_server::{
-    CodeModeExecConfig, HarnessKind, Result, default_env_dir, default_proxy_dir, run_blocks_server,
-    run_codemode_exec_server, run_harness_server, run_validate_agent_deltas, run_validate_jsonrpc,
+    CodeModeExecConfig, HarnessKind, MultiplexerConfig, Result, default_env_dir, default_proxy_dir,
+    run_blocks_server, run_codemode_exec_server, run_harness_server, run_multiplexer_server,
+    run_validate_agent_deltas, run_validate_jsonrpc,
 };
 use std::{path::PathBuf, time::Duration};
 
@@ -23,6 +24,7 @@ enum CliCommand {
     ClaudeCode(HarnessCommand),
     Amp(HarnessCommand),
     CodemodeExec(CodeModeExecCommand),
+    Multiplexer(CodeModeExecCommand),
     ValidateJsonrpc,
     ValidateAgentDeltas,
 }
@@ -75,6 +77,15 @@ fn run() -> Result<()> {
             max_output_bytes: command.max_output_bytes,
             default_timeout: Duration::from_secs(command.default_timeout_seconds),
             max_concurrency: command.max_concurrency,
+        }),
+        CliCommand::Multiplexer(command) => run_multiplexer_server(MultiplexerConfig {
+            codemode: CodeModeExecConfig {
+                proxy_dir: command.proxy_dir,
+                env_dir: command.env_dir,
+                max_output_bytes: command.max_output_bytes,
+                default_timeout: Duration::from_secs(command.default_timeout_seconds),
+                max_concurrency: command.max_concurrency,
+            },
         }),
         CliCommand::ValidateJsonrpc => run_validate_jsonrpc(),
         CliCommand::ValidateAgentDeltas => run_validate_agent_deltas(),

--- a/crates/harness-server/src/multiplexer.rs
+++ b/crates/harness-server/src/multiplexer.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     io::{self, BufRead, Write},
     sync::{Arc, Condvar, Mutex},
     thread,
@@ -43,6 +43,8 @@ pub enum MultiplexerCommand {
         cwd: String,
         #[serde(default)]
         model: Option<String>,
+        #[serde(default)]
+        model_provider: Option<String>,
         #[serde(default)]
         metadata: Value,
     },
@@ -89,7 +91,15 @@ pub enum MultiplexerEventKind {
     #[serde(rename = "codemode.result")]
     CodeModeResult { output: String, is_error: bool },
     #[serde(rename = "session.started")]
-    SessionStarted { session_id: String },
+    SessionStarted {
+        session_id: String,
+        harness: HarnessProcessKind,
+        cwd: String,
+        #[serde(default)]
+        model: Option<String>,
+        #[serde(default)]
+        model_provider: Option<String>,
+    },
     #[serde(rename = "turn.event")]
     TurnEvent {
         session_id: String,
@@ -102,6 +112,16 @@ pub enum MultiplexerEventKind {
     SessionStopped { session_id: String },
     #[serde(rename = "error")]
     Error { message: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MultiplexerSession {
+    session_id: String,
+    harness: HarnessProcessKind,
+    cwd: String,
+    model: Option<String>,
+    model_provider: Option<String>,
+    metadata: Value,
 }
 
 pub fn run_multiplexer_server(config: MultiplexerConfig) -> Result<()> {
@@ -118,6 +138,7 @@ where
         config.codemode.max_concurrency.max(1),
     ));
     let stdout = Arc::new(Mutex::new(output));
+    let sessions = Arc::new(Mutex::new(HashMap::new()));
     let mut workers = VecDeque::new();
 
     for raw in input.lines() {
@@ -172,16 +193,91 @@ where
                     drop(permit);
                 }));
             }
-            unsupported => {
+            MultiplexerCommand::SessionStart {
+                session_id,
+                harness,
+                cwd,
+                model,
+                model_provider,
+                metadata,
+            } => {
+                let session = MultiplexerSession {
+                    session_id: session_id.clone(),
+                    harness: harness.clone(),
+                    cwd: cwd.clone(),
+                    model: model.clone(),
+                    model_provider: model_provider.clone(),
+                    metadata,
+                };
+                sessions
+                    .lock()
+                    .expect("session registry lock poisoned")
+                    .insert(session_id.clone(), session);
                 write_event(
                     &stdout,
-                    &MultiplexerEvent::error(
-                        request.id,
-                        format!(
-                            "{} is not implemented by this multiplexer yet",
-                            unsupported.type_name()
-                        ),
-                    ),
+                    &MultiplexerEvent {
+                        id: request.id,
+                        event: MultiplexerEventKind::SessionStarted {
+                            session_id,
+                            harness,
+                            cwd,
+                            model,
+                            model_provider,
+                        },
+                    },
+                )?;
+            }
+            MultiplexerCommand::SessionStop { session_id } => {
+                sessions
+                    .lock()
+                    .expect("session registry lock poisoned")
+                    .remove(&session_id);
+                write_event(
+                    &stdout,
+                    &MultiplexerEvent {
+                        id: request.id,
+                        event: MultiplexerEventKind::SessionStopped { session_id },
+                    },
+                )?;
+            }
+            MultiplexerCommand::TurnStart {
+                session_id,
+                turn_id: _,
+                input: _,
+                metadata: _,
+            } => {
+                write_session_turn_error(
+                    &stdout,
+                    &sessions,
+                    request.id,
+                    &session_id,
+                    "turn.start",
+                )?;
+            }
+            MultiplexerCommand::TurnSteer {
+                session_id,
+                turn_id: _,
+                input: _,
+                metadata: _,
+            } => {
+                write_session_turn_error(
+                    &stdout,
+                    &sessions,
+                    request.id,
+                    &session_id,
+                    "turn.steer",
+                )?;
+            }
+            MultiplexerCommand::TurnInterrupt {
+                session_id,
+                turn_id: _,
+            } => {
+                write_session_turn_error(
+                    &stdout,
+                    &sessions,
+                    request.id,
+                    &session_id,
+                    "turn.interrupt",
                 )?;
             }
         }
@@ -198,6 +294,22 @@ where
     Ok(())
 }
 
+impl MultiplexerSession {
+    fn description(&self) -> String {
+        let model = self.model.as_deref().unwrap_or("default");
+        let provider = self.model_provider.as_deref().unwrap_or("default");
+        let metadata_state = if self.metadata.is_null() {
+            "without metadata"
+        } else {
+            "with metadata"
+        };
+        format!(
+            "session {} ({:?}, provider {provider}, model {model}, cwd {}, {metadata_state})",
+            self.session_id, self.harness, self.cwd
+        )
+    }
+}
+
 impl MultiplexerCommand {
     pub fn type_name(&self) -> &'static str {
         match self {
@@ -209,6 +321,26 @@ impl MultiplexerCommand {
             Self::SessionStop { .. } => "session.stop",
         }
     }
+}
+
+fn write_session_turn_error<W: Write>(
+    stdout: &Arc<Mutex<W>>,
+    sessions: &Arc<Mutex<HashMap<String, MultiplexerSession>>>,
+    request_id: String,
+    session_id: &str,
+    command: &str,
+) -> Result<()> {
+    let message = {
+        let sessions = sessions.lock().expect("session registry lock poisoned");
+        match sessions.get(session_id) {
+            Some(session) => format!(
+                "{command} is not implemented yet for {}",
+                session.description()
+            ),
+            None => format!("{command} references unknown session {session_id}"),
+        }
+    };
+    write_event(stdout, &MultiplexerEvent::error(request_id, message))
 }
 
 impl MultiplexerEvent {
@@ -269,7 +401,26 @@ impl Drop for Permit {
 
 #[cfg(test)]
 mod tests {
+    use std::{path::PathBuf, time::Duration};
+
     use super::*;
+
+    #[derive(Clone)]
+    struct SharedOutput(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedOutput {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("shared output lock poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn codemode_request_round_trips_with_dotted_type() {
@@ -291,7 +442,7 @@ mod tests {
 
     #[test]
     fn future_session_request_shapes_are_typed() {
-        let raw = r#"{"id":"req_2","type":"session.start","session_id":"boxsess_1","harness":"codex","cwd":"/workspace","model":"gpt-5"}"#;
+        let raw = r#"{"id":"req_2","type":"session.start","session_id":"boxsess_1","harness":"codex","cwd":"/workspace","model":"gpt-5","model_provider":"openai"}"#;
         let parsed: MultiplexerRequest = serde_json::from_str(raw).expect("request parses");
         assert_eq!(
             parsed.command,
@@ -300,6 +451,7 @@ mod tests {
                 harness: HarnessProcessKind::Codex,
                 cwd: "/workspace".to_owned(),
                 model: Some("gpt-5".to_owned()),
+                model_provider: Some("openai".to_owned()),
                 metadata: Value::Null,
             }
         );
@@ -312,5 +464,66 @@ mod tests {
         assert_eq!(encoded["id"], "req_3");
         assert_eq!(encoded["type"], "error");
         assert_eq!(encoded["message"], "not ready");
+    }
+
+    #[test]
+    fn session_start_records_harness_model_and_turns_reference_session() {
+        let input = concat!(
+            r#"{"id":"req_1","type":"session.start","session_id":"boxsess_1","harness":"codex","cwd":"/workspace","model":"gpt-5","model_provider":"openai"}"#,
+            "\n",
+            r#"{"id":"req_2","type":"turn.start","session_id":"boxsess_1","turn_id":"turn_1","input":{"text":"hi"}}"#,
+            "\n",
+            r#"{"id":"req_3","type":"turn.start","session_id":"missing","turn_id":"turn_2","input":{"text":"hi"}}"#,
+            "\n",
+        );
+        let output = Arc::new(Mutex::new(Vec::new()));
+
+        run_multiplexer_io(
+            test_config(),
+            input.as_bytes(),
+            SharedOutput(output.clone()),
+        )
+        .expect("multiplexer runs");
+
+        let text = String::from_utf8(output.lock().expect("shared output lock poisoned").clone())
+            .expect("output is utf8");
+        let events = text
+            .lines()
+            .map(|line| serde_json::from_str::<MultiplexerEvent>(line).expect("event parses"))
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 3);
+        assert_eq!(
+            events[0].event,
+            MultiplexerEventKind::SessionStarted {
+                session_id: "boxsess_1".to_owned(),
+                harness: HarnessProcessKind::Codex,
+                cwd: "/workspace".to_owned(),
+                model: Some("gpt-5".to_owned()),
+                model_provider: Some("openai".to_owned()),
+            }
+        );
+        let MultiplexerEventKind::Error { message } = &events[1].event else {
+            panic!("expected turn error");
+        };
+        assert!(message.contains("turn.start is not implemented yet"));
+        assert!(message.contains("provider openai"));
+        assert!(message.contains("model gpt-5"));
+
+        let MultiplexerEventKind::Error { message } = &events[2].event else {
+            panic!("expected unknown-session error");
+        };
+        assert_eq!(message, "turn.start references unknown session missing");
+    }
+
+    fn test_config() -> MultiplexerConfig {
+        MultiplexerConfig {
+            codemode: CodeModeExecConfig {
+                proxy_dir: PathBuf::from("/tmp/proxy"),
+                env_dir: PathBuf::from("/tmp/env"),
+                max_output_bytes: 10_000,
+                default_timeout: Duration::from_secs(1),
+                max_concurrency: 1,
+            },
+        }
     }
 }

--- a/crates/harness-server/src/multiplexer.rs
+++ b/crates/harness-server/src/multiplexer.rs
@@ -1,0 +1,316 @@
+use std::{
+    collections::VecDeque,
+    io::{self, BufRead, Write},
+    sync::{Arc, Condvar, Mutex},
+    thread,
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::Result;
+use crate::codemode::{CodeModeExecConfig, CodeModeRunInput, run_codemode};
+
+#[derive(Clone, Debug)]
+pub struct MultiplexerConfig {
+    pub codemode: CodeModeExecConfig,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct MultiplexerRequest {
+    pub id: String,
+    #[serde(flatten)]
+    pub command: MultiplexerCommand,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum MultiplexerCommand {
+    #[serde(rename = "codemode.run_python")]
+    CodeModeRunPython {
+        script: String,
+        #[serde(default)]
+        timeout_seconds: Option<u64>,
+        #[serde(default)]
+        max_output_bytes: Option<usize>,
+        #[serde(default)]
+        principal: Option<String>,
+    },
+    #[serde(rename = "session.start")]
+    SessionStart {
+        session_id: String,
+        harness: HarnessProcessKind,
+        cwd: String,
+        #[serde(default)]
+        model: Option<String>,
+        #[serde(default)]
+        metadata: Value,
+    },
+    #[serde(rename = "turn.start")]
+    TurnStart {
+        session_id: String,
+        turn_id: String,
+        input: Value,
+        #[serde(default)]
+        metadata: Value,
+    },
+    #[serde(rename = "turn.steer")]
+    TurnSteer {
+        session_id: String,
+        turn_id: String,
+        input: Value,
+        #[serde(default)]
+        metadata: Value,
+    },
+    #[serde(rename = "turn.interrupt")]
+    TurnInterrupt { session_id: String, turn_id: String },
+    #[serde(rename = "session.stop")]
+    SessionStop { session_id: String },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum HarnessProcessKind {
+    Codex,
+    ClaudeCode,
+    Amp,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct MultiplexerEvent {
+    pub id: String,
+    #[serde(flatten)]
+    pub event: MultiplexerEventKind,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum MultiplexerEventKind {
+    #[serde(rename = "codemode.result")]
+    CodeModeResult { output: String, is_error: bool },
+    #[serde(rename = "session.started")]
+    SessionStarted { session_id: String },
+    #[serde(rename = "turn.event")]
+    TurnEvent {
+        session_id: String,
+        turn_id: String,
+        event: Value,
+    },
+    #[serde(rename = "turn.completed")]
+    TurnCompleted { session_id: String, turn_id: String },
+    #[serde(rename = "session.stopped")]
+    SessionStopped { session_id: String },
+    #[serde(rename = "error")]
+    Error { message: String },
+}
+
+pub fn run_multiplexer_server(config: MultiplexerConfig) -> Result<()> {
+    run_multiplexer_io(config, io::stdin().lock(), io::stdout())
+}
+
+pub(crate) fn run_multiplexer_io<R, W>(config: MultiplexerConfig, input: R, output: W) -> Result<()>
+where
+    R: BufRead,
+    W: Write + Send + 'static,
+{
+    let config = Arc::new(config);
+    let limiter = Arc::new(ConcurrencyLimiter::new(
+        config.codemode.max_concurrency.max(1),
+    ));
+    let stdout = Arc::new(Mutex::new(output));
+    let mut workers = VecDeque::new();
+
+    for raw in input.lines() {
+        let raw = raw?;
+        if raw.trim().is_empty() {
+            continue;
+        }
+        let request = match serde_json::from_str::<MultiplexerRequest>(&raw) {
+            Ok(request) => request,
+            Err(error) => {
+                write_event(
+                    &stdout,
+                    &MultiplexerEvent::error(
+                        "parse-error",
+                        format!("invalid multiplexer request JSON: {error}"),
+                    ),
+                )?;
+                continue;
+            }
+        };
+
+        match request.command {
+            MultiplexerCommand::CodeModeRunPython {
+                script,
+                timeout_seconds,
+                max_output_bytes,
+                principal,
+            } => {
+                let permit = limiter.acquire();
+                let worker_config = Arc::clone(&config);
+                let worker_stdout = Arc::clone(&stdout);
+                workers.push_back(thread::spawn(move || {
+                    let output = run_codemode(
+                        &worker_config.codemode,
+                        CodeModeRunInput {
+                            script,
+                            timeout_seconds,
+                            max_output_bytes,
+                            principal,
+                        },
+                    );
+                    let event = MultiplexerEvent {
+                        id: request.id,
+                        event: MultiplexerEventKind::CodeModeResult {
+                            output: output.output,
+                            is_error: output.is_error,
+                        },
+                    };
+                    if let Err(error) = write_event(&worker_stdout, &event) {
+                        eprintln!("multiplexer: failed to write CodeMode result: {error}");
+                    }
+                    drop(permit);
+                }));
+            }
+            unsupported => {
+                write_event(
+                    &stdout,
+                    &MultiplexerEvent::error(
+                        request.id,
+                        format!(
+                            "{} is not implemented by this multiplexer yet",
+                            unsupported.type_name()
+                        ),
+                    ),
+                )?;
+            }
+        }
+
+        while workers.front().is_some_and(thread::JoinHandle::is_finished) {
+            let worker = workers.pop_front().expect("front checked");
+            let _ = worker.join();
+        }
+    }
+
+    for worker in workers {
+        let _ = worker.join();
+    }
+    Ok(())
+}
+
+impl MultiplexerCommand {
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Self::CodeModeRunPython { .. } => "codemode.run_python",
+            Self::SessionStart { .. } => "session.start",
+            Self::TurnStart { .. } => "turn.start",
+            Self::TurnSteer { .. } => "turn.steer",
+            Self::TurnInterrupt { .. } => "turn.interrupt",
+            Self::SessionStop { .. } => "session.stop",
+        }
+    }
+}
+
+impl MultiplexerEvent {
+    pub fn error(id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            event: MultiplexerEventKind::Error {
+                message: message.into(),
+            },
+        }
+    }
+}
+
+fn write_event<W: Write>(stdout: &Arc<Mutex<W>>, event: &MultiplexerEvent) -> Result<()> {
+    let mut stdout = stdout.lock().expect("stdout lock poisoned");
+    serde_json::to_writer(&mut *stdout, event)?;
+    stdout.write_all(b"\n")?;
+    stdout.flush()?;
+    Ok(())
+}
+
+struct ConcurrencyLimiter {
+    inner: Mutex<usize>,
+    available: Condvar,
+}
+
+struct Permit {
+    limiter: Arc<ConcurrencyLimiter>,
+}
+
+impl ConcurrencyLimiter {
+    fn new(max: usize) -> Self {
+        Self {
+            inner: Mutex::new(max),
+            available: Condvar::new(),
+        }
+    }
+
+    fn acquire(self: &Arc<Self>) -> Permit {
+        let mut slots = self.inner.lock().expect("limiter lock poisoned");
+        while *slots == 0 {
+            slots = self.available.wait(slots).expect("limiter lock poisoned");
+        }
+        *slots -= 1;
+        Permit {
+            limiter: Arc::clone(self),
+        }
+    }
+}
+
+impl Drop for Permit {
+    fn drop(&mut self) {
+        let mut slots = self.limiter.inner.lock().expect("limiter lock poisoned");
+        *slots += 1;
+        self.limiter.available.notify_one();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codemode_request_round_trips_with_dotted_type() {
+        let raw = r#"{"id":"req_1","type":"codemode.run_python","script":"print(1)","timeout_seconds":5,"max_output_bytes":200,"principal":"user-1"}"#;
+        let parsed: MultiplexerRequest = serde_json::from_str(raw).expect("request parses");
+        assert_eq!(parsed.id, "req_1");
+        assert_eq!(
+            parsed.command,
+            MultiplexerCommand::CodeModeRunPython {
+                script: "print(1)".to_owned(),
+                timeout_seconds: Some(5),
+                max_output_bytes: Some(200),
+                principal: Some("user-1".to_owned()),
+            }
+        );
+        let encoded = serde_json::to_value(parsed).expect("request serializes");
+        assert_eq!(encoded["type"], "codemode.run_python");
+    }
+
+    #[test]
+    fn future_session_request_shapes_are_typed() {
+        let raw = r#"{"id":"req_2","type":"session.start","session_id":"boxsess_1","harness":"codex","cwd":"/workspace","model":"gpt-5"}"#;
+        let parsed: MultiplexerRequest = serde_json::from_str(raw).expect("request parses");
+        assert_eq!(
+            parsed.command,
+            MultiplexerCommand::SessionStart {
+                session_id: "boxsess_1".to_owned(),
+                harness: HarnessProcessKind::Codex,
+                cwd: "/workspace".to_owned(),
+                model: Some("gpt-5".to_owned()),
+                metadata: Value::Null,
+            }
+        );
+    }
+
+    #[test]
+    fn error_event_uses_request_id() {
+        let event = MultiplexerEvent::error("req_3", "not ready");
+        let encoded = serde_json::to_value(event).expect("event serializes");
+        assert_eq!(encoded["id"], "req_3");
+        assert_eq!(encoded["type"], "error");
+        assert_eq!(encoded["message"], "not ready");
+    }
+}

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -20,13 +20,14 @@ use centaur_iron_proxy::{
 };
 use centaur_sandbox_agent_k8s::{
     AgentSandboxBackend, AgentSandboxConfig, GitHubTokenRef, IronControlSettings, IronProxyConfig,
-    OtlpEgressTarget, ToolSource, ToolsConfig,
+    OtlpEgressTarget, StateVolumeConfig, ToolSource, ToolsConfig,
 };
 use centaur_sandbox_core::{Mount, MountKind, SandboxSpec};
 use centaur_sandbox_local::LocalSandboxBackend;
 use centaur_sandbox_manager::WarmPoolConfig;
-use centaur_session_core::HarnessType;
-use centaur_session_runtime::SandboxWorkloadMode;
+use centaur_session_core::{AgentProfileId, HarnessType};
+use centaur_session_runtime::{AgentBoxRuntime, SandboxWorkloadMode};
+use centaur_session_sqlx::PgSessionStore;
 use centaur_workflows::WorkflowHostSandboxRuntime;
 use clap::{Args as ClapArgs, Parser, ValueEnum};
 use tracing::{error, info, warn};
@@ -94,11 +95,12 @@ impl Args {
 
     pub(crate) async fn codemode_mcp_config(
         &self,
+        store: PgSessionStore,
         sandbox_runtime: SandboxRuntime,
         iron_control: Option<SessionRegistrar>,
     ) -> Result<Option<CodeModeMcpConfig>, ServerError> {
         self.codemode
-            .config(&self.sandbox, sandbox_runtime, iron_control)
+            .config(&self.sandbox, store, sandbox_runtime, iron_control)
             .await
     }
 }
@@ -504,17 +506,42 @@ struct CodeModeArgs {
         env = "CODEMODE_HARNESS_SERVER_PATH"
     )]
     harness_server_path: Option<PathBuf>,
+    #[arg(
+        long = "codemode-box-profile-id",
+        env = "CODEMODE_BOX_PROFILE_ID",
+        default_value = "codemode-default"
+    )]
+    box_profile_id: String,
+    #[arg(
+        long = "codemode-box-profile-display-name",
+        env = "CODEMODE_BOX_PROFILE_DISPLAY_NAME",
+        default_value = "Code Mode"
+    )]
+    box_profile_display_name: String,
+    #[arg(
+        long = "codemode-box-profile-distribution-ref",
+        env = "CODEMODE_BOX_PROFILE_DISTRIBUTION_REF"
+    )]
+    box_profile_distribution_ref: Option<String>,
 }
 
 impl CodeModeArgs {
     async fn config(
         &self,
         sandbox: &SandboxArgs,
+        store: PgSessionStore,
         runtime: SandboxRuntime,
         iron_control: Option<SessionRegistrar>,
     ) -> Result<Option<CodeModeMcpConfig>, ServerError> {
         if !self.enabled {
             return Ok(None);
+        }
+        if matches!(sandbox.backend, SandboxBackendKind::AgentK8s) && !sandbox.state_volume_enabled
+        {
+            return Err(ServerError::UnsupportedConfig(
+                "Code Mode MCP durable boxes require --session-sandbox-state-volume-enabled=true"
+                    .to_owned(),
+            ));
         }
 
         let bin_dir = self.bin_dir();
@@ -524,6 +551,26 @@ impl CodeModeArgs {
             self.bootstrap_tools(&bin_dir, &proxy_dir, &env_dir).await?;
         }
         let sandbox_spec = self.sandbox_spec(sandbox, &proxy_dir, &env_dir);
+        let box_profile_id =
+            AgentProfileId::parse(self.box_profile_id.clone()).map_err(|error| {
+                ServerError::CodeMode(format!(
+                    "invalid Code Mode box profile id {}: {error}",
+                    self.box_profile_id
+                ))
+            })?;
+        let agent_box_runtime = AgentBoxRuntime::with_spec_factory(
+            store,
+            runtime.clone(),
+            {
+                let sandbox_spec = sandbox_spec.clone();
+                move |agent_box| {
+                    sandbox_spec
+                        .clone()
+                        .env("CENTAUR_CODEMODE_PRINCIPAL", agent_box.owner_key.as_str())
+                }
+            },
+            sandbox.state_volume_mount_path.clone(),
+        );
         info!(
             index_path = %bin_dir.join(".centaur-tools.json").display(),
             proxy_dir = %proxy_dir.display(),
@@ -533,12 +580,17 @@ impl CodeModeArgs {
         );
         Ok(Some(CodeModeMcpConfig {
             runtime,
-            sandbox_spec,
+            agent_box_runtime,
             index_path: bin_dir.join(".centaur-tools.json"),
             iron_control,
             max_output_bytes: self.max_output_bytes,
             default_timeout_seconds: self.default_timeout_seconds,
             default_principal: self.default_principal.clone(),
+            box_profile_id,
+            box_profile_display_name: self.box_profile_display_name.clone(),
+            box_profile_distribution_ref: clean_optional_value(
+                self.box_profile_distribution_ref.as_deref(),
+            ),
         }))
     }
 
@@ -729,6 +781,29 @@ struct SandboxArgs {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     warm_pool_replenish_interval_secs: u64,
+    #[arg(
+        long = "session-sandbox-state-volume-enabled",
+        env = "SESSION_SANDBOX_STATE_VOLUME_ENABLED",
+        default_value_t = false
+    )]
+    state_volume_enabled: bool,
+    #[arg(
+        long = "session-sandbox-state-volume-mount-path",
+        env = "SESSION_SANDBOX_STATE_VOLUME_MOUNT_PATH",
+        default_value = "/home/agent/state"
+    )]
+    state_volume_mount_path: String,
+    #[arg(
+        long = "session-sandbox-state-volume-size",
+        env = "SESSION_SANDBOX_STATE_VOLUME_SIZE",
+        default_value = "10Gi"
+    )]
+    state_volume_size: String,
+    #[arg(
+        long = "session-sandbox-state-volume-storage-class-name",
+        env = "SESSION_SANDBOX_STATE_VOLUME_STORAGE_CLASS_NAME"
+    )]
+    state_volume_storage_class_name: Option<String>,
     #[arg(
         long = "session-sandbox-k8s-context",
         alias = "kubernetes-context",
@@ -1367,6 +1442,18 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
             .collect();
         config.ready_timeout = Duration::from_secs(args.ready_timeout_secs);
         config.iron_proxy = args.iron_proxy.to_config()?;
+        if args.state_volume_enabled {
+            let mut state_volume = StateVolumeConfig::new(
+                args.state_volume_mount_path.clone(),
+                args.state_volume_size.clone(),
+            );
+            if let Some(storage_class_name) =
+                clean_optional_value(args.state_volume_storage_class_name.as_deref())
+            {
+                state_volume = state_volume.storage_class_name(storage_class_name);
+            }
+            config.state_volume = Some(state_volume);
+        }
         if let Some(proxy) = config.iron_proxy.as_mut() {
             // The k8s backend derives the static sandbox PG DSN catalog from
             // these fragments (see `pg_sandbox_dsns`); `to_config` only ships
@@ -2033,6 +2120,30 @@ mod tests {
     }
 
     #[test]
+    fn codemode_profile_distribution_flags_are_parsed() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--codemode-mcp-enabled",
+            "--codemode-box-profile-id",
+            "hermes-researcher",
+            "--codemode-box-profile-display-name",
+            "Hermes Researcher",
+            "--codemode-box-profile-distribution-ref",
+            "nous/hermes-researcher:2026-06",
+        ])
+        .unwrap();
+
+        assert_eq!(args.codemode.box_profile_id, "hermes-researcher");
+        assert_eq!(args.codemode.box_profile_display_name, "Hermes Researcher");
+        assert_eq!(
+            args.codemode.box_profile_distribution_ref.as_deref(),
+            Some("nous/hermes-researcher:2026-06")
+        );
+    }
+
+    #[test]
     fn agent_k8s_config_converts_from_sandbox_args() {
         let args = Args::try_parse_from([
             "centaur-api-server",
@@ -2048,6 +2159,13 @@ mod tests {
             "github-access-token-read-packages, extra-secret ",
             "--session-sandbox-ready-timeout-secs",
             "42",
+            "--session-sandbox-state-volume-enabled",
+            "--session-sandbox-state-volume-mount-path",
+            "/home/agent/box",
+            "--session-sandbox-state-volume-size",
+            "20Gi",
+            "--session-sandbox-state-volume-storage-class-name",
+            "fast",
             "--kubernetes-sandbox-iron-proxy-mode",
             "disabled",
         ])
@@ -2062,6 +2180,10 @@ mod tests {
         );
         assert_eq!(config.ready_timeout, Duration::from_secs(42));
         assert!(config.iron_proxy.is_none());
+        let state_volume = config.state_volume.expect("state volume should be enabled");
+        assert_eq!(state_volume.mount_path, "/home/agent/box");
+        assert_eq!(state_volume.size, "20Gi");
+        assert_eq!(state_volume.storage_class_name.as_deref(), Some("fast"));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -605,7 +605,7 @@ impl CodeModeArgs {
         env_dir: &std::path::Path,
     ) -> SandboxSpec {
         let mut args = vec![
-            "codemode-exec".to_owned(),
+            "multiplexer".to_owned(),
             "--max-output-bytes".to_owned(),
             self.max_output_bytes.to_string(),
             "--default-timeout-seconds".to_owned(),
@@ -627,8 +627,8 @@ impl CodeModeArgs {
             .clone()
             .unwrap_or_else(|| "centaur-agent:latest".to_owned());
         let mut spec = SandboxSpec::new(image)
-            .label("centaur.ai/component", "codemode-exec")
-            .env("CENTAUR_WORKLOAD", "codemode-exec");
+            .label("centaur.ai/component", "codemode-multiplexer")
+            .env("CENTAUR_WORKLOAD", "codemode-multiplexer");
         match sandbox.backend {
             SandboxBackendKind::Local => {
                 let binary = self
@@ -1979,6 +1979,57 @@ mod tests {
 
         assert_eq!(args.sandbox.backend, SandboxBackendKind::AgentK8s);
         assert_eq!(args.sandbox.k8s_namespace, "centaur-test");
+    }
+
+    #[test]
+    fn codemode_sandbox_runs_multiplexer_workload() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--codemode-mcp-enabled",
+            "--codemode-max-output-bytes",
+            "1234",
+            "--codemode-timeout-seconds",
+            "17",
+            "--codemode-max-concurrency",
+            "3",
+        ])
+        .unwrap();
+
+        let spec = args.codemode.sandbox_spec(
+            &args.sandbox,
+            std::path::Path::new("/tmp/codemode-proxy"),
+            std::path::Path::new("/tmp/codemode-env"),
+        );
+
+        assert_eq!(spec.args[0], "multiplexer");
+        assert!(
+            spec.args
+                .windows(2)
+                .any(|pair| pair == ["--max-output-bytes", "1234"])
+        );
+        assert!(
+            spec.args
+                .windows(2)
+                .any(|pair| pair == ["--default-timeout-seconds", "17"])
+        );
+        assert!(
+            spec.args
+                .windows(2)
+                .any(|pair| pair == ["--max-concurrency", "3"])
+        );
+        assert_eq!(
+            spec.labels.get("centaur.ai/component").map(String::as_str),
+            Some("codemode-multiplexer")
+        );
+        assert_eq!(
+            spec.env
+                .iter()
+                .find(|env| env.name == "CENTAUR_WORKLOAD")
+                .map(|env| env.value.as_str()),
+            Some("codemode-multiplexer")
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/codemode_mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/codemode_mcp.rs
@@ -2,8 +2,11 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 
 use axum::Router;
 use centaur_iron_control::SessionRegistrar;
-use centaur_sandbox_core::{SandboxId, SandboxIoGuard, SandboxRead, SandboxSpec, SandboxWrite};
-use centaur_session_runtime::SandboxRuntime;
+use centaur_sandbox_core::{SandboxId, SandboxIoGuard, SandboxRead, SandboxWrite};
+use centaur_session_core::{
+    AgentBoxAccessRole, AgentBoxOwnerKey, AgentBoxOwnerScope, AgentBoxPrincipalId, AgentProfileId,
+};
+use centaur_session_runtime::{AgentBoxRuntime, EnsureAgentBoxRequest, SandboxRuntime};
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     handler::server::wrapper::Parameters,
@@ -16,6 +19,7 @@ use rmcp::{
     },
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     sync::{Mutex, oneshot},
@@ -25,12 +29,15 @@ use tokio_util::sync::CancellationToken;
 #[derive(Clone)]
 pub struct CodeModeMcpConfig {
     pub runtime: SandboxRuntime,
-    pub sandbox_spec: SandboxSpec,
+    pub agent_box_runtime: AgentBoxRuntime,
     pub index_path: PathBuf,
     pub iron_control: Option<SessionRegistrar>,
     pub max_output_bytes: usize,
     pub default_timeout_seconds: u64,
     pub default_principal: String,
+    pub box_profile_id: AgentProfileId,
+    pub box_profile_display_name: String,
+    pub box_profile_distribution_ref: Option<String>,
 }
 
 pub fn nest_codemode_mcp<S>(router: Router<S>, config: CodeModeMcpConfig) -> Router<S>
@@ -363,19 +370,30 @@ impl CodeModeExecutor {
             return Ok(session);
         }
 
-        let mut spec = self.config.sandbox_spec.clone();
-        spec = spec.env("CENTAUR_CODEMODE_PRINCIPAL", &principal.env_principal);
-        if let Some(iron_control_principal) = &principal.iron_control_principal {
-            spec.iron_control_principal = Some(iron_control_principal.clone());
-        }
-        let (sandbox_id, io) =
-            self.config
-                .runtime
-                .create_running_io(spec)
-                .await
-                .map_err(|error| {
-                    ErrorData::internal_error(format!("creating Code Mode sandbox: {error}"), None)
-                })?;
+        let request = self.agent_box_request(principal)?;
+        let (agent_box, io) = self
+            .config
+            .agent_box_runtime
+            .ensure_running_box_io(request)
+            .await
+            .map_err(|error| {
+                ErrorData::internal_error(format!("creating Code Mode agent box: {error}"), None)
+            })?;
+        let sandbox_id = SandboxId::new(
+            agent_box
+                .active_sandbox_id
+                .as_deref()
+                .ok_or_else(|| {
+                    ErrorData::internal_error(
+                        format!(
+                            "Code Mode agent box {} has no active sandbox",
+                            agent_box.box_id
+                        ),
+                        None,
+                    )
+                })?
+                .to_owned(),
+        );
 
         let pending = Arc::new(Mutex::new(HashMap::new()));
         let session = Arc::new(SandboxSession {
@@ -399,9 +417,35 @@ impl CodeModeExecutor {
             principal = %principal.env_principal,
             session_key = %principal.session_key,
             sandbox_id = %sandbox_id.as_str(),
+            agent_box_id = %agent_box.box_id,
+            profile_id = %agent_box.profile_id,
             "claimed Code Mode sandbox"
         );
         Ok(session)
+    }
+
+    fn agent_box_request(
+        &self,
+        principal: &ResolvedPrincipal,
+    ) -> Result<EnsureAgentBoxRequest, ErrorData> {
+        Ok(EnsureAgentBoxRequest {
+            profile_id: self.config.box_profile_id.clone(),
+            profile_display_name: self.config.box_profile_display_name.clone(),
+            profile_distribution_ref: self.config.box_profile_distribution_ref.clone(),
+            owner_scope: owner_scope_for_principal(&principal.env_principal),
+            owner_key: AgentBoxOwnerKey::parse(principal.env_principal.clone())
+                .map_err(internal_error)?,
+            egress_principal_id: principal.iron_control_principal.clone(),
+            grant_principal_id: Some(
+                AgentBoxPrincipalId::parse(principal.session_key.clone())
+                    .map_err(internal_error)?,
+            ),
+            grant_role: AgentBoxAccessRole::Owner,
+            metadata: json!({
+                "source": "codemode_mcp",
+                "env_principal": principal.env_principal,
+            }),
+        })
     }
 
     async fn drop_session(&self, principal: &ResolvedPrincipal) {
@@ -419,6 +463,18 @@ fn header_value(parts: Option<&http::request::Parts>, name: &'static str) -> Opt
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn owner_scope_for_principal(principal: &str) -> AgentBoxOwnerScope {
+    if principal.starts_with("slack-user-") {
+        AgentBoxOwnerScope::User
+    } else if principal.starts_with("slack-channel-") {
+        AgentBoxOwnerScope::Channel
+    } else if principal.starts_with("slack-team-") {
+        AgentBoxOwnerScope::Team
+    } else {
+        AgentBoxOwnerScope::Custom
+    }
 }
 
 async fn read_responses(
@@ -668,5 +724,30 @@ impl ToolProject {
             }
         }
         lines.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn principal_prefixes_map_to_box_owner_scopes() {
+        assert_eq!(
+            owner_scope_for_principal("slack-user-T123-U123"),
+            AgentBoxOwnerScope::User
+        );
+        assert_eq!(
+            owner_scope_for_principal("slack-channel-T123-C123"),
+            AgentBoxOwnerScope::Channel
+        );
+        assert_eq!(
+            owner_scope_for_principal("slack-team-T123"),
+            AgentBoxOwnerScope::Team
+        );
+        assert_eq!(
+            owner_scope_for_principal("prn_123"),
+            AgentBoxOwnerScope::Custom
+        );
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/codemode_mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/codemode_mcp.rs
@@ -172,7 +172,7 @@ struct CodeModeExecutor {
     claim_lock: Mutex<()>,
 }
 
-type PendingResponse = oneshot::Sender<Result<ExecResponse, String>>;
+type PendingResponse = oneshot::Sender<Result<PythonRunOutput, String>>;
 type PendingResponses = Arc<Mutex<HashMap<String, PendingResponse>>>;
 
 struct SandboxSession {
@@ -299,8 +299,9 @@ impl CodeModeExecutor {
         timeout_seconds: Option<u64>,
     ) -> Result<PythonRunOutput, ErrorData> {
         let session = self.session(principal).await?;
-        let request = ExecRequest {
+        let request = RunPythonRequest {
             id: format!("run_{}", uuid::Uuid::new_v4()),
+            request_type: "codemode.run_python",
             script,
             timeout_seconds,
             max_output_bytes: Some(self.config.max_output_bytes),
@@ -335,10 +336,7 @@ impl CodeModeExecutor {
                 ErrorData::internal_error("Code Mode sandbox response channel closed", None)
             })?
             .map_err(|message| ErrorData::internal_error(message, None))?;
-        Ok(PythonRunOutput {
-            output: response.output,
-            is_error: response.is_error,
-        })
+        Ok(response)
     }
 
     async fn session(
@@ -432,16 +430,9 @@ async fn read_responses(
     let mut lines = BufReader::new(stdout).lines();
     loop {
         match lines.next_line().await {
-            Ok(Some(line)) => match serde_json::from_str::<ExecResponse>(&line) {
+            Ok(Some(line)) => match serde_json::from_str::<MultiplexerEvent>(&line) {
                 Ok(response) => {
-                    if let Some(sender) = pending.lock().await.remove(&response.id) {
-                        let _ = sender.send(Ok(response));
-                    } else {
-                        tracing::warn!(
-                            sandbox_id = %sandbox_id.as_str(),
-                            "received stale Code Mode response"
-                        );
-                    }
+                    handle_multiplexer_event(&sandbox_id, response, &pending).await;
                 }
                 Err(error) => tracing::warn!(
                     sandbox_id = %sandbox_id.as_str(),
@@ -496,20 +487,67 @@ fn internal_error(error: impl std::fmt::Display) -> ErrorData {
     ErrorData::internal_error(error.to_string(), None)
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-struct ExecRequest {
+async fn handle_multiplexer_event(
+    sandbox_id: &SandboxId,
+    response: MultiplexerEvent,
+    pending: &PendingResponses,
+) {
+    let response_id = response.id.clone();
+    let result = match response.event {
+        MultiplexerEventKind::CodeModeResult { output, is_error } => {
+            Some(Ok(PythonRunOutput { output, is_error }))
+        }
+        MultiplexerEventKind::Error { message } => Some(Err(message)),
+        MultiplexerEventKind::Unknown => {
+            tracing::debug!(
+                sandbox_id = %sandbox_id.as_str(),
+                response_id,
+                "ignoring non-CodeMode multiplexer event"
+            );
+            None
+        }
+    };
+    let Some(result) = result else {
+        return;
+    };
+    if let Some(sender) = pending.lock().await.remove(&response_id) {
+        let _ = sender.send(result);
+    } else {
+        tracing::warn!(
+            sandbox_id = %sandbox_id.as_str(),
+            response_id,
+            "received stale Code Mode response"
+        );
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct RunPythonRequest {
     id: String,
+    #[serde(rename = "type")]
+    request_type: &'static str,
     script: String,
     timeout_seconds: Option<u64>,
     max_output_bytes: Option<usize>,
     principal: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-struct ExecResponse {
+#[derive(Debug, Deserialize)]
+struct MultiplexerEvent {
     id: String,
-    output: String,
-    is_error: bool,
+    #[serde(flatten)]
+    event: MultiplexerEventKind,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum MultiplexerEventKind {
+    #[serde(rename = "codemode.result")]
+    CodeModeResult { output: String, is_error: bool },
+    #[serde(rename = "error")]
+    Error { message: String },
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), ServerError> {
         .as_ref()
         .map(|runtime| runtime.registrar.clone());
     let codemode = args
-        .codemode_mcp_config(sandbox_runtime.clone(), codemode_registrar)
+        .codemode_mcp_config(store.clone(), sandbox_runtime.clone(), codemode_registrar)
         .await?;
     if let Some(iron_control) = iron_control {
         info!("iron-control session registration enabled");

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -232,6 +232,28 @@ impl AgentSandboxBackend {
         }
     }
 
+    async fn ensure_named_volume_claims(&self, spec: &SandboxSpec) -> SandboxResult<()> {
+        let Some(state_volume) = &self.config.state_volume else {
+            return Ok(());
+        };
+        for mount in &spec.mounts {
+            let MountKind::NamedVolume(claim_name) = &mount.kind else {
+                continue;
+            };
+            let pvc = named_volume_claim_json(claim_name, state_volume)?;
+            match self
+                .persistent_volume_claims()
+                .create(&PostParams::default(), &pvc)
+                .await
+            {
+                Ok(_) => {}
+                Err(err) if is_already_exists(&err) => {}
+                Err(err) => return Err(map_kube_error("create named volume pvc", err)),
+            }
+        }
+        Ok(())
+    }
+
     async fn wait_until_running(&self, id: &SandboxId) -> SandboxResult<()> {
         let deadline = Instant::now() + self.config.ready_timeout;
         loop {
@@ -300,6 +322,7 @@ impl SandboxBackend for AgentSandboxBackend {
     async fn create(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
         let id = SandboxId::new(next_sandbox_name());
         let mut spec = spec;
+        self.ensure_named_volume_claims(&spec).await?;
         let resolved_iron_proxy = self.resolve_iron_proxy(&id, &spec).await?;
         if let Some(resolved) = &resolved_iron_proxy {
             iron_proxy::apply_proxy_env(&mut spec, resolved);
@@ -534,7 +557,14 @@ fn build_agent_sandbox(
 
     let (mut volumes, mut volume_mounts) = mount_json(spec);
     let mut init_containers = Vec::new();
-    if let Some(state_volume) = &config.state_volume {
+    let explicit_state_mount = config.state_volume.as_ref().is_some_and(|state_volume| {
+        spec.mounts
+            .iter()
+            .any(|mount| mount.target_path == state_volume.mount_path)
+    });
+    if let Some(state_volume) = &config.state_volume
+        && !explicit_state_mount
+    {
         volume_mounts.push(json!({
             "name": "state",
             "mountPath": state_volume.mount_path,
@@ -625,7 +655,11 @@ fn build_agent_sandbox(
     insert_optional(
         &mut agent_spec,
         "volumeClaimTemplates",
-        config.state_volume.as_ref().map(state_volume_claim_json),
+        config
+            .state_volume
+            .as_ref()
+            .filter(|_| !explicit_state_mount)
+            .map(state_volume_claim_template_json),
     );
 
     let mut annotations = config.annotations.clone();
@@ -689,7 +723,7 @@ fn resources_json(spec: &SandboxSpec) -> Option<Value> {
     (!limits.is_empty()).then(|| json!({ "limits": limits }))
 }
 
-fn state_volume_claim_json(state_volume: &StateVolumeConfig) -> Vec<Value> {
+fn state_volume_claim_template_json(state_volume: &StateVolumeConfig) -> Vec<Value> {
     let mut pvc_spec = json!({
         "accessModes": ["ReadWriteOnce"],
         "resources": {
@@ -709,6 +743,32 @@ fn state_volume_claim_json(state_volume: &StateVolumeConfig) -> Vec<Value> {
         },
         "spec": pvc_spec,
     })]
+}
+
+fn named_volume_claim_json(
+    claim_name: &str,
+    state_volume: &StateVolumeConfig,
+) -> SandboxResult<PersistentVolumeClaim> {
+    let mut pvc = json!({
+        "metadata": {
+            "name": claim_name,
+        },
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {
+                "requests": {
+                    "storage": state_volume.size,
+                },
+            },
+        },
+    });
+    insert_optional(
+        &mut pvc["spec"],
+        "storageClassName",
+        state_volume.storage_class_name.clone(),
+    );
+    serde_json::from_value(pvc)
+        .map_err(|err| SandboxError::InvalidSpec(format!("invalid named volume PVC: {err}")))
 }
 
 fn state_pvc_name(id: &SandboxId) -> String {
@@ -747,6 +807,10 @@ fn is_not_found(err: &Error) -> bool {
     matches!(err, Error::Api(api_error) if api_error.code == 404)
 }
 
+fn is_already_exists(err: &Error) -> bool {
+    matches!(err, Error::Api(api_error) if api_error.code == 409)
+}
+
 fn map_kube_error(operation: &str, err: Error) -> SandboxError {
     if is_not_found(&err) {
         SandboxError::NotFound(operation.to_owned())
@@ -757,8 +821,9 @@ fn map_kube_error(operation: &str, err: Error) -> SandboxError {
 
 #[cfg(test)]
 mod tests {
-    use centaur_sandbox_core::{ResourceLimits, SandboxSpec};
+    use centaur_sandbox_core::{Mount, ResourceLimits, SandboxSpec};
     use k8s_openapi::api::core::v1::{PodCondition, PodStatus};
+    use serde_json::json;
 
     use super::*;
 
@@ -801,6 +866,55 @@ mod tests {
         assert_eq!(container.stdin, Some(true));
         assert_eq!(container.volume_mounts.as_ref().unwrap().len(), 2);
         assert!(container.resources.as_ref().unwrap().limits.is_some());
+    }
+
+    #[test]
+    fn named_state_volume_replaces_sandbox_owned_state_template() {
+        let spec = SandboxSpec::new("centaur-agent:latest").mount(Mount::new(
+            MountKind::NamedVolume("agent-box-abox-123".to_owned()),
+            "/home/agent/state",
+        ));
+        let config = AgentSandboxConfig::new("centaur")
+            .state_volume(StateVolumeConfig::new("/home/agent/state", "10Gi"));
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+
+        assert!(sandbox.spec.volume_claim_templates.is_none());
+        let container = &sandbox.spec.pod_template.spec.containers[0];
+        let mounts = container.volume_mounts.as_ref().unwrap();
+        assert_eq!(
+            mounts
+                .iter()
+                .filter(|mount| mount.mount_path == "/home/agent/state")
+                .count(),
+            1
+        );
+        let state_mount = mounts
+            .iter()
+            .find(|mount| mount.mount_path == "/home/agent/state")
+            .unwrap();
+        let volumes = sandbox.spec.pod_template.spec.volumes.as_ref().unwrap();
+        let state_volume = volumes
+            .iter()
+            .find(|volume| volume.name == state_mount.name)
+            .unwrap();
+        let claim = state_volume.persistent_volume_claim.as_ref().unwrap();
+        assert_eq!(claim.claim_name, "agent-box-abox-123");
+        assert_eq!(claim.read_only, Some(false));
+    }
+
+    #[test]
+    fn named_volume_claim_uses_state_volume_storage_settings() {
+        let state_volume =
+            StateVolumeConfig::new("/home/agent/state", "10Gi").storage_class_name("fast");
+
+        let pvc = named_volume_claim_json("agent-box-abox-123", &state_volume).unwrap();
+        let encoded = serde_json::to_value(pvc).unwrap();
+
+        assert_eq!(encoded["metadata"]["name"], "agent-box-abox-123");
+        assert_eq!(encoded["spec"]["accessModes"], json!(["ReadWriteOnce"]));
+        assert_eq!(encoded["spec"]["resources"]["requests"]["storage"], "10Gi");
+        assert_eq!(encoded["spec"]["storageClassName"], "fast");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -12,6 +12,10 @@ use thiserror::Error;
 use time::OffsetDateTime;
 
 pub const MAX_THREAD_KEY_BYTES: usize = 512;
+pub const MAX_AGENT_PROFILE_ID_BYTES: usize = 128;
+pub const MAX_AGENT_BOX_ID_BYTES: usize = 128;
+pub const MAX_AGENT_BOX_OWNER_KEY_BYTES: usize = 256;
+pub const MAX_AGENT_BOX_PRINCIPAL_BYTES: usize = 256;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ThreadKey(String);
@@ -115,6 +119,120 @@ fn validate_thread_key(value: &str) -> Result<(), ThreadKeyError> {
     Ok(())
 }
 
+macro_rules! bounded_agent_text {
+    ($name:ident, $kind:literal, $max:ident) => {
+        #[derive(Clone, Debug, Eq, PartialEq, Hash)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn parse(value: impl Into<String>) -> Result<Self, AgentIdentityError> {
+                let value = value.into();
+                validate_agent_text($kind, &value, $max)?;
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            pub fn into_string(self) -> String {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = AgentIdentityError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Self::parse(value)
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = AgentIdentityError;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                Self::parse(value)
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                self.as_str()
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::parse(value).map_err(de::Error::custom)
+            }
+        }
+    };
+}
+
+bounded_agent_text!(
+    AgentProfileId,
+    "agent profile id",
+    MAX_AGENT_PROFILE_ID_BYTES
+);
+bounded_agent_text!(AgentBoxId, "agent box id", MAX_AGENT_BOX_ID_BYTES);
+bounded_agent_text!(
+    AgentBoxOwnerKey,
+    "agent box owner key",
+    MAX_AGENT_BOX_OWNER_KEY_BYTES
+);
+bounded_agent_text!(
+    AgentBoxPrincipalId,
+    "agent box principal id",
+    MAX_AGENT_BOX_PRINCIPAL_BYTES
+);
+
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+pub enum AgentIdentityError {
+    #[error("{kind} is required")]
+    Empty { kind: &'static str },
+    #[error("{kind} must be at most {max} bytes")]
+    TooLong { kind: &'static str, max: usize },
+    #[error("{kind} must not contain ASCII control characters")]
+    ControlCharacter { kind: &'static str },
+}
+
+fn validate_agent_text(
+    kind: &'static str,
+    value: &str,
+    max: usize,
+) -> Result<(), AgentIdentityError> {
+    if value.is_empty() {
+        return Err(AgentIdentityError::Empty { kind });
+    }
+    if value.len() > max {
+        return Err(AgentIdentityError::TooLong { kind, max });
+    }
+    if value.chars().any(|ch| ch.is_ascii_control()) {
+        return Err(AgentIdentityError::ControlCharacter { kind });
+    }
+    Ok(())
+}
+
 #[derive(
     Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, AsRefStr, Display, EnumString,
 )]
@@ -148,6 +266,79 @@ pub struct Session {
     /// iron-control principal OID this session's egress proxy binds to,
     /// captured at registration so a resumed session can recreate its sandbox.
     pub iron_control_principal: Option<String>,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum AgentBoxOwnerScope {
+    User,
+    Team,
+    Channel,
+    Project,
+    Repo,
+    Thread,
+    Custom,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum AgentBoxStatus {
+    Active,
+    Suspended,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum AgentBoxAccessRole {
+    Owner,
+    Member,
+    Viewer,
+    Automation,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AgentProfile {
+    pub profile_id: AgentProfileId,
+    pub display_name: String,
+    /// Optional distribution/source ref for Hermes-style profile packages.
+    pub distribution_ref: Option<String>,
+    pub metadata: Value,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AgentBox {
+    pub box_id: AgentBoxId,
+    pub profile_id: AgentProfileId,
+    /// Ownership describes what this durable home represents. Access grants
+    /// decide who may use it, so principal resolution can evolve independently
+    /// from box identity.
+    pub owner_scope: AgentBoxOwnerScope,
+    pub owner_key: AgentBoxOwnerKey,
+    /// Stable volume key. The active sandbox may die and be replaced; the next
+    /// sandbox mounts this same state volume.
+    pub state_volume_key: String,
+    pub active_sandbox_id: Option<String>,
+    pub egress_principal_id: Option<String>,
+    pub status: AgentBoxStatus,
+    pub metadata: Value,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+    pub last_used_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AgentBoxAccessGrant {
+    pub box_id: AgentBoxId,
+    pub principal_id: AgentBoxPrincipalId,
+    pub role: AgentBoxAccessRole,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
 }
@@ -226,7 +417,7 @@ pub fn empty_object() -> Value {
 mod tests {
     use std::str::FromStr;
 
-    use super::{HarnessType, ThreadKey};
+    use super::*;
 
     #[test]
     fn thread_key_accepts_namespaced_values() {
@@ -274,5 +465,38 @@ mod tests {
     #[test]
     fn harness_type_rejects_unsupported_values() {
         assert!(HarnessType::from_str("claude-code").is_err());
+    }
+
+    #[test]
+    fn agent_box_identity_types_reject_empty_and_control_chars() {
+        assert!(AgentProfileId::parse("profile-default").is_ok());
+        assert!(AgentBoxId::parse("abox_123").is_ok());
+        assert!(AgentBoxOwnerKey::parse("slack-user-t123-u456").is_ok());
+        assert!(AgentBoxPrincipalId::parse("slack-channel-t123-c789").is_ok());
+
+        assert!(matches!(
+            AgentBoxOwnerKey::parse(""),
+            Err(AgentIdentityError::Empty { .. })
+        ));
+        assert!(matches!(
+            AgentBoxPrincipalId::parse("bad\nprincipal"),
+            Err(AgentIdentityError::ControlCharacter { .. })
+        ));
+    }
+
+    #[test]
+    fn agent_box_enums_parse_stable_storage_values() {
+        assert_eq!(
+            "team".parse::<AgentBoxOwnerScope>().unwrap(),
+            AgentBoxOwnerScope::Team
+        );
+        assert_eq!(
+            "automation".parse::<AgentBoxAccessRole>().unwrap(),
+            AgentBoxAccessRole::Automation
+        );
+        assert_eq!(
+            "suspended".parse::<AgentBoxStatus>().unwrap(),
+            AgentBoxStatus::Suspended
+        );
     }
 }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -6,15 +6,16 @@ use std::{
 
 use centaur_iron_control::SessionRegistrar;
 use centaur_sandbox_core::{
-    Mount, SandboxBackend, SandboxError, SandboxId, SandboxIoGuard, SandboxRead, SandboxSpec,
-    SandboxStatus, SandboxWrite,
+    Mount, MountKind, SandboxBackend, SandboxError, SandboxId, SandboxIoGuard, SandboxRead,
+    SandboxSpec, SandboxStatus, SandboxWrite,
 };
 use centaur_sandbox_manager::{
     SandboxManager, WarmPoolConfig, WarmPoolError, WarmPoolManager, WarmSandboxSpecFactory,
 };
 use centaur_session_core::{
-    ExecutionStatus, HarnessType, MessageRole, Session, SessionEvent, SessionExecution,
-    SessionMessageInput, ThreadKey,
+    AgentBox, AgentBoxAccessRole, AgentBoxOwnerKey, AgentBoxOwnerScope, AgentBoxPrincipalId,
+    AgentBoxStatus, AgentProfileId, ExecutionStatus, HarnessType, MessageRole, Session,
+    SessionEvent, SessionExecution, SessionMessageInput, ThreadKey,
 };
 use centaur_session_sqlx::{
     PgSessionStore, SessionEventListener, SessionStoreError, default_metadata,
@@ -44,6 +45,7 @@ const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 
 type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str) -> SandboxSpec + Send + Sync>;
+type AgentBoxSpecFactory = Arc<dyn Fn(&AgentBox) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
 type ExecutionSpanRegistry = Arc<Mutex<HashMap<String, Span>>>;
 
@@ -63,6 +65,27 @@ pub struct SandboxRuntime {
     spec_factory: SandboxSpecFactory,
     warm_spec_factory: Option<WarmSandboxSpecFactory>,
     workload_key: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct AgentBoxRuntime {
+    store: PgSessionStore,
+    sandbox_runtime: SandboxRuntime,
+    spec_factory: AgentBoxSpecFactory,
+    state_mount_path: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct EnsureAgentBoxRequest {
+    pub profile_id: AgentProfileId,
+    pub profile_display_name: String,
+    pub profile_distribution_ref: Option<String>,
+    pub owner_scope: AgentBoxOwnerScope,
+    pub owner_key: AgentBoxOwnerKey,
+    pub egress_principal_id: Option<String>,
+    pub grant_principal_id: Option<AgentBoxPrincipalId>,
+    pub grant_role: AgentBoxAccessRole,
+    pub metadata: Value,
 }
 
 #[derive(Clone, Debug)]
@@ -1371,6 +1394,13 @@ impl SandboxRuntime {
         Ok((handle.id, io))
     }
 
+    pub async fn open_sandbox_io(
+        &self,
+        sandbox_id: &SandboxId,
+    ) -> Result<centaur_sandbox_core::SandboxIoParts, SessionRuntimeError> {
+        Ok(self.manager.open_io(sandbox_id).await?.into_parts())
+    }
+
     pub async fn stop_sandbox(&self, sandbox_id: &SandboxId) -> Result<(), SessionRuntimeError> {
         self.manager.stop(sandbox_id).await?;
         Ok(())
@@ -1424,6 +1454,178 @@ impl SandboxRuntime {
             warm_spec_factory: Some(warm_spec_factory),
             workload_key: Some(workload_key),
         }
+    }
+}
+
+impl AgentBoxRuntime {
+    pub fn new(
+        store: PgSessionStore,
+        sandbox_runtime: SandboxRuntime,
+        spec: SandboxSpec,
+        state_mount_path: impl Into<String>,
+    ) -> Self {
+        Self::with_spec_factory(
+            store,
+            sandbox_runtime,
+            move |_box| spec.clone(),
+            state_mount_path,
+        )
+    }
+
+    pub fn with_spec_factory<F>(
+        store: PgSessionStore,
+        sandbox_runtime: SandboxRuntime,
+        spec_factory: F,
+        state_mount_path: impl Into<String>,
+    ) -> Self
+    where
+        F: Fn(&AgentBox) -> SandboxSpec + Send + Sync + 'static,
+    {
+        Self {
+            store,
+            sandbox_runtime,
+            spec_factory: Arc::new(spec_factory),
+            state_mount_path: state_mount_path.into(),
+        }
+    }
+
+    pub async fn ensure_running_box(
+        &self,
+        request: EnsureAgentBoxRequest,
+    ) -> Result<AgentBox, SessionRuntimeError> {
+        self.store
+            .ensure_agent_profile(
+                &request.profile_id,
+                &request.profile_display_name,
+                request.profile_distribution_ref.as_deref(),
+                empty_metadata_if_null(&request.metadata),
+            )
+            .await?;
+        let mut agent_box = self
+            .store
+            .ensure_agent_box(
+                &request.profile_id,
+                request.owner_scope,
+                &request.owner_key,
+                request.egress_principal_id.as_deref(),
+                request.metadata,
+            )
+            .await?;
+
+        if let Some(principal_id) = request.grant_principal_id {
+            self.store
+                .grant_agent_box_access(&agent_box.box_id, &principal_id, request.grant_role)
+                .await?;
+        }
+
+        agent_box = self.ensure_box_sandbox(agent_box).await?;
+        Ok(agent_box)
+    }
+
+    pub async fn ensure_running_box_io(
+        &self,
+        request: EnsureAgentBoxRequest,
+    ) -> Result<(AgentBox, centaur_sandbox_core::SandboxIoParts), SessionRuntimeError> {
+        let agent_box = self.ensure_running_box(request).await?;
+        let sandbox_id = agent_box.active_sandbox_id.as_deref().ok_or_else(|| {
+            SessionRuntimeError::BadRequest(format!(
+                "agent box {} has no active sandbox after ensure",
+                agent_box.box_id
+            ))
+        })?;
+        let io = self
+            .sandbox_runtime
+            .open_sandbox_io(&SandboxId::new(sandbox_id))
+            .await?;
+        Ok((agent_box, io))
+    }
+
+    async fn ensure_box_sandbox(
+        &self,
+        agent_box: AgentBox,
+    ) -> Result<AgentBox, SessionRuntimeError> {
+        if let Some(sandbox_id) = agent_box.active_sandbox_id.as_deref() {
+            let id = SandboxId::new(sandbox_id);
+            match self.sandbox_runtime.manager.status(&id).await {
+                Ok(status) => match existing_sandbox_action(&status) {
+                    ExistingSandboxAction::Reuse => return Ok(agent_box),
+                    ExistingSandboxAction::ResumeOrReplace => {
+                        if self.sandbox_runtime.manager.resume(&id).await.is_ok() {
+                            return self
+                                .store
+                                .set_agent_box_sandbox(
+                                    &agent_box.box_id,
+                                    Some(sandbox_id),
+                                    AgentBoxStatus::Active,
+                                )
+                                .await
+                                .map_err(Into::into);
+                        }
+                    }
+                    ExistingSandboxAction::Replace => {
+                        let _ = self.sandbox_runtime.manager.stop(&id).await;
+                    }
+                },
+                Err(SandboxError::NotFound(_)) => {}
+                Err(error) => return Err(SessionRuntimeError::Sandbox(error)),
+            }
+        }
+
+        let spec = decorate_agent_box_spec(
+            (self.spec_factory)(&agent_box),
+            &agent_box,
+            &self.state_mount_path,
+        );
+        let handle = match self.sandbox_runtime.manager.create_running(spec).await {
+            Ok(handle) => handle,
+            Err(error) => {
+                let _ = self
+                    .store
+                    .mark_agent_box_failed(&agent_box.box_id, &error.to_string())
+                    .await;
+                return Err(SessionRuntimeError::Sandbox(error));
+            }
+        };
+        self.store
+            .set_agent_box_sandbox(
+                &agent_box.box_id,
+                Some(handle.id.as_str()),
+                AgentBoxStatus::Active,
+            )
+            .await
+            .map_err(Into::into)
+    }
+}
+
+fn decorate_agent_box_spec(
+    mut spec: SandboxSpec,
+    agent_box: &AgentBox,
+    state_mount_path: &str,
+) -> SandboxSpec {
+    spec = spec
+        .label("centaur.ai/agent-box-id", agent_box.box_id.as_str())
+        .label("centaur.ai/agent-profile-id", agent_box.profile_id.as_str())
+        .env("CENTAUR_AGENT_BOX_ID", agent_box.box_id.as_str())
+        .env("CENTAUR_AGENT_PROFILE_ID", agent_box.profile_id.as_str())
+        .env(
+            "CENTAUR_AGENT_BOX_STATE_VOLUME",
+            &agent_box.state_volume_key,
+        )
+        .mount(Mount::new(
+            MountKind::NamedVolume(agent_box.state_volume_key.clone()),
+            state_mount_path,
+        ));
+    if let Some(egress_principal_id) = &agent_box.egress_principal_id {
+        spec.iron_control_principal = Some(egress_principal_id.clone());
+    }
+    spec
+}
+
+fn empty_metadata_if_null(metadata: &Value) -> Value {
+    if metadata.is_null() {
+        json!({})
+    } else {
+        metadata.clone()
     }
 }
 
@@ -3405,7 +3607,7 @@ pub enum SessionRuntimeError {
 mod tests {
     use super::*;
     use centaur_sandbox_core::MountKind;
-    use centaur_session_core::SessionStatus;
+    use centaur_session_core::{AgentBoxId, SessionStatus};
     use serde_json::json;
     use time::OffsetDateTime;
 
@@ -3896,6 +4098,46 @@ mod tests {
             existing_sandbox_action(&SandboxStatus::Unknown("rollout missing".to_owned())),
             ExistingSandboxAction::Replace
         );
+    }
+
+    #[test]
+    fn agent_box_spec_mounts_stable_state_volume() {
+        let now = OffsetDateTime::UNIX_EPOCH;
+        let agent_box = AgentBox {
+            box_id: AgentBoxId::parse("abox_123").unwrap(),
+            profile_id: AgentProfileId::parse("profile-default").unwrap(),
+            owner_scope: AgentBoxOwnerScope::Team,
+            owner_key: AgentBoxOwnerKey::parse("team-protocol").unwrap(),
+            state_volume_key: "agent-box-abox-123".to_owned(),
+            active_sandbox_id: None,
+            egress_principal_id: Some("prn_team".to_owned()),
+            status: AgentBoxStatus::Active,
+            metadata: json!({}),
+            created_at: now,
+            updated_at: now,
+            last_used_at: now,
+        };
+
+        let spec = decorate_agent_box_spec(
+            SandboxSpec::new("centaur-agent:test"),
+            &agent_box,
+            "/home/agent/box",
+        );
+
+        assert_eq!(
+            spec.labels
+                .get("centaur.ai/agent-box-id")
+                .map(String::as_str),
+            Some("abox_123")
+        );
+        assert_eq!(spec.iron_control_principal.as_deref(), Some("prn_team"));
+        assert!(spec.mounts.iter().any(|mount| {
+            mount.target_path == "/home/agent/box"
+                && mount.kind == MountKind::NamedVolume("agent-box-abox-123".to_owned())
+        }));
+        assert!(spec.env.iter().any(|env| {
+            env.name == "CENTAUR_AGENT_BOX_STATE_VOLUME" && env.value == "agent-box-abox-123"
+        }));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0011_agent_profiles_boxes.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0011_agent_profiles_boxes.sql
@@ -1,0 +1,77 @@
+create table if not exists agent_profiles (
+    profile_id text primary key,
+    display_name text not null,
+    distribution_ref text,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint agent_profiles_id_len
+        check (octet_length(profile_id) between 1 and 128),
+    constraint agent_profiles_id_no_control
+        check (profile_id !~ '[[:cntrl:]]'),
+    constraint agent_profiles_display_name_len
+        check (octet_length(display_name) between 1 and 512),
+    constraint agent_profiles_distribution_ref_len
+        check (distribution_ref is null or octet_length(distribution_ref) between 1 and 1024)
+);
+
+create table if not exists agent_boxes (
+    box_id text primary key,
+    profile_id text not null references agent_profiles(profile_id) on delete restrict,
+    owner_scope text not null,
+    owner_key text not null,
+    state_volume_key text not null unique,
+    active_sandbox_id text unique,
+    egress_principal_id text,
+    status text not null,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    last_used_at timestamptz not null default now(),
+    constraint agent_boxes_id_len
+        check (octet_length(box_id) between 1 and 128),
+    constraint agent_boxes_id_no_control
+        check (box_id !~ '[[:cntrl:]]'),
+    constraint agent_boxes_owner_scope_supported
+        check (owner_scope in ('user', 'team', 'channel', 'project', 'repo', 'thread', 'custom')),
+    constraint agent_boxes_owner_key_len
+        check (octet_length(owner_key) between 1 and 256),
+    constraint agent_boxes_owner_key_no_control
+        check (owner_key !~ '[[:cntrl:]]'),
+    constraint agent_boxes_state_volume_key_len
+        check (octet_length(state_volume_key) between 1 and 253),
+    constraint agent_boxes_active_sandbox_id_len
+        check (active_sandbox_id is null or octet_length(active_sandbox_id) between 1 and 253),
+    constraint agent_boxes_egress_principal_len
+        check (egress_principal_id is null or octet_length(egress_principal_id) between 1 and 256),
+    constraint agent_boxes_status_supported
+        check (status in ('active', 'suspended', 'failed'))
+);
+
+create unique index if not exists agent_boxes_owner_profile_idx
+    on agent_boxes (owner_scope, owner_key, profile_id);
+
+create index if not exists agent_boxes_status_last_used_idx
+    on agent_boxes (status, last_used_at desc);
+
+create index if not exists agent_boxes_active_sandbox_idx
+    on agent_boxes (active_sandbox_id)
+    where active_sandbox_id is not null;
+
+create table if not exists agent_box_access_grants (
+    box_id text not null references agent_boxes(box_id) on delete cascade,
+    principal_id text not null,
+    role text not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    primary key (box_id, principal_id),
+    constraint agent_box_access_principal_len
+        check (octet_length(principal_id) between 1 and 256),
+    constraint agent_box_access_principal_no_control
+        check (principal_id !~ '[[:cntrl:]]'),
+    constraint agent_box_access_role_supported
+        check (role in ('owner', 'member', 'viewer', 'automation'))
+);
+
+create index if not exists agent_box_access_principal_idx
+    on agent_box_access_grants (principal_id, role);

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -3,6 +3,8 @@
 use std::str::FromStr;
 
 use centaur_session_core::{
+    AgentBox, AgentBoxAccessGrant, AgentBoxAccessRole, AgentBoxId, AgentBoxOwnerKey,
+    AgentBoxOwnerScope, AgentBoxPrincipalId, AgentBoxStatus, AgentProfile, AgentProfileId,
     ExecutionStatus, HarnessType, Session, SessionEvent, SessionExecution, SessionMessage,
     SessionMessageInput, SessionStatus, ThreadKey, empty_object,
 };
@@ -613,6 +615,239 @@ impl PgSessionStore {
         Ok(())
     }
 
+    pub async fn ensure_agent_profile(
+        &self,
+        profile_id: &AgentProfileId,
+        display_name: &str,
+        distribution_ref: Option<&str>,
+        metadata: Value,
+    ) -> Result<AgentProfile, SessionStoreError> {
+        let row = sqlx::query_as::<_, AgentProfileRow>(
+            r#"
+            insert into agent_profiles
+                (profile_id, display_name, distribution_ref, metadata)
+            values ($1, $2, $3, $4)
+            on conflict (profile_id) do update
+            set
+                display_name = excluded.display_name,
+                distribution_ref = coalesce(excluded.distribution_ref, agent_profiles.distribution_ref),
+                metadata = case
+                    when excluded.metadata = '{}'::jsonb then agent_profiles.metadata
+                    else agent_profiles.metadata || excluded.metadata
+                end,
+                updated_at = now()
+            returning
+                profile_id,
+                display_name,
+                distribution_ref,
+                metadata,
+                created_at,
+                updated_at
+            "#,
+        )
+        .bind(profile_id.as_str())
+        .bind(display_name)
+        .bind(distribution_ref)
+        .bind(metadata)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn ensure_agent_box(
+        &self,
+        profile_id: &AgentProfileId,
+        owner_scope: AgentBoxOwnerScope,
+        owner_key: &AgentBoxOwnerKey,
+        egress_principal_id: Option<&str>,
+        metadata: Value,
+    ) -> Result<AgentBox, SessionStoreError> {
+        let box_id = prefixed_id("abox");
+        let state_volume_key = stable_box_volume_key(&box_id);
+        let row = sqlx::query_as::<_, AgentBoxRow>(
+            r#"
+            insert into agent_boxes
+                (
+                    box_id,
+                    profile_id,
+                    owner_scope,
+                    owner_key,
+                    state_volume_key,
+                    egress_principal_id,
+                    status,
+                    metadata
+                )
+            values ($1, $2, $3, $4, $5, $6, $7, $8)
+            on conflict (owner_scope, owner_key, profile_id) do update
+            set
+                egress_principal_id = coalesce(excluded.egress_principal_id, agent_boxes.egress_principal_id),
+                metadata = case
+                    when excluded.metadata = '{}'::jsonb then agent_boxes.metadata
+                    else agent_boxes.metadata || excluded.metadata
+                end,
+                updated_at = now(),
+                last_used_at = now()
+            returning
+                box_id,
+                profile_id,
+                owner_scope,
+                owner_key,
+                state_volume_key,
+                active_sandbox_id,
+                egress_principal_id,
+                status,
+                metadata,
+                created_at,
+                updated_at,
+                last_used_at
+            "#,
+        )
+        .bind(&box_id)
+        .bind(profile_id.as_str())
+        .bind(owner_scope.as_ref())
+        .bind(owner_key.as_str())
+        .bind(&state_volume_key)
+        .bind(egress_principal_id)
+        .bind(AgentBoxStatus::Active.as_ref())
+        .bind(metadata)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn get_agent_box(
+        &self,
+        box_id: &AgentBoxId,
+    ) -> Result<Option<AgentBox>, SessionStoreError> {
+        let row = sqlx::query_as::<_, AgentBoxRow>(
+            r#"
+            select
+                box_id,
+                profile_id,
+                owner_scope,
+                owner_key,
+                state_volume_key,
+                active_sandbox_id,
+                egress_principal_id,
+                status,
+                metadata,
+                created_at,
+                updated_at,
+                last_used_at
+            from agent_boxes
+            where box_id = $1
+            "#,
+        )
+        .bind(box_id.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(TryInto::try_into).transpose()
+    }
+
+    pub async fn set_agent_box_sandbox(
+        &self,
+        box_id: &AgentBoxId,
+        active_sandbox_id: Option<&str>,
+        status: AgentBoxStatus,
+    ) -> Result<AgentBox, SessionStoreError> {
+        let row = sqlx::query_as::<_, AgentBoxRow>(
+            r#"
+            update agent_boxes
+            set
+                active_sandbox_id = $2,
+                status = $3,
+                updated_at = now(),
+                last_used_at = now()
+            where box_id = $1
+            returning
+                box_id,
+                profile_id,
+                owner_scope,
+                owner_key,
+                state_volume_key,
+                active_sandbox_id,
+                egress_principal_id,
+                status,
+                metadata,
+                created_at,
+                updated_at,
+                last_used_at
+            "#,
+        )
+        .bind(box_id.as_str())
+        .bind(active_sandbox_id)
+        .bind(status.as_ref())
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn mark_agent_box_failed(
+        &self,
+        box_id: &AgentBoxId,
+        error: &str,
+    ) -> Result<AgentBox, SessionStoreError> {
+        let row = sqlx::query_as::<_, AgentBoxRow>(
+            r#"
+            update agent_boxes
+            set
+                status = $2,
+                metadata = metadata || jsonb_build_object('last_error', $3::text),
+                updated_at = now()
+            where box_id = $1
+            returning
+                box_id,
+                profile_id,
+                owner_scope,
+                owner_key,
+                state_volume_key,
+                active_sandbox_id,
+                egress_principal_id,
+                status,
+                metadata,
+                created_at,
+                updated_at,
+                last_used_at
+            "#,
+        )
+        .bind(box_id.as_str())
+        .bind(AgentBoxStatus::Failed.as_ref())
+        .bind(error)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn grant_agent_box_access(
+        &self,
+        box_id: &AgentBoxId,
+        principal_id: &AgentBoxPrincipalId,
+        role: AgentBoxAccessRole,
+    ) -> Result<AgentBoxAccessGrant, SessionStoreError> {
+        let row = sqlx::query_as::<_, AgentBoxAccessGrantRow>(
+            r#"
+            insert into agent_box_access_grants
+                (box_id, principal_id, role)
+            values ($1, $2, $3)
+            on conflict (box_id, principal_id) do update
+            set role = excluded.role, updated_at = now()
+            returning box_id, principal_id, role, created_at, updated_at
+            "#,
+        )
+        .bind(box_id.as_str())
+        .bind(principal_id.as_str())
+        .bind(role.as_ref())
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
     pub async fn update_harness_thread_id(
         &self,
         thread_key: &ThreadKey,
@@ -876,6 +1111,91 @@ impl TryFrom<SessionEventRow> for SessionEvent {
     }
 }
 
+#[derive(Debug, FromRow)]
+struct AgentProfileRow {
+    profile_id: String,
+    display_name: String,
+    distribution_ref: Option<String>,
+    metadata: Value,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+}
+
+impl TryFrom<AgentProfileRow> for AgentProfile {
+    type Error = SessionStoreError;
+
+    fn try_from(row: AgentProfileRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            profile_id: parse_persisted(row.profile_id)?,
+            display_name: row.display_name,
+            distribution_ref: row.distribution_ref,
+            metadata: row.metadata,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct AgentBoxRow {
+    box_id: String,
+    profile_id: String,
+    owner_scope: String,
+    owner_key: String,
+    state_volume_key: String,
+    active_sandbox_id: Option<String>,
+    egress_principal_id: Option<String>,
+    status: String,
+    metadata: Value,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+    last_used_at: OffsetDateTime,
+}
+
+impl TryFrom<AgentBoxRow> for AgentBox {
+    type Error = SessionStoreError;
+
+    fn try_from(row: AgentBoxRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            box_id: parse_persisted(row.box_id)?,
+            profile_id: parse_persisted(row.profile_id)?,
+            owner_scope: parse_persisted(row.owner_scope)?,
+            owner_key: parse_persisted(row.owner_key)?,
+            state_volume_key: row.state_volume_key,
+            active_sandbox_id: row.active_sandbox_id,
+            egress_principal_id: row.egress_principal_id,
+            status: parse_persisted(row.status)?,
+            metadata: row.metadata,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            last_used_at: row.last_used_at,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct AgentBoxAccessGrantRow {
+    box_id: String,
+    principal_id: String,
+    role: String,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+}
+
+impl TryFrom<AgentBoxAccessGrantRow> for AgentBoxAccessGrant {
+    type Error = SessionStoreError;
+
+    fn try_from(row: AgentBoxAccessGrantRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            box_id: parse_persisted(row.box_id)?,
+            principal_id: parse_persisted(row.principal_id)?,
+            role: parse_persisted(row.role)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
 fn parse_persisted<T>(value: String) -> Result<T, SessionStoreError>
 where
     T: FromStr,
@@ -888,6 +1208,10 @@ where
 
 fn prefixed_id(prefix: &str) -> String {
     format!("{prefix}_{}", Uuid::new_v4().simple())
+}
+
+fn stable_box_volume_key(box_id: &str) -> String {
+    format!("agent-box-{}", box_id.replace('_', "-"))
 }
 
 pub fn default_metadata(metadata: Option<Value>) -> Value {


### PR DESCRIPTION
## Summary
- Add a typed harness-server multiplexer protocol with CodeMode execution plus session.start envelopes for harness/model/provider selection.
- Route CodeMode MCP through the multiplexer and durable agent boxes keyed by owner scope/key/profile.
- Add agent profile/box SQL tables, runtime helpers, stable named PVC mounting, and Helm state-volume wiring.

## Validation
- cargo test --manifest-path crates/harness-server/Cargo.toml
- cargo test -p centaur-api-server -p centaur-session-core -p centaur-session-sqlx -p centaur-session-runtime -p centaur-sandbox-agent-k8s
- just build-one api-rs
- just build-one agent
- git diff --check
- Local K8s E2E on OrbStack namespace `muxbox` with images `centaur-api-rs:user-box-runtime-fa3cf57` and `centaur-agent:user-box-runtime-fa3cf57`:
  - Deployed api-rs + Postgres with CodeMode MCP enabled and sandbox state volumes enabled.
  - Initialized `/mcp`, called `run_python` for principal `local-proof-user`, and wrote/read `/home/agent/state/local-proof.txt`; response was `durable-ok`.
  - Verified DB row `abox_aba4faa0f4f449ada6bcb04be10def6a` with `owner_scope=custom`, `owner_key=local-proof-user`, `state_volume_key=agent-box-abox-aba4faa0f4f449ada6bcb04be10def6a`, active sandbox `asbx-1781274923826-1`.
  - Deleted sandbox `asbx-1781274923826-1`; next `run_python` reclaimed once, created `asbx-1781274978604-2`, and returned `durable-ok` from the same state PVC.

## Notes
- Base branch is codemode-tool-calling.
- Real harness binary integration tests remain ignored as before because they require local auth/networked CLIs.