### PR TITLE
fix(sandbox): restore codex as the default harness

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.52
+version: 0.1.53
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -166,9 +166,7 @@ sandbox:
   # Which harness the sandbox runs: codex | amp | claudecode. Selects the
   # iron-proxy auth fragment api-rs registers and must agree with the sandbox
   # image's default CMD (services/sandbox/Dockerfile).
-  # NOTE: claudecode is a preview-463 dogfood default — flip back to codex
-  # (together with the Dockerfile CMD) before merging.
-  harnessEngine: claudecode
+  harnessEngine: codex
   extraEnv: {}
   stateVolume:
     enabled: false

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -232,6 +232,4 @@ COPY --link --chown=1001:1001 services/sandbox/SYSTEM_PROMPT.md /home/agent/AGEN
 
 ENTRYPOINT ["/entrypoint.sh"]
 # Default CMD uses Rust blocks mode; pass --mode=jsonrpc for raw App Server JSON-RPC.
-# NOTE: claude-code is a preview-463 dogfood default — flip back to codex
-# (together with sandbox.harnessEngine in contrib/chart) before merging.
-CMD ["harness-server", "claude-code"]
+CMD ["harness-server", "codex"]


### PR DESCRIPTION
## Problem
The sandbox image `CMD` and the chart's `sandbox.harnessEngine` both default to **claude-code**, carried in from the api-rs migration (#344). Both lines carry a NOTE:

> `claude-code is a preview-463 dogfood default — flip back to codex (together with …) before merging.`

…but it shipped to `main` un-reverted.

Since the harness engine is fixed by the image `CMD` (`harness-server codex|claude-code|amp`) with no chart/api-rs override, this makes claude-code the de-facto default for any deployment tracking the chart at `main`. A deployment provisioned for codex (`OPENAI_API_KEY` via the proxy) then runs claude-code with no Anthropic credential and fails with **`Not logged in · Please run /login`**. codex is also the native protocol (Codex App Server V2) and `harness-server`'s own no-arg default.

## Change
Restore the documented-intended default:
- `services/sandbox/Dockerfile`: `CMD ["harness-server", "codex"]`
- `contrib/chart/values.yaml`: `sandbox.harnessEngine: codex`

Operators who want to dogfood claude-code can still set `sandbox.harnessEngine` (and the image CMD).

## Question
Was shipping claude-code as the `main` default intentional (an ongoing dogfood), or an oversight per the NOTE? If intentional, feel free to close — happy to defer. Either way the comment seemed worth surfacing.