### PR TITLE
fix(api-rs): deliver overlay.systemPrompt to sandboxes

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.55
+version: 0.1.56
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -133,6 +133,10 @@ spec:
 {{- if .Values.overlay.systemPrompt }}
             - name: CENTAUR_OVERLAY_DIR
               value: {{ .Values.overlay.mountPath | quote }}
+            # api-rs mounts this ConfigMap's SYSTEM_PROMPT.md into each sandbox as
+            # ~/AGENTS_OVERLAY.md (the entrypoint appends it to AGENTS.md).
+            - name: KUBERNETES_OVERLAY_CONFIGMAP
+              value: {{ include "centaur.componentName" (dict "root" . "component" "overlay") | quote }}
 {{- end }}
             - name: SESSION_SANDBOX_BACKEND
               value: {{ .Values.apiRs.sandboxBackend | quote }}

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -2364,7 +2364,10 @@ mod tests {
             .find(|mount| mount.target_path == SANDBOX_OVERLAY_PROMPT_PATH)
             .expect("overlay prompt mount present");
         assert!(overlay.read_only);
-        assert_eq!(overlay.sub_path.as_deref(), Some(OVERLAY_CONFIGMAP_PROMPT_KEY));
+        assert_eq!(
+            overlay.sub_path.as_deref(),
+            Some(OVERLAY_CONFIGMAP_PROMPT_KEY)
+        );
         assert_eq!(
             overlay.kind,
             MountKind::ConfigMap {

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -39,6 +39,12 @@ use crate::{
 };
 
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
+/// Where the org overlay system prompt is mounted in the sandbox. The sandbox
+/// entrypoint appends this file to the agent's effective `AGENTS.md`.
+const SANDBOX_OVERLAY_PROMPT_PATH: &str = "/home/agent/AGENTS_OVERLAY.md";
+/// Key in the overlay ConfigMap (rendered from `overlay.systemPrompt`) holding
+/// the prompt; projected as `SANDBOX_OVERLAY_PROMPT_PATH` via `subPath`.
+const OVERLAY_CONFIGMAP_PROMPT_KEY: &str = "SYSTEM_PROMPT.md";
 
 /// OTLP env always forwarded from the api-rs process into codex sandboxes,
 /// mirroring the Python control plane's `_SANDBOX_PASSTHROUGH_ENV_KEYS`. The
@@ -540,6 +546,14 @@ struct SandboxArgs {
     centaur_api_url: Option<String>,
     #[arg(long = "repos-path", env = "REPOS_PATH")]
     repos_path: Option<String>,
+    /// Name of the ConfigMap holding the org overlay system prompt (key
+    /// `SYSTEM_PROMPT.md`, rendered from the chart's `overlay.systemPrompt`).
+    /// When set, api-rs mounts that key into each sandbox as
+    /// `~/AGENTS_OVERLAY.md`, which the sandbox entrypoint appends to the
+    /// agent's `AGENTS.md`. Mirrors how the legacy Python control plane injected
+    /// the assembled prompt via a ConfigMap `subPath` mount.
+    #[arg(long = "overlay-configmap", env = "KUBERNETES_OVERLAY_CONFIGMAP")]
+    overlay_configmap: Option<String>,
     #[arg(
         long = "session-sandbox-passthrough-env",
         env = "SESSION_SANDBOX_PASSTHROUGH_ENV",
@@ -838,6 +852,20 @@ impl SandboxArgs {
                             },
                             SANDBOX_REPOS_MOUNT_PATH,
                         )
+                        .read_only(),
+                    );
+                }
+                if let Some(overlay_configmap) =
+                    clean_optional_value(self.overlay_configmap.as_deref())
+                {
+                    workload = workload.mount(
+                        Mount::new(
+                            MountKind::ConfigMap {
+                                name: overlay_configmap,
+                            },
+                            SANDBOX_OVERLAY_PROMPT_PATH,
+                        )
+                        .sub_path(OVERLAY_CONFIGMAP_PROMPT_KEY)
                         .read_only(),
                     );
                 }
@@ -2311,6 +2339,60 @@ mod tests {
                         source_path: "/var/lib/centaur/repos".to_owned(),
                     })
         }));
+    }
+
+    #[test]
+    fn codex_workload_mounts_overlay_configmap_as_agents_overlay() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-workload",
+            "codex-app-server",
+            "--overlay-configmap",
+            "centaur-centaur-overlay",
+        ])
+        .unwrap();
+
+        let workload = args.sandbox.container_workload_mode().unwrap();
+        let SandboxWorkloadMode::CodexAppServer { mounts, .. } = workload else {
+            panic!("expected codex app server workload");
+        };
+
+        let overlay = mounts
+            .iter()
+            .find(|mount| mount.target_path == SANDBOX_OVERLAY_PROMPT_PATH)
+            .expect("overlay prompt mount present");
+        assert!(overlay.read_only);
+        assert_eq!(overlay.sub_path.as_deref(), Some(OVERLAY_CONFIGMAP_PROMPT_KEY));
+        assert_eq!(
+            overlay.kind,
+            MountKind::ConfigMap {
+                name: "centaur-centaur-overlay".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn codex_workload_has_no_overlay_mount_when_unset() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-workload",
+            "codex-app-server",
+        ])
+        .unwrap();
+
+        let workload = args.sandbox.container_workload_mode().unwrap();
+        let SandboxWorkloadMode::CodexAppServer { mounts, .. } = workload else {
+            panic!("expected codex app server workload");
+        };
+        assert!(
+            !mounts
+                .iter()
+                .any(|mount| mount.target_path == SANDBOX_OVERLAY_PROMPT_PATH)
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -729,11 +729,15 @@ fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
     let mut mounts = Vec::with_capacity(spec.mounts.len());
     for (index, mount) in spec.mounts.iter().enumerate() {
         let name = format!("mount-{index}");
-        mounts.push(json!({
+        let mut volume_mount = json!({
             "name": name,
             "mountPath": mount.target_path,
             "readOnly": mount.read_only,
-        }));
+        });
+        if let Some(sub_path) = &mount.sub_path {
+            volume_mount["subPath"] = json!(sub_path);
+        }
+        mounts.push(volume_mount);
         volumes.push(match &mount.kind {
             MountKind::EmptyDir => json!({
                 "name": name,
@@ -750,6 +754,12 @@ fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
                 "name": name,
                 "hostPath": {
                     "path": source_path,
+                },
+            }),
+            MountKind::ConfigMap { name: configmap_name } => json!({
+                "name": name,
+                "configMap": {
+                    "name": configmap_name,
                 },
             }),
         });
@@ -841,6 +851,32 @@ mod tests {
     use k8s_openapi::api::core::v1::{PodCondition, PodStatus};
 
     use super::*;
+
+    #[test]
+    fn mount_json_renders_configmap_subpath() {
+        let spec = SandboxSpec::new("centaur-agent:latest").mount(
+            centaur_sandbox_core::Mount::new(
+                MountKind::ConfigMap {
+                    name: "centaur-centaur-overlay".to_owned(),
+                },
+                "/home/agent/AGENTS_OVERLAY.md",
+            )
+            .sub_path("SYSTEM_PROMPT.md")
+            .read_only(),
+        );
+
+        let (volumes, mounts) = mount_json(&spec);
+
+        assert_eq!(volumes.len(), 1);
+        assert_eq!(volumes[0]["configMap"]["name"], "centaur-centaur-overlay");
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0]["mountPath"], "/home/agent/AGENTS_OVERLAY.md");
+        assert_eq!(mounts[0]["subPath"], "SYSTEM_PROMPT.md");
+        assert_eq!(mounts[0]["readOnly"], true);
+        // The generated volume name and volumeMount name must match so the
+        // mount resolves to the volume.
+        assert_eq!(volumes[0]["name"], mounts[0]["name"]);
+    }
 
     #[test]
     fn builds_agent_sandbox_spec_with_state_volume_and_limits() {

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -756,10 +756,14 @@ fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
                     "path": source_path,
                 },
             }),
+            // `optional` so a missing/misnamed ConfigMap degrades gracefully
+            // (the consumer treats the mounted file as optional) instead of
+            // wedging the pod in ContainerCreating.
             MountKind::ConfigMap { name: configmap_name } => json!({
                 "name": name,
                 "configMap": {
                     "name": configmap_name,
+                    "optional": true,
                 },
             }),
         });
@@ -869,6 +873,7 @@ mod tests {
 
         assert_eq!(volumes.len(), 1);
         assert_eq!(volumes[0]["configMap"]["name"], "centaur-centaur-overlay");
+        assert_eq!(volumes[0]["configMap"]["optional"], true);
         assert_eq!(mounts.len(), 1);
         assert_eq!(mounts[0]["mountPath"], "/home/agent/AGENTS_OVERLAY.md");
         assert_eq!(mounts[0]["subPath"], "SYSTEM_PROMPT.md");
@@ -876,6 +881,53 @@ mod tests {
         // The generated volume name and volumeMount name must match so the
         // mount resolves to the volume.
         assert_eq!(volumes[0]["name"], mounts[0]["name"]);
+    }
+
+    #[test]
+    fn agent_sandbox_crd_round_trips_configmap_overlay_mount() {
+        // Guards the load-bearing step the isolated mount_json test can't: the
+        // rendered JSON must survive deserialization into the typed
+        // agents.x-k8s.io Sandbox CRD without the configMap volume / subPath
+        // being silently dropped (e.g. after a CRD regen).
+        let spec = SandboxSpec::new("centaur-agent:latest").mount(
+            centaur_sandbox_core::Mount::new(
+                MountKind::ConfigMap {
+                    name: "centaur-centaur-overlay".to_owned(),
+                },
+                "/home/agent/AGENTS_OVERLAY.md",
+            )
+            .sub_path("SYSTEM_PROMPT.md")
+            .read_only(),
+        );
+        let config = AgentSandboxConfig::new("centaur");
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+        let pod_spec = &sandbox.spec.pod_template.spec;
+
+        let volume = pod_spec
+            .volumes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|v| {
+                v.config_map
+                    .as_ref()
+                    .and_then(|cm| cm.name.as_deref())
+                    == Some("centaur-centaur-overlay")
+            })
+            .expect("overlay configMap volume present in CRD");
+        assert_eq!(volume.config_map.as_ref().unwrap().optional, Some(true));
+
+        let mount = pod_spec.containers[0]
+            .volume_mounts
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|m| m.mount_path == "/home/agent/AGENTS_OVERLAY.md")
+            .expect("overlay volumeMount present in CRD");
+        assert_eq!(mount.sub_path.as_deref(), Some("SYSTEM_PROMPT.md"));
+        assert_eq!(mount.name, volume.name);
+        assert_eq!(mount.read_only, Some(true));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -759,7 +759,9 @@ fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
             // `optional` so a missing/misnamed ConfigMap degrades gracefully
             // (the consumer treats the mounted file as optional) instead of
             // wedging the pod in ContainerCreating.
-            MountKind::ConfigMap { name: configmap_name } => json!({
+            MountKind::ConfigMap {
+                name: configmap_name,
+            } => json!({
                 "name": name,
                 "configMap": {
                     "name": configmap_name,
@@ -910,9 +912,7 @@ mod tests {
             .unwrap()
             .iter()
             .find(|v| {
-                v.config_map
-                    .as_ref()
-                    .and_then(|cm| cm.name.as_deref())
+                v.config_map.as_ref().and_then(|cm| cm.name.as_deref())
                     == Some("centaur-centaur-overlay")
             })
             .expect("overlay configMap volume present in CRD");

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -126,10 +126,14 @@ impl Mount {
 pub enum MountKind {
     EmptyDir,
     NamedVolume(String),
-    Bind { source_path: String },
+    Bind {
+        source_path: String,
+    },
     /// A Kubernetes ConfigMap by name. Combined with `Mount::sub_path`, a single
     /// key is projected as one file.
-    ConfigMap { name: String },
+    ConfigMap {
+        name: String,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -94,6 +94,11 @@ pub struct Mount {
     pub kind: MountKind,
     pub target_path: String,
     pub read_only: bool,
+    /// Mount only this single sub-path of the source into `target_path`
+    /// (Kubernetes `volumeMount.subPath`). Lets a single ConfigMap key be
+    /// mounted as one file (e.g. the overlay prompt as `~/AGENTS_OVERLAY.md`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sub_path: Option<String>,
 }
 
 impl Mount {
@@ -102,11 +107,17 @@ impl Mount {
             kind,
             target_path: target_path.into(),
             read_only: false,
+            sub_path: None,
         }
     }
 
     pub fn read_only(mut self) -> Self {
         self.read_only = true;
+        self
+    }
+
+    pub fn sub_path(mut self, sub_path: impl Into<String>) -> Self {
+        self.sub_path = Some(sub_path.into());
         self
     }
 }
@@ -116,6 +127,9 @@ pub enum MountKind {
     EmptyDir,
     NamedVolume(String),
     Bind { source_path: String },
+    /// A Kubernetes ConfigMap by name. Combined with `Mount::sub_path`, a single
+    /// key is projected as one file.
+    ConfigMap { name: String },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem
`overlay.systemPrompt` is a no-op on the Rust control plane. The chart renders it into a ConfigMap (`overlay-configmap.yaml`) and sets `CENTAUR_OVERLAY_DIR` + a `checksum/overlay` annotation on api-rs — but the ConfigMap is **mounted nowhere** (api-rs's only volume is `repo-cache`) and **api-rs never consumes it** (no overlay reader anywhere in `services/api-rs`). So the org overlay never reaches the sandbox: the agent runs on the bare baked base prompt and silently ignores the operator's overlay.

Confirmed live: in the sandbox, `~/workspace/AGENTS.md` is the base prompt only, `CENTAUR_OVERLAY_DIR` is unset, there is no `~/AGENTS_OVERLAY.md`, and `/app/overlay/org` doesn't exist in the api-rs pod — though the `…-overlay` ConfigMap holds the prompt.

## Fix
The legacy Python control plane delivered the prompt via a ConfigMap `subPath` mount (`services/api/api/sandbox/{prompt_assembly,kubernetes}.py`); the Rust rewrite never ported it. This wires it through minimally, reusing the sandbox entrypoint's **existing** `~/AGENTS_OVERLAY.md` contract (`entrypoint.sh` already appends that file to the effective `AGENTS.md` — no entrypoint change):

- **centaur-sandbox-core**: add `MountKind::ConfigMap { name }` + optional `Mount::sub_path` (project a single ConfigMap key as one file).
- **centaur-sandbox-agent-k8s**: render the `configMap` volume (`optional: true`) + `volumeMount.subPath`.
- **centaur-api-server**: add `--overlay-configmap` / `KUBERNETES_OVERLAY_CONFIGMAP`; when set, the codex sandbox mounts that ConfigMap's `SYSTEM_PROMPT.md` at `~/AGENTS_OVERLAY.md`, read-only.
- **chart** (`apirs.yaml`): pass the overlay ConfigMap name to api-rs when `overlay.systemPrompt` is set.

The volume is `optional: true`, so a missing/misnamed ConfigMap degrades gracefully (the entrypoint already guards `~/AGENTS_OVERLAY.md` with `[ -f ]`) rather than wedging the pod.

## Scope
Delivers the overlay **system prompt** only. The `[Active deployment]` block + persona injection that the Python `prompt_assembly` also produced are a related, separate gap left for follow-up — happy to adjust shape if you'd prefer it unified.

## Verification
- `cargo test -p centaur-sandbox-core -p centaur-sandbox-agent-k8s -p centaur-api-server` — green, incl. new tests: `mount_json_renders_configmap_subpath`, `agent_sandbox_crd_round_trips_configmap_overlay_mount`, `codex_workload_mounts_overlay_configmap_as_agents_overlay`, `codex_workload_has_no_overlay_mount_when_unset`.
- `helm lint` + `helm template contrib/chart -f values.dev.yaml` — pass; api-rs renders `KUBERNETES_OVERLAY_CONFIGMAP`.