### PR TITLE
refactor(api-rs): stop injecting tool placeholder env vars into sandboxes

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -819,7 +819,6 @@ impl SandboxArgs {
     }
 
     fn codex_app_server_env_template(&self) -> Result<Vec<(String, String)>, ServerError> {
-        let tool_fragment = self.discover_tool_proxy_fragment()?;
         let mut envs = vec![(
             "CENTAUR_API_URL".to_owned(),
             self.centaur_api_url_override
@@ -843,15 +842,12 @@ impl SandboxArgs {
             envs.push(("CLAUDE_CODE_AUTH_MODE".to_owned(), mode));
         }
 
-        // Inject the proxy fragments' placeholder credentials so env-based
+        // Inject the infra/harness placeholder credentials so env-based
         // consumers send the proxy_value iron-proxy replaces with the real
         // secret: codex's OPENAI_API_KEY (api_key mode → codex logs in and
         // hits api.openai.com instead of falling back to the ChatGPT
-        // auth.json), git's GITHUB_TOKEN, and the rest of the infra/tool set.
-        for (name, value) in self
-            .iron_proxy
-            .sandbox_placeholder_env(tool_fragment.as_ref())?
-        {
+        // auth.json), git's GITHUB_TOKEN, and the rest of the infra set.
+        for (name, value) in self.iron_proxy.sandbox_placeholder_env()? {
             if !envs.iter().any(|(existing, _)| existing == &name) {
                 envs.push((name, value));
             }
@@ -999,13 +995,9 @@ impl SandboxArgs {
     }
 
     fn workflow_host_env_template(&self) -> Result<Vec<(String, String)>, ServerError> {
-        let tool_fragment = self.discover_tool_proxy_fragment()?;
         let mut envs = Vec::new();
 
-        for (name, value) in self
-            .iron_proxy
-            .sandbox_placeholder_env(tool_fragment.as_ref())?
-        {
+        for (name, value) in self.iron_proxy.sandbox_placeholder_env()? {
             envs.push((name, value));
         }
 
@@ -1392,20 +1384,16 @@ impl IronProxyArgs {
         Ok(infra)
     }
 
-    /// Placeholder env (`PLACEHOLDER=PLACEHOLDER`) for every secret the proxy
-    /// fragments declare — infra, harness, and tools — so env-based consumers
-    /// in the sandbox send the proxy_value iron-proxy replaces with the real
-    /// credential (codex's `OPENAI_API_KEY`, git's `GITHUB_TOKEN`, …). Mirrors
-    /// the full fragment set registered as iron-control roles.
-    fn sandbox_placeholder_env(
-        &self,
-        tool_fragment: Option<&DiscoveredToolProxyFragment>,
-    ) -> Result<BTreeMap<String, String>, ServerError> {
-        let mut fragments = vec![self.infra_fragment()?];
-        if let Some(tool_fragment) = tool_fragment {
-            fragments.push(tool_fragment.fragment.clone());
-        }
-        Ok(centaur_iron_proxy::placeholder_env(&fragments))
+    /// Placeholder env (`PLACEHOLDER=PLACEHOLDER`) for the infra/harness
+    /// secrets, whose consumers read credentials straight from the environment
+    /// (codex's `OPENAI_API_KEY`, git's `GITHUB_TOKEN`, …). Discovered tool
+    /// secrets contribute nothing here: tools read credentials through the SDK,
+    /// whose `StubBackend` already returns the key name iron-proxy matches on,
+    /// and the cloudwatch tool embeds its own throwaway SigV4 credentials.
+    fn sandbox_placeholder_env(&self) -> Result<BTreeMap<String, String>, ServerError> {
+        Ok(centaur_iron_proxy::placeholder_env(&[
+            self.infra_fragment()?
+        ]))
     }
 
     fn env_from_secret_names(&self) -> Vec<String> {

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -1275,19 +1275,11 @@ secrets = [
         );
         assert_eq!(config["rules"].as_sequence().unwrap().len(), 2);
 
-        // The sandbox AWS SDK gets seeded placeholder credentials to sign with.
+        // No sandbox env rides along: the tool embeds its own throwaway SigV4
+        // credentials, so aws_auth contributes nothing to placeholder env.
         let placeholders =
             centaur_iron_proxy::placeholder_env(std::slice::from_ref(&discovered.fragment));
-        assert_eq!(
-            placeholders.get("AWS_ACCESS_KEY_ID").map(String::as_str),
-            Some("AWS_ACCESS_KEY_ID")
-        );
-        assert_eq!(
-            placeholders
-                .get("AWS_SECRET_ACCESS_KEY")
-                .map(String::as_str),
-            Some("AWS_SECRET_ACCESS_KEY")
-        );
+        assert!(placeholders.is_empty());
 
         let _ = fs::remove_dir_all(temp);
     }

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -99,8 +99,13 @@ fn normalize_auth_mode(value: &str) -> String {
     value.replace('-', "_")
 }
 
+/// The `PLACEHOLDER=PLACEHOLDER` env for replace-mode secrets whose consumers
+/// read credentials straight from the environment (codex's `OPENAI_API_KEY`,
+/// git's `GITHUB_TOKEN`, …) rather than through the tool SDK, whose
+/// `StubBackend` already hands back the key name. Only the infra/harness
+/// fragments have such consumers; tool fragments are excluded at the call site.
 pub fn placeholder_env(fragments: &[ProxyFragment]) -> BTreeMap<String, String> {
-    let mut env: BTreeMap<String, String> = fragments
+    fragments
         .iter()
         .flat_map(|fragment| &fragment.transforms)
         .filter(|transform| transform.is_secrets())
@@ -108,42 +113,7 @@ pub fn placeholder_env(fragments: &[ProxyFragment]) -> BTreeMap<String, String> 
         .filter_map(|secret| secret.proxy_value())
         .filter(|value| !value.is_empty() && !value.contains('='))
         .map(|value| (value.to_owned(), value.to_owned()))
-        .collect();
-    // The `aws_auth` transform re-signs at the proxy, but the in-sandbox AWS SDK
-    // still needs credentials in its environment to produce the inbound SigV4
-    // signature. Seed each declared placeholder ref (var name == value, the same
-    // convention the secrets transform uses) so the SDK signs with throwaway
-    // values the proxy strips and replaces with the real keys.
-    for transform in fragments
-        .iter()
-        .flat_map(|fragment| &fragment.transforms)
-        .filter(|transform| transform.name == "aws_auth")
-    {
-        for field in ["access_key_id", "secret_access_key", "session_token"] {
-            if let Some(name) = transform
-                .config
-                .extra
-                .get(field)
-                .and_then(placeholder_ref)
-                .filter(|value| !value.is_empty() && !value.contains('='))
-            {
-                env.entry(name.clone()).or_insert(name);
-            }
-        }
-    }
-    env
-}
-
-/// Extract a `{placeholder: NAME}` ref (or a bare `NAME` string) from an
-/// `aws_auth` credential field, matching how iron-control's translator reads it.
-fn placeholder_ref(value: &serde_yaml::Value) -> Option<String> {
-    value
-        .as_mapping()
-        .and_then(|mapping| mapping.get(serde_yaml::Value::from("placeholder")))
-        .and_then(serde_yaml::Value::as_str)
-        .or_else(|| value.as_str())
-        .filter(|name| !name.is_empty())
-        .map(ToOwned::to_owned)
+        .collect()
 }
 
 /// The static catalog of sandbox Postgres DSN env vars declared across

--- a/tools/research/archiver/docsend/playwright.py
+++ b/tools/research/archiver/docsend/playwright.py
@@ -41,10 +41,9 @@ BROWSER_USE_PROFILE_ID = os.environ.get("BROWSER_USE_PROFILE_ID", "")  # noqa: T
 
 
 def browser_use_api_key() -> str:
-    value = secret("BROWSER_USE_API_KEY", "")
-    if value == "BROWSER_USE_API_KEY":
-        value = os.environ.get("BROWSER_USE_API_KEY", "")  # noqa: TID251
-    return value
+    # Server mode returns the stub key name; the proxy swaps it for the real
+    # key in the query string (match_query). Local mode returns the env value.
+    return secret("BROWSER_USE_API_KEY", "")
 
 
 def prepare_playwright_tls() -> None:

--- a/tools/research/docsend/client.py
+++ b/tools/research/docsend/client.py
@@ -29,10 +29,9 @@ BROWSER_USE_PROFILE_ID = os.environ.get("BROWSER_USE_PROFILE_ID", "")  # noqa: T
 
 
 def _browser_use_api_key() -> str:
-    value = secret("BROWSER_USE_API_KEY", "")
-    if value == "BROWSER_USE_API_KEY":
-        value = os.environ.get("BROWSER_USE_API_KEY", "")  # noqa: TID251
-    return value
+    # Server mode returns the stub key name; the proxy swaps it for the real
+    # key in the query string (match_query). Local mode returns the env value.
+    return secret("BROWSER_USE_API_KEY", "")
 
 
 def _prepare_playwright_tls() -> None:


### PR DESCRIPTION
Tool-fragment secrets no longer contribute `NAME=NAME` placeholder env vars to sandbox or workflow-host env. They were redundant: the SDK's StubBackend returns the key name when the env var is absent, which is exactly the placeholder value iron-proxy matches on, and the cloudwatch tool already signs with embedded throwaway SigV4 credentials so the `aws_auth` env seeding was dead weight. Placeholder env now comes only from the infra/harness fragments, whose consumers (codex, claude-code, git/gh, harness CLIs) read credentials directly from the environment.

Also fixes the docsend and archiver browser-use clients, which rejected the stub key name and re-read the env var — they would have returned an empty key once the env var disappeared. They now trust the stub, which the proxy swaps in the query string.