### PR TITLE
[codex] fix Slack thread context in execute input

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -317,6 +317,8 @@ async function syncThreadMessageToSession(
 
   const forwardInput: ForwardSessionInput = {
     afterEventId: lastEventId,
+    executeContextMessages:
+      shouldStartExecution && shouldIncludeContext ? candidateMessages : undefined,
     executeMessage: shouldStartExecution ? serializedMessage : undefined,
     harnessType: overrides.harnessType,
     messages: messagesToAppend,

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from 'chat'
 import { createSlackAdapter } from '@chat-adapter/slack'
 import { createPostgresState } from '@chat-adapter/state-pg'
+import { WebClient } from '@slack/web-api'
 import pg from 'pg'
 import {
   codexAppServerToChatSdkStream,
@@ -251,7 +252,9 @@ async function syncThreadMessageToSession(
   const executedMessageIds = new Set(state.executedMessageIds ?? [])
   const shouldStartExecution =
     input.mode === 'execute' && state.activeExecution !== true && !executedMessageIds.has(message.id)
-  const shouldIncludeContext = shouldStartExecution && state.historyForwarded !== true
+  const shouldRefreshThreadContext = shouldStartExecution && isSlackThreadReply(message)
+  const shouldIncludeContext =
+    shouldStartExecution && (state.historyForwarded !== true || shouldRefreshThreadContext)
   const isDuplicateIncrementalMessage =
     messageIds.has(message.id) && !shouldStartExecution && !shouldIncludeContext
   const trace: SlackbotV2Trace = {
@@ -287,9 +290,11 @@ async function syncThreadMessageToSession(
   })
   let context: SlackbotV2ApiMessage[] | undefined
 
-  if (shouldIncludeContext && !state.historyForwarded) {
+  if (shouldIncludeContext) {
     const contextStartedAtMs = nowMs()
-    context = await collectInitialContext(thread, message)
+    context = shouldRefreshThreadContext
+      ? await collectSlackThreadContext(input.options, message)
+      : await collectInitialContext(thread, message)
     // collectInitialContext re-serializes the current message; mirror the
     // flag-stripped text on that copy too.
     for (const item of context) {
@@ -1286,6 +1291,150 @@ function shouldAwaitSlackHandoff(rawBody: string): boolean {
   } catch {
     return false
   }
+}
+
+function isSlackThreadReply(message: ChatMessage): boolean {
+  const raw = message.raw
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false
+  const item = raw as Record<string, unknown>
+  const threadTs = typeof item.thread_ts === 'string' ? item.thread_ts : ''
+  const ts = typeof item.ts === 'string' ? item.ts : message.id
+  return Boolean(threadTs && ts && threadTs !== ts)
+}
+
+async function collectSlackThreadContext(
+  options: SlackbotV2Options,
+  currentMessage: ChatMessage
+): Promise<SlackbotV2ApiMessage[]> {
+  const raw = slackRawRecord(currentMessage)
+  const channel = stringField(raw.channel)
+  const threadTs = stringField(raw.thread_ts)
+  const currentTs = stringField(raw.ts) || currentMessage.id
+  if (!channel || !threadTs) return [await serializeMessage(currentMessage)]
+
+  const client = new WebClient(options.botToken, { slackApiUrl: options.slackApiUrl })
+  const messages: SlackbotV2ApiMessage[] = []
+  let cursor: string | undefined
+  do {
+    const response = await client.conversations.replies({
+      channel,
+      ts: threadTs,
+      limit: 200,
+      cursor
+    })
+    const slackMessages = Array.isArray(response.messages) ? response.messages : []
+    for (const rawMessage of slackMessages) {
+      const message = rawMessage as Record<string, unknown>
+      const messageTs = stringField(message.ts)
+      if (!messageTs || compareSlackTs(messageTs, currentTs) > 0) continue
+      if (isSelfSlackBotMessage(options, message)) continue
+      messages.push(slackApiMessageFromSlack(message, currentMessage))
+    }
+    const nextCursor = response.response_metadata?.next_cursor
+    cursor = typeof nextCursor === 'string' && nextCursor.trim() ? nextCursor : undefined
+  } while (cursor)
+
+  const currentIndex = messages.findIndex(message => message.id === currentMessage.id)
+  const serializedCurrent = await serializeMessage(currentMessage)
+  if (currentIndex >= 0) {
+    messages[currentIndex] = serializedCurrent
+  } else {
+    messages.push(serializedCurrent)
+  }
+  return messages
+}
+
+function slackApiMessageFromSlack(
+  message: Record<string, unknown>,
+  currentMessage: ChatMessage
+): SlackbotV2ApiMessage {
+  const rawCurrent = slackRawRecord(currentMessage)
+  const id = stringField(message.ts) || randomUUID()
+  const actorId = slackActorId(message)
+  const isBot = Boolean(message.bot_id || message.bot_profile)
+  return {
+    attachments: [],
+    author: {
+      fullName: actorId,
+      isBot,
+      isMe: Boolean(actorId && actorId === currentMessage.author.userId),
+      userId: actorId,
+      userName: actorId
+    },
+    id,
+    isMention: id === currentMessage.id ? currentMessage.isMention === true : false,
+    raw: message,
+    teamId:
+      stringField(message.team)
+      || stringField(message.team_id)
+      || stringField(rawCurrent.team)
+      || stringField(rawCurrent.team_id),
+    text: normalizeSlackText(stringField(message.text)),
+    threadId: currentMessage.threadId,
+    timestamp: slackTimestampToIso(id)
+  }
+}
+
+function slackRawRecord(message: ChatMessage): Record<string, unknown> {
+  return message.raw && typeof message.raw === 'object' && !Array.isArray(message.raw)
+    ? (message.raw as Record<string, unknown>)
+    : {}
+}
+
+function slackActorId(message: Record<string, unknown>): string {
+  const profile = message.bot_profile
+  if (profile && typeof profile === 'object' && !Array.isArray(profile)) {
+    const userId = stringField((profile as Record<string, unknown>).user_id)
+    if (userId) return userId
+  }
+  return stringField(message.user) || stringField(message.bot_id)
+}
+
+function isSelfSlackBotMessage(
+  options: SlackbotV2Options,
+  message: Record<string, unknown>
+): boolean {
+  const botUserId = options.botUserId
+  if (!botUserId) return false
+  if (stringField(message.user) === botUserId) return true
+  const profile = message.bot_profile
+  if (profile && typeof profile === 'object' && !Array.isArray(profile)) {
+    return stringField((profile as Record<string, unknown>).user_id) === botUserId
+  }
+  return false
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function compareSlackTs(a: string, b: string): number {
+  const left = Number(a)
+  const right = Number(b)
+  if (Number.isFinite(left) && Number.isFinite(right)) return left - right
+  return a.localeCompare(b)
+}
+
+function slackTimestampToIso(ts: string): string {
+  const seconds = Number(ts)
+  return Number.isFinite(seconds)
+    ? new Date(seconds * 1000).toISOString()
+    : new Date().toISOString()
+}
+
+function normalizeSlackText(input: string): string {
+  return input
+    .replace(/<([a-z]+:\/\/[^>|]+)\|([^>]+)>/gi, '$2 ($1)')
+    .replace(/<([a-z]+:\/\/[^>]+)>/gi, '$1')
+    .replace(/<#([A-Z0-9]+)\|([^>]+)>/g, '#$2')
+    .replace(/<#([A-Z0-9]+)>/g, '#$1')
+    .replace(/<@([A-Z0-9]+)>/g, '@$1')
+    .replace(/<!subteam\^([A-Z0-9]+)\|([^>]+)>/g, '@$2')
+    .replace(/<!(channel|here|everyone)>/g, '@$1')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .trim()
 }
 
 function rendererOptions(thread: Thread, options: SlackbotV2Options): CodexAppServerToChatStreamOptions {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -158,7 +158,13 @@ export async function forwardToSessionApi(
   if (!input.executeMessage) return null
 
   const executeStartedAtMs = nowMs()
-  const execution = await executeSession(options, input.threadId, input.executeMessage, input.model)
+  const execution = await executeSession(
+    options,
+    input.threadId,
+    input.executeMessage,
+    input.model,
+    input.executeContextMessages
+  )
   traceLog(options, 'slackbotv2_session_execute_complete', input.trace, {
     execution_id: execution.execution_id,
     phase_ms: elapsedMs(executeStartedAtMs)
@@ -338,13 +344,14 @@ async function executeSession(
   options: SlackbotV2Options,
   threadId: string,
   message: SlackbotV2ApiMessage,
-  model?: string
+  model?: string,
+  contextMessages?: SlackbotV2ApiMessage[]
 ): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
   const body: SlackbotV2ExecuteSessionRequest = {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }),
-    input_lines: toCodexInputLines(message, threadId, model),
+    input_lines: toCodexInputLines(message, threadId, model, contextMessages),
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
   }
@@ -474,13 +481,20 @@ function sessionMetadata(
 function toCodexInputLines(
   message: SlackbotV2ApiMessage,
   threadId: string,
-  model?: string
+  model?: string,
+  contextMessages?: SlackbotV2ApiMessage[]
 ): string[] {
   const staged = new Map<SlackbotV2ApiAttachment, string>()
   const lines: string[] = []
   for (const attachment of message.attachments) {
     if (!attachment.dataBase64) continue
-    const inlineLine = toCodexInputLineWithStaged(message, threadId, staged, model)
+    const inlineLine = toCodexInputLineWithStaged(
+      message,
+      threadId,
+      staged,
+      model,
+      contextMessages
+    )
     if (
       inlineLine.length <= MAX_CODEX_INPUT_LINE_CHARS
       && attachment.dataBase64.length <= MAX_CODEX_INPUT_LINE_CHARS
@@ -491,7 +505,7 @@ function toCodexInputLines(
     staged.set(attachment, stagedAttachmentId)
     lines.push(...stagedAttachmentInputLines(attachment, stagedAttachmentId))
   }
-  lines.push(toCodexInputLineWithStaged(message, threadId, staged, model))
+  lines.push(toCodexInputLineWithStaged(message, threadId, staged, model, contextMessages))
   return lines
 }
 
@@ -499,7 +513,8 @@ function toCodexInputLineWithStaged(
   message: SlackbotV2ApiMessage,
   threadId: string,
   staged: Map<SlackbotV2ApiAttachment, string>,
-  model?: string
+  model?: string,
+  contextMessages?: SlackbotV2ApiMessage[]
 ): string {
   return JSON.stringify({
     type: 'user',
@@ -508,7 +523,7 @@ function toCodexInputLineWithStaged(
     ...(model ? { model } : {}),
     message: {
       role: 'user',
-      content: codexInputContent(message, staged)
+      content: codexInputContent(message, staged, contextMessages)
     }
   })
 }
@@ -539,9 +554,14 @@ function stagedAttachmentInputLines(
 
 function codexInputContent(
   message: SlackbotV2ApiMessage,
-  staged: Map<SlackbotV2ApiAttachment, string> = new Map()
+  staged: Map<SlackbotV2ApiAttachment, string> = new Map(),
+  contextMessages?: SlackbotV2ApiMessage[]
 ): JsonValue[] {
   const content: JsonValue[] = []
+  const threadContext = slackThreadContext(message, contextMessages)
+  if (threadContext) {
+    content.push({ type: 'text', text: threadContext })
+  }
   if (message.text.trim()) {
     content.push({ type: 'text', text: message.text })
   }
@@ -549,6 +569,51 @@ function codexInputContent(
     content.push(codexAttachmentInput(attachment, staged.get(attachment)))
   }
   return content.length > 0 ? content : [{ type: 'text', text: 'continue' }]
+}
+
+function slackThreadContext(
+  currentMessage: SlackbotV2ApiMessage,
+  contextMessages: SlackbotV2ApiMessage[] | undefined
+): string | undefined {
+  const priorMessages = (contextMessages ?? []).filter(message => message.id !== currentMessage.id)
+  if (priorMessages.length === 0) return undefined
+
+  const lines = [
+    '# Slack Thread Context',
+    '',
+    'Earlier messages in this Slack thread, in chronological order:'
+  ]
+  for (const [index, message] of priorMessages.entries()) {
+    const author = slackContextAuthor(message)
+    const text = slackContextMessageText(message)
+    lines.push('', `${index + 1}. ${author}:`, indentSlackContext(text || '[no text]'))
+  }
+  lines.push('', '# Current Request', '', 'The user message follows in the next content block.', '---')
+  return lines.join('\n')
+}
+
+function slackContextAuthor(message: SlackbotV2ApiMessage): string {
+  const displayName = message.author.fullName || message.author.userName || message.author.userId
+  const userId = message.author.userId && message.author.userId !== displayName
+    ? ` (${message.author.userId})`
+    : ''
+  const bot = message.author.isBot === true ? ' bot' : ''
+  return `${displayName || 'unknown'}${userId}${bot}`
+}
+
+function slackContextMessageText(message: SlackbotV2ApiMessage): string {
+  const fields = [message.text.trim()]
+  for (const attachment of message.attachments) {
+    fields.push(attachmentDescription(attachment))
+  }
+  return fields.filter(Boolean).join('\n')
+}
+
+function indentSlackContext(text: string): string {
+  return text
+    .split('\n')
+    .map(line => `   ${line}`)
+    .join('\n')
 }
 
 function codexAttachmentInput(

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -136,6 +136,7 @@ export type SlackbotV2Trace = {
 
 export type ForwardSessionInput = {
   afterEventId: number
+  executeContextMessages?: SlackbotV2ApiMessage[]
   executionId?: string
   executeMessage?: SlackbotV2ApiMessage
   /** Harness override parsed from message flags (--claude/--amp/--codex). */

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -337,6 +337,11 @@ describe('slackbotv2', () => {
     ])
     expect(codexApi.executes).toHaveLength(1)
     expect(codexApi.executes[0]!.body.idempotency_key).toBe(mention.ts)
+    const executeInput = JSON.stringify(JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!))
+    expect(executeInput).toContain('Root context for the thread.')
+    expect(executeInput).toContain('First preceding reply.')
+    expect(executeInput).toContain('Second preceding reply.')
+    expect(executeInput).toContain('summarize the thread so far')
   })
 
   it('refreshes Slack thread context for a reply mention after a root mention', async () => {
@@ -400,6 +405,12 @@ describe('slackbotv2', () => {
       rootMention.ts,
       replyMention.ts
     ])
+    const replyExecuteInput = JSON.stringify(
+      JSON.parse(codexApi.executes[1]!.body.input_lines.at(-1)!)
+    )
+    expect(replyExecuteInput).toContain('start from this root mention')
+    expect(replyExecuteInput).toContain('Important reply between mentions.')
+    expect(replyExecuteInput).toContain('now use the full thread')
   })
 
   it('stages large Slack file attachments without exceeding session input line limits', async () => {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -295,6 +295,113 @@ describe('slackbotv2', () => {
     expectSlackRenderedReply(renderedReplies[1]!, 'Executed request 2.')
   })
 
+  it('includes all preceding Slack thread messages for a first mid-thread mention', async () => {
+    const parent = await postUserMessage('Root context for the thread.')
+    const firstReply = await postUserMessage('First preceding reply.', parent.ts)
+    const secondReply = await postUserMessage('Second preceding reply.', parent.ts)
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> summarize the thread so far`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-mid-thread-history',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> summarize the thread so far`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    expect(codexApi.appends).toHaveLength(1)
+    expect(codexApi.appends[0]!.body.messages.map(message => message.client_message_id)).toEqual([
+      parent.ts,
+      firstReply.ts,
+      secondReply.ts,
+      mention.ts
+    ])
+    expect(sessionMessageTexts(codexApi.appends[0]!.body.messages)).toEqual([
+      'Root context for the thread.',
+      'First preceding reply.',
+      'Second preceding reply.',
+      `@${BOT_USER_ID} summarize the thread so far`
+    ])
+    expect(codexApi.executes).toHaveLength(1)
+    expect(codexApi.executes[0]!.body.idempotency_key).toBe(mention.ts)
+  })
+
+  it('refreshes Slack thread context for a reply mention after a root mention', async () => {
+    const rootMention = await postUserMessage(`<@${BOT_USER_ID}> start from this root mention`)
+    const rootWaits: Promise<unknown>[] = []
+    const rootResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-root-before-reply-mention',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: rootMention.ts,
+          text: `<@${BOT_USER_ID}> start from this root mention`
+        }
+      }),
+      {},
+      waitUntilContext(rootWaits)
+    )
+    expect(rootResponse.status).toBe(200)
+    await Promise.all(rootWaits)
+
+    await postUserMessage('Important reply between mentions.', rootMention.ts)
+    const replyMention = await postUserMessage(
+      `<@${BOT_USER_ID}> now use the full thread`,
+      rootMention.ts
+    )
+    const replyWaits: Promise<unknown>[] = []
+    const replyResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-reply-mention-after-root',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: replyMention.ts,
+          thread_ts: rootMention.ts,
+          text: `<@${BOT_USER_ID}> now use the full thread`
+        }
+      }),
+      {},
+      waitUntilContext(replyWaits)
+    )
+
+    expect(replyResponse.status).toBe(200)
+    await Promise.all(replyWaits)
+
+    expect(codexApi.appends).toHaveLength(2)
+    expect(sessionMessageTexts(codexApi.appends[0]!.body.messages)).toEqual([
+      `@${BOT_USER_ID} start from this root mention`
+    ])
+    expect(sessionMessageTexts(codexApi.appends[1]!.body.messages)).toEqual([
+      'Important reply between mentions.',
+      `@${BOT_USER_ID} now use the full thread`
+    ])
+    expect(codexApi.executes.map(execute => execute.body.idempotency_key)).toEqual([
+      rootMention.ts,
+      replyMention.ts
+    ])
+  })
+
   it('stages large Slack file attachments without exceeding session input line limits', async () => {
     const parent = await postUserMessage('Context before the video upload.')
     const mention = await postUserMessage(`<@${BOT_USER_ID}> inspect this mp4`, parent.ts)
@@ -359,7 +466,9 @@ describe('slackbotv2', () => {
     expect(serializedTurn).not.toContain('dataBase64')
   })
 
-  it('executes a root app mention when Slack has no thread history yet', async () => {
+  it('executes a root app mention without channel history', async () => {
+    await postUserMessage('Prior channel message A.')
+    await postUserMessage('Prior channel message B.')
     const mention = await postUserMessage(`<@${BOT_USER_ID}> answer from a new root message`)
     slackApi.failRepliesWithThreadNotFound(CHANNEL_ID, mention.ts)
     const waits: Promise<unknown>[] = []


### PR DESCRIPTION
## Summary
- include fetched Slack thread context in the model-facing `/execute` input for mention turns
- keep the existing durable `/messages` append behavior unchanged
- strengthen Slackbot regression tests so prior thread messages must appear in `/execute.input_lines`

## Root Cause
Slackbot fetched and appended late-mention thread history, but `/execute` still sent only the triggering message. If the prior execution failed or the sandbox was cold, Codex saw only the latest ask and tried to recover context with tool calls.

## Validation
- `bun test test/chat-sdk-emulate.test.ts --test-name-pattern 'includes all preceding|refreshes Slack thread context'`\n- `bun test test/session-api.test.ts`\n- `pnpm --dir services/slackbotv2 check:types`\n- `git diff --check`