### PR TITLE
Restore Slack requester identity context

### DIFF
--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -132,19 +132,24 @@ function slackTeamId(raw: unknown): string | undefined {
   return undefined
 }
 
+function rawSlackString(raw: unknown, key: string): string | undefined {
+  if (!isJsonObject(raw)) return undefined
+  return stringValue(raw[key])
+}
+
 export async function forwardToSessionApi(
   options: SlackbotV2Options,
   input: ForwardSessionInput,
   callbacks: ForwardSessionApiCallbacks = {}
 ): Promise<AsyncIterable<SlackbotV2RendererSource> | null> {
   const createStartedAtMs = nowMs()
-  await createSession(options, input.threadId, input.harnessType)
+  await createSession(options, input.threadId, input.harnessType, sessionRequesterMessage(input))
   traceLog(options, 'slackbotv2_session_create_complete', input.trace, {
     phase_ms: elapsedMs(createStartedAtMs)
   })
   if (input.messages.length > 0) {
     const appendStartedAtMs = nowMs()
-    await appendSessionMessages(options, input.threadId, input.messages)
+    await appendSessionMessages(options, input.threadId, input.messages, !input.executeMessage)
     traceLog(options, 'slackbotv2_session_append_complete', input.trace, {
       message_count: input.messages.length,
       phase_ms: elapsedMs(appendStartedAtMs)
@@ -255,13 +260,37 @@ async function bytesToBase64(data: Buffer | Blob): Promise<string> {
 
 const DEFAULT_HARNESS_TYPE = 'codex'
 
+type RequesterIdentity = {
+  githubHandle?: string
+  githubHandleSource?: string
+  githubUnavailableReason?: string
+  slackDisplayName?: string
+  slackMention?: string
+  slackUserId?: string
+  slackUserName?: string
+}
+
+type RequesterIdentityCacheEntry = {
+  expiresAtMs: number
+  identity: RequesterIdentity
+}
+
+const REQUESTER_IDENTITY_CACHE_SUCCESS_TTL_MS = 6 * 60 * 60 * 1000
+const REQUESTER_IDENTITY_CACHE_MISS_TTL_MS = 10 * 60 * 1000
+const requesterIdentityCache = new Map<string, RequesterIdentityCacheEntry>()
+
+export function clearRequesterIdentityCacheForTests(): void {
+  requesterIdentityCache.clear()
+}
+
 async function createSession(
   options: SlackbotV2Options,
   threadId: string,
-  harnessType?: string
+  harnessType?: string,
+  message?: SlackbotV2ApiMessage
 ): Promise<void> {
   const requested = harnessType ?? DEFAULT_HARNESS_TYPE
-  const response = await postCreateSession(options, threadId, requested)
+  const response = await postCreateSession(options, threadId, requested, message)
   if (response.ok) return
 
   let body = ''
@@ -276,7 +305,7 @@ async function createSession(
   // keep the thread alive on its existing harness instead of failing the message.
   const existing = response.status === 409 ? existingHarnessFromConflict(body) : undefined
   if (existing && existing !== requested) {
-    const retry = await postCreateSession(options, threadId, existing)
+    const retry = await postCreateSession(options, threadId, existing, message)
     await ensureApiOk(retry, 'create session')
     return
   }
@@ -292,7 +321,8 @@ async function createSession(
 async function postCreateSession(
   options: SlackbotV2Options,
   threadId: string,
-  harnessType: string
+  harnessType: string,
+  message?: SlackbotV2ApiMessage
 ): Promise<Response> {
   const fetchFn = options.fetch ?? fetch
   const body: SlackbotV2CreateSessionRequest = {
@@ -300,7 +330,8 @@ async function postCreateSession(
     metadata: {
       source: 'slackbotv2',
       platform: 'slack',
-      thread_id: threadId
+      thread_id: threadId,
+      ...sessionRequesterMetadata(message)
     }
   }
   return fetchFn(apiSessionUrl(options.apiUrl, threadId), {
@@ -323,14 +354,258 @@ function existingHarnessFromConflict(body: string): string | undefined {
   return /already exists with harness_type ([A-Za-z0-9_-]+)/.exec(body)?.[1]
 }
 
+function sessionRequesterMessage(input: ForwardSessionInput): SlackbotV2ApiMessage | undefined {
+  return input.executeMessage ?? input.messages.find(message => message.author.isMe !== true)
+}
+
+function sessionRequesterMetadata(
+  message?: SlackbotV2ApiMessage,
+  identity?: RequesterIdentity
+): JsonObject {
+  const slackUserId = identity?.slackUserId ?? messageRequesterUserId(message)
+  const slackUserName = identity?.slackUserName ?? message?.author.userName
+  const slackDisplayName = identity?.slackDisplayName ?? message?.author.fullName
+  return {
+    ...(slackUserId ? { slack_user_id: slackUserId } : {}),
+    ...(slackUserName ? { slack_user_name: slackUserName } : {}),
+    ...(slackDisplayName ? { slack_display_name: slackDisplayName } : {}),
+    ...(identity?.githubHandle ? { github_handle: identity.githubHandle } : {})
+  }
+}
+
+function messageRequesterUserId(message: SlackbotV2ApiMessage | undefined): string | undefined {
+  if (!message) return undefined
+  const rawUserId = rawSlackUserId(message.raw)
+  const authorUserId = stringValue(message.author.userId)
+  return authorUserId ?? rawUserId
+}
+
+function rawSlackUserId(raw: unknown): string | undefined {
+  if (!isJsonObject(raw)) return undefined
+  const directUser = stringValue(raw.user)
+  if (directUser) return directUser
+  const user = raw.user
+  if (isJsonObject(user)) {
+    return stringValue(user.id) ?? stringValue(user.user_id)
+  }
+  const botProfile = raw.bot_profile
+  if (isJsonObject(botProfile)) return stringValue(botProfile.user_id)
+  return undefined
+}
+
+async function resolveRequesterIdentity(
+  options: SlackbotV2Options,
+  message: SlackbotV2ApiMessage
+): Promise<RequesterIdentity> {
+  const slackUserId = messageRequesterUserId(message)
+  const identity: RequesterIdentity = {
+    slackDisplayName: stringValue(message.author.fullName),
+    slackMention: slackUserId ? `<@${slackUserId}>` : undefined,
+    slackUserId,
+    slackUserName: stringValue(message.author.userName)
+  }
+  if (!identity.slackUserId) return identity
+
+  const cacheKey = requesterIdentityCacheKey(message, identity.slackUserId)
+  const cached = cacheKey ? cachedRequesterIdentity(cacheKey) : undefined
+  if (cached) return mergeRequesterIdentity(identity, cached)
+
+  const profile = await fetchSlackUserProfile(options, identity.slackUserId)
+  if (!profile) {
+    identity.githubUnavailableReason = 'Slack profile could not be fetched'
+    cacheRequesterIdentity(cacheKey, identity)
+    return identity
+  }
+
+  identity.slackDisplayName =
+    stringValue(profile.display_name)
+    ?? stringValue(profile.real_name)
+    ?? stringValue(profile.name)
+    ?? identity.slackDisplayName
+  identity.slackUserName = stringValue(profile.name) ?? identity.slackUserName
+
+  const github = extractGithubHandleFromSlackProfile(profile)
+  if (github.handle) {
+    identity.githubHandle = github.handle
+    identity.githubHandleSource = github.source ?? 'Slack profile custom field'
+  } else {
+    identity.githubUnavailableReason = github.reason
+  }
+  cacheRequesterIdentity(cacheKey, identity)
+  return identity
+}
+
+function requesterIdentityCacheKey(
+  message: SlackbotV2ApiMessage,
+  slackUserId: string
+): string | undefined {
+  const teamId = message.teamId || slackTeamId(message.raw) || rawSlackString(message.raw, 'team_id')
+  return teamId ? `slack:${teamId}:${slackUserId}` : `slack:${slackUserId}`
+}
+
+function cachedRequesterIdentity(cacheKey: string): RequesterIdentity | undefined {
+  const cached = requesterIdentityCache.get(cacheKey)
+  if (!cached) return undefined
+  if (cached.expiresAtMs <= Date.now()) {
+    requesterIdentityCache.delete(cacheKey)
+    return undefined
+  }
+  return cached.identity
+}
+
+function cacheRequesterIdentity(cacheKey: string | undefined, identity: RequesterIdentity): void {
+  if (!cacheKey) return
+  const ttlMs = identity.githubHandle
+    ? REQUESTER_IDENTITY_CACHE_SUCCESS_TTL_MS
+    : REQUESTER_IDENTITY_CACHE_MISS_TTL_MS
+  requesterIdentityCache.set(cacheKey, {
+    expiresAtMs: Date.now() + ttlMs,
+    identity: { ...identity }
+  })
+}
+
+function mergeRequesterIdentity(
+  fallback: RequesterIdentity,
+  cached: RequesterIdentity
+): RequesterIdentity {
+  return {
+    ...fallback,
+    ...cached,
+    slackDisplayName: cached.slackDisplayName ?? fallback.slackDisplayName,
+    slackMention: fallback.slackMention ?? cached.slackMention,
+    slackUserId: fallback.slackUserId ?? cached.slackUserId,
+    slackUserName: cached.slackUserName ?? fallback.slackUserName
+  }
+}
+
+async function fetchSlackUserProfile(
+  options: SlackbotV2Options,
+  userId: string
+): Promise<JsonObject | null> {
+  const token = options.botToken
+  if (!token) return null
+  if (options.fetch && !options.slackApiUrl) return null
+  try {
+    const [userPayload, profilePayload] = await Promise.all([
+      slackApiGet(options, 'users.info', { user: userId }),
+      slackApiGet(options, 'users.profile.get', { include_labels: 'true', user: userId })
+    ])
+    const user = isJsonObject(userPayload?.user) ? userPayload.user : undefined
+    const userProfile = isJsonObject(user?.profile) ? user.profile : undefined
+    const profile = isJsonObject(profilePayload?.profile) ? profilePayload.profile : userProfile
+    if (!user && !profile) return null
+    return {
+      ...(user ?? {}),
+      ...(profile ?? {}),
+      ...(profile?.fields ? { fields: profile.fields } : {}),
+      ...(profile?.custom_fields ? { custom_fields: profile.custom_fields } : {})
+    }
+  } catch {
+    return null
+  }
+}
+
+async function slackApiGet(
+  options: SlackbotV2Options,
+  method: string,
+  params: Record<string, string>
+): Promise<JsonObject | null> {
+  const url = slackApiMethodUrl(options.slackApiUrl, method)
+  for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value)
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { authorization: `Bearer ${options.botToken}` }
+  })
+  const payload = await response.json()
+  if (!response.ok || !isJsonObject(payload) || payload.ok === false) return null
+  return payload
+}
+
+function slackApiMethodUrl(slackApiUrl: string | undefined, method: string): URL {
+  return new URL(method, slackApiUrl ?? 'https://slack.com/api/')
+}
+
+const GITHUB_LABEL_RE = /\bgithub\b/i
+const GITHUB_URL_RE = /github\.com\/([A-Za-z0-9-]{1,39})(?:[/?#]|$)/i
+const GITHUB_PREFIX_RE = /\bgithub\s*[:=]\s*@?([A-Za-z0-9-]{1,39})\b/i
+const GITHUB_HANDLE_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
+
+function extractGithubHandleFromSlackProfile(
+  profile: JsonObject
+): { handle?: string; source?: string; reason: string } {
+  const fields = slackProfileCustomFields(profile)
+  if (fields.length === 0) return { reason: 'no GitHub custom field found on Slack profile' }
+
+  let sawGithubField = false
+  for (const field of fields) {
+    const labelMentionsGithub = GITHUB_LABEL_RE.test(field.label)
+    const valueMentionsGithub = GITHUB_LABEL_RE.test(field.value)
+    if (!labelMentionsGithub && !valueMentionsGithub) continue
+    sawGithubField = true
+
+    const source = field.label
+      ? `Slack profile custom field "${field.label}"`
+      : 'Slack profile custom field'
+    const urlMatch = GITHUB_URL_RE.exec(field.value)
+    const prefixedMatch = GITHUB_PREFIX_RE.exec(field.value)
+    const handle =
+      validGithubHandle(urlMatch?.[1] ?? '')
+      ?? validGithubHandle(prefixedMatch?.[1] ?? '')
+      ?? (labelMentionsGithub ? validGithubHandle(field.value) : undefined)
+    if (handle) return { handle: `@${handle}`, source, reason: '' }
+  }
+
+  return {
+    reason: sawGithubField
+      ? 'GitHub profile field did not contain a valid GitHub handle'
+      : 'no GitHub custom field found on Slack profile'
+  }
+}
+
+function slackProfileCustomFields(profile: JsonObject): Array<{ label: string; value: string }> {
+  const fields: Array<{ label: string; value: string }> = []
+  collectSlackCustomFields(fields, profile.custom_fields)
+  collectSlackCustomFields(fields, profile.fields)
+  return fields
+}
+
+function collectSlackCustomFields(
+  fields: Array<{ label: string; value: string }>,
+  rawFields: unknown
+): void {
+  if (!isJsonObject(rawFields)) return
+  for (const [key, rawValue] of Object.entries(rawFields)) {
+    if (isJsonObject(rawValue)) {
+      const value = stringValue(rawValue.value)
+      if (value) {
+        fields.push({
+          label: stringValue(rawValue.label) ?? stringValue(rawValue.alt) ?? key,
+          value
+        })
+      }
+    } else {
+      const value = stringValue(rawValue)
+      if (value) fields.push({ label: key, value })
+    }
+  }
+}
+
+function validGithubHandle(value: string): string | undefined {
+  const candidate = value.trim().replace(/^@/, '').replace(/\/+$/, '').split('/', 1)[0] ?? ''
+  return GITHUB_HANDLE_RE.test(candidate) ? candidate : undefined
+}
+
 async function appendSessionMessages(
   options: SlackbotV2Options,
   threadId: string,
-  messages: SlackbotV2ApiMessage[]
+  messages: SlackbotV2ApiMessage[],
+  includeRequesterContext = false
 ): Promise<void> {
   const fetchFn = options.fetch ?? fetch
   const body: SlackbotV2AppendMessagesRequest = {
-    messages: messages.map(toSessionMessage)
+    messages: await Promise.all(
+      messages.map(message => toSessionMessage(options, message, includeRequesterContext))
+    )
   }
   const response = await fetchFn(apiSessionUrl(options.apiUrl, threadId, 'messages'), {
     method: 'POST',
@@ -348,10 +623,11 @@ async function executeSession(
   contextMessages?: SlackbotV2ApiMessage[]
 ): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
+  const requesterIdentity = await resolveRequesterIdentity(options, message)
   const body: SlackbotV2ExecuteSessionRequest = {
     idempotency_key: message.id,
-    metadata: sessionMetadata(message, { action: 'execute' }),
-    input_lines: toCodexInputLines(message, threadId, model, contextMessages),
+    metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),
+    input_lines: toCodexInputLines(message, threadId, model, requesterIdentity, contextMessages),
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
   }
@@ -429,17 +705,32 @@ function apiHeaders(options: SlackbotV2Options, jsonBody = true): HeadersInit {
   }
 }
 
-function toSessionMessage(message: SlackbotV2ApiMessage): SlackbotV2SessionMessage {
+async function toSessionMessage(
+  options: SlackbotV2Options,
+  message: SlackbotV2ApiMessage,
+  includeRequesterContext: boolean
+): Promise<SlackbotV2SessionMessage> {
+  const requesterIdentity =
+    includeRequesterContext && message.isMention && !message.author.isMe
+      ? await resolveRequesterIdentity(options, message)
+      : undefined
   return {
     client_message_id: message.id,
     role: message.author.isMe ? 'assistant' : 'user',
-    parts: sessionMessageParts(message),
-    metadata: sessionMetadata(message)
+    parts: sessionMessageParts(message, requesterIdentity),
+    metadata: sessionMetadata(message, {}, requesterIdentity)
   }
 }
 
-function sessionMessageParts(message: SlackbotV2ApiMessage): JsonValue[] {
+function sessionMessageParts(
+  message: SlackbotV2ApiMessage,
+  requesterIdentity?: RequesterIdentity
+): JsonValue[] {
   const parts: JsonValue[] = []
+  const requesterContext = requesterIdentityContext(requesterIdentity)
+  if (requesterContext) {
+    parts.push({ type: 'text', text: requesterContext })
+  }
   if (message.text.trim()) {
     parts.push({ type: 'text', text: message.text })
   }
@@ -463,7 +754,8 @@ function sessionAttachmentPart(attachment: SlackbotV2ApiAttachment): JsonObject 
 
 function sessionMetadata(
   message: SlackbotV2ApiMessage,
-  extra: JsonObject = {}
+  extra: JsonObject = {},
+  requesterIdentity?: RequesterIdentity
 ): JsonObject {
   return {
     source: 'slackbotv2',
@@ -474,6 +766,7 @@ function sessionMetadata(
     timestamp: message.timestamp,
     user_id: message.author.userId,
     user_name: message.author.userName,
+    ...sessionRequesterMetadata(message, requesterIdentity),
     ...extra
   }
 }
@@ -482,6 +775,7 @@ function toCodexInputLines(
   message: SlackbotV2ApiMessage,
   threadId: string,
   model?: string,
+  requesterIdentity?: RequesterIdentity,
   contextMessages?: SlackbotV2ApiMessage[]
 ): string[] {
   const staged = new Map<SlackbotV2ApiAttachment, string>()
@@ -493,6 +787,7 @@ function toCodexInputLines(
       threadId,
       staged,
       model,
+      requesterIdentity,
       contextMessages
     )
     if (
@@ -505,7 +800,16 @@ function toCodexInputLines(
     staged.set(attachment, stagedAttachmentId)
     lines.push(...stagedAttachmentInputLines(attachment, stagedAttachmentId))
   }
-  lines.push(toCodexInputLineWithStaged(message, threadId, staged, model, contextMessages))
+  lines.push(
+    toCodexInputLineWithStaged(
+      message,
+      threadId,
+      staged,
+      model,
+      requesterIdentity,
+      contextMessages
+    )
+  )
   return lines
 }
 
@@ -514,16 +818,17 @@ function toCodexInputLineWithStaged(
   threadId: string,
   staged: Map<SlackbotV2ApiAttachment, string>,
   model?: string,
+  requesterIdentity?: RequesterIdentity,
   contextMessages?: SlackbotV2ApiMessage[]
 ): string {
   return JSON.stringify({
     type: 'user',
     thread_key: threadId,
-    trace_metadata: sessionMetadata(message, { action: 'execute' }),
+    trace_metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),
     ...(model ? { model } : {}),
     message: {
       role: 'user',
-      content: codexInputContent(message, staged, contextMessages)
+      content: codexInputContent(message, staged, requesterIdentity, contextMessages)
     }
   })
 }
@@ -552,12 +857,63 @@ function stagedAttachmentInputLines(
   return lines
 }
 
+function requesterIdentityContext(identity: RequesterIdentity | undefined): string | undefined {
+  if (!identity?.slackUserId && !identity?.slackUserName && !identity?.githubHandle) return undefined
+
+  const lines = [
+    '# Requester Context',
+    '',
+    'The Slack user who prompted this turn is:',
+    ...(identity.slackUserId ? [`- Slack user ID: ${identity.slackUserId}`] : []),
+    ...(identity.slackMention ? [`- Slack mention: ${identity.slackMention}`] : []),
+    ...(identity.slackUserName ? [`- Slack username: ${identity.slackUserName}`] : []),
+    ...(identity.slackDisplayName ? [`- Slack display name: ${identity.slackDisplayName}`] : [])
+  ]
+
+  if (identity.githubHandle) {
+    const githubLogin = identity.githubHandle.replace(/^@/, '')
+    lines.push(
+      `- GitHub handle from Slack profile: ${identity.githubHandle}`,
+      `- GitHub handle source: ${identity.githubHandleSource ?? 'Slack profile custom field'}`,
+      '- GitHub handle verified: yes',
+      '',
+      '## GitHub PR Attribution',
+      '',
+      '- If you create a GitHub PR for this Slack request, '
+        + `the PR body MUST contain this standalone line: \`Prompted by: ${identity.githubHandle}\``,
+      '- The credited prompter is the requester in this section, not the Slack thread OP/root author.',
+      '- This is a GitHub PR body requirement, not a Slack response mention rule.',
+      `- Assign the PR to the requester when possible: \`${githubLogin}\``
+    )
+  } else {
+    lines.push(
+      '- GitHub handle from Slack profile: unavailable',
+      `- GitHub handle unavailable reason: ${identity.githubUnavailableReason ?? 'not resolved'}`,
+      '- GitHub handle verified: no',
+      '',
+      '## GitHub PR Attribution',
+      '',
+      '- If you create a GitHub PR for this Slack request, do not infer a GitHub '
+        + 'username from Slack display name, real name, or email.',
+      '- Omit the `Prompted by` line unless a verified GitHub handle is present.'
+    )
+  }
+
+  lines.push('', 'The user message follows in the next content block.', '---')
+  return lines.join('\n')
+}
+
 function codexInputContent(
   message: SlackbotV2ApiMessage,
   staged: Map<SlackbotV2ApiAttachment, string> = new Map(),
+  requesterIdentity?: RequesterIdentity,
   contextMessages?: SlackbotV2ApiMessage[]
 ): JsonValue[] {
   const content: JsonValue[] = []
+  const requesterContext = requesterIdentityContext(requesterIdentity)
+  if (requesterContext) {
+    content.push({ type: 'text', text: requesterContext })
+  }
   const threadContext = slackThreadContext(message, contextMessages)
   if (threadContext) {
     content.push({ type: 'text', text: threadContext })

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -20,12 +20,15 @@ import {
   type SlackbotV2ExecuteSessionRequest,
   type SlackbotV2SessionMessage
 } from '../src/index'
+import { clearRequesterIdentityCacheForTests } from '../src/session-api'
 
 const BOT_TOKEN = 'xoxb-slackbotv2-emulate'
 const USER_TOKEN = 'xoxp-slackbotv2-user'
+const USER_B_TOKEN = 'xoxp-slackbotv2-user-b'
 const SIGNING_SECRET = 'slackbotv2-signing-secret'
 const BOT_USER_ID = 'U000000001'
 const USER_ID = 'USLACKBOTV2USER'
+const USER_B_ID = 'USLACKBOTV2USERB'
 const TEAM_ID = 'T000000001'
 const CHANNEL_ID = 'C000000001'
 /** How real Slack renders a streamed message whose stream broke or was never stopped. */
@@ -35,6 +38,7 @@ let emulator: Emulator
 let slackApi: PatchedSlackApi
 let codexApi: MockSessionApi
 let slack: WebClient
+let slackB: WebClient
 let slackApiUrl: string
 let bot: SlackbotV2
 
@@ -51,11 +55,18 @@ beforeAll(async () => {
         [USER_TOKEN]: {
           login: USER_ID,
           scopes: ['chat:write', 'channels:read', 'users:read']
+        },
+        [USER_B_TOKEN]: {
+          login: USER_B_ID,
+          scopes: ['chat:write', 'channels:read', 'users:read']
         }
       },
       slack: {
         team: { name: 'Slackbot V2', domain: 'slackbot-v2' },
-        users: [{ name: 'tester', real_name: 'Test User', email: 'tester@example.com' }],
+        users: [
+          { name: 'tester', real_name: 'Test User', email: 'tester@example.com' },
+          { name: 'builder', real_name: 'Build User', email: 'builder@example.com' }
+        ],
         channels: [{ name: 'slackbot-v2' }],
         bots: [{ name: 'centaur' }],
         signing_secret: SIGNING_SECRET
@@ -66,9 +77,11 @@ beforeAll(async () => {
   codexApi = await startMockCodexApi()
   slackApiUrl = `${slackApi.url}/api/`
   slack = new WebClient(USER_TOKEN, { slackApiUrl })
+  slackB = new WebClient(USER_B_TOKEN, { slackApiUrl })
 })
 
 beforeEach(() => {
+  clearRequesterIdentityCacheForTests()
   emulator.reset()
   slackApi.reset()
   codexApi.reset()
@@ -342,6 +355,285 @@ describe('slackbotv2', () => {
     expect(executeInput).toContain('First preceding reply.')
     expect(executeInput).toContain('Second preceding reply.')
     expect(executeInput).toContain('summarize the thread so far')
+  })
+
+  it('injects Slack requester identity and verified GitHub handle into Codex input', async () => {
+    slackApi.setUserProfile(USER_ID, {
+      name: 'akshaan',
+      real_name: 'Akshaan Kakar',
+      fields: {
+        X_GITHUB: {
+          label: 'GitHub',
+          value: 'https://github.com/decofe'
+        }
+      }
+    })
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> what is my name?`)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-requester-identity',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> what is my name?`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    expect(codexApi.creates[0]!.body.metadata).toEqual(
+      expect.objectContaining({
+        slack_user_id: USER_ID
+      })
+    )
+    const executeMetadata = codexApi.executes[0]!.body.metadata
+    expect(executeMetadata).toEqual(
+      expect.objectContaining({
+        github_handle: '@decofe',
+        slack_display_name: 'Akshaan Kakar',
+        slack_user_id: USER_ID,
+        slack_user_name: 'akshaan'
+      })
+    )
+    const input = JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!) as {
+      message: { content: Array<{ text?: string; type: string }> }
+    }
+    expect(input.message.content[0]?.text).toContain('# Requester Context')
+    expect(input.message.content[0]?.text).toContain(`Slack user ID: ${USER_ID}`)
+    expect(input.message.content[0]?.text).toContain('Slack username: akshaan')
+    expect(input.message.content[0]?.text).toContain('GitHub handle from Slack profile: @decofe')
+    expect(input.message.content[0]?.text).toContain('Prompted by: @decofe')
+    expect(input.message.content[1]?.text).toBe(`@${BOT_USER_ID} what is my name?`)
+  })
+
+  it('caches Slack requester identity across mentions from the same user', async () => {
+    slackApi.setUserProfile(USER_ID, {
+      name: 'akshaan',
+      real_name: 'Akshaan Kakar',
+      fields: {
+        X_GITHUB: {
+          label: 'GitHub',
+          value: 'https://github.com/decofe'
+        }
+      }
+    })
+
+    for (const index of [1, 2]) {
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> identity cache ${index}`)
+      const waits: Promise<unknown>[] = []
+      const response = await bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: `Ev-slackbotv2-requester-identity-cache-${index}`,
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            text: `<@${BOT_USER_ID}> identity cache ${index}`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+      expect(response.status).toBe(200)
+      await Promise.all(waits)
+    }
+
+    expect(codexApi.executes).toHaveLength(2)
+    expect(slackApi.userProfileMethodRequestCount(USER_ID, '/api/users.profile.get')).toBe(1)
+    for (const execute of codexApi.executes) {
+      const input = JSON.parse(execute.body.input_lines.at(-1)!) as {
+        message: { content: Array<{ text?: string; type: string }> }
+      }
+      expect(input.message.content[0]?.text).toContain('GitHub handle from Slack profile: @decofe')
+    }
+  })
+
+  it('uses the reply mention requester identity instead of the root requester', async () => {
+    slackApi.setUserProfile(USER_ID, {
+      name: 'alice',
+      real_name: 'Alice Requester',
+      fields: {
+        X_GITHUB: {
+          label: 'GitHub',
+          value: 'alice-gh'
+        }
+      }
+    })
+    slackApi.setUserProfile(USER_B_ID, {
+      name: 'bob',
+      real_name: 'Bob Builder',
+      fields: {
+        X_GITHUB: {
+          label: 'GitHub',
+          value: 'https://github.com/bob-gh'
+        }
+      }
+    })
+
+    const rootMention = await postUserMessage(`<@${BOT_USER_ID}> start this PR thread`)
+    const rootWaits: Promise<unknown>[] = []
+    const rootResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-root-requester-a',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: rootMention.ts,
+          text: `<@${BOT_USER_ID}> start this PR thread`
+        }
+      }),
+      {},
+      waitUntilContext(rootWaits)
+    )
+    expect(rootResponse.status).toBe(200)
+    await Promise.all(rootWaits)
+
+    const replyMention = await postUserMessage(
+      `<@${BOT_USER_ID}> now make the PR`,
+      rootMention.ts,
+      slackB
+    )
+    const replyWaits: Promise<unknown>[] = []
+    const replyResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-reply-requester-b',
+        event: {
+          type: 'app_mention',
+          user: USER_B_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: replyMention.ts,
+          thread_ts: rootMention.ts,
+          text: `<@${BOT_USER_ID}> now make the PR`
+        }
+      }),
+      {},
+      waitUntilContext(replyWaits)
+    )
+    expect(replyResponse.status).toBe(200)
+    await Promise.all(replyWaits)
+
+    expect(codexApi.executes).toHaveLength(2)
+    const rootInput = JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!) as {
+      message: { content: Array<{ text?: string; type: string }> }
+    }
+    const replyInput = JSON.parse(codexApi.executes[1]!.body.input_lines.at(-1)!) as {
+      message: { content: Array<{ text?: string; type: string }> }
+    }
+    const rootContext = rootInput.message.content[0]?.text ?? ''
+    const replyContext = replyInput.message.content[0]?.text ?? ''
+
+    expect(rootContext).toContain(`Slack user ID: ${USER_ID}`)
+    expect(rootContext).toContain('GitHub handle from Slack profile: @alice-gh')
+    expect(replyContext).toContain(`Slack user ID: ${USER_B_ID}`)
+    expect(replyContext).toContain('Slack username: bob')
+    expect(replyContext).toContain('GitHub handle from Slack profile: @bob-gh')
+    expect(replyContext).toContain('Prompted by: @bob-gh')
+    expect(replyContext).not.toContain('@alice-gh')
+  })
+
+  it('includes reply mention requester identity when steering an active execution', async () => {
+    codexApi.autoRespond = false
+    slackApi.setUserProfile(USER_ID, {
+      name: 'alice',
+      real_name: 'Alice Requester',
+      fields: {
+        X_GITHUB: {
+          label: 'GitHub',
+          value: 'alice-gh'
+        }
+      }
+    })
+    slackApi.setUserProfile(USER_B_ID, {
+      name: 'bob',
+      real_name: 'Bob Builder',
+      fields: {
+        X_GITHUB: {
+          label: 'GitHub',
+          value: 'bob-gh'
+        }
+      }
+    })
+
+    const rootMention = await postUserMessage(`<@${BOT_USER_ID}> start a long PR run`)
+    const rootWaits: Promise<unknown>[] = []
+    const rootResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-active-root-requester-a',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: rootMention.ts,
+          text: `<@${BOT_USER_ID}> start a long PR run`
+        }
+      }),
+      {},
+      waitUntilContext(rootWaits)
+    )
+    expect(rootResponse.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    const replyMention = await postUserMessage(
+      `<@${BOT_USER_ID}> actually attribute the PR to me`,
+      rootMention.ts,
+      slackB
+    )
+    const replyWaits: Promise<unknown>[] = []
+    const replyResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-active-reply-requester-b',
+        event: {
+          type: 'app_mention',
+          user: USER_B_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: replyMention.ts,
+          thread_ts: rootMention.ts,
+          text: `<@${BOT_USER_ID}> actually attribute the PR to me`
+        }
+      }),
+      {},
+      waitUntilContext(replyWaits)
+    )
+    expect(replyResponse.status).toBe(200)
+    await Promise.all(replyWaits)
+
+    expect(codexApi.executes).toHaveLength(1)
+    expect(codexApi.appends).toHaveLength(2)
+    const steeredParts = codexApi.appends[1]!.body.messages[0]!.parts
+    const steeredText = steeredParts
+      .map(part => (isRecord(part) && typeof part.text === 'string' ? part.text : ''))
+      .join('\n')
+    expect(steeredText).toContain('# Requester Context')
+    expect(steeredText).toContain(`Slack user ID: ${USER_B_ID}`)
+    expect(steeredText).toContain('GitHub handle from Slack profile: @bob-gh')
+    expect(steeredText).toContain('Prompted by: @bob-gh')
+    expect(steeredText).not.toContain('@alice-gh')
+
+    codexApi.closeStreams()
+    await Promise.all(rootWaits)
   })
 
   it('refreshes Slack thread context for a reply mention after a root mention', async () => {
@@ -668,9 +960,9 @@ describe('slackbotv2', () => {
     await waitFor(() => codexApi.appends.length === 2)
     expect(codexApi.executes).toHaveLength(1)
     expect(codexApi.streamCount).toBe(1)
-    expect(sessionMessageTexts(codexApi.appends[1]!.body.messages)).toEqual([
-      `@${BOT_USER_ID} add this while still running`
-    ])
+    const secondAppendTexts = sessionMessageTexts(codexApi.appends[1]!.body.messages)
+    expect(secondAppendTexts[0]).toContain('# Requester Context')
+    expect(secondAppendTexts.at(-1)).toBe(`@${BOT_USER_ID} add this while still running`)
 
     codexApi.closeStreams()
     await Promise.all(firstWaits)
@@ -2721,8 +3013,12 @@ function apiMessageFromSlackEvent(input: {
   }
 }
 
-async function postUserMessage(text: string, threadTs?: string): Promise<{ ts: string }> {
-  const response = await slack.chat.postMessage({ channel: CHANNEL_ID, text, thread_ts: threadTs })
+async function postUserMessage(
+  text: string,
+  threadTs?: string,
+  client: WebClient = slack
+): Promise<{ ts: string }> {
+  const response = await client.chat.postMessage({ channel: CHANNEL_ID, text, thread_ts: threadTs })
   expect(response.ok).toBe(true)
   return { ts: String(response.ts) }
 }
@@ -3155,6 +3451,9 @@ type PatchedSlackApi = {
   failStreamAppendsAfter(count: number, error: string): void
   failStreamStopsLongerThan(maxChars: number): void
   reset(): void
+  setUserProfile(userId: string, profile: Record<string, unknown>): void
+  userProfileMethodRequestCount(userId: string, method: string): number
+  userProfileRequestCount(userId: string): number
   url: string
 }
 
@@ -3187,6 +3486,8 @@ type SlackStreamTranscript = {
 async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackApi> {
   const upstreamUrl = loopbackUrl(emulatorUrl)
   const calls: StreamCall[] = []
+  const userProfiles = new Map<string, Record<string, unknown>>()
+  const userProfileRequests = new Map<string, number>()
   const threadNotFoundReplies = new Set<string>()
   let maxStreamStopChars: number | null = null
   const appendFailure: { error: string; remaining: number } = { error: '', remaining: -1 }
@@ -3200,6 +3501,8 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       port,
       streams,
       threadNotFoundReplies,
+      userProfiles,
+      userProfileRequests,
       upstreamUrl
     }).catch(error => {
       res.writeHead(500, { 'content-type': 'application/json' })
@@ -3227,6 +3530,17 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       appendFailure.error = ''
       threadNotFoundReplies.clear()
       streams.clear()
+      userProfiles.clear()
+      userProfileRequests.clear()
+    },
+    setUserProfile(userId: string, profile: Record<string, unknown>) {
+      userProfiles.set(userId, profile)
+    },
+    userProfileMethodRequestCount(userId: string, method: string) {
+      return userProfileRequests.get(`${method}:${userId}`) ?? 0
+    },
+    userProfileRequestCount(userId: string) {
+      return userProfileRequests.get(userId) ?? 0
     },
     close: () => closeServer(server)
   }
@@ -3242,6 +3556,8 @@ async function handlePatchedSlackRequest(
     port: number
     streams: Map<string, StreamRecord>
     threadNotFoundReplies: Set<string>
+    userProfiles: Map<string, Record<string, unknown>>
+    userProfileRequests: Map<string, number>
     upstreamUrl: string
   }
 ): Promise<void> {
@@ -3282,6 +3598,34 @@ async function handlePatchedSlackRequest(
     const body = await requestBody(request)
     input.calls.push({ method: 'assistant.threads.setTitle', body })
     await sendWebResponse(res, Response.json({ ok: true }))
+    return
+  }
+  if (path === '/api/users.info' || path === '/api/users.profile.get') {
+    const userId = url.searchParams.get('user') ?? stringField((await requestBody(request)).user)
+    input.userProfileRequests.set(userId, (input.userProfileRequests.get(userId) ?? 0) + 1)
+    input.userProfileRequests.set(path, (input.userProfileRequests.get(path) ?? 0) + 1)
+    input.userProfileRequests.set(`${path}:${userId}`, (input.userProfileRequests.get(`${path}:${userId}`) ?? 0) + 1)
+    const profile = input.userProfiles.get(userId) ?? {
+      name: 'tester',
+      real_name: 'Test User',
+      fields: {}
+    }
+    if (path === '/api/users.info') {
+      await sendWebResponse(
+        res,
+        Response.json({
+          ok: true,
+          user: {
+            id: userId,
+            name: profile.name,
+            real_name: profile.real_name,
+            profile
+          }
+        })
+      )
+      return
+    }
+    await sendWebResponse(res, Response.json({ ok: true, profile }))
     return
   }
   if (path === '/api/chat.startStream') {

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -111,7 +111,8 @@ describe('forwardToSessionApi overrides', () => {
     expect(inputLines).toHaveLength(1)
     const line = JSON.parse(inputLines[0]!)
     expect(line.model).toBe('claude-sonnet-4-6')
-    expect(line.message.content).toEqual([{ type: 'text', text: 'review this' }])
+    expect(line.message.content[0].text).toContain('# Requester Context')
+    expect(line.message.content.at(-1)).toEqual({ type: 'text', text: 'review this' })
   })
 
   test('omits model field when no override is set', async () => {


### PR DESCRIPTION
## Summary
- inject per-turn requester context into Codex input, including Slack identity and verified GitHub handle from Slack profile custom fields
- cache requester identity lookups and merge cached Slack API profile data with Chat SDK author fields
- ensure reply mentions from a second user attribute PR context to that replying requester, including while an execution is already active

## Testing
- `bun run check:types` in `services/slackbotv2`
- `bun test test/session-api.test.ts` in `services/slackbotv2`
- `bun test test/chat-sdk-emulate.test.ts --test-name-pattern 'requester identity|identity cache|steering an active execution|second mention while a stream is already active|forwards subscribed messages|thread context'` in `services/slackbotv2`
- `git diff --check`