### PR TITLE
feat(sandbox): make codex reasoning summaries configurable via env

### DIFF
--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -164,6 +164,7 @@ Sandbox entrypoint and wrappers:
 | `GOOGLE_APPLICATION_CREDENTIALS` | Sandbox entrypoint or `sandbox.extraEnv`. | Google ADC path; entrypoint creates a local stub when unset. |
 | `CODEX_API_KEY`, `CODEX_HOME`, `CODEX_CONTINUE_THREAD_ID` | `sandbox.extraEnv` or runtime resume. | Codex auth/config/resume behavior. |
 | `CODEX_AUTH_MODE` | `sandbox.extraEnv`. | Codex auth flow: `api_key` (default, hits `api.openai.com`) or `access_token` (hits `chatgpt.com` via the brokered ChatGPT login). See [Codex Auth Modes](/deploying-in-production#codex-auth-modes). |
+| `CODEX_MODEL_REASONING_SUMMARY` | `sandbox.extraEnv`. | Sets `model_reasoning_summary` in the Codex config (`auto`, `concise`, `detailed`, `none`). Codex >= 0.139 emits no reasoning summaries unless this is set, so renderers show no thinking trace. |
 | `CLAUDE_MODEL`, `CLAUDE_CONTINUE_SESSION_ID` | `sandbox.extraEnv` or runtime resume. | Claude model and resume behavior. |
 | `CLAUDE_CODE_AUTH_MODE` | `sandbox.extraEnv`. | Claude Code auth flow: `api_key` (default, uses `ANTHROPIC_API_KEY`) or `access_token` (Claude.ai Pro or Max via the brokered OAuth login). See [Claude Auth Modes](/deploying-in-production#claude-auth-modes). |
 | `DEPLOY_ENV`, `ENVIRONMENT`, `TRACEPARENT` | Deployment env or wrapper-generated. | Runtime environment and trace context. |

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -117,6 +117,7 @@ Execution tuning:
 | `SLACK_FEEDBACK_COMMANDS`, `SLACK_FEEDBACK_ALLOWED_CHANNELS` | `slackbot.extraEnv`. | Feedback slash commands and optional channel allowlist. |
 | `SLACK_FEEDBACK_LINEAR_TEAM_ID`, `SLACK_FEEDBACK_LINEAR_PROJECT_ID` | `slackbot.extraEnv`. | Linear destination for feedback issues. |
 | `SLACKBOT_EXTERNAL_ORG_ALLOWLIST` | `slackbot.extraEnv`. | Slack team ids allowed for external org handoff. |
+| `SLACK_TEAM_ID` | `slackbot.extraEnv`. | Workspace team ID (e.g. `T01ABCD2EFG`) used to rewrite `https://*.slack.com/archives/...` URLs in final-delivery messages into native `slack://channel?team=...` deep links that open in the Slack app. Leave unset to keep archive URLs unchanged. |
 | `COMMIT_SHA` | Build/deploy env. | Commit shown in Slackbot metadata. |
 
 ## Sandbox
@@ -163,6 +164,7 @@ Sandbox entrypoint and wrappers:
 | `GOOGLE_APPLICATION_CREDENTIALS` | Sandbox entrypoint or `sandbox.extraEnv`. | Google ADC path; entrypoint creates a local stub when unset. |
 | `CODEX_API_KEY`, `CODEX_HOME`, `CODEX_CONTINUE_THREAD_ID` | `sandbox.extraEnv` or runtime resume. | Codex auth/config/resume behavior. |
 | `CODEX_AUTH_MODE` | `sandbox.extraEnv`. | Codex auth flow: `api_key` (default, hits `api.openai.com`) or `access_token` (hits `chatgpt.com` via the brokered ChatGPT login). See [Codex Auth Modes](/deploying-in-production#codex-auth-modes). |
+| `CODEX_MODEL_REASONING_SUMMARY` | `sandbox.extraEnv`. | Sets `model_reasoning_summary` in the Codex config (`auto`, `concise`, `detailed`, `none`). Codex >= 0.139 emits no reasoning summaries unless this is set, so renderers show no thinking trace. |
 | `CLAUDE_MODEL`, `CLAUDE_CONTINUE_SESSION_ID` | `sandbox.extraEnv` or runtime resume. | Claude model and resume behavior. |
 | `CLAUDE_CODE_AUTH_MODE` | `sandbox.extraEnv`. | Claude Code auth flow: `api_key` (default, uses `ANTHROPIC_API_KEY`) or `access_token` (Claude.ai Pro or Max via the brokered OAuth login). See [Claude Auth Modes](/deploying-in-production#claude-auth-modes). |
 | `DEPLOY_ENV`, `ENVIRONMENT`, `TRACEPARENT` | Deployment env or wrapper-generated. | Runtime environment and trace context. |

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -142,9 +142,35 @@ if [ -f "$HARNESS_CONFIG_DIR/codex/config.toml" ]; then
     CODEX_CONFIG_PATH="$HOME_DIR/.codex/config.toml" python3 - <<'PYEOF'
 from pathlib import Path
 import os
+import sys
 
 path = Path(os.environ["CODEX_CONFIG_PATH"])
 lines = path.read_text().splitlines()
+
+# CODEX_MODEL_REASONING_SUMMARY overrides model_reasoning_summary so deployments
+# can re-enable reasoning summaries (Codex >= 0.139 no longer emits them by
+# default) without rebuilding the sandbox image.
+summary = os.environ.get("CODEX_MODEL_REASONING_SUMMARY", "").strip()
+if summary:
+    if summary not in {"auto", "concise", "detailed", "none"}:
+        print(
+            f"ignoring invalid CODEX_MODEL_REASONING_SUMMARY: {summary!r} "
+            "(expected auto, concise, detailed, or none)",
+            file=sys.stderr,
+        )
+    else:
+        first_section = next(
+            (i for i, line in enumerate(lines) if line.lstrip().startswith("[")),
+            len(lines),
+        )
+        override = f'model_reasoning_summary = "{summary}"'
+        for i in range(first_section):
+            if lines[i].split("=", 1)[0].strip() == "model_reasoning_summary":
+                lines[i] = override
+                break
+        else:
+            lines.insert(first_section, override)
+
 features_start = next((i for i, line in enumerate(lines) if line.strip() == "[features]"), None)
 if features_start is None:
     lines.extend(["", "[features]", "multi_agent = false", "multi_agent_v2 = false"])


### PR DESCRIPTION
## Why

The codex CLI bump to 0.139 (#…recent releases) changed behavior: codex no longer emits reasoning summaries unless `model_reasoning_summary` is set in its config. Since `harness/codex/config.toml` doesn't set it, the app-server now emits reasoning items with empty `summary`/`content`, and downstream renderers (e.g. the Slack adapter, which reads the reasoning item text) silently lost the embedded thinking trace.

Reproduce on codex 0.139.0:

```
codex exec --json --skip-git-repo-check -c model_reasoning_effort='"low"' "What is 17 * 23 - 19?"
# -> no reasoning item, but usage shows reasoning_output_tokens > 0

codex exec --json --skip-git-repo-check -c model_reasoning_effort='"low"' -c model_reasoning_summary='"detailed"' "What is 17 * 23 - 19?"
# -> item.completed {type: reasoning, text: "**Calculating...**"}
```

## What

Make it configurable per deployment instead of baking a default into the image: the sandbox entrypoint merges `CODEX_MODEL_REASONING_SUMMARY` (`auto` | `concise` | `detailed` | `none`) into the generated `~/.codex/config.toml` — replacing an existing top-level `model_reasoning_summary` or inserting one before the first table. Invalid values warn to stderr and are ignored so a typo can't break every sandbox boot.

Deployments opt in through the existing `sandbox.extraEnv` chart value; no chart changes needed.

Tested the merge against `harness/codex/config.toml` for all four cases (unset, insert, replace-existing, invalid) — output stays valid TOML and the existing `[features]` rewrite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)