### PR TITLE
chore(chart): raise default idle-stop TTL to 3h

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.54
+version: 0.1.55
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -240,7 +240,7 @@ apiRs:
   sandboxWarmPoolReplenishIntervalSecs: 5
   # Reaper: stop sandboxes idle-paused longer than the idle TTL or older than
   # the max lifetime. 0 disables that sweep. Interval must be >= 1.
-  sandboxIdleStopTtlSecs: 3600
+  sandboxIdleStopTtlSecs: 10800 # 3 hours
   sandboxMaxLifetimeSecs: 259200 # 3 days
   sandboxReapIntervalSecs: 300
   ironProxy:


### PR DESCRIPTION
Raises the prod default `sandboxIdleStopTtlSecs` from 1h to 3h so idle sessions stay suspended-and-resumable longer before the reaper deletes them and their sandbox FS state. Chart bumped to 0.1.55. Follow-up to #538.