### PR TITLE
[codex] Port legacy ETL migrations to api-rs

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0011_slack_sync_tables.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0011_slack_sync_tables.sql
@@ -1,0 +1,139 @@
+create table if not exists slack_sync_channels (
+    channel_id text primary key,
+    channel_name text not null default '',
+    is_archived boolean not null default false,
+    is_syncable boolean not null default false,
+    topic text not null default '',
+    purpose text not null default '',
+    member_count integer not null default 0,
+    raw_payload jsonb not null default '{}'::jsonb,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+alter table slack_sync_channels
+    add column if not exists is_syncable boolean not null default false;
+
+create index if not exists idx_slack_sync_channels_syncable
+    on slack_sync_channels (is_syncable, channel_name);
+
+create table if not exists slack_sync_users (
+    user_id text primary key,
+    user_name text not null default '',
+    real_name text not null default '',
+    display_name text not null default '',
+    is_bot boolean not null default false,
+    is_deleted boolean not null default false,
+    team_id text not null default '',
+    raw_payload jsonb not null default '{}'::jsonb,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_slack_sync_users_real_name
+    on slack_sync_users (real_name);
+
+create table if not exists slack_sync_runs (
+    run_id text primary key,
+    workflow_run_id text,
+    mode text not null default 'incremental',
+    status text not null,
+    channels_requested jsonb not null default '[]'::jsonb,
+    channels_synced jsonb not null default '[]'::jsonb,
+    channels_skipped jsonb not null default '[]'::jsonb,
+    channels_failed jsonb not null default '[]'::jsonb,
+    messages_fetched integer not null default 0,
+    messages_upserted integer not null default 0,
+    threads_fetched integer not null default 0,
+    replies_fetched integer not null default 0,
+    replies_upserted integer not null default 0,
+    started_at timestamptz not null default now(),
+    finished_at timestamptz,
+    error_text text not null default '',
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_slack_sync_runs_started
+    on slack_sync_runs (started_at desc);
+
+create table if not exists slack_sync_messages (
+    channel_id text not null references slack_sync_channels(channel_id) on delete cascade,
+    message_ts text not null,
+    occurred_at timestamptz,
+    thread_ts text,
+    parent_message_ts text,
+    is_thread_root boolean not null default false,
+    user_id text not null default '',
+    bot_id text not null default '',
+    message_type text not null default 'message',
+    message_subtype text,
+    text text not null default '',
+    permalink text not null default '',
+    reply_count integer not null default 0,
+    reply_users jsonb not null default '[]'::jsonb,
+    latest_reply_ts text,
+    thread_refreshed_at timestamptz,
+    raw_payload jsonb not null default '{}'::jsonb,
+    source_run_id text references slack_sync_runs(run_id) on delete set null,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    primary key (channel_id, message_ts)
+);
+
+alter table slack_sync_messages
+    add column if not exists thread_refreshed_at timestamptz;
+
+create index if not exists idx_slack_sync_messages_thread
+    on slack_sync_messages (channel_id, thread_ts);
+
+create index if not exists idx_slack_sync_messages_occurred
+    on slack_sync_messages (occurred_at desc);
+
+create index if not exists idx_slack_sync_messages_user
+    on slack_sync_messages (user_id, occurred_at desc);
+
+create index if not exists idx_slack_sync_messages_text
+    on slack_sync_messages
+    using gin (to_tsvector('english', coalesce(text, '')));
+
+create table if not exists slack_sync_checkpoints (
+    channel_id text primary key references slack_sync_channels(channel_id) on delete cascade,
+    watermark_ts text,
+    last_run_id text references slack_sync_runs(run_id) on delete set null,
+    last_success_at timestamptz,
+    last_error text not null default '',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists slack_sync_backfill_jobs (
+    job_id bigserial primary key,
+    job_key text not null unique,
+    job_type text not null,
+    payload_version integer not null default 1,
+    channel_id text not null references slack_sync_channels(channel_id) on delete cascade,
+    status text not null default 'pending',
+    payload_json jsonb not null default '{}'::jsonb,
+    priority integer not null default 100,
+    attempt_count integer not null default 0,
+    last_run_id text references slack_sync_runs(run_id) on delete set null,
+    last_enqueued_at timestamptz not null default now(),
+    last_started_at timestamptz,
+    last_completed_at timestamptz,
+    last_error text not null default '',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_slack_sync_backfill_jobs_status_priority
+    on slack_sync_backfill_jobs (status, priority, updated_at);
+
+create index if not exists idx_slack_sync_backfill_jobs_channel_status
+    on slack_sync_backfill_jobs (channel_id, status);
+
+create unique index if not exists uq_slack_sync_channel_bootstrap_backfill
+    on slack_sync_backfill_jobs (channel_id)
+    where job_type = 'channel_bootstrap';

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0012_company_context_documents.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0012_company_context_documents.sql
@@ -1,0 +1,62 @@
+create extension if not exists pg_search;
+
+create table if not exists company_context_documents (
+    document_id text primary key,
+    source text not null,
+    source_type text not null,
+    source_document_id text not null,
+    source_chunk_id text not null default '',
+    parent_document_id text references company_context_documents(document_id) on delete cascade,
+    title text not null default '',
+    body text not null default '',
+    url text not null default '',
+    author_id text not null default '',
+    author_name text not null default '',
+    access_scope text not null default 'company',
+    occurred_at timestamptz,
+    source_updated_at timestamptz,
+    content_hash text not null default '',
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    check (source <> ''),
+    check (source_type <> ''),
+    check (source_document_id <> ''),
+    unique (source, source_type, source_document_id, source_chunk_id)
+);
+
+create index if not exists idx_company_context_documents_source_time
+    on company_context_documents (source, source_type, occurred_at desc);
+
+create index if not exists idx_company_context_documents_parent
+    on company_context_documents (parent_document_id);
+
+create index if not exists idx_company_context_documents_updated
+    on company_context_documents (source_updated_at desc);
+
+create index if not exists idx_company_context_documents_metadata
+    on company_context_documents using gin (metadata);
+
+drop index if exists idx_company_context_documents_bm25;
+
+create index idx_company_context_documents_bm25
+    on company_context_documents
+    using bm25 (
+        document_id,
+        title,
+        body,
+        source,
+        source_type,
+        access_scope,
+        occurred_at,
+        source_updated_at,
+        metadata
+    )
+    with (
+        key_field = 'document_id',
+        text_fields = '{
+            "document_id": {
+                "tokenizer": {"type": "keyword"}
+            }
+        }'
+    );

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0013_google_drive_sync_tables.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0013_google_drive_sync_tables.sql
@@ -1,0 +1,63 @@
+create table if not exists google_drive_sync_runs (
+    run_id text primary key,
+    workflow_run_id text,
+    mode text not null default 'incremental',
+    status text not null,
+    scopes_requested jsonb not null default '[]'::jsonb,
+    scopes_synced jsonb not null default '[]'::jsonb,
+    scopes_failed jsonb not null default '[]'::jsonb,
+    files_seen integer not null default 0,
+    files_upserted integer not null default 0,
+    docs_fetched integer not null default 0,
+    docs_upserted integer not null default 0,
+    started_at timestamptz not null default now(),
+    finished_at timestamptz,
+    error_text text not null default '',
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_google_drive_sync_runs_started
+    on google_drive_sync_runs (started_at desc);
+
+create table if not exists google_drive_sync_files (
+    file_id text primary key,
+    name text not null default '',
+    mime_type text not null default '',
+    web_view_link text not null default '',
+    drive_id text not null default '',
+    parent_ids jsonb not null default '[]'::jsonb,
+    owners jsonb not null default '[]'::jsonb,
+    last_modifying_user jsonb not null default '{}'::jsonb,
+    trashed boolean not null default false,
+    source_created_at timestamptz,
+    source_modified_at timestamptz,
+    text_content text not null default '',
+    text_hash text not null default '',
+    raw_payload jsonb not null default '{}'::jsonb,
+    source_run_id text references google_drive_sync_runs(run_id) on delete set null,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    last_content_synced_at timestamptz,
+    last_error text not null default '',
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_google_drive_sync_files_modified
+    on google_drive_sync_files (source_modified_at desc);
+
+create index if not exists idx_google_drive_sync_files_text
+    on google_drive_sync_files
+    using gin (to_tsvector('english', coalesce(text_content, '')));
+
+create index if not exists idx_google_drive_sync_files_parents
+    on google_drive_sync_files using gin (parent_ids);
+
+create table if not exists google_drive_sync_checkpoints (
+    scope_id text primary key,
+    watermark_time timestamptz,
+    last_run_id text references google_drive_sync_runs(run_id) on delete set null,
+    last_success_at timestamptz,
+    last_error text not null default '',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0014_google_calendar_sync_tables.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0014_google_calendar_sync_tables.sql
@@ -1,0 +1,104 @@
+create table if not exists google_calendar_sync_runs (
+    run_id text primary key,
+    workflow_run_id text,
+    mode text not null default 'incremental',
+    status text not null,
+    calendars_requested jsonb not null default '[]'::jsonb,
+    calendars_synced jsonb not null default '[]'::jsonb,
+    calendars_failed jsonb not null default '[]'::jsonb,
+    calendars_seen integer not null default 0,
+    calendars_upserted integer not null default 0,
+    events_seen integer not null default 0,
+    events_upserted integer not null default 0,
+    events_cancelled integer not null default 0,
+    started_at timestamptz not null default now(),
+    finished_at timestamptz,
+    error_text text not null default '',
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_google_calendar_sync_runs_started
+    on google_calendar_sync_runs (started_at desc);
+
+create table if not exists google_calendar_sync_calendars (
+    calendar_id text primary key,
+    summary text not null default '',
+    description text not null default '',
+    location text not null default '',
+    time_zone text not null default '',
+    access_role text not null default '',
+    is_primary boolean not null default false,
+    is_selected boolean not null default false,
+    is_hidden boolean not null default false,
+    background_color text not null default '',
+    foreground_color text not null default '',
+    raw_payload jsonb not null default '{}'::jsonb,
+    source_run_id text references google_calendar_sync_runs(run_id) on delete set null,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    last_error text not null default '',
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_google_calendar_sync_calendars_summary
+    on google_calendar_sync_calendars (summary);
+
+create table if not exists google_calendar_sync_events (
+    calendar_id text not null references google_calendar_sync_calendars(calendar_id) on delete cascade,
+    event_id text not null,
+    i_cal_uid text not null default '',
+    status text not null default '',
+    summary text not null default '',
+    description text not null default '',
+    location text not null default '',
+    html_link text not null default '',
+    creator jsonb not null default '{}'::jsonb,
+    organizer jsonb not null default '{}'::jsonb,
+    attendees jsonb not null default '[]'::jsonb,
+    start_payload jsonb not null default '{}'::jsonb,
+    end_payload jsonb not null default '{}'::jsonb,
+    start_at timestamptz,
+    end_at timestamptz,
+    is_all_day boolean not null default false,
+    recurring_event_id text not null default '',
+    original_start jsonb not null default '{}'::jsonb,
+    transparency text not null default '',
+    visibility text not null default '',
+    event_type text not null default '',
+    sequence integer not null default 0,
+    source_created_at timestamptz,
+    source_updated_at timestamptz,
+    content_text text not null default '',
+    content_hash text not null default '',
+    raw_payload jsonb not null default '{}'::jsonb,
+    source_run_id text references google_calendar_sync_runs(run_id) on delete set null,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    last_error text not null default '',
+    updated_at timestamptz not null default now(),
+    primary key (calendar_id, event_id)
+);
+
+create index if not exists idx_google_calendar_sync_events_start
+    on google_calendar_sync_events (start_at desc);
+
+create index if not exists idx_google_calendar_sync_events_updated
+    on google_calendar_sync_events (source_updated_at desc);
+
+create index if not exists idx_google_calendar_sync_events_text
+    on google_calendar_sync_events
+    using gin (to_tsvector('english', coalesce(content_text, '')));
+
+create index if not exists idx_google_calendar_sync_events_attendees
+    on google_calendar_sync_events using gin (attendees);
+
+create table if not exists google_calendar_sync_checkpoints (
+    calendar_id text primary key references google_calendar_sync_calendars(calendar_id) on delete cascade,
+    sync_token text not null default '',
+    watermark_time timestamptz,
+    last_run_id text references google_calendar_sync_runs(run_id) on delete set null,
+    last_success_at timestamptz,
+    last_error text not null default '',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0015_linear_sync_tables.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0015_linear_sync_tables.sql
@@ -1,0 +1,179 @@
+create table if not exists linear_sync_runs (
+    run_id text primary key,
+    workflow_run_id text,
+    mode text not null default 'incremental',
+    status text not null,
+    scopes_requested jsonb not null default '[]'::jsonb,
+    scopes_synced jsonb not null default '[]'::jsonb,
+    scopes_failed jsonb not null default '[]'::jsonb,
+    projects_seen integer not null default 0,
+    projects_upserted integer not null default 0,
+    issues_seen integer not null default 0,
+    issues_upserted integer not null default 0,
+    comments_seen integer not null default 0,
+    comments_upserted integer not null default 0,
+    started_at timestamptz not null default now(),
+    finished_at timestamptz,
+    error_text text not null default '',
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_linear_sync_runs_started
+    on linear_sync_runs (started_at desc);
+
+create table if not exists linear_sync_projects (
+    project_id text primary key,
+    name text not null default '',
+    description text not null default '',
+    slug_id text not null default '',
+    url text not null default '',
+    state text not null default '',
+    status_id text not null default '',
+    status_name text not null default '',
+    status_type text not null default '',
+    lead_user_id text not null default '',
+    lead_name text not null default '',
+    team_ids jsonb not null default '[]'::jsonb,
+    team_keys jsonb not null default '[]'::jsonb,
+    content_text text not null default '',
+    content_hash text not null default '',
+    source_created_at timestamptz,
+    source_updated_at timestamptz,
+    source_archived_at timestamptz,
+    source_completed_at timestamptz,
+    source_canceled_at timestamptz,
+    raw_payload jsonb not null default '{}'::jsonb,
+    source_run_id text references linear_sync_runs(run_id) on delete set null,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    last_error text not null default '',
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_linear_sync_projects_source_updated
+    on linear_sync_projects (source_updated_at desc);
+
+create index if not exists idx_linear_sync_projects_slug
+    on linear_sync_projects (slug_id);
+
+create index if not exists idx_linear_sync_projects_teams
+    on linear_sync_projects using gin (team_ids);
+
+create index if not exists idx_linear_sync_projects_text
+    on linear_sync_projects
+    using gin (to_tsvector('english', coalesce(content_text, '')));
+
+create table if not exists linear_sync_issues (
+    issue_id text primary key,
+    identifier text not null default '',
+    issue_number integer,
+    title text not null default '',
+    description text not null default '',
+    url text not null default '',
+    priority integer,
+    priority_label text not null default '',
+    estimate double precision,
+    due_date date,
+    team_id text not null default '',
+    team_key text not null default '',
+    team_name text not null default '',
+    project_id text not null default '',
+    project_name text not null default '',
+    cycle_id text not null default '',
+    cycle_name text not null default '',
+    state_id text not null default '',
+    state_name text not null default '',
+    state_type text not null default '',
+    assignee_user_id text not null default '',
+    assignee_name text not null default '',
+    creator_user_id text not null default '',
+    creator_name text not null default '',
+    parent_issue_id text not null default '',
+    parent_identifier text not null default '',
+    content_text text not null default '',
+    content_hash text not null default '',
+    source_created_at timestamptz,
+    source_updated_at timestamptz,
+    source_archived_at timestamptz,
+    source_started_at timestamptz,
+    source_completed_at timestamptz,
+    source_canceled_at timestamptz,
+    raw_payload jsonb not null default '{}'::jsonb,
+    source_run_id text references linear_sync_runs(run_id) on delete set null,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    last_error text not null default '',
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_linear_sync_issues_source_updated
+    on linear_sync_issues (source_updated_at desc);
+
+create index if not exists idx_linear_sync_issues_identifier
+    on linear_sync_issues (identifier);
+
+create index if not exists idx_linear_sync_issues_project
+    on linear_sync_issues (project_id);
+
+create index if not exists idx_linear_sync_issues_team
+    on linear_sync_issues (team_id);
+
+create index if not exists idx_linear_sync_issues_state
+    on linear_sync_issues (state_id);
+
+create index if not exists idx_linear_sync_issues_assignee
+    on linear_sync_issues (assignee_user_id);
+
+create index if not exists idx_linear_sync_issues_text
+    on linear_sync_issues
+    using gin (to_tsvector('english', coalesce(content_text, '')));
+
+create table if not exists linear_sync_comments (
+    comment_id text primary key,
+    issue_id text not null default '',
+    project_id text not null default '',
+    parent_comment_id text not null default '',
+    user_id text not null default '',
+    user_name text not null default '',
+    body text not null default '',
+    url text not null default '',
+    content_text text not null default '',
+    content_hash text not null default '',
+    source_created_at timestamptz,
+    source_updated_at timestamptz,
+    source_archived_at timestamptz,
+    source_edited_at timestamptz,
+    source_resolved_at timestamptz,
+    raw_payload jsonb not null default '{}'::jsonb,
+    source_run_id text references linear_sync_runs(run_id) on delete set null,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    last_error text not null default '',
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_linear_sync_comments_source_updated
+    on linear_sync_comments (source_updated_at desc);
+
+create index if not exists idx_linear_sync_comments_issue
+    on linear_sync_comments (issue_id);
+
+create index if not exists idx_linear_sync_comments_project
+    on linear_sync_comments (project_id);
+
+create index if not exists idx_linear_sync_comments_user
+    on linear_sync_comments (user_id);
+
+create index if not exists idx_linear_sync_comments_text
+    on linear_sync_comments
+    using gin (to_tsvector('english', coalesce(content_text, '')));
+
+create table if not exists linear_sync_checkpoints (
+    scope_id text primary key,
+    watermark_time timestamptz,
+    last_run_id text references linear_sync_runs(run_id) on delete set null,
+    last_success_at timestamptz,
+    last_error text not null default '',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);


### PR DESCRIPTION
## Summary

- Ports the legacy ETL table migrations into the Rust SQLx migration set.
- Adds schemas for Slack sync, company context documents, Google Drive sync, Google Calendar sync, and Linear sync.
- Keeps this PR migration-only; no RLS roles, policies, or iron-control access behavior are included.

## Why

The legacy Python `services/api/db/migrations` directory was removed when the repo moved to `api-rs`, but these workflow/table schemas are still referenced by the current ETL and company-context workflow code. Existing deployments may already have the tables, but fresh `api-rs` deployments need SQLx migrations to create them.

## Validation

- `cargo test -p centaur-session-sqlx`
- Applied every `centaur-session-sqlx` migration to a fresh `paradedb/paradedb:0.23.0-pg16` container and verified representative ETL tables exist.

## Notes

- `just build-one api-rs` is currently blocked on `origin/main` by an unrelated Rust compile error: `read_output_since` is called/implemented but is not a member of the `SandboxBackend` trait.
