### PR TITLE
[codex] Add Slack ETL RLS roles and PG settings

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use centaur_iron_proxy::{
-    PostgresListener, PostgresUpstream, ProxyFragment, SandboxEnv, Secret, SecretReplace,
-    Transform, TransformConfig,
+    PgDsnSetting, PgDsnSettingValueFrom, PostgresListener, PostgresUpstream, ProxyFragment,
+    SandboxEnv, Secret, SecretReplace, Transform, TransformConfig,
 };
 use serde::Serialize;
 use serde_yaml::Value as YamlValue;
@@ -416,6 +416,8 @@ struct PgDsnSecret {
     name: String,
     secret_ref: String,
     database: String,
+    role: Option<String>,
+    settings: Vec<PgDsnSetting>,
 }
 
 /// A `type = "aws_auth"` secret. The in-sandbox AWS SDK signs each request with
@@ -630,10 +632,68 @@ fn parse_pg_dsn_secret(
     secret_ref: String,
 ) -> Result<ToolSecret, ToolDiscoveryError> {
     let database = required_str(table, "database")?.to_owned();
+    let role = optional_str(table, "role").map(ToOwned::to_owned);
+    let settings = parse_pg_dsn_settings(table.get("settings"))?;
     Ok(ToolSecret::PgDsn(PgDsnSecret {
         name,
         secret_ref,
         database,
+        role,
+        settings,
+    }))
+}
+
+fn parse_pg_dsn_settings(
+    value: Option<&TomlValue>,
+) -> Result<Vec<PgDsnSetting>, ToolDiscoveryError> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let array = value.as_array().ok_or_else(|| {
+        ToolDiscoveryError::Invalid("pg_dsn settings must be an array".to_owned())
+    })?;
+    array
+        .iter()
+        .map(|item| {
+            let table = item.as_table().ok_or_else(|| {
+                ToolDiscoveryError::Invalid("pg_dsn setting must be a table".to_owned())
+            })?;
+            let name = required_str(table, "name")?.to_owned();
+            let literal = optional_str(table, "value").map(ToOwned::to_owned);
+            let value_from = parse_pg_dsn_setting_value_from(table.get("value_from"))?;
+            if literal.is_some() == value_from.is_some() {
+                return Err(ToolDiscoveryError::Invalid(format!(
+                    "pg_dsn setting {name:?} must declare exactly one of value or value_from"
+                )));
+            }
+            Ok(PgDsnSetting {
+                name,
+                value: literal,
+                value_from,
+            })
+        })
+        .collect()
+}
+
+fn parse_pg_dsn_setting_value_from(
+    value: Option<&TomlValue>,
+) -> Result<Option<PgDsnSettingValueFrom>, ToolDiscoveryError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let table = value.as_table().ok_or_else(|| {
+        ToolDiscoveryError::Invalid("pg_dsn setting value_from must be a table".to_owned())
+    })?;
+    let principal_label = optional_str(table, "principal_label").map(ToOwned::to_owned);
+    let principal_field = optional_str(table, "principal_field").map(ToOwned::to_owned);
+    if principal_label.is_none() && principal_field.is_none() {
+        return Err(ToolDiscoveryError::Invalid(
+            "pg_dsn setting value_from must declare principal_label or principal_field".to_owned(),
+        ));
+    }
+    Ok(Some(PgDsnSettingValueFrom {
+        principal_label,
+        principal_field,
     }))
 }
 
@@ -981,6 +1041,10 @@ fn postgres_listeners(secrets: &[ToolSecret]) -> Result<Vec<PostgresListener>, T
     by_name
         .into_values()
         .map(|secret| {
+            let mut extra = BTreeMap::new();
+            if let Some(role) = &secret.role {
+                extra.insert("role".to_owned(), yaml_string(role));
+            }
             Ok(PostgresListener {
                 name: Some(secret.name.to_lowercase()),
                 upstream: Some(PostgresUpstream {
@@ -999,6 +1063,8 @@ fn postgres_listeners(secrets: &[ToolSecret]) -> Result<Vec<PostgresListener>, T
                     database: Some(secret.database.clone()),
                     ..Default::default()
                 }),
+                settings: secret.settings.clone(),
+                extra,
                 ..Default::default()
             })
         })
@@ -1161,12 +1227,27 @@ mod tests {
             name: "RESHIFT_DSN".to_owned(),
             secret_ref: "RESHIFT_DSN".to_owned(),
             database: "warehouse".to_owned(),
+            role: Some("centaur_slack_reader".to_owned()),
+            settings: vec![PgDsnSetting {
+                name: "centaur.slack_channel_id".to_owned(),
+                value: None,
+                value_from: Some(PgDsnSettingValueFrom {
+                    principal_label: Some("slack_channel_id".to_owned()),
+                    principal_field: None,
+                }),
+            }],
         })])
         .unwrap();
 
         let sandbox_env = listeners[0].sandbox_env.as_ref().unwrap();
         assert_eq!(sandbox_env.name.as_deref(), Some("RESHIFT_DSN"));
         assert_eq!(sandbox_env.database.as_deref(), Some("warehouse"));
+        assert_eq!(
+            listeners[0].extra.get("role").and_then(YamlValue::as_str),
+            Some("centaur_slack_reader")
+        );
+        assert_eq!(listeners[0].settings.len(), 1);
+        assert_eq!(listeners[0].settings[0].name, "centaur.slack_channel_id");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -20,8 +20,8 @@ pub use models::{
     AwsAuthSecretInput, BrokerCredentialInput, BrokerCredentialRecord, EffectiveConfig,
     EffectivePgDsn, EffectiveReplace, EffectiveSecret, GcpAuthSecretInput, Grant, GrantSecret,
     Grantee, HmacSecretHeader, HmacSecretInput, IdentityInput, InjectConfig, OAuthTokenSecretInput,
-    PgDsnSecretInput, Principal, Proxy, ProxyInput, ReplaceConfig, RequestRule, Role, SECRET_TYPES,
-    SecretRecord, SecretSource, StaticSecretInput,
+    PgDsnSecretInput, PgDsnSettingInput, PgDsnSettingValueFromInput, Principal, Proxy, ProxyInput,
+    ReplaceConfig, RequestRule, Role, SECRET_TYPES, SecretRecord, SecretSource, StaticSecretInput,
 };
 pub use principal::{PrincipalRef, derive_principal};
 pub use registry::{

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -261,7 +261,10 @@ pub struct AwsAuthSecretInput {
 /// ``database`` is the database name to connect to on both the proxied and the
 /// upstream connection (the ``dsn`` source is opaque, so it can't be parsed out
 /// of the connection string); ``role`` is an optional Postgres role the proxy
-/// issues ``SET ROLE`` for.
+/// issues ``SET ROLE`` for. ``settings`` are optional Postgres GUCs the proxy
+/// sets after connecting. A setting can carry either a literal ``value`` or a
+/// structured ``value_from`` reference that iron-control resolves against the
+/// proxy's assigned principal at sync time.
 // Not `Eq`: holds a `SecretSource` (arbitrary `Value` config).
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct PgDsnSecretInput {
@@ -275,7 +278,26 @@ pub struct PgDsnSecretInput {
     pub role: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub labels: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub settings: Vec<PgDsnSettingInput>,
     pub dsn: SecretSource,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct PgDsnSettingInput {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value_from: Option<PgDsnSettingValueFromInput>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct PgDsnSettingValueFromInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub principal_label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub principal_field: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -13,6 +13,8 @@
 //! [`derive_principal`] is pure so the mapping is unit-tested directly; callers
 //! upsert the returned [`PrincipalRef`] at session start.
 
+use std::collections::BTreeMap;
+
 use crate::models::IdentityInput;
 use crate::util::{managed_labels, slugify};
 
@@ -21,17 +23,20 @@ use crate::util::{managed_labels, slugify};
 pub struct PrincipalRef {
     pub foreign_id: String,
     pub name: String,
+    pub labels: BTreeMap<String, String>,
 }
 
 impl PrincipalRef {
     /// Build the upsert body for this principal in ``namespace``, tagging it as
     /// Centaur-managed.
     pub fn to_identity_input(&self, namespace: &str) -> IdentityInput {
+        let mut labels = managed_labels();
+        labels.extend(self.labels.clone());
         IdentityInput {
             namespace: namespace.to_owned(),
             foreign_id: self.foreign_id.clone(),
             name: self.name.clone(),
-            labels: managed_labels(),
+            labels,
         }
     }
 }
@@ -45,6 +50,10 @@ impl PrincipalRef {
 /// thread still maps to a deterministic, distinct principal.
 pub fn derive_principal(thread_key: &str, slack_user_id: Option<&str>) -> PrincipalRef {
     let (team_id, conversation_id) = parse_slack_segments(thread_key);
+    let mut labels = BTreeMap::new();
+    if let Some(team) = team_id {
+        labels.insert("slack_team_id".to_owned(), team.to_owned());
+    }
     let scope = team_id
         .map(|team| format!("{}-", slugify(team)))
         .unwrap_or_default();
@@ -55,22 +64,27 @@ pub fn derive_principal(thread_key: &str, slack_user_id: Option<&str>) -> Princi
     if is_direct_message(conversation_id)
         && let Some(user) = slack_user_id.map(str::trim).filter(|user| !user.is_empty())
     {
+        labels.insert("slack_user_id".to_owned(), user.to_owned());
         return PrincipalRef {
             foreign_id: format!("slack-user-{scope}{}", slugify(user)),
             name: format!("Slack user {user}{team_suffix}"),
+            labels,
         };
     }
 
     if let Some(conversation_id) = conversation_id {
+        labels.insert("slack_channel_id".to_owned(), conversation_id.to_owned());
         return PrincipalRef {
             foreign_id: format!("slack-channel-{scope}{}", slugify(conversation_id)),
             name: format!("Slack channel {conversation_id}{team_suffix}"),
+            labels,
         };
     }
 
     PrincipalRef {
         foreign_id: format!("thread-{}", slugify(thread_key)),
         name: thread_key.to_owned(),
+        labels,
     }
 }
 
@@ -109,6 +123,10 @@ mod tests {
         let principal = derive_principal("slack:D0420:1780000000.0001", Some("U07ABC"));
         assert_eq!(principal.foreign_id, "slack-user-u07abc");
         assert_eq!(principal.name, "Slack user U07ABC");
+        assert_eq!(
+            principal.labels.get("slack_user_id").map(String::as_str),
+            Some("U07ABC")
+        );
     }
 
     #[test]
@@ -122,6 +140,10 @@ mod tests {
         let principal = derive_principal("chat:C123:1780000000.000000", Some("U07ABC"));
         assert_eq!(principal.foreign_id, "slack-channel-c123");
         assert_eq!(principal.name, "Slack channel C123");
+        assert_eq!(
+            principal.labels.get("slack_channel_id").map(String::as_str),
+            Some("C123")
+        );
     }
 
     #[test]
@@ -135,6 +157,14 @@ mod tests {
         let principal = derive_principal("slack:T123:C456:1780000000.0001", Some("U1"));
         assert_eq!(principal.foreign_id, "slack-channel-t123-c456");
         assert_eq!(principal.name, "Slack channel C456 (team T123)");
+        assert_eq!(
+            principal.labels.get("slack_team_id").map(String::as_str),
+            Some("T123")
+        );
+        assert_eq!(
+            principal.labels.get("slack_channel_id").map(String::as_str),
+            Some("C456")
+        );
     }
 
     #[test]
@@ -159,6 +189,10 @@ mod tests {
         assert_eq!(
             input.labels.get("managed-by").map(String::as_str),
             Some("centaur")
+        );
+        assert_eq!(
+            input.labels.get("slack_channel_id").map(String::as_str),
+            Some("C1")
         );
     }
 }

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -15,7 +15,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use centaur_iron_proxy::{
-    PostgresListener, ProxyFragment, Secret, SecretReplace, SourceKind, SourcePolicy, pg_foreign_id,
+    PgDsnSetting, PgDsnSettingValueFrom, PostgresListener, ProxyFragment, Secret, SecretReplace,
+    SourceKind, SourcePolicy, pg_foreign_id,
 };
 use serde_json::{Value as JsonValue, json};
 use serde_yaml::Value as YamlValue;
@@ -24,8 +25,8 @@ use crate::client::IronControlClient;
 use crate::error::IronControlError;
 use crate::models::{
     AwsAuthSecretInput, GcpAuthSecretInput, GrantSecret, Grantee, HmacSecretInput, IdentityInput,
-    InjectConfig, OAuthTokenSecretInput, PgDsnSecretInput, ReplaceConfig, RequestRule,
-    SecretSource, StaticSecretInput,
+    InjectConfig, OAuthTokenSecretInput, PgDsnSecretInput, PgDsnSettingInput,
+    PgDsnSettingValueFromInput, ReplaceConfig, RequestRule, SecretSource, StaticSecretInput,
 };
 use crate::util::{managed_labels, slugify};
 
@@ -536,8 +537,31 @@ fn pg_dsn_from_listener(
         description: None,
         role: role_to_set,
         labels: managed_labels(),
+        settings: listener
+            .settings
+            .iter()
+            .map(pg_setting_from_listener)
+            .collect(),
         dsn,
     })
+}
+
+fn pg_setting_from_listener(setting: &PgDsnSetting) -> PgDsnSettingInput {
+    PgDsnSettingInput {
+        name: setting.name.clone(),
+        value: setting.value.clone(),
+        value_from: setting.value_from.as_ref().map(
+            |PgDsnSettingValueFrom {
+                 principal_label,
+                 principal_field,
+             }| {
+                PgDsnSettingValueFromInput {
+                    principal_label: principal_label.clone(),
+                    principal_field: principal_field.clone(),
+                }
+            },
+        ),
+    }
 }
 
 /// Resolve a listener's ``upstream.dsn`` into an iron-control secret source.
@@ -991,6 +1015,10 @@ postgres:
     sandbox_env:
       database: analytics_db
     role: readonly
+    settings:
+      - name: centaur.slack_channel_id
+        value_from:
+          principal_label: slack_channel_id
 "#,
         )
         .unwrap();
@@ -1004,6 +1032,15 @@ postgres:
         assert_eq!(input.name, "analytics");
         assert_eq!(input.database, "analytics_db");
         assert_eq!(input.role.as_deref(), Some("readonly"));
+        assert_eq!(input.settings.len(), 1);
+        assert_eq!(input.settings[0].name, "centaur.slack_channel_id");
+        assert_eq!(
+            input.settings[0]
+                .value_from
+                .as_ref()
+                .and_then(|value_from| value_from.principal_label.as_deref()),
+            Some("slack_channel_id")
+        );
         assert_eq!(input.dsn.source_type, "env");
         assert_eq!(input.dsn.config, json!({ "var": "PG_ANALYTICS_DSN" }));
     }

--- a/services/api-rs/crates/centaur-iron-proxy/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/lib.rs
@@ -8,8 +8,9 @@ pub use fragment::{
     harness_auth_fragment, infra_fragment, load_fragment_str, pg_sandbox_dsns, placeholder_env,
 };
 pub use model::{
-    PostgresClient, PostgresListener, PostgresUpstream, ProxyFragment, SandboxEnv, Secret,
-    SecretReplace, Transform, TransformConfig, pg_foreign_id, pg_sandbox_env_var,
+    PgDsnSetting, PgDsnSettingValueFrom, PostgresClient, PostgresListener, PostgresUpstream,
+    ProxyFragment, SandboxEnv, Secret, SecretReplace, Transform, TransformConfig, pg_foreign_id,
+    pg_sandbox_env_var,
 };
 pub use source::{SourceKind, SourcePolicy};
 

--- a/services/api-rs/crates/centaur-iron-proxy/src/model/mod.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/model/mod.rs
@@ -3,8 +3,8 @@ mod proxy;
 mod transform;
 
 pub use postgres::{
-    PostgresClient, PostgresListener, PostgresUpstream, SandboxEnv, pg_foreign_id,
-    pg_sandbox_env_var,
+    PgDsnSetting, PgDsnSettingValueFrom, PostgresClient, PostgresListener, PostgresUpstream,
+    SandboxEnv, pg_foreign_id, pg_sandbox_env_var,
 };
 pub use proxy::ProxyFragment;
 pub use transform::{Secret, SecretReplace, Transform, TransformConfig};

--- a/services/api-rs/crates/centaur-iron-proxy/src/model/postgres.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/model/postgres.rs
@@ -15,6 +15,8 @@ pub struct PostgresListener {
     pub client: Option<PostgresClient>,
     #[serde(default, skip_serializing)]
     pub sandbox_env: Option<SandboxEnv>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub settings: Vec<PgDsnSetting>,
     #[serde(default, flatten)]
     pub extra: BTreeMap<String, Value>,
 }
@@ -45,6 +47,23 @@ pub struct SandboxEnv {
     pub database: Option<String>,
     #[serde(default, flatten)]
     pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PgDsnSetting {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_from: Option<PgDsnSettingValueFrom>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PgDsnSettingValueFrom {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal_field: Option<String>,
 }
 
 /// The iron-control `pg_dsn` secret foreign_id for a listener name. Shared so

--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -337,7 +337,7 @@ fn aws_auth_requires_hosts() {
 #[test]
 fn parses_pg_dsn_secret() {
     let parsed = tools::parse_secret(
-        &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN" }"#),
+        &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } }] }"#),
         &[],
     )
     .unwrap();
@@ -347,6 +347,16 @@ fn parses_pg_dsn_secret() {
     assert_eq!(pg.name, "RESHIFT_DSN");
     assert_eq!(pg.database, "pmadmin");
     assert_eq!(pg.secret_ref, "RESHIFT_DSN");
+    assert_eq!(pg.role.as_deref(), Some("centaur_slack_reader"));
+    assert_eq!(pg.settings.len(), 1);
+    assert_eq!(pg.settings[0].name, "centaur.slack_channel_id");
+    assert_eq!(
+        pg.settings[0]
+            .value_from
+            .as_ref()
+            .and_then(|value_from| value_from.principal_label.as_deref()),
+        Some("slack_channel_id")
+    );
 }
 
 #[test]
@@ -459,7 +469,7 @@ fn translates_oauth_with_json_key_fields() {
 fn translates_pg_dsn_to_input_with_roundtrip_foreign_id() {
     let secrets = vec![
         tools::parse_secret(
-            &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN" }"#),
+            &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } }] }"#),
             &[],
         )
         .unwrap(),
@@ -474,6 +484,15 @@ fn translates_pg_dsn_to_input_with_roundtrip_foreign_id() {
     assert_eq!(pg_sandbox_env_var(&input.foreign_id), "RESHIFT_DSN");
     assert_eq!(input.name, "RESHIFT_DSN");
     assert_eq!(input.database, "pmadmin");
+    assert_eq!(input.role.as_deref(), Some("centaur_slack_reader"));
+    assert_eq!(input.settings.len(), 1);
+    assert_eq!(
+        input.settings[0]
+            .value_from
+            .as_ref()
+            .and_then(|value_from| value_from.principal_label.as_deref()),
+        Some("slack_channel_id")
+    );
     assert_eq!(input.dsn.source_type, "env");
     assert_eq!(
         input.dsn.config,

--- a/services/api-rs/crates/centaur-perms/src/tools.rs
+++ b/services/api-rs/crates/centaur-perms/src/tools.rs
@@ -10,6 +10,7 @@
 
 use std::path::{Path, PathBuf};
 
+use centaur_iron_proxy::{PgDsnSetting, PgDsnSettingValueFrom};
 use eyre::{Context, Result, bail, eyre};
 use toml::Value;
 
@@ -133,6 +134,8 @@ pub struct PgDsnSecret {
     pub name: String,
     pub secret_ref: String,
     pub database: String,
+    pub role: Option<String>,
+    pub settings: Vec<PgDsnSetting>,
 }
 
 /// One header iron-proxy's `hmac_sign` transform writes onto the upstream
@@ -623,11 +626,61 @@ fn parse_gcp(table: &toml::Table, name: &str, secret_ref: &str) -> Result<GcpAut
 fn parse_pg_dsn(table: &toml::Table, name: &str, secret_ref: &str) -> Result<PgDsnSecret> {
     let database = req_str(table, "database")
         .wrap_err_with(|| format!("pg_dsn entry {name:?} requires a non-empty 'database'"))?;
+    let role = opt_str(table, "role");
+    let settings = parse_pg_dsn_settings(table.get("settings"))?;
     Ok(PgDsnSecret {
         name: name.to_owned(),
         secret_ref: secret_ref.to_owned(),
         database,
+        role,
+        settings,
     })
+}
+
+fn parse_pg_dsn_settings(value: Option<&Value>) -> Result<Vec<PgDsnSetting>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let array = value
+        .as_array()
+        .ok_or_else(|| eyre!("pg_dsn 'settings' must be an array"))?;
+    array
+        .iter()
+        .map(|item| {
+            let table = item
+                .as_table()
+                .ok_or_else(|| eyre!("pg_dsn setting must be a table"))?;
+            let name = req_str(table, "name").wrap_err("pg_dsn setting")?;
+            let literal = opt_str(table, "value");
+            let value_from = parse_pg_dsn_setting_value_from(table.get("value_from"))?;
+            if literal.is_some() == value_from.is_some() {
+                bail!("pg_dsn setting {name:?} must declare exactly one of value or value_from");
+            }
+            Ok(PgDsnSetting {
+                name,
+                value: literal,
+                value_from,
+            })
+        })
+        .collect()
+}
+
+fn parse_pg_dsn_setting_value_from(value: Option<&Value>) -> Result<Option<PgDsnSettingValueFrom>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let table = value
+        .as_table()
+        .ok_or_else(|| eyre!("pg_dsn setting value_from must be a table"))?;
+    let principal_label = opt_str(table, "principal_label");
+    let principal_field = opt_str(table, "principal_field");
+    if principal_label.is_none() && principal_field.is_none() {
+        bail!("pg_dsn setting value_from must declare principal_label or principal_field");
+    }
+    Ok(Some(PgDsnSettingValueFrom {
+        principal_label,
+        principal_field,
+    }))
 }
 
 /// Port of the `hmac_sign` branch of `_parse_secret`. `hosts` is required (no

--- a/services/api-rs/crates/centaur-perms/src/translate.rs
+++ b/services/api-rs/crates/centaur-perms/src/translate.rs
@@ -11,11 +11,13 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use centaur_iron_control::{
     AwsAuthSecretInput, GcpAuthSecretInput, HmacSecretHeader, HmacSecretInput, InjectConfig,
-    OAuthTokenSecretInput, PgDsnSecretInput, ReplaceConfig, RequestRule, SecretInput, SecretSource,
-    StaticSecretInput, gcp_auth_scopes_or_default, managed_labels, slugify,
-    source_from_placeholder, unique_foreign_id,
+    OAuthTokenSecretInput, PgDsnSecretInput, PgDsnSettingInput, PgDsnSettingValueFromInput,
+    ReplaceConfig, RequestRule, SecretInput, SecretSource, StaticSecretInput,
+    gcp_auth_scopes_or_default, managed_labels, slugify, source_from_placeholder,
+    unique_foreign_id,
 };
 use centaur_iron_proxy::SourcePolicy;
+use centaur_iron_proxy::{PgDsnSetting, PgDsnSettingValueFrom};
 
 use crate::tools::{
     AwsAuthSecret, BrokerTokenSecret, FieldSource, GcpAuthSecret, HmacSignSecret, HttpSecret,
@@ -206,9 +208,28 @@ fn pg_dsn_input(namespace: &str, pg: &PgDsnSecret, policy: &SourcePolicy) -> PgD
         name: pg.name.clone(),
         database: pg.database.clone(),
         description: None,
-        role: None,
+        role: pg.role.clone(),
         labels: managed_labels(),
+        settings: pg.settings.iter().map(pg_setting_input).collect(),
         dsn: source_from_placeholder(policy, &pg.secret_ref, None),
+    }
+}
+
+fn pg_setting_input(setting: &PgDsnSetting) -> PgDsnSettingInput {
+    PgDsnSettingInput {
+        name: setting.name.clone(),
+        value: setting.value.clone(),
+        value_from: setting.value_from.as_ref().map(
+            |PgDsnSettingValueFrom {
+                 principal_label,
+                 principal_field,
+             }| {
+                PgDsnSettingValueFromInput {
+                    principal_label: principal_label.clone(),
+                    principal_field: principal_field.clone(),
+                }
+            },
+        ),
     }
 }
 

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0016_slack_context_rls.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0016_slack_context_rls.sql
@@ -18,10 +18,8 @@ grant select on slack_sync_messages to centaur_slack_reader, centaur_slack_admin
 grant select on company_context_documents to centaur_slack_reader, centaur_slack_admin;
 
 alter table slack_sync_messages enable row level security;
-alter table slack_sync_messages force row level security;
 
 alter table company_context_documents enable row level security;
-alter table company_context_documents force row level security;
 
 drop policy if exists centaur_slack_messages_admin_select on slack_sync_messages;
 create policy centaur_slack_messages_admin_select

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0016_slack_context_rls.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0016_slack_context_rls.sql
@@ -1,0 +1,57 @@
+do $$
+begin
+    if not exists (select 1 from pg_roles where rolname = 'centaur_slack_reader') then
+        create role centaur_slack_reader nologin;
+    end if;
+
+    if not exists (select 1 from pg_roles where rolname = 'centaur_slack_admin') then
+        create role centaur_slack_admin nologin;
+    end if;
+end
+$$;
+
+grant usage on schema public to centaur_slack_reader, centaur_slack_admin;
+
+grant select on slack_sync_channels to centaur_slack_reader, centaur_slack_admin;
+grant select on slack_sync_users to centaur_slack_reader, centaur_slack_admin;
+grant select on slack_sync_messages to centaur_slack_reader, centaur_slack_admin;
+grant select on company_context_documents to centaur_slack_reader, centaur_slack_admin;
+
+alter table slack_sync_messages enable row level security;
+alter table slack_sync_messages force row level security;
+
+alter table company_context_documents enable row level security;
+alter table company_context_documents force row level security;
+
+drop policy if exists centaur_slack_messages_admin_select on slack_sync_messages;
+create policy centaur_slack_messages_admin_select
+    on slack_sync_messages
+    for select
+    to centaur_slack_admin
+    using (true);
+
+drop policy if exists centaur_slack_messages_reader_select on slack_sync_messages;
+create policy centaur_slack_messages_reader_select
+    on slack_sync_messages
+    for select
+    to centaur_slack_reader
+    using (
+        channel_id = nullif(current_setting('centaur.slack_channel_id', true), '')
+    );
+
+drop policy if exists centaur_context_docs_admin_select on company_context_documents;
+create policy centaur_context_docs_admin_select
+    on company_context_documents
+    for select
+    to centaur_slack_admin
+    using (true);
+
+drop policy if exists centaur_context_docs_reader_select on company_context_documents;
+create policy centaur_context_docs_reader_select
+    on company_context_documents
+    for select
+    to centaur_slack_reader
+    using (
+        source <> 'slack'
+        or metadata ->> 'channel_id' = nullif(current_setting('centaur.slack_channel_id', true), '')
+    );


### PR DESCRIPTION
## Summary
- Add SQLx migration `0016_slack_context_rls.sql` creating shared `centaur_slack_reader` and `centaur_slack_admin` Postgres roles.
- Enable/force RLS on `slack_sync_messages` and `company_context_documents`, with channel-scoped reader policies and all-row admin policies.
- Add the Centaur-side PG DSN settings contract: `settings[].value_from.principal_label`, Slack principal labels, and `role`/`settings` parsing for API discovery and `centaur-perms`.

## Notes
- Reader role uses `current_setting('centaur.slack_channel_id', true)` for Slack message rows.
- For `company_context_documents`, non-Slack docs remain visible to the reader role; Slack docs are filtered by `metadata->>channel_id`.
- The admin role is generic; assigning it to the `ai-agent` channel remains deployment/control-plane configuration, not hard-coded in Centaur.

## Validation
- `cargo fmt --check`
- `cargo test -p centaur-iron-control -p centaur-iron-proxy -p centaur-perms`
- `cargo check -p centaur-api-server`
- Applied migration SQL inside a staging Postgres transaction and rolled it back; verified rollback left zero matching roles/policies.
