### PR TITLE
feat(slackbotv2): per-turn codex reasoning effort via -rsn flag

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -100,6 +100,7 @@ pub(crate) fn run_codex_blocks_server() -> Result<()> {
                 input,
                 client_user_message_id,
                 model,
+                reasoning,
             }) => {
                 if let Err(error) = run_codex_user_turn(
                     &mut codex,
@@ -109,6 +110,7 @@ pub(crate) fn run_codex_blocks_server() -> Result<()> {
                     input,
                     client_user_message_id,
                     model,
+                    reasoning,
                 ) {
                     let fallback_thread_id = thread_id.as_deref().unwrap_or("codex");
                     eprintln!("Codex blocks turn failed: {error:#}");
@@ -144,6 +146,7 @@ fn run_codex_user_turn<W: Write>(
     input: Vec<UserInput>,
     client_user_message_id: Option<String>,
     model: Option<String>,
+    reasoning: Option<String>,
 ) -> Result<()> {
     if thread_id.is_none() {
         *thread_id = Some(start_or_resume_thread(codex, stdout, request_id)?);
@@ -162,6 +165,12 @@ fn run_codex_user_turn<W: Write>(
     }
     if let Some(model) = model {
         params["model"] = Value::String(model);
+    }
+    // Per-turn reasoning effort (codex `turn/start.effort`), parsed from the
+    // `-rsn` message flag. Values match codex's ReasoningEffort enum
+    // (none|minimal|low|medium|high|xhigh); validation happens upstream.
+    if let Some(reasoning) = reasoning {
+        params["effort"] = Value::String(reasoning);
     }
 
     let turn_request_id = next_request_id(request_id);

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -92,6 +92,9 @@ pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()>
                 input,
                 client_user_message_id,
                 model,
+                // Reasoning effort only applies to the codex harness; the
+                // emulated (claude/amp) app-server has no equivalent knob.
+                reasoning: _,
             }) => {
                 if let Some(model) = model {
                     state.model = model;
@@ -196,6 +199,7 @@ pub(crate) enum BlocksCommand {
         input: Vec<UserInput>,
         client_user_message_id: Option<String>,
         model: Option<String>,
+        reasoning: Option<String>,
     },
     Interrupt,
     AttachmentChunk,
@@ -228,6 +232,8 @@ struct BlocksLine {
     client_user_message_id: Option<String>,
     #[serde(default)]
     model: Option<String>,
+    #[serde(default)]
+    reasoning: Option<String>,
     #[serde(rename = "attachmentId", default)]
     attachment_id: Option<String>,
     #[serde(default)]
@@ -336,6 +342,10 @@ pub(crate) fn parse_blocks_line_with_state(
                     .model
                     .map(|model| model.trim().to_owned())
                     .filter(|model| !model.is_empty()),
+                reasoning: parsed
+                    .reasoning
+                    .map(|reasoning| reasoning.trim().to_owned())
+                    .filter(|reasoning| !reasoning.is_empty()),
             })
         }
         "attachment.chunk" => {
@@ -1163,6 +1173,33 @@ mod tests {
             panic!("expected user command");
         };
         assert_eq!(model, None);
+    }
+
+    #[test]
+    fn parses_blocks_user_line_with_reasoning_override() {
+        let line = r#"{"type":"user","thread_key":"web:t1","reasoning":"high","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#;
+        let BlocksCommand::User { reasoning, .. } = parse_blocks_line(line).expect("parses") else {
+            panic!("expected user command");
+        };
+        assert_eq!(reasoning.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn ignores_blank_reasoning_on_blocks_user_line() {
+        let line = r#"{"type":"user","reasoning":"  ","text":"hi"}"#;
+        let BlocksCommand::User { reasoning, .. } = parse_blocks_line(line).expect("parses") else {
+            panic!("expected user command");
+        };
+        assert_eq!(reasoning, None);
+    }
+
+    #[test]
+    fn defaults_reasoning_to_none_when_absent() {
+        let line = r#"{"type":"user","text":"hi"}"#;
+        let BlocksCommand::User { reasoning, .. } = parse_blocks_line(line).expect("parses") else {
+            panic!("expected user command");
+        };
+        assert_eq!(reasoning, None);
     }
 
     #[test]

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -247,6 +247,57 @@ fn fake_codex_blocks_mode_spawns_app_server_and_translates_user_blocks() {
 }
 
 #[test]
+fn fake_codex_blocks_mode_forwards_reasoning_as_turn_start_effort() {
+    let fake_codex = temp_path("fake-codex-effort.sh");
+    let fake_codex_log = temp_path("fake-codex-effort-requests.jsonl");
+    let script = fake_codex_app_server_script(&fake_codex_log);
+    std::fs::write(&fake_codex, script).expect("write fake codex script");
+    let mut permissions = std::fs::metadata(&fake_codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, permissions).expect("chmod fake codex script");
+
+    let mut bridge = BridgeProcess::spawn_harness_blocks(
+        Harness::Codex,
+        None,
+        Some((
+            "CODEX_BIN",
+            fake_codex.to_str().expect("utf-8 fake codex path"),
+        )),
+    );
+    let turn = bridge.run_blocks_user_line(
+        json!({
+            "type": "user",
+            "thread_key": "slack:C123:123.456",
+            "reasoning": "high",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "say codex blocks"}],
+            },
+        }),
+        Duration::from_secs(10),
+    );
+    bridge.finish_successfully();
+    assert_completed_turn(&turn);
+
+    let requests = std::fs::read_to_string(&fake_codex_log).expect("read fake codex request log");
+    let turn_start = requests
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("fake codex request JSON"))
+        .find(|value| value.get("method").and_then(Value::as_str) == Some("turn/start"))
+        .expect("blocks mode did not send turn/start");
+    assert_eq!(
+        turn_start.pointer("/params/effort").and_then(Value::as_str),
+        Some("high"),
+        "reasoning should be forwarded as turn/start effort; turn_start={turn_start}"
+    );
+
+    let _ = std::fs::remove_file(fake_codex);
+    let _ = std::fs::remove_file(fake_codex_log);
+}
+
+#[test]
 fn fake_amp_final_only_assistant_message_is_chunked_into_codex_deltas() {
     let expected = expected_long_text();
     let system = json!({
@@ -817,18 +868,25 @@ impl BridgeProcess {
     }
 
     fn run_blocks_user_turn(&mut self, prompt: &str, timeout: Duration) -> TurnCapture {
-        self.send(json!({
-            "type": "user",
-            "thread_key": "slack:C123:123.456",
-            "trace_metadata": {
-                "source": "slackbotv2",
-                "action": "execute"
-            },
-            "message": {
-                "role": "user",
-                "content": [{"type": "text", "text": prompt}],
-            },
-        }));
+        self.run_blocks_user_line(
+            json!({
+                "type": "user",
+                "thread_key": "slack:C123:123.456",
+                "trace_metadata": {
+                    "source": "slackbotv2",
+                    "action": "execute"
+                },
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": prompt}],
+                },
+            }),
+            timeout,
+        )
+    }
+
+    fn run_blocks_user_line(&mut self, user_line: Value, timeout: Duration) -> TurnCapture {
+        self.send(user_line);
 
         let deadline = Instant::now() + timeout;
         let mut capture = TurnCapture::default();

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -278,10 +278,11 @@ async function syncThreadMessageToSession(
   const serializedMessage = await serializeMessage(message)
   const overrides = extractMessageOverrides(serializedMessage.text)
   serializedMessage.text = overrides.cleanedText
-  if (overrides.harnessType || overrides.model) {
+  if (overrides.harnessType || overrides.model || overrides.reasoning) {
     traceLog(input.options, 'slackbotv2_forward_overrides_parsed', trace, {
       harness_type: overrides.harnessType,
-      model: overrides.model
+      model: overrides.model,
+      reasoning: overrides.reasoning
     })
   }
   traceLog(input.options, 'slackbotv2_forward_message_serialized', trace, {
@@ -323,6 +324,7 @@ async function syncThreadMessageToSession(
     harnessType: overrides.harnessType,
     messages: messagesToAppend,
     model: overrides.model,
+    reasoning: overrides.reasoning,
     onEventId: eventId => {
       lastEventId = Math.max(lastEventId, eventId)
     },

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -3,16 +3,20 @@
  *   --claude | --claude-code | --amp | --codex   pick the harness for the thread
  *   --model <name> (or --model=<name>)           pick the model within that harness
  *   --opus | --sonnet | --haiku                  model shortcuts (imply claude-code)
+ *   -rsn <effort> (or -rsn=<effort>)             per-turn reasoning effort (codex)
  *
  * Flags are stripped from the text before it reaches the agent. The harness
  * applies at session creation (the API pins a thread to one harness); the model
- * applies per turn via the blocks-protocol `model` field.
+ * and reasoning effort apply per turn via the blocks-protocol `model` /
+ * `reasoning` fields. Reasoning effort only affects the codex harness (it maps
+ * to codex's `turn/start` `effort`); other harnesses ignore it.
  */
 
 export type MessageOverrides = {
   cleanedText: string
   harnessType?: string
   model?: string
+  reasoning?: string
 }
 
 // Flag name -> HarnessType wire value (serde lowercase of the Rust enum).
@@ -32,15 +36,42 @@ const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> = 
 
 const MODEL_FLAG_PATTERN = /(?:^|\s)--model[=\s]+([A-Za-z0-9._/-]+)(?=\s|$)/i
 
+const REASONING_FLAG_PATTERN = /(?:^|\s)-rsn[=\s]+([A-Za-z-]+)(?=\s|$)/i
+
+// Codex reasoning efforts (turn/start `effort`), plus convenience aliases.
+const REASONING_EFFORTS: Record<string, string> = {
+  none: 'none',
+  minimal: 'minimal',
+  min: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  med: 'medium',
+  high: 'high',
+  hi: 'high',
+  xhigh: 'xhigh',
+  xhi: 'xhigh',
+  'x-high': 'xhigh'
+}
+
 export function extractMessageOverrides(text: string): MessageOverrides {
   let cleaned = text
   let harnessType: string | undefined
   let model: string | undefined
+  let reasoning: string | undefined
 
   const modelMatch = MODEL_FLAG_PATTERN.exec(cleaned)
   if (modelMatch) {
     model = modelMatch[1]
     cleaned = stripMatch(cleaned, modelMatch)
+  }
+
+  const reasoningMatch = REASONING_FLAG_PATTERN.exec(cleaned)
+  if (reasoningMatch) {
+    const normalized = REASONING_EFFORTS[reasoningMatch[1].toLowerCase()]
+    if (normalized) {
+      reasoning = normalized
+      cleaned = stripMatch(cleaned, reasoningMatch)
+    }
   }
 
   for (const [flag, harness] of Object.entries(HARNESS_FLAGS)) {
@@ -61,7 +92,8 @@ export function extractMessageOverrides(text: string): MessageOverrides {
   return {
     cleanedText: cleaned === text ? text : cleaned.trim(),
     harnessType,
-    model
+    model,
+    reasoning
   }
 }
 

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -36,6 +36,8 @@ const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> = 
 
 const MODEL_FLAG_PATTERN = /(?:^|\s)--model[=\s]+([A-Za-z0-9._/-]+)(?=\s|$)/i
 
+// Single dash by design: a short per-turn knob (`-rsn high`), so it can't reuse
+// the `--`-prefixed flagPattern() helper. Value-capturing like --model.
 const REASONING_FLAG_PATTERN = /(?:^|\s)-rsn[=\s]+([A-Za-z-]+)(?=\s|$)/i
 
 // Codex reasoning efforts (turn/start `effort`), plus convenience aliases.

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -168,7 +168,8 @@ export async function forwardToSessionApi(
     input.threadId,
     input.executeMessage,
     input.model,
-    input.executeContextMessages
+    input.executeContextMessages,
+    input.reasoning
   )
   traceLog(options, 'slackbotv2_session_execute_complete', input.trace, {
     execution_id: execution.execution_id,
@@ -620,14 +621,15 @@ async function executeSession(
   threadId: string,
   message: SlackbotV2ApiMessage,
   model?: string,
-  contextMessages?: SlackbotV2ApiMessage[]
+  contextMessages?: SlackbotV2ApiMessage[],
+  reasoning?: string
 ): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
   const requesterIdentity = await resolveRequesterIdentity(options, message)
   const body: SlackbotV2ExecuteSessionRequest = {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),
-    input_lines: toCodexInputLines(message, threadId, model, requesterIdentity, contextMessages),
+    input_lines: toCodexInputLines(message, threadId, model, requesterIdentity, contextMessages, reasoning),
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
   }
@@ -776,7 +778,8 @@ function toCodexInputLines(
   threadId: string,
   model?: string,
   requesterIdentity?: RequesterIdentity,
-  contextMessages?: SlackbotV2ApiMessage[]
+  contextMessages?: SlackbotV2ApiMessage[],
+  reasoning?: string
 ): string[] {
   const staged = new Map<SlackbotV2ApiAttachment, string>()
   const lines: string[] = []
@@ -788,7 +791,8 @@ function toCodexInputLines(
       staged,
       model,
       requesterIdentity,
-      contextMessages
+      contextMessages,
+      reasoning
     )
     if (
       inlineLine.length <= MAX_CODEX_INPUT_LINE_CHARS
@@ -807,7 +811,8 @@ function toCodexInputLines(
       staged,
       model,
       requesterIdentity,
-      contextMessages
+      contextMessages,
+      reasoning
     )
   )
   return lines
@@ -819,13 +824,15 @@ function toCodexInputLineWithStaged(
   staged: Map<SlackbotV2ApiAttachment, string>,
   model?: string,
   requesterIdentity?: RequesterIdentity,
-  contextMessages?: SlackbotV2ApiMessage[]
+  contextMessages?: SlackbotV2ApiMessage[],
+  reasoning?: string
 ): string {
   return JSON.stringify({
     type: 'user',
     thread_key: threadId,
     trace_metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),
     ...(model ? { model } : {}),
+    ...(reasoning ? { reasoning } : {}),
     message: {
       role: 'user',
       content: codexInputContent(message, staged, requesterIdentity, contextMessages)

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -144,6 +144,8 @@ export type ForwardSessionInput = {
   messages: SlackbotV2ApiMessage[]
   /** Per-turn model override parsed from message flags (--model/--opus/...). */
   model?: string
+  /** Per-turn reasoning effort parsed from the `-rsn` flag (codex only). */
+  reasoning?: string
   onEventId(eventId: number): void
   openStream: boolean
   threadId: string

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -7,7 +7,8 @@ describe('extractMessageOverrides', () => {
     expect(result).toEqual({
       cleanedText: 'review this PR --not-a-known-flag stays',
       harnessType: undefined,
-      model: undefined
+      model: undefined,
+      reasoning: undefined
     })
   })
 
@@ -15,7 +16,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--claude review this')).toEqual({
       cleanedText: 'review this',
       harnessType: 'claudecode',
-      model: undefined
+      model: undefined,
+      reasoning: undefined
     })
     expect(extractMessageOverrides('--claude-code review this').harnessType).toBe('claudecode')
     expect(extractMessageOverrides('--amp review this').harnessType).toBe('amp')
@@ -26,7 +28,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('review this --amp please')).toEqual({
       cleanedText: 'review this please',
       harnessType: 'amp',
-      model: undefined
+      model: undefined,
+      reasoning: undefined
     })
   })
 
@@ -38,12 +41,14 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--claude --model claude-sonnet-4-6 fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: 'claudecode',
-      model: 'claude-sonnet-4-6'
+      model: 'claude-sonnet-4-6',
+      reasoning: undefined
     })
     expect(extractMessageOverrides('--codex --model=gpt-5.2 fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: 'codex',
-      model: 'gpt-5.2'
+      model: 'gpt-5.2',
+      reasoning: undefined
     })
   })
 
@@ -51,7 +56,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--opus fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: 'claudecode',
-      model: 'claude-opus-4-8'
+      model: 'claude-opus-4-8',
+      reasoning: undefined
     })
     expect(extractMessageOverrides('--sonnet fix it').model).toBe('claude-sonnet-4-6')
     expect(extractMessageOverrides('--haiku fix it').model).toBe('claude-haiku-4-5')
@@ -61,7 +67,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--codex --opus fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: 'codex',
-      model: 'claude-opus-4-8'
+      model: 'claude-opus-4-8',
+      reasoning: undefined
     })
     expect(extractMessageOverrides('--sonnet --model claude-opus-4-8 fix it').model).toBe(
       'claude-opus-4-8'
@@ -78,7 +85,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--claude')).toEqual({
       cleanedText: '',
       harnessType: 'claudecode',
-      model: undefined
+      model: undefined,
+      reasoning: undefined
     })
   })
 
@@ -86,7 +94,57 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('what does --model do?')).toEqual({
       cleanedText: 'what does --model do?',
       harnessType: undefined,
-      model: undefined
+      model: undefined,
+      reasoning: undefined
+    })
+  })
+
+  test('parses -rsn with space or equals', () => {
+    expect(extractMessageOverrides('-rsn high fix it')).toEqual({
+      cleanedText: 'fix it',
+      harnessType: undefined,
+      model: undefined,
+      reasoning: 'high'
+    })
+    expect(extractMessageOverrides('-rsn=medium fix it').reasoning).toBe('medium')
+  })
+
+  test('-rsn is case-insensitive and normalizes the effort value', () => {
+    expect(extractMessageOverrides('-rsn HIGH fix it').reasoning).toBe('high')
+    expect(extractMessageOverrides('-rsn Medium fix it').reasoning).toBe('medium')
+  })
+
+  test('-rsn accepts short aliases', () => {
+    expect(extractMessageOverrides('-rsn min fix it').reasoning).toBe('minimal')
+    expect(extractMessageOverrides('-rsn med fix it').reasoning).toBe('medium')
+    expect(extractMessageOverrides('-rsn hi fix it').reasoning).toBe('high')
+    expect(extractMessageOverrides('-rsn xhi fix it').reasoning).toBe('xhigh')
+  })
+
+  test('-rsn combines with a harness flag', () => {
+    expect(extractMessageOverrides('-rsn high --codex audit this')).toEqual({
+      cleanedText: 'audit this',
+      harnessType: 'codex',
+      model: undefined,
+      reasoning: 'high'
+    })
+  })
+
+  test('-rsn with an unknown effort value is left untouched', () => {
+    expect(extractMessageOverrides('-rsn turbo fix it')).toEqual({
+      cleanedText: '-rsn turbo fix it',
+      harnessType: undefined,
+      model: undefined,
+      reasoning: undefined
+    })
+  })
+
+  test('-rsn without a value is left untouched', () => {
+    expect(extractMessageOverrides('what does -rsn do?')).toEqual({
+      cleanedText: 'what does -rsn do?',
+      harnessType: undefined,
+      model: undefined,
+      reasoning: undefined
     })
   })
 })

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -123,6 +123,25 @@ describe('forwardToSessionApi overrides', () => {
     expect('model' in line).toBe(false)
   })
 
+  test('includes reasoning override on the execute input line', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('audit this'), { reasoning: 'high' })
+    )
+    const execute = requests.find(request => request.url.endsWith('/execute'))
+    const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
+    expect(line.reasoning).toBe('high')
+  })
+
+  test('omits reasoning field when no override is set', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
+    const execute = requests.find(request => request.url.endsWith('/execute'))
+    const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
+    expect('reasoning' in line).toBe(false)
+  })
+
   test('retries session creation with existing harness on 409 conflict', async () => {
     const { fetchFn, requests } = fakeApi({
       createSession: [


### PR DESCRIPTION
## Motivation

Codex reasoning effort is fixed globally by `harness/codex/config.toml` (`model_reasoning_effort`), so every turn pays the same cost regardless of difficulty. A low default keeps routine turns cheap but underserves hard ones; a high default overpays for trivial ones. There's no way to dial it per turn.

## Change

Add a `-rsn <effort>` message flag that overrides reasoning effort for a single turn, mirroring the existing `--model` per-turn override path end to end:

- **`overrides.ts`** — parse and validate `-rsn` (space or `=` form), strip it from the prompt → `MessageOverrides.reasoning`. Unknown values (e.g. `-rsn turbo`) are left untouched rather than forwarded.
- **`index.ts` / `types.ts`** — carry `reasoning` on `ForwardSessionInput` (+ trace log).
- **`session-api.ts`** — thread through `executeSession` → `toCodexInputLines`, emitting a `reasoning` field on the blocks-protocol user line.
- **`crates/harness-server`** — `BlocksLine` / `BlocksCommand::User` parse `reasoning`; the codex runtime sets `turn/start` `effort`. The emulated claude/amp app-server ignores it (no equivalent knob).

Usage (tag the bot):

```
@centaur -rsn high audit this auth flow
@centaur -rsn=medium refactor the parser
@centaur fix this typo            # unchanged — uses the configured default
```

Accepted efforts match codex's `ReasoningEffort` enum, with short aliases:

| value | aliases |
|-------|---------|
| `none` | |
| `minimal` | `min` |
| `low` | |
| `medium` | `med` |
| `high` | `hi` |
| `xhigh` | `xhi`, `x-high` |

## Scope

Reasoning effort only affects the **codex** harness — combining `-rsn` with a claude/amp flag (e.g. `--opus`) silently no-ops, matching how those harnesses already lack a reasoning knob.

## Testing

- `bun test` (slackbotv2) — `overrides.test.ts` 16/16 (6 new `-rsn` cases: space/equals forms, case-insensitivity, aliases, combining with harness flags, unknown + empty values) and `session-api.test.ts` (2 new: `reasoning` lands on / is omitted from the execute blocks line, matching the `model` bar). Full suite: 64 pass, with 5 pre-existing failures in `chat-sdk-emulate.test.ts` (confirmed identical on a clean tree — unrelated Slack stream-sealing).
- `cargo test -p harness-server` — all pass. 3 new parse tests (`parses_blocks_user_line_with_reasoning_override`, `ignores_blank_reasoning_on_blocks_user_line`, `defaults_reasoning_to_none_when_absent`) plus an integration test (`fake_codex_blocks_mode_forwards_reasoning_as_turn_start_effort`) asserting `reasoning` reaches codex as `turn/start` `effort`. `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
