### PR TITLE
feat(sandbox): override codex reasoning effort via CODEX_MODEL_REASONING_EFFORT

### DIFF
--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -163,6 +163,7 @@ Sandbox entrypoint and wrappers:
 | `GOOGLE_APPLICATION_CREDENTIALS` | Sandbox entrypoint or `sandbox.extraEnv`. | Google ADC path; entrypoint creates a local stub when unset. |
 | `CODEX_API_KEY`, `CODEX_HOME`, `CODEX_CONTINUE_THREAD_ID` | `sandbox.extraEnv` or runtime resume. | Codex auth/config/resume behavior. |
 | `CODEX_AUTH_MODE` | `sandbox.extraEnv`. | Codex auth flow: `api_key` (default, hits `api.openai.com`) or `access_token` (hits `chatgpt.com` via the brokered ChatGPT login). See [Codex Auth Modes](/deploying-in-production#codex-auth-modes). |
+| `CENTAUR_CODEX_REASONING_EFFORT` | `sandbox.extraEnv`. | Overrides the codex `model_reasoning_effort` baked into `harness/codex/config.toml` at sandbox boot, without forking the image. One of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; an unknown value is ignored (the config default stands). |
 | `CLAUDE_MODEL`, `CLAUDE_CONTINUE_SESSION_ID` | `sandbox.extraEnv` or runtime resume. | Claude model and resume behavior. |
 | `CLAUDE_CODE_AUTH_MODE` | `sandbox.extraEnv`. | Claude Code auth flow: `api_key` (default, uses `ANTHROPIC_API_KEY`) or `access_token` (Claude.ai Pro or Max via the brokered OAuth login). See [Claude Auth Modes](/deploying-in-production#claude-auth-modes). |
 | `DEPLOY_ENV`, `ENVIRONMENT`, `TRACEPARENT` | Deployment env or wrapper-generated. | Runtime environment and trace context. |

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -163,7 +163,7 @@ Sandbox entrypoint and wrappers:
 | `GOOGLE_APPLICATION_CREDENTIALS` | Sandbox entrypoint or `sandbox.extraEnv`. | Google ADC path; entrypoint creates a local stub when unset. |
 | `CODEX_API_KEY`, `CODEX_HOME`, `CODEX_CONTINUE_THREAD_ID` | `sandbox.extraEnv` or runtime resume. | Codex auth/config/resume behavior. |
 | `CODEX_AUTH_MODE` | `sandbox.extraEnv`. | Codex auth flow: `api_key` (default, hits `api.openai.com`) or `access_token` (hits `chatgpt.com` via the brokered ChatGPT login). See [Codex Auth Modes](/deploying-in-production#codex-auth-modes). |
-| `CENTAUR_CODEX_REASONING_EFFORT` | `sandbox.extraEnv`. | Overrides the codex `model_reasoning_effort` baked into `harness/codex/config.toml` at sandbox boot, without forking the image. One of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; an unknown value is ignored (the config default stands). |
+| `CODEX_MODEL_REASONING_EFFORT` | `sandbox.extraEnv`. | Overrides the codex `model_reasoning_effort` (baked into `harness/codex/config.toml`) by patching the per-sandbox `~/.codex/config.toml` at boot, without forking the image. One of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; an unknown value is ignored (the config default stands). |
 | `CLAUDE_MODEL`, `CLAUDE_CONTINUE_SESSION_ID` | `sandbox.extraEnv` or runtime resume. | Claude model and resume behavior. |
 | `CLAUDE_CODE_AUTH_MODE` | `sandbox.extraEnv`. | Claude Code auth flow: `api_key` (default, uses `ANTHROPIC_API_KEY`) or `access_token` (Claude.ai Pro or Max via the brokered OAuth login). See [Claude Auth Modes](/deploying-in-production#claude-auth-modes). |
 | `DEPLOY_ENV`, `ENVIRONMENT`, `TRACEPARENT` | Deployment env or wrapper-generated. | Runtime environment and trace context. |

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -167,6 +167,34 @@ else:
     for name in sorted(feature_names - seen):
         rewritten.append(f"{name} = false")
     lines = lines[: features_start + 1] + rewritten + lines[features_end:]
+
+# Optional deploy-time override of the codex reasoning effort. Lets a deployment
+# (e.g. an org overlay via sandbox.extraEnv) set the default without forking the
+# baked-in config.toml. Validated against codex's ReasoningEffort enum; an
+# unknown value is ignored (the config default stands) rather than written.
+effort = (os.environ.get("CENTAUR_CODEX_REASONING_EFFORT") or "").strip().lower()
+if effort:
+    valid = {"none", "minimal", "low", "medium", "high", "xhigh"}
+    if effort not in valid:
+        import sys
+
+        print(
+            f"ignoring invalid CENTAUR_CODEX_REASONING_EFFORT={effort!r}; "
+            f"expected one of {sorted(valid)}",
+            file=sys.stderr,
+        )
+    else:
+        # model_reasoning_effort is a top-level key, before the first [table].
+        first_table = next(
+            (i for i, line in enumerate(lines) if line.lstrip().startswith("[")), len(lines)
+        )
+        override = f'model_reasoning_effort = "{effort}"'
+        for i in range(first_table):
+            if lines[i].split("=", 1)[0].strip() == "model_reasoning_effort":
+                lines[i] = override
+                break
+        else:
+            lines.insert(first_table, override)
 path.write_text("\n".join(lines).rstrip() + "\n")
 PYEOF
 else

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -142,6 +142,7 @@ if [ -f "$HARNESS_CONFIG_DIR/codex/config.toml" ]; then
     CODEX_CONFIG_PATH="$HOME_DIR/.codex/config.toml" python3 - <<'PYEOF'
 from pathlib import Path
 import os
+import sys
 
 path = Path(os.environ["CODEX_CONFIG_PATH"])
 lines = path.read_text().splitlines()
@@ -170,16 +171,15 @@ else:
 
 # Optional deploy-time override of the codex reasoning effort. Lets a deployment
 # (e.g. an org overlay via sandbox.extraEnv) set the default without forking the
-# baked-in config.toml. Validated against codex's ReasoningEffort enum; an
-# unknown value is ignored (the config default stands) rather than written.
-effort = (os.environ.get("CENTAUR_CODEX_REASONING_EFFORT") or "").strip().lower()
+# baked-in config.toml. Named after codex's own config key (model_reasoning_effort)
+# and validated against its ReasoningEffort enum; an unknown value is ignored (the
+# config default stands) rather than written.
+effort = (os.environ.get("CODEX_MODEL_REASONING_EFFORT") or "").strip().lower()
 if effort:
     valid = {"none", "minimal", "low", "medium", "high", "xhigh"}
     if effort not in valid:
-        import sys
-
         print(
-            f"ignoring invalid CENTAUR_CODEX_REASONING_EFFORT={effort!r}; "
+            f"ignoring invalid CODEX_MODEL_REASONING_EFFORT={effort!r}; "
             f"expected one of {sorted(valid)}",
             file=sys.stderr,
         )


### PR DESCRIPTION
## Motivation

The codex `model_reasoning_effort` lives in `harness/codex/config.toml`, which is baked into the agent image and copied into each sandbox at boot (`services/sandbox/entrypoint.sh`). A deployment that runs upstream `main` directly (no image fork) therefore has no way to change the reasoning default — it's static. Orgs that want a different default (e.g. `high` fleet-wide, or a cheaper `low`) currently can't, short of forking.

## Change

Add a deploy-time override. When `CODEX_MODEL_REASONING_EFFORT` is set, the entrypoint patches `model_reasoning_effort` in the copied `~/.codex/config.toml` — reusing the inline-Python step that already normalizes the `[features]` table, so it's one place and one pass:

- Validated against codex's `ReasoningEffort` enum (`none|minimal|low|medium|high|xhigh`); an unknown value is **ignored with a stderr note** rather than written, so a typo can't break codex startup.
- Unset leaves the baked-in config default untouched (no behavior change for existing deployments).
- Rewrites the existing top-level key in place, or inserts it before the first table if absent.

Delivery: this is injectable per-deployment via `sandbox.extraEnv` (→ `SESSION_SANDBOX_EXTRA_ENV` → every sandbox pod), so an org overlay can set the default without a fork:

```yaml
sandbox:
  extraEnv:
    CODEX_MODEL_REASONING_EFFORT: high
```

Documented in `docs/public/md/reference/configuration.md` alongside the other sandbox entrypoint env vars.

## Relationship to the per-turn flag

Complements (doesn't overlap) the per-turn `-rsn` override (#549): this sets the fleet **default**; `-rsn` overrides a **single turn** on top of it.

## Testing

- Extracted the entrypoint's inline-Python patch step and ran it against the real `harness/codex/config.toml`:
  - `CODEX_MODEL_REASONING_EFFORT=high` → `model_reasoning_effort = "high"`; `xhigh` → `"xhigh"`.
  - `=bogus` → unchanged (`"low"`) + stderr `ignoring invalid ...`.
  - unset → unchanged. The existing `[features]` normalization (`multi_agent`/`multi_agent_v2`) still applies in all cases.
- `bash -n services/sandbox/entrypoint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
