### PR TITLE
Limit Slackbot session append attachment payloads

### DIFF
--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -211,6 +211,7 @@ export function sessionStreamError(error: unknown): RustSessionStreamEvent {
 /** Largest attachment we are willing to buffer in memory and inline as base64. */
 export const MAX_INLINE_ATTACHMENT_BYTES = 100 * 1024 * 1024
 const MAX_CODEX_INPUT_LINE_CHARS = 900 * 1024
+const MAX_SESSION_ATTACHMENT_BASE64_CHARS = 64 * 1024
 const STAGED_ATTACHMENT_CHUNK_CHARS = 700 * 1024
 
 async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2ApiAttachment> {
@@ -744,7 +745,7 @@ function sessionAttachmentPart(attachment: SlackbotV2ApiAttachment): JsonObject 
   const part: JsonObject = { ...attachment, attachment_type: attachment.type, type: 'attachment' }
   if (
     typeof attachment.dataBase64 === 'string'
-    && attachment.dataBase64.length > MAX_CODEX_INPUT_LINE_CHARS
+    && attachment.dataBase64.length > MAX_SESSION_ATTACHMENT_BASE64_CHARS
   ) {
     delete part.dataBase64
     part.dataBase64Omitted = `${attachment.dataBase64.length} base64 chars omitted from stored session message`

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -752,6 +752,7 @@ describe('slackbotv2', () => {
       })
     )
     expect(appendedAttachment).not.toHaveProperty('dataBase64')
+    expect(JSON.stringify(codexApi.appends[0]!.body).length).toBeLessThan(64 * 1024)
 
     const inputLines = codexApi.executes[0]!.body.input_lines
     expect(inputLines.length).toBeGreaterThan(1)


### PR DESCRIPTION
## Summary
- lower the stored session-message attachment base64 cutoff to 64 KiB
- keep large current-turn attachments on the existing staged execution path
- add regression coverage that the append body stays under 64 KiB for a 2 MiB Slack file

## Tests
- bun test test/chat-sdk-emulate.test.ts
- bun run check:types

Prompted by: @akshaan