### PR TITLE
Remove session body limits

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -90,16 +90,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn append_messages_accepts_payloads_larger_than_axum_default_limit() {
+    async fn append_messages_does_not_apply_a_session_body_limit() {
         let pool =
             PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
         let app = build_router_with_runtime(
             PgSessionStore::new(pool),
             SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
-        );
-        let body = format!(
-            r#"{{"messages":[],"padding":"{}"}}"#,
-            "x".repeat(3 * 1024 * 1024)
         );
 
         let response = app
@@ -108,24 +104,25 @@ mod tests {
                     .method("POST")
                     .uri("/api/session/slack%3AC123%3A123.456/messages")
                     .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(body))
+                    .header(header::CONTENT_LENGTH, (256 * 1024 * 1024 + 1).to_string())
+                    .body(Body::from(r#"{"messages":"not-an-array"}"#))
                     .unwrap(),
             )
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_ne!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
     #[tokio::test]
-    async fn execute_accepts_payloads_larger_than_axum_default_limit() {
+    async fn execute_does_not_apply_a_session_body_limit() {
         let pool =
             PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
         let app = build_router_with_runtime(
             PgSessionStore::new(pool),
             SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
         );
-        let body = format!(r#"{{"input_lines":["{}"]"#, "x".repeat(3 * 1024 * 1024));
 
         let response = app
             .oneshot(
@@ -133,13 +130,15 @@ mod tests {
                     .method("POST")
                     .uri("/api/session/slack%3AC123%3A123.456/execute")
                     .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(body))
+                    .header(header::CONTENT_LENGTH, (256 * 1024 * 1024 + 1).to_string())
+                    .body(Body::from(r#"{"input_lines":"not-an-array"}"#))
                     .unwrap(),
             )
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_ne!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
     #[derive(Default)]

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -54,7 +54,6 @@ pub struct AppState {
 }
 
 const MAX_WEBHOOK_BODY_BYTES: usize = 1024 * 1024;
-const MAX_SESSION_JSON_BODY_BYTES: usize = 256 * 1024 * 1024;
 const REDACTED_WEBHOOK_HEADERS: &[&str] = &[
     "authorization",
     "cookie",
@@ -87,11 +86,11 @@ pub fn build_router_with_session_and_workflow_runtime(
         .route("/api/session/{thread_key}", post(create_or_get_session))
         .route(
             "/api/session/{thread_key}/messages",
-            post(append_messages).layer(DefaultBodyLimit::max(MAX_SESSION_JSON_BODY_BYTES)),
+            post(append_messages).layer(DefaultBodyLimit::disable()),
         )
         .route(
             "/api/session/{thread_key}/execute",
-            post(execute_session).layer(DefaultBodyLimit::max(MAX_SESSION_JSON_BODY_BYTES)),
+            post(execute_session).layer(DefaultBodyLimit::disable()),
         )
         .route("/api/session/{thread_key}/events", get(stream_events))
         .route("/api/sandboxes/drain", post(drain_sandboxes))


### PR DESCRIPTION
## Summary
- disable Axum body limits on session append and execute routes
- add regressions proving oversized session requests reach JSON validation instead of returning 413

## Test
- cargo test -p centaur-api-server

Prompted by: @akshaan