### PR TITLE
fix: handle large session attachments

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -89,6 +89,43 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn session_routes_accept_payloads_larger_than_axum_default_limit() {
+        for (uri, body) in [
+            (
+                "/api/session/test/messages",
+                format!(
+                    r#"{{"messages":[],"padding":"{}"}}"#,
+                    "x".repeat(3 * 1024 * 1024)
+                ),
+            ),
+            (
+                "/api/session/test/execute",
+                format!(r#"{{"input_lines":["{}"]"#, "x".repeat(3 * 1024 * 1024)),
+            ),
+        ] {
+            let pool = PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test")
+                .unwrap();
+            let app = build_router_with_runtime(
+                PgSessionStore::new(pool),
+                SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
+            );
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(uri)
+                        .header("content-type", "application/json")
+                        .body(Body::from(body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+    }
+
     #[derive(Default)]
     struct TestBackend {
         next_id: AtomicU64,

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -9,7 +9,7 @@ use std::{
 use axum::{
     Json, Router,
     body::{Body, Bytes},
-    extract::{MatchedPath, Path, Query, Request, State},
+    extract::{DefaultBodyLimit, MatchedPath, Path, Query, Request, State},
     http::{HeaderMap, Method, StatusCode, Uri},
     middleware::{self, Next},
     response::{
@@ -54,6 +54,7 @@ pub struct AppState {
 }
 
 const MAX_WEBHOOK_BODY_BYTES: usize = 1024 * 1024;
+const MAX_SESSION_JSON_BODY_BYTES: usize = 256 * 1024 * 1024;
 const REDACTED_WEBHOOK_HEADERS: &[&str] = &[
     "authorization",
     "cookie",
@@ -84,8 +85,14 @@ pub fn build_router_with_session_and_workflow_runtime(
         .route("/healthz", get(healthz))
         .route("/metrics", get(metrics))
         .route("/api/session/{thread_key}", post(create_or_get_session))
-        .route("/api/session/{thread_key}/messages", post(append_messages))
-        .route("/api/session/{thread_key}/execute", post(execute_session))
+        .route(
+            "/api/session/{thread_key}/messages",
+            post(append_messages).layer(DefaultBodyLimit::max(MAX_SESSION_JSON_BODY_BYTES)),
+        )
+        .route(
+            "/api/session/{thread_key}/execute",
+            post(execute_session).layer(DefaultBodyLimit::max(MAX_SESSION_JSON_BODY_BYTES)),
+        )
         .route("/api/session/{thread_key}/events", get(stream_events))
         .route("/api/sandboxes/drain", post(drain_sandboxes))
         .route(

--- a/services/api/tests/test_codex_app_wrapper.py
+++ b/services/api/tests/test_codex_app_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import importlib.util
 from pathlib import Path
 import tomllib
@@ -128,6 +129,89 @@ def test_request_attaches_traceparent(monkeypatch) -> None:
             },
         }
     ]
+
+
+def test_input_items_materializes_data_url_image(monkeypatch, tmp_path) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.setattr(wrapper, "UPLOADS_DIR", tmp_path)
+
+    items = wrapper.input_items(
+        {
+            "message": {
+                "content": [
+                    {"type": "text", "text": "please inspect this"},
+                    {
+                        "type": "image",
+                        "name": "image.png",
+                        "url": "data:image/png;base64,"
+                        + base64.b64encode(b"png-bytes").decode(),
+                    },
+                ]
+            }
+        }
+    )
+
+    assert items == [
+        {
+            "type": "text",
+            "text": "please inspect this\n"
+            + f"[Attached image saved to {tmp_path / 'image.png'}]",
+        },
+        {"type": "localImage", "path": str(tmp_path / "image.png"), "detail": "auto"},
+    ]
+    assert (tmp_path / "image.png").read_bytes() == b"png-bytes"
+
+
+def test_attachment_chunks_materialize_staged_file(monkeypatch, tmp_path) -> None:
+    wrapper = _load_wrapper()
+    monkeypatch.setattr(wrapper, "UPLOADS_DIR", tmp_path)
+    wrapper.ATTACHMENT_UPLOADS.clear()
+    wrapper.STAGED_ATTACHMENTS.clear()
+
+    data = base64.b64encode(b"large-attachment").decode()
+    wrapper.handle_attachment_chunk(
+        {
+            "type": "attachment.chunk",
+            "attachmentId": "att-1",
+            "name": "report.pdf",
+            "mimeType": "application/pdf",
+            "attachmentType": "file",
+            "dataBase64": data[:8],
+            "final": False,
+        }
+    )
+    wrapper.handle_attachment_chunk(
+        {
+            "type": "attachment.chunk",
+            "attachmentId": "att-1",
+            "name": "report.pdf",
+            "mimeType": "application/pdf",
+            "attachmentType": "file",
+            "dataBase64": data[8:],
+            "final": True,
+        }
+    )
+
+    items = wrapper.input_items(
+        {
+            "message": {
+                "content": [
+                    {
+                        "type": "attachment",
+                        "attachment_type": "file",
+                        "mimeType": "application/pdf",
+                        "name": "report.pdf",
+                        "stagedAttachmentId": "att-1",
+                    }
+                ]
+            }
+        }
+    )
+
+    assert items == [
+        {"type": "text", "text": f"[Attached file saved to {tmp_path / 'report.pdf'}]"}
+    ]
+    assert (tmp_path / "report.pdf").read_bytes() == b"large-attachment"
 
 
 def test_configure_codex_otel_writes_startup_config(monkeypatch, tmp_path) -> None:
@@ -468,8 +552,7 @@ def test_start_or_resume_thread_falls_back_to_fresh_thread_on_resume_failure(
     assert len(failure_events) == 1
     assert "no rollout found" in failure_events[0]["message"]
     assert (
-        failure_events[0]["resume_thread_id"]
-        == "019ead10-eee3-74c3-a9fc-aa3e8bc53783"
+        failure_events[0]["resume_thread_id"] == "019ead10-eee3-74c3-a9fc-aa3e8bc53783"
     )
     assert {"type": "thread.started", "thread_id": "fresh-thread-id"} in emitted
 

--- a/services/sandbox/codex-app-wrapper.py
+++ b/services/sandbox/codex-app-wrapper.py
@@ -9,10 +9,14 @@ APIs for thread goals, and emits Codex-shaped NDJSON events for Centaur.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
+import mimetypes
 import os
 from pathlib import Path
 import queue
+import re
 import signal
 import subprocess
 import sys
@@ -23,7 +27,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib import request as urllib_request
 from urllib.error import HTTPError, URLError
-from urllib.parse import unquote
+from urllib.parse import unquote, unquote_to_bytes
 
 from opentelemetry.proto.common.v1.common_pb2 import KeyValue
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
@@ -52,8 +56,13 @@ LLM_INPUTS_BY_TURN_ID: dict[str, str] = {}
 LLM_OUTPUTS_BY_TURN_ID: dict[str, str] = {}
 CURRENT_TRACE_METADATA: dict[str, Any] = {}
 TRACE_METADATA_BY_TURN_ID: dict[str, dict[str, Any]] = {}
+ATTACHMENT_UPLOADS: dict[str, dict[str, Any]] = {}
+STAGED_ATTACHMENTS: dict[str, dict[str, Any]] = {}
 
 LAMINAR_METADATA_PREFIX = "lmnr.association.properties.metadata."
+DATA_URL_PREFIX = "data:"
+UPLOADS_DIR = Path(os.environ.get("CENTAUR_UPLOADS_DIR", str(Path.home() / "uploads")))
+SAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
 def emit(payload: dict[str, Any]) -> None:
@@ -176,27 +185,251 @@ def api_stdin_reader() -> None:
     INPUTS.put(None)
 
 
-def text_from_blocks(blocks: list[dict[str, Any]]) -> str:
-    parts: list[str] = []
-    for block in blocks:
-        btype = block.get("type")
-        if btype == "text":
-            parts.append(str(block.get("text") or ""))
-        elif btype == "image":
-            parts.append(
-                "[User sent an image attachment; if needed, ask them to upload it as a file reference.]"
-            )
-        else:
-            parts.append(json.dumps(block, ensure_ascii=False))
-    return "\n".join(p for p in parts if p).strip()
-
-
 def input_items(turn_input: dict[str, Any]) -> list[dict[str, Any]]:
     blocks = turn_input.get("message", {}).get("content") or []
     if not isinstance(blocks, list):
         blocks = []
-    text = text_from_blocks(blocks)
-    return [{"type": "text", "text": text or "continue"}]
+    items: list[dict[str, Any]] = []
+    for block in blocks:
+        if isinstance(block, dict):
+            items.extend(input_items_from_block(block))
+    return coalesce_text_items(items) or [{"type": "text", "text": "continue"}]
+
+
+def input_items_from_block(block: dict[str, Any]) -> list[dict[str, Any]]:
+    btype = block.get("type")
+    if btype == "text":
+        text = str(block.get("text") or "").strip()
+        return [{"type": "text", "text": text}] if text else []
+    if btype == "image":
+        return input_items_from_image_block(block)
+    if btype == "attachment":
+        return input_items_from_attachment_block(block)
+    return [{"type": "text", "text": json.dumps(block, ensure_ascii=False)}]
+
+
+def input_items_from_image_block(block: dict[str, Any]) -> list[dict[str, Any]]:
+    name = str(block.get("name") or "image")
+    detail = image_detail(block.get("detail"))
+    url = str(block.get("url") or "")
+    if url.startswith(DATA_URL_PREFIX):
+        materialized = materialize_data_url(url, name)
+        if materialized:
+            path, mime_type = materialized
+            return local_file_items(path, mime_type, detail=detail, is_image=True)
+        return [
+            {"type": "text", "text": f"[Attached image could not be decoded: {name}]"}
+        ]
+    if url:
+        return [
+            {"type": "text", "text": f"[Attached image: {name}]"},
+            {"type": "image", "url": url, "detail": detail},
+        ]
+    return [{"type": "text", "text": f"[Attached image metadata without data: {name}]"}]
+
+
+def input_items_from_attachment_block(block: dict[str, Any]) -> list[dict[str, Any]]:
+    name = str(block.get("name") or "attachment")
+    mime_type = optional_string(block.get("mimeType"))
+    local_path = optional_string(block.get("localPath")) or optional_string(
+        block.get("path")
+    )
+    if local_path:
+        path = Path(local_path)
+        if path.exists():
+            return local_file_items(
+                path,
+                mime_type,
+                is_image=optional_string(block.get("attachment_type")) == "image",
+            )
+
+    staged_attachment_id = optional_string(block.get("stagedAttachmentId"))
+    if staged_attachment_id:
+        staged = STAGED_ATTACHMENTS.get(staged_attachment_id)
+        if staged:
+            path = Path(str(staged.get("path") or ""))
+            if path.exists():
+                return local_file_items(
+                    path,
+                    optional_string(staged.get("mimeType")) or mime_type,
+                    is_image=optional_string(staged.get("attachmentType")) == "image",
+                )
+        return [
+            {
+                "type": "text",
+                "text": f"[Attachment was not staged successfully: {name}]",
+            }
+        ]
+
+    data_base64 = optional_string(block.get("dataBase64"))
+    if data_base64:
+        path = materialize_base64(data_base64, name, mime_type)
+        if path:
+            return local_file_items(
+                path,
+                mime_type,
+                is_image=optional_string(block.get("attachment_type")) == "image",
+            )
+        return [{"type": "text", "text": f"[Attachment could not be decoded: {name}]"}]
+
+    fetch_error = optional_string(block.get("fetchError"))
+    url = optional_string(block.get("url"))
+    fields = [f"name={name}"]
+    if mime_type:
+        fields.append(f"mime={mime_type}")
+    if url:
+        fields.append(f"url={url}")
+    if fetch_error:
+        fields.append(f"fetch_error={fetch_error}")
+    return [{"type": "text", "text": f"[Slack attachment: {' '.join(fields)}]"}]
+
+
+def local_file_items(
+    path: Path,
+    mime_type: str | None,
+    *,
+    detail: str = "auto",
+    is_image: bool = False,
+) -> list[dict[str, Any]]:
+    text = f"[Attached file saved to {path}]"
+    if is_image or (mime_type and mime_type.startswith("image/")):
+        return [
+            {"type": "text", "text": f"[Attached image saved to {path}]"},
+            {"type": "localImage", "path": str(path), "detail": detail},
+        ]
+    return [{"type": "text", "text": text}]
+
+
+def materialize_data_url(url: str, name: str) -> tuple[Path, str | None] | None:
+    try:
+        header, encoded = url.split(",", 1)
+    except ValueError:
+        return None
+    metadata = header[len(DATA_URL_PREFIX) :]
+    mime_type = metadata.split(";", 1)[0] or None
+    try:
+        if ";base64" in metadata:
+            data = base64.b64decode(encoded, validate=True)
+        else:
+            data = unquote_to_bytes(encoded)
+    except (binascii.Error, ValueError):
+        return None
+    return write_upload_bytes(data, name, mime_type), mime_type
+
+
+def materialize_base64(
+    data_base64: str, name: str, mime_type: str | None
+) -> Path | None:
+    try:
+        data = base64.b64decode(data_base64, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    return write_upload_bytes(data, name, mime_type)
+
+
+def write_upload_bytes(data: bytes, name: str, mime_type: str | None) -> Path:
+    UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+    path = unique_upload_path(name, mime_type)
+    path.write_bytes(data)
+    return path
+
+
+def handle_attachment_chunk(chunk_input: dict[str, Any]) -> None:
+    attachment_id = optional_string(chunk_input.get("attachmentId"))
+    if not attachment_id:
+        emit({"type": "error", "message": "attachment chunk missing attachmentId"})
+        return
+    name = str(chunk_input.get("name") or "attachment")
+    mime_type = optional_string(chunk_input.get("mimeType"))
+    upload = ATTACHMENT_UPLOADS.get(attachment_id)
+    if upload is None:
+        UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+        path = unique_upload_path(name, mime_type)
+        upload = {
+            "path": path,
+            "name": name,
+            "mimeType": mime_type,
+            "attachmentType": optional_string(chunk_input.get("attachmentType")),
+        }
+        ATTACHMENT_UPLOADS[attachment_id] = upload
+
+    data_base64 = optional_string(chunk_input.get("dataBase64"))
+    if data_base64:
+        try:
+            data = base64.b64decode(data_base64, validate=True)
+        except (binascii.Error, ValueError):
+            ATTACHMENT_UPLOADS.pop(attachment_id, None)
+            emit(
+                {
+                    "type": "error",
+                    "message": f"invalid attachment chunk for {attachment_id}",
+                }
+            )
+            return
+        with Path(upload["path"]).open("ab") as file:
+            file.write(data)
+
+    if bool(chunk_input.get("final")):
+        STAGED_ATTACHMENTS[attachment_id] = upload
+        ATTACHMENT_UPLOADS.pop(attachment_id, None)
+
+
+def unique_upload_path(name: str, mime_type: str | None) -> Path:
+    base = sanitize_upload_name(name)
+    suffix = Path(base).suffix
+    if not suffix:
+        suffix = extension_for_mime_type(mime_type)
+        if suffix:
+            base = f"{base}{suffix}"
+    path = UPLOADS_DIR / base
+    if not path.exists():
+        return path
+    stem = path.stem or "attachment"
+    suffix = path.suffix
+    return UPLOADS_DIR / f"{stem}-{uuid.uuid4().hex[:8]}{suffix}"
+
+
+def sanitize_upload_name(name: str) -> str:
+    leaf = Path(name).name.strip()
+    leaf = SAFE_FILENAME_RE.sub("_", leaf)
+    leaf = leaf.strip("._")
+    return leaf or "attachment"
+
+
+def extension_for_mime_type(mime_type: str | None) -> str:
+    if not mime_type:
+        return ""
+    if mime_type == "image/jpeg":
+        return ".jpg"
+    return mimetypes.guess_extension(mime_type) or ""
+
+
+def image_detail(value: Any) -> str:
+    detail = str(value or "auto")
+    return detail if detail in {"auto", "low", "high"} else "auto"
+
+
+def optional_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def coalesce_text_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    for item in items:
+        if item.get("type") == "text" and merged and merged[-1].get("type") == "text":
+            text = "\n".join(
+                part
+                for part in [
+                    str(merged[-1].get("text") or "").strip(),
+                    str(item.get("text") or "").strip(),
+                ]
+                if part
+            )
+            if text:
+                merged[-1]["text"] = text
+            continue
+        merged.append(item)
+    return merged
 
 
 def trace_metadata_from_input(turn_input: dict[str, Any]) -> dict[str, Any]:
@@ -812,6 +1045,9 @@ def handle_input(turn_input: dict[str, Any]) -> None:
     input_type = turn_input.get("type")
     if input_type == "interrupt":
         interrupt_active_turn()
+        return
+    if input_type == "attachment.chunk":
+        handle_attachment_chunk(turn_input)
         return
     if input_type not in {"user", "turn.start"}:
         return

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -199,6 +199,8 @@ export function sessionStreamError(error: unknown): RustSessionStreamEvent {
 
 /** Largest attachment we are willing to buffer in memory and inline as base64. */
 export const MAX_INLINE_ATTACHMENT_BYTES = 100 * 1024 * 1024
+const MAX_CODEX_INPUT_LINE_CHARS = 900 * 1024
+const STAGED_ATTACHMENT_CHUNK_CHARS = 700 * 1024
 
 async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2ApiAttachment> {
   const serialized: SlackbotV2ApiAttachment = {
@@ -289,7 +291,7 @@ async function executeSession(
   const body: SlackbotV2ExecuteSessionRequest = {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }),
-    input_lines: [toCodexInputLine(message, threadId)],
+    input_lines: toCodexInputLines(message, threadId),
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
   }
@@ -382,9 +384,21 @@ function sessionMessageParts(message: SlackbotV2ApiMessage): JsonValue[] {
     parts.push({ type: 'text', text: message.text })
   }
   for (const attachment of message.attachments) {
-    parts.push({ ...attachment, attachment_type: attachment.type, type: 'attachment' })
+    parts.push(sessionAttachmentPart(attachment))
   }
   return parts.length > 0 ? parts : [{ type: 'text', text: '' }]
+}
+
+function sessionAttachmentPart(attachment: SlackbotV2ApiAttachment): JsonObject {
+  const part: JsonObject = { ...attachment, attachment_type: attachment.type, type: 'attachment' }
+  if (
+    typeof attachment.dataBase64 === 'string'
+    && attachment.dataBase64.length > MAX_CODEX_INPUT_LINE_CHARS
+  ) {
+    delete part.dataBase64
+    part.dataBase64Omitted = `${attachment.dataBase64.length} base64 chars omitted from stored session message`
+  }
+  return part
 }
 
 function sessionMetadata(
@@ -404,30 +418,97 @@ function sessionMetadata(
   }
 }
 
-function toCodexInputLine(message: SlackbotV2ApiMessage, threadId: string): string {
+function toCodexInputLines(
+  message: SlackbotV2ApiMessage,
+  threadId: string
+): string[] {
+  const staged = new Map<SlackbotV2ApiAttachment, string>()
+  const lines: string[] = []
+  for (const attachment of message.attachments) {
+    if (!attachment.dataBase64) continue
+    const inlineLine = toCodexInputLineWithStaged(message, threadId, staged)
+    if (
+      inlineLine.length <= MAX_CODEX_INPUT_LINE_CHARS
+      && attachment.dataBase64.length <= MAX_CODEX_INPUT_LINE_CHARS
+    ) {
+      continue
+    }
+    const stagedAttachmentId = `att-${message.id}-${staged.size + 1}`
+    staged.set(attachment, stagedAttachmentId)
+    lines.push(...stagedAttachmentInputLines(attachment, stagedAttachmentId))
+  }
+  lines.push(toCodexInputLineWithStaged(message, threadId, staged))
+  return lines
+}
+
+function toCodexInputLineWithStaged(
+  message: SlackbotV2ApiMessage,
+  threadId: string,
+  staged: Map<SlackbotV2ApiAttachment, string>
+): string {
   return JSON.stringify({
     type: 'user',
     thread_key: threadId,
     trace_metadata: sessionMetadata(message, { action: 'execute' }),
     message: {
       role: 'user',
-      content: codexInputContent(message)
+      content: codexInputContent(message, staged)
     }
   })
 }
 
-function codexInputContent(message: SlackbotV2ApiMessage): JsonValue[] {
+function stagedAttachmentInputLines(
+  attachment: SlackbotV2ApiAttachment,
+  stagedAttachmentId: string
+): string[] {
+  const dataBase64 = attachment.dataBase64
+  if (!dataBase64) return []
+  const lines: string[] = []
+  const chunkSize = STAGED_ATTACHMENT_CHUNK_CHARS - (STAGED_ATTACHMENT_CHUNK_CHARS % 4)
+  for (let offset = 0, index = 0; offset < dataBase64.length; offset += chunkSize, index += 1) {
+    const chunk = dataBase64.slice(offset, offset + chunkSize)
+    lines.push(JSON.stringify({
+      type: 'attachment.chunk',
+      attachmentId: stagedAttachmentId,
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      attachmentType: attachment.type,
+      chunkIndex: index,
+      final: offset + chunkSize >= dataBase64.length,
+      dataBase64: chunk
+    }))
+  }
+  return lines
+}
+
+function codexInputContent(
+  message: SlackbotV2ApiMessage,
+  staged: Map<SlackbotV2ApiAttachment, string> = new Map()
+): JsonValue[] {
   const content: JsonValue[] = []
   if (message.text.trim()) {
     content.push({ type: 'text', text: message.text })
   }
   for (const attachment of message.attachments) {
-    content.push(codexAttachmentInput(attachment))
+    content.push(codexAttachmentInput(attachment, staged.get(attachment)))
   }
   return content.length > 0 ? content : [{ type: 'text', text: 'continue' }]
 }
 
-function codexAttachmentInput(attachment: SlackbotV2ApiAttachment): JsonValue {
+function codexAttachmentInput(
+  attachment: SlackbotV2ApiAttachment,
+  stagedAttachmentId?: string
+): JsonValue {
+  if (stagedAttachmentId) {
+    return {
+      type: 'attachment',
+      attachment_type: attachment.type,
+      stagedAttachmentId,
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      size: attachment.size
+    }
+  }
   const dataUrl =
     attachment.dataBase64 && attachment.mimeType
       ? `data:${attachment.mimeType};base64,${attachment.dataBase64}`
@@ -438,6 +519,16 @@ function codexAttachmentInput(attachment: SlackbotV2ApiAttachment): JsonValue {
       url: dataUrl ?? attachment.url,
       detail: 'auto',
       name: attachment.name
+    }
+  }
+  if (attachment.dataBase64) {
+    return {
+      type: 'attachment',
+      attachment_type: attachment.type,
+      dataBase64: attachment.dataBase64,
+      mimeType: attachment.mimeType,
+      name: attachment.name,
+      size: attachment.size
     }
   }
   return {
@@ -452,8 +543,7 @@ function attachmentDescription(attachment: SlackbotV2ApiAttachment): string {
     `type=${attachment.type}`,
     attachment.mimeType ? `mime=${attachment.mimeType}` : undefined,
     attachment.url ? `url=${attachment.url}` : undefined,
-    // TODO: Upload files through POST /session/{thread_key}/attachments and pass refs here.
-    attachment.dataBase64 ? `base64=${attachment.dataBase64}` : undefined,
+    attachment.dataBase64Omitted ? `content=${attachment.dataBase64Omitted}` : undefined,
     attachment.fetchError ? `fetch_error=${attachment.fetchError}` : undefined
   ].filter(Boolean)
   return `[Slack attachment: ${fields.join(' ')}]`

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -17,6 +17,7 @@ export type SlackbotV2ApiAuthor = {
 
 export type SlackbotV2ApiAttachment = {
   dataBase64?: string
+  dataBase64Omitted?: string
   fetchError?: string
   fetchMetadata?: Record<string, string>
   height?: number

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -293,6 +293,70 @@ describe('slackbotv2', () => {
     expectSlackRenderedReply(renderedReplies[1]!, 'Executed request 2.')
   })
 
+  it('stages large Slack file attachments without exceeding session input line limits', async () => {
+    const parent = await postUserMessage('Context before the video upload.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> inspect this mp4`, parent.ts)
+    const fileUrl = `${slackApi.url}/files/large-upload.mp4`
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-large-mp4',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> inspect this mp4`,
+          files: [
+            {
+              id: 'F-large-mp4',
+              mimetype: 'video/mp4',
+              name: 'large-upload.mp4',
+              size: 2 * 1024 * 1024,
+              url_private: fileUrl
+            }
+          ]
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    const appendedAttachment = codexApi.appends[0]!.body.messages
+      .flatMap(message => message.parts)
+      .find(part => isRecord(part) && part.type === 'attachment')
+    expect(appendedAttachment).toEqual(
+      expect.objectContaining({
+        attachment_type: 'video',
+        dataBase64Omitted: expect.stringContaining('base64 chars omitted'),
+        mimeType: 'video/mp4',
+        name: 'large-upload.mp4'
+      })
+    )
+    expect(appendedAttachment).not.toHaveProperty('dataBase64')
+
+    const inputLines = codexApi.executes[0]!.body.input_lines
+    expect(inputLines.length).toBeGreaterThan(1)
+    for (const line of inputLines) {
+      expect(line.length).toBeLessThanOrEqual(1048576)
+    }
+
+    const chunkInputs = inputLines.slice(0, -1).map(line => JSON.parse(line))
+    expect(chunkInputs.every(input => input.type === 'attachment.chunk')).toBe(true)
+    expect(chunkInputs.at(-1)).toEqual(expect.objectContaining({ final: true }))
+
+    const turnInput = JSON.parse(inputLines.at(-1)!) as Record<string, unknown>
+    const serializedTurn = JSON.stringify(turnInput)
+    expect(serializedTurn).toContain('"stagedAttachmentId"')
+    expect(serializedTurn).not.toContain('dataBase64')
+  })
+
   it('executes a root app mention when Slack has no thread history yet', async () => {
     const mention = await postUserMessage(`<@${BOT_USER_ID}> answer from a new root message`)
     slackApi.failRepliesWithThreadNotFound(CHANNEL_ID, mention.ts)
@@ -2542,6 +2606,19 @@ async function handlePatchedSlackRequest(
       res,
       new Response('captured-image', {
         headers: { 'content-type': 'image/png' }
+      })
+    )
+    return
+  }
+
+  if (
+    url.pathname.endsWith('/files/large-upload.mp4')
+    || url.pathname.endsWith('/large-upload.mp4')
+  ) {
+    await sendWebResponse(
+      res,
+      new Response(new Uint8Array(2 * 1024 * 1024), {
+        headers: { 'content-type': 'video/mp4' }
       })
     )
     return


### PR DESCRIPTION
- **Failure:** inline Slack attachments exceeded Axum’s 2 MiB session request limit and returned 413 before spawn.
- **Fix:** on the current production/overlay-aware base, raise only the session route limit, omit large transcript base64, chunk execution input, and materialize chunks in the existing Codex wrapper. This does not update `main`.
- **Test:** 23 Rust API tests, 16 wrapper tests, 31 Slackbot tests, typecheck, and diff checks pass.
