### PR TITLE
Persist session attachments in API

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -457,6 +457,7 @@ name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -52,6 +52,9 @@ impl IntoResponse for ApiError {
             Self::Runtime(SessionRuntimeError::Store(SessionStoreError::NotFound { .. })) => {
                 StatusCode::NOT_FOUND
             }
+            Self::Runtime(SessionRuntimeError::Store(SessionStoreError::AttachmentNotFound {
+                ..
+            })) => StatusCode::NOT_FOUND,
             Self::Runtime(SessionRuntimeError::Store(SessionStoreError::HarnessConflict {
                 ..
             })) => StatusCode::CONFLICT,

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -41,8 +41,9 @@ use crate::{
     ApiError,
     types::{
         AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest,
-        EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
-        ListWorkflowRunsQuery, SessionSseEvent, stream_error_sse,
+        DownloadAttachmentQuery, EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest,
+        ExecuteSessionResponse, ListWorkflowRunsQuery, SessionSseEvent, UploadAttachmentRequest,
+        UploadAttachmentResponse, stream_error_sse,
     },
 };
 
@@ -84,6 +85,14 @@ pub fn build_router_with_session_and_workflow_runtime(
         .route("/healthz", get(healthz))
         .route("/metrics", get(metrics))
         .route("/api/session/{thread_key}", post(create_or_get_session))
+        .route(
+            "/agent/attachments/upload",
+            post(upload_attachment).layer(DefaultBodyLimit::disable()),
+        )
+        .route(
+            "/agent/attachments/{attachment_id}/download",
+            get(download_attachment),
+        )
         .route(
             "/api/session/{thread_key}/messages",
             post(append_messages).layer(DefaultBodyLimit::disable()),
@@ -220,6 +229,76 @@ async fn append_messages(
         ok: true,
         message_ids,
     }))
+}
+
+async fn upload_attachment(
+    State(state): State<AppState>,
+    Json(request): Json<UploadAttachmentRequest>,
+) -> Result<Json<UploadAttachmentResponse>, ApiError> {
+    let data = general_purpose::STANDARD
+        .decode(request.data)
+        .map_err(|error| ApiError::BadRequest(format!("invalid attachment data: {error}")))?;
+    let name = safe_attachment_name(&request.name);
+    let mime_type = safe_mime_type(&request.mime_type);
+    let attachment = state
+        .runtime
+        .create_attachment(
+            &request.thread_key,
+            &name,
+            &mime_type,
+            &data,
+            request.source_url.as_deref(),
+        )
+        .await?;
+    Ok(Json(UploadAttachmentResponse {
+        download_url: format!("/agent/attachments/{}/download", attachment.id),
+        id: attachment.id,
+        name: attachment.name,
+        mime_type: attachment.mime_type,
+    }))
+}
+
+async fn download_attachment(
+    State(state): State<AppState>,
+    Path(attachment_id): Path<String>,
+    Query(query): Query<DownloadAttachmentQuery>,
+) -> Result<Response, ApiError> {
+    let attachment = state
+        .runtime
+        .get_attachment(&query.thread_key, &attachment_id)
+        .await?;
+    Ok((
+        [
+            ("content-type", attachment.mime_type),
+            (
+                "content-disposition",
+                format!(
+                    "attachment; filename=\"{}\"",
+                    attachment.name.replace('"', "")
+                ),
+            ),
+        ],
+        Body::from(attachment.data),
+    )
+        .into_response())
+}
+
+fn safe_attachment_name(name: &str) -> String {
+    name.rsplit(['/', '\\'])
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("attachment")
+        .to_owned()
+}
+
+fn safe_mime_type(mime_type: &str) -> String {
+    let trimmed = mime_type.trim();
+    if trimmed.is_empty() {
+        "application/octet-stream".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
 }
 
 async fn execute_session(
@@ -849,5 +928,19 @@ mod webhook_tests {
         )
         .unwrap_err();
         assert!(matches!(error, ApiError::Internal(_)));
+    }
+
+    #[test]
+    fn sanitizes_attachment_names() {
+        assert_eq!(safe_attachment_name("report.pdf"), "report.pdf");
+        assert_eq!(safe_attachment_name("../secret.txt"), "secret.txt");
+        assert_eq!(safe_attachment_name(r"C:\tmp\chart.png"), "chart.png");
+        assert_eq!(safe_attachment_name("   "), "attachment");
+    }
+
+    #[test]
+    fn defaults_empty_attachment_mime_type() {
+        assert_eq!(safe_mime_type("text/plain"), "text/plain");
+        assert_eq!(safe_mime_type("  "), "application/octet-stream");
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -24,6 +24,29 @@ pub struct AppendMessagesResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UploadAttachmentRequest {
+    pub thread_key: ThreadKey,
+    pub name: String,
+    pub mime_type: String,
+    pub data: String,
+    #[serde(default)]
+    pub source_url: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UploadAttachmentResponse {
+    pub id: String,
+    pub name: String,
+    pub mime_type: String,
+    pub download_url: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct DownloadAttachmentQuery {
+    pub thread_key: ThreadKey,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExecuteSessionRequest {
     pub idempotency_key: Option<String>,
     pub metadata: Option<Value>,

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -12,6 +12,7 @@ centaur-sandbox-manager.workspace = true
 centaur-session-core.workspace = true
 centaur-session-sqlx.workspace = true
 centaur-telemetry.workspace = true
+base64.workspace = true
 futures-util.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use base64::{Engine as _, engine::general_purpose};
 use centaur_iron_control::SessionRegistrar;
 use centaur_sandbox_core::{
     Mount, SandboxBackend, SandboxError, SandboxId, SandboxIoGuard, SandboxRead, SandboxSpec,
@@ -18,7 +19,7 @@ use centaur_session_core::{
     SessionMessageInput, ThreadKey,
 };
 use centaur_session_sqlx::{
-    PgSessionStore, SessionEventListener, SessionStoreError, default_metadata,
+    AttachmentRecord, PgSessionStore, SessionEventListener, SessionStoreError, default_metadata,
 };
 use centaur_telemetry::{
     record_sandbox_warm_pool_claim, record_session_execution_finished,
@@ -315,7 +316,10 @@ impl SessionRuntime {
                 message_count = messages.len(),
                 "appending session messages"
             );
-            let message_ids = self.store.append_messages(thread_key, messages).await?;
+            let messages = self
+                .materialize_message_attachments(thread_key, messages)
+                .await?;
+            let message_ids = self.store.append_messages(thread_key, &messages).await?;
             info!(
                 component = COMPONENT_SESSION_RUNTIME,
                 event = "session_messages_append_completed",
@@ -343,9 +347,117 @@ impl SessionRuntime {
                 return Err(error);
             }
         };
-        self.forward_messages_to_active_execution(thread_key, messages, &message_ids)
+        let stored_messages = self.store.list_messages(thread_key).await?;
+        let appended_messages = message_ids
+            .iter()
+            .filter_map(|message_id| {
+                stored_messages
+                    .iter()
+                    .find(|message| message.message_id == *message_id)
+                    .map(|message| SessionMessageInput {
+                        client_message_id: message.client_message_id.clone(),
+                        role: message.role.clone(),
+                        parts: message.parts.clone(),
+                        metadata: message.metadata.clone(),
+                    })
+            })
+            .collect::<Vec<_>>();
+        self.forward_messages_to_active_execution(thread_key, &appended_messages, &message_ids)
             .await;
         Ok(message_ids)
+    }
+
+    pub async fn create_attachment(
+        &self,
+        thread_key: &ThreadKey,
+        name: &str,
+        mime_type: &str,
+        data: &[u8],
+        source_url: Option<&str>,
+    ) -> Result<AttachmentRecord, SessionRuntimeError> {
+        Ok(self
+            .store
+            .create_attachment(thread_key, name, mime_type, data, source_url)
+            .await?)
+    }
+
+    pub async fn get_attachment(
+        &self,
+        thread_key: &ThreadKey,
+        attachment_id: &str,
+    ) -> Result<AttachmentRecord, SessionRuntimeError> {
+        Ok(self.store.get_attachment(thread_key, attachment_id).await?)
+    }
+
+    async fn materialize_message_attachments(
+        &self,
+        thread_key: &ThreadKey,
+        messages: &[SessionMessageInput],
+    ) -> Result<Vec<SessionMessageInput>, SessionRuntimeError> {
+        let mut normalized = Vec::with_capacity(messages.len());
+        for message in messages {
+            let mut parts = Vec::with_capacity(message.parts.len());
+            for part in &message.parts {
+                parts.push(self.materialize_attachment_part(thread_key, part).await?);
+            }
+            normalized.push(SessionMessageInput {
+                client_message_id: message.client_message_id.clone(),
+                role: message.role.clone(),
+                parts,
+                metadata: message.metadata.clone(),
+            });
+        }
+        Ok(normalized)
+    }
+
+    async fn materialize_attachment_part(
+        &self,
+        thread_key: &ThreadKey,
+        part: &Value,
+    ) -> Result<Value, SessionRuntimeError> {
+        let Some(object) = part.as_object() else {
+            return Ok(part.clone());
+        };
+        if object.get("type").and_then(|value| value.as_str()) != Some("attachment") {
+            return Ok(part.clone());
+        }
+        let Some(data_base64) = object.get("dataBase64").and_then(|value| value.as_str()) else {
+            return Ok(part.clone());
+        };
+
+        let data = general_purpose::STANDARD
+            .decode(data_base64)
+            .map_err(|error| {
+                SessionRuntimeError::BadRequest(format!("invalid attachment dataBase64: {error}"))
+            })?;
+        let name = object
+            .get("name")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("attachment");
+        let mime_type = object
+            .get("mimeType")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("application/octet-stream");
+        let source_url = object.get("url").and_then(|value| value.as_str());
+        let attachment = self
+            .store
+            .create_attachment(thread_key, name, mime_type, &data, source_url)
+            .await?;
+
+        Ok(json!({
+            "type": "attachment_ref",
+            "attachment_id": attachment.id,
+            "name": attachment.name,
+            "mimeType": attachment.mime_type,
+            "size": attachment.data.len(),
+            "attachment_type": object
+                .get("attachment_type")
+                .or_else(|| object.get("attachmentType"))
+                .cloned()
+                .unwrap_or_else(|| Value::String("file".to_owned())),
+        }))
     }
 
     /// Stop every non-terminal sandbox the backend currently owns.

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0017_session_attachments.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0017_session_attachments.sql
@@ -1,0 +1,15 @@
+create table if not exists attachments (
+    id text primary key,
+    thread_key text not null references sessions(thread_key) on delete cascade,
+    name text not null,
+    mime_type text not null,
+    data bytea not null,
+    source_url text,
+    created_at timestamptz not null default now(),
+    constraint attachments_id_len check (octet_length(id) between 1 and 128),
+    constraint attachments_name_len check (octet_length(name) between 1 and 512),
+    constraint attachments_mime_type_len check (octet_length(mime_type) between 1 and 255)
+);
+
+create index if not exists attachments_thread_created_idx
+    on attachments (thread_key, created_at desc, id);

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -6,7 +6,7 @@ use centaur_session_core::{
     ExecutionStatus, HarnessType, Session, SessionEvent, SessionExecution, SessionMessage,
     SessionMessageInput, SessionStatus, ThreadKey, empty_object,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::{
     FromRow, PgPool,
@@ -20,6 +20,17 @@ static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
 pub const SESSION_EVENTS_CHANNEL: &str = "centaur_session_events";
 const DEFAULT_MAX_CONNECTIONS: u32 = 500;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AttachmentRecord {
+    pub id: String,
+    pub thread_key: ThreadKey,
+    pub name: String,
+    pub mime_type: String,
+    pub data: Vec<u8>,
+    pub source_url: Option<String>,
+    pub created_at: OffsetDateTime,
+}
 
 #[derive(Clone, Debug)]
 pub struct CreateExecutionResult {
@@ -181,6 +192,58 @@ impl PgSessionStore {
         .await?;
 
         rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    pub async fn create_attachment(
+        &self,
+        thread_key: &ThreadKey,
+        name: &str,
+        mime_type: &str,
+        data: &[u8],
+        source_url: Option<&str>,
+    ) -> Result<AttachmentRecord, SessionStoreError> {
+        let id = prefixed_id("att");
+        let row = sqlx::query_as::<_, AttachmentRow>(
+            r#"
+            insert into attachments (id, thread_key, name, mime_type, data, source_url)
+            values ($1, $2, $3, $4, $5, $6)
+            returning id, thread_key, name, mime_type, data, source_url, created_at
+            "#,
+        )
+        .bind(&id)
+        .bind(thread_key.as_str())
+        .bind(name)
+        .bind(mime_type)
+        .bind(data)
+        .bind(source_url)
+        .fetch_one(&self.pool)
+        .await?;
+
+        row.try_into()
+    }
+
+    pub async fn get_attachment(
+        &self,
+        thread_key: &ThreadKey,
+        attachment_id: &str,
+    ) -> Result<AttachmentRecord, SessionStoreError> {
+        let row = sqlx::query_as::<_, AttachmentRow>(
+            r#"
+            select id, thread_key, name, mime_type, data, source_url, created_at
+            from attachments
+            where thread_key = $1 and id = $2
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(attachment_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| SessionStoreError::AttachmentNotFound {
+            thread_key: thread_key.as_str().to_owned(),
+            attachment_id: attachment_id.to_owned(),
+        })?;
+
+        row.try_into()
     }
 
     pub async fn create_execution(
@@ -704,6 +767,11 @@ pub enum SessionStoreError {
         existing: Option<String>,
         requested: Option<String>,
     },
+    #[error("attachment {attachment_id} not found for thread_key {thread_key}")]
+    AttachmentNotFound {
+        thread_key: String,
+        attachment_id: String,
+    },
     #[error("invalid persisted value: {0}")]
     InvalidPersistedValue(String),
     #[error("invalid notification payload on {channel}: {payload}: {error}")]
@@ -758,6 +826,33 @@ struct SessionMessageRow {
     parts: Value,
     metadata: Value,
     created_at: OffsetDateTime,
+}
+
+#[derive(Debug, FromRow)]
+struct AttachmentRow {
+    id: String,
+    thread_key: String,
+    name: String,
+    mime_type: String,
+    data: Vec<u8>,
+    source_url: Option<String>,
+    created_at: OffsetDateTime,
+}
+
+impl TryFrom<AttachmentRow> for AttachmentRecord {
+    type Error = SessionStoreError;
+
+    fn try_from(row: AttachmentRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: row.id,
+            thread_key: parse_persisted(row.thread_key)?,
+            name: row.name,
+            mime_type: row.mime_type,
+            data: row.data,
+            source_url: row.source_url,
+            created_at: row.created_at,
+        })
+    }
 }
 
 impl TryFrom<SessionMessageRow> for SessionMessage {

--- a/services/sandbox/call.sh
+++ b/services/sandbox/call.sh
@@ -122,7 +122,10 @@ agent_execute() {
     return $?
   fi
 
-  if ! printf '%s' "$payload" | jq -e '(.message | type) == "string" and (.message | length) > 0' >/dev/null 2>&1; then
+  if ! printf '%s' "$payload" | jq -e '
+    ((.message | type) == "string" and (.message | length) > 0)
+    or ((.parts | type) == "array" and (.parts | length) > 0)
+  ' >/dev/null 2>&1; then
     request "POST" "$U/agent/execute" "$payload"
     return $?
   fi
@@ -162,7 +165,12 @@ agent_execute() {
       assignment_generation: $assignment_generation,
       message_id: (.message_id // $message_id),
       role: (.role // "user"),
-      parts: [{type: "text", text: .message}]
+      parts: (
+        if (.parts | type) == "array" and (.parts | length) > 0
+        then .parts
+        else [{type: "text", text: .message}]
+        end
+      )
     }
     + (if .user_id != null then {user_id: .user_id} else {} end)
     + (if .metadata != null then {metadata: .metadata} else {} end)
@@ -208,7 +216,7 @@ case "$tool" in
     ;;
   discover)
     if [ "$2" = "agent" ]; then
-      printf '%s\n' '{"tool":"agent","description":"Sub-agent dispatch (built-in, not a tool plugin)","methods":[{"name":"execute","description":"Spawn a sub-agent. Body: {\"thread_key\":\"task:<purpose>-<id>\",\"message\":\"...\",\"harness\":\"<persona>\"}. Returns {execution_id, status}."},{"name":"status","description":"Poll sub-agent. Usage: call agent status '\''?key=<thread_key>'\''"},{"name":"runtime","description":"Inspect active persona/overlay/available personas for a thread. Usage: call agent runtime '\''?key=<thread_key>'\''"},{"name":"stop","description":"Stop sub-agent. Body: {\"thread_key\":\"...\"}"}]}'
+      printf '%s\n' '{"tool":"agent","description":"Sub-agent dispatch (built-in, not a tool plugin)","methods":[{"name":"execute","description":"Spawn a sub-agent. Body: {\"thread_key\":\"task:<purpose>-<id>\",\"message\":\"...\",\"harness\":\"<persona>\"}. For multimodal input, pass \"parts\" instead of \"message\". Returns {execution_id, status}."},{"name":"status","description":"Poll sub-agent. Usage: call agent status '\''?key=<thread_key>'\''"},{"name":"runtime","description":"Inspect active persona/overlay/available personas for a thread. Usage: call agent runtime '\''?key=<thread_key>'\''"},{"name":"stop","description":"Stop sub-agent. Body: {\"thread_key\":\"...\"}"}]}'
     else
       request "GET" "$TU/tools/$2"
     fi


### PR DESCRIPTION
## Summary\n- add a session-scoped attachments table plus store methods\n- materialize incoming session attachment parts with dataBase64 into DB rows and replace them with attachment_ref parts\n- add SDK-compatible /agent/attachments upload/download routes\n\n## Root cause\nThe sandbox prompt and tool SDK expected an attachments DB/API surface, but api-rs had no attachments migration or /agent/attachments routes. Slackbotv2 could inline attachment bytes into session messages, but nothing persisted them as durable DB attachment records.\n\n## Validation\n- cargo fmt --check\n- cargo check -p centaur-api-server\n- cargo test -p centaur-api-server attachment