### PR TITLE
[codex] fix Slack stream payload budgeting

### DIFF
--- a/patches/@chat-adapter__slack@4.30.0.patch
+++ b/patches/@chat-adapter__slack@4.30.0.patch
@@ -2,7 +2,7 @@ diff --git a/dist/index.js b/dist/index.js
 index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22eed819d8e 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -31,6 +31,176 @@ import {
+@@ -31,6 +31,216 @@ import {
    toModalElement,
    toPlainText
  } from "chat";
@@ -11,6 +11,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +var STREAM_CHUNK_LIMIT = 256;
 +var STREAM_TASK_LIMIT = 50;
 +var STREAM_FENCE_RESERVE = 64;
++var STREAM_CARD_OVERHEAD = 320;
 +// Slack hard-expires a streaming message ~300s after chat.startStream
 +// (measured in production: appends fail with message_not_in_streaming_state
 +// at ~303-304s). Rotate segments well before that so long renders survive.
@@ -23,7 +24,11 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +// size cap (msg_too_long). Budget the per-segment structured content too.
 +function streamSegmentTaskCharBudget() {
 +  const value = Number(process.env.SLACK_STREAM_SEGMENT_TASK_CHAR_BUDGET ?? "");
-+  return Number.isFinite(value) && value > 0 ? value : 16e3;
++  return Number.isFinite(value) && value > 0 ? value : 9e3;
++}
++function streamSegmentPayloadCharBudget() {
++  const value = Number(process.env.SLACK_STREAM_SEGMENT_PAYLOAD_CHAR_BUDGET ?? "");
++  return Number.isFinite(value) && value > 0 ? value : 11e3;
 +}
 +function slackStreamErrorCode(error) {
 +  if (!error || typeof error !== "object") {
@@ -54,6 +59,19 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +  } catch {
 +  }
 +}
++function annotateSlackStreamMessage(error, segment) {
++  if (!error || typeof error !== "object" && typeof error !== "function") {
++    return;
++  }
++  const streamTs = segment?.streamer?.streamTs;
++  if (typeof streamTs !== "string" || streamTs.length === 0) {
++    return;
++  }
++  try {
++    error.slackStreamMessageId = streamTs;
++  } catch {
++  }
++}
 +function slackAnswerLostAnnotation(error) {
 +  if (!error || typeof error !== "object" && typeof error !== "function") {
 +    return void 0;
@@ -61,8 +79,30 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +  const value = error.slackAnswerLost;
 +  return typeof value === "boolean" ? value : void 0;
 +}
++function jsonChars(value) {
++  if (value === void 0) {
++    return 0;
++  }
++  try {
++    return JSON.stringify(value).length;
++  } catch {
++    return 0;
++  }
++}
 +function taskChunkChars(chunk) {
-+  return (typeof chunk.title === "string" ? chunk.title.length : 0) + (typeof chunk.details === "string" ? chunk.details.length : 0) + (typeof chunk.output === "string" ? chunk.output.length : 0) + 64;
++  return (typeof chunk.id === "string" ? chunk.id.length : 0) + (typeof chunk.title === "string" ? chunk.title.length : 0) + (typeof chunk.status === "string" ? chunk.status.length : 0) + (typeof chunk.details === "string" ? chunk.details.length : 0) + (typeof chunk.output === "string" ? chunk.output.length : 0) + jsonChars(chunk.sources) + STREAM_CARD_OVERHEAD;
++}
++function segmentPayloadChars(segment) {
++  return segment.length + segment.taskCharsTotal;
++}
++function segmentMarkdownAvailable(segment) {
++  return Math.max(
++    0,
++    Math.min(
++      STREAM_SEGMENT_LIMIT - segment.length,
++      streamSegmentPayloadCharBudget() - segmentPayloadChars(segment)
++    )
++  );
 +}
 +var FENCE_PATTERN = /^(`{3,}|~{3,})/;
 +var Fence = class {
@@ -179,7 +219,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
  
  // src/cards.ts
  import {
-@@ -3434,26 +3604,210 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3434,26 +3644,216 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -228,10 +268,16 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +      if (segment.stopped || !(segment.hasContent || force)) {
 +        return void 0;
 +      }
-+      const result = await segment.streamer.stop({
-+        token,
-+        ...blocks ? { blocks } : {}
-+      });
++      let result;
++      try {
++        result = await segment.streamer.stop({
++          token,
++          ...blocks ? { blocks } : {}
++        });
++      } catch (error) {
++        annotateSlackStreamMessage(error, segment);
++        throw error;
++      }
 +      segment.stopped = true;
 +      if (result) {
 +        provisionalResult = result;
@@ -317,10 +363,10 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +        if (isExpired(current)) {
 +          await rotateCurrentForAge();
 +        }
-+        if (current.length === STREAM_SEGMENT_LIMIT) {
++        if (current.length === STREAM_SEGMENT_LIMIT || segmentMarkdownAvailable(current) === 0 && current.hasContent) {
 +          await rotateSegment(fence.closing, fence.opening);
 +        }
-+        const available = STREAM_SEGMENT_LIMIT - current.length;
++        const available = segmentMarkdownAvailable(current);
 +        const first = remaining.codePointAt(0);
 +        const width = first !== void 0 && first > 65535 ? 2 : 1;
 +        if (available < width) {
@@ -376,7 +422,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +        } else if (!existing.stopped) {
 +          const previous = existing.taskChars.get(id) ?? 0;
 +          const projected = existing.taskCharsTotal - previous + Math.max(previous, chunkChars);
-+          if (projected <= streamSegmentTaskCharBudget()) {
++          if (projected <= streamSegmentTaskCharBudget() && existing.length + projected <= streamSegmentPayloadCharBudget()) {
 +            return existing;
 +          }
 +          taskSegments.delete(id);
@@ -387,7 +433,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +      if (isExpired(current)) {
 +        await rotateCurrentForAge();
 +      }
-+      if (current.cards >= STREAM_TASK_LIMIT || current.taskCharsTotal + chunkChars > streamSegmentTaskCharBudget()) {
++      if (current.cards >= STREAM_TASK_LIMIT || current.taskCharsTotal + chunkChars > streamSegmentTaskCharBudget() || segmentPayloadChars(current) + chunkChars > streamSegmentPayloadCharBudget()) {
 +        await createStructuredSegment();
 +      } else {
 +        structured.add(current);
@@ -399,7 +445,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
      const sendStructuredChunk = async (chunk) => {
        if (!structuredChunksSupported) {
          return;
-@@ -3463,8 +3817,45 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3463,8 +3863,45 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
@@ -446,7 +492,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
          structuredChunksSupported = false;
          this.logger.warn(
            "Structured streaming chunk failed, falling back to text-only streaming. Ensure your Slack app manifest includes assistant_view, assistant:write scope, and @slack/web-api >= 7.14.0",
-@@ -3479,31 +3870,91 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3479,31 +3916,91 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
      };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@chat-adapter/slack@4.30.0':
-    hash: 3969edeaa8632fe39c4f2a10d6c3505e86aa4eb1cb970fb86eacca4f5deea5ca
+    hash: f656c319fc04061edbaf3a94ae5d46cbed31057d1057cad70748abb12ef4e151
     path: patches/@chat-adapter__slack@4.30.0.patch
 
 importers:
@@ -70,7 +70,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.30.0
-        version: 4.30.0(patch_hash=3969edeaa8632fe39c4f2a10d6c3505e86aa4eb1cb970fb86eacca4f5deea5ca)(zod@4.4.3)
+        version: 4.30.0(patch_hash=f656c319fc04061edbaf3a94ae5d46cbed31057d1057cad70748abb12ef4e151)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
@@ -1131,7 +1131,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.30.0(patch_hash=3969edeaa8632fe39c4f2a10d6c3505e86aa4eb1cb970fb86eacca4f5deea5ca)(zod@4.4.3)':
+  '@chat-adapter/slack@4.30.0(patch_hash=f656c319fc04061edbaf3a94ae5d46cbed31057d1057cad70748abb12ef4e151)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.30.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -562,6 +562,20 @@ async function renderExecutionAttempt(
       error: errorMessage(error),
       slack_answer_lost: answerLost ?? 'unknown'
     })
+    const replaceMessageId = isSlackStreamSizeLimitError(error)
+      ? slackStreamMessageId(error)
+      : undefined
+    if (isSlackStreamSizeLimitError(error) && !replaceMessageId) {
+      // Size-limit failures should be prevented by stream segmentation. If
+      // Slack still rejects a stream as too large but does not expose the
+      // failed stream message id, do not post a separate duplicate fallback.
+      rendered = true
+      traceLog(options, 'slackbotv2_render_failed_size_limit_no_replacement', trace, {
+        error: errorMessage(error),
+        slack_answer_lost: answerLost ?? 'unknown'
+      })
+      return 'complete'
+    }
     const fallback = await renderFallbackFinalAnswer(
       thread,
       options,
@@ -570,7 +584,8 @@ async function renderExecutionAttempt(
         executionId: input.executionId,
         threadId: input.threadId
       },
-      trace
+      trace,
+      replaceMessageId ? { replaceMessageId } : undefined
     )
     if (fallback) {
       rendered = true
@@ -605,6 +620,29 @@ function slackAnswerLost(error: unknown): boolean | undefined {
   return typeof value === 'boolean' ? value : undefined
 }
 
+function isSlackStreamSizeLimitError(error: unknown): boolean {
+  const code = slackStreamErrorCode(error)
+  return code.includes('msg_too_long') || code.includes('msg_blocks_too_long')
+}
+
+function slackStreamMessageId(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const value = (error as { slackStreamMessageId?: unknown }).slackStreamMessageId
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function slackStreamErrorCode(error: unknown): string {
+  if (!error || typeof error !== 'object') return typeof error === 'string' ? error : ''
+  const record = error as Record<string, unknown>
+  if (typeof record.error === 'string') return record.error
+  const data = record.data
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    const dataError = (data as Record<string, unknown>).error
+    if (typeof dataError === 'string') return dataError
+  }
+  return typeof record.message === 'string' ? record.message : ''
+}
+
 const FALLBACK_OPEN_MAX_ATTEMPTS = 4
 
 /**
@@ -620,7 +658,8 @@ async function renderFallbackFinalAnswer(
   thread: Thread,
   options: SlackbotV2Options,
   source: { afterEventId: number; executionId?: string; threadId: string },
-  trace?: SlackbotV2Trace
+  trace?: SlackbotV2Trace,
+  replacement?: { replaceMessageId: string }
 ): Promise<{ lastEventId: number } | null> {
   const startedAtMs = nowMs()
   let lastEventId = source.afterEventId
@@ -665,12 +704,16 @@ async function renderFallbackFinalAnswer(
       })
       return null
     }
-    await thread.post(
-      truncateSlackText(text, SLACK_FALLBACK_TEXT_MAX_CHARS, 'Slack final answer')
-    )
+    const fallbackText = truncateSlackText(text, SLACK_FALLBACK_TEXT_MAX_CHARS, 'Slack final answer')
+    if (replacement) {
+      await thread.adapter.editMessage(thread.id, replacement.replaceMessageId, fallbackText)
+    } else {
+      await thread.post(fallbackText)
+    }
     traceLog(options, 'slackbotv2_render_fallback_complete', trace, {
       chars: text.length,
       last_event_id: lastEventId,
+      replacement_message_id: replacement?.replaceMessageId,
       phase_ms: elapsedMs(startedAtMs)
     })
     return { lastEventId }
@@ -916,6 +959,20 @@ async function recoverRenderObligation(
         error: errorMessage(error),
         slack_answer_lost: answerLost ?? 'unknown'
       })
+      const replaceMessageId = isSlackStreamSizeLimitError(error)
+        ? slackStreamMessageId(error)
+        : undefined
+      if (isSlackStreamSizeLimitError(error) && !replaceMessageId) {
+        // Size-limit failures should be prevented by stream segmentation. If
+        // Slack still rejects a stream as too large but does not expose the
+        // failed stream message id, do not post a separate duplicate fallback.
+        rendered = true
+        traceLog(options, 'slackbotv2_render_recovery_failed_size_limit_no_replacement', trace, {
+          error: errorMessage(error),
+          slack_answer_lost: answerLost ?? 'unknown'
+        })
+        return false
+      }
       const fallback = await renderFallbackFinalAnswer(
         thread,
         options,
@@ -924,7 +981,8 @@ async function recoverRenderObligation(
           executionId: obligation.executionId,
           threadId
         },
-        trace
+        trace,
+        replaceMessageId ? { replaceMessageId } : undefined
       )
       if (!fallback) throw error
       rendered = true

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1182,13 +1182,15 @@ describe('slackbotv2', () => {
     expect(renderedText).not.toContain('Execution completed, but no final text was captured.')
   })
 
-  it('reposts the durable final answer exactly once when Slack rejects the stream stop as too long', async () => {
+  it('replaces the failed stream with the durable final answer when Slack rejects stop as too long', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
     bot = createTestBot({ state: sharedState })
     codexApi.autoRespond = false
     // Every stop fails: the streamed message never finalizes, so its content
-    // breaks in real Slack. The bot must repost the durable answer once.
+    // breaks in real Slack. Size-limit failures should be prevented by
+    // segmentation; if one still happens, replace the broken stream instead of
+    // posting a duplicate fallback reply in the thread.
     slackApi.failStreamStopsLongerThan(10)
 
     const parent = await postUserMessage('Context before an oversized Slack render.')
@@ -1240,13 +1242,10 @@ describe('slackbotv2', () => {
     await Promise.all(waits)
     expect(slackApi.calls.some(call => call.method === 'chat.stopStream')).toBe(true)
     const texts = await threadTexts(parent.ts)
-    // The streamed message broke ("Something went wrong"), so the durable
-    // final answer must be reposted - exactly once, never duplicated.
-    expect(texts.some(text => text.includes(BROKEN_STREAM_TEXT))).toBe(true)
-    const visibleFinalReplies = texts.filter(text =>
+    expect(texts.some(text => text.includes(BROKEN_STREAM_TEXT))).toBe(false)
+    expect(texts.filter(text =>
       text.includes('TOO_LONG_FALLBACK_VISIBLE')
-    )
-    expect(visibleFinalReplies).toHaveLength(1)
+    )).toHaveLength(1)
     const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
     expect(threadState).toEqual(
       expect.objectContaining({
@@ -1496,6 +1495,71 @@ describe('slackbotv2', () => {
     } finally {
       delete process.env.SLACK_STREAM_SEGMENT_TASK_CHAR_BUDGET
     }
+  })
+
+  it('keeps card-heavy structured streams below Slack finalization payload limits', async () => {
+    slackApi.failStreamStopsLongerThan(12_000)
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before a production-sized card render.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> run enough steps to paginate`, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-structured-payload-budget',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> run enough steps to paginate`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    for (let index = 1; index <= 36; index++) {
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: `cmd-payload-${index}`,
+            type: 'commandExecution',
+            command: `step-${index} ${'x'.repeat(220)}`,
+            status: 'completed',
+            aggregatedOutput: ''
+          }
+        })
+      )
+    }
+    codexApi.emitSessionEvent(key, 'session.execution_completed', {
+      execution_id: 'exe-structured-payload-budget',
+      status: 'completed',
+      result_text: 'STRUCTURED_PAYLOAD_BUDGET_ANSWER_VISIBLE'
+    })
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts.length).toBeGreaterThanOrEqual(2)
+    for (const transcript of transcripts) {
+      expect(streamTranscriptPayloadChars(transcript)).toBeLessThanOrEqual(12_000)
+    }
+    const texts = await threadTexts(parent.ts)
+    expect(texts.some(text => text.includes(BROKEN_STREAM_TEXT))).toBe(false)
+    expect(texts.filter(text =>
+      text.includes('STRUCTURED_PAYLOAD_BUDGET_ANSWER_VISIBLE')
+    )).toHaveLength(1)
   })
 
   it('recovers the final answer when thread state already advanced past the terminal event', async () => {
@@ -1755,13 +1819,16 @@ describe('slackbotv2', () => {
     expect(transcripts.length).toBeGreaterThan(1)
     expect(transcripts.flatMap(transcript => transcript.chunks).filter(chunk => chunk.type === 'task_update').length)
       .toBeGreaterThan(50)
-    expect(
+    const taskCounts = transcripts.map(transcript =>
       new Set(
-        transcripts[0]!.chunks
+        transcript.chunks
           .filter(chunk => chunk.type === 'task_update')
           .map(chunk => stringField(chunk.id))
       ).size
-    ).toBe(50)
+    )
+    expect(taskCounts[0]).toBeGreaterThan(0)
+    expect(taskCounts[0]).toBeLessThan(50)
+    expect(Math.max(...taskCounts)).toBeLessThanOrEqual(50)
     expect(await threadText(parent.ts)).toContain('TASK_STREAM_CONTINUATION_OK')
   })
 
@@ -3470,6 +3537,7 @@ type StreamCall = {
 
 type StreamRecord = {
   channel: string
+  payloadChars: number
   text: string
   ts: string
 }
@@ -3749,6 +3817,7 @@ async function startStream(
   const channel = stringField(body.channel)
   const threadTs = stringField(body.thread_ts)
   const text = streamBodyText(body) || ' '
+  const payloadChars = streamBodyPayloadChars(body)
   const posted = await postSlack(emulatorUrl, request, '/api/chat.postMessage', {
     channel,
     thread_ts: threadTs || undefined,
@@ -3757,7 +3826,7 @@ async function startStream(
   if (!posted.ok) return Response.json(posted)
   const ts = stringField(posted.ts)
   calls.push({ method: 'chat.startStream', body, streamTs: ts })
-  streams.set(streamKey(channel, ts), { channel, ts, text })
+  streams.set(streamKey(channel, ts), { channel, payloadChars, ts, text })
   return Response.json({ ok: true, channel, ts })
 }
 
@@ -3783,8 +3852,9 @@ async function appendStream(
     return Response.json({ ok: false, error: appendFailure.error })
   }
   if (appendFailure.remaining > 0) appendFailure.remaining -= 1
-  const record = streams.get(streamKey(channel, ts)) ?? { channel, ts, text: '' }
+  const record = streams.get(streamKey(channel, ts)) ?? { channel, payloadChars: 0, ts, text: '' }
   record.text += streamBodyText(body)
+  record.payloadChars += streamBodyPayloadChars(body)
   streams.set(streamKey(channel, ts), record)
   await postSlack(emulatorUrl, request, '/api/chat.update', {
     channel,
@@ -3806,9 +3876,10 @@ async function stopStream(
   const ts = stringField(body.ts)
   calls.push({ method: 'chat.stopStream', body, streamTs: ts })
   const key = streamKey(channel, ts)
-  const record = streams.get(key) ?? { channel, ts, text: '' }
+  const record = streams.get(key) ?? { channel, payloadChars: 0, ts, text: '' }
   const text = [record.text, streamBodyText(body)].filter(part => part.trim()).join('\n')
-  if (maxStreamStopChars !== null && text.length > maxStreamStopChars) {
+  const payloadChars = record.payloadChars + streamBodyPayloadChars(body)
+  if (maxStreamStopChars !== null && payloadChars > maxStreamStopChars) {
     // A stream that is never stopped breaks in real Slack: the message shows
     // "Something went wrong" instead of the streamed content.
     await postSlack(emulatorUrl, request, '/api/chat.update', {
@@ -3858,6 +3929,14 @@ async function postSlack(
 
 function streamBodyText(body: Record<string, unknown>): string {
   return [stringField(body.markdown_text), chunksText(body.chunks)].filter(Boolean).join('\n')
+}
+
+function streamBodyPayloadChars(body: Record<string, unknown>): number {
+  return (
+    stringField(body.markdown_text).length
+    + JSON.stringify(streamChunks(body.chunks)).length
+    + JSON.stringify(body.blocks ?? []).length
+  )
 }
 
 function streamChunks(value: unknown): Record<string, unknown>[] {
@@ -4031,6 +4110,10 @@ function slackStreamTranscripts(calls: StreamCall[]): SlackStreamTranscript[] {
     const chunks = streamCalls.flatMap(call => streamChunks(call.body.chunks))
     return { appends, calls: streamCalls, chunks, start, stop, streamTs }
   })
+}
+
+function streamTranscriptPayloadChars(transcript: SlackStreamTranscript): number {
+  return transcript.calls.reduce((total, call) => total + streamBodyPayloadChars(call.body), 0)
 }
 
 function chunkText(chunk: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary

Fixes Slack `msg_too_long` failures for card-heavy agent streams by making the Slack stream segment estimator account for structured task payload size, not just visible text. If Slack still returns a stream size-limit error, the durable-answer fallback now replaces the failed streaming message in-place instead of posting a second reply.

## Root Cause

The Slack adapter was rotating stream segments based on markdown length and an optimistic task-card estimate. In the investigated production thread, the final answer was small, but the accumulated Slack `plan` block serialized above Slack's stream finalization limit, so `chat.stopStream` failed with `msg_too_long` and the recovery fallback posted a second answer while the failed stream stayed visible.

## Changes

- Add a conservative per-card overhead and include task id, status, sources, and structured field size in task payload estimation.
- Lower the default structured task budget and add an overall per-segment payload budget below Slack's 12k stream limit.
- Make markdown appends respect the combined structured-plus-markdown payload budget.
- Annotate Slack stream stop failures with the failed stream message id.
- For `msg_too_long` / `msg_blocks_too_long`, drain the durable final answer and edit the failed stream message to that text instead of posting a duplicate fallback reply.
- Extend the Slack emulator to fail based on accumulated stream payload size, not only visible text.
- Add a production-shaped regression test for card-heavy streams with a small final answer.

## Validation

- `pnpm install`
- `pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts` - 62 pass
- `pnpm --filter slackbotv2 check:types`
- Replayed the exact production event stream locally with the new estimator; it paginates into two stream segments estimated at 8,983 and 9,684 chars, both below the 11k internal ceiling and Slack's 12k stream limit.