### PR TITLE
fix(api-rs): make interval schedule ticks idempotent across reconciles

### DIFF
--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -1559,15 +1559,35 @@ fn next_schedule_time(
     after: DateTime<Utc>,
 ) -> Result<DateTime<Utc>, WorkflowRuntimeError> {
     match &schedule.kind {
-        WorkflowScheduleKind::Interval { interval_seconds } => Ok(after
-            + chrono::Duration::from_std(Duration::from_secs(*interval_seconds)).map_err(
-                |error| {
+        WorkflowScheduleKind::Interval { interval_seconds } => {
+            // Align the next run to a fixed epoch boundary so the value is
+            // stable across reconcile cycles. `reconcile_schedules` runs on
+            // every reconcile tick and spawns a schedule-tick keyed on this
+            // timestamp's RFC3339. Returning `after + interval` (a moving
+            // target) produces a new key every cycle and therefore a duplicate
+            // tick each cycle -- the schedule-tick firehose. Bucketing to the
+            // next epoch-aligned boundary yields the same value for the whole
+            // window, mirroring how the cron arm produces a stable occurrence.
+            let interval = i64::try_from(*interval_seconds)
+                .ok()
+                .filter(|seconds| *seconds > 0)
+                .ok_or_else(|| {
                     WorkflowRuntimeError::BadRequest(format!(
-                        "invalid interval for schedule {:?}: {error}",
+                        "invalid interval {interval_seconds} for schedule {:?}",
                         schedule.schedule_id
                     ))
-                },
-            )?),
+                })?;
+            // `after.timestamp()` is always >= 0 here, so floor division gives
+            // the boundary at or below `after`; `+ interval` makes it strictly
+            // after, matching the previous "next run is in the future" contract.
+            let next_secs = (after.timestamp() / interval + 1) * interval;
+            DateTime::from_timestamp(next_secs, 0).ok_or_else(|| {
+                WorkflowRuntimeError::BadRequest(format!(
+                    "interval schedule {:?} produced an out-of-range next run",
+                    schedule.schedule_id
+                ))
+            })
+        }
         WorkflowScheduleKind::Cron { cron } => {
             let timezone = schedule.timezone.parse::<Tz>().map_err(|error| {
                 WorkflowRuntimeError::BadRequest(format!(
@@ -2755,6 +2775,40 @@ mod tests {
         assert_eq!(
             workflow_queue_class("github_issue_triage"),
             WorkflowQueueClass::Standard
+        );
+    }
+
+    #[test]
+    fn interval_schedule_next_run_is_stable_across_reconciles() {
+        // Regression guard for the schedule-tick firehose: two reconcile cycles
+        // at different wall-clock instants inside the same interval window must
+        // produce the same next run (hence the same idempotency key), instead of
+        // each computing `now + interval` and spawning a duplicate tick.
+        let schedule = normalize_schedule(json!({
+            "workflow_name": "slack_sync",
+            "schedule_id": "slack_sync",
+            "interval_seconds": 3600,
+            "enabled": true,
+            "no_delivery": true,
+        }))
+        .unwrap();
+
+        let base = Utc.with_ymd_and_hms(2026, 6, 8, 12, 0, 0).unwrap();
+        let next = next_schedule_time(&schedule, base).unwrap();
+        // Epoch-aligned boundary, strictly after `after`.
+        assert!(next > base);
+        assert_eq!(next.timestamp() % 3600, 0);
+        assert_eq!(next, Utc.with_ymd_and_hms(2026, 6, 8, 13, 0, 0).unwrap());
+
+        // A later reconcile within the same hour yields the identical boundary.
+        let later = Utc.with_ymd_and_hms(2026, 6, 8, 12, 47, 31).unwrap();
+        assert_eq!(next_schedule_time(&schedule, later).unwrap(), next);
+
+        // A point exactly on a boundary advances to the following one.
+        let on_boundary = Utc.with_ymd_and_hms(2026, 6, 8, 13, 0, 0).unwrap();
+        assert_eq!(
+            next_schedule_time(&schedule, on_boundary).unwrap(),
+            Utc.with_ymd_and_hms(2026, 6, 8, 14, 0, 0).unwrap()
         );
     }
 


### PR DESCRIPTION
## Problem

Interval-based workflow schedules spawn a **new duplicate schedule-tick every reconcile cycle**, so a single enabled interval schedule accumulates an unbounded pile of overlapping ticks. In one deployment an alert scan reached **thousands** of pending ticks; each fires a workflow run, which spawns a sandbox, eventually exhausting node capacity and taking the service down.

## Root cause

`reconcile_schedules` is what spawns the per-schedule tick tasks, and it runs on **two** paths — not just at startup:

1. **Startup**, once, when api-rs boots (`reconcile_schedules(&schedule_client, &startup_schedules)`).
2. **The periodic metadata reconciler.** `spawn_workflow_metadata_reconciler` ticks a `tokio::time::interval` every `WORKFLOW_RECONCILE_INTERVAL_SECS` (**default 60s**) and calls `reconcile_workflow_metadata_once`, which re-discovers workflows, rebuilds the schedule registry, and at the end calls `reconcile_schedules(schedule_client, &next_schedules)` again.

So in steady state `reconcile_schedules` runs roughly **once a minute**, forever. For each enabled schedule it computes `next_run_at = next_schedule_time(schedule, Utc::now())` and calls `spawn_schedule_tick`, whose idempotency key is:

```
schedule-tick:{schedule_id}:{scheduled_at_rfc3339}
```

- **Cron arm:** `next_schedule_time` returns the next fixed wall-clock occurrence. That value is identical on every reconcile within the window, so the idempotency key is stable and the spawn dedupes — exactly **one** pending tick.
- **Interval arm (before this change):** it returned `after + interval`, i.e. `now() + interval` — a **moving target**. Every 60s reconcile computes a `scheduled_at` ~60s later than the last, producing a different idempotency key and therefore a **brand-new tick each cycle**. The removed-workflow reaper only cancels ticks for schedules that no longer exist, so it never reclaims these duplicates; they accumulate until the queue (and the sandboxes they spawn) overwhelm the cluster.

This was observed directly in a deployment: with an interval schedule enabled, the `"reconciled absurd workflow schedule … next_run_at=…"` log line printed a *new* `next_run_at` every 60s (one duplicate tick per cycle); with the fix below, `next_run_at` stays pinned to the same boundary across every reconcile.

## Fix

Align the interval next-run to a fixed epoch boundary:

```rust
let next_secs = (after.timestamp() / interval + 1) * interval;
```

Every reconcile inside the same interval window now computes the **same** boundary, producing a stable idempotency key that dedupes to a single tick — the same property the cron arm already has. The boundary is strictly after `after`, preserving the existing "next run is in the future" contract.

Adds a regression test asserting that two reconciles at different instants inside one window return an identical, boundary-aligned next run, and that a point exactly on a boundary advances to the following one.
