### PR TITLE
fix(rendering): coalesce streamed reasoning into one Thinking task

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -53,6 +53,34 @@ describe('CodexAppServerRendererEventMapper', () => {
     })
   })
 
+  it('coalesces streamed reasoning summary deltas into a single Thinking task', async () => {
+    // Codex streams a reasoning summary as many small deltas (≈ one word each).
+    // They must accumulate into one Thinking task keyed by the reasoning itemId,
+    // not a fresh task per delta (which rendered the trace one word per line).
+    const chunks = await collect(
+      codexAppServerToChatSdkStream(
+        toAsyncIterable([
+          { method: 'item/reasoning/summaryTextDelta', params: { threadId: 't', turnId: 'turn-1', itemId: 'reasoning-7', summaryIndex: 0, delta: 'Consider' } },
+          { method: 'item/reasoning/summaryTextDelta', params: { threadId: 't', turnId: 'turn-1', itemId: 'reasoning-7', summaryIndex: 0, delta: 'ing the' } },
+          { method: 'item/reasoning/summaryTextDelta', params: { threadId: 't', turnId: 'turn-1', itemId: 'reasoning-7', summaryIndex: 0, delta: ' investor' } },
+          { method: 'item/reasoning/summaryTextDelta', params: { threadId: 't', turnId: 'turn-1', itemId: 'reasoning-7', summaryIndex: 0, delta: ' update' } },
+          { method: 'item/agentMessage/delta', params: { threadId: 't', turnId: 'turn-1', itemId: 'answer-1', delta: 'Done.' } },
+          { method: 'turn/completed', params: { threadId: 't', turn: { id: 'turn-1', items: [], status: 'completed' } } }
+        ])
+      )
+    )
+
+    const thinking = chunks.filter(
+      (chunk): chunk is Extract<(typeof chunks)[number], { type: 'task_update' }> =>
+        chunk.type === 'task_update' && chunk.title === 'Thinking'
+    )
+    // The four deltas coalesce into exactly one Thinking task (no per-word
+    // explosion) finalized at turn end, with the full accumulated summary —
+    // even though no consolidated reasoning item was delivered.
+    expect(new Set(thinking.map(chunk => chunk.id))).toEqual(new Set(['thinking-reasoning-7']))
+    expect(thinking.some(chunk => chunk.details === 'Considering the investor update')).toBe(true)
+  })
+
   it('maps commentary to Thinking task updates instead of message deltas', () => {
     const mapper = new CodexAppServerRendererEventMapper()
 
@@ -236,6 +264,12 @@ describe('CodexAppServerRendererEventMapper', () => {
             }
           },
           {
+            method: 'item/completed',
+            params: {
+              item: { type: 'reasoning', id: 'reasoning-1', summary: ['Inspecting the event stream'], content: [] }
+            }
+          },
+          {
             method: 'item/agentMessage/delta',
             params: {
               threadId: 'thread-1',
@@ -268,19 +302,25 @@ describe('CodexAppServerRendererEventMapper', () => {
       title: 'Inspect App Server events',
       status: 'complete'
     })
+    // Reasoning renders as a single Thinking task from the consolidated item,
+    // not one task per streamed delta.
     expect(chunks).toContainEqual({
       type: 'task_update',
-      id: 'reasoning-1',
+      id: 'thinking-reasoning-1',
       title: 'Thinking',
-      status: 'in_progress',
+      status: 'complete',
       details: 'Inspecting the event stream'
     })
-    expect(chunks).toContainEqual({
-      type: 'task_update',
-      id: 'reasoning-1',
-      title: 'Thinking',
-      status: 'complete'
-    })
+    expect(
+      new Set(
+        chunks
+          .filter(
+            (chunk): chunk is Extract<(typeof chunks)[number], { type: 'task_update' }> =>
+              chunk.type === 'task_update' && chunk.title === 'Thinking'
+          )
+          .map(chunk => chunk.id)
+      )
+    ).toEqual(new Set(['thinking-reasoning-1']))
     expect(chunks).toContainEqual({ type: 'markdown_text', text: 'Done.' })
   })
 

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -49,6 +49,7 @@ type CodexMapperState = {
   harnessAnswerText: string
   answerText: string
   commentaryByItemId: Map<string, string>
+  reasoningByItemId: Map<string, string>
   harnessCommentaryText: string
   commentaryText: string
   completedItemIds: Set<string>
@@ -108,6 +109,10 @@ export class CodexAppServerRendererEventMapper
     if (this.state.done) return []
     this.state.done = true
     const out: RendererEvent[] = []
+    // Finalize any reasoning whose deltas never produced a completed item.
+    for (const id of Array.from(this.state.reasoningByItemId.keys())) {
+      this.finalizeReasoning(out, { id })
+    }
     completeThinkingTasks(this.state)
     completeOpenTasks(this.state)
     this.emitActivitySummary(out, { final: true })
@@ -292,17 +297,22 @@ export class CodexAppServerRendererEventMapper
       }
     }
 
-    const reasoningMessage = reasoningText(event).trim()
-    if (reasoningMessage) {
-      const task: HarnessTask = {
-        id: `reasoning-${++this.state.stepCounter}`,
-        title: 'Thinking',
-        status: isReasoningDeltaEvent(event) ? 'in_progress' : 'complete',
-        details: [section([text(reasoningMessage)])],
-        output: []
+    // Reasoning is streamed as many ~per-word deltas, but the chat-sdk layer
+    // emits a task's `details` only once — so a task-per-delta rendered the trace
+    // as one "Thinking" line per word (and a duplicate block per summary part).
+    // Accumulate the deltas and render a single Thinking task from the
+    // consolidated reasoning item, mirroring the pre-rewrite normalizer which
+    // rendered reasoning from the completed item's text, not the deltas.
+    if (isReasoningDeltaEvent(event)) {
+      const id = reasoningItemId(event)
+      if (id) {
+        this.state.reasoningByItemId.set(id, (this.state.reasoningByItemId.get(id) ?? '') + reasoningText(event))
       }
-      this.state.taskByUseId.set(task.id, task)
-      this.emitActivitySummary(out)
+    } else if (event?.type === 'item.completed' && event?.item?.type === 'reasoning') {
+      this.finalizeReasoning(out, event.item)
+    } else if (event?.type === 'reasoning') {
+      // Legacy single-shot reasoning event (full text in one payload).
+      this.finalizeReasoning(out, { id: reasoningItemId(event), summary: [reasoningText(event)] })
     }
 
     if (isTerminalCodexAppServerEvent(event)) {
@@ -383,6 +393,29 @@ export class CodexAppServerRendererEventMapper
       })
     }
     this.emitPendingAssistantText(out)
+  }
+
+  // Render the consolidated reasoning item as a single Thinking task. Prefers the
+  // item's own summary/content (the authoritative full text); falls back to the
+  // deltas accumulated for this item when the completed item carries no text.
+  private finalizeReasoning(out: RendererEvent[], item: any): void {
+    const id = String(item?.id ?? '')
+    const consolidated = [...asStringArray(item?.summary), ...asStringArray(item?.content)]
+      .map(part => part.trim())
+      .filter(Boolean)
+      .join('\n\n')
+    const body = (consolidated || (id ? this.state.reasoningByItemId.get(id) ?? '' : '')).trim()
+    if (id) this.state.reasoningByItemId.delete(id)
+    if (!body) return
+    const taskId = `thinking-${id || `reasoning-${++this.state.stepCounter}`}`
+    this.state.taskByUseId.set(taskId, {
+      id: taskId,
+      title: 'Thinking',
+      status: 'complete',
+      details: [section([text(body)])],
+      output: []
+    })
+    this.emitActivitySummary(out)
   }
 
   private emitPendingAssistantText(
@@ -680,6 +713,7 @@ function newState(): CodexMapperState {
     harnessAnswerText: '',
     answerText: '',
     commentaryByItemId: new Map(),
+    reasoningByItemId: new Map(),
     harnessCommentaryText: '',
     commentaryText: '',
     completedItemIds: new Set(),
@@ -918,6 +952,14 @@ function isReasoningDeltaEvent(event: any): boolean {
     event?.type === 'item.reasoning.summaryTextDelta' ||
     event?.type === 'item.reasoning.textDelta'
   )
+}
+
+function reasoningItemId(event: any): string {
+  return String(event?.itemId ?? event?.item_id ?? event?.item?.id ?? '')
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(item => String(item ?? '')) : []
 }
 
 function terminalResultText(event: any): string {


### PR DESCRIPTION
## Problem (regression since the app-server rewrite, #344)

When reasoning summaries are enabled, the Slack/Chat-SDK "Thinking" trace renders as **one task per streamed word** plus a **duplicated block per summary part**, e.g.:

<img width="555" height="575" alt="image" src="https://github.com/user-attachments/assets/c37f4ba0-3b66-4bd2-b8b8-2cc0927bdb9f" />

Codex ≥ 0.139 emits no reasoning summaries by default, so this path is dormant on a default config — it only surfaces when a deployment opts back in (`model_reasoning_summary = auto|concise|detailed`). That's why it isn't seen day to day, but it's a real bug in the renderer for anyone who enables summaries.

## Root cause

In `packages/rendering/src/codex-app-server.ts`, every event carrying reasoning text minted a **brand-new task**:

```ts
const reasoningMessage = reasoningText(event).trim()
if (reasoningMessage) {
  const task = { id: `reasoning-${++this.state.stepCounter}`, title: 'Thinking', ... }
  this.state.taskByUseId.set(task.id, task)
}
```

`reasoningText()` returns `event.delta` for `item/reasoning/summaryTextDelta` / `textDelta`, and each delta is a tiny fragment (≈ one word). So N deltas → N separate "Thinking" tasks with N different ids. It never accumulates by the reasoning item id (unlike the adjacent *commentary* thinking path, which does). The existing test fed only a **single** delta, so the per-delta id coincidentally equalled the itemId and the explosion was never covered.

It also conflicts with the chat-sdk emission contract: `changedActivityTaskUpdates` emits a task's `details` only once per id (`emittedActivityRunByTaskId`), which assumes a task body is set-once — true for a command string, false for a growing reasoning stream.

## Why this is a regression

The pre-rewrite (Python) normalizer rendered reasoning from the **consolidated item**, not the deltas — `services/api/api/sandbox/normalize.py`:

```python
if item_type == "reasoning" and phase in ("updated", "completed"):
    text = _as_str(item.get("text")) or _as_str(item.get("thinking"))
    return [{"type": "reasoning", "text": text}] if text else []
```

i.e. one coherent block per reasoning item from its full text. The app-server rewrite replaced that with per-delta task creation.

## Fix

Restore the former behavior: accumulate `summaryTextDelta`/`textDelta` by `itemId`, and render a **single** Thinking task from the consolidated reasoning item delivered on `item/completed` (`{ type: "reasoning", id, summary: string[], content: string[] }`), preferring the item's own `summary`/`content` and falling back to the accumulated deltas when the completed item carries no text (finalized at turn end). One Thinking block per reasoning item — which also satisfies the emit-details-once contract the per-delta path violated.

Adds tests for both the consolidated-item path and the deltas-only fallback.
