### PR TITLE
fix(ci): repair overlay release workflows

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -61,6 +61,7 @@ jobs:
             target: ""
           - service: discordbot
             image: centaur-discordbot
+            context: .
             dockerfile: services/discordbot/Dockerfile
             target: ""
           - service: agent
@@ -164,6 +165,7 @@ jobs:
           - image: centaur-agent
           - image: centaur-iron-proxy
           - image: centaur-console
+          - image: centaur-discordbot
 
     steps:
       - name: Download digests

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -54,6 +54,12 @@ jobs:
         with:
           version: v4.1.1
 
+      - name: Add chart repositories
+        run: helm repo add onepassword https://1password.github.io/connect-helm-charts
+
+      - name: Build chart dependencies
+        run: helm dependency build contrib/chart
+
       - name: Lint chart
         run: helm lint contrib/chart
 


### PR DESCRIPTION
## Summary
- add an explicit local Docker context for the Discordbot image build and publish its manifest
- add the 1Password Helm repo and build chart dependencies before chart release

## Validation
- git diff --check
- ruby -ryaml -e 'YAML.load_file(".github/workflows/publish-images.yml"); YAML.load_file(".github/workflows/release-chart.yml")'
- isolated HELM_REPOSITORY_CONFIG/HELM_REPOSITORY_CACHE helm repo add + helm dependency build + helm lint
- docker build -f services/discordbot/Dockerfile --build-arg RUST_BUILD_PROFILE=debug -t centaur-discordbot:ci-followup .