### PR TITLE
feat(chart): wire Google OAuth credentials into the console

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.59
+version: 0.1.60
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -119,6 +119,20 @@ spec:
                 secretKeyRef:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+{{- if $console.googleOauth.enabled }}
+            # Google OAuth app credentials, needed by the broker-credential
+            # OAuth refresh loop. Gated on console.googleOauth.enabled.
+            - name: IRON_CONTROL_GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_GOOGLE_CLIENT_ID" $prefix }}
+            - name: IRON_CONTROL_GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_GOOGLE_CLIENT_SECRET" $prefix }}
+{{- end }}
             - name: RAILS_ENV
               value: {{ $console.railsEnv | quote }}
             - name: RAILS_LOG_TO_STDOUT

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -145,6 +145,21 @@ spec:
                 secretKeyRef:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+{{- if $console.googleOauth.enabled }}
+            # Google OAuth app credentials (sign-in + brokered token refresh).
+            # Gated on console.googleOauth.enabled; the keys must exist in the
+            # shared infra Secret when enabled.
+            - name: IRON_CONTROL_GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_GOOGLE_CLIENT_ID" $prefix }}
+            - name: IRON_CONTROL_GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_GOOGLE_CLIENT_SECRET" $prefix }}
+{{- end }}
             - name: RAILS_ENV
               value: {{ $console.railsEnv | quote }}
             - name: PORT

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -98,6 +98,14 @@ console:
     # database.yml — the connection URL carries no database path, so Rails
     # resolves the name from there.
     name: iron_control_production
+  # Google as an OAuth identity provider for console sign-in (and the
+  # broker-credential refresh loop). Off by default — not every deployment uses
+  # Google to log in. When enabled, the IRON_CONTROL_GOOGLE_CLIENT_ID and
+  # IRON_CONTROL_GOOGLE_CLIENT_SECRET env vars are sourced from the shared infra
+  # Secret (keys <secretManager.envPrefix>IRON_CONTROL_GOOGLE_CLIENT_ID /
+  # _SECRET), which must exist or the console pods CreateContainerConfigError.
+  googleOauth:
+    enabled: false
   service:
     httpPort: 3000
   # Optional Ingress for the console. Bring your own controller — Tailscale


### PR DESCRIPTION
Adds the Google OAuth app credentials to the console web and worker containers. The console reads them as `IRON_CONTROL_GOOGLE_CLIENT_ID` and `IRON_CONTROL_GOOGLE_CLIENT_SECRET` (1:1 with the secret keys, matching the other console env vars), sourced from the shared infra Secret keys `CENTAUR_SECRET_IRON_CONTROL_GOOGLE_CLIENT_ID` and `CENTAUR_SECRET_IRON_CONTROL_GOOGLE_CLIENT_SECRET` via explicit secretKeyRefs (the console never envFroms the shared Secret).

The worker gets the same pair since it runs the broker-credential OAuth refresh loop. Chart version bumped to 0.1.60.

Note: the two secret keys must exist in the infra Secret before rolling this out, or the pods will CreateContainerConfigError on the missing secretKeyRef.