### PR TITLE
fix: bypass proxy for workflow metric pushes

### DIFF
--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -564,7 +564,8 @@ def push_metric_lines(lines: list[str]) -> None:
         method="POST",
     )
     try:
-        urllib.request.urlopen(request, timeout=2).close()
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        opener.open(request, timeout=2).close()
     except Exception as exc:
         print(f"workflow_metric_push_error error={exc}", file=sys.stderr)
 


### PR DESCRIPTION
## Summary
- bypass HTTP proxy env vars for Python workflow-host VictoriaMetrics push imports
- keeps tool/workflow HTTP calls unchanged; only metric pushes use a no-proxy urllib opener

## Why
Prod workflow-host pods receive VICTORIAMETRICS_URL, but they also run with HTTP_PROXY. Their NO_PROXY did not include vmsingle-internal.monitoring.svc.cluster.local, so ETL metric pushes tried to resolve the in-cluster VM service through the sandbox proxy path and failed before samples landed.

## Validation
- python3 -m py_compile services/workflow-python/workflow_host.py
- uvx ruff check services/workflow-python/workflow_host.py
- local behavioral probe: with HTTP_PROXY/http_proxy set to a bad localhost proxy, push_metric_lines still reached a local test HTTP server