### PR TITLE
Configure Paradigm overlay source

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -10,9 +10,13 @@
 {{- $apiWorkflowDirList := list -}}
 {{- $sandboxWorkflowDirList := list -}}
 {{- $skillDirs := list -}}
+{{- $repoCacheOverlayDir := "" -}}
 {{- range $source := $overlaySources -}}
 {{- $repo := get $source "repo" | default "" -}}
 {{- if $repo -}}
+{{- if gt (len $overlaySources) 1 -}}
+{{- $repoCacheOverlayDir = printf "/home/agent/github/%s" $repo -}}
+{{- end -}}
 {{- with (get $source "toolsSubdir") -}}
 {{- $toolSource := dict "repo" $repo "subdir" . -}}
 {{- with (get $source "ref") }}{{- $_ := set $toolSource "ref" . -}}{{- end -}}
@@ -250,6 +254,9 @@ spec:
 {{- $sandboxEnvList := list }}
 {{- if and .Values.repoCache.enabled (gt (len $skillDirs) 0) }}
 {{- $sandboxEnvList = append $sandboxEnvList (dict "name" "CENTAUR_SKILL_DIRS" "value" (join ":" $skillDirs)) }}
+{{- end }}
+{{- if and .Values.repoCache.enabled $repoCacheOverlayDir }}
+{{- $sandboxEnvList = append $sandboxEnvList (dict "name" "CENTAUR_OVERLAY_DIR" "value" $repoCacheOverlayDir) }}
 {{- end }}
 {{- range $k, $v := .Values.sandbox.extraEnv }}
 {{- $sandboxEnvList = append $sandboxEnvList (dict "name" $k "value" ($v | toString)) }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -173,11 +173,11 @@ overlay:
 # the repo's default branch. Directories missing from a repo are skipped at
 # runtime. Set a subdir to "" to explicitly disable that surface for a source.
 overlays:
-  sources: []
-  # - repo: paradigmxyz/centaur
-  #   ref: ""
-  # - repo: your-org/centaur-overlay
-  #   ref: main
+  sources:
+    - repo: paradigmxyz/centaur
+      ref: ""
+    - repo: paradigmxyz/centaur-paradigm
+      ref: main
   # - repo: your-org/workflows-only
   #   ref: main
   #   toolsSubdir: ""


### PR DESCRIPTION
## Summary
- configure default chart overlay sources explicitly
- layer `paradigmxyz/centaur-paradigm` after `paradigmxyz/centaur` so Paradigm overlay content shadows base content
- propagate repo-cache overlay sources into sandbox `CENTAUR_OVERLAY_DIR`, pointing at the last configured overlay repo, so the sandbox entrypoint can load overlay `.agents/skills` and `services/sandbox/SYSTEM_PROMPT.md`

## Verification
- `uv run --with pyyaml python -c "import yaml; v=yaml.safe_load(open('contrib/chart/values.yaml')); print(v['overlays']['sources'][-1]['repo'])"`
- `git diff --check`

Could not run `helm template`: `helm` is not installed in this sandbox.