### PR TITLE
fix: expose workflow ETL metrics via API

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "centaur-session-core",
  "centaur-session-runtime",
  "centaur-session-sqlx",
+ "centaur-telemetry",
  "chrono",
  "chrono-tz",
  "cron",

--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -43,12 +43,23 @@ pub const SESSION_EXECUTIONS_TOTAL: &str = "centaur_session_executions_total";
 pub const SESSION_EXECUTION_DURATION_SECONDS: &str = "centaur_session_execution_duration_seconds";
 pub const SANDBOX_OPERATIONS_TOTAL: &str = "centaur_sandbox_operations_total";
 pub const SANDBOX_WARM_POOL_CLAIMS_TOTAL: &str = "centaur_sandbox_warm_pool_claims_total";
+pub const ETL_ITEMS_SEEN_TOTAL: &str = "etl_items_seen_total";
+pub const ETL_ITEMS_ENQUEUED_TOTAL: &str = "etl_items_enqueued_total";
+pub const ETL_ITEMS_UPSERTED_TOTAL: &str = "etl_items_upserted_total";
+pub const ETL_ITEMS_DELETED_TOTAL: &str = "etl_items_deleted_total";
+pub const ETL_ITEMS_FAILED_TOTAL: &str = "etl_items_failed_total";
+pub const COMPANY_CONTEXT_DOCUMENTS_CHANGED_TOTAL: &str = "company_context_documents_changed_total";
+pub const COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS: &str = "company_context_document_size_chars";
+pub const COMPANY_CONTEXT_PROJECTION_LAG_SECONDS: &str = "company_context_projection_lag_seconds";
 
 const HTTP_REQUEST_DURATION_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
 ];
 const SESSION_EXECUTION_DURATION_BUCKETS: &[f64] = &[
     0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 300.0, 900.0,
+];
+const COMPANY_CONTEXT_DOCUMENT_SIZE_BUCKETS: &[f64] = &[
+    100.0, 500.0, 1_000.0, 5_000.0, 10_000.0, 25_000.0, 50_000.0, 100_000.0, 250_000.0, 500_000.0,
 ];
 
 static PROMETHEUS_HANDLE: LazyLock<Mutex<Option<PrometheusHandle>>> =
@@ -169,6 +180,10 @@ pub fn prometheus_handle() -> Result<PrometheusHandle, TelemetryError> {
             Matcher::Full(SESSION_EXECUTION_DURATION_SECONDS.to_owned()),
             SESSION_EXECUTION_DURATION_BUCKETS,
         )?
+        .set_buckets_for_metric(
+            Matcher::Full(COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS.to_owned()),
+            COMPANY_CONTEXT_DOCUMENT_SIZE_BUCKETS,
+        )?
         .install_recorder()?;
     describe_metrics();
     *handle = Some(new_handle.clone());
@@ -247,6 +262,27 @@ pub fn record_sandbox_warm_pool_claim(result: &'static str) {
         "result" => result,
     )
     .increment(1);
+}
+
+pub fn record_workflow_counter(name: &str, labels: &[(String, String)], value: u64) {
+    if value == 0 {
+        return;
+    }
+    metrics::counter!(name.to_owned(), workflow_metric_labels(labels)).increment(value);
+}
+
+pub fn set_workflow_gauge(name: &str, labels: &[(String, String)], value: f64) {
+    if !value.is_finite() {
+        return;
+    }
+    metrics::gauge!(name.to_owned(), workflow_metric_labels(labels)).set(value);
+}
+
+pub fn record_workflow_histogram(name: &str, labels: &[(String, String)], value: f64) {
+    if !value.is_finite() {
+        return;
+    }
+    metrics::histogram!(name.to_owned(), workflow_metric_labels(labels)).record(value);
 }
 
 pub fn http_status_class(status: u16) -> &'static str {
@@ -347,6 +383,46 @@ fn describe_metrics() {
         SANDBOX_WARM_POOL_CLAIMS_TOTAL,
         "Session warm-pool claim attempts by result."
     );
+    metrics::describe_counter!(
+        ETL_ITEMS_SEEN_TOTAL,
+        "Source items fetched or observed by ETL workflows."
+    );
+    metrics::describe_counter!(
+        ETL_ITEMS_ENQUEUED_TOTAL,
+        "Source items enqueued by ETL workflows."
+    );
+    metrics::describe_counter!(
+        ETL_ITEMS_UPSERTED_TOTAL,
+        "Source items upserted by ETL workflows."
+    );
+    metrics::describe_counter!(
+        ETL_ITEMS_DELETED_TOTAL,
+        "Source items deleted by ETL workflows."
+    );
+    metrics::describe_counter!(
+        ETL_ITEMS_FAILED_TOTAL,
+        "Source items that failed processing in ETL workflows."
+    );
+    metrics::describe_counter!(
+        COMPANY_CONTEXT_DOCUMENTS_CHANGED_TOTAL,
+        "Company context document changes observed by ETL workflows."
+    );
+    metrics::describe_histogram!(
+        COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS,
+        "Company context document sizes in characters."
+    );
+    metrics::describe_gauge!(
+        COMPANY_CONTEXT_PROJECTION_LAG_SECONDS,
+        metrics::Unit::Seconds,
+        "Company context projection lag in seconds."
+    );
+}
+
+fn workflow_metric_labels(labels: &[(String, String)]) -> Vec<metrics::Label> {
+    labels
+        .iter()
+        .map(|(key, value)| metrics::Label::new(key.clone(), value.clone()))
+        .collect()
 }
 
 fn build_otlp_tracer_provider(
@@ -550,6 +626,29 @@ mod tests {
             r#"centaur_sandbox_operations_total{backend="local",operation="create",status="success"}"#
         ));
         assert!(metrics.contains(r#"centaur_sandbox_warm_pool_claims_total{result="hit"}"#));
+    }
+
+    #[test]
+    fn prometheus_metrics_render_workflow_metrics() {
+        prometheus_handle().unwrap();
+        record_workflow_counter(
+            ETL_ITEMS_SEEN_TOTAL,
+            &[
+                ("environment".to_owned(), "production".to_owned()),
+                ("item_type".to_owned(), "thread_refresh_reply".to_owned()),
+                ("namespace".to_owned(), "centaur-system".to_owned()),
+                ("source".to_owned(), "slack".to_owned()),
+                ("source_type".to_owned(), "channel".to_owned()),
+            ],
+            7,
+        );
+
+        let metrics = render_metrics().unwrap();
+
+        assert!(metrics.contains("etl_items_seen_total{"));
+        assert!(metrics.contains(r#"environment="production""#));
+        assert!(metrics.contains(r#"namespace="centaur-system""#));
+        assert!(metrics.contains(r#"source="slack""#));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/Cargo.toml
+++ b/services/api-rs/crates/centaur-workflows/Cargo.toml
@@ -11,6 +11,7 @@ centaur-session-core.workspace = true
 centaur-session-runtime.workspace = true
 centaur-session-sqlx.workspace = true
 centaur-sandbox-core.workspace = true
+centaur-telemetry.workspace = true
 chrono.workspace = true
 chrono-tz.workspace = true
 cron.workspace = true

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -1899,6 +1899,9 @@ async fn run_python_workflow_host_local(
                     "python workflow log"
                 );
             }
+            Some("ctx.metric") => {
+                record_python_workflow_metric(&message);
+            }
             Some(message_type) if message_type.starts_with("ctx.") => {
                 let response =
                     handle_python_context_request(&message, &ctx, &session_runtime, &input).await;
@@ -2028,6 +2031,9 @@ where
                     "python workflow log"
                 );
             }
+            Some("ctx.metric") => {
+                record_python_workflow_metric(&message);
+            }
             Some(message_type) if message_type.starts_with("ctx.") => {
                 let response =
                     handle_python_context_request(&message, &ctx, &session_runtime, &input).await;
@@ -2045,6 +2051,114 @@ where
     Err(WorkflowRuntimeError::Internal(format!(
         "Python workflow host exited before workflow.result: stderr={stderr}"
     )))
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum PythonWorkflowMetricKind {
+    Counter,
+    Gauge,
+    Histogram,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PythonWorkflowMetric {
+    kind: PythonWorkflowMetricKind,
+    name: String,
+    value: f64,
+    labels: Vec<(String, String)>,
+}
+
+fn record_python_workflow_metric(message: &Value) {
+    let metric = match parse_python_workflow_metric(message) {
+        Ok(metric) => metric,
+        Err(error) => {
+            warn!(%error, message = %message, "ignored invalid Python workflow metric");
+            return;
+        }
+    };
+
+    match metric.kind {
+        PythonWorkflowMetricKind::Counter => {
+            if metric.value > 0.0 && metric.value.fract() == 0.0 {
+                centaur_telemetry::record_workflow_counter(
+                    &metric.name,
+                    &metric.labels,
+                    metric.value as u64,
+                );
+            } else {
+                warn!(
+                    metric = %metric.name,
+                    value = metric.value,
+                    "ignored invalid Python workflow counter value"
+                );
+            }
+        }
+        PythonWorkflowMetricKind::Gauge => {
+            centaur_telemetry::set_workflow_gauge(&metric.name, &metric.labels, metric.value);
+        }
+        PythonWorkflowMetricKind::Histogram => {
+            centaur_telemetry::record_workflow_histogram(
+                &metric.name,
+                &metric.labels,
+                metric.value,
+            );
+        }
+    }
+}
+
+fn parse_python_workflow_metric(message: &Value) -> Result<PythonWorkflowMetric, String> {
+    let kind = match message.get("kind").and_then(Value::as_str) {
+        Some("counter") => PythonWorkflowMetricKind::Counter,
+        Some("gauge") => PythonWorkflowMetricKind::Gauge,
+        Some("histogram") => PythonWorkflowMetricKind::Histogram,
+        other => return Err(format!("unsupported metric kind {other:?}")),
+    };
+    let name = message
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| is_valid_prometheus_name(name))
+        .ok_or_else(|| "metric name missing or invalid".to_owned())?
+        .to_owned();
+    let value = message
+        .get("value")
+        .and_then(Value::as_f64)
+        .filter(|value| value.is_finite())
+        .ok_or_else(|| "metric value missing or invalid".to_owned())?;
+    let labels = message
+        .get("labels")
+        .and_then(Value::as_object)
+        .map(|labels| {
+            labels
+                .iter()
+                .filter(|(key, _)| is_valid_prometheus_name(key))
+                .map(|(key, value)| {
+                    (
+                        key.to_owned(),
+                        value
+                            .as_str()
+                            .map(str::to_owned)
+                            .unwrap_or_else(|| value.to_string()),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(PythonWorkflowMetric {
+        kind,
+        name,
+        value,
+        labels,
+    })
+}
+
+fn is_valid_prometheus_name(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
 async fn handle_python_context_request(
@@ -2758,6 +2872,51 @@ mod tests {
             workflow_queue_class("github_issue_triage"),
             WorkflowQueueClass::Standard
         );
+    }
+
+    #[test]
+    fn parses_python_workflow_metric_notification() {
+        let metric = parse_python_workflow_metric(&json!({
+            "type": "ctx.metric",
+            "kind": "counter",
+            "name": "etl_items_seen_total",
+            "value": 12,
+            "labels": {
+                "namespace": "centaur-system",
+                "environment": "production",
+                "source": "slack",
+                "source_type": "channel",
+                "item_type": "thread_refresh_reply",
+            },
+        }))
+        .unwrap();
+
+        assert_eq!(metric.kind, PythonWorkflowMetricKind::Counter);
+        assert_eq!(metric.name, "etl_items_seen_total");
+        assert_eq!(metric.value, 12.0);
+        assert!(
+            metric
+                .labels
+                .contains(&("namespace".to_owned(), "centaur-system".to_owned()))
+        );
+        assert!(
+            metric
+                .labels
+                .contains(&("source".to_owned(), "slack".to_owned()))
+        );
+    }
+
+    #[test]
+    fn rejects_python_workflow_metric_with_invalid_name() {
+        let error = parse_python_workflow_metric(&json!({
+            "type": "ctx.metric",
+            "kind": "counter",
+            "name": "bad-name",
+            "value": 1,
+        }))
+        .unwrap_err();
+
+        assert_eq!(error, "metric name missing or invalid");
     }
 
     #[tokio::test]

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -110,6 +110,7 @@ class RpcClient:
     def __init__(self) -> None:
         self._next_request_id = 1
         self._pending: dict[str, asyncio.Future[Any]] = {}
+        self._notifications: set[asyncio.Task[None]] = set()
         self._write_lock = asyncio.Lock()
 
     async def write(self, payload: dict[str, Any]) -> None:
@@ -118,7 +119,13 @@ class RpcClient:
             sys.stdout.flush()
 
     def notify(self, payload: dict[str, Any]) -> None:
-        asyncio.create_task(self.write(payload))
+        task = asyncio.create_task(self.write(payload))
+        self._notifications.add(task)
+        task.add_done_callback(self._notifications.discard)
+
+    async def drain_notifications(self) -> None:
+        if self._notifications:
+            await asyncio.gather(*list(self._notifications), return_exceptions=True)
 
     async def request(self, payload: dict[str, Any]) -> Any:
         request_id = str(self._next_request_id)
@@ -140,6 +147,9 @@ class RpcClient:
             fut.set_result(response.get("value"))
         else:
             fut.set_exception(RuntimeError(str(response.get("error") or "context RPC failed")))
+
+
+_METRIC_RPC: RpcClient | None = None
 
 
 def resolve_tool_shim() -> str | None:
@@ -410,6 +420,7 @@ def increment_metric(metric: str, count: int, **labels: str) -> None:
     labels = metric_runtime_labels(labels)
     key = metric_key(metric, labels)
     _METRIC_COUNTERS[key] = _METRIC_COUNTERS.get(key, 0.0) + float(count)
+    emit_metric_event("counter", metric, count, labels)
     push_metric_lines([format_metric_line(metric, labels, _METRIC_COUNTERS[key])])
 
 
@@ -417,6 +428,7 @@ def set_gauge(metric: str, value: float, **labels: str) -> None:
     labels = metric_runtime_labels(labels)
     key = metric_key(metric, labels)
     _METRIC_GAUGES[key] = float(value)
+    emit_metric_event("gauge", metric, float(value), labels)
     push_metric_lines([format_metric_line(metric, labels, _METRIC_GAUGES[key])])
 
 
@@ -439,6 +451,7 @@ def observe_histogram(
     numeric = float(value)
     histogram["count"] += 1
     histogram["sum"] += numeric
+    emit_metric_event("histogram", metric, numeric, labels)
     for bucket in buckets:
         if numeric <= bucket:
             histogram["buckets"][bucket] += 1
@@ -468,6 +481,22 @@ def metric_key(
     metric: str, labels: dict[str, str]
 ) -> tuple[str, tuple[tuple[str, str], ...]]:
     return (metric, tuple(sorted((key, str(value)) for key, value in labels.items())))
+
+
+def emit_metric_event(
+    kind: str, metric: str, value: int | float, labels: dict[str, str]
+) -> None:
+    if _METRIC_RPC is None:
+        return
+    _METRIC_RPC.notify(
+        {
+            "type": "ctx.metric",
+            "kind": kind,
+            "name": metric,
+            "value": value,
+            "labels": labels,
+        }
+    )
 
 
 def metric_runtime_labels(labels: dict[str, str]) -> dict[str, str]:
@@ -778,6 +807,7 @@ def normalize_schedule(workflow: RegisteredWorkflow) -> dict[str, Any] | None:
 
 
 async def run_workflow(message: dict[str, Any], rpc: RpcClient) -> dict[str, Any]:
+    global _METRIC_RPC
     workflows = discover_workflows()
     workflow_name = str(message.get("workflow_name") or "")
     registered = workflows.get(workflow_name)
@@ -792,6 +822,8 @@ async def run_workflow(message: dict[str, Any], rpc: RpcClient) -> dict[str, Any
         workflow_name=workflow_name,
         pool=pool,
     )
+    previous_metric_rpc = _METRIC_RPC
+    _METRIC_RPC = rpc
     try:
         inp = coerce_input(message.get("input") or {}, registered.input_cls)
         result = registered.handler(inp, ctx)
@@ -799,6 +831,8 @@ async def run_workflow(message: dict[str, Any], rpc: RpcClient) -> dict[str, Any
             result = await result
         return {"type": "workflow.result", "result": jsonable(result)}
     finally:
+        await rpc.drain_notifications()
+        _METRIC_RPC = previous_metric_rpc
         if pool is not None:
             await pool.close()
 


### PR DESCRIPTION
## Summary
- emit workflow ETL metric notifications from the Python host while keeping the existing VictoriaMetrics push path
- register workflow counters, gauges, and histograms in the Rust API Prometheus registry
- handle metric notifications from both local and sandbox workflow hosts so /metrics includes etl_items_seen_total, etl_items_upserted_total, etl_items_failed_total, and related workflow metrics

## Root cause
Workflow ETL metrics were written directly to VictoriaMetrics from Python, so the API process Prometheus registry did not expose them on /metrics. Grafana panels using the existing Prometheus datasource saw no recent series.

## Validation
- cargo test -p centaur-telemetry -p centaur-workflows
- python3 -m py_compile services/workflow-python/workflow_host.py
- git diff --check