### PR TITLE
feat(slackbot): name session principals after the channel or DM

### DIFF
--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -51,10 +51,12 @@ impl PrincipalRef {
 ///
 /// ``conversation_name`` is the human-readable channel name (or DM partner's
 /// display name) the slackbot resolves and carries in session metadata. When
-/// present and non-empty it becomes the principal's display ``name``; otherwise
-/// we fall back to a synthetic name built from the ids. The name is cosmetic —
-/// ``foreign_id`` (the upsert key) is always derived from ids, so the same
-/// conversation maps to one stable principal regardless of any later rename.
+/// present and non-empty it is formatted into the principal's display ``name``
+/// (``Slack DM @<name>`` for a DM, ``Slack Channel #<name>`` for a channel);
+/// otherwise we fall back to a synthetic name built from the ids. The name is
+/// cosmetic — ``foreign_id`` (the upsert key) is always derived from ids, so the
+/// same conversation maps to one stable principal regardless of any later
+/// rename.
 pub fn derive_principal(
     thread_key: &str,
     slack_user_id: Option<&str>,
@@ -82,7 +84,7 @@ pub fn derive_principal(
         return PrincipalRef {
             foreign_id: format!("slack-user-{scope}{}", slugify(user)),
             name: display_name
-                .map(ToOwned::to_owned)
+                .map(|name| format!("Slack DM @{name}"))
                 .unwrap_or_else(|| format!("Slack user {user}{team_suffix}")),
             labels,
         };
@@ -93,7 +95,7 @@ pub fn derive_principal(
         return PrincipalRef {
             foreign_id: format!("slack-channel-{scope}{}", slugify(conversation_id)),
             name: display_name
-                .map(ToOwned::to_owned)
+                .map(|name| format!("Slack Channel #{name}"))
                 .unwrap_or_else(|| format!("Slack channel {conversation_id}{team_suffix}")),
             labels,
         };
@@ -207,14 +209,14 @@ mod tests {
             derive_principal("slack:T123:C456:ts", Some("U1"), Some("eng-oncall"));
         // Key stays derived from ids so renames never split the principal.
         assert_eq!(principal.foreign_id, "slack-channel-t123-c456");
-        assert_eq!(principal.name, "eng-oncall");
+        assert_eq!(principal.name, "Slack Channel #eng-oncall");
     }
 
     #[test]
     fn conversation_name_overrides_the_dm_display_name() {
         let principal = derive_principal("slack:D0420:ts", Some("U07ABC"), Some("Ada Lovelace"));
         assert_eq!(principal.foreign_id, "slack-user-u07abc");
-        assert_eq!(principal.name, "Ada Lovelace");
+        assert_eq!(principal.name, "Slack DM @Ada Lovelace");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -85,7 +85,7 @@ pub fn derive_principal(
             foreign_id: format!("slack-user-{scope}{}", slugify(user)),
             name: display_name
                 .map(|name| format!("Slack DM @{name}"))
-                .unwrap_or_else(|| format!("Slack user {user}{team_suffix}")),
+                .unwrap_or_else(|| format!("Slack User {user}{team_suffix}")),
             labels,
         };
     }
@@ -96,7 +96,7 @@ pub fn derive_principal(
             foreign_id: format!("slack-channel-{scope}{}", slugify(conversation_id)),
             name: display_name
                 .map(|name| format!("Slack Channel #{name}"))
-                .unwrap_or_else(|| format!("Slack channel {conversation_id}{team_suffix}")),
+                .unwrap_or_else(|| format!("Slack Channel {conversation_id}{team_suffix}")),
             labels,
         };
     }
@@ -144,7 +144,7 @@ mod tests {
     fn dm_with_user_keys_on_the_user() {
         let principal = derive_principal("slack:D0420:1780000000.0001", Some("U07ABC"), None);
         assert_eq!(principal.foreign_id, "slack-user-u07abc");
-        assert_eq!(principal.name, "Slack user U07ABC");
+        assert_eq!(principal.name, "Slack User U07ABC");
         assert_eq!(
             principal.labels.get("slack_user_id").map(String::as_str),
             Some("U07ABC")
@@ -161,7 +161,7 @@ mod tests {
     fn channel_keys_on_the_channel_even_with_a_user() {
         let principal = derive_principal("chat:C123:1780000000.000000", Some("U07ABC"), None);
         assert_eq!(principal.foreign_id, "slack-channel-c123");
-        assert_eq!(principal.name, "Slack channel C123");
+        assert_eq!(principal.name, "Slack Channel C123");
         assert_eq!(
             principal.labels.get("slack_channel_id").map(String::as_str),
             Some("C123")
@@ -178,7 +178,7 @@ mod tests {
     fn team_id_is_folded_into_the_channel_key() {
         let principal = derive_principal("slack:T123:C456:1780000000.0001", Some("U1"), None);
         assert_eq!(principal.foreign_id, "slack-channel-t123-c456");
-        assert_eq!(principal.name, "Slack channel C456 (team T123)");
+        assert_eq!(principal.name, "Slack Channel C456 (team T123)");
         assert_eq!(
             principal.labels.get("slack_team_id").map(String::as_str),
             Some("T123")
@@ -193,7 +193,7 @@ mod tests {
     fn team_id_is_folded_into_the_dm_user_key() {
         let principal = derive_principal("slack:T123:D9:ts", Some("U07ABC"), None);
         assert_eq!(principal.foreign_id, "slack-user-t123-u07abc");
-        assert_eq!(principal.name, "Slack user U07ABC (team T123)");
+        assert_eq!(principal.name, "Slack User U07ABC (team T123)");
     }
 
     #[test]
@@ -221,7 +221,7 @@ mod tests {
     #[test]
     fn blank_conversation_name_falls_back_to_the_synthetic_name() {
         let principal = derive_principal("chat:C123:ts", None, Some("   "));
-        assert_eq!(principal.name, "Slack channel C123");
+        assert_eq!(principal.name, "Slack Channel C123");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -205,8 +205,7 @@ mod tests {
 
     #[test]
     fn conversation_name_overrides_the_channel_display_name_but_not_the_key() {
-        let principal =
-            derive_principal("slack:T123:C456:ts", Some("U1"), Some("eng-oncall"));
+        let principal = derive_principal("slack:T123:C456:ts", Some("U1"), Some("eng-oncall"));
         // Key stays derived from ids so renames never split the principal.
         assert_eq!(principal.foreign_id, "slack-channel-t123-c456");
         assert_eq!(principal.name, "Slack Channel #eng-oncall");

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -48,7 +48,18 @@ impl PrincipalRef {
 /// channel so everyone in the channel shares one principal. When the thread key
 /// is not a recognizable Slack conversation, the whole key is slugged so every
 /// thread still maps to a deterministic, distinct principal.
-pub fn derive_principal(thread_key: &str, slack_user_id: Option<&str>) -> PrincipalRef {
+///
+/// ``conversation_name`` is the human-readable channel name (or DM partner's
+/// display name) the slackbot resolves and carries in session metadata. When
+/// present and non-empty it becomes the principal's display ``name``; otherwise
+/// we fall back to a synthetic name built from the ids. The name is cosmetic —
+/// ``foreign_id`` (the upsert key) is always derived from ids, so the same
+/// conversation maps to one stable principal regardless of any later rename.
+pub fn derive_principal(
+    thread_key: &str,
+    slack_user_id: Option<&str>,
+    conversation_name: Option<&str>,
+) -> PrincipalRef {
     let (team_id, conversation_id) = parse_slack_segments(thread_key);
     let mut labels = BTreeMap::new();
     if let Some(team) = team_id {
@@ -60,6 +71,9 @@ pub fn derive_principal(thread_key: &str, slack_user_id: Option<&str>) -> Princi
     let team_suffix = team_id
         .map(|team| format!(" (team {team})"))
         .unwrap_or_default();
+    let display_name = conversation_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty());
 
     if is_direct_message(conversation_id)
         && let Some(user) = slack_user_id.map(str::trim).filter(|user| !user.is_empty())
@@ -67,7 +81,9 @@ pub fn derive_principal(thread_key: &str, slack_user_id: Option<&str>) -> Princi
         labels.insert("slack_user_id".to_owned(), user.to_owned());
         return PrincipalRef {
             foreign_id: format!("slack-user-{scope}{}", slugify(user)),
-            name: format!("Slack user {user}{team_suffix}"),
+            name: display_name
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| format!("Slack user {user}{team_suffix}")),
             labels,
         };
     }
@@ -76,14 +92,18 @@ pub fn derive_principal(thread_key: &str, slack_user_id: Option<&str>) -> Princi
         labels.insert("slack_channel_id".to_owned(), conversation_id.to_owned());
         return PrincipalRef {
             foreign_id: format!("slack-channel-{scope}{}", slugify(conversation_id)),
-            name: format!("Slack channel {conversation_id}{team_suffix}"),
+            name: display_name
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| format!("Slack channel {conversation_id}{team_suffix}")),
             labels,
         };
     }
 
     PrincipalRef {
         foreign_id: format!("thread-{}", slugify(thread_key)),
-        name: thread_key.to_owned(),
+        name: display_name
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| thread_key.to_owned()),
         labels,
     }
 }
@@ -120,7 +140,7 @@ mod tests {
 
     #[test]
     fn dm_with_user_keys_on_the_user() {
-        let principal = derive_principal("slack:D0420:1780000000.0001", Some("U07ABC"));
+        let principal = derive_principal("slack:D0420:1780000000.0001", Some("U07ABC"), None);
         assert_eq!(principal.foreign_id, "slack-user-u07abc");
         assert_eq!(principal.name, "Slack user U07ABC");
         assert_eq!(
@@ -131,13 +151,13 @@ mod tests {
 
     #[test]
     fn dm_without_user_falls_back_to_the_conversation() {
-        let principal = derive_principal("slack:D0420:1780000000.0001", None);
+        let principal = derive_principal("slack:D0420:1780000000.0001", None, None);
         assert_eq!(principal.foreign_id, "slack-channel-d0420");
     }
 
     #[test]
     fn channel_keys_on_the_channel_even_with_a_user() {
-        let principal = derive_principal("chat:C123:1780000000.000000", Some("U07ABC"));
+        let principal = derive_principal("chat:C123:1780000000.000000", Some("U07ABC"), None);
         assert_eq!(principal.foreign_id, "slack-channel-c123");
         assert_eq!(principal.name, "Slack channel C123");
         assert_eq!(
@@ -148,13 +168,13 @@ mod tests {
 
     #[test]
     fn private_group_keys_on_the_channel() {
-        let principal = derive_principal("slack:G99:ts", Some("U1"));
+        let principal = derive_principal("slack:G99:ts", Some("U1"), None);
         assert_eq!(principal.foreign_id, "slack-channel-g99");
     }
 
     #[test]
     fn team_id_is_folded_into_the_channel_key() {
-        let principal = derive_principal("slack:T123:C456:1780000000.0001", Some("U1"));
+        let principal = derive_principal("slack:T123:C456:1780000000.0001", Some("U1"), None);
         assert_eq!(principal.foreign_id, "slack-channel-t123-c456");
         assert_eq!(principal.name, "Slack channel C456 (team T123)");
         assert_eq!(
@@ -169,21 +189,43 @@ mod tests {
 
     #[test]
     fn team_id_is_folded_into_the_dm_user_key() {
-        let principal = derive_principal("slack:T123:D9:ts", Some("U07ABC"));
+        let principal = derive_principal("slack:T123:D9:ts", Some("U07ABC"), None);
         assert_eq!(principal.foreign_id, "slack-user-t123-u07abc");
         assert_eq!(principal.name, "Slack user U07ABC (team T123)");
     }
 
     #[test]
     fn non_slack_thread_keys_slug_the_whole_key() {
-        let principal = derive_principal("api", None);
+        let principal = derive_principal("api", None, None);
         assert_eq!(principal.foreign_id, "thread-api");
         assert_eq!(principal.name, "api");
     }
 
     #[test]
+    fn conversation_name_overrides_the_channel_display_name_but_not_the_key() {
+        let principal =
+            derive_principal("slack:T123:C456:ts", Some("U1"), Some("eng-oncall"));
+        // Key stays derived from ids so renames never split the principal.
+        assert_eq!(principal.foreign_id, "slack-channel-t123-c456");
+        assert_eq!(principal.name, "eng-oncall");
+    }
+
+    #[test]
+    fn conversation_name_overrides_the_dm_display_name() {
+        let principal = derive_principal("slack:D0420:ts", Some("U07ABC"), Some("Ada Lovelace"));
+        assert_eq!(principal.foreign_id, "slack-user-u07abc");
+        assert_eq!(principal.name, "Ada Lovelace");
+    }
+
+    #[test]
+    fn blank_conversation_name_falls_back_to_the_synthetic_name() {
+        let principal = derive_principal("chat:C123:ts", None, Some("   "));
+        assert_eq!(principal.name, "Slack channel C123");
+    }
+
+    #[test]
     fn identity_input_carries_namespace_and_managed_label() {
-        let input = derive_principal("chat:C1:ts", None).to_identity_input("default");
+        let input = derive_principal("chat:C1:ts", None, None).to_identity_input("default");
         assert_eq!(input.namespace, "default");
         assert_eq!(input.foreign_id, "slack-channel-c1");
         assert_eq!(

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -38,15 +38,18 @@ impl SessionRegistrar {
 
     /// Upsert the principal for ``thread_key`` and assign it the configured
     /// roles. ``slack_user_id`` keys a 1:1 DM principal; it is ignored for
-    /// channel threads. Returns the upserted principal record (its ``id`` is
-    /// the OID) so callers can bind the session's egress proxy to the same
-    /// identity. Idempotent.
+    /// channel threads. ``conversation_name`` is the human-readable channel/DM
+    /// name (when the slackbot resolved one) used as the principal's display
+    /// name. Returns the upserted principal record (its ``id`` is the OID) so
+    /// callers can bind the session's egress proxy to the same identity.
+    /// Idempotent.
     pub async fn register_session(
         &self,
         thread_key: &str,
         slack_user_id: Option<&str>,
+        conversation_name: Option<&str>,
     ) -> Result<Principal> {
-        let principal = derive_principal(thread_key, slack_user_id);
+        let principal = derive_principal(thread_key, slack_user_id, conversation_name);
         let record = self
             .client
             .upsert_principal(&principal.to_identity_input(&self.namespace))

--- a/services/api-rs/crates/centaur-perms/src/principal.rs
+++ b/services/api-rs/crates/centaur-perms/src/principal.rs
@@ -18,7 +18,9 @@ pub fn resolve_principal(
     namespace: &str,
 ) -> IdentityInput {
     if principal.contains(':') {
-        derive_principal(principal, slack_user).to_identity_input(namespace)
+        // The CLI has no resolved conversation name; the synthetic display name
+        // is fine for operator-driven lookups.
+        derive_principal(principal, slack_user, None).to_identity_input(namespace)
     } else {
         IdentityInput {
             namespace: namespace.to_owned(),

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -255,6 +255,14 @@ impl SessionRuntime {
                 .and_then(|metadata| metadata.get("slack_user_id"))
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned);
+            // The human-readable channel/DM name the slackbot resolved, used as
+            // the principal's display name. Read it here for the same reason,
+            // before `metadata` is consumed below.
+            let slack_conversation_name = metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("slack_conversation_name"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
             let mut harness_switched = false;
             let session = match self
                 .store
@@ -284,7 +292,11 @@ impl SessionRuntime {
                 // to bind to, so a registration failure must fail session creation
                 // rather than silently boot a sandbox with a non-functional proxy.
                 let principal = registrar
-                    .register_session(thread_key.as_str(), slack_user_id.as_deref())
+                    .register_session(
+                        thread_key.as_str(),
+                        slack_user_id.as_deref(),
+                        slack_conversation_name.as_deref(),
+                    )
                     .await?;
                 // Persist the principal OID on the session row so a resumed session
                 // can recreate its sandbox after a restart without re-deriving it.

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -334,6 +334,19 @@ export function clearRequesterIdentityCacheForTests(): void {
   requesterIdentityCache.clear()
 }
 
+type ConversationNameCacheEntry = {
+  expiresAtMs: number
+  name: string | null
+}
+
+const CONVERSATION_NAME_CACHE_SUCCESS_TTL_MS = 6 * 60 * 60 * 1000
+const CONVERSATION_NAME_CACHE_MISS_TTL_MS = 10 * 60 * 1000
+const conversationNameCache = new Map<string, ConversationNameCacheEntry>()
+
+export function clearConversationNameCacheForTests(): void {
+  conversationNameCache.clear()
+}
+
 type CreateSessionOutcome = {
   /** The API restarted the thread onto the requested harness. */
   harnessSwitched: boolean
@@ -392,13 +405,18 @@ async function postCreateSession(
   onHarnessConflict?: 'reject' | 'restart'
 ): Promise<Response> {
   const fetchFn = options.fetch ?? fetch
+  // The conversation name becomes the session principal's display name in
+  // iron-control; resolve it here so it rides the create-session metadata that
+  // api-rs reads when it registers the principal.
+  const conversationName = message ? await resolveConversationName(options, message) : undefined
   const body: SlackbotV2CreateSessionRequest = {
     harness_type: harnessType,
     metadata: {
       source: 'slackbotv2',
       platform: 'slack',
       thread_id: threadId,
-      ...sessionRequesterMetadata(message)
+      ...sessionRequesterMetadata(message),
+      ...(conversationName ? { slack_conversation_name: conversationName } : {})
     },
     ...(onHarnessConflict ? { on_harness_conflict: onHarnessConflict } : {})
   }
@@ -580,6 +598,79 @@ async function fetchSlackUserProfile(
   } catch {
     return null
   }
+}
+
+// Resolve the human-readable name for the conversation a message belongs to,
+// used as the session principal's display name. A 1:1 DM principal keys on the
+// user, so its name is the DM partner's display name (already resolved for the
+// requester); a channel/group principal keys on the channel, so its name is the
+// channel name fetched from Slack. Returns undefined when no name can be
+// resolved, so the principal falls back to its synthetic id-based name.
+async function resolveConversationName(
+  options: SlackbotV2Options,
+  message: SlackbotV2ApiMessage
+): Promise<string | undefined> {
+  const conversationId = slackConversationId(message)
+  const kind = slackConversationKind(conversationId)
+  if (kind === 'dm') {
+    const identity = await resolveRequesterIdentity(options, message)
+    return identity.slackDisplayName ?? identity.slackUserName ?? undefined
+  }
+  if (kind === 'channel' && conversationId) {
+    return (await fetchSlackChannelName(options, conversationId)) ?? undefined
+  }
+  return undefined
+}
+
+// The conversation (channel/DM) id, preferring the raw event's `channel` field
+// and falling back to the conversation segment of the thread key
+// (`<source>:[<team>:]<conversation>[:<ts>]`). Slack ids carry their type in the
+// first letter: C/G are channels/groups, D is a direct message.
+function slackConversationId(message: SlackbotV2ApiMessage): string | undefined {
+  const fromRaw = rawSlackString(message.raw, 'channel')
+  if (fromRaw) return fromRaw
+  for (const segment of message.threadId.split(':').slice(1)) {
+    const first = segment.charAt(0)
+    if (first === 'C' || first === 'D' || first === 'G') return segment
+  }
+  return undefined
+}
+
+function slackConversationKind(
+  conversationId: string | undefined
+): 'channel' | 'dm' | undefined {
+  const first = conversationId?.charAt(0)
+  if (first === 'D') return 'dm'
+  if (first === 'C' || first === 'G') return 'channel'
+  return undefined
+}
+
+async function fetchSlackChannelName(
+  options: SlackbotV2Options,
+  channelId: string
+): Promise<string | null> {
+  const token = options.botToken
+  if (!token) return null
+  if (options.fetch && !options.slackApiUrl) return null
+
+  const cached = conversationNameCache.get(channelId)
+  if (cached && cached.expiresAtMs > Date.now()) return cached.name
+
+  let name: string | null = null
+  try {
+    const payload = await slackApiGet(options, 'conversations.info', { channel: channelId })
+    const channel = isJsonObject(payload?.channel) ? payload.channel : undefined
+    name = stringValue(channel?.name_normalized) ?? stringValue(channel?.name) ?? null
+  } catch {
+    name = null
+  }
+  conversationNameCache.set(channelId, {
+    expiresAtMs:
+      Date.now() +
+      (name ? CONVERSATION_NAME_CACHE_SUCCESS_TTL_MS : CONVERSATION_NAME_CACHE_MISS_TTL_MS),
+    name
+  })
+  return name
 }
 
 async function slackApiGet(

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test'
-import { forwardToSessionApi, harnessRestartPreamble } from '../src/session-api'
+import {
+  clearConversationNameCacheForTests,
+  clearRequesterIdentityCacheForTests,
+  forwardToSessionApi,
+  harnessRestartPreamble
+} from '../src/session-api'
 import type {
   ForwardSessionInput,
   SlackbotV2ApiMessage,
@@ -275,5 +280,89 @@ describe('harnessRestartPreamble', () => {
     expect(preamble).toContain('…(earlier messages truncated)')
     expect(preamble).toContain('most recent line')
     expect(preamble.length).toBeLessThan(26_000)
+  })
+})
+
+describe('session principal display name', () => {
+  function slackOptions(fetchFn: SlackbotV2Options['fetch']): SlackbotV2Options {
+    return {
+      apiUrl: 'http://api.test',
+      botToken: 'xoxb-test',
+      fetch: fetchFn,
+      signingSecret: 'secret',
+      // A slackApiUrl is required for the bot to make real Slack API calls
+      // (channel/profile lookups); without it those lookups are skipped.
+      slackApiUrl: 'http://slack.test/api/'
+    }
+  }
+
+  function createBody(requests: RecordedRequest[]): { metadata?: { slack_conversation_name?: string } } {
+    return (requests.find(request => request.url.endsWith('.000100'))?.body ?? {}) as {
+      metadata?: { slack_conversation_name?: string }
+    }
+  }
+
+  // slackApiGet uses the global fetch (not options.fetch), so Slack lookups are
+  // stubbed by swapping globalThis.fetch for the duration of the run; the
+  // session API itself still goes through the injected options.fetch.
+  async function withSlackStub(
+    stub: (url: string) => Response,
+    run: () => Promise<void>
+  ): Promise<void> {
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) =>
+      stub(String(input))) as typeof fetch
+    clearConversationNameCacheForTests()
+    clearRequesterIdentityCacheForTests()
+    try {
+      await run()
+    } finally {
+      globalThis.fetch = realFetch
+    }
+  }
+
+  test('channel sessions name the principal after the channel', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await withSlackStub(
+      url =>
+        url.includes('conversations.info')
+          ? Response.json({ channel: { id: 'C1', name_normalized: 'eng-oncall' }, ok: true })
+          : Response.json({ ok: true }),
+      async () => {
+        await forwardToSessionApi(slackOptions(fetchFn), forwardInput(apiMessage('hi')))
+      }
+    )
+    expect(createBody(requests).metadata?.slack_conversation_name).toBe('eng-oncall')
+  })
+
+  test('DM sessions name the principal after the DM partner', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const dm = apiMessage('hi')
+    dm.threadId = 'slack:D9:1700000000.000100'
+    dm.raw = { channel: 'D9' }
+    await withSlackStub(
+      url =>
+        url.includes('users.info')
+          ? Response.json({ ok: true, user: { profile: { display_name: 'Ada Lovelace' } } })
+          : Response.json({ ok: true }),
+      async () => {
+        await forwardToSessionApi(slackOptions(fetchFn), forwardInput(dm))
+      }
+    )
+    expect(createBody(requests).metadata?.slack_conversation_name).toBe('Ada Lovelace')
+  })
+
+  test('falls back to no name when the channel lookup fails', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await withSlackStub(
+      url =>
+        url.includes('conversations.info')
+          ? Response.json({ error: 'channel_not_found', ok: false })
+          : Response.json({ ok: true }),
+      async () => {
+        await forwardToSessionApi(slackOptions(fetchFn), forwardInput(apiMessage('hi')))
+      }
+    )
+    expect('slack_conversation_name' in (createBody(requests).metadata ?? {})).toBe(false)
   })
 })


### PR DESCRIPTION
Session principals now display the real Slack channel name or DM partner's name instead of a synthetic id-based label (e.g. `Slack channel C456`).

The slackbot resolves the name (`conversations.info` for channels, the requester's display name for DMs; both cached) and sends it as `slack_conversation_name` in session metadata. api-rs uses it as the principal's display name in `derive_principal`, falling back to the existing synthetic name when it's absent. The principal `foreign_id` still keys on ids, so a channel rename never splits one conversation into two principals.

Channel names require the `channels:read` / `groups:read` Slack scopes; without them the lookup fails closed and the synthetic name is used.