### PR TITLE
feat: emit missing ETL metrics

### DIFF
--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -43,11 +43,16 @@ pub const SESSION_EXECUTIONS_TOTAL: &str = "centaur_session_executions_total";
 pub const SESSION_EXECUTION_DURATION_SECONDS: &str = "centaur_session_execution_duration_seconds";
 pub const SANDBOX_OPERATIONS_TOTAL: &str = "centaur_sandbox_operations_total";
 pub const SANDBOX_WARM_POOL_CLAIMS_TOTAL: &str = "centaur_sandbox_warm_pool_claims_total";
+pub const ETL_ACTIVE_SCOPES: &str = "etl_active_scopes";
+pub const ETL_FAILED_SCOPES: &str = "etl_failed_scopes";
+pub const ETL_SCOPE_SYNC_FRESHNESS_SECONDS: &str = "etl_scope_sync_freshness_seconds";
 pub const ETL_ITEMS_SEEN_TOTAL: &str = "etl_items_seen_total";
 pub const ETL_ITEMS_ENQUEUED_TOTAL: &str = "etl_items_enqueued_total";
 pub const ETL_ITEMS_UPSERTED_TOTAL: &str = "etl_items_upserted_total";
 pub const ETL_ITEMS_DELETED_TOTAL: &str = "etl_items_deleted_total";
 pub const ETL_ITEMS_FAILED_TOTAL: &str = "etl_items_failed_total";
+pub const ETL_BACKFILL_JOBS: &str = "etl_backfill_jobs";
+pub const ETL_BACKFILL_JOB_AGE_SECONDS: &str = "etl_backfill_job_age_seconds";
 pub const COMPANY_CONTEXT_DOCUMENTS_CHANGED_TOTAL: &str = "company_context_documents_changed_total";
 pub const COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS: &str = "company_context_document_size_chars";
 pub const COMPANY_CONTEXT_PROJECTION_LAG_SECONDS: &str = "company_context_projection_lag_seconds";
@@ -265,9 +270,6 @@ pub fn record_sandbox_warm_pool_claim(result: &'static str) {
 }
 
 pub fn record_workflow_counter(name: &str, labels: &[(String, String)], value: u64) {
-    if value == 0 {
-        return;
-    }
     metrics::counter!(name.to_owned(), workflow_metric_labels(labels)).increment(value);
 }
 
@@ -383,6 +385,13 @@ fn describe_metrics() {
         SANDBOX_WARM_POOL_CLAIMS_TOTAL,
         "Session warm-pool claim attempts by result."
     );
+    metrics::describe_gauge!(ETL_ACTIVE_SCOPES, "Current active ETL scopes by source.");
+    metrics::describe_gauge!(ETL_FAILED_SCOPES, "Current failed ETL scopes by source.");
+    metrics::describe_gauge!(
+        ETL_SCOPE_SYNC_FRESHNESS_SECONDS,
+        metrics::Unit::Seconds,
+        "Oldest successful ETL scope sync age in seconds by source."
+    );
     metrics::describe_counter!(
         ETL_ITEMS_SEEN_TOTAL,
         "Source items fetched or observed by ETL workflows."
@@ -402,6 +411,15 @@ fn describe_metrics() {
     metrics::describe_counter!(
         ETL_ITEMS_FAILED_TOTAL,
         "Source items that failed processing in ETL workflows."
+    );
+    metrics::describe_gauge!(
+        ETL_BACKFILL_JOBS,
+        "Current ETL backfill jobs by source, job type, and status."
+    );
+    metrics::describe_gauge!(
+        ETL_BACKFILL_JOB_AGE_SECONDS,
+        metrics::Unit::Seconds,
+        "Oldest ETL backfill job age in seconds by source, job type, and status."
     );
     metrics::describe_counter!(
         COMPANY_CONTEXT_DOCUMENTS_CHANGED_TOTAL,
@@ -642,10 +660,44 @@ mod tests {
             ],
             7,
         );
+        record_workflow_counter(
+            COMPANY_CONTEXT_DOCUMENTS_CHANGED_TOTAL,
+            &[
+                ("action".to_owned(), "noop".to_owned()),
+                ("environment".to_owned(), "production".to_owned()),
+                ("namespace".to_owned(), "centaur-system".to_owned()),
+                ("source".to_owned(), "slack".to_owned()),
+                ("source_type".to_owned(), "slack_thread".to_owned()),
+            ],
+            0,
+        );
+        set_workflow_gauge(
+            ETL_BACKFILL_JOBS,
+            &[
+                ("environment".to_owned(), "production".to_owned()),
+                ("job_type".to_owned(), "thread_refresh".to_owned()),
+                ("namespace".to_owned(), "centaur-system".to_owned()),
+                ("source".to_owned(), "slack".to_owned()),
+                ("status".to_owned(), "pending".to_owned()),
+            ],
+            3.0,
+        );
+        set_workflow_gauge(
+            ETL_ACTIVE_SCOPES,
+            &[
+                ("environment".to_owned(), "production".to_owned()),
+                ("namespace".to_owned(), "centaur-system".to_owned()),
+                ("source".to_owned(), "slack".to_owned()),
+            ],
+            11.0,
+        );
 
         let metrics = render_metrics().unwrap();
 
         assert!(metrics.contains("etl_items_seen_total{"));
+        assert!(metrics.contains("etl_active_scopes{"));
+        assert!(metrics.contains("company_context_documents_changed_total{"));
+        assert!(metrics.contains("etl_backfill_jobs{"));
         assert!(metrics.contains(r#"environment="production""#));
         assert!(metrics.contains(r#"namespace="centaur-system""#));
         assert!(metrics.contains(r#"source="slack""#));

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -304,6 +304,13 @@ def install_vm_metrics_compat_module(api_mod: types.ModuleType) -> None:
     vm_metrics.record_etl_items_failed = record_etl_items_failed
     vm_metrics.record_etl_items_seen = record_etl_items_seen
     vm_metrics.record_etl_items_upserted = record_etl_items_upserted
+    vm_metrics.set_etl_active_scopes = set_etl_active_scopes
+    vm_metrics.set_etl_backfill_job_age_seconds = set_etl_backfill_job_age_seconds
+    vm_metrics.set_etl_backfill_jobs = set_etl_backfill_jobs
+    vm_metrics.set_etl_failed_scopes = set_etl_failed_scopes
+    vm_metrics.set_etl_scope_sync_freshness_seconds = (
+        set_etl_scope_sync_freshness_seconds
+    )
     vm_metrics.record_company_context_documents_changed = (
         record_company_context_documents_changed
     )
@@ -382,6 +389,63 @@ def record_etl_items_failed(
     )
 
 
+def set_etl_active_scopes(source: str, count: int) -> None:
+    set_gauge(
+        "etl_active_scopes",
+        max(count, 0),
+        source=source,
+    )
+
+
+def set_etl_failed_scopes(source: str, count: int) -> None:
+    set_gauge(
+        "etl_failed_scopes",
+        max(count, 0),
+        source=source,
+    )
+
+
+def set_etl_scope_sync_freshness_seconds(
+    source: str,
+    freshness_s: int | float,
+) -> None:
+    set_gauge(
+        "etl_scope_sync_freshness_seconds",
+        max(float(freshness_s), 0.0),
+        source=source,
+    )
+
+
+def set_etl_backfill_jobs(
+    source: str,
+    job_type: str,
+    status: str,
+    count: int,
+) -> None:
+    set_gauge(
+        "etl_backfill_jobs",
+        max(count, 0),
+        source=source,
+        job_type=job_type,
+        status=status,
+    )
+
+
+def set_etl_backfill_job_age_seconds(
+    source: str,
+    job_type: str,
+    status: str,
+    age_s: int | float,
+) -> None:
+    set_gauge(
+        "etl_backfill_job_age_seconds",
+        max(float(age_s), 0.0),
+        source=source,
+        job_type=job_type,
+        status=status,
+    )
+
+
 def record_company_context_documents_changed(
     source: str,
     source_type: str,
@@ -418,7 +482,7 @@ def set_company_context_projection_lag(source: str, projection_lag_s: float) -> 
 
 
 def increment_metric(metric: str, count: int, **labels: str) -> None:
-    if count <= 0:
+    if count < 0:
         return
     labels = metric_runtime_labels(labels)
     key = metric_key(metric, labels)

--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -13,6 +13,10 @@ from api.runtime_control import canonical_json, decode_jsonb
 from api.vm_metrics import (
     observe_company_context_document_size,
     record_company_context_documents_changed,
+    set_company_context_projection_lag,
+    set_etl_active_scopes,
+    set_etl_failed_scopes,
+    set_etl_scope_sync_freshness_seconds,
 )
 from api.workflow_engine import WorkflowContext
 
@@ -24,6 +28,19 @@ MIN_THREAD_MESSAGES = 5
 FALSE_ENV_VALUES = {"0", "false", "no", "off"}
 SLACK_MENTION_RE = re.compile(r"<@([A-Z0-9]+)>")
 SLACK_CHANNEL_RE = re.compile(r"<#([A-Z0-9]+)(?:\|([^>]+))?>")
+COMPANY_CONTEXT_SOURCE_TYPES = {
+    "slack": ("slack_channel_day", "slack_thread"),
+    "google_drive": ("google_doc",),
+    "google_calendar": ("calendar_event",),
+    "linear": ("linear_issue",),
+}
+COMPANY_CONTEXT_DOCUMENT_ACTIONS = ("inserted", "updated", "deleted", "noop")
+ETL_CHECKPOINT_TABLES = {
+    "slack": "slack_sync_checkpoints",
+    "google_drive": "google_drive_sync_checkpoints",
+    "google_calendar": "google_calendar_sync_checkpoints",
+    "linear": "linear_sync_checkpoints",
+}
 
 
 def _positive_int(value: int | str | None, default: int) -> int:
@@ -170,6 +187,95 @@ async def _latest_successful_watermark(pool, current_run_id: str) -> dt.datetime
         return None
     output = decode_jsonb(row["output_json"], {})
     return _parse_datetime(str(output.get("watermark") or ""))
+
+
+def _emit_company_context_counter_baselines(enabled_sources: list[str]) -> None:
+    """Initialize dashboard counter labelsets even when a run has no changes."""
+    for source in enabled_sources:
+        for source_type in COMPANY_CONTEXT_SOURCE_TYPES.get(source, ()):
+            for action in COMPANY_CONTEXT_DOCUMENT_ACTIONS:
+                record_company_context_documents_changed(
+                    source,
+                    source_type,
+                    action,
+                    0,
+                )
+
+
+async def _emit_company_context_document_size_snapshot(
+    pool,
+    enabled_sources: list[str],
+) -> None:
+    """Observe current projected document sizes so the corpus p95 panel has data."""
+    if not enabled_sources:
+        return
+    rows = await pool.fetch(
+        "SELECT source, source_type, LENGTH(COALESCE(body, '')) AS body_chars "
+        "FROM company_context_documents "
+        "WHERE source = ANY($1::text[]) "
+        "ORDER BY source, source_type, document_id",
+        enabled_sources,
+    )
+    seen_source_types: set[tuple[str, str]] = set()
+    for row in rows:
+        source = str(row["source"] or "")
+        source_type = str(row["source_type"] or "")
+        if not source or not source_type:
+            continue
+        seen_source_types.add((source, source_type))
+        observe_company_context_document_size(
+            source,
+            source_type,
+            int(row["body_chars"] or 0),
+        )
+
+    for source in enabled_sources:
+        for source_type in COMPANY_CONTEXT_SOURCE_TYPES.get(source, ()):
+            if (source, source_type) not in seen_source_types:
+                observe_company_context_document_size(source, source_type, 0)
+
+
+async def _emit_etl_scope_metrics(pool, enabled_sources: list[str]) -> None:
+    """Publish source scope health gauges used by the Grafana overview row."""
+    for source in enabled_sources:
+        table = ETL_CHECKPOINT_TABLES.get(source)
+        if not table:
+            continue
+        row = await pool.fetchrow(
+            "SELECT COUNT(*) AS active_scopes, "
+            "COUNT(*) FILTER (WHERE last_error <> '') AS failed_scopes, "
+            "COALESCE("
+            "  EXTRACT(EPOCH FROM NOW() - MIN(last_success_at) "
+            "    FILTER (WHERE last_success_at IS NOT NULL)"
+            "  ), "
+            "  0"
+            ") AS freshness_seconds "
+            f"FROM {table}",
+        )
+        set_etl_active_scopes(source, int(row["active_scopes"] or 0) if row else 0)
+        set_etl_failed_scopes(source, int(row["failed_scopes"] or 0) if row else 0)
+        set_etl_scope_sync_freshness_seconds(
+            source,
+            float(row["freshness_seconds"] or 0.0) if row else 0.0,
+        )
+
+
+def _emit_company_context_projection_lag(
+    enabled_sources: list[str],
+    source_watermarks: dict[str, dt.datetime | None],
+) -> None:
+    """Set per-source lag gauges from the newest projected source update time."""
+    now = dt.datetime.now(dt.timezone.utc)
+    for source in enabled_sources:
+        watermark = source_watermarks.get(source)
+        if isinstance(watermark, dt.datetime):
+            lag_seconds = max(
+                (now - watermark.astimezone(dt.timezone.utc)).total_seconds(),
+                0.0,
+            )
+        else:
+            lag_seconds = 0.0
+        set_company_context_projection_lag(source, lag_seconds)
 
 
 async def _load_slack_lookup_maps(pool) -> tuple[dict[str, str], dict[str, str]]:
@@ -1046,6 +1152,17 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     google_drive_enabled = _env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED")
     google_calendar_enabled = _env_flag_enabled("GOOGLE_CALENDAR_ETL_ENABLED")
     linear_enabled = _env_flag_enabled("LINEAR_ETL_ENABLED")
+    enabled_sources = [
+        source
+        for source, enabled in (
+            ("slack", slack_enabled),
+            ("google_drive", google_drive_enabled),
+            ("google_calendar", google_calendar_enabled),
+            ("linear", linear_enabled),
+        )
+        if enabled
+    ]
+    _emit_company_context_counter_baselines(enabled_sources)
     changed = {
         "channel_days": [],
         "threads": [],
@@ -1226,6 +1343,15 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         if value is not None
     ]
     watermark = max(watermark_candidates) if watermark_candidates else None
+    source_watermarks = {
+        "slack": changed["max_updated_at"] or last_watermark,
+        "google_drive": drive_changed["max_updated_at"] or last_watermark,
+        "google_calendar": calendar_changed["max_updated_at"] or last_watermark,
+        "linear": linear_changed["max_updated_at"] or last_watermark,
+    }
+    _emit_company_context_projection_lag(enabled_sources, source_watermarks)
+    await _emit_etl_scope_metrics(ctx._pool, enabled_sources)
+    await _emit_company_context_document_size_snapshot(ctx._pool, enabled_sources)
     result = {
         "status": "completed",
         "changed_messages": changed["changed_messages"],

--- a/workflows/slack/backfill.py
+++ b/workflows/slack/backfill.py
@@ -13,6 +13,8 @@ from api.vm_metrics import (
     record_etl_items_failed,
     record_etl_items_seen,
     record_etl_items_upserted,
+    set_etl_backfill_job_age_seconds,
+    set_etl_backfill_jobs,
 )
 from api.workflow_engine import WorkflowContext
 from workflows.slack.shared import (
@@ -26,6 +28,7 @@ from workflows.slack.shared import (
     enqueue_backfill_job,
     env_flag_enabled,
     failure_reason,
+    load_backfill_job_metrics,
     mark_thread_refreshed,
     mark_backfill_job_completed,
     mark_backfill_job_failed,
@@ -64,6 +67,20 @@ SCHEDULE = {
     ),
     "no_delivery": True,
 }
+
+
+async def _emit_backfill_job_metrics(pool) -> None:
+    """Publish current Slack backfill queue state for Grafana panels."""
+    for row in await load_backfill_job_metrics(pool):
+        job_type = str(row["job_type"])
+        status = str(row["status"])
+        set_etl_backfill_jobs("slack", job_type, status, int(row["job_count"]))
+        set_etl_backfill_job_age_seconds(
+            "slack",
+            job_type,
+            status,
+            float(row["oldest_age_seconds"]),
+        )
 
 
 @dataclass
@@ -183,6 +200,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     channel_pages_per_job = positive_int(
         inp.channel_pages_per_job, DEFAULT_CHANNEL_PAGES_PER_JOB
     )
+    await _emit_backfill_job_metrics(ctx._pool)
     jobs = await claim_backfill_jobs(ctx._pool, channel_batch_limit)
     if not jobs:
         ctx.log("slack_backfill_skipped_no_jobs")
@@ -190,6 +208,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             "status": "skipped",
             "reason": "no_pending_backfills",
         }
+    await _emit_backfill_job_metrics(ctx._pool)
 
     client = shared_client()
     access_mode = client._etl_access_mode()
@@ -451,6 +470,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         counts=counts,
         error_text=error_text,
     )
+    await _emit_backfill_job_metrics(ctx._pool)
 
     return {
         "status": status,

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -18,6 +18,12 @@ BACKFILL_JOB_CHANNEL_CONTINUATION = "channel_continuation"
 BACKFILL_JOB_CHANNEL_BOOTSTRAP = "channel_bootstrap"
 BACKFILL_JOB_THREAD_REFRESH = "thread_refresh"
 BACKFILL_JOB_PAYLOAD_VERSION = 1
+BACKFILL_JOB_TYPES = (
+    BACKFILL_JOB_CHANNEL_BOOTSTRAP,
+    BACKFILL_JOB_CHANNEL_CONTINUATION,
+    BACKFILL_JOB_THREAD_REFRESH,
+)
+BACKFILL_JOB_STATUSES = ("pending", "running", "completed", "failed")
 
 
 def positive_int(value: int | str | None, default: int) -> int:
@@ -1189,6 +1195,49 @@ async def claim_backfill_jobs(pool, limit: int) -> list[dict[str, Any]]:
                 limit,
             )
     return [dict(row) for row in rows]
+
+
+async def load_backfill_job_metrics(pool) -> list[dict[str, Any]]:
+    """Summarize Slack backfill queue state for dashboard gauges."""
+    rows = await pool.fetch(
+        "SELECT job_type, status, COUNT(*) AS job_count, "
+        "COALESCE("
+        "  EXTRACT(EPOCH FROM NOW() - MIN("
+        "    CASE status "
+        "      WHEN 'pending' THEN COALESCE(last_enqueued_at, updated_at, created_at) "
+        "      WHEN 'running' THEN COALESCE(last_started_at, updated_at, created_at) "
+        "      WHEN 'completed' THEN COALESCE(last_completed_at, updated_at, created_at) "
+        "      ELSE COALESCE(updated_at, last_enqueued_at, created_at) "
+        "    END"
+        "  )), "
+        "  0"
+        ") AS oldest_age_seconds "
+        "FROM slack_sync_backfill_jobs "
+        "GROUP BY job_type, status",
+    )
+    summary = {
+        (job_type, status): {"job_count": 0, "oldest_age_seconds": 0.0}
+        for job_type in BACKFILL_JOB_TYPES
+        for status in BACKFILL_JOB_STATUSES
+    }
+    for row in rows:
+        job_type = str(row["job_type"] or "")
+        status = str(row["status"] or "")
+        if not job_type or not status:
+            continue
+        summary[(job_type, status)] = {
+            "job_count": int(row["job_count"] or 0),
+            "oldest_age_seconds": float(row["oldest_age_seconds"] or 0.0),
+        }
+
+    return [
+        {
+            "job_type": job_type,
+            "status": status,
+            **values,
+        }
+        for (job_type, status), values in sorted(summary.items())
+    ]
 
 
 async def mark_backfill_job_failed(


### PR DESCRIPTION
## Summary

- emit the missing Grafana ETL overview gauges: `etl_active_scopes`, `etl_failed_scopes`, and `etl_scope_sync_freshness_seconds`
- emit Slack backfill queue gauges for `etl_backfill_jobs` and `etl_backfill_job_age_seconds` from `slack_sync_backfill_jobs`
- emit company context projection lag, zero-value change counter baselines, and current document size histogram observations so the existing panels get series after workflow runs

## Validation

- `python3 -m py_compile services/workflow-python/workflow_host.py workflows/slack/shared.py workflows/slack/backfill.py workflows/company_context_documents.py`
- `git diff --check`
- `cargo test -p centaur-telemetry -p centaur-workflows`
