### PR TITLE
fix(linear): import LinearReadonlyClient from workflows.linear.readonly

### DIFF
--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -2,23 +2,15 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import Any
 
-try:
-    from api.integrations.linear import LinearReadonlyClient
-except ModuleNotFoundError:
-    api_src = Path(__file__).resolve().parents[3] / "services" / "api"
-    if api_src.exists():
-        sys.path.insert(0, str(api_src))
-    from api.integrations.linear import LinearReadonlyClient
+from workflows.linear.readonly import LinearReadonlyClient
 
 
 class LinearClient(LinearReadonlyClient):
     """Tool-facing Linear client.
 
-    Read-only GraphQL methods live in ``api.integrations.linear`` so workflows
+    Read-only GraphQL methods live in ``workflows.linear.readonly`` so workflows
     can reuse them. Tool-only mutations stay here.
     """
 

--- a/tools/productivity/linear/test_client.py
+++ b/tools/productivity/linear/test_client.py
@@ -11,14 +11,14 @@ import types
 from pathlib import Path
 from typing import Any
 
-# client.py inherits from api.integrations.linear.LinearReadonlyClient, which
-# lives in the legacy api service and may not be present. The mutation logic
-# under test never touches readonly behavior, so stub the base class before
-# loading the module.
-if "api.integrations.linear" not in sys.modules:
-    api_pkg = types.ModuleType("api")
-    integrations_pkg = types.ModuleType("api.integrations")
-    linear_mod = types.ModuleType("api.integrations.linear")
+# client.py inherits from workflows.linear.readonly.LinearReadonlyClient, which
+# lives in the workflows package and may not be importable in isolation. The
+# mutation logic under test never touches readonly behavior, so stub the base
+# class before loading the module.
+if "workflows.linear.readonly" not in sys.modules:
+    workflows_pkg = types.ModuleType("workflows")
+    linear_pkg = types.ModuleType("workflows.linear")
+    readonly_mod = types.ModuleType("workflows.linear.readonly")
 
     class LinearReadonlyClient:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -27,12 +27,12 @@ if "api.integrations.linear" not in sys.modules:
         def _query(self, query: str, variables: dict | None = None) -> dict:
             raise NotImplementedError
 
-    linear_mod.LinearReadonlyClient = LinearReadonlyClient
-    integrations_pkg.linear = linear_mod
-    api_pkg.integrations = integrations_pkg
-    sys.modules["api"] = api_pkg
-    sys.modules["api.integrations"] = integrations_pkg
-    sys.modules["api.integrations.linear"] = linear_mod
+    readonly_mod.LinearReadonlyClient = LinearReadonlyClient
+    linear_pkg.readonly = readonly_mod
+    workflows_pkg.linear = linear_pkg
+    sys.modules["workflows"] = workflows_pkg
+    sys.modules["workflows.linear"] = linear_pkg
+    sys.modules["workflows.linear.readonly"] = readonly_mod
 
 spec = importlib.util.spec_from_file_location(
     "linear_client", Path(__file__).with_name("client.py")


### PR DESCRIPTION
## Problem

Every `linear` tool invocation crashes at import in the sandbox tool environment:

```
centaur-tools call linear.add_label failed: ...
  File ".../tools/productivity/linear/client.py", line 15, in <module>
    from api.integrations.linear import LinearReadonlyClient
ModuleNotFoundError: No module named 'api'
```

Read-only calls made from the workflow **host** still worked (the host puts `/opt/centaur` on `sys.path` and imports the readonly client directly), which masked the breakage; only tool-shim calls (e.g. `add_label`, `add_comment`) fail.