### PR TITLE
test: add API integration test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,66 @@ jobs:
         working-directory: services/api-rs
         run: cargo test --workspace
 
+      - name: Start API integration test dependencies
+        run: |
+          docker run --detach --name centaur-api-integration-test-postgres \
+            --publish 127.0.0.1:15432:5432 \
+            --env POSTGRES_USER=postgres \
+            --env POSTGRES_PASSWORD=postgres \
+            --env POSTGRES_DB=centaur \
+            paradedb/paradedb:0.23.0-pg16 \
+            -c shared_preload_libraries=pg_search,pg_cron \
+            -c max_connections=500
+          for attempt in {1..60}; do
+            if docker logs centaur-api-integration-test-postgres 2>&1 \
+              | grep -q 'PostgreSQL init process complete' \
+              && docker exec centaur-api-integration-test-postgres \
+              psql -U postgres -d centaur -tAc 'select 1' >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs centaur-api-integration-test-postgres
+          exit 1
+
+      - name: Run API integration test
+        working-directory: services/api-rs
+        env:
+          API_INTEGRATION_WORKFLOW_DIR: ${{ runner.temp }}/api-integration-workflows
+          BIND_ADDR: 127.0.0.1:18080
+          CENTAUR_API_URL: http://127.0.0.1:18080
+          DATABASE_URL: postgres://postgres:postgres@127.0.0.1:15432/centaur?sslmode=disable
+          RUN_MIGRATIONS: "true"
+          RUST_LOG: info
+          WORKFLOW_DIRS: ${{ runner.temp }}/api-integration-workflows
+          WORKFLOW_HOST_SANDBOX: "false"
+          WORKFLOW_REAP_REMOVED_AFTER_TICKS: "1"
+          WORKFLOW_RECONCILE_INTERVAL_SECS: "1"
+        run: |
+          mkdir -p "$API_INTEGRATION_WORKFLOW_DIR"
+          cargo build --locked -p centaur-api-server -p centaur-api-integration-test
+
+          ./target/debug/centaur-api-server > "$RUNNER_TEMP/centaur-api-server.log" 2>&1 &
+          api_pid="$!"
+          echo "$api_pid" > "$RUNNER_TEMP/centaur-api-server.pid"
+          trap 'kill "$api_pid" 2>/dev/null || true' EXIT
+
+          ./target/debug/centaur-api-integration-test
+
+      - name: Dump API integration test logs
+        if: ${{ failure() }}
+        run: |
+          cat "$RUNNER_TEMP/centaur-api-server.log" || true
+          docker logs centaur-api-integration-test-postgres || true
+
+      - name: Cleanup API integration test dependencies
+        if: ${{ always() }}
+        run: |
+          if [ -f "$RUNNER_TEMP/centaur-api-server.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/centaur-api-server.pid")" 2>/dev/null || true
+          fi
+          docker rm -f centaur-api-integration-test-postgres || true
+
   slackbotv2-tests:
     name: Slackbot v2 tests
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -24,6 +24,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
   packages: write
 
 env:
@@ -123,8 +124,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # Tags are applied by the merge job on the multi-arch manifest;
           # per-arch builds are pushed by digest only. Fork PRs run with a
-          # read-only GITHUB_TOKEN, so they build without pushing.
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=${{ !github.event.pull_request.head.repo.fork }}
+          # read-only GITHUB_TOKEN, so they build without pushing. The api-rs
+          # amd64 leg also loads the same built image into Docker for the
+          # API integration test below.
+          outputs: |
+            type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=${{ !github.event.pull_request.head.repo.fork }}
+            ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' && 'type=docker,name=centaur-api-rs:integration-test' || '' }}
           build-args: |
             RUST_BUILD_PROFILE=${{ env.RUST_BUILD_PROFILE }}
           cache-from: |
@@ -135,6 +140,112 @@ jobs:
           cache-to: |
             ${{ !github.event.pull_request.head.repo.fork && format('type=registry,ref={0}/{1}/{2}:buildcache-{3},mode=max', env.REGISTRY, env.IMAGE_NAMESPACE, matrix.image, env.PLATFORM_SLUG) || '' }}
             type=gha,mode=max,scope=${{ matrix.image }}-${{ env.PLATFORM_SLUG }}
+
+      - name: Set up Rust for API integration test
+        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Cache Rust for API integration test
+        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: services/api-rs
+
+      - name: Start API integration test dependencies
+        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
+        run: |
+          docker network create centaur-api-integration-test
+          docker run --detach --name centaur-api-integration-test-postgres \
+            --network centaur-api-integration-test \
+            --env POSTGRES_USER=postgres \
+            --env POSTGRES_PASSWORD=postgres \
+            --env POSTGRES_DB=centaur \
+            paradedb/paradedb:0.23.0-pg16 \
+            -c shared_preload_libraries=pg_search,pg_cron \
+            -c max_connections=500
+          for attempt in {1..60}; do
+            if docker exec centaur-api-integration-test-postgres pg_isready -U postgres -d centaur; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs centaur-api-integration-test-postgres
+          exit 1
+
+      - name: Start API image
+        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
+        run: |
+          docker run --detach --name centaur-api-integration-test \
+            --network centaur-api-integration-test \
+            --publish 127.0.0.1:18080:8080 \
+            --env DATABASE_URL=postgres://postgres:postgres@centaur-api-integration-test-postgres:5432/centaur \
+            --env RUN_MIGRATIONS=true \
+            --env BIND_ADDR=0.0.0.0:8080 \
+            --env WORKFLOW_HOST_SANDBOX=false \
+            --env RUST_LOG=info \
+            centaur-api-rs:integration-test
+
+      - name: Run API integration test
+        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
+        working-directory: services/api-rs
+        env:
+          API_INTEGRATION_TEST_REPORT: ${{ runner.temp }}/api-integration-test-report.md
+          API_INTEGRATION_TEST_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          CENTAUR_API_URL: http://127.0.0.1:18080
+        run: cargo run --locked -p centaur-api-integration-test
+
+      - name: Comment API integration test results
+        if: ${{ always() && matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+        env:
+          API_INTEGRATION_TEST_REPORT: ${{ runner.temp }}/api-integration-test-report.md
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          marker="<!-- centaur-api-integration-test-results -->"
+          report="$API_INTEGRATION_TEST_REPORT"
+          if [ ! -s "$report" ]; then
+            source_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/${SOURCE_SHA}/services/api-rs/crates/centaur-api-integration-test/src/main.rs#L15"
+            {
+              printf '| Test | Result |\n'
+              printf '| --- | --- |\n'
+              printf '| [API integration test command](%s) | Failed |\n' "$source_url"
+            } > "$report"
+          fi
+
+          body_file="${RUNNER_TEMP}/api-integration-test-comment.md"
+          {
+            printf '%s\n\n' "$marker"
+            printf '### API integration test results\n\n'
+            cat "$report"
+          } > "$body_file"
+
+          comment_id="$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${marker}\"))) | .id" \
+              2>/dev/null | tail -n 1 || true
+          )"
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              -F body=@"$body_file"
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -F body=@"$body_file"
+          fi
+
+      - name: Dump API integration test logs
+        if: ${{ failure() && matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
+        run: |
+          docker logs centaur-api-integration-test || true
+          docker logs centaur-api-integration-test-postgres || true
+
+      - name: Cleanup API integration test containers
+        if: ${{ always() && matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
+        run: |
+          docker rm -f centaur-api-integration-test centaur-api-integration-test-postgres || true
+          docker network rm centaur-api-integration-test || true
 
       - name: Export digest
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -24,7 +24,6 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
   packages: write
 
 env:
@@ -43,6 +42,10 @@ jobs:
   # arm64 is only built on pushes to main and release tags — PR and manual
   # dispatch builds stay amd64-only to keep iteration fast.
   build:
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
@@ -198,42 +201,64 @@ jobs:
 
       - name: Comment API integration test results
         if: ${{ always() && matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+        continue-on-error: true
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           API_INTEGRATION_TEST_REPORT: ${{ runner.temp }}/api-integration-test-report.md
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          marker="<!-- centaur-api-integration-test-results -->"
-          report="$API_INTEGRATION_TEST_REPORT"
-          if [ ! -s "$report" ]; then
-            source_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/${SOURCE_SHA}/services/api-rs/crates/centaur-api-integration-test/src/main.rs#L15"
-            {
-              printf '| Test | Result |\n'
-              printf '| --- | --- |\n'
-              printf '| [API integration test command](%s) | Failed |\n' "$source_url"
-            } > "$report"
-          fi
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('node:fs')
 
-          body_file="${RUNNER_TEMP}/api-integration-test-comment.md"
-          {
-            printf '%s\n\n' "$marker"
-            printf '### API integration test results\n\n'
-            cat "$report"
-          } > "$body_file"
+            const marker = '<!-- centaur-api-integration-test-results -->'
+            const reportPath = process.env.API_INTEGRATION_TEST_REPORT
+            let report = ''
+            try {
+              report = fs.readFileSync(reportPath, 'utf8')
+            } catch (error) {
+              console.log(`No API integration test report found at ${reportPath}: ${error.message}`)
+            }
 
-          comment_id="$(
-            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${marker}\"))) | .id" \
-              2>/dev/null | tail -n 1 || true
-          )"
-          if [ -n "$comment_id" ]; then
-            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
-              -F body=@"$body_file"
-          else
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              -F body=@"$body_file"
-          fi
+            if (!report.trim()) {
+              const sourceUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/blob/${process.env.SOURCE_SHA}/services/api-rs/crates/centaur-api-integration-test/src/main.rs#L15`
+              report = [
+                '| Test | Result |',
+                '| --- | --- |',
+                `| [API integration test command](${sourceUrl}) | Failed |`,
+                ''
+              ].join('\n')
+            }
+
+            const body = `${marker}\n\n### API integration test results\n\n${report}`
+            const issueNumber = context.payload.pull_request.number
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            })
+            const existingComment = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.includes(marker)
+            )
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              })
+              console.log('Updated API integration test results comment')
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              })
+              console.log('Created API integration test results comment')
+            }
 
       - name: Dump API integration test logs
         if: ${{ failure() && matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -127,12 +127,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # Tags are applied by the merge job on the multi-arch manifest;
           # per-arch builds are pushed by digest only. Fork PRs run with a
-          # read-only GITHUB_TOKEN, so they build without pushing. The api-rs
-          # amd64 leg also loads the same built image into Docker for the
-          # API integration test below.
+          # read-only GITHUB_TOKEN, so they build without pushing. Fork PRs
+          # load the api-rs amd64 image into Docker directly; same-repo PRs
+          # and pushes pull the pushed digest for the API integration test.
           outputs: |
             type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=${{ !github.event.pull_request.head.repo.fork }}
-            ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' && 'type=docker,name=centaur-api-rs:integration-test' || '' }}
+            ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' && github.event.pull_request.head.repo.fork && 'type=docker,name=centaur-api-rs:integration-test' || '' }}
           build-args: |
             RUST_BUILD_PROFILE=${{ env.RUST_BUILD_PROFILE }}
           cache-from: |
@@ -143,6 +143,13 @@ jobs:
           cache-to: |
             ${{ !github.event.pull_request.head.repo.fork && format('type=registry,ref={0}/{1}/{2}:buildcache-{3},mode=max', env.REGISTRY, env.IMAGE_NAMESPACE, matrix.image, env.PLATFORM_SLUG) || '' }}
             type=gha,mode=max,scope=${{ matrix.image }}-${{ env.PLATFORM_SLUG }}
+
+      - name: Load API image for integration test
+        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' && !github.event.pull_request.head.repo.fork }}
+        run: |
+          image="${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}"
+          docker pull "$image"
+          docker tag "$image" centaur-api-rs:integration-test
 
       - name: Set up Rust for API integration test
         if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -184,15 +184,26 @@ jobs:
           docker logs centaur-api-integration-test-postgres
           exit 1
 
+      - name: Prepare API integration workflow overlay
+        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
+        run: |
+          workflow_dir="$RUNNER_TEMP/api-integration-workflows"
+          mkdir -p "$workflow_dir"
+          echo "API_INTEGRATION_WORKFLOW_DIR=$workflow_dir" >> "$GITHUB_ENV"
+
       - name: Start API image
         if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
         run: |
           docker run --detach --name centaur-api-integration-test \
             --network centaur-api-integration-test \
             --publish 127.0.0.1:18080:8080 \
+            --volume "$API_INTEGRATION_WORKFLOW_DIR:/tmp/centaur-api-integration-workflows" \
             --env DATABASE_URL=postgres://postgres:postgres@centaur-api-integration-test-postgres:5432/centaur \
             --env RUN_MIGRATIONS=true \
             --env BIND_ADDR=0.0.0.0:8080 \
+            --env WORKFLOW_DIRS=/tmp/centaur-api-integration-workflows \
+            --env WORKFLOW_RECONCILE_INTERVAL_SECS=1 \
+            --env WORKFLOW_REAP_REMOVED_AFTER_TICKS=1 \
             --env WORKFLOW_HOST_SANDBOX=false \
             --env RUST_LOG=info \
             centaur-api-rs:integration-test

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -42,10 +42,6 @@ jobs:
   # arm64 is only built on pushes to main and release tags — PR and manual
   # dispatch builds stay amd64-only to keep iteration fast.
   build:
-    permissions:
-      contents: read
-      packages: write
-      pull-requests: write
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
@@ -127,12 +123,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # Tags are applied by the merge job on the multi-arch manifest;
           # per-arch builds are pushed by digest only. Fork PRs run with a
-          # read-only GITHUB_TOKEN, so they build without pushing. Fork PRs
-          # load the api-rs amd64 image into Docker directly; same-repo PRs
-          # and pushes pull the pushed digest for the API integration test.
-          outputs: |
-            type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=${{ !github.event.pull_request.head.repo.fork }}
-            ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' && github.event.pull_request.head.repo.fork && 'type=docker,name=centaur-api-rs:integration-test' || '' }}
+          # read-only GITHUB_TOKEN, so they build without pushing.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=${{ !github.event.pull_request.head.repo.fork }}
           build-args: |
             RUST_BUILD_PROFILE=${{ env.RUST_BUILD_PROFILE }}
           cache-from: |
@@ -143,152 +135,6 @@ jobs:
           cache-to: |
             ${{ !github.event.pull_request.head.repo.fork && format('type=registry,ref={0}/{1}/{2}:buildcache-{3},mode=max', env.REGISTRY, env.IMAGE_NAMESPACE, matrix.image, env.PLATFORM_SLUG) || '' }}
             type=gha,mode=max,scope=${{ matrix.image }}-${{ env.PLATFORM_SLUG }}
-
-      - name: Load API image for integration test
-        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' && !github.event.pull_request.head.repo.fork }}
-        run: |
-          image="${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}"
-          docker pull "$image"
-          docker tag "$image" centaur-api-rs:integration-test
-
-      - name: Set up Rust for API integration test
-        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-
-      - name: Cache Rust for API integration test
-        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: services/api-rs
-
-      - name: Start API integration test dependencies
-        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
-        run: |
-          docker network create centaur-api-integration-test
-          docker run --detach --name centaur-api-integration-test-postgres \
-            --network centaur-api-integration-test \
-            --env POSTGRES_USER=postgres \
-            --env POSTGRES_PASSWORD=postgres \
-            --env POSTGRES_DB=centaur \
-            paradedb/paradedb:0.23.0-pg16 \
-            -c shared_preload_libraries=pg_search,pg_cron \
-            -c max_connections=500
-          for attempt in {1..60}; do
-            if docker exec centaur-api-integration-test-postgres pg_isready -U postgres -d centaur; then
-              exit 0
-            fi
-            sleep 1
-          done
-          docker logs centaur-api-integration-test-postgres
-          exit 1
-
-      - name: Prepare API integration workflow overlay
-        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
-        run: |
-          workflow_dir="$RUNNER_TEMP/api-integration-workflows"
-          mkdir -p "$workflow_dir"
-          echo "API_INTEGRATION_WORKFLOW_DIR=$workflow_dir" >> "$GITHUB_ENV"
-
-      - name: Start API image
-        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
-        run: |
-          docker run --detach --name centaur-api-integration-test \
-            --network centaur-api-integration-test \
-            --publish 127.0.0.1:18080:8080 \
-            --volume "$API_INTEGRATION_WORKFLOW_DIR:/tmp/centaur-api-integration-workflows" \
-            --env DATABASE_URL=postgres://postgres:postgres@centaur-api-integration-test-postgres:5432/centaur \
-            --env RUN_MIGRATIONS=true \
-            --env BIND_ADDR=0.0.0.0:8080 \
-            --env WORKFLOW_DIRS=/tmp/centaur-api-integration-workflows \
-            --env WORKFLOW_RECONCILE_INTERVAL_SECS=1 \
-            --env WORKFLOW_REAP_REMOVED_AFTER_TICKS=1 \
-            --env WORKFLOW_HOST_SANDBOX=false \
-            --env RUST_LOG=info \
-            centaur-api-rs:integration-test
-
-      - name: Run API integration test
-        if: ${{ matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
-        working-directory: services/api-rs
-        env:
-          API_INTEGRATION_TEST_REPORT: ${{ runner.temp }}/api-integration-test-report.md
-          API_INTEGRATION_TEST_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          CENTAUR_API_URL: http://127.0.0.1:18080
-        run: cargo run --locked -p centaur-api-integration-test
-
-      - name: Comment API integration test results
-        if: ${{ always() && matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
-        continue-on-error: true
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
-        env:
-          API_INTEGRATION_TEST_REPORT: ${{ runner.temp }}/api-integration-test-report.md
-          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const fs = require('node:fs')
-
-            const marker = '<!-- centaur-api-integration-test-results -->'
-            const reportPath = process.env.API_INTEGRATION_TEST_REPORT
-            let report = ''
-            try {
-              report = fs.readFileSync(reportPath, 'utf8')
-            } catch (error) {
-              console.log(`No API integration test report found at ${reportPath}: ${error.message}`)
-            }
-
-            if (!report.trim()) {
-              const sourceUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/blob/${process.env.SOURCE_SHA}/services/api-rs/crates/centaur-api-integration-test/src/main.rs#L15`
-              report = [
-                '| Test | Result |',
-                '| --- | --- |',
-                `| [API integration test command](${sourceUrl}) | Failed |`,
-                ''
-              ].join('\n')
-            }
-
-            const body = `${marker}\n\n### API integration test results\n\n${report}`
-            const issueNumber = context.payload.pull_request.number
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-            })
-            const existingComment = comments.find(comment =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.body?.includes(marker)
-            )
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body,
-              })
-              console.log('Updated API integration test results comment')
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                body,
-              })
-              console.log('Created API integration test results comment')
-            }
-
-      - name: Dump API integration test logs
-        if: ${{ failure() && matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
-        run: |
-          docker logs centaur-api-integration-test || true
-          docker logs centaur-api-integration-test-postgres || true
-
-      - name: Cleanup API integration test containers
-        if: ${{ always() && matrix.service == 'api-rs' && matrix.platform == 'linux/amd64' }}
-        run: |
-          docker rm -f centaur-api-integration-test centaur-api-integration-test-postgres || true
-          docker network rm centaur-api-integration-test || true
 
       - name: Export digest
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -284,6 +284,7 @@ name = "centaur-api-integration-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "centaur-session-core",
  "eventsource-stream",
  "futures-util",
  "reqwest",

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -280,6 +280,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "centaur-api-integration-test"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "eventsource-stream",
+ "futures-util",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "centaur-api-server"
 version = "0.1.0"
 dependencies = [

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/absurd-sdk",
     "crates/centaur-api-server",
+    "crates/centaur-api-integration-test",
     "crates/centaur-iron-control",
     "crates/centaur-iron-proxy",
     "crates/centaur-perms",

--- a/services/api-rs/crates/centaur-api-integration-test/Cargo.toml
+++ b/services/api-rs/crates/centaur-api-integration-test/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+centaur-session-core.workspace = true
 eventsource-stream.workspace = true
 futures-util.workspace = true
 reqwest.workspace = true

--- a/services/api-rs/crates/centaur-api-integration-test/Cargo.toml
+++ b/services/api-rs/crates/centaur-api-integration-test/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "centaur-api-integration-test"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+eventsource-stream.workspace = true
+futures-util.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+uuid.workspace = true
+
+[lints]
+workspace = true

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -239,6 +239,11 @@ async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<(
 
 async fn test_session_turn(http: &HttpClient, base_url: &str) -> Result<()> {
     let thread_key = test_thread_key("turn")?;
+    let harness_wire_value = serde_json::to_value(HarnessType::Codex)
+        .context("serialize executable harness type")?
+        .as_str()
+        .context("serialized executable harness type was not a string")?
+        .to_owned();
     post_json_ok(
         http,
         session_url(base_url, &thread_key),
@@ -262,7 +267,10 @@ async fn test_session_turn(http: &HttpClient, base_url: &str) -> Result<()> {
                 {
                     "client_message_id": "api-integration-test-message-1",
                     "role": "user",
-                    "parts": [{"type": "text", "text": "Reply with exactly PONG."}],
+                    "parts": [{
+                        "type": "text",
+                        "text": "Reply with PONG, the model, and the harness.",
+                    }],
                     "metadata": {
                         "source": "centaur-api-integration-test",
                         "model": TEST_MODEL,
@@ -291,7 +299,10 @@ async fn test_session_turn(http: &HttpClient, base_url: &str) -> Result<()> {
         },
         "message": {
             "role": "user",
-            "content": [{"type": "text", "text": "Reply with exactly PONG."}],
+            "content": [{
+                "type": "text",
+                "text": "Reply with PONG, the model, and the harness.",
+            }],
         },
     }))
     .context("serialize execute input line")?;
@@ -363,7 +374,6 @@ async fn test_session_turn(http: &HttpClient, base_url: &str) -> Result<()> {
     }
     let mut events = response.bytes_stream().eventsource();
     timeout(Duration::from_secs(20), async {
-        let mut saw_model_input = false;
         let mut saw_output = false;
         while let Some(event) = events.next().await {
             let event = event.context("read session event")?;
@@ -371,18 +381,11 @@ async fn test_session_turn(http: &HttpClient, base_url: &str) -> Result<()> {
                 "session.output.line" => {
                     let line = parse_json(&event.data)?;
                     let line_type = line.get("type").and_then(Value::as_str);
-                    if line_type == Some("user")
-                        && line.get("model").and_then(Value::as_str) == Some(TEST_MODEL)
-                        && line.get("thread_key").and_then(Value::as_str)
-                            == Some(thread_key.as_str())
-                    {
-                        saw_model_input = true;
-                    }
                     if line_type == Some("item.agentMessage.delta")
-                        && line
-                            .get("delta")
-                            .and_then(Value::as_str)
-                            .is_some_and(|delta| delta.contains("PONG"))
+                        && let Some(delta) = line.get("delta").and_then(Value::as_str)
+                        && delta.contains("PONG")
+                        && delta.contains(&format!("model={TEST_MODEL}"))
+                        && delta.contains(&format!("harness={harness_wire_value}"))
                     {
                         saw_output = true;
                     }
@@ -392,11 +395,10 @@ async fn test_session_turn(http: &HttpClient, base_url: &str) -> Result<()> {
                     if payload.get("execution_id").and_then(Value::as_str)
                         == Some(execution_id.as_str())
                     {
-                        if !saw_model_input {
-                            bail!("execution completed before the model input line was observed");
-                        }
                         if !saw_output {
-                            bail!("execution completed before a PONG output line was observed");
+                            bail!(
+                                "execution completed before a PONG model/harness output line was observed"
+                            );
                         }
                         return Ok(());
                     }

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -1,6 +1,7 @@
 use std::{env, fs, time::Duration};
 
 use anyhow::{Context, Result, bail};
+use centaur_session_core::HarnessType;
 use eventsource_stream::Eventsource;
 use futures_util::StreamExt;
 use reqwest::{Client as HttpClient, StatusCode};
@@ -165,15 +166,32 @@ async fn wait_for_health(http: &HttpClient, base_url: &str) -> Result<()> {
 }
 
 async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<()> {
-    let cases = ["codex", "amp", "claudecode"];
+    let cases = [
+        (HarnessType::Codex, "codex"),
+        (HarnessType::Amp, "amp"),
+        (HarnessType::ClaudeCode, "claudecode"),
+    ];
 
-    for wire_value in cases {
+    for (harness_type, expected_wire_value) in cases {
+        let harness_wire_value =
+            serde_json::to_value(&harness_type).context("serialize harness type")?;
+        let wire_value = harness_wire_value
+            .as_str()
+            .context("serialized harness type was not a string")?
+            .to_owned();
+        if wire_value != expected_wire_value {
+            bail!(
+                "typed harness {:?} serialized to {wire_value:?}, expected {expected_wire_value:?}",
+                harness_type
+            );
+        }
+
         let thread_key = test_thread_key(format!("harness-{wire_value}"))?;
         let session = post_json_ok(
             http,
             session_url(base_url, &thread_key),
             json!({
-                "harness_type": wire_value,
+                "harness_type": harness_wire_value,
                 "metadata": {
                     "source": "centaur-api-integration-test",
                     "harness_wire_value": wire_value,
@@ -186,7 +204,7 @@ async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<(
         if session.get("thread_key").and_then(Value::as_str) != Some(thread_key.as_str()) {
             bail!("session thread key mismatch for {wire_value}");
         }
-        if session.get("harness_type").and_then(Value::as_str) != Some(wire_value) {
+        if session.get("harness_type").and_then(Value::as_str) != Some(wire_value.as_str()) {
             bail!(
                 "session harness mismatch for {wire_value}: got {}",
                 session
@@ -225,7 +243,7 @@ async fn test_session_turn(http: &HttpClient, base_url: &str) -> Result<()> {
         http,
         session_url(base_url, &thread_key),
         json!({
-            "harness_type": "codex",
+            "harness_type": HarnessType::Codex,
             "metadata": {
                     "source": "centaur-api-integration-test",
                     "purpose": "container-api-integration-test",

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -1,4 +1,8 @@
-use std::{env, fs, time::Duration};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use anyhow::{Context, Result, bail};
 use centaur_session_core::HarnessType;
@@ -45,6 +49,14 @@ async fn main() -> Result<()> {
         "Session execute forwards model context and completes",
         line,
         test_session_turn(&http, &base_url).await,
+    );
+
+    let line = line!() + 1;
+    record_result(
+        &mut results,
+        "Workflows API runs added workflows and cancels removed workflows",
+        line,
+        test_workflows_api(&http, &base_url).await,
     );
 
     let line = line!() + 1;
@@ -439,8 +451,248 @@ async fn test_metrics(http: &HttpClient, base_url: &str) -> Result<()> {
     Ok(())
 }
 
+async fn test_workflows_api(http: &HttpClient, base_url: &str) -> Result<()> {
+    let workflow_dir = integration_workflow_dir()?;
+    fs::create_dir_all(&workflow_dir)
+        .with_context(|| format!("create workflow dir {}", workflow_dir.display()))?;
+
+    let unique = Uuid::new_v4().simple().to_string();
+    let sentinel_name = format!("api_integration_sentinel_{unique}");
+    let workflow_name = format!("api_integration_workflow_{unique}");
+    let workflow_path = workflow_dir.join(format!("{workflow_name}.py"));
+
+    write_sentinel_workflow(&workflow_dir, &sentinel_name)?;
+    write_test_workflow(&workflow_path, &workflow_name)?;
+
+    wait_for_workflow_schedule(http, base_url, &workflow_name, true)
+        .await
+        .context("wait for added workflow schedule to be discovered")?;
+
+    let completed_run_id = create_workflow_run(
+        http,
+        base_url,
+        &workflow_name,
+        json!({
+            "case": "added-workflow-run",
+            "sleep_ms": 0,
+        }),
+    )
+    .await
+    .context("create added workflow run")?;
+    let completed_run =
+        wait_for_workflow_run_status(http, base_url, &completed_run_id, &["completed"])
+            .await
+            .context("wait for added workflow run completion")?;
+    let output = completed_run
+        .pointer("/result/output")
+        .context("completed workflow run missing result output")?;
+    if output.get("workflow_name").and_then(Value::as_str) != Some(workflow_name.as_str()) {
+        bail!("completed workflow output did not echo workflow name: {completed_run}");
+    }
+    if output.pointer("/received/case").and_then(Value::as_str) != Some("added-workflow-run") {
+        bail!("completed workflow output did not echo input: {completed_run}");
+    }
+
+    let removed_run_id = create_workflow_run(
+        http,
+        base_url,
+        &workflow_name,
+        json!({
+            "case": "removed-workflow-run",
+            "sleep_ms": 60_000,
+        }),
+    )
+    .await
+    .context("create long-running workflow run")?;
+    wait_for_workflow_run_status(http, base_url, &removed_run_id, &["running"])
+        .await
+        .context("wait for long-running workflow run to start")?;
+
+    fs::remove_file(&workflow_path)
+        .with_context(|| format!("remove workflow file {}", workflow_path.display()))?;
+
+    wait_for_workflow_schedule(http, base_url, &workflow_name, false)
+        .await
+        .context("wait for removed workflow schedule to be dropped")?;
+    wait_for_workflow_run_status(http, base_url, &removed_run_id, &["cancelled"])
+        .await
+        .context("wait for removed workflow run to be cancelled")?;
+
+    Ok(())
+}
+
+fn integration_workflow_dir() -> Result<PathBuf> {
+    let path = env::var("API_INTEGRATION_WORKFLOW_DIR")
+        .context("API_INTEGRATION_WORKFLOW_DIR must point at the mounted workflow test dir")?;
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        bail!("API_INTEGRATION_WORKFLOW_DIR must not be empty");
+    }
+    Ok(PathBuf::from(trimmed))
+}
+
+fn write_sentinel_workflow(workflow_dir: &Path, workflow_name: &str) -> Result<()> {
+    let path = workflow_dir.join(format!("{workflow_name}.py"));
+    let source = format!(
+        r#"
+WORKFLOW_NAME = "{workflow_name}"
+
+
+async def handler(params, ctx):
+    return {{"workflow_name": ctx.workflow_name, "received": params}}
+"#
+    );
+    fs::write(&path, source).with_context(|| format!("write sentinel workflow {}", path.display()))
+}
+
+fn write_test_workflow(path: &Path, workflow_name: &str) -> Result<()> {
+    let source = format!(
+        r#"
+import asyncio
+
+WORKFLOW_NAME = "{workflow_name}"
+SCHEDULE = {{
+    "schedule_id": "{workflow_name}",
+    "interval_seconds": 3600,
+    "enabled": True,
+    "no_delivery": True,
+    "input": {{"source": "centaur-api-integration-test"}},
+}}
+
+
+async def handler(params, ctx):
+    sleep_ms = int(params.get("sleep_ms") or 0)
+    if sleep_ms:
+        await asyncio.sleep(sleep_ms / 1000)
+    return {{
+        "workflow_name": ctx.workflow_name,
+        "run_id": ctx.run_id,
+        "task_id": ctx.task_id,
+        "received": params,
+    }}
+"#
+    );
+    fs::write(path, source).with_context(|| format!("write test workflow {}", path.display()))
+}
+
+async fn create_workflow_run(
+    http: &HttpClient,
+    base_url: &str,
+    workflow_name: &str,
+    input: Value,
+) -> Result<String> {
+    let response = post_json_ok(
+        http,
+        format!("{base_url}/api/workflows/runs"),
+        json!({
+            "workflow_name": workflow_name,
+            "input": input,
+            "idempotency_key": format!("{workflow_name}-{}", Uuid::new_v4().simple()),
+            "harness_type": HarnessType::Codex,
+            "max_attempts": 1,
+        }),
+    )
+    .await?;
+    if response.get("ok").and_then(Value::as_bool) != Some(true) {
+        bail!("workflow create response was not ok: {response}");
+    }
+    if response.get("created").and_then(Value::as_bool) != Some(true) {
+        bail!("workflow create response did not create a new run: {response}");
+    }
+    response
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .context("workflow create response missing run_id")
+}
+
+async fn wait_for_workflow_run_status(
+    http: &HttpClient,
+    base_url: &str,
+    run_id: &str,
+    expected_statuses: &[&str],
+) -> Result<Value> {
+    let deadline = Instant::now() + Duration::from_secs(25);
+    let mut last_run = Value::Null;
+
+    while Instant::now() < deadline {
+        let body = get_json_ok(http, format!("{base_url}/api/workflows/runs/{run_id}")).await?;
+        let run = body
+            .get("run")
+            .cloned()
+            .context("workflow run response missing run")?;
+        let status = run
+            .get("status")
+            .and_then(Value::as_str)
+            .context("workflow run missing status")?;
+        if expected_statuses.contains(&status) {
+            return Ok(run);
+        }
+        if matches!(status, "completed" | "failed" | "cancelled") {
+            bail!(
+                "workflow run {run_id} reached terminal status {status}, expected one of {:?}: {run}",
+                expected_statuses
+            );
+        }
+        last_run = run;
+        sleep(Duration::from_millis(250)).await;
+    }
+
+    bail!(
+        "workflow run {run_id} did not reach one of {:?} before timeout; last run: {last_run}",
+        expected_statuses
+    )
+}
+
+async fn wait_for_workflow_schedule(
+    http: &HttpClient,
+    base_url: &str,
+    schedule_id: &str,
+    should_exist: bool,
+) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut last_body = Value::Null;
+
+    while Instant::now() < deadline {
+        let body = get_json_ok(http, format!("{base_url}/api/workflows/schedules")).await?;
+        let present = body
+            .get("schedules")
+            .and_then(Value::as_array)
+            .context("workflow schedules response missing schedules")?
+            .iter()
+            .any(|schedule| {
+                schedule.get("schedule_id").and_then(Value::as_str) == Some(schedule_id)
+            });
+        if present == should_exist {
+            return Ok(());
+        }
+        last_body = body;
+        sleep(Duration::from_millis(250)).await;
+    }
+
+    let expectation = if should_exist { "appear" } else { "disappear" };
+    bail!("workflow schedule {schedule_id} did not {expectation}; last response: {last_body}")
+}
+
 fn parse_json(data: &str) -> Result<Value> {
     serde_json::from_str(data).with_context(|| format!("parse event payload as JSON: {data}"))
+}
+
+async fn get_json_ok(http: &HttpClient, url: impl AsRef<str>) -> Result<Value> {
+    let response = http
+        .get(url.as_ref())
+        .send()
+        .await
+        .with_context(|| format!("GET {}", url.as_ref()))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("GET {} returned {status}: {text}", url.as_ref());
+    }
+    response
+        .json::<Value>()
+        .await
+        .with_context(|| format!("parse GET {} response", url.as_ref()))
 }
 
 async fn post_json_ok(http: &HttpClient, url: impl AsRef<str>, body: Value) -> Result<Value> {

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -1,0 +1,454 @@
+use std::{env, fs, time::Duration};
+
+use anyhow::{Context, Result, bail};
+use eventsource_stream::Eventsource;
+use futures_util::StreamExt;
+use reqwest::{Client as HttpClient, StatusCode};
+use serde_json::{Value, json};
+use tokio::time::{Instant, sleep, timeout};
+use uuid::Uuid;
+
+const DEFAULT_API_URL: &str = "http://127.0.0.1:18080";
+const SOURCE_PATH: &str = "services/api-rs/crates/centaur-api-integration-test/src/main.rs";
+const TEST_MODEL: &str = "gpt-api-integration-test";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let base_url = env::var("CENTAUR_API_URL")
+        .unwrap_or_else(|_| DEFAULT_API_URL.to_owned())
+        .trim_end_matches('/')
+        .to_owned();
+    let http = HttpClient::new();
+
+    let mut results = Vec::new();
+
+    let line = line!() + 1;
+    record_result(
+        &mut results,
+        "API health endpoint responds",
+        line,
+        wait_for_health(&http, &base_url).await,
+    );
+
+    let line = line!() + 1;
+    record_result(
+        &mut results,
+        "Harness wire values match the API contract",
+        line,
+        test_harness_wire_values(&http, &base_url).await,
+    );
+
+    let line = line!() + 1;
+    record_result(
+        &mut results,
+        "Session execute forwards model context and completes",
+        line,
+        test_session_turn(&http, &base_url).await,
+    );
+
+    let line = line!() + 1;
+    record_result(
+        &mut results,
+        "Metrics expose API request counters",
+        line,
+        test_metrics(&http, &base_url).await,
+    );
+
+    write_report(&results)?;
+
+    if results.iter().all(|result| result.passed) {
+        println!("centaur-api integration test passed");
+        Ok(())
+    } else {
+        bail!("centaur-api integration test failed")
+    }
+}
+
+#[derive(Debug)]
+struct TestResult {
+    summary: &'static str,
+    line: u32,
+    passed: bool,
+}
+
+fn record_result(
+    results: &mut Vec<TestResult>,
+    summary: &'static str,
+    line: u32,
+    result: Result<()>,
+) {
+    match result {
+        Ok(()) => results.push(TestResult {
+            summary,
+            line,
+            passed: true,
+        }),
+        Err(error) => {
+            eprintln!("{summary}: {error:#}");
+            results.push(TestResult {
+                summary,
+                line,
+                passed: false,
+            });
+        }
+    }
+}
+
+fn write_report(results: &[TestResult]) -> Result<()> {
+    let report = render_report(results);
+    println!("{report}");
+    if let Ok(path) = env::var("API_INTEGRATION_TEST_REPORT")
+        && !path.trim().is_empty()
+    {
+        fs::write(&path, report)
+            .with_context(|| format!("write integration test report {path}"))?;
+    }
+    Ok(())
+}
+
+fn render_report(results: &[TestResult]) -> String {
+    let mut report = String::from("| Test | Result |\n| --- | --- |\n");
+    for result in results {
+        let status = if result.passed { "Passed" } else { "Failed" };
+        report.push_str(&format!(
+            "| [{}]({}) | {status} |\n",
+            result.summary,
+            source_link(result.line)
+        ));
+    }
+    report
+}
+
+fn source_link(line: u32) -> String {
+    match (
+        env::var("GITHUB_SERVER_URL"),
+        env::var("GITHUB_REPOSITORY"),
+        env::var("API_INTEGRATION_TEST_SOURCE_SHA").or_else(|_| env::var("GITHUB_SHA")),
+    ) {
+        (Ok(server), Ok(repository), Ok(sha))
+            if !server.is_empty() && !repository.is_empty() && !sha.is_empty() =>
+        {
+            format!("{server}/{repository}/blob/{sha}/{SOURCE_PATH}#L{line}")
+        }
+        _ => format!("{SOURCE_PATH}#L{line}"),
+    }
+}
+
+async fn wait_for_health(http: &HttpClient, base_url: &str) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let url = format!("{base_url}/healthz");
+    let mut last_error = String::new();
+
+    while Instant::now() < deadline {
+        match http.get(&url).send().await {
+            Ok(response) if response.status() == StatusCode::OK => {
+                let body = response
+                    .json::<Value>()
+                    .await
+                    .context("parse /healthz body")?;
+                if body.get("ok").and_then(Value::as_bool) == Some(true) {
+                    return Ok(());
+                }
+                last_error = format!("unexpected /healthz body: {body}");
+            }
+            Ok(response) => {
+                last_error = format!("/healthz returned {}", response.status());
+            }
+            Err(error) => {
+                last_error = error.to_string();
+            }
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    bail!("api did not become healthy at {url}: {last_error}")
+}
+
+async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<()> {
+    let cases = ["codex", "amp", "claudecode"];
+
+    for wire_value in cases {
+        let thread_key = test_thread_key(format!("harness-{wire_value}"))?;
+        let session = post_json_ok(
+            http,
+            session_url(base_url, &thread_key),
+            json!({
+                "harness_type": wire_value,
+                "metadata": {
+                    "source": "centaur-api-integration-test",
+                    "harness_wire_value": wire_value,
+                },
+            }),
+        )
+        .await
+        .with_context(|| format!("create {wire_value} session"))?;
+
+        if session.get("thread_key").and_then(Value::as_str) != Some(thread_key.as_str()) {
+            bail!("session thread key mismatch for {wire_value}");
+        }
+        if session.get("harness_type").and_then(Value::as_str) != Some(wire_value) {
+            bail!(
+                "session harness mismatch for {wire_value}: got {}",
+                session
+                    .get("harness_type")
+                    .and_then(Value::as_str)
+                    .unwrap_or("<missing>")
+            );
+        }
+        if session.get("status").and_then(Value::as_str) != Some("idle") {
+            bail!("new {wire_value} session was not idle: {session}");
+        }
+    }
+
+    let invalid_thread_key = test_thread_key("invalid-harness")?;
+    let invalid_response = http
+        .post(session_url(base_url, &invalid_thread_key))
+        .json(&json!({
+            "harness_type": "claude-code",
+            "metadata": {"source": "centaur-api-integration-test"},
+        }))
+        .send()
+        .await
+        .context("send invalid harness request")?;
+    if invalid_response.status() != StatusCode::UNPROCESSABLE_ENTITY {
+        let status = invalid_response.status();
+        let body = invalid_response.text().await.unwrap_or_default();
+        bail!("stale claude-code harness value returned {status}: {body}");
+    }
+
+    Ok(())
+}
+
+async fn test_session_turn(http: &HttpClient, base_url: &str) -> Result<()> {
+    let thread_key = test_thread_key("turn")?;
+    post_json_ok(
+        http,
+        session_url(base_url, &thread_key),
+        json!({
+            "harness_type": "codex",
+            "metadata": {
+                    "source": "centaur-api-integration-test",
+                    "purpose": "container-api-integration-test",
+            },
+            "on_harness_conflict": "restart",
+        }),
+    )
+    .await
+    .context("create executable session")?;
+
+    let append = post_json_ok(
+        http,
+        format!("{}/messages", session_url(base_url, &thread_key)),
+        json!({
+            "messages": [
+                {
+                    "client_message_id": "api-integration-test-message-1",
+                    "role": "user",
+                    "parts": [{"type": "text", "text": "Reply with exactly PONG."}],
+                    "metadata": {
+                        "source": "centaur-api-integration-test",
+                        "model": TEST_MODEL,
+                    },
+                },
+            ],
+        }),
+    )
+    .await
+    .context("append user message")?;
+    let message_ids = append
+        .get("message_ids")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or_default();
+    if append.get("ok").and_then(Value::as_bool) != Some(true) || message_ids != 1 {
+        bail!("append response was not successful: {append:?}");
+    }
+
+    let input_line = serde_json::to_string(&json!({
+        "type": "user",
+        "model": TEST_MODEL,
+        "trace_metadata": {
+            "source": "centaur-api-integration-test",
+            "action": "execute",
+        },
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": "Reply with exactly PONG."}],
+        },
+    }))
+    .context("serialize execute input line")?;
+
+    let first_execute = post_json_ok(
+        http,
+        format!("{}/execute", session_url(base_url, &thread_key)),
+        json!({
+            "idempotency_key": "api-integration-test-execute-1",
+            "metadata": {
+                    "source": "centaur-api-integration-test",
+                    "model": TEST_MODEL,
+            },
+            "input_lines": [input_line],
+            "idle_timeout_ms": 5_000,
+            "max_duration_ms": 15_000,
+        }),
+    )
+    .await
+    .context("execute session")?;
+    if first_execute.get("ok").and_then(Value::as_bool) != Some(true) {
+        bail!("execute response was not ok");
+    }
+    if first_execute.get("thread_key").and_then(Value::as_str) != Some(thread_key.as_str()) {
+        bail!("execute response thread key mismatch");
+    }
+    let execution_id = first_execute
+        .get("execution_id")
+        .and_then(Value::as_str)
+        .context("execute response missing execution_id")?
+        .to_owned();
+
+    let replay = post_json_ok(
+        http,
+        format!("{}/execute", session_url(base_url, &thread_key)),
+        json!({
+            "idempotency_key": "api-integration-test-execute-1",
+            "metadata": {"source": "centaur-api-integration-test", "replay": true},
+            "input_lines": [],
+            "idle_timeout_ms": 5_000,
+            "max_duration_ms": 15_000,
+        }),
+    )
+    .await
+    .context("replay idempotent execute")?;
+    if replay.get("execution_id").and_then(Value::as_str) != Some(execution_id.as_str()) {
+        bail!(
+            "idempotent execute returned different execution id: {} vs {}",
+            replay
+                .get("execution_id")
+                .and_then(Value::as_str)
+                .unwrap_or("<missing>"),
+            execution_id
+        );
+    }
+
+    let response = http
+        .get(format!(
+            "{}/events?after_event_id=0",
+            session_url(base_url, &thread_key)
+        ))
+        .send()
+        .await
+        .context("open session event stream")?;
+    if response.status() != StatusCode::OK {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        bail!("open session event stream returned {status}: {body}");
+    }
+    let mut events = response.bytes_stream().eventsource();
+    timeout(Duration::from_secs(20), async {
+        let mut saw_model_input = false;
+        let mut saw_output = false;
+        while let Some(event) = events.next().await {
+            let event = event.context("read session event")?;
+            match event.event.as_str() {
+                "session.output.line" => {
+                    let line = parse_json(&event.data)?;
+                    let line_type = line.get("type").and_then(Value::as_str);
+                    if line_type == Some("user")
+                        && line.get("model").and_then(Value::as_str) == Some(TEST_MODEL)
+                        && line.get("thread_key").and_then(Value::as_str)
+                            == Some(thread_key.as_str())
+                    {
+                        saw_model_input = true;
+                    }
+                    if line_type == Some("item.agentMessage.delta")
+                        && line
+                            .get("delta")
+                            .and_then(Value::as_str)
+                            .is_some_and(|delta| delta.contains("PONG"))
+                    {
+                        saw_output = true;
+                    }
+                }
+                "session.execution_completed" => {
+                    let payload = parse_json(&event.data)?;
+                    if payload.get("execution_id").and_then(Value::as_str)
+                        == Some(execution_id.as_str())
+                    {
+                        if !saw_model_input {
+                            bail!("execution completed before the model input line was observed");
+                        }
+                        if !saw_output {
+                            bail!("execution completed before a PONG output line was observed");
+                        }
+                        return Ok(());
+                    }
+                }
+                "session.execution_failed" | "session.execution_cancelled" => {
+                    bail!("execution reached terminal failure event: {}", event.data);
+                }
+                _ => {}
+            }
+        }
+        bail!("session event stream ended before execution completed")
+    })
+    .await
+    .context("timed out waiting for session execution completion")??;
+
+    Ok(())
+}
+
+async fn test_metrics(http: &HttpClient, base_url: &str) -> Result<()> {
+    let response = http
+        .get(format!("{base_url}/metrics"))
+        .send()
+        .await
+        .context("request /metrics")?;
+    if response.status() != StatusCode::OK {
+        bail!("/metrics returned {}", response.status());
+    }
+    let body = response.text().await.context("read /metrics body")?;
+    for needle in [
+        r#"http_server_requests_total{method="GET",route="/healthz",status="200"}"#,
+        r#"http_server_requests_total{method="POST",route="/api/session/{thread_key}",status="200"}"#,
+        r#"http_server_requests_total{method="POST",route="/api/session/{thread_key}/execute",status="200"}"#,
+    ] {
+        if !body.contains(needle) {
+            bail!("missing expected metric {needle:?}");
+        }
+    }
+    Ok(())
+}
+
+fn parse_json(data: &str) -> Result<Value> {
+    serde_json::from_str(data).with_context(|| format!("parse event payload as JSON: {data}"))
+}
+
+async fn post_json_ok(http: &HttpClient, url: impl AsRef<str>, body: Value) -> Result<Value> {
+    let response = http
+        .post(url.as_ref())
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("POST {}", url.as_ref()))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("POST {} returned {status}: {text}", url.as_ref());
+    }
+    response
+        .json::<Value>()
+        .await
+        .with_context(|| format!("parse POST {} response", url.as_ref()))
+}
+
+fn test_thread_key(suffix: impl AsRef<str>) -> Result<String> {
+    Ok(format!(
+        "api-integration-test:{}:{}",
+        Uuid::new_v4().simple(),
+        suffix.as_ref()
+    ))
+}
+
+fn session_url(base_url: &str, thread_key: &str) -> String {
+    format!("{base_url}/api/session/{thread_key}")
+}

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -263,7 +263,7 @@ async fn test_session_turn(http: &HttpClient, base_url: &str) -> Result<()> {
             "harness_type": HarnessType::Codex,
             "metadata": {
                     "source": "centaur-api-integration-test",
-                    "purpose": "container-api-integration-test",
+                    "purpose": "api-integration-test",
             },
             "on_harness_conflict": "restart",
         }),

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1612,7 +1612,8 @@ impl SandboxWorkloadMode {
         match self {
             Self::MockAppServer { image } => SandboxSpec::new(image)
                 .command(["/bin/sh", "-lc"])
-                .args([mock_app_server_script()]),
+                .args([mock_app_server_script()])
+                .env("CENTAUR_HARNESS_TYPE", harness.as_ref()),
             Self::CodexAppServer {
                 image, env, mounts, ..
             } => {
@@ -1654,7 +1655,9 @@ fn sandbox_spec_key(spec: &SandboxSpec) -> String {
 
 fn mock_app_server_script() -> &'static str {
     r#"while IFS= read -r line; do
-printf '%s\n' "$line"
+model="$(printf '%s\n' "$line" | sed -n 's/.*"model":"\([^"]*\)".*/\1/p')"
+[ -n "$model" ] || model="unknown"
+harness="${CENTAUR_HARNESS_TYPE:-unknown}"
 printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"startup"}'
 sleep 0.2
 printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"app_server_started"}'
@@ -1666,7 +1669,7 @@ while [ "$turn_index" -le 3 ]; do
   turn_id="mock-turn-$turn_index"
   printf '{"type":"turn.started","turn_id":"%s"}\n' "$turn_id"
   sleep 0.2
-  printf '{"type":"item.agentMessage.delta","turnId":"%s","session_id":"mock-codex-thread","delta":"PONG %s"}\n' "$turn_id" "$turn_index"
+  printf '{"type":"item.agentMessage.delta","turnId":"%s","session_id":"mock-codex-thread","delta":"PONG model=%s harness=%s"}\n' "$turn_id" "$model" "$harness"
   sleep 0.2
   printf '{"type":"turn.completed","turn":{"id":"%s"},"usage":{"input_tokens":0,"output_tokens":1}}\n' "$turn_id"
   sleep 0.2

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1654,6 +1654,7 @@ fn sandbox_spec_key(spec: &SandboxSpec) -> String {
 
 fn mock_app_server_script() -> &'static str {
     r#"while IFS= read -r line; do
+printf '%s\n' "$line"
 printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"startup"}'
 sleep 0.2
 printf '%s\n' '{"type":"system","subtype":"wrapper_heartbeat","phase":"app_server_started"}'


### PR DESCRIPTION
## Summary
- add a Rust API integration-test client that hits the built api-rs image
- run it from publish-images after loading the api-rs build into Docker
- upsert a PR comment table with linkified Passed/Failed rows

## Testing
- cargo fmt --all --check
- cargo check --locked -p centaur-api-integration-test
- cargo clippy -p centaur-api-integration-test -- -D warnings
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-images.yml"); puts "workflow yaml ok"'
- git diff --check
- local Docker/ParadeDB/API integration run