### PR TITLE
feat: assign roles and secrets to a principal from the console

### DIFF
--- a/services/console/app/controllers/console/base_secrets_controller.rb
+++ b/services/console/app/controllers/console/base_secrets_controller.rb
@@ -11,7 +11,7 @@ module Console
     layout "console"
 
     before_action :assign_kind
-    before_action :set_secret, only: %i[edit update]
+    before_action :set_secret, only: %i[edit update destroy]
 
     def new
       @secret = model.new(namespace: "default")
@@ -35,6 +35,18 @@ module Console
         redirect_to console_secret_path(kind, @secret.oid), notice: "Secret updated."
       else
         render :edit, status: :unprocessable_entity
+      end
+    end
+
+    # Destroys the secret and its dependents (source, rules, and any grants of it,
+    # via dependent: :destroy). A managed wrapper can be deleted here too; the OAuth
+    # flow recreates it on the next consent.
+    def destroy
+      if @secret.destroy
+        redirect_to console_secrets_path, notice: "Secret deleted."
+      else
+        redirect_to console_secret_path(kind, @secret.oid),
+                    alert: @secret.errors.full_messages.to_sentence.presence || "Could not delete secret."
       end
     end
 

--- a/services/console/app/controllers/console/principals_controller.rb
+++ b/services/console/app/controllers/console/principals_controller.rb
@@ -15,6 +15,10 @@ module Console
       @principal.principal_roles.find_or_create_by!(role: role)
       redirect_to console_principal_path(@principal.oid),
                   notice: "Assigned role #{role_label(role)}."
+    rescue ActiveRecord::RecordNotUnique
+      # A concurrent submit already created the assignment; the end state is what
+      # the operator asked for, so report success rather than 500.
+      redirect_to console_principal_path(@principal.oid), notice: "Assigned role #{role_label(role)}."
     rescue ActiveRecord::RecordInvalid => e
       redirect_to console_principal_path(@principal.oid), alert: e.record.errors.full_messages.to_sentence
     end
@@ -33,6 +37,10 @@ module Console
       @principal.grants.create_with(created_by: current_user).find_or_create_by!(grantable_assoc(secret) => secret)
       redirect_to console_principal_path(@principal.oid),
                   notice: "Granted #{secret_label(secret)}."
+    rescue ActiveRecord::RecordNotUnique
+      # A concurrent submit already created the grant; the secret is granted either
+      # way, so report success rather than 500.
+      redirect_to console_principal_path(@principal.oid), notice: "Granted #{secret_label(secret)}."
     rescue ActiveRecord::RecordInvalid => e
       redirect_to console_principal_path(@principal.oid), alert: e.record.errors.full_messages.to_sentence
     end

--- a/services/console/app/controllers/console/principals_controller.rb
+++ b/services/console/app/controllers/console/principals_controller.rb
@@ -1,0 +1,75 @@
+module Console
+  # Mutations for the principal detail page: assign/unassign roles and grant/revoke
+  # secrets directly. The read-only show action lives on ConsoleController; this
+  # controller only handles the POST/DELETE actions wired from that page. Gated by
+  # the app-wide require_login (not admin -- mirrors the secret/credential forms).
+  class PrincipalsController < ApplicationController
+    include SecretKinds
+
+    layout "console"
+
+    before_action :set_principal
+
+    def assign_role
+      role = Role.find_by_oid!(params[:role_id])
+      @principal.principal_roles.find_or_create_by!(role: role)
+      redirect_to console_principal_path(@principal.oid),
+                  notice: "Assigned role #{role_label(role)}."
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to console_principal_path(@principal.oid), alert: e.record.errors.full_messages.to_sentence
+    end
+
+    def unassign_role
+      role = Role.find_by_oid!(params[:role_id])
+      @principal.principal_roles.find_by!(role: role).destroy!
+      redirect_to console_principal_path(@principal.oid),
+                  notice: "Unassigned role #{role_label(role)}."
+    end
+
+    def grant_secret
+      secret = resolve_grantable(params[:grantable])
+      return redirect_to console_principal_path(@principal.oid), alert: "Pick a secret to grant." unless secret
+
+      @principal.grants.create_with(created_by: current_user).find_or_create_by!(grantable_assoc(secret) => secret)
+      redirect_to console_principal_path(@principal.oid),
+                  notice: "Granted #{secret_label(secret)}."
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to console_principal_path(@principal.oid), alert: e.record.errors.full_messages.to_sentence
+    end
+
+    def revoke_grant
+      grant = @principal.grants.find_by_oid!(params[:grant_id])
+      grant.destroy!
+      redirect_to console_principal_path(@principal.oid), notice: "Revoked grant."
+    end
+
+    private
+
+    # Parse the "<kind>:<oid>" value from the grant dropdown into a secret record.
+    # Returns nil for a blank/unknown selection so the action can flash and bail.
+    def resolve_grantable(value)
+      kind, oid = value.to_s.split(":", 2)
+      cfg = SECRET_KINDS[kind]
+      return nil if cfg.nil? || oid.blank?
+      cfg[:model].find_by_oid!(oid)
+    end
+
+    # The Grant belongs_to association for a grantable record, e.g. a StaticSecret
+    # maps to :static_secret. The class name underscores directly to the assoc.
+    def grantable_assoc(secret)
+      secret.class.name.underscore.to_sym
+    end
+
+    def role_label(role)
+      role.name.presence || role.foreign_id.presence || role.oid
+    end
+
+    def secret_label(secret)
+      secret.try(:name).presence || secret.foreign_id.presence || secret.oid
+    end
+
+    def set_principal
+      @principal = Principal.find_by_oid!(params[:id])
+    end
+  end
+end

--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -31,6 +31,17 @@ class ConsoleController < ApplicationController
       "pg_dsn" => @principal.granted_pg_dsn_secrets,
       "hmac" => @principal.granted_hmac_secrets
     }
+    # Direct grants (revocable here) -- distinct from @granted, which also folds in
+    # grants inherited from roles.
+    @direct_grants = @principal.grants
+      .includes(Grant::GRANTABLE_ASSOCIATIONS)
+      .order(:id)
+    # Assignment options for the inline forms. Roles/secrets span all namespaces;
+    # the namespace is shown as a label on each option.
+    @assignable_roles = Role.where.not(id: @principal.role_ids).order(:namespace, :id)
+    @assignable_secrets = SECRET_KINDS.transform_values do |cfg|
+      cfg[:model].order(:namespace, :id)
+    end
   end
 
   def secrets

--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -90,8 +90,8 @@ class ConsoleController < ApplicationController
 
   def credential
     @credential = BrokerCredential.find_by_oid!(params[:id])
-    # The grantable static secret(s) wrapping this credential, for the cross-link.
-    @wrapping_secrets = @credential.static_secrets.order(:id)
+    # The grantable static secret wrapping this credential, for the cross-link.
+    @wrapping_secret = @credential.static_secret
   end
 
   # Registered OAuth apps and the consent flows they drive. Like credentials,

--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -36,6 +36,17 @@ class ConsoleController < ApplicationController
     @direct_grants = @principal.grants
       .includes(Grant::GRANTABLE_ASSOCIATIONS)
       .order(:id)
+    # How each effective secret is reached, for the Source column: keyed by
+    # [kind, secret_id], a list of { type: :direct } / { type: :role, role: } --
+    # a secret can be granted directly and/or through one or more roles.
+    @grant_sources = Hash.new { |h, k| h[k] = [] }
+    @principal.effective_grants.includes(:role).each do |grant|
+      assoc = Grant::GRANTABLE_ASSOCIATIONS.find { |a| grant.public_send("#{a}_id") }
+      next unless assoc
+      kind = assoc.to_s.delete_suffix("_secret")
+      @grant_sources[[ kind, grant.public_send("#{assoc}_id") ]] <<
+        (grant.role ? { type: :role, role: grant.role } : { type: :direct })
+    end
     # Assignment options for the inline forms. Roles/secrets span all namespaces;
     # the namespace is shown as a label on each option.
     @assignable_roles = Role.where.not(id: @principal.role_ids).order(:namespace, :id)

--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -48,10 +48,18 @@ class ConsoleController < ApplicationController
         (grant.role ? { type: :role, role: grant.role } : { type: :direct })
     end
     # Assignment options for the inline forms. Roles/secrets span all namespaces;
-    # the namespace is shown as a label on each option.
+    # the namespace is shown as a label on each option. Already-directly-granted
+    # secrets are filtered out of the grant dropdown (they're in the table above);
+    # a role-inherited secret stays offered, so it can be promoted to a direct grant.
     @assignable_roles = Role.where.not(id: @principal.role_ids).order(:namespace, :id)
-    @assignable_secrets = SECRET_KINDS.transform_values do |cfg|
-      cfg[:model].order(:namespace, :id)
+    granted_ids = Hash.new { |h, k| h[k] = [] }
+    @direct_grants.each do |grant|
+      assoc = Grant::GRANTABLE_ASSOCIATIONS.find { |a| grant.public_send("#{a}_id") }
+      next unless assoc
+      granted_ids[assoc.to_s.delete_suffix("_secret")] << grant.public_send("#{assoc}_id")
+    end
+    @assignable_secrets = SECRET_KINDS.each_with_object({}) do |(kind, cfg), acc|
+      acc[kind] = cfg[:model].where.not(id: granted_ids[kind]).order(:namespace, :id)
     end
   end
 

--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -46,7 +46,11 @@ class ConsoleController < ApplicationController
 
   def secrets
     @secrets_by_kind = SECRET_KINDS.transform_values do |cfg|
-      cfg[:model].includes(cfg[:includes]).order(created_at: :asc, id: :asc)
+      rel = cfg[:model].includes(cfg[:includes]).order(created_at: :asc, id: :asc)
+      # Static secrets may wrap a broker credential (the "managed" badge); eager
+      # load the credential and its app so the list doesn't fan out per row.
+      rel = rel.includes(broker_credential: :oauth_app) if cfg[:model] == StaticSecret
+      rel
     end
   end
 
@@ -67,6 +71,8 @@ class ConsoleController < ApplicationController
 
   def credential
     @credential = BrokerCredential.find_by_oid!(params[:id])
+    # The grantable static secret(s) wrapping this credential, for the cross-link.
+    @wrapping_secrets = @credential.static_secrets.order(:id)
   end
 
   # Registered OAuth apps and the consent flows they drive. Like credentials,

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -175,8 +175,36 @@ module Oauth
         )
         credential.next_attempt_at = credential.compute_next_attempt_at(now: now)
         credential.save!
+        ensure_wrapping_secret(credential)
         credential
       end
+    end
+
+    # Wraps a minted credential in a grantable static secret, so an operator can
+    # grant the integration's token to a principal straight from the console (a
+    # broker credential is not grantable on its own). The secret injects the live
+    # access token as `Authorization: Bearer <token>` through a token_broker source
+    # pointing at the credential, scoped to the provider's API hosts. The token
+    # stays fresh because the source resolves the credential live at sync time.
+    #
+    # Created once per credential (keyed on the broker_credential association) and
+    # left untouched on re-consent, so any operator edits -- a different header,
+    # extra rules -- survive. Has no created_by: the unauthenticated flow has no
+    # current user, like the credential it wraps.
+    def ensure_wrapping_secret(credential)
+      secret = StaticSecret.find_or_initialize_by(broker_credential: credential)
+      return secret unless secret.new_record?
+
+      secret.namespace = credential.namespace
+      secret.foreign_id = credential.foreign_id
+      secret.name = "#{credential.name} token"
+      secret.inject_config = { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+      secret.source = SecretSource.new(source_type: "token_broker", config: { "credential_id" => credential.oid })
+      secret.rules = Array(@provider.api_hosts).each_with_index.map do |host, position|
+        RequestRule.new(host: host, http_methods: [], paths: [], position: position)
+      end
+      secret.save!
+      secret
     end
 
     def read_and_clear_flow_cookie

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -98,6 +98,11 @@ module Oauth
       # credential. Log the messages only -- never token values.
       Rails.logger.error { "oauth flow credential save failed: #{e.record.errors.full_messages.to_sentence}" }
       render_result(:error, message: "Connecting the integration failed while saving the credential.")
+    rescue ActiveRecord::RecordNotUnique
+      # A concurrent consent for the same account won the unique index on the
+      # credential or its wrapping secret. The winner's record is already saved, so
+      # the user just needs to retry; the next consent upserts cleanly.
+      render_result(:error, message: "Another consent for this account is in progress. Try again.")
     end
 
     private
@@ -187,16 +192,17 @@ module Oauth
     # pointing at the credential, scoped to the provider's API hosts. The token
     # stays fresh because the source resolves the credential live at sync time.
     #
-    # Created once per credential (keyed on the broker_credential association) and
-    # left untouched on re-consent, so any operator edits -- a different header,
-    # extra rules -- survive. Has no created_by: the unauthenticated flow has no
-    # current user, like the credential it wraps.
+    # Created once per credential (keyed on the broker_credential association, which
+    # a unique index enforces) and left untouched on re-consent, so any operator
+    # edits -- a different header, extra rules -- survive. Has no created_by: the
+    # unauthenticated flow has no current user, like the credential it wraps. Left
+    # without a foreign_id: it is found by association, and copying the credential's
+    # would risk colliding with an operator-created secret.
     def ensure_wrapping_secret(credential)
       secret = StaticSecret.find_or_initialize_by(broker_credential: credential)
       return secret unless secret.new_record?
 
       secret.namespace = credential.namespace
-      secret.foreign_id = credential.foreign_id
       secret.name = "#{credential.name} token"
       secret.inject_config = { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
       secret.source = SecretSource.new(source_type: "token_broker", config: { "credential_id" => credential.oid })

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -23,6 +23,16 @@ module ApplicationHelper
     end
   end
 
+  # The broker credential a record wraps when it is an OAuth-flow-managed static
+  # secret; nil for ordinary secrets and for non-static kinds. Drives the "managed"
+  # badge and the credential <-> secret cross-links. Lives in a helper (not a
+  # controller helper_method) so it is available to both the ConsoleController
+  # views and the Console::BaseSecretsController edit form.
+  def managed_credential(record)
+    return nil unless record.respond_to?(:broker_credential)
+    record.broker_credential
+  end
+
   # The muted secondary line shown under a record's primary identifier in console
   # tables: the namespace, optionally preceded by the opaque oid and a small dot.
   # Pass oid: when the primary line is the foreign_id (so the oid still shows);

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -38,10 +38,11 @@ class BrokerCredential < ApplicationRecord
   # Set on credentials minted by the OAuth consent flow; they delegate their
   # client_id/client_secret to the app (see #effective_client_secret).
   belongs_to :oauth_app, optional: true
-  # Grantable static secrets wrapping this credential (the OAuth consent flow
-  # auto-creates one). Nullify on delete -- the before_destroy guard below already
-  # blocks deletion while a token_broker source still references the credential.
-  has_many :static_secrets, dependent: :nullify
+  # The grantable static secret wrapping this credential (the OAuth consent flow
+  # auto-creates one; at most one, enforced by a unique index). Nullify on delete --
+  # the before_destroy guard below already blocks deletion while a token_broker
+  # source still references the credential.
+  has_one :static_secret, dependent: :nullify
 
   attr_writer :refresh_client
 

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -38,6 +38,10 @@ class BrokerCredential < ApplicationRecord
   # Set on credentials minted by the OAuth consent flow; they delegate their
   # client_id/client_secret to the app (see #effective_client_secret).
   belongs_to :oauth_app, optional: true
+  # Grantable static secrets wrapping this credential (the OAuth consent flow
+  # auto-creates one). Nullify on delete -- the before_destroy guard below already
+  # blocks deletion while a token_broker source still references the credential.
+  has_many :static_secrets, dependent: :nullify
 
   attr_writer :refresh_client
 

--- a/services/console/app/models/static_secret.rb
+++ b/services/console/app/models/static_secret.rb
@@ -38,7 +38,14 @@ class StaticSecret < ApplicationRecord
 
   has_one :source, class_name: "SecretSource", dependent: :destroy
   has_many :rules, class_name: "RequestRule", dependent: :destroy
-  belongs_to :created_by, class_name: "User"
+  # Optional: a static secret auto-created by the OAuth consent flow has no console
+  # operator behind it (the public flow runs unauthenticated), like the credential
+  # it wraps.
+  belongs_to :created_by, class_name: "User", optional: true
+  # Set when this secret wraps a managed broker credential (auto-created by the
+  # OAuth consent flow). The token_broker source carries the credential_id the
+  # proxy resolves at sync; this association is the console-level link.
+  belongs_to :broker_credential, optional: true
 
   # Maps to a single entry in the iron-proxy `secrets` transform array. The
   # caller is responsible for skipping secrets without a source.

--- a/services/console/app/views/console/base_secrets/edit.html.erb
+++ b/services/console/app/views/console/base_secrets/edit.html.erb
@@ -9,5 +9,14 @@
   </div>
 </div>
 
+<% if (cred = managed_credential(@secret)) %>
+  <div class="mb-6 rounded-lg border border-amber-500/40 bg-amber-500/[0.06] px-4 py-3 text-sm text-amber-200/90">
+    <span class="font-semibold">Managed secret.</span>
+    Maintained by the
+    <% if cred.oauth_app %><%= cred.oauth_app.slug %> <% end %>OAuth integration (broker credential <%= cred.oid %>).
+    You can tighten its request rules, but changing or removing the token_broker source stops token delivery, and re-consent will not repair it.
+  </div>
+<% end %>
+
 <%= render "errors", secret: @secret %>
 <%= render "form_#{@kind}", secret: @secret %>

--- a/services/console/app/views/console/base_secrets/edit.html.erb
+++ b/services/console/app/views/console/base_secrets/edit.html.erb
@@ -6,6 +6,9 @@
   <div class="mt-2 flex flex-wrap items-center gap-3">
     <h1 class="page-title">Edit <%= title %></h1>
     <span class="resource-badge"><%= secret_kind_label(@kind) %></span>
+    <%= button_to "Delete", [ :console, @secret ], method: :delete,
+          class: "ml-auto cursor-pointer rounded border border-red-500/40 px-3 py-1.5 text-sm text-red-300 transition-colors hover:border-red-500/60 hover:bg-red-500/10",
+          data: { turbo_confirm: "Delete this secret? Any grants of it are removed too. This cannot be undone." } %>
   </div>
 </div>
 

--- a/services/console/app/views/console/base_secrets/edit.html.erb
+++ b/services/console/app/views/console/base_secrets/edit.html.erb
@@ -6,9 +6,6 @@
   <div class="mt-2 flex flex-wrap items-center gap-3">
     <h1 class="page-title">Edit <%= title %></h1>
     <span class="resource-badge"><%= secret_kind_label(@kind) %></span>
-    <%= button_to "Delete", [ :console, @secret ], method: :delete,
-          class: "ml-auto cursor-pointer rounded border border-red-500/40 px-3 py-1.5 text-sm text-red-300 transition-colors hover:border-red-500/60 hover:bg-red-500/10",
-          data: { turbo_confirm: "Delete this secret? Any grants of it are removed too. This cannot be undone." } %>
   </div>
 </div>
 

--- a/services/console/app/views/console/credential.html.erb
+++ b/services/console/app/views/console/credential.html.erb
@@ -87,10 +87,10 @@
   <p class="-mt-6 mb-8 text-xs text-zinc-600">Client id and secret are inherited from the OAuth app; rotating the app's secret applies here.</p>
 <% end %>
 
-<% if @wrapping_secrets.any? %>
-  <%= def_section.call("Grantable As", @wrapping_secrets.map { |s|
-    [ "Static secret", link_to(s.name.presence || s.foreign_id.presence || s.oid, console_secret_path("static", s.oid), class: "console-link") ]
-  }) %>
+<% if @wrapping_secret %>
+  <%= def_section.call("Grantable As", [
+    [ "Static secret", link_to(@wrapping_secret.name.presence || @wrapping_secret.foreign_id.presence || @wrapping_secret.oid, console_secret_path("static", @wrapping_secret.oid), class: "console-link") ]
+  ]) %>
   <p class="-mt-6 mb-8 text-xs text-zinc-600">Grant this credential to a principal by granting the static secret above; it injects the live token into matching requests.</p>
 <% end %>
 

--- a/services/console/app/views/console/credential.html.erb
+++ b/services/console/app/views/console/credential.html.erb
@@ -87,6 +87,13 @@
   <p class="-mt-6 mb-8 text-xs text-zinc-600">Client id and secret are inherited from the OAuth app; rotating the app's secret applies here.</p>
 <% end %>
 
+<% if @wrapping_secrets.any? %>
+  <%= def_section.call("Grantable As", @wrapping_secrets.map { |s|
+    [ "Static secret", link_to(s.name.presence || s.foreign_id.presence || s.oid, console_secret_path("static", s.oid), class: "console-link") ]
+  }) %>
+  <p class="-mt-6 mb-8 text-xs text-zinc-600">Grant this credential to a principal by granting the static secret above; it injects the live token into matching requests.</p>
+<% end %>
+
 <%= def_section.call("Metadata", [
   [ "Created", local_time(@credential.created_at) ],
   [ "Updated", local_time(@credential.updated_at) ]

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -153,7 +153,9 @@
                 <td class="console-td-nowrap">
                   <span class="resource-badge"><%= secret_kind_label(kind) %></span>
                 </td>
-                <td class="console-td-nowrap text-centaur-400"><%= s.oid %></td>
+                <td class="console-td-nowrap">
+                  <%= link_to s.oid, console_secret_path(kind, s.oid), class: "console-link" %>
+                </td>
                 <td class="console-td-nowrap text-zinc-300"><%= s.foreign_id || "—" %></td>
                 <td class="console-td-nowrap text-zinc-100"><%= s.try(:name).presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
                 <td class="console-td-nowrap">

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -27,23 +27,102 @@
 <section class="mb-8">
   <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Assigned Roles</h2>
   <% if @roles.any? %>
-    <div class="flex flex-wrap gap-2">
+    <div class="mb-4 flex flex-wrap gap-2">
       <% @roles.each do |r| %>
         <span class="inline-flex items-center gap-2 rounded-lg border border-ink-600 bg-ink-800 px-3 py-1.5 text-sm">
           <span class="text-centaur-400"><%= r.oid %></span>
           <span class="text-zinc-300"><%= r.name.presence || r.foreign_id %></span>
+          <%= button_to "×", console_principal_unassign_role_path(@principal.oid, r.oid), method: :delete,
+                form: { class: "inline", data: { turbo_confirm: "Unassign #{r.name.presence || r.foreign_id} from this principal?" } },
+                class: "cursor-pointer leading-none text-zinc-500 transition-colors hover:text-red-400",
+                title: "Unassign role" %>
         </span>
       <% end %>
     </div>
   <% else %>
-    <p class="text-sm text-zinc-600">No roles assigned.</p>
+    <p class="mb-4 text-sm text-zinc-600">No roles assigned.</p>
+  <% end %>
+
+  <% if @assignable_roles.any? %>
+    <%= form_with url: console_principal_assign_role_path(@principal.oid), method: :post, data: { turbo: false } do %>
+      <div class="flex flex-wrap items-center gap-3">
+        <select name="role_id" class="form-input max-w-md">
+          <% @assignable_roles.each do |r| %>
+            <option value="<%= r.oid %>"><%= r.name.presence || r.foreign_id.presence || r.oid %> (<%= r.namespace %>)</option>
+          <% end %>
+        </select>
+        <%= submit_tag "Assign role", class: "btn-primary" %>
+      </div>
+    <% end %>
+  <% else %>
+    <p class="text-sm text-zinc-600">No more roles available to assign.</p>
+  <% end %>
+</section>
+
+<!-- Direct grants -->
+<section class="mb-8">
+  <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Direct Grants</h2>
+  <p class="mb-4 text-sm text-zinc-500">Secrets granted to this principal directly. Grants inherited from roles are managed on the role, not here.</p>
+
+  <% if @direct_grants.any? %>
+    <div class="console-panel mb-4">
+      <table class="console-table">
+        <thead class="console-table-head">
+          <tr>
+            <th class="console-th">Type</th>
+            <th class="console-th">ID</th>
+            <th class="console-th">Foreign ID</th>
+            <th class="console-th">Name</th>
+            <th class="console-th text-right"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-ink-700">
+          <% @direct_grants.each do |grant| %>
+            <% s = grant.grantable %>
+            <tr class="console-row-hover">
+              <td class="console-td-nowrap">
+                <span class="resource-badge"><%= secret_kind_label(s.class.name.underscore.delete_suffix("_secret")) %></span>
+              </td>
+              <td class="console-td-nowrap text-centaur-400"><%= s.oid %></td>
+              <td class="console-td-nowrap text-zinc-300"><%= s.foreign_id || "—" %></td>
+              <td class="console-td-nowrap text-zinc-100"><%= s.try(:name).presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
+              <td class="console-td-nowrap text-right">
+                <%= button_to "Revoke", console_principal_revoke_grant_path(@principal.oid, grant.oid), method: :delete,
+                      form: { data: { turbo_confirm: "Revoke this grant?" } },
+                      class: "cursor-pointer rounded border border-ink-600 px-3 py-1.5 text-zinc-400 transition-colors hover:border-red-500/40 hover:text-red-300" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="mb-4 rounded-xl border border-dashed border-ink-600 bg-ink-850/40 px-5 py-10 text-center text-zinc-600">
+      No direct grants. Use the form below to grant a secret.
+    </div>
+  <% end %>
+
+  <%= form_with url: console_principal_grant_secret_path(@principal.oid), method: :post, data: { turbo: false } do %>
+    <div class="flex flex-wrap items-center gap-3">
+      <select name="grantable" class="form-input max-w-md">
+        <% @assignable_secrets.each do |kind, secrets| %>
+          <% next if secrets.empty? %>
+          <optgroup label="<%= secret_kind_label(kind) %>">
+            <% secrets.each do |s| %>
+              <option value="<%= kind %>:<%= s.oid %>"><%= s.try(:name).presence || s.foreign_id.presence || s.oid %> (<%= s.namespace %>)</option>
+            <% end %>
+          </optgroup>
+        <% end %>
+      </select>
+      <%= submit_tag "Grant secret", class: "btn-primary" %>
+    </div>
   <% end %>
 </section>
 
 <!-- Effective grants -->
 <section>
   <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Effective Grants</h2>
-  <p class="mb-4 text-sm text-zinc-500">Every secret this principal resolves to: direct grants plus grants inherited from its roles.</p>
+  <p class="mb-4 text-sm text-zinc-500">Every secret this principal resolves to: the direct grants above plus grants inherited from its roles. Read-only.</p>
 
   <% total = @granted.values.sum(&:size) %>
   <% if total.zero? %>

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -79,11 +79,14 @@
         <tbody class="divide-y divide-ink-700">
           <% @direct_grants.each do |grant| %>
             <% s = grant.grantable %>
+            <% kind = s.class.name.underscore.delete_suffix("_secret") %>
             <tr class="console-row-hover">
               <td class="console-td-nowrap">
-                <span class="resource-badge"><%= secret_kind_label(s.class.name.underscore.delete_suffix("_secret")) %></span>
+                <span class="resource-badge"><%= secret_kind_label(kind) %></span>
               </td>
-              <td class="console-td-nowrap text-centaur-400"><%= s.oid %></td>
+              <td class="console-td-nowrap">
+                <%= link_to s.oid, console_secret_path(kind, s.oid), class: "console-link" %>
+              </td>
               <td class="console-td-nowrap text-zinc-300"><%= s.foreign_id || "—" %></td>
               <td class="console-td-nowrap text-zinc-100"><%= s.try(:name).presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
               <td class="console-td-nowrap text-right">

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -138,11 +138,14 @@
             <th class="console-th">ID</th>
             <th class="console-th">Foreign ID</th>
             <th class="console-th">Name</th>
+            <th class="console-th">Source</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-ink-700">
           <% @granted.each do |kind, records| %>
             <% records.each do |s| %>
+              <% sources = @grant_sources[[ kind, s.id ]] %>
+              <% roles = sources.select { |x| x[:type] == :role }.map { |x| x[:role] }.uniq %>
               <tr class="console-row-hover">
                 <td class="console-td-nowrap">
                   <span class="resource-badge"><%= secret_kind_label(kind) %></span>
@@ -150,6 +153,17 @@
                 <td class="console-td-nowrap text-centaur-400"><%= s.oid %></td>
                 <td class="console-td-nowrap text-zinc-300"><%= s.foreign_id || "—" %></td>
                 <td class="console-td-nowrap text-zinc-100"><%= s.try(:name).presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
+                <td class="console-td-nowrap">
+                  <div class="flex flex-wrap gap-1">
+                    <% if sources.any? { |x| x[:type] == :direct } %>
+                      <span class="inline-flex items-center rounded bg-centaur-500/10 px-2 py-0.5 text-[11px] text-centaur-300 ring-1 ring-centaur-500/30">direct</span>
+                    <% end %>
+                    <% roles.each do |r| %>
+                      <span class="inline-flex items-center rounded bg-ink-700 px-2 py-0.5 text-[11px] text-zinc-300 ring-1 ring-ink-600"
+                            title="<%= r.oid %>">via <%= r.name.presence || r.foreign_id || r.oid %></span>
+                    <% end %>
+                  </div>
+                </td>
               </tr>
             <% end %>
           <% end %>

--- a/services/console/app/views/console/secret.html.erb
+++ b/services/console/app/views/console/secret.html.erb
@@ -7,7 +7,12 @@
     <h1 class="page-title"><%= title %></h1>
     <span class="resource-badge"><%= secret_kind_label(@kind) %></span>
     <% if secret_form_kinds.key?(@kind) %>
-      <a href="<%= edit_polymorphic_path([ :console, @secret ]) %>" class="btn-secondary ml-auto">Edit</a>
+      <div class="ml-auto flex items-center gap-2">
+        <a href="<%= edit_polymorphic_path([ :console, @secret ]) %>" class="btn-secondary">Edit</a>
+        <%= button_to "Delete", [ :console, @secret ], method: :delete,
+              class: "cursor-pointer rounded border border-red-500/40 px-3 py-1.5 text-sm text-red-300 transition-colors hover:border-red-500/60 hover:bg-red-500/10",
+              data: { turbo_confirm: "Delete this secret? Any grants of it are removed too. This cannot be undone." } %>
+      </div>
     <% end %>
   </div>
   <div class="mt-2 flex flex-wrap items-center gap-2 text-sm">

--- a/services/console/app/views/console/secret.html.erb
+++ b/services/console/app/views/console/secret.html.erb
@@ -31,6 +31,16 @@
   <% end %>
 </div>
 
+<% if (cred = managed_credential(@secret)) %>
+  <div class="mb-8 rounded-lg border border-centaur-500/30 bg-centaur-500/[0.06] px-4 py-3 text-sm text-zinc-300">
+    <span class="font-semibold text-centaur-300">Managed secret.</span>
+    Auto-created by the
+    <% if cred.oauth_app %><%= link_to "#{cred.oauth_app.slug} OAuth integration", console_oauth_app_path(cred.oauth_app.oid), class: "console-link" %><% else %>OAuth consent flow<% end %>
+    to deliver broker credential <%= link_to cred.oid, console_credential_path(cred.oid), class: "console-link" %>.
+    Its source is maintained by the integration; changing it will break token delivery.
+  </div>
+<% end %>
+
 <!-- Sources -->
 <section class="mb-8">
   <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Sources</h2>

--- a/services/console/app/views/console/secrets.html.erb
+++ b/services/console/app/views/console/secrets.html.erb
@@ -62,6 +62,10 @@
                     <% else %>
                       <span class="text-zinc-600">unnamed</span>
                     <% end %>
+                    <% if (cred = managed_credential(s)) %>
+                      <span class="ml-2 inline-flex items-center rounded bg-centaur-500/10 px-1.5 py-0.5 text-[11px] text-centaur-300 ring-1 ring-centaur-500/30"
+                            title="Managed by the <%= cred.oauth_app&.slug %> OAuth integration">managed</span>
+                    <% end %>
                   </td>
                   <td class="console-td-nowrap">
                     <% types = secret_source_types(s) %>

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -26,6 +26,15 @@ Rails.application.routes.draw do
   root "console#principals"
   get "console/principals", to: "console#principals", as: :console_principals
   get "console/principals/:id", to: "console#principal", as: :console_principal
+  # Role assignments and direct grants managed from the principal detail page. The
+  # extra /roles and /grants path segments keep these clear of the show route above
+  # and avoid clobbering the console_principal_path helper.
+  namespace :console do
+    post   "principals/:id/roles",            to: "principals#assign_role",   as: :principal_assign_role
+    delete "principals/:id/roles/:role_id",   to: "principals#unassign_role", as: :principal_unassign_role
+    post   "principals/:id/grants",           to: "principals#grant_secret",  as: :principal_grant_secret
+    delete "principals/:id/grants/:grant_id", to: "principals#revoke_grant",  as: :principal_revoke_grant
+  end
   get "console/secrets", to: "console#secrets", as: :console_secrets
   # One controller per secret kind for the create/edit forms. Declared before the
   # show route so their paths win over the generic `:kind/:id` match.

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -39,9 +39,9 @@ Rails.application.routes.draw do
   # One controller per secret kind for the create/edit forms. Declared before the
   # show route so their paths win over the generic `:kind/:id` match.
   namespace :console do
-    resources :static_secrets, only: %i[new create edit update], path: "secrets/static"
-    resources :pg_dsn_secrets, only: %i[new create edit update], path: "secrets/pg_dsn"
-    resources :gcp_auth_secrets, only: %i[new create edit update], path: "secrets/gcp_auth"
+    resources :static_secrets, only: %i[new create edit update destroy], path: "secrets/static"
+    resources :pg_dsn_secrets, only: %i[new create edit update destroy], path: "secrets/pg_dsn"
+    resources :gcp_auth_secrets, only: %i[new create edit update destroy], path: "secrets/gcp_auth"
   end
   get "console/secrets/:kind/:id", to: "console#secret", as: :console_secret
   get "console/credentials", to: "console#credentials", as: :console_credentials

--- a/services/console/db/migrate/20260615224547_link_static_secrets_to_broker_credentials.rb
+++ b/services/console/db/migrate/20260615224547_link_static_secrets_to_broker_credentials.rb
@@ -9,6 +9,9 @@ class LinkStaticSecretsToBrokerCredentials < ActiveRecord::Migration[8.1]
     # references (the token_broker source still carries the credential_id the
     # proxy resolves at sync; this association is the console-level link). Nullable
     # and nullify-on-delete: an ordinary static secret has no broker credential.
-    add_reference :static_secrets, :broker_credential, null: true, foreign_key: true
+    # The index is unique among non-null values: at most one managed wrapper per
+    # credential (a has_one), while ordinary secrets keep a null reference.
+    add_reference :static_secrets, :broker_credential, null: true, foreign_key: true,
+                  index: { unique: true, where: "broker_credential_id IS NOT NULL" }
   end
 end

--- a/services/console/db/migrate/20260615224547_link_static_secrets_to_broker_credentials.rb
+++ b/services/console/db/migrate/20260615224547_link_static_secrets_to_broker_credentials.rb
@@ -1,0 +1,14 @@
+class LinkStaticSecretsToBrokerCredentials < ActiveRecord::Migration[8.1]
+  def change
+    # The OAuth consent flow auto-creates a static secret wrapping a minted broker
+    # credential. The flow is unauthenticated, so that secret has no operator --
+    # like the credential itself, whose created_by is already nullable.
+    change_column_null :static_secrets, :created_by_id, true
+
+    # First-class link from a wrapping static secret to the broker credential it
+    # references (the token_broker source still carries the credential_id the
+    # proxy resolves at sync; this association is the console-level link). Nullable
+    # and nullify-on-delete: an ordinary static secret has no broker credential.
+    add_reference :static_secrets, :broker_credential, null: true, foreign_key: true
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_100100) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_224547) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -304,8 +304,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_100100) do
   end
 
   create_table "static_secrets", force: :cascade do |t|
+    t.bigint "broker_credential_id"
     t.datetime "created_at", null: false
-    t.bigint "created_by_id", null: false
+    t.bigint "created_by_id"
     t.string "description"
     t.string "foreign_id"
     t.jsonb "inject_config"
@@ -314,6 +315,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_100100) do
     t.string "namespace", default: "default", null: false
     t.jsonb "replace_config"
     t.datetime "updated_at", null: false
+    t.index ["broker_credential_id"], name: "index_static_secrets_on_broker_credential_id"
     t.index ["created_by_id"], name: "index_static_secrets_on_created_by_id"
     t.index ["labels"], name: "index_static_secrets_on_labels", using: :gin
     t.index ["namespace", "foreign_id"], name: "index_static_secrets_on_namespace_and_foreign_id", unique: true
@@ -379,6 +381,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_100100) do
   add_foreign_key "secret_sources", "oauth_token_secrets"
   add_foreign_key "secret_sources", "pg_dsn_secrets"
   add_foreign_key "secret_sources", "static_secrets"
+  add_foreign_key "static_secrets", "broker_credentials"
   add_foreign_key "static_secrets", "users", column: "created_by_id"
   add_foreign_key "user_identities", "users"
   add_foreign_key "users", "users", column: "approved_by_id"

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -315,7 +315,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_224547) do
     t.string "namespace", default: "default", null: false
     t.jsonb "replace_config"
     t.datetime "updated_at", null: false
-    t.index ["broker_credential_id"], name: "index_static_secrets_on_broker_credential_id"
+    t.index ["broker_credential_id"], name: "index_static_secrets_on_broker_credential_id", unique: true, where: "(broker_credential_id IS NOT NULL)"
     t.index ["created_by_id"], name: "index_static_secrets_on_created_by_id"
     t.index ["labels"], name: "index_static_secrets_on_labels", using: :gin
     t.index ["namespace", "foreign_id"], name: "index_static_secrets_on_namespace_and_foreign_id", unique: true

--- a/services/console/lib/oauth/providers/google.rb
+++ b/services/console/lib/oauth/providers/google.rb
@@ -17,6 +17,11 @@ module Oauth
       # Always requested in addition to the app's scopes, so the token response
       # carries an id_token identifying the Google account.
       IDENTITY_SCOPES = %w[openid https://www.googleapis.com/auth/userinfo.email].freeze
+      # Hosts a minted access token may be sent to, as request-rule host patterns.
+      # Every Google API is served under *.googleapis.com; accounts.google.com is
+      # auth-only and intentionally excluded. Drives the rules on the static secret
+      # auto-created alongside a minted credential.
+      API_HOSTS = %w[*.googleapis.com].freeze
       # The issuers Google stamps into the id_token; both forms are accepted per
       # Google's OIDC discovery document.
       VALID_ISSUERS = %w[https://accounts.google.com accounts.google.com].freeze
@@ -25,6 +30,7 @@ module Oauth
       def authorization_endpoint = AUTHORIZATION_ENDPOINT
       def token_endpoint = TOKEN_ENDPOINT
       def identity_scopes = IDENTITY_SCOPES
+      def api_hosts = API_HOSTS
 
       # Provider-specific query params for the authorization redirect. Both are
       # required to guarantee a refresh token, including on re-consent:

--- a/services/console/test/controllers/console/principals_controller_test.rb
+++ b/services/console/test/controllers/console/principals_controller_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+module Console
+  # Covers the role-assignment and direct-grant mutations wired from the principal
+  # detail page: assign/unassign roles and grant/revoke secrets, plus idempotency
+  # and the signed-out gate.
+  class PrincipalsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @operator = users(:acme_admin)
+      post login_url, params: { email: @operator.email, password: "password123456" }
+    end
+
+    test "redirects to login when signed out" do
+      delete logout_url
+      post console_principal_assign_role_url(principals(:acme_user_bob).oid),
+           params: { role_id: roles(:acme_admin_role).oid }
+      assert_redirected_to login_path
+    end
+
+    test "assign_role attaches the role and redirects with a notice" do
+      principal = principals(:acme_user_bob)
+      role = roles(:acme_admin_role)
+      assert_difference -> { principal.principal_roles.count }, 1 do
+        post console_principal_assign_role_url(principal.oid), params: { role_id: role.oid }
+      end
+      assert_redirected_to console_principal_path(principal.oid)
+      assert_equal "Assigned role #{role.name}.", flash[:notice]
+      assert principal.reload.roles.include?(role)
+    end
+
+    test "assign_role is idempotent" do
+      principal = principals(:acme_user_alice)
+      role = roles(:acme_infra) # already assigned via fixture
+      assert_no_difference -> { principal.principal_roles.count } do
+        post console_principal_assign_role_url(principal.oid), params: { role_id: role.oid }
+      end
+      assert_redirected_to console_principal_path(principal.oid)
+    end
+
+    test "unassign_role detaches the role" do
+      principal = principals(:acme_user_alice)
+      role = roles(:acme_infra)
+      assert_difference -> { principal.principal_roles.count }, -1 do
+        delete console_principal_unassign_role_url(principal.oid, role.oid)
+      end
+      assert_redirected_to console_principal_path(principal.oid)
+      assert_not principal.reload.roles.include?(role)
+    end
+
+    test "grant_secret creates a direct grant at the default direct priority" do
+      principal = principals(:acme_user_bob)
+      secret = static_secrets(:github_token_inject)
+      assert_difference -> { principal.grants.count }, 1 do
+        post console_principal_grant_secret_url(principal.oid), params: { grantable: "static:#{secret.oid}" }
+      end
+      assert_redirected_to console_principal_path(principal.oid)
+      grant = principal.grants.find_by(static_secret: secret)
+      assert_not_nil grant
+      assert_equal Grant::DEFAULT_DIRECT_PRIORITY, grant.priority
+    end
+
+    test "grant_secret works for a non-static secret kind" do
+      principal = principals(:acme_user_bob)
+      secret = pg_dsn_secrets(:acme_analytics_pg)
+      assert_difference -> { principal.grants.count }, 1 do
+        post console_principal_grant_secret_url(principal.oid), params: { grantable: "pg_dsn:#{secret.oid}" }
+      end
+      assert principal.grants.exists?(pg_dsn_secret: secret)
+    end
+
+    test "grant_secret is idempotent" do
+      principal = principals(:acme_channel)
+      secret = static_secrets(:github_token_inject) # already granted via fixture
+      assert_no_difference -> { principal.grants.count } do
+        post console_principal_grant_secret_url(principal.oid), params: { grantable: "static:#{secret.oid}" }
+      end
+      assert_redirected_to console_principal_path(principal.oid)
+    end
+
+    test "grant_secret with a blank selection flashes an alert" do
+      principal = principals(:acme_user_bob)
+      assert_no_difference -> { principal.grants.count } do
+        post console_principal_grant_secret_url(principal.oid), params: { grantable: "" }
+      end
+      assert_equal "Pick a secret to grant.", flash[:alert]
+    end
+
+    test "revoke_grant removes the direct grant" do
+      principal = principals(:acme_channel)
+      grant = grants(:acme_channel_github_token)
+      assert_difference -> { principal.grants.count }, -1 do
+        delete console_principal_revoke_grant_url(principal.oid, grant.oid)
+      end
+      assert_redirected_to console_principal_path(principal.oid)
+      assert_not Grant.exists?(grant.id)
+    end
+
+    test "an unknown principal oid is a 404" do
+      post console_principal_assign_role_url("prn_missing"), params: { role_id: roles(:acme_infra).oid }
+      assert_response :not_found
+    end
+  end
+end

--- a/services/console/test/controllers/console/secrets_controller_test.rb
+++ b/services/console/test/controllers/console/secrets_controller_test.rb
@@ -107,6 +107,24 @@ module Console
       assert_equal [ "only.example.com" ], secret.rules.map(&:host)
     end
 
+    test "the edit page offers a delete button" do
+      get edit_console_static_secret_url(static_secrets(:acme_prod_api_key).oid)
+      assert_response :ok
+      assert_select "form[action=?][method=?]", console_static_secret_path(static_secrets(:acme_prod_api_key).oid), "post" do
+        assert_select "input[name=_method][value=delete]"
+      end
+    end
+
+    test "DELETE destroy removes the secret and cascades its grants" do
+      secret = static_secrets(:github_token_inject) # granted directly to acme_channel
+      assert_difference -> { StaticSecret.count } => -1, -> { Grant.count } => -1 do
+        delete console_static_secret_url(secret.oid)
+      end
+      assert_redirected_to console_secrets_path
+      assert_equal "Secret deleted.", flash[:notice]
+      assert_not StaticSecret.exists?(secret.id)
+    end
+
     # --- pg_dsn -----------------------------------------------------------
 
     test "GET new renders without error" do
@@ -157,6 +175,15 @@ module Console
       secret.reload
       assert_nil secret.role.presence
       assert_equal "REPORTING_DSN", secret.dsn_source.config["var"]
+    end
+
+    test "DELETE destroy removes a pg_dsn secret" do
+      secret = pg_dsn_secrets(:acme_reporting_pg)
+      assert_difference -> { PgDsnSecret.count } => -1 do
+        delete console_pg_dsn_secret_url(secret.oid)
+      end
+      assert_redirected_to console_secrets_path
+      assert_equal "Secret deleted.", flash[:notice]
     end
 
     test "POST create captures ordered session settings and drops blank-name rows" do

--- a/services/console/test/controllers/console/secrets_controller_test.rb
+++ b/services/console/test/controllers/console/secrets_controller_test.rb
@@ -33,6 +33,17 @@ module Console
       assert_response :ok
     end
 
+    # The managed-secret guard banner is behavior (a warning), not form markup, so
+    # it is asserted here unlike the rest of the rendered form.
+    test "edit warns when the secret is an OAuth-flow-managed wrapper" do
+      get edit_console_static_secret_url(static_secrets(:acme_managed_gmail_secret).oid)
+      assert_response :ok
+      assert_match "Managed secret", response.body
+      # An ordinary secret shows no such warning.
+      get edit_console_static_secret_url(static_secrets(:acme_prod_api_key).oid)
+      assert_no_match "Managed secret", response.body
+    end
+
     test "POST create builds a static secret with a source and rules" do
       assert_difference -> { StaticSecret.count } => 1,
                         -> { SecretSource.count } => 1,

--- a/services/console/test/controllers/console/secrets_controller_test.rb
+++ b/services/console/test/controllers/console/secrets_controller_test.rb
@@ -107,14 +107,6 @@ module Console
       assert_equal [ "only.example.com" ], secret.rules.map(&:host)
     end
 
-    test "the edit page offers a delete button" do
-      get edit_console_static_secret_url(static_secrets(:acme_prod_api_key).oid)
-      assert_response :ok
-      assert_select "form[action=?][method=?]", console_static_secret_path(static_secrets(:acme_prod_api_key).oid), "post" do
-        assert_select "input[name=_method][value=delete]"
-      end
-    end
-
     test "DELETE destroy removes the secret and cascades its grants" do
       secret = static_secrets(:github_token_inject) # granted directly to acme_channel
       assert_difference -> { StaticSecret.count } => -1, -> { Grant.count } => -1 do

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -141,6 +141,18 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", console_oauth_app_path(app.oid)
   end
 
+  test "principal detail page renders the role and direct-grant management forms" do
+    principal = principals(:acme_channel)
+    get console_principal_url(principal.oid)
+    assert_response :ok
+    assert_select "h2", text: "Direct Grants"
+    assert_select "select[name=role_id]"
+    assert_select "select[name=grantable] optgroup"
+    # Each direct grant exposes a revoke form; each assigned role chip a remove (×) form.
+    assert_select "form[action=?]", console_principal_revoke_grant_path(principal.oid, grants(:acme_channel_github_token).oid)
+    assert_select "form[action=?]", console_principal_unassign_role_path(principal.oid, roles(:acme_infra).oid)
+  end
+
   test "header shows the signed-in operator and a sign-out control" do
     get console_principals_url
     assert_response :ok

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -27,6 +27,21 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "span[title=?]", secret.name
   end
 
+  test "secret detail page offers delete for an editable kind but not for others" do
+    static = static_secrets(:acme_prod_api_key)
+    get console_secret_url("static", static.oid)
+    assert_response :ok
+    assert_select "form[action=?][method=?]", console_static_secret_path(static.oid), "post" do
+      assert_select "input[name=_method][value=delete]"
+    end
+    assert_select "button", text: "Delete"
+    # A kind without a form (e.g. oauth_token) has no delete route, so no button
+    # (the only delete-method form left is the layout's Sign out).
+    get console_secret_url("oauth_token", oauth_token_secrets(:acme_gmail_oauth).oid)
+    assert_response :ok
+    assert_select "button", text: "Delete", count: 0
+  end
+
   test "secret detail page shows the full source reference" do
     secret = oauth_token_secrets(:acme_gmail_oauth)
     get console_secret_url("oauth_token", secret.oid)

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -190,8 +190,23 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "section table th", text: "Source"
     # A directly granted secret is tagged "direct".
     assert_select "td", text: "direct"
-    # The role-inherited secret names the role it comes through.
+    # The role-inherited secret names the role it comes through, and its id links
+    # to the secret (it appears only in the effective table, not the direct one).
     assert_select "td span", text: "via #{roles(:acme_infra).name}"
+    assert_select "a[href=?]", console_secret_path("static", static_secrets(:acme_prod_api_key).oid)
+  end
+
+  test "grant dropdown omits secrets already granted directly but keeps the rest" do
+    principal = principals(:acme_channel) # github_token_inject is granted directly
+    get console_principal_url(principal.oid)
+    assert_response :ok
+    granted = static_secrets(:github_token_inject)
+    ungranted = static_secrets(:acme_staging_api_key)
+    assert_select "select[name=grantable] option[value=?]", "static:#{granted.oid}", count: 0
+    assert_select "select[name=grantable] option[value=?]", "static:#{ungranted.oid}"
+    # A kind with no direct grant on this principal still lists all its secrets.
+    gcp = gcp_auth_secrets(:acme_bigquery)
+    assert_select "select[name=grantable] option[value=?]", "gcp_auth:#{gcp.oid}"
   end
 
   test "header shows the signed-in operator and a sign-out control" do

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -180,6 +180,18 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[action=?]", console_principal_unassign_role_path(principal.oid, roles(:acme_infra).oid)
   end
 
+  test "effective grants table sources each secret as direct or via a role" do
+    principal = principals(:acme_channel) # direct grants + acme_prod_api_key via the acme_infra role
+    get console_principal_url(principal.oid)
+    assert_response :ok
+    # The Source column exists.
+    assert_select "section table th", text: "Source"
+    # A directly granted secret is tagged "direct".
+    assert_select "td", text: "direct"
+    # The role-inherited secret names the role it comes through.
+    assert_select "td span", text: "via #{roles(:acme_infra).name}"
+  end
+
   test "header shows the signed-in operator and a sign-out control" do
     get console_principals_url
     assert_response :ok

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -178,6 +178,8 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     # Each direct grant exposes a revoke form; each assigned role chip a remove (×) form.
     assert_select "form[action=?]", console_principal_revoke_grant_path(principal.oid, grants(:acme_channel_github_token).oid)
     assert_select "form[action=?]", console_principal_unassign_role_path(principal.oid, roles(:acme_infra).oid)
+    # The direct grant's id links to the secret's detail page.
+    assert_select "a[href=?]", console_secret_path("static", static_secrets(:github_token_inject).oid)
   end
 
   test "effective grants table sources each secret as direct or via a role" do

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -86,6 +86,33 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "span", text: credential.status
   end
 
+  test "secrets table badges an OAuth-flow-managed static secret" do
+    secret = static_secrets(:acme_managed_gmail_secret)
+    get console_secrets_url
+    assert_response :ok
+    assert_select "span", text: "managed"
+    # Only the wrapping secret is badged, not ordinary static secrets.
+    assert_select "span", text: "managed", count: StaticSecret.where.not(broker_credential_id: nil).count
+  end
+
+  test "managed secret detail page links to the credential it wraps" do
+    secret = static_secrets(:acme_managed_gmail_secret)
+    cred = secret.broker_credential
+    get console_secret_url("static", secret.oid)
+    assert_response :ok
+    assert_match "Managed secret", response.body
+    assert_select "a[href=?]", console_credential_path(cred.oid)
+  end
+
+  test "credential detail page links to the static secret that makes it grantable" do
+    cred = broker_credentials(:acme_managed_gmail)
+    secret = static_secrets(:acme_managed_gmail_secret)
+    get console_credential_url(cred.oid)
+    assert_response :ok
+    assert_select "h2", text: "Grantable As"
+    assert_select "a[href=?]", console_secret_path("static", secret.oid)
+  end
+
   test "credential detail page shows refresh and client data" do
     credential = broker_credentials(:acme_managed_gmail)
     get console_credential_url(credential.oid)

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -151,6 +151,44 @@ module Oauth
       assert_includes response.body, cred.oid
     end
 
+    test "callback wraps the minted credential in a grantable static secret" do
+      state = start_flow
+      stub_exchange(status: 200, body: token_body)
+
+      assert_difference -> { StaticSecret.count } => 1 do
+        get oauth_callback_url(slug: "google"), params: { state: state, code: "auth-code" }
+      end
+
+      cred = BrokerCredential.find_by(oauth_app: @app, provider_subject: "google-sub-1")
+      secret = cred.static_secrets.sole
+      assert_equal cred, secret.broker_credential # first-class link to the credential
+      assert_equal cred.namespace, secret.namespace
+      assert_equal cred.foreign_id, secret.foreign_id
+      assert_nil secret.created_by # the unauthenticated flow has no operator
+      assert_equal({ "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }, secret.inject_config)
+      assert_equal "token_broker", secret.source.source_type
+      assert_equal cred.oid, secret.source.config["credential_id"]
+      assert_equal [ "*.googleapis.com" ], secret.rules.map(&:host)
+      # The source resolves the credential's live token at sync time.
+      assert_equal({ "type" => "control_plane", "value" => "AT" }, secret.source.to_proxy_source)
+    end
+
+    test "re-consent neither duplicates the wrapping secret nor clobbers operator edits" do
+      state1 = start_flow
+      stub_exchange(status: 200, body: token_body)
+      get oauth_callback_url(slug: "google"), params: { state: state1, code: "code-1" }
+      secret = StaticSecret.find_by(foreign_id: "google-google-google-sub-1")
+      assert_not_nil secret
+      secret.update!(name: "operator-renamed")
+
+      state2 = start_flow
+      stub_exchange(status: 200, body: token_body)
+      assert_no_difference -> { StaticSecret.count } do
+        get oauth_callback_url(slug: "google"), params: { state: state2, code: "code-2" }
+      end
+      assert_equal "operator-renamed", secret.reload.name
+    end
+
     test "callback works with a disabled console session" do
       user = users(:member_user)
       sign_in user

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -160,10 +160,10 @@ module Oauth
       end
 
       cred = BrokerCredential.find_by(oauth_app: @app, provider_subject: "google-sub-1")
-      secret = cred.static_secrets.sole
+      secret = cred.static_secret
       assert_equal cred, secret.broker_credential # first-class link to the credential
       assert_equal cred.namespace, secret.namespace
-      assert_equal cred.foreign_id, secret.foreign_id
+      assert_nil secret.foreign_id # found by association, so no collidable foreign_id
       assert_nil secret.created_by # the unauthenticated flow has no operator
       assert_equal({ "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }, secret.inject_config)
       assert_equal "token_broker", secret.source.source_type
@@ -177,7 +177,8 @@ module Oauth
       state1 = start_flow
       stub_exchange(status: 200, body: token_body)
       get oauth_callback_url(slug: "google"), params: { state: state1, code: "code-1" }
-      secret = StaticSecret.find_by(foreign_id: "google-google-google-sub-1")
+      cred = BrokerCredential.find_by(oauth_app: @app, provider_subject: "google-sub-1")
+      secret = cred.static_secret
       assert_not_nil secret
       secret.update!(name: "operator-renamed")
 

--- a/services/console/test/fixtures/request_rules.yml
+++ b/services/console/test/fixtures/request_rules.yml
@@ -25,6 +25,12 @@ oauth_gmail_host:
   paths: []
   oauth_token_secret: acme_gmail_oauth
 
+managed_gmail_host:
+  host: "*.googleapis.com"
+  http_methods: []
+  paths: []
+  static_secret: acme_managed_gmail_secret
+
 hmac_webhook_host:
   host: hooks.example.com
   http_methods: ["POST"]

--- a/services/console/test/fixtures/secret_sources.yml
+++ b/services/console/test/fixtures/secret_sources.yml
@@ -32,6 +32,7 @@ broker_token:
   config:
     credential_id: managed-gmail
     credential_namespace: acme
+  static_secret: acme_managed_gmail_secret
 
 # Keyfile source for the acme_gcs_keyfile gcp_auth secret.
 gcp_keyfile:

--- a/services/console/test/fixtures/static_secrets.yml
+++ b/services/console/test/fixtures/static_secrets.yml
@@ -60,11 +60,11 @@ globex_prod_secret:
   created_by: globex_admin
 
 # Auto-created by the OAuth consent flow to wrap a managed broker credential, so
-# the integration's token becomes grantable. Has no created_by (the flow is
-# unauthenticated) and links to the credential it wraps via broker_credential.
+# the integration's token becomes grantable. Like the real wrapper, it has no
+# created_by (the flow is unauthenticated) and no foreign_id (it is found via the
+# broker_credential association, not by foreign_id).
 acme_managed_gmail_secret:
   namespace: acme
-  foreign_id: google-managed-gmail
   name: Managed Gmail token
   inject_config:
     header: Authorization

--- a/services/console/test/fixtures/static_secrets.yml
+++ b/services/console/test/fixtures/static_secrets.yml
@@ -58,3 +58,15 @@ globex_prod_secret:
     header: X-Api-Key
     formatter: "{{ .Value }}"
   created_by: globex_admin
+
+# Auto-created by the OAuth consent flow to wrap a managed broker credential, so
+# the integration's token becomes grantable. Has no created_by (the flow is
+# unauthenticated) and links to the credential it wraps via broker_credential.
+acme_managed_gmail_secret:
+  namespace: acme
+  foreign_id: google-managed-gmail
+  name: Managed Gmail token
+  inject_config:
+    header: Authorization
+    formatter: "Bearer {{ .Value }}"
+  broker_credential: acme_managed_gmail

--- a/services/console/test/lib/iron/bootstrap_test.rb
+++ b/services/console/test/lib/iron/bootstrap_test.rb
@@ -12,9 +12,11 @@ class Iron::BootstrapTest < ActiveSupport::TestCase
     Proxy.delete_all
     RequestRule.delete_all
     SecretSource.delete_all
+    # StaticSecret references BrokerCredential (wrapping secrets), so clear it
+    # first: delete_all bypasses the dependent: :nullify that would handle this.
+    StaticSecret.delete_all
     BrokerCredential.delete_all
     OauthApp.delete_all
-    StaticSecret.delete_all
     GcpAuthSecret.delete_all
     AwsAuthSecret.delete_all
     OauthTokenSecret.delete_all

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -32,6 +32,15 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert build_credential.valid?
   end
 
+  test "at most one wrapping static secret per credential" do
+    cred = create_credential
+    StaticSecret.create!(namespace: "default", name: "wrapper", broker_credential: cred,
+                         inject_config: { "header" => "Authorization" })
+    dup = StaticSecret.new(namespace: "default", name: "dup", broker_credential: cred,
+                           inject_config: { "header" => "Authorization" })
+    assert_raises(ActiveRecord::RecordNotUnique) { dup.save!(validate: false) }
+  end
+
   test "invalid without a client_id" do
     bc = build_credential(client_id: nil)
     refute bc.valid?

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM ironsh/iron-proxy:0.42.0-rc.8@sha256:0fb21317bdec25321e7215e6538357164ec2df6840649cdbe5ca6922d22ba79e
+FROM ironsh/iron-proxy:0.44.0@sha256:ac4159f987e781a5c6011a880e338794155171884de005e4c9c7b5329786bbe5
 
 USER root
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \


### PR DESCRIPTION
The console principal detail page was read-only. Operators can now assign/unassign roles and grant/revoke secrets directly from the page instead of dropping down to the JSON API.

Adds a `Console::PrincipalsController` following the existing console mutation pattern (button_to POST/DELETE, redirect + flash, idempotent `find_or_create_by!`, gated by `require_login`). The page gains role remove buttons, an assign-role dropdown, and a new Direct Grants section with revoke buttons and a grant-secret dropdown (optgroups per secret kind). The effective-grants table stays read-only. Dropdowns span all namespaces with the namespace shown per option.

Covered by a new `Console::PrincipalsControllerTest` (assign/unassign, grant for static and non-static kinds, revoke, idempotency, blank selection, 404) plus a render test on the detail page.