### PR TITLE
fix: include Slack thread attachments in context

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -5,6 +5,7 @@ import {
   Chat,
   StreamingPlan,
   type Adapter,
+  type Attachment,
   type Logger,
   type Message as ChatMessage,
   type StateAdapter,
@@ -27,6 +28,7 @@ import {
   harnessRestartPreamble,
   isRetryableSessionApiError,
   openSessionEventStream,
+  serializeAttachment,
   serializeMessage,
   sessionStreamError
 } from './session-api'
@@ -35,6 +37,7 @@ import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from './slack-events
 import type {
   ForwardSessionInput,
   SlackbotV2,
+  SlackbotV2ApiAttachment,
   SlackbotV2ApiMessage,
   SlackbotV2ExecuteSessionResponse,
   SlackbotV2MessageMode,
@@ -74,6 +77,8 @@ type SlackAssistantAdapter = {
   ): Promise<void>
   setAssistantTitle?(channelId: string, threadTs: string, title: string): Promise<void>
 }
+
+const MAX_SLACK_MESSAGE_ATTACHMENTS = 20
 
 type SlackbotV2RequestContext = {
   retryableErrors: unknown[]
@@ -1404,7 +1409,7 @@ async function collectSlackThreadContext(
       const messageTs = stringField(message.ts)
       if (!messageTs || compareSlackTs(messageTs, currentTs) > 0) continue
       if (isSelfSlackBotMessage(options, message)) continue
-      messages.push(slackApiMessageFromSlack(message, currentMessage))
+      messages.push(await slackApiMessageFromSlack(options, message, currentMessage))
     }
     cursor = response.nextCursor
   } while (cursor)
@@ -1419,16 +1424,17 @@ async function collectSlackThreadContext(
   return messages
 }
 
-function slackApiMessageFromSlack(
+async function slackApiMessageFromSlack(
+  options: SlackbotV2Options,
   message: Record<string, unknown>,
   currentMessage: ChatMessage
-): SlackbotV2ApiMessage {
+): Promise<SlackbotV2ApiMessage> {
   const rawCurrent = slackRawRecord(currentMessage)
   const id = stringField(message.ts) || randomUUID()
   const actorId = slackActorId(message)
   const isBot = Boolean(message.bot_id || message.bot_profile)
   return {
-    attachments: [],
+    attachments: await slackApiAttachmentsFromFiles(options, message, rawCurrent),
     author: {
       fullName: actorId,
       isBot,
@@ -1448,6 +1454,82 @@ function slackApiMessageFromSlack(
     threadId: currentMessage.threadId,
     timestamp: slackTimestampToIso(id)
   }
+}
+
+async function slackApiAttachmentsFromFiles(
+  options: SlackbotV2Options,
+  message: Record<string, unknown>,
+  rawCurrent: Record<string, unknown>
+): Promise<SlackbotV2ApiAttachment[]> {
+  const files = slackFiles(message)
+  if (files.length === 0) return []
+  const teamId =
+    stringField(message.team)
+    || stringField(message.team_id)
+    || stringField(rawCurrent.team)
+    || stringField(rawCurrent.team_id)
+  const attachments: SlackbotV2ApiAttachment[] = []
+  for (const file of files.slice(0, MAX_SLACK_MESSAGE_ATTACHMENTS)) {
+    attachments.push(await serializeAttachment(slackFileAttachment(options, file, teamId)))
+  }
+  if (files.length > MAX_SLACK_MESSAGE_ATTACHMENTS) {
+    attachments.push({
+      fetchError:
+        `only the first ${MAX_SLACK_MESSAGE_ATTACHMENTS} Slack message attachments were fetched`,
+      name: 'additional Slack thread attachments',
+      type: 'file'
+    })
+  }
+  return attachments
+}
+
+function slackFiles(message: Record<string, unknown>): Record<string, unknown>[] {
+  return Array.isArray(message.files)
+    ? (message.files.filter(file =>
+        file && typeof file === 'object' && !Array.isArray(file)
+      ) as Record<string, unknown>[])
+    : []
+}
+
+function slackFileAttachment(
+  options: SlackbotV2Options,
+  file: Record<string, unknown>,
+  teamId: string
+): Attachment {
+  const url = stringField(file.url_private_download) || stringField(file.url_private)
+  const mimeType = stringField(file.mimetype)
+  const fetchMetadata: Record<string, string> = {}
+  if (url) fetchMetadata.url = url
+  if (teamId) fetchMetadata.teamId = teamId
+  return {
+    fetchData: url ? () => fetchSlackFile(options, url) : undefined,
+    fetchMetadata: Object.keys(fetchMetadata).length > 0 ? fetchMetadata : undefined,
+    height: numberField(file.original_h),
+    mimeType,
+    name: stringField(file.name) || stringField(file.title) || stringField(file.id),
+    size: numberField(file.size),
+    type: slackFileAttachmentType(mimeType),
+    url,
+    width: numberField(file.original_w)
+  }
+}
+
+async function fetchSlackFile(options: SlackbotV2Options, url: string): Promise<Buffer> {
+  const fetchFn = options.fetch ?? fetch
+  const response = await fetchFn(url, {
+    headers: { authorization: `Bearer ${options.botToken}` }
+  })
+  if (!response.ok) {
+    throw new Error(`failed to fetch Slack file: ${response.status} ${response.statusText}`)
+  }
+  return Buffer.from(await response.arrayBuffer())
+}
+
+function slackFileAttachmentType(mimeType: string): Attachment['type'] {
+  if (mimeType.startsWith('image/')) return 'image'
+  if (mimeType.startsWith('video/')) return 'video'
+  if (mimeType.startsWith('audio/')) return 'audio'
+  return 'file'
 }
 
 function slackRawRecord(message: ChatMessage): Record<string, unknown> {
@@ -1481,6 +1563,10 @@ function isSelfSlackBotMessage(
 
 function stringField(value: unknown): string {
   return typeof value === 'string' ? value : ''
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 function compareSlackTs(a: string, b: string): number {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -264,7 +264,7 @@ export const MAX_INLINE_ATTACHMENT_BYTES = 100 * 1024 * 1024
 const MAX_CODEX_INPUT_LINE_CHARS = 900 * 1024
 const STAGED_ATTACHMENT_CHUNK_CHARS = 700 * 1024
 
-async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2ApiAttachment> {
+export async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2ApiAttachment> {
   const serialized: SlackbotV2ApiAttachment = {
     fetchMetadata: attachment.fetchMetadata,
     height: attachment.height,
@@ -957,7 +957,7 @@ function toCodexInputLines(
 ): string[] {
   const staged = new Map<SlackbotV2ApiAttachment, string>()
   const lines: string[] = []
-  for (const attachment of message.attachments) {
+  for (const attachment of executableAttachments(message, contextMessages)) {
     if (!attachment.dataBase64) continue
     const inlineLine = toCodexInputLineWithStaged(
       message,
@@ -990,6 +990,19 @@ function toCodexInputLines(
     )
   )
   return lines
+}
+
+function executableAttachments(
+  message: SlackbotV2ApiMessage,
+  contextMessages?: SlackbotV2ApiMessage[]
+): SlackbotV2ApiAttachment[] {
+  const attachments: SlackbotV2ApiAttachment[] = []
+  for (const item of contextMessages ?? []) {
+    if (item.id === message.id) continue
+    attachments.push(...item.attachments)
+  }
+  attachments.push(...message.attachments)
+  return attachments
 }
 
 function toCodexInputLineWithStaged(
@@ -1109,6 +1122,17 @@ function codexInputContent(
       content.push({ type: 'text', text: threadContext })
     }
   }
+  for (const contextAttachment of slackThreadContextAttachments(message, contextMessages)) {
+    content.push({
+      type: 'text',
+      text:
+        `Earlier Slack thread attachment from ${slackContextAuthor(contextAttachment.message)}: `
+        + attachmentDescription(contextAttachment.attachment)
+    })
+    content.push(
+      codexAttachmentInput(contextAttachment.attachment, staged.get(contextAttachment.attachment))
+    )
+  }
   if (message.text.trim()) {
     content.push({ type: 'text', text: message.text })
   }
@@ -1137,6 +1161,23 @@ function slackThreadContext(
   }
   lines.push('', '# Current Request', '', 'The user message follows in the next content block.', '---')
   return lines.join('\n')
+}
+
+function slackThreadContextAttachments(
+  currentMessage: SlackbotV2ApiMessage,
+  contextMessages: SlackbotV2ApiMessage[] | undefined
+): Array<{ attachment: SlackbotV2ApiAttachment; message: SlackbotV2ApiMessage }> {
+  const attachments: Array<{
+    attachment: SlackbotV2ApiAttachment
+    message: SlackbotV2ApiMessage
+  }> = []
+  for (const message of contextMessages ?? []) {
+    if (message.id === currentMessage.id) continue
+    for (const attachment of message.attachments) {
+      attachments.push({ attachment, message })
+    }
+  }
+  return attachments
 }
 
 function slackContextAuthor(message: SlackbotV2ApiMessage): string {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -357,6 +357,64 @@ describe('slackbotv2', () => {
     expect(executeInput).toContain('summarize the thread so far')
   })
 
+  it('fetches attachments from preceding Slack thread messages for a mid-thread mention', async () => {
+    const parent = await postUserMessage('Root context before an attachment.')
+    const priorReply = await postUserMessage('Screenshot is attached here.', parent.ts)
+    const fileUrl = `${slackApi.url}/files/captured.png`
+    slackApi.addFileToMessage(CHANNEL_ID, priorReply.ts, {
+      id: 'F-thread-context-image',
+      mimetype: 'image/png',
+      name: 'thread-context.png',
+      original_h: 600,
+      original_w: 800,
+      size: 16,
+      url_private: fileUrl
+    })
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> inspect the earlier screenshot`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-mid-thread-history-attachment',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> inspect the earlier screenshot`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    const appendedAttachment = codexApi.appends[0]!.body.messages
+      .flatMap(message => message.parts)
+      .find(part => isRecord(part) && part.type === 'attachment')
+    expect(appendedAttachment).toEqual(
+      expect.objectContaining({
+        attachment_type: 'image',
+        dataBase64: Buffer.from('captured-image').toString('base64'),
+        mimeType: 'image/png',
+        name: 'thread-context.png',
+        type: 'attachment',
+        url: fileUrl
+      })
+    )
+
+    const executeInput = JSON.stringify(JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!))
+    expect(executeInput).toContain('Screenshot is attached here.')
+    expect(executeInput).toContain('Earlier Slack thread attachment')
+    expect(executeInput).toContain(
+      `data:image/png;base64,${Buffer.from('captured-image').toString('base64')}`
+    )
+  })
+
   it('injects Slack requester identity and verified GitHub handle into Codex input', async () => {
     slackApi.setUserProfile(USER_ID, {
       name: 'akshaan',
@@ -3530,6 +3588,7 @@ function writeMockSseEvent(stream: ServerResponse, event: MockSessionEvent): voi
 }
 
 type PatchedSlackApi = {
+  addFileToMessage(channel: string, ts: string, file: Record<string, unknown>): void
   calls: StreamCall[]
   close(): Promise<void>
   failRepliesWithThreadNotFound(channel: string, ts: string): void
@@ -3572,6 +3631,7 @@ type SlackStreamTranscript = {
 async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackApi> {
   const upstreamUrl = loopbackUrl(emulatorUrl)
   const calls: StreamCall[] = []
+  const threadMessageFiles = new Map<string, Record<string, unknown>[]>()
   const userProfiles = new Map<string, Record<string, unknown>>()
   const userProfileRequests = new Map<string, number>()
   const threadNotFoundReplies = new Set<string>()
@@ -3587,6 +3647,7 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       port,
       streams,
       threadNotFoundReplies,
+      threadMessageFiles,
       userProfiles,
       userProfileRequests,
       upstreamUrl
@@ -3597,6 +3658,10 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
   })
   await listen(server, port)
   return {
+    addFileToMessage(channel: string, ts: string, file: Record<string, unknown>) {
+      const key = slackReplyKey(channel, ts)
+      threadMessageFiles.set(key, [...(threadMessageFiles.get(key) ?? []), file])
+    },
     calls,
     url: `http://127.0.0.1:${port}`,
     failRepliesWithThreadNotFound(channel: string, ts: string) {
@@ -3615,6 +3680,7 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       appendFailure.remaining = -1
       appendFailure.error = ''
       threadNotFoundReplies.clear()
+      threadMessageFiles.clear()
       streams.clear()
       userProfiles.clear()
       userProfileRequests.clear()
@@ -3642,6 +3708,7 @@ async function handlePatchedSlackRequest(
     port: number
     streams: Map<string, StreamRecord>
     threadNotFoundReplies: Set<string>
+    threadMessageFiles: Map<string, Record<string, unknown>[]>
     userProfiles: Map<string, Record<string, unknown>>
     userProfileRequests: Map<string, number>
     upstreamUrl: string
@@ -3749,6 +3816,27 @@ async function handlePatchedSlackRequest(
       )
     ) {
       await sendWebResponse(res, Response.json({ ok: false, error: 'thread_not_found' }))
+      return
+    }
+    if (input.threadMessageFiles.size > 0) {
+      const rawBody = await request.arrayBuffer()
+      const proxied = await fetch(new URL(`${path}${url.search}`, input.upstreamUrl), {
+        method: request.method,
+        headers: request.headers,
+        body: rawBody.byteLength > 0 ? rawBody : undefined
+      })
+      const payload = await proxied.json() as Record<string, unknown>
+      if (Array.isArray(payload.messages)) {
+        payload.messages = payload.messages.map(message => {
+          if (!message || typeof message !== 'object' || Array.isArray(message)) return message
+          const item = message as Record<string, unknown>
+          const files = input.threadMessageFiles.get(
+            slackReplyKey(stringField(body.channel), stringField(item.ts))
+          )
+          return files ? { ...item, files: [...slackFileArray(item.files), ...files] } : item
+        })
+      }
+      await sendWebResponse(res, Response.json(payload, { status: proxied.status }))
       return
     }
   }
@@ -4176,6 +4264,14 @@ function slackReplyKey(channel: string, ts: string): string {
 
 function stringField(value: unknown): string {
   return typeof value === 'string' ? value : ''
+}
+
+function slackFileArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? (value.filter(item =>
+        item && typeof item === 'object' && !Array.isArray(item)
+      ) as Record<string, unknown>[])
+    : []
 }
 
 function parseMaybeJson(value: string): unknown {


### PR DESCRIPTION
## Summary
- Fetch files attached to historical Slack thread replies returned by conversations.replies.
- Serialize those files through the existing Slackbot attachment path, including private Slack downloads with the bot token.
- Include prior-thread attachments in the Codex execution input so the agent can inspect earlier images/files, not just see text descriptions.

## Validation
- bun tsgo --project tsconfig.json --noEmit
- bun test test/chat-sdk-emulate.test.ts -t "mid-thread"
- just build-one slackbotv2
- just deploy
- kubectl exec -n centaur deploy/centaur-centaur-slackbotv2 -- bun -e "const r=await fetch('http://localhost:3001/health'); console.log(r.status, await r.text())"

## Notes
- Full `bun test test` still has 5 existing stream-budget/rendering tests failing, and those failures reproduce individually outside this change area.