### PR TITLE
feat: store Slack ETL message attachments

### DIFF
--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -96,7 +96,12 @@ Slack ETL writes normalized Slack data into dedicated tables:
 | `slack_sync_message_attachments` | Slack files attached to synced root messages and replies, including metadata, download status, checksum, and bounded `bytea` content when fetched. |
 | `slack_sync_checkpoints` | Per-channel watermarks and last error state. |
 | `slack_sync_backfill_jobs` | Deferred channel-history and thread-refresh jobs. |
-| `company_context_documents` | Derived channel-day and thread documents for retrieval. |
+| `company_context_documents` | Derived channel-day, thread, and attachment-metadata documents for retrieval. |
+
+Attachment document projection indexes Slack file names, titles, MIME/file
+types, Slack permalinks, download status, checksums, and the message the file
+was attached to. It does not parse attachment bytes or index private Slack
+download URLs.
 
 The first incremental run reads a small recent window so useful data appears
 quickly, then seeds historical backfill jobs for the configured lookback. Later

--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -39,8 +39,8 @@ posting to Slack.
 
 Create a Slack user token for ETL reads and store it as `SLACK_ETL_TOKEN` in
 the same secret source used by tools. The Slack tool declares it as an optional
-HTTP secret for `slack.com`; iron-proxy injects the real value when the tool
-calls Slack.
+HTTP secret for `slack.com` and `files.slack.com`; iron-proxy injects the real
+value when the tool calls Slack.
 
 The token must be able to call:
 
@@ -50,6 +50,7 @@ The token must be able to call:
 | `conversations.history` | Read channel root messages. |
 | `conversations.replies` | Refresh thread replies. |
 | `users.list` | Resolve Slack user metadata for documents. |
+| `files:read` / file URL access | Download message attachment bytes from `files.slack.com`. |
 
 Slack ETL currently syncs public channels visible to the configured ETL user
 token. It does not sync private channels, DMs, or Slackbot-only live thread
@@ -70,6 +71,8 @@ once Slack ETL is enabled, but can be tuned independently.
 | `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `5` | Maximum Slack history pages drained before a job is requeued. |
 | `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS` | `30` | Historical window seeded for first-time channel backfills. |
 | `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `3` | Recent thread window eligible for reply refresh. |
+| `SLACK_ETL_ATTACHMENTS_ENABLED` | `true` | Download Slack message attachment bytes into Postgres. Metadata rows are still written when downloads are disabled. |
+| `SLACK_ETL_ATTACHMENT_MAX_BYTES` | `10485760` | Per-file byte cap for Slack attachment downloads. Oversized files keep metadata with `skipped_too_large` status. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | empty | Comma-separated channel-name globs to skip, without needing the leading `#`. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
@@ -90,6 +93,7 @@ Slack ETL writes normalized Slack data into dedicated tables:
 | `slack_sync_users` | Slack user display metadata used when rendering documents. |
 | `slack_sync_runs` | One row per incremental or backfill workflow run, with counts and channel outcomes. |
 | `slack_sync_messages` | Root messages and replies keyed by `(channel_id, message_ts)`. |
+| `slack_sync_message_attachments` | Slack files attached to synced root messages and replies, including metadata, download status, checksum, and bounded `bytea` content when fetched. |
 | `slack_sync_checkpoints` | Per-channel watermarks and last error state. |
 | `slack_sync_backfill_jobs` | Deferred channel-history and thread-refresh jobs. |
 | `company_context_documents` | Derived channel-day and thread documents for retrieval. |

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -96,7 +96,12 @@ Slack ETL writes normalized Slack data into dedicated tables:
 | `slack_sync_message_attachments` | Slack files attached to synced root messages and replies, including metadata, download status, checksum, and bounded `bytea` content when fetched. |
 | `slack_sync_checkpoints` | Per-channel watermarks and last error state. |
 | `slack_sync_backfill_jobs` | Deferred channel-history and thread-refresh jobs. |
-| `company_context_documents` | Derived channel-day and thread documents for retrieval. |
+| `company_context_documents` | Derived channel-day, thread, and attachment-metadata documents for retrieval. |
+
+Attachment document projection indexes Slack file names, titles, MIME/file
+types, Slack permalinks, download status, checksums, and the message the file
+was attached to. It does not parse attachment bytes or index private Slack
+download URLs.
 
 The first incremental run reads a small recent window so useful data appears
 quickly, then seeds historical backfill jobs for the configured lookback. Later

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -39,8 +39,8 @@ posting to Slack.
 
 Create a Slack user token for ETL reads and store it as `SLACK_ETL_TOKEN` in
 the same secret source used by tools. The Slack tool declares it as an optional
-HTTP secret for `slack.com`; iron-proxy injects the real value when the tool
-calls Slack.
+HTTP secret for `slack.com` and `files.slack.com`; iron-proxy injects the real
+value when the tool calls Slack.
 
 The token must be able to call:
 
@@ -50,6 +50,7 @@ The token must be able to call:
 | `conversations.history` | Read channel root messages. |
 | `conversations.replies` | Refresh thread replies. |
 | `users.list` | Resolve Slack user metadata for documents. |
+| `files:read` / file URL access | Download message attachment bytes from `files.slack.com`. |
 
 Slack ETL currently syncs public channels visible to the configured ETL user
 token. It does not sync private channels, DMs, or Slackbot-only live thread
@@ -70,6 +71,8 @@ once Slack ETL is enabled, but can be tuned independently.
 | `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `5` | Maximum Slack history pages drained before a job is requeued. |
 | `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS` | `30` | Historical window seeded for first-time channel backfills. |
 | `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `3` | Recent thread window eligible for reply refresh. |
+| `SLACK_ETL_ATTACHMENTS_ENABLED` | `true` | Download Slack message attachment bytes into Postgres. Metadata rows are still written when downloads are disabled. |
+| `SLACK_ETL_ATTACHMENT_MAX_BYTES` | `10485760` | Per-file byte cap for Slack attachment downloads. Oversized files keep metadata with `skipped_too_large` status. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | empty | Comma-separated channel-name globs to skip, without needing the leading `#`. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
@@ -90,6 +93,7 @@ Slack ETL writes normalized Slack data into dedicated tables:
 | `slack_sync_users` | Slack user display metadata used when rendering documents. |
 | `slack_sync_runs` | One row per incremental or backfill workflow run, with counts and channel outcomes. |
 | `slack_sync_messages` | Root messages and replies keyed by `(channel_id, message_ts)`. |
+| `slack_sync_message_attachments` | Slack files attached to synced root messages and replies, including metadata, download status, checksum, and bounded `bytea` content when fetched. |
 | `slack_sync_checkpoints` | Per-channel watermarks and last error state. |
 | `slack_sync_backfill_jobs` | Deferred channel-history and thread-refresh jobs. |
 | `company_context_documents` | Derived channel-day and thread documents for retrieval. |

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0017_slack_sync_message_attachments.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0017_slack_sync_message_attachments.sql
@@ -1,0 +1,56 @@
+create table if not exists slack_sync_message_attachments (
+    channel_id text not null,
+    message_ts text not null,
+    slack_file_id text not null,
+    name text not null default '',
+    title text not null default '',
+    mimetype text not null default '',
+    filetype text not null default '',
+    size_bytes bigint not null default 0,
+    url_private text not null default '',
+    permalink text not null default '',
+    download_status text not null default 'metadata_only',
+    download_error text not null default '',
+    content_sha256 text,
+    content_bytes bytea,
+    raw_payload jsonb not null default '{}'::jsonb,
+    source_run_id text references slack_sync_runs(run_id) on delete set null,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    primary key (channel_id, message_ts, slack_file_id),
+    foreign key (channel_id, message_ts)
+        references slack_sync_messages(channel_id, message_ts)
+        on delete cascade
+);
+
+create index if not exists idx_slack_sync_message_attachments_message
+    on slack_sync_message_attachments (channel_id, message_ts);
+
+create index if not exists idx_slack_sync_message_attachments_file
+    on slack_sync_message_attachments (slack_file_id);
+
+create index if not exists idx_slack_sync_message_attachments_status
+    on slack_sync_message_attachments (download_status, updated_at desc);
+
+grant select on slack_sync_message_attachments to centaur_slack_reader, centaur_slack_admin;
+
+alter table slack_sync_message_attachments enable row level security;
+
+drop policy if exists centaur_slack_message_attachments_admin_select
+    on slack_sync_message_attachments;
+create policy centaur_slack_message_attachments_admin_select
+    on slack_sync_message_attachments
+    for select
+    to centaur_slack_admin
+    using (true);
+
+drop policy if exists centaur_slack_message_attachments_reader_select
+    on slack_sync_message_attachments;
+create policy centaur_slack_message_attachments_reader_select
+    on slack_sync_message_attachments
+    for select
+    to centaur_slack_reader
+    using (
+        channel_id = nullif(current_setting('centaur.slack_channel_id', true), '')
+    );

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -5,6 +5,7 @@ import {
   Chat,
   StreamingPlan,
   type Adapter,
+  type Attachment,
   type Logger,
   type Message as ChatMessage,
   type StateAdapter,
@@ -27,6 +28,7 @@ import {
   harnessRestartPreamble,
   isRetryableSessionApiError,
   openSessionEventStream,
+  serializeAttachment,
   serializeMessage,
   sessionStreamError
 } from './session-api'
@@ -35,6 +37,7 @@ import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from './slack-events
 import type {
   ForwardSessionInput,
   SlackbotV2,
+  SlackbotV2ApiAttachment,
   SlackbotV2ApiMessage,
   SlackbotV2ExecuteSessionResponse,
   SlackbotV2MessageMode,
@@ -74,6 +77,8 @@ type SlackAssistantAdapter = {
   ): Promise<void>
   setAssistantTitle?(channelId: string, threadTs: string, title: string): Promise<void>
 }
+
+const MAX_SLACK_MESSAGE_ATTACHMENTS = 20
 
 type SlackbotV2RequestContext = {
   retryableErrors: unknown[]
@@ -1404,7 +1409,7 @@ async function collectSlackThreadContext(
       const messageTs = stringField(message.ts)
       if (!messageTs || compareSlackTs(messageTs, currentTs) > 0) continue
       if (isSelfSlackBotMessage(options, message)) continue
-      messages.push(slackApiMessageFromSlack(message, currentMessage))
+      messages.push(await slackApiMessageFromSlack(options, message, currentMessage))
     }
     cursor = response.nextCursor
   } while (cursor)
@@ -1419,16 +1424,17 @@ async function collectSlackThreadContext(
   return messages
 }
 
-function slackApiMessageFromSlack(
+async function slackApiMessageFromSlack(
+  options: SlackbotV2Options,
   message: Record<string, unknown>,
   currentMessage: ChatMessage
-): SlackbotV2ApiMessage {
+): Promise<SlackbotV2ApiMessage> {
   const rawCurrent = slackRawRecord(currentMessage)
   const id = stringField(message.ts) || randomUUID()
   const actorId = slackActorId(message)
   const isBot = Boolean(message.bot_id || message.bot_profile)
   return {
-    attachments: [],
+    attachments: await slackApiAttachmentsFromFiles(options, message, rawCurrent),
     author: {
       fullName: actorId,
       isBot,
@@ -1448,6 +1454,82 @@ function slackApiMessageFromSlack(
     threadId: currentMessage.threadId,
     timestamp: slackTimestampToIso(id)
   }
+}
+
+async function slackApiAttachmentsFromFiles(
+  options: SlackbotV2Options,
+  message: Record<string, unknown>,
+  rawCurrent: Record<string, unknown>
+): Promise<SlackbotV2ApiAttachment[]> {
+  const files = slackFiles(message)
+  if (files.length === 0) return []
+  const teamId =
+    stringField(message.team)
+    || stringField(message.team_id)
+    || stringField(rawCurrent.team)
+    || stringField(rawCurrent.team_id)
+  const attachments: SlackbotV2ApiAttachment[] = []
+  for (const file of files.slice(0, MAX_SLACK_MESSAGE_ATTACHMENTS)) {
+    attachments.push(await serializeAttachment(slackFileAttachment(options, file, teamId)))
+  }
+  if (files.length > MAX_SLACK_MESSAGE_ATTACHMENTS) {
+    attachments.push({
+      fetchError:
+        `only the first ${MAX_SLACK_MESSAGE_ATTACHMENTS} Slack message attachments were fetched`,
+      name: 'additional Slack thread attachments',
+      type: 'file'
+    })
+  }
+  return attachments
+}
+
+function slackFiles(message: Record<string, unknown>): Record<string, unknown>[] {
+  return Array.isArray(message.files)
+    ? (message.files.filter(file =>
+        file && typeof file === 'object' && !Array.isArray(file)
+      ) as Record<string, unknown>[])
+    : []
+}
+
+function slackFileAttachment(
+  options: SlackbotV2Options,
+  file: Record<string, unknown>,
+  teamId: string
+): Attachment {
+  const url = stringField(file.url_private_download) || stringField(file.url_private)
+  const mimeType = stringField(file.mimetype)
+  const fetchMetadata: Record<string, string> = {}
+  if (url) fetchMetadata.url = url
+  if (teamId) fetchMetadata.teamId = teamId
+  return {
+    fetchData: url ? () => fetchSlackFile(options, url) : undefined,
+    fetchMetadata: Object.keys(fetchMetadata).length > 0 ? fetchMetadata : undefined,
+    height: numberField(file.original_h),
+    mimeType,
+    name: stringField(file.name) || stringField(file.title) || stringField(file.id),
+    size: numberField(file.size),
+    type: slackFileAttachmentType(mimeType),
+    url,
+    width: numberField(file.original_w)
+  }
+}
+
+async function fetchSlackFile(options: SlackbotV2Options, url: string): Promise<Buffer> {
+  const fetchFn = options.fetch ?? fetch
+  const response = await fetchFn(url, {
+    headers: { authorization: `Bearer ${options.botToken}` }
+  })
+  if (!response.ok) {
+    throw new Error(`failed to fetch Slack file: ${response.status} ${response.statusText}`)
+  }
+  return Buffer.from(await response.arrayBuffer())
+}
+
+function slackFileAttachmentType(mimeType: string): Attachment['type'] {
+  if (mimeType.startsWith('image/')) return 'image'
+  if (mimeType.startsWith('video/')) return 'video'
+  if (mimeType.startsWith('audio/')) return 'audio'
+  return 'file'
 }
 
 function slackRawRecord(message: ChatMessage): Record<string, unknown> {
@@ -1481,6 +1563,10 @@ function isSelfSlackBotMessage(
 
 function stringField(value: unknown): string {
   return typeof value === 'string' ? value : ''
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 function compareSlackTs(a: string, b: string): number {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -264,7 +264,7 @@ export const MAX_INLINE_ATTACHMENT_BYTES = 100 * 1024 * 1024
 const MAX_CODEX_INPUT_LINE_CHARS = 900 * 1024
 const STAGED_ATTACHMENT_CHUNK_CHARS = 700 * 1024
 
-async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2ApiAttachment> {
+export async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2ApiAttachment> {
   const serialized: SlackbotV2ApiAttachment = {
     fetchMetadata: attachment.fetchMetadata,
     height: attachment.height,
@@ -957,7 +957,7 @@ function toCodexInputLines(
 ): string[] {
   const staged = new Map<SlackbotV2ApiAttachment, string>()
   const lines: string[] = []
-  for (const attachment of message.attachments) {
+  for (const attachment of executableAttachments(message, contextMessages)) {
     if (!attachment.dataBase64) continue
     const inlineLine = toCodexInputLineWithStaged(
       message,
@@ -990,6 +990,19 @@ function toCodexInputLines(
     )
   )
   return lines
+}
+
+function executableAttachments(
+  message: SlackbotV2ApiMessage,
+  contextMessages?: SlackbotV2ApiMessage[]
+): SlackbotV2ApiAttachment[] {
+  const attachments: SlackbotV2ApiAttachment[] = []
+  for (const item of contextMessages ?? []) {
+    if (item.id === message.id) continue
+    attachments.push(...item.attachments)
+  }
+  attachments.push(...message.attachments)
+  return attachments
 }
 
 function toCodexInputLineWithStaged(
@@ -1109,6 +1122,17 @@ function codexInputContent(
       content.push({ type: 'text', text: threadContext })
     }
   }
+  for (const contextAttachment of slackThreadContextAttachments(message, contextMessages)) {
+    content.push({
+      type: 'text',
+      text:
+        `Earlier Slack thread attachment from ${slackContextAuthor(contextAttachment.message)}: `
+        + attachmentDescription(contextAttachment.attachment)
+    })
+    content.push(
+      codexAttachmentInput(contextAttachment.attachment, staged.get(contextAttachment.attachment))
+    )
+  }
   if (message.text.trim()) {
     content.push({ type: 'text', text: message.text })
   }
@@ -1137,6 +1161,23 @@ function slackThreadContext(
   }
   lines.push('', '# Current Request', '', 'The user message follows in the next content block.', '---')
   return lines.join('\n')
+}
+
+function slackThreadContextAttachments(
+  currentMessage: SlackbotV2ApiMessage,
+  contextMessages: SlackbotV2ApiMessage[] | undefined
+): Array<{ attachment: SlackbotV2ApiAttachment; message: SlackbotV2ApiMessage }> {
+  const attachments: Array<{
+    attachment: SlackbotV2ApiAttachment
+    message: SlackbotV2ApiMessage
+  }> = []
+  for (const message of contextMessages ?? []) {
+    if (message.id === currentMessage.id) continue
+    for (const attachment of message.attachments) {
+      attachments.push({ attachment, message })
+    }
+  }
+  return attachments
 }
 
 function slackContextAuthor(message: SlackbotV2ApiMessage): string {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -357,6 +357,64 @@ describe('slackbotv2', () => {
     expect(executeInput).toContain('summarize the thread so far')
   })
 
+  it('fetches attachments from preceding Slack thread messages for a mid-thread mention', async () => {
+    const parent = await postUserMessage('Root context before an attachment.')
+    const priorReply = await postUserMessage('Screenshot is attached here.', parent.ts)
+    const fileUrl = `${slackApi.url}/files/captured.png`
+    slackApi.addFileToMessage(CHANNEL_ID, priorReply.ts, {
+      id: 'F-thread-context-image',
+      mimetype: 'image/png',
+      name: 'thread-context.png',
+      original_h: 600,
+      original_w: 800,
+      size: 16,
+      url_private: fileUrl
+    })
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> inspect the earlier screenshot`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-mid-thread-history-attachment',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> inspect the earlier screenshot`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    const appendedAttachment = codexApi.appends[0]!.body.messages
+      .flatMap(message => message.parts)
+      .find(part => isRecord(part) && part.type === 'attachment')
+    expect(appendedAttachment).toEqual(
+      expect.objectContaining({
+        attachment_type: 'image',
+        dataBase64: Buffer.from('captured-image').toString('base64'),
+        mimeType: 'image/png',
+        name: 'thread-context.png',
+        type: 'attachment',
+        url: fileUrl
+      })
+    )
+
+    const executeInput = JSON.stringify(JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!))
+    expect(executeInput).toContain('Screenshot is attached here.')
+    expect(executeInput).toContain('Earlier Slack thread attachment')
+    expect(executeInput).toContain(
+      `data:image/png;base64,${Buffer.from('captured-image').toString('base64')}`
+    )
+  })
+
   it('injects Slack requester identity and verified GitHub handle into Codex input', async () => {
     slackApi.setUserProfile(USER_ID, {
       name: 'akshaan',
@@ -3530,6 +3588,7 @@ function writeMockSseEvent(stream: ServerResponse, event: MockSessionEvent): voi
 }
 
 type PatchedSlackApi = {
+  addFileToMessage(channel: string, ts: string, file: Record<string, unknown>): void
   calls: StreamCall[]
   close(): Promise<void>
   failRepliesWithThreadNotFound(channel: string, ts: string): void
@@ -3572,6 +3631,7 @@ type SlackStreamTranscript = {
 async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackApi> {
   const upstreamUrl = loopbackUrl(emulatorUrl)
   const calls: StreamCall[] = []
+  const threadMessageFiles = new Map<string, Record<string, unknown>[]>()
   const userProfiles = new Map<string, Record<string, unknown>>()
   const userProfileRequests = new Map<string, number>()
   const threadNotFoundReplies = new Set<string>()
@@ -3587,6 +3647,7 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       port,
       streams,
       threadNotFoundReplies,
+      threadMessageFiles,
       userProfiles,
       userProfileRequests,
       upstreamUrl
@@ -3597,6 +3658,10 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
   })
   await listen(server, port)
   return {
+    addFileToMessage(channel: string, ts: string, file: Record<string, unknown>) {
+      const key = slackReplyKey(channel, ts)
+      threadMessageFiles.set(key, [...(threadMessageFiles.get(key) ?? []), file])
+    },
     calls,
     url: `http://127.0.0.1:${port}`,
     failRepliesWithThreadNotFound(channel: string, ts: string) {
@@ -3615,6 +3680,7 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       appendFailure.remaining = -1
       appendFailure.error = ''
       threadNotFoundReplies.clear()
+      threadMessageFiles.clear()
       streams.clear()
       userProfiles.clear()
       userProfileRequests.clear()
@@ -3642,6 +3708,7 @@ async function handlePatchedSlackRequest(
     port: number
     streams: Map<string, StreamRecord>
     threadNotFoundReplies: Set<string>
+    threadMessageFiles: Map<string, Record<string, unknown>[]>
     userProfiles: Map<string, Record<string, unknown>>
     userProfileRequests: Map<string, number>
     upstreamUrl: string
@@ -3749,6 +3816,27 @@ async function handlePatchedSlackRequest(
       )
     ) {
       await sendWebResponse(res, Response.json({ ok: false, error: 'thread_not_found' }))
+      return
+    }
+    if (input.threadMessageFiles.size > 0) {
+      const rawBody = await request.arrayBuffer()
+      const proxied = await fetch(new URL(`${path}${url.search}`, input.upstreamUrl), {
+        method: request.method,
+        headers: request.headers,
+        body: rawBody.byteLength > 0 ? rawBody : undefined
+      })
+      const payload = await proxied.json() as Record<string, unknown>
+      if (Array.isArray(payload.messages)) {
+        payload.messages = payload.messages.map(message => {
+          if (!message || typeof message !== 'object' || Array.isArray(message)) return message
+          const item = message as Record<string, unknown>
+          const files = input.threadMessageFiles.get(
+            slackReplyKey(stringField(body.channel), stringField(item.ts))
+          )
+          return files ? { ...item, files: [...slackFileArray(item.files), ...files] } : item
+        })
+      }
+      await sendWebResponse(res, Response.json(payload, { status: proxied.status }))
       return
     }
   }
@@ -4176,6 +4264,14 @@ function slackReplyKey(channel: string, ts: string): string {
 
 function stringField(value: unknown): string {
   return typeof value === 'string' ? value : ''
+}
+
+function slackFileArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? (value.filter(item =>
+        item && typeof item === 'object' && !Array.isArray(item)
+      ) as Record<string, unknown>[])
+    : []
 }
 
 function parseMaybeJson(value: string): unknown {

--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -32,4 +32,5 @@ secrets = [
 ]
 optional_secrets = [
     {type = "http", name = "SLACK_SEARCH_TOKEN", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["slack.com"]},
+    {type = "http", name = "SLACK_ETL_TOKEN", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["slack.com", "files.slack.com"]},
 ]

--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -29,7 +29,7 @@ FALSE_ENV_VALUES = {"0", "false", "no", "off"}
 SLACK_MENTION_RE = re.compile(r"<@([A-Z0-9]+)>")
 SLACK_CHANNEL_RE = re.compile(r"<#([A-Z0-9]+)(?:\|([^>]+))?>")
 COMPANY_CONTEXT_SOURCE_TYPES = {
-    "slack": ("slack_channel_day", "slack_thread"),
+    "slack": ("slack_channel_day", "slack_thread", "slack_attachment"),
     "google_drive": ("google_doc",),
     "google_calendar": ("calendar_event",),
     "linear": ("linear_issue",),
@@ -299,8 +299,10 @@ async def _load_changed_message_keys(pool, since: dt.datetime | None) -> dict[st
     if since is None:
         where_sql = ""
         args: list[Any] = []
+        attachment_where_sql = ""
     else:
         where_sql = "WHERE updated_at > $1"
+        attachment_where_sql = "WHERE a.updated_at > $1"
         args = [since]
 
     channel_day_rows = await pool.fetch(
@@ -321,10 +323,35 @@ async def _load_changed_message_keys(pool, since: dt.datetime | None) -> dict[st
         f"FROM slack_sync_messages {where_sql}",
         *args,
     )
+    attachment_rows = await pool.fetch(
+        "SELECT a.channel_id, c.channel_name, a.message_ts, a.slack_file_id, "
+        "a.name, a.title, a.mimetype, a.filetype, a.size_bytes, a.permalink, "
+        "a.download_status, a.download_error, a.content_sha256, a.updated_at, "
+        "m.occurred_at, m.thread_ts, m.parent_message_ts, m.user_id, "
+        "u.user_name, u.real_name, u.display_name, m.text, "
+        "m.permalink AS message_permalink "
+        "FROM slack_sync_message_attachments a "
+        "JOIN slack_sync_messages m "
+        "  ON m.channel_id = a.channel_id AND m.message_ts = a.message_ts "
+        "LEFT JOIN slack_sync_channels c ON c.channel_id = a.channel_id "
+        "LEFT JOIN slack_sync_users u ON u.user_id = m.user_id "
+        f"{attachment_where_sql} "
+        "ORDER BY a.updated_at, a.channel_id, a.message_ts, a.slack_file_id",
+        *args,
+    )
+    attachment_stats = await pool.fetchrow(
+        "SELECT COUNT(*) AS changed_attachments, MAX(updated_at) AS max_updated_at "
+        f"FROM slack_sync_message_attachments a {attachment_where_sql}",
+        *args,
+    )
 
-    max_updated_at = stats["max_updated_at"] if stats else None
-    if isinstance(max_updated_at, dt.datetime):
-        max_updated_at = max_updated_at.astimezone(dt.timezone.utc)
+    max_updated_candidates = []
+    for candidate in (
+        stats["max_updated_at"] if stats else None,
+        attachment_stats["max_updated_at"] if attachment_stats else None,
+    ):
+        if isinstance(candidate, dt.datetime):
+            max_updated_candidates.append(candidate.astimezone(dt.timezone.utc))
 
     return {
         "channel_days": [
@@ -335,8 +362,14 @@ async def _load_changed_message_keys(pool, since: dt.datetime | None) -> dict[st
         "threads": [
             (str(row["channel_id"]), str(row["thread_ts"])) for row in thread_rows
         ],
+        "attachments": list(attachment_rows),
         "changed_messages": int(stats["changed_messages"] or 0) if stats else 0,
-        "max_updated_at": max_updated_at,
+        "changed_attachments": (
+            int(attachment_stats["changed_attachments"] or 0) if attachment_stats else 0
+        ),
+        "max_updated_at": max(max_updated_candidates)
+        if max_updated_candidates
+        else None,
     }
 
 
@@ -692,6 +725,119 @@ def _thread_document(
         "occurred_at": first["occurred_at"],
         "source_updated_at": last_updated,
         "content_hash": _content_hash(title, body, permalink, metadata),
+        "metadata": metadata,
+    }
+
+
+def _slack_attachment_document(
+    row: Any,
+    *,
+    users_by_id: dict[str, str],
+    channels_by_id: dict[str, str],
+) -> dict[str, Any] | None:
+    """Render one Slack attachment metadata document."""
+    channel_id = str(row["channel_id"] or "")
+    message_ts = str(row["message_ts"] or "")
+    slack_file_id = str(row["slack_file_id"] or "")
+    if not channel_id or not message_ts or not slack_file_id:
+        return None
+
+    channel_name = str(
+        row["channel_name"] or channels_by_id.get(channel_id) or channel_id
+    )
+    filename = str(row["name"] or "")
+    attachment_title = str(row["title"] or "")
+    label = attachment_title or filename or slack_file_id
+    title = f"Slack attachment: {label}"
+    message_permalink = str(row["message_permalink"] or "")
+    attachment_permalink = str(row["permalink"] or "")
+    mimetype = str(row["mimetype"] or "")
+    filetype = str(row["filetype"] or "")
+    download_status = str(row["download_status"] or "")
+    download_error = str(row["download_error"] or "")
+    content_sha256 = str(row["content_sha256"] or "")
+    size_bytes = int(row["size_bytes"] or 0)
+    author_name = _display_name(row)
+    message_text = _resolve_slack_mentions(
+        str(row["text"] or ""),
+        users_by_id=users_by_id,
+        channels_by_id=channels_by_id,
+    )
+
+    lines = [
+        f"# {title}",
+        "",
+        "- Source: Slack attachment",
+        f"- Channel: #{channel_name}",
+        f"- Attached message: {message_permalink}",
+    ]
+    if attachment_permalink:
+        lines.append(f"- Attachment permalink: {attachment_permalink}")
+    if filename:
+        lines.append(f"- Filename: {filename}")
+    if attachment_title:
+        lines.append(f"- Title: {attachment_title}")
+    if mimetype:
+        lines.append(f"- MIME type: {mimetype}")
+    if filetype:
+        lines.append(f"- File type: {filetype}")
+    if size_bytes:
+        lines.append(f"- Size: {size_bytes} bytes")
+    if download_status:
+        lines.append(f"- Download status: {download_status}")
+    if download_error:
+        lines.append(f"- Download error: {download_error}")
+    if content_sha256:
+        lines.append(f"- Content SHA-256: {content_sha256}")
+    lines.extend(
+        [
+            f"- Attached by: {author_name}",
+            f"- Attached at: {_format_time(row['occurred_at'])}",
+            "",
+            "---",
+            "",
+            "Attached to Slack message:",
+            "",
+            message_text,
+        ]
+    )
+
+    body = "\n".join(lines).strip()
+    source_document_id = f"{channel_id}:{message_ts}:{slack_file_id}"
+    metadata = {
+        "channel_id": channel_id,
+        "channel_name": channel_name,
+        "message_ts": message_ts,
+        "thread_ts": str(row["thread_ts"] or ""),
+        "parent_message_ts": str(row["parent_message_ts"] or ""),
+        "slack_file_id": slack_file_id,
+        "filename": filename,
+        "title": attachment_title,
+        "mimetype": mimetype,
+        "filetype": filetype,
+        "size_bytes": size_bytes,
+        "download_status": download_status,
+        "content_sha256": content_sha256,
+        "message_permalink": message_permalink,
+        "attachment_permalink": attachment_permalink,
+    }
+    url = attachment_permalink or message_permalink
+    return {
+        "document_id": f"slack:attachment:{channel_id}:{message_ts}:{slack_file_id}",
+        "source": "slack",
+        "source_type": "slack_attachment",
+        "source_document_id": source_document_id,
+        "source_chunk_id": "",
+        "parent_document_id": None,
+        "title": title,
+        "body": body,
+        "url": url,
+        "author_id": str(row["user_id"] or ""),
+        "author_name": author_name,
+        "access_scope": "company",
+        "occurred_at": row["occurred_at"],
+        "source_updated_at": row["updated_at"],
+        "content_hash": _content_hash(title, body, url, metadata),
         "metadata": metadata,
     }
 
@@ -1166,7 +1312,9 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     changed = {
         "channel_days": [],
         "threads": [],
+        "attachments": [],
         "changed_messages": 0,
+        "changed_attachments": 0,
         "max_updated_at": None,
     }
     users_by_id: dict[str, str] = {}
@@ -1252,6 +1400,28 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     "slack_thread",
                     "deleted",
                 )
+            continue
+        observe_company_context_document_size(
+            "slack",
+            str(document["source_type"]),
+            len(str(document["body"] or "")),
+        )
+        action = await _upsert_document(ctx._pool, document)
+        record_company_context_documents_changed(
+            "slack",
+            str(document["source_type"]),
+            action,
+        )
+        if action in {"inserted", "updated"}:
+            documents_upserted += 1
+
+    for row in changed["attachments"]:
+        document = _slack_attachment_document(
+            row,
+            users_by_id=users_by_id,
+            channels_by_id=channels_by_id,
+        )
+        if document is None:
             continue
         observe_company_context_document_size(
             "slack",
@@ -1355,11 +1525,13 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     result = {
         "status": "completed",
         "changed_messages": changed["changed_messages"],
+        "changed_slack_attachments": changed["changed_attachments"],
         "changed_drive_files": drive_changed["changed_files"],
         "changed_calendar_events": calendar_changed["changed_events"],
         "changed_linear_issues": linear_changed["changed_issues"],
         "channel_day_documents": len(changed["channel_days"]),
         "thread_candidates": len(changed["threads"]),
+        "slack_attachment_documents": len(changed["attachments"]),
         "drive_documents": len(drive_changed["files"]),
         "calendar_event_documents": len(calendar_changed["events"]),
         "linear_issue_documents": len(linear_changed["issues"]),

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -3,17 +3,22 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import json
+import mimetypes
 import os
 import re
 import time
 from collections.abc import Callable
 from typing import Any, ClassVar, Protocol
+from urllib import error as urllib_error
+from urllib import request as urllib_request
 
 from centaur_sdk import secret
 from api.runtime_control import canonical_json
 
 FALSE_ENV_VALUES = {"0", "false", "no", "off"}
+DEFAULT_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024
 BACKFILL_JOB_CHANNEL_CONTINUATION = "channel_continuation"
 BACKFILL_JOB_CHANNEL_BOOTSTRAP = "channel_bootstrap"
 BACKFILL_JOB_THREAD_REFRESH = "thread_refresh"
@@ -41,6 +46,19 @@ def env_flag_enabled(name: str, default: bool = True) -> bool:
     if value is None:
         return default
     return value.strip().lower() not in FALSE_ENV_VALUES
+
+
+def attachment_download_enabled() -> bool:
+    """Return whether Slack ETL should download attachment bytes into Postgres."""
+    return env_flag_enabled("SLACK_ETL_ATTACHMENTS_ENABLED", default=True)
+
+
+def attachment_max_bytes() -> int:
+    """Return the per-file Slack ETL attachment byte cap."""
+    return positive_int(
+        os.getenv("SLACK_ETL_ATTACHMENT_MAX_BYTES"),
+        DEFAULT_ATTACHMENT_MAX_BYTES,
+    )
 
 
 class SlackSyncClient(Protocol):
@@ -124,9 +142,146 @@ def message_row(
         "reply_count": int(message.get("reply_count") or 0),
         "reply_users": message.get("reply_users") or [],
         "latest_reply_ts": message.get("latest_reply"),
-        "raw_payload": message,
+        "raw_payload": _message_raw_payload(message),
+        "attachments": message.get("files") or [],
         "source_run_id": run_id,
     }
+
+
+def _message_raw_payload(message: dict[str, Any]) -> dict[str, Any]:
+    """Return the message payload without byte content so it can be stored as JSONB."""
+    raw_payload = dict(message)
+    files = raw_payload.get("files")
+    if isinstance(files, list):
+        raw_payload["files"] = [
+            _attachment_raw_payload(file_obj)
+            for file_obj in files
+            if isinstance(file_obj, dict)
+        ]
+    return raw_payload
+
+
+def _attachment_raw_payload(attachment: dict[str, Any]) -> dict[str, Any]:
+    raw_payload = attachment.get("raw_payload")
+    if isinstance(raw_payload, dict):
+        return raw_payload
+    return {
+        key: value for key, value in attachment.items() if key not in {"content_bytes"}
+    }
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _attachment_rows(row: dict[str, Any]) -> list[dict[str, Any]]:
+    """Project normalized Slack file metadata into DB rows."""
+    attachments = row.get("attachments") or []
+    if not isinstance(attachments, list):
+        return []
+
+    result: list[dict[str, Any]] = []
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        slack_file_id = str(attachment.get("id") or "").strip()
+        if not slack_file_id:
+            continue
+        result.append(
+            {
+                "channel_id": row["channel_id"],
+                "message_ts": row["message_ts"],
+                "slack_file_id": slack_file_id,
+                "name": str(attachment.get("name") or ""),
+                "title": str(attachment.get("title") or ""),
+                "mimetype": str(attachment.get("mimetype") or ""),
+                "filetype": str(attachment.get("filetype") or ""),
+                "size_bytes": _safe_int(attachment.get("size")),
+                "url_private": str(attachment.get("url_private") or ""),
+                "permalink": str(attachment.get("permalink") or ""),
+                "download_status": str(
+                    attachment.get("download_status") or "metadata_only"
+                ),
+                "download_error": str(attachment.get("download_error") or ""),
+                "content_sha256": attachment.get("content_sha256"),
+                "content_bytes": attachment.get("content_bytes"),
+                "raw_payload": _attachment_raw_payload(attachment),
+                "source_run_id": row["source_run_id"],
+            }
+        )
+    return result
+
+
+async def _replace_message_attachments(conn, row: dict[str, Any]) -> int:
+    """Replace attachment rows for one observed Slack message."""
+    attachments = _attachment_rows(row)
+    attachment_ids = [attachment["slack_file_id"] for attachment in attachments]
+
+    for attachment in attachments:
+        await conn.execute(
+            "INSERT INTO slack_sync_message_attachments ("
+            "channel_id, message_ts, slack_file_id, name, title, mimetype, filetype, "
+            "size_bytes, url_private, permalink, download_status, download_error, "
+            "content_sha256, content_bytes, raw_payload, source_run_id, last_seen_at, updated_at"
+            ") VALUES ("
+            "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, "
+            "$15::jsonb, $16, NOW(), NOW()"
+            ") ON CONFLICT (channel_id, message_ts, slack_file_id) DO UPDATE SET "
+            "name = EXCLUDED.name, "
+            "title = EXCLUDED.title, "
+            "mimetype = EXCLUDED.mimetype, "
+            "filetype = EXCLUDED.filetype, "
+            "size_bytes = EXCLUDED.size_bytes, "
+            "url_private = EXCLUDED.url_private, "
+            "permalink = EXCLUDED.permalink, "
+            "download_status = EXCLUDED.download_status, "
+            "download_error = EXCLUDED.download_error, "
+            "content_sha256 = EXCLUDED.content_sha256, "
+            "content_bytes = EXCLUDED.content_bytes, "
+            "raw_payload = EXCLUDED.raw_payload, "
+            "source_run_id = EXCLUDED.source_run_id, "
+            "last_seen_at = NOW(), "
+            "updated_at = NOW()",
+            attachment["channel_id"],
+            attachment["message_ts"],
+            attachment["slack_file_id"],
+            attachment["name"],
+            attachment["title"],
+            attachment["mimetype"],
+            attachment["filetype"],
+            attachment["size_bytes"],
+            attachment["url_private"],
+            attachment["permalink"],
+            attachment["download_status"],
+            attachment["download_error"],
+            attachment["content_sha256"],
+            attachment["content_bytes"],
+            canonical_json(attachment["raw_payload"]),
+            attachment["source_run_id"],
+        )
+
+    if attachment_ids:
+        await conn.execute(
+            "DELETE FROM slack_sync_message_attachments "
+            "WHERE channel_id = $1 "
+            "  AND message_ts = $2 "
+            "  AND NOT (slack_file_id = ANY($3::text[]))",
+            row["channel_id"],
+            row["message_ts"],
+            attachment_ids,
+        )
+    else:
+        await conn.execute(
+            "DELETE FROM slack_sync_message_attachments "
+            "WHERE channel_id = $1 AND message_ts = $2",
+            row["channel_id"],
+            row["message_ts"],
+        )
+    return len(attachments)
 
 
 def channel_ref(channel: dict[str, Any], reason: str | None = None) -> dict[str, str]:
@@ -212,6 +367,7 @@ async def upsert_messages(pool, rows: list[dict[str, Any]]) -> int:
                     canonical_json(row["raw_payload"]),
                     row["source_run_id"],
                 )
+                await _replace_message_attachments(conn, row)
     return len(rows)
 
 
@@ -484,7 +640,10 @@ class SlackEtlClient:
     def _is_auth_error(self, error: Exception) -> bool:
         response = getattr(error, "response", None)
         status_code = getattr(response, "status_code", None)
-        return status_code in {401, 403} or self._slack_error_code(error) in self._AUTH_ERROR_CODES
+        return (
+            status_code in {401, 403}
+            or self._slack_error_code(error) in self._AUTH_ERROR_CODES
+        )
 
     def _raise_slack_api_error(
         self,
@@ -610,6 +769,97 @@ class SlackEtlClient:
 
         return re.sub(r"<@([A-Z0-9]+)>", replace_mention, text)
 
+    def _download_slack_file_bytes(
+        self,
+        url: str,
+        *,
+        max_bytes: int,
+    ) -> tuple[str, bytes]:
+        """Fetch one Slack file with the ETL token, enforcing the byte cap."""
+        request = urllib_request.Request(
+            url,
+            headers={"Authorization": f"Bearer {self.token}"},
+            method="GET",
+        )
+        with urllib_request.urlopen(
+            request,
+            timeout=self._api_timeout_seconds(),
+        ) as response:
+            body = response.read(max_bytes + 1)
+            mime_type = response.headers.get_content_type()
+        if len(body) > max_bytes:
+            raise ValueError(
+                f"slack file exceeds SLACK_ETL_ATTACHMENT_MAX_BYTES ({max_bytes} bytes)"
+            )
+        return mime_type, body
+
+    def _serialize_file(self, file_obj: dict[str, Any]) -> dict[str, Any] | None:
+        """Normalize Slack file metadata and optionally include downloaded bytes."""
+        slack_file_id = str(file_obj.get("id") or "").strip()
+        if not slack_file_id:
+            return None
+
+        name = str(file_obj.get("name") or "")
+        url_private = str(
+            file_obj.get("url_private_download") or file_obj.get("url_private") or ""
+        )
+        mimetype = str(file_obj.get("mimetype") or "")
+        size_bytes = _safe_int(file_obj.get("size"))
+        normalized: dict[str, Any] = {
+            "id": slack_file_id,
+            "name": name,
+            "title": str(file_obj.get("title") or ""),
+            "mimetype": mimetype,
+            "filetype": str(file_obj.get("filetype") or ""),
+            "size": size_bytes,
+            "url_private": url_private,
+            "permalink": str(file_obj.get("permalink") or ""),
+            "download_status": "metadata_only",
+            "download_error": "",
+            "content_sha256": None,
+            "content_bytes": None,
+            "raw_payload": file_obj,
+        }
+
+        if not attachment_download_enabled():
+            normalized["download_status"] = "disabled"
+            return normalized
+        if not url_private:
+            normalized["download_status"] = "missing_url"
+            return normalized
+
+        max_bytes = attachment_max_bytes()
+        if size_bytes > max_bytes:
+            normalized["download_status"] = "skipped_too_large"
+            normalized["download_error"] = (
+                f"slack file size {size_bytes} exceeds SLACK_ETL_ATTACHMENT_MAX_BYTES "
+                f"({max_bytes} bytes)"
+            )
+            return normalized
+
+        try:
+            response_mimetype, body = self._download_slack_file_bytes(
+                url_private,
+                max_bytes=max_bytes,
+            )
+        except (OSError, ValueError, urllib_error.URLError) as exc:
+            normalized["download_status"] = "failed"
+            normalized["download_error"] = str(exc)
+            return normalized
+
+        normalized["download_status"] = "downloaded"
+        normalized["content_bytes"] = body
+        normalized["content_sha256"] = hashlib.sha256(body).hexdigest()
+        if not normalized["mimetype"]:
+            normalized["mimetype"] = (
+                response_mimetype
+                or mimetypes.guess_type(name)[0]
+                or "application/octet-stream"
+            )
+        if not normalized["size"]:
+            normalized["size"] = len(body)
+        return normalized
+
     def _serialize_message(
         self,
         msg: dict[str, Any],
@@ -639,6 +889,13 @@ class SlackEtlClient:
             "subtype": msg.get("subtype"),
             "parent_user_id": msg.get("parent_user_id"),
             "bot_id": msg.get("bot_id"),
+            "files": [
+                normalized
+                for file_obj in msg.get("files", []) or []
+                if isinstance(file_obj, dict)
+                for normalized in [self._serialize_file(file_obj)]
+                if normalized is not None
+            ],
         }
         if channel_name is not None:
             message["channel"] = channel_name
@@ -662,7 +919,9 @@ class SlackEtlClient:
             batch = response.get(result_key, []) or []
             items.extend(batch)
 
-            next_cursor = response.get("response_metadata", {}).get("next_cursor") or None
+            next_cursor = (
+                response.get("response_metadata", {}).get("next_cursor") or None
+            )
             has_more = bool(next_cursor or response.get("has_more"))
             if not has_more or not batch:
                 return items, next_cursor, has_more
@@ -678,7 +937,9 @@ class SlackEtlClient:
         return raw.lstrip("#").strip()
 
     def _looks_like_channel_id(self, channel: str) -> bool:
-        return bool(self._CHANNEL_ID_RE.fullmatch(self._clean_channel_ref(channel).upper()))
+        return bool(
+            self._CHANNEL_ID_RE.fullmatch(self._clean_channel_ref(channel).upper())
+        )
 
     def _resolve_etl_channel(self, channel: str) -> str:
         normalized = self._clean_channel_ref(channel)
@@ -688,7 +949,9 @@ class SlackEtlClient:
         for item in self._list_etl_channels(limit=10_000):
             if item["name"] == normalized:
                 return item["id"]
-        raise RuntimeError(f"Channel '{channel}' not found through Slack ETL user token")
+        raise RuntimeError(
+            f"Channel '{channel}' not found through Slack ETL user token"
+        )
 
     def _resolve_etl_channel_name(self, channel: str, channel_id: str) -> str:
         normalized = channel.lstrip("#")
@@ -820,7 +1083,9 @@ class SlackEtlClient:
                 resolved_channel=channel_id,
             )
 
-        messages = [self._serialize_message(msg, channel_id, user_cache) for msg in raw_messages]
+        messages = [
+            self._serialize_message(msg, channel_id, user_cache) for msg in raw_messages
+        ]
 
         return {
             "channel": channel_name,
@@ -894,7 +1159,9 @@ class SlackEtlClient:
                 resolved_channel=channel_id,
             )
 
-        messages = [self._serialize_message(msg, channel_id, user_cache) for msg in raw_messages]
+        messages = [
+            self._serialize_message(msg, channel_id, user_cache) for msg in raw_messages
+        ]
 
         return {
             "channel_id": channel_id,
@@ -932,9 +1199,13 @@ class SlackEtlClient:
         if cursor is None and normalized_oldest is None:
             if watermark is not None:
                 lookback_seconds = max(lookback_days, 0) * 86400
-                normalized_oldest = self._format_ts(max(float(watermark) - lookback_seconds, 0.0))
+                normalized_oldest = self._format_ts(
+                    max(float(watermark) - lookback_seconds, 0.0)
+                )
             elif lookback_days > 0:
-                normalized_oldest = self._format_ts(max(time.time() - (lookback_days * 86400), 0.0))
+                normalized_oldest = self._format_ts(
+                    max(time.time() - (lookback_days * 86400), 0.0)
+                )
 
         page = self._get_etl_channel_history_page(
             channel=channel,

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def _load_shared():
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    api_module = types.ModuleType("api")
+    runtime_control = types.ModuleType("api.runtime_control")
+    runtime_control.canonical_json = lambda value: json.dumps(value, sort_keys=True)
+    api_module.runtime_control = runtime_control
+    sys.modules.setdefault("api", api_module)
+    sys.modules.setdefault("api.runtime_control", runtime_control)
+
+    centaur_sdk = types.ModuleType("centaur_sdk")
+    centaur_sdk.secret = lambda _name, default=None: default
+    sys.modules.setdefault("centaur_sdk", centaur_sdk)
+
+    return importlib.import_module("workflows.slack.shared")
+
+
+shared = _load_shared()
+
+
+def test_serialize_message_downloads_slack_file_bytes(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ATTACHMENTS_ENABLED", "true")
+    monkeypatch.setenv("SLACK_ETL_ATTACHMENT_MAX_BYTES", "100")
+    client = object.__new__(shared.SlackEtlClient)
+    client.token = "xoxp-test"
+
+    def fake_download(url: str, *, max_bytes: int):
+        assert url == "https://files.slack.com/files-pri/T/F-test/download/report.txt"
+        assert max_bytes == 100
+        return "text/plain", b"hello"
+
+    monkeypatch.setattr(client, "_download_slack_file_bytes", fake_download)
+
+    message = client._serialize_message(
+        {
+            "user": "U123",
+            "text": "see attached",
+            "ts": "1770000000.000100",
+            "files": [
+                {
+                    "id": "F123",
+                    "name": "report.txt",
+                    "title": "Report",
+                    "mimetype": "",
+                    "filetype": "text",
+                    "size": 5,
+                    "url_private_download": (
+                        "https://files.slack.com/files-pri/T/F-test/download/report.txt"
+                    ),
+                }
+            ],
+        },
+        "C123",
+        {"U123": "alice"},
+    )
+
+    assert message["files"][0]["download_status"] == "downloaded"
+    assert message["files"][0]["content_bytes"] == b"hello"
+    assert message["files"][0]["content_sha256"] == hashlib.sha256(b"hello").hexdigest()
+    assert message["files"][0]["mimetype"] == "text/plain"
+
+
+def test_serialize_message_skips_oversized_slack_file(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ATTACHMENTS_ENABLED", "true")
+    monkeypatch.setenv("SLACK_ETL_ATTACHMENT_MAX_BYTES", "10")
+    client = object.__new__(shared.SlackEtlClient)
+    client.token = "xoxp-test"
+
+    def fail_download(*_args, **_kwargs):
+        raise AssertionError("oversized files should not be downloaded")
+
+    monkeypatch.setattr(client, "_download_slack_file_bytes", fail_download)
+
+    message = client._serialize_message(
+        {
+            "user": "U123",
+            "text": "",
+            "ts": "1770000000.000200",
+            "files": [
+                {
+                    "id": "F-large",
+                    "name": "large.mov",
+                    "size": 11,
+                    "url_private": "https://files.slack.com/files-pri/T/F-large",
+                }
+            ],
+        },
+        "C123",
+        {},
+    )
+
+    assert message["files"][0]["download_status"] == "skipped_too_large"
+    assert "SLACK_ETL_ATTACHMENT_MAX_BYTES" in message["files"][0]["download_error"]
+    assert message["files"][0]["content_bytes"] is None
+
+
+def test_replace_message_attachments_upserts_and_deletes_stale_rows():
+    class FakeConn:
+        def __init__(self) -> None:
+            self.calls = []
+
+        async def execute(self, sql, *args):
+            self.calls.append((sql, args))
+
+    conn = FakeConn()
+    row = shared.message_row(
+        {
+            "channel_id": "C123",
+            "timestamp": "1770000000.000300",
+            "files": [
+                {
+                    "id": "F123",
+                    "name": "report.txt",
+                    "title": "Report",
+                    "mimetype": "text/plain",
+                    "filetype": "text",
+                    "size": 5,
+                    "url_private": "https://files.slack.com/files-pri/T/F123",
+                    "permalink": "https://example.slack.com/files/F123",
+                    "download_status": "downloaded",
+                    "content_sha256": hashlib.sha256(b"hello").hexdigest(),
+                    "content_bytes": b"hello",
+                }
+            ],
+        },
+        "run_123",
+    )
+
+    assert "content_bytes" not in row["raw_payload"]["files"][0]
+    count = asyncio.run(shared._replace_message_attachments(conn, row))
+
+    assert count == 1
+    assert len(conn.calls) == 2
+    upsert_sql, upsert_args = conn.calls[0]
+    delete_sql, delete_args = conn.calls[1]
+    assert "INSERT INTO slack_sync_message_attachments" in upsert_sql
+    assert upsert_args[0:4] == ("C123", "1770000000.000300", "F123", "report.txt")
+    assert upsert_args[13] == b"hello"
+    assert "NOT (slack_file_id = ANY" in delete_sql
+    assert delete_args == ("C123", "1770000000.000300", ["F123"])

--- a/workflows/tests/test_company_context_documents_attachments.py
+++ b/workflows/tests/test_company_context_documents_attachments.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def _load_projection_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    api_module = sys.modules.get("api") or types.ModuleType("api")
+    runtime_control = sys.modules.get("api.runtime_control") or types.ModuleType(
+        "api.runtime_control"
+    )
+    runtime_control.canonical_json = lambda value: json.dumps(value, sort_keys=True)
+    runtime_control.decode_jsonb = lambda value, default: (
+        value if value is not None else default
+    )
+
+    vm_metrics = types.ModuleType("api.vm_metrics")
+    for name in (
+        "observe_company_context_document_size",
+        "record_company_context_documents_changed",
+        "set_company_context_projection_lag",
+        "set_etl_active_scopes",
+        "set_etl_failed_scopes",
+        "set_etl_scope_sync_freshness_seconds",
+    ):
+        setattr(vm_metrics, name, lambda *_args, **_kwargs: None)
+
+    workflow_engine = types.ModuleType("api.workflow_engine")
+    workflow_engine.WorkflowContext = object
+
+    api_module.runtime_control = runtime_control
+    api_module.vm_metrics = vm_metrics
+    api_module.workflow_engine = workflow_engine
+    sys.modules.setdefault("api", api_module)
+    sys.modules.setdefault("api.runtime_control", runtime_control)
+    sys.modules.setdefault("api.vm_metrics", vm_metrics)
+    sys.modules.setdefault("api.workflow_engine", workflow_engine)
+
+    return importlib.import_module("workflows.company_context_documents")
+
+
+projection = _load_projection_module()
+
+
+def test_slack_attachment_document_indexes_metadata_without_private_url():
+    row = {
+        "channel_id": "C123",
+        "channel_name": "eng",
+        "message_ts": "1770000000.000100",
+        "slack_file_id": "F123",
+        "name": "roadmap.pdf",
+        "title": "Q3 Roadmap",
+        "mimetype": "application/pdf",
+        "filetype": "pdf",
+        "size_bytes": 12345,
+        "permalink": "https://example.slack.com/files/U123/F123/roadmap.pdf",
+        "download_status": "downloaded",
+        "download_error": "",
+        "content_sha256": "abc123",
+        "updated_at": dt.datetime(2026, 6, 15, 12, 1, tzinfo=dt.UTC),
+        "occurred_at": dt.datetime(2026, 6, 15, 12, 0, tzinfo=dt.UTC),
+        "thread_ts": "1770000000.000100",
+        "parent_message_ts": None,
+        "user_id": "U123",
+        "user_name": "alice",
+        "real_name": "Alice Example",
+        "display_name": "alice",
+        "text": "Please review <#C999|product> and <@U456>",
+        "message_permalink": "https://example.slack.com/archives/C123/p1770000000000100",
+        "url_private": "https://files.slack.com/files-pri/T/F123/roadmap.pdf",
+    }
+
+    document = projection._slack_attachment_document(
+        row,
+        users_by_id={"U456": "bob"},
+        channels_by_id={"C999": "product"},
+    )
+
+    assert document is not None
+    assert document["document_id"] == "slack:attachment:C123:1770000000.000100:F123"
+    assert document["source_type"] == "slack_attachment"
+    assert document["title"] == "Slack attachment: Q3 Roadmap"
+    assert document["url"] == "https://example.slack.com/files/U123/F123/roadmap.pdf"
+    assert "- Filename: roadmap.pdf" in document["body"]
+    assert "- MIME type: application/pdf" in document["body"]
+    assert "- File type: pdf" in document["body"]
+    assert "- Content SHA-256: abc123" in document["body"]
+    assert "Please review #product and @bob" in document["body"]
+    assert "files-pri" not in document["body"]
+    assert "url_private" not in document["metadata"]
+    assert document["metadata"]["message_permalink"].endswith("p1770000000000100")


### PR DESCRIPTION
## Summary
- add a Slack ETL attachment table keyed by channel/message/file with metadata, download status, checksums, and bounded bytea content
- preserve Slack files during ETL serialization and write attachment rows alongside message upserts
- document attachment config/scopes and declare SLACK_ETL_TOKEN for slack.com/files.slack.com

## Validation
- uv run --python 3.11 --with pytest pytest workflows/slack/tests/test_shared_attachments.py
- uv run --python 3.11 --with ruff ruff check workflows/slack/shared.py workflows/slack/tests/test_shared_attachments.py
- uv run --python 3.11 --with ruff ruff format --check workflows/slack/shared.py workflows/slack/tests/test_shared_attachments.py
- cargo test -p centaur-session-sqlx
- just build-one api-rs
- local Helm deploy with apiRs.image.pullPolicy=Never and apiRs.ironProxy.mode=disabled
- verified migration 17 applied locally and slack_sync workflow request completed with slack_etl_disabled as expected

## Notes
Local deploy required disabling api-rs iron proxy because this dev cluster does not have IRON_CONTROL_URL/IRON_CONTROL_API_KEY configured for the newer binary.