### PR TITLE
fix: normalize escaped Slack line breaks for Slack send messages (not slackbot)

### DIFF
--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1411,6 +1411,11 @@ class SlackClient:
             return f"\n\n_(requested by @{requester_name})_"
         return ""
 
+    @staticmethod
+    def _normalize_message_text(text: str) -> str:
+        """Convert shell-friendly escaped line breaks into Slack line breaks."""
+        return text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\r", "\r")
+
     def send_message(
         self,
         channel: str,
@@ -1437,11 +1442,11 @@ class SlackClient:
         """
         channel_id = self._resolve_message_destination(channel)
 
-        message_text = text
+        message_text = self._normalize_message_text(text)
         if not no_attribution:
             attribution = self._format_requester_attribution()
             if attribution:
-                message_text = text + attribution
+                message_text += attribution
 
         try:
             kwargs = {"channel": channel_id, "text": message_text}

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -169,6 +169,15 @@ def test_send_message_omits_unfurl_flags_by_default() -> None:
     assert "unfurl_media" not in fake_web_client.last_kwargs
 
 
+def test_send_message_normalizes_escaped_line_breaks() -> None:
+    client, fake_web_client = _make_client()
+
+    client.send_message("paradigm-pulse", "*Title*\\n- one\\r\\n- two", no_attribution=True)
+
+    assert fake_web_client.last_kwargs is not None
+    assert fake_web_client.last_kwargs["text"] == "*Title*\n- one\n- two"
+
+
 def test_send_message_opens_dm_for_user_id_destination() -> None:
     client, fake_web_client = _make_client()
 


### PR DESCRIPTION
## Summary
- Normalize literal escaped line breaks before posting Slack messages through the Slack tool.
- Add a regression test covering `\\n` and `\\r\\n` input from shell-friendly command arguments.

## Problem
Slack messages sent through the CLI could contain literal `\\n` sequences when agents passed multi-line content through shell command arguments. Slack renders those as text instead of line breaks, producing hard-to-read channel messages.

## Fix
The Slack client now normalizes shell-friendly escaped line breaks at the posting boundary before attribution is appended. This keeps the behavior consistent for `slack send` and `slack dm` without changing callers that already pass real newlines.

## Verification
- `PYTHONPATH=..:/home/agent/branches/paradigmxyz/centaur uv run --no-project --with pytest --with slack-sdk --with typer --with python-dotenv --with rich --with structlog pytest tests/test_client.py -q`

Prompted by: @goksu
