### PR TITLE
fix: pin iron-proxy multi-arch base image index digest

### DIFF
--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
-FROM ironsh/iron-proxy:0.44.0@sha256:ac4159f987e781a5c6011a880e338794155171884de005e4c9c7b5329786bbe5
+# Pin the multi-arch image index digest (not a single-arch manifest) so the
+# amd64 and arm64 build matrix each resolve to the matching platform. Pinning
+# an arch-specific digest here builds an amd64 base on arm64 runners, which
+# fails with "exec format error".
+FROM ironsh/iron-proxy:0.44.0@sha256:1038c4559d60770f46199ee2ed7c61efcf62cac604a4f3436c3d9f0ec8067b29
 
 USER root
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,9 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-# Pin the multi-arch image index digest (not a single-arch manifest) so the
-# amd64 and arm64 build matrix each resolve to the matching platform. Pinning
-# an arch-specific digest here builds an amd64 base on arm64 runners, which
-# fails with "exec format error".
 FROM ironsh/iron-proxy:0.44.0@sha256:1038c4559d60770f46199ee2ed7c61efcf62cac604a4f3436c3d9f0ec8067b29
 
 USER root


### PR DESCRIPTION
The iron-proxy base image was pinned to the amd64-specific manifest digest (`ac4159...`) rather than the multi-arch image index. The publish-images matrix builds for both amd64 and arm64 on pushes to main, so the arm64 build pulled an amd64 base and failed at `apk add` with `exec format error`. This repins to the multi-arch index digest (`1038c455...`) so each platform resolves to its matching arch.