### PR TITLE
feat(discordbot): name session principals after the Discord channel

### DIFF
--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -1,8 +1,9 @@
 //! Derive the iron-control principal a session's proxy should act as.
 //!
 //! A principal is the identity that holds roles and owns proxies. For Centaur
-//! the principal is the Slack conversation: a **user** for a 1:1 DM, or a
-//! **channel** for a multi-party channel/group thread. The thread key is
+//! the principal is the conversation: a Discord **channel** (every thread in it
+//! shares one principal), or — for Slack — a **user** for a 1:1 DM and a
+//! **channel** for a multi-party channel/group thread. The Slack thread key is
 //! ``<source>:[<team_id>:]<conversation_id>[:<thread_ts>]`` — segments are
 //! identified by their Slack prefix rather than position, because the optional
 //! team id shifts everything after it (``T`` = team, ``C``/``G`` = channel,
@@ -62,6 +63,31 @@ pub fn derive_principal(
     slack_user_id: Option<&str>,
     conversation_name: Option<&str>,
 ) -> PrincipalRef {
+    let display_name = conversation_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty());
+
+    // Discord sessions key on the channel so every thread in a channel shares
+    // one principal (mirrors the Slack channel model). The thread key is
+    // ``discord:<guild_id>:<channel_id>[:<thread_id>]``; the guild id is folded
+    // into the key so the same channel id in two guilds never collides.
+    if let Some((guild_id, channel_id)) = parse_discord_segments(thread_key) {
+        let mut labels = BTreeMap::new();
+        labels.insert("discord_guild_id".to_owned(), guild_id.to_owned());
+        let scope = format!("{}-", slugify(guild_id));
+        let key_id = channel_id.unwrap_or(guild_id);
+        if let Some(channel) = channel_id {
+            labels.insert("discord_channel_id".to_owned(), channel.to_owned());
+        }
+        return PrincipalRef {
+            foreign_id: format!("discord-channel-{scope}{}", slugify(key_id)),
+            name: display_name
+                .map(|name| format!("Discord Channel #{name}"))
+                .unwrap_or_else(|| format!("Discord Channel {key_id} (guild {guild_id})")),
+            labels,
+        };
+    }
+
     let (team_id, conversation_id) = parse_slack_segments(thread_key);
     let mut labels = BTreeMap::new();
     if let Some(team) = team_id {
@@ -73,9 +99,6 @@ pub fn derive_principal(
     let team_suffix = team_id
         .map(|team| format!(" (team {team})"))
         .unwrap_or_default();
-    let display_name = conversation_name
-        .map(str::trim)
-        .filter(|name| !name.is_empty());
 
     if is_direct_message(conversation_id)
         && let Some(user) = slack_user_id.map(str::trim).filter(|user| !user.is_empty())
@@ -127,6 +150,18 @@ fn parse_slack_segments(thread_key: &str) -> (Option<&str>, Option<&str>) {
         }
     }
     (team, conversation)
+}
+
+/// The guild and (optional) channel segments of a ``discord:<guild>:<channel>``
+/// thread key, or ``None`` when the key is not a Discord thread. The discordbot
+/// encodes session threads as ``discord:<guild_id>:<channel_id>[:<thread_id>]``,
+/// so keying on the channel groups every thread in a channel onto one principal.
+fn parse_discord_segments(thread_key: &str) -> Option<(&str, Option<&str>)> {
+    let rest = thread_key.strip_prefix("discord:")?;
+    let mut segments = rest.split(':').map(str::trim);
+    let guild = segments.next().filter(|guild| !guild.is_empty())?;
+    let channel = segments.next().filter(|channel| !channel.is_empty());
+    Some((guild, channel))
 }
 
 /// Slack direct-message conversation ids start with ``D``.
@@ -222,6 +257,35 @@ mod tests {
     fn blank_conversation_name_falls_back_to_the_synthetic_name() {
         let principal = derive_principal("chat:C123:ts", None, Some("   "));
         assert_eq!(principal.name, "Slack Channel C123");
+    }
+
+    #[test]
+    fn discord_sessions_key_on_the_channel() {
+        // Two threads in the same channel resolve to one principal.
+        let thread_a = derive_principal("discord:111:222:333", None, None);
+        let thread_b = derive_principal("discord:111:222:444", None, None);
+        assert_eq!(thread_a.foreign_id, "discord-channel-111-222");
+        assert_eq!(thread_a.foreign_id, thread_b.foreign_id);
+        assert_eq!(thread_a.name, "Discord Channel 222 (guild 111)");
+        assert_eq!(
+            thread_a
+                .labels
+                .get("discord_channel_id")
+                .map(String::as_str),
+            Some("222")
+        );
+        assert_eq!(
+            thread_a.labels.get("discord_guild_id").map(String::as_str),
+            Some("111")
+        );
+    }
+
+    #[test]
+    fn discord_conversation_name_overrides_the_display_name_but_not_the_key() {
+        let principal = derive_principal("discord:111:222:333", None, Some("general"));
+        // Key stays derived from the ids so a channel rename never splits it.
+        assert_eq!(principal.foreign_id, "discord-channel-111-222");
+        assert_eq!(principal.name, "Discord Channel #general");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -255,12 +255,17 @@ impl SessionRuntime {
                 .and_then(|metadata| metadata.get("slack_user_id"))
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned);
-            // The human-readable channel/DM name the slackbot resolved, used as
-            // the principal's display name. Read it here for the same reason,
-            // before `metadata` is consumed below.
-            let slack_conversation_name = metadata
+            // The human-readable conversation name the chat bot resolved
+            // (Slack channel/DM, or Discord channel), used as the principal's
+            // display name. Read it here for the same reason, before `metadata`
+            // is consumed below.
+            let conversation_name = metadata
                 .as_ref()
-                .and_then(|metadata| metadata.get("slack_conversation_name"))
+                .and_then(|metadata| {
+                    metadata
+                        .get("slack_conversation_name")
+                        .or_else(|| metadata.get("discord_conversation_name"))
+                })
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned);
             let mut harness_switched = false;
@@ -295,7 +300,7 @@ impl SessionRuntime {
                     .register_session(
                         thread_key.as_str(),
                         slack_user_id.as_deref(),
-                        slack_conversation_name.as_deref(),
+                        conversation_name.as_deref(),
                     )
                     .await?;
                 // Persist the principal OID on the session row so a resumed session

--- a/services/discordbot/src/discord-threading.ts
+++ b/services/discordbot/src/discord-threading.ts
@@ -82,6 +82,47 @@ export async function renameThreadFromMessage(
   }
 }
 
+/**
+ * Best-effort fetch of a Discord channel's name (`GET /channels/{id}`), used to
+ * name the session principal in iron-control. Returns undefined on any failure
+ * — the name is cosmetic, so a lookup failure just falls back to the synthetic
+ * id-based principal name in api-rs.
+ */
+export async function fetchDiscordChannelName(
+  options: DiscordbotOptions,
+  channelId: string,
+  logger: Logger,
+): Promise<string | undefined> {
+  const fetchFn = options.fetch ?? fetch;
+  const apiBase = (options.discordApiUrl ?? DEFAULT_DISCORD_API_URL).replace(
+    /\/$/,
+    "",
+  );
+  try {
+    const response = await fetchFn(`${apiBase}/channels/${channelId}`, {
+      method: "GET",
+      headers: { authorization: `Bot ${options.botToken}` },
+    });
+    if (!response.ok) {
+      logger.warn("discordbot_channel_name_failed", {
+        status: response.status,
+        channel_id: channelId,
+      });
+      return undefined;
+    }
+    const channel = (await response.json()) as { name?: unknown };
+    return typeof channel.name === "string" && channel.name.length > 0
+      ? channel.name
+      : undefined;
+  } catch (error) {
+    logger.warn("discordbot_channel_name_error", {
+      error: error instanceof Error ? error.message : String(error),
+      channel_id: channelId,
+    });
+    return undefined;
+  }
+}
+
 function clipOneLine(value: string, max: number): string {
   const oneLine = value.replace(/\s+/g, " ").trim();
   if (oneLine.length <= max) return oneLine;

--- a/services/discordbot/src/index.ts
+++ b/services/discordbot/src/index.ts
@@ -28,6 +28,7 @@ import { DiscordNarrator, reactToDiscordMessage } from "./discord-narrator";
 import { fetchThreadStarterMessage } from "./discord-starter";
 import {
   deriveThreadName,
+  fetchDiscordChannelName,
   isThreadCreatedForMessage,
   renameThreadFromMessage,
 } from "./discord-threading";
@@ -124,6 +125,51 @@ const DEFAULT_MAX_CONCURRENT_EXECUTIONS_PER_GUILD = 3;
 const ANSWER_EDIT_INTERVAL_MS = 1_500;
 const ANSWER_MESSAGE_MAX_CHARS = DISCORD_FALLBACK_TEXT_MAX_CHARS;
 const ANSWER_MAX_FULL_MESSAGES = 10;
+
+// The resolved channel name becomes the session principal's display name in
+// iron-control (see api-rs derive_principal). api-rs re-upserts the principal on
+// every create, so the name must ride every create to stay stable — cache the
+// per-channel lookup (mirrors slackbotv2's conversations.info cache). Misses
+// expire sooner so a transient channel-fetch failure self-heals.
+const CONVERSATION_NAME_CACHE_SUCCESS_TTL_MS = 6 * 60 * 60 * 1000;
+const CONVERSATION_NAME_CACHE_MISS_TTL_MS = 10 * 60 * 1000;
+type ConversationNameCacheEntry = {
+  expiresAtMs: number;
+  name: string | undefined;
+};
+const conversationNameCache = new Map<string, ConversationNameCacheEntry>();
+
+export function clearConversationNameCacheForTests(): void {
+  conversationNameCache.clear();
+}
+
+/**
+ * Resolve the Discord channel name for a thread key, used to name the session
+ * principal. Cached per channel and never throws — the name is cosmetic, so a
+ * fetch failure just falls back to the synthetic id-based principal name in
+ * api-rs.
+ */
+export async function resolveDiscordConversationName(
+  options: DiscordbotOptions,
+  threadKey: string,
+  logger: Logger,
+): Promise<string | undefined> {
+  const { channelId } = parseDiscordThreadKey(threadKey);
+  if (!channelId) return undefined;
+  const cached = conversationNameCache.get(channelId);
+  if (cached && cached.expiresAtMs > Date.now()) return cached.name;
+
+  const name = await fetchDiscordChannelName(options, channelId, logger);
+  conversationNameCache.set(channelId, {
+    expiresAtMs:
+      Date.now() +
+      (name
+        ? CONVERSATION_NAME_CACHE_SUCCESS_TTL_MS
+        : CONVERSATION_NAME_CACHE_MISS_TTL_MS),
+    name,
+  });
+  return name;
+}
 
 export function createDiscordbot(options: DiscordbotOptions): Discordbot {
   const userName = options.userName ?? "centaur";
@@ -464,9 +510,17 @@ async function syncThreadMessageToSession(
   const messagesToAppend = candidateMessages.filter(
     (item) => !messageIds.has(item.id),
   );
+  // Names the session principal in iron-control; resolved (and cached) here so
+  // it rides every create. Cosmetic, so a failed lookup just yields undefined.
+  const conversationName = await resolveDiscordConversationName(
+    input.options,
+    thread.id,
+    logger,
+  );
 
   const forwardInput: ForwardSessionInput = {
     afterEventId: lastEventId,
+    conversationName,
     executeMessage: shouldStartExecution ? serializedMessage : undefined,
     messages: messagesToAppend,
     onEventId: (eventId) => {

--- a/services/discordbot/src/session-api.ts
+++ b/services/discordbot/src/session-api.ts
@@ -188,7 +188,7 @@ export async function forwardToSessionApi(
   callbacks: ForwardSessionApiCallbacks = {},
 ): Promise<AsyncIterable<DiscordbotRendererSource> | null> {
   const createStartedAtMs = nowMs();
-  await createSession(options, input.threadId);
+  await createSession(options, input.threadId, input.conversationName);
   traceLog(options, "discordbot_session_create_complete", input.trace, {
     phase_ms: elapsedMs(createStartedAtMs),
   });
@@ -357,14 +357,18 @@ async function bytesToBase64(data: Buffer | Blob): Promise<string> {
 async function createSession(
   options: DiscordbotOptions,
   threadId: string,
+  conversationName?: string,
 ): Promise<void> {
   const fetchFn = options.fetch ?? fetch;
+  const name = conversationName?.trim();
   const body: DiscordbotCreateSessionRequest = {
     harness_type: "codex",
     metadata: {
       source: "discordbot",
       platform: "discord",
       thread_id: threadId,
+      // api-rs reads this as the session principal's display name.
+      ...(name ? { discord_conversation_name: name } : {}),
     },
   };
   const response = await fetchFn(apiSessionUrl(options.apiUrl, threadId), {

--- a/services/discordbot/src/types.ts
+++ b/services/discordbot/src/types.ts
@@ -163,6 +163,12 @@ export type DiscordbotTrace = {
 
 export type ForwardSessionInput = {
   afterEventId: number;
+  /**
+   * Human-readable channel name carried in the create-session metadata as
+   * `discord_conversation_name`; api-rs uses it as the session principal's
+   * display name.
+   */
+  conversationName?: string;
   executionId?: string;
   executeMessage?: DiscordbotApiMessage;
   messages: DiscordbotApiMessage[];

--- a/services/discordbot/test/index.test.ts
+++ b/services/discordbot/test/index.test.ts
@@ -1,10 +1,25 @@
-import { describe, expect, it } from "bun:test";
-import type { Thread } from "chat";
-import { hasLiveActiveExecution, streamAnswerToThread } from "../src/index";
-import type { DiscordbotOptions } from "../src/types";
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { Logger, Thread } from "chat";
+import {
+  clearConversationNameCacheForTests,
+  hasLiveActiveExecution,
+  resolveDiscordConversationName,
+  streamAnswerToThread,
+} from "../src/index";
+import type { DiscordbotFetch, DiscordbotOptions } from "../src/types";
 import { AsyncTextQueue } from "../src/utils";
 
 const TTL_MS = 30 * 60 * 1000;
+
+const noopLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+  child() {
+    return noopLogger;
+  },
+} as unknown as Logger;
 
 describe("hasLiveActiveExecution", () => {
   it("is false when no execution is marked", () => {
@@ -154,5 +169,74 @@ describe("streamAnswerToThread", () => {
     expect(messages.length).toBe(2);
     expect(messages[0]?.content).toBe("partial answer ");
     expect(messages[1]?.content).toContain("⚠️");
+  });
+});
+
+describe("resolveDiscordConversationName", () => {
+  beforeEach(() => clearConversationNameCacheForTests());
+
+  function options(fetchFn: DiscordbotFetch): DiscordbotOptions {
+    return {
+      apiUrl: "http://localhost",
+      applicationId: "app",
+      botToken: "token",
+      discordApiUrl: "https://discord.test/api",
+      fetch: fetchFn,
+      publicKey: "key",
+    };
+  }
+
+  it("resolves the channel name from GET /channels/{channelId}", async () => {
+    const fetchFn: DiscordbotFetch = async (url) => {
+      expect(String(url)).toBe("https://discord.test/api/channels/C1");
+      return Response.json({ name: "general" });
+    };
+    expect(
+      await resolveDiscordConversationName(
+        options(fetchFn),
+        "discord:G1:C1:T1",
+        noopLogger,
+      ),
+    ).toBe("general");
+  });
+
+  it("caches by channel so a second thread does not re-fetch", async () => {
+    let fetches = 0;
+    const fetchFn: DiscordbotFetch = async () => {
+      fetches += 1;
+      return Response.json({ name: "general" });
+    };
+    const opts = options(fetchFn);
+    expect(
+      await resolveDiscordConversationName(opts, "discord:G1:C1:T1", noopLogger),
+    ).toBe("general");
+    expect(
+      await resolveDiscordConversationName(opts, "discord:G1:C1:T2", noopLogger),
+    ).toBe("general");
+    expect(fetches).toBe(1);
+  });
+
+  it("returns undefined when the thread key has no channel segment", async () => {
+    let fetched = false;
+    const fetchFn: DiscordbotFetch = async () => {
+      fetched = true;
+      return Response.json({ name: "general" });
+    };
+    expect(
+      await resolveDiscordConversationName(options(fetchFn), "api", noopLogger),
+    ).toBeUndefined();
+    expect(fetched).toBe(false);
+  });
+
+  it("returns undefined (never throws) when the channel fetch fails", async () => {
+    const fetchFn: DiscordbotFetch = async () =>
+      Response.json({ message: "Missing Access" }, { status: 403 });
+    expect(
+      await resolveDiscordConversationName(
+        options(fetchFn),
+        "discord:G1:C1:T1",
+        noopLogger,
+      ),
+    ).toBeUndefined();
   });
 });

--- a/services/discordbot/test/session-api.test.ts
+++ b/services/discordbot/test/session-api.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "bun:test";
 import {
+  forwardToSessionApi,
   isContentlessApiMessage,
   isDiscordPermissionError,
   isRetryableSessionApiError,
   SessionApiError,
 } from "../src/session-api";
-import type { DiscordbotApiMessage } from "../src/types";
+import type {
+  DiscordbotApiMessage,
+  DiscordbotFetch,
+  DiscordbotOptions,
+  ForwardSessionInput,
+} from "../src/types";
 
 function apiMessage(
   overrides: Partial<DiscordbotApiMessage> = {},
@@ -100,6 +106,79 @@ describe("isDiscordPermissionError", () => {
     ).toBe(false);
     expect(isDiscordPermissionError(new Error("boom"))).toBe(false);
     expect(isDiscordPermissionError("boom")).toBe(false);
+  });
+});
+
+describe("forwardToSessionApi principal naming", () => {
+  function recorderApi(): {
+    fetchFn: DiscordbotFetch;
+    creates: Array<Record<string, unknown>>;
+  } {
+    const creates: Array<Record<string, unknown>> = [];
+    const fetchFn: DiscordbotFetch = async (input, init) => {
+      const url = String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      if (url.endsWith("/execute")) {
+        return Response.json({
+          execution_id: "exec-1",
+          ok: true,
+          status: "running",
+          thread_key: "discord:G1:C1:T1",
+        });
+      }
+      if (url.endsWith("/messages")) return Response.json({ ok: true });
+      creates.push(body);
+      return Response.json({ ok: true });
+    };
+    return { fetchFn, creates };
+  }
+
+  function options(fetchFn: DiscordbotFetch): DiscordbotOptions {
+    return {
+      apiUrl: "http://api.test",
+      applicationId: "app",
+      botToken: "token",
+      fetch: fetchFn,
+      publicKey: "key",
+    };
+  }
+
+  function forwardInput(
+    overrides: Partial<ForwardSessionInput> = {},
+  ): ForwardSessionInput {
+    return {
+      afterEventId: 0,
+      executeMessage: apiMessage(),
+      messages: [apiMessage()],
+      onEventId: () => undefined,
+      openStream: false,
+      threadId: "discord:G1:C1:T1",
+      ...overrides,
+    };
+  }
+
+  it("carries the channel name as create-session metadata", async () => {
+    const { fetchFn, creates } = recorderApi();
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput({ conversationName: "general" }),
+    );
+    expect(
+      (creates[0] as { metadata: { discord_conversation_name?: string } })
+        .metadata.discord_conversation_name,
+    ).toBe("general");
+  });
+
+  it("omits the channel name when unset or blank", async () => {
+    const { fetchFn, creates } = recorderApi();
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput({ conversationName: "  " }),
+    );
+    expect(
+      "discord_conversation_name" in
+        (creates[0] as { metadata: object }).metadata,
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
Discord sessions currently register an iron-control principal named after the raw thread key, with a separate principal per thread. This brings them in line with how Slack sessions work: every thread in a channel now shares one principal, and that principal is named after the channel instead of an opaque id.

The bot resolves the channel name through Discord and passes it along when it creates a session; the control plane keys the principal on the channel and uses the name for display, falling back to the ids when no name is available. The grouping key is always derived from ids, so renaming a channel never splits a principal.