### PR TITLE
[codex] Add Granola MCP OAuth DCR

### DIFF
--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -119,6 +119,10 @@ spec:
                 secretKeyRef:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+{{- if $console.publicUrl }}
+            - name: CENTAUR_CONSOLE_PUBLIC_URL
+              value: {{ $console.publicUrl | quote }}
+{{- end }}
 {{- if $console.googleOauth.enabled }}
             # Google OAuth app credentials, needed by the broker-credential
             # OAuth refresh loop. Gated on console.googleOauth.enabled.

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -145,6 +145,10 @@ spec:
                 secretKeyRef:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+{{- if $console.publicUrl }}
+            - name: CENTAUR_CONSOLE_PUBLIC_URL
+              value: {{ $console.publicUrl | quote }}
+{{- end }}
 {{- if $console.googleOauth.enabled }}
             # Google OAuth app credentials (sign-in + brokered token refresh).
             # Gated on console.googleOauth.enabled; the keys must exist in the

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -106,6 +106,10 @@ console:
   # _SECRET), which must exist or the console pods CreateContainerConfigError.
   googleOauth:
     enabled: false
+  # Public HTTPS origin for OAuth redirect URIs and generated callback URLs,
+  # for example https://console.example.com. Leave empty to derive from the
+  # incoming request.
+  publicUrl: ""
   service:
     httpPort: 3000
   # Optional Ingress for the console. Bring your own controller — Tailscale

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -366,6 +366,8 @@ pub struct BrokerCredentialInput {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub labels: BTreeMap<String, String>,
     pub token_endpoint: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scopes: Vec<String>,
     pub client_id: String,
@@ -401,6 +403,8 @@ pub struct BrokerCredentialRecord {
     pub status: Option<String>,
     #[serde(default)]
     pub client_id: Option<String>,
+    #[serde(default)]
+    pub resource: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/services/api-rs/crates/centaur-perms/src/main.rs
+++ b/services/api-rs/crates/centaur-perms/src/main.rs
@@ -163,6 +163,10 @@ struct BrokerCreateArgs {
     #[arg(long)]
     token_endpoint: String,
 
+    /// OAuth resource indicator sent on refresh token requests.
+    #[arg(long)]
+    resource: Option<String>,
+
     /// OAuth client id (literal, not secret; echoed back by iron-control).
     #[arg(long)]
     client_id: String,
@@ -786,6 +790,7 @@ async fn broker_create(
         description: args.description.clone(),
         labels: managed_labels(),
         token_endpoint: args.token_endpoint.clone(),
+        resource: args.resource.clone(),
         scopes: args.scopes.clone(),
         client_id: args.client_id.clone(),
         client_secret: args.client_secret.clone(),

--- a/services/console/README.md
+++ b/services/console/README.md
@@ -68,7 +68,7 @@ Register these callback URLs with the provider:
 
 Both providers request the `openid`, `email`, and `profile` scopes. Client credentials may also be stored in Rails credentials under `console_auth.<provider>.client_id` and `console_auth.<provider>.client_secret`, but environment variables take precedence.
 
-Google OAuth consent apps for broker credentials are configured separately in the console under **OAuth Apps**. Those app callbacks use `/oauth/<slug>/callback` and currently support Google only; Slack support here applies to operator console sign-in.
+OAuth consent apps for broker credentials are configured separately in the console under **OAuth Apps**. Those app callbacks use `/oauth/<slug>/callback` and support Google static clients plus Granola MCP Dynamic Client Registration; Slack support here applies to operator console sign-in.
 
 ## Encryption Keys
 

--- a/services/console/app/controllers/api/v1/broker_credentials_controller.rb
+++ b/services/console/app/controllers/api/v1/broker_credentials_controller.rb
@@ -49,7 +49,7 @@ module Api
 
       def assign_and_save!(ref, attrs)
         base = attrs.permit(:namespace, :foreign_id, :name, :description, :token_endpoint,
-                            :client_id, :client_secret,
+                            :resource, :client_id, :client_secret,
                             :early_refresh_slack_seconds, :early_refresh_fraction,
                             :max_refresh_interval_seconds, :refresh_timeout_seconds,
                             labels: {}, scopes: [])
@@ -104,8 +104,9 @@ module Api
           description: ref.description,
           labels: ref.labels,
           token_endpoint: ref.token_endpoint,
+          resource: ref.resource,
           scopes: ref.scopes,
-          client_id: ref.client_id,
+          client_id: ref.effective_client_id,
           token_endpoint_header_names: (ref.token_endpoint_headers || {}).keys,
           early_refresh_slack_seconds: ref.early_refresh_slack_seconds,
           early_refresh_fraction: ref.early_refresh_fraction,

--- a/services/console/app/controllers/api/v1/oauth_apps_controller.rb
+++ b/services/console/app/controllers/api/v1/oauth_apps_controller.rb
@@ -2,8 +2,8 @@ module Api
   module V1
     # Operator CRUD for OAuth apps. An app's whole identity is its globally-unique
     # `slug`, so it is addressed by oid or slug (no namespace/foreign_id), and
-    # `PUT` upserts by slug. client_secret is required and write-only: it is
-    # accepted on writes but NEVER serialized back.
+    # `PUT` upserts by slug. client_secret is provider-specific and write-only:
+    # it is accepted on writes but NEVER serialized back.
     class OauthAppsController < Api::BaseController
       def index
         records, meta = paginated_apps

--- a/services/console/app/controllers/console/broker_credentials_controller.rb
+++ b/services/console/app/controllers/console/broker_credentials_controller.rb
@@ -58,7 +58,7 @@ module Console
     # re-bootstraps the credential (mirrors the API controller's seed handling).
     def assign_form(credential)
       fields = credential_params.permit(:namespace, :foreign_id, :name, :description,
-                                        :token_endpoint, :client_id,
+                                        :token_endpoint, :resource, :client_id,
                                         :early_refresh_slack_seconds, :early_refresh_fraction,
                                         :max_refresh_interval_seconds, :refresh_timeout_seconds)
       fields[:namespace] = fields[:namespace].presence || "default"

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -35,6 +35,8 @@ module Oauth
     # Tests swap in an AuthorizationCodeClient built around an http double,
     # mirroring BrokerCredential#refresh_client.
     class_attribute :exchange_client_factory, default: -> { Broker::AuthorizationCodeClient.new }
+    class_attribute :registration_client_factory,
+                    default: -> { Oauth::DynamicClientRegistrationClient.new }
 
     before_action :set_app
 
@@ -46,6 +48,7 @@ module Oauth
       unless @app.scopes_allowed?(requested_scopes)
         return render_result(:error, status: :unprocessable_entity, message: "One or more requested scopes are not allowed for this integration.")
       end
+      return unless ensure_client_registration
 
       nonce = SecureRandom.urlsafe_base64(32)
       code_verifier = SecureRandom.urlsafe_base64(64)
@@ -122,6 +125,35 @@ module Oauth
       raw.split(/[,\s]+/).map(&:strip).reject(&:blank?)
     end
 
+    def ensure_client_registration
+      return true if @app.client_id.present?
+      unless @provider.dynamic_client_registration?
+        render_result(:error, status: :unprocessable_entity,
+                      message: "This integration has no OAuth client configured.")
+        return false
+      end
+
+      @app.with_lock do
+        @app.reload
+        next if @app.client_id.present?
+
+        result = registration_client_factory.call.register(
+          registration_endpoint: @provider.registration_endpoint,
+          metadata: @provider.registration_metadata(
+            app: @app,
+            redirect_uri: oauth_callback_redirect_uri(@app.slug)
+          )
+        )
+        @app.client_id = result.client_id
+        @app.client_secret = result.client_secret if result.client_secret.present?
+        @app.save!
+      end
+      true
+    rescue Broker::ExchangeError => e
+      render_result(:error, message: "Registering the integration failed (#{e.reason}).")
+      false
+    end
+
     def authorization_url(requested_scopes, state, code_verifier)
       challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
       query = {
@@ -146,7 +178,8 @@ module Oauth
         client_secret: @app.client_secret,
         code: code.to_s,
         redirect_uri: oauth_callback_redirect_uri(@app.slug),
-        code_verifier: code_verifier.to_s
+        code_verifier: code_verifier.to_s,
+        resource: @provider.resource
       )
     end
 
@@ -163,15 +196,18 @@ module Oauth
           credential.foreign_id = "#{@app.provider}-#{@app.slug}-#{identity[:subject]}"
           credential.name = "#{@app.provider.capitalize} – #{identity[:email]}"
           credential.token_endpoint = @provider.token_endpoint
+          credential.resource = @provider.resource
           credential.external_user_key = SecureRandom.urlsafe_base64(16)
         end
 
         now = Time.current
         expires_in = result.expires_in&.positive? ? result.expires_in : BrokerCredential::DEFAULT_EXPIRES_IN_SECONDS
+        granted_scopes = result.scope.presence&.split || (Array(state["scopes"]) | @provider.identity_scopes)
         credential.assign_attributes(
           provider_email: identity[:email],
           # Store exactly what the IdP granted, so the refresh POST re-requests it.
-          scopes: (result.scope.presence&.split || Array(state["scopes"])),
+          scopes: granted_scopes,
+          resource: @provider.resource,
           refresh_token: result.refresh_token,
           access_token: result.access_token,
           expires_at: now + expires_in,

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -151,6 +151,7 @@ class BrokerCredential < ApplicationRecord
       client_secret: effective_client_secret,
       refresh_token: refresh_token,
       scopes: scopes,
+      resource: resource,
       headers: token_endpoint_headers || {},
       timeout: refresh_timeout_seconds
     )

--- a/services/console/app/models/oauth_app.rb
+++ b/services/console/app/models/oauth_app.rb
@@ -1,6 +1,6 @@
 # An operator-registered OAuth application: the provider, the OAuth client
-# (client_id + encrypted client_secret), and the scopes its consent flow
-# requests.
+# (client_id + encrypted client_secret, unless dynamically registered), and the
+# scopes its consent flow requests.
 #
 # Each app has a globally-unique +slug+ that names its well-known consent links:
 # a team member who knows the integration ("google") clicks
@@ -13,8 +13,7 @@
 # the app, so rotating the app's secret fixes every credential it minted.
 #
 # Provider-generic by design: one model with a `provider` column and a small
-# strategy registry (Oauth::Providers), not a table per provider. Today the only
-# provider is Google.
+# strategy registry (Oauth::Providers), not a table per provider.
 class OauthApp < ApplicationRecord
   oid_prefix "oap"
 
@@ -38,8 +37,8 @@ class OauthApp < ApplicationRecord
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validate :slug_does_not_shadow_oid
   validates :provider, inclusion: { in: ->(_) { Oauth::Providers.keys }, message: "is not a supported provider" }
-  validates :client_id, presence: true
-  validates :client_secret, presence: true
+  validates :client_id, presence: true, if: :client_id_required?
+  validates :client_secret, presence: true, if: :client_secret_required?
   validates :credential_namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validate :labels_is_a_hash
   validate :allowed_scopes_valid
@@ -50,6 +49,10 @@ class OauthApp < ApplicationRecord
 
   # True when every requested scope is within the allowlist.
   def scopes_allowed?(requested) = (Array(requested) - Array(allowed_scopes)).empty?
+
+  def client_id_required? = provider_strategy&.client_id_required? != false
+
+  def client_secret_required? = provider_strategy&.client_secret_required? != false
 
   private
 

--- a/services/console/app/views/console/broker_credentials/_form.html.erb
+++ b/services/console/app/views/console/broker_credentials/_form.html.erb
@@ -37,6 +37,12 @@
           <p class="form-hint">The IdP endpoint control refreshes against.</p>
         </div>
         <div>
+          <label class="form-label" for="credential_resource">Resource</label>
+          <%= text_field_tag "credential[resource]", credential.resource, id: "credential_resource", class: "form-input #{field_error_class(credential, :resource)}", placeholder: "https://mcp.example.com/mcp" %>
+          <%= field_error(credential, :resource) %>
+          <p class="form-hint">Optional OAuth resource indicator sent on token requests.</p>
+        </div>
+        <div>
           <label class="form-label" for="credential_client_id">Client ID *</label>
           <%= text_field_tag "credential[client_id]", credential.client_id, id: "credential_client_id", class: "form-input #{field_error_class(credential, :client_id)}" %>
           <%= field_error(credential, :client_id) %>

--- a/services/console/app/views/console/credential.html.erb
+++ b/services/console/app/views/console/credential.html.erb
@@ -65,6 +65,7 @@
 <%= def_section.call("OAuth Client", [
   [ "Client ID", @credential.effective_client_id ],
   [ "Token endpoint", @credential.token_endpoint ],
+  [ "Resource", @credential.resource ],
   [ "Scopes", Array(@credential.scopes).join("\n") ],
   ([ "Token endpoint headers", Array(@credential.token_endpoint_headers&.keys).map { |k| "#{k}: [redacted]" }.join("\n") ] if @credential.token_endpoint_headers.present?)
 ].compact) %>

--- a/services/console/app/views/console/oauth_apps/_form.html.erb
+++ b/services/console/app/views/console/oauth_apps/_form.html.erb
@@ -31,16 +31,16 @@
           <%= field_error(app, :provider) %>
         </div>
         <div>
-          <label class="form-label" for="oauth_app_client_id">Client ID *</label>
+          <label class="form-label" for="oauth_app_client_id">Client ID</label>
           <%= text_field_tag "oauth_app[client_id]", app.client_id, id: "oauth_app_client_id", class: "form-input #{field_error_class(app, :client_id)}" %>
           <%= field_error(app, :client_id) %>
-          <p class="form-hint">Not secret. Sent on every authorization and refresh.</p>
+          <p class="form-hint">Not secret. Leave blank for providers that register dynamically.</p>
         </div>
         <div>
-          <label class="form-label" for="oauth_app_client_secret">Client secret<%= " *".html_safe if app.new_record? %></label>
+          <label class="form-label" for="oauth_app_client_secret">Client secret</label>
           <%= password_field_tag "oauth_app[client_secret]", nil, id: "oauth_app_client_secret", class: "form-input #{field_error_class(app, :client_secret)}", autocomplete: "off", placeholder: app.new_record? ? nil : "•••••••• (unchanged)" %>
           <%= field_error(app, :client_secret) %>
-          <p class="form-hint">Stored encrypted.<%= " Leave blank to keep the current secret." unless app.new_record? %></p>
+          <p class="form-hint">Stored encrypted when present.<%= " Leave blank to keep the current secret." unless app.new_record? %></p>
         </div>
         <div>
           <label class="form-label" for="oauth_app_credential_namespace">Credential namespace</label>

--- a/services/console/db/migrate/20260616105000_add_mcp_oauth_fields.rb
+++ b/services/console/db/migrate/20260616105000_add_mcp_oauth_fields.rb
@@ -1,0 +1,6 @@
+class AddMcpOauthFields < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :oauth_apps, :client_id, true
+    add_column :broker_credentials, :resource, :string
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_224547) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_16_105000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -68,6 +68,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_224547) do
     t.string "provider_subject"
     t.integer "refresh_timeout_seconds", default: 30, null: false
     t.text "refresh_token"
+    t.string "resource"
     t.jsonb "scopes", default: [], null: false
     t.string "token_endpoint", null: false
     t.text "token_endpoint_headers"
@@ -156,7 +157,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_224547) do
 
   create_table "oauth_apps", force: :cascade do |t|
     t.jsonb "allowed_scopes", default: [], null: false
-    t.string "client_id", null: false
+    t.string "client_id"
     t.text "client_secret"
     t.datetime "created_at", null: false
     t.bigint "created_by_id", null: false

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -745,6 +745,7 @@ The OAuth client credentials it refreshes with are fields on the credential, res
 | `name`, `description`          | optional    | |
 | `labels`                       | optional    | |
 | `token_endpoint`               | required    | OAuth token endpoint the refresh request is sent to. |
+| `resource`                     | optional    | OAuth resource indicator sent on authorization-code and refresh-token requests. Required by MCP providers such as Granola. |
 | `scopes`                       | optional    | Array of strings. |
 | `client_id`                    | required    | OAuth client id. Returned in responses. |
 | `client_secret`                | optional    | OAuth client secret. Write-only and encrypted at rest; omit for public clients. Never returned. |
@@ -807,6 +808,7 @@ Returns `201`. The token blob, the `refresh_token` seed, and the `client_secret`
     "description": null,
     "labels": {},
     "token_endpoint": "https://oauth2.googleapis.com/token",
+    "resource": null,
     "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
     "client_id": "1234.apps.googleusercontent.com",
     "token_endpoint_header_names": [],
@@ -860,11 +862,16 @@ When a refresh fails unrecoverably (for example the IdP returns `invalid_grant` 
 
 ## OAuth apps
 
-An OAuth app registers an OAuth client (provider, client id, and client secret) and the scopes its [consent flow](#oauth-consent-flow) requests. The app's whole identity is a globally-unique `slug`: a team member who knows the integration (for example `google`) opens `/oauth/<slug>/start`, consents, and each completed consent mints (or updates) a [broker credential](#broker-credentials) linked back to the app. The minted credential is refreshed by the normal broker loop and delegates its `client_id` / `client_secret` to the app.
+An OAuth app registers an OAuth client (provider, client id, and optionally client secret) and the scopes its [consent flow](#oauth-consent-flow) requests. The app's whole identity is a globally-unique `slug`: a team member who knows the integration (for example `google` or `granola`) opens `/oauth/<slug>/start`, consents, and each completed consent mints (or updates) a [broker credential](#broker-credentials) linked back to the app. The minted credential is refreshed by the normal broker loop and delegates its `client_id` / `client_secret` to the app.
 
 Only managing the app's configuration requires API key auth. The consent flow endpoints themselves are unauthenticated and live on iron-control's own domain (see [OAuth consent flow](#oauth-consent-flow)).
 
-Google is the only supported provider in this release. The `provider` field is validated against the supported set, so an unknown provider returns `422`.
+Supported providers are:
+
+- `google` — static OAuth client. Supply `client_id` and `client_secret`.
+- `granola` — Granola MCP. Leave `client_id` and `client_secret` blank; `/oauth/<slug>/start` dynamically registers a public client with Granola DCR and stores the returned client id.
+
+The `provider` field is validated against the supported set, so an unknown provider returns `422`.
 
 ### Attributes
 
@@ -873,14 +880,14 @@ Google is the only supported provider in this release. The `provider` field is v
 | `slug`                 | required    | The app's identity: globally-unique, URL-safe, and the name in the well-known consent links (`/oauth/<slug>/start`). Must not start with the opaque-id prefix. |
 | `description`          | optional    | |
 | `labels`               | optional    | |
-| `provider`             | required    | The provider strategy. Currently only `"google"`. |
-| `client_id`            | required    | OAuth client id. Not secret; returned in responses. |
-| `client_secret`        | required on create | OAuth client secret. Write-only and encrypted at rest; on update it is only changed when supplied. Never returned. |
+| `provider`             | required    | The provider strategy: `"google"` or `"granola"`. |
+| `client_id`            | provider-specific | OAuth client id. Not secret; returned in responses. Required for Google; filled automatically for Granola after DCR. |
+| `client_secret`        | provider-specific | OAuth client secret. Write-only and encrypted at rest; required for Google, omitted for Granola's public client. On update it is only changed when supplied. Never returned. |
 | `allowed_scopes`       | required    | Non-empty array of scope strings the start endpoint requests. A flow's optional `scopes` param must be a subset; omitting it requests all of these. |
 | `credential_namespace` | optional    | Namespace for credentials minted by this app's flows. Defaults to `"default"`. |
 | `enabled`              | optional    | Defaults to `true`. A disabled app rejects new consent flows; existing credentials keep refreshing. |
 
-The `client_secret` is required and write-only: it is accepted on writes but never returned in any response.
+The `client_secret` is write-only: it is accepted on writes but never returned in any response.
 
 ### Create
 
@@ -920,6 +927,20 @@ Returns `201`. The `client_secret` is never echoed back:
 }
 ```
 
+Granola MCP apps use Dynamic Client Registration and can be created without client credentials:
+
+```json
+{
+  "data": {
+    "slug": "granola",
+    "description": "Granola MCP",
+    "provider": "granola",
+    "allowed_scopes": ["mcp"],
+    "credential_namespace": "default"
+  }
+}
+```
+
 ### Other operations
 
 | Method | Path | Notes |
@@ -933,6 +954,8 @@ Returns `201`. The `client_secret` is never echoed back:
 ## OAuth consent flow
 
 The consent flow turns a team member's OAuth consent into a managed broker credential. It runs on iron-control's own domain and is deliberately unauthenticated: the member reaches it with a single well-known link keyed by the app's `slug`. There is no external app to integrate with, so the start endpoint takes no `user` or `return_to`: after consent the member lands on an iron-control result page, and the credential's `external_user_key` is generated automatically. Safety comes from the consent itself (a credential is only created after a successful code exchange) and upsert-on-reconsent (re-consenting for the same provider account updates the existing credential instead of creating a new one).
+
+For Dynamic Client Registration providers, currently Granola MCP, `/oauth/<slug>/start` registers the app's redirect URI with the provider before building the authorization redirect. Set `CENTAUR_CONSOLE_PUBLIC_URL` to the HTTPS public origin so providers that reject plain HTTP redirect URIs can register successfully.
 
 One redirect URI is registered with the IdP per app, keyed by its slug:
 

--- a/services/console/lib/broker/authorization_code_client.rb
+++ b/services/console/lib/broker/authorization_code_client.rb
@@ -41,7 +41,8 @@ module Broker
     # the app is misconfigured. The console-login flow passes false: it requests no
     # offline access and only needs the id_token to identify the operator.
     def exchange(token_endpoint:, client_id:, client_secret:, code:, redirect_uri:,
-                 code_verifier:, timeout: DEFAULT_TIMEOUT, require_refresh_token: true)
+                 code_verifier:, resource: nil, timeout: DEFAULT_TIMEOUT,
+                 require_refresh_token: true)
       raise ArgumentError, "token endpoint is required" if token_endpoint.blank?
       raise ArgumentError, "client_id is required" if client_id.blank?
       raise ArgumentError, "code is required" if code.blank?
@@ -56,6 +57,7 @@ module Broker
         "code_verifier" => code_verifier
       }
       form["client_secret"] = client_secret if client_secret.present?
+      form["resource"] = resource if resource.present?
 
       response = perform(token_endpoint, form, timeout)
 

--- a/services/console/lib/broker/refresh_client.rb
+++ b/services/console/lib/broker/refresh_client.rb
@@ -33,7 +33,7 @@ module Broker
     # retryable vs. unrecoverable). scopes is an array; headers is a name=>value
     # hash applied verbatim to the token POST.
     def refresh(token_endpoint:, client_id:, refresh_token:, client_secret: nil,
-                scopes: [], headers: {}, timeout: DEFAULT_TIMEOUT)
+                scopes: [], resource: nil, headers: {}, timeout: DEFAULT_TIMEOUT)
       raise ArgumentError, "token endpoint is required" if token_endpoint.blank?
       raise ArgumentError, "client_id is required" if client_id.blank?
       raise ArgumentError, "refresh_token is required" if refresh_token.blank?
@@ -45,6 +45,7 @@ module Broker
       }
       form["client_secret"] = client_secret if client_secret.present?
       form["scope"] = scopes.join(" ") if scopes.present?
+      form["resource"] = resource if resource.present?
 
       response = perform(token_endpoint, form, headers, timeout)
 

--- a/services/console/lib/oauth/dynamic_client_registration_client.rb
+++ b/services/console/lib/oauth/dynamic_client_registration_client.rb
@@ -1,0 +1,87 @@
+require "json"
+require "net/http"
+require "uri"
+
+module Oauth
+  # Performs an RFC 7591 Dynamic Client Registration request for OAuth providers
+  # that issue public client credentials on demand (for example MCP servers).
+  #
+  # SECURITY: this class never logs registration responses. Some providers may
+  # return a client_secret even when the requested auth method is public.
+  class DynamicClientRegistrationClient
+    Result = Data.define(:client_id, :client_secret, :token_endpoint_auth_method)
+    Response = Data.define(:status, :body)
+
+    DEFAULT_TIMEOUT = 30
+    MAX_BODY_BYTES = 64 * 1024
+
+    def initialize(http: nil)
+      @http = http
+    end
+
+    def register(registration_endpoint:, metadata:, timeout: DEFAULT_TIMEOUT)
+      raise ArgumentError, "registration endpoint is required" if registration_endpoint.blank?
+      raise ArgumentError, "metadata must be a hash" unless metadata.is_a?(Hash)
+
+      response = perform(registration_endpoint, metadata, timeout)
+      classify_error(response.status, response.body) if response.status / 100 != 2
+      parse_success(response)
+    end
+
+    private
+
+    def perform(url, metadata, timeout)
+      if @http
+        return @http.call(url: url, metadata: metadata, headers: {}, timeout: timeout)
+      end
+
+      uri = URI.parse(url)
+      req = Net::HTTP::Post.new(uri)
+      req["Content-Type"] = "application/json"
+      req["Accept"] = "application/json"
+      req.body = JSON.generate(metadata)
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = timeout
+      http.read_timeout = timeout
+
+      res = http.request(req)
+      Response.new(status: res.code.to_i, body: res.body.to_s.byteslice(0, MAX_BODY_BYTES))
+    rescue StandardError => e
+      raise Broker::ExchangeError.new("dynamic client registration request failed: #{e.class}",
+                                      stage: "network")
+    end
+
+    def parse_success(response)
+      parsed = JSON.parse(response.body)
+      client_id = parsed["client_id"]
+      if client_id.blank?
+        raise Broker::ExchangeError.new("registration endpoint returned no client_id",
+                                        stage: "parse", status: response.status)
+      end
+
+      Result.new(
+        client_id: client_id,
+        client_secret: parsed["client_secret"],
+        token_endpoint_auth_method: parsed["token_endpoint_auth_method"]
+      )
+    rescue JSON::ParserError, TypeError
+      raise Broker::ExchangeError.new("parsing registration response failed",
+                                      stage: "parse", status: response.status)
+    end
+
+    def classify_error(status, body)
+      oauth_error = begin
+        JSON.parse(body.to_s)["error"]
+      rescue JSON::ParserError, TypeError
+        nil
+      end
+
+      raise Broker::ExchangeError.new("registration endpoint http #{status}",
+                                      stage: oauth_error.present? ? "oauth" : "http",
+                                      code: oauth_error.presence,
+                                      status: status)
+    end
+  end
+end

--- a/services/console/lib/oauth/providers.rb
+++ b/services/console/lib/oauth/providers.rb
@@ -9,7 +9,7 @@ module Oauth
     # Memoized so a strategy is built once per process. The strategies are
     # stateless, so sharing one instance across flows is safe.
     def self.registry
-      @registry ||= { Google::KEY => Google.new }.freeze
+      @registry ||= { Google::KEY => Google.new, Granola::KEY => Granola.new }.freeze
     end
 
     # The strategy for +key+, or nil for an unknown provider (the flow

--- a/services/console/lib/oauth/providers/google.rb
+++ b/services/console/lib/oauth/providers/google.rb
@@ -31,6 +31,10 @@ module Oauth
       def token_endpoint = TOKEN_ENDPOINT
       def identity_scopes = IDENTITY_SCOPES
       def api_hosts = API_HOSTS
+      def resource = nil
+      def dynamic_client_registration? = false
+      def client_id_required? = true
+      def client_secret_required? = true
 
       # Provider-specific query params for the authorization redirect. Both are
       # required to guarantee a refresh token, including on re-consent:

--- a/services/console/lib/oauth/providers/granola.rb
+++ b/services/console/lib/oauth/providers/granola.rb
@@ -1,0 +1,79 @@
+require "base64"
+require "json"
+
+module Oauth
+  module Providers
+    # Granola MCP uses OAuth 2.1 with Dynamic Client Registration. The MCP
+    # resource indicator is required on both authorization and token requests.
+    class Granola
+      KEY = "granola"
+      AUTHORIZATION_ENDPOINT = "https://mcp-auth.granola.ai/oauth2/authorize"
+      TOKEN_ENDPOINT = "https://mcp-auth.granola.ai/oauth2/token"
+      REGISTRATION_ENDPOINT = "https://mcp-auth.granola.ai/oauth2/register"
+      RESOURCE = "https://mcp.granola.ai/mcp"
+      IDENTITY_SCOPES = %w[openid email profile offline_access].freeze
+      API_HOSTS = %w[mcp.granola.ai].freeze
+      VALID_ISSUERS = %w[https://mcp-auth.granola.ai].freeze
+
+      def key = KEY
+      def authorization_endpoint = AUTHORIZATION_ENDPOINT
+      def token_endpoint = TOKEN_ENDPOINT
+      def registration_endpoint = REGISTRATION_ENDPOINT
+      def identity_scopes = IDENTITY_SCOPES
+      def api_hosts = API_HOSTS
+      def resource = RESOURCE
+      def dynamic_client_registration? = true
+      def client_id_required? = false
+      def client_secret_required? = false
+
+      def extra_authorization_params = { "resource" => RESOURCE }
+
+      def registration_metadata(app:, redirect_uri:)
+        scopes = (Array(app.allowed_scopes) | identity_scopes).join(" ")
+        {
+          "client_name" => app.description.presence || "iron-control #{app.slug}",
+          "redirect_uris" => [ redirect_uri ],
+          "grant_types" => %w[authorization_code refresh_token],
+          "response_types" => %w[code],
+          "token_endpoint_auth_method" => "none",
+          "scope" => scopes
+        }
+      end
+
+      def identity_from(result, client_id:)
+        if result.id_token.blank?
+          raise Broker::ExchangeError.new("token response carried no id_token",
+                                          stage: "oauth", code: "missing_id_token")
+        end
+
+        claims = decode_id_token_claims(result.id_token)
+        unless claims["aud"] == client_id
+          raise Broker::ExchangeError.new("id_token aud did not match client_id",
+                                          stage: "oauth", code: "id_token_aud_mismatch")
+        end
+        unless VALID_ISSUERS.include?(claims["iss"])
+          raise Broker::ExchangeError.new("id_token iss was not Granola MCP auth",
+                                          stage: "oauth", code: "id_token_iss_invalid")
+        end
+
+        subject = claims["sub"]
+        if subject.blank?
+          raise Broker::ExchangeError.new("id_token carried no sub",
+                                          stage: "oauth", code: "id_token_missing_sub")
+        end
+
+        { subject: subject, email: claims["email"] }
+      end
+
+      private
+
+      def decode_id_token_claims(id_token)
+        seg = id_token.split(".")[1].to_s
+        seg += "=" * ((4 - seg.length % 4) % 4)
+        JSON.parse(Base64.urlsafe_decode64(seg))
+      rescue ArgumentError, JSON::ParserError
+        raise Broker::ExchangeError.new("id_token payload did not decode", stage: "parse")
+      end
+    end
+  end
+end

--- a/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
@@ -32,6 +32,7 @@ module Api
         data = json_body.fetch("data")
         assert_equal "https://oauth2.googleapis.com/token", data["token_endpoint"]
         assert_equal "gmail-client-id", data["client_id"]
+        assert_nil data["resource"]
         refute data.key?("client_secret")
         refute data.key?("access_token")
         refute data.key?("refresh_token")
@@ -47,6 +48,7 @@ module Api
         assert_response :ok
         data = json_body.fetch("data")
         assert_equal app.oid, data["oauth_app_id"]
+        assert_equal app.client_id, data["client_id"]
         assert_equal "sub-ser", data["provider_subject"]
         assert_equal "p@example.com", data["provider_email"]
         assert_equal "user-ser", data["external_user_key"]
@@ -57,6 +59,7 @@ module Api
           data: {
             namespace: "acme", foreign_id: "new-managed",
             token_endpoint: "https://idp.example/token",
+            resource: "https://mcp.example.com/mcp",
             scopes: [ "x" ],
             client_id: "the-client-id",
             client_secret: "the-client-secret",
@@ -71,6 +74,7 @@ module Api
         assert_response :created
         data = json_body.fetch("data")
         assert_equal "the-client-id", data["client_id"]
+        assert_equal "https://mcp.example.com/mcp", data["resource"]
         refute data.key?("client_secret")
         refute data.key?("refresh_token")
         assert_equal [ "X-Api-Key" ], data["token_endpoint_header_names"]
@@ -79,6 +83,7 @@ module Api
         created = BrokerCredential.find_by_oid(data["id"])
         assert_equal "super-secret-seed", created.refresh_token # persisted + decryptable
         assert_equal "the-client-secret", created.client_secret
+        assert_equal "https://mcp.example.com/mcp", created.resource
         assert_equal({ "X-Api-Key" => "k" }, created.token_endpoint_headers)
       end
 

--- a/services/console/test/controllers/api/v1/oauth_apps_controller_test.rb
+++ b/services/console/test/controllers/api/v1/oauth_apps_controller_test.rb
@@ -66,6 +66,26 @@ module Api
         assert_equal "acme", created.credential_namespace
       end
 
+      test "create allows Granola app without preconfigured client credentials" do
+        body = valid_body(
+          provider: "granola",
+          slug: "api-granola",
+          client_id: nil,
+          client_secret: nil,
+          allowed_scopes: [ "mcp" ]
+        )
+
+        assert_difference -> { OauthApp.count } => 1 do
+          post api_v1_oauth_apps_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :created
+        data = json_body.fetch("data")
+        assert_equal "granola", data["provider"]
+        assert_nil data["client_id"]
+        created = OauthApp.find_by_oid(data["id"])
+        assert_nil created.client_secret
+      end
+
       test "create rejects an unsupported provider" do
         assert_no_difference -> { OauthApp.count } do
           post api_v1_oauth_apps_url, params: valid_body(provider: "github").to_json, headers: auth_headers

--- a/services/console/test/controllers/console/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/console/broker_credentials_controller_test.rb
@@ -34,6 +34,7 @@ module Console
           credential: {
             namespace: "acme", foreign_id: "new-managed", name: "new-managed",
             token_endpoint: "https://idp.example/token", client_id: "cid",
+            resource: "https://mcp.example.com/mcp",
             client_secret: "shhh", scopes: "scope.a\nscope.b\n",
             refresh_token: "seed-token",
             early_refresh_fraction: "0.5", early_refresh_slack_seconds: "120",
@@ -50,6 +51,7 @@ module Console
       assert_equal({ "Authorization" => "Basic abc" }, cred.token_endpoint_headers)
       assert_equal({ "team" => "comms" }, cred.labels)
       assert_equal "shhh", cred.client_secret
+      assert_equal "https://mcp.example.com/mcp", cred.resource
       assert_equal "seed-token", cred.refresh_token
       assert_equal 0.5, cred.early_refresh_fraction
       assert_equal 120, cred.early_refresh_slack_seconds

--- a/services/console/test/controllers/console/oauth_apps_controller_test.rb
+++ b/services/console/test/controllers/console/oauth_apps_controller_test.rb
@@ -49,6 +49,25 @@ module Console
       assert_equal @operator, app.created_by
     end
 
+    test "POST create builds a Granola app without preconfigured client credentials" do
+      assert_difference -> { OauthApp.count } => 1 do
+        post console_oauth_app_forms_url, params: {
+          oauth_app: {
+            slug: "new-granola", description: "New Granola integration",
+            provider: "granola", credential_namespace: "acme", enabled: "1",
+            allowed_scopes: "mcp\n"
+          }
+        }
+      end
+
+      app = OauthApp.find_by!(slug: "new-granola")
+      assert_redirected_to console_oauth_app_path(app.oid)
+      assert_equal "granola", app.provider
+      assert_nil app.client_id
+      assert_nil app.client_secret
+      assert_equal %w[mcp], app.allowed_scopes
+    end
+
     test "POST create with an invalid provider is rejected without writing" do
       assert_no_difference -> { OauthApp.count } do
         post console_oauth_app_forms_url, params: {

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -16,6 +16,8 @@ module Oauth
 
     teardown do
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new }
+      FlowsController.registration_client_factory = -> { Oauth::DynamicClientRegistrationClient.new }
+      StubRegistrationClient.reset!
     end
 
     class StubHTTP
@@ -33,12 +35,53 @@ module Oauth
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: StubHTTP.new(status: status, body: body)) }
     end
 
+    class StubRegistrationClient
+      class << self
+        attr_accessor :captured, :result, :error
+
+        def reset!
+          self.captured = nil
+          self.result = Oauth::DynamicClientRegistrationClient::Result.new(
+            client_id: "granola-client-id",
+            client_secret: nil,
+            token_endpoint_auth_method: "none"
+          )
+          self.error = nil
+        end
+      end
+
+      reset!
+
+      def register(registration_endpoint:, metadata:, timeout: Oauth::DynamicClientRegistrationClient::DEFAULT_TIMEOUT)
+        self.class.captured = {
+          registration_endpoint: registration_endpoint,
+          metadata: metadata,
+          timeout: timeout
+        }
+        raise self.class.error if self.class.error
+        self.class.result
+      end
+    end
+
+    def stub_registration
+      StubRegistrationClient.reset!
+      FlowsController.registration_client_factory = -> { StubRegistrationClient.new }
+    end
+
     def id_token(claims)
       "h.#{Base64.urlsafe_encode64(claims.to_json, padding: false)}.s"
     end
 
     def token_body(sub: "google-sub-1", email: "user@example.com", aud: CLIENT_ID,
                    iss: "https://accounts.google.com", scope: "https://www.googleapis.com/auth/gmail.readonly openid", **overrides)
+      {
+        access_token: "AT", refresh_token: "RT", expires_in: 3600, scope: scope,
+        id_token: id_token({ "aud" => aud, "iss" => iss, "sub" => sub, "email" => email })
+      }.merge(overrides).to_json
+    end
+
+    def granola_token_body(sub: "granola-sub-1", email: "user@example.com", aud: "granola-client-id",
+                           iss: "https://mcp-auth.granola.ai", scope: "mcp openid email offline_access", **overrides)
       {
         access_token: "AT", refresh_token: "RT", expires_in: 3600, scope: scope,
         id_token: id_token({ "aud" => aud, "iss" => iss, "sub" => sub, "email" => email })
@@ -123,6 +166,45 @@ module Oauth
       refute_includes scopes, "https://www.googleapis.com/auth/gmail.readonly"
     end
 
+    test "start dynamically registers Granola and redirects with MCP resource" do
+      granola = oauth_apps(:acme_granola)
+      assert_nil granola.client_id
+      stub_registration
+
+      get oauth_start_url(slug: "granola")
+
+      assert_response :redirect
+      assert_equal "granola-client-id", granola.reload.client_id
+      assert_nil granola.client_secret
+      assert_equal "https://mcp-auth.granola.ai/oauth2/register", StubRegistrationClient.captured[:registration_endpoint]
+      metadata = StubRegistrationClient.captured[:metadata]
+      assert_equal [ "http://www.example.com/oauth/granola/callback" ], metadata["redirect_uris"]
+      assert_equal "none", metadata["token_endpoint_auth_method"]
+      assert_includes metadata["scope"].split, "mcp"
+
+      uri = URI.parse(response.location)
+      assert_equal "mcp-auth.granola.ai", uri.host
+      q = URI.decode_www_form(uri.query).to_h
+      assert_equal "granola-client-id", q["client_id"]
+      assert_equal "https://mcp.granola.ai/mcp", q["resource"]
+      assert_includes q["scope"].split, "offline_access"
+    end
+
+    test "start renders an error page when Granola dynamic registration fails" do
+      stub_registration
+      StubRegistrationClient.error = Broker::ExchangeError.new(
+        "registration endpoint rejected redirect uri",
+        stage: "oauth",
+        code: "invalid_redirect_uri"
+      )
+
+      get oauth_start_url(slug: "granola")
+
+      assert_response :unprocessable_entity
+      assert_match "invalid_redirect_uri", response.body
+      assert_nil oauth_apps(:acme_granola).reload.client_id
+    end
+
     # --- callback -------------------------------------------------------------
 
     test "callback happy path mints a live credential and renders a success page" do
@@ -171,6 +253,28 @@ module Oauth
       assert_equal [ "*.googleapis.com" ], secret.rules.map(&:host)
       # The source resolves the credential's live token at sync time.
       assert_equal({ "type" => "control_plane", "value" => "AT" }, secret.source.to_proxy_source)
+    end
+
+    test "Granola callback mints an MCP-scoped credential and wrapper" do
+      stub_registration
+      state = start_flow(slug: "granola")
+      stub_exchange(status: 200, body: granola_token_body)
+
+      assert_difference -> { BrokerCredential.count } => 1 do
+        get oauth_callback_url(slug: "granola"), params: { state: state, code: "auth-code" }
+      end
+      assert_response :ok
+
+      cred = BrokerCredential.find_by(oauth_app: oauth_apps(:acme_granola), provider_subject: "granola-sub-1")
+      assert_equal "https://mcp-auth.granola.ai/oauth2/token", cred.token_endpoint
+      assert_equal "https://mcp.granola.ai/mcp", cred.resource
+      assert_equal %w[mcp openid email offline_access], cred.scopes
+      assert_equal "AT", cred.access_token
+      assert_equal "RT", cred.refresh_token
+
+      secret = cred.static_secret
+      assert_equal [ "mcp.granola.ai" ], secret.rules.map(&:host)
+      assert_equal "token_broker", secret.source.source_type
     end
 
     test "re-consent neither duplicates the wrapping secret nor clobbers operator edits" do

--- a/services/console/test/fixtures/oauth_apps.yml
+++ b/services/console/test/fixtures/oauth_apps.yml
@@ -25,3 +25,13 @@ acme_google_disabled:
   credential_namespace: acme
   enabled: false
   created_by: acme_admin
+
+acme_granola:
+  slug: granola
+  description: Acme Granola MCP integration
+  provider: granola
+  allowed_scopes:
+    - mcp
+  credential_namespace: acme
+  enabled: true
+  created_by: acme_admin

--- a/services/console/test/lib/broker/authorization_code_client_test.rb
+++ b/services/console/test/lib/broker/authorization_code_client_test.rb
@@ -57,6 +57,12 @@ module Broker
       assert_equal "verifier", form["code_verifier"]
     end
 
+    test "resource indicator is included when supplied" do
+      client, http = client_with(status: 200, body: success_body)
+      client.exchange(**base_args(resource: "https://mcp.example.com/mcp"))
+      assert_equal "https://mcp.example.com/mcp", http.captured[:form]["resource"]
+    end
+
     test "missing expires_in yields nil" do
       client, _ = client_with(status: 200, body: success_body(expires_in: nil))
       assert_nil client.exchange(**base_args).expires_in

--- a/services/console/test/lib/broker/refresh_client_test.rb
+++ b/services/console/test/lib/broker/refresh_client_test.rb
@@ -51,6 +51,12 @@ module Broker
       assert_equal "k", http.captured[:headers]["X-Api-Key"]
     end
 
+    test "resource indicator is included when supplied" do
+      client, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
+      client.refresh(**base_args(resource: "https://mcp.example.com/mcp"))
+      assert_equal "https://mcp.example.com/mcp", http.captured[:form]["resource"]
+    end
+
     test "absent refresh_token in response means no rotation" do
       client, _ = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
       result = client.refresh(**base_args)

--- a/services/console/test/lib/oauth/dynamic_client_registration_client_test.rb
+++ b/services/console/test/lib/oauth/dynamic_client_registration_client_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+module Oauth
+  class DynamicClientRegistrationClientTest < ActiveSupport::TestCase
+    class StubHTTP
+      attr_reader :captured
+
+      def initialize(status:, body:)
+        @status = status
+        @body = body
+      end
+
+      def call(url:, metadata:, headers:, timeout:)
+        @captured = { url: url, metadata: metadata, headers: headers, timeout: timeout }
+        DynamicClientRegistrationClient::Response.new(status: @status, body: @body)
+      end
+    end
+
+    def client_with(status:, body:)
+      http = StubHTTP.new(status: status, body: body)
+      [ DynamicClientRegistrationClient.new(http: http), http ]
+    end
+
+    test "happy path parses registered public client metadata" do
+      client, http = client_with(status: 201, body: {
+        client_id: "client_123",
+        token_endpoint_auth_method: "none"
+      }.to_json)
+
+      result = client.register(
+        registration_endpoint: "https://mcp-auth.example/oauth2/register",
+        metadata: { "redirect_uris" => [ "https://control.example/oauth/granola/callback" ] }
+      )
+
+      assert_equal "client_123", result.client_id
+      assert_nil result.client_secret
+      assert_equal "none", result.token_endpoint_auth_method
+      assert_equal "https://mcp-auth.example/oauth2/register", http.captured[:url]
+    end
+
+    test "OAuth error body raises an ExchangeError with the code" do
+      client, _ = client_with(status: 400, body: { error: "invalid_redirect_uri" }.to_json)
+      err = assert_raises(Broker::ExchangeError) do
+        client.register(registration_endpoint: "https://idp.example/register", metadata: {})
+      end
+      assert_equal "oauth", err.stage
+      assert_equal "invalid_redirect_uri", err.code
+    end
+
+    test "missing client_id is a parse error" do
+      client, _ = client_with(status: 201, body: {}.to_json)
+      err = assert_raises(Broker::ExchangeError) do
+        client.register(registration_endpoint: "https://idp.example/register", metadata: {})
+      end
+      assert_equal "parse", err.stage
+    end
+  end
+end

--- a/services/console/test/lib/oauth/providers/granola_test.rb
+++ b/services/console/test/lib/oauth/providers/granola_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+module Oauth
+  module Providers
+    class GranolaTest < ActiveSupport::TestCase
+      CLIENT_ID = "client_123".freeze
+
+      def provider = Granola.new
+
+      def id_token(claims)
+        "h.#{Base64.urlsafe_encode64(claims.to_json, padding: false)}.s"
+      end
+
+      test "registration metadata requests a public MCP client" do
+        app = oauth_apps(:acme_granola)
+        metadata = provider.registration_metadata(
+          app: app,
+          redirect_uri: "https://control.example/oauth/granola/callback"
+        )
+
+        assert_equal [ "https://control.example/oauth/granola/callback" ], metadata["redirect_uris"]
+        assert_equal %w[authorization_code refresh_token], metadata["grant_types"]
+        assert_equal %w[code], metadata["response_types"]
+        assert_equal "none", metadata["token_endpoint_auth_method"]
+        scopes = metadata["scope"].split
+        assert_includes scopes, "mcp"
+        assert_includes scopes, "offline_access"
+        assert_includes scopes, "openid"
+      end
+
+      test "identity_from accepts Granola issuer and returns subject and email" do
+        result = Broker::AuthorizationCodeClient::Result.new(
+          access_token: "AT",
+          refresh_token: "RT",
+          expires_in: 3600,
+          scope: "mcp openid email offline_access",
+          id_token: id_token({
+            "aud" => CLIENT_ID,
+            "iss" => "https://mcp-auth.granola.ai",
+            "sub" => "granola-sub-1",
+            "email" => "user@example.com"
+          })
+        )
+
+        identity = provider.identity_from(result, client_id: CLIENT_ID)
+        assert_equal "granola-sub-1", identity[:subject]
+        assert_equal "user@example.com", identity[:email]
+      end
+
+      test "identity_from rejects another audience" do
+        result = Broker::AuthorizationCodeClient::Result.new(
+          access_token: "AT",
+          refresh_token: "RT",
+          expires_in: 3600,
+          scope: "mcp",
+          id_token: id_token({
+            "aud" => "other-client",
+            "iss" => "https://mcp-auth.granola.ai",
+            "sub" => "granola-sub-1"
+          })
+        )
+
+        err = assert_raises(Broker::ExchangeError) { provider.identity_from(result, client_id: CLIENT_ID) }
+        assert_equal "id_token_aud_mismatch", err.code
+      end
+    end
+  end
+end

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -203,11 +203,13 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   test "refresh passes client credentials and token-endpoint headers to the client" do
     captured = {}
     bc = create_credential(client_id: "the-id", client_secret: "the-secret",
+                           resource: "https://mcp.example.com/mcp",
                            token_endpoint_headers: { "X-Api-Key" => "k" })
     bc.refresh_client = StubClient.new { |**kw| captured = kw; result }
     bc.refresh!
     assert_equal "the-id", captured[:client_id]
     assert_equal "the-secret", captured[:client_secret]
+    assert_equal "https://mcp.example.com/mcp", captured[:resource]
     assert_equal({ "X-Api-Key" => "k" }, captured[:headers])
   end
 

--- a/services/console/test/models/oauth_app_test.rb
+++ b/services/console/test/models/oauth_app_test.rb
@@ -19,11 +19,16 @@ class OauthAppTest < ActiveSupport::TestCase
   test "provider must be a registered provider" do
     refute build_app(provider: "github").valid?
     assert build_app(provider: "google").valid?
+    assert build_app(provider: "granola", client_id: nil, client_secret: nil, allowed_scopes: %w[mcp]).valid?
   end
 
-  test "client_id and client_secret are required" do
+  test "client_id and client_secret are required for static-client providers" do
     refute build_app(client_id: nil).valid?
     refute build_app(client_secret: nil).valid?
+  end
+
+  test "dynamic-registration providers may start without client credentials" do
+    assert build_app(provider: "granola", client_id: nil, client_secret: nil, allowed_scopes: %w[mcp]).valid?
   end
 
   test "credential_namespace must be url-safe" do


### PR DESCRIPTION
## Summary

Adds Granola as an OAuth provider in centaur-console with support for MCP-style OAuth flows that use dynamic client registration and resource-aware token requests.

## Changes

- Add OAuth dynamic client registration support for providers without a static client ID/secret.
- Add a Granola OAuth provider with MCP authorization/token/DCR metadata, scopes, and resource URL handling.
- Persist OAuth app/broker credential resource metadata and expose it through API/UI surfaces.
- Carry OAuth token resource data into iron-control Rust models and `centaur-perms` output.
- Add Helm wiring for `CENTAUR_CONSOLE_PUBLIC_URL` so callback URLs work behind local/public routes.
- Update docs and add focused controller/model/client/provider tests.

## Validation

- `git diff --check`
- `cargo check -p centaur-iron-control -p centaur-perms`
- `helm template centaur contrib/chart --set console.enabled=true --set console.publicUrl=https://centaur.example.test --set ironControl.enabled=true`
- `docker run ... bundle exec rails test ...` for 119 focused console OAuth/DCR tests
- Local OrbStack smoke test: completed Granola OAuth flow, granted the resulting credential to `api:granola-mcp-local`, spawned a sandbox under that principal, and verified Granola MCP `initialize`, `tools/list`, and `get_account_info` through the sandbox iron-proxy.
