### PR TITLE
[codex] optimize Slack first response handoff

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -141,6 +141,32 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
+    #[tokio::test]
+    async fn session_turn_does_not_apply_a_session_body_limit() {
+        let pool =
+            PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
+        let app = build_router_with_runtime(
+            PgSessionStore::new(pool),
+            SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/session/slack%3AC123%3A123.456/turn")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::CONTENT_LENGTH, (256 * 1024 * 1024 + 1).to_string())
+                    .body(Body::from(r#"{"messages":"not-an-array"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
     #[derive(Default)]
     struct TestBackend {
         next_id: AtomicU64,

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -44,7 +44,8 @@ use crate::{
     types::{
         AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
         EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
-        ListWorkflowRunsQuery, OnHarnessConflict, SessionSseEvent, stream_error_sse,
+        ListWorkflowRunsQuery, OnHarnessConflict, SessionSseEvent, SessionTurnRequest,
+        SessionTurnResponse, stream_error_sse,
     },
 };
 
@@ -93,6 +94,10 @@ pub fn build_router_with_session_and_workflow_runtime(
         .route(
             "/api/session/{thread_key}/execute",
             post(execute_session).layer(DefaultBodyLimit::disable()),
+        )
+        .route(
+            "/api/session/{thread_key}/turn",
+            post(session_turn).layer(DefaultBodyLimit::disable()),
         )
         .route("/api/session/{thread_key}/events", get(stream_events))
         .route("/api/sandboxes/drain", post(drain_sandboxes))
@@ -196,10 +201,7 @@ async fn create_or_get_session(
     Json(request): Json<CreateSessionRequest>,
 ) -> Result<Json<CreateSessionResponse>, ApiError> {
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
-    let on_harness_conflict = match request.on_harness_conflict {
-        Some(OnHarnessConflict::Restart) => HarnessConflictPolicy::Restart,
-        Some(OnHarnessConflict::Reject) | None => HarnessConflictPolicy::Reject,
-    };
+    let on_harness_conflict = harness_conflict_policy(request.on_harness_conflict);
     let outcome = state
         .runtime
         .create_or_get_session(
@@ -213,6 +215,61 @@ async fn create_or_get_session(
     Ok(Json(CreateSessionResponse {
         session: outcome.session,
         harness_switched: outcome.harness_switched,
+    }))
+}
+
+async fn session_turn(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Json(request): Json<SessionTurnRequest>,
+) -> Result<Json<SessionTurnResponse>, ApiError> {
+    let thread_key = ThreadKey::try_from(raw_thread_key)?;
+    let SessionTurnRequest {
+        harness_type,
+        persona_id,
+        metadata,
+        on_harness_conflict,
+        messages,
+        execute,
+    } = request;
+    let outcome = state
+        .runtime
+        .create_or_get_session(
+            &thread_key,
+            &harness_type,
+            persona_id.as_deref(),
+            metadata,
+            harness_conflict_policy(on_harness_conflict),
+        )
+        .await?;
+    let message_ids = if messages.is_empty() {
+        Vec::new()
+    } else {
+        state
+            .runtime
+            .append_messages(&thread_key, &messages)
+            .await?
+    };
+    let execution = state
+        .runtime
+        .execute_session(
+            &thread_key,
+            ExecuteSessionInput {
+                idempotency_key: execute.idempotency_key,
+                metadata: execute.metadata,
+                input_lines: execute.input_lines,
+                idle_timeout_ms: execute.idle_timeout_ms,
+                max_duration_ms: execute.max_duration_ms,
+            },
+        )
+        .await?;
+    Ok(Json(SessionTurnResponse {
+        ok: true,
+        execution_id: execution.execution_id,
+        thread_key: execution.thread_key,
+        status: execution.status.to_string(),
+        harness_switched: outcome.harness_switched,
+        message_ids,
     }))
 }
 
@@ -257,6 +314,15 @@ async fn execute_session(
         thread_key: execution.thread_key,
         status: execution.status.to_string(),
     }))
+}
+
+fn harness_conflict_policy(
+    on_harness_conflict: Option<OnHarnessConflict>,
+) -> HarnessConflictPolicy {
+    match on_harness_conflict {
+        Some(OnHarnessConflict::Restart) => HarnessConflictPolicy::Restart,
+        Some(OnHarnessConflict::Reject) | None => HarnessConflictPolicy::Reject,
+    }
 }
 
 async fn drain_sandboxes(State(state): State<AppState>) -> Result<Json<Value>, ApiError> {

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -62,6 +62,28 @@ pub struct ExecuteSessionResponse {
     pub status: String,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SessionTurnRequest {
+    pub harness_type: HarnessType,
+    pub persona_id: Option<String>,
+    pub metadata: Option<Value>,
+    #[serde(default)]
+    pub on_harness_conflict: Option<OnHarnessConflict>,
+    #[serde(default)]
+    pub messages: Vec<SessionMessageInput>,
+    pub execute: ExecuteSessionRequest,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SessionTurnResponse {
+    pub ok: bool,
+    pub execution_id: String,
+    pub thread_key: ThreadKey,
+    pub status: String,
+    pub harness_switched: bool,
+    pub message_ids: Vec<String>,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct EventsQuery {
     pub after_event_id: Option<i64>,

--- a/services/api-rs/crates/centaur-sandbox-manager/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/lib.rs
@@ -13,7 +13,10 @@ pub use manager::{ManagedSandbox, SandboxManager};
 pub use reaper::{SandboxReaper, SandboxReaperConfig};
 pub use reconcile::{DriftReason, ReconcileAction, ReconcileOutcome, ReconcilePlan};
 pub use store::{DesiredStateStore, InMemoryDesiredStateStore};
-pub use warm_pool::{WarmPoolConfig, WarmPoolError, WarmPoolManager, WarmSandboxSpecFactory};
+pub use warm_pool::{
+    WarmPoolClaimOutcome, WarmPoolConfig, WarmPoolError, WarmPoolManager, WarmPoolStaleReason,
+    WarmPoolStaleSandbox, WarmSandboxSpecFactory,
+};
 
 #[cfg(test)]
 mod tests {

--- a/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
@@ -16,6 +16,41 @@ pub struct WarmPoolConfig {
     pub bootstrap_iron_control_principal: Option<String>,
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct WarmPoolClaimOutcome {
+    pub sandbox_id: Option<String>,
+    pub stale: Vec<WarmPoolStaleSandbox>,
+}
+
+#[derive(Clone, Debug)]
+pub struct WarmPoolStaleSandbox {
+    pub sandbox_id: String,
+    pub reason: WarmPoolStaleReason,
+    pub detail: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WarmPoolStaleReason {
+    NotFound,
+    NotRunning,
+}
+
+impl WarmPoolStaleReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotFound => "not_found",
+            Self::NotRunning => "not_running",
+        }
+    }
+
+    pub fn metric_label(self) -> &'static str {
+        match self {
+            Self::NotFound => "stale_not_found",
+            Self::NotRunning => "stale_not_running",
+        }
+    }
+}
+
 pub struct WarmPoolManager {
     manager: Arc<SandboxManager>,
     store: PgSessionStore,
@@ -63,18 +98,22 @@ impl WarmPoolManager {
         &self,
         thread_key: &str,
         iron_control_principal: Option<&str>,
-    ) -> Result<Option<String>, WarmPoolError> {
+    ) -> Result<WarmPoolClaimOutcome, WarmPoolError> {
+        let mut stale = Vec::new();
         loop {
             let Some(sandbox_id) = self
                 .store
                 .claim_ready_warm_sandbox(self.workload_key.as_str(), thread_key)
                 .await?
             else {
-                return Ok(None);
+                return Ok(WarmPoolClaimOutcome {
+                    sandbox_id: None,
+                    stale,
+                });
             };
 
             let id = SandboxId::new(sandbox_id.as_str());
-            let failure = match self.manager.status(&id).await {
+            let (failure, stale_reason) = match self.manager.status(&id).await {
                 // Only `Running` accepts `open_io`. `Created` means the
                 // runtime regressed after the replenisher saw it running
                 // (backends wait for readiness before returning from create),
@@ -93,10 +132,19 @@ impl WarmPoolManager {
                             .await;
                         return Err(WarmPoolError::Sandbox(error));
                     }
-                    return Ok(Some(sandbox_id));
+                    return Ok(WarmPoolClaimOutcome {
+                        sandbox_id: Some(sandbox_id),
+                        stale,
+                    });
                 }
-                Ok(status) => format!("claimed warm sandbox was not running: {status:?}"),
-                Err(SandboxError::NotFound(_)) => "claimed warm sandbox was not found".to_owned(),
+                Ok(status) => (
+                    format!("claimed warm sandbox was not running: {status:?}"),
+                    WarmPoolStaleReason::NotRunning,
+                ),
+                Err(SandboxError::NotFound(_)) => (
+                    "claimed warm sandbox was not found".to_owned(),
+                    WarmPoolStaleReason::NotFound,
+                ),
                 Err(error) => {
                     let error_message = error.to_string();
                     warn!(%sandbox_id, error = %error_message);
@@ -108,6 +156,11 @@ impl WarmPoolManager {
                 }
             };
             warn!(%sandbox_id, error = %failure, thread_key);
+            stale.push(WarmPoolStaleSandbox {
+                sandbox_id: sandbox_id.clone(),
+                reason: stale_reason,
+                detail: failure.clone(),
+            });
             self.store
                 .mark_warm_sandbox_failed(&sandbox_id, &failure)
                 .await?;

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1063,37 +1063,83 @@ impl SessionRuntime {
                     .claim(thread_key.as_str(), iron_control_principal)
                     .await
                 {
-                    Ok(Some(sandbox_id)) => {
-                        record_sandbox_warm_pool_claim("hit");
-                        span.record("centaur.sandbox_id", sandbox_id.as_str());
-                        span.record("sandbox_id", sandbox_id.as_str());
-                        self.store
-                            .update_sandbox_id(thread_key, Some(sandbox_id.as_str()))
-                            .await?;
-                        self.store
-                            .append_event(
-                                thread_key,
-                                None,
-                                "session.warm_sandbox_claimed",
+                    Ok(outcome) => {
+                        for stale in &outcome.stale {
+                            record_sandbox_warm_pool_claim(stale.reason.metric_label());
+                        }
+                        let stale_count = outcome.stale.len();
+                        let stale_reasons = outcome
+                            .stale
+                            .iter()
+                            .map(|stale| stale.reason.as_str())
+                            .collect::<Vec<_>>();
+                        let stale_sandboxes = outcome
+                            .stale
+                            .iter()
+                            .map(|stale| {
                                 json!({
-                                    "sandbox_id": sandbox_id.as_str(),
-                                    "workload_key": warm_pool.workload_key(),
-                                    "iron_control_principal": iron_control_principal,
-                                }),
-                            )
-                            .await?;
-                        info!(
-                            component = COMPONENT_SESSION_RUNTIME,
-                            event = "sandbox_ensure_warm_claimed",
-                            thread_key = %thread_key,
-                            execution_id,
-                            sandbox_id = %sandbox_id,
-                            workload_key = warm_pool.workload_key(),
-                            "claimed warm session sandbox"
-                        );
-                        return Ok(sandbox_id);
+                                    "sandbox_id": stale.sandbox_id.as_str(),
+                                    "reason": stale.reason.as_str(),
+                                    "detail": stale.detail.as_str(),
+                                })
+                            })
+                            .collect::<Vec<_>>();
+                        if stale_count > 0 {
+                            warn!(
+                                component = COMPONENT_SESSION_RUNTIME,
+                                event = "sandbox_ensure_warm_stale_skipped",
+                                thread_key = %thread_key,
+                                execution_id,
+                                stale_count,
+                                stale_reasons = ?stale_reasons,
+                                workload_key = warm_pool.workload_key(),
+                                "skipped stale warm session sandboxes"
+                            );
+                        }
+                        if let Some(sandbox_id) = outcome.sandbox_id {
+                            record_sandbox_warm_pool_claim(if stale_count == 0 {
+                                "hit"
+                            } else {
+                                "hit_after_stale"
+                            });
+                            span.record("centaur.sandbox_id", sandbox_id.as_str());
+                            span.record("sandbox_id", sandbox_id.as_str());
+                            self.store
+                                .update_sandbox_id(thread_key, Some(sandbox_id.as_str()))
+                                .await?;
+                            self.store
+                                .append_event(
+                                    thread_key,
+                                    None,
+                                    "session.warm_sandbox_claimed",
+                                    json!({
+                                        "sandbox_id": sandbox_id.as_str(),
+                                        "workload_key": warm_pool.workload_key(),
+                                        "iron_control_principal": iron_control_principal,
+                                        "stale_skipped": stale_count,
+                                        "stale_reasons": stale_reasons,
+                                        "stale_sandboxes": stale_sandboxes,
+                                    }),
+                                )
+                                .await?;
+                            info!(
+                                component = COMPONENT_SESSION_RUNTIME,
+                                event = "sandbox_ensure_warm_claimed",
+                                thread_key = %thread_key,
+                                execution_id,
+                                sandbox_id = %sandbox_id,
+                                workload_key = warm_pool.workload_key(),
+                                stale_skipped = stale_count,
+                                "claimed warm session sandbox"
+                            );
+                            return Ok(sandbox_id);
+                        }
+                        record_sandbox_warm_pool_claim(if stale_count == 0 {
+                            "miss"
+                        } else {
+                            "miss_after_stale"
+                        });
                     }
-                    Ok(None) => record_sandbox_warm_pool_claim("miss"),
                     Err(error) => {
                         record_sandbox_warm_pool_claim("error");
                         return Err(SessionRuntimeError::WarmPool(error));

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -61,7 +61,9 @@ export type {
   SlackbotV2Fetch,
   SlackbotV2Options,
   SlackbotV2SessionMessage,
-  SlackbotV2SessionMessageRole
+  SlackbotV2SessionMessageRole,
+  SlackbotV2SessionTurnRequest,
+  SlackbotV2SessionTurnResponse
 } from './types'
 
 type WaitUntilContext = {
@@ -1141,14 +1143,30 @@ async function renderExecutionStream(
     )
     return
   }
-  const titleStartedAtMs = nowMs()
-  await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
+  const metadataStartedAtMs = nowMs()
+  const metadataUpdates = [
+    scheduleAssistantTitle(
+      thread,
+      titleFromMessage(message.text, options.userName),
+      options,
+      'slackbotv2_render_slack_metadata_set',
+      trace
+    )
+  ]
   if (!assistantStatusVisible) {
-    await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
+    metadataUpdates.push(
+      scheduleAssistantStatus(
+        thread,
+        options.assistantStatus ?? 'Thinking...',
+        options,
+        'slackbotv2_render_slack_metadata_set',
+        trace
+      )
+    )
   }
-  traceLog(options, 'slackbotv2_render_slack_metadata_set', trace, {
+  traceLog(options, 'slackbotv2_render_slack_metadata_scheduled', trace, {
     assistant_status_already_visible: assistantStatusVisible,
-    phase_ms: elapsedMs(titleStartedAtMs)
+    phase_ms: elapsedMs(metadataStartedAtMs)
   })
   try {
     const visibleStream = await streamAfterFirstChunk(
@@ -1169,6 +1187,7 @@ async function renderExecutionStream(
       )
     )
   } finally {
+    await Promise.allSettled(metadataUpdates)
     await setAssistantStatus(thread, '')
   }
 }
@@ -1184,11 +1203,25 @@ async function renderRecoveredExecutionStream(
     await renderPlainTextExecutionStream(thread, stream, message, options, trace)
     return
   }
-  const titleStartedAtMs = nowMs()
-  await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
-  await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
-  traceLog(options, 'slackbotv2_render_slack_metadata_set', trace, {
-    phase_ms: elapsedMs(titleStartedAtMs)
+  const metadataStartedAtMs = nowMs()
+  const metadataUpdates = [
+    scheduleAssistantTitle(
+      thread,
+      titleFromMessage(message.text, options.userName),
+      options,
+      'slackbotv2_render_slack_metadata_set',
+      trace
+    ),
+    scheduleAssistantStatus(
+      thread,
+      options.assistantStatus ?? 'Thinking...',
+      options,
+      'slackbotv2_render_slack_metadata_set',
+      trace
+    )
+  ]
+  traceLog(options, 'slackbotv2_render_slack_metadata_scheduled', trace, {
+    phase_ms: elapsedMs(metadataStartedAtMs)
   })
   try {
     const visibleStream = await streamAfterFirstChunk(
@@ -1212,6 +1245,7 @@ async function renderRecoveredExecutionStream(
       }
     )
   } finally {
+    await Promise.allSettled(metadataUpdates)
     await setAssistantStatus(thread, '')
   }
 }
@@ -1225,14 +1259,30 @@ async function renderPlainTextExecutionStream(
   assistantStatusVisible = false
 ): Promise<void> {
   const fallback = new SlackRenderFallback()
-  const titleStartedAtMs = nowMs()
-  await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
+  const metadataStartedAtMs = nowMs()
+  const metadataUpdates = [
+    scheduleAssistantTitle(
+      thread,
+      titleFromMessage(message.text, options.userName),
+      options,
+      'slackbotv2_render_plain_text_metadata_set',
+      trace
+    )
+  ]
   if (!assistantStatusVisible) {
-    await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
+    metadataUpdates.push(
+      scheduleAssistantStatus(
+        thread,
+        options.assistantStatus ?? 'Thinking...',
+        options,
+        'slackbotv2_render_plain_text_metadata_set',
+        trace
+      )
+    )
   }
-  traceLog(options, 'slackbotv2_render_plain_text_metadata_set', trace, {
+  traceLog(options, 'slackbotv2_render_plain_text_metadata_scheduled', trace, {
     assistant_status_already_visible: assistantStatusVisible,
-    phase_ms: elapsedMs(titleStartedAtMs)
+    phase_ms: elapsedMs(metadataStartedAtMs)
   })
   try {
     const chatStream = fallback.collectChatSdk(
@@ -1256,6 +1306,7 @@ async function renderPlainTextExecutionStream(
     })
     await thread.post(text)
   } finally {
+    await Promise.allSettled(metadataUpdates)
     await setAssistantStatus(thread, '')
   }
 }
@@ -1659,7 +1710,12 @@ function rendererOptions(thread: Thread, options: SlackbotV2Options): CodexAppSe
     async onRendererEvent(event: RendererEvent) {
       await mapper?.onRendererEvent?.(event)
       if (event.type === 'renderer.title.update') {
-        await setAssistantTitle(thread, event.title)
+        void scheduleAssistantTitle(
+          thread,
+          event.title,
+          options,
+          'slackbotv2_render_slack_metadata_set'
+        )
       }
     }
   }
@@ -1720,15 +1776,66 @@ async function setAssistantStatus(thread: Thread, status: string): Promise<boole
   )
 }
 
-async function setAssistantTitle(thread: Thread, title: string | undefined): Promise<void> {
+async function setAssistantTitle(thread: Thread, title: string | undefined): Promise<boolean> {
   const normalized = title?.trim()
-  if (!normalized) return
+  if (!normalized) return false
   const target = slackAssistantTarget(thread)
   const adapter = thread.adapter as SlackAssistantAdapter
-  if (!target || !adapter.setAssistantTitle) return
-  await ignoreAssistantError(() =>
+  if (!target || !adapter.setAssistantTitle) return false
+  return await ignoreAssistantError(() =>
     adapter.setAssistantTitle!(target.channel, target.threadTs, clipOneLine(normalized, 80))
   )
+}
+
+function scheduleAssistantStatus(
+  thread: Thread,
+  status: string,
+  options: SlackbotV2Options,
+  eventName: string,
+  trace?: SlackbotV2Trace
+): Promise<void> {
+  return scheduleAssistantMetadataUpdate(options, eventName, 'status', trace, () =>
+    setAssistantStatus(thread, status)
+  )
+}
+
+function scheduleAssistantTitle(
+  thread: Thread,
+  title: string | undefined,
+  options: SlackbotV2Options,
+  eventName: string,
+  trace?: SlackbotV2Trace
+): Promise<void> {
+  return scheduleAssistantMetadataUpdate(options, eventName, 'title', trace, () =>
+    setAssistantTitle(thread, title)
+  )
+}
+
+function scheduleAssistantMetadataUpdate(
+  options: SlackbotV2Options,
+  eventName: string,
+  kind: 'status' | 'title',
+  trace: SlackbotV2Trace | undefined,
+  update: () => Promise<boolean>
+): Promise<void> {
+  const startedAtMs = nowMs()
+  const promise = update()
+    .then(visible => {
+      traceLog(options, eventName, trace, {
+        kind,
+        phase_ms: elapsedMs(startedAtMs),
+        visible
+      })
+    })
+    .catch(error => {
+      traceLog(options, `${eventName}_failed`, trace, {
+        error: errorMessage(error),
+        kind,
+        phase_ms: elapsedMs(startedAtMs)
+      })
+    })
+  backgroundWaitUntil(promise)
+  return promise
 }
 
 async function ignoreAssistantError(fn: () => Promise<void>): Promise<boolean> {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -12,7 +12,9 @@ import type {
   SlackbotV2ExecuteSessionResponse,
   SlackbotV2Options,
   SlackbotV2RendererSource,
-  SlackbotV2SessionMessage
+  SlackbotV2SessionMessage,
+  SlackbotV2SessionTurnRequest,
+  SlackbotV2SessionTurnResponse
 } from './types'
 import { elapsedMs, isJsonObject, nowMs, stringValue, toAsyncIterable, traceLog } from './utils'
 
@@ -149,6 +151,34 @@ export async function forwardToSessionApi(
   input: ForwardSessionInput,
   callbacks: ForwardSessionApiCallbacks = {}
 ): Promise<AsyncIterable<SlackbotV2RendererSource> | null> {
+  if (input.executeMessage && !input.harnessType) {
+    try {
+      const turnStartedAtMs = nowMs()
+      const execution = await executeSessionTurn(options, input)
+      traceLog(options, 'slackbotv2_session_turn_complete', input.trace, {
+        execution_id: execution.execution_id,
+        harness_switched: execution.harness_switched,
+        message_count: input.messages.length,
+        phase_ms: elapsedMs(turnStartedAtMs)
+      })
+      if (input.messages.length > 0) {
+        await callbacks.onMessagesAppended?.()
+      }
+      await callbacks.onExecutionStarted?.(execution)
+      if (!input.openStream) return null
+
+      return openSessionEventStream(options, {
+        ...input,
+        executionId: input.executionId ?? execution.execution_id
+      })
+    } catch (error) {
+      if (!isSessionTurnUnavailableError(error)) throw error
+      traceLog(options, 'slackbotv2_session_turn_unavailable', input.trace, {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
   const createStartedAtMs = nowMs()
   const created = await createSession(
     options,
@@ -405,11 +435,32 @@ async function postCreateSession(
   onHarnessConflict?: 'reject' | 'restart'
 ): Promise<Response> {
   const fetchFn = options.fetch ?? fetch
+  const body = await createSessionRequestBody(
+    options,
+    threadId,
+    harnessType,
+    message,
+    onHarnessConflict
+  )
+  return fetchFn(apiSessionUrl(options.apiUrl, threadId), {
+    method: 'POST',
+    headers: apiHeaders(options),
+    body: JSON.stringify(body)
+  })
+}
+
+async function createSessionRequestBody(
+  options: SlackbotV2Options,
+  threadId: string,
+  harnessType: string,
+  message?: SlackbotV2ApiMessage,
+  onHarnessConflict?: 'reject' | 'restart'
+): Promise<SlackbotV2CreateSessionRequest> {
   // The conversation name becomes the session principal's display name in
   // iron-control; resolve it here so it rides the create-session metadata that
   // api-rs reads when it registers the principal.
   const conversationName = message ? await resolveConversationName(options, message) : undefined
-  const body: SlackbotV2CreateSessionRequest = {
+  return {
     harness_type: harnessType,
     metadata: {
       source: 'slackbotv2',
@@ -420,11 +471,6 @@ async function postCreateSession(
     },
     ...(onHarnessConflict ? { on_harness_conflict: onHarnessConflict } : {})
   }
-  return fetchFn(apiSessionUrl(options.apiUrl, threadId), {
-    method: 'POST',
-    headers: apiHeaders(options),
-    body: JSON.stringify(body)
-  })
 }
 
 async function harnessSwitchedFromResponse(response: Response): Promise<boolean> {
@@ -793,7 +839,103 @@ async function executeSession(
 ): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
   const requesterIdentity = await resolveRequesterIdentity(options, message)
-  const body: SlackbotV2ExecuteSessionRequest = {
+  const body = executeSessionRequestBody(
+    options,
+    threadId,
+    message,
+    requesterIdentity,
+    model,
+    contextMessages,
+    contextPreamble
+  )
+  const response = await fetchFn(apiSessionUrl(options.apiUrl, threadId, 'execute'), {
+    method: 'POST',
+    headers: apiHeaders(options),
+    body: JSON.stringify(body)
+  })
+  await ensureApiOk(response, 'execute session')
+  return (await response.json()) as SlackbotV2ExecuteSessionResponse
+}
+
+async function executeSessionTurn(
+  options: SlackbotV2Options,
+  input: ForwardSessionInput
+): Promise<SlackbotV2SessionTurnResponse> {
+  const message = input.executeMessage
+  if (!message) throw new Error('execute message is required for a session turn')
+
+  const requested = options.defaultHarnessType ?? DEFAULT_HARNESS_TYPE
+  const response = await postSessionTurn(options, input, requested)
+  if (response.ok) return (await response.json()) as SlackbotV2SessionTurnResponse
+
+  let body = ''
+  try {
+    body = await response.text()
+  } catch {
+    body = ''
+  }
+  const existing = response.status === 409 ? existingHarnessFromConflict(body) : undefined
+  if (existing && existing !== requested) {
+    const retry = await postSessionTurn(options, input, existing)
+    await ensureApiOk(retry, 'session turn')
+    return (await retry.json()) as SlackbotV2SessionTurnResponse
+  }
+  throw new SessionApiError({
+    action: 'session turn',
+    body,
+    retryable: isRetryableApiStatus(response.status),
+    status: response.status,
+    statusText: response.statusText
+  })
+}
+
+async function postSessionTurn(
+  options: SlackbotV2Options,
+  input: ForwardSessionInput,
+  harnessType: string
+): Promise<Response> {
+  const message = input.executeMessage
+  if (!message) throw new Error('execute message is required for a session turn')
+  const fetchFn = options.fetch ?? fetch
+  const requesterIdentity = await resolveRequesterIdentity(options, message)
+  const createRequest = await createSessionRequestBody(
+    options,
+    input.threadId,
+    harnessType,
+    sessionRequesterMessage(input)
+  )
+  const body: SlackbotV2SessionTurnRequest = {
+    ...createRequest,
+    execute: executeSessionRequestBody(
+      options,
+      input.threadId,
+      message,
+      requesterIdentity,
+      input.model,
+      input.executeContextMessages,
+      input.contextPreamble
+    ),
+    messages: await Promise.all(
+      input.messages.map(item => toSessionMessage(options, item, false))
+    )
+  }
+  return fetchFn(apiSessionUrl(options.apiUrl, input.threadId, 'turn'), {
+    method: 'POST',
+    headers: apiHeaders(options),
+    body: JSON.stringify(body)
+  })
+}
+
+function executeSessionRequestBody(
+  options: SlackbotV2Options,
+  threadId: string,
+  message: SlackbotV2ApiMessage,
+  requesterIdentity: RequesterIdentity,
+  model?: string,
+  contextMessages?: SlackbotV2ApiMessage[],
+  contextPreamble?: string
+): SlackbotV2ExecuteSessionRequest {
+  return {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),
     input_lines: toCodexInputLines(
@@ -807,13 +949,6 @@ async function executeSession(
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
   }
-  const response = await fetchFn(apiSessionUrl(options.apiUrl, threadId, 'execute'), {
-    method: 'POST',
-    headers: apiHeaders(options),
-    body: JSON.stringify(body)
-  })
-  await ensureApiOk(response, 'execute session')
-  return (await response.json()) as SlackbotV2ExecuteSessionResponse
 }
 
 async function ensureApiOk(response: Response, action: string): Promise<void> {
@@ -835,6 +970,14 @@ async function ensureApiOk(response: Response, action: string): Promise<void> {
 
 function isRetryableApiStatus(status: number): boolean {
   return status === 408 || status === 425 || status === 429 || status >= 500
+}
+
+function isSessionTurnUnavailableError(error: unknown): boolean {
+  return (
+    error instanceof SessionApiError
+    && error.action === 'session turn'
+    && (error.status === 404 || error.status === 405 || error.status === 501)
+  )
 }
 
 async function streamSessionNotifications(
@@ -863,7 +1006,7 @@ async function streamSessionNotifications(
 function apiSessionUrl(
   apiUrl: string,
   threadId: string,
-  suffix?: 'messages' | 'execute' | 'events'
+  suffix?: 'messages' | 'execute' | 'events' | 'turn'
 ): string {
   const path = `/api/session/${encodeURIComponent(threadId)}${suffix ? `/${suffix}` : ''}`
   return new URL(path, ensureTrailingSlash(apiUrl)).toString()

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -76,6 +76,20 @@ export type SlackbotV2ExecuteSessionResponse = {
   thread_key: string
 }
 
+export type SlackbotV2SessionTurnRequest = {
+  execute: SlackbotV2ExecuteSessionRequest
+  harness_type: string
+  messages: SlackbotV2SessionMessage[]
+  metadata: JsonObject
+  /** 'restart': switch the thread to harness_type if it's pinned to another harness. */
+  on_harness_conflict?: 'reject' | 'restart'
+}
+
+export type SlackbotV2SessionTurnResponse = SlackbotV2ExecuteSessionResponse & {
+  harness_switched: boolean
+  message_ids: string[]
+}
+
 export type SlackbotV2Fetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 export type SlackbotV2Options = {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -18,7 +18,8 @@ import {
   type SlackbotV2ApiMessage,
   type SlackbotV2CreateSessionRequest,
   type SlackbotV2ExecuteSessionRequest,
-  type SlackbotV2SessionMessage
+  type SlackbotV2SessionMessage,
+  type SlackbotV2SessionTurnRequest
 } from '../src/index'
 import { clearRequesterIdentityCacheForTests } from '../src/session-api'
 
@@ -3263,6 +3264,7 @@ type MockSessionApi = {
   holdNextExecute(): () => void
   reset(): void
   streamCount: number
+  turns: MockSessionRequest<SlackbotV2SessionTurnRequest>[]
   url: string
 }
 
@@ -3272,6 +3274,8 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
   const eventRequests: MockSessionEventRequest[] = []
   const events: MockSessionEvent[] = []
   const executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[] = []
+  const turns: MockSessionRequest<SlackbotV2SessionTurnRequest>[] = []
+  const turnAppendedClientMessageIds = new Map<string, Set<string>>()
   const idempotentExecutions = new Map<string, string>()
   const streams = new Set<ServerResponse>()
   let autoRespond = true
@@ -3293,6 +3297,8 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       events,
       eventRequests,
       executes,
+      turnAppendedClientMessageIds,
+      turns,
       get autoRespond() {
         return autoRespond
       },
@@ -3336,12 +3342,15 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
     creates,
     eventRequests,
     executes,
+    turns,
     reset() {
       appends.length = 0
       creates.length = 0
       eventRequests.length = 0
       events.length = 0
       executes.length = 0
+      turns.length = 0
+      turnAppendedClientMessageIds.clear()
       idempotentExecutions.clear()
       executeHoldRelease?.()
       executeHold = null
@@ -3441,17 +3450,19 @@ async function handleMockCodexRequest(
     failNextExecuteAfterAccept: boolean
     failNextEvents: boolean
     failNextExecute: boolean
-      idempotentExecutions: Map<string, string>
+    idempotentExecutions: Map<string, string>
     nextEventId(): number
     port: number
     setFailNextEvents(value: boolean): void
     setFailNextExecute(value: boolean): void
     setFailNextExecuteAfterAccept(value: boolean): void
     streams: Set<ServerResponse>
+    turnAppendedClientMessageIds: Map<string, Set<string>>
+    turns: MockSessionRequest<SlackbotV2SessionTurnRequest>[]
   }
 ): Promise<void> {
   const url = new URL(req.url ?? '/', `http://127.0.0.1:${input.port}`)
-  const match = /^\/api\/session\/([^/]+)(?:\/(messages|execute|events))?$/.exec(url.pathname)
+  const match = /^\/api\/session\/([^/]+)(?:\/(messages|execute|events|turn))?$/.exec(url.pathname)
   if (!match?.[1]) {
     await sendWebResponse(res, new Response('not found', { status: 404 }))
     return
@@ -3517,7 +3528,78 @@ async function handleMockCodexRequest(
     return
   }
 
+  if (endpoint === 'turn') {
+    const body = (await request.json()) as SlackbotV2SessionTurnRequest
+    input.turns.push({ threadKey, body })
+    input.creates.push({
+      threadKey,
+      body: {
+        harness_type: body.harness_type,
+        metadata: body.metadata,
+        ...(body.on_harness_conflict
+          ? { on_harness_conflict: body.on_harness_conflict }
+          : {})
+      }
+    })
+    if (
+      body.messages.length > 0
+      && hasNewTurnAppendMessages(input.turnAppendedClientMessageIds, threadKey, body.messages)
+    ) {
+      input.appends.push({ threadKey, body: { messages: body.messages } })
+    }
+    await handleMockExecute(res, input, threadKey, body.execute, {
+      harness_switched: false,
+      message_ids: body.messages.map((_, index) => `msg-${index + 1}`)
+    })
+    return
+  }
+
   const body = (await request.json()) as SlackbotV2ExecuteSessionRequest
+  await handleMockExecute(res, input, threadKey, body)
+}
+
+function hasNewTurnAppendMessages(
+  appendedClientMessageIds: Map<string, Set<string>>,
+  threadKey: string,
+  messages: SlackbotV2SessionMessage[]
+): boolean {
+  let threadIds = appendedClientMessageIds.get(threadKey)
+  if (!threadIds) {
+    threadIds = new Set()
+    appendedClientMessageIds.set(threadKey, threadIds)
+  }
+  let hasNew = false
+  for (const message of messages) {
+    const clientMessageId = message.client_message_id
+    if (!clientMessageId) {
+      hasNew = true
+      continue
+    }
+    if (!threadIds.has(clientMessageId)) hasNew = true
+    threadIds.add(clientMessageId)
+  }
+  return hasNew
+}
+
+async function handleMockExecute(
+  res: ServerResponse,
+  input: {
+    autoRespond: boolean
+    events: MockSessionEvent[]
+    executeHold: Promise<void> | null
+    executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[]
+    failNextExecuteAfterAccept: boolean
+    failNextExecute: boolean
+    idempotentExecutions: Map<string, string>
+    nextEventId(): number
+    setFailNextExecute(value: boolean): void
+    setFailNextExecuteAfterAccept(value: boolean): void
+    streams: Set<ServerResponse>
+  },
+  threadKey: string,
+  body: SlackbotV2ExecuteSessionRequest,
+  responseExtra: Record<string, unknown> = {}
+): Promise<void> {
   input.executes.push({ threadKey, body })
   if (input.failNextExecute) {
     input.setFailNextExecute(false)
@@ -3562,6 +3644,7 @@ async function handleMockCodexRequest(
     Response.json({
       ok: true,
       execution_id: executionId,
+      ...responseExtra,
       thread_key: threadKey,
       status: 'completed'
     })

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -58,6 +58,22 @@ function fakeApi(responses: { createSession?: Array<{ body?: unknown; status: nu
     const url = String(input)
     const body = init?.body ? JSON.parse(String(init.body)) : undefined
     requests.push({ body, url })
+    if (url.endsWith('/turn')) {
+      if (createResponses.length > 0) {
+        const next = createResponses.shift()!
+        if (next.status >= 400) {
+          return Response.json(next.body ?? { ok: false }, { status: next.status })
+        }
+      }
+      return Response.json({
+        execution_id: 'exec-1',
+        harness_switched: false,
+        message_ids: (body?.messages ?? []).map((_: unknown, index: number) => `msg-${index + 1}`),
+        ok: true,
+        status: 'running',
+        thread_key: 'slack:C1:1700000000.000100'
+      })
+    }
     if (url.endsWith('/execute')) {
       return Response.json({
         execution_id: 'exec-1',
@@ -88,7 +104,7 @@ describe('forwardToSessionApi overrides', () => {
   test('creates session with default codex harness', async () => {
     const { fetchFn, requests } = fakeApi()
     await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
-    const create = requests.find(request => request.url.endsWith('.000100'))
+    const create = requests.find(request => request.url.endsWith('/turn'))
     expect((create?.body as { harness_type?: string }).harness_type).toBe('codex')
   })
 
@@ -123,8 +139,10 @@ describe('forwardToSessionApi overrides', () => {
   test('omits model field when no override is set', async () => {
     const { fetchFn, requests } = fakeApi()
     await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
-    const execute = requests.find(request => request.url.endsWith('/execute'))
-    const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
+    const turn = requests.find(request => request.url.endsWith('/turn'))
+    const line = JSON.parse(
+      (turn?.body as { execute: { input_lines: string[] } }).execute.input_lines[0]!
+    )
     expect('model' in line).toBe(false)
   })
 
@@ -171,19 +189,19 @@ describe('forwardToSessionApi overrides', () => {
       ]
     })
     await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
-    const creates = requests.filter(request => request.url.endsWith('.000100'))
+    const creates = requests.filter(request => request.url.endsWith('/turn'))
     expect(creates.map(request => (request.body as { harness_type: string }).harness_type)).toEqual(
       ['codex', 'amp']
     )
   })
 
-  test('surfaces non-conflict create failures', async () => {
+  test('surfaces non-conflict turn failures', async () => {
     const { fetchFn } = fakeApi({
       createSession: [{ body: { error: 'boom', ok: false }, status: 500 }]
     })
     await expect(
       forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
-    ).rejects.toThrow('create session failed: 500')
+    ).rejects.toThrow('session turn failed: 500')
   })
 })
 
@@ -201,7 +219,7 @@ describe('forwardToSessionApi harness restart', () => {
   test('default create does not request restart', async () => {
     const { fetchFn, requests } = fakeApi()
     await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
-    const create = requests.find(request => request.url.endsWith('.000100'))
+    const create = requests.find(request => request.url.endsWith('/turn'))
     expect('on_harness_conflict' in (create?.body as object)).toBe(false)
   })
 
@@ -297,7 +315,9 @@ describe('session principal display name', () => {
   }
 
   function createBody(requests: RecordedRequest[]): { metadata?: { slack_conversation_name?: string } } {
-    return (requests.find(request => request.url.endsWith('.000100'))?.body ?? {}) as {
+    return (requests.find(request => request.url.endsWith('/turn'))?.body
+      ?? requests.find(request => request.url.endsWith('.000100'))?.body
+      ?? {}) as {
       metadata?: { slack_conversation_name?: string }
     }
   }


### PR DESCRIPTION
## Summary

- add a combined `POST /api/session/{thread_key}/turn` path that create/gets the session, appends Slack messages, and starts execution in one API request
- use the combined path for normal Slack execute turns, with fallback to the legacy create/append/execute flow for skewed API deploys and explicit harness switches
- schedule Slack title/status metadata updates without blocking stream opening, while preserving the immediate `Thinking...` status path
- add warm-pool claim quality signals for stale skipped sandboxes, `hit_after_stale`, and `miss_after_stale`

## Validation

- `bun tsgo --project tsconfig.json --noEmit`
- `bun test test`
- `cargo test -p centaur-api-server -p centaur-sandbox-manager -p centaur-session-runtime --lib`
