### PR TITLE
Lower repo-cache sync interval default

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.60
+version: 0.1.61
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -227,7 +227,7 @@ repoCache:
   # tool server is enabled.
   repositories: []
   repositoryRefs: {}
-  syncIntervalSeconds: 300
+  syncIntervalSeconds: 30
   image:
     repository: ""
     tag: ""


### PR DESCRIPTION
## Summary
- lower the Helm chart default repo-cache sync interval from 300s to 30s

## Validation
- git diff --check