### PR TITLE
Deduplicate overlapping assistant text snapshots

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -150,6 +150,36 @@ describe('CodexAppServerRendererEventMapper', () => {
     })
   })
 
+  it('deduplicates overlapping non-canonical assistant text snapshots', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'true' }
+    })
+
+    const chunks = [
+      'Test',
+      'Tested tempo',
+      'tempo-obs',
+      '-obs across',
+      ' across all datasources'
+    ]
+    const deltas = chunks.flatMap(text =>
+      mapper.process({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text }] }
+      })
+    )
+
+    expect(
+      deltas
+        .filter(event => event.type === 'renderer.message.delta')
+        .map(event => (event.type === 'renderer.message.delta' ? event.delta : ''))
+        .join('')
+    ).toBe('Tested tempo-obs across all datasources')
+  })
+
   it('maps app-server agent message deltas keyed by turnId', () => {
     const mapper = new CodexAppServerRendererEventMapper()
     const events = mapper.process({

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -505,7 +505,7 @@ export class CodexAppServerRendererEventMapper
       } else if (assistantText.startsWith(before)) {
         this.state[key] = assistantText
       } else {
-        this.state[key] = before + assistantText
+        this.state[key] = appendWithOverlap(before, assistantText)
       }
       recomposeBuffers(this.state)
       return { bufferChanged: true }
@@ -891,6 +891,18 @@ function assistantEventLooksCanonical(event: any): boolean {
       message?.model ||
       message?.usage
   )
+}
+
+function appendWithOverlap(previous: string, next: string): string {
+  if (!previous) return next
+  if (!next) return previous
+  const max = Math.min(previous.length, next.length)
+  for (let length = max; length > 0; length -= 1) {
+    if (previous.endsWith(next.slice(0, length))) {
+      return previous + next.slice(length)
+    }
+  }
+  return previous + next
 }
 
 function textHash(value: string): string {


### PR DESCRIPTION
## Summary
- Deduplicate overlapping non-canonical assistant text snapshots in the Codex App Server renderer
- Add a regression for mixed/overlapping assistant snapshot chunks like `Test` + `Tested`

## Tests
- `bun test packages/rendering/src/codex-app-server.test.ts`
- `bun test services/slackbotv2/test/chat-sdk-emulate.test.ts -t "does not duplicate final text|syncs thread context"`
- `pnpm --filter @centaur/rendering typecheck`

Prompted by: @Zygimantass