### PR TITLE
[codex] make console probes configurable

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.60
+version: 0.1.61
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -175,23 +175,23 @@ spec:
             httpGet:
               path: /up
               port: http
-            failureThreshold: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
+            failureThreshold: {{ $console.startupProbe.failureThreshold }}
+            periodSeconds: {{ $console.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ $console.startupProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: /up
               port: http
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 5
+            failureThreshold: {{ $console.readinessProbe.failureThreshold }}
+            periodSeconds: {{ $console.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ $console.readinessProbe.timeoutSeconds }}
           livenessProbe:
             httpGet:
               path: /up
               port: http
-            failureThreshold: 6
-            periodSeconds: 10
-            timeoutSeconds: 5
+            failureThreshold: {{ $console.livenessProbe.failureThreshold }}
+            periodSeconds: {{ $console.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ $console.livenessProbe.timeoutSeconds }}
           securityContext:
 {{ toYaml .Values.containerSecurityContext | nindent 12 }}
             # No readOnlyRootFilesystem — Rails writes to tmp/ at runtime.

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -28,6 +28,9 @@
             "httpPort": { "type": "integer" }
           }
         },
+        "startupProbe": { "$ref": "#/definitions/probeConfig" },
+        "readinessProbe": { "$ref": "#/definitions/probeConfig" },
+        "livenessProbe": { "$ref": "#/definitions/probeConfig" },
         "ingress": {
           "type": "object",
           "properties": {
@@ -48,6 +51,14 @@
           }
         },
         "resources": { "type": "object" }
+      }
+    },
+    "probeConfig": {
+      "type": "object",
+      "properties": {
+        "failureThreshold": { "type": "integer" },
+        "periodSeconds": { "type": "integer" },
+        "timeoutSeconds": { "type": "integer" }
       }
     }
   },

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -108,6 +108,18 @@ console:
     enabled: false
   service:
     httpPort: 3000
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+  readinessProbe:
+    failureThreshold: 6
+    periodSeconds: 10
+    timeoutSeconds: 5
+  livenessProbe:
+    failureThreshold: 6
+    periodSeconds: 10
+    timeoutSeconds: 5
   # Optional Ingress for the console. Bring your own controller — Tailscale
   # operator, Cloudflare, ingress-nginx, etc. — via className + annotations +
   # tls. Mirrors the top-level `ingress` block (which is wired to the


### PR DESCRIPTION
## Summary
- expose console startup/readiness/liveness probe settings in the Helm chart values
- wire the console Deployment probes through those values instead of hardcoded thresholds
- bump the chart version to 0.1.61

## Why
During the `prd-centaur-na` rollout, `centaur-api-rs` startup registration and proxy sync traffic made `centaur-console` intermittently miss `/up`. The chart hardcoded the console readiness/liveness probes, so the live stabilization could not be represented in Git.

This lets infra pin the temporary relaxed console probe values while warm pools stay disabled pending `iron-proxy#190`.

Related infra follow-up: tempoxyz/prd-centaur-infra#410.

## Validation
- `ruby -ryaml -e 'YAML.load_file(ARGV.fetch(0)); puts "values yaml ok"' contrib/chart/values.yaml`
- `ruby -rjson -e 'JSON.parse(File.read(ARGV.fetch(0))); puts "schema json ok"' contrib/chart/values.schema.json`
- `helm lint contrib/chart --set console.enabled=true --set console.readinessProbe.failureThreshold=60 --set console.readinessProbe.timeoutSeconds=10 --set console.livenessProbe.failureThreshold=60 --set console.livenessProbe.timeoutSeconds=10`
- `helm template centaur contrib/chart --set console.enabled=true --set console.readinessProbe.failureThreshold=60 --set console.readinessProbe.timeoutSeconds=10 --set console.livenessProbe.failureThreshold=60 --set console.livenessProbe.timeoutSeconds=10` renders the console Deployment with readiness/liveness `failureThreshold: 60` and `timeoutSeconds: 10`.
