### PR TITLE
Reload overlay skills on centaur-tools refresh

### DIFF
--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -251,56 +251,8 @@ fi
 mkdir -p "$HOME_DIR/uploads"
 
 # ── Copy project skills into workspace (so `skill` tool discovers them) ──────
-BAKED_IN_CENTAUR_SKILLS="$HOME_DIR/.agents/skills"
-MOUNTED_CENTAUR_SKILLS="$HOME_DIR/centaur-skills"
-MOUNTED_ORG_SKILLS="$HOME_DIR/centaur-overlay-skills"
-OVERLAY_TREE_SKILLS=""
-if [ -n "${CENTAUR_OVERLAY_DIR:-}" ] && [ -d "${CENTAUR_OVERLAY_DIR}/.agents/skills" ]; then
-    OVERLAY_TREE_SKILLS="${CENTAUR_OVERLAY_DIR}/.agents/skills"
-fi
-CENTAUR_SKILLS=""
-if [ -d "$HOME_DIR/github" ]; then
-    CENTAUR_SKILLS="$(find "$HOME_DIR/github" -path '*/centaur/.agents/skills' -type d -print -quit 2>/dev/null || true)"
-fi
-WS_SKILLS="$WORKSPACE_DIR/.agents/skills"
-
-copy_skill_dir() {
-    local skills_src="$1"
-    local skill_entry skill_name
-    if [ ! -d "$skills_src" ]; then
-        return 0
-    fi
-    mkdir -p "$WS_SKILLS"
-    for skill_entry in "$skills_src"/* "$skills_src"/.[!.]* "$skills_src"/..?*; do
-        if [ ! -e "$skill_entry" ]; then
-            continue
-        fi
-        skill_name="$(basename "$skill_entry")"
-        rm -rf "$WS_SKILLS/$skill_name"
-        cp -R "$skill_entry" "$WS_SKILLS"/
-    done
-}
-
-for SKILLS_SRC in "$BAKED_IN_CENTAUR_SKILLS" "$MOUNTED_CENTAUR_SKILLS" "$CENTAUR_SKILLS" "$MOUNTED_ORG_SKILLS" "$OVERLAY_TREE_SKILLS"; do
-    copy_skill_dir "$SKILLS_SRC"
-done
-
-if [ -n "${CENTAUR_SKILL_DIRS:-}" ]; then
-    IFS=':' read -ra _centaur_skill_dirs <<< "$CENTAUR_SKILL_DIRS"
-    for SKILLS_SRC in "${_centaur_skill_dirs[@]}"; do
-        if [ -n "$SKILLS_SRC" ]; then
-            copy_skill_dir "$SKILLS_SRC"
-        fi
-    done
-    unset _centaur_skill_dirs
-fi
-unset -f copy_skill_dir
-
-if [ -d "$WS_SKILLS" ]; then
-    mkdir -p "$WORKSPACE_DIR/.claude"
-    rm -rf "$WORKSPACE_DIR/.claude/skills"
-    ln -sf "$WS_SKILLS" "$WORKSPACE_DIR/.claude/skills"
-fi
+WORKSPACE_DIR="$WORKSPACE_DIR" install-tool-shims --refresh-skills \
+    || echo "warning: failed to reload Centaur skills" >&2
 
 # ── Assemble system prompt from bind mounts ──────────────────────────────────
 # Base prompt: mounted as AGENTS_BASE.md when present, fallback to baked-in AGENTS.md.

--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -19,6 +19,22 @@ def _split_paths(value: str) -> list[Path]:
     return [Path(part) for part in value.split(":") if part]
 
 
+def _home_dir() -> Path:
+    return Path.home()
+
+
+def _workspace_dir() -> Path:
+    env_workspace = os.environ.get("WORKSPACE_DIR") or os.environ.get("CENTAUR_WORKSPACE_DIR")
+    if env_workspace:
+        return Path(env_workspace)
+
+    home_dir = _home_dir()
+    state_workspace = Path(os.environ.get("CENTAUR_STATE_DIR", str(home_dir / "state"))) / "workspace"
+    if os.environ.get("CENTAUR_PERSISTENT_STATE") == "1" or state_workspace.exists():
+        return state_workspace
+    return home_dir / "workspace"
+
+
 def _git_env() -> tuple[dict[str, str], tempfile.TemporaryDirectory[str] | None]:
     env = os.environ.copy()
     env["GIT_TERMINAL_PROMPT"] = "0"
@@ -175,6 +191,78 @@ def _refresh_tool_dirs(tool_dirs: list[Path]) -> int:
         if _refresh_tool_dir(tool_dir):
             refreshed += 1
     return refreshed
+
+
+def _copy_skill_dir(skills_src: Path, workspace_skills: Path) -> int:
+    if not skills_src.is_dir():
+        return 0
+
+    copied = 0
+    workspace_skills.mkdir(parents=True, exist_ok=True)
+    for skill_entry in sorted(skills_src.iterdir(), key=lambda entry: entry.name):
+        skill_name = skill_entry.name
+        target = workspace_skills / skill_name
+        if target.exists() or target.is_symlink():
+            if target.is_dir() and not target.is_symlink():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+        if skill_entry.is_dir() and not skill_entry.is_symlink():
+            shutil.copytree(skill_entry, target, symlinks=True)
+        else:
+            shutil.copy2(skill_entry, target, follow_symlinks=False)
+        copied += 1
+    return copied
+
+
+def _first_base_centaur_skills(home_dir: Path) -> Path | None:
+    github_dir = home_dir / "github"
+    if not github_dir.is_dir():
+        return None
+    for skills_dir in sorted(github_dir.glob("*/centaur/.agents/skills")):
+        if skills_dir.is_dir():
+            return skills_dir
+    return None
+
+
+def _skill_sources() -> list[Path]:
+    home_dir = _home_dir()
+    sources = [
+        home_dir / ".agents" / "skills",
+        home_dir / "centaur-skills",
+    ]
+    if base_skills := _first_base_centaur_skills(home_dir):
+        sources.append(base_skills)
+    sources.append(home_dir / "centaur-overlay-skills")
+
+    overlay_dir = os.environ.get("CENTAUR_OVERLAY_DIR")
+    if overlay_dir:
+        overlay_tree_skills = Path(overlay_dir) / ".agents" / "skills"
+        if overlay_tree_skills.is_dir():
+            sources.append(overlay_tree_skills)
+
+    sources.extend(_split_paths(os.environ.get("CENTAUR_SKILL_DIRS", "")))
+    return sources
+
+
+def _refresh_skill_dirs(workspace_dir: Path) -> int:
+    workspace_skills = workspace_dir / ".agents" / "skills"
+    copied = 0
+    for skills_src in _skill_sources():
+        copied += _copy_skill_dir(skills_src, workspace_skills)
+
+    if workspace_skills.is_dir():
+        claude_dir = workspace_dir / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        claude_skills = claude_dir / "skills"
+        if claude_skills.exists() or claude_skills.is_symlink():
+            if claude_skills.is_dir() and not claude_skills.is_symlink():
+                shutil.rmtree(claude_skills)
+            else:
+                claude_skills.unlink()
+        claude_skills.symlink_to(workspace_skills)
+
+    return copied
 
 
 def _discover_scripts(tool_dirs: list[Path]) -> dict[str, dict[str, str]]:
@@ -393,13 +481,21 @@ if __name__ == "__main__":
 
 def main(argv: list[str]) -> int:
     refresh = "--refresh" in argv[1:]
+    refresh_skills_only = "--refresh-skills" in argv[1:]
     tool_dirs = _split_paths(os.environ.get("TOOL_DIRS", ""))
     bin_dir = Path(os.environ.get("CENTAUR_TOOL_BIN_DIR", str(Path.home() / ".local/bin")))
     bin_dir.mkdir(parents=True, exist_ok=True)
 
+    if refresh_skills_only:
+        copied = _refresh_skill_dirs(_workspace_dir())
+        print(f"reloaded {copied} Centaur skill entries", file=sys.stderr)
+        return 0
+
     if refresh:
         refreshed = _refresh_tool_dirs(tool_dirs)
         print(f"refreshed {refreshed} Centaur tool source dirs", file=sys.stderr)
+        copied = _refresh_skill_dirs(_workspace_dir())
+        print(f"reloaded {copied} Centaur skill entries", file=sys.stderr)
 
     scripts = _discover_scripts(tool_dirs)
     pythonpath_parts = [


### PR DESCRIPTION
## Summary
- reload sandbox skills when `centaur-tools refresh` runs
- share the same skill reload implementation with sandbox startup via `install-tool-shims --refresh-skills`
- preserve existing overlay precedence and `.claude/skills` symlink setup

Prompted by: @Zygimantass

## Tests
- `uv run python -m py_compile services/sandbox/install_tool_shims.py`
- sandbox-style `install_tool_shims.py --refresh-skills` simulation
- generated `centaur-tools refresh` simulation with local `install-tool-shims` wrapper
