### PR TITLE
feat(sandbox): configure harness config via env overlays

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -39,6 +39,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     opentelemetry-proto==1.42.1 \
     pysocks>=1.7.1 \
     slack-sdk==3.39.0 \
+    tomli-w==1.2.0 \
     && find /usr/local/lib/python3.12 /usr/lib/python3 -type d -name __pycache__ -prune -exec rm -rf '{}' +
 
 # ── GitHub CLI + Node.js 24 (LTS) + Docker CLI (single layer, cached) ─────────────

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -220,7 +220,35 @@ if effort:
                 break
         else:
             lines.insert(first_table, override)
-path.write_text("\n".join(lines).rstrip() + "\n")
+
+text = "\n".join(lines).rstrip() + "\n"
+
+# CODEX_CONFIG_OVERLAY: deep-merge an operator-supplied TOML fragment over the
+# baked config so a deployment can configure codex -- e.g. point it at a custom
+# model provider via a [model_providers.*] block -- through sandbox.extraEnv,
+# without forking config.toml. Unset is a no-op; invalid TOML is ignored (the
+# baked config stands) rather than written.
+overlay_raw = (os.environ.get("CODEX_CONFIG_OVERLAY") or "").strip()
+if overlay_raw:
+    import tomllib
+    import tomli_w
+
+    def _deep_merge(base, overlay):
+        for key, value in overlay.items():
+            if isinstance(value, dict) and isinstance(base.get(key), dict):
+                _deep_merge(base[key], value)
+            else:
+                base[key] = value
+        return base
+
+    try:
+        merged = _deep_merge(tomllib.loads(text), tomllib.loads(overlay_raw))
+    except tomllib.TOMLDecodeError as exc:
+        print(f"ignoring invalid CODEX_CONFIG_OVERLAY: {exc}", file=sys.stderr)
+    else:
+        text = tomli_w.dumps(merged)
+
+path.write_text(text)
 PYEOF
 else
     echo "missing Codex harness config: $HARNESS_CONFIG_DIR/codex/config.toml" >&2
@@ -231,6 +259,39 @@ fi
 mkdir -p "$HOME_DIR/.claude"
 if [ -f "$HARNESS_CONFIG_DIR/claude/settings.json" ]; then
     cp "$HARNESS_CONFIG_DIR/claude/settings.json" "$HOME_DIR/.claude/settings.json"
+fi
+
+# CLAUDE_SETTINGS_OVERLAY: deep-merge an operator-supplied JSON fragment over the
+# baked settings.json (symmetric to CODEX_CONFIG_OVERLAY), so a deployment can
+# configure Claude Code via sandbox.extraEnv without forking the image. Unset is
+# a no-op; invalid JSON is ignored.
+if [ -n "${CLAUDE_SETTINGS_OVERLAY:-}" ]; then
+    CLAUDE_SETTINGS_PATH="$HOME_DIR/.claude/settings.json" python3 - <<'PYEOF'
+import json
+import os
+import sys
+from pathlib import Path
+
+path = Path(os.environ["CLAUDE_SETTINGS_PATH"])
+try:
+    overlay = json.loads(os.environ["CLAUDE_SETTINGS_OVERLAY"])
+except json.JSONDecodeError as exc:
+    print(f"ignoring invalid CLAUDE_SETTINGS_OVERLAY: {exc}", file=sys.stderr)
+    sys.exit(0)
+existing = path.read_text() if path.exists() else ""
+base = json.loads(existing) if existing.strip() else {}
+
+def _deep_merge(b, o):
+    for key, value in o.items():
+        if isinstance(value, dict) and isinstance(b.get(key), dict):
+            _deep_merge(b[key], value)
+        else:
+            b[key] = value
+    return b
+
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(_deep_merge(base, overlay), indent=2) + "\n")
+PYEOF
 fi
 
 # CLAUDE_CODE_AUTH_MODE selects how Claude Code authenticates with the upstream


### PR DESCRIPTION
## What

Adds two deployment-time overlay env vars so an operator can configure the codex and Claude Code harnesses through `sandbox.extraEnv`, without forking the baked config files or maintaining a derived sandbox image:

- **`CODEX_CONFIG_OVERLAY`** — a TOML fragment deep-merged over the baked `~/.codex/config.toml`. The motivating use case is pointing codex at a custom model provider via a `[model_providers.*]` block, e.g.:
  ```toml
  model_provider = "myproxy"
  [model_providers.myproxy]
  name = "openai"
  base_url = "https://proxy.internal/backend-api/codex"
  wire_api = "responses"
  supports_websockets = false
  ```
- **`CLAUDE_SETTINGS_OVERLAY`** — a JSON fragment deep-merged over the baked `~/.claude/settings.json` (symmetric, for the Claude Code harness).

## Why

This generalizes the same "configure the harness from a deployment without forking config" pattern already established by `CODEX_MODEL_REASONING_SUMMARY` / `CODEX_MODEL_REASONING_EFFORT` (#597). Those knobs cover individual keys; an operator running a custom egress/proxy or alternate provider needs to add a whole `[model_providers.*]` table, which today forces either a config fork or a derived image. A deep-merge overlay covers that case with no schema coupling.

## Behavior

- Both are **no-ops when unset**.
- **Invalid input is ignored** (the baked config stands) and logged to stderr, rather than failing the sandbox — same failure posture as the existing reasoning overrides.
- Deep-merge semantics: nested tables/objects merge recursively; scalars and arrays replace. Existing baked keys not named in the overlay are preserved.
- The codex overlay re-serializes via `tomli-w` (added to the sandbox image deps); the claude overlay uses stdlib `json`.

## Notes for review

- The codex overlay runs as the final step of the existing `config.toml` python block, after the reasoning-summary/effort line edits, so it composes with them.
- `tomllib` is stdlib on the sandbox's Python 3.12; only `tomli-w` (writer) is a new dependency.