### PR TITLE
fix: cache proxy sync configs

### DIFF
--- a/services/console/app/controllers/api/v1/proxy_sync_controller.rb
+++ b/services/console/app/controllers/api/v1/proxy_sync_controller.rb
@@ -19,7 +19,8 @@ module Api
     # yet. Each secret still carries its own per-secret `rules`.
     class ProxySyncController < Api::ProxyBaseController
       def create
-        current_hash = current_proxy.config_hash
+        snapshot = current_proxy.sync_config_snapshot
+        current_hash = snapshot[:config_hash]
 
         if params[:config_hash].presence == current_hash
           render json: { config_hash: current_hash }
@@ -27,7 +28,7 @@ module Api
           # The config is assembled from the proxy's principal (empty when
           # unassigned). status and principal_id let an unassigned proxy tell "no
           # config yet" apart from "config is genuinely empty", and detect a swap.
-          config = current_proxy.sync_config
+          config = snapshot[:config]
           render json: {
             config_hash: current_hash,
             status: current_proxy.status,

--- a/services/console/app/jobs/prune_principal_sync_config_snapshots_job.rb
+++ b/services/console/app/jobs/prune_principal_sync_config_snapshots_job.rb
@@ -1,0 +1,7 @@
+class PrunePrincipalSyncConfigSnapshotsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    PrincipalSyncConfigSnapshot.prune_expired!
+  end
+end

--- a/services/console/app/models/aws_auth_secret.rb
+++ b/services/console/app/models/aws_auth_secret.rb
@@ -11,6 +11,7 @@ class AwsAuthSecret < ApplicationRecord
   oid_prefix "aas"
 
   include ForeignIdCollisionGuard
+  include SyncConfigCacheInvalidation
 
   URL_SAFE_FORMAT = /\A[A-Za-z0-9\-._~]+\z/
   URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -50,6 +50,7 @@ class BrokerCredential < ApplicationRecord
   # is no FK to cascade or nullify, so deletion would silently leave those secrets
   # undeliverable. The operator must remove the references first.
   before_destroy :ensure_not_referenced
+  before_commit :bump_referencing_principal_sync_config_versions, if: :sync_config_relevant_change?
 
   serialize :token_endpoint_headers, coder: JSON
   encrypts :access_token
@@ -195,6 +196,21 @@ class BrokerCredential < ApplicationRecord
     return unless SecretSource.referencing_broker_credential(self).exists?
     errors.add(:base, "is referenced by one or more token_broker secret sources; remove those references first")
     throw :abort
+  end
+
+  def sync_config_relevant_change?
+    previous_changes.key?("access_token") ||
+      previous_changes.key?("dead") ||
+      previous_changes.key?("last_refresh") ||
+      previous_changes.key?("expires_at")
+  end
+
+  def bump_referencing_principal_sync_config_versions
+    ids = SecretSource.referencing_broker_credential(self).flat_map do |source|
+      owner = source.sync_config_owner
+      owner ? Principal.effective_grantee_ids_for_grantable(owner) : []
+    end
+    Principal.bump_sync_config_cache_versions(ids)
   end
 
   def labels_is_a_hash

--- a/services/console/app/models/concerns/sync_config_cache_invalidation.rb
+++ b/services/console/app/models/concerns/sync_config_cache_invalidation.rb
@@ -1,0 +1,20 @@
+module SyncConfigCacheInvalidation
+  extend ActiveSupport::Concern
+
+  included do
+    before_commit :bump_sync_config_cache_for_record
+  end
+
+  private
+
+  def bump_sync_config_cache_for_record
+    Principal.bump_sync_config_cache_versions(sync_config_affected_principal_ids)
+  end
+
+  # Grantable secret models intentionally use broad invalidation. Admin writes to
+  # these rows are rare compared with proxy sync polling, and over-invalidation is
+  # safer than maintaining a per-model list of config-affecting columns.
+  def sync_config_affected_principal_ids
+    Principal.effective_grantee_ids_for_grantable(self)
+  end
+end

--- a/services/console/app/models/concerns/sync_config_owner_invalidation.rb
+++ b/services/console/app/models/concerns/sync_config_owner_invalidation.rb
@@ -1,0 +1,22 @@
+module SyncConfigOwnerInvalidation
+  extend ActiveSupport::Concern
+
+  include SyncConfigCacheInvalidation
+
+  def sync_config_owner
+    self.class::OWNER_ASSOCIATIONS.each do |assoc|
+      id = public_send("#{assoc}_id")
+      next if id.blank?
+
+      return assoc.to_s.classify.constantize.find_by(id: id)
+    end
+    nil
+  end
+
+  private
+
+  def sync_config_affected_principal_ids
+    owner = sync_config_owner
+    owner ? Principal.effective_grantee_ids_for_grantable(owner) : []
+  end
+end

--- a/services/console/app/models/gcp_auth_secret.rb
+++ b/services/console/app/models/gcp_auth_secret.rb
@@ -7,6 +7,7 @@ class GcpAuthSecret < ApplicationRecord
   oid_prefix "gas"
 
   include ForeignIdCollisionGuard
+  include SyncConfigCacheInvalidation
 
   URL_SAFE_FORMAT = /\A[A-Za-z0-9\-._~]+\z/
   URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"

--- a/services/console/app/models/grant.rb
+++ b/services/console/app/models/grant.rb
@@ -1,6 +1,8 @@
 class Grant < ApplicationRecord
   oid_prefix "grant"
 
+  include SyncConfigCacheInvalidation
+
   GRANTEE_ASSOCIATIONS = %i[principal role].freeze
   GRANTABLE_ASSOCIATIONS = %i[static_secret gcp_auth_secret aws_auth_secret oauth_token_secret pg_dsn_secret hmac_secret].freeze
 
@@ -42,6 +44,13 @@ class Grant < ApplicationRecord
   end
 
   private
+
+  def sync_config_affected_principal_ids
+    ids = []
+    ids << principal_id if principal_id.present?
+    ids += PrincipalRole.where(role_id: role_id).pluck(:principal_id) if role_id.present?
+    ids
+  end
 
   # A grant left without an explicit priority defaults by grantee: direct grants
   # outrank role grants. The column is NOT NULL with no DB default, so Grant.new

--- a/services/console/app/models/hmac_secret.rb
+++ b/services/console/app/models/hmac_secret.rb
@@ -9,6 +9,7 @@ class HmacSecret < ApplicationRecord
   oid_prefix "hms"
 
   include ForeignIdCollisionGuard
+  include SyncConfigCacheInvalidation
 
   URL_SAFE_FORMAT = /\A[A-Za-z0-9\-._~]+\z/
   URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"

--- a/services/console/app/models/oauth_token_secret.rb
+++ b/services/console/app/models/oauth_token_secret.rb
@@ -8,6 +8,7 @@ class OauthTokenSecret < ApplicationRecord
   oid_prefix "ots"
 
   include ForeignIdCollisionGuard
+  include SyncConfigCacheInvalidation
 
   URL_SAFE_FORMAT = /\A[A-Za-z0-9\-._~]+\z/
   URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -14,6 +14,7 @@ class PgDsnSecret < ApplicationRecord
   oid_prefix "pgs"
 
   include ForeignIdCollisionGuard
+  include SyncConfigCacheInvalidation
 
   URL_SAFE_FORMAT = /\A[A-Za-z0-9\-._~]+\z/
   URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -11,7 +11,10 @@ class Principal < ApplicationRecord
   has_many :proxies, dependent: :nullify
   has_many :principal_roles, dependent: :destroy
   has_many :roles, through: :principal_roles
+  has_many :sync_config_snapshots, class_name: "PrincipalSyncConfigSnapshot", dependent: :destroy
   belongs_to :created_by, class_name: "User"
+
+  before_commit :bump_own_sync_config_cache_version, on: :update, if: :sync_config_fields_changed?
 
   URL_SAFE_FORMAT = /\A[A-Za-z0-9\-._~]+\z/
   URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"
@@ -117,6 +120,37 @@ class Principal < ApplicationRecord
     redact_secrets ? self.class.redact_live_secrets(config) : config
   end
 
+  def self.bump_sync_config_cache_versions(ids)
+    ids = Array(ids).compact.uniq
+    return if ids.empty?
+
+    where(id: ids).update_all("sync_config_cache_version = sync_config_cache_version + 1")
+  end
+
+  def self.effective_grantee_ids_for_grantable(grantable)
+    association = grantable.model_name.singular.to_sym
+    grants = Grant.where(association => grantable)
+    direct_ids = grants.where.not(principal_id: nil).pluck(:principal_id)
+    role_ids = grants.where.not(role_id: nil).pluck(:role_id)
+    role_principal_ids = role_ids.empty? ? [] : PrincipalRole.where(role_id: role_ids).pluck(:principal_id)
+    direct_ids + role_principal_ids
+  end
+
+  # Deep-walk a config payload and blank out the inline value of every
+  # control_plane source, leaving the rest of the structure intact.
+  def self.redact_live_secrets(value)
+    case value
+    when Hash
+      redacted = value.transform_values { |v| redact_live_secrets(v) }
+      redacted["value"] = REDACTED if redacted["type"] == "control_plane" && redacted.key?("value")
+      redacted
+    when Array
+      value.map { |v| redact_live_secrets(v) }
+    else
+      value
+    end
+  end
+
   private
 
   # The single place secret order is decided for every sync array. iron-proxy
@@ -143,20 +177,11 @@ class Principal < ApplicationRecord
       .order(Arel.sql("granted_priorities.effective_priority ASC, #{model.table_name}.id ASC"))
   end
 
-  public
+  def sync_config_fields_changed?
+    previous_changes.key?("name") || previous_changes.key?("labels")
+  end
 
-  # Deep-walk a config payload and blank out the inline value of every
-  # control_plane source, leaving the rest of the structure intact.
-  def self.redact_live_secrets(value)
-    case value
-    when Hash
-      redacted = value.transform_values { |v| redact_live_secrets(v) }
-      redacted["value"] = REDACTED if redacted["type"] == "control_plane" && redacted.key?("value")
-      redacted
-    when Array
-      value.map { |v| redact_live_secrets(v) }
-    else
-      value
-    end
+  def bump_own_sync_config_cache_version
+    self.class.bump_sync_config_cache_versions(id)
   end
 end

--- a/services/console/app/models/principal_role.rb
+++ b/services/console/app/models/principal_role.rb
@@ -1,6 +1,8 @@
 class PrincipalRole < ApplicationRecord
   oid_prefix "prole"
 
+  include SyncConfigCacheInvalidation
+
   belongs_to :principal
   belongs_to :role
 
@@ -8,6 +10,10 @@ class PrincipalRole < ApplicationRecord
   validate :same_namespace
 
   private
+
+  def sync_config_affected_principal_ids
+    [ principal_id ]
+  end
 
   # A principal may only hold roles from its own namespace; roles are scoped to
   # a namespace and crossing that boundary would leak secrets across tenants.

--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -1,0 +1,44 @@
+class PrincipalSyncConfigSnapshot < ApplicationRecord
+  TTL = 10.minutes
+  RETENTION = 1.hour
+
+  belongs_to :principal
+
+  encrypts :payload
+  serialize :payload, coder: JSON
+
+  validates :principal_cache_version, presence: true
+  validates :principal_id, uniqueness: { scope: :principal_cache_version }
+
+  def self.fetch_for(principal)
+    version = principal.sync_config_cache_version
+    snapshot = find_by(principal: principal, principal_cache_version: version)
+    return snapshot if snapshot&.fresh?
+
+    build_for(principal)
+  end
+
+  def self.prune_expired!
+    where("updated_at < ?", RETENTION.ago).delete_all
+  end
+
+  def fresh?
+    updated_at >= TTL.ago
+  end
+
+  def self.build_for(principal)
+    principal.with_lock do
+      principal.reload
+      version = principal.sync_config_cache_version
+      snapshot = find_or_initialize_by(principal: principal, principal_cache_version: version)
+      return snapshot if snapshot.persisted? && snapshot.fresh?
+
+      config = principal.effective_config(redact_secrets: false)
+      snapshot.payload = config
+      snapshot.save!
+      snapshot
+    end
+  rescue ActiveRecord::RecordNotUnique
+    retry
+  end
+end

--- a/services/console/app/models/proxy.rb
+++ b/services/console/app/models/proxy.rb
@@ -45,6 +45,11 @@ class Proxy < ApplicationRecord
     principal&.effective_config(redact_secrets: false) || Principal::EMPTY_CONFIG
   end
 
+  def sync_config_snapshot
+    config = principal ? PrincipalSyncConfigSnapshot.fetch_for(principal).payload : Principal::EMPTY_CONFIG
+    { config_hash: config_hash_for(config), config: config }
+  end
+
   # Opaque, deterministic fingerprint of the delivered config. The proxy treats
   # this as an ETag: it echoes its current hash on each sync and only re-applies
   # config when the hash changes.
@@ -52,7 +57,11 @@ class Proxy < ApplicationRecord
     # The principal identity and assignment time are folded in so that any
     # assignment change forces a refresh, even a swap between principals whose
     # effective secrets happen to be identical (or an unassign to empty).
-    payload = sync_config.merge(
+    config_hash_for(sync_config)
+  end
+
+  def config_hash_for(config)
+    payload = config.merge(
       "principal" => principal&.oid,
       "principal_assigned_at" => principal_assigned_at&.utc&.iso8601
     )

--- a/services/console/app/models/request_rule.rb
+++ b/services/console/app/models/request_rule.rb
@@ -3,6 +3,8 @@ require "ipaddr"
 class RequestRule < ApplicationRecord
   oid_prefix "rqr"
 
+  include SyncConfigOwnerInvalidation
+
   HTTP_METHODS = %w[GET HEAD POST PUT PATCH DELETE OPTIONS CONNECT].freeze
   METHOD_WILDCARD = "*".freeze
 

--- a/services/console/app/models/secret_source.rb
+++ b/services/console/app/models/secret_source.rb
@@ -1,6 +1,8 @@
 class SecretSource < ApplicationRecord
   oid_prefix "scs"
 
+  include SyncConfigOwnerInvalidation
+
   SOURCE_TYPES = %w[env aws_sm aws_ssm 1password 1password_connect control_plane token_broker].freeze
 
   UNIVERSAL_OPTIONAL = %w[json_key ttl].freeze

--- a/services/console/app/models/static_secret.rb
+++ b/services/console/app/models/static_secret.rb
@@ -2,6 +2,7 @@ class StaticSecret < ApplicationRecord
   oid_prefix "ssr"
 
   include ForeignIdCollisionGuard
+  include SyncConfigCacheInvalidation
 
   has_many :grants, dependent: :destroy
 

--- a/services/console/config/recurring.yml
+++ b/services/console/config/recurring.yml
@@ -19,3 +19,6 @@ production:
   broker_poll_refresh:
     class: "Broker::PollRefreshJob"
     schedule: every minute
+  prune_principal_sync_config_snapshots:
+    class: "PrunePrincipalSyncConfigSnapshotsJob"
+    schedule: every 10 minutes

--- a/services/console/db/migrate/20260616170000_create_principal_sync_config_snapshots.rb
+++ b/services/console/db/migrate/20260616170000_create_principal_sync_config_snapshots.rb
@@ -1,0 +1,17 @@
+class CreatePrincipalSyncConfigSnapshots < ActiveRecord::Migration[8.1]
+  def change
+    add_column :principals, :sync_config_cache_version, :bigint, null: false, default: 0
+
+    create_table :principal_sync_config_snapshots do |t|
+      t.references :principal, null: false, foreign_key: true
+      t.bigint :principal_cache_version, null: false
+      t.text :payload, null: false
+
+      t.timestamps
+    end
+
+    add_index :principal_sync_config_snapshots, [ :principal_id, :principal_cache_version ],
+              unique: true, name: "idx_principal_sync_snapshots_on_principal_version"
+    add_index :principal_sync_config_snapshots, :updated_at
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_224547) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -219,6 +219,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_224547) do
     t.index ["role_id"], name: "index_principal_roles_on_role_id"
   end
 
+  create_table "principal_sync_config_snapshots", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "payload", null: false
+    t.bigint "principal_cache_version", null: false
+    t.bigint "principal_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["principal_id", "principal_cache_version"], name: "idx_principal_sync_snapshots_on_principal_version", unique: true
+    t.index ["principal_id"], name: "index_principal_sync_config_snapshots_on_principal_id"
+    t.index ["updated_at"], name: "index_principal_sync_config_snapshots_on_updated_at"
+  end
+
   create_table "principals", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "created_by_id", null: false
@@ -226,6 +237,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_224547) do
     t.jsonb "labels", default: {}, null: false
     t.string "name"
     t.string "namespace", default: "default", null: false
+    t.bigint "sync_config_cache_version", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["created_by_id"], name: "index_principals_on_created_by_id"
     t.index ["labels"], name: "index_principals_on_labels", using: :gin
@@ -367,6 +379,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_224547) do
   add_foreign_key "pg_dsn_secrets", "users", column: "created_by_id"
   add_foreign_key "principal_roles", "principals"
   add_foreign_key "principal_roles", "roles"
+  add_foreign_key "principal_sync_config_snapshots", "principals"
   add_foreign_key "principals", "users", column: "created_by_id"
   add_foreign_key "proxies", "principals", on_delete: :nullify
   add_foreign_key "request_rules", "aws_auth_secrets"

--- a/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
@@ -52,6 +52,39 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     refute body.key?("ingest_token")
   end
 
+  test "cold sync stores an encrypted principal snapshot" do
+    assert_difference -> { PrincipalSyncConfigSnapshot.count }, 1 do
+      post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
+    end
+    assert_response :ok
+
+    snapshot = PrincipalSyncConfigSnapshot.find_by!(principal: @proxy.principal)
+    assert_equal @proxy.principal.sync_config_cache_version, snapshot.principal_cache_version
+    assert_equal "s3cr3t-db-pass", snapshot.payload.dig("secrets", 1, "source", "value")
+
+    raw = PrincipalSyncConfigSnapshot.connection.select_value(
+      "SELECT payload FROM principal_sync_config_snapshots WHERE id = #{snapshot.id}"
+    )
+    refute_includes raw, "s3cr3t-db-pass"
+  end
+
+  test "secret changes bump principal cache version and build a new snapshot" do
+    post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
+    assert_response :ok
+    original_version = @proxy.principal.reload.sync_config_cache_version
+
+    @replace.source.update!(secret: "rotated-db-pass")
+
+    assert_operator @proxy.principal.reload.sync_config_cache_version, :>, original_version
+    assert_difference -> { PrincipalSyncConfigSnapshot.count }, 1 do
+      post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
+    end
+    assert_response :ok
+
+    entry = json_body.fetch("secrets").find { |s| s.dig("source", "type") == "control_plane" }
+    assert_equal "rotated-db-pass", entry.dig("source", "value")
+  end
+
   test "env source maps inject_config and rules (http_methods -> methods)" do
     post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
     assert_response :ok
@@ -244,5 +277,37 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_equal "assigned", json_body.fetch("status")
     assert_equal @proxy.principal.oid, json_body.fetch("principal_id")
+  end
+
+  test "broker credential token changes bump reachable principal cache version" do
+    admin = users(:acme_admin)
+    credential = BrokerCredential.create!(
+      namespace: "acme", foreign_id: "sync-cache-#{SecureRandom.hex(4)}",
+      name: "sync cache broker", token_endpoint: "https://oauth.example.com/token",
+      client_id: "client", refresh_token: "refresh", access_token: "token-1",
+      expires_at: 1.hour.from_now, last_refresh: Time.current, created_by: admin
+    )
+    secret = StaticSecret.new(
+      namespace: "acme", name: "brokered",
+      inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+      created_by: admin
+    )
+    secret.build_source(source_type: "token_broker", config: { "credential_id" => credential.oid })
+    secret.rules.build(host: "api.example.com", position: 0)
+    secret.save!
+    Grant.create!(principal: @proxy.principal, static_secret: secret, created_by: admin)
+
+    post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
+    assert_response :ok
+    original_version = @proxy.principal.reload.sync_config_cache_version
+
+    credential.update!(access_token: "token-2", expires_at: 2.hours.from_now, last_refresh: Time.current)
+
+    assert_operator @proxy.principal.reload.sync_config_cache_version, :>, original_version
+    post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
+    assert_response :ok
+
+    entry = json_body.fetch("secrets").find { |s| s.dig("source", "value") == "token-2" }
+    refute_nil entry
   end
 end

--- a/services/console/test/jobs/prune_principal_sync_config_snapshots_job_test.rb
+++ b/services/console/test/jobs/prune_principal_sync_config_snapshots_job_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class PrunePrincipalSyncConfigSnapshotsJobTest < ActiveJob::TestCase
+  test "deletes snapshots older than retention" do
+    principal = principals(:acme_channel)
+    old = PrincipalSyncConfigSnapshot.create!(
+      principal: principal,
+      principal_cache_version: 10,
+      payload: Principal::EMPTY_CONFIG,
+      created_at: PrincipalSyncConfigSnapshot::RETENTION.ago - 1.minute,
+      updated_at: PrincipalSyncConfigSnapshot::RETENTION.ago - 1.minute
+    )
+    fresh = PrincipalSyncConfigSnapshot.create!(
+      principal: principal,
+      principal_cache_version: 11,
+      payload: Principal::EMPTY_CONFIG
+    )
+
+    PrunePrincipalSyncConfigSnapshotsJob.perform_now
+
+    assert_not PrincipalSyncConfigSnapshot.exists?(old.id)
+    assert PrincipalSyncConfigSnapshot.exists?(fresh.id)
+  end
+end


### PR DESCRIPTION
Caches proxy sync effective configs in encrypted principal-level snapshots keyed by a cache version, so startup sync storms can reuse known payloads without recomputing grants for every proxy. Model after_commit callbacks bump affected principal versions for grant, secret, rule, role, and broker credential changes, and a recurring job prunes expired snapshots. Validated with the full console Rails test suite and RuboCop.