### PR TITLE
feat: add slack oauth app provider

### DIFF
--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -161,7 +161,7 @@ module Oauth
         if credential.new_record?
           credential.namespace = @app.credential_namespace
           credential.foreign_id = "#{@app.provider}-#{@app.slug}-#{identity[:subject]}"
-          credential.name = "#{@app.provider.capitalize} – #{identity[:email].presence || identity[:subject]}"
+          credential.name = "#{@app.provider.capitalize} – #{identity_display_name(identity)}"
           credential.token_endpoint = @provider.token_endpoint
           credential.external_user_key = SecureRandom.urlsafe_base64(16)
         end
@@ -188,6 +188,10 @@ module Oauth
     def granted_scopes(result, state)
       return Array(state["scopes"]) if result.scope.blank?
       @provider.parse_granted_scopes(result.scope)
+    end
+
+    def identity_display_name(identity)
+      identity[:name].presence || identity[:email].presence || identity[:subject]
     end
 
     # Wraps a minted credential in a grantable static secret, so an operator can

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -128,11 +128,11 @@ module Oauth
         "client_id" => @app.client_id,
         "redirect_uri" => oauth_callback_redirect_uri(@app.slug),
         "response_type" => "code",
-        "scope" => (requested_scopes | @provider.identity_scopes).join(@provider.scope_separator),
         "state" => state,
         "code_challenge" => challenge,
         "code_challenge_method" => "S256"
       }.merge(@provider.extra_authorization_params)
+      query[@provider.authorization_scope_param] = (requested_scopes | @provider.identity_scopes).join(@provider.scope_separator)
 
       uri = URI.parse(@provider.authorization_endpoint)
       uri.query = URI.encode_www_form(query)

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -160,7 +160,7 @@ module Oauth
         credential = BrokerCredential.find_or_initialize_by(oauth_app: @app, provider_subject: identity[:subject])
         if credential.new_record?
           credential.namespace = @app.credential_namespace
-          credential.foreign_id = "#{@app.provider}-#{@app.slug}-#{identity[:subject]}"
+          credential.foreign_id = "#{@app.provider}-#{@app.slug}-#{identity[:subject].downcase}"
           credential.name = "#{@app.provider.capitalize} – #{identity_display_name(identity)}"
           credential.token_endpoint = @provider.token_endpoint
           credential.external_user_key = SecureRandom.urlsafe_base64(16)

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -89,6 +89,7 @@ module Oauth
       result = exchange_code(params[:code], flow["code_verifier"])
       identity = @provider.identity_from(result, client_id: @app.client_id)
       @credential = upsert_credential(state, result, identity)
+      enqueue_identity_enrichment(@credential)
 
       render_result(:success, identity: identity)
     rescue Broker::ExchangeError => e
@@ -192,6 +193,11 @@ module Oauth
 
     def identity_display_name(identity)
       identity[:name].presence || identity[:email].presence || identity[:subject]
+    end
+
+    def enqueue_identity_enrichment(credential)
+      return unless @app.provider == Oauth::Providers::Slack::KEY
+      Oauth::EnrichCredentialIdentityJob.perform_later(credential.id)
     end
 
     # Wraps a minted credential in a grantable static secret, so an operator can

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -128,7 +128,7 @@ module Oauth
         "client_id" => @app.client_id,
         "redirect_uri" => oauth_callback_redirect_uri(@app.slug),
         "response_type" => "code",
-        "scope" => (requested_scopes | @provider.identity_scopes).join(" "),
+        "scope" => (requested_scopes | @provider.identity_scopes).join(@provider.scope_separator),
         "state" => state,
         "code_challenge" => challenge,
         "code_challenge_method" => "S256"
@@ -161,7 +161,7 @@ module Oauth
         if credential.new_record?
           credential.namespace = @app.credential_namespace
           credential.foreign_id = "#{@app.provider}-#{@app.slug}-#{identity[:subject]}"
-          credential.name = "#{@app.provider.capitalize} – #{identity[:email]}"
+          credential.name = "#{@app.provider.capitalize} – #{identity[:email].presence || identity[:subject]}"
           credential.token_endpoint = @provider.token_endpoint
           credential.external_user_key = SecureRandom.urlsafe_base64(16)
         end
@@ -171,7 +171,7 @@ module Oauth
         credential.assign_attributes(
           provider_email: identity[:email],
           # Store exactly what the IdP granted, so the refresh POST re-requests it.
-          scopes: (result.scope.presence&.split || Array(state["scopes"])),
+          scopes: granted_scopes(result, state),
           refresh_token: result.refresh_token,
           access_token: result.access_token,
           expires_at: now + expires_in,
@@ -183,6 +183,11 @@ module Oauth
         ensure_wrapping_secret(credential)
         credential
       end
+    end
+
+    def granted_scopes(result, state)
+      return Array(state["scopes"]) if result.scope.blank?
+      @provider.parse_granted_scopes(result.scope)
     end
 
     # Wraps a minted credential in a grantable static secret, so an operator can

--- a/services/console/app/jobs/oauth/enrich_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_credential_identity_job.rb
@@ -1,0 +1,32 @@
+module Oauth
+  class EnrichCredentialIdentityJob < ApplicationJob
+    queue_as :default
+
+    def perform(credential_id)
+      credential = BrokerCredential.includes(:oauth_app, :static_secret).find_by(id: credential_id)
+      return unless credential&.oauth_app&.provider == Oauth::Providers::Slack::KEY
+      return if credential.access_token.blank? || credential.provider_subject.blank?
+
+      profile = credential.oauth_app.provider_strategy.slack_profile(
+        credential.access_token,
+        credential.provider_subject,
+        credential.scopes.join(",")
+      )
+      display_name = profile[:name].presence || profile[:email].presence
+      return if display_name.blank?
+
+      new_name = "#{credential.oauth_app.provider.capitalize} – #{display_name}"
+      old_name = credential.name
+      credential.update!(
+        name: new_name,
+        provider_email: profile[:email].presence || credential.provider_email
+      )
+
+      secret = credential.static_secret
+      return unless secret
+      return if old_name.present? && secret.name != "#{old_name} token"
+
+      secret.update!(name: "#{new_name} token")
+    end
+  end
+end

--- a/services/console/app/jobs/oauth/enrich_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_credential_identity_job.rb
@@ -1,16 +1,27 @@
+require "json"
+require "net/http"
+require "uri"
+
 module Oauth
   class EnrichCredentialIdentityJob < ApplicationJob
     queue_as :default
+
+    AUTH_TEST_ENDPOINT = "https://slack.com/api/auth.test"
+    USERS_INFO_ENDPOINT = "https://slack.com/api/users.info"
+
+    class << self
+      attr_accessor :slack_api_http
+    end
 
     def perform(credential_id)
       credential = BrokerCredential.includes(:oauth_app, :static_secret).find_by(id: credential_id)
       return unless credential&.oauth_app&.provider == Oauth::Providers::Slack::KEY
       return if credential.access_token.blank? || credential.provider_subject.blank?
 
-      profile = credential.oauth_app.provider_strategy.slack_profile(
+      profile = slack_profile(
         credential.access_token,
         credential.provider_subject,
-        credential.scopes.join(",")
+        credential.scopes
       )
       display_name = profile[:name].presence || profile[:email].presence
       return if display_name.blank?
@@ -27,6 +38,59 @@ module Oauth
       return if old_name.present? && secret.name != "#{old_name} token"
 
       secret.update!(name: "#{new_name} token")
+    end
+
+    private
+
+    def slack_profile(access_token, user_id, scopes)
+      profile = {}
+      profile[:name] = auth_test_user(access_token)
+      return profile unless scopes.include?("users:read")
+
+      info = slack_api(USERS_INFO_ENDPOINT, access_token, "user" => user_id)
+      return profile unless info.is_a?(Hash) && info["ok"] == true
+
+      user = info["user"].is_a?(Hash) ? info["user"] : {}
+      user_profile = user["profile"].is_a?(Hash) ? user["profile"] : {}
+      profile[:name] = user_profile["display_name"].presence ||
+                       user_profile["real_name"].presence ||
+                       user["real_name"].presence ||
+                       user["name"].presence ||
+                       profile[:name]
+      profile[:email] = user_profile["email"].presence if scopes.include?("users:read.email")
+      profile
+    rescue StandardError => e
+      Rails.logger.debug { "slack oauth profile lookup failed: #{e.class}" }
+      profile
+    end
+
+    def auth_test_user(access_token)
+      response = slack_api(AUTH_TEST_ENDPOINT, access_token)
+      return nil unless response.is_a?(Hash) && response["ok"] == true
+      response["user"].presence
+    end
+
+    def slack_api(url, access_token, params = {})
+      return nil if access_token.blank?
+
+      if self.class.slack_api_http
+        return self.class.slack_api_http.call(
+          url: url, access_token: access_token, params: params
+        )
+      end
+
+      uri = URI.parse(url)
+      req = Net::HTTP::Post.new(uri)
+      req["Authorization"] = "Bearer #{access_token}"
+      req["Accept"] = "application/json"
+      req.set_form_data(params) if params.any?
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = 5
+      http.read_timeout = 5
+
+      JSON.parse(http.request(req).body.to_s)
     end
   end
 end

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -151,10 +151,14 @@ class BrokerCredential < ApplicationRecord
       client_id: effective_client_id,
       client_secret: effective_client_secret,
       refresh_token: refresh_token,
-      scopes: scopes,
+      scopes: refresh_scopes_for_provider,
       headers: token_endpoint_headers || {},
       timeout: refresh_timeout_seconds
     )
+  end
+
+  def refresh_scopes_for_provider
+    oauth_app&.provider_strategy&.refresh_scopes(scopes) || scopes
   end
 
   def apply_success!(result, now:)

--- a/services/console/app/models/oauth_app.rb
+++ b/services/console/app/models/oauth_app.rb
@@ -13,8 +13,7 @@
 # the app, so rotating the app's secret fixes every credential it minted.
 #
 # Provider-generic by design: one model with a `provider` column and a small
-# strategy registry (Oauth::Providers), not a table per provider. Today the only
-# provider is Google.
+# strategy registry (Oauth::Providers), not a table per provider.
 class OauthApp < ApplicationRecord
   oid_prefix "oap"
 

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -864,7 +864,7 @@ An OAuth app registers an OAuth client (provider, client id, and client secret) 
 
 Only managing the app's configuration requires API key auth. The consent flow endpoints themselves are unauthenticated and live on iron-control's own domain (see [OAuth consent flow](#oauth-consent-flow)).
 
-Google is the only supported provider in this release. The `provider` field is validated against the supported set, so an unknown provider returns `422`.
+Google and Slack are supported providers in this release. The `provider` field is validated against the supported set, so an unknown provider returns `422`.
 
 ### Attributes
 
@@ -873,7 +873,7 @@ Google is the only supported provider in this release. The `provider` field is v
 | `slug`                 | required    | The app's identity: globally-unique, URL-safe, and the name in the well-known consent links (`/oauth/<slug>/start`). Must not start with the opaque-id prefix. |
 | `description`          | optional    | |
 | `labels`               | optional    | |
-| `provider`             | required    | The provider strategy. Currently only `"google"`. |
+| `provider`             | required    | The provider strategy. Currently `"google"` or `"slack"`. |
 | `client_id`            | required    | OAuth client id. Not secret; returned in responses. |
 | `client_secret`        | required on create | OAuth client secret. Write-only and encrypted at rest; on update it is only changed when supplied. Never returned. |
 | `allowed_scopes`       | required    | Non-empty array of scope strings the start endpoint requests. A flow's optional `scopes` param must be a subset; omitting it requests all of these. |
@@ -973,6 +973,10 @@ A tampered, expired, or missing flow state or cookie renders an error page with 
 | Provider | `provider` value |
 | -------- | ---------------- |
 | Google   | `google`         |
+| Slack    | `slack`          |
+
+Slack OAuth apps should have token rotation enabled so the callback receives a refresh token for the broker refresh loop.
+Slack OAuth apps should use normal Slack API scopes such as `channels:history`, not Sign in with Slack scopes such as `openid`, `email`, or `profile`.
 
 ## Principals
 

--- a/services/console/lib/broker/authorization_code_client.rb
+++ b/services/console/lib/broker/authorization_code_client.rb
@@ -13,10 +13,11 @@ module Broker
   # response body. Callers must keep the same discipline. Mirrors RefreshClient's
   # injectable-HTTP design and 64 KiB body cap.
   class AuthorizationCodeClient
-    # Normalized success result. scope is the space-separated granted-scope string
-    # (nil if the IdP omitted it); id_token is the raw JWT (nil if absent -- the
-    # provider strategy decides whether that is fatal).
-    Result = Data.define(:access_token, :refresh_token, :expires_in, :scope, :id_token)
+    # Normalized success result. scope is the granted-scope string in the
+    # provider's native format (nil if omitted); id_token is the raw JWT (nil if
+    # absent -- the provider strategy decides whether that is fatal). response is
+    # the parsed provider response for provider-specific metadata.
+    Result = Data.define(:access_token, :refresh_token, :expires_in, :scope, :id_token, :response)
 
     # The minimal HTTP response shape consumed, so tests can inject a double
     # without Net::HTTP.
@@ -90,6 +91,11 @@ module Broker
 
     def parse_success(response, require_refresh_token:)
       parsed = JSON.parse(response.body)
+      if parsed["ok"] == false && parsed["error"].present?
+        raise ExchangeError.new("token endpoint rejected code: #{parsed["error"]}",
+                                stage: "oauth", code: parsed["error"], status: response.status)
+      end
+
       access_token = parsed["access_token"]
       if access_token.blank?
         raise ExchangeError.new("token endpoint returned an empty access_token",
@@ -111,7 +117,8 @@ module Broker
         refresh_token: refresh_token,
         expires_in: expires_in ? Integer(expires_in) : nil,
         scope: parsed["scope"],
-        id_token: parsed["id_token"]
+        id_token: parsed["id_token"],
+        response: parsed
       )
     rescue JSON::ParserError, ArgumentError, TypeError
       raise ExchangeError.new("parsing token response failed", stage: "parse", status: response.status)

--- a/services/console/lib/broker/authorization_code_client.rb
+++ b/services/console/lib/broker/authorization_code_client.rb
@@ -96,13 +96,14 @@ module Broker
                                 stage: "oauth", code: parsed["error"], status: response.status)
       end
 
-      access_token = parsed["access_token"]
+      token_payload = parsed["authed_user"].is_a?(Hash) && parsed.dig("authed_user", "access_token").present? ? parsed["authed_user"] : parsed
+      access_token = token_payload["access_token"]
       if access_token.blank?
         raise ExchangeError.new("token endpoint returned an empty access_token",
                                 stage: "parse", status: response.status)
       end
 
-      refresh_token = parsed["refresh_token"]
+      refresh_token = token_payload["refresh_token"]
       if require_refresh_token && refresh_token.blank?
         # With access_type=offline + prompt=consent a refresh token is always
         # returned; its absence means the app is misconfigured at the IdP. The
@@ -111,13 +112,13 @@ module Broker
                                 stage: "oauth", code: "missing_refresh_token", status: response.status)
       end
 
-      expires_in = parsed["expires_in"]
+      expires_in = token_payload["expires_in"]
       Result.new(
         access_token: access_token,
         refresh_token: refresh_token,
         expires_in: expires_in ? Integer(expires_in) : nil,
-        scope: parsed["scope"],
-        id_token: parsed["id_token"],
+        scope: token_payload["scope"] || parsed["scope"],
+        id_token: token_payload["id_token"] || parsed["id_token"],
         response: parsed
       )
     rescue JSON::ParserError, ArgumentError, TypeError

--- a/services/console/lib/broker/refresh_client.rb
+++ b/services/console/lib/broker/refresh_client.rb
@@ -83,6 +83,12 @@ module Broker
 
     def parse_success(response)
       parsed = JSON.parse(response.body)
+      if parsed["ok"] == false && parsed["error"].present?
+        raise RefreshError.new("token endpoint rejected credential: #{parsed["error"]}",
+                               stage: "oauth", code: parsed["error"],
+                               status: response.status, retryable: false)
+      end
+
       access_token = parsed["access_token"]
       if access_token.blank?
         raise RefreshError.new("token endpoint returned an empty access_token",

--- a/services/console/lib/oauth/providers.rb
+++ b/services/console/lib/oauth/providers.rb
@@ -9,7 +9,10 @@ module Oauth
     # Memoized so a strategy is built once per process. The strategies are
     # stateless, so sharing one instance across flows is safe.
     def self.registry
-      @registry ||= { Google::KEY => Google.new }.freeze
+      @registry ||= {
+        Google::KEY => Google.new,
+        Slack::KEY => Slack.new
+      }.freeze
     end
 
     # The strategy for +key+, or nil for an unknown provider (the flow

--- a/services/console/lib/oauth/providers/google.rb
+++ b/services/console/lib/oauth/providers/google.rb
@@ -31,6 +31,10 @@ module Oauth
       def token_endpoint = TOKEN_ENDPOINT
       def identity_scopes = IDENTITY_SCOPES
       def api_hosts = API_HOSTS
+      def scope_separator = " "
+
+      def parse_granted_scopes(scope) = scope.to_s.split
+      def refresh_scopes(scopes) = Array(scopes)
 
       # Provider-specific query params for the authorization redirect. Both are
       # required to guarantee a refresh token, including on re-consent:

--- a/services/console/lib/oauth/providers/google.rb
+++ b/services/console/lib/oauth/providers/google.rb
@@ -31,6 +31,7 @@ module Oauth
       def token_endpoint = TOKEN_ENDPOINT
       def identity_scopes = IDENTITY_SCOPES
       def api_hosts = API_HOSTS
+      def authorization_scope_param = "scope"
       def scope_separator = " "
 
       def parse_granted_scopes(scope) = scope.to_s.split

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -75,7 +75,8 @@ module Oauth
           profile[:email] = user_profile["email"].presence
         end
         profile
-      rescue StandardError
+      rescue StandardError => e
+        Rails.logger.debug { "slack oauth profile lookup failed: #{e.class}" }
         profile
       end
 

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -1,3 +1,7 @@
+require "json"
+require "net/http"
+require "uri"
+
 module Oauth
   module Providers
     # Slack user-token consent-flow strategy. Uses Slack's standard OAuth v2
@@ -12,6 +16,11 @@ module Oauth
       IDENTITY_SCOPES = [].freeze
       API_HOSTS = %w[slack.com].freeze
       VALID_ISSUERS = %w[https://slack.com].freeze
+      AUTH_TEST_ENDPOINT = "https://slack.com/api/auth.test"
+
+      class << self
+        attr_accessor :auth_test_http
+      end
 
       def key = KEY
       def authorization_endpoint = AUTHORIZATION_ENDPOINT
@@ -33,13 +42,50 @@ module Oauth
         if user_id.present?
           return {
             subject: user_id,
-            email: result.response.dig("authed_user", "email")
+            email: result.response.dig("authed_user", "email"),
+            name: slack_user_name(result.access_token, result.response)
           }
         end
 
         Login::IdToken.identity(result.id_token, client_id: client_id,
                                                  valid_issuers: VALID_ISSUERS)
-                      .slice(:subject, :email)
+                      .slice(:subject, :email, :name)
+      end
+
+      private
+
+      def slack_user_name(access_token, response)
+        response.dig("authed_user", "name").presence ||
+          response.dig("authed_user", "user").presence ||
+          auth_test_user(access_token)
+      end
+
+      def auth_test_user(access_token)
+        return nil if access_token.blank?
+
+        response = if self.class.auth_test_http
+          self.class.auth_test_http.call(access_token: access_token)
+        else
+          perform_auth_test(access_token)
+        end
+        return nil unless response.is_a?(Hash) && response["ok"] == true
+        response["user"].presence
+      rescue StandardError
+        nil
+      end
+
+      def perform_auth_test(access_token)
+        uri = URI.parse(AUTH_TEST_ENDPOINT)
+        req = Net::HTTP::Post.new(uri)
+        req["Authorization"] = "Bearer #{access_token}"
+        req["Accept"] = "application/json"
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http.open_timeout = 5
+        http.read_timeout = 5
+
+        JSON.parse(http.request(req).body.to_s)
       end
     end
   end

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -1,7 +1,3 @@
-require "json"
-require "net/http"
-require "uri"
-
 module Oauth
   module Providers
     # Slack user-token consent-flow strategy. Uses Slack's standard OAuth v2
@@ -16,12 +12,6 @@ module Oauth
       IDENTITY_SCOPES = [].freeze
       API_HOSTS = %w[slack.com].freeze
       VALID_ISSUERS = %w[https://slack.com].freeze
-      AUTH_TEST_ENDPOINT = "https://slack.com/api/auth.test"
-      USERS_INFO_ENDPOINT = "https://slack.com/api/users.info"
-
-      class << self
-        attr_accessor :slack_api_http
-      end
 
       def key = KEY
       def authorization_endpoint = AUTHORIZATION_ENDPOINT
@@ -53,64 +43,11 @@ module Oauth
                       .slice(:subject, :email, :name)
       end
 
-      def slack_profile(access_token, user_id, scope)
-        profile = {}
-        profile[:name] = auth_test_user(access_token)
-        return profile unless parse_granted_scopes(scope).include?("users:read")
-
-        info = slack_api(USERS_INFO_ENDPOINT, access_token, "user" => user_id)
-        return profile unless info.is_a?(Hash) && info["ok"] == true
-
-        user = info["user"].is_a?(Hash) ? info["user"] : {}
-        user_profile = user["profile"].is_a?(Hash) ? user["profile"] : {}
-        profile[:name] = user_profile["display_name"].presence ||
-                         user_profile["real_name"].presence ||
-                         user["real_name"].presence ||
-                         user["name"].presence ||
-                         profile[:name]
-        if parse_granted_scopes(scope).include?("users:read.email")
-          profile[:email] = user_profile["email"].presence
-        end
-        profile
-      rescue StandardError => e
-        Rails.logger.debug { "slack oauth profile lookup failed: #{e.class}" }
-        profile
-      end
-
       private
 
       def slack_user_name(response)
         response.dig("authed_user", "name").presence ||
           response.dig("authed_user", "user").presence
-      end
-
-      def auth_test_user(access_token)
-        response = slack_api(AUTH_TEST_ENDPOINT, access_token)
-        return nil unless response.is_a?(Hash) && response["ok"] == true
-        response["user"].presence
-      end
-
-      def slack_api(url, access_token, params = {})
-        return nil if access_token.blank?
-
-        if self.class.slack_api_http
-          return self.class.slack_api_http.call(
-            url: url, access_token: access_token, params: params
-          )
-        end
-
-        uri = URI.parse(url)
-        req = Net::HTTP::Post.new(uri)
-        req["Authorization"] = "Bearer #{access_token}"
-        req["Accept"] = "application/json"
-        req.set_form_data(params) if params.any?
-
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.scheme == "https"
-        http.open_timeout = 5
-        http.read_timeout = 5
-
-        JSON.parse(http.request(req).body.to_s)
       end
     end
   end

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -1,12 +1,12 @@
 module Oauth
   module Providers
-    # Slack user-token consent-flow strategy. Uses Slack's user-centric OAuth v2
-    # endpoints so the broker stores a single user token, with identity carried
-    # by the returned OIDC id_token.
+    # Slack user-token consent-flow strategy. Uses Slack's standard OAuth v2
+    # authorize/access endpoints with user_scope, so the broker stores the nested
+    # authed_user token returned by Slack.
     class Slack
       KEY = "slack"
-      AUTHORIZATION_ENDPOINT = "https://slack.com/oauth/v2_user/authorize"
-      TOKEN_ENDPOINT = "https://slack.com/api/oauth.v2.user.access"
+      AUTHORIZATION_ENDPOINT = "https://slack.com/oauth/v2/authorize"
+      TOKEN_ENDPOINT = "https://slack.com/api/oauth.v2.access"
       # Do not add Sign in with Slack scopes here. Slack rejects requests that
       # mix SIWS scopes with normal API scopes such as channels:history.
       IDENTITY_SCOPES = [].freeze
@@ -18,6 +18,7 @@ module Oauth
       def token_endpoint = TOKEN_ENDPOINT
       def identity_scopes = IDENTITY_SCOPES
       def api_hosts = API_HOSTS
+      def authorization_scope_param = "user_scope"
       def scope_separator = ","
       def extra_authorization_params = {}
 

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -1,7 +1,3 @@
-require "json"
-require "net/http"
-require "uri"
-
 module Oauth
   module Providers
     # Slack user-token consent-flow strategy. Uses Slack's standard OAuth v2
@@ -16,11 +12,6 @@ module Oauth
       IDENTITY_SCOPES = [].freeze
       API_HOSTS = %w[slack.com].freeze
       VALID_ISSUERS = %w[https://slack.com].freeze
-      AUTH_TEST_ENDPOINT = "https://slack.com/api/auth.test"
-
-      class << self
-        attr_accessor :auth_test_http
-      end
 
       def key = KEY
       def authorization_endpoint = AUTHORIZATION_ENDPOINT
@@ -43,7 +34,7 @@ module Oauth
           return {
             subject: user_id,
             email: result.response.dig("authed_user", "email"),
-            name: slack_user_name(result.access_token, result.response)
+            name: slack_user_name(result.response)
           }
         end
 
@@ -54,38 +45,9 @@ module Oauth
 
       private
 
-      def slack_user_name(access_token, response)
+      def slack_user_name(response)
         response.dig("authed_user", "name").presence ||
-          response.dig("authed_user", "user").presence ||
-          auth_test_user(access_token)
-      end
-
-      def auth_test_user(access_token)
-        return nil if access_token.blank?
-
-        response = if self.class.auth_test_http
-          self.class.auth_test_http.call(access_token: access_token)
-        else
-          perform_auth_test(access_token)
-        end
-        return nil unless response.is_a?(Hash) && response["ok"] == true
-        response["user"].presence
-      rescue StandardError
-        nil
-      end
-
-      def perform_auth_test(access_token)
-        uri = URI.parse(AUTH_TEST_ENDPOINT)
-        req = Net::HTTP::Post.new(uri)
-        req["Authorization"] = "Bearer #{access_token}"
-        req["Accept"] = "application/json"
-
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.scheme == "https"
-        http.open_timeout = 5
-        http.read_timeout = 5
-
-        JSON.parse(http.request(req).body.to_s)
+          response.dig("authed_user", "user").presence
       end
     end
   end

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -41,11 +41,10 @@ module Oauth
       def identity_from(result, client_id:)
         user_id = result.response&.dig("authed_user", "id")
         if user_id.present?
-          profile = slack_profile(result.access_token, user_id, result.scope)
           return {
             subject: user_id,
-            email: result.response.dig("authed_user", "email").presence || profile[:email],
-            name: slack_user_name(result.response).presence || profile[:name]
+            email: result.response.dig("authed_user", "email"),
+            name: slack_user_name(result.response)
           }
         end
 
@@ -53,8 +52,6 @@ module Oauth
                                                  valid_issuers: VALID_ISSUERS)
                       .slice(:subject, :email, :name)
       end
-
-      private
 
       def slack_profile(access_token, user_id, scope)
         profile = {}
@@ -80,6 +77,8 @@ module Oauth
         profile
       end
 
+      private
+
       def slack_user_name(response)
         response.dig("authed_user", "name").presence ||
           response.dig("authed_user", "user").presence
@@ -95,7 +94,9 @@ module Oauth
         return nil if access_token.blank?
 
         if self.class.slack_api_http
-          return self.class.slack_api_http.call(url: url, access_token: access_token, params: params)
+          return self.class.slack_api_http.call(
+            url: url, access_token: access_token, params: params
+          )
         end
 
         uri = URI.parse(url)

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -1,0 +1,45 @@
+module Oauth
+  module Providers
+    # Slack user-token consent-flow strategy. Uses Slack's user-centric OAuth v2
+    # endpoints so the broker stores a single user token, with identity carried
+    # by the returned OIDC id_token.
+    class Slack
+      KEY = "slack"
+      AUTHORIZATION_ENDPOINT = "https://slack.com/oauth/v2_user/authorize"
+      TOKEN_ENDPOINT = "https://slack.com/api/oauth.v2.user.access"
+      # Do not add Sign in with Slack scopes here. Slack rejects requests that
+      # mix SIWS scopes with normal API scopes such as channels:history.
+      IDENTITY_SCOPES = [].freeze
+      API_HOSTS = %w[slack.com].freeze
+      VALID_ISSUERS = %w[https://slack.com].freeze
+
+      def key = KEY
+      def authorization_endpoint = AUTHORIZATION_ENDPOINT
+      def token_endpoint = TOKEN_ENDPOINT
+      def identity_scopes = IDENTITY_SCOPES
+      def api_hosts = API_HOSTS
+      def scope_separator = ","
+      def extra_authorization_params = {}
+
+      def parse_granted_scopes(scope)
+        scope.to_s.split(/[,\s]+/).reject(&:blank?)
+      end
+
+      def refresh_scopes(_scopes) = []
+
+      def identity_from(result, client_id:)
+        user_id = result.response&.dig("authed_user", "id")
+        if user_id.present?
+          return {
+            subject: user_id,
+            email: result.response.dig("authed_user", "email")
+          }
+        end
+
+        Login::IdToken.identity(result.id_token, client_id: client_id,
+                                                 valid_issuers: VALID_ISSUERS)
+                      .slice(:subject, :email)
+      end
+    end
+  end
+end

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -1,3 +1,7 @@
+require "json"
+require "net/http"
+require "uri"
+
 module Oauth
   module Providers
     # Slack user-token consent-flow strategy. Uses Slack's standard OAuth v2
@@ -12,6 +16,12 @@ module Oauth
       IDENTITY_SCOPES = [].freeze
       API_HOSTS = %w[slack.com].freeze
       VALID_ISSUERS = %w[https://slack.com].freeze
+      AUTH_TEST_ENDPOINT = "https://slack.com/api/auth.test"
+      USERS_INFO_ENDPOINT = "https://slack.com/api/users.info"
+
+      class << self
+        attr_accessor :slack_api_http
+      end
 
       def key = KEY
       def authorization_endpoint = AUTHORIZATION_ENDPOINT
@@ -31,10 +41,11 @@ module Oauth
       def identity_from(result, client_id:)
         user_id = result.response&.dig("authed_user", "id")
         if user_id.present?
+          profile = slack_profile(result.access_token, user_id, result.scope)
           return {
             subject: user_id,
-            email: result.response.dig("authed_user", "email"),
-            name: slack_user_name(result.response)
+            email: result.response.dig("authed_user", "email").presence || profile[:email],
+            name: slack_user_name(result.response).presence || profile[:name]
           }
         end
 
@@ -45,9 +56,59 @@ module Oauth
 
       private
 
+      def slack_profile(access_token, user_id, scope)
+        profile = {}
+        profile[:name] = auth_test_user(access_token)
+        return profile unless parse_granted_scopes(scope).include?("users:read")
+
+        info = slack_api(USERS_INFO_ENDPOINT, access_token, "user" => user_id)
+        return profile unless info.is_a?(Hash) && info["ok"] == true
+
+        user = info["user"].is_a?(Hash) ? info["user"] : {}
+        user_profile = user["profile"].is_a?(Hash) ? user["profile"] : {}
+        profile[:name] = user_profile["display_name"].presence ||
+                         user_profile["real_name"].presence ||
+                         user["real_name"].presence ||
+                         user["name"].presence ||
+                         profile[:name]
+        if parse_granted_scopes(scope).include?("users:read.email")
+          profile[:email] = user_profile["email"].presence
+        end
+        profile
+      rescue StandardError
+        profile
+      end
+
       def slack_user_name(response)
         response.dig("authed_user", "name").presence ||
           response.dig("authed_user", "user").presence
+      end
+
+      def auth_test_user(access_token)
+        response = slack_api(AUTH_TEST_ENDPOINT, access_token)
+        return nil unless response.is_a?(Hash) && response["ok"] == true
+        response["user"].presence
+      end
+
+      def slack_api(url, access_token, params = {})
+        return nil if access_token.blank?
+
+        if self.class.slack_api_http
+          return self.class.slack_api_http.call(url: url, access_token: access_token, params: params)
+        end
+
+        uri = URI.parse(url)
+        req = Net::HTTP::Post.new(uri)
+        req["Authorization"] = "Bearer #{access_token}"
+        req["Accept"] = "application/json"
+        req.set_form_data(params) if params.any?
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http.open_timeout = 5
+        http.read_timeout = 5
+
+        JSON.parse(http.request(req).body.to_s)
       end
     end
   end

--- a/services/console/test/controllers/api/v1/oauth_apps_controller_test.rb
+++ b/services/console/test/controllers/api/v1/oauth_apps_controller_test.rb
@@ -27,7 +27,8 @@ module Api
       test "index lists apps without the client_secret" do
         get api_v1_oauth_apps_url, headers: auth_headers
         assert_response :ok
-        row = json_body.fetch("data").first
+        row = json_body.fetch("data").find { |app| app["slug"] == "google" }
+        assert_not_nil row
         assert_equal "google", row["provider"]
         refute row.key?("client_secret")
         refute row.key?("namespace")

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -14,10 +14,15 @@ module Oauth
       @app = oauth_apps(:acme_google) # slug "google"
       @app.update!(client_secret: "app-secret")
       oauth_apps(:acme_slack).update!(client_secret: "slack-secret")
+      Oauth::Providers::Slack.auth_test_http = ->(access_token:) {
+        assert_equal "xoxe.xoxp-1-user", access_token
+        { "ok" => true, "user" => "grace" }
+      }
     end
 
     teardown do
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new }
+      Oauth::Providers::Slack.auth_test_http = nil
     end
 
     class StubHTTP
@@ -203,12 +208,14 @@ module Oauth
       cred = BrokerCredential.find_by(oauth_app: app, provider_subject: "U0R7MFMJM")
       assert_equal "acme", cred.namespace
       assert_equal "slack-slack-U0R7MFMJM", cred.foreign_id
+      assert_equal "Slack – grace", cred.name
       assert_equal "https://slack.com/api/oauth.v2.access", cred.token_endpoint
       assert_nil cred.provider_email
       assert_equal %w[chat:write], cred.scopes
       assert_equal "xoxe.xoxp-1-user", cred.access_token
       assert_equal "xoxe-1-refresh", cred.refresh_token
       assert_equal [ "slack.com" ], cred.static_secret.rules.map(&:host)
+      assert_equal "Slack – grace token", cred.static_secret.name
     end
 
     test "callback wraps the minted credential in a grantable static secret" do

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -49,10 +49,17 @@ module Oauth
 
     def slack_token_body(sub: "U0R7MFMJM", scope: "chat:write", id_token_value: nil, **overrides)
       {
-        ok: true, access_token: "xoxe.xoxp-1-user", refresh_token: "xoxe-1-refresh",
-        expires_in: 43_200, token_type: "user", scope: scope,
+        ok: true, access_token: "xoxe.xoxb-1-bot", refresh_token: "xoxe-1-bot-refresh",
+        expires_in: 43_200, token_type: "bot", scope: "commands",
         id_token: id_token_value,
-        authed_user: { id: sub }
+        authed_user: {
+          id: sub,
+          access_token: "xoxe.xoxp-1-user",
+          refresh_token: "xoxe-1-refresh",
+          expires_in: 43_200,
+          scope: scope,
+          token_type: "user"
+        }
       }.merge(overrides).to_json
     end
 
@@ -99,13 +106,14 @@ module Oauth
       assert_response :redirect
       uri = URI.parse(response.location)
       assert_equal "slack.com", uri.host
-      assert_equal "/oauth/v2_user/authorize", uri.path
+      assert_equal "/oauth/v2/authorize", uri.path
       q = URI.decode_www_form(uri.query).to_h
       assert_equal SLACK_CLIENT_ID, q["client_id"]
       assert_equal "http://www.example.com/oauth/slack/callback", q["redirect_uri"]
       assert_equal "code", q["response_type"]
       assert_equal "S256", q["code_challenge_method"]
-      scopes = q["scope"].split(",")
+      assert_nil q["scope"]
+      scopes = q["user_scope"].split(",")
       assert_includes scopes, "chat:write"
       assert_includes scopes, "channels:history"
       refute_includes scopes, "openid"
@@ -195,7 +203,7 @@ module Oauth
       cred = BrokerCredential.find_by(oauth_app: app, provider_subject: "U0R7MFMJM")
       assert_equal "acme", cred.namespace
       assert_equal "slack-slack-U0R7MFMJM", cred.foreign_id
-      assert_equal "https://slack.com/api/oauth.v2.user.access", cred.token_endpoint
+      assert_equal "https://slack.com/api/oauth.v2.access", cred.token_endpoint
       assert_nil cred.provider_email
       assert_equal %w[chat:write], cred.scopes
       assert_equal "xoxe.xoxp-1-user", cred.access_token

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -203,7 +203,7 @@ module Oauth
       app = oauth_apps(:acme_slack)
       cred = BrokerCredential.find_by(oauth_app: app, provider_subject: "U0R7MFMJM")
       assert_equal "acme", cred.namespace
-      assert_equal "slack-slack-U0R7MFMJM", cred.foreign_id
+      assert_equal "slack-slack-u0r7mfmjm", cred.foreign_id
       assert_equal "Slack – grace", cred.name
       assert_equal "https://slack.com/api/oauth.v2.access", cred.token_endpoint
       assert_nil cred.provider_email

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -14,15 +14,10 @@ module Oauth
       @app = oauth_apps(:acme_google) # slug "google"
       @app.update!(client_secret: "app-secret")
       oauth_apps(:acme_slack).update!(client_secret: "slack-secret")
-      Oauth::Providers::Slack.auth_test_http = ->(access_token:) {
-        assert_equal "xoxe.xoxp-1-user", access_token
-        { "ok" => true, "user" => "grace" }
-      }
     end
 
     teardown do
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new }
-      Oauth::Providers::Slack.auth_test_http = nil
     end
 
     class StubHTTP
@@ -59,6 +54,7 @@ module Oauth
         id_token: id_token_value,
         authed_user: {
           id: sub,
+          user: "grace",
           access_token: "xoxe.xoxp-1-user",
           refresh_token: "xoxe-1-refresh",
           expires_in: 43_200,

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -14,17 +14,10 @@ module Oauth
       @app = oauth_apps(:acme_google) # slug "google"
       @app.update!(client_secret: "app-secret")
       oauth_apps(:acme_slack).update!(client_secret: "slack-secret")
-      Oauth::Providers::Slack.slack_api_http = ->(url:, access_token:, params:) {
-        assert_equal Oauth::Providers::Slack::AUTH_TEST_ENDPOINT, url
-        assert_equal "xoxe.xoxp-1-user", access_token
-        assert_empty params
-        { "ok" => true, "user" => "grace" }
-      }
     end
 
     teardown do
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new }
-      Oauth::Providers::Slack.slack_api_http = nil
     end
 
     class StubHTTP

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -8,10 +8,12 @@ module Oauth
   # an HTTP double returning a canned token response.
   class FlowsControllerTest < ActionDispatch::IntegrationTest
     CLIENT_ID = "acme-google-client-id".freeze
+    SLACK_CLIENT_ID = "acme-slack-client-id".freeze
 
     setup do
       @app = oauth_apps(:acme_google) # slug "google"
       @app.update!(client_secret: "app-secret")
+      oauth_apps(:acme_slack).update!(client_secret: "slack-secret")
     end
 
     teardown do
@@ -42,6 +44,15 @@ module Oauth
       {
         access_token: "AT", refresh_token: "RT", expires_in: 3600, scope: scope,
         id_token: id_token({ "aud" => aud, "iss" => iss, "sub" => sub, "email" => email })
+      }.merge(overrides).to_json
+    end
+
+    def slack_token_body(sub: "U0R7MFMJM", scope: "chat:write", id_token_value: nil, **overrides)
+      {
+        ok: true, access_token: "xoxe.xoxp-1-user", refresh_token: "xoxe-1-refresh",
+        expires_in: 43_200, token_type: "user", scope: scope,
+        id_token: id_token_value,
+        authed_user: { id: sub }
       }.merge(overrides).to_json
     end
 
@@ -81,6 +92,25 @@ module Oauth
                    .verified(q["state"], purpose: FlowsController::STATE_PURPOSE)
       assert_equal @app.oid, state["app"]
       assert response.cookies["oauth_flow"].present?
+    end
+
+    test "start redirects to Slack with comma separated scopes" do
+      get oauth_start_url(slug: "slack")
+      assert_response :redirect
+      uri = URI.parse(response.location)
+      assert_equal "slack.com", uri.host
+      assert_equal "/oauth/v2_user/authorize", uri.path
+      q = URI.decode_www_form(uri.query).to_h
+      assert_equal SLACK_CLIENT_ID, q["client_id"]
+      assert_equal "http://www.example.com/oauth/slack/callback", q["redirect_uri"]
+      assert_equal "code", q["response_type"]
+      assert_equal "S256", q["code_challenge_method"]
+      scopes = q["scope"].split(",")
+      assert_includes scopes, "chat:write"
+      assert_includes scopes, "channels:history"
+      refute_includes scopes, "openid"
+      refute_includes scopes, "email"
+      refute_includes scopes, "profile"
     end
 
     test "start works without any session" do
@@ -149,6 +179,28 @@ module Oauth
       assert cred.next_attempt_at.present?
       assert_nil cred.created_by
       assert_includes response.body, cred.oid
+    end
+
+    test "callback happy path supports Slack user tokens" do
+      state = start_flow(slug: "slack", scopes: "chat:write")
+      stub_exchange(status: 200, body: slack_token_body)
+
+      assert_difference -> { BrokerCredential.count } => 1 do
+        get oauth_callback_url(slug: "slack"), params: { state: state, code: "auth-code" }
+      end
+      assert_response :ok
+      assert_match "Connected", response.body
+
+      app = oauth_apps(:acme_slack)
+      cred = BrokerCredential.find_by(oauth_app: app, provider_subject: "U0R7MFMJM")
+      assert_equal "acme", cred.namespace
+      assert_equal "slack-slack-U0R7MFMJM", cred.foreign_id
+      assert_equal "https://slack.com/api/oauth.v2.user.access", cred.token_endpoint
+      assert_nil cred.provider_email
+      assert_equal %w[chat:write], cred.scopes
+      assert_equal "xoxe.xoxp-1-user", cred.access_token
+      assert_equal "xoxe-1-refresh", cred.refresh_token
+      assert_equal [ "slack.com" ], cred.static_secret.rules.map(&:host)
     end
 
     test "callback wraps the minted credential in a grantable static secret" do

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -14,10 +14,17 @@ module Oauth
       @app = oauth_apps(:acme_google) # slug "google"
       @app.update!(client_secret: "app-secret")
       oauth_apps(:acme_slack).update!(client_secret: "slack-secret")
+      Oauth::Providers::Slack.slack_api_http = ->(url:, access_token:, params:) {
+        assert_equal Oauth::Providers::Slack::AUTH_TEST_ENDPOINT, url
+        assert_equal "xoxe.xoxp-1-user", access_token
+        assert_empty params
+        { "ok" => true, "user" => "grace" }
+      }
     end
 
     teardown do
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new }
+      Oauth::Providers::Slack.slack_api_http = nil
     end
 
     class StubHTTP

--- a/services/console/test/fixtures/oauth_apps.yml
+++ b/services/console/test/fixtures/oauth_apps.yml
@@ -25,3 +25,15 @@ acme_google_disabled:
   credential_namespace: acme
   enabled: false
   created_by: acme_admin
+
+acme_slack:
+  slug: slack
+  description: Acme Slack integration
+  provider: slack
+  client_id: acme-slack-client-id
+  allowed_scopes:
+    - chat:write
+    - channels:history
+  credential_namespace: acme
+  enabled: true
+  created_by: acme_admin

--- a/services/console/test/jobs/oauth/enrich_credential_identity_job_test.rb
+++ b/services/console/test/jobs/oauth/enrich_credential_identity_job_test.rb
@@ -3,11 +3,11 @@ require "test_helper"
 module Oauth
   class EnrichCredentialIdentityJobTest < ActiveJob::TestCase
     setup do
-      Oauth::Providers::Slack.slack_api_http = nil
+      Oauth::EnrichCredentialIdentityJob.slack_api_http = nil
     end
 
     teardown do
-      Oauth::Providers::Slack.slack_api_http = nil
+      Oauth::EnrichCredentialIdentityJob.slack_api_http = nil
     end
 
     def slack_credential(**overrides)
@@ -36,12 +36,12 @@ module Oauth
     end
 
     test "updates the credential and wrapper secret names from Slack profile details" do
-      Oauth::Providers::Slack.slack_api_http = ->(url:, access_token:, params:) {
+      Oauth::EnrichCredentialIdentityJob.slack_api_http = ->(url:, access_token:, params:) {
         assert_equal "AT", access_token
-        if url == Oauth::Providers::Slack::AUTH_TEST_ENDPOINT
+        if url == Oauth::EnrichCredentialIdentityJob::AUTH_TEST_ENDPOINT
           { "ok" => true, "user" => "fallback" }
         else
-          assert_equal Oauth::Providers::Slack::USERS_INFO_ENDPOINT, url
+          assert_equal Oauth::EnrichCredentialIdentityJob::USERS_INFO_ENDPOINT, url
           assert_equal({ "user" => "U12345" }, params)
           {
             "ok" => true,
@@ -64,8 +64,24 @@ module Oauth
       assert_equal "Slack – Grace Hopper token", secret.reload.name
     end
 
+    test "uses auth test username without users read scope" do
+      calls = []
+      Oauth::EnrichCredentialIdentityJob.slack_api_http = ->(url:, access_token:, params:) {
+        calls << [ url, params ]
+        { "ok" => true, "user" => "grace" }
+      }
+      credential = slack_credential(scopes: %w[channels:history])
+      secret = wrap_credential(credential)
+
+      Oauth::EnrichCredentialIdentityJob.perform_now(credential.id)
+
+      assert_equal "Slack – grace", credential.reload.name
+      assert_equal "Slack – grace token", secret.reload.name
+      assert_equal [ [ Oauth::EnrichCredentialIdentityJob::AUTH_TEST_ENDPOINT, {} ] ], calls
+    end
+
     test "does not clobber an operator-renamed wrapper secret" do
-      Oauth::Providers::Slack.slack_api_http = ->(url:, access_token:, params:) {
+      Oauth::EnrichCredentialIdentityJob.slack_api_http = ->(url:, access_token:, params:) {
         { "ok" => true, "user" => "grace" }
       }
       credential = slack_credential(scopes: %w[channels:history])

--- a/services/console/test/jobs/oauth/enrich_credential_identity_job_test.rb
+++ b/services/console/test/jobs/oauth/enrich_credential_identity_job_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+module Oauth
+  class EnrichCredentialIdentityJobTest < ActiveJob::TestCase
+    setup do
+      Oauth::Providers::Slack.slack_api_http = nil
+    end
+
+    teardown do
+      Oauth::Providers::Slack.slack_api_http = nil
+    end
+
+    def slack_credential(**overrides)
+      app = oauth_apps(:acme_slack)
+      app.update!(client_secret: "slack-secret")
+      BrokerCredential.create!({
+        namespace: "acme",
+        foreign_id: "slack-slack-u12345",
+        name: "Slack – U12345",
+        token_endpoint: Oauth::Providers::Slack::TOKEN_ENDPOINT,
+        oauth_app: app,
+        provider_subject: "U12345",
+        access_token: "AT",
+        refresh_token: "RT",
+        scopes: %w[users:read users:read.email channels:history]
+      }.merge(overrides))
+    end
+
+    def wrap_credential(credential, name: "#{credential.name} token")
+      StaticSecret.create!(
+        namespace: credential.namespace,
+        name: name,
+        broker_credential: credential,
+        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+      )
+    end
+
+    test "updates the credential and wrapper secret names from Slack profile details" do
+      Oauth::Providers::Slack.slack_api_http = ->(url:, access_token:, params:) {
+        assert_equal "AT", access_token
+        if url == Oauth::Providers::Slack::AUTH_TEST_ENDPOINT
+          { "ok" => true, "user" => "fallback" }
+        else
+          assert_equal Oauth::Providers::Slack::USERS_INFO_ENDPOINT, url
+          assert_equal({ "user" => "U12345" }, params)
+          {
+            "ok" => true,
+            "user" => {
+              "profile" => {
+                "display_name" => "Grace Hopper",
+                "email" => "grace@example.com"
+              }
+            }
+          }
+        end
+      }
+      credential = slack_credential
+      secret = wrap_credential(credential)
+
+      Oauth::EnrichCredentialIdentityJob.perform_now(credential.id)
+
+      assert_equal "Slack – Grace Hopper", credential.reload.name
+      assert_equal "grace@example.com", credential.provider_email
+      assert_equal "Slack – Grace Hopper token", secret.reload.name
+    end
+
+    test "does not clobber an operator-renamed wrapper secret" do
+      Oauth::Providers::Slack.slack_api_http = ->(url:, access_token:, params:) {
+        { "ok" => true, "user" => "grace" }
+      }
+      credential = slack_credential(scopes: %w[channels:history])
+      secret = wrap_credential(credential, name: "operator name")
+
+      Oauth::EnrichCredentialIdentityJob.perform_now(credential.id)
+
+      assert_equal "Slack – grace", credential.reload.name
+      assert_equal "operator name", secret.reload.name
+    end
+  end
+end

--- a/services/console/test/lib/broker/authorization_code_client_test.rb
+++ b/services/console/test/lib/broker/authorization_code_client_test.rb
@@ -47,6 +47,7 @@ module Broker
       assert_equal 3600, result.expires_in
       assert_equal "openid email", result.scope
       assert_equal "the.id.token", result.id_token
+      assert_equal "AT", result.response["access_token"]
 
       form = http.captured[:form]
       assert_equal "authorization_code", form["grant_type"]
@@ -68,6 +69,13 @@ module Broker
       assert_equal "oauth", err.stage
       assert_equal "invalid_grant", err.code
       assert_equal "invalid_grant", err.reason
+    end
+
+    test "Slack-style ok false response raises an oauth ExchangeError" do
+      client, _ = client_with(status: 200, body: { ok: false, error: "invalid_code" }.to_json)
+      err = assert_raises(ExchangeError) { client.exchange(**base_args) }
+      assert_equal "oauth", err.stage
+      assert_equal "invalid_code", err.code
     end
 
     test "5xx raises an http ExchangeError" do

--- a/services/console/test/lib/broker/authorization_code_client_test.rb
+++ b/services/console/test/lib/broker/authorization_code_client_test.rb
@@ -98,6 +98,30 @@ module Broker
       assert_nil result.refresh_token
     end
 
+    test "parses Slack nested authed_user token payload" do
+      body = {
+        ok: true,
+        access_token: "BOT",
+        refresh_token: "BOT-RT",
+        expires_in: 43_200,
+        scope: "commands",
+        authed_user: {
+          id: "U123",
+          access_token: "USER",
+          refresh_token: "USER-RT",
+          expires_in: 43_200,
+          scope: "channels:history,im:history"
+        }
+      }.to_json
+
+      client, _ = client_with(status: 200, body: body)
+      result = client.exchange(**base_args)
+      assert_equal "USER", result.access_token
+      assert_equal "USER-RT", result.refresh_token
+      assert_equal "channels:history,im:history", result.scope
+      assert_equal "U123", result.response.dig("authed_user", "id")
+    end
+
     test "empty access_token raises a parse error" do
       client, _ = client_with(status: 200, body: success_body(access_token: ""))
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }

--- a/services/console/test/lib/broker/refresh_client_test.rb
+++ b/services/console/test/lib/broker/refresh_client_test.rb
@@ -70,6 +70,14 @@ module Broker
       assert_equal "invalid_grant", err.reason
     end
 
+    test "Slack-style ok false response is unrecoverable" do
+      client, _ = client_with(status: 200, body: { ok: false, error: "invalid_refresh_token" }.to_json)
+      err = assert_raises(Broker::RefreshError) { client.refresh(**base_args) }
+      refute err.retryable?
+      assert_equal "oauth", err.stage
+      assert_equal "invalid_refresh_token", err.code
+    end
+
     test "5xx is retryable" do
       client, _ = client_with(status: 503, body: "upstream down")
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_args) }

--- a/services/console/test/lib/oauth/providers/google_test.rb
+++ b/services/console/test/lib/oauth/providers/google_test.rb
@@ -14,7 +14,7 @@ module Oauth
         id_token = "h.#{payload}.s"
         Broker::AuthorizationCodeClient::Result.new(**{
           access_token: "AT", refresh_token: "RT", expires_in: 3600,
-          scope: "openid email", id_token: id_token
+          scope: "openid email", id_token: id_token, response: {}
         }.merge(overrides))
       end
 
@@ -63,7 +63,7 @@ module Oauth
       test "undecodable payload raises a parse error" do
         result = Broker::AuthorizationCodeClient::Result.new(
           access_token: "AT", refresh_token: "RT", expires_in: 3600,
-          scope: nil, id_token: "h.!!!not-base64!!!.s"
+          scope: nil, id_token: "h.!!!not-base64!!!.s", response: {}
         )
         err = assert_raises(Broker::ExchangeError) { strategy.identity_from(result, client_id: CLIENT_ID) }
         assert_equal "parse", err.stage

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -7,14 +7,6 @@ module Oauth
 
       def strategy = Slack.new
 
-      setup do
-        Slack.slack_api_http = nil
-      end
-
-      teardown do
-        Slack.slack_api_http = nil
-      end
-
       def result_with(claims:, scope: "openid,email,profile", **overrides)
         payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
         id_token = "h.#{payload}.s"
@@ -46,38 +38,6 @@ module Oauth
         assert_equal "U12345", identity[:subject]
         assert_nil identity[:email]
         assert_nil identity[:name]
-      end
-
-      test "looks up users.info profile when user scopes allow it" do
-        calls = []
-        Slack.slack_api_http = ->(url:, access_token:, params:) {
-          calls << [ url, params ]
-          assert_equal "AT", access_token
-          if url == Slack::AUTH_TEST_ENDPOINT
-            { "ok" => true, "user" => "fallback" }
-          else
-            assert_equal Slack::USERS_INFO_ENDPOINT, url
-            assert_equal({ "user" => "U12345" }, params)
-            {
-              "ok" => true,
-              "user" => {
-                "name" => "graceh",
-                "profile" => {
-                  "display_name" => "Grace Hopper",
-                  "email" => "grace@example.com"
-                }
-              }
-            }
-          end
-        }
-
-        profile = strategy.slack_profile(
-          "AT", "U12345", "users:read,users:read.email,channels:history"
-        )
-        assert_equal "Grace Hopper", profile[:name]
-        assert_equal "grace@example.com", profile[:email]
-        assert_equal [ [ Slack::AUTH_TEST_ENDPOINT, {} ],
-                       [ Slack::USERS_INFO_ENDPOINT, { "user" => "U12345" } ] ], calls
       end
 
       test "uses Slack response name when present" do

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -36,12 +36,6 @@ module Oauth
       end
 
       test "uses Slack authed_user id when no id_token is returned for API scopes" do
-        Slack.slack_api_http = ->(url:, access_token:, params:) {
-          assert_equal "AT", access_token
-          assert_empty params
-          assert_equal Slack::AUTH_TEST_ENDPOINT, url
-          { "ok" => true, "user" => "grace" }
-        }
         result = result_with(
           claims: valid_claims,
           id_token: nil,
@@ -51,10 +45,10 @@ module Oauth
         identity = strategy.identity_from(result, client_id: CLIENT_ID)
         assert_equal "U12345", identity[:subject]
         assert_nil identity[:email]
-        assert_equal "grace", identity[:name]
+        assert_nil identity[:name]
       end
 
-      test "uses users.info profile when user scopes allow it" do
+      test "looks up users.info profile when user scopes allow it" do
         calls = []
         Slack.slack_api_http = ->(url:, access_token:, params:) {
           calls << [ url, params ]
@@ -76,16 +70,12 @@ module Oauth
             }
           end
         }
-        result = result_with(
-          claims: valid_claims,
-          id_token: nil,
-          scope: "users:read,users:read.email,channels:history",
-          response: { "authed_user" => { "id" => "U12345" } }
-        )
 
-        identity = strategy.identity_from(result, client_id: CLIENT_ID)
-        assert_equal "Grace Hopper", identity[:name]
-        assert_equal "grace@example.com", identity[:email]
+        profile = strategy.slack_profile(
+          "AT", "U12345", "users:read,users:read.email,channels:history"
+        )
+        assert_equal "Grace Hopper", profile[:name]
+        assert_equal "grace@example.com", profile[:email]
         assert_equal [ [ Slack::AUTH_TEST_ENDPOINT, {} ],
                        [ Slack::USERS_INFO_ENDPOINT, { "user" => "U12345" } ] ], calls
       end

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -64,9 +64,10 @@ module Oauth
 
       test "exposes provider constants" do
         assert_equal "slack", strategy.key
-        assert_equal "https://slack.com/oauth/v2_user/authorize", strategy.authorization_endpoint
-        assert_equal "https://slack.com/api/oauth.v2.user.access", strategy.token_endpoint
+        assert_equal "https://slack.com/oauth/v2/authorize", strategy.authorization_endpoint
+        assert_equal "https://slack.com/api/oauth.v2.access", strategy.token_endpoint
         assert_equal [], strategy.identity_scopes
+        assert_equal "user_scope", strategy.authorization_scope_param
         assert_equal ",", strategy.scope_separator
         assert_equal({}, strategy.extra_authorization_params)
       end

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -7,6 +7,14 @@ module Oauth
 
       def strategy = Slack.new
 
+      setup do
+        Slack.auth_test_http = nil
+      end
+
+      teardown do
+        Slack.auth_test_http = nil
+      end
+
       def result_with(claims:, scope: "openid,email,profile", **overrides)
         payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
         id_token = "h.#{payload}.s"
@@ -28,6 +36,10 @@ module Oauth
       end
 
       test "uses Slack authed_user id when no id_token is returned for API scopes" do
+        Slack.auth_test_http = ->(access_token:) {
+          assert_equal "AT", access_token
+          { "ok" => true, "user" => "grace" }
+        }
         result = result_with(
           claims: valid_claims,
           id_token: nil,
@@ -37,6 +49,24 @@ module Oauth
         identity = strategy.identity_from(result, client_id: CLIENT_ID)
         assert_equal "U12345", identity[:subject]
         assert_nil identity[:email]
+        assert_equal "grace", identity[:name]
+      end
+
+      test "uses Slack response name without calling auth.test" do
+        called = false
+        Slack.auth_test_http = ->(access_token:) {
+          called = true
+          { "ok" => true, "user" => "ignored" }
+        }
+        result = result_with(
+          claims: valid_claims,
+          id_token: nil,
+          response: { "authed_user" => { "id" => "U12345", "name" => "ada" } }
+        )
+
+        identity = strategy.identity_from(result, client_id: CLIENT_ID)
+        assert_equal "ada", identity[:name]
+        refute called
       end
 
       test "aud mismatch raises an oauth exchange error" do

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -7,14 +7,6 @@ module Oauth
 
       def strategy = Slack.new
 
-      setup do
-        Slack.auth_test_http = nil
-      end
-
-      teardown do
-        Slack.auth_test_http = nil
-      end
-
       def result_with(claims:, scope: "openid,email,profile", **overrides)
         payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
         id_token = "h.#{payload}.s"
@@ -36,10 +28,6 @@ module Oauth
       end
 
       test "uses Slack authed_user id when no id_token is returned for API scopes" do
-        Slack.auth_test_http = ->(access_token:) {
-          assert_equal "AT", access_token
-          { "ok" => true, "user" => "grace" }
-        }
         result = result_with(
           claims: valid_claims,
           id_token: nil,
@@ -49,15 +37,10 @@ module Oauth
         identity = strategy.identity_from(result, client_id: CLIENT_ID)
         assert_equal "U12345", identity[:subject]
         assert_nil identity[:email]
-        assert_equal "grace", identity[:name]
+        assert_nil identity[:name]
       end
 
-      test "uses Slack response name without calling auth.test" do
-        called = false
-        Slack.auth_test_http = ->(access_token:) {
-          called = true
-          { "ok" => true, "user" => "ignored" }
-        }
+      test "uses Slack response name when present" do
         result = result_with(
           claims: valid_claims,
           id_token: nil,
@@ -66,7 +49,6 @@ module Oauth
 
         identity = strategy.identity_from(result, client_id: CLIENT_ID)
         assert_equal "ada", identity[:name]
-        refute called
       end
 
       test "aud mismatch raises an oauth exchange error" do

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+module Oauth
+  module Providers
+    class SlackTest < ActiveSupport::TestCase
+      CLIENT_ID = "the-client-id".freeze
+
+      def strategy = Slack.new
+
+      def result_with(claims:, scope: "openid,email,profile", **overrides)
+        payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
+        id_token = "h.#{payload}.s"
+        Broker::AuthorizationCodeClient::Result.new(**{
+          access_token: "AT", refresh_token: "RT", expires_in: 43_200,
+          scope: scope, id_token: id_token, response: {}
+        }.merge(overrides))
+      end
+
+      def valid_claims(**overrides)
+        { "aud" => CLIENT_ID, "iss" => "https://slack.com",
+          "sub" => "U0R7MFMJM", "email" => "user@example.com" }.merge(overrides)
+      end
+
+      test "happy path extracts subject and email" do
+        identity = strategy.identity_from(result_with(claims: valid_claims), client_id: CLIENT_ID)
+        assert_equal "U0R7MFMJM", identity[:subject]
+        assert_equal "user@example.com", identity[:email]
+      end
+
+      test "uses Slack authed_user id when no id_token is returned for API scopes" do
+        result = result_with(
+          claims: valid_claims,
+          id_token: nil,
+          response: { "authed_user" => { "id" => "U12345" } }
+        )
+
+        identity = strategy.identity_from(result, client_id: CLIENT_ID)
+        assert_equal "U12345", identity[:subject]
+        assert_nil identity[:email]
+      end
+
+      test "aud mismatch raises an oauth exchange error" do
+        result = result_with(claims: valid_claims("aud" => "someone-else"))
+        err = assert_raises(Broker::ExchangeError) { strategy.identity_from(result, client_id: CLIENT_ID) }
+        assert_equal "oauth", err.stage
+        assert_equal "id_token_aud_mismatch", err.code
+      end
+
+      test "bad issuer raises" do
+        result = result_with(claims: valid_claims("iss" => "https://evil.example"))
+        err = assert_raises(Broker::ExchangeError) { strategy.identity_from(result, client_id: CLIENT_ID) }
+        assert_equal "id_token_iss_invalid", err.code
+      end
+
+      test "missing id_token raises" do
+        result = result_with(claims: valid_claims, id_token: nil)
+        err = assert_raises(Broker::ExchangeError) { strategy.identity_from(result, client_id: CLIENT_ID) }
+        assert_equal "missing_id_token", err.code
+      end
+
+      test "parses comma or space separated granted scopes" do
+        assert_equal %w[openid email profile], strategy.parse_granted_scopes("openid,email profile")
+      end
+
+      test "exposes provider constants" do
+        assert_equal "slack", strategy.key
+        assert_equal "https://slack.com/oauth/v2_user/authorize", strategy.authorization_endpoint
+        assert_equal "https://slack.com/api/oauth.v2.user.access", strategy.token_endpoint
+        assert_equal [], strategy.identity_scopes
+        assert_equal ",", strategy.scope_separator
+        assert_equal({}, strategy.extra_authorization_params)
+      end
+    end
+  end
+end

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -7,6 +7,14 @@ module Oauth
 
       def strategy = Slack.new
 
+      setup do
+        Slack.slack_api_http = nil
+      end
+
+      teardown do
+        Slack.slack_api_http = nil
+      end
+
       def result_with(claims:, scope: "openid,email,profile", **overrides)
         payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
         id_token = "h.#{payload}.s"
@@ -28,6 +36,12 @@ module Oauth
       end
 
       test "uses Slack authed_user id when no id_token is returned for API scopes" do
+        Slack.slack_api_http = ->(url:, access_token:, params:) {
+          assert_equal "AT", access_token
+          assert_empty params
+          assert_equal Slack::AUTH_TEST_ENDPOINT, url
+          { "ok" => true, "user" => "grace" }
+        }
         result = result_with(
           claims: valid_claims,
           id_token: nil,
@@ -37,7 +51,43 @@ module Oauth
         identity = strategy.identity_from(result, client_id: CLIENT_ID)
         assert_equal "U12345", identity[:subject]
         assert_nil identity[:email]
-        assert_nil identity[:name]
+        assert_equal "grace", identity[:name]
+      end
+
+      test "uses users.info profile when user scopes allow it" do
+        calls = []
+        Slack.slack_api_http = ->(url:, access_token:, params:) {
+          calls << [ url, params ]
+          assert_equal "AT", access_token
+          if url == Slack::AUTH_TEST_ENDPOINT
+            { "ok" => true, "user" => "fallback" }
+          else
+            assert_equal Slack::USERS_INFO_ENDPOINT, url
+            assert_equal({ "user" => "U12345" }, params)
+            {
+              "ok" => true,
+              "user" => {
+                "name" => "graceh",
+                "profile" => {
+                  "display_name" => "Grace Hopper",
+                  "email" => "grace@example.com"
+                }
+              }
+            }
+          end
+        }
+        result = result_with(
+          claims: valid_claims,
+          id_token: nil,
+          scope: "users:read,users:read.email,channels:history",
+          response: { "authed_user" => { "id" => "U12345" } }
+        )
+
+        identity = strategy.identity_from(result, client_id: CLIENT_ID)
+        assert_equal "Grace Hopper", identity[:name]
+        assert_equal "grace@example.com", identity[:email]
+        assert_equal [ [ Slack::AUTH_TEST_ENDPOINT, {} ],
+                       [ Slack::USERS_INFO_ENDPOINT, { "user" => "U12345" } ] ], calls
       end
 
       test "uses Slack response name when present" do

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -95,6 +95,18 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert_equal "app-secret", captured[:client_secret]
   end
 
+  test "refresh lets the provider choose refresh scopes" do
+    captured = {}
+    app = build_app(provider: "slack", client_id: "app-cid", client_secret: "app-secret",
+                    allowed_scopes: %w[chat:write])
+    bc = create_credential(client_id: nil, client_secret: nil, oauth_app: app,
+                           provider_subject: "U123", created_by: nil, refresh_token: "rt",
+                           scopes: %w[chat:write openid])
+    bc.refresh_client = StubClient.new { |**kw| captured = kw; result }
+    bc.refresh!
+    assert_equal [], captured[:scopes]
+  end
+
   test "external_user_key must be url-safe and bounded" do
     app = build_app
     bc = build_credential(oauth_app: app, provider_subject: "sub-5", created_by: nil, client_id: nil)

--- a/services/console/test/models/oauth_app_test.rb
+++ b/services/console/test/models/oauth_app_test.rb
@@ -19,6 +19,7 @@ class OauthAppTest < ActiveSupport::TestCase
   test "provider must be a registered provider" do
     refute build_app(provider: "github").valid?
     assert build_app(provider: "google").valid?
+    assert build_app(provider: "slack").valid?
   end
 
   test "client_id and client_secret are required" do


### PR DESCRIPTION
Adds Slack as an OAuth app provider for the console consent flow using Slack user-token OAuth endpoints. The flow now supports provider-specific scope formatting/parsing, Slack token refresh behavior, and Slack-style OAuth error responses, with focused tests and docs updated.
