### PR TITLE
rendering: collapse streamed reasoning into one Thinking card per item

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -472,6 +472,42 @@ describe('CodexAppServerRendererEventMapper', () => {
     })
   })
 
+  it('keeps separate Thinking tasks for distinct reasoning items', async () => {
+    const chunks = await collect(
+      codexAppServerToChatSdkStream(
+        toAsyncIterable([
+          {
+            method: 'item/reasoning/summaryTextDelta',
+            params: {
+              itemId: 'reasoning-1',
+              delta: 'First thought'
+            }
+          },
+          {
+            method: 'item/reasoning/summaryTextDelta',
+            params: {
+              itemId: 'reasoning-2',
+              delta: 'Second thought'
+            }
+          },
+          {
+            method: 'turn/completed',
+            params: {
+              turn: { id: 'turn-1', items: [], status: 'completed' }
+            }
+          }
+        ])
+      )
+    )
+
+    const thinkingIds = new Set(
+      chunks
+        .filter(chunk => chunk.type === 'task_update' && chunk.title === 'Thinking')
+        .map(chunk => (chunk as { id: string }).id)
+    )
+    expect(thinkingIds).toEqual(new Set(['reasoning-1', 'reasoning-2']))
+  })
+
   it('streams command details once and command output incrementally', async () => {
     const chunks = await collect(
       codexAppServerToChatSdkStream(


### PR DESCRIPTION
## What

Limits the number of interactive "Thinking" boxes Slack renders for a single turn, without changing the final answer that goes out.

## Why

Reported in Slack: Centaur stacks lots of near-empty **Thinking** boxes, increasingly aggressively.

Root cause is in the Codex App Server → Chat SDK mapper. App Server streams a reasoning summary as a *burst* of `summaryTextDelta` fragments that all share one `itemId`, but the mapper minted a brand-new `reasoning-${counter}` task id for **every fragment** (`codex-app-server.ts`). Each fragment therefore became its own interactive card, and the stream conflater couldn't merge them because the ids differed — one thought fanned out into many boxes.

The per-fragment id existed because Thinking `details` were emitted **once per task id**, so reusing an id would have dropped all but the first fragment's text.

## Change

- Key the Thinking card by the reasoning `itemId` and accumulate delta text into it (`reasoningUpdate`), so a burst of fragments updates **one** card in place. Multiple summary sections for the same item are separated by a paragraph break.
- Thinking `details` now re-emit as the accumulated body grows (deduped by text), instead of once-per-id — this removes the reason the per-fragment id existed. The existing signature dedup still drops no-op repeats (e.g. the final `in_progress → complete` flip when the body is unchanged), so non-Thinking cards keep emitting their run block exactly once.
- Reasoning items without an `itemId` (e.g. a one-shot `reasoning` blob from another harness) still get their own card via the step counter.

Net effect: the box count now tracks **distinct reasoning items**, not streamed fragment volume.

## Stability

- Final-answer text emission and the oversized-payload guards are untouched; this only changes how reasoning cards are keyed/updated.
- Per-card body stays bounded (details are already truncated downstream), so collapsing fragments into one card does not risk oversized Slack blocks.

## Tests

- New: streamed reasoning deltas for one item fold into a single `reasoning-1` card whose body streams to the full text and finishes `complete`.
- New: distinct reasoning items keep separate cards.
- Existing single-delta App Server test still passes unchanged.
- `bun test src` in `packages/rendering`: 20 pass / 0 fail. Package typecheck clean.
- `slackbotv2` has 7 pre-existing failing tests on `main` (timing/payload-limit suites); this branch produces the **identical** failure set (verified by stashing the change), so it neither fixes nor regresses them.

Prompted by: @goksu