### PR TITLE
Add OpenRouter provider support for Codex harness-server

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -11,8 +11,48 @@ use crate::server::{BlocksCommand, BlocksState, parse_blocks_line_with_state, wr
 use crate::util::write_value;
 use crate::{AppServerRuntime, HarnessServerError, Result};
 
-#[derive(Debug, Default)]
-pub struct CodexHarnessServer;
+#[derive(Debug, Clone, Copy)]
+pub struct CodexHarnessServer {
+    fallback_model_provider: &'static str,
+}
+
+impl CodexHarnessServer {
+    pub fn codex() -> Self {
+        Self {
+            fallback_model_provider: "openai",
+        }
+    }
+
+    fn default_model(&self) -> Option<String> {
+        env::var("CODEX_MODEL")
+            .ok()
+            .or_else(|| env::var("OPENROUTER_MODEL").ok())
+            .map(|model| model.trim().to_owned())
+            .filter(|model| !model.is_empty())
+    }
+
+    fn model_provider_for(&self, model: Option<&str>) -> String {
+        env::var("CODEX_MODEL_PROVIDER")
+            .ok()
+            .map(|provider| provider.trim().to_owned())
+            .filter(|provider| !provider.is_empty())
+            .or_else(|| {
+                model
+                    .map(str::trim)
+                    .filter(|model| !model.is_empty())
+                    .filter(|model| model.contains('/'))
+                    .map(|_| "openrouter".to_string())
+            })
+            .or_else(|| {
+                env::var("OPENROUTER_MODEL")
+                    .ok()
+                    .map(|model| model.trim().to_owned())
+                    .filter(|model| !model.is_empty())
+                    .map(|_| "openrouter".to_string())
+            })
+            .unwrap_or_else(|| self.fallback_model_provider.to_string())
+    }
+}
 
 impl AppServerRuntime for CodexHarnessServer {
     fn run_stdio(&self) -> Result<()> {
@@ -65,7 +105,7 @@ impl AppServerRuntime for CodexHarnessServer {
     }
 }
 
-pub(crate) fn run_codex_blocks_server() -> Result<()> {
+pub(crate) fn run_codex_blocks_server(config: CodexHarnessServer) -> Result<()> {
     let mut codex = CodexJsonRpcChild::spawn()?;
     let mut stdout = io::stdout().lock();
     let mut request_id = 1_i64;
@@ -108,7 +148,11 @@ pub(crate) fn run_codex_blocks_server() -> Result<()> {
                     &mut thread_id,
                     input,
                     client_user_message_id,
-                    model,
+                    {
+                        let model = model.or_else(|| config.default_model());
+                        let model_provider = config.model_provider_for(model.as_deref());
+                        (model, model_provider)
+                    },
                 ) {
                     let fallback_thread_id = thread_id.as_deref().unwrap_or("codex");
                     eprintln!("Codex blocks turn failed: {error:#}");
@@ -143,10 +187,16 @@ fn run_codex_user_turn<W: Write>(
     thread_id: &mut Option<String>,
     input: Vec<UserInput>,
     client_user_message_id: Option<String>,
-    model: Option<String>,
+    model_and_provider: (Option<String>, String),
 ) -> Result<()> {
+    let (model, model_provider) = model_and_provider;
     if thread_id.is_none() {
-        *thread_id = Some(start_or_resume_thread(codex, stdout, request_id)?);
+        *thread_id = Some(start_or_resume_thread(
+            codex,
+            stdout,
+            request_id,
+            &model_provider,
+        )?);
     }
     let current_thread_id = thread_id
         .as_ref()
@@ -181,6 +231,7 @@ fn start_or_resume_thread<W: Write>(
     codex: &mut CodexJsonRpcChild,
     stdout: &mut W,
     request_id: &mut i64,
+    model_provider: &str,
 ) -> Result<String> {
     let cwd = env::current_dir()?.display().to_string();
     let resume = env::var("CODEX_CONTINUE_THREAD_ID")
@@ -194,6 +245,7 @@ fn start_or_resume_thread<W: Write>(
                 "approvalPolicy": "never",
                 "approvalsReviewer": "user",
                 "sandbox": "danger-full-access",
+                "modelProvider": model_provider,
             }),
         )
     } else {
@@ -205,6 +257,7 @@ fn start_or_resume_thread<W: Write>(
                 "approvalPolicy": "never",
                 "approvalsReviewer": "user",
                 "sandbox": "danger-full-access",
+                "modelProvider": model_provider,
                 "excludeTurns": false,
             }),
         )

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -34,7 +34,7 @@ use crate::{HarnessServerError, Result};
 
 pub fn server_for(kind: HarnessKind) -> Box<dyn AppServerRuntime> {
     match kind {
-        HarnessKind::Codex => Box::new(CodexHarnessServer),
+        HarnessKind::Codex => Box::new(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => Box::new(AppServerNormalizer::new(ClaudeCodeHarness)),
         HarnessKind::Amp => Box::new(AppServerNormalizer::new(AmpHarness)),
     }
@@ -46,7 +46,7 @@ pub fn run_harness_server(kind: HarnessKind) -> Result<()> {
 
 pub fn run_blocks_server(kind: HarnessKind) -> Result<()> {
     match kind {
-        HarnessKind::Codex => crate::codex::run_codex_blocks_server(),
+        HarnessKind::Codex => crate::codex::run_codex_blocks_server(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => run_blocks_app_server(&ClaudeCodeHarness),
         HarnessKind::Amp => run_blocks_app_server(&AmpHarness),
     }

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -107,6 +107,119 @@ fn fake_claude_app_server_streams_codex_v2_notifications() {
 }
 
 #[test]
+fn fake_codex_blocks_mode_uses_openrouter_provider_when_model_is_configured() {
+    let fake_codex = temp_path("fake-openrouter-codex.sh");
+    let fake_codex_log = temp_path("fake-openrouter-codex-requests.jsonl");
+    let script = fake_codex_app_server_script(&fake_codex_log);
+    std::fs::write(&fake_codex, script).expect("write fake codex script");
+    let mut permissions = std::fs::metadata(&fake_codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, permissions).expect("chmod fake codex script");
+
+    let mut bridge = BridgeProcess::spawn_harness_blocks_envs(
+        Harness::Codex,
+        None,
+        Some((
+            "CODEX_BIN",
+            fake_codex.to_str().expect("utf-8 fake codex path"),
+        )),
+        &[("OPENROUTER_MODEL", "openrouter/auto")],
+    );
+    let turn = bridge.run_blocks_user_turn("say openrouter blocks", Duration::from_secs(10));
+    bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_codex_v2_turn(&turn);
+
+    let requests = std::fs::read_to_string(&fake_codex_log).expect("read fake codex request log");
+    let requests: Vec<Value> = requests
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("fake codex request JSON"))
+        .collect();
+    let thread_start = requests
+        .iter()
+        .find(|value| value.get("method").and_then(Value::as_str) == Some("thread/start"))
+        .unwrap_or_else(|| panic!("blocks mode did not send thread/start; requests={requests:?}"));
+    assert_eq!(
+        thread_start
+            .pointer("/params/modelProvider")
+            .and_then(Value::as_str),
+        Some("openrouter")
+    );
+    let turn_start = requests
+        .iter()
+        .find(|value| value.get("method").and_then(Value::as_str) == Some("turn/start"))
+        .unwrap_or_else(|| panic!("blocks mode did not send turn/start; requests={requests:?}"));
+    assert_eq!(
+        turn_start.pointer("/params/model").and_then(Value::as_str),
+        Some("openrouter/auto")
+    );
+
+    let _ = std::fs::remove_file(fake_codex);
+    let _ = std::fs::remove_file(fake_codex_log);
+}
+
+#[test]
+fn fake_codex_blocks_mode_uses_openrouter_provider_for_explicit_model_slug() {
+    let fake_codex = temp_path("fake-openrouter-flag-codex.sh");
+    let fake_codex_log = temp_path("fake-openrouter-flag-codex-requests.jsonl");
+    let script = fake_codex_app_server_script(&fake_codex_log);
+    std::fs::write(&fake_codex, script).expect("write fake codex script");
+    let mut permissions = std::fs::metadata(&fake_codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, permissions).expect("chmod fake codex script");
+
+    let mut bridge = BridgeProcess::spawn_harness_blocks(
+        Harness::Codex,
+        None,
+        Some((
+            "CODEX_BIN",
+            fake_codex.to_str().expect("utf-8 fake codex path"),
+        )),
+    );
+    let turn = bridge.run_blocks_user_turn_with_model(
+        "say explicit openrouter blocks",
+        Some("anthropic/claude-fable-5"),
+        Duration::from_secs(10),
+    );
+    bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_codex_v2_turn(&turn);
+
+    let requests = std::fs::read_to_string(&fake_codex_log).expect("read fake codex request log");
+    let requests: Vec<Value> = requests
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("fake codex request JSON"))
+        .collect();
+    let thread_start = requests
+        .iter()
+        .find(|value| value.get("method").and_then(Value::as_str) == Some("thread/start"))
+        .unwrap_or_else(|| panic!("blocks mode did not send thread/start; requests={requests:?}"));
+    assert_eq!(
+        thread_start
+            .pointer("/params/modelProvider")
+            .and_then(Value::as_str),
+        Some("openrouter")
+    );
+    let turn_start = requests
+        .iter()
+        .find(|value| value.get("method").and_then(Value::as_str) == Some("turn/start"))
+        .unwrap_or_else(|| panic!("blocks mode did not send turn/start; requests={requests:?}"));
+    assert_eq!(
+        turn_start.pointer("/params/model").and_then(Value::as_str),
+        Some("anthropic/claude-fable-5")
+    );
+
+    let _ = std::fs::remove_file(fake_codex);
+    let _ = std::fs::remove_file(fake_codex_log);
+}
+
+#[test]
 fn fake_amp_app_server_streams_codex_v2_notifications() {
     let fake_amp = concat!(
         "printf '%s\\n' ",
@@ -612,7 +725,7 @@ impl BridgeProcess {
         command_override: Option<String>,
         extra_env: Option<(&str, &str)>,
     ) -> Self {
-        Self::spawn_harness_with_args(harness, harness.args(), command_override, extra_env)
+        Self::spawn_harness_with_args(harness, harness.args(), command_override, extra_env, &[])
     }
 
     fn spawn_harness_blocks(
@@ -620,7 +733,28 @@ impl BridgeProcess {
         command_override: Option<String>,
         extra_env: Option<(&str, &str)>,
     ) -> Self {
-        Self::spawn_harness_with_args(harness, harness.blocks_args(), command_override, extra_env)
+        Self::spawn_harness_with_args(
+            harness,
+            harness.blocks_args(),
+            command_override,
+            extra_env,
+            &[],
+        )
+    }
+
+    fn spawn_harness_blocks_envs(
+        harness: Harness,
+        command_override: Option<String>,
+        extra_env: Option<(&str, &str)>,
+        extra_envs: &[(&str, &str)],
+    ) -> Self {
+        Self::spawn_harness_with_args(
+            harness,
+            harness.blocks_args(),
+            command_override,
+            extra_env,
+            extra_envs,
+        )
     }
 
     fn spawn_harness_with_args(
@@ -628,6 +762,7 @@ impl BridgeProcess {
         args: &'static [&'static str],
         command_override: Option<String>,
         extra_env: Option<(&str, &str)>,
+        extra_envs: &[(&str, &str)],
     ) -> Self {
         let bin = env!("CARGO_BIN_EXE_harness-server");
         let mut command = Command::new(bin);
@@ -640,6 +775,9 @@ impl BridgeProcess {
         for env_key in [
             "CENTAUR_CLAUDE_APP_BRIDGE_COMMAND",
             "CENTAUR_AMP_APP_BRIDGE_COMMAND",
+            "CODEX_MODEL",
+            "CODEX_MODEL_PROVIDER",
+            "OPENROUTER_MODEL",
         ] {
             command.env_remove(env_key);
         }
@@ -649,6 +787,9 @@ impl BridgeProcess {
             command.env(env_key, raw);
         }
         if let Some((key, value)) = extra_env {
+            command.env(key, value);
+        }
+        for (key, value) in extra_envs {
             command.env(key, value);
         }
 
@@ -817,7 +958,16 @@ impl BridgeProcess {
     }
 
     fn run_blocks_user_turn(&mut self, prompt: &str, timeout: Duration) -> TurnCapture {
-        self.send(json!({
+        self.run_blocks_user_turn_with_model(prompt, None, timeout)
+    }
+
+    fn run_blocks_user_turn_with_model(
+        &mut self,
+        prompt: &str,
+        model: Option<&str>,
+        timeout: Duration,
+    ) -> TurnCapture {
+        let mut input = json!({
             "type": "user",
             "thread_key": "slack:C123:123.456",
             "trace_metadata": {
@@ -828,7 +978,11 @@ impl BridgeProcess {
                 "role": "user",
                 "content": [{"type": "text", "text": prompt}],
             },
-        }));
+        });
+        if let Some(model) = model {
+            input["model"] = Value::String(model.to_string());
+        }
+        self.send(input);
 
         let deadline = Instant::now() + timeout;
         let mut capture = TurnCapture::default();

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -80,6 +80,7 @@ Store one secret per enabled harness credential:
 | Harness | API value | Slack selector | Credential to store | Upstream |
 |---------|-----------|----------------|---------------------|----------|
 | Codex default | `codex` | none or `--codex` | `OPENAI_API_KEY` | `api.openai.com` |
+| Codex with OpenRouter provider | `codex` | none or `--codex` | `OPENROUTER_API_KEY` | `openrouter.ai` |
 | Amp | `amp` | `--amp` | `AMP_API_KEY` | `ampcode.com` |
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
@@ -91,7 +92,12 @@ headers the secret is bound to.
 
 When `ironProxy.secretSource` is `onepassword`, [iron-proxy](https://docs.iron.sh) resolves these values
 from `op://$OP_VAULT/<SECRET_NAME>/credential`. For example, store the default
-Codex credential in a 1Password item named `OPENAI_API_KEY`.
+Codex credential in a 1Password item named `OPENAI_API_KEY`. To run Codex
+through OpenRouter, store `OPENROUTER_API_KEY` and set `OPENROUTER_MODEL` to a
+model slug such as `openrouter/auto`, or set `CODEX_MODEL_PROVIDER=openrouter`
+alongside `CODEX_MODEL`. Per-turn Codex model overrides with provider-style
+slugs such as `--model anthropic/claude-fable-5` also select the OpenRouter
+provider even when `OPENROUTER_MODEL` is unset.
 
 Whatever source you pick, the vault is shared across the whole deployment,
 so any thread can use any configured credential. Per-user and per-channel

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -73,7 +73,7 @@ Onboard me to Centaur locally. Use https://centaur.run/llms-full.txt and follow 
       <li>
         <a href="/architecture#execution-path">
           <strong>Harness agnostic.</strong>
-          <span>Use Amp, Codex, Claude Code, pi-mono, or your own CLI harness with the same durable execution model.</span>
+          <span>Use Amp, Codex, Codex through OpenRouter, Claude Code, pi-mono, or your own CLI harness with the same durable execution model.</span>
         </a>
       </li>
       <li>

--- a/docs/pages/secrets/onepassword.mdx
+++ b/docs/pages/secrets/onepassword.mdx
@@ -110,6 +110,7 @@ Store enabled harness credentials the same way:
 | Credential | Used for |
 |------------|----------|
 | `OPENAI_API_KEY` | Codex default |
+| `OPENROUTER_API_KEY` | OpenRouter via Codex |
 | `AMP_API_KEY` | Amp |
 | `ANTHROPIC_API_KEY` | Claude Code and pi-mono |
 

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -80,6 +80,7 @@ Store one secret per enabled harness credential:
 | Harness | API value | Slack selector | Credential to store | Upstream |
 |---------|-----------|----------------|---------------------|----------|
 | Codex default | `codex` | none or `--codex` | `OPENAI_API_KEY` | `api.openai.com` |
+| Codex with OpenRouter provider | `codex` | none or `--codex` | `OPENROUTER_API_KEY` | `openrouter.ai` |
 | Amp | `amp` | `--amp` | `AMP_API_KEY` | `ampcode.com` |
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
@@ -91,7 +92,12 @@ headers the secret is bound to.
 
 When `ironProxy.secretSource` is `onepassword`, [iron-proxy](https://docs.iron.sh) resolves these values
 from `op://$OP_VAULT/<SECRET_NAME>/credential`. For example, store the default
-Codex credential in a 1Password item named `OPENAI_API_KEY`.
+Codex credential in a 1Password item named `OPENAI_API_KEY`. To run Codex
+through OpenRouter, store `OPENROUTER_API_KEY` and set `OPENROUTER_MODEL` to a
+model slug such as `openrouter/auto`, or set `CODEX_MODEL_PROVIDER=openrouter`
+alongside `CODEX_MODEL`. Per-turn Codex model overrides with provider-style
+slugs such as `--model anthropic/claude-fable-5` also select the OpenRouter
+provider even when `OPENROUTER_MODEL` is unset.
 
 Whatever source you pick, the vault is shared across the whole deployment,
 so any thread can use any configured credential. Per-user and per-channel

--- a/docs/public/md/index.md
+++ b/docs/public/md/index.md
@@ -73,7 +73,7 @@ Onboard me to Centaur locally. Use https://centaur.run/llms-full.txt and follow 
       <li>
         <a href="/architecture#execution-path">
           <strong>Harness agnostic.</strong>
-          <span>Use Amp, Codex, Claude Code, pi-mono, or your own CLI harness with the same durable execution model.</span>
+          <span>Use Amp, Codex, Codex through OpenRouter, Claude Code, pi-mono, or your own CLI harness with the same durable execution model.</span>
         </a>
       </li>
       <li>

--- a/docs/public/md/secrets/onepassword.md
+++ b/docs/public/md/secrets/onepassword.md
@@ -110,6 +110,7 @@ Store enabled harness credentials the same way:
 | Credential | Used for |
 |------------|----------|
 | `OPENAI_API_KEY` | Codex default |
+| `OPENROUTER_API_KEY` | OpenRouter via Codex |
 | `AMP_API_KEY` | Amp |
 | `ANTHROPIC_API_KEY` | Claude Code and pi-mono |
 

--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -24,5 +24,12 @@ job_max_runtime_seconds = 1800
 [tools]
 view_image = true
 
+[model_providers.openrouter]
+name = "OpenRouter"
+base_url = "https://openrouter.ai/api/v1"
+env_key = "OPENROUTER_API_KEY"
+wire_api = "responses"
+requires_openai_auth = false
+
 [projects."/"]
 trust_level = "trusted"

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -918,6 +918,15 @@ impl SandboxArgs {
         {
             envs.push(("OPENAI_API_KEY".to_owned(), "OPENAI_API_KEY".to_owned()));
         }
+        if !envs
+            .iter()
+            .any(|(existing, _)| existing == "OPENROUTER_API_KEY")
+        {
+            envs.push((
+                "OPENROUTER_API_KEY".to_owned(),
+                "OPENROUTER_API_KEY".to_owned(),
+            ));
+        }
 
         // OTLP trace wiring rides from this process into every sandbox (the
         // same hardcoded set the Python control plane forwarded). The harness
@@ -1654,6 +1663,9 @@ impl IronProxyHarnessArgs {
                 fragments.push(fragment);
             }
         }
+        if let Some(fragment) = harness_auth_fragment("openrouter", "api_key")? {
+            fragments.push(fragment);
+        }
         Ok(fragments)
     }
 }
@@ -2134,6 +2146,10 @@ mod tests {
         assert!(
             env.iter()
                 .any(|(name, value)| name == "OPENAI_API_KEY" && value == "OPENAI_API_KEY")
+        );
+        assert!(
+            env.iter()
+                .any(|(name, value)| name == "OPENROUTER_API_KEY" && value == "OPENROUTER_API_KEY")
         );
     }
 

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -14,14 +14,14 @@ pub fn load_fragment_str(contents: &str) -> Result<ProxyFragment> {
     })
 }
 
-/// The harness auth fragment for ``engine`` (`codex`/`claude-code`) and
-/// ``auth_mode`` (`api_key`/`access_token`). These are infra — known in advance
-/// — so they are baked in rather than discovered from disk. Returns ``None``
-/// for an unknown engine/mode pair.
+/// The harness auth fragment for ``engine`` and ``auth_mode``. These are infra
+/// — known in advance — so they are baked in rather than discovered from disk.
+/// Returns ``None`` for an unknown engine/mode pair.
 pub fn harness_auth_fragment(engine: &str, auth_mode: &str) -> Result<Option<ProxyFragment>> {
     let yaml = match (engine, normalize_auth_mode(auth_mode).as_str()) {
         ("codex", "api_key") => CODEX_API_KEY_FRAGMENT,
         ("codex", "access_token") => CODEX_ACCESS_TOKEN_FRAGMENT,
+        ("openrouter", "api_key") => OPENROUTER_API_KEY_FRAGMENT,
         ("claude-code", "api_key") => CLAUDE_CODE_API_KEY_FRAGMENT,
         ("claude-code", "access_token") => CLAUDE_CODE_ACCESS_TOKEN_FRAGMENT,
         _ => return Ok(None),
@@ -41,6 +41,20 @@ transforms:
             header: Authorization
             formatter: "Bearer {{.Value}}"
           rules: [{ host: api.openai.com }]
+"#;
+
+const OPENROUTER_API_KEY_FRAGMENT: &str = r#"
+transforms:
+  - name: secrets
+    config:
+      secrets:
+        - id: OPENROUTER_API_KEY_AUTHORIZATION
+          source:
+            placeholder: OPENROUTER_API_KEY
+          inject:
+            header: Authorization
+            formatter: "Bearer {{.Value}}"
+          rules: [{ host: openrouter.ai }]
 "#;
 
 // The `openai-codex` broker credential this references is managed by

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -12,6 +12,11 @@ fn harness_auth_fragments_are_baked_in() {
         .unwrap();
     assert!(placeholder_env(&[codex_access]).is_empty());
 
+    let openrouter = harness_auth_fragment("openrouter", "api_key")
+        .unwrap()
+        .unwrap();
+    assert!(placeholder_env(&[openrouter]).is_empty());
+
     assert!(harness_auth_fragment("codex", "bogus").unwrap().is_none());
 
     let infra = infra_fragment().unwrap();


### PR DESCRIPTION
## Summary
- Add OpenRouter as a Codex provider configuration, not a user-facing harness selector.
- Keep runtime routing on `codex`; blocks-mode Codex auto-selects `modelProvider=openrouter` when `OPENROUTER_MODEL` is set, when `CODEX_MODEL_PROVIDER=openrouter` is set, or when a per-turn Codex `--model` override is a provider-style slug such as `anthropic/claude-fable-5`.
- Wire `OPENROUTER_API_KEY` through the sandbox placeholder env and iron-proxy auth fragment for `openrouter.ai`.
- Update docs for operator configuration and keep Slack/API harness values unchanged.

## Verification
- `cargo test --manifest-path crates/harness-server/Cargo.toml`
- `cargo test -p centaur-iron-proxy -p centaur-session-core`
- `cargo check -p centaur-session-runtime -p centaur-session-cli -p centaur-api-server`