### PR TITLE
feat(slackbotv2): per-turn codex reasoning effort via -rsn flag

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -140,6 +140,7 @@ pub(crate) fn run_codex_blocks_server(config: CodexHarnessServer) -> Result<()> 
                 input,
                 client_user_message_id,
                 model,
+                reasoning,
             }) => {
                 if let Err(error) = run_codex_user_turn(
                     &mut codex,
@@ -153,6 +154,7 @@ pub(crate) fn run_codex_blocks_server(config: CodexHarnessServer) -> Result<()> 
                         let model_provider = config.model_provider_for(model.as_deref());
                         (model, model_provider)
                     },
+                    reasoning,
                 ) {
                     let fallback_thread_id = thread_id.as_deref().unwrap_or("codex");
                     eprintln!("Codex blocks turn failed: {error:#}");
@@ -188,6 +190,7 @@ fn run_codex_user_turn<W: Write>(
     input: Vec<UserInput>,
     client_user_message_id: Option<String>,
     model_and_provider: (Option<String>, String),
+    reasoning: Option<String>,
 ) -> Result<()> {
     let (model, model_provider) = model_and_provider;
     if thread_id.is_none() {
@@ -212,6 +215,12 @@ fn run_codex_user_turn<W: Write>(
     }
     if let Some(model) = model {
         params["model"] = Value::String(model);
+    }
+    // Per-turn reasoning effort (codex `turn/start.effort`), parsed from the
+    // `-rsn` message flag. Values match codex's ReasoningEffort enum
+    // (none|minimal|low|medium|high|xhigh); validation happens upstream.
+    if let Some(reasoning) = reasoning {
+        params["effort"] = Value::String(reasoning);
     }
 
     let turn_request_id = next_request_id(request_id);

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -92,6 +92,9 @@ pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()>
                 input,
                 client_user_message_id,
                 model,
+                // Reasoning effort only applies to the codex harness; the
+                // emulated (claude/amp) app-server has no equivalent knob.
+                reasoning: _,
             }) => {
                 if let Some(model) = model {
                     state.model = model;
@@ -196,6 +199,7 @@ pub(crate) enum BlocksCommand {
         input: Vec<UserInput>,
         client_user_message_id: Option<String>,
         model: Option<String>,
+        reasoning: Option<String>,
     },
     Interrupt,
     AttachmentChunk,
@@ -228,6 +232,8 @@ struct BlocksLine {
     client_user_message_id: Option<String>,
     #[serde(default)]
     model: Option<String>,
+    #[serde(default)]
+    reasoning: Option<String>,
     #[serde(rename = "attachmentId", default)]
     attachment_id: Option<String>,
     #[serde(default)]
@@ -336,6 +342,10 @@ pub(crate) fn parse_blocks_line_with_state(
                     .model
                     .map(|model| model.trim().to_owned())
                     .filter(|model| !model.is_empty()),
+                reasoning: parsed
+                    .reasoning
+                    .map(|reasoning| reasoning.trim().to_owned())
+                    .filter(|reasoning| !reasoning.is_empty()),
             })
         }
         "attachment.chunk" => {
@@ -1163,6 +1173,33 @@ mod tests {
             panic!("expected user command");
         };
         assert_eq!(model, None);
+    }
+
+    #[test]
+    fn parses_blocks_user_line_with_reasoning_override() {
+        let line = r#"{"type":"user","thread_key":"web:t1","reasoning":"high","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#;
+        let BlocksCommand::User { reasoning, .. } = parse_blocks_line(line).expect("parses") else {
+            panic!("expected user command");
+        };
+        assert_eq!(reasoning.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn ignores_blank_reasoning_on_blocks_user_line() {
+        let line = r#"{"type":"user","reasoning":"  ","text":"hi"}"#;
+        let BlocksCommand::User { reasoning, .. } = parse_blocks_line(line).expect("parses") else {
+            panic!("expected user command");
+        };
+        assert_eq!(reasoning, None);
+    }
+
+    #[test]
+    fn defaults_reasoning_to_none_when_absent() {
+        let line = r#"{"type":"user","text":"hi"}"#;
+        let BlocksCommand::User { reasoning, .. } = parse_blocks_line(line).expect("parses") else {
+            panic!("expected user command");
+        };
+        assert_eq!(reasoning, None);
     }
 
     #[test]

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -360,6 +360,57 @@ fn fake_codex_blocks_mode_spawns_app_server_and_translates_user_blocks() {
 }
 
 #[test]
+fn fake_codex_blocks_mode_forwards_reasoning_as_turn_start_effort() {
+    let fake_codex = temp_path("fake-codex-effort.sh");
+    let fake_codex_log = temp_path("fake-codex-effort-requests.jsonl");
+    let script = fake_codex_app_server_script(&fake_codex_log);
+    std::fs::write(&fake_codex, script).expect("write fake codex script");
+    let mut permissions = std::fs::metadata(&fake_codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, permissions).expect("chmod fake codex script");
+
+    let mut bridge = BridgeProcess::spawn_harness_blocks(
+        Harness::Codex,
+        None,
+        Some((
+            "CODEX_BIN",
+            fake_codex.to_str().expect("utf-8 fake codex path"),
+        )),
+    );
+    let turn = bridge.run_blocks_user_line(
+        json!({
+            "type": "user",
+            "thread_key": "slack:C123:123.456",
+            "reasoning": "high",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "say codex blocks"}],
+            },
+        }),
+        Duration::from_secs(10),
+    );
+    bridge.finish_successfully();
+    assert_completed_turn(&turn);
+
+    let requests = std::fs::read_to_string(&fake_codex_log).expect("read fake codex request log");
+    let turn_start = requests
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("fake codex request JSON"))
+        .find(|value| value.get("method").and_then(Value::as_str) == Some("turn/start"))
+        .expect("blocks mode did not send turn/start");
+    assert_eq!(
+        turn_start.pointer("/params/effort").and_then(Value::as_str),
+        Some("high"),
+        "reasoning should be forwarded as turn/start effort; turn_start={turn_start}"
+    );
+
+    let _ = std::fs::remove_file(fake_codex);
+    let _ = std::fs::remove_file(fake_codex_log);
+}
+
+#[test]
 fn fake_amp_final_only_assistant_message_is_chunked_into_codex_deltas() {
     let expected = expected_long_text();
     let system = json!({
@@ -982,7 +1033,11 @@ impl BridgeProcess {
         if let Some(model) = model {
             input["model"] = Value::String(model.to_string());
         }
-        self.send(input);
+        self.run_blocks_user_line(input, timeout)
+    }
+
+    fn run_blocks_user_line(&mut self, user_line: Value, timeout: Duration) -> TurnCapture {
+        self.send(user_line);
 
         let deadline = Instant::now() + timeout;
         let mut capture = TurnCapture::default();

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -310,10 +310,11 @@ async function syncThreadMessageToSession(
   const serializedMessage = await serializeMessage(message)
   const overrides = extractMessageOverrides(serializedMessage.text)
   serializedMessage.text = overrides.cleanedText
-  if (overrides.harnessType || overrides.model) {
+  if (overrides.harnessType || overrides.model || overrides.reasoning) {
     traceLog(input.options, 'slackbotv2_forward_overrides_parsed', trace, {
       harness_type: overrides.harnessType,
-      model: overrides.model
+      model: overrides.model,
+      reasoning: overrides.reasoning
     })
   }
   traceLog(input.options, 'slackbotv2_forward_message_serialized', trace, {
@@ -357,6 +358,7 @@ async function syncThreadMessageToSession(
     harnessType: shouldStartExecution ? overrides.harnessType : undefined,
     messages: messagesToAppend,
     model: overrides.model,
+    reasoning: overrides.reasoning,
     onEventId: eventId => {
       lastEventId = Math.max(lastEventId, eventId)
     },

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -2,20 +2,24 @@
  * Inline message directives, restored from the v1 slackbot:
  *   --claude | --claude-code | --amp | --codex   pick the harness for the thread
  *   --model <name> (or --model=<name>)           pick the model within that harness
+ *   -rsn <effort> (or -rsn=<effort>)             per-turn reasoning effort (codex)
  *   --fable | --opus | --sonnet | --haiku        model shortcuts (imply claude-code)
  *
  * Flags are stripped from the text before it reaches the agent. The harness
  * applies at session creation — an explicit harness flag on a thread pinned to
- * another harness restarts the thread on the requested one. The model applies
- * per turn via the blocks-protocol `model` field; `--model` accepts either a
- * full model id (claude-sonnet-4-6, gpt-5.2, …), an amp mode (deep/fast), or a
- * Claude alias (fable/opus/sonnet/haiku) which expands to the full id.
+ * another harness restarts the thread on the requested one. The model and
+ * reasoning effort apply per turn via the blocks-protocol `model` / `reasoning`
+ * fields; `--model` accepts either a full model id (claude-sonnet-4-6, gpt-5.2,
+ * ...), an amp mode (deep/fast), or a Claude alias (fable/opus/sonnet/haiku)
+ * which expands to the full id. Reasoning effort only affects the codex harness
+ * (it maps to codex's `turn/start` `effort`); other harnesses ignore it.
  */
 
 export type MessageOverrides = {
   cleanedText: string
   harnessType?: string
   model?: string
+  reasoning?: string
 }
 
 // Flag name -> HarnessType wire value (serde lowercase of the Rust enum).
@@ -46,16 +50,45 @@ const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> =
 
 const MODEL_FLAG_PATTERN = /(?:^|\s)--model[=\s]+([A-Za-z0-9._/-]+)(?=\s|$)/i
 
+// Single dash by design: a short per-turn knob (`-rsn high`), so it can't reuse
+// the `--`-prefixed flagPattern() helper. Value-capturing like --model.
+const REASONING_FLAG_PATTERN = /(?:^|\s)-rsn[=\s]+([A-Za-z-]+)(?=\s|$)/i
+
+// Codex reasoning efforts (turn/start `effort`), plus convenience aliases.
+const REASONING_EFFORTS: Record<string, string> = {
+  none: 'none',
+  minimal: 'minimal',
+  min: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  med: 'medium',
+  high: 'high',
+  hi: 'high',
+  xhigh: 'xhigh',
+  xhi: 'xhigh',
+  'x-high': 'xhigh'
+}
+
 export function extractMessageOverrides(text: string): MessageOverrides {
   let cleaned = text
   let harnessType: string | undefined
   let model: string | undefined
+  let reasoning: string | undefined
 
   const modelMatch = MODEL_FLAG_PATTERN.exec(cleaned)
   if (modelMatch) {
     const value = modelMatch[1]!
     model = CLAUDE_MODEL_ALIASES[value.toLowerCase()] ?? value
     cleaned = stripMatch(cleaned, modelMatch)
+  }
+
+  const reasoningMatch = REASONING_FLAG_PATTERN.exec(cleaned)
+  if (reasoningMatch) {
+    const normalized = REASONING_EFFORTS[reasoningMatch[1]!.toLowerCase()]
+    if (normalized) {
+      reasoning = normalized
+      cleaned = stripMatch(cleaned, reasoningMatch)
+    }
   }
 
   for (const [flag, harness] of Object.entries(HARNESS_FLAGS)) {
@@ -76,7 +109,8 @@ export function extractMessageOverrides(text: string): MessageOverrides {
   return {
     cleanedText: cleaned === text ? text : cleaned.trim(),
     harnessType,
-    model
+    model,
+    reasoning
   }
 }
 

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -185,7 +185,8 @@ export async function forwardToSessionApi(
     input.executeMessage,
     input.model,
     input.executeContextMessages,
-    input.contextPreamble
+    input.contextPreamble,
+    input.reasoning
   )
   traceLog(options, 'slackbotv2_session_execute_complete', input.trace, {
     execution_id: execution.execution_id,
@@ -789,7 +790,8 @@ async function executeSession(
   message: SlackbotV2ApiMessage,
   model?: string,
   contextMessages?: SlackbotV2ApiMessage[],
-  contextPreamble?: string
+  contextPreamble?: string,
+  reasoning?: string
 ): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
   const requesterIdentity = await resolveRequesterIdentity(options, message)
@@ -802,7 +804,8 @@ async function executeSession(
       model,
       requesterIdentity,
       contextMessages,
-      contextPreamble
+      contextPreamble,
+      reasoning
     ),
     ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
@@ -953,7 +956,8 @@ function toCodexInputLines(
   model?: string,
   requesterIdentity?: RequesterIdentity,
   contextMessages?: SlackbotV2ApiMessage[],
-  contextPreamble?: string
+  contextPreamble?: string,
+  reasoning?: string
 ): string[] {
   const staged = new Map<SlackbotV2ApiAttachment, string>()
   const lines: string[] = []
@@ -966,7 +970,8 @@ function toCodexInputLines(
       model,
       requesterIdentity,
       contextMessages,
-      contextPreamble
+      contextPreamble,
+      reasoning
     )
     if (
       inlineLine.length <= MAX_CODEX_INPUT_LINE_CHARS
@@ -986,7 +991,8 @@ function toCodexInputLines(
       model,
       requesterIdentity,
       contextMessages,
-      contextPreamble
+      contextPreamble,
+      reasoning
     )
   )
   return lines
@@ -1012,13 +1018,15 @@ function toCodexInputLineWithStaged(
   model?: string,
   requesterIdentity?: RequesterIdentity,
   contextMessages?: SlackbotV2ApiMessage[],
-  contextPreamble?: string
+  contextPreamble?: string,
+  reasoning?: string
 ): string {
   return JSON.stringify({
     type: 'user',
     thread_key: threadId,
     trace_metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),
     ...(model ? { model } : {}),
+    ...(reasoning ? { reasoning } : {}),
     message: {
       role: 'user',
       content: codexInputContent(

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -157,6 +157,8 @@ export type ForwardSessionInput = {
   messages: SlackbotV2ApiMessage[]
   /** Per-turn model override parsed from message flags (--model/--opus/...). */
   model?: string
+  /** Per-turn reasoning effort parsed from the `-rsn` flag (codex only). */
+  reasoning?: string
   onEventId(eventId: number): void
   openStream: boolean
   threadId: string

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -7,7 +7,8 @@ describe('extractMessageOverrides', () => {
     expect(result).toEqual({
       cleanedText: 'review this PR --not-a-known-flag stays',
       harnessType: undefined,
-      model: undefined
+      model: undefined,
+      reasoning: undefined
     })
   })
 
@@ -15,7 +16,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--claude review this')).toEqual({
       cleanedText: 'review this',
       harnessType: 'claudecode',
-      model: undefined
+      model: undefined,
+      reasoning: undefined
     })
     expect(extractMessageOverrides('--claude-code review this').harnessType).toBe('claudecode')
     expect(extractMessageOverrides('--amp review this').harnessType).toBe('amp')
@@ -26,7 +28,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('review this --amp please')).toEqual({
       cleanedText: 'review this please',
       harnessType: 'amp',
-      model: undefined
+      model: undefined,
+      reasoning: undefined
     })
   })
 
@@ -38,12 +41,14 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--claude --model claude-sonnet-4-6 fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: 'claudecode',
-      model: 'claude-sonnet-4-6'
+      model: 'claude-sonnet-4-6',
+      reasoning: undefined
     })
     expect(extractMessageOverrides('--codex --model=gpt-5.2 fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: 'codex',
-      model: 'gpt-5.2'
+      model: 'gpt-5.2',
+      reasoning: undefined
     })
   })
 
@@ -51,7 +56,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--opus fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: 'claudecode',
-      model: 'claude-opus-4-8'
+      model: 'claude-opus-4-8',
+      reasoning: undefined
     })
     expect(extractMessageOverrides('--sonnet fix it').model).toBe('claude-sonnet-4-6')
     expect(extractMessageOverrides('--haiku fix it').model).toBe('claude-haiku-4-5')
@@ -77,7 +83,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--codex --opus fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: 'codex',
-      model: 'claude-opus-4-8'
+      model: 'claude-opus-4-8',
+      reasoning: undefined
     })
     expect(extractMessageOverrides('--sonnet --model claude-opus-4-8 fix it').model).toBe(
       'claude-opus-4-8'
@@ -94,7 +101,8 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--claude')).toEqual({
       cleanedText: '',
       harnessType: 'claudecode',
-      model: undefined
+      model: undefined,
+      reasoning: undefined
     })
   })
 
@@ -102,7 +110,57 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('what does --model do?')).toEqual({
       cleanedText: 'what does --model do?',
       harnessType: undefined,
-      model: undefined
+      model: undefined,
+      reasoning: undefined
+    })
+  })
+
+  test('parses -rsn with space or equals', () => {
+    expect(extractMessageOverrides('-rsn high fix it')).toEqual({
+      cleanedText: 'fix it',
+      harnessType: undefined,
+      model: undefined,
+      reasoning: 'high'
+    })
+    expect(extractMessageOverrides('-rsn=medium fix it').reasoning).toBe('medium')
+  })
+
+  test('-rsn is case-insensitive and normalizes the effort value', () => {
+    expect(extractMessageOverrides('-rsn HIGH fix it').reasoning).toBe('high')
+    expect(extractMessageOverrides('-rsn Medium fix it').reasoning).toBe('medium')
+  })
+
+  test('-rsn accepts short aliases', () => {
+    expect(extractMessageOverrides('-rsn min fix it').reasoning).toBe('minimal')
+    expect(extractMessageOverrides('-rsn med fix it').reasoning).toBe('medium')
+    expect(extractMessageOverrides('-rsn hi fix it').reasoning).toBe('high')
+    expect(extractMessageOverrides('-rsn xhi fix it').reasoning).toBe('xhigh')
+  })
+
+  test('-rsn combines with a harness flag', () => {
+    expect(extractMessageOverrides('-rsn high --codex audit this')).toEqual({
+      cleanedText: 'audit this',
+      harnessType: 'codex',
+      model: undefined,
+      reasoning: 'high'
+    })
+  })
+
+  test('-rsn with an unknown effort value is left untouched', () => {
+    expect(extractMessageOverrides('-rsn turbo fix it')).toEqual({
+      cleanedText: '-rsn turbo fix it',
+      harnessType: undefined,
+      model: undefined,
+      reasoning: undefined
+    })
+  })
+
+  test('-rsn without a value is left untouched', () => {
+    expect(extractMessageOverrides('what does -rsn do?')).toEqual({
+      cleanedText: 'what does -rsn do?',
+      harnessType: undefined,
+      model: undefined,
+      reasoning: undefined
     })
   })
 })

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -128,6 +128,25 @@ describe('forwardToSessionApi overrides', () => {
     expect('model' in line).toBe(false)
   })
 
+  test('includes reasoning override on the execute input line', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('audit this'), { reasoning: 'high' })
+    )
+    const execute = requests.find(request => request.url.endsWith('/execute'))
+    const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
+    expect(line.reasoning).toBe('high')
+  })
+
+  test('omits reasoning field when no override is set', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
+    const execute = requests.find(request => request.url.endsWith('/execute'))
+    const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
+    expect('reasoning' in line).toBe(false)
+  })
+
   test('retries session creation with existing harness on 409 conflict', async () => {
     const { fetchFn, requests } = fakeApi({
       createSession: [


### PR DESCRIPTION
Replacement for #549 with conflicts resolved against current main.\n\nValidation:\n- cargo test --manifest-path crates/harness-server/Cargo.toml\n- pnpm --dir services/slackbotv2 test\n- pnpm --dir services/slackbotv2 check:types