### PR TITLE
feat: tighten ETL context RLS

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0019_etl_context_rls.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0019_etl_context_rls.sql
@@ -1,0 +1,234 @@
+create or replace function centaur_current_slack_channel_id()
+returns text
+language sql
+stable
+as $$
+    select nullif(current_setting('centaur.slack_channel_id', true), '')
+$$;
+
+create table if not exists slack_context_rls_admin_channels (
+    channel_id text primary key,
+    created_at timestamptz not null default now()
+);
+
+create or replace function centaur_etl_admin_channel()
+returns boolean
+language sql
+stable
+as $$
+    select exists (
+        select 1
+        from slack_context_rls_admin_channels
+        where channel_id = centaur_current_slack_channel_id()
+    )
+$$;
+
+grant select on slack_context_rls_admin_channels
+    to centaur_slack_reader, centaur_slack_admin;
+grant execute on function centaur_current_slack_channel_id()
+    to centaur_slack_reader, centaur_slack_admin;
+grant execute on function centaur_etl_admin_channel()
+    to centaur_slack_reader, centaur_slack_admin;
+
+alter table slack_sync_channels enable row level security;
+alter table slack_sync_users enable row level security;
+alter table slack_sync_messages enable row level security;
+alter table slack_sync_message_attachments enable row level security;
+alter table company_context_documents enable row level security;
+
+drop policy if exists centaur_slack_channels_admin_select on slack_sync_channels;
+create policy centaur_slack_channels_admin_select
+    on slack_sync_channels
+    for select
+    to centaur_slack_admin
+    using (true);
+
+drop policy if exists centaur_slack_channels_reader_select on slack_sync_channels;
+create policy centaur_slack_channels_reader_select
+    on slack_sync_channels
+    for select
+    to centaur_slack_reader
+    using (
+        centaur_etl_admin_channel()
+        or channel_id = centaur_current_slack_channel_id()
+    );
+
+drop policy if exists centaur_slack_users_admin_select on slack_sync_users;
+create policy centaur_slack_users_admin_select
+    on slack_sync_users
+    for select
+    to centaur_slack_admin
+    using (true);
+
+drop policy if exists centaur_slack_users_reader_select on slack_sync_users;
+create policy centaur_slack_users_reader_select
+    on slack_sync_users
+    for select
+    to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_slack_messages_reader_select on slack_sync_messages;
+create policy centaur_slack_messages_reader_select
+    on slack_sync_messages
+    for select
+    to centaur_slack_reader
+    using (
+        centaur_etl_admin_channel()
+        or channel_id = centaur_current_slack_channel_id()
+    );
+
+drop policy if exists centaur_slack_message_attachments_reader_select
+    on slack_sync_message_attachments;
+create policy centaur_slack_message_attachments_reader_select
+    on slack_sync_message_attachments
+    for select
+    to centaur_slack_reader
+    using (
+        centaur_etl_admin_channel()
+        or channel_id = centaur_current_slack_channel_id()
+    );
+
+drop policy if exists centaur_context_docs_reader_select on company_context_documents;
+create policy centaur_context_docs_reader_select
+    on company_context_documents
+    for select
+    to centaur_slack_reader
+    using (
+        centaur_etl_admin_channel()
+        or (
+            source = 'slack'
+            and metadata ->> 'channel_id' = centaur_current_slack_channel_id()
+        )
+    );
+
+grant select on
+    google_drive_sync_runs,
+    google_drive_sync_files,
+    google_drive_sync_checkpoints,
+    google_calendar_sync_runs,
+    google_calendar_sync_calendars,
+    google_calendar_sync_events,
+    google_calendar_sync_checkpoints,
+    linear_sync_runs,
+    linear_sync_projects,
+    linear_sync_issues,
+    linear_sync_comments,
+    linear_sync_checkpoints
+to centaur_slack_reader, centaur_slack_admin;
+
+alter table google_drive_sync_runs enable row level security;
+alter table google_drive_sync_files enable row level security;
+alter table google_drive_sync_checkpoints enable row level security;
+alter table google_calendar_sync_runs enable row level security;
+alter table google_calendar_sync_calendars enable row level security;
+alter table google_calendar_sync_events enable row level security;
+alter table google_calendar_sync_checkpoints enable row level security;
+alter table linear_sync_runs enable row level security;
+alter table linear_sync_projects enable row level security;
+alter table linear_sync_issues enable row level security;
+alter table linear_sync_comments enable row level security;
+alter table linear_sync_checkpoints enable row level security;
+
+drop policy if exists centaur_google_drive_runs_admin_select on google_drive_sync_runs;
+create policy centaur_google_drive_runs_admin_select
+    on google_drive_sync_runs for select to centaur_slack_admin using (true);
+drop policy if exists centaur_google_drive_runs_reader_select on google_drive_sync_runs;
+create policy centaur_google_drive_runs_reader_select
+    on google_drive_sync_runs for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_google_drive_files_admin_select on google_drive_sync_files;
+create policy centaur_google_drive_files_admin_select
+    on google_drive_sync_files for select to centaur_slack_admin using (true);
+drop policy if exists centaur_google_drive_files_reader_select on google_drive_sync_files;
+create policy centaur_google_drive_files_reader_select
+    on google_drive_sync_files for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_google_drive_checkpoints_admin_select
+    on google_drive_sync_checkpoints;
+create policy centaur_google_drive_checkpoints_admin_select
+    on google_drive_sync_checkpoints for select to centaur_slack_admin using (true);
+drop policy if exists centaur_google_drive_checkpoints_reader_select
+    on google_drive_sync_checkpoints;
+create policy centaur_google_drive_checkpoints_reader_select
+    on google_drive_sync_checkpoints for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_google_calendar_runs_admin_select on google_calendar_sync_runs;
+create policy centaur_google_calendar_runs_admin_select
+    on google_calendar_sync_runs for select to centaur_slack_admin using (true);
+drop policy if exists centaur_google_calendar_runs_reader_select on google_calendar_sync_runs;
+create policy centaur_google_calendar_runs_reader_select
+    on google_calendar_sync_runs for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_google_calendar_calendars_admin_select
+    on google_calendar_sync_calendars;
+create policy centaur_google_calendar_calendars_admin_select
+    on google_calendar_sync_calendars for select to centaur_slack_admin using (true);
+drop policy if exists centaur_google_calendar_calendars_reader_select
+    on google_calendar_sync_calendars;
+create policy centaur_google_calendar_calendars_reader_select
+    on google_calendar_sync_calendars for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_google_calendar_events_admin_select
+    on google_calendar_sync_events;
+create policy centaur_google_calendar_events_admin_select
+    on google_calendar_sync_events for select to centaur_slack_admin using (true);
+drop policy if exists centaur_google_calendar_events_reader_select
+    on google_calendar_sync_events;
+create policy centaur_google_calendar_events_reader_select
+    on google_calendar_sync_events for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_google_calendar_checkpoints_admin_select
+    on google_calendar_sync_checkpoints;
+create policy centaur_google_calendar_checkpoints_admin_select
+    on google_calendar_sync_checkpoints for select to centaur_slack_admin using (true);
+drop policy if exists centaur_google_calendar_checkpoints_reader_select
+    on google_calendar_sync_checkpoints;
+create policy centaur_google_calendar_checkpoints_reader_select
+    on google_calendar_sync_checkpoints for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_linear_runs_admin_select on linear_sync_runs;
+create policy centaur_linear_runs_admin_select
+    on linear_sync_runs for select to centaur_slack_admin using (true);
+drop policy if exists centaur_linear_runs_reader_select on linear_sync_runs;
+create policy centaur_linear_runs_reader_select
+    on linear_sync_runs for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_linear_projects_admin_select on linear_sync_projects;
+create policy centaur_linear_projects_admin_select
+    on linear_sync_projects for select to centaur_slack_admin using (true);
+drop policy if exists centaur_linear_projects_reader_select on linear_sync_projects;
+create policy centaur_linear_projects_reader_select
+    on linear_sync_projects for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_linear_issues_admin_select on linear_sync_issues;
+create policy centaur_linear_issues_admin_select
+    on linear_sync_issues for select to centaur_slack_admin using (true);
+drop policy if exists centaur_linear_issues_reader_select on linear_sync_issues;
+create policy centaur_linear_issues_reader_select
+    on linear_sync_issues for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_linear_comments_admin_select on linear_sync_comments;
+create policy centaur_linear_comments_admin_select
+    on linear_sync_comments for select to centaur_slack_admin using (true);
+drop policy if exists centaur_linear_comments_reader_select on linear_sync_comments;
+create policy centaur_linear_comments_reader_select
+    on linear_sync_comments for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());
+
+drop policy if exists centaur_linear_checkpoints_admin_select on linear_sync_checkpoints;
+create policy centaur_linear_checkpoints_admin_select
+    on linear_sync_checkpoints for select to centaur_slack_admin using (true);
+drop policy if exists centaur_linear_checkpoints_reader_select on linear_sync_checkpoints;
+create policy centaur_linear_checkpoints_reader_select
+    on linear_sync_checkpoints for select to centaur_slack_reader
+    using (centaur_etl_admin_channel());

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import asyncpg
 
-from centaur_sdk.tool_sdk import secret
+from centaur_sdk.tool_sdk import get_tool_context, secret
 
 DEFAULT_SEARCH_LIMIT = 10
 MAX_SEARCH_LIMIT = 50
@@ -80,7 +80,7 @@ def _clamp(value: int, *, minimum: int, maximum: int) -> int:
 
 
 def _scoped_database_url() -> str:
-    value = os.getenv(COMPANY_CONTEXT_DSN_ENV)
+    value = os.getenv(COMPANY_CONTEXT_DSN_ENV)  # noqa: TID251
     if value is None:
         value = secret(COMPANY_CONTEXT_DSN_ENV, default="")
     value = value.strip()
@@ -247,6 +247,28 @@ def _slack_after_query(query: str, latest_date: str | None) -> str:
     return f"{query} after:{latest_date[:10]}"
 
 
+def _current_slack_channel_id() -> str | None:
+    """Return the channel/group id for the active Slack thread, or None for DMs."""
+    try:
+        thread_key = get_tool_context().thread_key
+    except LookupError:
+        return None
+    if not thread_key:
+        return None
+    for segment in str(thread_key).split(":")[1:]:
+        clean = segment.strip()
+        if clean.startswith(("C", "G")):
+            return clean
+        if clean.startswith("D"):
+            return None
+    return None
+
+
+async def _is_etl_admin_channel(conn: asyncpg.Connection) -> bool:
+    value = await conn.fetchval("SELECT centaur_etl_admin_channel()")
+    return bool(value)
+
+
 def _load_slack_client() -> Any:
     """Load the sibling Slack tool client without making company_context import it eagerly."""
     candidate_roots = [
@@ -409,12 +431,18 @@ class CompanyContextClient:
                     source_type=source_type,
                 )
                 try:
-                    live_query = _slack_after_query(query, latest.get("latest_date"))
-                    live_messages = _load_slack_client().search_messages(
-                        live_query,
-                        max_results=limit,
-                    )
-                    live_results = [_live_slack_result(message) for message in live_messages]
+                    slack_channel_id = _current_slack_channel_id()
+                    if slack_channel_id is None:
+                        live_error = "live Slack search requires a channel-scoped thread"
+                    else:
+                        live_channels = None if await _is_etl_admin_channel(conn) else [slack_channel_id]
+                        live_query = _slack_after_query(query, latest.get("latest_date"))
+                        live_messages = _load_slack_client().search_messages(
+                            live_query,
+                            max_results=limit,
+                            channels=live_channels,
+                        )
+                        live_results = [_live_slack_result(message) for message in live_messages]
                 except Exception as exc:
                     live_error = str(exc)
 

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -10,16 +10,19 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 import client as company_context_client
-from centaur_sdk.tool_sdk import ToolContext, reset_tool_context, set_tool_context
 from client import CompanyContextClient
+
+from centaur_sdk.tool_sdk import ToolContext, reset_tool_context, set_tool_context
 
 
 class _FakeConnection:
-    def __init__(self, *, rows=None, row=None) -> None:
+    def __init__(self, *, rows=None, row=None, val=None) -> None:
         self.rows = rows or []
         self.row = row
+        self.val = val
         self.fetch_calls = []
         self.fetchrow_calls = []
+        self.fetchval_calls = []
         self.closed = False
 
     async def fetch(self, query, *args):
@@ -30,6 +33,10 @@ class _FakeConnection:
         self.fetchrow_calls.append((query, args))
         return self.row
 
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append((query, args))
+        return self.val
+
     async def close(self):
         self.closed = True
 
@@ -39,8 +46,8 @@ class _FakeSlackClient:
         self.messages = messages or []
         self.calls = []
 
-    def search_messages(self, query, max_results=20):
-        self.calls.append((query, max_results))
+    def search_messages(self, query, max_results=20, channels=None):
+        self.calls.append((query, max_results, channels))
         return self.messages
 
 
@@ -121,6 +128,7 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
 
     monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
     monkeypatch.setattr(company_context_client, "_load_slack_client", lambda: fake_slack)
+    monkeypatch.setattr(company_context_client, "_current_slack_channel_id", lambda: "C123")
 
     result = CompanyContextClient("postgresql://example").search(
         "ParadeDB BM25",
@@ -134,7 +142,7 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
     assert result["indexed_count"] == 1
     assert result["live_count"] == 0
     assert result["indexed_cutoff"] == "2026-05-10T15:30:00+00:00"
-    assert fake_slack.calls == [("ParadeDB BM25 after:2026-05-10", 5)]
+    assert fake_slack.calls == [("ParadeDB BM25 after:2026-05-10", 5, ["C123"])]
     assert result["results"][0] == {
         "document_id": "slack:thread:C123:1770000000.000000",
         "source": "slack",
@@ -207,6 +215,7 @@ def test_search_appends_live_slack_gap_results(monkeypatch):
 
     monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
     monkeypatch.setattr(company_context_client, "_load_slack_client", lambda: fake_slack)
+    monkeypatch.setattr(company_context_client, "_current_slack_channel_id", lambda: "C123")
 
     result = CompanyContextClient("postgresql://example").search(
         "state root mismatch",
@@ -220,7 +229,7 @@ def test_search_appends_live_slack_gap_results(monkeypatch):
     assert result["live_count"] == 1
     assert result["indexed_cutoff"] == "2026-05-10T15:30:00+00:00"
     assert result["live_error"] is None
-    assert fake_slack.calls == [("state root mismatch after:2026-05-10", 7)]
+    assert fake_slack.calls == [("state root mismatch after:2026-05-10", 7, ["C123"])]
     assert result["results"] == [
         {
             "document_id": "",
@@ -269,6 +278,7 @@ def test_search_preserves_existing_slack_after_modifier(monkeypatch):
 
     monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
     monkeypatch.setattr(company_context_client, "_load_slack_client", lambda: fake_slack)
+    monkeypatch.setattr(company_context_client, "_current_slack_channel_id", lambda: "C123")
 
     result = CompanyContextClient("postgresql://example").search(
         "state root after:2026-05-11",
@@ -276,7 +286,7 @@ def test_search_preserves_existing_slack_after_modifier(monkeypatch):
     )
 
     assert result["status"] == "ok"
-    assert fake_slack.calls == [("state root after:2026-05-11", 10)]
+    assert fake_slack.calls == [("state root after:2026-05-11", 10, ["C123"])]
 
 
 def test_search_uses_or_terms_and_drops_stop_words(monkeypatch):


### PR DESCRIPTION
## Summary
- tighten ETL RLS so Slack channel principals only see Slack rows/docs for their channel unless allowlisted as admin
- keep projected Slack documents visible to their source channel while restricting Google Drive, Google Calendar, and Linear ETL rows/docs to admin channels
- scope live Slack fallback searches to the current Slack channel unless the channel is allowlisted as an ETL admin

## Validation
- `uv run --with ruff ruff check tools/productivity/company_context/client.py tools/productivity/company_context/tests/test_client.py`
- `uv run --with pytest --with asyncpg --with rich pytest tools/productivity/company_context/tests/test_client.py`
- `cargo test -p centaur-api-server postgres_listeners_retain_sandbox_env_name_and_database`
