### PR TITLE
feat: add GitHub OAuth app provider

### DIFF
--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -147,7 +147,8 @@ module Oauth
         client_secret: @app.client_secret,
         code: code.to_s,
         redirect_uri: oauth_callback_redirect_uri(@app.slug),
-        code_verifier: code_verifier.to_s
+        code_verifier: code_verifier.to_s,
+        require_refresh_token: @provider.refreshable?
       )
     end
 
@@ -162,7 +163,7 @@ module Oauth
         if credential.new_record?
           credential.namespace = @app.credential_namespace
           credential.foreign_id = "#{@app.provider}-#{@app.slug}-#{identity[:subject].downcase}"
-          credential.name = "#{@app.provider.capitalize} – #{identity_display_name(identity)}"
+          credential.name = "#{@provider.display_name} – #{identity_display_name(identity)}"
           credential.token_endpoint = @provider.token_endpoint
           credential.external_user_key = SecureRandom.urlsafe_base64(16)
         end
@@ -179,7 +180,7 @@ module Oauth
           last_refresh: now,
           failure_count: 0, dead: false, dead_reason: nil
         )
-        credential.next_attempt_at = credential.compute_next_attempt_at(now: now)
+        credential.next_attempt_at = @provider.refreshable? ? credential.compute_next_attempt_at(now: now) : nil
         credential.save!
         ensure_wrapping_secret(credential)
         credential
@@ -196,8 +197,12 @@ module Oauth
     end
 
     def enqueue_identity_enrichment(credential)
-      return unless @app.provider == Oauth::Providers::Slack::KEY
-      Oauth::EnrichCredentialIdentityJob.perform_later(credential.id)
+      case @app.provider
+      when Oauth::Providers::Slack::KEY
+        Oauth::EnrichCredentialIdentityJob.perform_later(credential.id)
+      when Oauth::Providers::Github::KEY
+        Oauth::EnrichGithubCredentialIdentityJob.perform_later(credential.id)
+      end
     end
 
     # Wraps a minted credential in a grantable static secret, so an operator can

--- a/services/console/app/jobs/oauth/enrich_github_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_github_credential_identity_job.rb
@@ -1,0 +1,125 @@
+require "json"
+require "net/http"
+require "uri"
+
+module Oauth
+  class EnrichGithubCredentialIdentityJob < ApplicationJob
+    queue_as :default
+
+    USER_ENDPOINT = "https://api.github.com/user"
+    class GithubProfileRetryableError < StandardError; end
+
+    retry_on GithubProfileRetryableError, wait: :polynomially_longer, attempts: 5 do |job, error|
+      credential_id = job.arguments.first
+      Rails.logger.warn do
+        "github oauth credential identity enrichment failed after retries: " \
+          "credential_id=#{credential_id.inspect} error=#{error.class}"
+      end
+    end
+
+    class << self
+      attr_accessor :github_api_http
+    end
+
+    def perform(credential_id)
+      credential = BrokerCredential.includes(:oauth_app, :static_secret).find_by(id: credential_id)
+      return unless credential&.oauth_app&.provider == Oauth::Providers::Github::KEY
+      return if credential.access_token.blank?
+
+      profile = github_profile(credential.access_token)
+      subject = profile[:subject].presence
+      display_name = profile[:name].presence || profile[:email].presence || subject
+      if subject.blank? || display_name.blank?
+        Rails.logger.warn do
+          "github oauth credential identity enrichment returned no identity: " \
+            "credential=#{credential.oid}"
+        end
+        return
+      end
+
+      old_name = credential.name
+      credential.update!(
+        name: "GitHub – #{display_name}",
+        provider_subject: subject,
+        provider_email: profile[:email].presence || credential.provider_email,
+        foreign_id: "github-#{credential.oauth_app.slug}-#{subject.downcase}"
+      )
+
+      secret = credential.static_secret
+      return unless secret
+      return if old_name.present? && secret.name != "#{old_name} token"
+
+      secret.update!(name: "#{credential.name} token")
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+      Rails.logger.warn do
+        "github oauth credential identity enrichment failed to persist: " \
+          "credential=#{credential&.oid || credential_id.inspect} error=#{e.class}"
+      end
+    end
+
+    private
+
+    def github_profile(access_token)
+      response = github_api(access_token)
+      return {} unless response.is_a?(Hash)
+
+      login = response["login"].presence
+      id = response["id"]
+      return {} if login.blank? || id.blank?
+
+      {
+        subject: id.to_s,
+        email: response["email"].presence,
+        name: response["name"].presence || login
+      }
+    rescue GithubProfileRetryableError
+      raise
+    rescue StandardError => e
+      Rails.logger.debug { "github oauth profile lookup failed: #{e.class}" }
+      {}
+    end
+
+    def github_api(access_token)
+      return nil if access_token.blank?
+
+      if self.class.github_api_http
+        return self.class.github_api_http.call(
+          url: USER_ENDPOINT,
+          access_token: access_token
+        )
+      end
+
+      uri = URI.parse(USER_ENDPOINT)
+      req = Net::HTTP::Get.new(uri)
+      req["Accept"] = "application/vnd.github+json"
+      req["Authorization"] = "Bearer #{access_token}"
+      req["X-GitHub-Api-Version"] = "2022-11-28"
+      req["User-Agent"] = "centaur-console"
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = 5
+      http.read_timeout = 5
+
+      response = http.request(req)
+      status = response.code.to_i
+      if status == 429 || status >= 500
+        raise GithubProfileRetryableError, "github user lookup http #{status}"
+      end
+      unless status / 100 == 2
+        Rails.logger.warn { "github oauth profile lookup failed: status=#{status}" }
+        return nil
+      end
+
+      parsed = JSON.parse(response.body.to_s)
+      parsed.is_a?(Hash) ? parsed : nil
+    rescue GithubProfileRetryableError
+      raise
+    rescue JSON::ParserError => e
+      Rails.logger.warn { "github oauth profile lookup returned invalid JSON: #{e.class}" }
+      nil
+    rescue StandardError => e
+      raise GithubProfileRetryableError, e.class.name
+    end
+  end
+end

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -59,7 +59,9 @@ class BrokerCredential < ApplicationRecord
   encrypts :token_endpoint_headers
 
   scope :refreshable, -> {
-    where(dead: false).where("next_attempt_at IS NULL OR next_attempt_at <= ?", Time.current)
+    where(dead: false)
+      .where("last_refresh IS NULL OR refresh_token IS NOT NULL")
+      .where("next_attempt_at IS NULL OR next_attempt_at <= ?", Time.current)
   }
 
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }

--- a/services/console/lib/oauth/providers.rb
+++ b/services/console/lib/oauth/providers.rb
@@ -10,6 +10,7 @@ module Oauth
     # stateless, so sharing one instance across flows is safe.
     def self.registry
       @registry ||= {
+        Github::KEY => Github.new,
         Google::KEY => Google.new,
         Slack::KEY => Slack.new
       }.freeze

--- a/services/console/lib/oauth/providers/github.rb
+++ b/services/console/lib/oauth/providers/github.rb
@@ -1,0 +1,49 @@
+require "digest"
+
+module Oauth
+  module Providers
+    # GitHub OAuth App consent-flow strategy. GitHub's OAuth App token response
+    # carries the access token and scopes but no account identity. To keep the
+    # callback path free of external API calls, the flow stores a deterministic
+    # pending identity derived from the token and EnrichGithubCredentialIdentityJob
+    # replaces it with the authenticated GitHub user id/name/email.
+    class Github
+      KEY = "github"
+      AUTHORIZATION_ENDPOINT = "https://github.com/login/oauth/authorize"
+      TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token"
+      USER_ENDPOINT = "https://api.github.com/user"
+      IDENTITY_SCOPES = [].freeze
+      API_HOSTS = %w[api.github.com github.com].freeze
+
+      def key = KEY
+      def display_name = "GitHub"
+      def authorization_endpoint = AUTHORIZATION_ENDPOINT
+      def token_endpoint = TOKEN_ENDPOINT
+      def identity_scopes = IDENTITY_SCOPES
+      def api_hosts = API_HOSTS
+      def authorization_scope_param = "scope"
+      def scope_separator = " "
+      def extra_authorization_params = {}
+      def refreshable? = false
+
+      def parse_granted_scopes(scope)
+        scope.to_s.split(/[,\s]+/).reject(&:blank?)
+      end
+
+      def refresh_scopes(_scopes) = []
+
+      def identity_from(result, client_id:)
+        if result.access_token.blank?
+          raise Broker::ExchangeError.new("token response returned an empty access_token",
+                                          stage: "parse", code: "missing_access_token")
+        end
+
+        {
+          subject: "pending-#{Digest::SHA256.hexdigest(result.access_token)[0, 32]}",
+          email: nil,
+          name: "Pending GitHub account"
+        }
+      end
+    end
+  end
+end

--- a/services/console/lib/oauth/providers/google.rb
+++ b/services/console/lib/oauth/providers/google.rb
@@ -27,12 +27,14 @@ module Oauth
       VALID_ISSUERS = %w[https://accounts.google.com accounts.google.com].freeze
 
       def key = KEY
+      def display_name = "Google"
       def authorization_endpoint = AUTHORIZATION_ENDPOINT
       def token_endpoint = TOKEN_ENDPOINT
       def identity_scopes = IDENTITY_SCOPES
       def api_hosts = API_HOSTS
       def authorization_scope_param = "scope"
       def scope_separator = " "
+      def refreshable? = true
 
       def parse_granted_scopes(scope) = scope.to_s.split
       def refresh_scopes(scopes) = Array(scopes)

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -14,6 +14,7 @@ module Oauth
       VALID_ISSUERS = %w[https://slack.com].freeze
 
       def key = KEY
+      def display_name = "Slack"
       def authorization_endpoint = AUTHORIZATION_ENDPOINT
       def token_endpoint = TOKEN_ENDPOINT
       def identity_scopes = IDENTITY_SCOPES
@@ -21,6 +22,7 @@ module Oauth
       def authorization_scope_param = "user_scope"
       def scope_separator = ","
       def extra_authorization_params = {}
+      def refreshable? = true
 
       def parse_granted_scopes(scope)
         scope.to_s.split(/[,\s]+/).reject(&:blank?)

--- a/services/console/test/controllers/api/v1/oauth_apps_controller_test.rb
+++ b/services/console/test/controllers/api/v1/oauth_apps_controller_test.rb
@@ -69,7 +69,7 @@ module Api
 
       test "create rejects an unsupported provider" do
         assert_no_difference -> { OauthApp.count } do
-          post api_v1_oauth_apps_url, params: valid_body(provider: "github").to_json, headers: auth_headers
+          post api_v1_oauth_apps_url, params: valid_body(provider: "unsupported").to_json, headers: auth_headers
         end
         assert_response :unprocessable_entity
       end

--- a/services/console/test/controllers/console/oauth_apps_controller_test.rb
+++ b/services/console/test/controllers/console/oauth_apps_controller_test.rb
@@ -53,7 +53,7 @@ module Console
       assert_no_difference -> { OauthApp.count } do
         post console_oauth_app_forms_url, params: {
           oauth_app: {
-            provider: "github", slug: "gh", client_id: "cid", client_secret: "shh",
+            provider: "unsupported", slug: "bad-provider", client_id: "cid", client_secret: "shh",
             allowed_scopes: "a"
           }
         }

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -7,17 +7,23 @@ module Oauth
   # swapping the controller's exchange_client_factory for a client wrapped around
   # an HTTP double returning a canned token response.
   class FlowsControllerTest < ActionDispatch::IntegrationTest
+    include ActiveJob::TestHelper
+
     CLIENT_ID = "acme-google-client-id".freeze
     SLACK_CLIENT_ID = "acme-slack-client-id".freeze
+    GITHUB_CLIENT_ID = "acme-github-client-id".freeze
 
     setup do
       @app = oauth_apps(:acme_google) # slug "google"
       @app.update!(client_secret: "app-secret")
       oauth_apps(:acme_slack).update!(client_secret: "slack-secret")
+      oauth_apps(:acme_github).update!(client_secret: "github-secret")
+      clear_enqueued_jobs
     end
 
     teardown do
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new }
+      clear_enqueued_jobs
     end
 
     class StubHTTP
@@ -61,6 +67,14 @@ module Oauth
           scope: scope,
           token_type: "user"
         }
+      }.merge(overrides).to_json
+    end
+
+    def github_token_body(scope: "repo,read:user", **overrides)
+      {
+        access_token: "gho-user-token",
+        token_type: "bearer",
+        scope: scope
       }.merge(overrides).to_json
     end
 
@@ -120,6 +134,23 @@ module Oauth
       refute_includes scopes, "openid"
       refute_includes scopes, "email"
       refute_includes scopes, "profile"
+    end
+
+    test "start redirects to GitHub with space separated scopes" do
+      get oauth_start_url(slug: "github")
+      assert_response :redirect
+      uri = URI.parse(response.location)
+      assert_equal "github.com", uri.host
+      assert_equal "/login/oauth/authorize", uri.path
+      q = URI.decode_www_form(uri.query).to_h
+      assert_equal GITHUB_CLIENT_ID, q["client_id"]
+      assert_equal "http://www.example.com/oauth/github/callback", q["redirect_uri"]
+      assert_equal "code", q["response_type"]
+      assert_equal "S256", q["code_challenge_method"]
+      assert_nil q["user_scope"]
+      scopes = q["scope"].split
+      assert_includes scopes, "repo"
+      assert_includes scopes, "read:user"
     end
 
     test "start works without any session" do
@@ -212,6 +243,35 @@ module Oauth
       assert_equal "xoxe-1-refresh", cred.refresh_token
       assert_equal [ "slack.com" ], cred.static_secret.rules.map(&:host)
       assert_equal "Slack – grace token", cred.static_secret.name
+    end
+
+    test "callback happy path supports GitHub OAuth app tokens" do
+      state = start_flow(slug: "github", scopes: "repo read:user")
+      stub_exchange(status: 200, body: github_token_body)
+
+      assert_enqueued_with(job: Oauth::EnrichGithubCredentialIdentityJob) do
+        assert_difference -> { BrokerCredential.count } => 1 do
+          get oauth_callback_url(slug: "github"), params: { state: state, code: "auth-code" }
+        end
+      end
+      assert_response :ok
+      assert_match "Connected", response.body
+
+      app = oauth_apps(:acme_github)
+      cred = BrokerCredential.find_by(oauth_app: app)
+      assert_equal "acme", cred.namespace
+      assert_match(/\Agithub-github-pending-[a-f0-9]{32}\z/, cred.foreign_id)
+      assert_match(/\Apending-[a-f0-9]{32}\z/, cred.provider_subject)
+      assert_equal "GitHub – Pending GitHub account", cred.name
+      assert_equal "https://github.com/login/oauth/access_token", cred.token_endpoint
+      assert_nil cred.provider_email
+      assert_equal %w[repo read:user], cred.scopes
+      assert_equal "gho-user-token", cred.access_token
+      assert_nil cred.refresh_token
+      assert_nil cred.next_attempt_at
+      assert_equal [ "api.github.com", "github.com" ], cred.static_secret.rules.map(&:host)
+      assert_equal "GitHub – Pending GitHub account token", cred.static_secret.name
+      refute_includes BrokerCredential.refreshable, cred
     end
 
     test "callback wraps the minted credential in a grantable static secret" do

--- a/services/console/test/fixtures/oauth_apps.yml
+++ b/services/console/test/fixtures/oauth_apps.yml
@@ -37,3 +37,15 @@ acme_slack:
   credential_namespace: acme
   enabled: true
   created_by: acme_admin
+
+acme_github:
+  slug: github
+  description: Acme GitHub integration
+  provider: github
+  client_id: acme-github-client-id
+  allowed_scopes:
+    - repo
+    - read:user
+  credential_namespace: acme
+  enabled: true
+  created_by: acme_admin

--- a/services/console/test/jobs/oauth/enrich_github_credential_identity_job_test.rb
+++ b/services/console/test/jobs/oauth/enrich_github_credential_identity_job_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+module Oauth
+  class EnrichGithubCredentialIdentityJobTest < ActiveJob::TestCase
+    setup do
+      Oauth::EnrichGithubCredentialIdentityJob.github_api_http = nil
+    end
+
+    teardown do
+      Oauth::EnrichGithubCredentialIdentityJob.github_api_http = nil
+    end
+
+    def github_credential(**overrides)
+      app = oauth_apps(:acme_github)
+      app.update!(client_secret: "github-secret")
+      BrokerCredential.create!({
+        namespace: "acme",
+        foreign_id: "github-github-pending-abc123",
+        name: "GitHub – Pending GitHub account",
+        token_endpoint: Oauth::Providers::Github::TOKEN_ENDPOINT,
+        oauth_app: app,
+        provider_subject: "pending-abc123",
+        access_token: "gho-token",
+        refresh_token: nil,
+        scopes: %w[repo read:user]
+      }.merge(overrides))
+    end
+
+    def wrap_credential(credential, name: "#{credential.name} token")
+      StaticSecret.create!(
+        namespace: credential.namespace,
+        name: name,
+        broker_credential: credential,
+        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+      )
+    end
+
+    test "updates the credential and wrapper secret names from GitHub profile details" do
+      Oauth::EnrichGithubCredentialIdentityJob.github_api_http = ->(url:, access_token:) {
+        assert_equal Oauth::EnrichGithubCredentialIdentityJob::USER_ENDPOINT, url
+        assert_equal "gho-token", access_token
+        { "id" => 99_123, "login" => "octocat", "name" => "Octo Cat", "email" => "octo@example.com" }
+      }
+      credential = github_credential
+      secret = wrap_credential(credential)
+
+      Oauth::EnrichGithubCredentialIdentityJob.perform_now(credential.id)
+
+      assert_equal "GitHub – Octo Cat", credential.reload.name
+      assert_equal "99123", credential.provider_subject
+      assert_equal "octo@example.com", credential.provider_email
+      assert_equal "github-github-99123", credential.foreign_id
+      assert_equal "GitHub – Octo Cat token", secret.reload.name
+    end
+
+    test "falls back to login for display name" do
+      Oauth::EnrichGithubCredentialIdentityJob.github_api_http = ->(url:, access_token:) {
+        { "id" => 99_123, "login" => "octocat", "name" => nil, "email" => nil }
+      }
+      credential = github_credential
+      secret = wrap_credential(credential)
+
+      Oauth::EnrichGithubCredentialIdentityJob.perform_now(credential.id)
+
+      assert_equal "GitHub – octocat", credential.reload.name
+      assert_equal "GitHub – octocat token", secret.reload.name
+    end
+
+    test "does not clobber an operator-renamed wrapper secret" do
+      Oauth::EnrichGithubCredentialIdentityJob.github_api_http = ->(url:, access_token:) {
+        { "id" => 99_123, "login" => "octocat", "name" => "Octo Cat" }
+      }
+      credential = github_credential
+      secret = wrap_credential(credential, name: "operator name")
+
+      Oauth::EnrichGithubCredentialIdentityJob.perform_now(credential.id)
+
+      assert_equal "GitHub – Octo Cat", credential.reload.name
+      assert_equal "operator name", secret.reload.name
+    end
+  end
+end

--- a/services/console/test/lib/oauth/providers/github_test.rb
+++ b/services/console/test/lib/oauth/providers/github_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+module Oauth
+  module Providers
+    class GithubTest < ActiveSupport::TestCase
+      def result(access_token: "gho_token", scope: "repo,read:user")
+        Broker::AuthorizationCodeClient::Result.new(
+          access_token: access_token, refresh_token: nil, expires_in: nil,
+          scope: scope, id_token: nil, response: {}
+        )
+      end
+
+      test "builds a deterministic pending identity without calling GitHub" do
+        identity = Github.new.identity_from(result, client_id: "unused")
+
+        assert_match(/\Apending-[a-f0-9]{32}\z/, identity[:subject])
+        assert_nil identity[:email]
+        assert_equal "Pending GitHub account", identity[:name]
+        assert_equal identity, Github.new.identity_from(result, client_id: "unused")
+      end
+
+      test "missing access token raises a parse error" do
+        err = assert_raises(Broker::ExchangeError) do
+          Github.new.identity_from(result(access_token: nil), client_id: "unused")
+        end
+        assert_equal "missing_access_token", err.code
+      end
+
+      test "parses comma or space separated granted scopes" do
+        assert_equal %w[repo read:user gist], Github.new.parse_granted_scopes("repo,read:user gist")
+      end
+
+      test "exposes provider constants" do
+        strategy = Github.new
+        assert_equal "github", strategy.key
+        assert_equal "GitHub", strategy.display_name
+        assert_equal "https://github.com/login/oauth/authorize", strategy.authorization_endpoint
+        assert_equal "https://github.com/login/oauth/access_token", strategy.token_endpoint
+        assert_equal [], strategy.identity_scopes
+        assert_equal "scope", strategy.authorization_scope_param
+        assert_equal " ", strategy.scope_separator
+        refute strategy.refreshable?
+      end
+    end
+  end
+end

--- a/services/console/test/models/oauth_app_test.rb
+++ b/services/console/test/models/oauth_app_test.rb
@@ -17,7 +17,8 @@ class OauthAppTest < ActiveSupport::TestCase
   end
 
   test "provider must be a registered provider" do
-    refute build_app(provider: "github").valid?
+    refute build_app(provider: "nope").valid?
+    assert build_app(provider: "github").valid?
     assert build_app(provider: "google").valid?
     assert build_app(provider: "slack").valid?
   end


### PR DESCRIPTION
Adds GitHub as a supported console OAuth app provider alongside Google and Slack. The callback exchanges the authorization code and stores a pending GitHub credential without making a GitHub API call, then a dedicated GitHub enrichment job resolves the authorizing user through GET /user and updates the credential and wrapper secret names.

Validated with the focused console Rails test suite and a console Docker image build.
