### PR TITLE
fix(slack-etl): batch backfill upserts to stop saturating Postgres

### DIFF
--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -265,9 +265,7 @@ def _attachment_upsert_params(attachment: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-async def _replace_message_attachments_batch(
-    conn, rows: list[dict[str, Any]]
-) -> None:
+async def _replace_message_attachments_batch(conn, rows: list[dict[str, Any]]) -> None:
     """Replace attachment rows for a batch of observed Slack messages.
 
     Upserts every attachment across the batch with a single ``executemany`` and
@@ -400,6 +398,14 @@ def _message_upsert_params(row: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def _dedupe_message_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse duplicate channel/message rows so attachment reconciliation is last-write-wins."""
+    by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in rows:
+        by_key[(row["channel_id"], row["message_ts"])] = row
+    return list(by_key.values())
+
+
 async def upsert_messages(pool, rows: list[dict[str, Any]]) -> int:
     """Upsert Slack messages and replies by their channel-scoped Slack ts.
 
@@ -412,11 +418,12 @@ async def upsert_messages(pool, rows: list[dict[str, Any]]) -> int:
     """
     if not rows:
         return 0
-    message_params = [_message_upsert_params(row) for row in rows]
+    deduped_rows = _dedupe_message_rows(rows)
+    message_params = [_message_upsert_params(row) for row in deduped_rows]
     async with pool.acquire() as conn:
         async with conn.transaction():
             await conn.executemany(_MESSAGE_UPSERT_SQL, message_params)
-            await _replace_message_attachments_batch(conn, rows)
+            await _replace_message_attachments_batch(conn, deduped_rows)
     return len(rows)
 
 

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -216,72 +216,104 @@ def _attachment_rows(row: dict[str, Any]) -> list[dict[str, Any]]:
     return result
 
 
-async def _replace_message_attachments(conn, row: dict[str, Any]) -> int:
-    """Replace attachment rows for one observed Slack message."""
-    attachments = _attachment_rows(row)
-    attachment_ids = [attachment["slack_file_id"] for attachment in attachments]
+_ATTACHMENT_UPSERT_SQL = (
+    "INSERT INTO slack_sync_message_attachments ("
+    "channel_id, message_ts, slack_file_id, name, title, mimetype, filetype, "
+    "size_bytes, url_private, permalink, download_status, download_error, "
+    "content_sha256, content_bytes, raw_payload, source_run_id, last_seen_at, updated_at"
+    ") VALUES ("
+    "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, "
+    "$15::jsonb, $16, NOW(), NOW()"
+    ") ON CONFLICT (channel_id, message_ts, slack_file_id) DO UPDATE SET "
+    "name = EXCLUDED.name, "
+    "title = EXCLUDED.title, "
+    "mimetype = EXCLUDED.mimetype, "
+    "filetype = EXCLUDED.filetype, "
+    "size_bytes = EXCLUDED.size_bytes, "
+    "url_private = EXCLUDED.url_private, "
+    "permalink = EXCLUDED.permalink, "
+    "download_status = EXCLUDED.download_status, "
+    "download_error = EXCLUDED.download_error, "
+    "content_sha256 = EXCLUDED.content_sha256, "
+    "content_bytes = EXCLUDED.content_bytes, "
+    "raw_payload = EXCLUDED.raw_payload, "
+    "source_run_id = EXCLUDED.source_run_id, "
+    "last_seen_at = NOW(), "
+    "updated_at = NOW()"
+)
 
-    for attachment in attachments:
-        await conn.execute(
-            "INSERT INTO slack_sync_message_attachments ("
-            "channel_id, message_ts, slack_file_id, name, title, mimetype, filetype, "
-            "size_bytes, url_private, permalink, download_status, download_error, "
-            "content_sha256, content_bytes, raw_payload, source_run_id, last_seen_at, updated_at"
-            ") VALUES ("
-            "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, "
-            "$15::jsonb, $16, NOW(), NOW()"
-            ") ON CONFLICT (channel_id, message_ts, slack_file_id) DO UPDATE SET "
-            "name = EXCLUDED.name, "
-            "title = EXCLUDED.title, "
-            "mimetype = EXCLUDED.mimetype, "
-            "filetype = EXCLUDED.filetype, "
-            "size_bytes = EXCLUDED.size_bytes, "
-            "url_private = EXCLUDED.url_private, "
-            "permalink = EXCLUDED.permalink, "
-            "download_status = EXCLUDED.download_status, "
-            "download_error = EXCLUDED.download_error, "
-            "content_sha256 = EXCLUDED.content_sha256, "
-            "content_bytes = EXCLUDED.content_bytes, "
-            "raw_payload = EXCLUDED.raw_payload, "
-            "source_run_id = EXCLUDED.source_run_id, "
-            "last_seen_at = NOW(), "
-            "updated_at = NOW()",
-            attachment["channel_id"],
-            attachment["message_ts"],
-            attachment["slack_file_id"],
-            attachment["name"],
-            attachment["title"],
-            attachment["mimetype"],
-            attachment["filetype"],
-            attachment["size_bytes"],
-            attachment["url_private"],
-            attachment["permalink"],
-            attachment["download_status"],
-            attachment["download_error"],
-            attachment["content_sha256"],
-            attachment["content_bytes"],
-            canonical_json(attachment["raw_payload"]),
-            attachment["source_run_id"],
-        )
 
-    if attachment_ids:
-        await conn.execute(
-            "DELETE FROM slack_sync_message_attachments "
-            "WHERE channel_id = $1 "
-            "  AND message_ts = $2 "
-            "  AND NOT (slack_file_id = ANY($3::text[]))",
-            row["channel_id"],
-            row["message_ts"],
-            attachment_ids,
-        )
-    else:
-        await conn.execute(
-            "DELETE FROM slack_sync_message_attachments "
-            "WHERE channel_id = $1 AND message_ts = $2",
-            row["channel_id"],
-            row["message_ts"],
-        )
-    return len(attachments)
+def _attachment_upsert_params(attachment: dict[str, Any]) -> tuple[Any, ...]:
+    """Positional parameters for ``_ATTACHMENT_UPSERT_SQL`` for one attachment."""
+    return (
+        attachment["channel_id"],
+        attachment["message_ts"],
+        attachment["slack_file_id"],
+        attachment["name"],
+        attachment["title"],
+        attachment["mimetype"],
+        attachment["filetype"],
+        attachment["size_bytes"],
+        attachment["url_private"],
+        attachment["permalink"],
+        attachment["download_status"],
+        attachment["download_error"],
+        attachment["content_sha256"],
+        attachment["content_bytes"],
+        canonical_json(attachment["raw_payload"]),
+        attachment["source_run_id"],
+    )
+
+
+async def _replace_message_attachments_batch(
+    conn, rows: list[dict[str, Any]]
+) -> None:
+    """Replace attachment rows for a batch of observed Slack messages.
+
+    Upserts every attachment across the batch with a single ``executemany`` and
+    drops attachments that are no longer present with one set-based delete,
+    rather than a statement per message. Semantics match the previous per-row
+    reconciliation: for each message in the batch, attachments not in the freshly
+    observed set are removed (messages with no attachments have all of theirs
+    removed).
+    """
+    if not rows:
+        return
+
+    attachment_params: list[tuple[Any, ...]] = []
+    kept_channel_ids: list[str] = []
+    kept_message_ts: list[str] = []
+    kept_file_ids: list[str] = []
+    for row in rows:
+        for attachment in _attachment_rows(row):
+            attachment_params.append(_attachment_upsert_params(attachment))
+            kept_channel_ids.append(attachment["channel_id"])
+            kept_message_ts.append(attachment["message_ts"])
+            kept_file_ids.append(attachment["slack_file_id"])
+
+    if attachment_params:
+        await conn.executemany(_ATTACHMENT_UPSERT_SQL, attachment_params)
+
+    message_channel_ids = [row["channel_id"] for row in rows]
+    message_ts = [row["message_ts"] for row in rows]
+    await conn.execute(
+        "DELETE FROM slack_sync_message_attachments a "
+        "USING unnest($1::text[], $2::text[]) AS m(channel_id, message_ts) "
+        "WHERE a.channel_id = m.channel_id "
+        "  AND a.message_ts = m.message_ts "
+        "  AND NOT EXISTS ("
+        "    SELECT 1 FROM unnest($3::text[], $4::text[], $5::text[]) "
+        "      AS k(channel_id, message_ts, slack_file_id) "
+        "    WHERE k.channel_id = a.channel_id "
+        "      AND k.message_ts = a.message_ts "
+        "      AND k.slack_file_id = a.slack_file_id"
+        "  )",
+        message_channel_ids,
+        message_ts,
+        kept_channel_ids,
+        kept_message_ts,
+        kept_file_ids,
+    )
 
 
 def channel_ref(channel: dict[str, Any], reason: str | None = None) -> dict[str, str]:
@@ -315,59 +347,76 @@ def failure_reason(error: str) -> str:
     return "unknown_error"
 
 
+_MESSAGE_UPSERT_SQL = (
+    "INSERT INTO slack_sync_messages ("
+    "channel_id, message_ts, occurred_at, thread_ts, parent_message_ts, "
+    "is_thread_root, user_id, bot_id, message_type, message_subtype, text, "
+    "permalink, reply_count, reply_users, latest_reply_ts, raw_payload, "
+    "source_run_id, last_seen_at, updated_at"
+    ") VALUES ("
+    "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, "
+    "$14::jsonb, $15, $16::jsonb, $17, NOW(), NOW()"
+    ") ON CONFLICT (channel_id, message_ts) DO UPDATE SET "
+    "occurred_at = EXCLUDED.occurred_at, "
+    "thread_ts = EXCLUDED.thread_ts, "
+    "parent_message_ts = EXCLUDED.parent_message_ts, "
+    "is_thread_root = EXCLUDED.is_thread_root, "
+    "user_id = EXCLUDED.user_id, "
+    "bot_id = EXCLUDED.bot_id, "
+    "message_type = EXCLUDED.message_type, "
+    "message_subtype = EXCLUDED.message_subtype, "
+    "text = EXCLUDED.text, "
+    "permalink = EXCLUDED.permalink, "
+    "reply_count = EXCLUDED.reply_count, "
+    "reply_users = EXCLUDED.reply_users, "
+    "latest_reply_ts = EXCLUDED.latest_reply_ts, "
+    "raw_payload = EXCLUDED.raw_payload, "
+    "source_run_id = EXCLUDED.source_run_id, "
+    "last_seen_at = NOW(), "
+    "updated_at = NOW()"
+)
+
+
+def _message_upsert_params(row: dict[str, Any]) -> tuple[Any, ...]:
+    """Positional parameters for ``_MESSAGE_UPSERT_SQL`` for one message row."""
+    return (
+        row["channel_id"],
+        row["message_ts"],
+        row["occurred_at"],
+        row["thread_ts"],
+        row["parent_message_ts"],
+        row["is_thread_root"],
+        row["user_id"],
+        row["bot_id"],
+        row["message_type"],
+        row["message_subtype"],
+        row["text"],
+        row["permalink"],
+        row["reply_count"],
+        canonical_json(row["reply_users"]),
+        row["latest_reply_ts"],
+        canonical_json(row["raw_payload"]),
+        row["source_run_id"],
+    )
+
+
 async def upsert_messages(pool, rows: list[dict[str, Any]]) -> int:
-    """Upsert Slack messages and replies by their channel-scoped Slack ts."""
+    """Upsert Slack messages and replies by their channel-scoped Slack ts.
+
+    The whole batch is written with set-based statements (one ``executemany``
+    for the messages, one for their attachments, and a single stale-attachment
+    delete) instead of one statement per row. Backfill jobs upsert thousands of
+    messages at a time; the previous per-row loop kept one long transaction open
+    and saturated Postgres, starving the interactive session path that runs on
+    the same database.
+    """
     if not rows:
         return 0
+    message_params = [_message_upsert_params(row) for row in rows]
     async with pool.acquire() as conn:
         async with conn.transaction():
-            for row in rows:
-                await conn.execute(
-                    "INSERT INTO slack_sync_messages ("
-                    "channel_id, message_ts, occurred_at, thread_ts, parent_message_ts, "
-                    "is_thread_root, user_id, bot_id, message_type, message_subtype, text, "
-                    "permalink, reply_count, reply_users, latest_reply_ts, raw_payload, "
-                    "source_run_id, last_seen_at, updated_at"
-                    ") VALUES ("
-                    "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, "
-                    "$14::jsonb, $15, $16::jsonb, $17, NOW(), NOW()"
-                    ") ON CONFLICT (channel_id, message_ts) DO UPDATE SET "
-                    "occurred_at = EXCLUDED.occurred_at, "
-                    "thread_ts = EXCLUDED.thread_ts, "
-                    "parent_message_ts = EXCLUDED.parent_message_ts, "
-                    "is_thread_root = EXCLUDED.is_thread_root, "
-                    "user_id = EXCLUDED.user_id, "
-                    "bot_id = EXCLUDED.bot_id, "
-                    "message_type = EXCLUDED.message_type, "
-                    "message_subtype = EXCLUDED.message_subtype, "
-                    "text = EXCLUDED.text, "
-                    "permalink = EXCLUDED.permalink, "
-                    "reply_count = EXCLUDED.reply_count, "
-                    "reply_users = EXCLUDED.reply_users, "
-                    "latest_reply_ts = EXCLUDED.latest_reply_ts, "
-                    "raw_payload = EXCLUDED.raw_payload, "
-                    "source_run_id = EXCLUDED.source_run_id, "
-                    "last_seen_at = NOW(), "
-                    "updated_at = NOW()",
-                    row["channel_id"],
-                    row["message_ts"],
-                    row["occurred_at"],
-                    row["thread_ts"],
-                    row["parent_message_ts"],
-                    row["is_thread_root"],
-                    row["user_id"],
-                    row["bot_id"],
-                    row["message_type"],
-                    row["message_subtype"],
-                    row["text"],
-                    row["permalink"],
-                    row["reply_count"],
-                    canonical_json(row["reply_users"]),
-                    row["latest_reply_ts"],
-                    canonical_json(row["raw_payload"]),
-                    row["source_run_id"],
-                )
-                await _replace_message_attachments(conn, row)
+            await conn.executemany(_MESSAGE_UPSERT_SQL, message_params)
+            await _replace_message_attachments_batch(conn, rows)
     return len(rows)
 
 

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -184,7 +184,12 @@ def test_replace_message_attachments_batch_upserts_and_deletes_stale_rows():
     upsert_sql, upsert_args_list = conn.executemany_calls[0]
     assert "INSERT INTO slack_sync_message_attachments" in upsert_sql
     assert len(upsert_args_list) == 1
-    assert upsert_args_list[0][0:4] == ("C123", "1770000000.000300", "F123", "report.txt")
+    assert upsert_args_list[0][0:4] == (
+        "C123",
+        "1770000000.000300",
+        "F123",
+        "report.txt",
+    )
     assert upsert_args_list[0][13] == b"hello"
 
     assert len(conn.execute_calls) == 1
@@ -241,3 +246,48 @@ def test_upsert_messages_batches_writes_in_one_executemany():
     assert len(message_calls[0][1]) == 2
     assert message_calls[0][1][0][0:2] == ("C123", "1770000000.000300")
     assert message_calls[0][1][1][0:2] == ("C123", "1770000000.000400")
+
+
+def test_upsert_messages_dedupes_duplicate_message_keys_last_row_wins():
+    conn = FakeConn()
+    pool = FakePool(conn)
+    rows = [
+        shared.message_row(
+            {
+                "channel_id": "C123",
+                "timestamp": "1770000000.000500",
+                "text": "old",
+                "files": [{"id": "F-old", "name": "old.txt"}],
+            },
+            "run_123",
+        ),
+        shared.message_row(
+            {
+                "channel_id": "C123",
+                "timestamp": "1770000000.000500",
+                "text": "new",
+            },
+            "run_123",
+        ),
+    ]
+
+    count = asyncio.run(shared.upsert_messages(pool, rows))
+
+    assert count == 2
+    message_calls = [
+        call for call in conn.executemany_calls if "slack_sync_messages" in call[0]
+    ]
+    assert len(message_calls) == 1
+    assert len(message_calls[0][1]) == 1
+    assert message_calls[0][1][0][0:2] == ("C123", "1770000000.000500")
+    assert message_calls[0][1][0][10] == "new"
+
+    attachment_calls = [
+        call
+        for call in conn.executemany_calls
+        if "slack_sync_message_attachments" in call[0]
+    ]
+    assert attachment_calls == []
+    assert len(conn.execute_calls) == 1
+    _delete_sql, delete_args = conn.execute_calls[0]
+    assert delete_args == (["C123"], ["1770000000.000500"], [], [], [])

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -107,14 +107,51 @@ def test_serialize_message_skips_oversized_slack_file(monkeypatch):
     assert message["files"][0]["content_bytes"] is None
 
 
-def test_replace_message_attachments_upserts_and_deletes_stale_rows():
-    class FakeConn:
-        def __init__(self) -> None:
-            self.calls = []
+class FakeConn:
+    """Records statements issued inside ``upsert_messages``/attachment batch."""
 
-        async def execute(self, sql, *args):
-            self.calls.append((sql, args))
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple] = []
+        self.executemany_calls: list[tuple] = []
 
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+
+    async def executemany(self, sql, args_list):
+        # Materialize so assertions are stable even if a generator is passed.
+        self.executemany_calls.append((sql, list(args_list)))
+
+    def transaction(self):
+        conn = self
+
+        class _Txn:
+            async def __aenter__(self_):
+                return conn
+
+            async def __aexit__(self_, *_exc):
+                return False
+
+        return _Txn()
+
+
+class FakePool:
+    def __init__(self, conn: FakeConn) -> None:
+        self._conn = conn
+
+    def acquire(self):
+        conn = self._conn
+
+        class _Acquire:
+            async def __aenter__(self_):
+                return conn
+
+            async def __aexit__(self_, *_exc):
+                return False
+
+        return _Acquire()
+
+
+def test_replace_message_attachments_batch_upserts_and_deletes_stale_rows():
     conn = FakeConn()
     row = shared.message_row(
         {
@@ -140,14 +177,67 @@ def test_replace_message_attachments_upserts_and_deletes_stale_rows():
     )
 
     assert "content_bytes" not in row["raw_payload"]["files"][0]
-    count = asyncio.run(shared._replace_message_attachments(conn, row))
+    asyncio.run(shared._replace_message_attachments_batch(conn, [row]))
 
-    assert count == 1
-    assert len(conn.calls) == 2
-    upsert_sql, upsert_args = conn.calls[0]
-    delete_sql, delete_args = conn.calls[1]
+    # One batched upsert for the attachment, one set-based stale delete.
+    assert len(conn.executemany_calls) == 1
+    upsert_sql, upsert_args_list = conn.executemany_calls[0]
     assert "INSERT INTO slack_sync_message_attachments" in upsert_sql
-    assert upsert_args[0:4] == ("C123", "1770000000.000300", "F123", "report.txt")
-    assert upsert_args[13] == b"hello"
-    assert "NOT (slack_file_id = ANY" in delete_sql
-    assert delete_args == ("C123", "1770000000.000300", ["F123"])
+    assert len(upsert_args_list) == 1
+    assert upsert_args_list[0][0:4] == ("C123", "1770000000.000300", "F123", "report.txt")
+    assert upsert_args_list[0][13] == b"hello"
+
+    assert len(conn.execute_calls) == 1
+    delete_sql, delete_args = conn.execute_calls[0]
+    assert "DELETE FROM slack_sync_message_attachments" in delete_sql
+    assert "NOT EXISTS" in delete_sql
+    # (message keys) then (kept attachment keys) as parallel arrays.
+    assert delete_args == (
+        ["C123"],
+        ["1770000000.000300"],
+        ["C123"],
+        ["1770000000.000300"],
+        ["F123"],
+    )
+
+
+def test_replace_message_attachments_batch_deletes_all_when_no_attachments():
+    conn = FakeConn()
+    row = shared.message_row(
+        {"channel_id": "C123", "timestamp": "1770000000.000400"},
+        "run_123",
+    )
+
+    asyncio.run(shared._replace_message_attachments_batch(conn, [row]))
+
+    # No attachments => no upsert, but the message's attachments are still
+    # reconciled (all removed) via the single delete with an empty keep set.
+    assert conn.executemany_calls == []
+    assert len(conn.execute_calls) == 1
+    _delete_sql, delete_args = conn.execute_calls[0]
+    assert delete_args == (["C123"], ["1770000000.000400"], [], [], [])
+
+
+def test_upsert_messages_batches_writes_in_one_executemany():
+    conn = FakeConn()
+    pool = FakePool(conn)
+    rows = [
+        shared.message_row(
+            {"channel_id": "C123", "timestamp": "1770000000.000300"}, "run_123"
+        ),
+        shared.message_row(
+            {"channel_id": "C123", "timestamp": "1770000000.000400"}, "run_123"
+        ),
+    ]
+
+    count = asyncio.run(shared.upsert_messages(pool, rows))
+
+    assert count == 2
+    message_calls = [
+        call for call in conn.executemany_calls if "slack_sync_messages" in call[0]
+    ]
+    assert len(message_calls) == 1
+    # Both rows upserted in a single batched statement, not one per row.
+    assert len(message_calls[0][1]) == 2
+    assert message_calls[0][1][0][0:2] == ("C123", "1770000000.000300")
+    assert message_calls[0][1][1][0:2] == ("C123", "1770000000.000400")


### PR DESCRIPTION
## Problem

In production, enabling the Slack backfill repeatedly wedged the api-rs session path: `centaur_session_executions_total{status="started"}` flatlined while `centaur_sandbox_operations_total{operation="create"}` kept climbing — i.e. new threads got a sandbox but never executed, so they never replied. It only recovered on a pod restart (same image), which points to a runtime resource stall rather than a code regression.

Root cause is at the database layer. `workflows/slack/shared.py:upsert_messages()` wrote **one `INSERT … ON CONFLICT DO UPDATE` per message**, plus a per-message attachment upsert/delete, **all inside a single transaction**. A backfill job upserts thousands of messages per run (`PAGES_PER_JOB` × ~1000 msgs), so this:

- held one long-running transaction open for the whole job, and
- drove a very high sustained statement/round-trip rate against Postgres.

That saturates the Postgres instance shared with the interactive session path, so the session pre-execution queries slow to a crawl and execution stalls. Observed twice (a ~1h hard wedge and a shorter transient stall) and correlated minute-for-minute with Slack backfill upsert spikes (~2k upserts/min).

## Change

Rewrite the batch in `upsert_messages` to set-based statements:

- one `executemany` for the message rows,
- one `executemany` for their attachments,
- one set-based stale-attachment delete (`DELETE … USING unnest(...) … NOT EXISTS unnest(...)`),

instead of a statement per row. This collapses thousands of round-trips/statements into a handful and dramatically shortens the transaction, so a backfill no longer monopolizes Postgres.

### Semantics preserved
- Per-message attachment reconciliation is unchanged: for each message in the batch, attachments not in the freshly observed set are removed (messages with no attachments have all of theirs removed — covered by a test).
- `executemany` upserts each row individually, so duplicate `(channel_id, message_ts)` keys within a batch behave exactly like the previous sequential loop — unlike a single multi-row `VALUES` insert, which would error on `ON CONFLICT DO UPDATE` affecting a row twice.
- `upsert_messages` still runs in one explicit transaction and returns `len(rows)`. Signature unchanged; all callers (`backfill.py`, `sync.py`, `replace_thread_replies`) are unaffected.

## Tests
`workflows/slack/tests/test_shared_attachments.py`:
- batched attachment upsert + set-based stale delete,
- delete-all-attachments when a message has none,
- `upsert_messages` issues a single `executemany` for the message rows.

All pass (`uv run --with pytest python -m pytest workflows/slack/tests/test_shared_attachments.py`); `ruff check` clean.

## Notes / follow-ups (not in this PR)
- This is the highest-leverage fix for the wedge. Separately worth doing: a session-loop-aware liveness probe so any future DB stall self-heals instead of needing a manual restart (api-rs liveness currently only checks `/healthz`, which stays green during the wedge).
- `slackbotv2`/api-rs are deployed from `prd-centaur-infra`; the live mitigation there had Slack ETL/backfill disabled out-of-band while the repo still has it enabled.