### PR TITLE
fix(proxy): allow Railway project token header

### DIFF
--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -67,3 +67,21 @@ fn access_token_fragment_carries_no_broker_credentials_block() {
         .unwrap();
     assert!(!codex.top_level.contains_key("broker_credentials"));
 }
+
+#[test]
+fn shipped_proxy_allowlist_preserves_railway_project_tokens() {
+    let config: serde_yaml::Value =
+        serde_yaml::from_str(include_str!("../../../../iron-proxy/iron-proxy.yaml")).unwrap();
+    let transforms = config["transforms"].as_sequence().unwrap();
+    let header_allowlist = transforms
+        .iter()
+        .find(|transform| transform["name"].as_str() == Some("header_allowlist"))
+        .unwrap();
+    let headers = header_allowlist["config"]["headers"]
+        .as_sequence()
+        .unwrap();
+
+    assert!(headers
+        .iter()
+        .any(|header| header.as_str() == Some("project-access-token")));
+}

--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -66,6 +66,7 @@ transforms:
         - "api-access-key"
         - "api-signature"
         - "api-timestamp"
+        - "project-access-token"
         - "fx-access-key"
         - "fx-access-sign"
         - "fx-access-timestamp"


### PR DESCRIPTION
## Summary

- allow the shipped iron-proxy config to preserve Railway's `Project-Access-Token` header
- keep the allowlist scoped to the exact Railway project-token header
- add a Rust regression test for the shipped proxy header allowlist now that the legacy Python API config test was removed

## Why

Railway project tokens authenticate with `Project-Access-Token`, while account and workspace tokens use `Authorization: Bearer ...`. Without this allowlist entry, iron-proxy strips the project-token header before the request reaches Railway.

Supersedes the closed conflicting PR #390, replayed on top of current `main`.

## Test

- `cargo test -p centaur-iron-proxy shipped_proxy_allowlist_preserves_railway_project_tokens`
- `cargo test -p centaur-iron-proxy`