### PR TITLE
fix: resolve secret grant conflicts across types so direct grants win

### DIFF
--- a/services/console/app/models/aws_auth_secret.rb
+++ b/services/console/app/models/aws_auth_secret.rb
@@ -41,6 +41,12 @@ class AwsAuthSecret < ApplicationRecord
     { "name" => "aws_auth", "config" => config }
   end
 
+  # aws_auth re-signs requests with SigV4, which owns the Authorization header;
+  # used for cross-type conflict detection in Principal#served_credentials.
+  def proxy_conflict_targets
+    [ "header:authorization" ]
+  end
+
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true

--- a/services/console/app/models/gcp_auth_secret.rb
+++ b/services/console/app/models/gcp_auth_secret.rb
@@ -39,6 +39,12 @@ class GcpAuthSecret < ApplicationRecord
     { "name" => "gcp_auth", "config" => config }
   end
 
+  # gcp_auth always sets the Authorization header (a Bearer access token); used
+  # for cross-type conflict detection in Principal#served_credentials.
+  def proxy_conflict_targets
+    [ "header:authorization" ]
+  end
+
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true

--- a/services/console/app/models/hmac_secret.rb
+++ b/services/console/app/models/hmac_secret.rb
@@ -49,6 +49,12 @@ class HmacSecret < ApplicationRecord
     { "name" => "hmac_sign", "config" => config }
   end
 
+  # hmac_sign injects its signature (and companion values) into the named request
+  # headers; used for cross-type conflict detection in Principal#served_credentials.
+  def proxy_conflict_targets
+    headers.map { |h| "header:#{h["name"].downcase}" }
+  end
+
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true

--- a/services/console/app/models/oauth_token_secret.rb
+++ b/services/console/app/models/oauth_token_secret.rb
@@ -46,6 +46,13 @@ class OauthTokenSecret < ApplicationRecord
     entry
   end
 
+  # oauth_token injects the minted bearer into its configured header, defaulting
+  # to Authorization (the proxy's default when none is set); used for cross-type
+  # conflict detection in Principal#served_credentials.
+  def proxy_conflict_targets
+    [ "header:#{(header.presence || "Authorization").downcase}" ]
+  end
+
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -69,27 +69,26 @@ class Principal < ApplicationRecord
   end
 
   # The `secrets` array delivered to iron-proxy. Each entry maps to the proxy's
-  # `secrets` transform `secretEntry` shape. Secrets without a source are skipped
-  # because the proxy requires a source to resolve a value; a brokered source whose
-  # credential has no current access token (bootstrapping or dead) is skipped too,
-  # so the proxy never receives an empty inline value.
+  # `secrets` transform `secretEntry` shape. The served set (see
+  # #served_credentials) has already dropped secrets without a deliverable source
+  # and the losers of any cross-type conflict.
   def sync_secrets
-    granted_static_secrets.filter_map do |ss|
-      next unless ss.source&.deliverable?
-      ss.to_proxy_secret
-    end
+    served_credentials[:static].map(&:to_proxy_secret)
   end
 
   # The `transforms` array delivered to iron-proxy: one gcp_auth transform per
-  # granted GcpAuthSecret, one hmac_sign transform per granted HmacSecret, plus a
-  # single oauth_token transform bundling every granted OauthTokenSecret as one
-  # `tokens` entry.
+  # granted GcpAuthSecret, one aws_auth transform per granted AwsAuthSecret, one
+  # hmac_sign transform per granted HmacSecret, plus a single oauth_token
+  # transform bundling every granted OauthTokenSecret as one `tokens` entry.
+  # Credentials that lost a cross-type conflict are omitted (see
+  # #served_credentials).
   def sync_transforms
-    transforms = granted_gcp_auth_secrets.map(&:to_proxy_transform)
-    transforms += granted_aws_auth_secrets.map(&:to_proxy_transform)
-    transforms += granted_hmac_secrets.map(&:to_proxy_transform)
+    served = served_credentials
+    transforms = served[:gcp_auth].map(&:to_proxy_transform)
+    transforms += served[:aws_auth].map(&:to_proxy_transform)
+    transforms += served[:hmac].map(&:to_proxy_transform)
 
-    oauth_entries = granted_oauth_token_secrets.map(&:to_proxy_entry)
+    oauth_entries = served[:oauth].map(&:to_proxy_entry)
     transforms << { "name" => "oauth_token", "config" => { "tokens" => oauth_entries } } if oauth_entries.any?
 
     transforms
@@ -153,12 +152,93 @@ class Principal < ApplicationRecord
 
   private
 
+  # The credentials actually delivered to the proxy, grouped by type, after
+  # cross-type conflict resolution. Static secrets without a deliverable source
+  # are dropped first (the proxy can't resolve a value for them) so a
+  # non-deliverable winner never suppresses a credential that would otherwise
+  # serve. The result is recomputed on each call so callers see live grant state.
+  def served_credentials
+    static = granted_static_secrets.select { |ss| ss.source&.deliverable? }
+    gcp_auth = granted_gcp_auth_secrets.to_a
+    aws_auth = granted_aws_auth_secrets.to_a
+    hmac = granted_hmac_secrets.to_a
+    oauth = granted_oauth_token_secrets.to_a
+
+    suppressed = suppressed_conflict_credentials(static + gcp_auth + aws_auth + hmac + oauth)
+
+    {
+      static: static - suppressed,
+      gcp_auth: gcp_auth - suppressed,
+      aws_auth: aws_auth - suppressed,
+      hmac: hmac - suppressed,
+      oauth: oauth - suppressed
+    }
+  end
+
+  # Cross-type conflict resolution. The wire protocol applies the `secrets` array
+  # (static secrets) before the `transforms` array (gcp_auth, aws_auth, hmac_sign,
+  # oauth_token), so the proxy's last-transform-wins cannot let a direct static
+  # secret beat a role-granted transform. We resolve it here instead: each
+  # credential claims the (host-or-cidr, header-or-param) pairs it writes;
+  # processing claimants strongest-first, any credential overlapping a pair a
+  # stronger one already took is withheld. Strength is the effective grant
+  # priority (direct outranks role), tie-broken by newest id then class name so
+  # the outcome is deterministic and stable for config_hash.
+  #
+  # Scope matching is exact-string: a wildcard host (`*.googleapis.com`) and an
+  # exact host (`storage.googleapis.com`) count as distinct, and method/path
+  # narrowing on a rule is ignored. This is conservative -- some genuine
+  # conflicts may still ship and be settled by proxy order -- rather than
+  # over-eager, so nothing legitimate is dropped.
+  def suppressed_conflict_credentials(credentials)
+    candidates = credentials.filter_map do |cred|
+      keys = conflict_keys_for(cred)
+      [ cred, keys ] unless keys.empty?
+    end
+
+    candidates.sort_by! do |cred, _keys|
+      [ -cred.effective_priority.to_i, -cred.id, cred.class.name ]
+    end
+
+    claimed = {}
+    suppressed = []
+    candidates.each do |cred, keys|
+      if keys.any? { |key| claimed.key?(key) }
+        suppressed << cred
+      else
+        keys.each { |key| claimed[key] = true }
+      end
+    end
+    suppressed
+  end
+
+  # The [scope, target] pairs a credential writes: the cross product of the
+  # hosts/cidrs its rules match and the headers/params it injects. Empty when the
+  # credential scopes nothing (no rules) or writes no header/param target, in
+  # which case it never participates in a conflict.
+  def conflict_keys_for(cred)
+    scopes = cred.rules.filter_map { |rule| conflict_scope(rule) }
+    targets = cred.proxy_conflict_targets
+    return [] if scopes.empty? || targets.empty?
+    scopes.product(targets)
+  end
+
+  def conflict_scope(rule)
+    if rule.host.present?
+      "host:#{rule.host.strip.downcase.delete_suffix(".")}"
+    elsif rule.cidr.present?
+      "cidr:#{rule.cidr}"
+    end
+  end
+
   # The single place secret order is decided for every sync array. iron-proxy
   # applies matching transforms in array order and the LAST one wins, so we emit
   # in ASCENDING priority: the highest-priority grant lands last and becomes
   # authoritative. A secret reachable by several grants (e.g. both directly and
   # via a role) collapses to one row taking the strongest priority among them
   # (MAX), and the id tiebreak keeps the order deterministic for config_hash.
+  # The selected effective_priority also drives cross-type conflict resolution
+  # (see #suppressed_conflict_credentials).
   #
   # Do NOT add an `.order(:id)`-style sort to the per-type callers above or emit
   # grants in any other order downstream: that would silently let the wrong
@@ -173,6 +253,7 @@ class Principal < ApplicationRecord
     model
       .joins("INNER JOIN (#{priorities.to_sql}) granted_priorities " \
              "ON granted_priorities.secret_id = #{model.table_name}.id")
+      .select("#{model.table_name}.*", "granted_priorities.effective_priority")
       .includes(*includes)
       .order(Arel.sql("granted_priorities.effective_priority ASC, #{model.table_name}.id ASC"))
   end

--- a/services/console/app/models/static_secret.rb
+++ b/services/console/app/models/static_secret.rb
@@ -60,6 +60,27 @@ class StaticSecret < ApplicationRecord
     entry
   end
 
+  # The request targets this secret writes, normalized for cross-type conflict
+  # detection (see Principal#served_credentials): a header (case-insensitive) or
+  # a query param. A replace with no match_headers rewrites the body/path/query
+  # rather than a header, so it claims no target and never collides with a header
+  # injector.
+  def proxy_conflict_targets
+    if inject_config.present?
+      if inject_config["header"].present?
+        [ "header:#{inject_config["header"].downcase}" ]
+      elsif inject_config["query_param"].present?
+        [ "query:#{inject_config["query_param"]}" ]
+      else
+        []
+      end
+    elsif replace_config.present?
+      Array(replace_config["match_headers"]).map { |h| "header:#{h.downcase}" }
+    else
+      []
+    end
+  end
+
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -261,6 +261,85 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal static_secrets(:acme_prod_api_key).id, ids.last
   end
 
+  # --- cross-type conflict resolution -------------------------------------
+
+  # Builds a static secret injecting `header` on `host`, granted directly to
+  # globex_user (priority 100).
+  def grant_direct_static(host:, header:)
+    secret = StaticSecret.new(namespace: "globex", foreign_id: "static-#{SecureRandom.hex(4)}",
+                              inject_config: { "header" => header, "formatter" => "Bearer {{ .Value }}" },
+                              created_by: users(:globex_admin))
+    secret.build_source(source_type: "control_plane", secret: "direct-token")
+    secret.rules.build(host: host, position: 0)
+    secret.save!
+    Grant.create!(principal: principals(:globex_user), static_secret: secret, created_by: users(:globex_admin))
+    secret
+  end
+
+  # Builds a gcp_auth secret (writes Authorization) matching `host`, granted to
+  # globex_user through the globex_infra role (priority 0).
+  def grant_role_gcp(host:)
+    PrincipalRole.find_or_create_by!(principal: principals(:globex_user), role: roles(:globex_infra))
+    secret = GcpAuthSecret.new(namespace: "globex", foreign_id: "gcp-#{SecureRandom.hex(4)}",
+                               credentials_provider: { "type" => "workload_identity" },
+                               scopes: [ "https://www.googleapis.com/auth/cloud-platform" ],
+                               created_by: users(:globex_admin))
+    secret.rules.build(host: host, position: 0)
+    secret.save!
+    Grant.create!(role: roles(:globex_infra), gcp_auth_secret: secret, created_by: users(:globex_admin))
+    secret
+  end
+
+  test "a direct static secret suppresses a role-granted transform on the same host and header" do
+    grant_direct_static(host: "api.test.com", header: "Authorization")
+    grant_role_gcp(host: "api.test.com")
+    principal = principals(:globex_user)
+
+    assert_equal 1, principal.sync_secrets.length
+    assert_empty principal.sync_transforms, "the lower-priority role gcp_auth should be withheld"
+  end
+
+  test "credentials writing different headers on the same host both serve" do
+    grant_direct_static(host: "api.test.com", header: "X-Api-Key")
+    grant_role_gcp(host: "api.test.com")
+    principal = principals(:globex_user)
+
+    assert_equal 1, principal.sync_secrets.length
+    assert_equal 1, principal.sync_transforms.count { |t| t["name"] == "gcp_auth" }
+  end
+
+  test "credentials writing the same header on different hosts both serve" do
+    grant_direct_static(host: "api.test.com", header: "Authorization")
+    grant_role_gcp(host: "other.test.com")
+    principal = principals(:globex_user)
+
+    assert_equal 1, principal.sync_secrets.length
+    assert_equal 1, principal.sync_transforms.count { |t| t["name"] == "gcp_auth" }
+  end
+
+  test "exact and wildcard hosts are treated as distinct conflict scopes" do
+    # Conservative matching: a `*.test.com` rule does not collide with an exact
+    # `api.test.com` rule, so both ship and the proxy settles them by order.
+    grant_direct_static(host: "*.test.com", header: "Authorization")
+    grant_role_gcp(host: "api.test.com")
+    principal = principals(:globex_user)
+
+    assert_equal 1, principal.sync_secrets.length
+    assert_equal 1, principal.sync_transforms.count { |t| t["name"] == "gcp_auth" }
+  end
+
+  test "a promoted role transform suppresses a lower-priority direct static secret" do
+    grant_direct_static(host: "api.test.com", header: "Authorization")
+    gcp = grant_role_gcp(host: "api.test.com")
+    # Promote the role grant above the direct grant (priority 100): now the
+    # transform wins the conflict and the static secret is withheld.
+    Grant.find_by!(gcp_auth_secret: gcp).update!(priority: 900)
+    principal = principals(:globex_user)
+
+    assert_empty principal.sync_secrets, "the now-lower-priority direct static secret should be withheld"
+    assert_equal 1, principal.sync_transforms.count { |t| t["name"] == "gcp_auth" }
+  end
+
   test "effective_config redacts inline control_plane values by default but not when asked for live secrets" do
     principal = principals(:acme_channel)
     SecretSource.create!(source_type: "control_plane", secret: "s3cr3t",


### PR DESCRIPTION
Direct grants were being overridden by role grants across secret types. Grant priority (direct > role) was only honored within a single secret type, but the wire protocol applies the `secrets` array (static secrets) before the `transforms` array (gcp_auth, etc.), so a role-granted Google gcp_auth always overwrote a direct static secret on the same header regardless of priority.

This resolves conflicts at config-assembly time in the console rather than relying on proxy ordering. Each secret type reports the targets it writes via `proxy_conflict_targets`, and `Principal#served_credentials` withholds any credential that overlaps a (host-or-cidr, header-or-param) pair a stronger grant already claimed. Only the winner is served, so a direct grant beats a role grant on a genuine collision across all secret types.

Scope matching is intentionally conservative (exact-string host, method/path narrowing ignored): a missed conflict still ships and is settled by proxy order, but nothing legitimate is ever dropped. Suppression is currently silent in `effective_config`, and partial overlaps drop the whole loser; both are noted as follow-ups.