### PR TITLE
test: specify googleapis secret deconfliction

### DIFF
--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -361,6 +361,29 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_empty principal.sync_transforms, "the lower-priority google oauth_token should be withheld"
   end
 
+  test "a higher-priority wildcard googleapis static secret suppresses all google auth transforms" do
+    grant_direct_static(host: "*.googleapis.com", header: "Authorization")
+    grant_role_gcp(host: "bigquery.googleapis.com")
+    grant_role_oauth
+    grant_role_gcp(host: "*.googleapis.com")
+    principal = principals(:globex_user)
+
+    assert_equal 1, principal.sync_secrets.length
+    assert_empty principal.sync_transforms, "lower-priority google auth transforms should be withheld"
+  end
+
+  test "equal-priority google auth transforms all serve without a stronger wildcard static secret" do
+    grant_role_gcp(host: "bigquery.googleapis.com")
+    grant_role_oauth
+    grant_role_gcp(host: "*.googleapis.com")
+    principal = principals(:globex_user)
+
+    transforms = principal.sync_transforms
+    assert_equal 2, transforms.count { |t| t["name"] == "gcp_auth" }
+    assert_equal 1, transforms.count { |t| t["name"] == "oauth_token" }
+    assert_equal 1, transforms.find { |t| t["name"] == "oauth_token" }.dig("config", "tokens").length
+  end
+
   test "a promoted role transform suppresses a lower-priority direct static secret" do
     grant_direct_static(host: "api.test.com", header: "Authorization")
     gcp = grant_role_gcp(host: "api.test.com")


### PR DESCRIPTION
Adds regression coverage for Google API credential deconfliction.

The tests pin two cases: a higher-priority directly assigned *.googleapis.com static secret suppresses lower-priority Google auth transforms, and equal-priority Google auth transforms continue to serve when no stronger static secret exists.