### PR TITLE
feat: label tool credential secrets

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -2385,6 +2385,16 @@ mod tests {
                                 ..Default::default()
                             }),
                             rules: vec![serde_yaml::from_str("{host: api.tool.test}").unwrap()],
+                            extra: BTreeMap::from([(
+                                "labels".to_owned(),
+                                serde_yaml::from_str(
+                                    r#"
+centaur-tool: tool
+centaur-tool-overlay: overlay
+"#,
+                                )
+                                .unwrap(),
+                            )]),
                             ..Default::default()
                         }],
                         ..Default::default()
@@ -2413,6 +2423,10 @@ mod tests {
                         .as_ref()
                         .and_then(|replace| replace.proxy_value.as_deref())
                         == Some("TOOL_API_KEY")
+                    && secret.extra.get("labels").is_some_and(|labels| {
+                        labels["centaur-tool"].as_str() == Some("tool")
+                            && labels["centaur-tool-overlay"].as_str() == Some("overlay")
+                    })
             })
         }));
     }

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -2385,16 +2385,6 @@ mod tests {
                                 ..Default::default()
                             }),
                             rules: vec![serde_yaml::from_str("{host: api.tool.test}").unwrap()],
-                            extra: BTreeMap::from([(
-                                "labels".to_owned(),
-                                serde_yaml::from_str(
-                                    r#"
-centaur-tool: tool
-centaur-tool-overlay: overlay
-"#,
-                                )
-                                .unwrap(),
-                            )]),
                             ..Default::default()
                         }],
                         ..Default::default()
@@ -2423,10 +2413,6 @@ centaur-tool-overlay: overlay
                         .as_ref()
                         .and_then(|replace| replace.proxy_value.as_deref())
                         == Some("TOOL_API_KEY")
-                    && secret.extra.get("labels").is_some_and(|labels| {
-                        labels["centaur-tool"].as_str() == Some("tool")
-                            && labels["centaur-tool-overlay"].as_str() == Some("overlay")
-                    })
             })
         }));
     }

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -156,6 +156,60 @@ fn clean_optional_path(value: Option<&Path>) -> Option<PathBuf> {
     })
 }
 
+fn tool_labels(tool: &str, overlay: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("centaur-tool".to_owned(), tool.to_owned()),
+        ("centaur-tool-overlay".to_owned(), overlay.to_owned()),
+    ])
+}
+
+fn overlay_name_for_root(root: &Path) -> String {
+    let candidate = if root.file_name().and_then(|name| name.to_str()) == Some("tools") {
+        root.parent().and_then(|parent| parent.file_name())
+    } else {
+        root.file_name()
+    };
+    candidate
+        .and_then(|name| name.to_str())
+        .map(centaur_iron_control::slugify)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+fn merge_tool_labels(target: &mut BTreeMap<String, String>, incoming: &BTreeMap<String, String>) {
+    merge_csv_label(target, incoming, "centaur-tool");
+    merge_csv_label(target, incoming, "centaur-tool-overlay");
+}
+
+fn merge_csv_label(
+    target: &mut BTreeMap<String, String>,
+    incoming: &BTreeMap<String, String>,
+    key: &str,
+) {
+    let mut values = BTreeSet::new();
+    if let Some(existing) = target.get(key) {
+        values.extend(
+            existing
+                .split(',')
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned),
+        );
+    }
+    if let Some(next) = incoming.get(key) {
+        values.extend(
+            next.split(',')
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned),
+        );
+    }
+    if !values.is_empty() {
+        target.insert(
+            key.to_owned(),
+            values.into_iter().collect::<Vec<_>>().join(","),
+        );
+    }
+}
+
 fn default_tools_config() -> Option<PathBuf> {
     let cwd = env::current_dir().ok()?;
     find_ancestor_file(&cwd, "tools.toml")
@@ -233,7 +287,7 @@ fn collect_tools(tool_dirs: &[PathBuf]) -> Result<Vec<LoadedToolMeta>, ToolDisco
             if !pyproject_path.exists() {
                 continue;
             }
-            let Some(meta) = load_tool_meta(&tool_dir, &pyproject_path)? else {
+            let Some(meta) = load_tool_meta(base_dir, &tool_dir, &pyproject_path)? else {
                 continue;
             };
             if let Some(prev_dir_idx) = seen.insert(meta.name.clone(), dir_idx) {
@@ -299,6 +353,7 @@ fn is_visible_dir(path: &Path) -> bool {
 }
 
 fn load_tool_meta(
+    source_root: &Path,
     tool_dir: &Path,
     pyproject_path: &Path,
 ) -> Result<Option<LoadedToolMeta>, ToolDiscoveryError> {
@@ -334,24 +389,26 @@ fn load_tool_meta(
         })?
         .to_owned();
     let default_hosts = string_array(tool_conf.get("hosts"));
-    let secrets =
-        match parse_secret_list(tool_conf.get("secrets"), &default_hosts).and_then(|mut secrets| {
+    let labels = tool_labels(&name, &overlay_name_for_root(source_root));
+    let secrets = match parse_secret_list(tool_conf.get("secrets"), &default_hosts, &labels)
+        .and_then(|mut secrets| {
             secrets.extend(parse_secret_list(
                 tool_conf.get("optional_secrets"),
                 &default_hosts,
+                &labels,
             )?);
             Ok(secrets)
         }) {
-            Ok(secrets) => secrets,
-            Err(error) => {
-                warn!(
-                    tool = %name,
-                    error = %error,
-                    "api-rs tool invalid secret metadata"
-                );
-                return Ok(None);
-            }
-        };
+        Ok(secrets) => secrets,
+        Err(error) => {
+            warn!(
+                tool = %name,
+                error = %error,
+                "api-rs tool invalid secret metadata"
+            );
+            return Ok(None);
+        }
+    };
     Ok(Some(LoadedToolMeta { name, secrets }))
 }
 
@@ -368,6 +425,7 @@ enum ToolSecret {
 struct HttpSecret {
     name: String,
     secret_ref: String,
+    labels: BTreeMap<String, String>,
     mode: HttpSecretMode,
     hosts: Vec<String>,
     replacer: String,
@@ -394,6 +452,7 @@ struct OAuthFieldSource {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct OAuthTokenSecret {
     name: String,
+    labels: BTreeMap<String, String>,
     grant: String,
     hosts: Vec<String>,
     fields: Vec<(String, OAuthFieldSource)>,
@@ -407,6 +466,7 @@ struct OAuthTokenSecret {
 struct GcpAuthSecret {
     name: String,
     secret_ref: String,
+    labels: BTreeMap<String, String>,
     hosts: Vec<String>,
     scopes: Vec<String>,
 }
@@ -415,6 +475,7 @@ struct GcpAuthSecret {
 struct PgDsnSecret {
     name: String,
     secret_ref: String,
+    labels: BTreeMap<String, String>,
     database: String,
     role: Option<String>,
     settings: Vec<PgDsnSetting>,
@@ -430,6 +491,7 @@ struct PgDsnSecret {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct AwsAuthSecret {
     name: String,
+    labels: BTreeMap<String, String>,
     hosts: Vec<String>,
     access_key_id_ref: String,
     secret_access_key_ref: String,
@@ -441,6 +503,7 @@ struct AwsAuthSecret {
 fn parse_secret_list(
     value: Option<&TomlValue>,
     default_hosts: &[String],
+    labels: &BTreeMap<String, String>,
 ) -> Result<Vec<ToolSecret>, ToolDiscoveryError> {
     let Some(value) = value else {
         return Ok(Vec::new());
@@ -450,13 +513,14 @@ fn parse_secret_list(
         .ok_or_else(|| ToolDiscoveryError::Invalid("'secrets' must be an array".to_owned()))?;
     entries
         .iter()
-        .map(|entry| parse_secret(entry, default_hosts))
+        .map(|entry| parse_secret(entry, default_hosts, labels))
         .collect()
 }
 
 fn parse_secret(
     value: &TomlValue,
     default_hosts: &[String],
+    labels: &BTreeMap<String, String>,
 ) -> Result<ToolSecret, ToolDiscoveryError> {
     if let Some(name) = value.as_str() {
         let name = nonempty(name, "secret name")?.to_owned();
@@ -469,6 +533,7 @@ fn parse_secret(
         return Ok(ToolSecret::Http(HttpSecret {
             name: name.clone(),
             secret_ref: name.clone(),
+            labels: labels.clone(),
             mode: HttpSecretMode::Replace,
             hosts: default_hosts.to_vec(),
             replacer: name,
@@ -491,11 +556,11 @@ fn parse_secret(
         .unwrap_or(name.as_str())
         .to_owned();
     match optional_str(table, "type").unwrap_or("http") {
-        "http" | "header" => parse_http_secret(table, name, secret_ref, default_hosts),
-        "oauth_token" => parse_oauth_token_secret(table, name),
-        "gcp_auth" => parse_gcp_auth_secret(table, name, secret_ref),
-        "pg_dsn" => parse_pg_dsn_secret(table, name, secret_ref),
-        "aws_auth" => parse_aws_auth_secret(table, name),
+        "http" | "header" => parse_http_secret(table, name, secret_ref, default_hosts, labels),
+        "oauth_token" => parse_oauth_token_secret(table, name, labels),
+        "gcp_auth" => parse_gcp_auth_secret(table, name, secret_ref, labels),
+        "pg_dsn" => parse_pg_dsn_secret(table, name, secret_ref, labels),
+        "aws_auth" => parse_aws_auth_secret(table, name, labels),
         "brokered_token" | "hmac_sign" => Err(ToolDiscoveryError::Invalid(format!(
             "api-rs iron-control tool discovery does not yet support secret type {:?}",
             optional_str(table, "type").unwrap_or("unknown")
@@ -511,6 +576,7 @@ fn parse_http_secret(
     name: String,
     secret_ref: String,
     default_hosts: &[String],
+    labels: &BTreeMap<String, String>,
 ) -> Result<ToolSecret, ToolDiscoveryError> {
     let hosts =
         optional_string_array(table.get("hosts"))?.unwrap_or_else(|| default_hosts.to_vec());
@@ -537,6 +603,7 @@ fn parse_http_secret(
             Ok(ToolSecret::Http(HttpSecret {
                 name,
                 secret_ref,
+                labels: labels.clone(),
                 mode: HttpSecretMode::Replace,
                 hosts,
                 replacer,
@@ -571,6 +638,7 @@ fn parse_http_secret(
             Ok(ToolSecret::Http(HttpSecret {
                 name,
                 secret_ref,
+                labels: labels.clone(),
                 mode: HttpSecretMode::Inject,
                 hosts,
                 replacer: String::new(),
@@ -591,6 +659,7 @@ fn parse_http_secret(
 fn parse_oauth_token_secret(
     table: &toml::Table,
     name: String,
+    labels: &BTreeMap<String, String>,
 ) -> Result<ToolSecret, ToolDiscoveryError> {
     let grant = required_str(table, "grant")?.to_owned();
     let hosts = required_string_array(table.get("hosts"), "hosts")?;
@@ -603,6 +672,7 @@ fn parse_oauth_token_secret(
     let audience = optional_str(table, "audience").map(ToOwned::to_owned);
     Ok(ToolSecret::OAuthToken(OAuthTokenSecret {
         name,
+        labels: labels.clone(),
         grant,
         hosts,
         fields,
@@ -617,10 +687,12 @@ fn parse_gcp_auth_secret(
     table: &toml::Table,
     name: String,
     secret_ref: String,
+    labels: &BTreeMap<String, String>,
 ) -> Result<ToolSecret, ToolDiscoveryError> {
     Ok(ToolSecret::GcpAuth(GcpAuthSecret {
         name,
         secret_ref,
+        labels: labels.clone(),
         hosts: optional_string_array(table.get("hosts"))?.unwrap_or_default(),
         scopes: optional_string_array(table.get("scopes"))?.unwrap_or_default(),
     }))
@@ -630,6 +702,7 @@ fn parse_pg_dsn_secret(
     table: &toml::Table,
     name: String,
     secret_ref: String,
+    labels: &BTreeMap<String, String>,
 ) -> Result<ToolSecret, ToolDiscoveryError> {
     let database = required_str(table, "database")?.to_owned();
     let role = optional_str(table, "role").map(ToOwned::to_owned);
@@ -637,6 +710,7 @@ fn parse_pg_dsn_secret(
     Ok(ToolSecret::PgDsn(PgDsnSecret {
         name,
         secret_ref,
+        labels: labels.clone(),
         database,
         role,
         settings,
@@ -700,6 +774,7 @@ fn parse_pg_dsn_setting_value_from(
 fn parse_aws_auth_secret(
     table: &toml::Table,
     name: String,
+    labels: &BTreeMap<String, String>,
 ) -> Result<ToolSecret, ToolDiscoveryError> {
     // `hosts` is required (no tool-level fallback, matching the centaur-perms
     // loader); the credential refs are placeholders the proxy re-signs with.
@@ -715,6 +790,7 @@ fn parse_aws_auth_secret(
         optional_string_array(table.get("allowed_services"))?.unwrap_or_default();
     Ok(ToolSecret::AwsAuth(AwsAuthSecret {
         name,
+        labels: labels.clone(),
         hosts,
         access_key_id_ref,
         secret_access_key_ref,
@@ -776,21 +852,21 @@ fn fragment_from_secrets(secrets: Vec<ToolSecret>) -> Result<ProxyFragment, Tool
 }
 
 fn http_secret_transform(secrets: &[ToolSecret]) -> Result<Option<Transform>, ToolDiscoveryError> {
-    let mut grouped = BTreeMap::<HttpSecretKey, BTreeSet<String>>::new();
+    let mut grouped =
+        BTreeMap::<HttpSecretKey, (BTreeSet<String>, BTreeMap<String, String>)>::new();
     for secret in secrets {
         let ToolSecret::Http(secret) = secret else {
             continue;
         };
-        grouped
-            .entry(HttpSecretKey::from(secret))
-            .or_default()
-            .extend(secret.hosts.iter().cloned());
+        let entry = grouped.entry(HttpSecretKey::from(secret)).or_default();
+        entry.0.extend(secret.hosts.iter().cloned());
+        merge_tool_labels(&mut entry.1, &secret.labels);
     }
     if grouped.is_empty() {
         return Ok(None);
     }
     let mut entries = Vec::new();
-    for (key, hosts) in grouped {
+    for (key, (hosts, labels)) in grouped {
         let mut extra = BTreeMap::new();
         let mut entry = Secret {
             id: Some(key.name.clone()),
@@ -798,6 +874,7 @@ fn http_secret_transform(secrets: &[ToolSecret]) -> Result<Option<Transform>, To
             rules: host_rules(hosts)?,
             ..Default::default()
         };
+        entry.extra.insert("labels".to_owned(), yaml_value(labels)?);
         match key.mode {
             HttpSecretMode::Replace => {
                 extra.insert("match_headers".to_owned(), yaml_value(&key.match_headers)?);
@@ -870,7 +947,8 @@ impl From<&HttpSecret> for HttpSecretKey {
 }
 
 fn gcp_auth_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDiscoveryError> {
-    let mut by_ref = BTreeMap::<String, (BTreeSet<String>, BTreeSet<String>)>::new();
+    let mut by_ref =
+        BTreeMap::<String, (BTreeSet<String>, BTreeSet<String>, BTreeMap<String, String>)>::new();
     for secret in secrets {
         let ToolSecret::GcpAuth(secret) = secret else {
             continue;
@@ -878,9 +956,10 @@ fn gcp_auth_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDis
         let entry = by_ref.entry(secret.secret_ref.clone()).or_default();
         entry.0.extend(secret.hosts.iter().cloned());
         entry.1.extend(secret.scopes.iter().cloned());
+        merge_tool_labels(&mut entry.2, &secret.labels);
     }
     let mut transforms = Vec::new();
-    for (secret_ref, (hosts, scopes)) in by_ref {
+    for (secret_ref, (hosts, scopes, labels)) in by_ref {
         let mut config = BTreeMap::new();
         config.insert(
             "keyfile".to_owned(),
@@ -900,6 +979,7 @@ fn gcp_auth_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDis
             hosts
         };
         config.insert("rules".to_owned(), yaml_value(host_rules(hosts)?)?);
+        config.insert("labels".to_owned(), yaml_value(labels)?);
         transforms.push(Transform {
             name: "gcp_auth".to_owned(),
             config: TransformConfig {
@@ -919,8 +999,15 @@ fn aws_auth_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDis
     // the access-key placeholder) instead of colliding foreign_ids. Mirrors the
     // dedup `gcp_auth_transforms` does by secret_ref.
     type AwsCredKey = (String, String, Option<String>);
-    let mut by_cred =
-        BTreeMap::<AwsCredKey, (BTreeSet<String>, BTreeSet<String>, BTreeSet<String>)>::new();
+    let mut by_cred = BTreeMap::<
+        AwsCredKey,
+        (
+            BTreeSet<String>,
+            BTreeSet<String>,
+            BTreeSet<String>,
+            BTreeMap<String, String>,
+        ),
+    >::new();
     for secret in secrets {
         let ToolSecret::AwsAuth(secret) = secret else {
             continue;
@@ -935,11 +1022,12 @@ fn aws_auth_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDis
         entry.0.extend(secret.hosts.iter().cloned());
         entry.1.extend(secret.allowed_regions.iter().cloned());
         entry.2.extend(secret.allowed_services.iter().cloned());
+        merge_tool_labels(&mut entry.3, &secret.labels);
     }
     let mut transforms = Vec::new();
     for (
         (access_key_id_ref, secret_access_key_ref, session_token_ref),
-        (hosts, regions, services),
+        (hosts, regions, services, labels),
     ) in by_cred
     {
         let mut config = BTreeMap::new();
@@ -970,6 +1058,7 @@ fn aws_auth_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDis
             );
         }
         config.insert("rules".to_owned(), yaml_value(host_rules(hosts)?)?);
+        config.insert("labels".to_owned(), yaml_value(labels)?);
         transforms.push(Transform {
             name: "aws_auth".to_owned(),
             config: TransformConfig {
@@ -990,6 +1079,7 @@ fn oauth_token_transform(secrets: &[ToolSecret]) -> Result<Option<Transform>, To
         };
         let mut token = BTreeMap::new();
         token.insert("grant".to_owned(), yaml_string(&secret.grant));
+        token.insert("labels".to_owned(), yaml_value(&secret.labels)?);
         for (field_name, source) in &secret.fields {
             token.insert(field_name.clone(), oauth_field_source(source)?);
         }
@@ -1036,7 +1126,10 @@ fn postgres_listeners(secrets: &[ToolSecret]) -> Result<Vec<PostgresListener>, T
         let ToolSecret::PgDsn(secret) = secret else {
             continue;
         };
-        by_name.entry(secret.name.clone()).or_insert(secret.clone());
+        by_name
+            .entry(secret.name.clone())
+            .and_modify(|existing| merge_tool_labels(&mut existing.labels, &secret.labels))
+            .or_insert(secret.clone());
     }
     by_name
         .into_values()
@@ -1045,6 +1138,7 @@ fn postgres_listeners(secrets: &[ToolSecret]) -> Result<Vec<PostgresListener>, T
             if let Some(role) = &secret.role {
                 extra.insert("role".to_owned(), yaml_string(role));
             }
+            extra.insert("labels".to_owned(), yaml_value(&secret.labels)?);
             Ok(PostgresListener {
                 name: Some(secret.name.to_lowercase()),
                 upstream: Some(PostgresUpstream {
@@ -1226,6 +1320,7 @@ mod tests {
         let listeners = postgres_listeners(&[ToolSecret::PgDsn(PgDsnSecret {
             name: "RESHIFT_DSN".to_owned(),
             secret_ref: "RESHIFT_DSN".to_owned(),
+            labels: tool_labels("company_context", "centaur"),
             database: "warehouse".to_owned(),
             role: Some("centaur_slack_reader".to_owned()),
             settings: vec![PgDsnSetting {
@@ -1295,10 +1390,31 @@ secrets = [
         let secrets = discovered.fragment.transforms[0].config.secrets.clone();
         assert_eq!(secrets.len(), 1);
         assert_eq!(secrets[0].id.as_deref(), Some("OVERLAY_TOKEN"));
+        let labels = secrets[0]
+            .extra
+            .get("labels")
+            .and_then(YamlValue::as_mapping)
+            .expect("static secret labels");
+        assert_eq!(
+            labels
+                .get(YamlValue::String("centaur-tool".to_owned()))
+                .and_then(YamlValue::as_str),
+            Some("alpha")
+        );
+        assert_eq!(
+            labels
+                .get(YamlValue::String("centaur-tool-overlay".to_owned()))
+                .and_then(YamlValue::as_str),
+            Some("overlay")
+        );
         assert_eq!(
             discovered.fragment.transforms[1].name,
             "oauth_token".to_owned()
         );
+        let tokens = discovered.fragment.transforms[1].config.extra["tokens"]
+            .as_sequence()
+            .expect("oauth tokens");
+        assert_eq!(tokens[0]["labels"]["centaur-tool"].as_str(), Some("gsuite"));
 
         let _ = fs::remove_dir_all(temp);
     }

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -179,6 +179,8 @@ pub struct OAuthTokenSecretInput {
     pub foreign_id: String,
     pub name: String,
     pub grant: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_endpoint: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -206,6 +208,8 @@ pub struct GcpAuthSecretInput {
     pub foreign_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
     pub scopes: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subject: Option<String>,

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -278,7 +278,7 @@ fn static_secret_from_secret(
         foreign_id: format!("{role}-{}", slugify(&identity)),
         name: identity,
         description: None,
-        labels: managed_labels(),
+        labels: resource_labels(secret.extra.get("labels")),
         inject_config,
         replace_config,
         source,
@@ -536,7 +536,7 @@ fn pg_dsn_from_listener(
         database,
         description: None,
         role: role_to_set,
-        labels: managed_labels(),
+        labels: resource_labels(listener.extra.get("labels")),
         settings: listener
             .settings
             .iter()
@@ -608,6 +608,7 @@ const OAUTH_RESERVED_KEYS: &[&str] = &[
     "scopes",
     "audience",
     "header",
+    "labels",
     "value_prefix",
 ];
 
@@ -672,6 +673,7 @@ fn oauth_token_from_value(
         foreign_id: format!("{role}-oauth-{}", slugify(identity)),
         name: format!("OAuth {grant}"),
         grant,
+        labels: resource_labels(yaml_get(token, "labels")),
         token_endpoint: yaml_str(token, "token_endpoint").map(ToOwned::to_owned),
         scopes: yaml_string_array(yaml_get(token, "scopes")),
         audience: yaml_str(token, "audience").map(ToOwned::to_owned),
@@ -726,6 +728,7 @@ fn gcp_auth_from_transform(
         namespace: namespace.to_owned(),
         foreign_id,
         name: Some(format!("GCP Auth ({role})")),
+        labels: resource_labels(config.get("labels")),
         scopes,
         subject: config
             .get("subject")
@@ -774,7 +777,7 @@ fn aws_auth_from_transform(
         foreign_id: format!("{role}-aws-{}", slugify(&placeholder)),
         name: Some(format!("AWS Auth ({role})")),
         description: None,
-        labels: managed_labels(),
+        labels: resource_labels(config.get("labels")),
         access_key_id,
         secret_access_key,
         session_token,
@@ -835,6 +838,21 @@ fn yaml_bool(value: Option<&YamlValue>) -> bool {
     value.and_then(YamlValue::as_bool).unwrap_or(false)
 }
 
+fn resource_labels(value: Option<&YamlValue>) -> BTreeMap<String, String> {
+    let mut labels = managed_labels();
+    if let Some(mapping) = value.and_then(YamlValue::as_mapping) {
+        for (key, value) in mapping {
+            let (Some(key), Some(value)) = (key.as_str(), value.as_str()) else {
+                continue;
+            };
+            if !key.is_empty() {
+                labels.insert(key.to_owned(), value.to_owned());
+            }
+        }
+    }
+    labels
+}
+
 fn sequence(value: Option<&YamlValue>) -> Vec<YamlValue> {
     value
         .and_then(YamlValue::as_sequence)
@@ -886,6 +904,9 @@ transforms:
         - replace:
             proxy_value: XAI_API_KEY
             match_headers: ["Authorization"]
+          labels:
+            centaur-tool: xai
+            centaur-tool-overlay: centaur
           rules: [{ host: api.x.ai }]
 "#,
         )
@@ -904,6 +925,18 @@ transforms:
         assert!(input.inject_config.is_none());
         assert_eq!(input.source.source_type, "env");
         assert_eq!(input.source.config, json!({ "var": "XAI_API_KEY" }));
+        assert_eq!(
+            input.labels.get("managed-by").map(String::as_str),
+            Some("centaur")
+        );
+        assert_eq!(
+            input.labels.get("centaur-tool").map(String::as_str),
+            Some("xai")
+        );
+        assert_eq!(
+            input.labels.get("centaur-tool-overlay").map(String::as_str),
+            Some("centaur")
+        );
         assert_eq!(input.rules.len(), 1);
         assert_eq!(input.rules[0].host.as_deref(), Some("api.x.ai"));
     }

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -138,6 +138,7 @@ pub async fn grant_inputs_to_role(
     inputs: Vec<SecretInput>,
 ) -> Result<Vec<String>, IronControlError> {
     let existing = client.list_role_grants(role_oid).await?;
+    let inputs = coalesce_secret_inputs(inputs);
     let mut grant_ids = Vec::with_capacity(inputs.len());
     for input in inputs {
         let secret = match input {
@@ -173,6 +174,93 @@ pub async fn grant_inputs_to_role(
         grant_ids.push(grant.id);
     }
     Ok(grant_ids)
+}
+
+fn coalesce_secret_inputs(inputs: Vec<SecretInput>) -> Vec<SecretInput> {
+    let mut out: Vec<SecretInput> = Vec::with_capacity(inputs.len());
+    for mut input in inputs {
+        let Some(key) = secret_input_key(&input) else {
+            out.push(input);
+            continue;
+        };
+        if let Some(position) = out
+            .iter()
+            .position(|existing| secret_input_key(existing).as_ref() == Some(&key))
+        {
+            merge_secret_input_labels(&out[position], &mut input);
+            preserve_secret_input_foreign_id(&out[position], &mut input);
+            out[position] = input;
+        } else {
+            out.push(input);
+        }
+    }
+    out
+}
+
+fn secret_input_key(input: &SecretInput) -> Option<(&'static str, &str)> {
+    match input {
+        SecretInput::Static(input) => Some(("static", input.name.as_str())),
+        SecretInput::OAuthToken(input) => Some(("oauth_token", input.foreign_id.as_str())),
+        SecretInput::GcpAuth(input) => input
+            .foreign_id
+            .as_deref()
+            .map(|foreign_id| ("gcp_auth", foreign_id)),
+        SecretInput::PgDsn(input) => Some(("pg_dsn", input.foreign_id.as_str())),
+        SecretInput::Hmac(input) => Some(("hmac", input.foreign_id.as_str())),
+        SecretInput::AwsAuth(input) => Some(("aws_auth", input.foreign_id.as_str())),
+    }
+}
+
+fn preserve_secret_input_foreign_id(existing: &SecretInput, next: &mut SecretInput) {
+    match (existing, next) {
+        (SecretInput::Static(existing), SecretInput::Static(next)) => {
+            next.foreign_id.clone_from(&existing.foreign_id);
+        }
+        (SecretInput::OAuthToken(existing), SecretInput::OAuthToken(next)) => {
+            next.foreign_id.clone_from(&existing.foreign_id);
+        }
+        (SecretInput::GcpAuth(existing), SecretInput::GcpAuth(next)) => {
+            next.foreign_id.clone_from(&existing.foreign_id);
+        }
+        (SecretInput::PgDsn(existing), SecretInput::PgDsn(next)) => {
+            next.foreign_id.clone_from(&existing.foreign_id);
+        }
+        (SecretInput::Hmac(existing), SecretInput::Hmac(next)) => {
+            next.foreign_id.clone_from(&existing.foreign_id);
+        }
+        (SecretInput::AwsAuth(existing), SecretInput::AwsAuth(next)) => {
+            next.foreign_id.clone_from(&existing.foreign_id);
+        }
+        _ => {}
+    }
+}
+
+fn merge_secret_input_labels(existing: &SecretInput, next: &mut SecretInput) {
+    let mut labels = secret_input_labels(existing).clone();
+    labels.extend(secret_input_labels(next).clone());
+    *secret_input_labels_mut(next) = labels;
+}
+
+fn secret_input_labels(input: &SecretInput) -> &BTreeMap<String, String> {
+    match input {
+        SecretInput::Static(input) => &input.labels,
+        SecretInput::OAuthToken(input) => &input.labels,
+        SecretInput::GcpAuth(input) => &input.labels,
+        SecretInput::PgDsn(input) => &input.labels,
+        SecretInput::Hmac(input) => &input.labels,
+        SecretInput::AwsAuth(input) => &input.labels,
+    }
+}
+
+fn secret_input_labels_mut(input: &mut SecretInput) -> &mut BTreeMap<String, String> {
+    match input {
+        SecretInput::Static(input) => &mut input.labels,
+        SecretInput::OAuthToken(input) => &mut input.labels,
+        SecretInput::GcpAuth(input) => &mut input.labels,
+        SecretInput::PgDsn(input) => &mut input.labels,
+        SecretInput::Hmac(input) => &mut input.labels,
+        SecretInput::AwsAuth(input) => &mut input.labels,
+    }
 }
 
 /// Pure translation: a fragment's transforms → the secret resources to upsert.
@@ -939,6 +1027,53 @@ transforms:
         );
         assert_eq!(input.rules.len(), 1);
         assert_eq!(input.rules[0].host.as_deref(), Some("api.x.ai"));
+    }
+
+    #[test]
+    fn coalesces_duplicate_inputs_without_losing_tool_labels() {
+        let fragment = load_fragment_str(
+            r#"
+transforms:
+  - name: secrets
+    config:
+      secrets:
+        - replace:
+            proxy_value: SHARED_API_KEY
+            match_headers: ["Authorization"]
+          rules: [{ host: base.example.com }]
+        - replace:
+            proxy_value: SHARED_API_KEY
+            match_headers: ["Authorization"]
+          labels:
+            centaur-tool: shared-tool
+            centaur-tool-overlay: overlay
+          rules: [{ host: tool.example.com }]
+"#,
+        )
+        .unwrap();
+        let inputs =
+            secret_inputs_from_fragment("default", "infra", &fragment, &env_policy()).unwrap();
+        assert_eq!(inputs.len(), 2);
+
+        let inputs = coalesce_secret_inputs(inputs);
+
+        assert_eq!(inputs.len(), 1);
+        let SecretInput::Static(input) = &inputs[0] else {
+            panic!("expected a static secret");
+        };
+        assert_eq!(input.foreign_id, "infra-shared-api-key");
+        assert_eq!(
+            input.labels.get("managed-by").map(String::as_str),
+            Some("centaur")
+        );
+        assert_eq!(
+            input.labels.get("centaur-tool").map(String::as_str),
+            Some("shared-tool")
+        );
+        assert_eq!(
+            input.labels.get("centaur-tool-overlay").map(String::as_str),
+            Some("overlay")
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -138,7 +138,6 @@ pub async fn grant_inputs_to_role(
     inputs: Vec<SecretInput>,
 ) -> Result<Vec<String>, IronControlError> {
     let existing = client.list_role_grants(role_oid).await?;
-    let inputs = coalesce_secret_inputs(inputs);
     let mut grant_ids = Vec::with_capacity(inputs.len());
     for input in inputs {
         let secret = match input {
@@ -174,43 +173,6 @@ pub async fn grant_inputs_to_role(
         grant_ids.push(grant.id);
     }
     Ok(grant_ids)
-}
-
-fn coalesce_secret_inputs(inputs: Vec<SecretInput>) -> Vec<SecretInput> {
-    let mut out: Vec<SecretInput> = Vec::with_capacity(inputs.len());
-    for input in inputs {
-        if let Some(position) = out
-            .iter()
-            .position(|existing| static_secret_name(existing) == static_secret_name(&input))
-        {
-            if let (SecretInput::Static(existing), SecretInput::Static(mut next)) =
-                (&out[position], input)
-            {
-                next.foreign_id.clone_from(&existing.foreign_id);
-                next.labels = merged_labels(&existing.labels, &next.labels);
-                out[position] = SecretInput::Static(next);
-            }
-        } else {
-            out.push(input);
-        }
-    }
-    out
-}
-
-fn static_secret_name(input: &SecretInput) -> Option<&str> {
-    let SecretInput::Static(input) = input else {
-        return None;
-    };
-    Some(input.name.as_str())
-}
-
-fn merged_labels(
-    existing: &BTreeMap<String, String>,
-    next: &BTreeMap<String, String>,
-) -> BTreeMap<String, String> {
-    let mut labels = existing.clone();
-    labels.extend(next.clone());
-    labels
 }
 
 /// Pure translation: a fragment's transforms → the secret resources to upsert.
@@ -977,53 +939,6 @@ transforms:
         );
         assert_eq!(input.rules.len(), 1);
         assert_eq!(input.rules[0].host.as_deref(), Some("api.x.ai"));
-    }
-
-    #[test]
-    fn coalesces_duplicate_inputs_without_losing_tool_labels() {
-        let fragment = load_fragment_str(
-            r#"
-transforms:
-  - name: secrets
-    config:
-      secrets:
-        - replace:
-            proxy_value: SHARED_API_KEY
-            match_headers: ["Authorization"]
-          rules: [{ host: base.example.com }]
-        - replace:
-            proxy_value: SHARED_API_KEY
-            match_headers: ["Authorization"]
-          labels:
-            centaur-tool: shared-tool
-            centaur-tool-overlay: overlay
-          rules: [{ host: tool.example.com }]
-"#,
-        )
-        .unwrap();
-        let inputs =
-            secret_inputs_from_fragment("default", "infra", &fragment, &env_policy()).unwrap();
-        assert_eq!(inputs.len(), 2);
-
-        let inputs = coalesce_secret_inputs(inputs);
-
-        assert_eq!(inputs.len(), 1);
-        let SecretInput::Static(input) = &inputs[0] else {
-            panic!("expected a static secret");
-        };
-        assert_eq!(input.foreign_id, "infra-shared-api-key");
-        assert_eq!(
-            input.labels.get("managed-by").map(String::as_str),
-            Some("centaur")
-        );
-        assert_eq!(
-            input.labels.get("centaur-tool").map(String::as_str),
-            Some("shared-tool")
-        );
-        assert_eq!(
-            input.labels.get("centaur-tool-overlay").map(String::as_str),
-            Some("overlay")
-        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -178,18 +178,18 @@ pub async fn grant_inputs_to_role(
 
 fn coalesce_secret_inputs(inputs: Vec<SecretInput>) -> Vec<SecretInput> {
     let mut out: Vec<SecretInput> = Vec::with_capacity(inputs.len());
-    for mut input in inputs {
-        let Some(key) = secret_input_key(&input) else {
-            out.push(input);
-            continue;
-        };
+    for input in inputs {
         if let Some(position) = out
             .iter()
-            .position(|existing| secret_input_key(existing).as_ref() == Some(&key))
+            .position(|existing| static_secret_name(existing) == static_secret_name(&input))
         {
-            merge_secret_input_labels(&out[position], &mut input);
-            preserve_secret_input_foreign_id(&out[position], &mut input);
-            out[position] = input;
+            if let (SecretInput::Static(existing), SecretInput::Static(mut next)) =
+                (&out[position], input)
+            {
+                next.foreign_id.clone_from(&existing.foreign_id);
+                next.labels = merged_labels(&existing.labels, &next.labels);
+                out[position] = SecretInput::Static(next);
+            }
         } else {
             out.push(input);
         }
@@ -197,70 +197,20 @@ fn coalesce_secret_inputs(inputs: Vec<SecretInput>) -> Vec<SecretInput> {
     out
 }
 
-fn secret_input_key(input: &SecretInput) -> Option<(&'static str, &str)> {
-    match input {
-        SecretInput::Static(input) => Some(("static", input.name.as_str())),
-        SecretInput::OAuthToken(input) => Some(("oauth_token", input.foreign_id.as_str())),
-        SecretInput::GcpAuth(input) => input
-            .foreign_id
-            .as_deref()
-            .map(|foreign_id| ("gcp_auth", foreign_id)),
-        SecretInput::PgDsn(input) => Some(("pg_dsn", input.foreign_id.as_str())),
-        SecretInput::Hmac(input) => Some(("hmac", input.foreign_id.as_str())),
-        SecretInput::AwsAuth(input) => Some(("aws_auth", input.foreign_id.as_str())),
-    }
+fn static_secret_name(input: &SecretInput) -> Option<&str> {
+    let SecretInput::Static(input) = input else {
+        return None;
+    };
+    Some(input.name.as_str())
 }
 
-fn preserve_secret_input_foreign_id(existing: &SecretInput, next: &mut SecretInput) {
-    match (existing, next) {
-        (SecretInput::Static(existing), SecretInput::Static(next)) => {
-            next.foreign_id.clone_from(&existing.foreign_id);
-        }
-        (SecretInput::OAuthToken(existing), SecretInput::OAuthToken(next)) => {
-            next.foreign_id.clone_from(&existing.foreign_id);
-        }
-        (SecretInput::GcpAuth(existing), SecretInput::GcpAuth(next)) => {
-            next.foreign_id.clone_from(&existing.foreign_id);
-        }
-        (SecretInput::PgDsn(existing), SecretInput::PgDsn(next)) => {
-            next.foreign_id.clone_from(&existing.foreign_id);
-        }
-        (SecretInput::Hmac(existing), SecretInput::Hmac(next)) => {
-            next.foreign_id.clone_from(&existing.foreign_id);
-        }
-        (SecretInput::AwsAuth(existing), SecretInput::AwsAuth(next)) => {
-            next.foreign_id.clone_from(&existing.foreign_id);
-        }
-        _ => {}
-    }
-}
-
-fn merge_secret_input_labels(existing: &SecretInput, next: &mut SecretInput) {
-    let mut labels = secret_input_labels(existing).clone();
-    labels.extend(secret_input_labels(next).clone());
-    *secret_input_labels_mut(next) = labels;
-}
-
-fn secret_input_labels(input: &SecretInput) -> &BTreeMap<String, String> {
-    match input {
-        SecretInput::Static(input) => &input.labels,
-        SecretInput::OAuthToken(input) => &input.labels,
-        SecretInput::GcpAuth(input) => &input.labels,
-        SecretInput::PgDsn(input) => &input.labels,
-        SecretInput::Hmac(input) => &input.labels,
-        SecretInput::AwsAuth(input) => &input.labels,
-    }
-}
-
-fn secret_input_labels_mut(input: &mut SecretInput) -> &mut BTreeMap<String, String> {
-    match input {
-        SecretInput::Static(input) => &mut input.labels,
-        SecretInput::OAuthToken(input) => &mut input.labels,
-        SecretInput::GcpAuth(input) => &mut input.labels,
-        SecretInput::PgDsn(input) => &mut input.labels,
-        SecretInput::Hmac(input) => &mut input.labels,
-        SecretInput::AwsAuth(input) => &mut input.labels,
-    }
+fn merged_labels(
+    existing: &BTreeMap<String, String>,
+    next: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut labels = existing.clone();
+    labels.extend(next.clone());
+    labels
 }
 
 /// Pure translation: a fragment's transforms → the secret resources to upsert.

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -77,11 +77,11 @@ fn shipped_proxy_allowlist_preserves_railway_project_tokens() {
         .iter()
         .find(|transform| transform["name"].as_str() == Some("header_allowlist"))
         .unwrap();
-    let headers = header_allowlist["config"]["headers"]
-        .as_sequence()
-        .unwrap();
+    let headers = header_allowlist["config"]["headers"].as_sequence().unwrap();
 
-    assert!(headers
-        .iter()
-        .any(|header| header.as_str() == Some("project-access-token")));
+    assert!(
+        headers
+            .iter()
+            .any(|header| header.as_str() == Some("project-access-token"))
+    );
 }

--- a/services/api-rs/crates/centaur-perms/src/main.rs
+++ b/services/api-rs/crates/centaur-perms/src/main.rs
@@ -459,12 +459,22 @@ async fn principals_grant(
     for tool in &args.tools {
         let manifest = tools::find_tool(&dirs, tool)?;
         let role = RoleSpec::tool(&manifest.name);
+        let tool_labels = translate::ToolLabels {
+            tool: manifest.name.clone(),
+            overlay: tools::overlay_name_for_tool_dir(&manifest.dir, &dirs),
+        };
         let role_id = client
             .upsert_role(&role_identity(&role, &cli.namespace))
             .await?
             .id;
         let secrets: Vec<_> = manifest.all_secrets().cloned().collect();
-        let translation = translate::translate(&cli.namespace, &role.foreign_id, &secrets, &policy);
+        let translation = translate::translate_for_tool(
+            &cli.namespace,
+            &role.foreign_id,
+            &tool_labels,
+            &secrets,
+            &policy,
+        );
         let granted = grant_inputs_to_role(client, &role_id, translation.inputs).await?;
         assign_role_idempotent(client, &principal_id, &role_id).await?;
         println!(
@@ -613,7 +623,17 @@ async fn roles_grant(cli: &Cli, client: &IronControlClient, args: &RoleGrantArgs
         // Key the secret resources on the tool's canonical role so the same
         // secret object is shared no matter which role it's granted to.
         let tool_role = RoleSpec::tool(&manifest.name).foreign_id;
-        let translation = translate::translate(&cli.namespace, &tool_role, &selected, &policy);
+        let tool_labels = translate::ToolLabels {
+            tool: manifest.name.clone(),
+            overlay: tools::overlay_name_for_tool_dir(&manifest.dir, &dirs),
+        };
+        let translation = translate::translate_for_tool(
+            &cli.namespace,
+            &tool_role,
+            &tool_labels,
+            &selected,
+            &policy,
+        );
         let granted = grant_inputs_to_role(client, &role.id, translation.inputs).await?;
         println!(
             "  tool {} (from {}): {} secret(s) registered and granted to {}",

--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -645,6 +645,46 @@ fn duplicate_secret_names_get_unique_foreign_ids() {
     assert_eq!(b.foreign_id, "tool-x-tok-2");
 }
 
+#[test]
+fn translate_for_tool_adds_tool_identity_labels() {
+    let secrets = vec![tools::parse_secret(
+        &entry(
+            r#"{ type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"] }"#,
+        ),
+        &[],
+    )
+    .unwrap()];
+    let labels = translate::ToolLabels {
+        tool: "slack".to_owned(),
+        overlay: "centaur-paradigm".to_owned(),
+    };
+    let out = translate::translate_for_tool(
+        "default",
+        "tool-slack",
+        &labels,
+        &secrets,
+        &SourcePolicy::env(),
+    );
+    let SecretInput::Static(secret) = &out.inputs[0] else {
+        panic!()
+    };
+    assert_eq!(
+        secret.labels.get("managed-by").map(String::as_str),
+        Some("centaur")
+    );
+    assert_eq!(
+        secret.labels.get("centaur-tool").map(String::as_str),
+        Some("slack")
+    );
+    assert_eq!(
+        secret
+            .labels
+            .get("centaur-tool-overlay")
+            .map(String::as_str),
+        Some("centaur-paradigm")
+    );
+}
+
 // ----- overlay resolution ---------------------------------------------------
 
 fn tmp_root(tag: &str) -> PathBuf {
@@ -695,6 +735,21 @@ fn finds_tool_in_category_subdir() {
     let manifest = tools::find_tool(&[base], "slack").unwrap();
     assert_eq!(manifest.name, "slack");
     assert_eq!(manifest.secrets[0].name(), "SLACK_BOT_TOKEN");
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn overlay_name_uses_parent_when_root_is_tools_dir() {
+    let root = tmp_root("overlay-name");
+    let tools_dir = root.join("centaur-paradigm").join("tools");
+    write_tool(&tools_dir, "productivity/slack", SLACK_A);
+
+    let manifest = tools::find_tool(std::slice::from_ref(&tools_dir), "slack").unwrap();
+    assert_eq!(
+        tools::overlay_name_for_tool_dir(&manifest.dir, &[tools_dir]),
+        "centaur-paradigm"
+    );
 
     fs::remove_dir_all(&root).unwrap();
 }

--- a/services/api-rs/crates/centaur-perms/src/tools.rs
+++ b/services/api-rs/crates/centaur-perms/src/tools.rs
@@ -287,6 +287,32 @@ pub fn find_tool(dirs: &[PathBuf], name: &str) -> Result<ToolManifest> {
     parse_manifest(&tool_dir)
 }
 
+/// Derive the operator-facing overlay identity for the root that supplied a
+/// tool manifest. A root ending in `tools` is treated as a repo/overlay tools
+/// directory, so `/repo/centaur/tools` becomes `centaur`.
+pub fn overlay_name_for_tool_dir(tool_dir: &Path, dirs: &[PathBuf]) -> String {
+    let matching_root = dirs
+        .iter()
+        .filter(|root| tool_dir.starts_with(root))
+        .max_by_key(|root| root.components().count());
+    matching_root
+        .map(|root| overlay_name_for_root(root))
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+fn overlay_name_for_root(root: &Path) -> String {
+    let candidate = if root.file_name().and_then(|n| n.to_str()) == Some("tools") {
+        root.parent().and_then(|p| p.file_name())
+    } else {
+        root.file_name()
+    };
+    candidate
+        .and_then(|n| n.to_str())
+        .map(centaur_iron_control::slugify)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
 /// Candidate tool directories under `base`: direct children carrying a
 /// `pyproject.toml`, plus the children of category folders (one level deep).
 fn collect_candidate_dirs(base: &Path) -> Vec<PathBuf> {

--- a/services/api-rs/crates/centaur-perms/src/translate.rs
+++ b/services/api-rs/crates/centaur-perms/src/translate.rs
@@ -30,6 +30,12 @@ pub struct Translation {
     pub inputs: Vec<SecretInput>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ToolLabels {
+    pub tool: String,
+    pub overlay: String,
+}
+
 fn rules_from_hosts(hosts: &[String]) -> Vec<RequestRule> {
     hosts.iter().map(RequestRule::host).collect()
 }
@@ -42,6 +48,38 @@ pub fn translate(
     secrets: &[ParsedSecret],
     policy: &SourcePolicy,
 ) -> Translation {
+    translate_with_labels(
+        namespace,
+        role_foreign_id,
+        secrets,
+        policy,
+        &managed_labels(),
+    )
+}
+
+pub fn translate_for_tool(
+    namespace: &str,
+    role_foreign_id: &str,
+    labels: &ToolLabels,
+    secrets: &[ParsedSecret],
+    policy: &SourcePolicy,
+) -> Translation {
+    translate_with_labels(
+        namespace,
+        role_foreign_id,
+        secrets,
+        policy,
+        &tool_labels(labels),
+    )
+}
+
+fn translate_with_labels(
+    namespace: &str,
+    role_foreign_id: &str,
+    secrets: &[ParsedSecret],
+    policy: &SourcePolicy,
+    labels: &BTreeMap<String, String>,
+) -> Translation {
     let mut out = Translation::default();
     let mut used = BTreeSet::new();
     for secret in secrets {
@@ -52,6 +90,7 @@ pub fn translate(
                     role_foreign_id,
                     http,
                     policy,
+                    labels,
                     &mut used,
                 )));
             }
@@ -61,6 +100,7 @@ pub fn translate(
                     role_foreign_id,
                     oauth,
                     policy,
+                    labels,
                     &mut used,
                 )));
             }
@@ -70,12 +110,14 @@ pub fn translate(
                     role_foreign_id,
                     gcp,
                     policy,
+                    labels,
                     &mut used,
                 )));
             }
             ParsedSecret::PgDsn(pg) => {
-                out.inputs
-                    .push(SecretInput::PgDsn(pg_dsn_input(namespace, pg, policy)));
+                out.inputs.push(SecretInput::PgDsn(pg_dsn_input(
+                    namespace, pg, policy, labels,
+                )));
             }
             ParsedSecret::Hmac(hmac) => {
                 out.inputs.push(SecretInput::Hmac(hmac_input(
@@ -83,6 +125,7 @@ pub fn translate(
                     role_foreign_id,
                     hmac,
                     policy,
+                    labels,
                     &mut used,
                 )));
             }
@@ -91,6 +134,7 @@ pub fn translate(
                     namespace,
                     role_foreign_id,
                     broker,
+                    labels,
                     &mut used,
                 )));
             }
@@ -100,6 +144,7 @@ pub fn translate(
                     role_foreign_id,
                     aws,
                     policy,
+                    labels,
                     &mut used,
                 )));
             }
@@ -108,11 +153,19 @@ pub fn translate(
     out
 }
 
+fn tool_labels(tool: &ToolLabels) -> BTreeMap<String, String> {
+    let mut labels = managed_labels();
+    labels.insert("centaur-tool".to_owned(), tool.tool.clone());
+    labels.insert("centaur-tool-overlay".to_owned(), tool.overlay.clone());
+    labels
+}
+
 fn static_input(
     namespace: &str,
     role: &str,
     http: &HttpSecret,
     policy: &SourcePolicy,
+    labels: &BTreeMap<String, String>,
     used: &mut BTreeSet<String>,
 ) -> StaticSecretInput {
     let (inject_config, replace_config) = match http.mode {
@@ -141,7 +194,7 @@ fn static_input(
         foreign_id: unique_foreign_id(format!("{role}-{}", slugify(&http.name)), used),
         name: http.name.clone(),
         description: None,
-        labels: managed_labels(),
+        labels: labels.clone(),
         inject_config,
         replace_config,
         source: source_from_placeholder(policy, &http.secret_ref, None),
@@ -154,6 +207,7 @@ fn oauth_input(
     role: &str,
     oauth: &OAuthTokenSecret,
     policy: &SourcePolicy,
+    labels: &BTreeMap<String, String>,
     used: &mut BTreeSet<String>,
 ) -> OAuthTokenSecretInput {
     let identity = oauth.token_endpoint.as_deref().unwrap_or(&oauth.name);
@@ -162,6 +216,7 @@ fn oauth_input(
         foreign_id: unique_foreign_id(format!("{role}-oauth-{}", slugify(identity)), used),
         name: format!("OAuth {}", oauth.grant),
         grant: oauth.grant.clone(),
+        labels: labels.clone(),
         token_endpoint: oauth.token_endpoint.clone(),
         scopes: oauth.scopes.clone(),
         audience: oauth.audience.clone(),
@@ -176,6 +231,7 @@ fn gcp_input(
     role: &str,
     gcp: &GcpAuthSecret,
     policy: &SourcePolicy,
+    labels: &BTreeMap<String, String>,
     used: &mut BTreeSet<String>,
 ) -> GcpAuthSecretInput {
     GcpAuthSecretInput {
@@ -185,6 +241,7 @@ fn gcp_input(
             used,
         )),
         name: Some(format!("GCP Auth ({role})")),
+        labels: labels.clone(),
         scopes: gcp_auth_scopes_or_default(gcp.scopes.clone()),
         subject: None,
         keyfile: Some(source_from_placeholder(policy, &gcp.secret_ref, None)),
@@ -201,7 +258,12 @@ fn gcp_input(
 /// back to the tool's declared `name`. `pg_sandbox_env_var` appends `_DSN`, so a
 /// trailing `_dsn`/`-dsn` is stripped before slugifying — e.g. `RESHIFT_DSN`
 /// becomes `reshift`, which `pg_sandbox_env_var` turns back into `RESHIFT_DSN`.
-fn pg_dsn_input(namespace: &str, pg: &PgDsnSecret, policy: &SourcePolicy) -> PgDsnSecretInput {
+fn pg_dsn_input(
+    namespace: &str,
+    pg: &PgDsnSecret,
+    policy: &SourcePolicy,
+    labels: &BTreeMap<String, String>,
+) -> PgDsnSecretInput {
     PgDsnSecretInput {
         namespace: namespace.to_owned(),
         foreign_id: pg_dsn_foreign_id(&pg.name),
@@ -209,7 +271,7 @@ fn pg_dsn_input(namespace: &str, pg: &PgDsnSecret, policy: &SourcePolicy) -> PgD
         database: pg.database.clone(),
         description: None,
         role: pg.role.clone(),
-        labels: managed_labels(),
+        labels: labels.clone(),
         settings: pg.settings.iter().map(pg_setting_input).collect(),
         dsn: source_from_placeholder(policy, &pg.secret_ref, None),
     }
@@ -255,6 +317,7 @@ fn hmac_input(
     role: &str,
     hmac: &HmacSignSecret,
     policy: &SourcePolicy,
+    labels: &BTreeMap<String, String>,
     used: &mut BTreeSet<String>,
 ) -> HmacSecretInput {
     HmacSecretInput {
@@ -262,7 +325,7 @@ fn hmac_input(
         foreign_id: unique_foreign_id(format!("{role}-hmac-{}", slugify(&hmac.name)), used),
         name: hmac.name.clone(),
         description: None,
-        labels: managed_labels(),
+        labels: labels.clone(),
         timestamp_format: hmac.timestamp_format.clone(),
         signature_algorithm: hmac.algorithm.clone(),
         signature_key_encoding: hmac.key_encoding.clone(),
@@ -293,6 +356,7 @@ fn aws_input(
     role: &str,
     aws: &AwsAuthSecret,
     policy: &SourcePolicy,
+    labels: &BTreeMap<String, String>,
     used: &mut BTreeSet<String>,
 ) -> AwsAuthSecretInput {
     AwsAuthSecretInput {
@@ -300,7 +364,7 @@ fn aws_input(
         foreign_id: unique_foreign_id(format!("{role}-aws-{}", slugify(&aws.name)), used),
         name: Some(format!("AWS Auth ({role})")),
         description: None,
-        labels: managed_labels(),
+        labels: labels.clone(),
         access_key_id: source_from_placeholder(policy, &aws.access_key_id_ref, None),
         secret_access_key: source_from_placeholder(policy, &aws.secret_access_key_ref, None),
         session_token: aws
@@ -323,6 +387,7 @@ fn broker_token_input(
     namespace: &str,
     role: &str,
     broker: &BrokerTokenSecret,
+    labels: &BTreeMap<String, String>,
     used: &mut BTreeSet<String>,
 ) -> StaticSecretInput {
     StaticSecretInput {
@@ -330,7 +395,7 @@ fn broker_token_input(
         foreign_id: unique_foreign_id(format!("{role}-{}", slugify(&broker.name)), used),
         name: broker.name.clone(),
         description: None,
-        labels: managed_labels(),
+        labels: labels.clone(),
         inject_config: Some(InjectConfig {
             header: Some(broker.inject_header.clone()),
             query_param: None,

--- a/services/api-rs/crates/centaur-perms/src/translate.rs
+++ b/services/api-rs/crates/centaur-perms/src/translate.rs
@@ -42,6 +42,7 @@ fn rules_from_hosts(hosts: &[String]) -> Vec<RequestRule> {
 
 /// Translate every secret declared by a tool into iron-control inputs to grant
 /// to the tool's role (`role_foreign_id`, e.g. `tool-github`).
+#[cfg(test)]
 pub fn translate(
     namespace: &str,
     role_foreign_id: &str,


### PR DESCRIPTION
Adds tool identity labels to credential secrets registered from tool manifests, so the console can show which tool and overlay produced each resource.

Both registration paths now write the metadata: api-rs carries labels through discovered tool proxy fragments before upserting secrets onto the shared infra role, and centaur-perms writes the same labels when granting tools manually. When multiple tools share one generated credential resource, their tool and overlay identities are combined into stable comma-separated label values.
