### PR TITLE
Use replace mode for Slack tool secrets

### DIFF
--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -28,9 +28,9 @@ packages = ["."]
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "SLACK_BOT_TOKEN", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["slack.com"]},
+    {type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
 ]
 optional_secrets = [
-    {type = "http", name = "SLACK_SEARCH_TOKEN", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["slack.com"]},
-    {type = "http", name = "SLACK_ETL_TOKEN", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["slack.com", "files.slack.com"]},
+    {type = "http", name = "SLACK_SEARCH_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
+    {type = "http", name = "SLACK_ETL_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com", "files.slack.com"]},
 ]


### PR DESCRIPTION
## Summary
- Switch Slack productivity tool secrets from unconditional Authorization header injection to placeholder replacement.
- Apply the same replace behavior to SLACK_BOT_TOKEN, SLACK_SEARCH_TOKEN, and SLACK_ETL_TOKEN.
- This lets the Slack Python client choose the credential by sending the corresponding placeholder instead of having multiple Slack tokens race on the same Authorization header.

## Tests
- PYTHONPATH=..:../../.. uv run --no-project --with pytest --with slack-sdk --with typer --with python-dotenv --with rich --with structlog pytest tests/test_client.py