### PR TITLE
fix: add slackbot handoff observability

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -36,6 +36,7 @@ import { extractMessageOverrides } from './overrides'
 import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from './slack-events'
 import type {
   ForwardSessionInput,
+  JsonObject,
   SlackbotV2,
   SlackbotV2ApiAttachment,
   SlackbotV2ApiMessage,
@@ -47,7 +48,15 @@ import type {
   SlackbotV2ThreadState,
   SlackbotV2Trace
 } from './types'
-import { elapsedMs, errorMessage, noopLogger, nowMs, traceLog } from './utils'
+import {
+  elapsedMs,
+  errorMessage,
+  noopLogger,
+  nowMs,
+  startPendingOperationLog,
+  traceLog,
+  traceWarn
+} from './utils'
 
 export type {
   SlackbotV2,
@@ -122,38 +131,25 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
 
   chat.onNewMention(async (thread, message) => {
     if (!isAllowedSlackMessage(message, options, logger)) return
-    const assistantStatus = setInitialAssistantStatus(thread, options)
-    try {
-      await thread.subscribe()
-      await syncThreadMessageToSession(thread, message, {
-        initialAssistantStatusVisible: await assistantStatus,
-        mode: 'execute',
-        options,
-        state
-      })
-    } catch (error) {
-      if (await assistantStatus) await setAssistantStatus(thread, '')
-      throw error
-    }
+    await handleSlackMessageHandoff(thread, message, {
+      assistantStatusRequested: true,
+      mode: 'execute',
+      options,
+      state,
+      subscribe: true,
+      trigger: 'new_mention'
+    })
   })
 
   chat.onSubscribedMessage(async (thread, message) => {
     if (!isAllowedSlackMessage(message, options, logger)) return
-    const assistantStatus =
-      message.isMention === true
-        ? setInitialAssistantStatus(thread, options)
-        : Promise.resolve(false)
-    try {
-      await syncThreadMessageToSession(thread, message, {
-        initialAssistantStatusVisible: await assistantStatus,
-        mode: message.isMention === true ? 'execute' : 'append',
-        options,
-        state
-      })
-    } catch (error) {
-      if (await assistantStatus) await setAssistantStatus(thread, '')
-      throw error
-    }
+    await handleSlackMessageHandoff(thread, message, {
+      assistantStatusRequested: message.isMention === true,
+      mode: message.isMention === true ? 'execute' : 'append',
+      options,
+      state,
+      trigger: 'subscribed_message'
+    })
   })
 
   const app = new Hono()
@@ -164,6 +160,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
       return new globalThis.Response('ok', { status: 200 })
     }
     const awaitHandoff = shouldAwaitSlackHandoff(rawBody)
+    const webhookFields = slackWebhookLogFields(rawBody)
     const handoffTasks: Promise<unknown>[] = []
     const context: SlackbotV2RequestContext = {
       retryableErrors: [],
@@ -181,10 +178,34 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
       })
     })
     if (awaitHandoff && response.ok) {
+      const waitStartedAtMs = nowMs()
+      const waitFields = {
+        ...webhookFields,
+        response_status: response.status,
+        task_count: handoffTasks.length
+      }
+      traceLog(options, 'slackbotv2_webhook_handoff_wait_started', undefined, waitFields)
+      const stopPendingLog = startPendingOperationLog(
+        options,
+        'slackbotv2_webhook_handoff_wait_pending',
+        undefined,
+        waitFields,
+        waitStartedAtMs
+      )
+      let waitError: unknown
       try {
         await Promise.all(handoffTasks)
       } catch (error) {
+        waitError = error
         if (isRetryableSessionApiError(error)) context.retryableErrors.push(error)
+      } finally {
+        stopPendingLog()
+        traceLog(options, 'slackbotv2_webhook_handoff_wait_complete', undefined, {
+          ...waitFields,
+          error: waitError ? errorMessage(waitError) : undefined,
+          phase_ms: elapsedMs(waitStartedAtMs),
+          retryable_error_count: context.retryableErrors.length
+        })
       }
       if (context.retryableErrors.length > 0) {
         traceLog(options, 'slackbotv2_webhook_retry_requested', undefined, {
@@ -206,6 +227,104 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   }
 
   return { app, chat }
+}
+
+async function handleSlackMessageHandoff(
+  thread: Thread<SlackbotV2ThreadState>,
+  message: ChatMessage,
+  input: {
+    assistantStatusRequested: boolean
+    mode: SlackbotV2MessageMode
+    options: SlackbotV2Options
+    state: StateAdapter
+    subscribe?: boolean
+    trigger: string
+  }
+): Promise<void> {
+  const trace = createHandoffTrace(thread, message, input.mode)
+  traceLog(input.options, 'slackbotv2_handoff_started', trace, {
+    assistant_status_requested: input.assistantStatusRequested,
+    subscribe: input.subscribe === true,
+    trigger: input.trigger
+  })
+  const assistantStatus = input.assistantStatusRequested
+    ? setInitialAssistantStatus(thread, input.options, trace)
+    : Promise.resolve(false)
+  try {
+    if (input.subscribe) {
+      await subscribeSlackThreadForHandoff(thread, input.options, trace, input.trigger)
+    }
+    const assistantStatusVisible = await assistantStatus
+    traceLog(input.options, 'slackbotv2_handoff_sync_starting', trace, {
+      initial_assistant_status_visible: assistantStatusVisible,
+      trigger: input.trigger
+    })
+    await syncThreadMessageToSession(thread, message, {
+      initialAssistantStatusVisible: assistantStatusVisible,
+      mode: input.mode,
+      options: input.options,
+      state: input.state
+    })
+    traceLog(input.options, 'slackbotv2_handoff_complete', trace, {
+      trigger: input.trigger
+    })
+  } catch (error) {
+    traceWarn(input.options, 'slackbotv2_handoff_failed', trace, {
+      error: errorMessage(error),
+      trigger: input.trigger
+    })
+    if (await assistantStatus) await setAssistantStatus(thread, '', input.options, trace)
+    throw error
+  }
+}
+
+async function subscribeSlackThreadForHandoff(
+  thread: Thread<SlackbotV2ThreadState>,
+  options: SlackbotV2Options,
+  trace: SlackbotV2Trace,
+  trigger: string
+): Promise<void> {
+  const startedAtMs = nowMs()
+  const fields = { trigger }
+  traceLog(options, 'slackbotv2_handoff_subscribe_started', trace, fields)
+  const stopPendingLog = startPendingOperationLog(
+    options,
+    'slackbotv2_handoff_subscribe_pending',
+    trace,
+    fields,
+    startedAtMs
+  )
+  try {
+    await thread.subscribe()
+    traceLog(options, 'slackbotv2_handoff_subscribe_complete', trace, {
+      ...fields,
+      phase_ms: elapsedMs(startedAtMs)
+    })
+  } catch (error) {
+    traceWarn(options, 'slackbotv2_handoff_subscribe_failed', trace, {
+      ...fields,
+      error: errorMessage(error),
+      phase_ms: elapsedMs(startedAtMs)
+    })
+    throw error
+  } finally {
+    stopPendingLog()
+  }
+}
+
+function createHandoffTrace(
+  thread: Thread<SlackbotV2ThreadState>,
+  message: ChatMessage,
+  mode: SlackbotV2MessageMode
+): SlackbotV2Trace {
+  return {
+    includeContext: mode === 'execute',
+    messageId: message.id,
+    mode,
+    openStream: mode === 'execute',
+    startedAtMs: nowMs(),
+    threadId: thread.id
+  }
 }
 
 function createDefaultState(options: SlackbotV2Options, logger: Logger): StateAdapter {
@@ -291,7 +410,9 @@ async function syncThreadMessageToSession(
   }
   if (isDuplicateIncrementalMessage) {
     traceLog(input.options, 'slackbotv2_forward_duplicate_skipped', trace)
-    if (input.initialAssistantStatusVisible) await setAssistantStatus(thread, '')
+    if (input.initialAssistantStatusVisible) {
+      await setAssistantStatus(thread, '', input.options, trace)
+    }
     return
   }
   traceLog(input.options, 'slackbotv2_forward_started', trace, {
@@ -303,7 +424,7 @@ async function syncThreadMessageToSession(
       (await setInitialAssistantStatus(thread, input.options, trace))
     : false
   if (!shouldStartExecution && input.initialAssistantStatusVisible) {
-    await setAssistantStatus(thread, '')
+    await setAssistantStatus(thread, '', input.options, trace)
   }
 
   const serializeStartedAtMs = nowMs()
@@ -505,7 +626,7 @@ async function syncThreadMessageToSession(
         traceLog(input.options, 'slackbotv2_webhook_retry_marked', trace, {
           error: errorMessage(error)
         })
-        if (assistantStatusVisible) await setAssistantStatus(thread, '')
+        if (assistantStatusVisible) await setAssistantStatus(thread, '', input.options, trace)
         throw error
       }
     }
@@ -1146,7 +1267,7 @@ async function renderExecutionStream(
   const titleStartedAtMs = nowMs()
   await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
   if (!assistantStatusVisible) {
-    await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
+    await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   }
   traceLog(options, 'slackbotv2_render_slack_metadata_set', trace, {
     assistant_status_already_visible: assistantStatusVisible,
@@ -1171,7 +1292,7 @@ async function renderExecutionStream(
       )
     )
   } finally {
-    await setAssistantStatus(thread, '')
+    await setAssistantStatus(thread, '', options, trace)
   }
 }
 
@@ -1188,7 +1309,7 @@ async function renderRecoveredExecutionStream(
   }
   const titleStartedAtMs = nowMs()
   await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
-  await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
+  await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   traceLog(options, 'slackbotv2_render_slack_metadata_set', trace, {
     phase_ms: elapsedMs(titleStartedAtMs)
   })
@@ -1214,7 +1335,7 @@ async function renderRecoveredExecutionStream(
       }
     )
   } finally {
-    await setAssistantStatus(thread, '')
+    await setAssistantStatus(thread, '', options, trace)
   }
 }
 
@@ -1230,7 +1351,7 @@ async function renderPlainTextExecutionStream(
   const titleStartedAtMs = nowMs()
   await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
   if (!assistantStatusVisible) {
-    await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
+    await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   }
   traceLog(options, 'slackbotv2_render_plain_text_metadata_set', trace, {
     assistant_status_already_visible: assistantStatusVisible,
@@ -1258,7 +1379,7 @@ async function renderPlainTextExecutionStream(
     })
     await thread.post(text)
   } finally {
-    await setAssistantStatus(thread, '')
+    await setAssistantStatus(thread, '', options, trace)
   }
 }
 
@@ -1427,6 +1548,32 @@ function shouldAwaitSlackHandoff(rawBody: string): boolean {
   } catch {
     return false
   }
+}
+
+function slackWebhookLogFields(rawBody: string): JsonObject {
+  try {
+    const payload = JSON.parse(rawBody) as Record<string, unknown>
+    const rawEvent = payload.event
+    const event =
+      rawEvent && typeof rawEvent === 'object' && !Array.isArray(rawEvent)
+        ? (rawEvent as Record<string, unknown>)
+        : {}
+    const fields: JsonObject = {}
+    setStringField(fields, 'slack_event_id', payload.event_id)
+    setStringField(fields, 'slack_event_type', event.type)
+    setStringField(fields, 'slack_channel', event.channel)
+    setStringField(fields, 'slack_message_ts', event.ts)
+    setStringField(fields, 'slack_thread_ts', event.thread_ts)
+    setStringField(fields, 'slack_team_id', payload.team_id || event.team)
+    return fields
+  } catch {
+    return { slack_payload_parse_error: true }
+  }
+}
+
+function setStringField(fields: JsonObject, key: string, value: unknown): void {
+  const text = stringField(value)
+  if (text) fields[key] = text
 }
 
 function isSlackThreadReply(message: ChatMessage): boolean {
@@ -1700,7 +1847,12 @@ async function setInitialAssistantStatus(
   trace?: SlackbotV2Trace
 ): Promise<boolean> {
   const startedAtMs = nowMs()
-  const visible = await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...')
+  const visible = await setAssistantStatus(
+    thread,
+    options.assistantStatus ?? 'Thinking...',
+    options,
+    trace
+  )
   traceLog(options, 'slackbotv2_forward_initial_status_set', trace, {
     phase_ms: elapsedMs(startedAtMs),
     visible
@@ -1708,18 +1860,70 @@ async function setInitialAssistantStatus(
   return visible
 }
 
-async function setAssistantStatus(thread: Thread, status: string): Promise<boolean> {
+async function setAssistantStatus(
+  thread: Thread,
+  status: string,
+  options?: SlackbotV2Options,
+  trace?: SlackbotV2Trace
+): Promise<boolean> {
+  const startedAtMs = nowMs()
   const target = slackAssistantTarget(thread)
   const adapter = thread.adapter as SlackAssistantAdapter
-  if (!target || !adapter.setAssistantStatus) return false
-  return await ignoreAssistantError(() =>
-    adapter.setAssistantStatus!(
-      target.channel,
-      target.threadTs,
-      status,
-      status ? [status] : undefined
+  const fields = {
+    has_adapter: Boolean(adapter.setAssistantStatus),
+    has_target: Boolean(target),
+    operation: status ? 'set' : 'clear',
+    status_empty: !status
+  }
+  if (options) traceLog(options, 'slackbotv2_assistant_status_started', trace, fields)
+  if (!target || !adapter.setAssistantStatus) {
+    if (options) {
+      traceLog(options, 'slackbotv2_assistant_status_complete', trace, {
+        ...fields,
+        phase_ms: elapsedMs(startedAtMs),
+        visible: false
+      })
+    }
+    return false
+  }
+  const stopPendingLog = options
+    ? startPendingOperationLog(
+        options,
+        'slackbotv2_assistant_status_pending',
+        trace,
+        fields,
+        startedAtMs
+      )
+    : () => undefined
+  try {
+    const visible = await ignoreAssistantError(() =>
+      adapter.setAssistantStatus!(
+        target.channel,
+        target.threadTs,
+        status,
+        status ? [status] : undefined
+      )
     )
-  )
+    if (options) {
+      traceLog(options, 'slackbotv2_assistant_status_complete', trace, {
+        ...fields,
+        phase_ms: elapsedMs(startedAtMs),
+        visible
+      })
+    }
+    return visible
+  } catch (error) {
+    if (options) {
+      traceWarn(options, 'slackbotv2_assistant_status_failed', trace, {
+        ...fields,
+        error: errorMessage(error),
+        phase_ms: elapsedMs(startedAtMs)
+      })
+    }
+    throw error
+  } finally {
+    stopPendingLog()
+  }
 }
 
 async function setAssistantTitle(thread: Thread, title: string | undefined): Promise<void> {

--- a/services/slackbotv2/src/utils.ts
+++ b/services/slackbotv2/src/utils.ts
@@ -1,6 +1,9 @@
 import type { Logger } from 'chat'
 import type { JsonObject, SlackbotV2Options, SlackbotV2Trace } from './types'
 
+const PENDING_OPERATION_WARN_AFTER_MS = 5_000
+const PENDING_OPERATION_REPEAT_MS = 30_000
+
 export const noopLogger: Logger = {
   debug: () => undefined,
   info: () => undefined,
@@ -25,18 +28,71 @@ export function traceLog(
 ): void {
   const logger = options.logger ?? noopLogger
   logger.info(event, {
-    ...(trace
-      ? {
-          elapsed_ms: elapsedMs(trace.startedAtMs),
-          include_context: trace.includeContext,
-          message_id: trace.messageId,
-          mode: trace.mode,
-          open_stream: trace.openStream,
-          thread_id: trace.threadId
-        }
-      : {}),
+    ...traceFields(trace),
     ...fields
   })
+}
+
+export function traceWarn(
+  options: SlackbotV2Options,
+  event: string,
+  trace?: SlackbotV2Trace,
+  fields: JsonObject = {}
+): void {
+  const logger = options.logger ?? noopLogger
+  logger.warn(event, {
+    ...traceFields(trace),
+    ...fields
+  })
+}
+
+export function startPendingOperationLog(
+  options: SlackbotV2Options,
+  event: string,
+  trace?: SlackbotV2Trace,
+  fields: JsonObject = {},
+  startedAtMs: number = nowMs(),
+  warnAfterMs = PENDING_OPERATION_WARN_AFTER_MS,
+  repeatEveryMs = PENDING_OPERATION_REPEAT_MS
+): () => void {
+  let stopped = false
+  let timer: ReturnType<typeof globalThis.setTimeout> | undefined
+  const emit = () => {
+    if (stopped) return
+    traceWarn(options, event, trace, {
+      ...fields,
+      pending_ms: elapsedMs(startedAtMs)
+    })
+    timer = schedulePendingLog(emit, repeatEveryMs)
+  }
+  timer = schedulePendingLog(emit, warnAfterMs)
+  return () => {
+    stopped = true
+    if (timer !== undefined) globalThis.clearTimeout(timer)
+  }
+}
+
+function traceFields(trace?: SlackbotV2Trace): JsonObject {
+  return trace
+    ? {
+        elapsed_ms: elapsedMs(trace.startedAtMs),
+        include_context: trace.includeContext,
+        message_id: trace.messageId,
+        mode: trace.mode,
+        open_stream: trace.openStream,
+        thread_id: trace.threadId
+      }
+    : {}
+}
+
+function schedulePendingLog(
+  fn: () => void,
+  delayMs: number
+): ReturnType<typeof globalThis.setTimeout> {
+  const timer = globalThis.setTimeout(fn, delayMs)
+  const unref = (timer as { unref?: () => void }).unref
+  if (unref) unref.call(timer)
+  return timer
 }
 
 export function errorMessage(error: unknown): string {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -2298,6 +2298,8 @@ describe('slackbotv2', () => {
   })
 
   it('shows assistant status while waiting for slow session execute', async () => {
+    const logs: CapturedLog[] = []
+    bot = createTestBot({ logger: captureLogger(logs) })
     codexApi.autoRespond = false
     const releaseExecute = codexApi.holdNextExecute()
 
@@ -2338,10 +2340,57 @@ describe('slackbotv2', () => {
     ).toEqual(['Thinking...'])
     expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
     expect(codexApi.eventRequests).toHaveLength(0)
+    await waitFor(() => hasLog(logs, 'slackbotv2_webhook_handoff_wait_started'))
+    expect(logData(logs, 'slackbotv2_handoff_started')).toEqual(
+      expect.objectContaining({
+        assistant_status_requested: true,
+        message_id: mention.ts,
+        mode: 'execute',
+        thread_id: threadKey(parent.ts),
+        trigger: 'new_mention'
+      })
+    )
+    expect(logData(logs, 'slackbotv2_assistant_status_started')).toEqual(
+      expect.objectContaining({
+        message_id: mention.ts,
+        operation: 'set',
+        thread_id: threadKey(parent.ts)
+      })
+    )
+    expect(logData(logs, 'slackbotv2_assistant_status_complete')).toEqual(
+      expect.objectContaining({
+        operation: 'set',
+        visible: true
+      })
+    )
+    expect(logData(logs, 'slackbotv2_handoff_sync_starting')).toEqual(
+      expect.objectContaining({
+        initial_assistant_status_visible: true,
+        trigger: 'new_mention'
+      })
+    )
+    expect(logData(logs, 'slackbotv2_webhook_handoff_wait_started')).toEqual(
+      expect.objectContaining({
+        slack_channel: CHANNEL_ID,
+        slack_event_id: 'Ev-slackbotv2-slow-execute',
+        slack_event_type: 'app_mention',
+        slack_message_ts: mention.ts,
+        slack_thread_ts: parent.ts,
+        task_count: expect.any(Number)
+      })
+    )
 
     releaseExecute()
     const response = await responsePromise
     expect(response.status).toBe(200)
+    await waitFor(() => hasLog(logs, 'slackbotv2_webhook_handoff_wait_complete'))
+    expect(logData(logs, 'slackbotv2_webhook_handoff_wait_complete')).toEqual(
+      expect.objectContaining({
+        phase_ms: expect.any(Number),
+        retryable_error_count: 0,
+        slack_event_id: 'Ev-slackbotv2-slow-execute'
+      })
+    )
     await waitFor(() => codexApi.eventRequests.length === 1)
     await waitFor(() => codexApi.streamCount === 1)
     codexApi.closeStreams()
@@ -2924,6 +2973,34 @@ function createTestBot(
     state: createMemoryState(),
     ...overrides
   })
+}
+
+type CapturedLog = {
+  data?: unknown
+  event: string
+  level: 'debug' | 'info' | 'warn' | 'error'
+}
+
+function captureLogger(
+  logs: CapturedLog[]
+): NonNullable<Parameters<typeof createSlackbotV2>[0]['logger']> {
+  const logger: NonNullable<Parameters<typeof createSlackbotV2>[0]['logger']> = {
+    debug: (event: string, data?: unknown) => logs.push({ data, event, level: 'debug' }),
+    info: (event: string, data?: unknown) => logs.push({ data, event, level: 'info' }),
+    warn: (event: string, data?: unknown) => logs.push({ data, event, level: 'warn' }),
+    error: (event: string, data?: unknown) => logs.push({ data, event, level: 'error' }),
+    child: () => logger
+  }
+  return logger
+}
+
+function hasLog(logs: CapturedLog[], event: string): boolean {
+  return logs.some(log => log.event === event)
+}
+
+function logData(logs: CapturedLog[], event: string): Record<string, unknown> | undefined {
+  const data = logs.find(log => log.event === event)?.data
+  return isRecord(data) ? data : undefined
 }
 
 function sampleCodexNotifications(answer: string): ServerNotification[] {


### PR DESCRIPTION
Summary:
- Add structured Slackbot v2 handoff phase logs before session sync starts.
- Add assistant status and webhook wait pending warnings for Datadog measurement.
- Cover the slow execute handoff path with logging assertions.

Tests:
- bun run check:types
- bun test test
- git diff --check