### PR TITLE
Remove stale Centaur API key guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ This means clients and the API never need to know about harness-specific quirks.
 
 **Sandbox → API** (REST over Kubernetes services):
 
-Agents call tools via `curl $CENTAUR_API_URL/tools/<tool>/<method>` over the in-cluster service network. Auth is via `CENTAUR_API_KEY` injected when the sandbox Pod is created.
+Agents call tools through the generated `centaur-tools` catalog and direct tool CLIs. The tool runtime handles routing and credential access.
 
 ### Network Isolation
 
@@ -459,7 +459,7 @@ The entrypoint supports persona overlays via `AGENT_PERSONA`. Persona prompts ar
 ### Sandbox Pod Config
 
 - Runs under Kubernetes NetworkPolicies with API reachable through the in-cluster service URL
-- Entrypoint injects `CENTAUR_API_URL` and `CENTAUR_API_KEY` env vars
+- Entrypoint injects the runtime URLs and tool catalog environment needed by the sandbox
 - Stub API keys so harnesses init in API-key mode (not browser login)
 - `HTTPS_PROXY` routes LLM calls through the firewall
 - Resource limits: 4GB memory, 2 CPUs
@@ -488,7 +488,7 @@ Sandbox Pods never see real API keys. The firewall (`services/firewall/addon.py`
 ## Security Model
 
 - **API auth**: All callers authenticate with DB-backed API keys (`aiv2_*` prefix, stored in `api_keys` table). Local in-cluster service calls use the configured bypass paths where applicable.
-- **Sandbox auth**: Sandbox Pods get auto-issued HMAC-signed tokens (`sbx1.*` prefix) minted by the API. These are short-lived (2h TTL) and scoped to `agent` + `tools:*`.
+- **Sandbox auth**: Sandbox Pods use the runtime's tool and workflow surfaces; agents should not depend on a user-visible Centaur API key.
 - **Slack**: HMAC-SHA256 signature verification on all webhooks
 - **Public edge**: The Helm chart exposes public routes only when configured through Ingress, HTTPRoute, or service settings.
 - **Sandbox isolation**: Pods get stub keys only; real keys injected by firewall proxy in-flight
@@ -504,12 +504,11 @@ All API authentication uses **DB-backed keys** stored in the `api_keys` Postgres
 | Type | Prefix | Issued by | Used by | Scopes |
 |------|--------|-----------|---------|--------|
 | DB keys | `aiv2_*` | Admin API | Slackbot, CLI, external callers | Per-key (e.g. `["*"]`, `["agent:execute"]`) |
-| Sandbox tokens | `sbx1.*` | API (automatic) | Sandbox containers → API tool calls | `["agent", "tools:*"]` |
 
 ### How services get their keys
 
 - **Slackbot**: `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, and `SLACKBOT_API_KEY` are injected from the local infra Secret.
-- **Sandbox containers**: Auto-issued `sbx1.*` token injected as `CENTAUR_API_KEY` at container creation
+- **Sandbox containers**: Use runtime-provided tool CLIs and workflow context rather than a direct Centaur API key
 - **Local testing**: Use localhost bypass (no key needed from inside the API deployment), or create a key via admin API
 
 ## Secrets

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -112,9 +112,6 @@ def save_attachment(
         }
     ).encode()
     headers = {"Content-Type": "application/json"}
-    api_key = secret("CENTAUR_API_KEY", "").strip()
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
     request = urllib.request.Request(
         f"{base_url}/agent/attachments/upload",
         data=payload,

--- a/contrib/chart/templates/discordbot.yaml
+++ b/contrib/chart/templates/discordbot.yaml
@@ -59,13 +59,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "centaur.secretEnvName" . }}
                   key: {{ printf "%sDISCORDBOT_API_KEY" .Values.secretManager.envPrefix }}
-            # api-rs has no auth middleware yet, but discordbot still sends the key as a header;
-            # source it from the same infra secret.
-            - name: CENTAUR_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "centaur.secretEnvName" . }}
-                  key: {{ printf "%sDISCORDBOT_API_KEY" .Values.secretManager.envPrefix }}
             - name: DISCORDBOT_DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -51,13 +51,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "centaur.secretEnvName" . }}
                   key: {{ printf "%sSLACKBOT_API_KEY" .Values.secretManager.envPrefix }}
-            # api-rs has no auth middleware yet, but slackbotv2 still sends the
-            # key as a header; source it from the same infra secret.
-            - name: CENTAUR_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "centaur.secretEnvName" . }}
-                  key: {{ printf "%sSLACKBOT_API_KEY" .Values.secretManager.envPrefix }}
             - name: SLACKBOTV2_DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/contrib/scripts/muesli-push.sh
+++ b/contrib/scripts/muesli-push.sh
@@ -15,7 +15,7 @@
 #
 # Required env vars:
 #   CENTAUR_API_URL   e.g. https://centaur.example.com
-#   CENTAUR_API_KEY   an aiv2_* key with scope `workflows:muesli_meeting_ingest`
+#   MUESLI_API_KEY   an aiv2_* key with scope `workflows:muesli_meeting_ingest`
 #
 # Optional env vars:
 #   MUESLI_CLI            path to muesli-cli (default: /Applications/Muesli.app/Contents/MacOS/muesli-cli)
@@ -43,7 +43,7 @@ die() {
 }
 
 [ -n "${CENTAUR_API_URL:-}" ] || die "CENTAUR_API_URL is not set"
-[ -n "${CENTAUR_API_KEY:-}" ] || die "CENTAUR_API_KEY is not set"
+[ -n "${MUESLI_API_KEY:-}" ] || die "MUESLI_API_KEY is not set"
 command -v jq >/dev/null 2>&1 || die "jq is not installed (brew install jq)"
 command -v curl >/dev/null 2>&1 || die "curl is not installed"
 [ -x "$MUESLI_CLI" ] || die "muesli-cli not found at $MUESLI_CLI (set MUESLI_CLI)"
@@ -104,7 +104,7 @@ log "POST workflow_name=muesli_meeting_ingest trigger=muesli:${HOST_LABEL}:${MEE
 HTTP_CODE="$(curl -sS -o /tmp/muesli-push.resp -w '%{http_code}' \
     -X POST "${CENTAUR_API_URL%/}/workflows/runs" \
     -H "Content-Type: application/json" \
-    -H "x-api-key: $CENTAUR_API_KEY" \
+    -H "x-api-key: $MUESLI_API_KEY" \
     --data-binary "$BODY")"
 
 RESPONSE="$(cat /tmp/muesli-push.resp || true)"

--- a/docs/pages/extend/acme-example.mdx
+++ b/docs/pages/extend/acme-example.mdx
@@ -224,7 +224,7 @@ You can also inspect the runtime payload for a thread:
 
 ```bash
 curl -s "$CENTAUR_API_URL/agent/runtime?key=$THREAD_KEY" \
-  -H "X-Api-Key: $CENTAUR_API_KEY" | jq '.overlay'
+  -H "X-Api-Key: $RUNTIME_API_KEY" | jq '.overlay'
 ```
 
 ## What to change first

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -219,7 +219,7 @@ Then create a real run:
 ```bash
 curl -s "$CENTAUR_API_URL/api/workflows/runs" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: $CENTAUR_API_KEY" \
+  -H "X-Api-Key: $WORKFLOW_API_KEY" \
   -d '{
     "workflow_name": "nightly_report",
     "input": {"topic": "open incidents"}

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -99,7 +99,7 @@ Create a run through the API:
 ```bash
 curl -s "$CENTAUR_API_URL/workflows/runs" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: $CENTAUR_API_KEY" \
+  -H "X-Api-Key: $WORKFLOW_API_KEY" \
   -d '{
     "workflow_name": "nightly_report",
     "input": {"channel": "ops", "topic": "open incidents"},
@@ -111,7 +111,7 @@ Inspect it:
 
 ```bash
 curl -s "$CENTAUR_API_URL/workflows/runs/$RUN_ID" \
-  -H "X-Api-Key: $CENTAUR_API_KEY" | jq
+  -H "X-Api-Key: $WORKFLOW_API_KEY" | jq
 ```
 
 ## Schedule a workflow

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -107,7 +107,6 @@ Execution tuning:
 | `PORT` | Runtime env. | Slackbot HTTP port. |
 | `SLACK_API_URL` | `slackbot.extraEnv`. | Optional Slack Web API base URL override. |
 | `CENTAUR_API_URL` | Chart-rendered API service URL. | API base URL used by Slackbot. |
-| `CENTAUR_API_KEY` | Secret/env fallback. | Used only when `SLACKBOT_API_KEY` is unset. |
 | `CENTAUR_SLACK_EVENTS_PATH` | `slackbot.extraEnv`. | Slack Events API route; defaults to `/api/webhooks/slack`. |
 | `RUNTIME_ERROR_ALERT_CHANNEL` | `slackbot.runtimeErrorAlertChannel`. | Slack channel for runtime error alerts. |
 | `SLACK_EVENT_DEDUP_TTL_MS` | `slackbot.extraEnv`. | Slack event dedupe window. |
@@ -127,7 +126,7 @@ API-set variables:
 | --- | --- | --- |
 | `AGENT_IMAGE` | `sandbox.image.*`. | Sandbox image used by the Kubernetes backend. |
 | `AGENT_API_URL` | Chart-rendered API service URL. | Source for sandbox `CENTAUR_API_URL`; required by Kubernetes backend. |
-| `CENTAUR_API_URL`, `CENTAUR_API_KEY`, `CENTAUR_THREAD_KEY`, `CENTAUR_TRACE_ID` | API sandbox creation. | API callback, short-lived sandbox token, thread key, and trace id. |
+| `CENTAUR_API_URL`, `CENTAUR_THREAD_KEY`, `CENTAUR_TRACE_ID` | API sandbox creation. | API callback, thread key, and trace id. |
 | `AMP_MODE`, `AMP_THREAD_VISIBILITY`, `AMP_CONTINUE_THREAD_ID` | API env or resume path. | Amp mode and resume behavior. |
 | `FIREWALL_HOST`, `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` and lowercase variants | API sandbox creation. | Routes sandbox egress through per-sandbox iron-proxy. |
 | `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `GIT_SSL_CAINFO` | API sandbox creation. | Trust bundle for proxied TLS. |
@@ -219,5 +218,6 @@ Google Workspace ETL workflows:
 | --- | --- | --- |
 | `CENTAUR_NAMESPACE`, `CENTAUR_RELEASE` | Local shell or `.env`. | Namespace/release used by `just` and debug scripts. |
 | `JUST_BUILD_SEQUENTIAL` | Local shell. | Builds service images sequentially. |
-| `CENTAUR_API_URL`, `CENTAUR_API_KEY` | Local shell. | API target/key for contrib scripts. |
+| `CENTAUR_API_URL` | Local shell. | API target for contrib scripts. |
+| `MUESLI_API_KEY` | Local shell. | API key for the Muesli meeting ingest helper. |
 | `MUESLI_CLI`, `MUESLI_HOST`, `MUESLI_PUSH_LOG`, `MUESLI_SLACK_CHANNEL` | Local shell. | Muesli meeting ingest helper behavior. |

--- a/docs/public/md/extend/acme-example.md
+++ b/docs/public/md/extend/acme-example.md
@@ -224,7 +224,7 @@ You can also inspect the runtime payload for a thread:
 
 ```bash
 curl -s "$CENTAUR_API_URL/agent/runtime?key=$THREAD_KEY" \
-  -H "X-Api-Key: $CENTAUR_API_KEY" | jq '.overlay'
+  -H "X-Api-Key: $RUNTIME_API_KEY" | jq '.overlay'
 ```
 
 ## What to change first

--- a/docs/public/md/extend/workflows-v2.md
+++ b/docs/public/md/extend/workflows-v2.md
@@ -219,7 +219,7 @@ Then create a real run:
 ```bash
 curl -s "$CENTAUR_API_URL/api/workflows/runs" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: $CENTAUR_API_KEY" \
+  -H "X-Api-Key: $WORKFLOW_API_KEY" \
   -d '{
     "workflow_name": "nightly_report",
     "input": {"topic": "open incidents"}

--- a/docs/public/md/extend/workflows.md
+++ b/docs/public/md/extend/workflows.md
@@ -99,7 +99,7 @@ Create a run through the API:
 ```bash
 curl -s "$CENTAUR_API_URL/workflows/runs" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: $CENTAUR_API_KEY" \
+  -H "X-Api-Key: $WORKFLOW_API_KEY" \
   -d '{
     "workflow_name": "nightly_report",
     "input": {"channel": "ops", "topic": "open incidents"},
@@ -111,7 +111,7 @@ Inspect it:
 
 ```bash
 curl -s "$CENTAUR_API_URL/workflows/runs/$RUN_ID" \
-  -H "X-Api-Key: $CENTAUR_API_KEY" | jq
+  -H "X-Api-Key: $WORKFLOW_API_KEY" | jq
 ```
 
 ## Schedule a workflow

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -107,7 +107,6 @@ Execution tuning:
 | `PORT` | Runtime env. | Slackbot HTTP port. |
 | `SLACK_API_URL` | `slackbot.extraEnv`. | Optional Slack Web API base URL override. |
 | `CENTAUR_API_URL` | Chart-rendered API service URL. | API base URL used by Slackbot. |
-| `CENTAUR_API_KEY` | Secret/env fallback. | Used only when `SLACKBOT_API_KEY` is unset. |
 | `CENTAUR_SLACK_EVENTS_PATH` | `slackbot.extraEnv`. | Slack Events API route; defaults to `/api/webhooks/slack`. |
 | `RUNTIME_ERROR_ALERT_CHANNEL` | `slackbot.runtimeErrorAlertChannel`. | Slack channel for runtime error alerts. |
 | `SLACK_EVENT_DEDUP_TTL_MS` | `slackbot.extraEnv`. | Slack event dedupe window. |
@@ -127,7 +126,7 @@ API-set variables:
 | --- | --- | --- |
 | `AGENT_IMAGE` | `sandbox.image.*`. | Sandbox image used by the Kubernetes backend. |
 | `AGENT_API_URL` | Chart-rendered API service URL. | Source for sandbox `CENTAUR_API_URL`; required by Kubernetes backend. |
-| `CENTAUR_API_URL`, `CENTAUR_API_KEY`, `CENTAUR_THREAD_KEY`, `CENTAUR_TRACE_ID` | API sandbox creation. | API callback, short-lived sandbox token, thread key, and trace id. |
+| `CENTAUR_API_URL`, `CENTAUR_THREAD_KEY`, `CENTAUR_TRACE_ID` | API sandbox creation. | API callback, thread key, and trace id. |
 | `AMP_MODE`, `AMP_THREAD_VISIBILITY`, `AMP_CONTINUE_THREAD_ID` | API env or resume path. | Amp mode and resume behavior. |
 | `FIREWALL_HOST`, `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` and lowercase variants | API sandbox creation. | Routes sandbox egress through per-sandbox iron-proxy. |
 | `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `GIT_SSL_CAINFO` | API sandbox creation. | Trust bundle for proxied TLS. |
@@ -219,5 +218,6 @@ Google Workspace ETL workflows:
 | --- | --- | --- |
 | `CENTAUR_NAMESPACE`, `CENTAUR_RELEASE` | Local shell or `.env`. | Namespace/release used by `just` and debug scripts. |
 | `JUST_BUILD_SEQUENTIAL` | Local shell. | Builds service images sequentially. |
-| `CENTAUR_API_URL`, `CENTAUR_API_KEY` | Local shell. | API target/key for contrib scripts. |
+| `CENTAUR_API_URL` | Local shell. | API target for contrib scripts. |
+| `MUESLI_API_KEY` | Local shell. | API key for the Muesli meeting ingest helper. |
 | `MUESLI_CLI`, `MUESLI_HOST`, `MUESLI_PUSH_LOG`, `MUESLI_SLACK_CHANNEL` | Local shell. | Muesli meeting ingest helper behavior. |

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -3865,7 +3865,7 @@ mod tests {
 
     #[test]
     fn redacts_sensitive_values_from_output_lines() {
-        let line = r#"{"type":"item.completed","item":{"aggregatedOutput":"Authorization: Bearer sbx1.threadpayload.signature\nCENTAUR_API_KEY=sbx1.otherpayload.othersig\nSLACK_BOT_TOKEN=xoxb-1234567890-abcdef\n"}}"#;
+        let line = r#"{"type":"item.completed","item":{"aggregatedOutput":"Authorization: Bearer sbx1.threadpayload.signature\nSANDBOX_TOKEN=sbx1.otherpayload.othersig\nSLACK_BOT_TOKEN=xoxb-1234567890-abcdef\n"}}"#;
 
         let redacted = redact_sensitive_text(line);
 
@@ -3873,7 +3873,7 @@ mod tests {
         assert!(!redacted.contains("sbx1.otherpayload.othersig"));
         assert!(!redacted.contains("xoxb-1234567890-abcdef"));
         assert!(redacted.contains("Authorization: Bearer [REDACTED_TOKEN]"));
-        assert!(redacted.contains("CENTAUR_API_KEY=[REDACTED_TOKEN]"));
+        assert!(redacted.contains("SANDBOX_TOKEN=[REDACTED_TOKEN]"));
         assert!(redacted.contains("SLACK_BOT_TOKEN=[REDACTED_TOKEN]"));
     }
 

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -2625,10 +2625,7 @@ async fn call_python_workflow_tool(message: &Value) -> Result<Value, WorkflowRun
     let base_url = base_url.trim_end_matches('/');
     let url = format!("{base_url}/tools/{tool}/{method}");
     let args = message.get("args").cloned().unwrap_or_else(|| json!({}));
-    let mut request = reqwest::Client::new().post(&url).json(&args);
-    if let Ok(api_key) = env::var("CENTAUR_API_KEY") {
-        request = request.header("x-api-key", api_key);
-    }
+    let request = reqwest::Client::new().post(&url).json(&args);
     let response = request.send().await?;
     let status = response.status();
     let body: Value = response.json().await.unwrap_or_else(|_| json!({}));

--- a/services/discordbot/README.md
+++ b/services/discordbot/README.md
@@ -40,7 +40,7 @@ ingress** — only a `GET /health` endpoint that reflects the Gateway connection
 | `DISCORD_PUBLIC_KEY` | ✅ | Ed25519 public key (used by the adapter for any HTTP interactions). |
 | `DISCORD_APPLICATION_ID` | ✅ | Doubles as the bot user id for mention detection. |
 | `DISCORDBOT_GUILD_ALLOWLIST` | ✅ to do anything | Comma/space-separated guild IDs. **Fail-closed: empty ⇒ the bot ignores all messages.** |
-| `DISCORDBOT_API_KEY` | – | Bearer to api-rs (falls back to `CENTAUR_API_KEY`). Use a dedicated key, not the Slack one. |
+| `DISCORDBOT_API_KEY` | – | Bearer to api-rs. Use a dedicated key, not the Slack one. |
 | `CENTAUR_API_URL` | – | api-rs base URL (default `http://127.0.0.1:8080`). |
 | `DISCORDBOT_DATABASE_URL` / `DATABASE_URL` / `POSTGRES_URL` | ✅ | Thread-state store. The bot refuses to boot without one (no silent localhost fallback). |
 | `DISCORDBOT_TRIGGER_BOT_ALLOWLIST` | – | Comma/space-separated bot/webhook author IDs whose messages may enter sessions (e.g. a Sentry webhook). Empty (default) ⇒ all bot messages are ignored. Use the ID the message is authored as: the bot's user id, or the webhook id for webhook integrations. |

--- a/services/discordbot/src/server.ts
+++ b/services/discordbot/src/server.ts
@@ -34,7 +34,7 @@ const options: DiscordbotOptions = {
   activeExecutionTtlMs: optionalNumberEnv("DISCORDBOT_ACTIVE_EXECUTION_TTL_MS"),
   answerEditIntervalMs: optionalNumberEnv("DISCORDBOT_ANSWER_EDIT_INTERVAL_MS"),
   apiUrl,
-  apiKey: optionalEnv("DISCORDBOT_API_KEY") ?? optionalEnv("CENTAUR_API_KEY"),
+  apiKey: optionalEnv("DISCORDBOT_API_KEY"),
   applicationId,
   botToken,
   publicKey,

--- a/services/discordbot/src/session-api.ts
+++ b/services/discordbot/src/session-api.ts
@@ -498,10 +498,7 @@ function ensureTrailingSlash(value: string): string {
 }
 
 function apiHeaders(options: DiscordbotOptions, jsonBody = true): HeadersInit {
-  const apiKey =
-    options.apiKey ??
-    process.env.DISCORDBOT_API_KEY ??
-    process.env.CENTAUR_API_KEY;
+  const apiKey = options.apiKey ?? process.env.DISCORDBOT_API_KEY;
   return {
     ...(jsonBody ? { "content-type": "application/json" } : {}),
     ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -100,18 +100,10 @@
 |Do not serialize independent searches across Slack, CRM, notes, web, or observability unless one result is needed to construct the next query.
 |Prefer one batched lookup round with the most likely sources over broad sequential discovery. If a tool contract is already shown in this prompt, a live skill, or recent `<tool> --help` output, use that contract directly.
 |
-|[Centaur self-query — inspect your own database]
-|You can query Centaur's internal database (chat_messages, attachments, sandbox_sessions) via:
-|  curl -sS -X POST "$CENTAUR_API_URL/agent/query" \
-|    -H "Authorization: Bearer $CENTAUR_API_KEY" \
-|    -H "Content-Type: application/json" \
-|    -d '{"sql":"SELECT id, thread_key, name, mime_type, length(data) as bytes FROM attachments ORDER BY created_at DESC LIMIT 10"}'
-|Read-only SELECT only. Binary data (e.g. attachment bytes) is shown as "<N bytes>".
-|
 |[Observability — logs + execution data]
-|You have full access to Centaur's internal observability via tool CLIs such as `vlogs` and the self-query endpoint.
+|You have full access to Centaur's internal observability via tool CLIs such as `vlogs`.
 |If a user says a workflow, alert, or channel post never populated, or asks you to check the code for issues, investigate runtime evidence before proposing redesigns or simplifications: read the relevant code paths, check workflow status, and inspect `vlogs thread_trace` or `vlogs thread_logs` plus any other relevant observability tools first.
-|If a user reports an internal tool integration or auth failure, inspect runtime evidence before suggesting secret or permission rewiring: check live tool behavior, use `vlogs` or self-query evidence to confirm whether secrets resolved and what request failed, then compare the tool's code path with a known-good integration before recommending secret or permission changes.
+|If a user reports an internal tool integration or auth failure, inspect runtime evidence before suggesting secret or permission rewiring: check live tool behavior and `vlogs` evidence to confirm whether secrets resolved and what request failed, then compare the tool's code path with a known-good integration before recommending secret or permission changes.
 |
 |Logs (VictoriaLogs via `vlogs`):
 |  vlogs errors                                           → errors across all services (last 1h)
@@ -126,16 +118,6 @@
 |  vlogs tool_analytics --start 7d                        → tool usage stats
 |  vlogs query 'level:error AND event:tool_call_completed' --limit 20 → raw LogsQL
 |
-|Execution data (Postgres via self-query):
-|  curl -sS -X POST "$CENTAUR_API_URL/agent/query" \
-|    -H "Authorization: Bearer $CENTAUR_API_KEY" \
-|    -H "Content-Type: application/json" \
-|    -d '{"sql":"SELECT execution_id, thread_key, status, harness, created_at, started_at, completed_at, EXTRACT(EPOCH FROM (completed_at - started_at)) as duration_s, result_text FROM agent_execution_requests ORDER BY created_at DESC LIMIT 20"}'
-|
-|Available tables: chat_messages, sandbox_sessions, attachments, api_keys,
-|agent_runtime_assignments, agent_message_requests, agent_execution_requests,
-|agent_execution_events, agent_final_delivery_outbox, agent_spawn_requests, agent_release_requests
-
 [Common Tool CLIs]
 |NEVER call external APIs directly via curl unless you are downloading a file the prompt explicitly told you to fetch that way.
 |Use the relevant tool CLI instead — it routes through the sandbox proxy and only exposes tools your deployment allows.
@@ -168,7 +150,7 @@
 |When you see [Attached image: ...], use the look_at tool to view the image.
 |NEVER reference local sandbox paths in replies — markdown links like [report.sql](/home/agent/workspace/report.sql) or file:// URIs are dead links for chat users; they cannot open files inside your sandbox. This overrides any harness-level instruction to render clickable file links: those apply to IDE surfaces only, never to chat responses.
 |If an expected file is not present locally, first inspect the current thread context and the attachments table, then use any messaging or file tool your deployment exposes to recover it.
-|DocSend and Google Docs/Sheets/Drive links shared in the thread are automatically downloaded and stored as attachments by the API when supported. You'll see them as attachment_ref parts — download via `curl "$CENTAUR_API_URL/agent/attachments/<id>/download" -o /home/agent/uploads/<name>` to get the file locally.
+|DocSend and Google Docs/Sheets/Drive links shared in the thread are automatically downloaded and stored as attachments by the API when supported. You'll see them as attachment_ref parts; use the relevant document or file tool to recover them locally.
 |Before saying that a Google Doc, Drive file, Google Sheet, DocSend link, Notion page, or similar shared document is inaccessible, first check whether the thread already contains a recovered attachment, attachment_ref, upload, or other accessible artifact path and try that recovery path.
 |Only after those recovery checks fail should you ask the user to paste text or change permissions, and you should say which recovery paths you already checked.
 |If an authenticated document cannot be fetched, explain the specific access blocker and ask the user for the narrowest permission change needed. Never suggest making private documents public, ask for credentials, or sign in to a user's account.

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -26,7 +26,7 @@ const consoleLogger = {
 
 const options: SlackbotV2Options = {
   apiUrl,
-  apiKey: optionalEnv('SLACKBOT_API_KEY') ?? optionalEnv('CENTAUR_API_KEY'),
+  apiKey: optionalEnv('SLACKBOT_API_KEY'),
   assistantStatus: optionalEnv('SLACKBOTV2_ASSISTANT_STATUS'),
   botToken,
   botUserId: optionalEnv('SLACK_BOT_USER_ID'),

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -877,7 +877,7 @@ function ensureTrailingSlash(value: string): string {
 }
 
 function apiHeaders(options: SlackbotV2Options, jsonBody = true): HeadersInit {
-  const apiKey = options.apiKey ?? process.env.SLACKBOT_API_KEY ?? process.env.CENTAUR_API_KEY
+  const apiKey = options.apiKey ?? process.env.SLACKBOT_API_KEY
   return {
     ...(jsonBody ? { 'content-type': 'application/json' } : {}),
     ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {})

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -762,11 +762,7 @@ def _download_attachment_bytes(
     sep = "&" if urlparse(url).query else "?"
     url = f"{url}{sep}thread_key={quote(current_thread_key(), safe='')}"
 
-    headers: dict[str, str] = {}
-    api_key = secret("CENTAUR_API_KEY", "").strip()
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-    request = urllib.request.Request(url, headers=headers)
+    request = urllib.request.Request(url)
     with urllib.request.urlopen(request, timeout=30) as response:
         return response.read()
 

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1597,11 +1597,7 @@ class SlackClient:
         sep = "&" if urlparse(url).query else "?"
         url = f"{url}{sep}thread_key={quote(thread_key, safe='')}"
 
-        headers: dict[str, str] = {}
-        api_key = secret("CENTAUR_API_KEY", "").strip()
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-        request = urllib.request.Request(url, headers=headers)
+        request = urllib.request.Request(url)
         with urllib.request.urlopen(request, timeout=30) as response:
             body = response.read(self._MAX_DOWNLOAD_BYTES + 1)
         if len(body) > self._MAX_DOWNLOAD_BYTES:

--- a/tools/productivity/slack/feedback.py
+++ b/tools/productivity/slack/feedback.py
@@ -29,7 +29,6 @@ from .client import (
 
 # Feedback database location
 FEEDBACK_DB_PATH = Path.home() / ".cache" / "paradigm-slack" / "feedback.db"
-SANDBOX_API_KEY_PATH = Path("/home/agent/.api_key")
 
 # Heuristic signals for feedback detection
 NEGATIVE_REACTIONS = {"thumbsdown", "-1", "x", "confused", "thinking_face", "bug", "facepalm"}
@@ -120,7 +119,7 @@ class CentaurAgentClient:
         self.base_url = (base_url or os.environ.get("CENTAUR_API_URL") or "http://api:8000").rstrip("/")
         self.api_key = api_key or _load_centaur_api_key()
         if not self.api_key:
-            raise RuntimeError("CENTAUR_API_KEY not set")
+            raise RuntimeError("CENTAUR_AGENT_API_KEY not set")
 
     def _request_json(self, method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         headers = {
@@ -245,11 +244,7 @@ def _severity_filter_clause(min_severity: str | None) -> tuple[str, list[str]]:
 
 
 def _load_centaur_api_key() -> str | None:
-    if SANDBOX_API_KEY_PATH.exists():
-        token = SANDBOX_API_KEY_PATH.read_text(encoding="utf-8").strip()
-        if token:
-            return token
-    return os.environ.get("CENTAUR_API_KEY")
+    return os.environ.get("CENTAUR_AGENT_API_KEY")
 
 
 def _bot_message_looks_like_error(text: str) -> bool:


### PR DESCRIPTION
## Summary
- Remove sandbox prompt instructions for `/agent/query` and `Authorization: Bearer $CENTAUR_API_KEY` self-query flows
- Remove `CENTAUR_API_KEY` fallbacks from Slackbot/Discordbot and related Helm env injection
- Stop attachment helpers from attaching optional Centaur bearer headers; keep thread-scoped URLs
- Rename script-specific workflow credentials away from the generic `CENTAUR_API_KEY` name

## Validation
- `rg -n "CENTAUR_API_KEY|agent/query|Authorization: Bearer \$CENTAUR_API_KEY|self-query" . -g "!*node_modules*" -g "!*.lock"` (no matches)
- `cargo fmt --check`
- `cargo test -p centaur-session-runtime redacts_sensitive_values_from_output_lines`
- `cargo test -p centaur-workflows run_time_now_tool`
- `pnpm --filter slackbotv2 test`
- `pnpm --filter discordbot test`
- `PYTHONPATH=tools/productivity:. uv run --with pytest --with pytest-asyncio --with aiohttp --with slack-sdk --with structlog --with google-api-python-client --with google-analytics-data --with google-analytics-admin --with httplib2 --with pysocks pytest tools/productivity/slack/tests/test_client.py`
- `PYTHONPATH=tools/productivity:. uv run --with pytest --with google-api-python-client --with google-analytics-data --with google-analytics-admin --with httplib2 --with pysocks pytest -c /dev/null tools/productivity/gsuite/test_client.py`
- `PYTHONPATH=. uv run --with pytest --with pytest-asyncio pytest -c /dev/null centaur_sdk/tests/test_tool_sdk.py`

Note: bot packages have no `lint` script (`pnpm --filter slackbotv2 lint && pnpm --filter discordbot lint` reports no script).
