### PR TITLE
Allow sandboxes readonly Postgres access

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -2415,6 +2415,24 @@ mod tests {
                         == Some("TOOL_API_KEY")
             })
         }));
+        assert!(roles[0].1.postgres.iter().any(|listener| {
+            listener.name.as_deref() == Some("centaur-database")
+                && listener
+                    .sandbox_env
+                    .as_ref()
+                    .and_then(|sandbox_env| sandbox_env.name.as_deref())
+                    == Some("CENTAUR_DATABASE_URL")
+                && listener
+                    .sandbox_env
+                    .as_ref()
+                    .and_then(|sandbox_env| sandbox_env.database.as_deref())
+                    == Some("ai_v2")
+                && listener
+                    .extra
+                    .get("role")
+                    .and_then(serde_yaml::Value::as_str)
+                    == Some("centaur_readonly")
+        }));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
+++ b/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
@@ -24,3 +24,11 @@ transforms:
             proxy_value: SLACK_BOT_TOKEN
             match_headers: ["Authorization"]
           rules: [{ host: "*.slack.com" }]
+postgres:
+  - name: centaur-database
+    upstream:
+      dsn: { placeholder: DATABASE_URL }
+    sandbox_env:
+      name: CENTAUR_DATABASE_URL
+      database: ai_v2
+    role: centaur_readonly


### PR DESCRIPTION
## Summary
- add an infra pg_dsn listener that exposes the app database to sandboxes as CENTAUR_DATABASE_URL through iron-proxy
- bind the listener to the existing centaur_readonly role
- cover the infra role wiring in the api-rs args test

Note: main now includes 0020_centaur_readonly_role_only.sql from the centaur_investigator work, so this PR no longer carries a migration. That migration owns the all-table read-only grants.

## Tests
- cargo test -p centaur-iron-proxy
- cargo test -p centaur-iron-control postgres_listener_translates_to_pg_dsn_secret
- cargo test -p centaur-api-server args::tests::iron_control_registers_discovered_tool_secrets_on_infra_role