### PR TITLE
Remove legacy agent API leftovers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,23 +44,12 @@ just up
 From inside the API deployment (localhost bypass — no key needed):
 
 ```bash
-THREAD_KEY=test-e2e-1
-
-SPAWN=$(kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/spawn \
+RUN=$(kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/workflows/runs \
   -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"harness\":\"amp\"}")
-ASSIGNMENT_GENERATION=$(printf '%s' "$SPAWN" | jq -r '.assignment_generation')
+  -d '{"workflow_name":"slack_thread_turn","trigger_key":"test-e2e-1","input":{"thread_key":"slack:test-e2e:1","text":"Reply with exactly PONG and nothing else.","delivery":{"platform":"dev"}},"eager_start":true}')
+RUN_ID=$(printf '%s' "$RUN" | jq -r '.run_id')
 
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/message \
-  -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG and nothing else.\"}]}"
-
-EXECUTE=$(kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/execute \
-  -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"harness\":\"amp\",\"delivery\":{\"platform\":\"dev\"}}")
-EXECUTION_ID=$(printf '%s' "$EXECUTE" | jq -r '.execution_id')
-
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s "http://localhost:8000/agent/executions/${EXECUTION_ID}" | jq
+kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s "http://localhost:8000/workflows/runs/${RUN_ID}" | jq
 ```
 
 Or create a DB-backed key for external use (see [API Key Management](#api-key-management)).
@@ -84,130 +73,31 @@ Centaur is a modular service architecture. Each service communicates through wel
 
 **Client → API** (durable control-plane protocol):
 
-Clients (slackbot, CLI, external integrations) should stay thin. They persist input with `spawn -> message -> execute`, stream or replay output from the durable events endpoint, and only fall back to durable terminal state when the live stream is gone. The API owns runtime assignment, execution serialization, cancellation, and final-delivery recovery; Postgres is the source of truth.
+Clients (slackbot, CLI, external integrations) should stay thin. User turns enter through workflow runs; the workflow owns runtime assignment, transcript persistence, execution, and final delivery. Postgres is the source of truth.
 
-**Step 1: Assign or reuse a runtime** (`POST /agent/spawn`)
+**Start a user turn** (`POST /workflows/runs`)
 
-Pins one warm runtime to the thread and returns the current `assignment_generation`.
+Workflows are the user-turn entrypoint. Slackbot starts `slack_thread_turn`; local smoke tests can do the same through localhost bypass from inside the API deployment.
 
 ```
-POST /agent/spawn
+POST /workflows/runs
 {
-  "thread_key": "slack:C0AJ07U8Z1N:1773364194.179929",
-  "harness": "amp"
-}
-
-← {
+  "workflow_name": "slack_thread_turn",
+  "trigger_key": "slack:C0AJ07U8Z1N:1773364194.179929",
+  "input": {
     "thread_key": "slack:C0AJ07U8Z1N:1773364194.179929",
-    "runtime_id": "rtm_123",
-    "assignment_generation": 12,
-    "state": "assigned_idle"
-  }
-```
-
-**Step 2: Persist the user turn** (`POST /agent/message`)
-
-Writes one durable transcript event. Inline base64 image/document blocks are extracted into `attachments` and rewritten to lightweight `attachment_ref` parts.
-
-```
-POST /agent/message
-{
-  "thread_key": "slack:C0AJ07U8Z1N:1773364194.179929",
-  "assignment_generation": 12,
-  "role": "user",
-  "parts": [{"type": "text", "text": "analyze this"}],
-  "user_id": "U123",
-  "metadata": {"user_name": "alice", "platform": "slack"}
+    "text": "analyze this",
+    "delivery": {"platform": "slack"}
+  },
+  "eager_start": true
 }
 
-← {"ok": true, "message_id": "msg_123"}
+← {"ok": true, "run_id": "run_123", "status": "queued"}
 ```
 
-**Step 3: Enqueue execution** (`POST /agent/execute`)
+**Inspect the run** (`GET /workflows/runs/{run_id}`)
 
-Creates a durable execution request plus final-delivery obligation. The worker drives the attached container; the response is just the execution handle.
-
-```
-POST /agent/execute
-{
-  "thread_key": "slack:C0AJ07U8Z1N:1773364194.179929",
-  "assignment_generation": 12,
-  "harness": "amp",
-  "delivery": {"platform": "slack"}
-}
-
-← {"ok": true, "execution_id": "exe_123", "status": "queued"}
-```
-
-**Step 4: Stream or replay output** (`GET /agent/threads/{thread_key}/events`)
-
-Consumers tail durable events for one execution. On disconnect, reconnect with the last seen event id. If the execution already finished and no more rows remain, the API emits the terminal `execution_state` snapshot.
-
-```
-GET /agent/threads/slack:C0AJ07U8Z1N:1773364194.179929/events?execution_id=exe_123&after_event_id=0
-
-← SSE event: amp_raw_event
-← data: {"type":"assistant","message":{...}}
-← SSE event: turn.done
-← data: {"type":"turn.done","result":"..."}
-← SSE event: execution_state
-← data: {"status":"completed","result_text":"..."}
-```
-
-**Step 5: Release only when you really want to end the assignment** (`POST /agent/threads/{thread_key}/release`)
-
-Releases the thread-to-runtime pin and optionally cancels any non-terminal execution still tied to that assignment generation.
-
-**Inspect the active runtime for a thread** (`GET /agent/runtime?key={thread_key}`)
-
-Returns `{persona_id, persona, harness, engine, overlay: {loaded, mount_api, mount_sandbox, image}, available_personas, …}`. Sandboxes call this through `call agent runtime '?key='"$CENTAUR_THREAD_KEY"`; clients can call it directly to confirm what persona/overlay an assignment is actually running.
-
-**Durable state written for one turn:**
-
-| Table | What |
-|-------|------|
-| `agent_runtime_assignments` | Thread-to-runtime pin and active assignment generation |
-| `agent_message_requests` | Durable inbound transcript events |
-| `attachments` | Extracted attachment bytes for inline multimodal content |
-| `agent_execution_requests` | Queued/running/terminal execution row |
-| `agent_execution_events` | Replayable raw + projected execution events |
-| `agent_final_delivery_outbox` | Final-result delivery obligation for reconnect/retry paths |
-
-`POST /agent/connect` and `POST /agent/reconnect` are legacy endpoints now kept only as explicit `410 LEGACY_ENDPOINT_REMOVED` stubs. Do not build new clients on them.
-
-**API → Sandbox** (stdin/stdout, NDJSON):
-
-The API communicates with sandbox Pods through the active sandbox backend's attach stream. The wire format is **Anthropic message format** — this is the canonical protocol between the API and all sandboxes, regardless of which harness runs inside.
-
-```
-→ stdin:  {"type":"turn.start","turn_id":1,"text":"analyze this"}
-→ stdin:  {"type":"turn.start","turn_id":2,"content":[             // Anthropic content blocks
-             {"type":"text","text":"what is this?"},
-             {"type":"image","source":{"type":"base64","media_type":"image/png","data":"..."}}
-           ]}
-→ stdin:  {"type":"interrupt"}
-
-← stdout: {"type":"system","subtype":"init","session_id":"T-..."}
-← stdout: {"type":"assistant","message":{"role":"assistant","content":[...]}}
-← stdout: {"type":"result","subtype":"success","result":"..."}
-← stdout: {"type":"turn.done","turn_id":1,"result":"..."}
-```
-
-**Sandbox harness adapter** (`services/sandbox/harness_session.py`):
-
-The sandbox's `harness_session.py` translates the standard Anthropic format into whatever each harness CLI actually accepts:
-
-| Harness | Translation |
-|---------|-------------|
-| **claude-code** | Pass through directly (native Anthropic format) |
-| **amp** | Materialize image/document blocks to files on disk, replace with `@/path` text mentions (Amp stdin only accepts text blocks) |
-| **codex / pi-mono** | Extract text from content blocks, pass as CLI argument |
-
-This means clients and the API never need to know about harness-specific quirks. They speak Anthropic format; the sandbox adapter handles the rest.
-
-**Sandbox → API** (REST over Kubernetes services):
-
-Agents call tools through the generated `centaur-tools` catalog and direct tool CLIs. The tool runtime handles routing and credential access.
+Workflow and execution state are persisted in Postgres. Reconnects and process restarts recover from the run, execution rows, events, attachments, and final-delivery outbox.
 
 ### Network Isolation
 
@@ -704,60 +594,15 @@ just up
 All E2E curl commands below use `kubectl exec` for localhost bypass (no API key needed).
 To test from outside the container, create a DB-backed key via the [admin API](#api-key-management).
 
-### 2. Spawn a runtime assignment
+### 2. Start a workflow run
 
 ```bash
-THREAD_KEY=test-e2e-1
-
-SPAWN=$(kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/spawn \
+RUN=$(kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/workflows/runs \
   -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"harness\":\"amp\"}")
-ASSIGNMENT_GENERATION=$(printf '%s' "$SPAWN" | jq -r '.assignment_generation')
-```
+  -d '{"workflow_name":"slack_thread_turn","trigger_key":"test-e2e-1","input":{"thread_key":"slack:test-e2e:1","text":"Reply with exactly PONG and nothing else.","delivery":{"platform":"dev"}},"eager_start":true}')
+RUN_ID=$(printf '%s' "$RUN" | jq -r '.run_id')
 
-### 3. Persist a message
-
-```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/message \
-  -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG and nothing else.\"}]}"
-```
-
-### 4. Enqueue execution
-
-```bash
-EXECUTE=$(kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/execute \
-  -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"harness\":\"amp\",\"delivery\":{\"platform\":\"dev\"}}")
-EXECUTION_ID=$(printf '%s' "$EXECUTE" | jq -r '.execution_id')
-```
-
-### 5. Tail durable events (or reconnect later)
-
-```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -N \
-  "http://localhost:8000/agent/threads/${THREAD_KEY}/events?execution_id=${EXECUTION_ID}&after_event_id=0"
-```
-
-If this stream disconnects, reconnect with the last seen `event_id` as `after_event_id`. If the execution already finished, the endpoint emits the terminal `execution_state` snapshot.
-
-### 6. Inspect or cancel
-
-```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s "http://localhost:8000/agent/executions/${EXECUTION_ID}" | jq
-
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
-  "http://localhost:8000/agent/executions/${EXECUTION_ID}/cancel" \
-  -H "Content-Type: application/json" \
-  -d '{}'
-```
-
-### 7. Release the assignment when finished
-
-```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST "http://localhost:8000/agent/threads/${THREAD_KEY}/release" \
-  -H "Content-Type: application/json" \
-  -d '{"release_id":"rel-test-e2e-1","cancel_inflight":true}'
+kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s "http://localhost:8000/workflows/runs/${RUN_ID}" | jq
 ```
 
 ### Debugging

--- a/README.md
+++ b/README.md
@@ -42,13 +42,11 @@ Centaur is a self-hosted agent platform for teams that want one shared agent ins
 # 3. Progress and the final answer are delivered back to Slack.
 ```
 
-You can also drive Centaur directly through the API:
+You can also drive Centaur directly through the workflow API:
 
 ```text
-POST /agent/spawn      # assign or reuse a sandbox
-POST /agent/message    # store the user turn
-POST /agent/execute    # start the agent
-GET  /agent/threads/{thread_key}/events
+POST /workflows/runs             # start a durable workflow run
+GET  /workflows/runs/{run_id}    # inspect terminal state
 ```
 
 The platform handles sandbox lifecycle, durable transcript storage, tool access, credential injection, workflow execution, and final delivery.

--- a/docs/pages/architecture.mdx
+++ b/docs/pages/architecture.mdx
@@ -30,11 +30,10 @@ the API and follow the event stream.
 
 | Step | Endpoint | What it saves |
 |------|----------|----------------|
-| Start or reuse a sandbox | `POST /agent/spawn` | The thread's current sandbox assignment. |
-| Persist input | `POST /agent/message` | Writes the user turn and extracts large multimodal attachments. |
-| Run the agent | `POST /agent/execute` | A run row with status and final result. |
-| Follow output | `GET /agent/threads/{thread}/events` | Tool calls, model output, status changes, and final text. |
-| Clean up | `POST /agent/threads/{thread}/release` | Releases the sandbox and can cancel running work. |
+| Start user turn | `POST /workflows/runs` | A durable workflow run for the requested thread/trigger. |
+| Inspect state | `GET /workflows/runs/{run_id}` | Workflow status, output, execution linkage, and failure state. |
+
+Workflow steps persist runtime assignment, input, execution events, attachments, and final-delivery obligations in Postgres.
 
 Because each step is stored, a Slack reconnect, browser refresh, API restart,
 pod replacement, or worker failover does not erase the run. The event stream is
@@ -112,7 +111,7 @@ and does not protect against.
 |---------|-------------------|
 | Client disconnects | Reconnect to the event stream with `after_event_id`. |
 | API restarts | Reload assignments, executions, and terminal state from Postgres. |
-| Sandbox pod dies | The execution becomes terminal, the event trail remains in Postgres, and operators inspect `GET /agent/executions/{execution_id}` plus API/sandbox logs before retrying the turn. |
+| Sandbox pod dies | The workflow run becomes terminal, the event trail remains in Postgres, and operators inspect `GET /workflows/runs/{run_id}` plus API/sandbox logs before retrying the turn. |
 | Workflow worker restarts | Re-run the handler and skip completed checkpoints. |
 | Proxy restarts | Rebuild the key-injection map from the secret-manager cache. |
 | Tool changes | Discovery reloads plugin metadata; agents see the updated methods. |

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -277,9 +277,6 @@ kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
 
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
   curl -fsS http://localhost:8000/health/ready | jq
-
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS http://localhost:8000/health/tools | jq
 ```
 
 If you need to call operator routes from outside the cluster, create an admin
@@ -295,31 +292,20 @@ kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
 External operator calls then use:
 
 ```bash
-curl -s "$CENTAUR_API_URL/health/tools" \
+curl -s "$CENTAUR_API_URL/health/ready" \
   -H "X-Api-Key: $ADMIN_KEY" | jq
 ```
 
 Run one agent turn from inside the API deployment:
 
 ```bash
-THREAD_KEY=production-smoke-codex
-
-SPAWN=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/spawn \
+RUN=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/workflows/runs \
   -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\"}")
-ASSIGNMENT_GENERATION=$(printf '%s' "$SPAWN" | jq -r '.assignment_generation')
-
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/message \
-  -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG.\"}]}"
-
-EXECUTE=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/execute \
-  -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"delivery\":{\"platform\":\"dev\"}}")
-EXECUTION_ID=$(printf '%s' "$EXECUTE" | jq -r '.execution_id')
+  -d '{"workflow_name":"slack_thread_turn","trigger_key":"production-smoke-codex","input":{"thread_key":"slack:production-smoke:1","text":"Reply with exactly PONG.","delivery":{"platform":"dev"}},"eager_start":true}')
+RUN_ID=$(printf '%s' "$RUN" | jq -r '.run_id')
 
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s \
-  "http://localhost:8000/agent/executions/${EXECUTION_ID}" | jq
+  "http://localhost:8000/workflows/runs/${RUN_ID}" | jq
 ```
 
 Then run the same prompt through Slack:
@@ -342,7 +328,7 @@ execution before retrying:
 
 ```bash
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s \
-  "http://localhost:8000/agent/executions/${EXECUTION_ID}" | jq
+  "http://localhost:8000/workflows/runs/${RUN_ID}" | jq
 
 kubectl logs -n centaur-system deploy/centaur-centaur-api --tail=200
 kubectl get pods -n centaur-system -l centaur.ai/managed=true

--- a/docs/pages/extend/tools.mdx
+++ b/docs/pages/extend/tools.mdx
@@ -125,7 +125,7 @@ After deploy:
 
 ```bash
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS http://localhost:8000/health/tools | jq
+  curl -fsS http://localhost:8000/health/ready | jq
 ```
 
 Check that the tool appears and that missing-secret warnings match what you

--- a/docs/public/md/architecture.md
+++ b/docs/public/md/architecture.md
@@ -30,11 +30,10 @@ the API and follow the event stream.
 
 | Step | Endpoint | What it saves |
 |------|----------|----------------|
-| Start or reuse a sandbox | `POST /agent/spawn` | The thread's current sandbox assignment. |
-| Persist input | `POST /agent/message` | Writes the user turn and extracts large multimodal attachments. |
-| Run the agent | `POST /agent/execute` | A run row with status and final result. |
-| Follow output | `GET /agent/threads/{thread}/events` | Tool calls, model output, status changes, and final text. |
-| Clean up | `POST /agent/threads/{thread}/release` | Releases the sandbox and can cancel running work. |
+| Start user turn | `POST /workflows/runs` | A durable workflow run for the requested thread/trigger. |
+| Inspect state | `GET /workflows/runs/{run_id}` | Workflow status, output, execution linkage, and failure state. |
+
+Workflow steps persist runtime assignment, input, execution events, attachments, and final-delivery obligations in Postgres.
 
 Because each step is stored, a Slack reconnect, browser refresh, API restart,
 pod replacement, or worker failover does not erase the run. The event stream is
@@ -112,7 +111,7 @@ and does not protect against.
 |---------|-------------------|
 | Client disconnects | Reconnect to the event stream with `after_event_id`. |
 | API restarts | Reload assignments, executions, and terminal state from Postgres. |
-| Sandbox pod dies | The execution becomes terminal, the event trail remains in Postgres, and operators inspect `GET /agent/executions/{execution_id}` plus API/sandbox logs before retrying the turn. |
+| Sandbox pod dies | The workflow run becomes terminal, the event trail remains in Postgres, and operators inspect `GET /workflows/runs/{run_id}` plus API/sandbox logs before retrying the turn. |
 | Workflow worker restarts | Re-run the handler and skip completed checkpoints. |
 | Proxy restarts | Rebuild the key-injection map from the secret-manager cache. |
 | Tool changes | Discovery reloads plugin metadata; agents see the updated methods. |

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -277,9 +277,6 @@ kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
 
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
   curl -fsS http://localhost:8000/health/ready | jq
-
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS http://localhost:8000/health/tools | jq
 ```
 
 If you need to call operator routes from outside the cluster, create an admin
@@ -295,31 +292,20 @@ kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
 External operator calls then use:
 
 ```bash
-curl -s "$CENTAUR_API_URL/health/tools" \
+curl -s "$CENTAUR_API_URL/health/ready" \
   -H "X-Api-Key: $ADMIN_KEY" | jq
 ```
 
 Run one agent turn from inside the API deployment:
 
 ```bash
-THREAD_KEY=production-smoke-codex
-
-SPAWN=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/spawn \
+RUN=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/workflows/runs \
   -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\"}")
-ASSIGNMENT_GENERATION=$(printf '%s' "$SPAWN" | jq -r '.assignment_generation')
-
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/message \
-  -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG.\"}]}"
-
-EXECUTE=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/execute \
-  -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"delivery\":{\"platform\":\"dev\"}}")
-EXECUTION_ID=$(printf '%s' "$EXECUTE" | jq -r '.execution_id')
+  -d '{"workflow_name":"slack_thread_turn","trigger_key":"production-smoke-codex","input":{"thread_key":"slack:production-smoke:1","text":"Reply with exactly PONG.","delivery":{"platform":"dev"}},"eager_start":true}')
+RUN_ID=$(printf '%s' "$RUN" | jq -r '.run_id')
 
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s \
-  "http://localhost:8000/agent/executions/${EXECUTION_ID}" | jq
+  "http://localhost:8000/workflows/runs/${RUN_ID}" | jq
 ```
 
 Then run the same prompt through Slack:
@@ -342,7 +328,7 @@ execution before retrying:
 
 ```bash
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s \
-  "http://localhost:8000/agent/executions/${EXECUTION_ID}" | jq
+  "http://localhost:8000/workflows/runs/${RUN_ID}" | jq
 
 kubectl logs -n centaur-system deploy/centaur-centaur-api --tail=200
 kubectl get pods -n centaur-system -l centaur.ai/managed=true

--- a/docs/public/md/extend/tools.md
+++ b/docs/public/md/extend/tools.md
@@ -125,7 +125,7 @@ After deploy:
 
 ```bash
 kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS http://localhost:8000/health/tools | jq
+  curl -fsS http://localhost:8000/health/ready | jq
 ```
 
 Check that the tool appears and that missing-secret warnings match what you

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -9,9 +9,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@centaur/harness-events": "workspace:*",
-    "axios": "^1.13.6",
-    "eventsource-parser": "^3.0.6"
+    "axios": "^1.13.6"
   },
   "devDependencies": {
     "typescript": "5.9.3",

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,72 +1,4 @@
-import { EventSourceParserStream, type EventSourceMessage } from "eventsource-parser/stream";
 import axios, { type AxiosInstance } from "axios";
-
-export type InputContentBlock =
-  | { type: "text"; text: string }
-  | {
-      type: "image";
-      source_path?: string;
-      source: { type: "base64"; media_type: string; data: string };
-    }
-  | {
-      type: "document";
-      source_path?: string;
-      source: { type: "base64"; media_type: string; data: string };
-    };
-
-export interface SpawnOptions {
-  threadKey: string;
-  spawnId?: string;
-  harness?: string;
-  engine?: string;
-  personaId?: string;
-  agentsMdOverride?: string;
-}
-
-export interface SpawnResult {
-  ok: boolean;
-  runtime_id: string;
-  thread_key: string;
-  trace_id?: string;
-  assignment_state: string;
-  assignment_generation: number;
-  persona_id?: string | null;
-  prompt_ref?: string | null;
-  effective_agents_md_sha256?: string | null;
-}
-
-export interface MessageOptions {
-  threadKey: string;
-  assignmentGeneration: number;
-  messageId?: string;
-  role?: string;
-  event?: Record<string, unknown>;
-  parts?: InputContentBlock[];
-  userId?: string;
-  metadata?: Record<string, unknown>;
-}
-
-export interface ExecuteOptions {
-  threadKey: string;
-  assignmentGeneration: number;
-  executeId?: string;
-  harness?: string;
-  platform?: string;
-  userId?: string;
-  metadata?: Record<string, unknown>;
-  delivery?: Record<string, unknown>;
-}
-
-export interface ExecutionAccepted {
-  ok: boolean;
-  execution_id: string;
-  execute_id: string;
-  assignment_generation: number;
-  status: string;
-  final_key: string;
-  delivery_token: string;
-  idempotent?: boolean;
-}
 
 export interface WorkflowRunOptions {
   workflowName: string;
@@ -99,32 +31,14 @@ export interface WorkflowRunAccepted {
   idempotent?: boolean;
 }
 
-export interface ThreadMessageRecord {
-  id: string;
-  role: string;
-  parts: Array<Record<string, unknown>>;
-  user_id?: string | null;
-  metadata?: Record<string, unknown> | null;
-  created_at?: string | null;
-}
-
-export interface StreamEvent {
-  eventId: number;
-  eventKind: string;
-  data: Record<string, unknown>;
-}
-
 export class CentaurClient {
   readonly http: AxiosInstance;
-  private log?: { info: Function; warn: Function; error: Function };
 
   constructor(opts: {
     apiUrl: string;
     apiKey: string;
     timeoutMs?: number;
-    logger?: { info: Function; warn: Function; error: Function };
   }) {
-    this.log = opts.logger;
     this.http = axios.create({
       baseURL: opts.apiUrl,
       headers: { Authorization: `Bearer ${opts.apiKey}` },
@@ -132,66 +46,19 @@ export class CentaurClient {
     });
   }
 
-  private get authHeader(): string {
-    return (this.http.defaults.headers["Authorization"] ??
-      this.http.defaults.headers.common?.["Authorization"]) as string;
-  }
-
-  async spawn(opts: SpawnOptions): Promise<SpawnResult> {
-    const { data } = await this.http.post("/agent/spawn", {
-      thread_key: opts.threadKey,
-      spawn_id: opts.spawnId,
-      harness: opts.harness,
-      engine: opts.engine,
-      persona_id: opts.personaId,
-      agents_md_override: opts.agentsMdOverride,
-    });
-    return data as SpawnResult;
-  }
-
-  async message(opts: MessageOptions): Promise<{ ok: boolean; message_id: string; attachment_ids: string[] }> {
-    const body: Record<string, unknown> = {
-      thread_key: opts.threadKey,
-      assignment_generation: opts.assignmentGeneration,
-      message_id: opts.messageId,
-      metadata: opts.metadata,
-      user_id: opts.userId,
-    };
-
-    if (opts.event) {
-      body.event = opts.event;
-    } else {
-      body.role = opts.role ?? "user";
-      body.parts = opts.parts ?? [];
-    }
-
-    const { data } = await this.http.post("/agent/message", body);
-    return data as { ok: boolean; message_id: string; attachment_ids: string[] };
-  }
-
-  async execute(opts: ExecuteOptions): Promise<ExecutionAccepted> {
-    const { data } = await this.http.post("/agent/execute", {
-      thread_key: opts.threadKey,
-      assignment_generation: opts.assignmentGeneration,
-      execute_id: opts.executeId,
-      harness: opts.harness,
-      platform: opts.platform,
-      user_id: opts.userId,
-      metadata: opts.metadata,
-      delivery: opts.delivery,
-    });
-    return data as ExecutionAccepted;
-  }
-
   async startWorkflowRun(opts: WorkflowRunOptions): Promise<WorkflowRunAccepted> {
-    const { data } = await this.http.post("/workflows/runs", {
-      workflow_name: opts.workflowName,
-      trigger_key: opts.triggerKey,
-      input: opts.input ?? {},
-      eager_start: opts.eagerStart ?? false,
-    }, {
-      timeout: opts.timeoutMs,
-    });
+    const { data } = await this.http.post(
+      "/workflows/runs",
+      {
+        workflow_name: opts.workflowName,
+        trigger_key: opts.triggerKey,
+        input: opts.input ?? {},
+        eager_start: opts.eagerStart ?? false,
+      },
+      {
+        timeout: opts.timeoutMs,
+      },
+    );
     return data as WorkflowRunAccepted;
   }
 
@@ -219,10 +86,16 @@ export class CentaurClient {
     return data as { ok: boolean; items: WorkflowRunAccepted[] };
   }
 
-  async getWorkflowChildren(runId: string, limit = 200): Promise<{ ok: boolean; items: WorkflowRunAccepted[] }> {
-    const { data } = await this.http.get(`/workflows/runs/${encodeURIComponent(runId)}/children`, {
-      params: { limit },
-    });
+  async getWorkflowChildren(
+    runId: string,
+    limit = 200,
+  ): Promise<{ ok: boolean; items: WorkflowRunAccepted[] }> {
+    const { data } = await this.http.get(
+      `/workflows/runs/${encodeURIComponent(runId)}/children`,
+      {
+        params: { limit },
+      },
+    );
     return data as { ok: boolean; items: WorkflowRunAccepted[] };
   }
 
@@ -241,179 +114,6 @@ export class CentaurClient {
       correlation_id: opts.correlationId,
       payload: opts.payload ?? {},
     });
-    return data as Record<string, unknown>;
-  }
-
-  async *streamEvents(opts: {
-    threadKey: string;
-    afterEventId?: number;
-    executionId?: string;
-    pollMs?: number;
-    signal?: AbortSignal;
-  }): AsyncGenerator<StreamEvent, void, undefined> {
-    const params = new URLSearchParams();
-    if (opts.afterEventId !== undefined) params.set("after_event_id", String(opts.afterEventId));
-    if (opts.executionId) params.set("execution_id", opts.executionId);
-    if (opts.pollMs !== undefined) params.set("poll_ms", String(opts.pollMs));
-
-    const url = `${this.http.defaults.baseURL}/agent/threads/${encodeURIComponent(opts.threadKey)}/events?${params.toString()}`;
-    const res = await fetch(url, {
-      method: "GET",
-      headers: {
-        Authorization: this.authHeader,
-        "X-Centaur-Thread-Key": opts.threadKey,
-      },
-      signal: opts.signal,
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      throw new Error(`/agent/threads/{thread}/events failed (${res.status}): ${text.slice(0, 300)}`);
-    }
-    if (!res.body) return;
-
-    const stream = (res.body as ReadableStream<Uint8Array>)
-      .pipeThrough(new TextDecoderStream() as unknown as TransformStream<Uint8Array, string>)
-      .pipeThrough(new EventSourceParserStream());
-
-    for await (const event of stream as unknown as AsyncIterable<EventSourceMessage>) {
-      if (!event.data || event.data === "[DONE]") continue;
-      let parsed: Record<string, unknown> = { type: "unknown", raw: event.data };
-      try {
-        parsed = JSON.parse(event.data) as Record<string, unknown>;
-      } catch {
-        // keep raw fallback
-      }
-      yield {
-        eventId: Number(event.id || 0),
-        eventKind: event.event || "message",
-        data: parsed,
-      };
-    }
-  }
-
-  async getExecution(executionId: string) {
-    const { data } = await this.http.get(`/agent/executions/${encodeURIComponent(executionId)}`);
-    return data as Record<string, unknown>;
-  }
-
-  async getMessages(threadKey: string, opts?: { cursor?: string; limit?: number }) {
-    const { data } = await this.http.get("/agent/messages", {
-      params: {
-        thread_key: threadKey,
-        cursor: opts?.cursor,
-        limit: opts?.limit ?? 50,
-      },
-    });
-    return data as {
-      messages: ThreadMessageRecord[];
-      cursor: string | null;
-      has_more: boolean;
-    };
-  }
-
-  async listExecutions(threadKey: string, limit = 20) {
-    const { data } = await this.http.get(
-      `/agent/threads/${encodeURIComponent(threadKey)}/executions`,
-      { params: { limit } },
-    );
-    return data as { thread_key: string; executions: Array<Record<string, unknown>> };
-  }
-
-  async cancelExecution(executionId: string) {
-    const { data } = await this.http.post(`/agent/executions/${encodeURIComponent(executionId)}/cancel`);
-    return data as Record<string, unknown>;
-  }
-
-  async steerExecution(
-    executionId: string,
-    opts?: {
-      contentBlocks?: Array<Record<string, unknown>>;
-      messageId?: string;
-      userId?: string;
-      metadata?: Record<string, unknown>;
-      suppressCancellationDelivery?: boolean;
-    },
-  ) {
-    const { data } = await this.http.post(`/agent/executions/${encodeURIComponent(executionId)}/steer`, {
-      content_blocks: opts?.contentBlocks,
-      message_id: opts?.messageId,
-      user_id: opts?.userId,
-      metadata: {
-        ...(opts?.metadata || {}),
-        ...(opts?.suppressCancellationDelivery === undefined
-          ? {}
-          : { steer_replacement: opts.suppressCancellationDelivery }),
-      },
-    });
-    return data as Record<string, unknown>;
-  }
-
-  async releaseThread(threadKey: string, opts?: { releaseId?: string; cancelInflight?: boolean }) {
-    const { data } = await this.http.post(
-      `/agent/threads/${encodeURIComponent(threadKey)}/release`,
-      {
-        release_id: opts?.releaseId,
-        cancel_inflight: opts?.cancelInflight ?? false,
-      },
-    );
-    return data as Record<string, unknown>;
-  }
-
-  async claimFinalDeliveries(opts: { consumerId: string; limit?: number; leaseSeconds?: number; platform?: string }) {
-    const { data } = await this.http.post("/agent/final-deliveries/claim", {
-      consumer_id: opts.consumerId,
-      limit: opts.limit ?? 1,
-      lease_seconds: opts.leaseSeconds ?? 60,
-      platform: opts.platform,
-    });
-    return data as { deliveries: Array<Record<string, unknown>> };
-  }
-
-  async renewFinalDeliveryLease(executionId: string, opts: { consumerId: string; leaseSeconds?: number }) {
-    const { data } = await this.http.post(
-      `/agent/final-deliveries/${encodeURIComponent(executionId)}/heartbeat`,
-      {
-        consumer_id: opts.consumerId,
-        lease_seconds: opts.leaseSeconds ?? 60,
-      },
-    );
-    return data as Record<string, unknown>;
-  }
-
-  async markFinalDelivered(executionId: string, consumerId?: string) {
-    const { data } = await this.http.post(
-      `/agent/final-deliveries/${encodeURIComponent(executionId)}/delivered`,
-      { consumer_id: consumerId },
-    );
-    return data as Record<string, unknown>;
-  }
-
-  async markFinalFailed(
-    executionId: string,
-    error: string,
-    opts?: {
-      consumerId?: string;
-      retryAfterSeconds?: number;
-      nonRetryable?: boolean;
-      errorClass?: string;
-    },
-  ) {
-    const { data } = await this.http.post(
-      `/agent/final-deliveries/${encodeURIComponent(executionId)}/failed`,
-      {
-        consumer_id: opts?.consumerId,
-        error,
-        retry_after_seconds: opts?.retryAfterSeconds ?? 15,
-        non_retryable: opts?.nonRetryable ?? false,
-        error_class: opts?.errorClass,
-      },
-    );
-    return data as Record<string, unknown>;
-  }
-
-  async getStatus(threadKey: string) {
-    const { data } = await this.http.get("/agent/status", { params: { key: threadKey } });
     return data as Record<string, unknown>;
   }
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,10 +1,6 @@
 export { ApiError } from "./types";
 export { CentaurClient } from "./client";
 export type {
-  ExecuteOptions,
-  MessageOptions,
-  InputContentBlock,
-  ThreadMessageRecord,
   WorkflowRunOptions,
   WorkflowRunAccepted,
 } from "./client";

--- a/packages/api-client/test/client.test.ts
+++ b/packages/api-client/test/client.test.ts
@@ -1,233 +1,99 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { CentaurClient, type StreamEvent } from "../src/client";
-
-async function collectEvents(events: AsyncIterable<StreamEvent>): Promise<StreamEvent[]> {
-  const collected: StreamEvent[] = [];
-  for await (const event of events) {
-    collected.push(event);
-  }
-  return collected;
-}
-
-function sseResponse(body: string, init?: ResponseInit): Response {
-  return new Response(
-    new ReadableStream({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode(body));
-        controller.close();
-      },
-    }),
-    {
-      status: 200,
-      headers: { "Content-Type": "text/event-stream" },
-      ...init,
-    },
-  );
-}
+import { CentaurClient } from "../src/client";
 
 describe("CentaurClient", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
-  it("parses SSE ids, events, JSON data, [DONE], and invalid JSON payloads", async () => {
-    const fetchMock = vi.fn(async () => sseResponse([
-      "id: 11",
-      "event: amp_raw_event",
-      'data: {"type":"assistant","message":{"content":"hello"}}',
-      "",
-      "id: 12",
-      "event: done",
-      "data: [DONE]",
-      "",
-      "id: 13",
-      "data: not-json",
-      "",
-      "",
-    ].join("\n")));
-    vi.stubGlobal("fetch", fetchMock);
-
+  it("starts workflow runs through the workflow API", async () => {
     const client = new CentaurClient({
       apiUrl: "http://api.local",
       apiKey: "test-key",
     });
-
-    await expect(collectEvents(client.streamEvents({ threadKey: "thread-1" }))).resolves.toEqual([
-      {
-        eventId: 11,
-        eventKind: "amp_raw_event",
-        data: { type: "assistant", message: { content: "hello" } },
-      },
-      {
-        eventId: 13,
-        eventKind: "message",
-        data: { type: "unknown", raw: "not-json" },
-      },
-    ]);
-  });
-
-  it("URL encodes Slack thread keys in event stream URLs", async () => {
-    const fetchMock = vi.fn(async () => sseResponse(""));
-    vi.stubGlobal("fetch", fetchMock);
-    const client = new CentaurClient({
-      apiUrl: "http://api.local",
-      apiKey: "test-key",
+    const postMock = vi.spyOn(client.http, "post").mockResolvedValue({
+      data: { ok: true, run_id: "run-123", workflow_name: "nightly", status: "queued" },
     });
 
-    await collectEvents(client.streamEvents({
-      threadKey: "slack:C123:1700000000.000100",
-      executionId: "exe-1",
-      afterEventId: 42,
-      pollMs: 250,
-    }));
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://api.local/agent/threads/slack%3AC123%3A1700000000.000100/events?after_event_id=42&execution_id=exe-1&poll_ms=250",
-      expect.objectContaining({
-        method: "GET",
-        headers: {
-          Authorization: "Bearer test-key",
-          "X-Centaur-Thread-Key": "slack:C123:1700000000.000100",
-        },
+    await expect(
+      client.startWorkflowRun({
+        workflowName: "nightly",
+        triggerKey: "trigger-1",
+        input: { topic: "incidents" },
+        eagerStart: true,
+        timeoutMs: 5000,
       }),
+    ).resolves.toMatchObject({ run_id: "run-123" });
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/workflows/runs",
+      {
+        workflow_name: "nightly",
+        trigger_key: "trigger-1",
+        input: { topic: "incidents" },
+        eager_start: true,
+      },
+      { timeout: 5000 },
     );
   });
 
-  it("URL encodes Slack thread keys in path-based API calls", async () => {
+  it("reads and mutates workflow runs through workflow endpoints", async () => {
     const client = new CentaurClient({
       apiUrl: "http://api.local",
       apiKey: "test-key",
     });
     const getMock = vi.spyOn(client.http, "get").mockResolvedValue({
-      data: { thread_key: "slack:C123:1700000000.000100", executions: [] },
+      data: { ok: true, run_id: "run:123", workflow_name: "nightly", status: "completed" },
     });
-    const postMock = vi.spyOn(client.http, "post").mockResolvedValue({ data: { ok: true } });
-
-    await client.listExecutions("slack:C123:1700000000.000100", 2);
-    await client.releaseThread("slack:C123:1700000000.000100", {
-      releaseId: "release:1",
-      cancelInflight: true,
+    const postMock = vi.spyOn(client.http, "post").mockResolvedValue({
+      data: { ok: true, run_id: "run:123", workflow_name: "nightly", status: "cancelled" },
     });
 
-    expect(getMock).toHaveBeenCalledWith(
-      "/agent/threads/slack%3AC123%3A1700000000.000100/executions",
-      { params: { limit: 2 } },
-    );
-    expect(postMock).toHaveBeenCalledWith(
-      "/agent/threads/slack%3AC123%3A1700000000.000100/release",
-      {
-        release_id: "release:1",
-        cancel_inflight: true,
+    await client.getWorkflowRun("run:123");
+    await client.listWorkflowRuns({
+      workflowName: "nightly",
+      threadKey: "slack:C:1",
+      status: "running",
+      parentRunId: "root",
+      limit: 5,
+    });
+    await client.getWorkflowChildren("run:123", 10);
+    await client.cancelWorkflowRun("run:123");
+
+    expect(getMock).toHaveBeenNthCalledWith(1, "/workflows/runs/run%3A123");
+    expect(getMock).toHaveBeenNthCalledWith(2, "/workflows/runs", {
+      params: {
+        workflow_name: "nightly",
+        thread_key: "slack:C:1",
+        status: "running",
+        parent_run_id: "root",
+        limit: 5,
       },
-    );
-  });
-
-  it("throws useful errors for non-OK event stream responses", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(
-      "upstream unavailable",
-      { status: 503, statusText: "Service Unavailable" },
-    )));
-    const client = new CentaurClient({
-      apiUrl: "http://api.local",
-      apiKey: "test-key",
     });
-
-    await expect(
-      collectEvents(client.streamEvents({ threadKey: "slack:C123:1700000000.000100" })),
-    ).rejects.toThrow(
-      "/agent/threads/{thread}/events failed (503): upstream unavailable",
-    );
+    expect(getMock).toHaveBeenNthCalledWith(3, "/workflows/runs/run%3A123/children", {
+      params: { limit: 10 },
+    });
+    expect(postMock).toHaveBeenCalledWith("/workflows/runs/run%3A123/cancel");
   });
 
-  it("posts the expected steerExecution payload", async () => {
+  it("sends workflow events", async () => {
     const client = new CentaurClient({
       apiUrl: "http://api.local",
       apiKey: "test-key",
     });
     const postMock = vi.spyOn(client.http, "post").mockResolvedValue({ data: { ok: true } });
 
-    await client.steerExecution("exe:123", {
-      contentBlocks: [{ type: "text", text: "replacement" }],
-      messageId: "slack:1700000000.000200",
-      userId: "U123",
-      metadata: { platform: "slack" },
-      suppressCancellationDelivery: true,
+    await client.sendWorkflowEvent({
+      eventType: "approval.received",
+      correlationId: "corr-1",
+      payload: { approved: true },
     });
 
-    expect(postMock).toHaveBeenCalledWith(
-      "/agent/executions/exe%3A123/steer",
-      {
-        content_blocks: [{ type: "text", text: "replacement" }],
-        message_id: "slack:1700000000.000200",
-        user_id: "U123",
-        metadata: {
-          platform: "slack",
-          steer_replacement: true,
-        },
-      },
-    );
-  });
-
-  it("posts the expected final-delivery payloads", async () => {
-    const client = new CentaurClient({
-      apiUrl: "http://api.local",
-      apiKey: "test-key",
+    expect(postMock).toHaveBeenCalledWith("/workflows/events", {
+      event_type: "approval.received",
+      correlation_id: "corr-1",
+      payload: { approved: true },
     });
-    const postMock = vi.spyOn(client.http, "post").mockResolvedValue({ data: { ok: true, deliveries: [] } });
-
-    await client.claimFinalDeliveries({
-      consumerId: "slackbot-1",
-      limit: 3,
-      leaseSeconds: 120,
-      platform: "slack",
-    });
-    await client.renewFinalDeliveryLease("exe:123", {
-      consumerId: "slackbot-1",
-      leaseSeconds: 90,
-    });
-    await client.markFinalDelivered("exe:123", "slackbot-1");
-    await client.markFinalFailed("exe:123", "rate limited", {
-      consumerId: "slackbot-1",
-      retryAfterSeconds: 45,
-      nonRetryable: true,
-      errorClass: "slack_rate_limit",
-    });
-
-    expect(postMock).toHaveBeenNthCalledWith(
-      1,
-      "/agent/final-deliveries/claim",
-      {
-        consumer_id: "slackbot-1",
-        limit: 3,
-        lease_seconds: 120,
-        platform: "slack",
-      },
-    );
-    expect(postMock).toHaveBeenNthCalledWith(
-      2,
-      "/agent/final-deliveries/exe%3A123/heartbeat",
-      {
-        consumer_id: "slackbot-1",
-        lease_seconds: 90,
-      },
-    );
-    expect(postMock).toHaveBeenNthCalledWith(
-      3,
-      "/agent/final-deliveries/exe%3A123/delivered",
-      { consumer_id: "slackbot-1" },
-    );
-    expect(postMock).toHaveBeenNthCalledWith(
-      4,
-      "/agent/final-deliveries/exe%3A123/failed",
-      {
-        consumer_id: "slackbot-1",
-        error: "rate limited",
-        retry_after_seconds: 45,
-        non_retryable: true,
-        error_class: "slack_rate_limit",
-      },
-    );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,15 +18,9 @@ importers:
 
   packages/api-client:
     dependencies:
-      '@centaur/harness-events':
-        specifier: workspace:*
-        version: link:../harness-events
       axios:
         specifier: ^1.13.6
         version: 1.18.0
-      eventsource-parser:
-        specifier: ^3.0.6
-        version: 3.1.0
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -629,10 +623,6 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
-
-  eventsource-parser@3.1.0:
-    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
-    engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1759,8 +1749,6 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
-
-  eventsource-parser@3.1.0: {}
 
   expect-type@1.3.0: {}
 

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -2615,13 +2615,11 @@ async fn call_python_workflow_tool(message: &Value) -> Result<Value, WorkflowRun
         return serde_json::to_value(run_time_now_tool()).map_err(WorkflowRuntimeError::from);
     }
 
-    let base_url = env::var(WORKFLOW_TOOL_API_URL_ENV)
-        .or_else(|_| env::var("CENTAUR_PYTHON_API_URL"))
-        .map_err(|_| {
-            WorkflowRuntimeError::BadRequest(format!(
-                "{WORKFLOW_TOOL_API_URL_ENV} must be set for ctx.call_tool({tool}.{method})"
-            ))
-        })?;
+    let base_url = env::var(WORKFLOW_TOOL_API_URL_ENV).map_err(|_| {
+        WorkflowRuntimeError::BadRequest(format!(
+            "{WORKFLOW_TOOL_API_URL_ENV} must be set for ctx.call_tool({tool}.{method})"
+        ))
+    })?;
     let base_url = base_url.trim_end_matches('/');
     let url = format!("{base_url}/tools/{tool}/{method}");
     let args = message.get("args").cloned().unwrap_or_else(|| json!({}));

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -1050,7 +1050,7 @@ def feedback(
 
         console.print("\n[green]✓ Improvement agent dispatched[/]")
         console.print(f"  Thread key: {result['thread_key']}")
-        console.print(f"  Execution id: {result['execution_id']}")
+        console.print(f"  Run id: {result['run_id']}")
 
     elif action == "loop":
         console.print("[bold]Starting auto-improvement loop...[/]")
@@ -1074,7 +1074,7 @@ def feedback(
             )
             console.print(f"  Actionable: {result['actionable_items']}")
             if result["dispatched"]:
-                console.print(f"  Execution id: {result['execution_id']}")
+                console.print(f"  Run id: {result['run_id']}")
                 console.print(f"  Thread key: {result['thread_key']}")
             elif dry_run and result["actionable_items"]:
                 print(result["prompt"])

--- a/tools/productivity/slack/feedback.py
+++ b/tools/productivity/slack/feedback.py
@@ -10,7 +10,6 @@ import re
 import sqlite3
 import urllib.error
 import urllib.request
-import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -113,13 +112,13 @@ class SaveFeedbackResult:
 
 
 class CentaurAgentClient:
-    """Minimal client for starting a background improvement agent run."""
+    """Minimal client for starting a background improvement workflow run."""
 
     def __init__(self, base_url: str | None = None, api_key: str | None = None):
         self.base_url = (base_url or os.environ.get("CENTAUR_API_URL") or "http://api:8000").rstrip("/")
         self.api_key = api_key or _load_centaur_api_key()
         if not self.api_key:
-            raise RuntimeError("CENTAUR_AGENT_API_KEY not set")
+            raise RuntimeError("SLACK_FEEDBACK_API_KEY not set")
 
     def _request_json(self, method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         headers = {
@@ -159,49 +158,31 @@ class CentaurAgentClient:
         persona_id: str = "eng",
         thread_key: str | None = None,
     ) -> dict[str, Any]:
-        """Spawn, message, and execute a background improvement agent run."""
-        thread_key = thread_key or f"feedback-improvement:{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}:{uuid.uuid4().hex[:8]}"
-        spawn = self._request_json(
+        """Start a background improvement workflow run."""
+        thread_key = thread_key or f"feedback-improvement:{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+        run = self._request_json(
             "POST",
-            "/agent/spawn",
+            "/workflows/runs",
             {
-                "thread_key": thread_key,
-                "harness": harness,
-                "persona_id": persona_id,
-            },
-        )
-        assignment_generation = spawn["assignment_generation"]
-
-        self._request_json(
-            "POST",
-            "/agent/message",
-            {
-                "thread_key": thread_key,
-                "assignment_generation": assignment_generation,
-                "role": "user",
-                "parts": [{"type": "text", "text": prompt}],
-                "metadata": {"source": "slack-feedback-loop"},
-            },
-        )
-
-        execute = self._request_json(
-            "POST",
-            "/agent/execute",
-            {
-                "thread_key": thread_key,
-                "assignment_generation": assignment_generation,
-                "execute_id": f"feedback-improvement-{uuid.uuid4().hex[:12]}",
-                "harness": harness,
-                "delivery": {"platform": "dev"},
-                "metadata": {"source": "slack-feedback-loop"},
+                "workflow_name": "slack_feedback_improvement",
+                "trigger_key": thread_key,
+                "input": {
+                    "thread_key": thread_key,
+                    "prompt": prompt,
+                    "harness": harness,
+                    "persona_id": persona_id,
+                    "metadata": {"source": "slack-feedback-loop"},
+                    "delivery": {"platform": "dev"},
+                },
+                "eager_start": True,
             },
         )
 
         return {
             "thread_key": thread_key,
-            "assignment_generation": assignment_generation,
-            "execution_id": execute["execution_id"],
-            "status": execute.get("status"),
+            "run_id": run["run_id"],
+            "execution_id": run.get("execution_id") or run["run_id"],
+            "status": run.get("status"),
         }
 
 
@@ -244,7 +225,7 @@ def _severity_filter_clause(min_severity: str | None) -> tuple[str, list[str]]:
 
 
 def _load_centaur_api_key() -> str | None:
-    return os.environ.get("CENTAUR_AGENT_API_KEY")
+    return os.environ.get("SLACK_FEEDBACK_API_KEY")
 
 
 def _bot_message_looks_like_error(text: str) -> bool:

--- a/tools/productivity/slack/tests/test_feedback.py
+++ b/tools/productivity/slack/tests/test_feedback.py
@@ -74,8 +74,8 @@ def test_run_improvement_cycle_dispatches_only_actionable_items(tmp_path, monkey
             assert "git-branch paradigmxyz/centaur" in prompt
             return {
                 "thread_key": "feedback-improvement:test",
-                "assignment_generation": 7,
-                "execution_id": "exec-test-123",
+                "run_id": "run-test-123",
+                "execution_id": "run-test-123",
                 "status": "queued",
             }
 
@@ -100,7 +100,7 @@ def test_run_improvement_cycle_dispatches_only_actionable_items(tmp_path, monkey
 
     row_by_id = {row["id"]: row for row in rows}
     assert row_by_id[actionable_id]["status"] == "in_progress"
-    assert row_by_id[actionable_id]["agent_execution_id"] == "exec-test-123"
+    assert row_by_id[actionable_id]["agent_execution_id"] == "run-test-123"
     assert row_by_id[success_id]["status"] == "new"
     assert row_by_id[success_id]["agent_execution_id"] is None
 


### PR DESCRIPTION
## Summary
- Replace stale `/agent/spawn`, `/agent/message`, `/agent/execute`, and `/health/tools` docs with workflow-run and `/health/ready` examples
- Trim `@centaur/api-client` down to workflow APIs and remove obsolete agent-event dependencies
- Move Slack feedback auto-improvement dispatch from direct spawn/message/execute calls to a workflow run
- Remove the old `CENTAUR_PYTHON_API_URL` workflow tool-call fallback

## Validation
- `rg -n "agent/spawn|agent/message|agent/execute|agent/messages|/agent/threads|/agent/executions|health/tools|CENTAUR_PYTHON_API_URL|CENTAUR_AGENT_API_KEY|InputContentBlock|ExecutionAccepted|eventsource-parser|@centaur/harness-events" README.md AGENTS.md docs/pages docs/public/md packages/api-client tools/productivity/slack services/api-rs/crates/centaur-workflows pnpm-lock.yaml -g "!*node_modules*" -g "!*.lock"` (remaining lockfile harness-events hits are for rendering/slackbot/discordbot, not api-client)
- `pnpm --filter @centaur/api-client test`
- `PYTHONPATH=tools/productivity:. uv run --with pytest --with slack-sdk --with structlog --with aiohttp pytest tools/productivity/slack/tests/test_feedback.py`
- `cargo fmt --check`
- `cargo test -p centaur-workflows run_time_now_tool`
