### PR TITLE
fix: terminally skip permanent Slack backfill jobs

### DIFF
--- a/workflows/slack/backfill.py
+++ b/workflows/slack/backfill.py
@@ -28,10 +28,12 @@ from workflows.slack.shared import (
     enqueue_backfill_job,
     env_flag_enabled,
     failure_reason,
+    is_permanent_slack_backfill_error,
     load_backfill_job_metrics,
     mark_thread_refreshed,
     mark_backfill_job_completed,
     mark_backfill_job_failed,
+    mark_backfill_job_terminal_skipped,
     message_row,
     positive_int,
     record_run_finish,
@@ -237,6 +239,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     )
 
     synced: list[dict[str, str]] = []
+    skipped: list[dict[str, str]] = []
     failed: list[dict[str, str]] = []
     counts = {
         "messages_fetched": 0,
@@ -437,6 +440,25 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                 channel_id=channel_id,
                 error=error,
             )
+            if is_permanent_slack_backfill_error(error):
+                skipped.append(
+                    channel_ref({"id": channel_id, "name": channel_id}, error)
+                )
+                ctx.log(
+                    "slack_backfill_job_terminal_skipped",
+                    job_id=job_id,
+                    job_key=str(job["job_key"]),
+                    job_type=str(job.get("job_type") or ""),
+                    channel_id=channel_id,
+                    error=error,
+                )
+                await mark_backfill_job_terminal_skipped(
+                    ctx._pool,
+                    job_id=job_id,
+                    run_id=run_id,
+                    error=error,
+                )
+                continue
             failed.append(channel_ref({"id": channel_id, "name": channel_id}, error))
             record_etl_items_failed(
                 "slack",
@@ -465,7 +487,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         run_id=run_id,
         status=status,
         synced=synced,
-        skipped=[],
+        skipped=skipped,
         failed=failed,
         counts=counts,
         error_text=error_text,
@@ -476,6 +498,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         "status": status,
         "run_id": run_id,
         "channels_synced": len(synced),
+        "channels_skipped": len(skipped),
         "channels_failed": len(failed),
         **counts,
     }

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -29,6 +29,10 @@ BACKFILL_JOB_TYPES = (
     BACKFILL_JOB_THREAD_REFRESH,
 )
 BACKFILL_JOB_STATUSES = ("pending", "running", "completed", "failed")
+PERMANENT_SLACK_BACKFILL_ERRORS = (
+    "channel_not_found",
+    "thread_not_found",
+)
 
 
 def positive_int(value: int | str | None, default: int) -> int:
@@ -343,6 +347,15 @@ def failure_reason(error: str) -> str:
     if "write" in lowered or "database" in lowered or "postgres" in lowered:
         return "write_error"
     return "unknown_error"
+
+
+def is_permanent_slack_backfill_error(error: str) -> bool:
+    """Return whether a Slack backfill error should terminally skip the job."""
+    lowered = error.lower()
+    return any(
+        f"slack api error: {error_code}" in lowered
+        for error_code in PERMANENT_SLACK_BACKFILL_ERRORS
+    )
 
 
 _MESSAGE_UPSERT_SQL = (
@@ -1578,6 +1591,32 @@ async def mark_backfill_job_failed(
     await pool.execute(
         "UPDATE slack_sync_backfill_jobs SET "
         "status = 'failed', last_run_id = $2, last_error = $3, updated_at = NOW() "
+        "WHERE job_id = $1",
+        job_id,
+        run_id,
+        error,
+    )
+
+
+async def mark_backfill_job_terminal_skipped(
+    pool,
+    *,
+    job_id: int,
+    run_id: str,
+    error: str,
+) -> None:
+    """Mark a permanently unrefreshable backfill job terminal without retrying."""
+    await pool.execute(
+        "UPDATE slack_sync_backfill_jobs SET "
+        "status = 'completed', "
+        "last_run_id = $2, "
+        "payload_json = COALESCE(payload_json, '{}'::jsonb) || jsonb_build_object("
+        "    'terminal_skip_reason', $3::text, "
+        "    'terminal_skip_at', NOW()::text"
+        "), "
+        "last_completed_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW() "
         "WHERE job_id = $1",
         job_id,
         run_id,

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -28,6 +28,35 @@ def _load_shared():
     return importlib.import_module("workflows.slack.shared")
 
 
+def _load_backfill():
+    api_module = sys.modules.setdefault("api", types.ModuleType("api"))
+
+    vm_metrics = types.ModuleType("api.vm_metrics")
+    for name in (
+        "record_etl_items_deleted",
+        "record_etl_items_enqueued",
+        "record_etl_items_failed",
+        "record_etl_items_seen",
+        "record_etl_items_upserted",
+        "set_etl_backfill_job_age_seconds",
+        "set_etl_backfill_jobs",
+    ):
+        setattr(vm_metrics, name, lambda *_args, **_kwargs: None)
+    api_module.vm_metrics = vm_metrics
+    sys.modules["api.vm_metrics"] = vm_metrics
+
+    workflow_engine = types.ModuleType("api.workflow_engine")
+
+    class WorkflowContext:
+        pass
+
+    workflow_engine.WorkflowContext = WorkflowContext
+    api_module.workflow_engine = workflow_engine
+    sys.modules["api.workflow_engine"] = workflow_engine
+
+    return importlib.import_module("workflows.slack.backfill")
+
+
 shared = _load_shared()
 
 
@@ -149,6 +178,132 @@ class FakePool:
                 return False
 
         return _Acquire()
+
+
+class FakeExecutePool:
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple] = []
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+
+
+def test_permanent_slack_backfill_error_classifier():
+    assert shared.is_permanent_slack_backfill_error(
+        "Slack API error: thread_not_found"
+    )
+    assert shared.is_permanent_slack_backfill_error(
+        "Slack API error: channel_not_found"
+    )
+    assert not shared.is_permanent_slack_backfill_error(
+        "Slack API error: rate_limited"
+    )
+    assert not shared.is_permanent_slack_backfill_error("database write failed")
+
+
+def test_mark_backfill_job_terminal_skipped_completes_without_retry():
+    pool = FakeExecutePool()
+
+    asyncio.run(
+        shared.mark_backfill_job_terminal_skipped(
+            pool,
+            job_id=123,
+            run_id="run_123",
+            error="Slack API error: thread_not_found",
+        )
+    )
+
+    assert len(pool.execute_calls) == 1
+    sql, args = pool.execute_calls[0]
+    assert "status = 'completed'" in sql
+    assert "terminal_skip_reason" in sql
+    assert "terminal_skip_at" in sql
+    assert "last_error = ''" in sql
+    assert args == (123, "run_123", "Slack API error: thread_not_found")
+
+
+def test_backfill_handler_terminally_skips_permanent_slack_errors(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    monkeypatch.setenv("SLACK_BACKFILL_ENABLED", "true")
+    backfill = _load_backfill()
+    calls: dict[str, list] = {
+        "finish": [],
+        "terminal_skip": [],
+        "failure_metrics": [],
+    }
+
+    class FakeClient:
+        def _etl_access_mode(self):
+            return "test"
+
+        def _get_etl_thread_replies_page(self, *_args, **_kwargs):
+            raise RuntimeError("Slack API error: thread_not_found")
+
+    class FakeContext:
+        run_id = "wfr_123"
+        _pool = object()
+
+        def __init__(self) -> None:
+            self.logs: list[tuple] = []
+
+        def log(self, name, **fields):
+            self.logs.append((name, fields))
+
+    async def fake_claim_jobs(_pool, _limit):
+        return [
+            {
+                "job_id": 123,
+                "job_key": "thread_refresh:C123:1770000000.000100",
+                "job_type": shared.BACKFILL_JOB_THREAD_REFRESH,
+                "payload_version": shared.BACKFILL_JOB_PAYLOAD_VERSION,
+                "channel_id": "C123",
+                "payload_json": {"thread_ts": "1770000000.000100"},
+                "priority": 200,
+                "attempt_count": 1,
+            }
+        ]
+
+    async def fake_noop(*_args, **_kwargs):
+        return None
+
+    async def fake_record_finish(_pool, **kwargs):
+        calls["finish"].append(kwargs)
+
+    async def fake_terminal_skip(_pool, **kwargs):
+        calls["terminal_skip"].append(kwargs)
+
+    monkeypatch.setattr(backfill, "_emit_backfill_job_metrics", fake_noop)
+    monkeypatch.setattr(backfill, "claim_backfill_jobs", fake_claim_jobs)
+    monkeypatch.setattr(backfill, "shared_client", lambda: FakeClient())
+    monkeypatch.setattr(backfill, "record_run_start", fake_noop)
+    monkeypatch.setattr(backfill, "record_run_finish", fake_record_finish)
+    monkeypatch.setattr(
+        backfill, "mark_backfill_job_terminal_skipped", fake_terminal_skip
+    )
+    monkeypatch.setattr(
+        backfill,
+        "record_etl_items_failed",
+        lambda *args, **kwargs: calls["failure_metrics"].append((args, kwargs)),
+    )
+
+    ctx = FakeContext()
+    result = asyncio.run(backfill.handler(backfill.Input(channel_batch_limit=1), ctx))
+
+    assert result["status"] == "completed"
+    assert result["channels_skipped"] == 1
+    assert result["channels_failed"] == 0
+    assert calls["failure_metrics"] == []
+    assert calls["terminal_skip"] == [
+        {
+            "job_id": 123,
+            "run_id": "slack_sync_wfr_123",
+            "error": "Slack API error: thread_not_found",
+        }
+    ]
+    assert calls["finish"][0]["status"] == "completed"
+    assert len(calls["finish"][0]["skipped"]) == 1
+    assert calls["finish"][0]["failed"] == []
+    assert any(name == "slack_backfill_job_terminal_skipped" for name, _ in ctx.logs)
 
 
 def test_replace_message_attachments_batch_upserts_and_deletes_stale_rows():


### PR DESCRIPTION
## Summary

Marks permanently missing Slack backfill targets as terminal skips instead of failed retry candidates.

## Root Cause

Slack backfill jobs for deleted or inaccessible channels/threads can fail with permanent Slack API errors like `channel_not_found` or `thread_not_found`. The backfill scheduler reclaims failed jobs, so these poison jobs retry forever and keep producing failure metrics even though retrying cannot succeed.

## Changes

- Classify `channel_not_found` and `thread_not_found` Slack API errors as permanent backfill errors.
- Mark those jobs `completed` with terminal skip metadata in `payload_json`.
- Count terminal skips separately from failed channels and avoid emitting failure metrics for them.
- Add focused tests for classification, DB update behavior, and handler behavior.

## Validation

- `uv run --with pytest pytest workflows/slack/tests`
- `uv run --with ruff ruff check workflows/slack/backfill.py workflows/slack/shared.py workflows/slack/tests/test_shared_attachments.py`
