### PR TITLE
fix: correct company context DSN database

### DIFF
--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -27,5 +27,5 @@ packages = ["."]
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "pg_dsn", name = "COMPANY_CONTEXT_DSN", database = "ai_v2", secret_ref = "DATABASE_URL", role = "centaur_slack_reader", settings = [{name = "centaur.slack_channel_id", value_from = {principal_label = "slack_channel_id"}}]},
+    {type = "pg_dsn", name = "COMPANY_CONTEXT_DSN", database = "centaur", secret_ref = "DATABASE_URL", role = "centaur_slack_reader", settings = [{name = "centaur.slack_channel_id", value_from = {principal_label = "slack_channel_id"}}]},
 ]


### PR DESCRIPTION
## Summary
- change the `COMPANY_CONTEXT_DSN` pg_dsn declaration from database `ai_v2` to `centaur`
- fix the proxy error where the listener connected as `ai_v2` but the upstream `DATABASE_URL` resolved to `centaur`

## Validation
- `uv run python` TOML parse check confirms `COMPANY_CONTEXT_DSN` targets `centaur`
- `uv run --with pytest --with asyncpg --with slack-sdk --with rich pytest tools/productivity/company_context/tests/test_client.py` (`18 passed`)
