### PR TITLE
ci: add aggregate CI success check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,17 +187,3 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-
-  rust-ci-success:
-    name: Rust CI success
-    runs-on: ubuntu-latest
-    if: always()
-    needs:
-      - migration-order
-      - rust-api
-    timeout-minutes: 30
-    steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,3 +187,17 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+
+  rust-ci-success:
+    name: Rust CI success
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - migration-order
+      - rust-api
+    timeout-minutes: 30
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,3 +171,19 @@ jobs:
       - name: Discordbot tests
         working-directory: services/discordbot
         run: bun run test
+
+  ci-success:
+    name: CI success
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - migration-order
+      - rust-api
+      - slackbotv2-tests
+      - discordbot-checks
+    timeout-minutes: 30
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/console-ci.yml
+++ b/.github/workflows/console-ci.yml
@@ -112,3 +112,22 @@ jobs:
           IRON_CONTROL_DB_PASSWORD: postgres
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         run: bin/rails db:test:prepare test
+
+  console-ci-success:
+    name: Console CI success
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - scan_ruby
+      - scan_js
+      - lint
+      - test
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- add a single overall `CI success` fan-in job for required branch protection
- add `Console CI success` for the separate Console CI workflow
- make the aggregate success checks publish on every PR by moving path relevance checks inside the workflows
- skip expensive CI lanes when their files are not relevant
- leave image build workflows outside the aggregate required checks

Prompted by: @Zygimantass

## Testing
- `uv run --with pyyaml python -c 'import yaml; [yaml.safe_load(open(p)) for p in [".github/workflows/ci.yml", ".github/workflows/console-ci.yml"]]; print("yaml ok")'`