### PR TITLE
[codex] Allow api-rs to reach iron-proxy management

### DIFF
--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -177,7 +177,7 @@ spec:
         - protocol: TCP
           port: 5432
 {{- end }}
-    # Per-sandbox iron-proxy listeners (HTTP proxy + postgres port).
+    # Per-sandbox iron-proxy listeners (HTTP proxy, management API, and postgres port).
     - to:
         - podSelector:
             matchLabels:
@@ -185,6 +185,8 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.ironProxy.service.proxyPort }}
+        - protocol: TCP
+          port: {{ .Values.ironProxy.service.managementPort }}
         - protocol: TCP
           port: {{ .Values.ironProxy.service.pgPort }}
 {{- if $console.enabled }}


### PR DESCRIPTION
## Summary

- Allow api-rs egress to the per-sandbox iron-proxy management port from the Helm NetworkPolicy.
- Keep the port value wired through `ironProxy.service.managementPort` instead of hardcoding `9092`.

## Root Cause

The per-sandbox proxy NetworkPolicy admits api-rs ingress on the management port, and the proxy exposes `/v1/status` and `/v1/sync`, but the api-rs NetworkPolicy only allowed egress to proxy pods on the HTTP proxy and Postgres ports. With default-deny egress enabled, api-rs management calls timed out and fell back to the fixed reassign delay.

## Validation

- `helm lint contrib/chart`
- `helm template centaur contrib/chart -f /Users/magelinskaas/tempoxyz/prd-centaur-infra/clusters/centaur-na/argocd/values/centaur.yaml` rendered `centaur-api-rs` iron-proxy egress ports as `8080,9092,5432`.