### PR TITLE
fix: keep publish image builds running

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   group: publish-images-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   group: publish-images-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Updates the publish-images workflow so active runs on main are not canceled when another commit lands. Other refs continue to cancel in-progress runs, preserving stale-build cleanup for PRs and branch builds.
