### PR TITLE
ci: add aggregate required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,77 @@ permissions:
   contents: read
 
 jobs:
+  ci_changes:
+    name: Detect CI changes
+    runs-on: ubuntu-latest
+    outputs:
+      migration_order: ${{ steps.filter.outputs.migration_order }}
+      rust_api: ${{ steps.filter.outputs.rust_api }}
+      slackbotv2_tests: ${{ steps.filter.outputs.slackbotv2_tests }}
+      discordbot_checks: ${{ steps.filter.outputs.discordbot_checks }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: filter
+        name: Detect changed paths
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            changed_files="$(git diff --name-only "${base}...HEAD")"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            changed_files="$(git diff --name-only "${{ github.event.before }}...HEAD")"
+          else
+            git fetch --no-tags --depth=1 origin main
+            changed_files="$(git diff --name-only origin/main...HEAD)"
+          fi
+
+          matches() {
+            local pattern
+            for pattern in "$@"; do
+              if printf '%s\n' "${changed_files}" | grep -Eq "${pattern}"; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          set_output() {
+            local name="$1"
+            shift
+            if matches "$@"; then
+              echo "${name}=true" >>"${GITHUB_OUTPUT}"
+            else
+              echo "${name}=false" >>"${GITHUB_OUTPUT}"
+            fi
+          }
+
+          set_output migration_order \
+            '^services/api-rs/crates/centaur-session-sqlx/migrations/' \
+            '^services/console/db/migrate/' \
+            '^\.github/scripts/check-migration-order\.sh$' \
+            '^\.github/workflows/ci\.yml$'
+          set_output rust_api \
+            '^services/api-rs/' \
+            '^\.github/workflows/ci\.yml$'
+          set_output slackbotv2_tests \
+            '^services/slackbotv2/' \
+            '^package\.json$' \
+            '^pnpm-lock\.yaml$' \
+            '^\.github/workflows/ci\.yml$'
+          set_output discordbot_checks \
+            '^services/discordbot/' \
+            '^package\.json$' \
+            '^pnpm-lock\.yaml$' \
+            '^\.github/workflows/ci\.yml$'
+
   migration-order:
     name: Migration order
     runs-on: depot-ubuntu-24.04-16
+    needs: ci_changes
+    if: needs.ci_changes.outputs.migration_order == 'true'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -28,6 +96,8 @@ jobs:
   rust-api:
     name: Rust API fmt, clippy, and tests
     runs-on: depot-ubuntu-24.04-16
+    needs: ci_changes
+    if: needs.ci_changes.outputs.rust_api == 'true'
     services:
       postgres:
         image: postgres:17
@@ -132,6 +202,8 @@ jobs:
   slackbotv2-tests:
     name: Slackbot v2 tests
     runs-on: depot-ubuntu-24.04-16
+    needs: ci_changes
+    if: needs.ci_changes.outputs.slackbotv2_tests == 'true'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -158,6 +230,8 @@ jobs:
   discordbot-checks:
     name: Discordbot typecheck and tests
     runs-on: depot-ubuntu-24.04-16
+    needs: ci_changes
+    if: needs.ci_changes.outputs.discordbot_checks == 'true'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -192,6 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - ci_changes
       - migration-order
       - rust-api
       - slackbotv2-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,4 +276,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
+          allowed-skips: migration-order, rust-api, slackbotv2-tests, discordbot-checks
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,3 +202,17 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+
+  rust-ci-success:
+    name: Rust CI success
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - migration-order
+      - rust-api
+    timeout-minutes: 30
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,17 +202,3 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-
-  rust-ci-success:
-    name: Rust CI success
-    runs-on: ubuntu-latest
-    if: always()
-    needs:
-      - migration-order
-      - rust-api
-    timeout-minutes: 30
-    steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/console-ci.yml
+++ b/.github/workflows/console-ci.yml
@@ -167,4 +167,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
+          allowed-skips: scan_ruby, scan_js, lint, test
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/console-ci.yml
+++ b/.github/workflows/console-ci.yml
@@ -2,22 +2,52 @@ name: Console CI
 
 on:
   pull_request:
-    paths:
-      - services/console/**
-      - .github/workflows/console-ci.yml
   push:
     branches: [ main ]
-    paths:
-      - services/console/**
-      - .github/workflows/console-ci.yml
 
 defaults:
   run:
     working-directory: services/console
 
 jobs:
+  console_changes:
+    name: Detect Console CI changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: filter
+        name: Detect changed paths
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            changed_files="$(git diff --name-only "${base}...HEAD")"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            changed_files="$(git diff --name-only "${{ github.event.before }}...HEAD")"
+          else
+            git fetch --no-tags --depth=1 origin main
+            changed_files="$(git diff --name-only origin/main...HEAD)"
+          fi
+
+          if printf '%s\n' "${changed_files}" | grep -Eq '^(services/console/|\.github/workflows/console-ci\.yml$)'; then
+            echo "relevant=true" >>"${GITHUB_OUTPUT}"
+          else
+            echo "relevant=false" >>"${GITHUB_OUTPUT}"
+          fi
+
   scan_ruby:
     runs-on: depot-ubuntu-24.04-16
+    needs: console_changes
+    if: needs.console_changes.outputs.relevant == 'true'
 
     steps:
       - name: Checkout code
@@ -37,6 +67,8 @@ jobs:
 
   scan_js:
     runs-on: depot-ubuntu-24.04-16
+    needs: console_changes
+    if: needs.console_changes.outputs.relevant == 'true'
 
     steps:
       - name: Checkout code
@@ -53,6 +85,8 @@ jobs:
 
   lint:
     runs-on: depot-ubuntu-24.04-16
+    needs: console_changes
+    if: needs.console_changes.outputs.relevant == 'true'
     env:
       RUBOCOP_CACHE_ROOT: ${{ github.workspace }}/services/console/tmp/rubocop
     steps:
@@ -80,6 +114,8 @@ jobs:
 
   test:
     runs-on: depot-ubuntu-24.04-16
+    needs: console_changes
+    if: needs.console_changes.outputs.relevant == 'true'
 
     services:
       postgres:
@@ -118,6 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - console_changes
       - scan_ruby
       - scan_js
       - lint


### PR DESCRIPTION
## Summary
- add a single overall `CI success` fan-in job for required branch protection
- add `Console CI success` for the separate Console CI workflow
- make the aggregate success checks publish on every PR by moving path relevance checks inside the workflows
- skip expensive CI lanes when their files are not relevant
- leave image build workflows outside the aggregate required checks

Prompted by: @Zygimantass

## Testing
- `uv run --with pyyaml python -c 'import yaml; [yaml.safe_load(open(p)) for p in [".github/workflows/ci.yml", ".github/workflows/console-ci.yml"]]; print("yaml ok")'`