### PR TITLE
[codex] allow shared Postgres database DSN roles

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -1346,6 +1346,95 @@ mod tests {
     }
 
     #[test]
+    fn pg_dsn_listeners_can_share_a_database_with_distinct_roles() {
+        let temp = temp_dir("api-rs-tools-pg-dsn-shared-db");
+        let base = temp.join("base");
+        write_tool(
+            &base.join("infra").join("centaur_investigator"),
+            r#"
+[project]
+description = "investigate centaur"
+
+[tool.centaur]
+secrets = [{type = "pg_dsn", name = "CENTAUR_READONLY_DSN", database = "centaur", secret_ref = "DATABASE_URL", role = "centaur_readonly"}]
+"#,
+        );
+        write_tool(
+            &base.join("productivity").join("company_context"),
+            r#"
+[project]
+description = "company context"
+
+[tool.centaur]
+secrets = [{type = "pg_dsn", name = "COMPANY_CONTEXT_DSN", database = "centaur", secret_ref = "DATABASE_URL", role = "centaur_slack_reader", settings = [{name = "centaur.slack_channel_id", value_from = {principal_label = "slack_channel_id"}}]}]
+"#,
+        );
+
+        let discovered = discover_tool_proxy_fragment(std::slice::from_ref(&base)).unwrap();
+
+        assert_eq!(discovered.secret_count, 2);
+        assert_eq!(discovered.fragment.postgres.len(), 2);
+
+        let company_context = discovered
+            .fragment
+            .postgres
+            .iter()
+            .find(|listener| listener.name.as_deref() == Some("company_context_dsn"))
+            .expect("company context postgres listener");
+        assert_eq!(
+            company_context
+                .sandbox_env
+                .as_ref()
+                .and_then(|env| env.name.as_deref()),
+            Some("COMPANY_CONTEXT_DSN")
+        );
+        assert_eq!(
+            company_context
+                .sandbox_env
+                .as_ref()
+                .and_then(|env| env.database.as_deref()),
+            Some("centaur")
+        );
+        assert_eq!(
+            company_context
+                .extra
+                .get("role")
+                .and_then(YamlValue::as_str),
+            Some("centaur_slack_reader")
+        );
+        assert_eq!(company_context.settings.len(), 1);
+        assert_eq!(company_context.settings[0].name, "centaur.slack_channel_id");
+
+        let readonly = discovered
+            .fragment
+            .postgres
+            .iter()
+            .find(|listener| listener.name.as_deref() == Some("centaur_readonly_dsn"))
+            .expect("centaur readonly postgres listener");
+        assert_eq!(
+            readonly
+                .sandbox_env
+                .as_ref()
+                .and_then(|env| env.name.as_deref()),
+            Some("CENTAUR_READONLY_DSN")
+        );
+        assert_eq!(
+            readonly
+                .sandbox_env
+                .as_ref()
+                .and_then(|env| env.database.as_deref()),
+            Some("centaur")
+        );
+        assert_eq!(
+            readonly.extra.get("role").and_then(YamlValue::as_str),
+            Some("centaur_readonly")
+        );
+        assert!(readonly.settings.is_empty());
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
     fn discovers_http_oauth_and_overlay_shadowing() {
         let temp = temp_dir("api-rs-tools");
         let base = temp.join("base");

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -135,8 +135,8 @@ pub fn placeholder_env(fragments: &[ProxyFragment]) -> BTreeMap<String, String> 
 /// [`placeholder_env`] for `pg_dsn` secrets — each tool declares the DSN env
 /// var `name` and `database` verbatim in its `pyproject.toml`, so the shape is
 /// fixed at startup (tools don't hot-reload). iron-proxy multiplexes every
-/// upstream through one listener (routing by database), so the DSNs differ only
-/// by database; api-rs stamps the shared per-sandbox host/credential at create.
+/// upstream through one listener; api-rs stamps the shared per-sandbox
+/// host/credential at create and preserves the declared env var names.
 /// This lets every sandbox (warm/bootstrap included) be born with the full DSN
 /// set without resolving a principal — the reassignable proxy enforces
 /// per-principal access at runtime. Sorted and deduped for stable env ordering.

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -42,10 +42,10 @@ const PROXY_TLS_CA_CERT_PATH: &str = "/etc/iron-proxy/ca.crt";
 const PROXY_TLS_CA_KEY_PATH: &str = "/etc/iron-proxy/ca.key";
 const PROXY_LOG_LEVEL: &str = "info";
 // iron-control multiplexes every Postgres upstream through a single listener,
-// routing by database name; the control plane owns each upstream DSN/role/
-// database. api-rs binds one local port (matching the chart's pgPort) and one
-// shared client credential (random per sandbox) the sandbox presents on every
-// DSN. These are the deploy-level env vars iron-proxy reads for that listener.
+// while the control plane owns each upstream DSN/role/database. api-rs binds
+// one local port (matching the chart's pgPort) and one shared client credential
+// (random per sandbox) the sandbox presents on every DSN. These are the
+// deploy-level env vars iron-proxy reads for that listener.
 const PG_LISTENER_PORT: u16 = 5432;
 const PG_LISTEN_ENV: &str = "IRON_PROXY_PG_LISTEN";
 const PG_CLIENT_USER_ENV: &str = "IRON_PROXY_PG_CLIENT_USER";
@@ -132,9 +132,9 @@ pub(crate) struct ResolvedIronProxy {
 }
 
 /// The single Postgres listener the proxy multiplexes every upstream through.
-/// iron-control owns each upstream DSN/role/database and routes by database
-/// name; api-rs only assigns the local listen port and the shared client
-/// credential the sandbox presents (random per sandbox).
+/// iron-control owns each upstream DSN/role/database; api-rs only assigns the
+/// local listen port and the shared client credential the sandbox presents
+/// (random per sandbox).
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ResolvedPg {
     /// Local listen address the proxy binds (e.g. ``0.0.0.0:5432``).
@@ -238,11 +238,11 @@ impl AgentSandboxBackend {
     /// sandboxes — created under the roleless bootstrap principal — are still
     /// born with the full DSN set and a live listener; the reassignable proxy
     /// enforces per-principal access at runtime by routing only the claimed
-    /// principal's granted databases. iron-proxy multiplexes every upstream
-    /// through one listener, so the DSNs differ only by database; api-rs binds a
-    /// single local port and a shared client credential (random per sandbox,
-    /// set on both the proxy CLIENT_PASSWORD and every sandbox DSN). Returns
-    /// `None` when no fragment declares a `pg_dsn`.
+    /// principal's granted Postgres credentials. iron-proxy multiplexes every
+    /// upstream through one listener; api-rs binds a single local port and a
+    /// shared client credential (random per sandbox, set on both the proxy
+    /// CLIENT_PASSWORD and every sandbox DSN). Returns `None` when no fragment
+    /// declares a `pg_dsn`.
     fn resolved_pg_from_fragments(&self) -> Option<ResolvedPg> {
         let iron_proxy = self.config.iron_proxy.as_ref()?;
         let dsns: Vec<ResolvedPgDsn> = pg_sandbox_dsns(&iron_proxy.fragments)
@@ -859,9 +859,8 @@ pub(crate) fn apply_proxy_env(spec: &mut SandboxSpec, resolved: &ResolvedIronPro
         set_missing_env(spec, name, value);
     }
     // Each Postgres upstream reaches the sandbox as a DSN env var. They all
-    // point at the proxy's single listener with the same shared credential and
-    // differ only by database; iron-proxy routes on the database and fronts the
-    // real upstream.
+    // point at the proxy's single listener with the same shared credential; the
+    // control plane sync supplies the upstream DSN, role, and settings.
     if let Some(pg) = &resolved.pg {
         for dsn in &pg.dsns {
             let value = format!(

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -1,10 +1,12 @@
 # A Postgres upstream credential: a connection-string (DSN) resolved from a
 # secret source, plus an optional SET ROLE for the upstream session. Delivered to
-# iron-proxy in the single-listener `postgres` list, where it is keyed for routing
-# by `database` (the dbname a client sends to reach this upstream). `database` is
-# therefore required and must match the database the DSN connects to; centaur-console
-# enforces that match where the DSN is inspectable (control_plane/inline) and
-# documents it otherwise (the proxy returns FATAL 3D000 on a mismatch).
+# iron-proxy in the single-listener `postgres` list. `database` is the dbname a
+# client sends to reach this upstream, while `foreign_id` is the logical
+# credential identity used by the control plane and sandbox env-var derivation.
+# Multiple logical credentials can target the same database with different
+# roles/settings; centaur-console enforces that `database` matches the DSN where
+# the DSN is inspectable (control_plane/inline) and documents it otherwise (the
+# proxy returns FATAL 3D000 on a mismatch).
 #
 # `foreign_id` is also required: it identifies the upstream for credential
 # delivery (env-var supplied DSNs) and is the stable handle operators reference.
@@ -37,10 +39,9 @@ class PgDsnSecret < ApplicationRecord
   has_many :grants, dependent: :destroy
   belongs_to :created_by, class_name: "User"
 
-  # One entry in the proxy's synced `postgres` list, keyed for routing by
-  # `database`. The opaque id is carried too so the proxy can refer back to the
-  # canonical resource (it ignores fields it does not use). The DSN reuses the
-  # shared secrets source shape.
+  # One entry in the proxy's synced `postgres` list. The opaque id is carried
+  # too so the proxy can refer back to the canonical resource (it ignores fields
+  # it does not use). The DSN reuses the shared secrets source shape.
   def to_proxy_dsn(principal: nil)
     entry = {
       "id" => oid,
@@ -70,7 +71,7 @@ class PgDsnSecret < ApplicationRecord
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, presence: true, uniqueness: { scope: :namespace },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
-  validates :database, presence: true, uniqueness: { scope: :namespace }
+  validates :database, presence: true
   validate :labels_is_a_hash
   validate :settings_are_valid
   validate :dsn_source_present

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -543,7 +543,7 @@ Returns `201`. Response shape (note that `credentials` and `token_endpoint_heade
 
 ## PG DSN secrets
 
-A PG DSN secret is a Postgres upstream credential: a connection string (DSN) resolved from a single secret [source](#secret-sources), plus an optional `SET ROLE` for the upstream session. It is delivered to `iron-proxy` with a required `foreign_id` for sandbox env-var derivation and a required `database` for routing. The proxy multiplexes upstreams through one listener and routes by the Postgres database name the client sends, so `database` must be unique per namespace and must match the upstream DSN's database.
+A PG DSN secret is a Postgres upstream credential: a connection string (DSN) resolved from a single secret [source](#secret-sources), plus an optional `SET ROLE` for the upstream session. It is delivered to `iron-proxy` with a required `foreign_id` for sandbox env-var derivation and a required `database` for the dbname clients use through the proxy. Multiple logical credentials can target the same physical database with different roles or pinned settings; `database` must still match the upstream DSN's database.
 
 Listener and client knobs (bind address, client auth) are deliberately not modeled: they are proxy-host deployment concerns. There are no [request rules](#request-rules) either: a Postgres listener matches by port, not by request.
 
@@ -556,7 +556,7 @@ Listener and client knobs (bind address, client auth) are deliberately not model
 | `name`        | optional    | |
 | `description` | optional    | |
 | `labels`      | optional    | Object; defaults to `{}`. |
-| `database`    | required    | Database name clients connect to through the proxy. Must be unique per namespace and match the upstream DSN's database. |
+| `database`    | required    | Database name clients connect to through the proxy. Must match the upstream DSN's database. |
 | `role`        | optional    | Upstream `SET ROLE` applied to the session. |
 | `settings`    | optional    | Ordered array of session variables (GUCs) the proxy SETs at session start, before the `SET ROLE`, and pins so clients cannot override them. Each entry is `{ "name", "value" }` for a literal value, or `{ "name", "value_from" }` to resolve the value from the assigned proxy principal at sync time (see [principal-derived values](#principal-derived-setting-values)). Names must be a bare or dotted identifier; `role` and `session_authorization` are reserved. Replaced wholesale on update. |
 | `dsn`         | required    | A [secret source](#secret-sources) resolving to the connection string. Replaced wholesale on update. |
@@ -1397,7 +1397,7 @@ Notes on the proxy-sync payload, which differs from the REST representation:
 - The config hash incorporates the principal assignment, so assigning, swapping, or clearing the principal always changes the hash and the proxy refetches. A swap is a full replacement: the proxy should drop the previously delivered config rather than merge.
 - The delivered config covers the proxy's principal's **effective grants**: secrets granted to the principal directly plus those granted to any [role](#roles) it holds. A secret reachable through more than one path appears once.
 - `secrets` carries one entry per granted static secret that has a source (sourceless static secrets are skipped). `transforms` carries one `gcp_auth` transform per granted GCP auth secret, one `aws_auth` transform per granted AWS auth secret, one `hmac_sign` transform per granted HMAC secret, and a single bundled `oauth_token` transform whose `config.tokens` lists every granted OAuth token secret. An `hmac_sign` transform omits `allow_chunked_body` when it is `false`.
-- `postgres` carries one entry per granted PG DSN secret, with the opaque `id` and `foreign_id` alongside it for sandbox env-var derivation and operator lookup. The proxy routes Postgres sessions by `database`; `role` is omitted when blank, as is `settings` when no session variables are configured.
+- `postgres` carries one entry per granted PG DSN secret, with the opaque `id` and `foreign_id` alongside it for sandbox env-var derivation and operator lookup. `role` is omitted when blank, as is `settings` when no session variables are configured.
 - Each source is flattened: its `config` keys are merged up and tagged with `type` (the `source_type`). A `control_plane` source delivers its decrypted value inline as `value`.
 - Rules use `methods` here, versus `http_methods` in the REST API. Blank rule fields are omitted.
 - The top-level `rules`, `mcp`, and `ingest_token` fields the proxy also understands are intentionally omitted; iron-control has no models for them. Rules are carried per secret instead.

--- a/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
@@ -296,7 +296,7 @@ module Api
         assert_equal "pg-upsert", json_body.dig("data", "foreign_id")
       end
 
-      test "PUT rejects a pg_dsn secret when another secret uses the same database" do
+      test "PUT accepts a pg_dsn secret when another secret uses the same database" do
         existing = pg_dsn_secrets(:acme_analytics_pg)
         body = {
           data: {
@@ -307,13 +307,14 @@ module Api
           }
         }
 
-        assert_no_difference -> { PgDsnSecret.count } do
+        assert_difference -> { PgDsnSecret.count } => 1 do
           put api_v1_pg_dsn_secret_url(id: "pg-shared-database"),
               params: body.to_json,
               headers: auth_headers
         end
-        assert_response :unprocessable_entity
-        assert_includes json_body.dig("error", "details", "database"), "has already been taken"
+        assert_response :created
+        assert_equal "pg-shared-database", json_body.dig("data", "foreign_id")
+        assert_equal existing.database, json_body.dig("data", "database")
       end
 
       test "GET index is scoped by namespace" do

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -55,11 +55,10 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     assert_includes dup.errors[:foreign_id], "has already been taken"
   end
 
-  test "database is unique within a namespace" do
+  test "database can be shared by distinct logical credentials" do
     with_dsn(PgDsnSecret.new(base_attrs(foreign_id: "first-pg", database: "shared-db"))).save!
-    dup = with_dsn(PgDsnSecret.new(base_attrs(foreign_id: "second-pg", database: "shared-db")))
-    assert_not dup.valid?
-    assert_includes dup.errors[:database], "has already been taken"
+    other = with_dsn(PgDsnSecret.new(base_attrs(foreign_id: "second-pg", database: "shared-db")))
+    assert other.valid?
   end
 
   test "an inline DSN whose database matches is valid" do

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -183,6 +183,26 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal({ "type" => "env", "var" => "PG_ANALYTICS_DSN" }, entries.first["dsn"])
   end
 
+  test "sync_postgres keeps same-database PgDsnSecrets distinct by foreign_id" do
+    existing = pg_dsn_secrets(:acme_analytics_pg)
+    shared = PgDsnSecret.new(
+      namespace: existing.namespace,
+      foreign_id: "pg-analytics-shared-role",
+      name: "analytics shared role",
+      database: existing.database,
+      role: "readonly_alt",
+      created_by: users(:acme_admin)
+    )
+    shared.dsn_source = SecretSource.new(source_type: "env", config: { "var" => "PG_ANALYTICS_SHARED_DSN" })
+    shared.save!
+
+    entries = principal_with_grants(existing, shared).sync_postgres
+
+    assert_equal 2, entries.length
+    assert_equal %w[pg-analytics pg-analytics-shared-role], entries.map { |entry| entry["foreign_id"] }.sort
+    assert_equal [ "analytics" ], entries.map { |entry| entry["database"] }.uniq
+  end
+
   test "sync_postgres resolves value_from settings against the principal" do
     principal = principals(:globex_user)
     principal.update!(labels: { "slack_channel_id" => "C999" })


### PR DESCRIPTION
## Summary

Fix the staging api-rs startup crash caused by registering two logical `pg_dsn` tool secrets that both target the physical `centaur` database but require different proxy-owned roles/settings.

## Root Cause

`company_context` and `centaur_investigator` correctly declare different DSN env vars and roles in their tool manifests, but centaur-console rejected the second `pg_dsn` secret because it treated `database` as namespace-unique. The stable control-plane identity is `foreign_id`; `database` is the dbname clients use through the proxy and can be shared by distinct logical credentials.

## Changes

- Remove the console model uniqueness validation on `PgDsnSecret#database`.
- Keep same-database PG DSNs distinct in proxy sync by `foreign_id`.
- Add API/model/proxy-sync tests for same-database PG DSNs.
- Add an api-rs tool-discovery regression test showing two tool `pg_dsn` listeners can share `database = "centaur"` while retaining distinct roles/settings.
- Update console docs and api-rs comments so they no longer document `database` as globally unique.

## Validation

- `cargo fmt --check && cargo test -p centaur-api-server tool_discovery` in `services/api-rs`
- `PATH=/opt/homebrew/opt/ruby@3.3/bin:$PATH CENTAUR_CONSOLE_DB_PORT=55432 CENTAUR_CONSOLE_DB_PASSWORD=postgres RAILS_ENV=test bin/rails db:prepare`
- `PATH=/opt/homebrew/opt/ruby@3.3/bin:$PATH CENTAUR_CONSOLE_DB_PORT=55432 CENTAUR_CONSOLE_DB_PASSWORD=postgres bin/rails test test/models/pg_dsn_secret_test.rb test/controllers/api/v1/pg_dsn_secrets_controller_test.rb test/models/principal_test.rb`
