### PR TITLE
fix: route shared postgres dsn through iron proxy

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1203,10 +1203,9 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         config.ready_timeout = Duration::from_secs(args.ready_timeout_secs);
         config.iron_proxy = args.iron_proxy.to_config()?;
         if let Some(proxy) = config.iron_proxy.as_mut() {
-            // The k8s backend derives the static sandbox PG DSN catalog from
-            // these fragments (see `pg_sandbox_dsns`); `to_config` only ships
-            // the harness fragment, so add the infra fragment and the
-            // discovered tool fragment (where `pg_dsn` secrets are declared).
+            // `to_config` only ships the harness fragment, so add infra and
+            // discovered tool fragments for any static proxy placeholder
+            // metadata the backend needs.
             let mut fragments = vec![args.iron_proxy.infra_fragment()?];
             if let Some(tool_fragment) = args.discover_tool_proxy_fragment()? {
                 fragments.push(tool_fragment.fragment);

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -1148,10 +1148,11 @@ fn postgres_listeners(secrets: &[ToolSecret]) -> Result<Vec<PostgresListener>, T
                     )])?),
                     ..Default::default()
                 }),
-                // Retain the declared DSN env var name + database so api-rs can
-                // bake the sandbox PG DSNs from the static fragment catalog
-                // (see `pg_sandbox_dsns`). This is an api-rs-internal annotation
-                // (`skip_serializing`) and never reaches the proxy.
+                // Retain the declared DSN env var name + database as an
+                // api-rs-internal annotation (`skip_serializing`) for older
+                // fragment consumers. The shared Centaur Postgres route is now
+                // injected by the sandbox backend independently of tool
+                // discovery.
                 sandbox_env: Some(SandboxEnv {
                     name: Some(secret.name.clone()),
                     database: Some(secret.database.clone()),

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
-use centaur_iron_proxy::{ProxyFragment, SourceKind, SourcePolicy, pg_sandbox_dsns};
+use centaur_iron_proxy::{ProxyFragment, SourceKind, SourcePolicy};
 use centaur_sandbox_core::{SandboxError, SandboxId, SandboxResult, SandboxSpec};
 use k8s_openapi::api::core::v1::{
     Capabilities, Container, ContainerPort, EmptyDirVolumeSource, EnvFromSource,
@@ -47,6 +47,7 @@ const PROXY_LOG_LEVEL: &str = "info";
 // shared client credential (random per sandbox) the sandbox presents on every
 // DSN. These are the deploy-level env vars iron-proxy reads for that listener.
 const PG_LISTENER_PORT: u16 = 5432;
+const CENTAUR_POSTGRES_DSN_ENV: &str = "CENTAUR_POSTGRES_DSN";
 const PG_LISTEN_ENV: &str = "IRON_PROXY_PG_LISTEN";
 const PG_CLIENT_USER_ENV: &str = "IRON_PROXY_PG_CLIENT_USER";
 const PG_CLIENT_PASSWORD_ENV: &str = "IRON_PROXY_PG_CLIENT_PASSWORD";
@@ -146,17 +147,6 @@ struct ResolvedPg {
     /// Shared client password (random per sandbox); set on both the proxy
     /// (CLIENT_PASSWORD) and every sandbox DSN so the two agree.
     password: String,
-    /// One DSN per upstream, all pointing at this listener and differing only
-    /// by database.
-    dsns: Vec<ResolvedPgDsn>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct ResolvedPgDsn {
-    /// Sandbox env var that receives the proxied DSN.
-    sandbox_env_name: String,
-    /// Database the sandbox connects to; iron-proxy routes the listener on it.
-    database: String,
 }
 
 /// Env injected into a managed proxy pod so iron-proxy pulls its config from
@@ -190,7 +180,7 @@ impl AgentSandboxBackend {
                 "iron-proxy sandbox spec is missing its iron-control principal".to_owned(),
             )
         })?;
-        let pg = self.resolved_pg_from_fragments();
+        let pg = self.resolved_pg();
         let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
 
         Ok(Some(ResolvedIronProxy {
@@ -207,8 +197,7 @@ impl AgentSandboxBackend {
     /// Read the principal's effective config from iron-control for the
     /// replace-secret placeholders set as sandbox env (so tools send the value
     /// the proxy swaps for the real secret). The Postgres DSN catalog is
-    /// derived statically from fragments instead — see
-    /// [`Self::resolved_pg_from_fragments`].
+    /// provided as one fixed local DSN instead — see [`Self::resolved_pg`].
     async fn effective_replace_placeholders(
         &self,
         principal: &str,
@@ -232,32 +221,18 @@ impl AgentSandboxBackend {
             .collect())
     }
 
-    /// Build the single Postgres listener from the static fragment catalog
-    /// (every tool's declared `pg_dsn` env var name + database). Unlike the
-    /// per-principal `effective_config` path this needs no principal, so warm
-    /// sandboxes — created under the roleless bootstrap principal — are still
-    /// born with the full DSN set and a live listener; the reassignable proxy
-    /// enforces per-principal access at runtime by routing only the claimed
-    /// principal's granted databases. iron-proxy multiplexes every upstream
-    /// through one listener, so the DSNs differ only by database; api-rs binds a
-    /// single local port and a shared client credential (random per sandbox,
-    /// set on both the proxy CLIENT_PASSWORD and every sandbox DSN). Returns
-    /// `None` when no fragment declares a `pg_dsn`.
-    fn resolved_pg_from_fragments(&self) -> Option<ResolvedPg> {
-        let iron_proxy = self.config.iron_proxy.as_ref()?;
-        let dsns: Vec<ResolvedPgDsn> = pg_sandbox_dsns(&iron_proxy.fragments)
-            .into_iter()
-            .map(|(sandbox_env_name, database)| ResolvedPgDsn {
-                sandbox_env_name,
-                database,
-            })
-            .collect();
-        (!dsns.is_empty()).then(|| ResolvedPg {
+    /// Build the single local Postgres listener every managed iron-proxy
+    /// exposes. The sandbox always receives one database-less base DSN; tools
+    /// choose the database name, and iron-control decides which upstream
+    /// credential/role backs that database for the currently assigned
+    /// principal.
+    fn resolved_pg(&self) -> Option<ResolvedPg> {
+        self.config.iron_proxy.as_ref()?;
+        Some(ResolvedPg {
             listen: format!("0.0.0.0:{PG_LISTENER_PORT}"),
             port: PG_LISTENER_PORT,
             user: format!("pg-user-{}", uuid::Uuid::new_v4().simple()),
             password: format!("pg-{}", uuid::Uuid::new_v4().simple()),
-            dsns,
         })
     }
 
@@ -286,7 +261,7 @@ impl AgentSandboxBackend {
         let Some(principal_id) = principal_id else {
             return Ok(None);
         };
-        let pg = self.resolved_pg_from_fragments();
+        let pg = self.resolved_pg();
         let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
         Ok(Some(ResolvedIronProxy {
             proxy_host: iron_proxy_service_name(id),
@@ -858,18 +833,15 @@ pub(crate) fn apply_proxy_env(spec: &mut SandboxSpec, resolved: &ResolvedIronPro
     for (name, value) in &resolved.replace_placeholders {
         set_missing_env(spec, name, value);
     }
-    // Each Postgres upstream reaches the sandbox as a DSN env var. They all
-    // point at the proxy's single listener with the same shared credential and
-    // differ only by database; iron-proxy routes on the database and fronts the
-    // real upstream.
+    // The sandbox always gets one local Postgres base DSN. Tools choose the
+    // database name they connect to; iron-proxy routes that database to the
+    // assigned principal's effective pg_dsn secret.
     if let Some(pg) = &resolved.pg {
-        for dsn in &pg.dsns {
-            let value = format!(
-                "postgresql://{}:{}@{}:{}/{}",
-                pg.user, pg.password, resolved.proxy_host, pg.port, dsn.database,
-            );
-            set_missing_env(spec, &dsn.sandbox_env_name, &value);
-        }
+        let value = format!(
+            "postgresql://{}:{}@{}:{}",
+            pg.user, pg.password, resolved.proxy_host, pg.port,
+        );
+        set_missing_env(spec, CENTAUR_POSTGRES_DSN_ENV, &value);
     }
 }
 

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -1,10 +1,10 @@
 # A Postgres upstream credential: a connection-string (DSN) resolved from a
 # secret source, plus an optional SET ROLE for the upstream session. Delivered to
 # iron-proxy in the single-listener `postgres` list, where it is keyed for routing
-# by `database` (the dbname a client sends to reach this upstream). `database` is
-# therefore required and must match the database the DSN connects to; centaur-console
-# enforces that match where the DSN is inspectable (control_plane/inline) and
-# documents it otherwise (the proxy returns FATAL 3D000 on a mismatch).
+# by `database` (the dbname a client sends to reach this upstream). Multiple
+# secrets may target the same database so different principals can route that
+# database through different upstream roles. Principal sync emits only one
+# effective route per database, chosen by grant priority.
 #
 # `foreign_id` is also required: it identifies the upstream for credential
 # delivery (env-var supplied DSNs) and is the stable handle operators reference.
@@ -70,7 +70,7 @@ class PgDsnSecret < ApplicationRecord
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, presence: true, uniqueness: { scope: :namespace },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
-  validates :database, presence: true, uniqueness: { scope: :namespace }
+  validates :database, presence: true
   validate :labels_is_a_hash
   validate :settings_are_valid
   validate :dsn_source_present

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -86,14 +86,18 @@ class Principal < ApplicationRecord
     proxy_transforms_for(served_credentials)
   end
 
-  # The top-level `postgres` array delivered to iron-proxy: one DSN entry per
-  # granted PgDsnSecret, keyed by foreign_id. Entries without a DSN source are
-  # skipped because the proxy can't dial an upstream without one.
+  # The top-level `postgres` array delivered to iron-proxy: one effective DSN
+  # entry per database. Entries without a DSN source are skipped because the
+  # proxy can't dial an upstream without one. When several granted PG DSNs route
+  # the same database, existing grant priority ordering decides the winner:
+  # higher-priority grants appear later and overwrite lower-priority routes.
   def sync_postgres
-    granted_pg_dsn_secrets.filter_map do |pg|
+    winners = {}
+    granted_pg_dsn_secrets.each do |pg|
       next unless pg.dsn_source
-      pg.to_proxy_dsn(principal: self)
+      winners[pg.database] = pg
     end
+    winners.values.map { |pg| pg.to_proxy_dsn(principal: self) }
   end
 
   # The config this principal resolves to, in the same shape iron-proxy receives

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -543,7 +543,7 @@ Returns `201`. Response shape (note that `credentials` and `token_endpoint_heade
 
 ## PG DSN secrets
 
-A PG DSN secret is a Postgres upstream credential: a connection string (DSN) resolved from a single secret [source](#secret-sources), plus an optional `SET ROLE` for the upstream session. It is delivered to `iron-proxy` with a required `foreign_id` for sandbox env-var derivation and a required `database` for routing. The proxy multiplexes upstreams through one listener and routes by the Postgres database name the client sends, so `database` must be unique per namespace and must match the upstream DSN's database.
+A PG DSN secret is a Postgres upstream credential: a connection string (DSN) resolved from a single secret [source](#secret-sources), plus an optional `SET ROLE` for the upstream session. It is delivered to `iron-proxy` with a required `foreign_id` and a required `database` for routing. The proxy multiplexes upstreams through one listener and routes by the Postgres database name the client sends. Multiple secrets may use the same `database` so different principals can route that database through different upstream roles. A principal's effective proxy config emits only one route per database, with higher-priority grants winning.
 
 Listener and client knobs (bind address, client auth) are deliberately not modeled: they are proxy-host deployment concerns. There are no [request rules](#request-rules) either: a Postgres listener matches by port, not by request.
 
@@ -556,7 +556,7 @@ Listener and client knobs (bind address, client auth) are deliberately not model
 | `name`        | optional    | |
 | `description` | optional    | |
 | `labels`      | optional    | Object; defaults to `{}`. |
-| `database`    | required    | Database name clients connect to through the proxy. Must be unique per namespace and match the upstream DSN's database. |
+| `database`    | required    | Database name clients connect to through the proxy. Must match the upstream DSN's database. If several granted secrets use the same database, grant priority selects the effective route. |
 | `role`        | optional    | Upstream `SET ROLE` applied to the session. |
 | `settings`    | optional    | Ordered array of session variables (GUCs) the proxy SETs at session start, before the `SET ROLE`, and pins so clients cannot override them. Each entry is `{ "name", "value" }` for a literal value, or `{ "name", "value_from" }` to resolve the value from the assigned proxy principal at sync time (see [principal-derived values](#principal-derived-setting-values)). Names must be a bare or dotted identifier; `role` and `session_authorization` are reserved. Replaced wholesale on update. |
 | `dsn`         | required    | A [secret source](#secret-sources) resolving to the connection string. Replaced wholesale on update. |

--- a/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
@@ -296,7 +296,7 @@ module Api
         assert_equal "pg-upsert", json_body.dig("data", "foreign_id")
       end
 
-      test "PUT rejects a pg_dsn secret when another secret uses the same database" do
+      test "PUT can upsert a pg_dsn secret sharing another secret's database" do
         existing = pg_dsn_secrets(:acme_analytics_pg)
         body = {
           data: {
@@ -307,13 +307,13 @@ module Api
           }
         }
 
-        assert_no_difference -> { PgDsnSecret.count } do
+        assert_difference -> { PgDsnSecret.count } => 1 do
           put api_v1_pg_dsn_secret_url(id: "pg-shared-database"),
               params: body.to_json,
               headers: auth_headers
         end
-        assert_response :unprocessable_entity
-        assert_includes json_body.dig("error", "details", "database"), "has already been taken"
+        assert_response :created
+        assert_equal existing.database, json_body.dig("data", "database")
       end
 
       test "GET index is scoped by namespace" do

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -55,11 +55,10 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     assert_includes dup.errors[:foreign_id], "has already been taken"
   end
 
-  test "database is unique within a namespace" do
+  test "database can be shared within a namespace" do
     with_dsn(PgDsnSecret.new(base_attrs(foreign_id: "first-pg", database: "shared-db"))).save!
     dup = with_dsn(PgDsnSecret.new(base_attrs(foreign_id: "second-pg", database: "shared-db")))
-    assert_not dup.valid?
-    assert_includes dup.errors[:database], "has already been taken"
+    assert dup.valid?
   end
 
   test "an inline DSN whose database matches is valid" do

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -206,6 +206,29 @@ class PrincipalTest < ActiveSupport::TestCase
     )
   end
 
+  test "sync_postgres emits only the highest-priority route for each database" do
+    principal = principals(:globex_user)
+    low = pg_dsn_secrets(:acme_analytics_pg)
+    high = PgDsnSecret.new(
+      namespace: low.namespace,
+      foreign_id: "pg-analytics-privileged",
+      name: "analytics privileged",
+      database: low.database,
+      role: "centaur_readonly",
+      created_by: users(:acme_admin)
+    )
+    high.build_dsn_source(source_type: "env", config: { "var" => "PG_PRIVILEGED_DSN" })
+    high.save!
+
+    Grant.create!(principal: principal, pg_dsn_secret: low, created_by: users(:acme_admin), priority: 0)
+    Grant.create!(principal: principal, pg_dsn_secret: high, created_by: users(:acme_admin), priority: 100)
+
+    entries = principal.sync_postgres
+    assert_equal 1, entries.length
+    assert_equal "pg-analytics-privileged", entries.first["foreign_id"]
+    assert_equal "PG_PRIVILEGED_DSN", entries.first.dig("dsn", "var")
+  end
+
   test "sync_postgres is empty without pg_dsn grants" do
     assert_empty principals(:globex_user).sync_postgres
   end

--- a/tools/infra/centaur_investigator/client.py
+++ b/tools/infra/centaur_investigator/client.py
@@ -10,14 +10,15 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import parse_qs, unquote, urlparse, urlunparse
 
 import asyncpg
 
 from centaur_sdk import secret
 
-CENTAUR_READONLY_DSN_ENV = "CENTAUR_READONLY_DSN"
-READONLY_ROLE = "centaur_readonly"
+CENTAUR_POSTGRES_DSN_ENV = "CENTAUR_POSTGRES_DSN"
+CENTAUR_INVESTIGATOR_DATABASE_ENV = "CENTAUR_INVESTIGATOR_POSTGRES_DATABASE"
+DEFAULT_POSTGRES_DATABASE = "ai_v2"
 DEFAULT_LIMIT = 25
 MAX_LIMIT = 200
 DEFAULT_WINDOW_HOURS = 24
@@ -39,13 +40,25 @@ def _clamp(value: int, *, minimum: int, maximum: int) -> int:
 
 
 def _scoped_database_url() -> str:
-    value = os.getenv(CENTAUR_READONLY_DSN_ENV)  # noqa: TID251
+    value = os.getenv(CENTAUR_POSTGRES_DSN_ENV)  # noqa: TID251
     if value is None:
-        value = secret(CENTAUR_READONLY_DSN_ENV, default="")
+        value = secret(CENTAUR_POSTGRES_DSN_ENV, default="")
     value = value.strip()
-    if value == CENTAUR_READONLY_DSN_ENV:
+    if value == CENTAUR_POSTGRES_DSN_ENV:
         return ""
     return value
+
+
+def _database_url_with_name(value: str, database: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme and parsed.netloc and parsed.path in ("", "/"):
+        return urlunparse(parsed._replace(path=f"/{database}"))
+    return value
+
+
+def _postgres_database_name() -> str:
+    value = os.getenv(CENTAUR_INVESTIGATOR_DATABASE_ENV, DEFAULT_POSTGRES_DATABASE)  # noqa: TID251
+    return value.strip() or DEFAULT_POSTGRES_DATABASE
 
 
 def _isoformat(value: Any) -> str | None:
@@ -69,6 +82,13 @@ def _record_to_dict(row: Any) -> dict[str, Any]:
     if isinstance(row, dict):
         return {key: _serialize(value) for key, value in row.items()}
     return {key: _serialize(row[key]) for key in row}
+
+
+def _connection_role(connection: dict[str, Any]) -> str | None:
+    row = connection.get("row") if isinstance(connection, dict) else None
+    if not isinstance(row, dict):
+        return None
+    return str(row.get("active_role") or row.get("current_user") or "") or None
 
 
 def _normalize_ts(value: str | None) -> str | None:
@@ -284,17 +304,14 @@ class CentaurInvestigatorClient:
 
     def _require_database_url(self) -> str:
         if not self._database_url:
-            raise RuntimeError(f"{CENTAUR_READONLY_DSN_ENV} is required")
+            raise RuntimeError(f"{CENTAUR_POSTGRES_DSN_ENV} is required")
         return self._database_url
 
     async def _connect(self) -> asyncpg.Connection:
-        conn = await asyncpg.connect(self._require_database_url(), command_timeout=30)
-        try:
-            await conn.execute(f"SET ROLE {READONLY_ROLE}")
-        except Exception:
-            await conn.close()
-            raise
-        return conn
+        return await asyncpg.connect(
+            _database_url_with_name(self._require_database_url(), _postgres_database_name()),
+            command_timeout=30,
+        )
 
     async def _safe_fetch(
         self,
@@ -903,7 +920,7 @@ class CentaurInvestigatorClient:
             ),
             "postgres": {
                 "status": "ok",
-                "role": READONLY_ROLE,
+                "role": _connection_role(connection),
                 "connection": connection,
                 "sessions": sessions,
                 "nearby_sessions": nearby_sessions,

--- a/tools/infra/centaur_investigator/pyproject.toml
+++ b/tools/infra/centaur_investigator/pyproject.toml
@@ -27,6 +27,3 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 hosts = []
-secrets = [
-    {type = "pg_dsn", name = "CENTAUR_READONLY_DSN", database = "centaur", secret_ref = "DATABASE_URL", role = "centaur_readonly"},
-]

--- a/tools/infra/centaur_investigator/tests/test_client.py
+++ b/tools/infra/centaur_investigator/tests/test_client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime as dt
 import sys
-import tomllib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -10,17 +9,45 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 import client as centaur_client
-from client import CentaurInvestigatorClient, parse_slack_reference
+from client import (
+    CentaurInvestigatorClient,
+    _database_url_with_name,
+    _postgres_database_name,
+    parse_slack_reference,
+)
 
 
-def test_readonly_dsn_manifest_targets_centaur_database() -> None:
-    pyproject = tomllib.loads((Path(__file__).resolve().parents[1] / "pyproject.toml").read_text())
-    secrets = pyproject["tool"]["centaur"]["secrets"]
-    readonly = next(secret for secret in secrets if secret["name"] == "CENTAUR_READONLY_DSN")
+def test_database_url_with_name_appends_database_to_base_dsn() -> None:
+    assert (
+        _database_url_with_name("postgresql://user:pass@proxy:5432", "ai_v2")
+        == "postgresql://user:pass@proxy:5432/ai_v2"
+    )
+    assert (
+        _database_url_with_name("postgresql://user:pass@proxy:5432/other", "ai_v2")
+        == "postgresql://user:pass@proxy:5432/other"
+    )
+    assert (
+        _database_url_with_name("postgresql://user:pass@proxy:5432?sslmode=require", "ai_v2")
+        == "postgresql://user:pass@proxy:5432/ai_v2?sslmode=require"
+    )
 
-    assert readonly["type"] == "pg_dsn"
-    assert readonly["secret_ref"] == "DATABASE_URL"
-    assert readonly["database"] == "centaur"
+
+def test_postgres_database_name_defaults_to_ai_v2(monkeypatch) -> None:
+    monkeypatch.delenv("CENTAUR_INVESTIGATOR_POSTGRES_DATABASE", raising=False)
+
+    assert _postgres_database_name() == "ai_v2"
+
+
+def test_postgres_database_name_can_be_overridden(monkeypatch) -> None:
+    monkeypatch.setenv("CENTAUR_INVESTIGATOR_POSTGRES_DATABASE", "centaur")
+
+    assert _postgres_database_name() == "centaur"
+
+
+def test_postgres_database_name_uses_default_for_blank_override(monkeypatch) -> None:
+    monkeypatch.setenv("CENTAUR_INVESTIGATOR_POSTGRES_DATABASE", " ")
+
+    assert _postgres_database_name() == "ai_v2"
 
 
 class _FakeConnection:
@@ -219,7 +246,7 @@ def test_investigation_queries_readonly_tables_without_message_context(monkeypat
     assert result["postgres"]["role"] == "centaur_readonly"
     assert result["postgres"]["connection"]["row"]["current_user"] == "centaur_readonly"
     assert result["analysis"]["primary_source"] == "postgres_readonly_tables"
-    assert fake.execute_calls == ["SET ROLE centaur_readonly"]
+    assert fake.execute_calls == []
     assert fake.closed is True
 
     all_queries = "\n".join(query for query, _args in fake.fetch_calls + fake.fetchrow_calls)

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -10,6 +10,7 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import asyncpg
 
@@ -25,7 +26,9 @@ CHANNEL_DAY_SCORE_MULTIPLIER = 0.75
 DEFAULT_PREVIEW_CHARS = 280
 MAX_RELATED_CHILDREN = 25
 SLACK_LIVE_SOURCE_TYPE = "slack_live_message"
-COMPANY_CONTEXT_DSN_ENV = "COMPANY_CONTEXT_DSN"
+COMPANY_CONTEXT_DSN_ENV = "CENTAUR_POSTGRES_DSN"
+COMPANY_CONTEXT_DATABASE_ENV = "COMPANY_CONTEXT_POSTGRES_DATABASE"
+DEFAULT_POSTGRES_DATABASE = "ai_v2"
 _SLACK_AFTER_RE = re.compile(r"\bafter:\d{4}-\d{2}-\d{2}\b", re.IGNORECASE)
 
 _SEARCH_TERM_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:/-]*")
@@ -80,13 +83,25 @@ def _clamp(value: int, *, minimum: int, maximum: int) -> int:
 
 
 def _scoped_database_url() -> str:
-    value = os.getenv(COMPANY_CONTEXT_DSN_ENV)
+    value = os.getenv(COMPANY_CONTEXT_DSN_ENV)  # noqa: TID251
     if value is None:
         value = secret(COMPANY_CONTEXT_DSN_ENV, default="")
     value = value.strip()
     if value == COMPANY_CONTEXT_DSN_ENV:
         return ""
     return value
+
+
+def _database_url_with_name(value: str, database: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme and parsed.netloc and parsed.path in ("", "/"):
+        return urlunparse(parsed._replace(path=f"/{database}"))
+    return value
+
+
+def _postgres_database_name() -> str:
+    value = os.getenv(COMPANY_CONTEXT_DATABASE_ENV, DEFAULT_POSTGRES_DATABASE)  # noqa: TID251
+    return value.strip() or DEFAULT_POSTGRES_DATABASE
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -171,7 +186,8 @@ def _search_where_clause(term_count: int) -> str:
     ]
     for index in range(2, term_count + 2):
         clauses.append(
-            f"(title ||| ${index}::text::pdb.boost({TITLE_MATCH_BOOST}) OR body ||| ${index})"
+            f"(title ||| ${index}::text::pdb.boost({TITLE_MATCH_BOOST}) "
+            f"OR body ||| ${index}::text)"
         )
     return " OR ".join(clauses)
 
@@ -264,8 +280,34 @@ def _current_slack_channel_id() -> str | None:
     return None
 
 
-async def _is_etl_admin_channel(conn: asyncpg.Connection) -> bool:
-    value = await conn.fetchval("SELECT centaur_etl_admin_channel()")
+def _context_scope_clause(
+    param_index: int,
+    source_expr: str = "source",
+    metadata_expr: str = "metadata",
+) -> str:
+    """SQL predicate matching the app-level company_context visibility boundary."""
+    return (
+        "EXISTS ("
+        "SELECT 1 FROM slack_context_rls_admin_channels admins "
+        f"WHERE admins.channel_id = ${param_index}::text"
+        ") OR ("
+        f"${param_index}::text IS NOT NULL AND {source_expr} = 'slack' "
+        f"AND {metadata_expr} ->> 'channel_id' = ${param_index}::text"
+        ")"
+    )
+
+
+async def _is_etl_admin_channel(conn: asyncpg.Connection, slack_channel_id: str | None) -> bool:
+    value = await conn.fetchval(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM slack_context_rls_admin_channels
+            WHERE channel_id = $1
+        )
+        """,
+        slack_channel_id,
+    )
     return bool(value)
 
 
@@ -339,7 +381,10 @@ class CompanyContextClient:
         return self._database_url
 
     async def _connect(self) -> asyncpg.Connection:
-        return await asyncpg.connect(self._require_database_url(), command_timeout=30)
+        return await asyncpg.connect(
+            _database_url_with_name(self._require_database_url(), _postgres_database_name()),
+            command_timeout=30,
+        )
 
     async def _search_async(
         self,
@@ -353,6 +398,7 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
+            slack_channel_id = _current_slack_channel_id()
             terms = _search_terms(query)
             search_terms = [query, *terms]
             source_param = len(search_terms) + 1
@@ -360,6 +406,7 @@ class CompanyContextClient:
             occurred_after_param = len(search_terms) + 3
             occurred_before_param = len(search_terms) + 4
             limit_param = len(search_terms) + 5
+            slack_channel_param = len(search_terms) + 6
             rows = await conn.fetch(
                 f"""
                 SELECT
@@ -380,6 +427,7 @@ class CompanyContextClient:
                     paradedb.score(document_id) AS score
                 FROM company_context_documents
                 WHERE {_search_where_clause(len(terms))}
+                  AND ({_context_scope_clause(slack_channel_param)})
                   AND (${source_param}::text IS NULL OR source = ${source_param})
                   AND (${source_type_param}::text IS NULL OR source_type = ${source_type_param})
                   AND (${occurred_after_param}::timestamptz IS NULL
@@ -402,6 +450,7 @@ class CompanyContextClient:
                 occurred_after,
                 occurred_before,
                 limit,
+                slack_channel_id,
             )
             results = []
             for row in rows:
@@ -431,11 +480,14 @@ class CompanyContextClient:
                     source_type=source_type,
                 )
                 try:
-                    slack_channel_id = _current_slack_channel_id()
                     if slack_channel_id is None:
                         live_error = "live Slack search requires a channel-scoped thread"
                     else:
-                        live_channels = None if await _is_etl_admin_channel(conn) else [slack_channel_id]
+                        live_channels = (
+                            None
+                            if await _is_etl_admin_channel(conn, slack_channel_id)
+                            else [slack_channel_id]
+                        )
                         live_query = _slack_after_query(query, latest.get("latest_date"))
                         live_messages = _load_slack_client().search_messages(
                             live_query,
@@ -483,9 +535,22 @@ class CompanyContextClient:
                 MAX(occurred_at) AS latest_occurred_at,
                 COUNT(*)::bigint AS document_count
             FROM company_context_documents
-            WHERE ($1::text IS NULL OR source = $1)
-              AND ($2::text IS NULL OR source_type = $2)
+            WHERE (
+                EXISTS (
+                    SELECT 1
+                    FROM slack_context_rls_admin_channels admins
+                    WHERE admins.channel_id = $1::text
+                )
+                OR (
+                    $1::text IS NOT NULL
+                    AND source = 'slack'
+                    AND metadata ->> 'channel_id' = $1::text
+                )
+            )
+              AND ($2::text IS NULL OR source = $2)
+              AND ($3::text IS NULL OR source_type = $3)
             """,
+            _current_slack_channel_id(),
             source,
             source_type,
         )
@@ -557,6 +622,7 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
+            slack_channel_id = _current_slack_channel_id()
             rows = await conn.fetch(
                 """
                 SELECT
@@ -575,14 +641,27 @@ class CompanyContextClient:
                     source_updated_at,
                     metadata
                 FROM company_context_documents
-                WHERE ($1::text IS NULL OR source = $1)
-                  AND ($2::text IS NULL OR source_type = $2)
-                  AND ($3::timestamptz IS NULL OR occurred_at >= $3)
-                  AND ($4::timestamptz IS NULL OR occurred_at < $4)
+                WHERE (
+                    EXISTS (
+                        SELECT 1
+                        FROM slack_context_rls_admin_channels admins
+                        WHERE admins.channel_id = $1::text
+                    )
+                    OR (
+                        $1::text IS NOT NULL
+                        AND source = 'slack'
+                        AND metadata ->> 'channel_id' = $1::text
+                    )
+                )
+                  AND ($2::text IS NULL OR source = $2)
+                  AND ($3::text IS NULL OR source_type = $3)
+                  AND ($4::timestamptz IS NULL OR occurred_at >= $4)
+                  AND ($5::timestamptz IS NULL OR occurred_at < $5)
                 ORDER BY occurred_at ASC NULLS LAST, source_updated_at DESC NULLS LAST,
                          document_id ASC
-                LIMIT $5
+                LIMIT $6
                 """,
+                slack_channel_id,
                 source,
                 source_type,
                 occurred_after,
@@ -674,6 +753,7 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         parent = None
         if row["parent_document_id"]:
+            slack_channel_id = _current_slack_channel_id()
             parent_row = await conn.fetchrow(
                 """
                 SELECT
@@ -692,8 +772,21 @@ class CompanyContextClient:
                     metadata
                 FROM company_context_documents
                 WHERE document_id = $1
+                  AND (
+                    EXISTS (
+                        SELECT 1
+                        FROM slack_context_rls_admin_channels admins
+                        WHERE admins.channel_id = $2::text
+                    )
+                    OR (
+                        $2::text IS NOT NULL
+                        AND source = 'slack'
+                        AND metadata ->> 'channel_id' = $2::text
+                    )
+                  )
                 """,
                 row["parent_document_id"],
+                slack_channel_id,
             )
             if parent_row:
                 parent = _document_summary(parent_row)
@@ -716,11 +809,24 @@ class CompanyContextClient:
                 metadata
             FROM company_context_documents
             WHERE parent_document_id = $1
+              AND (
+                EXISTS (
+                    SELECT 1
+                    FROM slack_context_rls_admin_channels admins
+                    WHERE admins.channel_id = $3::text
+                )
+                OR (
+                    $3::text IS NOT NULL
+                    AND source = 'slack'
+                    AND metadata ->> 'channel_id' = $3::text
+                )
+              )
             ORDER BY occurred_at ASC NULLS LAST, document_id ASC
             LIMIT $2
             """,
             row["document_id"],
             max_children,
+            _current_slack_channel_id(),
         )
         children = [_document_summary(child_row) for child_row in child_rows]
         return {
@@ -739,6 +845,7 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
+            slack_channel_id = _current_slack_channel_id()
             row = await conn.fetchrow(
                 """
                 SELECT
@@ -758,8 +865,21 @@ class CompanyContextClient:
                     metadata
                 FROM company_context_documents
                 WHERE document_id = $1
+                  AND (
+                    EXISTS (
+                        SELECT 1
+                        FROM slack_context_rls_admin_channels admins
+                        WHERE admins.channel_id = $2::text
+                    )
+                    OR (
+                        $2::text IS NOT NULL
+                        AND source = 'slack'
+                        AND metadata ->> 'channel_id' = $2::text
+                    )
+                  )
                 """,
                 document_id,
+                slack_channel_id,
             )
             if not row:
                 return {

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -26,6 +26,3 @@ packages = ["."]
 
 [tool.centaur]
 module = "client.py"
-secrets = [
-    {type = "pg_dsn", name = "COMPANY_CONTEXT_DSN", database = "centaur", secret_ref = "DATABASE_URL", role = "centaur_slack_reader", settings = [{name = "centaur.slack_channel_id", value_from = {principal_label = "slack_channel_id"}}]},
-]

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 import sys
 from pathlib import Path
 
@@ -10,7 +11,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 import client as company_context_client
-from centaur_sdk.tool_sdk import ToolContext, reset_tool_context, set_tool_context
 from client import CompanyContextClient
 
 from centaur_sdk.tool_sdk import ToolContext, reset_tool_context, set_tool_context
@@ -60,7 +60,7 @@ def test_search_rejects_empty_query(query):
 
 
 def test_default_database_url_uses_company_context_dsn_env(monkeypatch):
-    monkeypatch.setenv("COMPANY_CONTEXT_DSN", "postgresql://scoped")
+    monkeypatch.setenv("CENTAUR_POSTGRES_DSN", "postgresql://scoped")
     monkeypatch.setenv("DATABASE_URL", "postgresql://raw-app-db")
 
     client = CompanyContextClient()
@@ -69,12 +69,12 @@ def test_default_database_url_uses_company_context_dsn_env(monkeypatch):
 
 
 def test_default_database_url_uses_tool_context_secret(monkeypatch):
-    monkeypatch.delenv("COMPANY_CONTEXT_DSN", raising=False)
+    monkeypatch.delenv("CENTAUR_POSTGRES_DSN", raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://raw-app-db")
     token = set_tool_context(
         ToolContext(
             name="company_context",
-            secrets={"COMPANY_CONTEXT_DSN": "postgresql://context-scoped"},
+            secrets={"CENTAUR_POSTGRES_DSN": "postgresql://context-scoped"},
         )
     )
     try:
@@ -86,16 +86,34 @@ def test_default_database_url_uses_tool_context_secret(monkeypatch):
 
 
 def test_default_database_url_does_not_fall_back_to_raw_database_url(monkeypatch):
-    monkeypatch.delenv("COMPANY_CONTEXT_DSN", raising=False)
+    monkeypatch.delenv("CENTAUR_POSTGRES_DSN", raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://raw-app-db")
     token = set_tool_context(ToolContext(name="company_context", secrets={}))
     try:
         client = CompanyContextClient()
 
-        with pytest.raises(RuntimeError, match="COMPANY_CONTEXT_DSN is required"):
+        with pytest.raises(RuntimeError, match="CENTAUR_POSTGRES_DSN is required"):
             client._require_database_url()
     finally:
         reset_tool_context(token)
+
+
+def test_postgres_database_name_defaults_to_ai_v2(monkeypatch):
+    monkeypatch.delenv("COMPANY_CONTEXT_POSTGRES_DATABASE", raising=False)
+
+    assert company_context_client._postgres_database_name() == "ai_v2"
+
+
+def test_postgres_database_name_can_be_overridden(monkeypatch):
+    monkeypatch.setenv("COMPANY_CONTEXT_POSTGRES_DATABASE", "centaur")
+
+    assert company_context_client._postgres_database_name() == "centaur"
+
+
+def test_postgres_database_name_uses_default_for_blank_override(monkeypatch):
+    monkeypatch.setenv("COMPANY_CONTEXT_POSTGRES_DATABASE", " ")
+
+    assert company_context_client._postgres_database_name() == "ai_v2"
 
 
 def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
@@ -165,8 +183,8 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
     }
     query, args = fake.fetch_calls[0]
     assert "title ||| $1::text::pdb.boost(8) OR body ||| $1::text::pdb.boost(2)" in query
-    assert "title ||| $2::text::pdb.boost(4) OR body ||| $2" in query
-    assert "title ||| $3::text::pdb.boost(4) OR body ||| $3" in query
+    assert "title ||| $2::text::pdb.boost(4) OR body ||| $2::text" in query
+    assert "title ||| $3::text::pdb.boost(4) OR body ||| $3::text" in query
     assert ") OR (" in query
     assert "WHEN 'slack_thread' THEN 1.25" in query
     assert "WHEN 'slack_channel_day' THEN 0.75" in query
@@ -181,6 +199,7 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
         None,
         None,
         5,
+        "C123",
     )
     assert fake.closed is True
 
@@ -306,11 +325,13 @@ def test_search_uses_or_terms_and_drops_stop_words(monkeypatch):
     assert result["status"] == "ok"
     query, args = fake.fetch_calls[0]
     assert "WHERE (title ||| $1::text::pdb.boost(8) OR body ||| $1::text::pdb.boost(2))" in query
-    assert "OR (title ||| $2::text::pdb.boost(4) OR body ||| $2)" in query
-    assert "OR (title ||| $3::text::pdb.boost(4) OR body ||| $3)" in query
-    assert "OR (title ||| $4::text::pdb.boost(4) OR body ||| $4)" in query
-    assert "OR (title ||| $5::text::pdb.boost(4) OR body ||| $5)" in query
+    assert "OR (title ||| $2::text::pdb.boost(4) OR body ||| $2::text)" in query
+    assert "OR (title ||| $3::text::pdb.boost(4) OR body ||| $3::text)" in query
+    assert "OR (title ||| $4::text::pdb.boost(4) OR body ||| $4::text)" in query
+    assert "OR (title ||| $5::text::pdb.boost(4) OR body ||| $5::text)" in query
     assert "title ||| $6::text::pdb.boost(4)" not in query
+    placeholders = {int(match.group(1)) for match in re.finditer(r"\$(\d+)", query)}
+    assert placeholders == set(range(1, len(args) + 1))
     assert args == (
         "what is the state root state mismatch in prod",
         "state",
@@ -322,6 +343,7 @@ def test_search_uses_or_terms_and_drops_stop_words(monkeypatch):
         None,
         None,
         3,
+        None,
     )
 
 
@@ -356,6 +378,7 @@ def test_search_applies_occurred_at_filters(monkeypatch):
         dt.datetime(2026, 5, 1, tzinfo=dt.UTC),
         dt.datetime(2026, 5, 8, 12, 30, tzinfo=dt.UTC),
         4,
+        None,
     )
 
 
@@ -448,6 +471,7 @@ def test_list_documents_returns_date_bounded_document_summaries(monkeypatch):
     query, args = fake.fetch_calls[0]
     assert "ORDER BY occurred_at ASC NULLS LAST" in query
     assert args == (
+        None,
         "google_calendar",
         "calendar_event",
         dt.datetime(2026, 5, 1, tzinfo=dt.UTC),
@@ -487,7 +511,7 @@ def test_latest_date_returns_latest_indexed_slack_timestamp(monkeypatch):
         "latest_occurred_at": "2026-05-10T14:00:00+00:00",
     }
     _, args = fake.fetchrow_calls[0]
-    assert args == ("slack", "slack_thread")
+    assert args == (None, "slack", "slack_thread")
     assert fake.closed is True
 
 
@@ -553,7 +577,7 @@ def test_read_document_returns_full_content_by_default(monkeypatch):
     assert result["content"] == body
     assert result["metadata"] == {"channel_name": "eng-ai"}
     _, args = fake.fetchrow_calls[0]
-    assert args == ("slack:channel_day:C123:2026-05-08",)
+    assert args == ("slack:channel_day:C123:2026-05-08", None)
     assert fake.closed is True
 
 
@@ -591,7 +615,7 @@ def test_read_document_can_return_bounded_content(monkeypatch):
     assert result["content"] == "x" * 1_200
     assert result["metadata"] == {"channel_name": "eng-ai"}
     _, args = fake.fetchrow_calls[0]
-    assert args == ("slack:channel_day:C123:2026-05-08",)
+    assert args == ("slack:channel_day:C123:2026-05-08", None)
     assert fake.closed is True
 
 


### PR DESCRIPTION
This replaces tool-discovered Postgres DSN env vars with one sandbox-provided, database-less `CENTAUR_POSTGRES_DSN`. The old model made each tool manifest declare a separate PG listener/env var, which meant warm sandbox injection depended on tool discovery and could not represent two credentials for the same logical database cleanly. That was the wrong ownership boundary: tools should choose the database they need, while iron-proxy and iron-control decide which upstream credential, role, and session settings the current principal is allowed to use.

With this change, the sandbox backend always injects the local base DSN and tools append their configured database name before connecting. `company_context` and `centaur_investigator` no longer auto-create PG DSN secrets from their manifests, so operators grant the appropriate PG DSN routes in the control plane. The console now allows multiple PG DSN secrets to target the same database and resolves the effective route by grant priority, which lets normal channels get the scoped company-context route while privileged debugging channels get the investigator route for the same dbname.

Tools should not call `SET ROLE` themselves or try to infer which database role they received. They should assume iron-proxy has already applied the effective role and session settings for the current principal, then apply any tool-specific result narrowing in their own queries. `company_context` keeps its Slack channel/admin visibility checks in application queries as a defense-in-depth layer, and its BM25 search SQL now uses contiguous, typed placeholders. `centaur_investigator` no longer calls `SET ROLE`; role selection is exclusively handled by iron-proxy from the effective PG DSN route.

Supersedes https://github.com/paradigmxyz/centaur/pull/652.
