### PR TITLE
Coalesce commentary Thinking task updates

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -83,7 +83,7 @@ describe('CodexAppServerRendererEventMapper', () => {
     expect(task).toMatchObject({
       type: 'renderer.task.update',
       task: {
-        id: 'thinking-thinking-1',
+        id: 'thinking-commentary',
         title: 'Thinking',
         status: 'in_progress'
       }
@@ -97,8 +97,52 @@ describe('CodexAppServerRendererEventMapper', () => {
       item: { id: 'cmd-1', type: 'commandExecution', command: 'pnpm test' }
     })
     expect(next.find(event => event.type === 'renderer.task.update')).toMatchObject({
-      task: { id: 'thinking-thinking-1', title: 'Thinking', status: 'complete' }
+      task: { id: 'thinking-commentary', title: 'Thinking', status: 'complete' }
     })
+  })
+
+  it('coalesces commentary segments into one Thinking task', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'thinking-1', type: 'agentMessage', phase: 'commentary' }
+    })
+    mapper.process({
+      type: 'item.completed',
+      item: {
+        id: 'thinking-1',
+        type: 'agentMessage',
+        phase: 'commentary',
+        text: 'Checking the runtime.'
+      }
+    })
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'thinking-2', type: 'agentMessage', phase: 'commentary' }
+    })
+    const events = mapper.process({
+      type: 'item.completed',
+      item: {
+        id: 'thinking-2',
+        type: 'agentMessage',
+        phase: 'commentary',
+        text: 'Inspecting the renderer.'
+      }
+    })
+
+    const tasks = events.filter(event => event.type === 'renderer.task.update')
+    expect(
+      new Set(tasks.map(event => (event.type === 'renderer.task.update' ? event.task.id : '')))
+    ).toEqual(new Set(['thinking-commentary']))
+    const task = tasks.at(-1)
+    expect(task).toMatchObject({
+      type: 'renderer.task.update',
+      task: { id: 'thinking-commentary', title: 'Thinking', status: 'in_progress' }
+    })
+    const details = plain(task?.type === 'renderer.task.update' ? task.task.details : undefined)
+    expect(details).toContain('Checking the runtime.')
+    expect(details).toContain('Inspecting the renderer.')
   })
 
   it('keeps one Thinking task in_progress across reasoning deltas until the item seals', () => {

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -15,6 +15,7 @@ import type {
 } from './types'
 
 const COMMAND_EXECUTION_TITLE = 'Command execution'
+const COMMENTARY_THINKING_TASK_ID = 'thinking-commentary'
 const PRE_STREAM_GRACE_MS = 500
 
 const limits = {
@@ -862,10 +863,9 @@ function commentaryItemId(event: any): string {
 function startThinkingTask(state: CodexMapperState, event: any): boolean {
   if (event?.type !== 'item.started') return false
   if (agentMessageItemPhase(event?.item) !== 'commentary') return false
-  const id = commentaryItemId(event)
-  if (!id || state.taskByUseId.has(`thinking-${id}`)) return false
-  state.taskByUseId.set(`thinking-${id}`, {
-    id: `thinking-${id}`,
+  if (!commentaryItemId(event) || state.taskByUseId.has(COMMENTARY_THINKING_TASK_ID)) return false
+  state.taskByUseId.set(COMMENTARY_THINKING_TASK_ID, {
+    id: COMMENTARY_THINKING_TASK_ID,
     title: 'Thinking',
     status: 'in_progress',
     details: [],
@@ -883,11 +883,12 @@ function upsertThinkingTask(state: CodexMapperState, event: any): void {
     state.commentaryByItemId.set(id, body)
     recomposeBuffers(state)
   }
-  state.taskByUseId.set(`thinking-${id}`, {
-    id: `thinking-${id}`,
+  const details = state.commentaryText.trim() || body
+  state.taskByUseId.set(COMMENTARY_THINKING_TASK_ID, {
+    id: COMMENTARY_THINKING_TASK_ID,
     title: 'Thinking',
     status: 'complete',
-    details: [section([text(body)])],
+    details: [section([text(details)])],
     output: []
   })
 }

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1436,10 +1436,15 @@ async function renderExecutionStream(
       )
     )
     if (!visibleStream) return
+    const taskDisplayMode = slackStreamTaskDisplayMode(options)
     await thread.post(
       new StreamingPlan(
         visibleStream,
-        { groupTasks: options.streamTaskDisplayMode ?? 'plan' }
+        {
+          // Slack supports "dense"; Chat SDK 4.31.0 forwards this value but
+          // its public type has not caught up yet.
+          groupTasks: taskDisplayMode as 'plan'
+        }
       )
     )
   } finally {
@@ -1476,13 +1481,14 @@ async function renderRecoveredExecutionStream(
       )
     )
     if (!visibleStream) return
+    const taskDisplayMode = slackStreamTaskDisplayMode(options)
     await thread.adapter.stream!(
       thread.id,
       visibleStream,
       {
         recipientTeamId: message.teamId,
         recipientUserId: message.author.userId,
-        taskDisplayMode: options.streamTaskDisplayMode ?? 'plan'
+        taskDisplayMode: taskDisplayMode as 'plan'
       }
     )
   } finally {
@@ -1605,6 +1611,10 @@ function isPlainTextOnlyRequest(text: string): boolean {
     || /\bno\s+interactive\s+blocks?\b/.test(normalized)
     || /\bno\s+dashboards?\b/.test(normalized)
   )
+}
+
+function slackStreamTaskDisplayMode(options: SlackbotV2Options): 'dense' | 'plan' | 'timeline' {
+  return options.streamTaskDisplayMode ?? 'dense'
 }
 
 function truncateSlackTaskField(value: string): string {

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -102,7 +102,7 @@ export type SlackbotV2Options = {
   slackApiUrl?: string
   state?: StateAdapter
   stateKeyPrefix?: string
-  streamTaskDisplayMode?: 'plan' | 'timeline'
+  streamTaskDisplayMode?: 'dense' | 'plan' | 'timeline'
   triggerBotAllowlist?: readonly string[]
   userName?: string
   mapper?: CodexAppServerToChatStreamOptions

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -4164,7 +4164,7 @@ function expectSlackPlanStreamShape(
         thread_ts: input.parentTs,
         recipient_user_id: USER_ID,
         recipient_team_id: TEAM_ID,
-        task_display_mode: 'plan'
+        task_display_mode: 'dense'
       })
     )
     expect(transcript.start.body.ts).toBeUndefined()
@@ -4228,7 +4228,7 @@ function expectSlackPlanStreamShape(
     expect(progressChunks).toContainEqual(
       expect.objectContaining({
         type: 'task_update',
-        id: 'thinking-commentary-1',
+        id: 'thinking-commentary',
         title: 'Thinking',
         status: 'complete'
       })


### PR DESCRIPTION
## Summary
- reuse one stable commentary Thinking task id instead of creating one task per commentary message
- show cumulative commentary details on that task
- default Slack task streams to native `dense` display mode to reduce task-card pressure
- add/update regression coverage for commentary coalescing and Slack stream payload shape

## Test plan
- bun test src
- bun run typecheck
- bun test test/chat-sdk-emulate.test.ts
- bun run check:types

Prompted by: @Rjected
Prompted by: @gakonst