### PR TITLE
fix: extend iron-proxy upstream header timeout

### DIFF
--- a/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
+++ b/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
@@ -1,3 +1,9 @@
+proxy:
+  # Codex compaction calls can legitimately take longer than iron-proxy's
+  # default 30s response-header timeout. Keep model-provider calls from being
+  # cut off while OpenAI is still computing the first response byte.
+  upstream_response_header_timeout: "120s"
+
 transforms:
   - name: secrets
     config:

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -20,6 +20,10 @@ fn harness_auth_fragments_are_baked_in() {
     assert!(harness_auth_fragment("codex", "bogus").unwrap().is_none());
 
     let infra = infra_fragment().unwrap();
+    assert_eq!(
+        infra.top_level["proxy"]["upstream_response_header_timeout"].as_str(),
+        Some("120s")
+    );
     let placeholders = placeholder_env(&[infra]);
     for name in ["AMP_API_KEY", "GITHUB_TOKEN", "SLACK_BOT_TOKEN"] {
         assert_eq!(placeholders.get(name).map(String::as_str), Some(name));

--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -4,6 +4,10 @@ dns:
 
 proxy:
   tunnel_listen: ":8080"
+  # Codex compaction calls can legitimately take longer than iron-proxy's
+  # default 30s response-header timeout. Keep model-provider calls from being
+  # cut off while OpenAI is still computing the first response byte.
+  upstream_response_header_timeout: "120s"
 
 management:
   listen: ":9092"


### PR DESCRIPTION
## Summary
- raise the managed iron-proxy upstream response-header timeout to 120s for sandbox proxies
- keep the packaged unmanaged iron-proxy config in sync
- add coverage that the infra proxy fragment carries the longer timeout

## Context
Codex compaction requests to `/v1/responses/compact` were failing at ~30s with iron-proxy logging `net/http: timeout awaiting response headers`. Successful compactions in the same window took 25-28s, so the default 30s header timeout was too tight for slow model-provider calls.

Prompted by: @Rjected

## Tests
- `cargo test -p centaur-iron-proxy`