### PR TITLE
fix: remove db-backed slack admin access

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0022_drop_slack_context_rls_admin_channels.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0022_drop_slack_context_rls_admin_channels.sql
@@ -152,6 +152,7 @@ revoke select on
 from centaur_slack_admin;
 
 revoke usage on schema public from centaur_slack_admin;
+revoke execute on function centaur_current_slack_channel_id() from centaur_slack_admin;
 
 drop function if exists centaur_etl_admin_channel();
 drop table if exists slack_context_rls_admin_channels;

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0022_drop_slack_context_rls_admin_channels.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0022_drop_slack_context_rls_admin_channels.sql
@@ -1,0 +1,113 @@
+create or replace function centaur_current_slack_channel_id()
+returns text
+language sql
+stable
+as $$
+    select nullif(current_setting('centaur.slack_channel_id', true), '')
+$$;
+
+drop policy if exists centaur_slack_channels_reader_select on slack_sync_channels;
+create policy centaur_slack_channels_reader_select
+    on slack_sync_channels
+    for select
+    to centaur_slack_reader
+    using (channel_id = centaur_current_slack_channel_id());
+
+drop policy if exists centaur_slack_users_reader_select on slack_sync_users;
+create policy centaur_slack_users_reader_select
+    on slack_sync_users
+    for select
+    to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_slack_messages_reader_select on slack_sync_messages;
+create policy centaur_slack_messages_reader_select
+    on slack_sync_messages
+    for select
+    to centaur_slack_reader
+    using (channel_id = centaur_current_slack_channel_id());
+
+drop policy if exists centaur_slack_message_attachments_reader_select
+    on slack_sync_message_attachments;
+create policy centaur_slack_message_attachments_reader_select
+    on slack_sync_message_attachments
+    for select
+    to centaur_slack_reader
+    using (channel_id = centaur_current_slack_channel_id());
+
+drop policy if exists centaur_context_docs_reader_select on company_context_documents;
+create policy centaur_context_docs_reader_select
+    on company_context_documents
+    for select
+    to centaur_slack_reader
+    using (
+        source = 'slack'
+        and metadata ->> 'channel_id' = centaur_current_slack_channel_id()
+    );
+
+drop policy if exists centaur_google_drive_runs_reader_select on google_drive_sync_runs;
+create policy centaur_google_drive_runs_reader_select
+    on google_drive_sync_runs for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_google_drive_files_reader_select on google_drive_sync_files;
+create policy centaur_google_drive_files_reader_select
+    on google_drive_sync_files for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_google_drive_checkpoints_reader_select
+    on google_drive_sync_checkpoints;
+create policy centaur_google_drive_checkpoints_reader_select
+    on google_drive_sync_checkpoints for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_google_calendar_runs_reader_select on google_calendar_sync_runs;
+create policy centaur_google_calendar_runs_reader_select
+    on google_calendar_sync_runs for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_google_calendar_calendars_reader_select
+    on google_calendar_sync_calendars;
+create policy centaur_google_calendar_calendars_reader_select
+    on google_calendar_sync_calendars for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_google_calendar_events_reader_select
+    on google_calendar_sync_events;
+create policy centaur_google_calendar_events_reader_select
+    on google_calendar_sync_events for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_google_calendar_checkpoints_reader_select
+    on google_calendar_sync_checkpoints;
+create policy centaur_google_calendar_checkpoints_reader_select
+    on google_calendar_sync_checkpoints for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_linear_runs_reader_select on linear_sync_runs;
+create policy centaur_linear_runs_reader_select
+    on linear_sync_runs for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_linear_projects_reader_select on linear_sync_projects;
+create policy centaur_linear_projects_reader_select
+    on linear_sync_projects for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_linear_issues_reader_select on linear_sync_issues;
+create policy centaur_linear_issues_reader_select
+    on linear_sync_issues for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_linear_comments_reader_select on linear_sync_comments;
+create policy centaur_linear_comments_reader_select
+    on linear_sync_comments for select to centaur_slack_reader
+    using (false);
+
+drop policy if exists centaur_linear_checkpoints_reader_select on linear_sync_checkpoints;
+create policy centaur_linear_checkpoints_reader_select
+    on linear_sync_checkpoints for select to centaur_slack_reader
+    using (false);
+
+drop function if exists centaur_etl_admin_channel();
+drop table if exists slack_context_rls_admin_channels;

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0022_drop_slack_context_rls_admin_channels.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0022_drop_slack_context_rls_admin_channels.sql
@@ -6,6 +6,7 @@ as $$
     select nullif(current_setting('centaur.slack_channel_id', true), '')
 $$;
 
+drop policy if exists centaur_slack_channels_admin_select on slack_sync_channels;
 drop policy if exists centaur_slack_channels_reader_select on slack_sync_channels;
 create policy centaur_slack_channels_reader_select
     on slack_sync_channels
@@ -13,6 +14,7 @@ create policy centaur_slack_channels_reader_select
     to centaur_slack_reader
     using (channel_id = centaur_current_slack_channel_id());
 
+drop policy if exists centaur_slack_users_admin_select on slack_sync_users;
 drop policy if exists centaur_slack_users_reader_select on slack_sync_users;
 create policy centaur_slack_users_reader_select
     on slack_sync_users
@@ -20,6 +22,7 @@ create policy centaur_slack_users_reader_select
     to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_slack_messages_admin_select on slack_sync_messages;
 drop policy if exists centaur_slack_messages_reader_select on slack_sync_messages;
 create policy centaur_slack_messages_reader_select
     on slack_sync_messages
@@ -27,6 +30,8 @@ create policy centaur_slack_messages_reader_select
     to centaur_slack_reader
     using (channel_id = centaur_current_slack_channel_id());
 
+drop policy if exists centaur_slack_message_attachments_admin_select
+    on slack_sync_message_attachments;
 drop policy if exists centaur_slack_message_attachments_reader_select
     on slack_sync_message_attachments;
 create policy centaur_slack_message_attachments_reader_select
@@ -35,6 +40,7 @@ create policy centaur_slack_message_attachments_reader_select
     to centaur_slack_reader
     using (channel_id = centaur_current_slack_channel_id());
 
+drop policy if exists centaur_context_docs_admin_select on company_context_documents;
 drop policy if exists centaur_context_docs_reader_select on company_context_documents;
 create policy centaur_context_docs_reader_select
     on company_context_documents
@@ -45,69 +51,108 @@ create policy centaur_context_docs_reader_select
         and metadata ->> 'channel_id' = centaur_current_slack_channel_id()
     );
 
+drop policy if exists centaur_google_drive_runs_admin_select on google_drive_sync_runs;
 drop policy if exists centaur_google_drive_runs_reader_select on google_drive_sync_runs;
 create policy centaur_google_drive_runs_reader_select
     on google_drive_sync_runs for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_google_drive_files_admin_select on google_drive_sync_files;
 drop policy if exists centaur_google_drive_files_reader_select on google_drive_sync_files;
 create policy centaur_google_drive_files_reader_select
     on google_drive_sync_files for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_google_drive_checkpoints_admin_select
+    on google_drive_sync_checkpoints;
 drop policy if exists centaur_google_drive_checkpoints_reader_select
     on google_drive_sync_checkpoints;
 create policy centaur_google_drive_checkpoints_reader_select
     on google_drive_sync_checkpoints for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_google_calendar_runs_admin_select on google_calendar_sync_runs;
 drop policy if exists centaur_google_calendar_runs_reader_select on google_calendar_sync_runs;
 create policy centaur_google_calendar_runs_reader_select
     on google_calendar_sync_runs for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_google_calendar_calendars_admin_select
+    on google_calendar_sync_calendars;
 drop policy if exists centaur_google_calendar_calendars_reader_select
     on google_calendar_sync_calendars;
 create policy centaur_google_calendar_calendars_reader_select
     on google_calendar_sync_calendars for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_google_calendar_events_admin_select
+    on google_calendar_sync_events;
 drop policy if exists centaur_google_calendar_events_reader_select
     on google_calendar_sync_events;
 create policy centaur_google_calendar_events_reader_select
     on google_calendar_sync_events for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_google_calendar_checkpoints_admin_select
+    on google_calendar_sync_checkpoints;
 drop policy if exists centaur_google_calendar_checkpoints_reader_select
     on google_calendar_sync_checkpoints;
 create policy centaur_google_calendar_checkpoints_reader_select
     on google_calendar_sync_checkpoints for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_linear_runs_admin_select on linear_sync_runs;
 drop policy if exists centaur_linear_runs_reader_select on linear_sync_runs;
 create policy centaur_linear_runs_reader_select
     on linear_sync_runs for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_linear_projects_admin_select on linear_sync_projects;
 drop policy if exists centaur_linear_projects_reader_select on linear_sync_projects;
 create policy centaur_linear_projects_reader_select
     on linear_sync_projects for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_linear_issues_admin_select on linear_sync_issues;
 drop policy if exists centaur_linear_issues_reader_select on linear_sync_issues;
 create policy centaur_linear_issues_reader_select
     on linear_sync_issues for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_linear_comments_admin_select on linear_sync_comments;
 drop policy if exists centaur_linear_comments_reader_select on linear_sync_comments;
 create policy centaur_linear_comments_reader_select
     on linear_sync_comments for select to centaur_slack_reader
     using (false);
 
+drop policy if exists centaur_linear_checkpoints_admin_select on linear_sync_checkpoints;
 drop policy if exists centaur_linear_checkpoints_reader_select on linear_sync_checkpoints;
 create policy centaur_linear_checkpoints_reader_select
     on linear_sync_checkpoints for select to centaur_slack_reader
     using (false);
 
+revoke select on
+    slack_sync_channels,
+    slack_sync_users,
+    slack_sync_messages,
+    slack_sync_message_attachments,
+    company_context_documents,
+    google_drive_sync_runs,
+    google_drive_sync_files,
+    google_drive_sync_checkpoints,
+    google_calendar_sync_runs,
+    google_calendar_sync_calendars,
+    google_calendar_sync_events,
+    google_calendar_sync_checkpoints,
+    linear_sync_runs,
+    linear_sync_projects,
+    linear_sync_issues,
+    linear_sync_comments,
+    linear_sync_checkpoints
+from centaur_slack_admin;
+
+revoke usage on schema public from centaur_slack_admin;
+
 drop function if exists centaur_etl_admin_channel();
 drop table if exists slack_context_rls_admin_channels;
+drop role if exists centaur_slack_admin;

--- a/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
@@ -57,7 +57,7 @@ struct VisibleRows {
 }
 
 #[tokio::test]
-async fn etl_context_rls_enforces_channel_and_admin_visibility() -> Result<(), Box<dyn Error>> {
+async fn etl_context_rls_enforces_channel_visibility() -> Result<(), Box<dyn Error>> {
     let Some(database_url) = test_database_url() else {
         return Ok(());
     };
@@ -82,7 +82,7 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
 
     assert_rls_enabled(conn).await?;
     assert_expected_policies(conn).await?;
-    assert_admin_channels_table_is_removed(conn).await?;
+    assert_legacy_admin_state_is_removed(conn).await?;
 
     insert_fixture_rows(conn).await?;
 
@@ -166,9 +166,6 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
         }
     );
 
-    let db_admin_role = visible_rows(conn, schema, "centaur_slack_admin", None).await?;
-    assert_eq!(db_admin_role, all_visible_rows());
-
     Ok(())
 }
 
@@ -212,7 +209,7 @@ async fn set_search_path(conn: &mut PgConnection, schema: &str) -> Result<(), sq
 async fn grant_schema_usage(conn: &mut PgConnection, schema: &str) -> Result<(), sqlx::Error> {
     conn.execute(
         format!(
-            r#"grant usage on schema "{}" to centaur_slack_reader, centaur_slack_admin"#,
+            r#"grant usage on schema "{}" to centaur_slack_reader"#,
             schema
         )
         .as_str(),
@@ -336,21 +333,14 @@ async fn assert_expected_policies(conn: &mut PgConnection) -> Result<(), sqlx::E
 
 fn expected_policies() -> Vec<(String, String)> {
     [
-        ("slack_sync_channels", "centaur_slack_channels_admin_select"),
         (
             "slack_sync_channels",
             "centaur_slack_channels_reader_select",
         ),
-        ("slack_sync_users", "centaur_slack_users_admin_select"),
         ("slack_sync_users", "centaur_slack_users_reader_select"),
-        ("slack_sync_messages", "centaur_slack_messages_admin_select"),
         (
             "slack_sync_messages",
             "centaur_slack_messages_reader_select",
-        ),
-        (
-            "slack_sync_message_attachments",
-            "centaur_slack_message_attachments_admin_select",
         ),
         (
             "slack_sync_message_attachments",
@@ -358,15 +348,7 @@ fn expected_policies() -> Vec<(String, String)> {
         ),
         (
             "company_context_documents",
-            "centaur_context_docs_admin_select",
-        ),
-        (
-            "company_context_documents",
             "centaur_context_docs_reader_select",
-        ),
-        (
-            "google_drive_sync_runs",
-            "centaur_google_drive_runs_admin_select",
         ),
         (
             "google_drive_sync_runs",
@@ -374,15 +356,7 @@ fn expected_policies() -> Vec<(String, String)> {
         ),
         (
             "google_drive_sync_files",
-            "centaur_google_drive_files_admin_select",
-        ),
-        (
-            "google_drive_sync_files",
             "centaur_google_drive_files_reader_select",
-        ),
-        (
-            "google_drive_sync_checkpoints",
-            "centaur_google_drive_checkpoints_admin_select",
         ),
         (
             "google_drive_sync_checkpoints",
@@ -390,15 +364,7 @@ fn expected_policies() -> Vec<(String, String)> {
         ),
         (
             "google_calendar_sync_runs",
-            "centaur_google_calendar_runs_admin_select",
-        ),
-        (
-            "google_calendar_sync_runs",
             "centaur_google_calendar_runs_reader_select",
-        ),
-        (
-            "google_calendar_sync_calendars",
-            "centaur_google_calendar_calendars_admin_select",
         ),
         (
             "google_calendar_sync_calendars",
@@ -406,43 +372,21 @@ fn expected_policies() -> Vec<(String, String)> {
         ),
         (
             "google_calendar_sync_events",
-            "centaur_google_calendar_events_admin_select",
-        ),
-        (
-            "google_calendar_sync_events",
             "centaur_google_calendar_events_reader_select",
-        ),
-        (
-            "google_calendar_sync_checkpoints",
-            "centaur_google_calendar_checkpoints_admin_select",
         ),
         (
             "google_calendar_sync_checkpoints",
             "centaur_google_calendar_checkpoints_reader_select",
         ),
-        ("linear_sync_runs", "centaur_linear_runs_admin_select"),
         ("linear_sync_runs", "centaur_linear_runs_reader_select"),
-        (
-            "linear_sync_projects",
-            "centaur_linear_projects_admin_select",
-        ),
         (
             "linear_sync_projects",
             "centaur_linear_projects_reader_select",
         ),
-        ("linear_sync_issues", "centaur_linear_issues_admin_select"),
         ("linear_sync_issues", "centaur_linear_issues_reader_select"),
         (
             "linear_sync_comments",
-            "centaur_linear_comments_admin_select",
-        ),
-        (
-            "linear_sync_comments",
             "centaur_linear_comments_reader_select",
-        ),
-        (
-            "linear_sync_checkpoints",
-            "centaur_linear_checkpoints_admin_select",
         ),
         (
             "linear_sync_checkpoints",
@@ -454,9 +398,7 @@ fn expected_policies() -> Vec<(String, String)> {
     .collect()
 }
 
-async fn assert_admin_channels_table_is_removed(
-    conn: &mut PgConnection,
-) -> Result<(), sqlx::Error> {
+async fn assert_legacy_admin_state_is_removed(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
     let table_name: Option<String> =
         sqlx::query_scalar("select to_regclass('slack_context_rls_admin_channels')::text")
             .fetch_one(&mut *conn)
@@ -474,6 +416,15 @@ async fn assert_admin_channels_table_is_removed(
     assert_eq!(
         function_count, 0,
         "admin-channel lookup function must be removed"
+    );
+
+    let admin_role_count: i64 =
+        sqlx::query_scalar("select count(*) from pg_roles where rolname = 'centaur_slack_admin'")
+            .fetch_one(&mut *conn)
+            .await?;
+    assert_eq!(
+        admin_role_count, 0,
+        "legacy slack admin DB role must be removed"
     );
     Ok(())
 }
@@ -626,43 +577,5 @@ fn empty_visible_rows() -> VisibleRows {
         linear_issues: 0,
         linear_comments: 0,
         linear_checkpoints: 0,
-    }
-}
-
-fn all_visible_rows() -> VisibleRows {
-    VisibleRows {
-        slack_channels: vec![
-            "C_ADMIN".to_owned(),
-            "C_ALPHA".to_owned(),
-            "C_BETA".to_owned(),
-        ],
-        slack_users: vec!["U_ALPHA".to_owned(), "U_BETA".to_owned()],
-        slack_messages: vec![
-            "C_ALPHA:1000.000001".to_owned(),
-            "C_BETA:1000.000002".to_owned(),
-        ],
-        slack_attachments: vec![
-            "C_ALPHA:1000.000001:F_ALPHA".to_owned(),
-            "C_BETA:1000.000002:F_BETA".to_owned(),
-        ],
-        context_docs: vec![
-            "doc_gcal".to_owned(),
-            "doc_gdrive".to_owned(),
-            "doc_linear".to_owned(),
-            "doc_slack_alpha".to_owned(),
-            "doc_slack_beta".to_owned(),
-        ],
-        google_drive_runs: 1,
-        google_drive_files: 1,
-        google_drive_checkpoints: 1,
-        google_calendar_runs: 1,
-        google_calendar_calendars: 1,
-        google_calendar_events: 1,
-        google_calendar_checkpoints: 1,
-        linear_runs: 1,
-        linear_projects: 1,
-        linear_issues: 1,
-        linear_comments: 1,
-        linear_checkpoints: 1,
     }
 }

--- a/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
@@ -12,6 +12,8 @@ const SLACK_ATTACHMENTS_RLS_SQL: &str =
 const SLACK_CONTEXT_ADMIN_CHANNELS_SQL: &str =
     include_str!("../migrations/0018_slack_context_rls_admin_channels.sql");
 const ETL_CONTEXT_RLS_SQL: &str = include_str!("../migrations/0021_etl_context_rls.sql");
+const DROP_SLACK_CONTEXT_ADMIN_CHANNELS_SQL: &str =
+    include_str!("../migrations/0022_drop_slack_context_rls_admin_channels.sql");
 
 const RLS_TABLES: &[&str] = &[
     "slack_sync_channels",
@@ -75,11 +77,12 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
     execute_migration(conn, SLACK_CONTEXT_ADMIN_CHANNELS_SQL).await?;
     create_minimal_non_slack_etl_tables(conn).await?;
     execute_migration(conn, ETL_CONTEXT_RLS_SQL).await?;
+    execute_migration(conn, DROP_SLACK_CONTEXT_ADMIN_CHANNELS_SQL).await?;
     grant_schema_usage(conn, schema).await?;
 
     assert_rls_enabled(conn).await?;
     assert_expected_policies(conn).await?;
-    assert_admin_channels_are_not_seeded(conn).await?;
+    assert_admin_channels_table_is_removed(conn).await?;
 
     insert_fixture_rows(conn).await?;
 
@@ -138,8 +141,30 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
     let unset_channel = visible_rows(conn, schema, "centaur_slack_reader", None).await?;
     assert_eq!(unset_channel, empty_visible_rows());
 
-    let admin_channel = visible_rows(conn, schema, "centaur_slack_reader", Some("C_ADMIN")).await?;
-    assert_eq!(admin_channel, all_visible_rows());
+    let formerly_admin_channel =
+        visible_rows(conn, schema, "centaur_slack_reader", Some("C_ADMIN")).await?;
+    assert_eq!(
+        formerly_admin_channel,
+        VisibleRows {
+            slack_channels: vec!["C_ADMIN".to_owned()],
+            slack_users: vec![],
+            slack_messages: vec![],
+            slack_attachments: vec![],
+            context_docs: vec![],
+            google_drive_runs: 0,
+            google_drive_files: 0,
+            google_drive_checkpoints: 0,
+            google_calendar_runs: 0,
+            google_calendar_calendars: 0,
+            google_calendar_events: 0,
+            google_calendar_checkpoints: 0,
+            linear_runs: 0,
+            linear_projects: 0,
+            linear_issues: 0,
+            linear_comments: 0,
+            linear_checkpoints: 0,
+        }
+    );
 
     let db_admin_role = visible_rows(conn, schema, "centaur_slack_admin", None).await?;
     assert_eq!(db_admin_role, all_visible_rows());
@@ -429,19 +454,33 @@ fn expected_policies() -> Vec<(String, String)> {
     .collect()
 }
 
-async fn assert_admin_channels_are_not_seeded(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
-    let count: i64 = sqlx::query_scalar("select count(*) from slack_context_rls_admin_channels")
-        .fetch_one(&mut *conn)
-        .await?;
-    assert_eq!(count, 0, "admin channels must be deployment-configured");
+async fn assert_admin_channels_table_is_removed(
+    conn: &mut PgConnection,
+) -> Result<(), sqlx::Error> {
+    let table_name: Option<String> =
+        sqlx::query_scalar("select to_regclass('slack_context_rls_admin_channels')::text")
+            .fetch_one(&mut *conn)
+            .await?;
+    assert_eq!(
+        table_name, None,
+        "admin channels must be managed by iron-control"
+    );
+
+    let function_count: i64 = sqlx::query_scalar(
+        "select count(*) from pg_proc where proname = 'centaur_etl_admin_channel'",
+    )
+    .fetch_one(&mut *conn)
+    .await?;
+    assert_eq!(
+        function_count, 0,
+        "admin-channel lookup function must be removed"
+    );
     Ok(())
 }
 
 async fn insert_fixture_rows(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
     sqlx::raw_sql(
         r#"
-        insert into slack_context_rls_admin_channels (channel_id) values ('C_ADMIN');
-
         insert into slack_sync_channels (channel_id, channel_name) values
             ('C_ALPHA', 'alpha'),
             ('C_BETA', 'beta'),

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -287,28 +287,10 @@ def _context_scope_clause(
 ) -> str:
     """SQL predicate matching the app-level company_context visibility boundary."""
     return (
-        "EXISTS ("
-        "SELECT 1 FROM slack_context_rls_admin_channels admins "
-        f"WHERE admins.channel_id = ${param_index}::text"
-        ") OR ("
-        f"${param_index}::text IS NOT NULL AND {source_expr} = 'slack' "
+        f"${param_index}::text IS NOT NULL "
+        f"AND {source_expr} = 'slack' "
         f"AND {metadata_expr} ->> 'channel_id' = ${param_index}::text"
-        ")"
     )
-
-
-async def _is_etl_admin_channel(conn: asyncpg.Connection, slack_channel_id: str | None) -> bool:
-    value = await conn.fetchval(
-        """
-        SELECT EXISTS (
-            SELECT 1
-            FROM slack_context_rls_admin_channels
-            WHERE channel_id = $1
-        )
-        """,
-        slack_channel_id,
-    )
-    return bool(value)
 
 
 def _load_slack_client() -> Any:
@@ -483,16 +465,11 @@ class CompanyContextClient:
                     if slack_channel_id is None:
                         live_error = "live Slack search requires a channel-scoped thread"
                     else:
-                        live_channels = (
-                            None
-                            if await _is_etl_admin_channel(conn, slack_channel_id)
-                            else [slack_channel_id]
-                        )
                         live_query = _slack_after_query(query, latest.get("latest_date"))
                         live_messages = _load_slack_client().search_messages(
                             live_query,
                             max_results=limit,
-                            channels=live_channels,
+                            channels=[slack_channel_id],
                         )
                         live_results = [_live_slack_result(message) for message in live_messages]
                 except Exception as exc:
@@ -528,25 +505,14 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         """Return latest indexed date using an existing DB connection."""
         row = await conn.fetchrow(
-            """
+            f"""
             SELECT
                 MAX(COALESCE(source_updated_at, occurred_at)) AS latest_date,
                 MAX(source_updated_at) AS latest_source_updated_at,
                 MAX(occurred_at) AS latest_occurred_at,
                 COUNT(*)::bigint AS document_count
             FROM company_context_documents
-            WHERE (
-                EXISTS (
-                    SELECT 1
-                    FROM slack_context_rls_admin_channels admins
-                    WHERE admins.channel_id = $1::text
-                )
-                OR (
-                    $1::text IS NOT NULL
-                    AND source = 'slack'
-                    AND metadata ->> 'channel_id' = $1::text
-                )
-            )
+            WHERE ({_context_scope_clause(1)})
               AND ($2::text IS NULL OR source = $2)
               AND ($3::text IS NULL OR source_type = $3)
             """,
@@ -624,7 +590,7 @@ class CompanyContextClient:
         try:
             slack_channel_id = _current_slack_channel_id()
             rows = await conn.fetch(
-                """
+                f"""
                 SELECT
                     document_id,
                     source,
@@ -641,18 +607,7 @@ class CompanyContextClient:
                     source_updated_at,
                     metadata
                 FROM company_context_documents
-                WHERE (
-                    EXISTS (
-                        SELECT 1
-                        FROM slack_context_rls_admin_channels admins
-                        WHERE admins.channel_id = $1::text
-                    )
-                    OR (
-                        $1::text IS NOT NULL
-                        AND source = 'slack'
-                        AND metadata ->> 'channel_id' = $1::text
-                    )
-                )
+                WHERE ({_context_scope_clause(1)})
                   AND ($2::text IS NULL OR source = $2)
                   AND ($3::text IS NULL OR source_type = $3)
                   AND ($4::timestamptz IS NULL OR occurred_at >= $4)
@@ -755,7 +710,7 @@ class CompanyContextClient:
         if row["parent_document_id"]:
             slack_channel_id = _current_slack_channel_id()
             parent_row = await conn.fetchrow(
-                """
+                f"""
                 SELECT
                     document_id,
                     source,
@@ -772,18 +727,7 @@ class CompanyContextClient:
                     metadata
                 FROM company_context_documents
                 WHERE document_id = $1
-                  AND (
-                    EXISTS (
-                        SELECT 1
-                        FROM slack_context_rls_admin_channels admins
-                        WHERE admins.channel_id = $2::text
-                    )
-                    OR (
-                        $2::text IS NOT NULL
-                        AND source = 'slack'
-                        AND metadata ->> 'channel_id' = $2::text
-                    )
-                  )
+                  AND ({_context_scope_clause(2)})
                 """,
                 row["parent_document_id"],
                 slack_channel_id,
@@ -792,7 +736,7 @@ class CompanyContextClient:
                 parent = _document_summary(parent_row)
 
         child_rows = await conn.fetch(
-            """
+            f"""
             SELECT
                 document_id,
                 source,
@@ -809,18 +753,7 @@ class CompanyContextClient:
                 metadata
             FROM company_context_documents
             WHERE parent_document_id = $1
-              AND (
-                EXISTS (
-                    SELECT 1
-                    FROM slack_context_rls_admin_channels admins
-                    WHERE admins.channel_id = $3::text
-                )
-                OR (
-                    $3::text IS NOT NULL
-                    AND source = 'slack'
-                    AND metadata ->> 'channel_id' = $3::text
-                )
-              )
+              AND ({_context_scope_clause(3)})
             ORDER BY occurred_at ASC NULLS LAST, document_id ASC
             LIMIT $2
             """,
@@ -847,7 +780,7 @@ class CompanyContextClient:
         try:
             slack_channel_id = _current_slack_channel_id()
             row = await conn.fetchrow(
-                """
+                f"""
                 SELECT
                     document_id,
                     source,
@@ -865,18 +798,7 @@ class CompanyContextClient:
                     metadata
                 FROM company_context_documents
                 WHERE document_id = $1
-                  AND (
-                    EXISTS (
-                        SELECT 1
-                        FROM slack_context_rls_admin_channels admins
-                        WHERE admins.channel_id = $2::text
-                    )
-                    OR (
-                        $2::text IS NOT NULL
-                        AND source = 'slack'
-                        AND metadata ->> 'channel_id' = $2::text
-                    )
-                  )
+                  AND ({_context_scope_clause(2)})
                 """,
                 document_id,
                 slack_channel_id,


### PR DESCRIPTION
## Summary
- remove the database-backed `slack_context_rls_admin_channels` table from the final RLS schema
- drop the legacy `centaur_slack_admin` DB role and its `*_admin_select` RLS policies
- replace reader policies so Slack history remains channel-scoped and non-Slack ETL tables are hidden from channel-scoped readers
- remove the company_context live Slack fallback's `centaur_etl_admin_channel()` lookup

## Why
Admin-channel and elevated tool access are now managed by iron-control principals/roles, so Postgres should not keep a second admin-channel table or a parallel admin DB role.

## Validation
- `cargo test -p centaur-session-sqlx --test etl_context_rls`
- `uv run --no-project --with pytest --with asyncpg --with python-dotenv --with rich --with slack-sdk --with typer pytest tools/productivity/company_context/tests/test_client.py`
- `git diff --check`
- confirmed migration `0022` is latest and unique in the branch