### PR TITLE
[codex] Add console public URL chart value

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.63
+version: 0.1.64
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -119,6 +119,10 @@ spec:
                 secretKeyRef:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+{{- with $console.publicUrl }}
+            - name: CENTAUR_CONSOLE_PUBLIC_URL
+              value: {{ . | quote }}
+{{- end }}
 {{- if $console.googleOauth.enabled }}
             # Google OAuth app credentials, needed by the broker-credential
             # OAuth refresh loop. Gated on console.googleOauth.enabled.

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -145,6 +145,10 @@ spec:
                 secretKeyRef:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+{{- with $console.publicUrl }}
+            - name: CENTAUR_CONSOLE_PUBLIC_URL
+              value: {{ . | quote }}
+{{- end }}
 {{- if $console.googleOauth.enabled }}
             # Google OAuth app credentials (sign-in + brokered token refresh).
             # Gated on console.googleOauth.enabled; the keys must exist in the

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -8,6 +8,7 @@
         "enabled": { "type": "boolean" },
         "replicaCount": { "type": "integer" },
         "railsEnv": { "type": "string" },
+        "publicUrl": { "type": "string" },
         "image": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -92,6 +92,11 @@ console:
     # IfNotPresent would pin pods to whatever digest a node already cached.
     pullPolicy: Always
   railsEnv: production
+  # Public origin for this console deployment, for example
+  # https://console.example.com. When set, the chart renders
+  # CENTAUR_CONSOLE_PUBLIC_URL so OAuth redirect URLs do not depend on the
+  # internal service host.
+  publicUrl: ""
   database:
     # Logical DB created on the bundled Postgres by the create-db init
     # container. Must match the primary connection's `database:` in the image's


### PR DESCRIPTION
## Summary

Adds a first-class `console.publicUrl` Helm value and renders it as `CENTAUR_CONSOLE_PUBLIC_URL` for both the console web and worker containers.

This lets deployments behind Tailscale, Cloudflare, or another proxy set a stable public origin for OAuth redirect URL generation instead of relying on the internal service host or request-derived origin.

Companion infra PR: tempoxyz/prd-centaur-infra#450.

## Validation

- `git diff --check`
- `helm lint contrib/chart`
- `helm dependency build contrib/chart && helm template centaur contrib/chart --set console.enabled=true --set console.publicUrl=https://console.example.com` confirmed `CENTAUR_CONSOLE_PUBLIC_URL` renders in both console containers
