### PR TITLE
fix: emit Slack health gauges from Slack workflows

### DIFF
--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -36,7 +36,6 @@ COMPANY_CONTEXT_SOURCE_TYPES = {
 }
 COMPANY_CONTEXT_DOCUMENT_ACTIONS = ("inserted", "updated", "deleted", "noop")
 ETL_CHECKPOINT_TABLES = {
-    "slack": "slack_sync_checkpoints",
     "google_drive": "google_drive_sync_checkpoints",
     "google_calendar": "google_calendar_sync_checkpoints",
     "linear": "linear_sync_checkpoints",

--- a/workflows/slack/backfill.py
+++ b/workflows/slack/backfill.py
@@ -25,6 +25,7 @@ from workflows.slack.shared import (
     channel_ref,
     claim_backfill_jobs,
     client as shared_client,
+    emit_slack_checkpoint_metrics,
     enqueue_backfill_job,
     env_flag_enabled,
     failure_reason,
@@ -202,6 +203,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     channel_pages_per_job = positive_int(
         inp.channel_pages_per_job, DEFAULT_CHANNEL_PAGES_PER_JOB
     )
+    await emit_slack_checkpoint_metrics(ctx._pool)
     await _emit_backfill_job_metrics(ctx._pool)
     jobs = await claim_backfill_jobs(ctx._pool, channel_batch_limit)
     if not jobs:
@@ -492,6 +494,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         counts=counts,
         error_text=error_text,
     )
+    await emit_slack_checkpoint_metrics(ctx._pool)
     await _emit_backfill_job_metrics(ctx._pool)
 
     return {

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -16,6 +16,11 @@ from urllib import request as urllib_request
 
 from centaur_sdk import secret
 from api.runtime_control import canonical_json
+from api.vm_metrics import (
+    set_etl_active_scopes,
+    set_etl_failed_scopes,
+    set_etl_scope_sync_freshness_seconds,
+)
 
 FALSE_ENV_VALUES = {"0", "false", "no", "off"}
 DEFAULT_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024
@@ -355,6 +360,30 @@ def is_permanent_slack_backfill_error(error: str) -> bool:
     return any(
         f"slack api error: {error_code}" in lowered
         for error_code in PERMANENT_SLACK_BACKFILL_ERRORS
+    )
+
+
+async def emit_slack_checkpoint_metrics(pool) -> None:
+    """Publish current Slack checkpoint health gauges for Grafana panels."""
+    row = await pool.fetchrow(
+        "SELECT COUNT(*) AS active_scopes, "
+        "COUNT(*) FILTER (WHERE c.last_error <> '') AS failed_scopes, "
+        "COALESCE("
+        "  EXTRACT(EPOCH FROM NOW() - MIN(c.last_success_at) "
+        "    FILTER (WHERE c.last_success_at IS NOT NULL)"
+        "  ), "
+        "  0"
+        ") AS freshness_seconds "
+        "FROM slack_sync_checkpoints c "
+        "JOIN slack_sync_channels ch ON ch.channel_id = c.channel_id "
+        "WHERE ch.is_syncable IS TRUE "
+        "AND ch.is_archived IS FALSE",
+    )
+    set_etl_active_scopes("slack", int(row["active_scopes"] or 0) if row else 0)
+    set_etl_failed_scopes("slack", int(row["failed_scopes"] or 0) if row else 0)
+    set_etl_scope_sync_freshness_seconds(
+        "slack",
+        float(row["freshness_seconds"] or 0.0) if row else 0.0,
     )
 
 

--- a/workflows/slack/sync.py
+++ b/workflows/slack/sync.py
@@ -22,6 +22,7 @@ from workflows.slack.shared import (
     BACKFILL_JOB_THREAD_REFRESH,
     channel_ref,
     client as shared_client,
+    emit_slack_checkpoint_metrics,
     enqueue_backfill_job,
     env_flag_enabled,
     failure_reason,
@@ -353,6 +354,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             access_mode=access_mode,
             reason=reason,
         )
+        await emit_slack_checkpoint_metrics(ctx._pool)
         return {
             "status": "skipped",
             "reason": reason,
@@ -367,6 +369,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             reason=reason,
             channels_skipped=excluded_channels,
         )
+        await emit_slack_checkpoint_metrics(ctx._pool)
         return {
             "status": "skipped",
             "reason": reason,
@@ -617,6 +620,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         counts=counts,
         error_text=error_text,
     )
+    await emit_slack_checkpoint_metrics(ctx._pool)
 
     return {
         "status": status,

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -21,6 +21,16 @@ def _load_shared():
     sys.modules.setdefault("api", api_module)
     sys.modules.setdefault("api.runtime_control", runtime_control)
 
+    vm_metrics = types.ModuleType("api.vm_metrics")
+    for name in (
+        "set_etl_active_scopes",
+        "set_etl_failed_scopes",
+        "set_etl_scope_sync_freshness_seconds",
+    ):
+        setattr(vm_metrics, name, lambda *_args, **_kwargs: None)
+    api_module.vm_metrics = vm_metrics
+    sys.modules["api.vm_metrics"] = vm_metrics
+
     centaur_sdk = types.ModuleType("centaur_sdk")
     centaur_sdk.secret = lambda _name, default=None: default
     sys.modules.setdefault("centaur_sdk", centaur_sdk)
@@ -38,8 +48,11 @@ def _load_backfill():
         "record_etl_items_failed",
         "record_etl_items_seen",
         "record_etl_items_upserted",
+        "set_etl_active_scopes",
         "set_etl_backfill_job_age_seconds",
         "set_etl_backfill_jobs",
+        "set_etl_failed_scopes",
+        "set_etl_scope_sync_freshness_seconds",
     ):
         setattr(vm_metrics, name, lambda *_args, **_kwargs: None)
     api_module.vm_metrics = vm_metrics
@@ -188,6 +201,60 @@ class FakeExecutePool:
         self.execute_calls.append((sql, args))
 
 
+class FakeFetchRowPool:
+    def __init__(self, row) -> None:
+        self.row = row
+        self.fetchrow_calls: list[tuple] = []
+
+    async def fetchrow(self, sql, *args):
+        self.fetchrow_calls.append((sql, args))
+        return self.row
+
+
+def test_emit_slack_checkpoint_metrics_reads_slack_checkpoints(monkeypatch):
+    calls: dict[str, list] = {
+        "active": [],
+        "failed": [],
+        "freshness": [],
+    }
+    monkeypatch.setattr(
+        shared,
+        "set_etl_active_scopes",
+        lambda *args: calls["active"].append(args),
+    )
+    monkeypatch.setattr(
+        shared,
+        "set_etl_failed_scopes",
+        lambda *args: calls["failed"].append(args),
+    )
+    monkeypatch.setattr(
+        shared,
+        "set_etl_scope_sync_freshness_seconds",
+        lambda *args: calls["freshness"].append(args),
+    )
+    pool = FakeFetchRowPool(
+        {
+            "active_scopes": 42,
+            "failed_scopes": 3,
+            "freshness_seconds": 123.5,
+        }
+    )
+
+    asyncio.run(shared.emit_slack_checkpoint_metrics(pool))
+
+    assert len(pool.fetchrow_calls) == 1
+    query = pool.fetchrow_calls[0][0]
+    assert "FROM slack_sync_checkpoints c" in query
+    assert "JOIN slack_sync_channels ch ON ch.channel_id = c.channel_id" in query
+    assert "ch.is_syncable IS TRUE" in query
+    assert "ch.is_archived IS FALSE" in query
+    assert calls == {
+        "active": [("slack", 42)],
+        "failed": [("slack", 3)],
+        "freshness": [("slack", 123.5)],
+    }
+
+
 def test_permanent_slack_backfill_error_classifier():
     assert shared.is_permanent_slack_backfill_error(
         "Slack API error: thread_not_found"
@@ -273,6 +340,7 @@ def test_backfill_handler_terminally_skips_permanent_slack_errors(monkeypatch):
         calls["terminal_skip"].append(kwargs)
 
     monkeypatch.setattr(backfill, "_emit_backfill_job_metrics", fake_noop)
+    monkeypatch.setattr(backfill, "emit_slack_checkpoint_metrics", fake_noop)
     monkeypatch.setattr(backfill, "claim_backfill_jobs", fake_claim_jobs)
     monkeypatch.setattr(backfill, "shared_client", lambda: FakeClient())
     monkeypatch.setattr(backfill, "record_run_start", fake_noop)

--- a/workflows/tests/test_company_context_documents_attachments.py
+++ b/workflows/tests/test_company_context_documents_attachments.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import importlib
 import json
@@ -41,13 +42,59 @@ def _load_projection_module():
     api_module.workflow_engine = workflow_engine
     sys.modules.setdefault("api", api_module)
     sys.modules.setdefault("api.runtime_control", runtime_control)
-    sys.modules.setdefault("api.vm_metrics", vm_metrics)
+    sys.modules["api.vm_metrics"] = vm_metrics
     sys.modules.setdefault("api.workflow_engine", workflow_engine)
 
     return importlib.import_module("workflows.company_context_documents")
 
 
 projection = _load_projection_module()
+
+
+class FakeScopeMetricsPool:
+    def __init__(self) -> None:
+        self.fetchrow_calls: list[str] = []
+
+    async def fetchrow(self, sql):
+        self.fetchrow_calls.append(sql)
+        return {
+            "active_scopes": 7,
+            "failed_scopes": 1,
+            "freshness_seconds": 42.0,
+        }
+
+
+def test_etl_scope_metrics_no_longer_emit_slack_scope_gauges(monkeypatch):
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        projection,
+        "set_etl_active_scopes",
+        lambda *args: calls.append(("active", *args)),
+    )
+    monkeypatch.setattr(
+        projection,
+        "set_etl_failed_scopes",
+        lambda *args: calls.append(("failed", *args)),
+    )
+    monkeypatch.setattr(
+        projection,
+        "set_etl_scope_sync_freshness_seconds",
+        lambda *args: calls.append(("freshness", *args)),
+    )
+    pool = FakeScopeMetricsPool()
+
+    asyncio.run(
+        projection._emit_etl_scope_metrics(pool, ["slack", "google_drive"])
+    )
+
+    assert len(pool.fetchrow_calls) == 1
+    assert "google_drive_sync_checkpoints" in pool.fetchrow_calls[0]
+    assert "slack_sync_checkpoints" not in pool.fetchrow_calls[0]
+    assert calls == [
+        ("active", "google_drive", 7),
+        ("failed", "google_drive", 1),
+        ("freshness", "google_drive", 42.0),
+    ]
 
 
 def test_slack_attachment_document_indexes_metadata_without_private_url():


### PR DESCRIPTION
## Summary

Moves Slack ETL checkpoint health gauge emission out of the company-context projection workflow and into the Slack ETL workflows that own the checkpoint state.

## Root Cause

The overview gauges for Slack active scopes, failed scopes, and sync freshness were emitted by `company_context_documents`. That workflow runs on a much slower projection cadence, so Slack health panels could go blank or stale even while Slack sync/backfill were running normally.

## Changes

- Add `emit_slack_checkpoint_metrics()` in Slack shared workflow helpers.
- Emit Slack checkpoint health gauges from `slack_sync` completion/skip paths.
- Emit Slack checkpoint health gauges from `slack_backfill` before and after backfill work.
- Stop `company_context_documents` from querying/emitting Slack checkpoint health.
- Add tests for Slack checkpoint metric emission and the company-context ownership split.

## Validation

- `uv run --with pytest pytest workflows/slack/tests workflows/tests`
- `uv run --with ruff ruff check workflows/slack/backfill.py workflows/slack/sync.py workflows/slack/shared.py workflows/slack/tests/test_shared_attachments.py workflows/company_context_documents.py workflows/tests/test_company_context_documents_attachments.py`
