### PR TITLE
fix: cold start slack sync from full lookback

### DIFF
--- a/workflows/slack/sync.py
+++ b/workflows/slack/sync.py
@@ -30,7 +30,6 @@ from workflows.slack.shared import (
     positive_int,
     record_run_finish,
     record_run_start,
-    seed_channel_bootstrap_job,
     upsert_messages,
     widen_channel_bootstrap_job,
     workflow_run_id_to_sync_run_id,
@@ -39,7 +38,6 @@ from workflows.slack.shared import (
 WORKFLOW_NAME = "slack_sync"
 
 DEFAULT_LOOKBACK_DAYS = 30
-DEFAULT_BOOTSTRAP_RECENT_HOURS = 6
 DEFAULT_THREAD_LOOKBACK_DAYS = 3
 DEFAULT_THREAD_REFRESH_INTERVAL_HOURS = 12
 DEFAULT_CHANNEL_PAGE_LIMIT = 100
@@ -132,12 +130,6 @@ def _ts_minus_days(ts: str | None, days: int) -> str | None:
     except (TypeError, ValueError):
         return None
     return f"{seconds:.6f}"
-
-
-def _ts_now_minus_hours(hours: int) -> str:
-    """Return the current time minus a fixed-hour window as a Slack timestamp."""
-    now = dt.datetime.now(dt.timezone.utc).timestamp()
-    return f"{max(now - (hours * 3_600), 0.0):.6f}"
 
 
 def _ts_now_minus_days(days: int) -> str:
@@ -434,7 +426,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                         str(state["watermark"]), thread_lookback_days
                     )
                 else:
-                    oldest = _ts_now_minus_hours(DEFAULT_BOOTSTRAP_RECENT_HOURS)
+                    oldest = _ts_now_minus_days(lookback_days)
 
             page = client._sync_etl_channel_history(
                 channel_id,
@@ -505,33 +497,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             next_state = page.get("sync_state") or {}
             initial_backfill_seeded = False
             bootstrap_widened = False
-            if checkpoint_watermark is None and oldest and inp.oldest is None:
-                bootstrap_oldest = _ts_now_minus_days(lookback_days)
-                initial_backfill_seeded = await seed_channel_bootstrap_job(
-                    ctx._pool,
-                    channel_id=channel_id,
-                    window_oldest=bootstrap_oldest,
-                    window_latest=oldest,
-                    lookback_days=lookback_days,
-                    thread_lookback_days=thread_lookback_days,
-                    run_id=run_id,
-                    priority=200,
-                )
-                if initial_backfill_seeded:
-                    record_etl_items_enqueued(
-                        "slack", "channel", "channel_bootstrap_job", 1
-                    )
-                    ctx.log(
-                        "slack_sync_backfill_seeded",
-                        channel_id=channel_id,
-                        channel_name=channel_name,
-                        job_type=BACKFILL_JOB_CHANNEL_BOOTSTRAP,
-                        job_key=_bootstrap_backfill_job_key(channel_id),
-                        bootstrap_recent_hours=DEFAULT_BOOTSTRAP_RECENT_HOURS,
-                        window_oldest_ts=bootstrap_oldest,
-                        window_latest_ts=oldest,
-                    )
-            elif checkpoint_watermark is not None and inp.oldest is None:
+            if checkpoint_watermark is not None and inp.oldest is None:
                 desired_oldest = _ts_now_minus_days(lookback_days)
                 bootstrap_widened = await widen_channel_bootstrap_job(
                     ctx._pool,

--- a/workflows/slack/tests/test_sync_cold_start.py
+++ b/workflows/slack/tests/test_sync_cold_start.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def _load_sync():
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    api_module = sys.modules.setdefault("api", types.ModuleType("api"))
+
+    runtime_control = types.ModuleType("api.runtime_control")
+    runtime_control.canonical_json = lambda value: json.dumps(value, sort_keys=True)
+    api_module.runtime_control = runtime_control
+    sys.modules["api.runtime_control"] = runtime_control
+
+    vm_metrics = types.ModuleType("api.vm_metrics")
+    for name in (
+        "record_etl_items_enqueued",
+        "record_etl_items_failed",
+        "record_etl_items_seen",
+        "record_etl_items_upserted",
+    ):
+        setattr(vm_metrics, name, lambda *_args, **_kwargs: None)
+    api_module.vm_metrics = vm_metrics
+    sys.modules["api.vm_metrics"] = vm_metrics
+
+    workflow_engine = types.ModuleType("api.workflow_engine")
+    workflow_engine.WorkflowContext = object
+    api_module.workflow_engine = workflow_engine
+    sys.modules["api.workflow_engine"] = workflow_engine
+
+    centaur_sdk = sys.modules.setdefault("centaur_sdk", types.ModuleType("centaur_sdk"))
+    centaur_sdk.secret = lambda _name, default=None: default
+
+    return importlib.import_module("workflows.slack.sync")
+
+
+class FakeContext:
+    run_id = "wfr_test"
+    _pool = object()
+
+    def __init__(self) -> None:
+        self.logs: list[tuple[str, dict]] = []
+
+    def log(self, name: str, **fields):
+        self.logs.append((name, fields))
+
+
+class FakeClient:
+    def __init__(self, *, cursor: str | None = None) -> None:
+        self.history_calls: list[dict] = []
+        self.cursor = cursor
+
+    def _etl_access_mode(self):
+        return "test"
+
+    def _list_etl_channels(self, *_args, **_kwargs):
+        return [{"id": "C123", "name": "cold-start"}]
+
+    def _list_etl_users(self, *_args, **_kwargs):
+        return []
+
+    def _sync_etl_channel_history(self, channel_id, **kwargs):
+        self.history_calls.append({"channel_id": channel_id, **kwargs})
+        return {
+            "messages": [
+                {
+                    "channel_id": channel_id,
+                    "timestamp": "1770000000.000100",
+                    "thread_ts": "1770000000.000100",
+                    "text": "hello",
+                }
+            ],
+            "sync_state": {
+                "cursor": self.cursor,
+                "watermark": "1770000000.000100",
+                "oldest": kwargs["oldest"],
+                "latest": None,
+            },
+        }
+
+
+async def _noop(*_args, **_kwargs):
+    return None
+
+
+async def _zero(*_args, **_kwargs):
+    return 0
+
+
+def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
+    calls: dict[str, list] = {
+        "checkpoint_success": [],
+        "enqueued": [],
+        "finish": [],
+        "widened": [],
+    }
+    fake_client = client or FakeClient()
+
+    async def fake_load_checkpoint(_pool, _channel_id):
+        return checkpoint
+
+    async def fake_upsert_messages(_pool, rows):
+        return len(rows)
+
+    async def fake_load_thread_refresh_times(*_args, **_kwargs):
+        return {}
+
+    async def fake_update_checkpoint_success(_pool, **kwargs):
+        calls["checkpoint_success"].append(kwargs)
+
+    async def fake_enqueue_backfill_job(_pool, **kwargs):
+        calls["enqueued"].append(kwargs)
+
+    async def fake_record_run_finish(_pool, **kwargs):
+        calls["finish"].append(kwargs)
+
+    async def fake_widen_channel_bootstrap_job(_pool, **kwargs):
+        calls["widened"].append(kwargs)
+        return False
+
+    monkeypatch.setattr(sync, "_client", lambda: fake_client)
+    monkeypatch.setattr(sync, "_upsert_channels", _noop)
+    monkeypatch.setattr(sync, "_upsert_users", _zero)
+    monkeypatch.setattr(sync, "_load_checkpoint", fake_load_checkpoint)
+    monkeypatch.setattr(sync, "_upsert_messages", fake_upsert_messages)
+    monkeypatch.setattr(sync, "load_thread_refresh_times", fake_load_thread_refresh_times)
+    monkeypatch.setattr(sync, "_update_checkpoint_success", fake_update_checkpoint_success)
+    monkeypatch.setattr(sync, "_update_checkpoint_failure", _noop)
+    monkeypatch.setattr(sync, "enqueue_backfill_job", fake_enqueue_backfill_job)
+    monkeypatch.setattr(sync, "record_run_start", _noop)
+    monkeypatch.setattr(sync, "record_run_finish", fake_record_run_finish)
+    monkeypatch.setattr(
+        sync,
+        "widen_channel_bootstrap_job",
+        fake_widen_channel_bootstrap_job,
+    )
+
+    return fake_client, calls
+
+
+def test_cold_start_channel_uses_full_lookback_window(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    sync = _load_sync()
+    client, calls = _patch_handler_io(monkeypatch, sync)
+
+    monkeypatch.setattr(sync, "_ts_now_minus_days", lambda days: f"days:{days}")
+
+    result = asyncio.run(sync.handler(sync.Input(), FakeContext()))
+
+    assert result["status"] == "completed"
+    assert client.history_calls[0]["oldest"] == "days:30"
+    assert calls["checkpoint_success"] == [
+        {
+            "channel_id": "C123",
+            "watermark_ts": "1770000000.000100",
+            "run_id": "slack_sync_wfr_test",
+        }
+    ]
+    assert calls["enqueued"] == []
+    assert calls["widened"] == []
+
+
+def test_watermarked_channel_keeps_incremental_overlap(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    sync = _load_sync()
+    client, calls = _patch_handler_io(
+        monkeypatch,
+        sync,
+        checkpoint={"watermark_ts": "1771000000.000100", "last_error": ""},
+    )
+
+    monkeypatch.setattr(
+        sync,
+        "_ts_minus_days",
+        lambda ts, days: f"minus:{ts}:{days}",
+    )
+    monkeypatch.setattr(sync, "_ts_now_minus_days", lambda days: f"days:{days}")
+
+    result = asyncio.run(sync.handler(sync.Input(), FakeContext()))
+
+    assert result["status"] == "completed"
+    assert client.history_calls[0]["oldest"] == "minus:1771000000.000100:3"
+    assert calls["widened"] == [
+        {
+            "channel_id": "C123",
+            "window_oldest": "days:30",
+            "lookback_days": 30,
+            "thread_lookback_days": 3,
+            "run_id": "slack_sync_wfr_test",
+            "priority": 150,
+        }
+    ]
+


### PR DESCRIPTION
## Summary
- use the configured Slack lookback window for channels without a checkpoint instead of the old 6-hour bootstrap window
- rely on Slack history cursor continuation to drain that bounded cold-start window
- add handler coverage for cold-start channels and existing watermarked incremental overlap

## Tests
- uv run --with pytest pytest workflows/slack/tests
- uv run --with pytest pytest workflows/slack/tests workflows/tests
- uv run --with ruff ruff check workflows/slack/sync.py workflows/slack/tests/test_sync_cold_start.py