### PR TITLE
Add Reth mainnet RPC URLs to sandbox instructions

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -120,6 +120,11 @@
 |  vlogs tool_analytics --start 7d                        → tool usage stats
 |  vlogs query 'level:error AND event:tool_call_completed' --limit 20 → raw LogsQL
 |
+[Ethereum Mainnet RPC]
+|When you need an Ethereum mainnet RPC endpoint and the user has not specified another provider, use the Reth-hosted mainnet endpoints:
+|  HTTP: https://ethereum.reth.rs/rpc
+|  WSS:  wss://ethereum.reth.rs/ws
+|
 [Common Tool CLIs]
 |NEVER call external APIs directly via curl unless you are downloading a file the prompt explicitly told you to fetch that way.
 |Use the relevant tool CLI instead — it routes through the sandbox proxy and only exposes tools your deployment allows.


### PR DESCRIPTION
## Summary
- Add Reth-hosted Ethereum mainnet HTTP and WSS RPC endpoints to sandbox instructions
- Instruct agents to use these endpoints when no other provider is specified

## Verification
- Confirmed Reth docs list Ethereum mainnet HTTP RPC as https://ethereum.reth.rs/rpc
- Searched for the corresponding Reth-hosted WSS endpoint before hardcoding wss://ethereum.reth.rs/ws

Prompted by: @DaniPopes