### PR TITLE
Instruct agents to hyperlink GitHub refs

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -19,6 +19,7 @@
 |Do not use chatbot boilerplate (for example: "Great question", "I hope this helps", "Let me know if...").
 |Keep claims concrete. If you cite market norms or facts, anchor them to a source.
 |Preserve factual details exactly: numbers, links, quotes, and user mentions.
+|Always hyperlink GitHub references such as PRs, issues, commits, and compare refs when the repository context is known (for example, link `#123` to the corresponding GitHub PR or issue).
 
 [User Interaction]
 |When a user asks whether a prior step finished, especially after an error or failed run, the first sentence must answer that status question from the available thread context or execution state before any new debugging, diagnosis, or code changes.


### PR DESCRIPTION
## Summary
- Add a writing-quality instruction to hyperlink GitHub PR, issue, commit, and compare references when repo context is known.

## Testing
- Not run; prompt-only change.

Prompted by: @DaniPopes