### PR TITLE
Fix Slack upload default target comments

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -7,7 +7,10 @@ use std::thread;
 use codex_app_server_protocol::UserInput;
 use serde_json::{Value, json};
 
-use crate::server::{BlocksCommand, BlocksState, parse_blocks_line_with_state, write_blocks_error};
+use crate::server::{
+    BlocksCommand, BlocksState, parse_blocks_line_with_state, set_current_thread_key,
+    write_blocks_error,
+};
 use crate::util::write_value;
 use crate::{AppServerRuntime, HarnessServerError, Result};
 
@@ -141,7 +144,9 @@ pub(crate) fn run_codex_blocks_server(config: CodexHarnessServer) -> Result<()> 
                 client_user_message_id,
                 model,
                 reasoning,
+                thread_key,
             }) => {
+                set_current_thread_key(thread_key.as_deref());
                 if let Err(error) = run_codex_user_turn(
                     &mut codex,
                     &mut stdout,

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -92,10 +92,12 @@ pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()>
                 input,
                 client_user_message_id,
                 model,
+                thread_key,
                 // Reasoning effort only applies to the codex harness; the
                 // emulated (claude/amp) app-server has no equivalent knob.
                 reasoning: _,
             }) => {
+                set_current_thread_key(thread_key.as_deref());
                 if let Some(model) = model {
                     state.model = model;
                 }
@@ -200,6 +202,7 @@ pub(crate) enum BlocksCommand {
         client_user_message_id: Option<String>,
         model: Option<String>,
         reasoning: Option<String>,
+        thread_key: Option<String>,
     },
     Interrupt,
     AttachmentChunk,
@@ -234,6 +237,8 @@ struct BlocksLine {
     model: Option<String>,
     #[serde(default)]
     reasoning: Option<String>,
+    #[serde(default)]
+    thread_key: Option<String>,
     #[serde(rename = "attachmentId", default)]
     attachment_id: Option<String>,
     #[serde(default)]
@@ -346,6 +351,10 @@ pub(crate) fn parse_blocks_line_with_state(
                     .reasoning
                     .map(|reasoning| reasoning.trim().to_owned())
                     .filter(|reasoning| !reasoning.is_empty()),
+                thread_key: parsed
+                    .thread_key
+                    .map(|thread_key| thread_key.trim().to_owned())
+                    .filter(|thread_key| !thread_key.is_empty()),
             })
         }
         "attachment.chunk" => {
@@ -356,6 +365,14 @@ pub(crate) fn parse_blocks_line_with_state(
         kind => Err(HarnessServerError::InvalidBlocksInput {
             message: format!("unsupported blocks input type `{kind}`"),
         }),
+    }
+}
+
+pub(crate) fn set_current_thread_key(thread_key: Option<&str>) {
+    if let Some(thread_key) = thread_key {
+        unsafe {
+            env::set_var("CENTAUR_THREAD_KEY", thread_key);
+        }
     }
 }
 
@@ -1158,12 +1175,28 @@ mod tests {
     #[test]
     fn parses_blocks_user_line_with_model_override() {
         let line = r#"{"type":"user","thread_key":"web:t1","model":"claude-sonnet-4-6","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#;
-        let BlocksCommand::User { model, input, .. } = parse_blocks_line(line).expect("parses")
+        let BlocksCommand::User {
+            model,
+            input,
+            thread_key,
+            ..
+        } = parse_blocks_line(line).expect("parses")
         else {
             panic!("expected user command");
         };
         assert_eq!(model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(thread_key.as_deref(), Some("web:t1"));
         assert_eq!(input.len(), 1);
+    }
+
+    #[test]
+    fn ignores_blank_thread_key_on_blocks_user_line() {
+        let line = r#"{"type":"user","thread_key":"  ","text":"hi"}"#;
+        let BlocksCommand::User { thread_key, .. } = parse_blocks_line(line).expect("parses")
+        else {
+            panic!("expected user command");
+        };
+        assert_eq!(thread_key, None);
     }
 
     #[test]

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -496,7 +496,7 @@ def upload(
 
     channel, upload_paths = _upload_target_and_files(target_or_file, files or [])
 
-    for file_path in upload_paths:
+    for index, file_path in enumerate(upload_paths):
         path = Path(file_path)
         if not path.exists():
             console.print(f"[red]File not found: {file_path}[/]")
@@ -510,7 +510,7 @@ def upload(
                 content_base64=base64.b64encode(path.read_bytes()).decode(),
                 filename=path.name,
                 title=path.name,
-                comment=comment if file_path == files[0] else None,  # Only comment on first file
+                comment=comment if index == 0 else None,
                 thread_ts=thread,
             )
             console.print(f"[green]✓ Uploaded {path.name}[/]")

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 
-from slack.cli import _upload_target_and_files
+from typer.testing import CliRunner
+
+from slack.cli import _upload_target_and_files, app
+
+
+runner = CliRunner()
 
 
 def test_upload_target_defaults_when_first_arg_is_file(tmp_path: Path) -> None:
@@ -30,3 +35,24 @@ def test_upload_target_single_missing_path_uses_default_context() -> None:
 
     assert channel is None
     assert files == ["chart.png"]
+
+
+def test_upload_single_file_with_default_context_does_not_index_missing_files(
+    tmp_path: Path, monkeypatch
+) -> None:
+    upload = tmp_path / "chart.png"
+    upload.write_bytes(b"png")
+    calls = []
+
+    def fake_upload_file(**kwargs):
+        calls.append(kwargs)
+        return {"permalink": "https://slack.example/files/chart.png"}
+
+    monkeypatch.setattr("slack.client.upload_file", fake_upload_file)
+
+    result = runner.invoke(app, ["upload", str(upload), "--comment", "chart"])
+
+    assert result.exit_code == 0
+    assert calls[0]["channel"] is None
+    assert calls[0]["filename"] == "chart.png"
+    assert calls[0]["comment"] == "chart"


### PR DESCRIPTION
## Summary
- avoid indexing the optional `files` argument when Slack upload defaults to the current thread
- keep upload comments attached only to the first normalized upload path
- propagate blocks-mode `thread_key` into `CENTAUR_THREAD_KEY` inside harness-server so shell commands like `slack upload <file>` can infer the Slack destination from warm or cold sandboxes
- add regression coverage for the Slack CLI single-file path and blocks-mode thread-key parsing

Prompted by: @Rjected

## Tests
- `cargo test --manifest-path crates/harness-server/Cargo.toml`
- `PYTHONPATH=$PWD/tools/productivity:$PWD uv run --with pytest --with typer --with slack-sdk --with python-dotenv --with rich --with structlog pytest tools/productivity/slack/tests/test_cli.py`