### PR TITLE
fix: isolate slack live workflow queue

### DIFF
--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -57,6 +57,11 @@ pub const ETL_BACKFILL_JOB_AGE_SECONDS: &str = "etl_backfill_job_age_seconds";
 pub const COMPANY_CONTEXT_DOCUMENTS_CHANGED_TOTAL: &str = "company_context_documents_changed_total";
 pub const COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS: &str = "company_context_document_size_chars";
 pub const COMPANY_CONTEXT_PROJECTION_LAG_SECONDS: &str = "company_context_projection_lag_seconds";
+pub const WORKFLOW_QUEUE_TASKS: &str = "workflow_queue_tasks";
+pub const WORKFLOW_QUEUE_TASKS_BY_WORKFLOW: &str = "workflow_queue_tasks_by_workflow";
+pub const WORKFLOW_QUEUE_OLDEST_TASK_AGE_SECONDS: &str = "workflow_queue_oldest_task_age_seconds";
+pub const WORKFLOW_QUEUE_OLDEST_TASK_AGE_BY_WORKFLOW_SECONDS: &str =
+    "workflow_queue_oldest_task_age_by_workflow_seconds";
 
 const HTTP_REQUEST_DURATION_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
@@ -303,6 +308,60 @@ pub fn record_workflow_histogram(name: &str, labels: &[(String, String)], value:
     metrics::histogram!(name.to_owned(), workflow_metric_labels(labels)).record(value);
 }
 
+pub fn set_workflow_queue_tasks(queue: &str, state: &str, value: f64) {
+    metrics::gauge!(
+        WORKFLOW_QUEUE_TASKS,
+        "queue" => queue.to_owned(),
+        "state" => state.to_owned(),
+    )
+    .set(value);
+}
+
+pub fn set_workflow_queue_tasks_by_workflow(
+    queue: &str,
+    state: &str,
+    workflow_name: &str,
+    value: f64,
+) {
+    metrics::gauge!(
+        WORKFLOW_QUEUE_TASKS_BY_WORKFLOW,
+        "queue" => queue.to_owned(),
+        "state" => state.to_owned(),
+        "workflow_name" => workflow_name.to_owned(),
+    )
+    .set(value);
+}
+
+pub fn set_workflow_queue_oldest_task_age_seconds(queue: &str, state: &str, value: f64) {
+    if !value.is_finite() {
+        return;
+    }
+    metrics::gauge!(
+        WORKFLOW_QUEUE_OLDEST_TASK_AGE_SECONDS,
+        "queue" => queue.to_owned(),
+        "state" => state.to_owned(),
+    )
+    .set(value);
+}
+
+pub fn set_workflow_queue_oldest_task_age_by_workflow_seconds(
+    queue: &str,
+    state: &str,
+    workflow_name: &str,
+    value: f64,
+) {
+    if !value.is_finite() {
+        return;
+    }
+    metrics::gauge!(
+        WORKFLOW_QUEUE_OLDEST_TASK_AGE_BY_WORKFLOW_SECONDS,
+        "queue" => queue.to_owned(),
+        "state" => state.to_owned(),
+        "workflow_name" => workflow_name.to_owned(),
+    )
+    .set(value);
+}
+
 pub fn http_status_class(status: u16) -> &'static str {
     match status / 100 {
         1 => "1xx",
@@ -454,6 +513,24 @@ fn describe_metrics() {
         COMPANY_CONTEXT_PROJECTION_LAG_SECONDS,
         metrics::Unit::Seconds,
         "Company context projection lag in seconds."
+    );
+    metrics::describe_gauge!(
+        WORKFLOW_QUEUE_TASKS,
+        "Current non-terminal workflow task count by queue and state."
+    );
+    metrics::describe_gauge!(
+        WORKFLOW_QUEUE_TASKS_BY_WORKFLOW,
+        "Current non-terminal workflow task count by queue, state, and workflow name."
+    );
+    metrics::describe_gauge!(
+        WORKFLOW_QUEUE_OLDEST_TASK_AGE_SECONDS,
+        metrics::Unit::Seconds,
+        "Oldest non-terminal workflow task age in seconds by queue and state."
+    );
+    metrics::describe_gauge!(
+        WORKFLOW_QUEUE_OLDEST_TASK_AGE_BY_WORKFLOW_SECONDS,
+        metrics::Unit::Seconds,
+        "Oldest non-terminal workflow task age in seconds by queue, state, and workflow name."
     );
 }
 
@@ -716,6 +793,20 @@ mod tests {
             ],
             11.0,
         );
+        set_workflow_queue_tasks("centaur_workflows_slack_live", "pending", 1.0);
+        set_workflow_queue_oldest_task_age_seconds("centaur_workflows_slack_live", "pending", 42.0);
+        set_workflow_queue_tasks_by_workflow(
+            "centaur_workflows_slack_live",
+            "pending",
+            "slack_sync",
+            1.0,
+        );
+        set_workflow_queue_oldest_task_age_by_workflow_seconds(
+            "centaur_workflows_slack_live",
+            "pending",
+            "slack_sync",
+            42.0,
+        );
 
         let metrics = render_metrics().unwrap();
 
@@ -723,9 +814,15 @@ mod tests {
         assert!(metrics.contains("etl_active_scopes{"));
         assert!(metrics.contains("company_context_documents_changed_total{"));
         assert!(metrics.contains("etl_backfill_jobs{"));
+        assert!(metrics.contains("workflow_queue_tasks{"));
+        assert!(metrics.contains("workflow_queue_tasks_by_workflow{"));
+        assert!(metrics.contains("workflow_queue_oldest_task_age_seconds{"));
+        assert!(metrics.contains("workflow_queue_oldest_task_age_by_workflow_seconds{"));
         assert!(metrics.contains(r#"environment="production""#));
         assert!(metrics.contains(r#"namespace="centaur-system""#));
         assert!(metrics.contains(r#"source="slack""#));
+        assert!(metrics.contains(r#"queue="centaur_workflows_slack_live""#));
+        assert!(metrics.contains(r#"workflow_name="slack_sync""#));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -35,6 +35,7 @@ use tokio::{
 use tracing::{info, warn};
 
 pub const WORKFLOW_QUEUE: &str = "centaur_workflows";
+pub const WORKFLOW_SLACK_LIVE_QUEUE: &str = "centaur_workflows_slack_live";
 pub const WORKFLOW_ETL_QUEUE: &str = "centaur_workflows_etl";
 pub const WORKFLOW_ETL_BACKFILL_QUEUE: &str = "centaur_workflows_etl_backfill";
 pub const WORKFLOW_SCHEDULE_QUEUE: &str = "centaur_workflow_schedules";
@@ -72,14 +73,24 @@ pub struct WorkflowRuntime {
 
 struct WorkflowRuntimeInner {
     client: Client,
+    slack_live_client: Client,
     etl_client: Client,
     etl_backfill_client: Client,
     _worker: Worker,
+    _slack_live_worker: Worker,
     _etl_worker: Worker,
     _etl_backfill_worker: Worker,
     _schedule_worker: Worker,
     webhook_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowWebhook>>>,
     schedule_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
+}
+
+#[derive(Clone)]
+struct WorkflowQueueClients {
+    standard: Client,
+    slack_live: Client,
+    etl: Client,
+    etl_backfill: Client,
 }
 
 #[derive(Clone)]
@@ -276,6 +287,19 @@ impl WorkflowRuntime {
         client
             .create_queue(Some(WORKFLOW_QUEUE), CreateQueueOptions::default())
             .await?;
+        let slack_live_client = Client::from_pool_with_options(
+            store.pool().clone(),
+            ClientOptions {
+                queue_name: WORKFLOW_SLACK_LIVE_QUEUE.to_owned(),
+                ..ClientOptions::default()
+            },
+        )?;
+        slack_live_client
+            .create_queue(
+                Some(WORKFLOW_SLACK_LIVE_QUEUE),
+                CreateQueueOptions::default(),
+            )
+            .await?;
         let etl_client = Client::from_pool_with_options(
             store.pool().clone(),
             ClientOptions {
@@ -326,6 +350,13 @@ impl WorkflowRuntime {
             let workflow_host_sandbox = task_workflow_host_sandbox.clone();
             async move { run_centaur_workflow(input, ctx, session_runtime, workflow_host_sandbox).await }
         })?;
+        let slack_live_session_runtime = session_runtime.clone();
+        let slack_live_workflow_host_sandbox = workflow_host_sandbox.clone();
+        slack_live_client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
+            let session_runtime = slack_live_session_runtime.clone();
+            let workflow_host_sandbox = slack_live_workflow_host_sandbox.clone();
+            async move { run_centaur_workflow(input, ctx, session_runtime, workflow_host_sandbox).await }
+        })?;
         let etl_session_runtime = session_runtime.clone();
         let etl_workflow_host_sandbox = workflow_host_sandbox.clone();
         etl_client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
@@ -346,29 +377,22 @@ impl WorkflowRuntime {
             },
         )?;
         let schedule_tick_client = schedule_client.clone();
-        let workflow_client_for_schedule = client.clone();
-        let etl_client_for_schedule = etl_client.clone();
-        let etl_backfill_client_for_schedule = etl_backfill_client.clone();
+        let workflow_clients_for_schedule = WorkflowQueueClients {
+            standard: client.clone(),
+            slack_live: slack_live_client.clone(),
+            etl: etl_client.clone(),
+            etl_backfill: etl_backfill_client.clone(),
+        };
         let schedule_registry_for_task = schedule_registry.clone();
         schedule_client.register_task_with(
             TaskRegistrationOptions::new(WORKFLOW_SCHEDULE_TASK),
             move |input: ScheduleTickInput, ctx| {
                 let schedule_client = schedule_tick_client.clone();
-                let workflow_client = workflow_client_for_schedule.clone();
-                let etl_client = etl_client_for_schedule.clone();
-                let etl_backfill_client = etl_backfill_client_for_schedule.clone();
+                let workflow_clients = workflow_clients_for_schedule.clone();
                 let schedules = schedule_registry_for_task.clone();
                 async move {
-                    run_schedule_tick(
-                        input,
-                        ctx,
-                        schedule_client,
-                        workflow_client,
-                        etl_client,
-                        etl_backfill_client,
-                        schedules,
-                    )
-                    .await
+                    run_schedule_tick(input, ctx, schedule_client, workflow_clients, schedules)
+                        .await
                 }
             },
         )?;
@@ -383,6 +407,14 @@ impl WorkflowRuntime {
             concurrency: 4,
             on_error: Some(Arc::new(|error| {
                 warn!(%error, "absurd workflow worker error");
+            })),
+            ..WorkerOptions::default()
+        });
+        let slack_live_worker = slack_live_client.start_worker(WorkerOptions {
+            worker_id: Some("centaur-api-rs-workflow-slack-live-worker".to_owned()),
+            concurrency: 1,
+            on_error: Some(Arc::new(|error| {
+                warn!(%error, "absurd workflow slack live worker error");
             })),
             ..WorkerOptions::default()
         });
@@ -416,6 +448,11 @@ impl WorkflowRuntime {
             "started absurd workflow worker"
         );
         info!(
+            queue = WORKFLOW_SLACK_LIVE_QUEUE,
+            task = WORKFLOW_TASK,
+            "started absurd workflow slack live worker"
+        );
+        info!(
             queue = WORKFLOW_ETL_QUEUE,
             task = WORKFLOW_TASK,
             "started absurd workflow etl worker"
@@ -434,9 +471,12 @@ impl WorkflowRuntime {
         if let Some(interval) = workflow_reconcile_interval() {
             spawn_workflow_metadata_reconciler(
                 schedule_client.clone(),
-                client.clone(),
-                etl_client.clone(),
-                etl_backfill_client.clone(),
+                WorkflowQueueClients {
+                    standard: client.clone(),
+                    slack_live: slack_live_client.clone(),
+                    etl: etl_client.clone(),
+                    etl_backfill: etl_backfill_client.clone(),
+                },
                 webhook_registry.clone(),
                 schedule_registry.clone(),
                 interval,
@@ -446,9 +486,11 @@ impl WorkflowRuntime {
         Ok(Self {
             inner: Arc::new(WorkflowRuntimeInner {
                 client,
+                slack_live_client,
                 etl_client,
                 etl_backfill_client,
                 _worker: worker,
+                _slack_live_worker: slack_live_worker,
                 _etl_worker: etl_worker,
                 _etl_backfill_worker: etl_backfill_worker,
                 _schedule_worker: schedule_worker,
@@ -497,6 +539,10 @@ impl WorkflowRuntime {
         let limit = limit.clamp(1, 200);
         let mut runs = Vec::new();
         runs.extend(self.list_runs_for_queue(WORKFLOW_QUEUE, limit).await?);
+        runs.extend(
+            self.list_runs_for_queue(WORKFLOW_SLACK_LIVE_QUEUE, limit)
+                .await?,
+        );
         runs.extend(self.list_runs_for_queue(WORKFLOW_ETL_QUEUE, limit).await?);
         runs.extend(
             self.list_runs_for_queue(WORKFLOW_ETL_BACKFILL_QUEUE, limit)
@@ -546,6 +592,7 @@ impl WorkflowRuntime {
     pub async fn get_run(&self, run_id: &str) -> Result<WorkflowRun, WorkflowRuntimeError> {
         for queue_name in [
             WORKFLOW_QUEUE,
+            WORKFLOW_SLACK_LIVE_QUEUE,
             WORKFLOW_ETL_QUEUE,
             WORKFLOW_ETL_BACKFILL_QUEUE,
         ] {
@@ -589,6 +636,7 @@ impl WorkflowRuntime {
     pub async fn cancel_run(&self, run_id: &str) -> Result<(), WorkflowRuntimeError> {
         for (queue_name, client) in [
             (WORKFLOW_QUEUE, &self.inner.client),
+            (WORKFLOW_SLACK_LIVE_QUEUE, &self.inner.slack_live_client),
             (WORKFLOW_ETL_QUEUE, &self.inner.etl_client),
             (WORKFLOW_ETL_BACKFILL_QUEUE, &self.inner.etl_backfill_client),
         ] {
@@ -608,6 +656,10 @@ impl WorkflowRuntime {
         self.inner
             .client
             .emit_event(event_name, payload.clone(), Some(WORKFLOW_QUEUE))
+            .await?;
+        self.inner
+            .slack_live_client
+            .emit_event(event_name, payload.clone(), Some(WORKFLOW_SLACK_LIVE_QUEUE))
             .await?;
         self.inner
             .etl_client
@@ -652,6 +704,7 @@ impl WorkflowRuntime {
     fn client_for_workflow(&self, workflow_name: &str) -> &Client {
         match workflow_queue_class(workflow_name) {
             WorkflowQueueClass::Standard => &self.inner.client,
+            WorkflowQueueClass::SlackLive => &self.inner.slack_live_client,
             WorkflowQueueClass::Etl => &self.inner.etl_client,
             WorkflowQueueClass::EtlBackfill => &self.inner.etl_backfill_client,
         }
@@ -661,15 +714,16 @@ impl WorkflowRuntime {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum WorkflowQueueClass {
     Standard,
+    SlackLive,
     Etl,
     EtlBackfill,
 }
 
 fn workflow_queue_class(workflow_name: &str) -> WorkflowQueueClass {
     match workflow_name {
+        "slack_sync" => WorkflowQueueClass::SlackLive,
         "slack_backfill" => WorkflowQueueClass::EtlBackfill,
-        "slack_sync"
-        | "google_calendar_sync"
+        "google_calendar_sync"
         | "google_drive_sync"
         | "linear_sync"
         | "company_context_documents"
@@ -678,11 +732,24 @@ fn workflow_queue_class(workflow_name: &str) -> WorkflowQueueClass {
     }
 }
 
+fn queue_name_for_class(class: WorkflowQueueClass) -> &'static str {
+    match class {
+        WorkflowQueueClass::Standard => WORKFLOW_QUEUE,
+        WorkflowQueueClass::SlackLive => WORKFLOW_SLACK_LIVE_QUEUE,
+        WorkflowQueueClass::Etl => WORKFLOW_ETL_QUEUE,
+        WorkflowQueueClass::EtlBackfill => WORKFLOW_ETL_BACKFILL_QUEUE,
+    }
+}
+
 fn absurd_queue_tables(
     queue_name: &str,
 ) -> Result<(&'static str, &'static str), WorkflowRuntimeError> {
     match queue_name {
         WORKFLOW_QUEUE => Ok(("absurd.t_centaur_workflows", "absurd.r_centaur_workflows")),
+        WORKFLOW_SLACK_LIVE_QUEUE => Ok((
+            "absurd.t_centaur_workflows_slack_live",
+            "absurd.r_centaur_workflows_slack_live",
+        )),
         WORKFLOW_ETL_QUEUE => Ok((
             "absurd.t_centaur_workflows_etl",
             "absurd.r_centaur_workflows_etl",
@@ -1252,9 +1319,7 @@ fn workflow_reconcile_interval() -> Option<Duration> {
 
 fn spawn_workflow_metadata_reconciler(
     schedule_client: Client,
-    workflow_client: Client,
-    etl_client: Client,
-    etl_backfill_client: Client,
+    workflow_clients: WorkflowQueueClients,
     webhook_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowWebhook>>>,
     schedule_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
     interval: Duration,
@@ -1262,6 +1327,7 @@ fn spawn_workflow_metadata_reconciler(
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval);
         let mut reaper = RemovedWorkflowReaper::from_env();
+        let mut queue_metrics = WorkflowQueueMetricsRecorder::default();
         // Startup discovery already ran; wait one full period before refreshing.
         ticker.tick().await;
         loop {
@@ -1274,15 +1340,22 @@ fn spawn_workflow_metadata_reconciler(
             .await
             {
                 Ok((metadata, schedules)) => {
+                    if let Err(error) = record_workflow_queue_metrics(
+                        &mut queue_metrics,
+                        [
+                            (WORKFLOW_QUEUE, &workflow_clients.standard),
+                            (WORKFLOW_SLACK_LIVE_QUEUE, &workflow_clients.slack_live),
+                            (WORKFLOW_ETL_QUEUE, &workflow_clients.etl),
+                            (WORKFLOW_ETL_BACKFILL_QUEUE, &workflow_clients.etl_backfill),
+                        ],
+                        &metadata.workflow_names,
+                    )
+                    .await
+                    {
+                        warn!(%error, "failed to record workflow queue metrics");
+                    }
                     if let Err(error) = reaper
-                        .reap(
-                            &workflow_client,
-                            &etl_client,
-                            &etl_backfill_client,
-                            &schedule_client,
-                            &metadata,
-                            &schedules,
-                        )
+                        .reap(&workflow_clients, &schedule_client, &metadata, &schedules)
                         .await
                     {
                         warn!(%error, "failed to reap removed workflow tasks");
@@ -1340,6 +1413,158 @@ struct RemovedWorkflowReaper {
     schedule_miss_counts: BTreeMap<String, u32>,
 }
 
+#[derive(Default)]
+struct WorkflowQueueMetricsRecorder {
+    seen_queue_states: BTreeSet<(String, String)>,
+    seen_workflow_states: BTreeSet<(String, String, String)>,
+}
+
+struct WorkflowQueueMetricRow {
+    queue_name: String,
+    workflow_name: String,
+    state: String,
+    task_count: i64,
+    oldest_age_seconds: f64,
+}
+
+const WORKFLOW_QUEUE_METRIC_STATES: &[&str] = &["pending", "running", "sleeping"];
+
+async fn record_workflow_queue_metrics(
+    recorder: &mut WorkflowQueueMetricsRecorder,
+    queues: [(&str, &Client); 4],
+    workflow_names: &BTreeSet<String>,
+) -> Result<(), WorkflowRuntimeError> {
+    let mut rows = Vec::new();
+    for (queue_name, client) in queues {
+        for state in WORKFLOW_QUEUE_METRIC_STATES {
+            recorder
+                .seen_queue_states
+                .insert((queue_name.to_owned(), (*state).to_owned()));
+        }
+        rows.extend(fetch_workflow_queue_metric_rows(client, queue_name).await?);
+    }
+
+    for workflow_name in workflow_names {
+        let queue_name = queue_name_for_class(workflow_queue_class(workflow_name));
+        for state in WORKFLOW_QUEUE_METRIC_STATES {
+            recorder.seen_workflow_states.insert((
+                queue_name.to_owned(),
+                (*state).to_owned(),
+                workflow_name.clone(),
+            ));
+        }
+    }
+
+    for row in &rows {
+        recorder
+            .seen_queue_states
+            .insert((row.queue_name.clone(), row.state.clone()));
+        recorder.seen_workflow_states.insert((
+            row.queue_name.clone(),
+            row.state.clone(),
+            row.workflow_name.clone(),
+        ));
+    }
+
+    for (queue_name, state) in &recorder.seen_queue_states {
+        centaur_telemetry::set_workflow_queue_tasks(queue_name, state, 0.0);
+        centaur_telemetry::set_workflow_queue_oldest_task_age_seconds(queue_name, state, 0.0);
+    }
+    for (queue_name, state, workflow_name) in &recorder.seen_workflow_states {
+        centaur_telemetry::set_workflow_queue_tasks_by_workflow(
+            queue_name,
+            state,
+            workflow_name,
+            0.0,
+        );
+        centaur_telemetry::set_workflow_queue_oldest_task_age_by_workflow_seconds(
+            queue_name,
+            state,
+            workflow_name,
+            0.0,
+        );
+    }
+
+    let mut queue_totals: BTreeMap<(String, String), (i64, f64)> = BTreeMap::new();
+    for row in rows {
+        let total = queue_totals
+            .entry((row.queue_name.clone(), row.state.clone()))
+            .or_insert((0, 0.0));
+        total.0 += row.task_count;
+        total.1 = total.1.max(row.oldest_age_seconds);
+
+        centaur_telemetry::set_workflow_queue_tasks_by_workflow(
+            &row.queue_name,
+            &row.state,
+            &row.workflow_name,
+            row.task_count as f64,
+        );
+        centaur_telemetry::set_workflow_queue_oldest_task_age_by_workflow_seconds(
+            &row.queue_name,
+            &row.state,
+            &row.workflow_name,
+            row.oldest_age_seconds,
+        );
+    }
+
+    for ((queue_name, state), (task_count, oldest_age_seconds)) in queue_totals {
+        centaur_telemetry::set_workflow_queue_tasks(&queue_name, &state, task_count as f64);
+        centaur_telemetry::set_workflow_queue_oldest_task_age_seconds(
+            &queue_name,
+            &state,
+            oldest_age_seconds,
+        );
+    }
+
+    Ok(())
+}
+
+async fn fetch_workflow_queue_metric_rows(
+    client: &Client,
+    queue_name: &str,
+) -> Result<Vec<WorkflowQueueMetricRow>, WorkflowRuntimeError> {
+    let (task_table, _) = absurd_queue_tables(queue_name)?;
+    let rows = sqlx::query(&format!(
+        r#"
+        select
+            coalesce(nullif(t.params->>'workflow_name', ''), 'unknown') as workflow_name,
+            t.state,
+            count(*)::bigint as task_count,
+            coalesce(
+                extract(
+                    epoch from now() - min(
+                        case
+                            when t.state = 'running'
+                                then coalesce(t.first_started_at, t.enqueue_at)
+                            else t.enqueue_at
+                        end
+                    )
+                ),
+                0
+            )::float8 as oldest_age_seconds
+        from {task_table} t
+        where t.task_name = $1
+          and t.state not in {ABSURD_TERMINAL_TASK_STATES}
+        group by 1, 2
+        "#,
+    ))
+    .bind(WORKFLOW_TASK)
+    .fetch_all(client.pool())
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(WorkflowQueueMetricRow {
+                queue_name: queue_name.to_owned(),
+                workflow_name: row.try_get("workflow_name")?,
+                state: row.try_get("state")?,
+                task_count: row.try_get("task_count")?,
+                oldest_age_seconds: row.try_get("oldest_age_seconds")?,
+            })
+        })
+        .collect()
+}
+
 impl RemovedWorkflowReaper {
     fn from_env() -> Self {
         let threshold = env::var(WORKFLOW_REAP_REMOVED_AFTER_TICKS_ENV)
@@ -1355,9 +1580,7 @@ impl RemovedWorkflowReaper {
 
     async fn reap(
         &mut self,
-        workflow_client: &Client,
-        etl_client: &Client,
-        etl_backfill_client: &Client,
+        workflow_clients: &WorkflowQueueClients,
         schedule_client: &Client,
         metadata: &PythonWorkflowMetadata,
         schedules: &BTreeMap<String, RegisteredWorkflowSchedule>,
@@ -1374,9 +1597,10 @@ impl RemovedWorkflowReaper {
 
         let mut active_runs = Vec::new();
         for (queue_name, client) in [
-            (WORKFLOW_QUEUE, workflow_client),
-            (WORKFLOW_ETL_QUEUE, etl_client),
-            (WORKFLOW_ETL_BACKFILL_QUEUE, etl_backfill_client),
+            (WORKFLOW_QUEUE, &workflow_clients.standard),
+            (WORKFLOW_SLACK_LIVE_QUEUE, &workflow_clients.slack_live),
+            (WORKFLOW_ETL_QUEUE, &workflow_clients.etl),
+            (WORKFLOW_ETL_BACKFILL_QUEUE, &workflow_clients.etl_backfill),
         ] {
             for (task_id, name) in
                 fetch_active_named_tasks(client, queue_name, WORKFLOW_TASK, "workflow_name").await?
@@ -1399,9 +1623,10 @@ impl RemovedWorkflowReaper {
                 continue;
             };
             let client = match queue_name {
-                WORKFLOW_ETL_QUEUE => etl_client,
-                WORKFLOW_ETL_BACKFILL_QUEUE => etl_backfill_client,
-                _ => workflow_client,
+                WORKFLOW_SLACK_LIVE_QUEUE => &workflow_clients.slack_live,
+                WORKFLOW_ETL_QUEUE => &workflow_clients.etl,
+                WORKFLOW_ETL_BACKFILL_QUEUE => &workflow_clients.etl_backfill,
+                _ => &workflow_clients.standard,
             };
             if let Err(error) = client.cancel_task(task_id, Some(queue_name)).await {
                 warn!(%error, queue_name, task_id, "failed to cancel run of removed workflow");
@@ -1518,9 +1743,7 @@ async fn run_schedule_tick(
     input: ScheduleTickInput,
     ctx: TaskContext,
     schedule_client: Client,
-    workflow_client: Client,
-    etl_client: Client,
-    etl_backfill_client: Client,
+    workflow_clients: WorkflowQueueClients,
     schedules: Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
 ) -> Result<Value, absurd::Error> {
     ctx.sleep_until("schedule_tick", input.scheduled_at).await?;
@@ -1562,9 +1785,10 @@ async fn run_schedule_tick(
         input.scheduled_at.to_rfc3339()
     );
     let target_client = match workflow_queue_class(&schedule.workflow_name) {
-        WorkflowQueueClass::Standard => &workflow_client,
-        WorkflowQueueClass::Etl => &etl_client,
-        WorkflowQueueClass::EtlBackfill => &etl_backfill_client,
+        WorkflowQueueClass::Standard => &workflow_clients.standard,
+        WorkflowQueueClass::SlackLive => &workflow_clients.slack_live,
+        WorkflowQueueClass::Etl => &workflow_clients.etl,
+        WorkflowQueueClass::EtlBackfill => &workflow_clients.etl_backfill,
     };
     let workflow_spawn = target_client
         .spawn(
@@ -3039,8 +3263,11 @@ mod tests {
 
     #[test]
     fn scheduled_etls_use_isolated_etl_queues() {
+        assert_eq!(
+            workflow_queue_class("slack_sync"),
+            WorkflowQueueClass::SlackLive
+        );
         for workflow_name in [
-            "slack_sync",
             "google_calendar_sync",
             "google_drive_sync",
             "linear_sync",


### PR DESCRIPTION
## Summary
- route slack_sync onto its own Absurd workflow queue and worker
- keep Slack live concurrency at 1 while separating it from bulk ETL workflows
- emit workflow queue depth and oldest-task-age gauges by queue/state/workflow

## Tests
- cargo test -p centaur-telemetry
- cargo test -p centaur-workflows