### PR TITLE
feat: add workflow allowlist policy

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.63
+version: 0.1.64
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -161,6 +161,14 @@ spec:
             - name: KUBERNETES_WORKFLOW_DIRS
               value: {{ $sandboxWorkflowDirs | quote }}
 {{- end }}
+{{- if not (hasKey .Values.apiRs.extraEnv "WORKFLOW_ENABLE_MODE") }}
+            - name: WORKFLOW_ENABLE_MODE
+              value: {{ .Values.apiRs.workflowEnableMode | quote }}
+{{- end }}
+{{- if not (hasKey .Values.apiRs.extraEnv "WORKFLOW_ALLOWED_NAMES") }}
+            - name: WORKFLOW_ALLOWED_NAMES
+              value: {{ .Values.apiRs.workflowAllowedNames | quote }}
+{{- end }}
 {{- if .Values.overlay.systemPrompt }}
             - name: CENTAUR_OVERLAY_DIR
               value: {{ .Values.overlay.mountPath | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -280,6 +280,11 @@ apiRs:
   sandboxReadyTimeoutSecs: 90
   sandboxWarmPoolSize: 3
   sandboxWarmPoolReplenishIntervalSecs: 5
+  # Workflow enablement policy. Production defaults to all workflows enabled.
+  # Set workflowEnableMode: allowlist in staging and list allowed workflow names
+  # in workflowAllowedNames as a comma/whitespace-separated string.
+  workflowEnableMode: all
+  workflowAllowedNames: ""
   # Reaper: stop sandboxes idle-paused longer than the idle TTL or older than
   # the max lifetime. 0 disables that sweep. Interval must be >= 1.
   sandboxIdleStopTtlSecs: 10800 # 3 hours

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -59,6 +59,7 @@ impl IntoResponse for ApiError {
                 ..
             })) => StatusCode::CONFLICT,
             Self::Workflow(WorkflowRuntimeError::BadRequest(_)) => StatusCode::BAD_REQUEST,
+            Self::Workflow(WorkflowRuntimeError::Disabled(_)) => StatusCode::FORBIDDEN,
             Self::Workflow(WorkflowRuntimeError::NotFound(_)) => StatusCode::NOT_FOUND,
             Self::Workflow(WorkflowRuntimeError::Upstream(_)) => StatusCode::BAD_GATEWAY,
             Self::Internal(_) | Self::Runtime(_) | Self::Workflow(_) | Self::Serialize(_) => {

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -49,6 +49,8 @@ const WORKFLOW_HOST_CLAIM_EXTENSION: Duration = Duration::from_secs(5 * 60);
 const WORKFLOW_HOST_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 const WORKFLOW_RECONCILE_INTERVAL_SECS_ENV: &str = "WORKFLOW_RECONCILE_INTERVAL_SECS";
 const DEFAULT_WORKFLOW_RECONCILE_INTERVAL_SECS: u64 = 60;
+const WORKFLOW_ENABLE_MODE_ENV: &str = "WORKFLOW_ENABLE_MODE";
+const WORKFLOW_ALLOWED_NAMES_ENV: &str = "WORKFLOW_ALLOWED_NAMES";
 /// How many consecutive reconcile passes a workflow must be missing from
 /// discovery before its active tasks are cancelled. 0 disables reaping.
 const WORKFLOW_REAP_REMOVED_AFTER_TICKS_ENV: &str = "WORKFLOW_REAP_REMOVED_AFTER_TICKS";
@@ -80,6 +82,93 @@ struct WorkflowRuntimeInner {
     _schedule_worker: Worker,
     webhook_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowWebhook>>>,
     schedule_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WorkflowEnablement {
+    mode: WorkflowEnableMode,
+    allowed_names: BTreeSet<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkflowEnableMode {
+    All,
+    Allowlist,
+}
+
+impl WorkflowEnablement {
+    fn all() -> Self {
+        Self {
+            mode: WorkflowEnableMode::All,
+            allowed_names: BTreeSet::new(),
+        }
+    }
+
+    fn allowlist(raw_allowed_names: &str) -> Self {
+        Self {
+            mode: WorkflowEnableMode::Allowlist,
+            allowed_names: parse_workflow_allowed_names(raw_allowed_names),
+        }
+    }
+
+    fn from_env() -> Result<Self, WorkflowRuntimeError> {
+        let raw_mode = env::var(WORKFLOW_ENABLE_MODE_ENV).unwrap_or_default();
+        let mode = raw_mode.trim();
+        if mode.is_empty() || mode.eq_ignore_ascii_case("all") {
+            return Ok(Self::all());
+        }
+        if mode.eq_ignore_ascii_case("allowlist") {
+            return Ok(Self::allowlist(
+                &env::var(WORKFLOW_ALLOWED_NAMES_ENV).unwrap_or_default(),
+            ));
+        }
+        Err(WorkflowRuntimeError::BadRequest(format!(
+            "{WORKFLOW_ENABLE_MODE_ENV} must be \"all\" or \"allowlist\", got {mode:?}"
+        )))
+    }
+
+    fn is_enabled(&self, workflow_name: &str) -> bool {
+        match self.mode {
+            WorkflowEnableMode::All => true,
+            WorkflowEnableMode::Allowlist => self.allowed_names.contains(workflow_name.trim()),
+        }
+    }
+
+    fn ensure_enabled(&self, workflow_name: &str) -> Result<(), WorkflowRuntimeError> {
+        if self.is_enabled(workflow_name) {
+            return Ok(());
+        }
+        Err(WorkflowRuntimeError::Disabled(format!(
+            "workflow {workflow_name:?} is disabled by {WORKFLOW_ENABLE_MODE_ENV}"
+        )))
+    }
+
+    fn filter_metadata(&self, metadata: &mut PythonWorkflowMetadata) {
+        if self.mode == WorkflowEnableMode::All {
+            return;
+        }
+        metadata
+            .workflow_names
+            .retain(|workflow_name| self.is_enabled(workflow_name));
+        metadata
+            .webhooks
+            .retain(|webhook| self.is_enabled(&webhook.workflow_name));
+        metadata.schedules.retain(|schedule| {
+            schedule
+                .get("workflow_name")
+                .and_then(Value::as_str)
+                .is_some_and(|workflow_name| self.is_enabled(workflow_name))
+        });
+    }
+}
+
+fn parse_workflow_allowed_names(raw: &str) -> BTreeSet<String> {
+    raw.split(|ch: char| ch == ',' || ch.is_whitespace())
+        .filter_map(|name| {
+            let name = name.trim();
+            (!name.is_empty()).then(|| name.to_owned())
+        })
+        .collect()
 }
 
 #[derive(Clone)]
@@ -316,8 +405,15 @@ impl WorkflowRuntime {
                 warn!(%error, "python workflow discovery failed");
                 PythonWorkflowMetadata::default()
             });
-        let schedule_registry = Arc::new(RwLock::new(build_schedule_registry(&discovery)?));
-        let webhook_registry = Arc::new(RwLock::new(build_webhook_registry(&discovery)?));
+        let enablement = WorkflowEnablement::from_env()?;
+        let schedule_registry = Arc::new(RwLock::new(build_schedule_registry(
+            &discovery,
+            &enablement,
+        )?));
+        let webhook_registry = Arc::new(RwLock::new(build_webhook_registry(
+            &discovery,
+            &enablement,
+        )?));
 
         let task_session_runtime = session_runtime.clone();
         let task_workflow_host_sandbox = workflow_host_sandbox.clone();
@@ -468,6 +564,7 @@ impl WorkflowRuntime {
                 "workflow_name must not be empty".to_owned(),
             ));
         }
+        WorkflowEnablement::from_env()?.ensure_enabled(workflow_name)?;
         let client = self.client_for_workflow(workflow_name);
         let spawn = client
             .spawn(
@@ -703,12 +800,19 @@ fn absurd_queue_tables(
 
 fn build_webhook_registry(
     discovery: &PythonWorkflowMetadata,
+    enablement: &WorkflowEnablement,
 ) -> Result<BTreeMap<String, RegisteredWorkflowWebhook>, WorkflowRuntimeError> {
     let mut registry = BTreeMap::new();
     for webhook in discovery.webhooks.clone() {
+        if !enablement.is_enabled(&webhook.workflow_name) {
+            continue;
+        }
         insert_webhook(&mut registry, webhook)?;
     }
     for webhook in default_workflow_webhooks() {
+        if !enablement.is_enabled(&webhook.workflow_name) {
+            continue;
+        }
         insert_webhook_if_absent(&mut registry, webhook)?;
     }
     if let Ok(raw) = env::var("WORKFLOW_WEBHOOKS_JSON") {
@@ -716,6 +820,9 @@ fn build_webhook_registry(
         if !trimmed.is_empty() {
             let webhooks: Vec<RegisteredWorkflowWebhook> = serde_json::from_str(trimmed)?;
             for webhook in webhooks {
+                if !enablement.is_enabled(&webhook.workflow_name) {
+                    continue;
+                }
                 insert_webhook_replace(&mut registry, webhook)?;
             }
         }
@@ -725,10 +832,14 @@ fn build_webhook_registry(
 
 fn build_schedule_registry(
     discovery: &PythonWorkflowMetadata,
+    enablement: &WorkflowEnablement,
 ) -> Result<BTreeMap<String, RegisteredWorkflowSchedule>, WorkflowRuntimeError> {
     let mut registry = BTreeMap::new();
     for schedule in &discovery.schedules {
         let schedule = normalize_schedule(schedule.clone())?;
+        if !enablement.is_enabled(&schedule.workflow_name) {
+            continue;
+        }
         if registry
             .insert(schedule.schedule_id.clone(), schedule.clone())
             .is_some()
@@ -1195,7 +1306,9 @@ async fn discover_python_workflow_metadata() -> Result<PythonWorkflowMetadata, W
             Some("workflow.discovery") => {
                 let _ = child.wait().await;
                 let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(message)?;
-                return Ok(metadata_from_discovery_payload(payload));
+                let mut metadata = metadata_from_discovery_payload(payload);
+                WorkflowEnablement::from_env()?.filter_metadata(&mut metadata);
+                return Ok(metadata);
             }
             Some("host.error") | Some("workflow.error") => {
                 let stderr = stderr_task.await.unwrap_or_default();
@@ -1305,9 +1418,10 @@ async fn reconcile_workflow_metadata_once(
     ),
     WorkflowRuntimeError,
 > {
+    let enablement = WorkflowEnablement::from_env()?;
     let discovery = discover_python_workflow_metadata().await?;
-    let next_webhooks = build_webhook_registry(&discovery)?;
-    let next_schedules = build_schedule_registry(&discovery)?;
+    let next_webhooks = build_webhook_registry(&discovery, &enablement)?;
+    let next_schedules = build_schedule_registry(&discovery, &enablement)?;
     {
         let mut webhooks = webhook_registry
             .write()
@@ -1765,6 +1879,9 @@ async fn run_centaur_workflow(
 ) -> absurd::Result<WorkflowResult> {
     let _heartbeat_guard = start_workflow_task_heartbeat(ctx.clone())
         .await
+        .map_err(absurd_error)?;
+    WorkflowEnablement::from_env()
+        .and_then(|enablement| enablement.ensure_enabled(&input.workflow_name))
         .map_err(absurd_error)?;
     match input.workflow_name.as_str() {
         "echo" => {
@@ -2924,6 +3041,10 @@ pub enum WorkflowRuntimeError {
     /// Maps to HTTP 400.
     #[error("{0}")]
     BadRequest(String),
+    /// The workflow exists but is disabled by environment policy. Maps to
+    /// HTTP 403.
+    #[error("{0}")]
+    Disabled(String),
     #[error("workflow run not found: {0}")]
     NotFound(String),
     /// Server-side failure (workflow host spawn/protocol, internal dispatch).
@@ -3169,6 +3290,85 @@ mod tests {
             metadata.schedules[0].get("workflow_name"),
             Some(&json!("scheduled_workflow"))
         );
+    }
+
+    #[test]
+    fn workflow_allowlist_parses_comma_and_whitespace_names() {
+        let enablement = WorkflowEnablement::allowlist("agent_turn, slack_sync\ncompany_context");
+        assert!(enablement.is_enabled("agent_turn"));
+        assert!(enablement.is_enabled("slack_sync"));
+        assert!(enablement.is_enabled("company_context"));
+        assert!(!enablement.is_enabled("google_drive_sync"));
+    }
+
+    #[test]
+    fn workflow_allowlist_filters_discovered_metadata() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [
+                {
+                    "workflow_name": "allowed_workflow",
+                    "source_path": "workflows/allowed_workflow.py",
+                    "schedule": {"schedule_id": "allowed", "cron": "*/5 * * * *"},
+                    "webhooks": [{
+                        "workflow_name": "allowed_workflow",
+                        "source_path": "workflows/allowed_workflow.py",
+                        "spec": {
+                            "slug": "allowed",
+                            "auth": {"type": "none"}
+                        }
+                    }]
+                },
+                {
+                    "workflow_name": "blocked_workflow",
+                    "source_path": "workflows/blocked_workflow.py",
+                    "schedule": {"schedule_id": "blocked", "cron": "*/10 * * * *"},
+                    "webhooks": [{
+                        "workflow_name": "blocked_workflow",
+                        "source_path": "workflows/blocked_workflow.py",
+                        "spec": {
+                            "slug": "blocked",
+                            "auth": {"type": "none"}
+                        }
+                    }]
+                },
+            ],
+        }))
+        .unwrap();
+        let mut metadata = metadata_from_discovery_payload(payload);
+        WorkflowEnablement::allowlist("allowed_workflow").filter_metadata(&mut metadata);
+
+        assert_eq!(
+            metadata.workflow_names,
+            BTreeSet::from(["allowed_workflow".to_owned()])
+        );
+        assert_eq!(metadata.schedules.len(), 1);
+        assert_eq!(
+            metadata.schedules[0].get("schedule_id"),
+            Some(&json!("allowed"))
+        );
+        assert_eq!(metadata.webhooks.len(), 1);
+        assert_eq!(metadata.webhooks[0].workflow_name, "allowed_workflow");
+    }
+
+    #[test]
+    fn workflow_allowlist_filters_default_webhooks() {
+        let metadata = PythonWorkflowMetadata::default();
+        let registry = build_webhook_registry(
+            &metadata,
+            &WorkflowEnablement::allowlist("github_issue_triage"),
+        )
+        .unwrap();
+        assert!(registry.contains_key("github-issue-triage"));
+        assert!(!registry.contains_key("github-consensus-ci-triage"));
+        assert!(!registry.contains_key("trivy-vulnerability-intake"));
+    }
+
+    #[test]
+    fn disabled_workflow_returns_policy_error() {
+        let error = WorkflowEnablement::allowlist("agent_turn")
+            .ensure_enabled("slack_sync")
+            .unwrap_err();
+        assert!(matches!(error, WorkflowRuntimeError::Disabled(_)));
     }
 
     #[test]

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -691,6 +691,24 @@ def workflow_dirs() -> list[Path]:
     return dirs
 
 
+def workflow_allowed_names() -> set[str]:
+    raw = os.getenv("WORKFLOW_ALLOWED_NAMES", "")
+    return {
+        name
+        for name in (part.strip() for part in raw.replace(",", " ").split())
+        if name
+    }
+
+
+def workflow_enabled(workflow_name: str) -> bool:
+    mode = os.getenv("WORKFLOW_ENABLE_MODE", "").strip().lower()
+    if not mode or mode == "all":
+        return True
+    if mode == "allowlist":
+        return workflow_name.strip() in workflow_allowed_names()
+    raise RuntimeError(f'WORKFLOW_ENABLE_MODE must be "all" or "allowlist", got {mode!r}')
+
+
 def configure_workflow_import_paths(dirs: list[Path]) -> None:
     for directory in dirs:
         candidate_paths = [directory.parent, directory]
@@ -761,6 +779,8 @@ def discover_workflows() -> dict[str, RegisteredWorkflow]:
                 print(f"workflow_load_error path={path} error={exc}", file=sys.stderr)
                 continue
             if registered is None:
+                continue
+            if not workflow_enabled(registered.workflow_name):
                 continue
             if registered.workflow_name in discovered:
                 raise RuntimeError(f"duplicate workflow name {registered.workflow_name!r}")


### PR DESCRIPTION
## Summary

Adds an environment-driven workflow enablement policy so production can keep all workflows enabled while staging can run only an explicit allowlist.

- Adds `WORKFLOW_ENABLE_MODE=all|allowlist` and `WORKFLOW_ALLOWED_NAMES` handling in the Rust workflow runtime.
- Blocks disabled direct workflow runs with a 403 and fails closed at task execution time.
- Filters Python workflow discovery so disabled workflows do not register schedules or webhooks.
- Adds Helm values under `apiRs.workflowEnableMode` and `apiRs.workflowAllowedNames`.

## Validation

- `cargo test -p centaur-workflows --lib`
- `cargo check -p centaur-api-server`
- `python3 -m py_compile services/workflow-python/workflow_host.py`
- `/Users/akshaan/Desktop/centaur/services/api/.venv/bin/ruff check services/workflow-python/workflow_host.py`
- `helm dependency build contrib/chart && helm template centaur contrib/chart`
- `helm template centaur contrib/chart --set apiRs.workflowEnableMode=allowlist --set-string apiRs.workflowAllowedNames='agent_turn\,slack_sync'`
- `just build-one api-rs` completed; deploy/smoke was skipped at user request.