### PR TITLE
fix: harden iron control secret registration

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -13,7 +13,8 @@ use std::os::unix::fs::PermissionsExt;
 
 use centaur_api_server::SandboxRuntime;
 use centaur_iron_control::{
-    IdentityInput, IronControlClient, RoleSpec, SessionRegistrar, register_role,
+    IdentityInput, IronControlClient, IronControlError, RegisterError, RoleSpec, SessionRegistrar,
+    register_role,
 };
 use centaur_iron_proxy::{
     ProxyFragment, SourceKind, SourcePolicy, harness_auth_fragment, infra_fragment,
@@ -610,7 +611,9 @@ impl SandboxArgs {
         let roles = self.iron_proxy.roles_to_register(tool_fragment.as_ref())?;
         let mut role_ids = Vec::with_capacity(roles.len());
         for (spec, fragment) in &roles {
-            role_ids.push(register_role(&client, &namespace, spec, fragment, &policy).await?);
+            role_ids.push(
+                register_role_with_retry(&client, &namespace, spec, fragment, &policy).await?,
+            );
         }
         let bootstrap = client
             .upsert_principal(&IdentityInput {
@@ -1156,6 +1159,52 @@ impl SandboxArgs {
             interval: Duration::from_secs(self.sandbox_reap_interval_secs),
             idle_ttl: ttl(self.sandbox_idle_stop_ttl_secs),
             max_lifetime: ttl(self.sandbox_max_lifetime_secs),
+        }
+    }
+}
+
+const IRON_CONTROL_REGISTER_MAX_ATTEMPTS: u32 = 5;
+const IRON_CONTROL_REGISTER_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
+
+async fn register_role_with_retry(
+    client: &IronControlClient,
+    namespace: &str,
+    spec: &RoleSpec,
+    fragment: &ProxyFragment,
+    policy: &SourcePolicy,
+) -> Result<String, RegisterError> {
+    let mut backoff = IRON_CONTROL_REGISTER_INITIAL_BACKOFF;
+    for attempt in 1..=IRON_CONTROL_REGISTER_MAX_ATTEMPTS {
+        match register_role(client, namespace, spec, fragment, policy).await {
+            Ok(role_id) => return Ok(role_id),
+            Err(error)
+                if attempt < IRON_CONTROL_REGISTER_MAX_ATTEMPTS
+                    && should_retry_iron_control_register(&error) =>
+            {
+                warn!(
+                    %error,
+                    role = %spec.foreign_id,
+                    attempt,
+                    max_attempts = IRON_CONTROL_REGISTER_MAX_ATTEMPTS,
+                    backoff_ms = backoff.as_millis(),
+                    "iron-control role registration failed; retrying"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff *= 2;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("iron-control registration retry loop always returns");
+}
+
+fn should_retry_iron_control_register(error: &RegisterError) -> bool {
+    match error {
+        RegisterError::Translate(_) => false,
+        RegisterError::Control(IronControlError::Transport { .. }) => true,
+        RegisterError::Control(IronControlError::Decode { .. }) => false,
+        RegisterError::Control(IronControlError::Status { status, .. }) => {
+            *status == 429 || (500..600).contains(status)
         }
     }
 }
@@ -1836,6 +1885,28 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn iron_control_registration_retry_policy_is_transient_only() {
+        let status_error = |status| {
+            RegisterError::Control(IronControlError::Status {
+                method: "PUT".to_owned(),
+                path: "/api/v1/static_secrets/example".to_owned(),
+                status,
+                body: String::new(),
+            })
+        };
+
+        assert!(should_retry_iron_control_register(&status_error(500)));
+        assert!(should_retry_iron_control_register(&status_error(503)));
+        assert!(should_retry_iron_control_register(&status_error(429)));
+        assert!(!should_retry_iron_control_register(&status_error(400)));
+        assert!(!should_retry_iron_control_register(
+            &RegisterError::Translate(centaur_iron_control::TranslateError::Unsupported {
+                what: "unsupported transform".to_owned(),
+            })
+        ));
     }
 
     #[test]

--- a/services/console/app/controllers/api/v1/static_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/static_secrets_controller.rb
@@ -68,7 +68,10 @@ module Api
           ref.assign_attributes(ss_attrs)
           ref.save!
 
-          replace_source!(ref, source_attrs)
+          ref.source&.destroy!
+          if source_attrs
+            SecretSource.create!(source_attrs.to_h.merge(static_secret: ref))
+          end
 
           ref.rules.destroy_all
           rules_attrs.each_with_index do |r, i|
@@ -76,23 +79,6 @@ module Api
           end
 
           ref.reload
-        end
-      end
-
-      def replace_source!(ref, source_attrs)
-        source = SecretSource.lock.where(static_secret: ref).first
-        unless source_attrs
-          source&.destroy!
-          return
-        end
-
-        attrs = source_attrs.to_h
-        if source && source.source_type == attrs["source_type"]
-          source.assign_attributes(attrs.except("source_type"))
-          source.save!
-        else
-          source&.destroy!
-          SecretSource.create!(attrs.merge(static_secret: ref))
         end
       end
 

--- a/services/console/app/controllers/api/v1/static_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/static_secrets_controller.rb
@@ -64,13 +64,11 @@ module Api
         end
 
         StaticSecret.transaction do
+          ref.lock! unless ref.new_record?
           ref.assign_attributes(ss_attrs)
           ref.save!
 
-          ref.source&.destroy!
-          if source_attrs
-            SecretSource.create!(source_attrs.to_h.merge(static_secret: ref))
-          end
+          replace_source!(ref, source_attrs)
 
           ref.rules.destroy_all
           rules_attrs.each_with_index do |r, i|
@@ -78,6 +76,23 @@ module Api
           end
 
           ref.reload
+        end
+      end
+
+      def replace_source!(ref, source_attrs)
+        source = SecretSource.lock.where(static_secret: ref).first
+        unless source_attrs
+          source&.destroy!
+          return
+        end
+
+        attrs = source_attrs.to_h
+        if source && source.source_type == attrs["source_type"]
+          source.assign_attributes(attrs.except("source_type"))
+          source.save!
+        else
+          source&.destroy!
+          SecretSource.create!(attrs.merge(static_secret: ref))
         end
       end
 

--- a/services/console/app/controllers/api/v1/static_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/static_secrets_controller.rb
@@ -27,9 +27,7 @@ module Api
       # PUT/PATCH upserts: an opaque id updates that record, any other identifier
       # is a foreign_id that is created when absent.
       def update
-        ref = resolve_for_upsert(StaticSecret)
-        was_new = ref.new_record?
-        assign_and_save!(ref, data_params)
+        ref, was_new = assign_upsert_with_retry
         render status: (was_new ? :created : :ok), json: { data: record_payload(ref) }
       rescue ActiveRecord::RecordInvalid => e
         render_validation_error(e.record)
@@ -46,6 +44,22 @@ module Api
       end
 
       private
+
+      def assign_upsert_with_retry
+        attempts = 0
+
+        begin
+          attempts += 1
+          ref = resolve_for_upsert(StaticSecret)
+          was_new = ref.new_record?
+          assign_and_save!(ref, data_params)
+          [ ref, was_new ]
+        rescue ActiveRecord::RecordNotUnique
+          raise if attempts >= 2
+
+          retry
+        end
+      end
 
       def assign_and_save!(ref, attrs)
         ss_attrs = permit_document(

--- a/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
@@ -201,6 +201,49 @@ module Api
         assert_equal "upserted", data["name"]
       end
 
+      test "PUT retries when a concurrent create wins the foreign_id race" do
+        body = {
+          data: {
+            namespace: "acme",
+            name: "retry-upserted",
+            inject_config: { "header" => "Authorization" },
+            source: { source_type: "env", config: { "var" => "UP" } }
+          }
+        }
+        calls = 0
+        original = Api::V1::StaticSecretsController.instance_method(:assign_and_save!)
+
+        Api::V1::StaticSecretsController.define_method(:assign_and_save!) do |ref, attrs|
+          calls += 1
+          if calls == 1
+            StaticSecret.create!(
+              namespace: "acme",
+              foreign_id: "raced-ref",
+              name: "winner",
+              inject_config: { "header" => "X-Old" }
+            )
+            raise ActiveRecord::RecordNotUnique, "duplicate key value violates unique constraint"
+          end
+
+          original.bind_call(self, ref, attrs)
+        end
+        Api::V1::StaticSecretsController.send(:private, :assign_and_save!)
+
+        assert_difference -> { StaticSecret.count } => 1 do
+          put api_v1_static_secret_url(id: "raced-ref"), params: body.to_json, headers: auth_headers
+        end
+        assert_response :ok
+
+        ref = StaticSecret.find_by!(namespace: "acme", foreign_id: "raced-ref")
+        assert_equal "retry-upserted", ref.name
+        assert_equal({ "header" => "Authorization" }, ref.inject_config)
+        assert_equal "UP", ref.source.config["var"]
+        assert_equal 2, calls
+      ensure
+        Api::V1::StaticSecretsController.define_method(:assign_and_save!, original)
+        Api::V1::StaticSecretsController.send(:private, :assign_and_save!)
+      end
+
       test "PUT by foreign_id updates an existing secret without creating" do
         ref = static_secrets(:acme_prod_api_key)
         body = {

--- a/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
@@ -227,7 +227,8 @@ module Api
 
       test "PUT updates SSR fields and replaces source and rules" do
         ref = static_secrets(:github_token_inject)
-        old_source = SecretSource.create!(source_type: "env", config: { "var" => "OLD" }, static_secret: ref)
+        old_source = SecretSource.create!(source_type: "env", config: { "var" => "OLD" },
+                                          static_secret: ref)
         old_rule = RequestRule.create!(host: "old.example.com", http_methods: [ "GET" ],
                                        paths: [ "/" ], position: 0, static_secret: ref)
 
@@ -249,36 +250,31 @@ module Api
         assert_equal "updated", ref.description
         assert_equal({ "header" => "X-New" }, ref.inject_config)
         assert_equal "NEW", ref.source.config["var"]
-        assert_equal old_source.id, ref.source.id
+        refute_equal old_source.id, ref.source.id
         assert_equal [ "new.example.com" ], ref.rules.map(&:host)
+        assert_nil SecretSource.find_by(id: old_source.id), "old source should be deleted"
         assert_nil RequestRule.find_by(id: old_rule.id), "old rule should be deleted"
       end
 
-      test "PUT recreates the source only when the source type changes" do
+      test "PUT does not retain omitted source fields" do
         ref = static_secrets(:github_token_inject)
-        old_source = SecretSource.create!(source_type: "env", config: { "var" => "OLD" },
-                                          static_secret: ref)
+        SecretSource.create!(source_type: "control_plane", secret: "OLD",
+                             static_secret: ref)
 
         body = {
           data: {
             namespace: ref.namespace,
             name: ref.name,
             inject_config: { "header" => "Authorization" },
-            source: {
-              source_type: "1password_connect",
-              config: { "secret_ref" => "op://vault/item/field" }
-            }
+            source: { source_type: "control_plane" }
           }
         }
 
         put api_v1_static_secret_url(id: ref.oid), params: body.to_json, headers: auth_headers
-        assert_response :ok
+        assert_response :unprocessable_content
 
         ref.reload
-        assert_equal "1password_connect", ref.source.source_type
-        assert_equal({ "secret_ref" => "op://vault/item/field" }, ref.source.config)
-        refute_equal old_source.id, ref.source.id
-        assert_nil SecretSource.find_by(id: old_source.id), "old source should be deleted"
+        assert_equal "OLD", ref.source.secret
       end
 
       test "PUT switches a secret from replace_config to inject_config" do

--- a/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
@@ -227,7 +227,7 @@ module Api
 
       test "PUT updates SSR fields and replaces source and rules" do
         ref = static_secrets(:github_token_inject)
-        SecretSource.create!(source_type: "env", config: { "var" => "OLD" }, static_secret: ref)
+        old_source = SecretSource.create!(source_type: "env", config: { "var" => "OLD" }, static_secret: ref)
         old_rule = RequestRule.create!(host: "old.example.com", http_methods: [ "GET" ],
                                        paths: [ "/" ], position: 0, static_secret: ref)
 
@@ -249,8 +249,36 @@ module Api
         assert_equal "updated", ref.description
         assert_equal({ "header" => "X-New" }, ref.inject_config)
         assert_equal "NEW", ref.source.config["var"]
+        assert_equal old_source.id, ref.source.id
         assert_equal [ "new.example.com" ], ref.rules.map(&:host)
         assert_nil RequestRule.find_by(id: old_rule.id), "old rule should be deleted"
+      end
+
+      test "PUT recreates the source only when the source type changes" do
+        ref = static_secrets(:github_token_inject)
+        old_source = SecretSource.create!(source_type: "env", config: { "var" => "OLD" },
+                                          static_secret: ref)
+
+        body = {
+          data: {
+            namespace: ref.namespace,
+            name: ref.name,
+            inject_config: { "header" => "Authorization" },
+            source: {
+              source_type: "1password_connect",
+              config: { "secret_ref" => "op://vault/item/field" }
+            }
+          }
+        }
+
+        put api_v1_static_secret_url(id: ref.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        ref.reload
+        assert_equal "1password_connect", ref.source.source_type
+        assert_equal({ "secret_ref" => "op://vault/item/field" }, ref.source.config)
+        refute_equal old_source.id, ref.source.id
+        assert_nil SecretSource.find_by(id: old_source.id), "old source should be deleted"
       end
 
       test "PUT switches a secret from replace_config to inject_config" do


### PR DESCRIPTION
## Summary
- make static secret source replacement concurrency-safe in centaur-console
- update existing static secret sources in place when the source type is unchanged
- retry transient Iron Control registration failures during api-rs startup

## Root Cause
During api-rs startup, multiple Iron Control static secret registrations can overlap. The console API previously replaced a static secret source by destroying the existing `SecretSource` row and then creating a new one. Under concurrent upserts, this can trip the one-source-per-static-secret unique index and return a Rails 500, which api-rs treated as fatal during startup.

## Validation
- `cargo test --manifest-path services/api-rs/Cargo.toml -p centaur-api-server`
- `cargo clippy --manifest-path services/api-rs/Cargo.toml -p centaur-api-server --all-targets -- -D warnings`
- Dockerized Rails test with Ruby 3.4.8 + throwaway Postgres: `bin/rails test test/controllers/api/v1/static_secrets_controller_test.rb`
