### PR TITLE
fix(slackbotv2): stop garbled final answers; reconcile diverged live renders

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -644,6 +644,45 @@ describe('CodexAppServerRendererEventMapper', () => {
     expect(taskChunk?.output).not.toContain('\u0000')
   })
 
+  it('suppresses the live delta instead of interleaving when the recomposed answer diverges from streamed text', () => {
+    // Two concurrent final-answer items compose as A + B. Growing A (a
+    // non-trailing component) after B was already streamed shifts B's bytes, so
+    // a byte-offset slice would re-read and re-emit B, duplicating it
+    // ("Hello world." -> "Hello world.world."). The guard refuses the
+    // non-continuation and freezes at the clean prefix instead, and records the
+    // divergence once for the metric.
+    const logs: string[] = []
+    const mapper = new CodexAppServerRendererEventMapper({
+      logInfo: event => logs.push(event)
+    })
+
+    const deltas: string[] = []
+    const run = (event: unknown) => {
+      for (const out of mapper.process(event)) {
+        if (out.type === 'renderer.message.delta') deltas.push(out.delta)
+      }
+    }
+
+    // A task makes the plan visible so answer deltas stream immediately.
+    run({ type: 'item.started', item: { id: 'cmd-1', type: 'commandExecution', command: 'true' } })
+    run({ type: 'item.started', item: { id: 'A', type: 'agentMessage', phase: 'final_answer' } })
+    run({ type: 'item.started', item: { id: 'B', type: 'agentMessage', phase: 'final_answer' } })
+    run({ type: 'item.agentMessage.delta', itemId: 'A', delta: 'Hello ' })
+    run({ type: 'item.agentMessage.delta', itemId: 'B', delta: 'world.' })
+    // A grows after B was already streamed: a byte-offset slice would duplicate
+    // "world." here. The guard suppresses the non-continuation instead.
+    run({ type: 'item.agentMessage.delta', itemId: 'A', delta: 'there ' })
+
+    const streamed = deltas.join('')
+    expect(streamed).toBe('Hello world.')
+    expect(streamed).not.toContain('world.world.')
+    expect(logs).toContain('codex_renderer_stream_divergence_suppressed')
+    // The signal is recorded once per render, not on every subsequent event.
+    expect(logs.filter(event => event === 'codex_renderer_stream_divergence_suppressed')).toHaveLength(
+      1
+    )
+  })
+
   it('marks open tasks as errors on Rust session failures and emits done', () => {
     const mapper = new CodexAppServerRendererEventMapper()
     mapper.process({

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -55,6 +55,7 @@ type CodexMapperState = {
   firstBufferedTextAt: number | null
   streamedCommentaryText: string
   streamedAnswerText: string
+  answerStreamDiverged: boolean
   agentMessagePhase: AgentMessagePhase | null
   agentMessagePhaseByItemId: Map<string, AgentMessagePhase>
   planText: string
@@ -454,6 +455,31 @@ export class CodexAppServerRendererEventMapper
     if (!canStream) return
 
     if (this.state.commentaryText.length > this.state.streamedCommentaryText.length) return
+    // Text already streamed to the consumer is immutable: Slack streaming, the
+    // chat adapter, and this delta stream all only ever append. answerText is
+    // recomposed on every event from compose(answerByItemId, harnessAnswerText),
+    // so when a non-trailing item grows, or an item.completed/assistant event
+    // rewrites an already-streamed region, the recomposed answerText stops being
+    // an extension of what we have already sent. Slicing by byte offset would
+    // then append misaligned bytes and interleave the answer with fragments of
+    // its own earlier text. Stream only a genuine continuation; the divergent
+    // text is left to the terminal reconcile rather than corrupting the live
+    // message. When the invariant holds (the common case) this is identical to a
+    // plain suffix slice.
+    if (!this.state.answerText.startsWith(this.state.streamedAnswerText)) {
+      if (!this.state.answerStreamDiverged) {
+        this.state.answerStreamDiverged = true
+        this.log('codex_renderer_stream_divergence_suppressed', {
+          agent_session_id: this.sessionId,
+          codex_session_id: this.state.threadId || undefined,
+          streamed_chars: this.state.streamedAnswerText.length,
+          answer_chars: this.state.answerText.length,
+          streamed_hash: textHash(this.state.streamedAnswerText),
+          answer_hash: textHash(this.state.answerText)
+        })
+      }
+      return
+    }
     if (this.state.answerText.length <= this.state.streamedAnswerText.length) return
     const delta = this.state.answerText.slice(this.state.streamedAnswerText.length)
     if (!delta) return
@@ -736,6 +762,7 @@ function newState(): CodexMapperState {
     firstBufferedTextAt: null,
     streamedCommentaryText: '',
     streamedAnswerText: '',
+    answerStreamDiverged: false,
     agentMessagePhase: null,
     agentMessagePhaseByItemId: new Map(),
     planText: '',

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -3,7 +3,6 @@ import { randomUUID } from 'node:crypto'
 import { Hono, type Context } from 'hono'
 import {
   Chat,
-  StreamingPlan,
   type Adapter,
   type Attachment,
   type Logger,
@@ -808,7 +807,7 @@ async function renderExecutionAttempt(
   let retry = false
   let fallbackLastEventId = 0
   try {
-    await renderExecutionStream(
+    const streamResult = await renderExecutionStream(
       thread,
       streamSessionAfterHandoff(options, input),
       message,
@@ -818,7 +817,34 @@ async function renderExecutionAttempt(
     )
     rendered = true
     outcome = 'complete'
-    traceLog(options, 'slackbotv2_render_complete', trace)
+    let divergenceReconciled = false
+    if (streamResult.diverged && streamResult.messageId) {
+      // The live answer stream diverged from the recomposed answer, so the delta
+      // stream was frozen at the last clean prefix to avoid interleaving. Swap
+      // the (possibly truncated) streamed message for the durable, de-duplicated
+      // final answer so the user sees the complete response instead of a message
+      // that looks cut off. Reuses the final-answer fallback, which derives the
+      // answer from the terminal result rather than the doubled live buffer.
+      const reconciled = await renderFallbackFinalAnswer(
+        thread,
+        options,
+        {
+          afterEventId: input.afterEventId,
+          executionId: input.executionId,
+          threadId: input.threadId
+        },
+        trace,
+        { replaceMessageId: streamResult.messageId }
+      )
+      if (reconciled) {
+        divergenceReconciled = true
+        fallbackLastEventId = reconciled.lastEventId
+      }
+    }
+    traceLog(options, 'slackbotv2_render_complete', trace, {
+      answer_diverged: streamResult.diverged,
+      divergence_reconciled: divergenceReconciled
+    })
     return 'complete'
   } catch (error) {
     // Check the Slack adapter's delivery annotation before retryability:
@@ -1340,7 +1366,7 @@ async function recoverRenderObligation(
       activeExecution: true,
       lastEventId
     })
-    await renderRecoveredExecutionStream(
+    const streamResult = await renderRecoveredExecutionStream(
       thread,
       streamOpenedSession(input, openedStream),
       obligation.message,
@@ -1349,7 +1375,31 @@ async function recoverRenderObligation(
     )
     rendered = true
     renderOutcome = 'complete'
-    traceLog(options, 'slackbotv2_render_recovery_complete', trace)
+    let divergenceReconciled = false
+    if (streamResult.diverged && streamResult.messageId) {
+      // Same divergence reconcile as the live path: the answer stream was
+      // frozen at the last clean prefix, so swap the streamed message for the
+      // durable, de-duplicated final answer instead of leaving it truncated.
+      const reconciled = await renderFallbackFinalAnswer(
+        thread,
+        options,
+        {
+          afterEventId: obligation.afterEventId,
+          executionId: obligation.executionId,
+          threadId
+        },
+        trace,
+        { replaceMessageId: streamResult.messageId }
+      )
+      if (reconciled) {
+        divergenceReconciled = true
+        lastEventId = Math.max(lastEventId, reconciled.lastEventId)
+      }
+    }
+    traceLog(options, 'slackbotv2_render_recovery_complete', trace, {
+      answer_diverged: streamResult.diverged,
+      divergence_reconciled: divergenceReconciled
+    })
   } catch (error) {
     const answerLost = slackAnswerLost(error)
     if (answerLost === false) {
@@ -1547,7 +1597,7 @@ async function renderExecutionStream(
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace,
   assistantStatusVisible = false
-): Promise<void> {
+): Promise<{ diverged: boolean; messageId?: string }> {
   if (isPlainTextOnlyRequest(message.text)) {
     await renderPlainTextExecutionStream(
       thread,
@@ -1557,7 +1607,7 @@ async function renderExecutionStream(
       trace,
       assistantStatusVisible
     )
-    return
+    return { diverged: false }
   }
   const titleStartedAtMs = nowMs()
   await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
@@ -1568,24 +1618,30 @@ async function renderExecutionStream(
     assistant_status_already_visible: assistantStatusVisible,
     phase_ms: elapsedMs(titleStartedAtMs)
   })
+  const capture = { diverged: false }
   try {
     const visibleStream = await streamAfterFirstChunk(
       conflateChatSdkStream(
         slackSafeChatSdkStream(
           codexAppServerToChatSdkStream(
             stream,
-            rendererOptions(thread, options)
+            rendererOptions(thread, options, capture)
           )
         )
       )
     )
-    if (!visibleStream) return
-    await thread.post(
-      new StreamingPlan(
-        visibleStream,
-        { groupTasks: options.streamTaskDisplayMode ?? 'plan' }
-      )
-    )
+    if (!visibleStream) return { diverged: false }
+    // Stream via the adapter (as renderRecoveredExecutionStream does) so the
+    // posted message id is available for divergence reconciliation. For Slack
+    // this matches thread.post(StreamingPlan): updateIntervalMs is a no-op
+    // (Slack streams server-side) and the recipient context is the message
+    // author.
+    const sent = await thread.adapter.stream!(thread.id, visibleStream, {
+      recipientTeamId: message.teamId,
+      recipientUserId: message.author.userId,
+      taskDisplayMode: options.streamTaskDisplayMode ?? 'plan'
+    })
+    return { diverged: capture.diverged, messageId: sent?.id }
   } finally {
     await setAssistantStatus(thread, '', options, trace)
   }
@@ -1597,10 +1653,10 @@ async function renderRecoveredExecutionStream(
   message: SlackbotV2ApiMessage,
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace
-): Promise<void> {
+): Promise<{ diverged: boolean; messageId?: string }> {
   if (isPlainTextOnlyRequest(message.text)) {
     await renderPlainTextExecutionStream(thread, stream, message, options, trace)
-    return
+    return { diverged: false }
   }
   const titleStartedAtMs = nowMs()
   await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
@@ -1608,19 +1664,20 @@ async function renderRecoveredExecutionStream(
   traceLog(options, 'slackbotv2_render_slack_metadata_set', trace, {
     phase_ms: elapsedMs(titleStartedAtMs)
   })
+  const capture = { diverged: false }
   try {
     const visibleStream = await streamAfterFirstChunk(
       conflateChatSdkStream(
         slackSafeChatSdkStream(
           codexAppServerToChatSdkStream(
             stream,
-            rendererOptions(thread, options)
+            rendererOptions(thread, options, capture)
           )
         )
       )
     )
-    if (!visibleStream) return
-    await thread.adapter.stream!(
+    if (!visibleStream) return { diverged: false }
+    const sent = await thread.adapter.stream!(
       thread.id,
       visibleStream,
       {
@@ -1629,6 +1686,7 @@ async function renderRecoveredExecutionStream(
         taskDisplayMode: options.streamTaskDisplayMode ?? 'plan'
       }
     )
+    return { diverged: capture.diverged, messageId: sent?.id }
   } finally {
     await setAssistantStatus(thread, '', options, trace)
   }
@@ -2096,10 +2154,33 @@ function normalizeSlackText(input: string): string {
     .trim()
 }
 
-function rendererOptions(thread: Thread, options: SlackbotV2Options): CodexAppServerToChatStreamOptions {
+// Surfaces the renderer's structured diagnostics (otherwise a no-op: nothing
+// wires logInfo), turns the answer-divergence guard into a Prometheus signal so
+// the real rate is measurable, and flips the per-render `capture.diverged` flag
+// so the caller can reconcile the message with the durable final answer.
+function rendererLogInfo(
+  options: SlackbotV2Options,
+  capture?: { diverged: boolean }
+): (event: string, fields: Record<string, unknown>) => void {
+  return (event, fields) => {
+    options.mapper?.logInfo?.(event, fields)
+    options.logger?.info(event, fields)
+    if (event === 'codex_renderer_stream_divergence_suppressed') {
+      slackbotMetrics.renderAnswerDivergence.inc()
+      if (capture) capture.diverged = true
+    }
+  }
+}
+
+function rendererOptions(
+  thread: Thread,
+  options: SlackbotV2Options,
+  capture?: { diverged: boolean }
+): CodexAppServerToChatStreamOptions {
   const mapper = options.mapper
   return {
     ...mapper,
+    logInfo: rendererLogInfo(options, capture),
     async onRendererEvent(event: RendererEvent) {
       await mapper?.onRendererEvent?.(event)
       if (event.type === 'renderer.title.update') {
@@ -2118,6 +2199,7 @@ function fallbackRendererOptions(options: SlackbotV2Options): CodexAppServerToCh
   const mapper = options.mapper
   return {
     ...mapper,
+    logInfo: rendererLogInfo(options),
     async onRendererEvent(event: RendererEvent) {
       try {
         await mapper?.onRendererEvent?.(event)

--- a/services/slackbotv2/src/metrics.ts
+++ b/services/slackbotv2/src/metrics.ts
@@ -258,6 +258,10 @@ export const slackbotMetrics = {
     labelNames: ['source'],
     name: 'slackbotv2_last_successful_render_timestamp_seconds'
   }),
+  renderAnswerDivergence: counter({
+    help: 'Live renders where the recomposed answer diverged from already-streamed text, so a delta was suppressed to avoid interleaving the message (once per render).',
+    name: 'slackbotv2_render_answer_divergence_total'
+  }),
   renderAttempts: counter({
     help: 'Slack render attempts by source and outcome.',
     labelNames: ['source', 'outcome'],

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1313,6 +1313,85 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('swaps the streamed message for the durable final answer when the live answer diverges', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ state: sharedState })
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before a diverging render.')
+    const mentionText = `<@${BOT_USER_ID}> answer with a late correction`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-divergence-swap',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: mentionText
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    const draft = 'Draft answer from the live deltas.'
+    const finalAnswer = 'Final reconciled answer from the result.'
+    // Stream a plan + the draft answer (so the answer delta reaches Slack), then
+    // seal the answer item with a DIFFERENT canonical text. The recomposed
+    // answer no longer extends the already-streamed text, so the renderer
+    // freezes the live stream instead of interleaving, and the render swaps the
+    // message for the durable result.
+    codexApi.emitOutputLines(
+      key,
+      sampleCodexNotifications(draft).map(notification => JSON.stringify(notification))
+    )
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        method: 'item/completed',
+        params: {
+          threadId: 'thread-1',
+          turnId: 'turn-1',
+          item: {
+            type: 'agentMessage',
+            id: 'answer-1',
+            text: finalAnswer,
+            phase: 'final_answer',
+            memoryCitation: null
+          }
+        }
+      })
+    )
+    codexApi.emitSessionEvent(key, 'session.execution_completed', {
+      execution_id: 'exe-divergence-swap',
+      status: 'completed',
+      result_text: finalAnswer
+    })
+
+    await Promise.all(waits)
+    await waitFor(async () => {
+      const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+      return threadState?.renderObligation === null
+    }, 3000)
+
+    const texts = await threadTexts(parent.ts)
+    // The streamed message was replaced in place with the durable final answer...
+    expect(texts.filter(text => text.includes(finalAnswer))).toHaveLength(1)
+    // ...and the diverging live draft is gone (neither interleaved nor left behind).
+    expect(texts.some(text => text.includes('Draft answer from the live deltas'))).toBe(false)
+  })
+
   it('reposts the durable final answer when the Slack stream expires mid-render', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()


### PR DESCRIPTION
## What was observed

- Final Slack answer sometimes rendered **scrambled** — words from earlier in the message spliced mid-word into later words: `not`+`Yep`, `centaur-na/`+`it`+`argocd`, `sand`+`d`+`boxes`.
- The garble persisted in the **final** message (never self-corrected).
- Rare; triggered when an answer is delivered via two sources (the "mixed live + result" path).
- Cause: live deltas are computed by byte offset — `answerText.slice(streamedAnswerText.length)` — but `answerText` is recomposed each event from `compose(answerByItemId, harnessAnswerText)`, so it is **not** append-only. When a non-trailing item grows (or `item.completed`/`assistant` rewrites an already-streamed region), the offset misaligns and interleaves the answer with its own earlier fragments. Slack/adapter/renderer are append-only, so it is never retracted.

## How it is being fixed

- **Renderer guard:** only emit a delta when `answerText` still starts with the already-streamed text; otherwise freeze (never emit a non-continuation). Happy path is byte-identical to before.
- **Swap, don't truncate:** on divergence, replace the streamed message with the durable, de-duplicated final answer via `renderFallbackFinalAnswer` (derived from the terminal result, not the doubled live buffer). Applied to both live (`renderExecutionAttempt`) and recovery (`recoverRenderObligation`) paths.
- **Message id:** live path now streams via `thread.adapter.stream!()` (like recovery) to get the streamed message id; equivalent for Slack (`updateIntervalMs` is a no-op there).
- **Observability:** wired the previously-dead `logInfo` and added counter `slackbotv2_render_answer_divergence_total` to measure the real divergence rate.

## Tests

- Renderer unit test: guard suppresses interleaving from concurrent sources and logs once.
- slackbotv2 e2e: diverging render swaps to the clean final answer. Full suite 84/0, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
