### PR TITLE
feat: track Slack ETL rate limits

### DIFF
--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -304,6 +304,7 @@ def install_vm_metrics_compat_module(api_mod: types.ModuleType) -> None:
     vm_metrics.record_etl_items_failed = record_etl_items_failed
     vm_metrics.record_etl_items_seen = record_etl_items_seen
     vm_metrics.record_etl_items_upserted = record_etl_items_upserted
+    vm_metrics.record_slack_etl_rate_limit = record_slack_etl_rate_limit
     vm_metrics.set_etl_active_scopes = set_etl_active_scopes
     vm_metrics.set_etl_backfill_job_age_seconds = set_etl_backfill_job_age_seconds
     vm_metrics.set_etl_backfill_jobs = set_etl_backfill_jobs
@@ -386,6 +387,26 @@ def record_etl_items_failed(
         source_type=source_type,
         item_type=item_type,
         reason=reason,
+    )
+
+
+def record_slack_etl_rate_limit(
+    workflow: str,
+    method: str,
+    outcome: str,
+    retry_after_seconds: int | float,
+) -> None:
+    retry_after = max(float(retry_after_seconds), 0.0)
+    labels = {
+        "workflow": workflow,
+        "method": method,
+        "outcome": outcome,
+    }
+    increment_metric("slack_etl_rate_limits_total", 1, **labels)
+    increment_metric(
+        "slack_etl_rate_limit_retry_after_seconds_total",
+        retry_after,
+        **labels,
     )
 
 

--- a/workflows/slack/backfill.py
+++ b/workflows/slack/backfill.py
@@ -214,7 +214,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         }
     await _emit_backfill_job_metrics(ctx._pool)
 
-    client = shared_client()
+    client = shared_client(workflow_name=WORKFLOW_NAME)
     access_mode = client._etl_access_mode()
     run_id = workflow_run_id_to_sync_run_id(ctx.run_id)
     requested = [

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -17,6 +17,7 @@ from urllib import request as urllib_request
 from centaur_sdk import secret
 from api.runtime_control import canonical_json
 from api.vm_metrics import (
+    record_slack_etl_rate_limit,
     set_etl_active_scopes,
     set_etl_failed_scopes,
     set_etl_scope_sync_freshness_seconds,
@@ -699,16 +700,39 @@ class SlackEtlClient:
         }
     )
 
-    def __init__(self, etl_token: str | None = None) -> None:
+    def __init__(
+        self,
+        etl_token: str | None = None,
+        *,
+        workflow_name: str = "slack_unknown",
+    ) -> None:
         from slack_sdk import WebClient
 
         token = (etl_token or secret("SLACK_ETL_TOKEN", default="")).strip()
         if not token:
             raise RuntimeError("SLACK_ETL_TOKEN not set for Slack ETL workflow")
         self.token = token
+        self._workflow_name = workflow_name
         self._client = WebClient(token=token, timeout=self._api_timeout_seconds())
         self._user_cache: dict[str, str] = {}
         self._ratelimit_deadlines: dict[str, float] = {}
+
+    def _record_rate_limit(
+        self,
+        *,
+        method: str,
+        outcome: str,
+        retry_after_seconds: float,
+    ) -> None:
+        try:
+            record_slack_etl_rate_limit(
+                getattr(self, "_workflow_name", "slack_unknown"),
+                method,
+                outcome,
+                retry_after_seconds,
+            )
+        except Exception:
+            pass
 
     @classmethod
     def _api_timeout_seconds(cls) -> int:
@@ -791,10 +815,20 @@ class SlackEtlClient:
             remaining = blocked_until - time.time()
             if remaining > 0:
                 if remaining > max_sleep:
+                    self._record_rate_limit(
+                        method=key,
+                        outcome="failed_fast",
+                        retry_after_seconds=round(remaining, 3),
+                    )
                     raise SlackEtlRateLimitError(
                         slack_method=key,
                         retry_after=round(remaining, 3),
                     )
+                self._record_rate_limit(
+                    method=key,
+                    outcome="slept_retry",
+                    retry_after_seconds=remaining,
+                )
                 time.sleep(remaining)
 
             try:
@@ -809,8 +843,18 @@ class SlackEtlClient:
                     )
                     self._ratelimit_deadlines[key] = time.time() + retry_after
                     if attempt < max_retries - 1 and retry_after <= max_sleep:
+                        self._record_rate_limit(
+                            method=key,
+                            outcome="slept_retry",
+                            retry_after_seconds=retry_after,
+                        )
                         time.sleep(retry_after)
                         continue
+                    self._record_rate_limit(
+                        method=key,
+                        outcome="failed_fast",
+                        retry_after_seconds=retry_after,
+                    )
                     raise SlackEtlRateLimitError(
                         slack_method=key,
                         retry_after=retry_after,
@@ -1382,9 +1426,9 @@ class SlackEtlClient:
         return sorted(users[:limit], key=lambda x: x["name"])
 
 
-def client() -> SlackSyncClient:
+def client(*, workflow_name: str = "slack_unknown") -> SlackSyncClient:
     """Construct the workflow-owned Slack ETL client."""
-    return SlackEtlClient()
+    return SlackEtlClient(workflow_name=workflow_name)
 
 
 async def enqueue_backfill_job(

--- a/workflows/slack/sync.py
+++ b/workflows/slack/sync.py
@@ -255,7 +255,7 @@ async def _load_checkpoint(pool, channel_id: str) -> dict[str, Any] | None:
 
 def _client():
     """Compatibility wrapper for tests patching the old helper."""
-    return shared_client()
+    return shared_client(workflow_name=WORKFLOW_NAME)
 
 
 async def _upsert_messages(pool, rows: list[dict[str, Any]]) -> int:

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -23,6 +23,7 @@ def _load_shared():
 
     vm_metrics = types.ModuleType("api.vm_metrics")
     for name in (
+        "record_slack_etl_rate_limit",
         "set_etl_active_scopes",
         "set_etl_failed_scopes",
         "set_etl_scope_sync_freshness_seconds",
@@ -48,6 +49,7 @@ def _load_backfill():
         "record_etl_items_failed",
         "record_etl_items_seen",
         "record_etl_items_upserted",
+        "record_slack_etl_rate_limit",
         "set_etl_active_scopes",
         "set_etl_backfill_job_age_seconds",
         "set_etl_backfill_jobs",
@@ -71,6 +73,93 @@ def _load_backfill():
 
 
 shared = _load_shared()
+
+
+class _FakeSlackResponse(dict):
+    def __init__(
+        self,
+        *,
+        error: str = "ratelimited",
+        headers: dict[str, str] | None = None,
+        status_code: int = 429,
+    ) -> None:
+        super().__init__({"error": error})
+        self.headers = headers or {}
+        self.status_code = status_code
+
+
+class _FakeSlackError(Exception):
+    def __init__(self, response: _FakeSlackResponse) -> None:
+        super().__init__("rate limited")
+        self.response = response
+
+
+def test_retry_on_ratelimit_records_slept_retry_by_workflow(monkeypatch):
+    client = object.__new__(shared.SlackEtlClient)
+    client._workflow_name = "slack_backfill"
+    client._ratelimit_deadlines = {}
+    calls = {"api": 0, "sleep": [], "metrics": []}
+    clock = {"now": 1000.0}
+
+    def fake_api_call():
+        calls["api"] += 1
+        if calls["api"] == 1:
+            raise _FakeSlackError(_FakeSlackResponse(headers={"Retry-After": "2"}))
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        shared,
+        "record_slack_etl_rate_limit",
+        lambda *args: calls["metrics"].append(args),
+    )
+
+    def fake_sleep(seconds):
+        calls["sleep"].append(seconds)
+        clock["now"] += seconds
+
+    monkeypatch.setattr(shared.time, "sleep", fake_sleep)
+    monkeypatch.setattr(shared.time, "time", lambda: clock["now"])
+
+    result = client._retry_on_ratelimit(
+        fake_api_call,
+        method_key="etl.conversations.history",
+    )
+
+    assert result == {"ok": True}
+    assert calls["sleep"] == [2.25]
+    assert calls["metrics"] == [
+        ("slack_backfill", "etl.conversations.history", "slept_retry", 2.25)
+    ]
+
+
+def test_retry_on_ratelimit_records_failed_fast_by_workflow(monkeypatch):
+    client = object.__new__(shared.SlackEtlClient)
+    client._workflow_name = "slack_sync"
+    client._ratelimit_deadlines = {}
+    calls = []
+
+    def fake_api_call():
+        raise _FakeSlackError(_FakeSlackResponse(headers={"Retry-After": "45"}))
+
+    monkeypatch.setattr(
+        shared,
+        "record_slack_etl_rate_limit",
+        lambda *args: calls.append(args),
+    )
+
+    try:
+        client._retry_on_ratelimit(
+            fake_api_call,
+            method_key="etl.conversations.replies",
+        )
+    except shared.SlackEtlRateLimitError as exc:
+        assert exc.payload["retry_after_seconds"] == 45.25
+    else:
+        raise AssertionError("expected SlackEtlRateLimitError")
+
+    assert calls == [
+        ("slack_sync", "etl.conversations.replies", "failed_fast", 45.25)
+    ]
 
 
 def test_serialize_message_downloads_slack_file_bytes(monkeypatch):
@@ -342,7 +431,7 @@ def test_backfill_handler_terminally_skips_permanent_slack_errors(monkeypatch):
     monkeypatch.setattr(backfill, "_emit_backfill_job_metrics", fake_noop)
     monkeypatch.setattr(backfill, "emit_slack_checkpoint_metrics", fake_noop)
     monkeypatch.setattr(backfill, "claim_backfill_jobs", fake_claim_jobs)
-    monkeypatch.setattr(backfill, "shared_client", lambda: FakeClient())
+    monkeypatch.setattr(backfill, "shared_client", lambda **_kwargs: FakeClient())
     monkeypatch.setattr(backfill, "record_run_start", fake_noop)
     monkeypatch.setattr(backfill, "record_run_finish", fake_record_finish)
     monkeypatch.setattr(

--- a/workflows/slack/tests/test_sync_cold_start.py
+++ b/workflows/slack/tests/test_sync_cold_start.py
@@ -26,6 +26,10 @@ def _load_sync():
         "record_etl_items_failed",
         "record_etl_items_seen",
         "record_etl_items_upserted",
+        "record_slack_etl_rate_limit",
+        "set_etl_active_scopes",
+        "set_etl_failed_scopes",
+        "set_etl_scope_sync_freshness_seconds",
     ):
         setattr(vm_metrics, name, lambda *_args, **_kwargs: None)
     api_module.vm_metrics = vm_metrics
@@ -135,6 +139,7 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
     monkeypatch.setattr(sync, "_update_checkpoint_success", fake_update_checkpoint_success)
     monkeypatch.setattr(sync, "_update_checkpoint_failure", _noop)
     monkeypatch.setattr(sync, "enqueue_backfill_job", fake_enqueue_backfill_job)
+    monkeypatch.setattr(sync, "emit_slack_checkpoint_metrics", _noop)
     monkeypatch.setattr(sync, "record_run_start", _noop)
     monkeypatch.setattr(sync, "record_run_finish", fake_record_run_finish)
     monkeypatch.setattr(
@@ -198,4 +203,3 @@ def test_watermarked_channel_keeps_incremental_overlap(monkeypatch):
             "priority": 150,
         }
     ]
-


### PR DESCRIPTION
## Summary
- add Slack ETL rate-limit metrics from the shared Slack ETL client
- label rate-limit pressure by workflow (`slack_sync` vs `slack_backfill`), Slack API method, and outcome
- emit both event count and total Retry-After seconds so dashboards can see pressure before hard failures

## Metrics
- `slack_etl_rate_limits_total{workflow,method,outcome}`
- `slack_etl_rate_limit_retry_after_seconds_total{workflow,method,outcome}`

`outcome="slept_retry"` tracks recoverable 429s that sleep and retry. `outcome="failed_fast"` tracks long or exhausted Retry-After paths that surface as workflow failures.

## Validation
- `uv run --with pytest pytest workflows/slack/tests/test_shared_attachments.py workflows/slack/tests/test_sync_cold_start.py`
- `uv run --with ruff ruff check services/workflow-python/workflow_host.py workflows/slack/shared.py workflows/slack/sync.py workflows/slack/backfill.py workflows/slack/tests/test_shared_attachments.py workflows/slack/tests/test_sync_cold_start.py`
