### PR TITLE
fix(api-rs): split startup health from readiness

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.65
+version: 0.1.66
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -350,7 +350,7 @@ spec:
             timeoutSeconds: {{ .Values.apiRs.startupProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: {{ .Values.apiRs.port }}
             failureThreshold: {{ .Values.apiRs.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.apiRs.readinessProbe.periodSeconds }}

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -38,6 +38,14 @@ async fn main() -> Result<()> {
     let line = line!() + 1;
     record_result(
         &mut results,
+        "API readiness endpoint responds",
+        line,
+        wait_for_ready(&http, &base_url).await,
+    );
+
+    let line = line!() + 1;
+    record_result(
+        &mut results,
         "Harness wire values match the API contract",
         line,
         test_harness_wire_values(&http, &base_url).await,
@@ -175,6 +183,38 @@ async fn wait_for_health(http: &HttpClient, base_url: &str) -> Result<()> {
     }
 
     bail!("api did not become healthy at {url}: {last_error}")
+}
+
+async fn wait_for_ready(http: &HttpClient, base_url: &str) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let url = format!("{base_url}/readyz");
+    let mut last_error = String::new();
+
+    while Instant::now() < deadline {
+        match http.get(&url).send().await {
+            Ok(response) if response.status() == StatusCode::OK => {
+                let body = response
+                    .json::<Value>()
+                    .await
+                    .context("parse /readyz body")?;
+                if body.get("ok").and_then(Value::as_bool) == Some(true)
+                    && body.get("ready").and_then(Value::as_bool) == Some(true)
+                {
+                    return Ok(());
+                }
+                last_error = format!("unexpected /readyz body: {body}");
+            }
+            Ok(response) => {
+                last_error = format!("/readyz returned {}", response.status());
+            }
+            Err(error) => {
+                last_error = error.to_string();
+            }
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    bail!("api did not become ready at {url}: {last_error}")
 }
 
 async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<()> {

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -22,6 +22,8 @@ pub enum ApiError {
     MethodNotAllowed(String),
     #[error("{0}")]
     PayloadTooLarge(String),
+    #[error("{0}")]
+    ServiceUnavailable(String),
     /// Server-side misconfiguration or invariant failure. The message is
     /// logged but never returned to the client.
     #[error("{0}")]
@@ -48,6 +50,7 @@ impl IntoResponse for ApiError {
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::MethodNotAllowed(_) => StatusCode::METHOD_NOT_ALLOWED,
             Self::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             Self::Runtime(SessionRuntimeError::BadRequest(_)) => StatusCode::BAD_REQUEST,
             Self::Runtime(SessionRuntimeError::Store(SessionStoreError::NotFound { .. })) => {
                 StatusCode::NOT_FOUND

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -20,7 +20,7 @@ mod tests {
     use async_trait::async_trait;
     use axum::{
         body::{Body, to_bytes},
-        http::{Request, StatusCode, header},
+        http::{Method, Request, StatusCode, header},
     };
     use centaur_sandbox_core::{
         ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
@@ -142,6 +142,86 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn runtime_routes_report_unavailable_until_runtime_is_ready() {
+        for request in [
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/session/slack%3AC123%3A123.456")
+                .body(Body::empty())
+                .unwrap(),
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/session/slack%3AC123%3A123.456")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"harness_type":"codex"}"#))
+                .unwrap(),
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/session/slack%3AC123%3A123.456/messages")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"messages":[]}"#))
+                .unwrap(),
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/session/slack%3AC123%3A123.456/execute")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"input_lines":[]}"#))
+                .unwrap(),
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/session/slack%3AC123%3A123.456/events")
+                .body(Body::empty())
+                .unwrap(),
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/sandboxes/drain")
+                .body(Body::empty())
+                .unwrap(),
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/workflows/schedules")
+                .body(Body::empty())
+                .unwrap(),
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/workflows/runs")
+                .body(Body::empty())
+                .unwrap(),
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/workflows/runs")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"workflow_name":"agent_turn","input":{}}"#))
+                .unwrap(),
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/workflows/runs/run-1")
+                .body(Body::empty())
+                .unwrap(),
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/workflows/runs/run-1/cancel")
+                .body(Body::empty())
+                .unwrap(),
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/workflows/events")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"event_name":"test.event","payload":{}}"#))
+                .unwrap(),
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/webhooks/test")
+                .body(Body::empty())
+                .unwrap(),
+        ] {
+            let app = build_router_with_app_state(AppState::unready());
+            let response = app.oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        }
     }
 
     #[tokio::test]

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -6,8 +6,8 @@ pub mod types;
 pub use centaur_session_runtime::{SandboxRuntime, SessionRuntime};
 pub use error::ApiError;
 pub use routes::{
-    build_router_with_runtime, build_router_with_session_and_workflow_runtime,
-    build_router_with_session_runtime,
+    AppState, build_router_with_app_state, build_router_with_runtime,
+    build_router_with_session_and_workflow_runtime, build_router_with_session_runtime,
 };
 
 #[cfg(test)]
@@ -31,7 +31,7 @@ mod tests {
     use sqlx::PgPool;
     use tower::ServiceExt;
 
-    use super::build_router_with_runtime;
+    use super::{AppState, build_router_with_app_state, build_router_with_runtime};
 
     #[tokio::test]
     async fn router_builds() {
@@ -87,6 +87,61 @@ mod tests {
                 r#"http_server_requests_total{method="GET",route="/healthz",status="200"}"#
             )
         );
+    }
+
+    #[tokio::test]
+    async fn healthz_is_available_before_runtime_is_ready() {
+        let app = build_router_with_app_state(AppState::unready());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn readyz_reports_starting_until_runtime_is_ready() {
+        let state = AppState::unready();
+        let app = build_router_with_app_state(state.clone());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/readyz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let pool =
+            PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();
+        state.mark_ready(
+            centaur_session_runtime::SessionRuntime::new(
+                PgSessionStore::new(pool),
+                SandboxRuntime::backend(Arc::new(TestBackend::default()), SandboxSpec::new("test")),
+            ),
+            None,
+        );
+        let app = build_router_with_app_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/readyz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -1,7 +1,7 @@
 mod args;
 mod tool_discovery;
 
-use centaur_api_server::build_router_with_session_and_workflow_runtime;
+use centaur_api_server::{AppState, build_router_with_app_state};
 use centaur_session_runtime::SessionRuntime;
 use centaur_session_sqlx::PgSessionStore;
 use centaur_telemetry::{TelemetryConfig, init_telemetry};
@@ -19,7 +19,41 @@ async fn main() -> Result<(), ServerError> {
     let telemetry = init_telemetry(TelemetryConfig::from_env())?;
 
     let args = Args::parse();
+    let listener = TcpListener::bind(args.server.bind_addr).await?;
+    info!(
+        bind_addr = %args.server.bind_addr,
+        "starting centaur api-rs server"
+    );
 
+    let app_state = AppState::unready();
+    let app = build_router_with_app_state(app_state.clone());
+    let mut server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal())
+            .await
+    });
+
+    tokio::select! {
+        result = &mut server => {
+            result??;
+            telemetry.shutdown();
+            return Ok(());
+        }
+        result = initialize_runtime(args, app_state) => {
+            if let Err(error) = result {
+                server.abort();
+                telemetry.shutdown();
+                return Err(error);
+            }
+        }
+    }
+
+    server.await??;
+    telemetry.shutdown();
+    Ok(())
+}
+
+async fn initialize_runtime(args: Args, app_state: AppState) -> Result<(), ServerError> {
     let store = PgSessionStore::connect(&args.server.database_url).await?;
     if args.server.run_migrations {
         store.run_migrations().await?;
@@ -63,16 +97,8 @@ async fn main() -> Result<(), ServerError> {
         adoption_runtime.adopt_orphaned_executions().await;
     });
 
-    let listener = TcpListener::bind(args.server.bind_addr).await?;
-    info!(bind_addr = %args.server.bind_addr, "starting centaur api-rs server");
-
-    axum::serve(
-        listener,
-        build_router_with_session_and_workflow_runtime(runtime, workflows),
-    )
-    .with_graceful_shutdown(shutdown_signal())
-    .await?;
-    telemetry.shutdown();
+    app_state.mark_ready(runtime, workflows);
+    info!("centaur api-rs runtime initialized");
     Ok(())
 }
 
@@ -88,6 +114,8 @@ async fn shutdown_signal() {
 pub(crate) enum ServerError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Join(#[from] tokio::task::JoinError),
     #[error(transparent)]
     Store(#[from] centaur_session_sqlx::SessionStoreError),
     #[error(transparent)]

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -3,6 +3,7 @@ use std::{
     convert::Infallible,
     convert::TryFrom,
     env,
+    sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
 
@@ -51,9 +52,63 @@ use crate::{
 
 #[derive(Clone)]
 pub struct AppState {
-    runtime: SessionRuntime,
+    initialized: Arc<RwLock<Option<AppRuntimeState>>>,
     metrics: PrometheusHandle,
+}
+
+#[derive(Clone)]
+struct AppRuntimeState {
+    runtime: SessionRuntime,
     workflows: Option<WorkflowRuntime>,
+}
+
+impl AppState {
+    pub fn unready() -> Self {
+        Self {
+            initialized: Arc::new(RwLock::new(None)),
+            metrics: prometheus_handle().expect("failed to initialize Prometheus metrics recorder"),
+        }
+    }
+
+    pub fn ready(runtime: SessionRuntime, workflows: Option<WorkflowRuntime>) -> Self {
+        let state = Self::unready();
+        state.mark_ready(runtime, workflows);
+        state
+    }
+
+    pub fn mark_ready(&self, runtime: SessionRuntime, workflows: Option<WorkflowRuntime>) {
+        let mut initialized = self
+            .initialized
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *initialized = Some(AppRuntimeState { runtime, workflows });
+    }
+
+    fn initialized(&self) -> Option<AppRuntimeState> {
+        self.initialized
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn is_ready(&self) -> bool {
+        self.initialized().is_some()
+    }
+
+    fn runtime(&self) -> Result<SessionRuntime, ApiError> {
+        self.initialized()
+            .map(|initialized| initialized.runtime)
+            .ok_or_else(|| ApiError::ServiceUnavailable("api-rs is still starting".to_owned()))
+    }
+
+    fn workflows(&self) -> Result<WorkflowRuntime, ApiError> {
+        let initialized = self
+            .initialized()
+            .ok_or_else(|| ApiError::ServiceUnavailable("api-rs is still starting".to_owned()))?;
+        initialized
+            .workflows
+            .ok_or_else(|| ApiError::BadRequest("workflow runtime is not enabled".to_owned()))
+    }
 }
 
 const MAX_WEBHOOK_BODY_BYTES: usize = 1024 * 1024;
@@ -81,10 +136,13 @@ pub fn build_router_with_session_and_workflow_runtime(
     runtime: SessionRuntime,
     workflows: Option<WorkflowRuntime>,
 ) -> Router {
-    let metrics_handle =
-        prometheus_handle().expect("failed to initialize Prometheus metrics recorder");
+    build_router_with_app_state(AppState::ready(runtime, workflows))
+}
+
+pub fn build_router_with_app_state(state: AppState) -> Router {
     Router::new()
         .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
         .route("/metrics", get(metrics))
         .route(
             "/api/session/{thread_key}",
@@ -149,15 +207,22 @@ pub fn build_router_with_session_and_workflow_runtime(
                 }),
         )
         .layer(middleware::from_fn(http_metrics))
-        .with_state(AppState {
-            runtime,
-            metrics: metrics_handle,
-            workflows,
-        })
+        .with_state(state)
 }
 
 async fn healthz() -> Json<Value> {
     Json(json!({"ok": true}))
+}
+
+async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
+    if state.is_ready() {
+        (StatusCode::OK, Json(json!({"ok": true, "ready": true})))
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"ok": false, "ready": false, "error": "api-rs is still starting"})),
+        )
+    }
 }
 
 async fn metrics(State(state): State<AppState>) -> Response {
@@ -205,7 +270,7 @@ async fn create_or_get_session(
         Some(OnHarnessConflict::Reject) | None => HarnessConflictPolicy::Reject,
     };
     let outcome = state
-        .runtime
+        .runtime()?
         .create_or_get_session(
             &thread_key,
             &request.harness_type,
@@ -260,7 +325,7 @@ async fn append_messages(
 ) -> Result<Json<AppendMessagesResponse>, ApiError> {
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
     let message_ids = state
-        .runtime
+        .runtime()?
         .append_messages(&thread_key, &request.messages)
         .await?;
     Ok(Json(AppendMessagesResponse {
@@ -276,7 +341,7 @@ async fn execute_session(
 ) -> Result<Json<ExecuteSessionResponse>, ApiError> {
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
     let execution = state
-        .runtime
+        .runtime()?
         .execute_session(
             &thread_key,
             ExecuteSessionInput {
@@ -297,7 +362,7 @@ async fn execute_session(
 }
 
 async fn drain_sandboxes(State(state): State<AppState>) -> Result<Json<Value>, ApiError> {
-    let report = state.runtime.drain().await?;
+    let report = state.runtime()?.drain().await?;
     let failed = report
         .failed
         .iter()
@@ -318,7 +383,7 @@ async fn stream_events(
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ApiError> {
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
     let events = state
-        .runtime
+        .runtime()?
         .stream_events(
             &thread_key,
             query.after_event_id.unwrap_or(0),
@@ -483,11 +548,8 @@ async fn invoke_workflow_webhook(
     ))
 }
 
-fn workflow_runtime(state: &AppState) -> Result<&WorkflowRuntime, ApiError> {
-    state
-        .workflows
-        .as_ref()
-        .ok_or_else(|| ApiError::BadRequest("workflow runtime is not enabled".to_owned()))
+fn workflow_runtime(state: &AppState) -> Result<WorkflowRuntime, ApiError> {
+    state.workflows()
 }
 
 fn content_type(headers: &HeaderMap) -> String {

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -286,8 +286,10 @@ async fn create_or_get_session(
 }
 
 async fn get_session_context(
+    State(state): State<AppState>,
     Path(raw_thread_key): Path<String>,
 ) -> Result<Json<SessionContextResponse>, ApiError> {
+    let _runtime = state.runtime()?;
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
     Ok(Json(SessionContextResponse {
         slack: slack_thread_context(&thread_key),


### PR DESCRIPTION
## Summary
- bind api-rs before slow runtime initialization so `/healthz` is available immediately
- add `/readyz` that stays 503 until session/workflow runtime startup completes
- point the Helm readiness probe at `/readyz` while startup/liveness continue using `/healthz`

## Root Cause
api-rs previously bound its HTTP listener only after DB, iron-control, sandbox, and workflow startup completed. In prod, iron-control/tool-secret reconciliation can take longer than the startup probe budget, so Kubernetes killed an otherwise healthy startup before `/healthz` existed.

## Behavior
During startup, Kubernetes can now distinguish a live process from a ready pod:
- `/healthz`: process/server is alive
- `/readyz`: runtime is initialized and the pod can receive traffic
- runtime-backed routes return 503 while startup is still in progress

## Validation
- `cargo test -p centaur-api-server`
- `helm dependency build contrib/chart`
- `helm template centaur contrib/chart --show-only templates/apirs.yaml`
