### PR TITLE
fix: allow disabling infra secret sync

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.64
+version: 0.1.65
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -151,6 +151,8 @@ spec:
               value: {{ printf "0.0.0.0:%v" .Values.apiRs.port | quote }}
             - name: RUN_MIGRATIONS
               value: {{ .Values.apiRs.runMigrations | quote }}
+            - name: IRON_CONTROL_SYNC_INFRA_SECRETS
+              value: {{ .Values.apiRs.syncInfraSecrets | quote }}
             - name: RUST_LOG
               value: info
             - name: TOOL_DIRS

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -235,6 +235,7 @@
     "apiRs": {
       "type": "object",
       "properties": {
+        "syncInfraSecrets": { "type": "boolean" },
         "metrics": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -280,6 +280,11 @@ apiRs:
   sandboxReadyTimeoutSecs: 90
   sandboxWarmPoolSize: 3
   sandboxWarmPoolReplenishIntervalSecs: 5
+  # When true, api-rs upserts the shared iron-control infra role and its
+  # backing secrets at startup and on tool-secret reconciliation intervals.
+  # Set false when multiple Centaur instances share one console/1Password
+  # Connect control plane and infra secrets are managed out of band.
+  syncInfraSecrets: true
   # Workflow enablement policy. Production defaults to all workflows enabled.
   # Set workflowEnableMode: allowlist in staging and list allowed workflow names
   # in workflowAllowedNames as a comma/whitespace-separated string.

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -576,6 +576,13 @@ struct SandboxArgs {
     #[command(flatten)]
     iron_control: IronControlArgs,
     #[arg(
+        long = "iron-control-sync-infra-secrets",
+        env = "IRON_CONTROL_SYNC_INFRA_SECRETS",
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
+    iron_control_sync_infra_secrets: bool,
+    #[arg(
         long = "workflow-host-sandbox",
         env = "WORKFLOW_HOST_SANDBOX",
         default_value_t = true
@@ -605,13 +612,29 @@ impl SandboxArgs {
             return Ok(None);
         };
         let namespace = self.iron_control.namespace.clone();
-        let policy = self.iron_proxy.source_policy();
-        let tool_fragment = self.discover_tool_proxy_fragment()?;
-        let roles = self.iron_proxy.roles_to_register(tool_fragment.as_ref())?;
-        let mut role_ids = Vec::with_capacity(roles.len());
-        for (spec, fragment) in &roles {
-            role_ids.push(register_role(&client, &namespace, spec, fragment, &policy).await?);
-        }
+        let role_ids = if self.iron_control_sync_infra_secrets {
+            let policy = self.iron_proxy.source_policy();
+            let tool_fragment = self.discover_tool_proxy_fragment()?;
+            let roles = self.iron_proxy.roles_to_register(tool_fragment.as_ref())?;
+            let mut role_ids = Vec::with_capacity(roles.len());
+            for (spec, fragment) in &roles {
+                role_ids.push(register_role(&client, &namespace, spec, fragment, &policy).await?);
+            }
+            role_ids
+        } else {
+            let spec = RoleSpec::infra();
+            vec![
+                client
+                    .upsert_role(&IdentityInput {
+                        namespace: namespace.clone(),
+                        foreign_id: spec.foreign_id,
+                        name: spec.name,
+                        labels: BTreeMap::from([("managed-by".to_owned(), "centaur".to_owned())]),
+                    })
+                    .await?
+                    .id,
+            ]
+        };
         let bootstrap = client
             .upsert_principal(&IdentityInput {
                 namespace: namespace.clone(),
@@ -651,6 +674,9 @@ impl SandboxArgs {
     fn iron_control_tool_reconciler(
         &self,
     ) -> Result<Option<IronControlToolReconciler>, ServerError> {
+        if !self.iron_control_sync_infra_secrets {
+            return Ok(None);
+        }
         let Some(client) = self.iron_control.client() else {
             return Ok(None);
         };
@@ -2414,6 +2440,30 @@ mod tests {
                         == Some("TOOL_API_KEY")
             })
         }));
+    }
+
+    #[test]
+    fn iron_control_infra_secret_sync_can_be_disabled() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--iron-control-url",
+            "http://console.local",
+            "--iron-control-api-key",
+            "iak_test",
+            "--iron-control-sync-infra-secrets",
+            "false",
+        ])
+        .unwrap();
+
+        assert!(!args.sandbox.iron_control_sync_infra_secrets);
+        assert!(
+            args.sandbox
+                .iron_control_tool_reconciler()
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adds an api-rs flag and Helm value to stop automatic iron-control infra secret synchronization when multiple Centaur instances share the same console or 1Password Connect backend. The disabled mode still ensures the shared infra role exists and assigns it to principals, but it skips secret and grant upserts plus the periodic reconciler.