### PR TITLE
fix: read company context watermark from absurd

### DIFF
--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -170,21 +170,25 @@ def _source_enabled() -> bool:
 
 
 async def _latest_successful_watermark(pool, current_run_id: str) -> dt.datetime | None:
-    """Load the last successful projection watermark from workflow output."""
+    """Load the last successful projection watermark from the active absurd ETL queue."""
     row = await pool.fetchrow(
-        "SELECT output_json FROM workflow_runs "
-        "WHERE workflow_name = $1 "
-        "  AND run_id <> $2 "
-        "  AND status = 'completed' "
-        "  AND output_json IS NOT NULL "
-        "ORDER BY completed_at DESC NULLS LAST, updated_at DESC "
+        "SELECT t.completed_payload "
+        "FROM absurd.t_centaur_workflows_etl t "
+        "JOIN absurd.r_centaur_workflows_etl r "
+        "  ON r.run_id = t.last_attempt_run "
+        "WHERE t.task_name = 'centaur.workflow' "
+        "  AND t.params->>'workflow_name' = $1 "
+        "  AND r.run_id::text <> $2 "
+        "  AND t.state = 'completed' "
+        "  AND t.completed_payload IS NOT NULL "
+        "ORDER BY r.completed_at DESC NULLS LAST, t.enqueue_at DESC "
         "LIMIT 1",
         WORKFLOW_NAME,
         current_run_id,
     )
     if not row:
         return None
-    output = decode_jsonb(row["output_json"], {})
+    output = decode_jsonb(row["completed_payload"], {})
     return _parse_datetime(str(output.get("watermark") or ""))
 
 

--- a/workflows/tests/test_company_context_documents_attachments.py
+++ b/workflows/tests/test_company_context_documents_attachments.py
@@ -64,6 +64,45 @@ class FakeScopeMetricsPool:
         }
 
 
+class FakeWatermarkPool:
+    def __init__(self) -> None:
+        self.query = ""
+        self.args: tuple = ()
+
+    async def fetchrow(self, query, *args):
+        self.query = query
+        self.args = args
+        return {
+            "completed_payload": {
+                "status": "completed",
+                "watermark": "2026-06-18T22:59:36+00:00",
+            }
+        }
+
+
+def test_latest_successful_watermark_reads_absurd_etl_queue():
+    pool = FakeWatermarkPool()
+
+    watermark = asyncio.run(
+        projection._latest_successful_watermark(
+            pool,
+            "4b2eb33c-6377-4b1a-97f0-ec28e4427eb5",
+        )
+    )
+
+    assert watermark == dt.datetime(2026, 6, 18, 22, 59, 36, tzinfo=dt.UTC)
+    assert "absurd.t_centaur_workflows_etl" in pool.query
+    assert "absurd.r_centaur_workflows_etl" in pool.query
+    assert "workflow_runs" not in pool.query
+    assert "t.completed_payload" in pool.query
+    assert "t.params->>'workflow_name' = $1" in pool.query
+    assert "r.run_id::text <> $2" in pool.query
+    assert pool.args == (
+        "company_context_documents",
+        "4b2eb33c-6377-4b1a-97f0-ec28e4427eb5",
+    )
+
+
 def test_etl_scope_metrics_no_longer_emit_slack_scope_gauges(monkeypatch):
     calls: list[tuple] = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- Read the `company_context_documents` incremental watermark from the active absurd ETL queue tables.
- Stop depending on the legacy `public.workflow_runs` table for the previous successful projection output.
- Add coverage for the absurd table query shape and payload parsing.

## Why

`public.workflow_runs` is legacy scheduler state and is stale in staging. `company_context_documents` now runs through the absurd ETL queue, so its previous successful output lives in `absurd.t_centaur_workflows_etl.completed_payload` joined to `absurd.r_centaur_workflows_etl` for completion ordering.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest workflows/tests/test_company_context_documents_attachments.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with ruff ruff check workflows/company_context_documents.py workflows/tests/test_company_context_documents_attachments.py`
