### PR TITLE
docs: update workflow scheduler references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,7 +397,7 @@ Runs go through: `queued → running → sleeping/waiting → running → … �
 
 - **Worker pool**: `WORKFLOW_WORKER_CONCURRENCY` workers (default 2) poll for claimable runs.
 - **Lease-based fencing**: Each worker holds a lease on its run, extended by a heartbeat. If the worker dies, the lease expires and another worker reclaims the run.
-- **Schedules**: Cron-based or interval-based schedules are configured in `workflow_schedules` table and ticked by the worker loop.
+- **Schedules**: Cron-based or interval-based schedules are discovered from workflow metadata by `api-rs`. The scheduler stores tick tasks in the Absurd `centaur_workflow_schedules` queue.
 - **External events**: `POST /workflows/events` delivers events that wake waiting runs.
 - **Child workflows**: Parent→child relationships are tracked; cancelling a parent cascels linked executions.
 
@@ -425,10 +425,13 @@ Runs go through: `queued → running → sleeping/waiting → running → … �
 
 | Table | What |
 |-------|------|
-| `workflow_runs` | Run metadata, status, input/output, parent/root hierarchy |
-| `workflow_checkpoints` | Per-step cached results, linked execution/child-run IDs |
-| `workflow_schedules` | Cron/interval schedule definitions with next_run_at tracking |
-| `workflow_events` | External events for `wait_for_event` correlation |
+| `absurd.queues` | Registered workflow queues, including standard, ETL, backfill, Slack-live, and schedule queues |
+| `absurd.t_centaur_workflows*` | Workflow task metadata, state, input params, idempotency keys, and completed payloads |
+| `absurd.r_centaur_workflows*` | Per-attempt run state, leases, timing, result payloads, and failures |
+| `absurd.c_centaur_workflows*` | Per-step checkpoint state |
+| `absurd.e_centaur_workflows*` | Emitted workflow events for event-driven resumes |
+| `absurd.w_centaur_workflows*` | Wait registrations for sleeps and external events |
+| `absurd.t_centaur_workflow_schedules` | Scheduler tick tasks for registered cron and interval schedules |
 
 ## Agent Sandbox
 

--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -120,8 +120,8 @@ From inside the API deployment, localhost bypass avoids needing an external API
 key:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
-  http://localhost:8000/workflows/runs \
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST \
+  http://localhost:8080/api/workflows/runs \
   -H "Content-Type: application/json" \
   -d '{
     "workflow_name": "slack_sync",
@@ -135,15 +135,15 @@ Then inspect the run:
 ```bash
 RUN_ID=wfr_...
 
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s \
-  "http://localhost:8000/workflows/runs/${RUN_ID}" | jq
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s \
+  "http://localhost:8080/api/workflows/runs/${RUN_ID}" | jq
 ```
 
 To drain pending historical work immediately:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
-  http://localhost:8000/workflows/runs \
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST \
+  http://localhost:8080/api/workflows/runs \
   -H "Content-Type: application/json" \
   -d '{
     "workflow_name": "slack_backfill",
@@ -155,8 +155,8 @@ kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
 To force document projection after rows have synced:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
-  http://localhost:8000/workflows/runs \
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST \
+  http://localhost:8080/api/workflows/runs \
   -H "Content-Type: application/json" \
   -d '{
     "workflow_name": "company_context_documents",
@@ -170,12 +170,25 @@ kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
 Check the workflow schedules:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- \
-  psql "$DATABASE_URL" -c \
-  "SELECT schedule_id, workflow_name, enabled, interval_seconds, next_run_at
-   FROM workflow_schedules
-   WHERE schedule_id IN ('slack_sync', 'slack_backfill', 'company_context_documents')
-   ORDER BY schedule_id;"
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s \
+  http://localhost:8080/api/workflows/schedules | jq \
+  '.schedules[]
+   | select(.schedule_id == "slack_sync"
+     or .schedule_id == "slack_backfill"
+     or .schedule_id == "company_context_documents")
+   | {schedule_id, workflow_name, enabled, interval_seconds}'
+```
+
+Check recent workflow runs:
+
+```bash
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s \
+  "http://localhost:8080/api/workflows/runs?limit=20" | jq \
+  '.runs[]
+   | select(.workflow_name == "slack_sync"
+     or .workflow_name == "slack_backfill"
+     or .workflow_name == "company_context_documents")
+   | {workflow_name, status, created_at, attempts}'
 ```
 
 Check sync health:

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -120,8 +120,8 @@ From inside the API deployment, localhost bypass avoids needing an external API
 key:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
-  http://localhost:8000/workflows/runs \
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST \
+  http://localhost:8080/api/workflows/runs \
   -H "Content-Type: application/json" \
   -d '{
     "workflow_name": "slack_sync",
@@ -135,15 +135,15 @@ Then inspect the run:
 ```bash
 RUN_ID=wfr_...
 
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s \
-  "http://localhost:8000/workflows/runs/${RUN_ID}" | jq
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s \
+  "http://localhost:8080/api/workflows/runs/${RUN_ID}" | jq
 ```
 
 To drain pending historical work immediately:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
-  http://localhost:8000/workflows/runs \
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST \
+  http://localhost:8080/api/workflows/runs \
   -H "Content-Type: application/json" \
   -d '{
     "workflow_name": "slack_backfill",
@@ -155,8 +155,8 @@ kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
 To force document projection after rows have synced:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
-  http://localhost:8000/workflows/runs \
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST \
+  http://localhost:8080/api/workflows/runs \
   -H "Content-Type: application/json" \
   -d '{
     "workflow_name": "company_context_documents",
@@ -170,12 +170,25 @@ kubectl exec -n centaur deploy/centaur-centaur-api -- curl -s -X POST \
 Check the workflow schedules:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- \
-  psql "$DATABASE_URL" -c \
-  "SELECT schedule_id, workflow_name, enabled, interval_seconds, next_run_at
-   FROM workflow_schedules
-   WHERE schedule_id IN ('slack_sync', 'slack_backfill', 'company_context_documents')
-   ORDER BY schedule_id;"
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s \
+  http://localhost:8080/api/workflows/schedules | jq \
+  '.schedules[]
+   | select(.schedule_id == "slack_sync"
+     or .schedule_id == "slack_backfill"
+     or .schedule_id == "company_context_documents")
+   | {schedule_id, workflow_name, enabled, interval_seconds}'
+```
+
+Check recent workflow runs:
+
+```bash
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s \
+  "http://localhost:8080/api/workflows/runs?limit=20" | jq \
+  '.runs[]
+   | select(.workflow_name == "slack_sync"
+     or .workflow_name == "slack_backfill"
+     or .workflow_name == "company_context_documents")
+   | {workflow_name, status, created_at, attempts}'
 ```
 
 Check sync health:


### PR DESCRIPTION
## Summary

- Update the developer guide to describe api-rs workflow scheduling through Absurd queues instead of the retired public workflow tables.
- Refresh Slack ETL run and verification examples to use api-rs `/api/workflows/*` endpoints.
- Mirror the Slack ETL source-doc updates into the checked-in public markdown copy.

## Why

Staging still has legacy `public.workflow_*` tables from the pre-Rust scheduler, but the new scheduler stores workflow and schedule state in Absurd queue tables. The docs were pointing operators at the old tables.

## Validation

- `rg -n "\\b(workflow_schedules|workflow_runs|workflow_checkpoints|workflow_events)\\b" -S AGENTS.md docs/pages docs/public/md services workflows -g '!*.lock'`
- `git diff --check -- AGENTS.md docs/pages/operate/slack-etl.mdx docs/public/md/operate/slack-etl.md`
