### PR TITLE
feat(chart): apply overlay DB migrations via an api-rs init-container

### DIFF
--- a/contrib/MIGRATING_TO_RS.md
+++ b/contrib/MIGRATING_TO_RS.md
@@ -125,7 +125,83 @@ from .database import Database
 If a tool imports Centaur SDK modules from the base image, ensure the local
 runner includes the Centaur root (for example `/opt/centaur`) in `PYTHONPATH`.
 
-## 5. Verify console and per-sandbox proxies
+## 5. Apply overlay database migrations
+
+api-rs applies only its own embedded core migrations. The legacy Python `api`
+also applied an overlay's `services/api/db/migrations/*.sql` (dbmate format,
+tracked in a `schema_migrations_overlay` table) whenever `CENTAUR_OVERLAY_DIR`
+was set; the Rust control plane does not. Without this, overlay-owned tables are
+never created and overlay workflows fail at runtime with
+`relation "..." does not exist`.
+
+api-rs restores this: **after** it runs its core migrations, it applies overlay
+migrations from the repo-cache clone (so overlay schema may depend on core),
+tracked in `schema_migrations_overlay` — a ledger independent of the core
+`schema_migrations`, so an applied version is never re-run (an upgrade from the
+legacy dbmate path skips versions it already recorded).
+
+It is **opt-in per source**: set `migrationsSubdir` (conventionally
+`services/api/db/migrations`) on an `overlays.sources` entry to enable it for that
+overlay. Unlike `toolsSubdir`/`workflowsSubdir`/`skillsSubdir`, it has no default,
+so the common case — sources that carry no DB migrations, including the base repo
+— applies nothing and adds no startup wait.
+
+```yaml
+overlays:
+  sources:
+    - repo: your-org/your-overlay
+      ref: main
+      migrationsSubdir: services/api/db/migrations  # opt in to overlay migrations
+```
+
+When at least one source opts in (and `repoCache.enabled` + `apiRs.runMigrations`
+are true), api-rs waits for the repo-cache readiness marker, then applies each
+pending `-- migrate:up` section in `NNN_` filename order, recording the numeric
+version. A migration body and its ledger insert commit together, so a failure
+rolls back and retries on the next start. A configured source whose migrations
+directory is absent at runtime is skipped, matching the overlay-subdir model.
+
+Because overlay migrations run **after** the core migrations but as a separate,
+independently-numbered set, they should be **self-contained** relative to each
+other (numbered independently of core). Migration files must follow dbmate
+conventions:
+
+- A **zero-padded numeric `NNN_` prefix** (e.g. `001_…`, `010_…`) — the prefix is
+  the version (files without one are skipped), and applies in lexical filename
+  order, so pad consistently.
+- `-- migrate:up` / `-- migrate:down` markers at the **start of a line**; the
+  `migrate:up` section must be non-empty (a malformed migration fails startup
+  rather than being silently recorded as applied).
+- `-- migrate:up transaction:false` is honored for a migration that cannot run in
+  a transaction (e.g. `CREATE INDEX CONCURRENTLY`); such a migration must contain a
+  **single statement** (Postgres wraps a multi-statement string in an implicit
+  transaction).
+
+If more than one source opts in, all opted-in sources share the single
+`schema_migrations_overlay` ledger keyed by version, so they must use **distinct
+version prefixes** (e.g. partition the number space) — otherwise a colliding
+version from a later source is treated as already applied and skipped.
+
+Tuning (`values.yaml`, under `apiRs`):
+
+- `applyOverlayMigrations` (default `true`) — master toggle; disables overlay
+  migrations even when a source opts in.
+- `overlayMigrations.readyTimeoutSeconds` (default `300`) — how long api-rs waits
+  for the repo-cache readiness marker before applying (on timeout it logs and
+  skips, and api-rs still starts).
+
+Verify (the apply runs in the api-rs container, logged at startup):
+
+```sh
+kubectl -n <ns> logs <api-rs-pod> | grep overlay
+kubectl -n <ns> exec deploy/<postgres> -- \
+  psql "$DATABASE_URL" -c "SELECT version FROM schema_migrations_overlay ORDER BY version"
+```
+
+The applied versions and the ledger rows should match the overlay's `NNN_`
+migration prefixes, and the overlay-owned tables should exist.
+
+## 6. Verify console and per-sandbox proxies
 
 api-rs-managed sandboxes use per-sandbox iron-proxy pods for outbound access and
 secret injection. When console is enabled, the proxy's effective config is
@@ -151,7 +227,7 @@ For Postgres-backed tools, a claimed session proxy with the right grants should
 eventually listen on `5432`. An idle bootstrap warm proxy may not listen on
 `5432`; that is expected.
 
-## 6. Understand the SQL-backed warm pool
+## 7. Understand the SQL-backed warm pool
 
 The api-rs warm pool is tracked in Postgres, not only through Kubernetes
 objects. Inspect it from the database used by api-rs:
@@ -178,7 +254,7 @@ kubectl -n centaur delete sandbox.agents.x-k8s.io <sandbox-id> \
   --ignore-not-found --wait=false
 ```
 
-## 7. Validate an end-to-end session
+## 8. Validate an end-to-end session
 
 At minimum, validate that a fresh api-rs sandbox can:
 
@@ -206,7 +282,7 @@ For a Postgres-backed tool, also verify that the sandbox receives a DSN pointing
 at its per-sandbox proxy and that the proxy is listening on the expected
 Postgres port.
 
-## 8. Common failure modes
+## 9. Common failure modes
 
 ### `401 Unauthorized` from an LLM provider
 

--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.66
+version: 0.1.67
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -87,6 +87,14 @@ so the defaults are safe for repos that only carry some surfaces.
 {{- else -}}
 {{- $_ := set $source "skillsSubdir" ".agents/skills" -}}
 {{- end -}}
+{{- /*
+Overlay DB migrations are OPT-IN per source (unlike tools/workflows/skills,
+which default on): set migrationsSubdir (conventionally "services/api/db/migrations")
+to have api-rs apply that source's dbmate migrations before startup. Left unset
+so the common case — sources that carry no DB migrations, including the base
+repo — renders no migration init-container and adds no startup wait.
+*/ -}}
+{{- with .migrationsSubdir }}{{- $_ := set $source "migrationsSubdir" . -}}{{- end -}}
 {{- with .promptPath }}{{- $_ := set $source "promptPath" . -}}{{- end -}}
 {{- with .personasSubdir }}{{- $_ := set $source "personasSubdir" . -}}{{- end -}}
 {{- $sources = append $sources $source -}}

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -8,6 +8,7 @@
 {{- $overlaySources := include "centaur.overlaySources" . | fromJsonArray -}}
 {{- $toolSources := list -}}
 {{- $apiWorkflowDirList := list -}}
+{{- $apiMigrationDirList := list -}}
 {{- $sandboxWorkflowDirList := list -}}
 {{- $skillDirs := list -}}
 {{- range $source := $overlaySources -}}
@@ -21,6 +22,9 @@
 {{- with (get $source "workflowsSubdir") -}}
 {{- $apiWorkflowDirList = append $apiWorkflowDirList (printf "%s/%s/%s" $.Values.repoCache.hostPath $repo .) -}}
 {{- $sandboxWorkflowDirList = append $sandboxWorkflowDirList (printf "/home/agent/github/%s/%s" $repo .) -}}
+{{- end -}}
+{{- with (get $source "migrationsSubdir") -}}
+{{- $apiMigrationDirList = append $apiMigrationDirList (printf "%s/%s/%s" $.Values.repoCache.hostPath $repo .) -}}
 {{- end -}}
 {{- with (get $source "skillsSubdir") -}}
 {{- $skillDirs = append $skillDirs (printf "/home/agent/github/%s/%s" $repo .) -}}
@@ -43,6 +47,10 @@
 {{- $sandboxWorkflowDirs := "" -}}
 {{- if and .Values.repoCache.enabled (gt (len $sandboxWorkflowDirList) 0) -}}
 {{- $sandboxWorkflowDirs = join ":" $sandboxWorkflowDirList -}}
+{{- end -}}
+{{- $overlayMigrationDirs := "" -}}
+{{- if and .Values.repoCache.enabled (gt (len $apiMigrationDirList) 0) -}}
+{{- $overlayMigrationDirs = join ":" $apiMigrationDirList -}}
 {{- end -}}
 {{- $apiRsMetricsAnnotations := dict -}}
 {{- if .Values.apiRs.metrics.scrapeAnnotations -}}
@@ -151,6 +159,19 @@ spec:
               value: {{ printf "0.0.0.0:%v" .Values.apiRs.port | quote }}
             - name: RUN_MIGRATIONS
               value: {{ .Values.apiRs.runMigrations | quote }}
+{{- if and $useOverlayRepoCache .Values.apiRs.applyOverlayMigrations (gt (len $apiMigrationDirList) 0) }}
+            # Overlay (dbmate-format) DB migrations applied by api-rs AFTER its core
+            # migrations (so overlay schema may depend on core), tracked in a separate
+            # schema_migrations_overlay ledger. Read from each opted-in source's
+            # migrationsSubdir on the repo-cache mount; api-rs waits for the repo-cache
+            # readiness marker first. See contrib/MIGRATING_TO_RS.md.
+            - name: OVERLAY_MIGRATION_DIRS
+              value: {{ $overlayMigrationDirs | quote }}
+            - name: OVERLAY_MIGRATIONS_READY_MARKER
+              value: {{ printf "%s/.repo-cache-ready" .Values.repoCache.hostPath | quote }}
+            - name: OVERLAY_MIGRATIONS_READY_TIMEOUT_SECS
+              value: {{ .Values.apiRs.overlayMigrations.readyTimeoutSeconds | quote }}
+{{- end }}
             - name: IRON_CONTROL_SYNC_INFRA_SECRETS
               value: {{ .Values.apiRs.syncInfraSecrets | quote }}
             - name: RUST_LOG

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -275,6 +275,21 @@ apiRs:
     pullPolicy: Always
   port: 8080
   runMigrations: true
+  # Apply an overlay's dbmate-format DB migrations from the repo-cache mount,
+  # AFTER api-rs runs its embedded core migrations (so overlay schema may depend
+  # on core). Restores the legacy `api` behavior of materializing overlay-owned
+  # tables, tracked in a separate schema_migrations_overlay ledger. OPT-IN: only
+  # takes effect for an overlays.sources entry that sets `migrationsSubdir`
+  # (conventionally "services/api/db/migrations") and only when repoCache is
+  # enabled and runMigrations is true; no-op for default/overlay-less installs.
+  # This master toggle additionally lets operators disable it even when a source
+  # opts in.
+  applyOverlayMigrations: true
+  overlayMigrations:
+    # api-rs waits up to this long for the repo-cache readiness marker before
+    # applying overlay migrations, so it does not read a not-yet-cloned tree. On
+    # timeout it logs and skips (api-rs still starts).
+    readyTimeoutSeconds: 300
   sandboxBackend: agent-k8s
   sandboxWorkload: codex-app-server
   sandboxReadyTimeoutSecs: 90

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -499,6 +499,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -443,6 +443,27 @@ pub(crate) struct ServerArgs {
     pub(crate) bind_addr: SocketAddr,
     #[arg(long, env = "RUN_MIGRATIONS", default_value_t = false)]
     pub(crate) run_migrations: bool,
+    /// Colon-separated overlay migration directories (each a dbmate
+    /// `services/api/db/migrations` dir on the repo-cache mount). Applied AFTER
+    /// the core migrations when `run_migrations` is set. Unset or empty disables
+    /// it. A single String (not a clap value-delimited list) so an empty env var
+    /// is a no-op rather than a hard startup error; split on ':' by the caller.
+    #[arg(long = "overlay-migration-dirs", env = "OVERLAY_MIGRATION_DIRS")]
+    pub(crate) overlay_migration_dirs: Option<String>,
+    /// Optional repo-cache readiness marker. When set, api-rs waits (bounded)
+    /// for this file before applying overlay migrations, so it does not read a
+    /// not-yet-cloned or half-written tree.
+    #[arg(
+        long = "overlay-migrations-ready-marker",
+        env = "OVERLAY_MIGRATIONS_READY_MARKER"
+    )]
+    pub(crate) overlay_migrations_ready_marker: Option<PathBuf>,
+    #[arg(
+        long = "overlay-migrations-ready-timeout-secs",
+        env = "OVERLAY_MIGRATIONS_READY_TIMEOUT_SECS",
+        default_value_t = 300
+    )]
+    pub(crate) overlay_migrations_ready_timeout_secs: u64,
 }
 
 #[derive(Debug, ClapArgs)]

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -53,10 +53,52 @@ async fn main() -> Result<(), ServerError> {
     Ok(())
 }
 
+/// Apply overlay (dbmate-format) migrations after the core migrations. Waits
+/// (bounded) for the repo-cache readiness marker first, when configured, so we
+/// apply against a complete clone rather than a half-written tree. No-op when no
+/// overlay migration directories are configured.
+async fn apply_overlay_migrations(
+    store: &PgSessionStore,
+    server: &args::ServerArgs,
+) -> Result<(), ServerError> {
+    let dirs: Vec<std::path::PathBuf> = server
+        .overlay_migration_dirs
+        .as_deref()
+        .unwrap_or_default()
+        .split(':')
+        .filter(|dir| !dir.is_empty())
+        .map(std::path::PathBuf::from)
+        .collect();
+    if dirs.is_empty() {
+        return Ok(());
+    }
+    if let Some(marker) = &server.overlay_migrations_ready_marker {
+        let deadline = std::time::Instant::now()
+            + std::time::Duration::from_secs(server.overlay_migrations_ready_timeout_secs);
+        while !tokio::fs::try_exists(marker).await.unwrap_or(false) {
+            if std::time::Instant::now() >= deadline {
+                info!(
+                    marker = %marker.display(),
+                    "repo-cache ready marker absent after timeout; skipping overlay migrations"
+                );
+                return Ok(());
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+    }
+    let applied = store.apply_overlay_migrations(&dirs).await?;
+    info!(applied, "overlay migrations applied");
+    Ok(())
+}
+
 async fn initialize_runtime(args: Args, app_state: AppState) -> Result<(), ServerError> {
     let store = PgSessionStore::connect(&args.server.database_url).await?;
     if args.server.run_migrations {
         store.run_migrations().await?;
+        // Overlay migrations run AFTER the core migrations so overlay schema may
+        // depend on core (the overlay set is tracked separately and applied from
+        // the repo-cache mount; see `args.server.overlay_migration_dirs`).
+        apply_overlay_migrations(&store, &args.server).await?;
     }
     let sandbox_runtime = args.sandbox_runtime().await?;
     let mut runtime = SessionRuntime::new(store.clone(), sandbox_runtime);

--- a/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-sqlx/Cargo.toml
@@ -12,6 +12,7 @@ serde_json.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 time.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -16,6 +16,9 @@ use thiserror::Error;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
+mod overlay;
+pub use overlay::apply_overlay_migrations;
+
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
 pub const SESSION_EVENTS_CHANNEL: &str = "centaur_session_events";
@@ -61,6 +64,16 @@ impl PgSessionStore {
     pub async fn run_migrations(&self) -> Result<(), SessionStoreError> {
         MIGRATOR.run(&self.pool).await?;
         Ok(())
+    }
+
+    /// Apply overlay (dbmate-format) migrations from `dirs`, AFTER the core
+    /// migrations, tracked in a separate `schema_migrations_overlay` ledger.
+    /// See [`apply_overlay_migrations`]. Returns the number newly applied.
+    pub async fn apply_overlay_migrations(
+        &self,
+        dirs: &[std::path::PathBuf],
+    ) -> Result<usize, SessionStoreError> {
+        overlay::apply_overlay_migrations(&self.pool, dirs).await
     }
 
     pub async fn listen_session_events(&self) -> Result<SessionEventListener, SessionStoreError> {
@@ -748,6 +761,8 @@ pub enum SessionStoreError {
     Sqlx(#[from] sqlx::Error),
     #[error(transparent)]
     Migrate(#[from] sqlx::migrate::MigrateError),
+    #[error("overlay migration failed: {0}")]
+    OverlayMigration(String),
 }
 
 #[derive(Debug, FromRow)]

--- a/services/api-rs/crates/centaur-session-sqlx/src/overlay.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/overlay.rs
@@ -1,0 +1,320 @@
+//! Overlay database migrations.
+//!
+//! api-rs applies only its own embedded core migrations (see
+//! [`PgSessionStore::run_migrations`](crate::PgSessionStore::run_migrations)).
+//! The legacy Python `api` additionally applied an overlay repository's
+//! `services/api/db/migrations/*.sql` (dbmate format) when `CENTAUR_OVERLAY_DIR`
+//! was set; the RS rewrite dropped that, so overlay-owned tables were never
+//! created.
+//!
+//! This restores it, applied AFTER the core migrations so overlay schema may
+//! depend on core. Each pending `-- migrate:up` section is applied in filename
+//! order and recorded in `schema_migrations_overlay` — a ledger independent of
+//! the core `schema_migrations`, so an applied version is never re-run (an
+//! upgrade from the legacy dbmate path therefore skips versions it already
+//! recorded). dbmate's `transaction:false` directive is honored.
+
+use std::path::{Path, PathBuf};
+
+use sqlx::PgPool;
+
+use crate::SessionStoreError;
+
+/// Ledger table for overlay migrations, kept separate from core `schema_migrations`.
+const OVERLAY_MIGRATIONS_TABLE: &str = "schema_migrations_overlay";
+
+/// Advisory-lock key that serializes overlay-migration application across api-rs
+/// replicas (the core sqlx migrator takes its own lock for the same reason). An
+/// arbitrary fixed value in the application range.
+const OVERLAY_MIGRATIONS_LOCK_KEY: i64 = 0x4f56_4c41_5900;
+
+/// Apply every pending overlay migration found in `dirs`, in filename order,
+/// recording each in [`OVERLAY_MIGRATIONS_TABLE`]. A directory that does not
+/// exist is skipped (an opted-in source may legitimately carry no migrations).
+/// Returns the number of migrations newly applied.
+///
+/// Serialized across processes with a Postgres advisory lock, so a scaled
+/// deployment (or an overlapping rolling deploy where two api-rs pods run with
+/// migrations enabled) applies the set exactly once.
+pub async fn apply_overlay_migrations(
+    pool: &PgPool,
+    dirs: &[PathBuf],
+) -> Result<usize, SessionStoreError> {
+    let mut lock = pool.acquire().await?;
+    sqlx::query("SELECT pg_advisory_lock($1)")
+        .bind(OVERLAY_MIGRATIONS_LOCK_KEY)
+        .execute(&mut *lock)
+        .await?;
+    let result = apply_locked(pool, dirs).await;
+    // Release the session lock on every path. (A crashed process releases it on
+    // disconnect, but here the connection returns to the pool still open.)
+    if let Err(error) = sqlx::query("SELECT pg_advisory_unlock($1)")
+        .bind(OVERLAY_MIGRATIONS_LOCK_KEY)
+        .execute(&mut *lock)
+        .await
+    {
+        tracing::warn!(%error, "failed to release overlay-migrations advisory lock");
+    }
+    result
+}
+
+async fn apply_locked(pool: &PgPool, dirs: &[PathBuf]) -> Result<usize, SessionStoreError> {
+    let create_sql = format!(
+        "CREATE TABLE IF NOT EXISTS {OVERLAY_MIGRATIONS_TABLE} \
+         (version varchar(255) PRIMARY KEY, applied_at timestamptz NOT NULL DEFAULT now())"
+    );
+    sqlx::query(&create_sql).execute(pool).await?;
+
+    let select_sql = format!("SELECT 1 FROM {OVERLAY_MIGRATIONS_TABLE} WHERE version = $1");
+    let insert_sql = format!(
+        "INSERT INTO {OVERLAY_MIGRATIONS_TABLE} (version) VALUES ($1) ON CONFLICT DO NOTHING"
+    );
+
+    let mut applied = 0usize;
+    for dir in dirs {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        if !dir.is_dir() {
+            tracing::warn!(dir = %dir.display(), "overlay migrations dir absent; skipping");
+            continue;
+        }
+        for path in sql_files_sorted(dir)? {
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default()
+                .to_owned();
+            let Some(version) = migration_version(&name) else {
+                tracing::info!(file = %name, "overlay migration has no numeric version prefix; skipping");
+                continue;
+            };
+            let already: Option<i32> = sqlx::query_scalar(&select_sql)
+                .bind(version)
+                .fetch_optional(pool)
+                .await?;
+            if already.is_some() {
+                continue;
+            }
+            let content = std::fs::read_to_string(&path).map_err(|error| {
+                SessionStoreError::OverlayMigration(format!("read {}: {error}", path.display()))
+            })?;
+            let up = extract_up_section(&content).ok_or_else(|| {
+                SessionStoreError::OverlayMigration(format!("{name}: no '-- migrate:up' section"))
+            })?;
+
+            // dbmate's `transaction:false` (e.g. CREATE INDEX CONCURRENTLY) cannot
+            // run inside a transaction. Postgres' simple protocol autocommits a
+            // lone statement but wraps a multi-statement string in an implicit
+            // transaction, so such migrations must be a SINGLE statement (see
+            // MIGRATING_TO_RS.md); the ledger row is then written separately.
+            if is_no_transaction(&content) {
+                sqlx::raw_sql(&up).execute(pool).await.map_err(|error| {
+                    SessionStoreError::OverlayMigration(format!("{name}: {error}"))
+                })?;
+                sqlx::query(&insert_sql).bind(version).execute(pool).await?;
+            } else {
+                // The body and the ledger insert commit together, so a failure
+                // rolls back and the version is retried on the next run.
+                let mut tx = pool.begin().await?;
+                sqlx::raw_sql(&up)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|error| {
+                        SessionStoreError::OverlayMigration(format!("{name}: {error}"))
+                    })?;
+                sqlx::query(&insert_sql)
+                    .bind(version)
+                    .execute(&mut *tx)
+                    .await?;
+                tx.commit().await?;
+            }
+            tracing::info!(version = %version, file = %name, "applied overlay migration");
+            applied += 1;
+        }
+    }
+    Ok(applied)
+}
+
+/// `*.sql` files in `dir`, sorted by filename (the `NNN_` prefix gives order).
+fn sql_files_sorted(dir: &Path) -> Result<Vec<PathBuf>, SessionStoreError> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .map_err(|error| {
+            SessionStoreError::OverlayMigration(format!("read_dir {}: {error}", dir.display()))
+        })?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("sql"))
+        .collect();
+    files.sort();
+    Ok(files)
+}
+
+/// The leading run of ASCII digits in `filename` (the dbmate version), or `None`
+/// for a file without a numeric prefix (not a migration).
+fn migration_version(filename: &str) -> Option<&str> {
+    let len = filename.bytes().take_while(u8::is_ascii_digit).count();
+    (len > 0).then(|| &filename[..len])
+}
+
+/// If `line` is a dbmate directive marker for `token` ("migrate:up"/"migrate:down"),
+/// returns the text AFTER the token (for option parsing like `transaction:false`).
+/// The `--` must be at the START of the line (column 0, as dbmate anchors markers,
+/// so an indented `--` comment inside a body is NOT a marker), and the token must
+/// be a whole token — followed by whitespace or end of line — so `migrate:upgrade`
+/// does not match `migrate:up`.
+fn marker_rest<'a>(line: &'a str, token: &str) -> Option<&'a str> {
+    let after = line.strip_prefix("--")?.trim_start().strip_prefix(token)?;
+    (after.is_empty() || after.starts_with(char::is_whitespace)).then_some(after)
+}
+
+fn marker_kind(line: &str) -> Option<&'static str> {
+    if marker_rest(line, "migrate:up").is_some() {
+        Some("up")
+    } else if marker_rest(line, "migrate:down").is_some() {
+        Some("down")
+    } else {
+        None
+    }
+}
+
+/// Extract the `-- migrate:up` section. Returns `None` if there is no up marker
+/// or the section is empty/whitespace (a malformed migration — fail loudly
+/// rather than record an empty no-op as applied).
+fn extract_up_section(content: &str) -> Option<String> {
+    let mut out = String::new();
+    let mut in_up = false;
+    let mut saw_up = false;
+    for line in content.lines() {
+        match marker_kind(line) {
+            Some("up") => {
+                in_up = true;
+                saw_up = true;
+            }
+            Some("down") => in_up = false,
+            _ if in_up => {
+                out.push_str(line);
+                out.push('\n');
+            }
+            _ => {}
+        }
+    }
+    // Require at least one non-blank, non-comment line so a comment-only up
+    // section is treated as malformed (None) rather than recorded as an applied
+    // no-op.
+    let has_sql = out.lines().any(|line| {
+        let t = line.trim();
+        !t.is_empty() && !t.starts_with("--")
+    });
+    (saw_up && has_sql).then_some(out)
+}
+
+/// True when the `-- migrate:up` marker carries dbmate's `transaction:false`.
+fn is_no_transaction(content: &str) -> bool {
+    content
+        .lines()
+        .find_map(|line| marker_rest(line, "migrate:up"))
+        .is_some_and(|after| after.contains("transaction:false"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_is_leading_digits_only() {
+        assert_eq!(migration_version("001_agent_memory.sql"), Some("001"));
+        assert_eq!(migration_version("010_x.sql"), Some("010"));
+        assert_eq!(
+            migration_version("20240101120000_x.sql"),
+            Some("20240101120000")
+        );
+        assert_eq!(migration_version("seed.sql"), None);
+        assert_eq!(migration_version("v1_x.sql"), None);
+        // Quotes/semicolons can never reach SQL: only a numeric prefix is taken.
+        assert_eq!(migration_version("1';drop.sql"), Some("1"));
+    }
+
+    #[test]
+    fn extracts_up_section_between_anchored_markers() {
+        let sql = "-- migrate:up\nCREATE TABLE a (id int);\n-- migrate:down\nDROP TABLE a;\n";
+        assert_eq!(
+            extract_up_section(sql).unwrap().trim(),
+            "CREATE TABLE a (id int);"
+        );
+    }
+
+    #[test]
+    fn down_marker_inside_body_does_not_truncate() {
+        // A non-line-start mention of the down marker must not flip capture off.
+        let sql = "-- migrate:up\nCREATE TABLE a (id int); -- see migrate:down for rollback\nCREATE TABLE b (id int);\n-- migrate:down\nDROP TABLE a;\n";
+        let up = extract_up_section(sql).unwrap();
+        assert!(up.contains("CREATE TABLE a"));
+        assert!(
+            up.contains("CREATE TABLE b"),
+            "body after the false marker must survive"
+        );
+        assert!(
+            !up.contains("DROP TABLE a"),
+            "real down section must be excluded"
+        );
+    }
+
+    #[test]
+    fn marker_less_or_empty_up_is_none() {
+        assert_eq!(extract_up_section("CREATE TABLE a (id int);\n"), None);
+        assert_eq!(
+            extract_up_section("-- migrate:up\n\n-- migrate:down\nDROP TABLE a;\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn transaction_false_detected_only_on_up_marker() {
+        assert!(is_no_transaction(
+            "-- migrate:up transaction:false\nCREATE INDEX CONCURRENTLY i ON a (id);\n"
+        ));
+        assert!(!is_no_transaction(
+            "-- migrate:up\nCREATE TABLE a (id int);\n"
+        ));
+        // A mention in the body is not the directive.
+        assert!(!is_no_transaction(
+            "-- migrate:up\nINSERT INTO a VALUES ('transaction:false');\n"
+        ));
+    }
+
+    #[test]
+    fn markers_must_be_at_column_zero() {
+        // An indented `--` is a SQL comment in the body, not a directive, so it
+        // must not toggle capture (matches dbmate, which anchors markers at ^).
+        let sql = "-- migrate:up\nDO $$ BEGIN\n  -- migrate:down would drop it\n  PERFORM 1;\nEND $$;\nCREATE TABLE keep (id int);\n-- migrate:down\nDROP TABLE keep;\n";
+        let up = extract_up_section(sql).unwrap();
+        assert!(
+            up.contains("PERFORM 1"),
+            "indented marker must not truncate"
+        );
+        assert!(up.contains("CREATE TABLE keep"));
+        assert!(!up.contains("DROP TABLE keep"));
+    }
+
+    #[test]
+    fn marker_requires_whole_token() {
+        // `migrate:upgrade` / `migrate:downstream` are not the up/down markers.
+        assert_eq!(marker_kind("-- migrate:upgrade the schema"), None);
+        assert_eq!(marker_kind("-- migrate:downstream"), None);
+        assert_eq!(marker_kind("-- migrate:up"), Some("up"));
+        assert_eq!(marker_kind("--migrate:up"), Some("up")); // no space after --
+        assert_eq!(marker_kind("-- migrate:down"), Some("down"));
+        let sql = "-- migrate:up\n-- migrate:upgrade note\nCREATE TABLE a (id int);\n";
+        assert!(extract_up_section(sql).unwrap().contains("CREATE TABLE a"));
+    }
+
+    #[test]
+    fn comment_only_up_section_is_none() {
+        // No real SQL — only comments — must be treated as malformed, not a no-op.
+        assert_eq!(
+            extract_up_section("-- migrate:up\n-- just a note\n-- migrate:down\nDROP TABLE a;\n"),
+            None
+        );
+    }
+}


### PR DESCRIPTION
## What

Makes api-rs apply an overlay's `dbmate`-format DB migrations **after** its own core migrations, so overlay-owned tables get created under the RS control plane. Fixes **gap 1 of #683**. (Gap 2 — base `company_context_documents` querying the removed `workflow_runs` — is addressed in #678.)

## Why

api-rs applies only its compile-time-embedded core sqlx migrations. The legacy Python `api` *also* applied an overlay's `services/api/db/migrations/*.sql` (dbmate, tracked in `schema_migrations_overlay`) via `CENTAUR_OVERLAY_DIR` — added in #566, removed with `services/api` in #521, never reimplemented. So under RS, overlay-owned tables are never created and overlay workflows fail at runtime with `relation "..." does not exist`. The chart still set `CENTAUR_OVERLAY_DIR`, making it look like they'd still apply.

## How

The applier lives in api-rs and runs **immediately after `run_migrations()`**, so the core schema is in place before overlay migrations run (overlay is a layer above core — thanks @goksu).

- **`centaur-session-sqlx::apply_overlay_migrations(pool, dirs)`** — for each opted-in overlay dir, applies each pending `-- migrate:up` section in `NNN_` filename order, recorded in a `schema_migrations_overlay` ledger independent of the core `schema_migrations` (so applied versions are never re-run; an upgrade from the legacy dbmate path skips versions it already recorded).
  - dbmate markers are matched **anchored at column 0** with a whole-token match (an indented `-- migrate:down` in a `$$` body, or `migrate:upgrade`, won't match).
  - The version is the numeric filename prefix, **bound as a query parameter** (never string-interpolated).
  - A missing/empty `migrate:up` section **fails loudly** rather than recording an empty no-op.
  - `-- migrate:up transaction:false` is honored (single-statement, e.g. `CREATE INDEX CONCURRENTLY`).
  - Serialized across processes with a **`pg_advisory_lock`** (mirrors the core sqlx migrator), so a scaled deployment / overlapping rolling deploy applies the set once.
- **api-rs** waits (bounded) for the repo-cache readiness marker before applying, so it reads a complete clone.
- **chart** — opt-in per `overlays.sources` entry via `migrationsSubdir` (conventionally `services/api/db/migrations`). It has **no default** (unlike `toolsSubdir`/`workflowsSubdir`/`skillsSubdir`), so default and overlay-less installs are unaffected. When a source opts in (and `repoCache.enabled` + `apiRs.runMigrations`), the api-rs container gets `OVERLAY_MIGRATION_DIRS` + the readiness-marker env. No init-container.

```yaml
overlays:
  sources:
    - repo: your-org/your-overlay
      ref: main
      migrationsSubdir: services/api/db/migrations  # opt in to overlay migrations
```

## Notes for reviewers

1. **Ordering** — overlay migrations run after the core migrator, in the same startup path, gated on `RUN_MIGRATIONS`. Overlay sets are numbered independently of core (a separate ledger).
2. **`transaction:false`** must be a single statement — Postgres wraps a multi-statement simple-query string in an implicit transaction, which would defeat `CREATE INDEX CONCURRENTLY`. Documented in `MIGRATING_TO_RS.md`.
3. **Multiple opted-in sources** share the one `schema_migrations_overlay` ledger keyed by version, so they must use distinct version prefixes (documented).
4. **`CENTAUR_OVERLAY_DIR`** is left as-is (it's the prompt-path var, gated on `overlay.systemPrompt`); flagging that it's now vestigial for migrations — a separate cleanup if you want it.

## Testing

- `cargo test -p centaur-session-sqlx` — 9 unit tests (version parsing, anchored/whole-token markers, indented-marker no-truncation, comment-only → malformed, `transaction:false` detection); `cargo fmt --check` + `clippy` clean.
- `helm lint` passes; chart `version` bumped. `helm template` permutations: default/overlay-less → no overlay env; opt-in source → the api-rs container gets `OVERLAY_MIGRATION_DIRS` (only the opted-in source) + the readiness marker; no `migrationsSubdir` and `applyOverlayMigrations=false` → nothing.
