### PR TITLE
feat: add role grant management UI

### DIFF
--- a/services/console/app/controllers/console/roles_controller.rb
+++ b/services/console/app/controllers/console/roles_controller.rb
@@ -1,0 +1,126 @@
+module Console
+  # Operator UI for roles: list/detail/create/edit and role-scoped secret grants.
+  # Roles are namespace-scoped bundles of secrets that principals can inherit.
+  class RolesController < ApplicationController
+    include KvRowParams
+    include SecretKinds
+
+    layout "console"
+
+    before_action :set_role, only: %i[show edit update grant_secret revoke_grant]
+
+    def index
+      @roles = Role.order(:namespace, :id)
+    end
+
+    def show
+      @grants = @role.grants.includes(Grant::GRANTABLE_ASSOCIATIONS).order(:id)
+      granted_ids = Hash.new { |h, k| h[k] = [] }
+      @grants.each do |grant|
+        assoc = grantable_assoc_for(grant)
+        next unless assoc
+        granted_ids[assoc.to_s.delete_suffix("_secret")] << grant.public_send("#{assoc}_id")
+      end
+      @assignable_secrets = SECRET_KINDS.each_with_object({}) do |(kind, cfg), acc|
+        acc[kind] = cfg[:model]
+          .where(namespace: @role.namespace)
+          .where.not(id: granted_ids[kind])
+          .order(:id)
+      end
+    end
+
+    def new
+      @role = Role.new(namespace: "default")
+    end
+
+    def create
+      @role = Role.new(created_by: current_user)
+      assign_form(@role, include_readonly: true)
+      if @role.save
+        redirect_to console_role_path(@role.oid), notice: "Role created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
+    def update
+      assign_form(@role, include_readonly: false)
+      if @role.save
+        redirect_to console_role_path(@role.oid), notice: "Role updated."
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def grant_secret
+      secret = resolve_grantable(params[:grantable])
+      return redirect_to console_role_path(@role.oid), alert: "Pick a secret to grant." unless secret
+      unless secret.namespace == @role.namespace
+        return redirect_to console_role_path(@role.oid),
+                           alert: "Secret must be in the same namespace as the role."
+      end
+
+      @role.grants.create_with(created_by: current_user)
+           .find_or_create_by!(grantable_assoc(secret) => secret)
+      redirect_to console_role_path(@role.oid), notice: "Granted #{secret_label(secret)}."
+    rescue ActiveRecord::RecordNotUnique
+      # A concurrent submit already created the grant; the requested end state is
+      # true, so report success rather than 500.
+      redirect_to console_role_path(@role.oid), notice: "Granted #{secret_label(secret)}."
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to console_role_path(@role.oid), alert: e.record.errors.full_messages.to_sentence
+    end
+
+    def revoke_grant
+      grant = @role.grants.find_by_oid!(params[:grant_id])
+      grant.destroy!
+      redirect_to console_role_path(@role.oid), notice: "Revoked grant."
+    end
+
+    private
+
+    def assign_form(role, include_readonly:)
+      fields =
+        if include_readonly
+          role_params.permit(:namespace, :foreign_id, :name)
+        else
+          role_params.permit(:name)
+        end
+      if include_readonly
+        fields[:namespace] = fields[:namespace].presence || "default"
+        fields[:foreign_id] = fields[:foreign_id].presence
+      end
+      role.assign_attributes(fields)
+      role.labels = label_params
+    end
+
+    def role_params
+      params.fetch(:role, ActionController::Parameters.new)
+    end
+
+    def resolve_grantable(value)
+      kind, oid = value.to_s.split(":", 2)
+      cfg = SECRET_KINDS[kind]
+      return nil if cfg.nil? || oid.blank?
+      cfg[:model].find_by_oid!(oid)
+    end
+
+    def grantable_assoc(secret)
+      secret.class.name.underscore.to_sym
+    end
+
+    def grantable_assoc_for(grant)
+      Grant::GRANTABLE_ASSOCIATIONS.find { |assoc| grant.public_send("#{assoc}_id") }
+    end
+
+    def secret_label(secret)
+      secret.try(:name).presence || secret.foreign_id.presence || secret.oid
+    end
+
+    def set_role
+      @role = Role.find_by_oid!(params[:id])
+    end
+  end
+end

--- a/services/console/app/controllers/console/secrets_controller.rb
+++ b/services/console/app/controllers/console/secrets_controller.rb
@@ -1,0 +1,57 @@
+module Console
+  # Mutations for grants from the secret detail page. The read-only show action
+  # lives on ConsoleController; this controller only handles granting a displayed
+  # secret to roles and revoking those role grants.
+  class SecretsController < ApplicationController
+    include SecretKinds
+
+    layout "console"
+
+    before_action :set_secret
+
+    def grant_role
+      role = Role.find_by_oid!(params[:role_id])
+      unless role.namespace == @secret.namespace
+        return redirect_to console_secret_path(@kind, @secret.oid),
+                           alert: "Role must be in the same namespace as the secret."
+      end
+
+      Grant.create_with(created_by: current_user)
+           .find_or_create_by!(role: role, grantable_assoc => @secret)
+      redirect_to console_secret_path(@kind, @secret.oid),
+                  notice: "Assigned secret to #{role_label(role)}."
+    rescue ActiveRecord::RecordNotUnique
+      # A concurrent submit already created the grant; the end state is what the
+      # operator asked for, so report success rather than 500.
+      redirect_to console_secret_path(@kind, @secret.oid),
+                  notice: "Assigned secret to #{role_label(role)}."
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to console_secret_path(@kind, @secret.oid), alert: e.record.errors.full_messages.to_sentence
+    end
+
+    def revoke_role_grant
+      grant = Grant.where(grantable_assoc => @secret)
+                   .where.not(role_id: nil)
+                   .find_by_oid!(params[:grant_id])
+      grant.destroy!
+      redirect_to console_secret_path(@kind, @secret.oid), notice: "Unassigned secret from role."
+    end
+
+    private
+
+    def set_secret
+      @kind = params[:kind]
+      cfg = SECRET_KINDS[@kind]
+      return render plain: "secret not found", status: :not_found unless cfg
+      @secret = cfg[:model].find_by_oid!(params[:id])
+    end
+
+    def grantable_assoc
+      @secret.class.name.underscore.to_sym
+    end
+
+    def role_label(role)
+      role.name.presence || role.foreign_id.presence || role.oid
+    end
+  end
+end

--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -47,11 +47,16 @@ class ConsoleController < ApplicationController
       @grant_sources[[ kind, grant.public_send("#{assoc}_id") ]] <<
         (grant.role ? { type: :role, role: grant.role } : { type: :direct })
     end
-    # Assignment options for the inline forms. Roles/secrets span all namespaces;
-    # the namespace is shown as a label on each option. Already-directly-granted
-    # secrets are filtered out of the grant dropdown (they're in the table above);
-    # a role-inherited secret stays offered, so it can be promoted to a direct grant.
-    @assignable_roles = Role.where.not(id: @principal.role_ids).order(:namespace, :id)
+    # Assignment options for the inline forms. Roles are namespace-scoped, so
+    # only same-namespace roles are assignable from this principal. Secrets span
+    # all namespaces; the namespace is shown as a label on each option.
+    # Already-directly-granted secrets are filtered out of the grant dropdown
+    # (they're in the table above); a role-inherited secret stays offered, so it
+    # can be promoted to a direct grant.
+    @assignable_roles = Role
+      .where(namespace: @principal.namespace)
+      .where.not(id: @principal.role_ids)
+      .order(:id)
     granted_ids = Hash.new { |h, k| h[k] = [] }
     @direct_grants.each do |grant|
       assoc = Grant::GRANTABLE_ASSOCIATIONS.find { |a| grant.public_send("#{a}_id") }
@@ -79,6 +84,13 @@ class ConsoleController < ApplicationController
 
     @kind = params[:kind]
     @secret = cfg[:model].includes(cfg[:includes]).find_by_oid!(params[:id])
+    grantable = @secret.class.name.underscore.to_sym
+    @role_grants = Grant.where(grantable => @secret).where.not(role_id: nil).includes(:role).order(:id)
+    granted_role_ids = @role_grants.map(&:role_id)
+    @assignable_roles = Role
+      .where(namespace: @secret.namespace)
+      .where.not(id: granted_role_ids)
+      .order(:id)
   end
 
   # Managed broker credentials and their refresh-loop status. Distinct from

--- a/services/console/app/models/grant.rb
+++ b/services/console/app/models/grant.rb
@@ -31,6 +31,7 @@ class Grant < ApplicationRecord
 
   validate :exactly_one_grantee
   validate :exactly_one_grantable
+  validate :role_grant_same_namespace
   validates :priority, presence: true, numericality: { only_integer: true }
 
   # The grantee this grant attaches the secret to: a principal or a role.
@@ -71,5 +72,12 @@ class Grant < ApplicationRecord
     set = GRANTABLE_ASSOCIATIONS.count { |assoc| send(assoc).present? }
     return if set == 1
     errors.add(:base, "must reference exactly one of #{GRANTABLE_ASSOCIATIONS.join(", ")}")
+  end
+
+  def role_grant_same_namespace
+    return unless role.present?
+    secret = grantable
+    return unless secret.present?
+    errors.add(:role, "must be in the same namespace as the secret") if role.namespace != secret.namespace
   end
 end

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -25,37 +25,51 @@
 
 <!-- Roles -->
 <section class="mb-8">
-  <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Assigned Roles</h2>
-  <% if @roles.any? %>
-    <div class="mb-4 flex flex-wrap gap-2">
-      <% @roles.each do |r| %>
-        <span class="inline-flex items-center gap-2 rounded-lg border border-ink-600 bg-ink-800 px-3 py-1.5 text-sm">
-          <span class="text-centaur-400"><%= r.oid %></span>
-          <span class="text-zinc-300"><%= r.name.presence || r.foreign_id %></span>
-          <%= button_to "×", console_principal_unassign_role_path(@principal.oid, r.oid), method: :delete,
-                form: { class: "inline", data: { turbo_confirm: "Unassign #{r.name.presence || r.foreign_id} from this principal?" } },
-                class: "cursor-pointer leading-none text-zinc-500 transition-colors hover:text-red-400",
-                title: "Unassign role" %>
-        </span>
-      <% end %>
+  <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+    <div>
+      <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Roles</h2>
     </div>
-  <% else %>
-    <p class="mb-4 text-sm text-zinc-600">No roles assigned.</p>
-  <% end %>
-
-  <% if @assignable_roles.any? %>
-    <%= form_with url: console_principal_assign_role_path(@principal.oid), method: :post, data: { turbo: false } do %>
-      <div class="flex flex-wrap items-center gap-3">
-        <select name="role_id" class="form-input max-w-md">
+    <% if @assignable_roles.any? %>
+      <%= form_with url: console_principal_assign_role_path(@principal.oid), method: :post, data: { turbo: false }, class: "flex flex-wrap items-center gap-3" do %>
+        <select name="role_id" class="form-input w-72 max-w-full" aria-label="Role to assign">
           <% @assignable_roles.each do |r| %>
-            <option value="<%= r.oid %>"><%= r.name.presence || r.foreign_id.presence || r.oid %> (<%= r.namespace %>)</option>
+            <option value="<%= r.oid %>"><%= r.name.presence || r.foreign_id.presence || r.oid %></option>
           <% end %>
         </select>
         <%= submit_tag "Assign role", class: "btn-primary" %>
-      </div>
+      <% end %>
     <% end %>
+  </div>
+
+  <% if @roles.any? %>
+    <div class="console-panel">
+      <table class="console-table">
+        <thead class="console-table-head">
+          <tr>
+            <th class="console-th">Role</th>
+            <th class="console-th">ID</th>
+            <th class="console-th">Foreign ID</th>
+            <th class="console-th text-right"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-ink-700">
+          <% @roles.each do |r| %>
+            <tr class="console-row-hover">
+              <td class="console-td-nowrap text-zinc-100"><%= r.name.presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
+              <td class="console-td-nowrap text-centaur-400"><%= r.oid %></td>
+              <td class="console-td-nowrap text-zinc-300"><%= r.foreign_id || "—" %></td>
+              <td class="console-td-nowrap text-right">
+                <%= button_to "Unassign", console_principal_unassign_role_path(@principal.oid, r.oid), method: :delete,
+                      form: { data: { turbo_confirm: "Unassign #{r.name.presence || r.foreign_id || r.oid} from this principal?" } },
+                      class: "cursor-pointer rounded border border-ink-600 px-3 py-1.5 text-zinc-400 transition-colors hover:border-red-500/40 hover:text-red-300" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   <% else %>
-    <p class="text-sm text-zinc-600">No more roles available to assign.</p>
+    <div class="empty-state">No roles assigned.</div>
   <% end %>
 </section>
 

--- a/services/console/app/views/console/roles/_errors.html.erb
+++ b/services/console/app/views/console/roles/_errors.html.erb
@@ -1,0 +1,10 @@
+<% if role.errors.any? %>
+  <div class="alert-error">
+    <p class="font-semibold">Role could not be saved.</p>
+    <ul class="mt-2 list-disc pl-5">
+      <% role.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/services/console/app/views/console/roles/_form.html.erb
+++ b/services/console/app/views/console/roles/_form.html.erb
@@ -1,0 +1,59 @@
+<%= render "errors", role: role %>
+
+<%= form_with model: [ :console, role ], data: { turbo: false }, class: "space-y-6" do %>
+  <section class="form-section">
+    <h2 class="form-section-heading">Identity</h2>
+    <div class="grid gap-5 sm:grid-cols-2">
+      <% if role.new_record? %>
+        <div>
+          <label class="form-label" for="role_namespace">Namespace</label>
+          <%= text_field_tag "role[namespace]", role.namespace.presence || "default", id: "role_namespace", class: "form-input #{field_error_class(role, :namespace)}" %>
+          <%= field_error(role, :namespace) %>
+        </div>
+        <div>
+          <label class="form-label" for="role_foreign_id">Foreign ID</label>
+          <%= text_field_tag "role[foreign_id]", role.foreign_id, id: "role_foreign_id", class: "form-input #{field_error_class(role, :foreign_id)}", placeholder: "stable-handle" %>
+          <%= field_error(role, :foreign_id) %>
+          <p class="form-hint">Optional. A stable, URL-safe handle operators can reference.</p>
+        </div>
+      <% else %>
+        <div>
+          <label class="form-label">Namespace</label>
+          <div class="form-input bg-ink-800 text-zinc-400"><%= role.namespace %></div>
+        </div>
+        <div>
+          <label class="form-label">Foreign ID</label>
+          <div class="form-input bg-ink-800 text-zinc-400"><%= role.foreign_id.presence || "—" %></div>
+        </div>
+      <% end %>
+      <div>
+        <label class="form-label" for="role_name">Name</label>
+        <%= text_field_tag "role[name]", role.name, id: "role_name", class: "form-input #{field_error_class(role, :name)}" %>
+        <%= field_error(role, :name) %>
+      </div>
+    </div>
+    <%= field_error(role, :labels) %>
+  </section>
+
+  <section data-controller="nested-fields" class="form-section">
+    <div class="mb-2 flex items-center justify-between">
+      <h2 class="form-section-heading mb-0">Labels</h2>
+      <button type="button" data-action="nested-fields#add" class="btn-secondary">Add label</button>
+    </div>
+
+    <div class="space-y-2" data-nested-fields-target="container">
+      <% (role.labels.presence || {}).each_with_index do |(k, v), i| %>
+        <%= render "console/base_secrets/label_row", index: i, key: k, value: v %>
+      <% end %>
+    </div>
+
+    <template data-nested-fields-target="template">
+      <%= render "console/base_secrets/label_row", index: "NEW_RECORD", key: "", value: "" %>
+    </template>
+  </section>
+
+  <div class="flex items-center gap-3">
+    <%= submit_tag role.new_record? ? "Create role" : "Save role", class: "btn-primary" %>
+    <a href="<%= role.persisted? ? console_role_path(role.oid) : console_roles_path %>" class="btn-secondary">Cancel</a>
+  </div>
+<% end %>

--- a/services/console/app/views/console/roles/edit.html.erb
+++ b/services/console/app/views/console/roles/edit.html.erb
@@ -1,0 +1,9 @@
+<% title = @role.name.presence || @role.foreign_id.presence || @role.oid %>
+<% content_for :title, "Edit #{title} · Centaur Console" %>
+
+<div class="mb-8">
+  <a href="<%= console_role_path(@role.oid) %>" class="back-link">← back to role</a>
+  <h1 class="mt-2 page-title">Edit Role</h1>
+</div>
+
+<%= render "form", role: @role %>

--- a/services/console/app/views/console/roles/index.html.erb
+++ b/services/console/app/views/console/roles/index.html.erb
@@ -1,0 +1,60 @@
+<% content_for :title, "Roles · Centaur Console" %>
+
+<div class="mb-8 flex items-start justify-between gap-4">
+  <div>
+    <h1 class="page-title">Roles</h1>
+    <p class="page-subtitle"><%= pluralize(@roles.size, "role") %> across all namespaces.</p>
+  </div>
+  <a href="<%= new_console_role_path %>" class="btn-primary">Add Role</a>
+</div>
+
+<div class="console-panel">
+  <table class="console-table">
+    <thead class="console-table-head">
+      <tr>
+        <th class="console-th">ID</th>
+        <th class="console-th">Name</th>
+        <th class="console-th">Labels</th>
+        <th class="console-th text-right"></th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-ink-700">
+      <% if @roles.empty? %>
+        <tr><td colspan="4" class="px-5 py-10 text-center text-zinc-600">No roles yet.</td></tr>
+      <% end %>
+      <% @roles.each do |role| %>
+        <tr class="group cursor-pointer console-row-hover"
+            onclick="window.location='<%= console_role_path(role.oid) %>'">
+          <td class="console-td-nowrap">
+            <% if role.foreign_id.present? %>
+              <div class="text-centaur-400 group-hover:glow" title="<%= role.foreign_id %>"><%= truncate_middle(role.foreign_id) %></div>
+              <%= id_meta_line(role.namespace, oid: role.oid) %>
+            <% else %>
+              <span class="text-centaur-400 group-hover:glow"><%= role.oid %></span>
+              <%= id_meta_line(role.namespace) %>
+            <% end %>
+          </td>
+          <td class="console-td-nowrap text-zinc-100">
+            <% if role.name.presence %>
+              <span title="<%= role.name %>"><%= truncate_middle(role.name) %></span>
+            <% else %>
+              <span class="text-zinc-600">unnamed</span>
+            <% end %>
+          </td>
+          <td class="console-td">
+            <% if role.labels.present? %>
+              <div class="flex flex-wrap gap-1">
+                <% role.labels.each do |k, v| %>
+                  <span class="label-chip"><%= k %>=<%= v %></span>
+                <% end %>
+              </div>
+            <% else %>
+              <span class="text-zinc-600">—</span>
+            <% end %>
+          </td>
+          <td class="console-td text-right text-zinc-600 group-hover:text-centaur-400">→</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/services/console/app/views/console/roles/new.html.erb
+++ b/services/console/app/views/console/roles/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "New Role · Centaur Console" %>
+
+<div class="mb-8">
+  <a href="<%= console_roles_path %>" class="back-link">← back to roles</a>
+  <h1 class="mt-2 page-title">New Role</h1>
+</div>
+
+<%= render "form", role: @role %>

--- a/services/console/app/views/console/roles/show.html.erb
+++ b/services/console/app/views/console/roles/show.html.erb
@@ -1,0 +1,91 @@
+<% title = @role.name.presence || @role.foreign_id.presence || @role.oid %>
+<% content_for :title, "#{title} · Centaur Console" %>
+
+<div class="mb-8">
+  <a href="<%= console_roles_path %>" class="back-link">← back to roles</a>
+  <div class="mt-2 flex flex-wrap items-center gap-3">
+    <h1 class="page-title"><%= title %></h1>
+    <div class="ml-auto flex items-center gap-2">
+      <a href="<%= edit_console_role_path(@role.oid) %>" class="btn-secondary">Edit</a>
+    </div>
+  </div>
+  <div class="mt-2 flex flex-wrap items-center gap-2 text-sm">
+    <span class="text-centaur-400 glow"><%= @role.oid %></span>
+    <span class="text-zinc-600">·</span>
+    <span class="rounded bg-ink-700 px-2 py-0.5 text-xs text-zinc-400"><%= @role.namespace %></span>
+    <% if @role.foreign_id.present? %>
+      <span class="text-zinc-600">·</span>
+      <span class="text-zinc-400">foreign_id: <span class="break-all text-zinc-200"><%= @role.foreign_id %></span></span>
+    <% end %>
+  </div>
+  <% if @role.labels.present? %>
+    <div class="mt-3 flex flex-wrap gap-1">
+      <% @role.labels.each do |k, v| %>
+        <span class="label-chip"><%= k %>=<%= v %></span>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<section>
+  <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+    <div>
+      <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Secrets</h2>
+    </div>
+    <% total_assignable = @assignable_secrets.values.sum(&:size) %>
+    <% if total_assignable.positive? %>
+      <%= form_with url: grant_secret_console_role_path(@role.oid), method: :post, data: { turbo: false }, class: "flex flex-wrap items-center gap-3" do %>
+        <select name="grantable" class="form-input w-80 max-w-full" aria-label="Secret to grant">
+          <% @assignable_secrets.each do |kind, secrets| %>
+            <% next if secrets.empty? %>
+            <optgroup label="<%= secret_kind_label(kind) %>">
+              <% secrets.each do |secret| %>
+                <option value="<%= kind %>:<%= secret.oid %>"><%= secret.try(:name).presence || secret.foreign_id.presence || secret.oid %></option>
+              <% end %>
+            </optgroup>
+          <% end %>
+        </select>
+        <%= submit_tag "Grant secret", class: "btn-primary" %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% if @grants.any? %>
+    <div class="console-panel">
+      <table class="console-table">
+        <thead class="console-table-head">
+          <tr>
+            <th class="console-th">Type</th>
+            <th class="console-th">ID</th>
+            <th class="console-th">Foreign ID</th>
+            <th class="console-th">Name</th>
+            <th class="console-th text-right"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-ink-700">
+          <% @grants.each do |grant| %>
+            <% secret = grant.grantable %>
+            <% kind = secret.class.name.underscore.delete_suffix("_secret") %>
+            <tr class="console-row-hover">
+              <td class="console-td-nowrap">
+                <span class="resource-badge"><%= secret_kind_label(kind) %></span>
+              </td>
+              <td class="console-td-nowrap">
+                <%= link_to secret.oid, console_secret_path(kind, secret.oid), class: "console-link" %>
+              </td>
+              <td class="console-td-nowrap text-zinc-300"><%= secret.foreign_id || "—" %></td>
+              <td class="console-td-nowrap text-zinc-100"><%= secret.try(:name).presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
+              <td class="console-td-nowrap text-right">
+                <%= button_to "Revoke", revoke_grant_console_role_path(@role.oid, grant.oid), method: :delete,
+                      form: { data: { turbo_confirm: "Revoke this grant?" } },
+                      class: "cursor-pointer rounded border border-ink-600 px-3 py-1.5 text-zinc-400 transition-colors hover:border-red-500/40 hover:text-red-300" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="empty-state">No secrets granted.</div>
+  <% end %>
+</section>

--- a/services/console/app/views/console/secret.html.erb
+++ b/services/console/app/views/console/secret.html.erb
@@ -46,6 +46,57 @@
   </div>
 <% end %>
 
+<!-- Roles -->
+<section class="mb-8">
+  <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+    <div>
+      <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Roles</h2>
+    </div>
+    <% if @assignable_roles.any? %>
+      <%= form_with url: console_secret_grant_role_path(@kind, @secret.oid), method: :post, data: { turbo: false }, class: "flex flex-wrap items-center gap-3" do %>
+        <select name="role_id" class="form-input w-72 max-w-full" aria-label="Role to assign">
+          <% @assignable_roles.each do |r| %>
+            <option value="<%= r.oid %>"><%= r.name.presence || r.foreign_id.presence || r.oid %></option>
+          <% end %>
+        </select>
+        <%= submit_tag "Assign role", class: "btn-primary" %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% if @role_grants.any? %>
+    <div class="console-panel">
+      <table class="console-table">
+        <thead class="console-table-head">
+          <tr>
+            <th class="console-th">Role</th>
+            <th class="console-th">ID</th>
+            <th class="console-th">Foreign ID</th>
+            <th class="console-th text-right"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-ink-700">
+          <% @role_grants.each do |grant| %>
+            <% role = grant.role %>
+            <tr class="console-row-hover">
+              <td class="console-td-nowrap text-zinc-100"><%= role.name.presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
+              <td class="console-td-nowrap"><%= link_to role.oid, console_role_path(role.oid), class: "console-link" %></td>
+              <td class="console-td-nowrap text-zinc-300"><%= role.foreign_id || "—" %></td>
+              <td class="console-td-nowrap text-right">
+                <%= button_to "Unassign", console_secret_revoke_role_grant_path(@kind, @secret.oid, grant.oid), method: :delete,
+                      form: { data: { turbo_confirm: "Unassign this secret from #{role.name.presence || role.foreign_id || role.oid}?" } },
+                      class: "cursor-pointer rounded border border-ink-600 px-3 py-1.5 text-zinc-400 transition-colors hover:border-red-500/40 hover:text-red-300" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="empty-state">No roles assigned.</div>
+  <% end %>
+</section>
+
 <!-- Sources -->
 <section class="mb-8">
   <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Sources</h2>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -35,10 +35,10 @@
             </a>
             <div class="flex items-center gap-4 text-sm">
               <nav class="flex items-center gap-1">
-                <% nav = [["principals", console_principals_path], ["secrets", console_secrets_path], ["credentials", console_credentials_path], ["oauth apps", console_oauth_apps_path]] %>
+                <% nav = [["principals", console_principals_path], ["roles", console_roles_path], ["secrets", console_secrets_path], ["credentials", console_credentials_path], ["oauth apps", console_oauth_apps_path]] %>
                 <% nav << ["users", console_users_path] if current_user&.admin? %>
                 <% nav.each do |name, path| %>
-                  <% active = request.path == path || (name == "principals" && request.path.start_with?("/console/principals")) %>
+                  <% active = request.path == path || (name == "principals" && request.path.start_with?("/console/principals")) || (name == "roles" && request.path.start_with?("/console/roles")) %>
                   <a href="<%= path %>"
                      class="px-4 py-2 transition-colors <%= active ? "text-centaur-400" : "text-zinc-400 hover:text-zinc-100" %>">
                     <%= name.capitalize %>

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -26,6 +26,14 @@ Rails.application.routes.draw do
   root "console#principals"
   get "console/principals", to: "console#principals", as: :console_principals
   get "console/principals/:id", to: "console#principal", as: :console_principal
+  namespace :console do
+    resources :roles, only: %i[index show new create edit update] do
+      member do
+        post "grants", to: "roles#grant_secret", as: :grant_secret
+        delete "grants/:grant_id", to: "roles#revoke_grant", as: :revoke_grant
+      end
+    end
+  end
   # Role assignments and direct grants managed from the principal detail page. The
   # extra /roles and /grants path segments keep these clear of the show route above
   # and avoid clobbering the console_principal_path helper.
@@ -42,6 +50,8 @@ Rails.application.routes.draw do
     resources :static_secrets, only: %i[new create edit update destroy], path: "secrets/static"
     resources :pg_dsn_secrets, only: %i[new create edit update destroy], path: "secrets/pg_dsn"
     resources :gcp_auth_secrets, only: %i[new create edit update destroy], path: "secrets/gcp_auth"
+    post   "secrets/:kind/:id/roles",           to: "secrets#grant_role",        as: :secret_grant_role
+    delete "secrets/:kind/:id/roles/:grant_id", to: "secrets#revoke_role_grant", as: :secret_revoke_role_grant
   end
   get "console/secrets/:kind/:id", to: "console#secret", as: :console_secret
   get "console/credentials", to: "console#credentials", as: :console_credentials

--- a/services/console/test/controllers/console/roles_controller_test.rb
+++ b/services/console/test/controllers/console/roles_controller_test.rb
@@ -1,0 +1,152 @@
+require "test_helper"
+
+module Console
+  class RolesControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @operator = users(:acme_admin)
+      post login_url, params: { email: @operator.email, password: "password123456" }
+    end
+
+    test "redirects to login when signed out" do
+      delete logout_url
+      get console_roles_url
+      assert_redirected_to login_path
+    end
+
+    test "index lists roles and links to new" do
+      role = roles(:acme_infra)
+      get console_roles_url
+      assert_response :ok
+      assert_select "h1", text: "Roles"
+      assert_select "a[href=?]", new_console_role_path, text: "Add Role"
+      assert_select "tr[onclick=?]", "window.location='#{console_role_path(role.oid)}'"
+    end
+
+    test "show renders role details and editable secret grants" do
+      role = roles(:acme_infra)
+      grant = grants(:acme_infra_prod_api_key)
+      get console_role_url(role.oid)
+      assert_response :ok
+      assert_select "h1", text: role.name
+      assert_select "a[href=?]", edit_console_role_path(role.oid), text: "Edit"
+      assert_select "a[href=?]", console_secret_path("static", static_secrets(:acme_prod_api_key).oid)
+      assert_select "form[action=?]", grant_secret_console_role_path(role.oid) do
+        assert_select "select[name=grantable][aria-label=?]", "Secret to grant"
+        assert_select "option[value=?]", "static:#{static_secrets(:acme_staging_api_key).oid}"
+        assert_select "option[value=?]", "static:#{static_secrets(:acme_prod_api_key).oid}", count: 0
+        assert_select "option[value=?]", "static:#{static_secrets(:globex_prod_secret).oid}", count: 0
+      end
+      assert_select "form[action=?]", revoke_grant_console_role_path(role.oid, grant.oid) do
+        assert_select "button[type=submit]", "Revoke"
+      end
+    end
+
+    test "new and edit render forms" do
+      role = roles(:acme_infra)
+      get new_console_role_url
+      assert_response :ok
+      assert_select "form[action=?]", console_roles_path
+      assert_select "input[name=?]", "role[namespace]"
+      assert_select "input[name=?]", "role[foreign_id]"
+
+      get edit_console_role_url(role.oid)
+      assert_response :ok
+      assert_select "form[action=?]", console_role_path(role.oid)
+      assert_select "input[name=?]", "role[name]"
+      assert_select "input[name=?]", "role[namespace]", count: 0
+      assert_select "input[name=?]", "role[foreign_id]", count: 0
+    end
+
+    test "create persists role identity and labels" do
+      assert_difference -> { Role.count }, 1 do
+        post console_roles_url, params: {
+          role: { namespace: "acme", foreign_id: "payments", name: "Payments" },
+          labels: { "0" => { key: "team", value: "finance" } }
+        }
+      end
+
+      role = Role.find_by!(namespace: "acme", foreign_id: "payments")
+      assert_redirected_to console_role_path(role.oid)
+      assert_equal "Payments", role.name
+      assert_equal({ "team" => "finance" }, role.labels)
+    end
+
+    test "create rejects invalid role without writing" do
+      assert_no_difference -> { Role.count } do
+        post console_roles_url, params: {
+          role: { namespace: "bad namespace", foreign_id: "broken", name: "Broken" }
+        }
+      end
+      assert_response :unprocessable_entity
+    end
+
+    test "update changes mutable fields only" do
+      role = roles(:acme_infra)
+      patch console_role_url(role.oid), params: {
+        role: { namespace: "globex", foreign_id: "changed", name: "Infrastructure" },
+        labels: { "0" => { key: "kind", value: "platform" } }
+      }
+
+      assert_redirected_to console_role_path(role.oid)
+      role.reload
+      assert_equal "Infrastructure", role.name
+      assert_equal "acme", role.namespace
+      assert_equal "infra", role.foreign_id
+      assert_equal({ "kind" => "platform" }, role.labels)
+    end
+
+    test "grant_secret grants a same-namespace secret at the default role priority" do
+      role = roles(:acme_admin_role)
+      secret = static_secrets(:acme_staging_api_key)
+
+      assert_difference -> { role.grants.count }, 1 do
+        post grant_secret_console_role_url(role.oid), params: { grantable: "static:#{secret.oid}" }
+      end
+
+      assert_redirected_to console_role_path(role.oid)
+      grant = role.grants.find_by(static_secret: secret)
+      assert_not_nil grant
+      assert_equal Grant::DEFAULT_ROLE_PRIORITY, grant.priority
+    end
+
+    test "grant_secret is idempotent" do
+      role = roles(:acme_infra)
+      secret = static_secrets(:acme_prod_api_key)
+
+      assert_no_difference -> { role.grants.count } do
+        post grant_secret_console_role_url(role.oid), params: { grantable: "static:#{secret.oid}" }
+      end
+
+      assert_redirected_to console_role_path(role.oid)
+    end
+
+    test "grant_secret rejects a secret from another namespace" do
+      role = roles(:acme_admin_role)
+      secret = static_secrets(:globex_prod_secret)
+
+      assert_no_difference -> { Grant.count } do
+        post grant_secret_console_role_url(role.oid), params: { grantable: "static:#{secret.oid}" }
+      end
+
+      assert_redirected_to console_role_path(role.oid)
+      assert_equal "Secret must be in the same namespace as the role.", flash[:alert]
+    end
+
+    test "revoke_grant removes the role grant" do
+      role = roles(:acme_infra)
+      grant = grants(:acme_infra_prod_api_key)
+
+      assert_difference -> { role.grants.count }, -1 do
+        delete revoke_grant_console_role_url(role.oid, grant.oid)
+      end
+
+      assert_redirected_to console_role_path(role.oid)
+      assert_not Grant.exists?(grant.id)
+    end
+
+    test "unknown role returns 404" do
+      get console_role_url("role_missing")
+      assert_response :not_found
+    end
+  end
+end

--- a/services/console/test/controllers/console/secrets_controller_test.rb
+++ b/services/console/test/controllers/console/secrets_controller_test.rb
@@ -336,5 +336,56 @@ module Console
       assert_nil secret.subject
       assert_equal({ "type" => "workload_identity" }, secret.credentials_provider)
     end
+
+    # --- role grants ------------------------------------------------------
+
+    test "POST grant_role grants the secret to a role at the default role priority" do
+      secret = static_secrets(:acme_staging_api_key)
+      role = roles(:acme_admin_role)
+
+      assert_difference -> { role.grants.count }, 1 do
+        post console_secret_grant_role_url("static", secret.oid), params: { role_id: role.oid }
+      end
+
+      assert_redirected_to console_secret_path("static", secret.oid)
+      grant = role.grants.find_by(static_secret: secret)
+      assert_not_nil grant
+      assert_equal Grant::DEFAULT_ROLE_PRIORITY, grant.priority
+    end
+
+    test "POST grant_role is idempotent" do
+      secret = static_secrets(:acme_prod_api_key)
+      role = roles(:acme_infra)
+
+      assert_no_difference -> { role.grants.count } do
+        post console_secret_grant_role_url("static", secret.oid), params: { role_id: role.oid }
+      end
+
+      assert_redirected_to console_secret_path("static", secret.oid)
+    end
+
+    test "POST grant_role rejects a role from another namespace" do
+      secret = static_secrets(:acme_staging_api_key)
+      role = roles(:globex_infra)
+
+      assert_no_difference -> { Grant.count } do
+        post console_secret_grant_role_url("static", secret.oid), params: { role_id: role.oid }
+      end
+
+      assert_redirected_to console_secret_path("static", secret.oid)
+      assert_equal "Role must be in the same namespace as the secret.", flash[:alert]
+    end
+
+    test "DELETE revoke_role_grant removes a role grant from the secret" do
+      secret = static_secrets(:acme_prod_api_key)
+      grant = grants(:acme_infra_prod_api_key)
+
+      assert_difference -> { roles(:acme_infra).grants.count }, -1 do
+        delete console_secret_revoke_role_grant_url("static", secret.oid, grant.oid)
+      end
+
+      assert_redirected_to console_secret_path("static", secret.oid)
+      assert_not Grant.exists?(grant.id)
+    end
   end
 end

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -52,6 +52,23 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: "op://eng/gmail/refresh-token"
   end
 
+  test "secret detail page renders editable role grants" do
+    secret = static_secrets(:acme_prod_api_key)
+    grant = grants(:acme_infra_prod_api_key)
+    get console_secret_url("static", secret.oid)
+    assert_response :ok
+    assert_select "h2", text: "Roles"
+    assert_select "form[action=?]", console_secret_grant_role_path("static", secret.oid) do
+      assert_select "select[name=role_id][aria-label=?]", "Role to assign"
+      assert_select "option[value=?]", roles(:acme_admin_role).oid
+      assert_select "option[value=?]", roles(:acme_infra).oid, count: 0
+      assert_select "option[value=?]", roles(:globex_infra).oid, count: 0
+    end
+    assert_select "form[action=?]", console_secret_revoke_role_grant_path("static", secret.oid, grant.oid) do
+      assert_select "button[type=submit]", "Unassign"
+    end
+  end
+
   test "secret detail page renders for every secret kind" do
     [
       [ "static", static_secrets(:github_token_inject) ],
@@ -187,12 +204,19 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     principal = principals(:acme_channel)
     get console_principal_url(principal.oid)
     assert_response :ok
+    assert_select "h2", text: "Roles"
+    assert_select "form[action=?]", console_principal_assign_role_path(principal.oid) do
+      assert_select "select[name=role_id][aria-label=?]", "Role to assign"
+      assert_select "option[value=?]", roles(:acme_admin_role).oid
+      assert_select "option[value=?]", roles(:globex_infra).oid, count: 0
+    end
+    assert_select "form[action=?]", console_principal_unassign_role_path(principal.oid, roles(:acme_infra).oid) do
+      assert_select "button[type=submit]", "Unassign"
+    end
     assert_select "h2", text: "Direct Grants"
-    assert_select "select[name=role_id]"
     assert_select "select[name=grantable] optgroup"
-    # Each direct grant exposes a revoke form; each assigned role chip a remove (×) form.
+    # Each direct grant exposes a revoke form.
     assert_select "form[action=?]", console_principal_revoke_grant_path(principal.oid, grants(:acme_channel_github_token).oid)
-    assert_select "form[action=?]", console_principal_unassign_role_path(principal.oid, roles(:acme_infra).oid)
     # The direct grant's id links to the secret's detail page.
     assert_select "a[href=?]", console_secret_path("static", static_secrets(:github_token_inject).oid)
   end

--- a/services/console/test/models/grant_test.rb
+++ b/services/console/test/models/grant_test.rb
@@ -19,6 +19,19 @@ class GrantTest < ActiveSupport::TestCase
     assert grant.valid?
   end
 
+  test "direct principal grants can cross namespaces" do
+    grant = Grant.new(valid_attrs(principal: principals(:globex_user),
+                                  static_secret: static_secrets(:github_token_inject)))
+    assert grant.valid?
+  end
+
+  test "role grants must stay in the secret namespace" do
+    grant = Grant.new(valid_attrs(principal: nil, role: roles(:globex_infra),
+                                  static_secret: static_secrets(:github_token_inject)))
+    assert_not grant.valid?
+    assert_includes grant.errors[:role], "must be in the same namespace as the secret"
+  end
+
   test "requires exactly one grantee" do
     grant = Grant.new(valid_attrs(principal: nil))
     assert_not grant.valid?
@@ -102,7 +115,8 @@ class GrantTest < ActiveSupport::TestCase
   end
 
   test "a role grant defaults to the lower role priority" do
-    grant = Grant.create!(valid_attrs(principal: nil, role: roles(:globex_infra)))
+    grant = Grant.create!(valid_attrs(principal: nil, role: roles(:globex_infra),
+                                      static_secret: static_secrets(:globex_prod_secret)))
     assert_equal Grant::DEFAULT_ROLE_PRIORITY, grant.priority
     assert_operator Grant::DEFAULT_DIRECT_PRIORITY, :>, Grant::DEFAULT_ROLE_PRIORITY
   end

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -324,8 +324,25 @@ class PrincipalTest < ActiveSupport::TestCase
     secret
   end
 
-  def grant_role_oauth(secret = oauth_token_secrets(:acme_gmail_oauth))
+  def grant_role_oauth(secret = nil)
     PrincipalRole.find_or_create_by!(principal: principals(:globex_user), role: roles(:globex_infra))
+    unless secret
+      secret = OauthTokenSecret.new(
+        namespace: "globex",
+        foreign_id: "oauth-#{SecureRandom.hex(4)}",
+        name: "gmail",
+        grant: "refresh_token",
+        token_endpoint: "https://oauth2.googleapis.com/token",
+        scopes: [ "https://www.googleapis.com/auth/gmail.readonly" ],
+        created_by: users(:globex_admin)
+      )
+      secret.sources.build(source_type: "1password", config: { "secret_ref" => "op://eng/gmail/refresh-token" },
+                           role: "refresh_token", role_kind: "credential_field")
+      secret.sources.build(source_type: "env", config: { "var" => "GMAIL_CLIENT_ID" },
+                           role: "client_id", role_kind: "credential_field")
+      secret.rules.build(host: "gmail.googleapis.com", http_methods: [ "GET" ], paths: [], position: 0)
+      secret.save!
+    end
     Grant.create!(role: roles(:globex_infra), oauth_token_secret: secret, created_by: users(:globex_admin))
     secret
   end


### PR DESCRIPTION
Adds role management controls to the console. Principal detail pages can assign and unassign roles, and secret detail pages can assign and unassign same-namespace role grants. This keeps role and secret grant management editable from the relevant detail views while preserving namespace boundaries.