### PR TITLE
fix: replace Linear API key placeholder

### DIFF
--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -844,6 +844,37 @@ fn real_slack_tool_parses_and_translates() {
 }
 
 #[test]
+fn real_linear_tool_replaces_authorization_placeholder() {
+    let Some(tools_dir) = repo_tools_dir() else {
+        return;
+    };
+    let manifest = tools::find_tool(&[tools_dir], "linear").unwrap();
+    let out = translate::translate(
+        "default",
+        "tool-linear",
+        &manifest.all_secrets().cloned().collect::<Vec<_>>(),
+        &SourcePolicy::env(),
+    );
+    let secret = out
+        .inputs
+        .iter()
+        .find_map(|input| match input {
+            SecretInput::Static(secret) if secret.foreign_id == "tool-linear-linear-api-key" => {
+                Some(secret)
+            }
+            _ => None,
+        })
+        .expect("expected the LINEAR_API_KEY static secret");
+    let replace = secret
+        .replace_config
+        .as_ref()
+        .expect("linear should replace the placeholder Authorization header");
+    assert!(secret.inject_config.is_none());
+    assert_eq!(replace.proxy_value, "LINEAR_API_KEY");
+    assert_eq!(replace.match_headers, vec!["Authorization".to_owned()]);
+}
+
+#[test]
 fn real_gsuite_tool_parses_oauth() {
     let Some(tools_dir) = repo_tools_dir() else {
         return;

--- a/tools/productivity/linear/pyproject.toml
+++ b/tools/productivity/linear/pyproject.toml
@@ -27,5 +27,5 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 secrets = [
-    {type = "http", name = "LINEAR_API_KEY", mode = "inject", inject_header = "Authorization", hosts = ["api.linear.app", "uploads.linear.app"]},
+    {type = "http", name = "LINEAR_API_KEY", mode = "replace", match_headers = ["Authorization"], hosts = ["api.linear.app", "uploads.linear.app"]},
 ]


### PR DESCRIPTION
## Summary
- Change the Linear tool secret wiring from header injection to placeholder replacement.
- The Linear client sends `Authorization: LINEAR_API_KEY`, so iron-proxy must replace that placeholder with the real key instead of trying to inject a missing header.
- Keep both `api.linear.app` and `uploads.linear.app` scoped to the same `Authorization` replacement.

## Test plan
- `python3` TOML parse check for `tools/productivity/linear/pyproject.toml`
- `cargo test -p centaur-api-server tool_discovery::tests::discovers_http_oauth_and_overlay_shadowing`