### PR TITLE
[codex] patch state-pg expired cache leases

### DIFF
--- a/patches/@chat-adapter__state-pg@4.31.0.patch
+++ b/patches/@chat-adapter__state-pg@4.31.0.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/index.js b/dist/index.js
+index 1d6553eeee2b45e88473ad96c9549268ffc39c72..74c3b0255781016b7fadbd7e7524d87ddae8d415 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -181,7 +181,12 @@ var PostgresStateAdapter = class {
+     const result = await this.pool.query(
+       `INSERT INTO chat_state_cache (key_prefix, cache_key, value, expires_at)
+        VALUES ($1, $2, $3, $4)
+-       ON CONFLICT (key_prefix, cache_key) DO NOTHING
++       ON CONFLICT (key_prefix, cache_key) DO UPDATE
++         SET value = EXCLUDED.value,
++             expires_at = EXCLUDED.expires_at,
++             updated_at = now()
++         WHERE chat_state_cache.expires_at IS NOT NULL
++           AND chat_state_cache.expires_at <= now()
+        RETURNING cache_key`,
+       [this.keyPrefix, key, serialized, expiresAt]
+     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ patchedDependencies:
   '@chat-adapter/slack@4.31.0':
     hash: f656c319fc04061edbaf3a94ae5d46cbed31057d1057cad70748abb12ef4e151
     path: patches/@chat-adapter__slack@4.31.0.patch
+  '@chat-adapter/state-pg@4.31.0':
+    hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
+    path: patches/@chat-adapter__state-pg@4.31.0.patch
 
 importers:
 
@@ -82,7 +85,7 @@ importers:
         version: 4.31.0(patch_hash=8f4fbb770159f924570fbad681297fcb9f8f7a6353a705cfcb78e39ef9e3a3ab)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
-        version: 4.31.0(zod@4.4.3)
+        version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
       chat:
         specifier: ^4.31.0
         version: 4.31.0(zod@4.4.3)
@@ -128,7 +131,7 @@ importers:
         version: 4.31.0(patch_hash=f656c319fc04061edbaf3a94ae5d46cbed31057d1057cad70748abb12ef4e151)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
-        version: 4.31.0(zod@4.4.3)
+        version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
       chat:
         specifier: ^4.31.0
         version: 4.31.0(zod@4.4.3)
@@ -1298,7 +1301,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/state-pg@4.31.0(zod@4.4.3)':
+  '@chat-adapter/state-pg@4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)':
     dependencies:
       chat: 4.31.0(zod@4.4.3)
       pg: 8.21.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
 patchedDependencies:
   '@chat-adapter/discord@4.31.0': patches/@chat-adapter__discord@4.31.0.patch
   '@chat-adapter/slack@4.31.0': patches/@chat-adapter__slack@4.31.0.patch
+  '@chat-adapter/state-pg@4.31.0': patches/@chat-adapter__state-pg@4.31.0.patch


### PR DESCRIPTION
## Summary

Adds a pnpm patch for `@chat-adapter/state-pg@4.31.0` so Centaur gets the expired-cache-lease fix before an upstream package release is available.

The patch changes `setIfNotExists()` in the published `dist/index.js` to replace an existing `chat_state_cache` row only when that row has expired. Active rows still block acquisition.

This prevents stale Slackbot/Discordbot render leases from blocking recovery forever after a worker dies or a recovery attempt times out.

## Validation

- `pnpm install`
- `pnpm --filter slackbotv2 check:types`
- `pnpm --filter discordbot check:types`
- `pnpm --filter slackbotv2 test`
- `pnpm --filter discordbot test`
- Verified `services/slackbotv2/node_modules/@chat-adapter/state-pg` resolves to the patched pnpm package hash and contains the expired-row takeover SQL.
