### PR TITLE
fix: omit chat task output before rendering

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -522,7 +522,8 @@ describe('CodexAppServerRendererEventMapper', () => {
               }
             }
           }
-        ])
+        ]),
+        { taskOutput: 'full' }
       )
     )
 
@@ -541,6 +542,74 @@ describe('CodexAppServerRendererEventMapper', () => {
       id: 'cmd-1',
       status: 'complete'
     })
+  })
+
+  it('omits command output before task updates by default', async () => {
+    const largeOutput = 'large-context-line\n'.repeat(1_000)
+    const chunks = await collect(
+      codexAppServerToChatSdkStream(
+        toAsyncIterable([
+          {
+            method: 'item/started',
+            params: {
+              threadId: 'thread-1',
+              turnId: 'turn-1',
+              item: {
+                id: 'cmd-1',
+                type: 'commandExecution',
+                command: 'gh run view --log',
+                status: 'inProgress'
+              }
+            }
+          },
+          {
+            method: 'item/commandExecution/outputDelta',
+            params: {
+              threadId: 'thread-1',
+              turnId: 'turn-1',
+              itemId: 'cmd-1',
+              delta: largeOutput.slice(0, 5_000)
+            }
+          },
+          {
+            method: 'item/commandExecution/outputDelta',
+            params: {
+              threadId: 'thread-1',
+              turnId: 'turn-1',
+              itemId: 'cmd-1',
+              delta: largeOutput.slice(5_000)
+            }
+          },
+          {
+            method: 'item/completed',
+            params: {
+              threadId: 'thread-1',
+              turnId: 'turn-1',
+              item: {
+                id: 'cmd-1',
+                type: 'commandExecution',
+                command: 'gh run view --log',
+                status: 'completed',
+                aggregatedOutput: largeOutput,
+                exitCode: 0
+              }
+            }
+          }
+        ])
+      )
+    )
+
+    const taskChunks = chunks.filter(
+      (chunk): chunk is Extract<(typeof chunks)[number], { type: 'task_update' }> =>
+        chunk.type === 'task_update' && chunk.id === 'cmd-1'
+    )
+    expect(taskChunks.map(chunk => chunk.output).filter(Boolean)).toEqual([])
+    expect(taskChunks.some(chunk => chunk.details?.includes('gh run view --log'))).toBe(true)
+    expect(taskChunks.at(-1)).toMatchObject({
+      id: 'cmd-1',
+      status: 'complete'
+    })
+    expect(JSON.stringify(taskChunks)).not.toContain('large-context-line')
   })
 
   it('preserves full command output in task updates', async () => {
@@ -564,7 +633,8 @@ describe('CodexAppServerRendererEventMapper', () => {
               }
             }
           }
-        ])
+        ]),
+        { taskOutput: 'full' }
       )
     )
 
@@ -598,7 +668,8 @@ describe('CodexAppServerRendererEventMapper', () => {
               }
             }
           }
-        ])
+        ]),
+        { taskOutput: 'full' }
       )
     )
 
@@ -632,7 +703,8 @@ describe('CodexAppServerRendererEventMapper', () => {
               }
             }
           }
-        ])
+        ]),
+        { taskOutput: 'full' }
       )
     )
 

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -73,6 +73,7 @@ export type CodexAppServerRendererEventMapperOptions = {
   sessionId?: string
   logInfo?: RendererLogInfo
   unknownAgentMessagePhase?: AgentMessagePhase
+  taskOutput?: 'full' | 'omit'
 }
 
 export type CodexAppServerToChatStreamOptions = CodexAppServerRendererEventMapperOptions & {
@@ -87,11 +88,13 @@ export class CodexAppServerRendererEventMapper
   private readonly sessionId: string
   private readonly logInfo?: RendererLogInfo
   private readonly unknownAgentMessagePhase: AgentMessagePhase
+  private readonly includeTaskOutput: boolean
 
   constructor(options: CodexAppServerRendererEventMapperOptions = {}) {
     this.sessionId = options.sessionId ?? ''
     this.logInfo = options.logInfo
     this.unknownAgentMessagePhase = options.unknownAgentMessagePhase ?? 'final_answer'
+    this.includeTaskOutput = options.taskOutput === 'full'
   }
 
   process(source: ServerNotification | RustSessionStreamEvent | unknown): RendererEvent[] {
@@ -199,16 +202,19 @@ export class CodexAppServerRendererEventMapper
     const command = commandExecution(event)
     if (command) {
       const id = commandId(command)
-      const aggregatedOutput = commandAggregatedOutput(command)
-      if (aggregatedOutput) this.state.commandOutputById.set(id, aggregatedOutput)
+      if (this.includeTaskOutput) {
+        const aggregatedOutput = commandAggregatedOutput(command)
+        if (aggregatedOutput) this.state.commandOutputById.set(id, aggregatedOutput)
+      }
       const existing = this.state.taskByUseId.get(id)
       const commandIndex = commandNumber(this.state, existing)
       const task = commandTask(
         command,
         String(event?.type ?? ''),
         existing,
-        this.state.commandOutputById.get(id),
-        commandIndex
+        this.includeTaskOutput ? this.state.commandOutputById.get(id) : undefined,
+        commandIndex,
+        this.includeTaskOutput
       )
       const merged = mergeTask(existing, task)
       this.state.taskByUseId.set(merged.id, merged)
@@ -225,7 +231,7 @@ export class CodexAppServerRendererEventMapper
     }
 
     const outputDelta = commandOutputDelta(event)
-    if (outputDelta) {
+    if (outputDelta && this.includeTaskOutput) {
       const current = this.state.commandOutputById.get(outputDelta.id) ?? ''
       const output = current + outputDelta.delta
       this.state.commandOutputById.set(outputDelta.id, output)
@@ -1296,7 +1302,8 @@ function commandTask(
   eventType: string,
   existing?: HarnessTask,
   accumulatedOutput?: string,
-  commandIndex?: number
+  commandIndex?: number,
+  includeOutput = true
 ): HarnessTask {
   const id = commandId(item)
   const rawCommand = String(item.command ?? 'Command')
@@ -1307,7 +1314,7 @@ function commandTask(
   const failed = isCommandFailure(item, eventType)
   const isCompletionUpdate =
     eventType === 'item.completed' || status === 'complete' || status === 'error'
-  const output = commandOutputElements(accumulatedOutput ?? '', exitCode)
+  const output = includeOutput ? commandOutputElements(accumulatedOutput ?? '', exitCode) : []
   return {
     id,
     title: commandExecutionTitle(commandIndex),


### PR DESCRIPTION
## Summary
- make the renderer omit command task output by default before accumulation/conversion
- keep `taskOutput: "full"` as an explicit renderer opt-in for consumers/tests that need full command output
- add a regression test proving large command output produces task updates with no output chunks on the default path

## Validation
- pnpm --filter @centaur/rendering test
- pnpm --filter slackbotv2 check:types
- pnpm --filter discordbot check:types
- pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts
- pnpm --filter discordbot test
- just build-one slackbotv2
- just build-one discordbot
- helm --kube-context orbstack upgrade --install centaur contrib/chart -n centaur --create-namespace -f contrib/chart/values.dev.yaml
- kubectl --context orbstack -n centaur rollout restart deploy/centaur-centaur-slackbotv2
- kubectl --context orbstack -n centaur rollout status deploy/centaur-centaur-slackbotv2 --timeout=180s
- local pod /health returned 200
- local pod default renderer probe returned {"taskUpdates":3,"outputChunks":0}
