### PR TITLE
Preserve Slack channel IDs in Codex prompts

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -153,6 +153,11 @@
 |If the user is asking what this deployment can do, do not stop at local workspace hints; use live discovery first, or explicitly say the answer is partial and non-exhaustive.
 |Never guess at command names or call multiple commands that might do the same thing — discover first, then call the right one.
 
+[Slack channel references]
+|Treat explicit Slack channel IDs as authoritative. If a user refers to a channel as `#name (C123...)`, `<#C123...|name>`, `#C123...`, or otherwise provides a channel ID, use that exact ID for Slack history/search/file operations.
+|When fetching or summarizing a specific Slack channel, verify that the fetched `channel_id` matches the requested channel ID before using the results. If it does not match, stop and report the mismatch.
+|Never substitute a search-derived or semantically similar channel for an explicitly requested Slack channel ID. If both a human-readable channel name and ID are present, the ID wins.
+
 [Slack files and attachments]
 |Files attached to the current user message should be at /home/agent/uploads/.
 |When you see [Attached image: ...], use the look_at tool to view the image.

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -2141,11 +2141,11 @@ function slackTimestampToIso(ts: string): string {
     : new Date().toISOString()
 }
 
-function normalizeSlackText(input: string): string {
+export function normalizeSlackText(input: string): string {
   return input
     .replace(/<([a-z]+:\/\/[^>|]+)\|([^>]+)>/gi, '$2 ($1)')
     .replace(/<([a-z]+:\/\/[^>]+)>/gi, '$1')
-    .replace(/<#([A-Z0-9]+)\|([^>]+)>/g, '#$2')
+    .replace(/<#([A-Z0-9]+)\|([^>]+)>/g, '#$2 ($1)')
     .replace(/<#([A-Z0-9]+)>/g, '#$1')
     .replace(/<@([A-Z0-9]+)>/g, '@$1')
     .replace(/<!subteam\^([A-Z0-9]+)\|([^>]+)>/g, '@$2')

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -13,6 +13,7 @@ import { createMemoryState } from '@chat-adapter/state-memory'
 import type { ServerNotification } from '@centaur/harness-events'
 import {
   createSlackbotV2,
+  normalizeSlackText,
   type SlackbotV2,
   type SlackbotV2AppendMessagesRequest,
   type SlackbotV2ApiMessage,
@@ -33,6 +34,14 @@ const TEAM_ID = 'T000000001'
 const CHANNEL_ID = 'C000000001'
 /** How real Slack renders a streamed message whose stream broke or was never stopped. */
 const BROKEN_STREAM_TEXT = ':warning: Something went wrong'
+
+describe('normalizeSlackText', () => {
+  it('preserves Slack channel IDs when rendering labeled channel mentions', () => {
+    expect(normalizeSlackText('<#C0AJ07U8Z1N|eng-centaur>')).toBe(
+      '#eng-centaur (C0AJ07U8Z1N)'
+    )
+  })
+})
 
 let emulator: Emulator
 let slackApi: PatchedSlackApi


### PR DESCRIPTION
## Summary
- render labeled Slack channel mentions as `#name (CID)` so Codex sees both the readable name and immutable ID
- add sandbox instructions that explicit Slack channel IDs are authoritative and must match fetched channel history
- add a regression test for channel mention normalization

## Tests
- `pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts`
- `pnpm --filter slackbotv2 check:types`

Prompted by: @Zygimantass