### PR TITLE
Add AI thread SLA metrics

### DIFF
--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -22,7 +22,7 @@ use centaur_session_sqlx::{
 };
 use centaur_telemetry::{
     record_sandbox_warm_pool_claim, record_session_execution_finished,
-    record_session_execution_started,
+    record_session_execution_started, record_session_failure, record_session_first_token_latency,
 };
 use futures_util::{SinkExt, Stream, StreamExt, stream};
 use serde_json::{Value, json};
@@ -37,6 +37,7 @@ use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
 use tracing::{Instrument, Span, error, info, info_span, warn};
 
 pub const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
+pub const SESSION_FIRST_TOKEN_EVENT: &str = "session.first_token";
 
 const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
@@ -748,7 +749,14 @@ impl SessionRuntime {
             .fail_execution(execution_id, &error_message)
             .await
         {
-            record_finished_execution_metric(&self.store, thread_key, &execution, "failed").await;
+            record_finished_execution_metric(
+                &self.store,
+                thread_key,
+                &execution,
+                "failed",
+                Some(runtime_error_failure_class(error)),
+            )
+            .await;
         }
     }
 
@@ -1967,6 +1975,16 @@ async fn run_stdout_pump(
             else {
                 continue;
             };
+            let first_token_execution = active_execution
+                .as_ref()
+                .filter(|execution| {
+                    execution.execution_id == output_execution_id
+                        && output_state.should_record_first_token(
+                            &output_execution_id,
+                            output_value.as_ref(),
+                        )
+                })
+                .cloned();
             let execution_span = ctx
                 .execution_spans
                 .lock()
@@ -1979,9 +1997,20 @@ async fn run_stdout_pump(
                 sandbox_id,
                 &output_execution_id,
             );
-            append_output_line(&ctx.store, &thread_key, Some(&output_execution_id), &line)
+            let output_event =
+                append_output_line(&ctx.store, &thread_key, Some(&output_execution_id), &line)
                 .instrument(output_span.clone())
                 .await?;
+            if let Some(execution) = first_token_execution {
+                record_first_token_observation(
+                    &ctx,
+                    &thread_key,
+                    &execution,
+                    &output_event,
+                    &mut output_state,
+                )
+                .await;
+            }
             if let Some(value) = output_value.as_ref() {
                 output_state.record_codex_app_server_spans(
                     &output_span,
@@ -2094,9 +2123,99 @@ async fn record_stdout_pump_failure(
     Ok(())
 }
 
+async fn record_first_token_observation(
+    ctx: &RuntimeContext,
+    thread_key: &ThreadKey,
+    execution: &SessionExecution,
+    output_event: &SessionEvent,
+    output_state: &mut StdoutPumpState,
+) {
+    match ctx
+        .store
+        .execution_event_exists(&execution.execution_id, SESSION_FIRST_TOKEN_EVENT)
+        .await
+    {
+        Ok(true) => {
+            output_state.mark_first_token_recorded(&execution.execution_id);
+            return;
+        }
+        Ok(false) => {}
+        Err(error) => {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_first_token_marker_check_failed",
+                thread_key = %thread_key,
+                execution_id = %execution.execution_id,
+                %error,
+                "failed to check existing first-token marker"
+            );
+        }
+    }
+
+    let Some(latency) = first_token_latency(execution, output_event) else {
+        output_state.mark_first_token_recorded(&execution.execution_id);
+        return;
+    };
+    let harness_label = match ctx.store.get_session(thread_key).await {
+        Ok(session) => session.harness_type.to_string(),
+        Err(error) => {
+            warn!(%thread_key, %error, "failed to load session for first-token metric labels");
+            "unknown".to_owned()
+        }
+    };
+    let latency_ms = duration_millis_u64(latency);
+    if let Err(error) = ctx
+        .store
+        .append_event(
+            thread_key,
+            Some(&execution.execution_id),
+            SESSION_FIRST_TOKEN_EVENT,
+            json!({
+                "execution_id": execution.execution_id.as_str(),
+                "thread_key": thread_key.as_str(),
+                "harness_type": harness_label.as_str(),
+                "latency_ms": latency_ms,
+                "output_event_id": output_event.event_id,
+            }),
+        )
+        .await
+    {
+        warn!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_first_token_marker_append_failed",
+            thread_key = %thread_key,
+            execution_id = %execution.execution_id,
+            output_event_id = output_event.event_id,
+            %error,
+            "failed to append first-token marker"
+        );
+    }
+    record_session_first_token_latency(&harness_label, latency);
+    output_state.mark_first_token_recorded(&execution.execution_id);
+    info!(
+        component = COMPONENT_SESSION_RUNTIME,
+        event = "session_first_token_observed",
+        thread_key = %thread_key,
+        execution_id = %execution.execution_id,
+        harness_type = %harness_label,
+        latency_ms,
+        output_event_id = output_event.event_id,
+        "session first answer token observed"
+    );
+}
+
+fn first_token_latency(
+    execution: &SessionExecution,
+    output_event: &SessionEvent,
+) -> Option<Duration> {
+    let started_at = execution.started_at.unwrap_or(execution.created_at);
+    (output_event.created_at - started_at).try_into().ok()
+}
+
 #[derive(Default)]
 struct StdoutPumpState {
     final_answer_text_by_execution: HashMap<String, String>,
+    first_token_recorded_by_execution: HashSet<String>,
     turn_execution_by_id: HashMap<String, String>,
     item_execution_by_id: HashMap<String, String>,
     tool_call_by_id: HashMap<String, ToolCallLabels>,
@@ -2158,8 +2277,41 @@ impl StdoutPumpState {
         )
     }
 
+    fn should_record_first_token(&self, execution_id: &str, value: Option<&Value>) -> bool {
+        if self
+            .first_token_recorded_by_execution
+            .contains(execution_id)
+            || self
+                .final_answer_text_by_execution
+                .get(execution_id)
+                .is_some_and(|text| !text.trim().is_empty())
+        {
+            return false;
+        }
+
+        let Some(value) = value else {
+            return false;
+        };
+        if output_line_final_answer_text(value).is_some() {
+            return true;
+        }
+        matches!(
+            terminal_output(value, ""),
+            Some(TerminalOutput::Completed {
+                result_text: Some(_),
+                ..
+            })
+        )
+    }
+
+    fn mark_first_token_recorded(&mut self, execution_id: &str) {
+        self.first_token_recorded_by_execution
+            .insert(execution_id.to_owned());
+    }
+
     fn forget(&mut self, execution_id: &str) {
         self.final_answer_text_by_execution.remove(execution_id);
+        self.first_token_recorded_by_execution.remove(execution_id);
         let tool_ids_to_forget = self
             .item_execution_by_id
             .iter()
@@ -2631,6 +2783,7 @@ async fn record_terminal_output(
     execution_id: &str,
     terminal: TerminalOutput,
 ) -> Result<(), SessionRuntimeError> {
+    let mut failure_class = None;
     let (terminal_execution, terminal_status) = match terminal {
         TerminalOutput::Completed {
             reason,
@@ -2661,6 +2814,7 @@ async fn record_terminal_output(
             (execution, "completed")
         }
         TerminalOutput::Failed { error } => {
+            failure_class = Some(terminal_failure_class(&error));
             let Some(execution) = ctx
                 .store
                 .fail_execution_if_active(execution_id, &error)
@@ -2684,8 +2838,14 @@ async fn record_terminal_output(
         }
     };
     ctx.execution_spans.lock().await.remove(execution_id);
-    record_finished_execution_metric(&ctx.store, thread_key, &terminal_execution, terminal_status)
-        .await;
+    record_finished_execution_metric(
+        &ctx.store,
+        thread_key,
+        &terminal_execution,
+        terminal_status,
+        failure_class,
+    )
+    .await;
     if let Some(idle_timeout) = idle_timeout_from_execution(&terminal_execution) {
         spawn_idle_pause(
             ctx.clone(),
@@ -2752,7 +2912,14 @@ async fn record_max_duration_failure(
             }),
         )
         .await?;
-    record_finished_execution_metric(&ctx.store, thread_key, &execution, "failed").await;
+    record_finished_execution_metric(
+        &ctx.store,
+        thread_key,
+        &execution,
+        "failed",
+        Some("timeout"),
+    )
+    .await;
     if let Some(idle_timeout) = idle_timeout.or_else(|| idle_timeout_from_execution(&execution))
         && let Some(sandbox_id) = ctx.store.get_session(thread_key).await?.sandbox_id
     {
@@ -2914,6 +3081,7 @@ async fn record_finished_execution_metric(
     thread_key: &ThreadKey,
     execution: &SessionExecution,
     status: &'static str,
+    failure_class: Option<&'static str>,
 ) {
     let harness_label = match store.get_session(thread_key).await {
         Ok(session) => session.harness_type.to_string(),
@@ -2923,12 +3091,44 @@ async fn record_finished_execution_metric(
         }
     };
     record_session_execution_finished(&harness_label, status, execution_duration(execution));
+    if let Some(failure_class) = failure_class {
+        record_session_failure(&harness_label, failure_class);
+    }
 }
 
 fn execution_duration(execution: &SessionExecution) -> Option<Duration> {
     let started_at = execution.started_at.unwrap_or(execution.created_at);
     let completed_at = execution.completed_at?;
     (completed_at - started_at).try_into().ok()
+}
+
+fn runtime_error_failure_class(error: &SessionRuntimeError) -> &'static str {
+    match error {
+        SessionRuntimeError::BadRequest(_) => "bad_request",
+        SessionRuntimeError::Store(_) => "store",
+        SessionRuntimeError::Sandbox(SandboxError::NotFound(_)) => "sandbox_not_found",
+        SessionRuntimeError::Sandbox(SandboxError::Unsupported { .. }) => "sandbox_unsupported",
+        SessionRuntimeError::Sandbox(SandboxError::NotReady(_)) => "sandbox_not_ready",
+        SessionRuntimeError::Sandbox(SandboxError::Io { .. }) => "sandbox_io",
+        SessionRuntimeError::Sandbox(SandboxError::Backend { .. }) => "sandbox_backend",
+        SessionRuntimeError::Sandbox(SandboxError::InvalidSpec(_)) => "sandbox_invalid_spec",
+        SessionRuntimeError::IronControl(_) => "iron_control",
+        SessionRuntimeError::WarmPool(_) => "warm_pool",
+    }
+}
+
+fn terminal_failure_class(error: &str) -> &'static str {
+    let error = error.to_ascii_lowercase();
+    if error.contains("max_duration") || error.contains("timeout") || error.contains("timed out") {
+        return "timeout";
+    }
+    if error.contains("execution orphaned") {
+        return "orphaned";
+    }
+    if error.contains("sandbox stdout") || error.contains("stdout closed") {
+        return "sandbox_io";
+    }
+    "harness"
 }
 
 fn should_attach_session_pipe(status: &SandboxStatus) -> bool {
@@ -3349,9 +3549,9 @@ async fn append_output_line(
     thread_key: &ThreadKey,
     execution_id: Option<&str>,
     line: &str,
-) -> Result<(), SessionRuntimeError> {
+) -> Result<SessionEvent, SessionRuntimeError> {
     let safe_line = redact_sensitive_text(line);
-    store
+    let event = store
         .append_event(
             thread_key,
             execution_id,
@@ -3359,7 +3559,7 @@ async fn append_output_line(
             Value::String(safe_line),
         )
         .await?;
-    Ok(())
+    Ok(event)
 }
 
 fn redact_sensitive_text(input: &str) -> String {
@@ -3820,6 +4020,39 @@ mod tests {
     #[test]
     fn timeout_event_uses_millisecond_duration() {
         assert_eq!(duration_millis_u64(Duration::from_millis(3_000)), 3_000);
+    }
+
+    #[test]
+    fn stdout_state_first_token_detection_uses_answer_text() {
+        let state = StdoutPumpState::default();
+        let turn_started = json!({"type": "turn.started", "turn_id": "turn-1"});
+        let delta = json!({
+            "type": "item.agentMessage.delta",
+            "turnId": "turn-1",
+            "itemId": "msg-1",
+            "delta": "Hello"
+        });
+        let terminal_result = json!({"type": "result", "result": {"text": "Done"}});
+
+        assert!(!state.should_record_first_token("exe-1", Some(&turn_started)));
+        assert!(state.should_record_first_token("exe-1", Some(&delta)));
+        assert!(state.should_record_first_token("exe-2", Some(&terminal_result)));
+    }
+
+    #[test]
+    fn terminal_failure_class_is_low_cardinality() {
+        assert_eq!(
+            terminal_failure_class("sandbox stdout closed before terminal output"),
+            "sandbox_io"
+        );
+        assert_eq!(
+            terminal_failure_class("execution orphaned by control plane restart"),
+            "orphaned"
+        );
+        assert_eq!(
+            terminal_failure_class("turn failed: model error"),
+            "harness"
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0024_session_event_execution_type_idx.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0024_session_event_execution_type_idx.sql
@@ -1,0 +1,3 @@
+create index if not exists session_events_execution_type_idx
+    on session_events (execution_id, event_type)
+    where execution_id is not null;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -484,6 +484,30 @@ impl PgSessionStore {
         rows.into_iter().map(TryInto::try_into).collect()
     }
 
+    pub async fn execution_event_exists(
+        &self,
+        execution_id: &str,
+        event_type: &str,
+    ) -> Result<bool, SessionStoreError> {
+        let exists = sqlx::query_scalar::<_, bool>(
+            r#"
+            select exists (
+                select 1
+                from session_events
+                where execution_id = $1
+                  and event_type = $2
+                limit 1
+            )
+            "#,
+        )
+        .bind(execution_id)
+        .bind(event_type)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(exists)
+    }
+
     pub async fn update_sandbox_id(
         &self,
         thread_key: &ThreadKey,

--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -41,6 +41,8 @@ pub const HTTP_REQUEST_DURATION_SECONDS: &str = "http_server_request_duration_se
 pub const HTTP_REQUESTS_IN_FLIGHT: &str = "http_server_requests_in_flight";
 pub const SESSION_EXECUTIONS_TOTAL: &str = "centaur_session_executions_total";
 pub const SESSION_EXECUTION_DURATION_SECONDS: &str = "centaur_session_execution_duration_seconds";
+pub const SESSION_FIRST_TOKEN_LATENCY_SECONDS: &str = "centaur_session_first_token_latency_seconds";
+pub const SESSION_FAILURES_TOTAL: &str = "centaur_session_failures_total";
 pub const SANDBOX_OPERATIONS_TOTAL: &str = "centaur_sandbox_operations_total";
 pub const SANDBOX_STARTUP_DURATION_SECONDS: &str = "centaur_sandbox_startup_duration_seconds";
 pub const SANDBOX_WARM_POOL_CLAIMS_TOTAL: &str = "centaur_sandbox_warm_pool_claims_total";
@@ -68,6 +70,9 @@ const HTTP_REQUEST_DURATION_BUCKETS: &[f64] = &[
 ];
 const SESSION_EXECUTION_DURATION_BUCKETS: &[f64] = &[
     0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 300.0, 900.0,
+];
+const SESSION_FIRST_TOKEN_LATENCY_BUCKETS: &[f64] = &[
+    0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 900.0,
 ];
 const SANDBOX_STARTUP_DURATION_BUCKETS: &[f64] =
     &[0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0];
@@ -194,6 +199,10 @@ pub fn prometheus_handle() -> Result<PrometheusHandle, TelemetryError> {
             SESSION_EXECUTION_DURATION_BUCKETS,
         )?
         .set_buckets_for_metric(
+            Matcher::Full(SESSION_FIRST_TOKEN_LATENCY_SECONDS.to_owned()),
+            SESSION_FIRST_TOKEN_LATENCY_BUCKETS,
+        )?
+        .set_buckets_for_metric(
             Matcher::Full(SANDBOX_STARTUP_DURATION_SECONDS.to_owned()),
             SANDBOX_STARTUP_DURATION_BUCKETS,
         )?
@@ -261,6 +270,23 @@ pub fn record_session_execution_finished(
         )
         .record(duration.as_secs_f64());
     }
+}
+
+pub fn record_session_first_token_latency(harness: &str, duration: Duration) {
+    metrics::histogram!(
+        SESSION_FIRST_TOKEN_LATENCY_SECONDS,
+        "harness" => normalize_label(harness),
+    )
+    .record(duration.as_secs_f64());
+}
+
+pub fn record_session_failure(harness: &str, failure_class: &str) {
+    metrics::counter!(
+        SESSION_FAILURES_TOTAL,
+        "failure_class" => normalize_label(failure_class),
+        "harness" => normalize_label(harness),
+    )
+    .increment(1);
 }
 
 pub fn record_sandbox_operation(backend: &str, operation: &'static str, status: &'static str) {
@@ -451,6 +477,15 @@ fn describe_metrics() {
         SESSION_EXECUTION_DURATION_SECONDS,
         metrics::Unit::Seconds,
         "Session execution runtime in seconds by harness and terminal status."
+    );
+    metrics::describe_histogram!(
+        SESSION_FIRST_TOKEN_LATENCY_SECONDS,
+        metrics::Unit::Seconds,
+        "Latency from session execution start to first answer token by harness."
+    );
+    metrics::describe_counter!(
+        SESSION_FAILURES_TOTAL,
+        "Session execution failures by harness and low-cardinality failure class."
     );
     metrics::describe_counter!(
         SANDBOX_OPERATIONS_TOTAL,
@@ -721,6 +756,8 @@ mod tests {
         prometheus_handle().unwrap();
         record_session_execution_started("codex");
         record_session_execution_finished("codex", "completed", Some(Duration::from_secs(2)));
+        record_session_first_token_latency("codex", Duration::from_millis(750));
+        record_session_failure("codex", "timeout");
         record_sandbox_operation("local", "create", "success");
         record_sandbox_startup_duration("local", "success", Duration::from_secs(4));
         record_sandbox_warm_pool_claim("hit");
@@ -738,6 +775,13 @@ mod tests {
         );
         assert!(metrics.contains(
             r#"centaur_session_execution_duration_seconds_count{harness="codex",status="completed"}"#
+        ));
+        assert!(
+            metrics
+                .contains(r#"centaur_session_first_token_latency_seconds_count{harness="codex"}"#)
+        );
+        assert!(metrics.contains(
+            r#"centaur_session_failures_total{failure_class="timeout",harness="codex"}"#
         ));
         assert!(metrics.contains(
             r#"centaur_sandbox_operations_total{backend="local",operation="create",status="success"}"#

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -377,11 +377,31 @@ function recordForward(
 function recordRenderAttempt(source: string, outcome: string, startedAtMs: number): void {
   slackbotMetrics.renderAttempts.inc({ outcome, source })
   slackbotMetrics.renderAttemptDuration.observe({ outcome, source }, observeSeconds(startedAtMs))
+  slackbotMetrics.sessionDelivery.inc({ delivery_status: deliveryStatusForRenderOutcome(outcome) })
   if (outcome === 'complete' || outcome === 'fallback' || outcome === 'answer_visible') {
     slackbotMetrics.lastSuccessfulRenderTimestamp.set(
       { source },
       Math.floor(Date.now() / 1000)
     )
+  }
+}
+
+function deliveryStatusForRenderOutcome(outcome: string): string {
+  switch (outcome) {
+    case 'complete':
+      return 'streamed'
+    case 'fallback':
+      return 'fallback_sent'
+    case 'answer_visible':
+      return 'answer_visible'
+    case 'retry':
+      return 'deferred'
+    case 'stream_error_rendered':
+      return 'error_visible'
+    case 'size_limit_no_replacement':
+      return 'failed_size_limit'
+    default:
+      return 'failed'
   }
 }
 

--- a/services/slackbotv2/src/metrics.ts
+++ b/services/slackbotv2/src/metrics.ts
@@ -306,6 +306,11 @@ export const slackbotMetrics = {
     labelNames: ['event'],
     name: 'slackbotv2_render_recovery_thread_events_total'
   }),
+  sessionDelivery: counter({
+    help: 'User-visible Slack delivery outcomes for AI session responses.',
+    labelNames: ['delivery_status'],
+    name: 'centaur_session_delivery_total'
+  }),
   sessionApiOperationDuration: histogram({
     help: 'Session API operation duration from Slackbot, in seconds.',
     labelNames: ['operation', 'outcome'],

--- a/services/slackbotv2/test/metrics.test.ts
+++ b/services/slackbotv2/test/metrics.test.ts
@@ -11,6 +11,9 @@ describe('slackbotv2 metrics', () => {
       outcome: 'success',
       route: '/api/webhooks/slack'
     })
+    slackbotMetrics.sessionDelivery.inc({
+      delivery_status: 'streamed'
+    })
 
     const bot = createSlackbotV2({
       apiUrl: 'http://api.test',
@@ -29,6 +32,9 @@ describe('slackbotv2 metrics', () => {
     expect(body).toContain('slackbotv2_info 1')
     expect(body).toContain(
       'slackbotv2_slack_webhook_requests_total{route="/api/webhooks/slack",event_type="app_mention",outcome="success"} 1'
+    )
+    expect(body).toContain(
+      'centaur_session_delivery_total{delivery_status="streamed"} 1'
     )
   })
 })


### PR DESCRIPTION
## Summary
- add Rust Prometheus metrics for session first-token latency and failure counts by low-cardinality failure class
- record first-token latency from execution start to the first answer-token output, with a durable `session.first_token` marker to avoid duplicate samples after stdout reattach
- add Slackbot `centaur_session_delivery_total{delivery_status=...}` from live/recovery render outcomes
- add an index for first-token marker lookups on `session_events`

## Validation
- `cargo test -p centaur-telemetry -p centaur-session-runtime`
- `bun test test/metrics.test.ts`
- `bun run check:types`