### PR TITLE
[codex] bound Slackbot stale render recovery

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -102,6 +102,7 @@ const RENDER_OBLIGATION_INDEX_MAX_LENGTH = 2000
 const RENDER_INDEX_TTL_MS = 30 * 24 * 60 * 60 * 1000
 const RENDER_RECOVERY_LEASE_TTL_MS = 2 * 60 * 1000
 const RENDER_LEASE_REFRESH_INTERVAL_MS = 60 * 1000
+const RENDER_RECOVERY_MAX_OBLIGATION_AGE_MS = 24 * 60 * 60 * 1000
 const RENDER_RECOVERY_THREAD_TIMEOUT_MS = 2 * 60 * 1000
 const RENDER_RECOVERY_MAX_THREAD_FAILURES = 5
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
@@ -1160,6 +1161,8 @@ async function recoverRenderObligations(
   await chat.initialize()
   const indexedThreadIds = await state.getList<string>(RENDER_OBLIGATION_INDEX_KEY)
   const threadIds = Array.from(new Set(indexedThreadIds))
+  const maxObligationAgeMs =
+    options.renderRecoveryMaxObligationAgeMs ?? RENDER_RECOVERY_MAX_OBLIGATION_AGE_MS
   const timeoutMs = options.renderRecoveryThreadTimeoutMs ?? RENDER_RECOVERY_THREAD_TIMEOUT_MS
   let abandonedCount = 0
   let activeObligationCount = 0
@@ -1168,6 +1171,7 @@ async function recoverRenderObligations(
   let leaseSkippedCount = 0
   let resolvedCount = 0
   let retryableDeferredCount = 0
+  let staleSkippedCount = 0
   let timedOutCount = 0
   traceLog(options, 'slackbotv2_render_recovery_scan', undefined, {
     indexed_thread_count: threadIds.length,
@@ -1182,6 +1186,23 @@ async function recoverRenderObligations(
       const obligation = threadState?.renderObligation
       if (!obligation) continue
       activeObligationCount += 1
+
+      const obligationAgeMs = renderObligationAgeMs(obligation)
+      if (obligationAgeMs !== undefined && obligationAgeMs > maxObligationAgeMs) {
+        staleSkippedCount += 1
+        recordRecoveryThreadEvent('stale_skipped')
+        traceLog(options, 'slackbotv2_render_recovery_stale_obligation_skipped', undefined, {
+          ...renderObligationFields(obligation),
+          max_obligation_age_ms: maxObligationAgeMs,
+          thread_id: threadId
+        })
+        await thread.setState({
+          activeExecution: false,
+          lastEventId: threadState?.lastEventId ?? 0,
+          renderObligation: null
+        })
+        continue
+      }
 
       // An obligation that keeps failing non-retryably (for example corrupt
       // state that can never address a Slack thread) must not poison the
@@ -1311,6 +1332,7 @@ async function recoverRenderObligations(
     phaseMs: elapsedMs(startedAtMs),
     resolvedCount,
     retryableDeferredCount,
+    staleSkippedCount,
     timedOutCount
   })
   recordRecoveryScan(deferredCount > 0 ? 'deferred' : 'complete', startedAtMs, {
@@ -1547,6 +1569,7 @@ function recordRenderRecoveryScan(
     phaseMs: number
     resolvedCount: number
     retryableDeferredCount: number
+    staleSkippedCount: number
     timedOutCount: number
   }
 ): void {
@@ -1560,21 +1583,27 @@ function recordRenderRecoveryScan(
     phase_ms: observation.phaseMs,
     resolved_count: observation.resolvedCount,
     retryable_deferred_count: observation.retryableDeferredCount,
+    stale_skipped_count: observation.staleSkippedCount,
     timed_out_count: observation.timedOutCount
   }
   traceLog(options, 'slackbotv2_render_recovery_scan_complete', undefined, fields)
 }
 
-function renderObligationFields(obligation: SlackbotV2RenderObligation): JsonObject {
+function renderObligationAgeMs(obligation: SlackbotV2RenderObligation): number | undefined {
   const messageTimestampMs = Date.parse(obligation.message.timestamp)
+  return Number.isFinite(messageTimestampMs)
+    ? Math.max(0, Date.now() - messageTimestampMs)
+    : undefined
+}
+
+function renderObligationFields(obligation: SlackbotV2RenderObligation): JsonObject {
+  const obligationAgeMs = renderObligationAgeMs(obligation)
   return {
     after_event_id: obligation.afterEventId,
     execution_id: obligation.executionId,
     message_id: obligation.message.id,
     message_timestamp: obligation.message.timestamp,
-    ...(Number.isFinite(messageTimestampMs)
-      ? { obligation_age_ms: Math.max(0, Date.now() - messageTimestampMs) }
-      : {})
+    ...(obligationAgeMs !== undefined ? { obligation_age_ms: obligationAgeMs } : {})
   }
 }
 

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -37,6 +37,9 @@ const options: SlackbotV2Options = {
     optionalEnv('SLACKBOTV2_DATABASE_URL') ??
     optionalEnv('DATABASE_URL') ??
     optionalEnv('POSTGRES_URL'),
+  renderRecoveryMaxObligationAgeMs: optionalNumberEnv(
+    'SLACKBOTV2_RENDER_RECOVERY_MAX_OBLIGATION_AGE_MS'
+  ),
   signingSecret,
   slackApiUrl: optionalEnv('SLACK_API_URL'),
   stateKeyPrefix: optionalEnv('SLACKBOTV2_STATE_KEY_PREFIX'),

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -96,6 +96,8 @@ export type SlackbotV2Options = {
   maxDurationMs?: number
   postgresUrl?: string
   recoverRenderObligationsOnStart?: boolean
+  /** Maximum Slack message age eligible for startup render recovery. */
+  renderRecoveryMaxObligationAgeMs?: number
   /** Per-thread deadline for one recovery attempt during the startup scan. */
   renderRecoveryThreadTimeoutMs?: number
   signingSecret: string

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -2554,6 +2554,67 @@ describe('slackbotv2', () => {
     expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)
   })
 
+  it('skips stale render obligations from Chat SDK state on startup', async () => {
+    const logs: CapturedLog[] = []
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+
+    const parent = await postUserMessage('Context before stale recovery.')
+    const mentionText = `<@${BOT_USER_ID}> this answer is too old to recover`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const key = threadKey(parent.ts)
+    const message = {
+      ...apiMessageFromSlackEvent({
+        isMention: true,
+        text: mentionText,
+        threadId: key,
+        ts: mention.ts
+      }),
+      timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString()
+    }
+    await sharedState.set(`thread-state:${key}`, {
+      activeExecution: true,
+      executedMessageIds: [mention.ts],
+      forwardedMessageIds: [mention.ts],
+      historyForwarded: true,
+      lastEventId: 0,
+      renderObligation: {
+        afterEventId: 0,
+        executionId: 'exe-stale-recovery',
+        message
+      }
+    })
+    await sharedState.appendToList('slackbotv2:render:index', key)
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('Stale recovered request.'))
+
+    bot = createTestBot({
+      logger: captureLogger(logs),
+      renderRecoveryMaxObligationAgeMs: 60 * 60 * 1000,
+      state: sharedState
+    })
+
+    await waitFor(async () => {
+      const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+      return threadState?.renderObligation === null
+    }, 2000)
+
+    expect(codexApi.eventRequests).toHaveLength(0)
+    expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
+    expect(slackApi.calls.some(call => call.method === 'chat.stopStream')).toBe(false)
+    const staleState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+    expect(staleState).toEqual(
+      expect.objectContaining({ activeExecution: false, renderObligation: null })
+    )
+    expect(logData(logs, 'slackbotv2_render_recovery_stale_obligation_skipped')).toEqual(
+      expect.objectContaining({
+        execution_id: 'exe-stale-recovery',
+        max_obligation_age_ms: 60 * 60 * 1000,
+        message_id: mention.ts,
+        thread_id: key
+      })
+    )
+  })
+
   it('does not let one hung recovery block the obligations queued behind it', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()


### PR DESCRIPTION
## Summary

- Add a default 24-hour max age for Slackbot v2 startup render recovery obligations.
- Clear stale render obligations without opening the session event stream or posting to Slack.
- Expose `SLACKBOTV2_RENDER_RECOVERY_MAX_OBLIGATION_AGE_MS` for deployments that need a different cutoff.
- Add a regression test covering stale recovery skip behavior.

## Root Cause

`slackbotv2` persists render obligations so a restart can recover answers that were generated but not delivered. The recovery path replayed from the saved `afterEventId` with no age bound, so a restart could render an old completed execution into Slack days later.

## Validation

- `pnpm --filter slackbotv2 test`
- `pnpm --filter slackbotv2 check:types`
- `git diff --check`
