### PR TITLE
Add Amplitude product analytics tool

### DIFF
--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -37,6 +37,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `company_context` | Search indexed company history across internal sources | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
+| `amplitude` | Query product analytics — event segmentation, funnels, retention, user activity, and taxonomy | `AMPLITUDE_API_KEY`, `AMPLITUDE_SECRET_KEY` |
 | `attio` | Work with CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
 | `pylon` | Read and manage support issues, accounts, contacts, teams, tags, and users | `PYLON_API_KEY` |
 
@@ -63,6 +64,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `demo` | Test tool hot-reload and basic tool plumbing | None |
 | `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Product analytics through HogQL, events, pageviews, and breakdowns | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
+| `amplitude` | Amplitude event segmentation, funnels, retention, user activity, realtime, and taxonomy | `AMPLITUDE_API_KEY`, `AMPLITUDE_SECRET_KEY` |
 | `profslice` | Extract Firefox Profiler data for analysis | None |
 | `reth` | Reth execution timing and performance metrics | None |
 | `reth-log-analyzer` | Parse Reth logs and generate performance graphs | None |

--- a/tools/infra/amplitude/.env.example
+++ b/tools/infra/amplitude/.env.example
@@ -1,0 +1,6 @@
+# Amplitude Dashboard REST + Taxonomy APIs — HTTP Basic auth with the
+# project's API key and secret key (Settings > Projects > General).
+AMPLITUDE_API_KEY=your-amplitude-api-key-here
+AMPLITUDE_SECRET_KEY=your-amplitude-secret-key-here
+# Data residency region: "us" (default) or "eu". Plain env var, not a secret.
+AMPLITUDE_REGION=us

--- a/tools/infra/amplitude/cli.py
+++ b/tools/infra/amplitude/cli.py
@@ -1,0 +1,230 @@
+"""CLI for the Amplitude Dashboard REST + Taxonomy APIs."""
+
+import json
+
+import typer
+from rich.console import Console
+
+from centaur_sdk import Table
+
+app = typer.Typer(name="amplitude", help="Amplitude product analytics (Dashboard REST + Taxonomy)")
+console = Console()
+
+
+def get_client():
+    from .client import AmplitudeClient
+
+    return AmplitudeClient()
+
+
+def _run(fn):
+    """Call a client method, printing errors and exiting non-zero on failure."""
+    try:
+        return fn()
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
+def _dump(result: dict) -> None:
+    print(json.dumps(result, indent=2))
+
+
+@app.command()
+def segmentation(
+    event: str = typer.Argument(..., help="Event type (use '_all' for any active event)"),
+    start: str = typer.Option(..., "--start", "-s", help="Start date (YYYY-MM-DD or YYYYMMDD)"),
+    end: str = typer.Option(..., "--end", "-e", help="End date (YYYY-MM-DD or YYYYMMDD)"),
+    metric: str = typer.Option("totals", "--metric", "-m", help="totals, uniques, average, ..."),
+    interval: int = typer.Option(1, "--interval", "-i", help="1=daily, 7=weekly, 30=monthly"),
+    group_by: str = typer.Option(None, "--group-by", "-g", help="Property to break down by"),
+    group_by_type: str = typer.Option("event", "--group-by-type", help="'event' or 'user'"),
+    limit: int = typer.Option(100, "--limit", "-n", help="Max breakdown groups"),
+    json_output: bool = typer.Option(False, "--json", help="Output raw JSON"),
+):
+    """Event segmentation — counts/uniques of an event over time."""
+    client = get_client()
+    result = _run(
+        lambda: client.segmentation(
+            event=event,
+            start=start,
+            end=end,
+            metric=metric,
+            interval=interval,
+            group_by=group_by,
+            group_by_type=group_by_type,
+            limit=limit,
+        )
+    )
+
+    if json_output:
+        _dump(result)
+        return
+
+    data = result.get("data", {})
+    x_values = data.get("xValues", [])
+    series = data.get("series", [])
+    labels = data.get("seriesLabels") or data.get("seriesMeta") or []
+
+    if not x_values or not series:
+        _dump(result)
+        return
+
+    table = Table(title=f"{event} — {metric} ({start} → {end})")
+    table.add_column("Date", style="dim")
+    for idx in range(len(series)):
+        label = labels[idx] if idx < len(labels) else f"series {idx + 1}"
+        table.add_column(str(label), style="cyan", justify="right")
+
+    for row_idx, x in enumerate(x_values):
+        cells = [str(s[row_idx]) if row_idx < len(s) else "" for s in series]
+        table.add_row(str(x), *cells)
+
+    console.print(table)
+
+
+@app.command()
+def funnel(
+    events: list[str] = typer.Argument(..., help="Event types in step order"),
+    start: str = typer.Option(..., "--start", "-s", help="Start date (YYYY-MM-DD or YYYYMMDD)"),
+    end: str = typer.Option(..., "--end", "-e", help="End date (YYYY-MM-DD or YYYYMMDD)"),
+    mode: str = typer.Option("ordered", "--mode", help="ordered, unordered, or sequential"),
+    window_days: int = typer.Option(None, "--window-days", help="Conversion window in days"),
+):
+    """Funnel conversion across an ordered sequence of events."""
+    client = get_client()
+    result = _run(
+        lambda: client.funnel(
+            events=events, start=start, end=end, mode=mode, conversion_window_days=window_days
+        )
+    )
+    _dump(result)
+
+
+@app.command()
+def retention(
+    start_event: str = typer.Argument(..., help="Event that starts the measurement"),
+    return_event: str = typer.Argument("_all", help="Return event ('_all' for any)"),
+    start: str = typer.Option(..., "--start", "-s", help="Start date (YYYY-MM-DD or YYYYMMDD)"),
+    end: str = typer.Option(..., "--end", "-e", help="End date (YYYY-MM-DD or YYYYMMDD)"),
+    mode: str = typer.Option("n-day", "--mode", help="n-day, rolling, or bracket"),
+    interval: int = typer.Option(1, "--interval", "-i", help="1=daily, 7=weekly, 30=monthly"),
+):
+    """Retention analysis between a start event and a return event."""
+    client = get_client()
+    result = _run(
+        lambda: client.retention(
+            start_event=start_event,
+            return_event=return_event,
+            start=start,
+            end=end,
+            retention_mode=mode,
+            interval=interval,
+        )
+    )
+    _dump(result)
+
+
+@app.command("events-list")
+def events_list(
+    json_output: bool = typer.Option(False, "--json", help="Output raw JSON"),
+):
+    """List every event type defined in the project."""
+    client = get_client()
+    result = _run(client.events_list)
+
+    if json_output:
+        _dump(result)
+        return
+
+    rows = result.get("data", result) if isinstance(result, dict) else result
+    if not isinstance(rows, list) or not rows:
+        _dump(result)
+        return
+
+    table = Table(title="Event Types")
+    table.add_column("Event", style="cyan")
+    table.add_column("Display Name", style="green")
+    table.add_column("Non-active", style="dim", justify="center")
+    for row in rows:
+        table.add_row(
+            str(row.get("name", "")),
+            str(row.get("display", row.get("name", ""))),
+            "yes" if row.get("non_active") else "",
+        )
+    console.print(table)
+
+
+@app.command("user-activity")
+def user_activity(
+    user: str = typer.Argument(..., help="Amplitude ID"),
+    limit: int = typer.Option(100, "--limit", "-n", help="Max events (up to 1000)"),
+    offset: int = typer.Option(0, "--offset", help="Pagination offset"),
+    direction: str = typer.Option("latest", "--direction", help="'latest' or 'earliest'"),
+):
+    """Fetch a single user's event stream by Amplitude ID."""
+    client = get_client()
+    result = _run(
+        lambda: client.user_activity(
+            user=user, limit=limit, offset=offset, direction=direction
+        )
+    )
+    _dump(result)
+
+
+@app.command("user-search")
+def user_search(
+    user: str = typer.Argument(..., help="Amplitude ID, Device ID, User ID, or prefix"),
+):
+    """Search for a user by identifier or prefix."""
+    client = get_client()
+    result = _run(lambda: client.user_search(user))
+    _dump(result)
+
+
+@app.command()
+def realtime(
+    interval: int = typer.Option(None, "--interval", "-i", help="Bucket size in seconds"),
+):
+    """Real-time active user counts."""
+    client = get_client()
+    result = _run(lambda: client.realtime(interval=interval))
+    _dump(result)
+
+
+@app.command()
+def annotations():
+    """List chart annotations for the project."""
+    client = get_client()
+    result = _run(client.annotations)
+    _dump(result)
+
+
+@app.command("taxonomy-events")
+def taxonomy_events():
+    """List event types in the tracking plan (Taxonomy API)."""
+    client = get_client()
+    result = _run(client.taxonomy_events)
+    _dump(result)
+
+
+@app.command("taxonomy-event-properties")
+def taxonomy_event_properties(
+    event_type: str = typer.Argument(..., help="Event type whose properties to list"),
+):
+    """List event properties for an event type (Taxonomy API)."""
+    client = get_client()
+    result = _run(lambda: client.taxonomy_event_properties(event_type))
+    _dump(result)
+
+
+@app.command("taxonomy-user-properties")
+def taxonomy_user_properties():
+    """List user properties in the tracking plan (Taxonomy API)."""
+    client = get_client()
+    result = _run(client.taxonomy_user_properties)
+    _dump(result)
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/infra/amplitude/client.py
+++ b/tools/infra/amplitude/client.py
@@ -1,0 +1,327 @@
+"""Amplitude Dashboard REST + Taxonomy API client.
+
+Mirrors the read/query surface of the Amplitude MCP using the Dashboard REST
+API (event segmentation, funnels, retention, user activity, realtime) and the
+Taxonomy API (tracking-plan event and property definitions). Authenticates with
+HTTP Basic using the project's API key and secret key.
+
+The Amplitude MCP's write surface — creating charts, dashboards, experiments,
+and feature flags — requires OAuth and is not exposed by these API-key REST
+endpoints, so it is intentionally out of scope here.
+"""
+
+import base64
+import json
+import os
+
+import httpx
+
+from centaur_sdk import secret
+
+_US_HOST = "amplitude.com"
+_EU_HOST = "analytics.eu.amplitude.com"
+
+
+def _fmt_date(value: str) -> str:
+    """Normalize a date to Amplitude's YYYYMMDD format.
+
+    Accepts YYYY-MM-DD, YYYY/MM/DD, or YYYYMMDD.
+    """
+    return value.replace("-", "").replace("/", "").strip()
+
+
+class AmplitudeClient:
+    """Client for the Amplitude Dashboard REST and Taxonomy APIs.
+
+    Requires a project API key and secret key (Settings > Projects > General).
+    Set AMPLITUDE_REGION to "eu" for EU-residency projects.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        secret_key: str | None = None,
+        region: str | None = None,
+        timeout: float = 60.0,
+    ):
+        """Initialize the Amplitude client.
+
+        Args:
+            api_key: Project API key (or set AMPLITUDE_API_KEY)
+            secret_key: Project secret key (or set AMPLITUDE_SECRET_KEY)
+            region: Data residency region, "us" (default) or "eu"
+            timeout: Request timeout in seconds
+        """
+        self._api_key = api_key
+        self._secret_key = secret_key
+        self._region = region
+        self.timeout = timeout
+        self._client: httpx.Client | None = None
+
+    @property
+    def region(self) -> str:
+        region = self._region or os.getenv("AMPLITUDE_REGION", "us")  # noqa: TID251
+        return region.strip().lower()
+
+    @property
+    def host(self) -> str:
+        return _EU_HOST if self.region == "eu" else _US_HOST
+
+    @property
+    def base_url(self) -> str:
+        return f"https://{self.host}"
+
+    def _credentials(self) -> tuple[str, str]:
+        api_key = self._api_key or secret("AMPLITUDE_API_KEY", "")
+        secret_key = self._secret_key or secret("AMPLITUDE_SECRET_KEY", "")
+        if not api_key or not secret_key:
+            raise RuntimeError(
+                "AMPLITUDE_API_KEY and AMPLITUDE_SECRET_KEY must be set "
+                "(Settings > Projects > General in Amplitude)."
+            )
+        return api_key, secret_key
+
+    def _auth_header(self) -> str:
+        api_key, secret_key = self._credentials()
+        token = base64.b64encode(f"{api_key}:{secret_key}".encode()).decode()
+        return f"Basic {token}"
+
+    @property
+    def client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(base_url=self.base_url, timeout=self.timeout)
+        return self._client
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        params: dict | list | None = None,
+    ) -> dict:
+        """Make an authenticated Dashboard REST / Taxonomy API request.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            endpoint: API endpoint path
+            params: Query parameters (dict, or list of tuples for repeated keys)
+
+        Returns:
+            JSON response data
+
+        Raises:
+            RuntimeError: If the request fails
+        """
+        headers = {"Authorization": self._auth_header()}
+        try:
+            response = self.client.request(method, endpoint, headers=headers, params=params)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(f"API error: {e.response.status_code} - {e.response.text}") from e
+        except httpx.RequestError as e:
+            raise RuntimeError(f"Request failed: {e}") from e
+
+    def _event_spec(
+        self,
+        event_type: str,
+        filters: list[dict] | None = None,
+        group_by: list[dict] | None = None,
+    ) -> str:
+        """Build the compact JSON for a Dashboard REST `e` event parameter."""
+        spec: dict = {"event_type": event_type}
+        if filters:
+            spec["filters"] = filters
+        if group_by:
+            spec["group_by"] = group_by
+        return json.dumps(spec, separators=(",", ":"))
+
+    def segmentation(
+        self,
+        event: str,
+        start: str,
+        end: str,
+        metric: str = "totals",
+        interval: int = 1,
+        group_by: str | None = None,
+        group_by_type: str = "event",
+        segment: list[dict] | None = None,
+        limit: int = 100,
+    ) -> dict:
+        """Event segmentation — counts/uniques of an event over time.
+
+        Args:
+            event: Event type (use "_all" for any active event)
+            start: Start date (YYYYMMDD or YYYY-MM-DD)
+            end: End date (YYYYMMDD or YYYY-MM-DD)
+            metric: uniques, totals, pct_dau, average, histogram, sums, value_avg
+            interval: 1 (daily), 7 (weekly), 30 (monthly)
+            group_by: Property to break down by (optional, up to one here)
+            group_by_type: "event" or "user" property for group_by
+            segment: Segment filter definitions (JSON array)
+            limit: Max breakdown groups returned
+
+        Returns:
+            Segmentation series data
+        """
+        gb = [{"type": group_by_type, "value": group_by}] if group_by else None
+        params: list[tuple[str, str]] = [
+            ("e", self._event_spec(event, group_by=gb)),
+            ("start", _fmt_date(start)),
+            ("end", _fmt_date(end)),
+            ("m", metric),
+            ("i", str(interval)),
+            ("limit", str(limit)),
+        ]
+        if segment:
+            params.append(("s", json.dumps(segment, separators=(",", ":"))))
+        return self._request("GET", "/api/2/events/segmentation", params=params)
+
+    def funnel(
+        self,
+        events: list[str],
+        start: str,
+        end: str,
+        mode: str = "ordered",
+        conversion_window_days: int | None = None,
+    ) -> dict:
+        """Funnel conversion across an ordered sequence of events.
+
+        Args:
+            events: Event types in step order (one `e` param per step)
+            start: Start date (YYYYMMDD or YYYY-MM-DD)
+            end: End date (YYYYMMDD or YYYY-MM-DD)
+            mode: ordered, unordered, or sequential
+            conversion_window_days: Conversion window in days (optional)
+
+        Returns:
+            Funnel conversion data
+        """
+        params: list[tuple[str, str]] = [("e", self._event_spec(e)) for e in events]
+        params += [
+            ("start", _fmt_date(start)),
+            ("end", _fmt_date(end)),
+            ("mode", mode),
+        ]
+        if conversion_window_days is not None:
+            params.append(("cs", str(conversion_window_days * 86_400_000)))
+        return self._request("GET", "/api/2/funnels", params=params)
+
+    def retention(
+        self,
+        start_event: str,
+        return_event: str,
+        start: str,
+        end: str,
+        retention_mode: str = "n-day",
+        interval: int = 1,
+    ) -> dict:
+        """Retention analysis between a start event and a return event.
+
+        Args:
+            start_event: Event that starts the retention measurement
+            return_event: Event that counts as a return ("_all" for any)
+            start: Start date (YYYYMMDD or YYYY-MM-DD)
+            end: End date (YYYYMMDD or YYYY-MM-DD)
+            retention_mode: n-day, rolling, or bracket
+            interval: 1 (daily), 7 (weekly), 30 (monthly)
+
+        Returns:
+            Retention data
+        """
+        params: list[tuple[str, str]] = [
+            ("se", self._event_spec(start_event)),
+            ("re", self._event_spec(return_event)),
+            ("start", _fmt_date(start)),
+            ("end", _fmt_date(end)),
+            ("rm", retention_mode),
+            ("i", str(interval)),
+        ]
+        return self._request("GET", "/api/2/retention", params=params)
+
+    def events_list(self) -> dict:
+        """List every event type defined in the project."""
+        return self._request("GET", "/api/2/events/list")
+
+    def user_activity(
+        self,
+        user: str,
+        limit: int = 100,
+        offset: int = 0,
+        direction: str = "latest",
+    ) -> dict:
+        """Fetch a single user's event stream by Amplitude ID.
+
+        Args:
+            user: Amplitude ID
+            limit: Max events (up to 1000)
+            offset: Pagination offset
+            direction: "latest" or "earliest"
+
+        Returns:
+            User details and recent events
+        """
+        params = {"user": user, "limit": limit, "offset": offset, "direction": direction}
+        return self._request("GET", "/api/2/useractivity", params=params)
+
+    def user_search(self, user: str) -> dict:
+        """Search for a user by Amplitude ID, Device ID, User ID, or prefix.
+
+        Args:
+            user: Identifier or prefix to match
+
+        Returns:
+            Matching users
+        """
+        return self._request("GET", "/api/2/usersearch", params={"user": user})
+
+    def realtime(self, interval: int | None = None) -> dict:
+        """Real-time active user counts.
+
+        Args:
+            interval: Interval in seconds (e.g. 300 for 5-minute buckets)
+
+        Returns:
+            Realtime active-user series
+        """
+        params = {"i": -interval * 1000} if interval else None
+        return self._request("GET", "/api/2/realtime", params=params)
+
+    def annotations(self) -> dict:
+        """List chart annotations for the project."""
+        return self._request("GET", "/api/2/annotations")
+
+    def taxonomy_events(self) -> dict:
+        """List event types in the tracking plan (Taxonomy API)."""
+        return self._request("GET", "/api/2/taxonomy/event")
+
+    def taxonomy_event_properties(self, event_type: str) -> dict:
+        """List event properties defined for an event type (Taxonomy API).
+
+        Args:
+            event_type: Event type whose properties to list
+        """
+        return self._request(
+            "GET", "/api/2/taxonomy/event-property", params={"event_type": event_type}
+        )
+
+    def taxonomy_user_properties(self) -> dict:
+        """List user properties in the tracking plan (Taxonomy API)."""
+        return self._request("GET", "/api/2/taxonomy/user-property")
+
+    def close(self):
+        """Close the HTTP client."""
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def _client() -> AmplitudeClient:
+    api_key = secret("AMPLITUDE_API_KEY", "")
+    secret_key = secret("AMPLITUDE_SECRET_KEY", "")
+    return AmplitudeClient(api_key=api_key, secret_key=secret_key)

--- a/tools/infra/amplitude/pyproject.toml
+++ b/tools/infra/amplitude/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "amplitude"
+description = "Amplitude product analytics — event segmentation, funnels, retention, taxonomy"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27.0",
+    "typer>=0.12.0",
+    "rich>=13.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.scripts]
+amplitude = "centaur_tool_amplitude.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_amplitude"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+
+[tool.centaur]
+module = "client.py"
+# Dashboard REST + Taxonomy APIs authenticate with HTTP Basic using
+# {api_key}:{secret_key}. The client base64-encodes both placeholders into one
+# Authorization header; iron-proxy decodes the header, swaps each placeholder
+# for the real value, and re-encodes before the request leaves the sandbox.
+# hosts covers both the US and EU data residency regions.
+secrets = [
+    {type = "http", name = "AMPLITUDE_API_KEY", match_headers = ["Authorization"], hosts = ["amplitude.com", "analytics.eu.amplitude.com"]},
+    {type = "http", name = "AMPLITUDE_SECRET_KEY", match_headers = ["Authorization"], hosts = ["amplitude.com", "analytics.eu.amplitude.com"]},
+]


### PR DESCRIPTION
Adds an Amplitude tool that gives agents the same read-and-query analytics reach as Amplitude's own assistant integration, built on the public REST surface so it works with a plain project key and secret. It can pull event trends over time, walk users through funnels, look at retention and realtime activity, inspect a single person's event history, and read the tracking plan. It follows the existing product-analytics tool already in the tree, supports both data regions, and leans on the established two-credential auth pattern so secrets are swapped in at the network edge rather than handled in-process.

Read-only by design: the parts of the assistant integration that create charts, dashboards, experiments, or flags need a different auth flow and aren't covered here.

Tested on our deployed instance