### PR TITLE
feat: support deployment default personas

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -971,6 +971,7 @@ name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",
@@ -979,6 +980,7 @@ dependencies = [
  "centaur-telemetry",
  "dashmap",
  "futures-util",
+ "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror",

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -971,7 +971,6 @@ name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
  "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -27,7 +27,7 @@ use centaur_sandbox_core::{Mount, MountKind, SandboxSpec};
 use centaur_sandbox_local::LocalSandboxBackend;
 use centaur_sandbox_manager::{SandboxReaperConfig, WarmPoolConfig};
 use centaur_session_core::HarnessType;
-use centaur_session_runtime::SandboxWorkloadMode;
+use centaur_session_runtime::{PersonaRegistry, SandboxWorkloadMode};
 use centaur_workflows::WorkflowHostSandboxRuntime;
 use clap::{Args as ClapArgs, Parser, ValueEnum};
 use tracing::{error, info, warn};
@@ -35,7 +35,8 @@ use tracing::{error, info, warn};
 use crate::{
     ServerError,
     tool_discovery::{
-        DiscoveredToolProxyFragment, ToolDiscoveryConfig, discover_tool_proxy_fragment,
+        DiscoveredToolProxyFragment, ToolDiscoveryConfig, discover_persona_registry,
+        discover_tool_proxy_fragment,
     },
 };
 
@@ -76,6 +77,10 @@ impl Args {
         &self,
     ) -> Result<Option<IronControlToolReconciler>, ServerError> {
         self.sandbox.iron_control_tool_reconciler()
+    }
+
+    pub(crate) fn persona_registry(&self) -> Result<PersonaRegistry, ServerError> {
+        self.sandbox.persona_registry()
     }
 
     pub(crate) fn warm_pool_config(&self) -> Option<WarmPoolConfig> {
@@ -473,6 +478,8 @@ struct SandboxArgs {
         default_value = "codex"
     )]
     default_harness: HarnessType,
+    #[arg(long = "centaur-default-persona", env = "CENTAUR_DEFAULT_PERSONA")]
+    default_persona: Option<String>,
     #[arg(
         long = "session-sandbox-k8s-namespace",
         alias = "kubernetes-namespace",
@@ -700,6 +707,14 @@ impl SandboxArgs {
                 .unwrap_or_default(),
             interval: Duration::from_secs(self.tool_proxy_reconcile_interval_secs),
         }))
+    }
+
+    fn persona_registry(&self) -> Result<PersonaRegistry, ServerError> {
+        let default_persona_id = clean_optional_value(self.default_persona.as_deref());
+        Ok(discover_persona_registry(
+            &self.tools.resolve_tool_dirs()?,
+            default_persona_id,
+        )?)
     }
 
     async fn runtime(&self) -> Result<SandboxRuntime, ServerError> {

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -73,6 +73,7 @@ async fn initialize_runtime(args: Args, app_state: AppState) -> Result<(), Serve
         info!("iron-control tool secret reconciliation enabled");
         tokio::spawn(reconciler.run());
     }
+    runtime = runtime.with_personas(args.persona_registry()?);
     if let Some(mut config) = args.warm_pool_config() {
         config.bootstrap_iron_control_principal = warm_pool_bootstrap_principal.clone();
         runtime = runtime.with_warm_pool(config);

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -29,7 +29,7 @@ use axum::{
 use base64::{Engine as _, engine::general_purpose};
 use centaur_session_core::ThreadKey;
 use centaur_session_runtime::{
-    ExecuteSessionInput, HarnessConflictPolicy, SandboxRuntime, SessionRuntime,
+    ExecuteSessionInput, HarnessConflictPolicy, PersonaSummary, SandboxRuntime, SessionRuntime,
 };
 use centaur_session_sqlx::PgSessionStore;
 use centaur_telemetry::{
@@ -187,6 +187,8 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
         .route("/metrics", get(metrics))
+        .route("/personas", get(list_personas))
+        .route("/api/personas", get(list_personas))
         .route(
             "/api/session/{thread_key}",
             post(create_or_get_session).get(get_session_context),
@@ -354,6 +356,12 @@ async fn get_session_context(
         slack: slack_thread_context(&thread_key),
         thread_key,
     }))
+}
+
+async fn list_personas(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<PersonaSummary>>, ApiError> {
+    Ok(Json(state.runtime()?.personas()))
 }
 
 fn slack_thread_context(thread_key: &ThreadKey) -> Option<SlackThreadContext> {

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -187,7 +187,6 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
         .route("/metrics", get(metrics))
-        .route("/personas", get(list_personas))
         .route("/api/personas", get(list_personas))
         .route(
             "/api/session/{thread_key}",

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -2,7 +2,6 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     env, fs,
     path::{Path, PathBuf},
-    process::Command,
 };
 
 use centaur_iron_proxy::{
@@ -116,7 +115,7 @@ impl ToolDiscoveryConfig {
 pub(crate) fn discover_tool_proxy_fragment(
     tool_dirs: &[PathBuf],
 ) -> Result<DiscoveredToolProxyFragment, ToolDiscoveryError> {
-    let tools = collect_tools(tool_dirs)?;
+    let tools = collect_plugin_metadata(tool_dirs)?.tools;
     let mut secrets = Vec::new();
     for tool in &tools {
         secrets.extend(tool.secrets.iter().cloned());
@@ -140,41 +139,8 @@ pub(crate) fn discover_persona_registry(
     tool_dirs: &[PathBuf],
     default_persona_id: Option<String>,
 ) -> Result<PersonaRegistry, ToolDiscoveryError> {
-    let mut seen = BTreeMap::<String, usize>::new();
-    let mut personas = Vec::<PersonaDefinition>::new();
-    let mut overlay_chain = Vec::new();
-
-    for (dir_idx, base_dir) in tool_dirs.iter().enumerate() {
-        overlay_chain.push(base_dir.display().to_string());
-        if !base_dir.exists() {
-            continue;
-        }
-        for persona_dir in candidate_tool_dirs(base_dir)? {
-            let pyproject_path = persona_dir.join("pyproject.toml");
-            if !pyproject_path.exists() {
-                continue;
-            }
-            let Some(persona) = load_persona_definition(base_dir, &persona_dir, &pyproject_path)?
-            else {
-                continue;
-            };
-            if let Some(prev_dir_idx) = seen.insert(persona.id.clone(), dir_idx) {
-                if let Some(prev_pos) = personas.iter().position(|item| item.id == persona.id) {
-                    warn!(
-                        persona = %persona.id,
-                        shadowed_dir = ?tool_dirs.get(prev_dir_idx),
-                        by_dir = ?base_dir,
-                        "api-rs persona metadata shadowed"
-                    );
-                    personas[prev_pos] = persona;
-                }
-            } else {
-                personas.push(persona);
-            }
-        }
-    }
-
-    PersonaRegistry::new(personas, default_persona_id, overlay_chain)
+    let plugins = collect_plugin_metadata(tool_dirs)?;
+    PersonaRegistry::new(plugins.personas, default_persona_id, plugins.overlay_chain)
         .map_err(ToolDiscoveryError::Invalid)
 }
 
@@ -311,42 +277,37 @@ fn parse_toml(path: &Path, contents: &str) -> Result<TomlValue, ToolDiscoveryErr
     })
 }
 
-fn sha256_hex(value: impl AsRef<[u8]>) -> String {
-    let digest = Sha256::digest(value.as_ref());
-    format!("sha256:{digest:x}")
-}
-
-fn git_head_for_path(path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(path)
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let head = String::from_utf8(output.stdout).ok()?;
-    let head = head.trim();
-    if head.is_empty() {
-        None
-    } else {
-        Some(head.to_owned())
-    }
-}
-
 #[derive(Clone, Debug)]
 struct LoadedToolMeta {
     name: String,
     secrets: Vec<ToolSecret>,
 }
 
-fn collect_tools(tool_dirs: &[PathBuf]) -> Result<Vec<LoadedToolMeta>, ToolDiscoveryError> {
-    let mut seen = BTreeMap::<String, usize>::new();
+#[derive(Clone, Debug, Default)]
+struct CollectedPluginMetadata {
+    tools: Vec<LoadedToolMeta>,
+    personas: Vec<PersonaDefinition>,
+    overlay_chain: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+enum LoadedPluginMeta {
+    Tool(LoadedToolMeta),
+    Persona(PersonaDefinition),
+}
+
+fn collect_plugin_metadata(
+    tool_dirs: &[PathBuf],
+) -> Result<CollectedPluginMetadata, ToolDiscoveryError> {
+    let mut seen_tools = BTreeMap::<String, usize>::new();
+    let mut seen_personas = BTreeMap::<String, usize>::new();
     let mut tools = Vec::<LoadedToolMeta>::new();
+    let mut personas = Vec::<PersonaDefinition>::new();
+    let mut overlay_chain = Vec::new();
     let mut existing = false;
 
     for (dir_idx, base_dir) in tool_dirs.iter().enumerate() {
+        overlay_chain.push(base_dir.display().to_string());
         if !base_dir.exists() {
             continue;
         }
@@ -356,21 +317,43 @@ fn collect_tools(tool_dirs: &[PathBuf]) -> Result<Vec<LoadedToolMeta>, ToolDisco
             if !pyproject_path.exists() {
                 continue;
             }
-            let Some(meta) = load_tool_meta(base_dir, &tool_dir, &pyproject_path)? else {
+            let Some(meta) = load_plugin_meta(base_dir, &tool_dir, &pyproject_path)? else {
                 continue;
             };
-            if let Some(prev_dir_idx) = seen.insert(meta.name.clone(), dir_idx) {
-                if let Some(prev_pos) = tools.iter().position(|tool| tool.name == meta.name) {
-                    warn!(
-                        tool = %meta.name,
-                        shadowed_dir = ?tool_dirs.get(prev_dir_idx),
-                        by_dir = ?base_dir,
-                        "api-rs tool metadata shadowed"
-                    );
-                    tools[prev_pos] = meta;
+            match meta {
+                LoadedPluginMeta::Tool(meta) => {
+                    if let Some(prev_dir_idx) = seen_tools.insert(meta.name.clone(), dir_idx) {
+                        if let Some(prev_pos) = tools.iter().position(|tool| tool.name == meta.name)
+                        {
+                            warn!(
+                                tool = %meta.name,
+                                shadowed_dir = ?tool_dirs.get(prev_dir_idx),
+                                by_dir = ?base_dir,
+                                "api-rs tool metadata shadowed"
+                            );
+                            tools[prev_pos] = meta;
+                        }
+                    } else {
+                        tools.push(meta);
+                    }
                 }
-            } else {
-                tools.push(meta);
+                LoadedPluginMeta::Persona(persona) => {
+                    if let Some(prev_dir_idx) = seen_personas.insert(persona.id.clone(), dir_idx) {
+                        if let Some(prev_pos) =
+                            personas.iter().position(|item| item.id == persona.id)
+                        {
+                            warn!(
+                                persona = %persona.id,
+                                shadowed_dir = ?tool_dirs.get(prev_dir_idx),
+                                by_dir = ?base_dir,
+                                "api-rs persona metadata shadowed"
+                            );
+                            personas[prev_pos] = persona;
+                        }
+                    } else {
+                        personas.push(persona);
+                    }
+                }
             }
         }
     }
@@ -378,7 +361,11 @@ fn collect_tools(tool_dirs: &[PathBuf]) -> Result<Vec<LoadedToolMeta>, ToolDisco
     if !existing {
         info!(tool_dirs = ?tool_dirs, "api-rs tool dirs missing");
     }
-    Ok(tools)
+    Ok(CollectedPluginMetadata {
+        tools,
+        personas,
+        overlay_chain,
+    })
 }
 
 fn candidate_tool_dirs(base_dir: &Path) -> Result<Vec<PathBuf>, ToolDiscoveryError> {
@@ -421,11 +408,11 @@ fn is_visible_dir(path: &Path) -> bool {
             .is_some_and(|name| !name.starts_with('.') && !name.starts_with('_'))
 }
 
-fn load_persona_definition(
+fn load_plugin_meta(
     source_root: &Path,
-    persona_dir: &Path,
+    plugin_dir: &Path,
     pyproject_path: &Path,
-) -> Result<Option<PersonaDefinition>, ToolDiscoveryError> {
+) -> Result<Option<LoadedPluginMeta>, ToolDiscoveryError> {
     let contents =
         fs::read_to_string(pyproject_path).map_err(|source| ToolDiscoveryError::Read {
             path: pyproject_path.to_path_buf(),
@@ -435,9 +422,9 @@ fn load_persona_definition(
         Ok(pyproject) => pyproject,
         Err(error) => {
             warn!(
-                persona_dir = ?persona_dir,
+                plugin_dir = ?plugin_dir,
                 error = %error,
-                "api-rs persona pyproject parse failed"
+                "api-rs plugin pyproject parse failed"
             );
             return Ok(None);
         }
@@ -448,13 +435,14 @@ fn load_persona_definition(
         .and_then(|value| value.get("centaur"))
         .unwrap_or(&default_tool_conf);
     if tool_conf.get("type").and_then(TomlValue::as_str) != Some("persona") {
-        return Ok(None);
+        return load_tool_meta(source_root, plugin_dir, tool_conf)
+            .map(|meta| meta.map(LoadedPluginMeta::Tool));
     }
-    let id = persona_dir
+    let id = plugin_dir
         .file_name()
         .and_then(|value| value.to_str())
         .ok_or_else(|| {
-            ToolDiscoveryError::Invalid(format!("invalid persona path {}", persona_dir.display()))
+            ToolDiscoveryError::Invalid(format!("invalid persona path {}", plugin_dir.display()))
         })?
         .to_owned();
     let prompt_file = tool_conf
@@ -462,50 +450,30 @@ fn load_persona_definition(
         .or_else(|| tool_conf.get("prompt"))
         .and_then(TomlValue::as_str)
         .unwrap_or("PROMPT.md");
-    let prompt_path = persona_dir.join(prompt_file);
+    let prompt_path = plugin_dir.join(prompt_file);
     let prompt = fs::read_to_string(&prompt_path).map_err(|source| ToolDiscoveryError::Read {
         path: prompt_path.clone(),
         source,
     })?;
-    Ok(Some(PersonaDefinition {
+    let prompt_hash = {
+        let digest = Sha256::digest(prompt.as_bytes());
+        format!("sha256:{digest:x}")
+    };
+    Ok(Some(LoadedPluginMeta::Persona(PersonaDefinition {
         id,
         source_root: source_root.display().to_string(),
-        source_path: persona_dir.display().to_string(),
-        source_ref: git_head_for_path(persona_dir),
-        prompt_hash: sha256_hex(&prompt),
+        source_path: plugin_dir.display().to_string(),
+        source_ref: None,
+        prompt_hash,
         prompt,
-    }))
+    })))
 }
 
 fn load_tool_meta(
     source_root: &Path,
     tool_dir: &Path,
-    pyproject_path: &Path,
+    tool_conf: &TomlValue,
 ) -> Result<Option<LoadedToolMeta>, ToolDiscoveryError> {
-    let contents =
-        fs::read_to_string(pyproject_path).map_err(|source| ToolDiscoveryError::Read {
-            path: pyproject_path.to_path_buf(),
-            source,
-        })?;
-    let pyproject = match parse_toml(pyproject_path, &contents) {
-        Ok(pyproject) => pyproject,
-        Err(error) => {
-            warn!(
-                tool_dir = ?tool_dir,
-                error = %error,
-                "api-rs tool pyproject parse failed"
-            );
-            return Ok(None);
-        }
-    };
-    let default_tool_conf = TomlValue::Table(Default::default());
-    let tool_conf = pyproject
-        .get("tool")
-        .and_then(|value| value.get("centaur"))
-        .unwrap_or(&default_tool_conf);
-    if tool_conf.get("type").and_then(TomlValue::as_str) == Some("persona") {
-        return Ok(None);
-    }
     let name = tool_dir
         .file_name()
         .and_then(|value| value.to_str())
@@ -1566,8 +1534,14 @@ secrets = [
             .expect("eng persona");
         assert_eq!(eng.source_root, overlay.display().to_string());
         assert!(eng.source_path.ends_with("personas/eng"));
-        assert_ne!(eng.prompt_hash, sha256_hex("base prompt"));
-        assert_eq!(eng.prompt_hash, sha256_hex("overlay prompt"));
+        assert_ne!(
+            eng.prompt_hash,
+            "sha256:c41ac32f8b086eecbd1c70d06689eb428de2a2c740d086640851985f26c4e2fc"
+        );
+        assert_eq!(
+            eng.prompt_hash,
+            "sha256:af70f573f4496a1cf92865966cb522c2c142a5789e075660a56bea66080bc738"
+        );
         assert!(
             discover_persona_registry(&[base.clone(), overlay.clone()], Some("missing".to_owned()))
                 .is_err()

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -2,14 +2,17 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     env, fs,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use centaur_iron_proxy::{
     PgDsnSetting, PgDsnSettingValueFrom, PostgresListener, PostgresUpstream, ProxyFragment,
     SandboxEnv, Secret, SecretReplace, Transform, TransformConfig,
 };
+use centaur_session_runtime::{PersonaDefinition, PersonaRegistry};
 use serde::Serialize;
 use serde_yaml::Value as YamlValue;
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use toml::Value as TomlValue;
 use tracing::{info, warn};
@@ -131,6 +134,48 @@ pub(crate) fn discover_tool_proxy_fragment(
         tool_count: tools.len(),
         secret_count,
     })
+}
+
+pub(crate) fn discover_persona_registry(
+    tool_dirs: &[PathBuf],
+    default_persona_id: Option<String>,
+) -> Result<PersonaRegistry, ToolDiscoveryError> {
+    let mut seen = BTreeMap::<String, usize>::new();
+    let mut personas = Vec::<PersonaDefinition>::new();
+    let mut overlay_chain = Vec::new();
+
+    for (dir_idx, base_dir) in tool_dirs.iter().enumerate() {
+        overlay_chain.push(base_dir.display().to_string());
+        if !base_dir.exists() {
+            continue;
+        }
+        for persona_dir in candidate_tool_dirs(base_dir)? {
+            let pyproject_path = persona_dir.join("pyproject.toml");
+            if !pyproject_path.exists() {
+                continue;
+            }
+            let Some(persona) = load_persona_definition(base_dir, &persona_dir, &pyproject_path)?
+            else {
+                continue;
+            };
+            if let Some(prev_dir_idx) = seen.insert(persona.id.clone(), dir_idx) {
+                if let Some(prev_pos) = personas.iter().position(|item| item.id == persona.id) {
+                    warn!(
+                        persona = %persona.id,
+                        shadowed_dir = ?tool_dirs.get(prev_dir_idx),
+                        by_dir = ?base_dir,
+                        "api-rs persona metadata shadowed"
+                    );
+                    personas[prev_pos] = persona;
+                }
+            } else {
+                personas.push(persona);
+            }
+        }
+    }
+
+    PersonaRegistry::new(personas, default_persona_id, overlay_chain)
+        .map_err(ToolDiscoveryError::Invalid)
 }
 
 fn split_tool_dirs(value: &str) -> Vec<PathBuf> {
@@ -266,6 +311,30 @@ fn parse_toml(path: &Path, contents: &str) -> Result<TomlValue, ToolDiscoveryErr
     })
 }
 
+fn sha256_hex(value: impl AsRef<[u8]>) -> String {
+    let digest = Sha256::digest(value.as_ref());
+    format!("sha256:{digest:x}")
+}
+
+fn git_head_for_path(path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let head = String::from_utf8(output.stdout).ok()?;
+    let head = head.trim();
+    if head.is_empty() {
+        None
+    } else {
+        Some(head.to_owned())
+    }
+}
+
 #[derive(Clone, Debug)]
 struct LoadedToolMeta {
     name: String,
@@ -350,6 +419,62 @@ fn is_visible_dir(path: &Path) -> bool {
             .file_name()
             .and_then(|name| name.to_str())
             .is_some_and(|name| !name.starts_with('.') && !name.starts_with('_'))
+}
+
+fn load_persona_definition(
+    source_root: &Path,
+    persona_dir: &Path,
+    pyproject_path: &Path,
+) -> Result<Option<PersonaDefinition>, ToolDiscoveryError> {
+    let contents =
+        fs::read_to_string(pyproject_path).map_err(|source| ToolDiscoveryError::Read {
+            path: pyproject_path.to_path_buf(),
+            source,
+        })?;
+    let pyproject = match parse_toml(pyproject_path, &contents) {
+        Ok(pyproject) => pyproject,
+        Err(error) => {
+            warn!(
+                persona_dir = ?persona_dir,
+                error = %error,
+                "api-rs persona pyproject parse failed"
+            );
+            return Ok(None);
+        }
+    };
+    let default_tool_conf = TomlValue::Table(Default::default());
+    let tool_conf = pyproject
+        .get("tool")
+        .and_then(|value| value.get("centaur"))
+        .unwrap_or(&default_tool_conf);
+    if tool_conf.get("type").and_then(TomlValue::as_str) != Some("persona") {
+        return Ok(None);
+    }
+    let id = persona_dir
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            ToolDiscoveryError::Invalid(format!("invalid persona path {}", persona_dir.display()))
+        })?
+        .to_owned();
+    let prompt_file = tool_conf
+        .get("prompt_file")
+        .or_else(|| tool_conf.get("prompt"))
+        .and_then(TomlValue::as_str)
+        .unwrap_or("PROMPT.md");
+    let prompt_path = persona_dir.join(prompt_file);
+    let prompt = fs::read_to_string(&prompt_path).map_err(|source| ToolDiscoveryError::Read {
+        path: prompt_path.clone(),
+        source,
+    })?;
+    Ok(Some(PersonaDefinition {
+        id,
+        source_root: source_root.display().to_string(),
+        source_path: persona_dir.display().to_string(),
+        source_ref: git_head_for_path(persona_dir),
+        prompt_hash: sha256_hex(&prompt),
+        prompt,
+    }))
 }
 
 fn load_tool_meta(
@@ -1421,6 +1546,37 @@ secrets = [
     }
 
     #[test]
+    fn discovers_personas_with_overlay_shadowing_and_default_validation() {
+        let temp = temp_dir("api-rs-personas");
+        let base = temp.join("base");
+        let overlay = temp.join("overlay");
+        write_persona(&base.join("personas").join("eng"), "base prompt");
+        write_persona(&overlay.join("personas").join("eng"), "overlay prompt");
+        write_persona(&overlay.join("personas").join("ops"), "ops prompt");
+
+        let registry =
+            discover_persona_registry(&[base.clone(), overlay.clone()], Some("eng".to_owned()))
+                .unwrap();
+        let personas = registry.summaries();
+
+        assert_eq!(personas.len(), 2);
+        let eng = personas
+            .iter()
+            .find(|persona| persona.id == "eng")
+            .expect("eng persona");
+        assert_eq!(eng.source_root, overlay.display().to_string());
+        assert!(eng.source_path.ends_with("personas/eng"));
+        assert_ne!(eng.prompt_hash, sha256_hex("base prompt"));
+        assert_eq!(eng.prompt_hash, sha256_hex("overlay prompt"));
+        assert!(
+            discover_persona_registry(&[base.clone(), overlay.clone()], Some("missing".to_owned()))
+                .is_err()
+        );
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
     fn discovers_aws_auth_tool_as_transform() {
         let temp = temp_dir("api-rs-tools-aws");
         let base = temp.join("base");
@@ -1493,5 +1649,21 @@ secrets = [
     fn write_tool(path: &Path, pyproject: &str) {
         fs::create_dir_all(path).unwrap();
         fs::write(path.join("pyproject.toml"), pyproject).unwrap();
+    }
+
+    fn write_persona(path: &Path, prompt: &str) {
+        fs::create_dir_all(path).unwrap();
+        fs::write(
+            path.join("pyproject.toml"),
+            r#"
+[project]
+description = "persona"
+
+[tool.centaur]
+type = "persona"
+"#,
+        )
+        .unwrap();
+        fs::write(path.join("PROMPT.md"), prompt).unwrap();
     }
 }

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-base64.workspace = true
 centaur-iron-control.workspace = true
 centaur-sandbox-core.workspace = true
 centaur-sandbox-manager.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+base64.workspace = true
 centaur-iron-control.workspace = true
 centaur-sandbox-core.workspace = true
 centaur-sandbox-manager.workspace = true
@@ -14,6 +15,7 @@ centaur-session-sqlx.workspace = true
 centaur-telemetry.workspace = true
 dashmap.workspace = true
 futures-util.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -45,13 +45,6 @@ const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
-const PERSONA_SPEC_ENV_KEYS: [&str; 5] = [
-    "AGENT_PERSONA",
-    "CENTAUR_PERSONA_ID",
-    "CENTAUR_PERSONA_PROMPT_HASH",
-    "CENTAUR_PERSONA_SOURCE_PATH",
-    "CENTAUR_PERSONA_SOURCE_REF",
-];
 
 type SandboxSpecFactory = Arc<
     dyn Fn(&ThreadKey, &str, &HarnessType, Option<&PersonaContext>) -> SandboxSpec + Send + Sync,
@@ -3398,7 +3391,13 @@ fn upsert_spec_env(spec: &mut SandboxSpec, name: &str, value: String) {
 }
 
 fn apply_persona_spec_env(mut spec: SandboxSpec, persona: Option<&PersonaContext>) -> SandboxSpec {
-    for name in PERSONA_SPEC_ENV_KEYS {
+    for name in [
+        "AGENT_PERSONA",
+        "CENTAUR_PERSONA_ID",
+        "CENTAUR_PERSONA_PROMPT_HASH",
+        "CENTAUR_PERSONA_SOURCE_PATH",
+        "CENTAUR_PERSONA_SOURCE_REF",
+    ] {
         remove_spec_env(&mut spec, name);
     }
     let Some(persona) = persona else {

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -45,11 +45,10 @@ const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
-const PERSONA_SPEC_ENV_KEYS: [&str; 6] = [
+const PERSONA_SPEC_ENV_KEYS: [&str; 5] = [
     "AGENT_PERSONA",
     "CENTAUR_PERSONA_ID",
     "CENTAUR_PERSONA_PROMPT_HASH",
-    "CENTAUR_EFFECTIVE_PROMPT_HASH",
     "CENTAUR_PERSONA_SOURCE_PATH",
     "CENTAUR_PERSONA_SOURCE_REF",
 ];
@@ -108,7 +107,6 @@ pub struct PersonaContext {
     pub source_path: String,
     pub source_ref: Option<String>,
     pub prompt_hash: String,
-    pub effective_prompt_hash: String,
     pub defaulted: bool,
     pub overlay_chain: Vec<String>,
 }
@@ -158,33 +156,21 @@ impl PersonaRegistry {
         self.personas.get(persona_id)
     }
 
-    fn context_for(
-        &self,
-        persona_id: &str,
-        harness_type: &HarnessType,
-        defaulted: bool,
-    ) -> Result<PersonaContext, String> {
+    fn context_for(&self, persona_id: &str, defaulted: bool) -> Result<PersonaContext, String> {
         let Some(persona) = self.get(persona_id) else {
             return Err(format!(
                 "persona {persona_id:?} is not available in this deployment"
             ));
         };
-        let mut context = PersonaContext {
+        Ok(PersonaContext {
             persona_id: persona.id.clone(),
             source_root: persona.source_root.clone(),
             source_path: persona.source_path.clone(),
             source_ref: persona.source_ref.clone(),
             prompt_hash: persona.prompt_hash.clone(),
-            effective_prompt_hash: String::new(),
             defaulted,
             overlay_chain: self.overlay_chain.clone(),
-        };
-        context.effective_prompt_hash = sha256_hex(format!(
-            "{}\n\n{}",
-            active_deployment_fingerprint_input(&context, harness_type),
-            persona.prompt
-        ));
-        Ok(context)
+        })
     }
 }
 
@@ -330,12 +316,11 @@ impl SessionRuntime {
     fn resolve_persona_for_create(
         &self,
         requested_persona_id: Option<&str>,
-        harness_type: &HarnessType,
     ) -> Result<PersonaResolution, SessionRuntimeError> {
         let requested = requested_persona_id.and_then(clean_persona_id);
         let selected = requested.or_else(|| self.default_persona_id());
         let defaulted = requested.is_none() && selected.is_some();
-        let context = self.resolve_persona_context(selected, harness_type, defaulted)?;
+        let context = self.resolve_persona_context(selected, defaulted)?;
         Ok(PersonaResolution {
             persona_id: selected.map(str::to_owned),
             context,
@@ -346,15 +331,14 @@ impl SessionRuntime {
     fn resolve_stored_persona(
         &self,
         persona_id: Option<&str>,
-        harness_type: &HarnessType,
+        _harness_type: &HarnessType,
     ) -> Result<Option<PersonaContext>, SessionRuntimeError> {
-        self.resolve_persona_context(persona_id.and_then(clean_persona_id), harness_type, false)
+        self.resolve_persona_context(persona_id.and_then(clean_persona_id), false)
     }
 
     fn resolve_persona_context(
         &self,
         persona_id: Option<&str>,
-        harness_type: &HarnessType,
         defaulted: bool,
     ) -> Result<Option<PersonaContext>, SessionRuntimeError> {
         let Some(persona_id) = persona_id else {
@@ -366,7 +350,7 @@ impl SessionRuntime {
             )));
         };
         registry
-            .context_for(persona_id, harness_type, defaulted)
+            .context_for(persona_id, defaulted)
             .map(Some)
             .map_err(SessionRuntimeError::BadRequest)
     }
@@ -479,7 +463,7 @@ impl SessionRuntime {
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned);
             let mut harness_switched = false;
-            let persona_resolution = self.resolve_persona_for_create(persona_id, harness_type)?;
+            let persona_resolution = self.resolve_persona_for_create(persona_id)?;
             let mut session_metadata = default_metadata(metadata);
             if let Some(context) = persona_resolution.context.as_ref() {
                 add_persona_metadata(&mut session_metadata, context);
@@ -3429,11 +3413,6 @@ fn apply_persona_spec_env(mut spec: SandboxSpec, persona: Option<&PersonaContext
     );
     upsert_spec_env(
         &mut spec,
-        "CENTAUR_EFFECTIVE_PROMPT_HASH",
-        persona.effective_prompt_hash.clone(),
-    );
-    upsert_spec_env(
-        &mut spec,
         "CENTAUR_PERSONA_SOURCE_PATH",
         persona.source_path.clone(),
     );
@@ -3451,32 +3430,6 @@ fn add_persona_metadata(metadata: &mut Value, context: &PersonaContext) {
     if let Value::Object(object) = metadata {
         object.insert("persona".to_owned(), json!(context));
     }
-}
-
-fn active_deployment_fingerprint_input(
-    context: &PersonaContext,
-    harness_type: &HarnessType,
-) -> String {
-    let source_ref = context.source_ref.as_deref().unwrap_or("unknown");
-    format!(
-        "harness={harness_type}\n\
-         persona_id={}\n\
-         persona_source_path={}\n\
-         persona_source_ref={source_ref}\n\
-         persona_prompt_hash={}\n\
-         persona_defaulted={}\n\
-         overlay_chain={}",
-        context.persona_id,
-        context.source_path,
-        context.prompt_hash,
-        context.defaulted,
-        context.overlay_chain.join(" -> "),
-    )
-}
-
-fn sha256_hex(value: impl AsRef<[u8]>) -> String {
-    let digest = Sha256::digest(value.as_ref());
-    format!("sha256:{digest:x}")
 }
 
 async fn record_finished_execution_metric(
@@ -5190,7 +5143,6 @@ mod tests {
             source_path: format!("/repo/tools/personas/{persona_id}"),
             source_ref: Some("abc123".to_owned()),
             prompt_hash: "sha256:prompt".to_owned(),
-            effective_prompt_hash: "sha256:effective".to_owned(),
             defaulted: false,
             overlay_chain: vec!["/repo/tools".to_owned()],
         }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1,9 +1,10 @@
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     sync::Arc,
     time::{Duration, SystemTime},
 };
 
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use centaur_iron_control::SessionRegistrar;
 use centaur_sandbox_core::{
     Mount, SandboxBackend, SandboxError, SandboxId, SandboxIoGuard, SandboxRead, SandboxSpec,
@@ -26,6 +27,7 @@ use centaur_telemetry::{
 };
 use dashmap::DashMap;
 use futures_util::{SinkExt, Stream, StreamExt, stream};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -44,6 +46,8 @@ const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
+const ACTIVE_DEPLOYMENT_ENV: &str = "CENTAUR_ACTIVE_DEPLOYMENT_BLOCK_B64";
+const PERSONA_PROMPT_ENV: &str = "CENTAUR_PERSONA_PROMPT_B64";
 
 type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str, &HarnessType) -> SandboxSpec + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
@@ -60,6 +64,92 @@ pub struct SessionRuntime {
     execution_spans: ExecutionSpanRegistry,
     iron_control: Option<SessionRegistrar>,
     warm_pool: Option<Arc<WarmPoolManager>>,
+    personas: Option<Arc<PersonaRegistry>>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct PersonaRegistry {
+    personas: BTreeMap<String, PersonaDefinition>,
+    default_persona_id: Option<String>,
+    overlay_chain: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PersonaDefinition {
+    pub id: String,
+    pub source_root: String,
+    pub source_path: String,
+    pub source_ref: Option<String>,
+    pub prompt_hash: String,
+    #[serde(skip_serializing)]
+    pub prompt: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PersonaSummary {
+    pub id: String,
+    pub source_root: String,
+    pub source_path: String,
+    pub source_ref: Option<String>,
+    pub prompt_hash: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PersonaContext {
+    pub persona_id: String,
+    pub source_root: String,
+    pub source_path: String,
+    pub source_ref: Option<String>,
+    pub prompt_hash: String,
+    pub effective_prompt_hash: String,
+    pub defaulted: bool,
+    pub overlay_chain: Vec<String>,
+}
+
+impl PersonaRegistry {
+    pub fn new(
+        personas: impl IntoIterator<Item = PersonaDefinition>,
+        default_persona_id: Option<String>,
+        overlay_chain: Vec<String>,
+    ) -> Result<Self, String> {
+        let personas = personas
+            .into_iter()
+            .map(|persona| (persona.id.clone(), persona))
+            .collect::<BTreeMap<_, _>>();
+        if let Some(default_persona_id) = default_persona_id.as_deref()
+            && !personas.contains_key(default_persona_id)
+        {
+            return Err(format!(
+                "CENTAUR_DEFAULT_PERSONA {default_persona_id:?} is not in the deployed persona registry"
+            ));
+        }
+        Ok(Self {
+            personas,
+            default_persona_id,
+            overlay_chain,
+        })
+    }
+
+    pub fn summaries(&self) -> Vec<PersonaSummary> {
+        self.personas
+            .values()
+            .map(|persona| PersonaSummary {
+                id: persona.id.clone(),
+                source_root: persona.source_root.clone(),
+                source_path: persona.source_path.clone(),
+                source_ref: persona.source_ref.clone(),
+                prompt_hash: persona.prompt_hash.clone(),
+            })
+            .collect()
+    }
+
+    fn default_persona_id(&self) -> Option<&str> {
+        self.default_persona_id.as_deref()
+    }
+
+    fn get(&self, persona_id: &str) -> Option<&PersonaDefinition> {
+        self.personas.get(persona_id)
+    }
 }
 
 #[derive(Clone)]
@@ -169,6 +259,12 @@ struct SandboxReadyObservation<'a> {
     startup_duration: Option<Duration>,
 }
 
+struct PersonaResolution {
+    persona_id: Option<String>,
+    context: Option<PersonaContext>,
+    defaulted: bool,
+}
+
 impl SessionRuntime {
     pub fn new(store: PgSessionStore, sandbox_runtime: SandboxRuntime) -> Self {
         Self {
@@ -179,7 +275,127 @@ impl SessionRuntime {
             execution_spans: Arc::new(Mutex::new(HashMap::new())),
             iron_control: None,
             warm_pool: None,
+            personas: None,
         }
+    }
+
+    pub fn with_personas(mut self, personas: PersonaRegistry) -> Self {
+        self.personas = Some(Arc::new(personas));
+        self
+    }
+
+    pub fn personas(&self) -> Vec<PersonaSummary> {
+        self.personas
+            .as_ref()
+            .map(|personas| personas.summaries())
+            .unwrap_or_default()
+    }
+
+    fn resolve_persona_for_create(
+        &self,
+        requested_persona_id: Option<&str>,
+        harness_type: &HarnessType,
+    ) -> Result<PersonaResolution, SessionRuntimeError> {
+        let requested_persona_id = requested_persona_id.and_then(clean_persona_id);
+        let defaulted = requested_persona_id.is_none();
+        let persona_id = requested_persona_id
+            .or_else(|| {
+                self.personas
+                    .as_ref()
+                    .and_then(|personas| personas.default_persona_id())
+            })
+            .map(str::to_owned);
+        let context = self.resolve_stored_persona_with_defaulted(
+            persona_id.as_deref(),
+            harness_type,
+            defaulted && persona_id.is_some(),
+        )?;
+        Ok(PersonaResolution {
+            persona_id,
+            context,
+            defaulted,
+        })
+    }
+
+    fn resolve_stored_persona(
+        &self,
+        persona_id: Option<&str>,
+        harness_type: &HarnessType,
+    ) -> Result<Option<PersonaContext>, SessionRuntimeError> {
+        self.resolve_stored_persona_with_defaulted(persona_id, harness_type, false)
+    }
+
+    fn resolve_stored_persona_with_defaulted(
+        &self,
+        persona_id: Option<&str>,
+        harness_type: &HarnessType,
+        defaulted: bool,
+    ) -> Result<Option<PersonaContext>, SessionRuntimeError> {
+        let Some(persona_id) = persona_id.and_then(clean_persona_id) else {
+            return Ok(None);
+        };
+        let Some(registry) = self.personas.as_ref() else {
+            return Err(SessionRuntimeError::BadRequest(format!(
+                "persona {persona_id:?} was requested but no persona registry is configured"
+            )));
+        };
+        let Some(persona) = registry.get(persona_id) else {
+            return Err(SessionRuntimeError::BadRequest(format!(
+                "persona {persona_id:?} is not available in this deployment"
+            )));
+        };
+        let mut context = PersonaContext {
+            persona_id: persona.id.clone(),
+            source_root: persona.source_root.clone(),
+            source_path: persona.source_path.clone(),
+            source_ref: persona.source_ref.clone(),
+            prompt_hash: persona.prompt_hash.clone(),
+            effective_prompt_hash: String::new(),
+            defaulted,
+            overlay_chain: registry.overlay_chain.clone(),
+        };
+        context.effective_prompt_hash = sha256_hex(format!(
+            "{}\n\n{}",
+            active_deployment_fingerprint_input(&context, harness_type),
+            persona.prompt
+        ));
+        Ok(Some(context))
+    }
+
+    fn apply_persona_to_spec(
+        &self,
+        spec: &mut SandboxSpec,
+        context: &PersonaContext,
+        harness_type: &HarnessType,
+    ) {
+        let Some(registry) = self.personas.as_ref() else {
+            return;
+        };
+        let Some(persona) = registry.get(&context.persona_id) else {
+            return;
+        };
+        upsert_spec_env(spec, "AGENT_PERSONA", context.persona_id.clone());
+        upsert_spec_env(spec, "CENTAUR_PERSONA_ID", context.persona_id.clone());
+        upsert_spec_env(
+            spec,
+            "CENTAUR_PERSONA_PROMPT_HASH",
+            context.prompt_hash.clone(),
+        );
+        upsert_spec_env(
+            spec,
+            "CENTAUR_EFFECTIVE_PROMPT_HASH",
+            context.effective_prompt_hash.clone(),
+        );
+        upsert_spec_env(
+            spec,
+            ACTIVE_DEPLOYMENT_ENV,
+            BASE64_STANDARD.encode(active_deployment_block(context, harness_type)),
+        );
+        upsert_spec_env(
+            spec,
+            PERSONA_PROMPT_ENV,
+            BASE64_STANDARD.encode(&persona.prompt),
+        );
     }
 
     fn context(&self) -> RuntimeContext {
@@ -284,17 +500,34 @@ impl SessionRuntime {
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned);
             let mut harness_switched = false;
+            let persona_resolution = self.resolve_persona_for_create(persona_id, harness_type)?;
+            let mut session_metadata = default_metadata(metadata);
+            if let Some(context) = persona_resolution.context.as_ref() {
+                add_persona_metadata(&mut session_metadata, context);
+            }
             let session = match self
                 .store
                 .create_or_get_session(
                     thread_key,
                     harness_type,
-                    persona_id,
-                    default_metadata(metadata),
+                    persona_resolution.persona_id.as_deref(),
+                    session_metadata,
                 )
                 .await
             {
                 Ok(session) => session,
+                Err(SessionStoreError::PersonaConflict { existing, .. })
+                    if persona_id.is_none() && persona_resolution.defaulted =>
+                {
+                    self.store
+                        .create_or_get_session(
+                            thread_key,
+                            harness_type,
+                            existing.as_deref(),
+                            default_metadata(None),
+                        )
+                        .await?
+                }
                 Err(SessionStoreError::HarnessConflict { existing, .. })
                     if on_harness_conflict == HarnessConflictPolicy::Restart =>
                 {
@@ -306,6 +539,23 @@ impl SessionRuntime {
                 }
                 Err(error) => return Err(error.into()),
             };
+            if let Some(context) = self.resolve_stored_persona(session.persona_id.as_deref(), harness_type)? {
+                self.store
+                    .append_event(
+                        thread_key,
+                        None,
+                        "session.persona_resolved",
+                        json!({
+                            "persona": context,
+                            "requested_persona_id": persona_id,
+                            "deployment_default_persona_id": self
+                                .personas
+                                .as_ref()
+                                .and_then(|personas| personas.default_persona_id().map(str::to_owned)),
+                        }),
+                    )
+                    .await?;
+            }
             if let Some(registrar) = &self.iron_control {
                 // iron-control is the source of truth for the session's egress
                 // proxy: without a registered principal the proxy has no identity
@@ -647,6 +897,7 @@ impl SessionRuntime {
                 .ensure_session_sandbox(
                     thread_key,
                     &session.harness_type,
+                    session.persona_id.as_deref(),
                     session.sandbox_id.as_deref(),
                     session.iron_control_principal.as_deref(),
                     &execution.execution_id,
@@ -960,6 +1211,7 @@ impl SessionRuntime {
         &self,
         thread_key: &ThreadKey,
         harness_type: &HarnessType,
+        persona_id: Option<&str>,
         existing_sandbox_id: Option<&str>,
         iron_control_principal: Option<&str>,
         execution_id: &str,
@@ -976,9 +1228,11 @@ impl SessionRuntime {
             sandbox_id = tracing::field::Empty,
             existing_sandbox_id = existing_sandbox_id.unwrap_or(""),
             iron_control_principal_present = iron_control_principal.is_some(),
+            persona_id = persona_id.unwrap_or(""),
         );
         let ensure_started = Instant::now();
         let result = async {
+            let persona_context = self.resolve_stored_persona(persona_id, harness_type)?;
             if let Some(sandbox_id) = existing_sandbox_id {
                 let id = SandboxId::new(sandbox_id);
                 match self.sandbox_runtime.manager.status(&id).await {
@@ -1111,10 +1365,18 @@ impl SessionRuntime {
                 .warm_harness
                 .as_ref()
                 .is_none_or(|warm| warm == harness_type);
+            let warm_persona_matches = persona_context.is_none();
             if !warm_harness_matches && self.warm_pool.is_some() {
                 record_sandbox_warm_pool_claim("harness_mismatch");
             }
-            if let Some(warm_pool) = self.warm_pool.as_ref().filter(|_| warm_harness_matches) {
+            if !warm_persona_matches && self.warm_pool.is_some() {
+                record_sandbox_warm_pool_claim("persona_specific");
+            }
+            if let Some(warm_pool) = self
+                .warm_pool
+                .as_ref()
+                .filter(|_| warm_harness_matches && warm_persona_matches)
+            {
                 match warm_pool
                     .claim(thread_key.as_str(), iron_control_principal)
                     .await
@@ -1173,6 +1435,9 @@ impl SessionRuntime {
 
             let mut spec =
                 (self.sandbox_runtime.spec_factory)(thread_key, execution_id, harness_type);
+            if let Some(context) = persona_context.as_ref() {
+                self.apply_persona_to_spec(&mut spec, context, harness_type);
+            }
             if let Some(principal) = iron_control_principal {
                 spec.iron_control_principal = Some(principal.to_owned());
             }
@@ -3133,6 +3398,77 @@ fn duration_millis_u64(duration: Duration) -> u64 {
     duration.as_millis().min(u128::from(u64::MAX)) as u64
 }
 
+fn clean_persona_id(value: &str) -> Option<&str> {
+    let value = value.trim();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn upsert_spec_env(spec: &mut SandboxSpec, name: &str, value: String) {
+    if let Some(existing) = spec.env.iter_mut().find(|env| env.name == name) {
+        existing.value = value;
+    } else {
+        spec.env
+            .push(centaur_sandbox_core::EnvVar::new(name, value));
+    }
+}
+
+fn add_persona_metadata(metadata: &mut Value, context: &PersonaContext) {
+    if let Value::Object(object) = metadata {
+        object.insert("persona".to_owned(), json!(context));
+    }
+}
+
+fn active_deployment_block(context: &PersonaContext, harness_type: &HarnessType) -> String {
+    let source_ref = context.source_ref.as_deref().unwrap_or("unknown");
+    let overlay_chain = if context.overlay_chain.is_empty() {
+        "[]".to_owned()
+    } else {
+        context.overlay_chain.join(" -> ")
+    };
+    format!(
+        "[Active deployment]\n\
+         harness: {harness_type}\n\
+         persona_id: {}\n\
+         persona_source_path: {}\n\
+         persona_source_ref: {source_ref}\n\
+         persona_prompt_hash: {}\n\
+         effective_prompt_hash: {}\n\
+         persona_defaulted: {}\n\
+         overlay_chain: {overlay_chain}",
+        context.persona_id,
+        context.source_path,
+        context.prompt_hash,
+        context.effective_prompt_hash,
+        context.defaulted,
+    )
+}
+
+fn active_deployment_fingerprint_input(
+    context: &PersonaContext,
+    harness_type: &HarnessType,
+) -> String {
+    let source_ref = context.source_ref.as_deref().unwrap_or("unknown");
+    format!(
+        "harness={harness_type}\n\
+         persona_id={}\n\
+         persona_source_path={}\n\
+         persona_source_ref={source_ref}\n\
+         persona_prompt_hash={}\n\
+         persona_defaulted={}\n\
+         overlay_chain={}",
+        context.persona_id,
+        context.source_path,
+        context.prompt_hash,
+        context.defaulted,
+        context.overlay_chain.join(" -> "),
+    )
+}
+
+fn sha256_hex(value: impl AsRef<[u8]>) -> String {
+    let digest = Sha256::digest(value.as_ref());
+    format!("sha256:{digest:x}")
+}
+
 async fn record_finished_execution_metric(
     store: &PgSessionStore,
     thread_key: &ThreadKey,
@@ -3912,6 +4248,35 @@ mod tests {
     use centaur_session_core::SessionStatus;
     use serde_json::json;
     use time::OffsetDateTime;
+
+    #[test]
+    fn persona_registry_validates_default_and_summarizes_without_prompt() {
+        let registry = PersonaRegistry::new(
+            [PersonaDefinition {
+                id: "eng".to_owned(),
+                source_root: "/repo/tools".to_owned(),
+                source_path: "/repo/tools/personas/eng".to_owned(),
+                source_ref: Some("abc123".to_owned()),
+                prompt_hash: "sha256:prompt".to_owned(),
+                prompt: "secret prompt".to_owned(),
+            }],
+            Some("eng".to_owned()),
+            vec!["/repo/tools".to_owned()],
+        )
+        .unwrap();
+
+        let summaries = registry.summaries();
+
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, "eng");
+        assert!(
+            serde_json::to_value(registry.get("eng").unwrap())
+                .unwrap()
+                .get("prompt")
+                .is_none()
+        );
+        assert!(PersonaRegistry::new(Vec::new(), Some("missing".to_owned()), Vec::new()).is_err());
+    }
 
     #[test]
     fn turn_completed_without_answer_text_is_terminal() {

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -4,7 +4,6 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use centaur_iron_control::SessionRegistrar;
 use centaur_sandbox_core::{
     Mount, SandboxBackend, SandboxError, SandboxId, SandboxIoGuard, SandboxRead, SandboxSpec,
@@ -46,10 +45,10 @@ const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
-const ACTIVE_DEPLOYMENT_ENV: &str = "CENTAUR_ACTIVE_DEPLOYMENT_BLOCK_B64";
-const PERSONA_PROMPT_ENV: &str = "CENTAUR_PERSONA_PROMPT_B64";
 
-type SandboxSpecFactory = Arc<dyn Fn(&ThreadKey, &str, &HarnessType) -> SandboxSpec + Send + Sync>;
+type SandboxSpecFactory = Arc<
+    dyn Fn(&ThreadKey, &str, &HarnessType, Option<&PersonaContext>) -> SandboxSpec + Send + Sync,
+>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
 type ExecutionSpanRegistry = Arc<Mutex<HashMap<String, Span>>>;
 type SessionPipeMap = Arc<DashMap<String, SessionPipe>>;
@@ -360,42 +359,6 @@ impl SessionRuntime {
             persona.prompt
         ));
         Ok(Some(context))
-    }
-
-    fn apply_persona_to_spec(
-        &self,
-        spec: &mut SandboxSpec,
-        context: &PersonaContext,
-        harness_type: &HarnessType,
-    ) {
-        let Some(registry) = self.personas.as_ref() else {
-            return;
-        };
-        let Some(persona) = registry.get(&context.persona_id) else {
-            return;
-        };
-        upsert_spec_env(spec, "AGENT_PERSONA", context.persona_id.clone());
-        upsert_spec_env(spec, "CENTAUR_PERSONA_ID", context.persona_id.clone());
-        upsert_spec_env(
-            spec,
-            "CENTAUR_PERSONA_PROMPT_HASH",
-            context.prompt_hash.clone(),
-        );
-        upsert_spec_env(
-            spec,
-            "CENTAUR_EFFECTIVE_PROMPT_HASH",
-            context.effective_prompt_hash.clone(),
-        );
-        upsert_spec_env(
-            spec,
-            ACTIVE_DEPLOYMENT_ENV,
-            BASE64_STANDARD.encode(active_deployment_block(context, harness_type)),
-        );
-        upsert_spec_env(
-            spec,
-            PERSONA_PROMPT_ENV,
-            BASE64_STANDARD.encode(&persona.prompt),
-        );
     }
 
     fn context(&self) -> RuntimeContext {
@@ -1433,11 +1396,12 @@ impl SessionRuntime {
                 }
             }
 
-            let mut spec =
-                (self.sandbox_runtime.spec_factory)(thread_key, execution_id, harness_type);
-            if let Some(context) = persona_context.as_ref() {
-                self.apply_persona_to_spec(&mut spec, context, harness_type);
-            }
+            let mut spec = (self.sandbox_runtime.spec_factory)(
+                thread_key,
+                execution_id,
+                harness_type,
+                persona_context.as_ref(),
+            );
             if let Some(principal) = iron_control_principal {
                 spec.iron_control_principal = Some(principal.to_owned());
             }
@@ -1957,9 +1921,10 @@ impl SandboxRuntime {
     pub fn backend(backend: Arc<dyn SandboxBackend>, spec: SandboxSpec) -> Self {
         let warm_spec = spec.clone();
         let spec_factory =
-            move |_thread_key: &ThreadKey, _execution_id: &str, _harness: &HarnessType| {
-                spec.clone()
-            };
+            move |_thread_key: &ThreadKey,
+                  _execution_id: &str,
+                  _harness: &HarnessType,
+                  _persona: Option<&PersonaContext>| { spec.clone() };
         let warm_spec_factory = move || warm_spec.clone();
         Self::backend_with_warm_spec_factory(backend, spec_factory, warm_spec_factory)
     }
@@ -1972,7 +1937,9 @@ impl SandboxRuntime {
         let warm_workload = workload.clone();
         let mut runtime = Self::backend_with_warm_spec_factory(
             backend,
-            move |thread_key, _execution_id, harness| workload.spec(thread_key, harness),
+            move |thread_key, _execution_id, harness, persona| {
+                workload.spec(thread_key, harness, persona)
+            },
             move || warm_workload.warm_spec(),
         );
         runtime.warm_harness = warm_harness;
@@ -1981,7 +1948,10 @@ impl SandboxRuntime {
 
     pub fn backend_with_spec_factory<F>(backend: Arc<dyn SandboxBackend>, spec_factory: F) -> Self
     where
-        F: Fn(&ThreadKey, &str, &HarnessType) -> SandboxSpec + Send + Sync + 'static,
+        F: Fn(&ThreadKey, &str, &HarnessType, Option<&PersonaContext>) -> SandboxSpec
+            + Send
+            + Sync
+            + 'static,
     {
         Self {
             manager: Arc::new(SandboxManager::new(backend)),
@@ -1998,7 +1968,10 @@ impl SandboxRuntime {
         warm_spec_factory: W,
     ) -> Self
     where
-        F: Fn(&ThreadKey, &str, &HarnessType) -> SandboxSpec + Send + Sync + 'static,
+        F: Fn(&ThreadKey, &str, &HarnessType, Option<&PersonaContext>) -> SandboxSpec
+            + Send
+            + Sync
+            + 'static,
         W: Fn() -> SandboxSpec + Send + Sync + 'static,
     {
         let warm_spec_factory: WarmSandboxSpecFactory = Arc::new(warm_spec_factory);
@@ -2048,23 +2021,36 @@ impl SandboxWorkloadMode {
         }
     }
 
-    fn spec(&self, thread_key: &ThreadKey, harness: &HarnessType) -> SandboxSpec {
-        self.spec_for(Some(thread_key), harness)
+    fn spec(
+        &self,
+        thread_key: &ThreadKey,
+        harness: &HarnessType,
+        persona: Option<&PersonaContext>,
+    ) -> SandboxSpec {
+        self.spec_for(Some(thread_key), harness, persona)
     }
 
     fn warm_spec(&self) -> SandboxSpec {
         match self {
-            Self::MockAppServer { .. } => self.spec_for(None, &HarnessType::Codex),
-            Self::CodexAppServer { harness, .. } => self.spec_for(None, harness),
+            Self::MockAppServer { .. } => self.spec_for(None, &HarnessType::Codex, None),
+            Self::CodexAppServer { harness, .. } => self.spec_for(None, harness, None),
         }
     }
 
-    fn spec_for(&self, thread_key: Option<&ThreadKey>, harness: &HarnessType) -> SandboxSpec {
+    fn spec_for(
+        &self,
+        thread_key: Option<&ThreadKey>,
+        harness: &HarnessType,
+        persona: Option<&PersonaContext>,
+    ) -> SandboxSpec {
         match self {
-            Self::MockAppServer { image } => SandboxSpec::new(image)
-                .command(["/bin/sh", "-lc"])
-                .args([mock_app_server_script()])
-                .env("CENTAUR_HARNESS_TYPE", harness.as_ref()),
+            Self::MockAppServer { image } => apply_persona_spec_env(
+                SandboxSpec::new(image)
+                    .command(["/bin/sh", "-lc"])
+                    .args([mock_app_server_script()])
+                    .env("CENTAUR_HARNESS_TYPE", harness.as_ref()),
+                persona,
+            ),
             Self::CodexAppServer {
                 image, env, mounts, ..
             } => {
@@ -2091,7 +2077,7 @@ impl SandboxWorkloadMode {
                 for (name, value) in env {
                     spec = spec.env(name.clone(), value.clone());
                 }
-                spec
+                apply_persona_spec_env(spec, persona)
             }
         }
     }
@@ -3412,35 +3398,47 @@ fn upsert_spec_env(spec: &mut SandboxSpec, name: &str, value: String) {
     }
 }
 
+fn apply_persona_spec_env(mut spec: SandboxSpec, persona: Option<&PersonaContext>) -> SandboxSpec {
+    remove_spec_env(&mut spec, "AGENT_PERSONA");
+    remove_spec_env(&mut spec, "CENTAUR_PERSONA_ID");
+    remove_spec_env(&mut spec, "CENTAUR_PERSONA_PROMPT_HASH");
+    remove_spec_env(&mut spec, "CENTAUR_EFFECTIVE_PROMPT_HASH");
+    remove_spec_env(&mut spec, "CENTAUR_PERSONA_SOURCE_PATH");
+    remove_spec_env(&mut spec, "CENTAUR_PERSONA_SOURCE_REF");
+    let Some(persona) = persona else {
+        return spec;
+    };
+    upsert_spec_env(&mut spec, "AGENT_PERSONA", persona.persona_id.clone());
+    upsert_spec_env(&mut spec, "CENTAUR_PERSONA_ID", persona.persona_id.clone());
+    upsert_spec_env(
+        &mut spec,
+        "CENTAUR_PERSONA_PROMPT_HASH",
+        persona.prompt_hash.clone(),
+    );
+    upsert_spec_env(
+        &mut spec,
+        "CENTAUR_EFFECTIVE_PROMPT_HASH",
+        persona.effective_prompt_hash.clone(),
+    );
+    upsert_spec_env(
+        &mut spec,
+        "CENTAUR_PERSONA_SOURCE_PATH",
+        persona.source_path.clone(),
+    );
+    if let Some(source_ref) = persona.source_ref.as_ref() {
+        upsert_spec_env(&mut spec, "CENTAUR_PERSONA_SOURCE_REF", source_ref.clone());
+    }
+    spec
+}
+
+fn remove_spec_env(spec: &mut SandboxSpec, name: &str) {
+    spec.env.retain(|env| env.name != name);
+}
+
 fn add_persona_metadata(metadata: &mut Value, context: &PersonaContext) {
     if let Value::Object(object) = metadata {
         object.insert("persona".to_owned(), json!(context));
     }
-}
-
-fn active_deployment_block(context: &PersonaContext, harness_type: &HarnessType) -> String {
-    let source_ref = context.source_ref.as_deref().unwrap_or("unknown");
-    let overlay_chain = if context.overlay_chain.is_empty() {
-        "[]".to_owned()
-    } else {
-        context.overlay_chain.join(" -> ")
-    };
-    format!(
-        "[Active deployment]\n\
-         harness: {harness_type}\n\
-         persona_id: {}\n\
-         persona_source_path: {}\n\
-         persona_source_ref: {source_ref}\n\
-         persona_prompt_hash: {}\n\
-         effective_prompt_hash: {}\n\
-         persona_defaulted: {}\n\
-         overlay_chain: {overlay_chain}",
-        context.persona_id,
-        context.source_path,
-        context.prompt_hash,
-        context.effective_prompt_hash,
-        context.defaulted,
-    )
 }
 
 fn active_deployment_fingerprint_input(
@@ -4886,7 +4884,7 @@ mod tests {
         );
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
 
-        let spec = workload.spec(&thread_key, &HarnessType::Codex);
+        let spec = workload.spec(&thread_key, &HarnessType::Codex, None);
 
         assert_eq!(spec.mounts.len(), 1);
         assert_eq!(spec.mounts[0].target_path, "/home/agent/github");
@@ -4900,6 +4898,31 @@ mod tests {
     }
 
     #[test]
+    fn codex_workload_reflects_resolved_persona_in_sandbox_spec() {
+        let workload = SandboxWorkloadMode::codex_app_server(
+            "centaur-agent:latest",
+            [("AGENT_PERSONA".to_owned(), "stale".to_owned())],
+            HarnessType::Codex,
+        );
+        let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+        let persona = test_persona_context("eng");
+
+        let spec = workload.spec(&thread_key, &HarnessType::Codex, Some(&persona));
+
+        assert_eq!(env_value(&spec, "AGENT_PERSONA"), Some("eng"));
+        assert_eq!(env_value(&spec, "CENTAUR_PERSONA_ID"), Some("eng"));
+        assert_eq!(
+            env_value(&spec, "CENTAUR_PERSONA_PROMPT_HASH"),
+            Some("sha256:prompt")
+        );
+        assert_eq!(
+            env_value(&spec, "CENTAUR_PERSONA_SOURCE_REF"),
+            Some("abc123")
+        );
+        assert_eq!(env_value(&workload.warm_spec(), "AGENT_PERSONA"), None);
+    }
+
+    #[test]
     fn codex_workload_does_not_inject_stale_continue_thread_id() {
         let workload = SandboxWorkloadMode::codex_app_server(
             "centaur-agent:latest",
@@ -4908,7 +4931,7 @@ mod tests {
         );
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
 
-        let spec = workload.spec(&thread_key, &HarnessType::Codex);
+        let spec = workload.spec(&thread_key, &HarnessType::Codex, None);
 
         assert_eq!(
             spec.env
@@ -4935,7 +4958,7 @@ mod tests {
         );
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
 
-        let claimed_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode);
+        let claimed_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode, None);
         let warm_spec = workload.warm_spec();
 
         assert_eq!(
@@ -4977,8 +5000,8 @@ mod tests {
         let second_thread_key = ThreadKey::parse("chat:C456:1780000000.000001").unwrap();
 
         assert_ne!(
-            sandbox_spec_key(&workload.spec(&first_thread_key, &HarnessType::ClaudeCode)),
-            sandbox_spec_key(&workload.spec(&second_thread_key, &HarnessType::ClaudeCode))
+            sandbox_spec_key(&workload.spec(&first_thread_key, &HarnessType::ClaudeCode, None)),
+            sandbox_spec_key(&workload.spec(&second_thread_key, &HarnessType::ClaudeCode, None))
         );
         assert_eq!(
             sandbox_spec_key(&workload.warm_spec()),
@@ -4995,9 +5018,9 @@ mod tests {
         );
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
 
-        let codex_spec = workload.spec(&thread_key, &HarnessType::Codex);
-        let claude_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode);
-        let amp_spec = workload.spec(&thread_key, &HarnessType::Amp);
+        let codex_spec = workload.spec(&thread_key, &HarnessType::Codex, None);
+        let claude_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode, None);
+        let amp_spec = workload.spec(&thread_key, &HarnessType::Amp, None);
 
         assert_eq!(codex_spec.args, vec!["harness-server", "codex"]);
         assert_eq!(claude_spec.args, vec!["harness-server", "claude-code"]);
@@ -5015,7 +5038,7 @@ mod tests {
         );
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
 
-        let spec = workload.spec(&thread_key, &HarnessType::ClaudeCode);
+        let spec = workload.spec(&thread_key, &HarnessType::ClaudeCode, None);
 
         assert_eq!(
             spec.labels.get("centaur.ai/component").map(String::as_str),
@@ -5044,7 +5067,9 @@ mod tests {
         // warm claim for it would hand over the wrong harness.
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
         assert_eq!(
-            workload.spec(&thread_key, &HarnessType::ClaudeCode).args,
+            workload
+                .spec(&thread_key, &HarnessType::ClaudeCode, None)
+                .args,
             vec!["harness-server", "claude-code"]
         );
     }
@@ -5144,6 +5169,19 @@ mod tests {
             .iter()
             .find(|env| env.name == name)
             .map(|env| env.value.as_str())
+    }
+
+    fn test_persona_context(persona_id: &str) -> PersonaContext {
+        PersonaContext {
+            persona_id: persona_id.to_owned(),
+            source_root: "/repo/tools".to_owned(),
+            source_path: format!("/repo/tools/personas/{persona_id}"),
+            source_ref: Some("abc123".to_owned()),
+            prompt_hash: "sha256:prompt".to_owned(),
+            effective_prompt_hash: "sha256:effective".to_owned(),
+            defaulted: false,
+            overlay_chain: vec!["/repo/tools".to_owned()],
+        }
     }
 }
 

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -45,6 +45,14 @@ const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
+const PERSONA_SPEC_ENV_KEYS: [&str; 6] = [
+    "AGENT_PERSONA",
+    "CENTAUR_PERSONA_ID",
+    "CENTAUR_PERSONA_PROMPT_HASH",
+    "CENTAUR_EFFECTIVE_PROMPT_HASH",
+    "CENTAUR_PERSONA_SOURCE_PATH",
+    "CENTAUR_PERSONA_SOURCE_REF",
+];
 
 type SandboxSpecFactory = Arc<
     dyn Fn(&ThreadKey, &str, &HarnessType, Option<&PersonaContext>) -> SandboxSpec + Send + Sync,
@@ -148,6 +156,35 @@ impl PersonaRegistry {
 
     fn get(&self, persona_id: &str) -> Option<&PersonaDefinition> {
         self.personas.get(persona_id)
+    }
+
+    fn context_for(
+        &self,
+        persona_id: &str,
+        harness_type: &HarnessType,
+        defaulted: bool,
+    ) -> Result<PersonaContext, String> {
+        let Some(persona) = self.get(persona_id) else {
+            return Err(format!(
+                "persona {persona_id:?} is not available in this deployment"
+            ));
+        };
+        let mut context = PersonaContext {
+            persona_id: persona.id.clone(),
+            source_root: persona.source_root.clone(),
+            source_path: persona.source_path.clone(),
+            source_ref: persona.source_ref.clone(),
+            prompt_hash: persona.prompt_hash.clone(),
+            effective_prompt_hash: String::new(),
+            defaulted,
+            overlay_chain: self.overlay_chain.clone(),
+        };
+        context.effective_prompt_hash = sha256_hex(format!(
+            "{}\n\n{}",
+            active_deployment_fingerprint_input(&context, harness_type),
+            persona.prompt
+        ));
+        Ok(context)
     }
 }
 
@@ -295,22 +332,12 @@ impl SessionRuntime {
         requested_persona_id: Option<&str>,
         harness_type: &HarnessType,
     ) -> Result<PersonaResolution, SessionRuntimeError> {
-        let requested_persona_id = requested_persona_id.and_then(clean_persona_id);
-        let defaulted = requested_persona_id.is_none();
-        let persona_id = requested_persona_id
-            .or_else(|| {
-                self.personas
-                    .as_ref()
-                    .and_then(|personas| personas.default_persona_id())
-            })
-            .map(str::to_owned);
-        let context = self.resolve_stored_persona_with_defaulted(
-            persona_id.as_deref(),
-            harness_type,
-            defaulted && persona_id.is_some(),
-        )?;
+        let requested = requested_persona_id.and_then(clean_persona_id);
+        let selected = requested.or_else(|| self.default_persona_id());
+        let defaulted = requested.is_none() && selected.is_some();
+        let context = self.resolve_persona_context(selected, harness_type, defaulted)?;
         Ok(PersonaResolution {
-            persona_id,
+            persona_id: selected.map(str::to_owned),
             context,
             defaulted,
         })
@@ -321,16 +348,16 @@ impl SessionRuntime {
         persona_id: Option<&str>,
         harness_type: &HarnessType,
     ) -> Result<Option<PersonaContext>, SessionRuntimeError> {
-        self.resolve_stored_persona_with_defaulted(persona_id, harness_type, false)
+        self.resolve_persona_context(persona_id.and_then(clean_persona_id), harness_type, false)
     }
 
-    fn resolve_stored_persona_with_defaulted(
+    fn resolve_persona_context(
         &self,
         persona_id: Option<&str>,
         harness_type: &HarnessType,
         defaulted: bool,
     ) -> Result<Option<PersonaContext>, SessionRuntimeError> {
-        let Some(persona_id) = persona_id.and_then(clean_persona_id) else {
+        let Some(persona_id) = persona_id else {
             return Ok(None);
         };
         let Some(registry) = self.personas.as_ref() else {
@@ -338,27 +365,16 @@ impl SessionRuntime {
                 "persona {persona_id:?} was requested but no persona registry is configured"
             )));
         };
-        let Some(persona) = registry.get(persona_id) else {
-            return Err(SessionRuntimeError::BadRequest(format!(
-                "persona {persona_id:?} is not available in this deployment"
-            )));
-        };
-        let mut context = PersonaContext {
-            persona_id: persona.id.clone(),
-            source_root: persona.source_root.clone(),
-            source_path: persona.source_path.clone(),
-            source_ref: persona.source_ref.clone(),
-            prompt_hash: persona.prompt_hash.clone(),
-            effective_prompt_hash: String::new(),
-            defaulted,
-            overlay_chain: registry.overlay_chain.clone(),
-        };
-        context.effective_prompt_hash = sha256_hex(format!(
-            "{}\n\n{}",
-            active_deployment_fingerprint_input(&context, harness_type),
-            persona.prompt
-        ));
-        Ok(Some(context))
+        registry
+            .context_for(persona_id, harness_type, defaulted)
+            .map(Some)
+            .map_err(SessionRuntimeError::BadRequest)
+    }
+
+    fn default_persona_id(&self) -> Option<&str> {
+        self.personas
+            .as_ref()
+            .and_then(|personas| personas.default_persona_id())
     }
 
     fn context(&self) -> RuntimeContext {
@@ -502,7 +518,9 @@ impl SessionRuntime {
                 }
                 Err(error) => return Err(error.into()),
             };
-            if let Some(context) = self.resolve_stored_persona(session.persona_id.as_deref(), harness_type)? {
+            if let Some(context) =
+                self.resolve_stored_persona(session.persona_id.as_deref(), harness_type)?
+            {
                 self.store
                     .append_event(
                         thread_key,
@@ -511,10 +529,7 @@ impl SessionRuntime {
                         json!({
                             "persona": context,
                             "requested_persona_id": persona_id,
-                            "deployment_default_persona_id": self
-                                .personas
-                                .as_ref()
-                                .and_then(|personas| personas.default_persona_id().map(str::to_owned)),
+                            "deployment_default_persona_id": self.default_persona_id(),
                         }),
                     )
                     .await?;
@@ -3399,12 +3414,9 @@ fn upsert_spec_env(spec: &mut SandboxSpec, name: &str, value: String) {
 }
 
 fn apply_persona_spec_env(mut spec: SandboxSpec, persona: Option<&PersonaContext>) -> SandboxSpec {
-    remove_spec_env(&mut spec, "AGENT_PERSONA");
-    remove_spec_env(&mut spec, "CENTAUR_PERSONA_ID");
-    remove_spec_env(&mut spec, "CENTAUR_PERSONA_PROMPT_HASH");
-    remove_spec_env(&mut spec, "CENTAUR_EFFECTIVE_PROMPT_HASH");
-    remove_spec_env(&mut spec, "CENTAUR_PERSONA_SOURCE_PATH");
-    remove_spec_env(&mut spec, "CENTAUR_PERSONA_SOURCE_REF");
+    for name in PERSONA_SPEC_ENV_KEYS {
+        remove_spec_env(&mut spec, name);
+    }
     let Some(persona) = persona else {
         return spec;
     };
@@ -4977,7 +4989,7 @@ mod tests {
         );
         let thread_key = ThreadKey::parse("slack:T123:C123:1780000000.000000").unwrap();
 
-        let claimed_spec = workload.spec(&thread_key, &HarnessType::Codex);
+        let claimed_spec = workload.spec(&thread_key, &HarnessType::Codex, None);
         let warm_spec = workload.warm_spec();
 
         assert_eq!(env_value(&claimed_spec, "SLACK_CHANNEL_ID"), Some("C123"));

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -414,7 +414,34 @@ elif [ -n "${CENTAUR_OVERLAY_DIR:-}" ] \
     cat "${CENTAUR_OVERLAY_DIR}/services/sandbox/SYSTEM_PROMPT.md" >> "$TARGET_PROMPT"
 fi
 
-# Persona prompt injection is done by the API when it writes AGENTS_BASE.md.
+# The API resolves personas against the deployment registry and passes a
+# materialized prompt bundle. Keep AGENT_PERSONA as reflective state only; the
+# prompt content below is the authoritative persona instruction for this
+# sandbox.
+if [ -n "${CENTAUR_ACTIVE_DEPLOYMENT_BLOCK_B64:-}" ] && [ -f "$TARGET_PROMPT" ]; then
+    ACTIVE_BLOCK_FILE="$(mktemp)"
+    if printf '%s' "$CENTAUR_ACTIVE_DEPLOYMENT_BLOCK_B64" | base64 -d > "$ACTIVE_BLOCK_FILE" 2>/dev/null; then
+        PROMPT_WITH_BLOCK="$(mktemp)"
+        cat "$ACTIVE_BLOCK_FILE" > "$PROMPT_WITH_BLOCK"
+        printf '\n\n---\n\n' >> "$PROMPT_WITH_BLOCK"
+        cat "$TARGET_PROMPT" >> "$PROMPT_WITH_BLOCK"
+        mv "$PROMPT_WITH_BLOCK" "$TARGET_PROMPT"
+    else
+        echo "warning: failed to decode CENTAUR_ACTIVE_DEPLOYMENT_BLOCK_B64" >&2
+    fi
+    rm -f "$ACTIVE_BLOCK_FILE" "${PROMPT_WITH_BLOCK:-}"
+fi
+
+if [ -n "${CENTAUR_PERSONA_PROMPT_B64:-}" ] && [ -f "$TARGET_PROMPT" ]; then
+    PERSONA_PROMPT_FILE="$(mktemp)"
+    if printf '%s' "$CENTAUR_PERSONA_PROMPT_B64" | base64 -d > "$PERSONA_PROMPT_FILE" 2>/dev/null; then
+        printf '\n\n---\n\n' >> "$TARGET_PROMPT"
+        cat "$PERSONA_PROMPT_FILE" >> "$TARGET_PROMPT"
+    else
+        echo "warning: failed to decode CENTAUR_PERSONA_PROMPT_B64" >&2
+    fi
+    rm -f "$PERSONA_PROMPT_FILE"
+fi
 
 # Switch to workspace so the harness reads workspace/AGENTS.md (with persona overlay)
 cd "$WORKSPACE_DIR"

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -414,34 +414,7 @@ elif [ -n "${CENTAUR_OVERLAY_DIR:-}" ] \
     cat "${CENTAUR_OVERLAY_DIR}/services/sandbox/SYSTEM_PROMPT.md" >> "$TARGET_PROMPT"
 fi
 
-# The API resolves personas against the deployment registry and passes a
-# materialized prompt bundle. Keep AGENT_PERSONA as reflective state only; the
-# prompt content below is the authoritative persona instruction for this
-# sandbox.
-if [ -n "${CENTAUR_ACTIVE_DEPLOYMENT_BLOCK_B64:-}" ] && [ -f "$TARGET_PROMPT" ]; then
-    ACTIVE_BLOCK_FILE="$(mktemp)"
-    if printf '%s' "$CENTAUR_ACTIVE_DEPLOYMENT_BLOCK_B64" | base64 -d > "$ACTIVE_BLOCK_FILE" 2>/dev/null; then
-        PROMPT_WITH_BLOCK="$(mktemp)"
-        cat "$ACTIVE_BLOCK_FILE" > "$PROMPT_WITH_BLOCK"
-        printf '\n\n---\n\n' >> "$PROMPT_WITH_BLOCK"
-        cat "$TARGET_PROMPT" >> "$PROMPT_WITH_BLOCK"
-        mv "$PROMPT_WITH_BLOCK" "$TARGET_PROMPT"
-    else
-        echo "warning: failed to decode CENTAUR_ACTIVE_DEPLOYMENT_BLOCK_B64" >&2
-    fi
-    rm -f "$ACTIVE_BLOCK_FILE" "${PROMPT_WITH_BLOCK:-}"
-fi
-
-if [ -n "${CENTAUR_PERSONA_PROMPT_B64:-}" ] && [ -f "$TARGET_PROMPT" ]; then
-    PERSONA_PROMPT_FILE="$(mktemp)"
-    if printf '%s' "$CENTAUR_PERSONA_PROMPT_B64" | base64 -d > "$PERSONA_PROMPT_FILE" 2>/dev/null; then
-        printf '\n\n---\n\n' >> "$TARGET_PROMPT"
-        cat "$PERSONA_PROMPT_FILE" >> "$TARGET_PROMPT"
-    else
-        echo "warning: failed to decode CENTAUR_PERSONA_PROMPT_B64" >&2
-    fi
-    rm -f "$PERSONA_PROMPT_FILE"
-fi
+# Persona prompt injection is done by the API when it writes AGENTS_BASE.md.
 
 # Switch to workspace so the harness reads workspace/AGENTS.md (with persona overlay)
 cd "$WORKSPACE_DIR"


### PR DESCRIPTION
## Summary
- add API-side persona registry discovery from ordered tool/overlay dirs, with overlay shadowing and CENTAUR_DEFAULT_PERSONA validation
- resolve/default personas during session creation, persist resolved persona identity, emit persona resolution metadata, and expose /personas + /api/personas
- materialize API-resolved persona prompt/deployment block into sandbox prompts and avoid warm-pool claims for persona-specific sessions

## Test plan
- cargo check -p centaur-session-runtime -p centaur-api-server
- cargo test -p centaur-session-runtime persona_registry_validates_default_and_summarizes_without_prompt
- cargo test -p centaur-api-server discovers_personas_with_overlay_shadowing_and_default_validation
- bash -n services/sandbox/entrypoint.sh