### PR TITLE
[codex] Set managed iron-proxy timeout to 120s

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -40,6 +40,7 @@ const PROXY_DNS_PROXY_IP: &str = "127.0.0.1";
 const PROXY_TLS_MODE: &str = "mitm";
 const PROXY_TLS_CA_CERT_PATH: &str = "/etc/iron-proxy/ca.crt";
 const PROXY_TLS_CA_KEY_PATH: &str = "/etc/iron-proxy/ca.key";
+const PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT: &str = "120s";
 const PROXY_LOG_LEVEL: &str = "info";
 // iron-control multiplexes every Postgres upstream through a single listener,
 // routing by database name; the control plane owns each upstream DSN/role/
@@ -970,6 +971,10 @@ fn iron_proxy_env_vars(
     // env instead of a config file. CA paths match the entrypoint's CA copy.
     for (name, value) in [
         ("IRON_PROXY_TUNNEL_LISTEN", format!(":{PROXY_TUNNEL_PORT}")),
+        (
+            "IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT",
+            PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT.to_owned(),
+        ),
         ("IRON_DNS_LISTEN", PROXY_DNS_LISTEN.to_owned()),
         ("IRON_DNS_PROXY_IP", PROXY_DNS_PROXY_IP.to_owned()),
         ("IRON_TLS_MODE", PROXY_TLS_MODE.to_owned()),
@@ -1575,6 +1580,24 @@ mod tests {
                 .iter()
                 .any(|rule| rule_allows_namespace_port(rule, "laminar", 8000))
         );
+    }
+
+    #[test]
+    fn managed_proxy_env_sets_response_header_timeout() {
+        let iron_proxy = IronProxyConfig::new("proxy:test", "ca-cert", "ca-key");
+        let sync = ProxySyncEnv {
+            proxy_id: "proxy-id".to_owned(),
+            control_url: "http://iron-control".to_owned(),
+            token: "proxy-token".to_owned(),
+        };
+
+        let env = iron_proxy_env_vars(&iron_proxy, &resolved(), &sync);
+        let timeout = env
+            .iter()
+            .find(|var| var.name == "IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT")
+            .and_then(|var| var.value.as_deref());
+
+        assert_eq!(timeout, Some("120s"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Managed per-sandbox iron-proxy pods skip the local proxy YAML when `IRON_CONTROL_PLANE_URL` is set, so the existing `upstream_response_header_timeout: "120s"` in the baked config was not applied in sync mode. That left long OpenAI requests subject to the proxy default response-header timeout, observed as 30s `net/http: timeout awaiting response headers` failures surfaced as 502s.

This PR sets `IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT=120s` in the generated managed proxy pod environment so sync-mode proxies match the intended static config behavior. Operator-provided `extra_env` is still applied after the defaults and can override it if needed.

## Live verification

Checked live `prd-centaur-na` sandbox proxy pod `centaur-system/asbx-1782160947929-38-proxy-1782160947952` before this fix was deployed:

- image was `ghcr.io/paradigmxyz/centaur/centaur-iron-proxy:main-sha-1233ff7`
- `IRON_CONTROL_PLANE_URL=http://centaur-console:3000`
- `IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT=<unset>`
- `/etc/iron-proxy/proxy.yaml` was absent
- process args were just `iron-proxy`
- proxy log reported managed mode: `IRON_CONTROL_PLANE_URL set; running without a local config`

Also sampled the newest five live proxy pods; all had `IRON_CONTROL_PLANE_URL` set and the timeout env unset. The live image SHA includes the earlier YAML timeout changes from PR #658, which confirms those config-file changes do not reach managed sandbox proxies.

## Staging timeout repro

Ran a non-streaming OpenAI Responses request from staging sandbox `stg-centaur-system/asbx-1782190865693-168` through its managed proxy `asbx-1782190865693-168-proxy-1782190865718`. The proxy had `IRON_CONTROL_PLANE_URL=http://centaur-console:3000` and `IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT` unset.

Request shape:

```json
{
  "model": "gpt-5.5",
  "input": "Generate a very long plain-text response of 18000 tokens. Use numbered lines. Each line should contain a different synthetic identifier and a short sentence. Do not summarize. Do not stop early.",
  "max_output_tokens": 20000
}
```

Client result:

- HTTP status: `502`
- `time_starttransfer`: `30.076149s`
- `time_total`: `30.076319s`
- response body: `bad gateway`

Proxy log:

- `POST /v1/responses`
- status: `502`
- duration: `30000.877ms`
- error: `net/http: timeout awaiting response headers`

This deterministically reproduces the response-header timeout failure in staging without relying on a naturally slow compaction request.

## Staging compaction path repro

Ran Codex inside the same staging sandbox through the same managed proxy, using a copied scratch `CODEX_HOME` and the default auto-compact limit.

Near-full context run:

- recorded `model_context_window`: `258400`
- seed turn input tokens: `256592`
- resume emitted local session events `compacted` then `context_compacted`
- proxy logged `POST /v1/responses/compact` to `api.openai.com`
- compact request status: `200`
- compact request duration: `5102.243ms`
- resumed turn duration: `10880ms`
- resumed TTFT: `10414ms`

This confirms the affected production path includes the managed sandbox proxy handling OpenAI response-header waits; compaction itself uses `POST /v1/responses/compact`, while normal Codex turns primarily use websocket `GET /v1/responses`.

## Validation

- `cargo test -p centaur-sandbox-agent-k8s managed_proxy_env_sets_response_header_timeout`
- `cargo test -p centaur-sandbox-agent-k8s`
- GitHub checks are green on the PR branch, including `Rust API fmt, clippy, and tests` and image publishing for `centaur-iron-proxy`.
