### PR TITLE
feat(api-rs): Anthropic Messages-compatible /v1/messages ingress

### DIFF
--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -1,6 +1,6 @@
-use std::env;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
+use std::{env, fs};
 
 use codex_app_server_protocol::UserInput;
 use serde_json::json;
@@ -237,8 +237,13 @@ impl HarnessServer for ClaudeCodeHarness {
         if !state.model.is_empty() {
             command.args(["--model", &state.model]);
         }
-        if PathBuf::from("AGENTS.md").is_file() {
+        if state.cwd.join("AGENTS.md").is_file() {
             command.args(["--append-system-prompt-file", "AGENTS.md"]);
+        }
+        if let Some(extra_system_prompt_file) = extra_system_prompt_file(state) {
+            command
+                .arg("--append-system-prompt-file")
+                .arg(extra_system_prompt_file);
         }
         if let Some(session_id) = &state.harness_session_id {
             command.args(["--resume", session_id]);
@@ -274,14 +279,32 @@ impl HarnessServer for ClaudeCodeHarness {
     }
 }
 
+fn extra_system_prompt_file(state: &ThreadState) -> Option<PathBuf> {
+    let prompt = env::var("CENTAUR_EXTRA_SYSTEM_PROMPT").ok()?;
+    if prompt.trim().is_empty() {
+        return None;
+    }
+    let path = state.cwd.join(".centaur-extra-system-prompt.md");
+    if let Err(error) = fs::write(&path, prompt) {
+        eprintln!("failed to write CENTAUR_EXTRA_SYSTEM_PROMPT file: {error}");
+        return None;
+    }
+    Some(path)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
     use codex_app_server_protocol::UserInput;
     use serde_json::{Value, json};
 
-    use crate::{HarnessServer, NormalizedContent, NormalizedEvent};
+    use crate::{HarnessServer, NormalizedContent, NormalizedEvent, ThreadState};
 
     use super::{ClaudeCodeHarness, ClaudeEventNormalizer};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn normalize(normalizer: &mut ClaudeEventNormalizer, event: Value) -> Vec<NormalizedEvent> {
         normalizer.normalize(serde_json::from_value(event).unwrap())
@@ -308,6 +331,64 @@ mod tests {
                 _ => None,
             })
             .collect()
+    }
+
+    fn test_thread_state(cwd: PathBuf) -> ThreadState {
+        ThreadState {
+            id: "thread-test".to_owned(),
+            cwd,
+            model: "claude-opus-4-test".to_owned(),
+            model_provider: "anthropic".to_owned(),
+            service_tier: None,
+            harness_session_id: None,
+            completed_turns: Vec::new(),
+            process: None,
+            thread_started_sent: false,
+        }
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "centaur-claude-test-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn command_appends_extra_system_prompt_file_after_agents_md() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let cwd = unique_temp_dir();
+        std::fs::write(cwd.join("AGENTS.md"), "internal persona").unwrap();
+        unsafe {
+            std::env::set_var("CENTAUR_EXTRA_SYSTEM_PROMPT", "caller guidance");
+        }
+        let command = ClaudeCodeHarness.command_for_turn(&test_thread_state(cwd.clone()));
+        unsafe {
+            std::env::remove_var("CENTAUR_EXTRA_SYSTEM_PROMPT");
+        }
+
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        let prompt_files = args
+            .windows(2)
+            .filter(|window| window[0] == "--append-system-prompt-file")
+            .map(|window| window[1].clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(prompt_files.len(), 2);
+        assert_eq!(prompt_files[0], "AGENTS.md");
+        assert_eq!(
+            std::fs::read_to_string(&prompt_files[1]).unwrap(),
+            "caller guidance"
+        );
+        assert_eq!(
+            PathBuf::from(&prompt_files[1]),
+            cwd.join(".centaur-extra-system-prompt.md")
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/anthropic/mod.rs
+++ b/services/api-rs/crates/centaur-api-server/src/anthropic/mod.rs
@@ -1,0 +1,444 @@
+//! Anthropic Messages API ingress backed by Centaur sessions.
+//!
+//! `POST /v1/messages` accepts Anthropic-compatible requests and maps them to
+//! the existing [`centaur_session_runtime::SessionRuntime`]. Thread continuity
+//! follows the client's Claude Code session id: the `X-Claude-Code-Session-Id`
+//! header (the same id Claude Code uses for `--resume`/`--continue`) keys the
+//! thread `api:claude:<session-id>`, so a resumed CLI session continues the same
+//! durable thread and warm sandbox with no extra plumbing. When the header is
+//! absent a fresh `api:<uuid-v4>` thread is generated and validated through
+//! [`centaur_session_core::ThreadKey`]. This endpoint defaults to
+//! `HarnessType::ClaudeCode` because that wrapper emits Anthropic-shaped
+//! content blocks. Request `model` selects the Claude Code model and request
+//! `system` is appended as an extra system prompt after Centaur's internal
+//! persona/AGENTS.md; neither replaces nor exposes Centaur's internal prompt.
+//! Because the app-server sandbox is created once and reused per thread, model
+//! and system are first-request-wins for a reused session. Codex
+//! model/system handling is out of scope for this ingress. Request `tools`
+//! remains accepted only for client compatibility and is decorative until tool
+//! support lands separately. v1 appends only the trailing `role:"user"` message
+//! from `messages[]`; full-history replay is a follow-up. The route is
+//! unauthenticated and network-gated like `/api/session/*`; authentication is a
+//! follow-up.
+
+mod translate;
+
+use std::{
+    convert::Infallible,
+    sync::{Arc, Mutex},
+};
+
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{
+        IntoResponse, Response, Sse,
+        sse::{Event, KeepAlive},
+    },
+};
+use centaur_session_core::{
+    HarnessType, MessageRole, SessionEvent, SessionMessageInput, ThreadKey, empty_object,
+};
+use centaur_session_runtime::{ExecuteSessionInput, HarnessConflictPolicy};
+use futures_util::{StreamExt, stream};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::{ApiError, error::error_chain, routes::AppState};
+use translate::{AnthropicTranslator, error_event};
+
+/// Header Claude Code sends carrying its stable session id — the same id it uses
+/// for `--resume`/`--continue`. The Centaur thread is keyed on it.
+const CLAUDE_SESSION_HEADER: &str = "x-claude-code-session-id";
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AnthropicMessagesRequest {
+    pub model: String,
+    pub messages: Vec<AnthropicInputMessage>,
+    #[serde(default)]
+    pub system: Option<Value>,
+    #[serde(default)]
+    pub stream: bool,
+    pub max_tokens: u32,
+    #[serde(default)]
+    pub metadata: Option<Value>,
+    #[serde(default)]
+    pub tools: Option<Value>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AnthropicInputMessage {
+    pub role: String,
+    pub content: AnthropicInputContent,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum AnthropicInputContent {
+    Text(String),
+    Blocks(Vec<Value>),
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct AnthropicMessage {
+    id: String,
+    #[serde(rename = "type")]
+    kind: &'static str,
+    role: &'static str,
+    model: String,
+    content: Vec<Value>,
+    stop_reason: Option<String>,
+    stop_sequence: Option<String>,
+    usage: AnthropicUsage,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct AnthropicUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+}
+
+#[derive(Debug)]
+pub(crate) struct AnthropicHttpError {
+    status: StatusCode,
+    error_type: &'static str,
+    message: String,
+}
+
+impl AnthropicHttpError {
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            error_type: "invalid_request_error",
+            message: message.into(),
+        }
+    }
+
+    fn internal(error: impl std::error::Error) -> Self {
+        tracing::error!(
+            error = %error_chain(&error),
+            "Anthropic Messages request failed"
+        );
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error_type: "api_error",
+            message: "internal server error".to_owned(),
+        }
+    }
+}
+
+impl From<ApiError> for AnthropicHttpError {
+    fn from(error: ApiError) -> Self {
+        let response = error.into_response();
+        let status = response.status();
+        if status.is_server_error() {
+            return Self {
+                status,
+                error_type: "api_error",
+                message: "internal server error".to_owned(),
+            };
+        }
+        Self {
+            status,
+            error_type: "invalid_request_error",
+            message: status
+                .canonical_reason()
+                .unwrap_or("request failed")
+                .to_owned(),
+        }
+    }
+}
+
+impl IntoResponse for AnthropicHttpError {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            Json(json!({
+                "type": "error",
+                "error": {
+                    "type": self.error_type,
+                    "message": self.message,
+                },
+            })),
+        )
+            .into_response()
+    }
+}
+
+pub(crate) async fn anthropic_messages(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<AnthropicMessagesRequest>,
+) -> Result<Response, AnthropicHttpError> {
+    let thread_key = thread_key_from_headers(&headers)?;
+    let model = non_empty_string(&request.model);
+    let system_prompt = flatten_system_prompt(request.system.as_ref());
+    let _decorative = (request.max_tokens, &request.tools);
+    let runtime = state.runtime()?;
+    let _outcome = runtime
+        .create_or_get_session(
+            &thread_key,
+            &HarnessType::ClaudeCode,
+            None,
+            request.metadata.clone(),
+            HarnessConflictPolicy::Reject,
+        )
+        .await
+        .map_err(AnthropicHttpError::internal)?;
+
+    let user_message = trailing_user_message(&request)?;
+    let parts = input_parts(user_message);
+    let session_message = SessionMessageInput {
+        client_message_id: None,
+        role: MessageRole::User,
+        parts: parts.clone(),
+        metadata: empty_object(),
+    };
+    runtime
+        .append_messages(&thread_key, &[session_message])
+        .await
+        .map_err(AnthropicHttpError::internal)?;
+
+    let input_line = serde_json::to_string(&json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": parts,
+        },
+    }))
+    .map_err(AnthropicHttpError::internal)?;
+    let execution = runtime
+        .execute_session(
+            &thread_key,
+            ExecuteSessionInput {
+                idempotency_key: None,
+                metadata: None,
+                input_lines: vec![input_line],
+                idle_timeout_ms: None,
+                max_duration_ms: None,
+                model,
+                system_prompt,
+            },
+        )
+        .await
+        .map_err(AnthropicHttpError::internal)?;
+    let events = runtime
+        .stream_events(&thread_key, 0, Some(&execution.execution_id))
+        .await
+        .map_err(AnthropicHttpError::internal)?;
+
+    let message_id = format!("msg_{}", Uuid::new_v4());
+    if request.stream {
+        let thread_key_for_log = thread_key.clone();
+        let translator = Arc::new(Mutex::new(AnthropicTranslator::new(
+            message_id,
+            request.model,
+        )));
+        let events = Box::pin(events);
+        let stream = stream::unfold(
+            (events, false, translator, thread_key_for_log),
+            |(mut events, done, translator, thread_key_for_log)| async move {
+                if done {
+                    return None;
+                }
+                let result = events.as_mut().next().await?;
+                let thread_key = thread_key_for_log.clone();
+                let (events_out, done) = match result {
+                    Ok(event) => {
+                        let done = is_terminal_session_event(&event);
+                        let events = translator
+                            .lock()
+                            .expect("Anthropic translator mutex poisoned")
+                            .translate_session_event(&event)
+                            .into_iter()
+                            .map(|event| Ok(event.into_sse_event()))
+                            .collect::<Vec<Result<Event, Infallible>>>();
+                        (events, done)
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            thread_key = %thread_key,
+                            error = %error_chain(&error),
+                            "session event stream failed"
+                        );
+                        (
+                            vec![Ok(
+                                error_event("api_error", "event stream failed").into_sse_event()
+                            )],
+                            true,
+                        )
+                    }
+                };
+                Some((events_out, (events, done, translator, thread_key_for_log)))
+            },
+        )
+        .flat_map(stream::iter);
+        return Ok(Sse::new(stream)
+            .keep_alive(KeepAlive::default())
+            .into_response());
+    }
+
+    let message = collect_non_streaming_message(events, message_id, request.model).await?;
+    Ok(Json(message).into_response())
+}
+
+/// Derive the Centaur thread key from the client's Claude Code session id so a
+/// resumed CLI session (`claude --resume`/`--continue`) continues the same
+/// durable thread and reuses its warm sandbox. Falls back to a fresh
+/// `api:<uuid>` thread when the header is absent (e.g. a raw SDK client).
+fn thread_key_from_headers(headers: &HeaderMap) -> Result<ThreadKey, AnthropicHttpError> {
+    let raw = match headers.get(CLAUDE_SESSION_HEADER) {
+        Some(value) => {
+            let session_id = value.to_str().map_err(|_| {
+                AnthropicHttpError::bad_request("X-Claude-Code-Session-Id must be valid UTF-8")
+            })?;
+            format!("api:claude:{session_id}")
+        }
+        None => format!("api:{}", Uuid::new_v4()),
+    };
+    ThreadKey::parse(raw).map_err(|error| AnthropicHttpError::bad_request(error.to_string()))
+}
+
+fn trailing_user_message(
+    request: &AnthropicMessagesRequest,
+) -> Result<&AnthropicInputMessage, AnthropicHttpError> {
+    if request.messages.is_empty() {
+        return Err(AnthropicHttpError::bad_request(
+            "messages must not be empty",
+        ));
+    }
+    // Drive the turn off the LAST `user` message rather than the literal trailing
+    // message: some Anthropic clients (e.g. Claude Code) append a trailing
+    // `system`-role message in `messages[]` carrying dynamic context, so the
+    // array can end on a non-user role. centaur owns conversation history via the
+    // thread, so the latest user turn is the input.
+    request
+        .messages
+        .iter()
+        .rev()
+        .find(|message| message.role == "user")
+        .ok_or_else(|| AnthropicHttpError::bad_request("messages must contain a user message"))
+}
+
+fn input_parts(message: &AnthropicInputMessage) -> Vec<Value> {
+    match &message.content {
+        AnthropicInputContent::Text(text) => vec![json!({"type": "text", "text": text})],
+        AnthropicInputContent::Blocks(blocks) => blocks.clone(),
+    }
+}
+
+fn flatten_system_prompt(system: Option<&Value>) -> Option<String> {
+    match system? {
+        Value::String(text) => non_empty_string(text),
+        Value::Array(blocks) => {
+            let text = blocks
+                .iter()
+                .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|block| block.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n");
+            non_empty_string(&text)
+        }
+        _ => None,
+    }
+}
+
+fn non_empty_string(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+async fn collect_non_streaming_message<S>(
+    events: S,
+    message_id: String,
+    model: String,
+) -> Result<AnthropicMessage, AnthropicHttpError>
+where
+    S: futures_util::Stream<
+            Item = Result<
+                centaur_session_core::SessionEvent,
+                centaur_session_runtime::SessionRuntimeError,
+            >,
+        >,
+{
+    futures_util::pin_mut!(events);
+    let mut translator = AnthropicTranslator::new(message_id.clone(), model.clone());
+    let mut failure = None;
+    while let Some(result) = events.next().await {
+        let event = result.map_err(AnthropicHttpError::internal)?;
+        if event.event_type == "session.execution_failed" {
+            failure = Some(
+                event
+                    .payload
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("execution failed")
+                    .to_owned(),
+            );
+        }
+        let _ = translator.translate_session_event(&event);
+        if is_terminal_session_event(&event) {
+            break;
+        }
+    }
+    if let Some(message) = failure {
+        return Err(AnthropicHttpError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error_type: "api_error",
+            message,
+        });
+    }
+
+    let mut content = translator.content();
+    if content.is_empty()
+        && let Some(result_text) = translator.terminal_result_text()
+        && !result_text.trim().is_empty()
+    {
+        content.push(json!({"type": "text", "text": result_text}));
+    }
+    Ok(AnthropicMessage {
+        id: message_id,
+        kind: "message",
+        role: "assistant",
+        model,
+        content,
+        stop_reason: Some("end_turn".to_owned()),
+        stop_sequence: None,
+        usage: AnthropicUsage {
+            input_tokens: 0,
+            output_tokens: 0,
+        },
+    })
+}
+
+fn is_terminal_session_event(event: &SessionEvent) -> bool {
+    matches!(
+        event.event_type.as_str(),
+        "session.execution_completed" | "session.execution_failed"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::HeaderMap;
+
+    use super::*;
+
+    #[test]
+    fn keys_thread_on_claude_session_id() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CLAUDE_SESSION_HEADER, "sess-abc-123".parse().unwrap());
+        let key = thread_key_from_headers(&headers).unwrap();
+        // Stable + namespaced: resuming the same session id lands on this thread.
+        assert_eq!(key.as_str(), "api:claude:sess-abc-123");
+    }
+
+    #[test]
+    fn generates_fresh_thread_without_session_id() {
+        let key = thread_key_from_headers(&HeaderMap::new()).unwrap();
+        assert!(key.as_str().starts_with("api:"));
+        assert!(!key.as_str().contains("claude"));
+    }
+}

--- a/services/api-rs/crates/centaur-api-server/src/anthropic/translate.rs
+++ b/services/api-rs/crates/centaur-api-server/src/anthropic/translate.rs
@@ -1,0 +1,630 @@
+use axum::response::sse::Event;
+use centaur_session_core::SessionEvent;
+use centaur_session_runtime::{
+    FinalAnswerTextUpdate, TerminalOutput, content_blocks, output_line_final_answer_text,
+    string_at_path, terminal_output, terminal_payload_text,
+};
+use serde_json::{Value, json};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AnthropicStreamEvent {
+    pub name: &'static str,
+    pub data: Value,
+}
+
+impl AnthropicStreamEvent {
+    pub fn into_sse_event(self) -> Event {
+        let data = serde_json::to_string(&self.data).unwrap_or_else(|_| "{}".to_owned());
+        Event::default().event(self.name).data(data)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OpenBlockKind {
+    Text,
+    Thinking,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct OpenBlock {
+    kind: OpenBlockKind,
+    index: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct AnthropicTranslator {
+    message_id: String,
+    model: String,
+    next_index: usize,
+    open_block: Option<OpenBlock>,
+    emitted_text: String,
+    final_answer_text: String,
+    terminal_result_text: Option<String>,
+    content: Vec<Value>,
+    started: bool,
+    stopped: bool,
+}
+
+impl AnthropicTranslator {
+    pub fn new(message_id: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            message_id: message_id.into(),
+            model: model.into(),
+            next_index: 0,
+            open_block: None,
+            emitted_text: String::new(),
+            final_answer_text: String::new(),
+            terminal_result_text: None,
+            content: Vec::new(),
+            started: false,
+            stopped: false,
+        }
+    }
+
+    pub fn content(&self) -> Vec<Value> {
+        self.content.clone()
+    }
+
+    pub fn terminal_result_text(&self) -> Option<&str> {
+        self.terminal_result_text.as_deref()
+    }
+
+    pub fn translate_session_event(&mut self, event: &SessionEvent) -> Vec<AnthropicStreamEvent> {
+        let mut out = Vec::new();
+        match event.event_type.as_str() {
+            "session.execution_started" => self.ensure_started(&mut out),
+            "session.output.line" => {
+                self.ensure_started(&mut out);
+                self.translate_output_line(&event.payload, &mut out);
+            }
+            "session.execution_completed" => {
+                self.ensure_started(&mut out);
+                if let Some(result_text) = string_at_path(&event.payload, &["result_text"]) {
+                    self.terminal_result_text = Some(result_text);
+                }
+                self.stop_message("end_turn", &mut out);
+            }
+            "session.execution_failed" => {
+                self.ensure_started(&mut out);
+                self.close_open_block(&mut out);
+                out.push(error_event(
+                    "api_error",
+                    string_at_path(&event.payload, &["error"])
+                        .unwrap_or_else(|| "execution failed".to_owned()),
+                ));
+                self.message_stop(&mut out);
+            }
+            "session.stream_error" => {
+                out.push(error_event(
+                    "api_error",
+                    string_at_path(&event.payload, &["error"])
+                        .unwrap_or_else(|| "event stream failed".to_owned()),
+                ));
+            }
+            _ => {}
+        }
+        out
+    }
+
+    fn translate_output_line(&mut self, payload: &Value, out: &mut Vec<AnthropicStreamEvent>) {
+        let Some(line) = payload.as_str() else {
+            return;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            return;
+        };
+
+        if !content_blocks(&value).is_empty() {
+            self.translate_anthropic_content_blocks(&value, out);
+        } else {
+            self.translate_codex_event(&value, out);
+        }
+
+        if let Some(update) = output_line_final_answer_text(&value) {
+            match update {
+                FinalAnswerTextUpdate::Append(delta) => self.final_answer_text.push_str(&delta),
+                FinalAnswerTextUpdate::Replace(canonical) => self.final_answer_text = canonical,
+            }
+        }
+        if let Some(TerminalOutput::Completed { result_text, .. }) =
+            terminal_output(&value, &self.final_answer_text)
+            && result_text.is_some()
+        {
+            self.terminal_result_text = result_text;
+        }
+    }
+
+    fn translate_anthropic_content_blocks(
+        &mut self,
+        value: &Value,
+        out: &mut Vec<AnthropicStreamEvent>,
+    ) {
+        for block in content_blocks(value) {
+            match block.get("type").and_then(Value::as_str) {
+                Some("text") => {
+                    let text = terminal_payload_text(block);
+                    if !text.is_empty() {
+                        self.emit_text_delta(&text, out);
+                    }
+                }
+                Some("thinking") => {
+                    let thinking = string_at_path(block, &["thinking"])
+                        .or_else(|| string_at_path(block, &["text"]))
+                        .unwrap_or_else(|| terminal_payload_text(block));
+                    if !thinking.is_empty() {
+                        self.emit_thinking_delta(&thinking, out);
+                    }
+                }
+                Some("tool_use") => self.emit_tool_use(block, out),
+                Some("tool_result") => self.emit_tool_result(block, out),
+                _ if block.get("tool_use_id").and_then(Value::as_str).is_some() => {
+                    self.emit_tool_result(block, out);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn translate_codex_event(&mut self, value: &Value, out: &mut Vec<AnthropicStreamEvent>) {
+        // Harness output comes in two codex-style shapes: dotted `type` with
+        // fields at the top level (`item.agentMessage.delta`, the Python codex
+        // wrapper) and slash `method` with a `params` envelope
+        // (`item/agentMessage/delta`, the Rust harness-server). Normalize the
+        // kind (slash -> dot) and read fields from `params` when present.
+        let Some(kind) = value
+            .get("method")
+            .and_then(Value::as_str)
+            .or_else(|| value.get("type").and_then(Value::as_str))
+        else {
+            return;
+        };
+        let normalized = kind.replace('/', ".");
+        let params = value.get("params").unwrap_or(value);
+        match normalized.as_str() {
+            "item.reasoning.textDelta" | "item.reasoning.summaryTextDelta" => {
+                let text = params
+                    .get("delta")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| terminal_payload_text(params));
+                if !text.is_empty() {
+                    self.emit_thinking_delta(&text, out);
+                }
+            }
+            "item.agentMessage.delta" => {
+                if let Some(delta) = params.get("delta").and_then(Value::as_str)
+                    && !delta.is_empty()
+                {
+                    self.emit_text_delta(delta, out);
+                }
+            }
+            "item.completed" => {
+                // Final agent-message text, emitted as a Replace so it dedups
+                // against the streamed deltas (suffix-only).
+                if let Some(item) = params.get("item")
+                    && item.get("type").and_then(Value::as_str) == Some("agentMessage")
+                    && let Some(full) = item.get("text").and_then(Value::as_str)
+                    && !full.is_empty()
+                {
+                    self.emit_replacement_text(full, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn emit_replacement_text(&mut self, full_text: &str, out: &mut Vec<AnthropicStreamEvent>) {
+        if let Some(suffix) = full_text.strip_prefix(&self.emitted_text) {
+            if !suffix.is_empty() {
+                self.emit_text_delta(suffix, out);
+            }
+            return;
+        }
+        self.close_open_block(out);
+        self.open_text_block(out);
+        self.emit_text_delta(full_text, out);
+    }
+
+    fn emit_text_delta(&mut self, text: &str, out: &mut Vec<AnthropicStreamEvent>) {
+        self.open_text_block(out);
+        let index = self.open_block.as_ref().expect("text block is open").index;
+        self.append_to_content(index, "text", text);
+        self.emitted_text.push_str(text);
+        out.push(AnthropicStreamEvent {
+            name: "content_block_delta",
+            data: json!({
+                "type": "content_block_delta",
+                "index": index,
+                "delta": {"type": "text_delta", "text": text},
+            }),
+        });
+    }
+
+    fn emit_thinking_delta(&mut self, thinking: &str, out: &mut Vec<AnthropicStreamEvent>) {
+        self.open_thinking_block(out);
+        let index = self
+            .open_block
+            .as_ref()
+            .expect("thinking block is open")
+            .index;
+        self.append_to_content(index, "thinking", thinking);
+        out.push(AnthropicStreamEvent {
+            name: "content_block_delta",
+            data: json!({
+                "type": "content_block_delta",
+                "index": index,
+                "delta": {"type": "thinking_delta", "thinking": thinking},
+            }),
+        });
+    }
+
+    fn emit_tool_use(&mut self, block: &Value, out: &mut Vec<AnthropicStreamEvent>) {
+        self.close_open_block(out);
+        let index = self.next_content_index();
+        let input = block.get("input").cloned().unwrap_or_else(|| json!({}));
+        let content_block = json!({
+            "type": "tool_use",
+            "id": string_at_path(block, &["id"]).unwrap_or_else(|| format!("toolu_{index}")),
+            "name": string_at_path(block, &["name"]).unwrap_or_else(|| "unknown".to_owned()),
+            "input": input,
+        });
+        let mut start_block = content_block.clone();
+        if let Some(object) = start_block.as_object_mut() {
+            object.insert("input".to_owned(), json!({}));
+        }
+        self.content.push(content_block);
+        out.push(content_block_start(index, start_block));
+        out.push(AnthropicStreamEvent {
+            name: "content_block_delta",
+            data: json!({
+                "type": "content_block_delta",
+                "index": index,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": serde_json::to_string(&input).unwrap_or_else(|_| "{}".to_owned()),
+                },
+            }),
+        });
+        out.push(content_block_stop(index));
+    }
+
+    fn emit_tool_result(&mut self, block: &Value, out: &mut Vec<AnthropicStreamEvent>) {
+        self.close_open_block(out);
+        let index = self.next_content_index();
+        let content_block = block.clone();
+        self.content.push(content_block.clone());
+        out.push(content_block_start(index, content_block));
+        out.push(content_block_stop(index));
+    }
+
+    fn open_text_block(&mut self, out: &mut Vec<AnthropicStreamEvent>) {
+        if self.open_block.as_ref().map(|block| block.kind) == Some(OpenBlockKind::Text) {
+            return;
+        }
+        self.close_open_block(out);
+        let index = self.next_content_index();
+        let block = json!({"type": "text", "text": ""});
+        self.content.push(block.clone());
+        self.open_block = Some(OpenBlock {
+            kind: OpenBlockKind::Text,
+            index,
+        });
+        out.push(content_block_start(index, block));
+    }
+
+    fn open_thinking_block(&mut self, out: &mut Vec<AnthropicStreamEvent>) {
+        if self.open_block.as_ref().map(|block| block.kind) == Some(OpenBlockKind::Thinking) {
+            return;
+        }
+        self.close_open_block(out);
+        let index = self.next_content_index();
+        let block = json!({"type": "thinking", "thinking": ""});
+        self.content.push(block.clone());
+        self.open_block = Some(OpenBlock {
+            kind: OpenBlockKind::Thinking,
+            index,
+        });
+        out.push(content_block_start(index, block));
+    }
+
+    pub fn close_open_block(&mut self, out: &mut Vec<AnthropicStreamEvent>) {
+        if let Some(open) = self.open_block.take() {
+            out.push(content_block_stop(open.index));
+        }
+    }
+
+    fn ensure_started(&mut self, out: &mut Vec<AnthropicStreamEvent>) {
+        if self.started {
+            return;
+        }
+        self.started = true;
+        out.push(AnthropicStreamEvent {
+            name: "message_start",
+            data: json!({
+                "type": "message_start",
+                "message": {
+                    "id": self.message_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "model": self.model,
+                    "content": [],
+                    "stop_reason": null,
+                    "stop_sequence": null,
+                    "usage": {"input_tokens": 0, "output_tokens": 0},
+                },
+            }),
+        });
+        out.push(AnthropicStreamEvent {
+            name: "ping",
+            data: json!({"type": "ping"}),
+        });
+    }
+
+    fn stop_message(&mut self, stop_reason: &str, out: &mut Vec<AnthropicStreamEvent>) {
+        self.close_open_block(out);
+        out.push(AnthropicStreamEvent {
+            name: "message_delta",
+            data: json!({
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": null},
+                "usage": {"output_tokens": 0},
+            }),
+        });
+        self.message_stop(out);
+    }
+
+    fn message_stop(&mut self, out: &mut Vec<AnthropicStreamEvent>) {
+        if self.stopped {
+            return;
+        }
+        self.stopped = true;
+        out.push(AnthropicStreamEvent {
+            name: "message_stop",
+            data: json!({"type": "message_stop"}),
+        });
+    }
+
+    fn next_content_index(&mut self) -> usize {
+        let index = self.next_index;
+        self.next_index += 1;
+        index
+    }
+
+    fn append_to_content(&mut self, index: usize, key: &str, value: &str) {
+        let Some(block) = self.content.get_mut(index).and_then(Value::as_object_mut) else {
+            return;
+        };
+        let current = block.entry(key.to_owned()).or_insert_with(|| json!(""));
+        if let Some(text) = current.as_str() {
+            *current = json!(format!("{text}{value}"));
+        }
+    }
+}
+
+fn content_block_start(index: usize, content_block: Value) -> AnthropicStreamEvent {
+    AnthropicStreamEvent {
+        name: "content_block_start",
+        data: json!({
+            "type": "content_block_start",
+            "index": index,
+            "content_block": content_block,
+        }),
+    }
+}
+
+fn content_block_stop(index: usize) -> AnthropicStreamEvent {
+    AnthropicStreamEvent {
+        name: "content_block_stop",
+        data: json!({"type": "content_block_stop", "index": index}),
+    }
+}
+
+pub fn error_event(error_type: &'static str, message: impl Into<String>) -> AnthropicStreamEvent {
+    AnthropicStreamEvent {
+        name: "error",
+        data: json!({
+            "type": "error",
+            "error": {"type": error_type, "message": message.into()},
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use centaur_session_core::ThreadKey;
+    use time::OffsetDateTime;
+
+    use super::*;
+
+    fn event(event_type: &str, payload: Value) -> SessionEvent {
+        SessionEvent {
+            event_id: 1,
+            thread_key: ThreadKey::parse("test:anthropic").unwrap(),
+            execution_id: Some("exe_1".to_owned()),
+            event_type: event_type.to_owned(),
+            payload,
+            created_at: OffsetDateTime::now_utc(),
+        }
+    }
+
+    fn output(value: Value) -> SessionEvent {
+        event("session.output.line", Value::String(value.to_string()))
+    }
+
+    fn names(events: &[AnthropicStreamEvent]) -> Vec<&'static str> {
+        events.iter().map(|event| event.name).collect()
+    }
+
+    fn translate(events: Vec<SessionEvent>) -> Vec<AnthropicStreamEvent> {
+        let mut translator = AnthropicTranslator::new("msg_test", "claude-test");
+        events
+            .iter()
+            .flat_map(|event| translator.translate_session_event(event))
+            .collect()
+    }
+
+    #[test]
+    fn codex_text_only_dedups_completed_replace() {
+        let out = translate(vec![
+            event("session.execution_started", json!({})),
+            output(json!({"type":"item.agentMessage.delta","delta":"Hello"})),
+            output(json!({"type":"item.agentMessage.delta","delta":" world"})),
+            output(
+                json!({"type":"item.completed","item":{"type":"agentMessage","text":"Hello world","phase":"final_answer"}}),
+            ),
+            event("session.execution_completed", json!({})),
+        ]);
+
+        assert_eq!(
+            names(&out),
+            vec![
+                "message_start",
+                "ping",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop",
+            ]
+        );
+        let text = out
+            .iter()
+            .filter(|event| event.name == "content_block_delta")
+            .map(|event| event.data["delta"]["text"].as_str().unwrap_or(""))
+            .collect::<String>();
+        assert_eq!(text, "Hello world");
+    }
+
+    #[test]
+    fn harness_server_slash_method_text() {
+        // The deployed Rust harness-server emits slash `method` events with a
+        // `params` envelope, not the dotted `type` shape.
+        let out = translate(vec![
+            event("session.execution_started", json!({})),
+            output(json!({"method":"item/agentMessage/delta","params":{"delta":"PO"}})),
+            output(json!({"method":"item/agentMessage/delta","params":{"delta":"NG"}})),
+            output(
+                json!({"method":"item/completed","params":{"item":{"type":"agentMessage","text":"PONG","phase":"final_answer"}}}),
+            ),
+            event("session.execution_completed", json!({})),
+        ]);
+
+        assert_eq!(
+            names(&out),
+            vec![
+                "message_start",
+                "ping",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop",
+            ]
+        );
+        let text = out
+            .iter()
+            .filter(|event| event.name == "content_block_delta")
+            .map(|event| event.data["delta"]["text"].as_str().unwrap_or(""))
+            .collect::<String>();
+        assert_eq!(text, "PONG");
+    }
+
+    #[test]
+    fn codex_reasoning_and_text() {
+        let out = translate(vec![
+            event("session.execution_started", json!({})),
+            output(json!({"type":"item.reasoning.textDelta","delta":"thinking"})),
+            output(json!({"type":"item.agentMessage.delta","delta":"answer"})),
+        ]);
+
+        assert_eq!(
+            names(&out),
+            vec![
+                "message_start",
+                "ping",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "content_block_start",
+                "content_block_delta",
+            ]
+        );
+        assert_eq!(out[3].data["delta"]["type"], json!("thinking_delta"));
+        assert_eq!(out[6].data["delta"]["type"], json!("text_delta"));
+    }
+
+    #[test]
+    fn claude_text_then_tool_use() {
+        let out = translate(vec![output(json!({
+            "type":"assistant",
+            "message":{"content":[
+                {"type":"text","text":"Let me check."},
+                {"type":"tool_use","id":"toolu_1","name":"search","input":{"query":"centaur"}}
+            ]}
+        }))]);
+
+        assert_eq!(
+            names(&out),
+            vec![
+                "message_start",
+                "ping",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+            ]
+        );
+        assert_eq!(out[6].data["delta"]["type"], json!("input_json_delta"));
+        assert_eq!(
+            out[6].data["delta"]["partial_json"],
+            json!("{\"query\":\"centaur\"}")
+        );
+    }
+
+    #[test]
+    fn claude_tool_result_is_surfaced_as_own_block() {
+        let out = translate(vec![output(json!({
+            "type":"user",
+            "message":{"content":[
+                {"type":"tool_result","tool_use_id":"toolu_1","content":"done"}
+            ]}
+        }))]);
+
+        assert_eq!(
+            names(&out),
+            vec![
+                "message_start",
+                "ping",
+                "content_block_start",
+                "content_block_stop"
+            ]
+        );
+        assert_eq!(out[2].data["content_block"]["type"], json!("tool_result"));
+    }
+
+    #[test]
+    fn execution_failed_emits_error_and_message_stop() {
+        let out = translate(vec![event(
+            "session.execution_failed",
+            json!({"error":"boom"}),
+        )]);
+
+        assert_eq!(
+            names(&out),
+            vec!["message_start", "ping", "error", "message_stop"]
+        );
+        assert_eq!(out[2].data["error"]["message"], json!("boom"));
+    }
+
+    #[test]
+    fn stream_error_emits_error_without_message_stop() {
+        let out = translate(vec![event("session.stream_error", json!({"error":"lost"}))]);
+
+        assert_eq!(names(&out), vec!["error"]);
+        assert_eq!(out[0].data["error"]["message"], json!("lost"));
+    }
+}

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -1,3 +1,4 @@
+mod anthropic;
 pub mod client;
 mod error;
 mod routes;
@@ -28,10 +29,18 @@ mod tests {
     };
     use centaur_session_runtime::SandboxRuntime;
     use centaur_session_sqlx::PgSessionStore;
+    use centaur_session_sqlx::SessionStoreError;
+    use serde_json::{Value, json};
     use sqlx::PgPool;
+    use tokio::{
+        io::{AsyncWriteExt, DuplexStream},
+        sync::Mutex,
+    };
     use tower::ServiceExt;
 
     use super::{AppState, build_router_with_app_state, build_router_with_runtime};
+
+    static DB_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
     #[tokio::test]
     async fn router_builds() {
@@ -330,6 +339,201 @@ mod tests {
         assert!(body.get("slack").is_none());
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn anthropic_messages_streams_sse_from_scripted_stdout() {
+        let _lock = DB_TEST_LOCK.lock().await;
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let app = anthropic_test_app(
+            store,
+            vec![
+                json!({"type":"assistant","message":{"content":[{"type":"text","text":"PONG"}]}})
+                    .to_string(),
+                json!({"type":"result","result":"PONG"}).to_string(),
+            ],
+        );
+        let thread_key = format!("api-test:{}", uuid::Uuid::new_v4());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header("X-Claude-Code-Session-Id", thread_key)
+                    .body(Body::from(
+                        json!({
+                            "model": "claude-test",
+                            "max_tokens": 16,
+                            "stream": true,
+                            "messages": [{"role": "user", "content": "ping"}]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        let events = sse_event_names(&body);
+        assert_eq!(
+            events,
+            vec![
+                "message_start",
+                "ping",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop",
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn anthropic_messages_returns_non_streaming_message() {
+        let _lock = DB_TEST_LOCK.lock().await;
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let app = anthropic_test_app(
+            store,
+            vec![
+                json!({"type":"assistant","message":{"content":[{"type":"text","text":"PONG"}]}})
+                    .to_string(),
+                json!({"type":"result","result":"PONG"}).to_string(),
+            ],
+        );
+        let thread_key = format!("api-test:{}", uuid::Uuid::new_v4());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header("X-Claude-Code-Session-Id", thread_key)
+                    .body(Body::from(
+                        json!({
+                            "model": "claude-test",
+                            "max_tokens": 16,
+                            "messages": [{"role": "user", "content": "ping"}]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["type"], json!("message"));
+        assert_eq!(value["role"], json!("assistant"));
+        assert_eq!(value["model"], json!("claude-test"));
+        assert_eq!(value["content"], json!([{"type": "text", "text": "PONG"}]));
+        assert_eq!(value["stop_reason"], json!("end_turn"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn anthropic_messages_threads_model_and_system_into_sandbox_env() {
+        let _lock = DB_TEST_LOCK.lock().await;
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let (app, backend) = anthropic_test_app_with_backend(
+            store,
+            vec![
+                json!({"type":"assistant","message":{"content":[{"type":"text","text":"PONG"}]}})
+                    .to_string(),
+                json!({"type":"result","result":"PONG"}).to_string(),
+            ],
+        );
+        let thread_key = format!("api-test:{}", uuid::Uuid::new_v4());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header("X-Claude-Code-Session-Id", thread_key)
+                    .body(Body::from(
+                        json!({
+                            "model": "claude-opus-4-test",
+                            "system": [
+                                {"type": "text", "text": "caller layer one"},
+                                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "ignored"}},
+                                {"type": "text", "text": "caller layer two"}
+                            ],
+                            "max_tokens": 16,
+                            "messages": [{"role": "user", "content": "ping"}]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let specs = backend.created_specs().await;
+        assert_eq!(specs.len(), 1);
+        assert_eq!(
+            env_value(&specs[0], "CLAUDE_MODEL"),
+            Some("claude-opus-4-test")
+        );
+        assert_eq!(
+            env_value(&specs[0], "CENTAUR_EXTRA_SYSTEM_PROMPT"),
+            Some("caller layer one\ncaller layer two")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn anthropic_messages_generates_thread_key_when_header_absent() {
+        let _lock = DB_TEST_LOCK.lock().await;
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let app = anthropic_test_app(
+            store,
+            vec![
+                json!({"type":"assistant","message":{"content":[{"type":"text","text":"PONG"}]}})
+                    .to_string(),
+                json!({"type":"result","result":"PONG"}).to_string(),
+            ],
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "model": "claude-test",
+                            "max_tokens": 16,
+                            "messages": [{"role": "user", "content": "ping"}]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            value["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("msg_"))
+        );
+    }
+
     #[derive(Default)]
     struct TestBackend {
         next_id: AtomicU64,
@@ -386,5 +590,143 @@ mod tests {
                 operation: "resume",
             })
         }
+    }
+
+    struct ScriptedStdoutBackend {
+        next_id: AtomicU64,
+        script: Mutex<Vec<String>>,
+        created_specs: Mutex<Vec<SandboxSpec>>,
+    }
+
+    impl ScriptedStdoutBackend {
+        fn new(script: Vec<String>) -> Self {
+            Self {
+                next_id: AtomicU64::new(0),
+                script: Mutex::new(script),
+                created_specs: Mutex::new(Vec::new()),
+            }
+        }
+
+        async fn created_specs(&self) -> Vec<SandboxSpec> {
+            self.created_specs.lock().await.clone()
+        }
+    }
+
+    #[async_trait]
+    impl SandboxBackend for ScriptedStdoutBackend {
+        fn name(&self) -> &'static str {
+            "scripted"
+        }
+
+        async fn create(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
+            self.created_specs.lock().await.push(spec);
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
+            Ok(SandboxHandle::new(
+                SandboxId::new(format!("scripted-{id}")),
+                self.name(),
+            ))
+        }
+
+        async fn open_io(&self, _id: &SandboxId) -> SandboxResult<SandboxIo> {
+            let script = self.script.lock().await.clone();
+            let (io, mut stdout, mut stdin) = mock_io();
+            tokio::spawn(async move {
+                let _ = tokio::io::copy(&mut stdin, &mut tokio::io::sink()).await;
+            });
+            tokio::spawn(async move {
+                for line in script {
+                    let _ = stdout.write_all(line.as_bytes()).await;
+                    let _ = stdout.write_all(b"\n").await;
+                }
+            });
+            Ok(io)
+        }
+
+        async fn status(&self, _id: &SandboxId) -> SandboxResult<SandboxStatus> {
+            Ok(SandboxStatus::Running)
+        }
+
+        async fn observe(&self, id: &SandboxId) -> SandboxResult<ObservedSandbox> {
+            Ok(ObservedSandbox::new(
+                id.clone(),
+                self.name(),
+                SandboxStatus::Running,
+            ))
+        }
+
+        async fn list_observed(&self) -> SandboxResult<Vec<ObservedSandbox>> {
+            Ok(Vec::new())
+        }
+
+        async fn stop(&self, _id: &SandboxId) -> SandboxResult<()> {
+            Ok(())
+        }
+
+        async fn pause(&self, _id: &SandboxId) -> SandboxResult<()> {
+            Ok(())
+        }
+
+        async fn resume(&self, _id: &SandboxId) -> SandboxResult<()> {
+            Ok(())
+        }
+    }
+
+    fn mock_io() -> (SandboxIo, DuplexStream, DuplexStream) {
+        let (stdin_near, stdin_far) = tokio::io::duplex(64 * 1024);
+        let (stdout_near, stdout_far) = tokio::io::duplex(64 * 1024);
+        let (stderr_near, _stderr_far) = tokio::io::duplex(1024);
+        let io = SandboxIo::new(
+            Box::pin(stdin_near),
+            Box::pin(stdout_near),
+            Box::pin(stderr_near),
+        );
+        (io, stdout_far, stdin_far)
+    }
+
+    async fn test_store() -> Option<PgSessionStore> {
+        let Ok(url) = std::env::var("SESSION_RUNTIME_TEST_DATABASE_URL") else {
+            eprintln!("skipping: SESSION_RUNTIME_TEST_DATABASE_URL not set");
+            return None;
+        };
+        let store = PgSessionStore::connect(&url)
+            .await
+            .expect("connect test db");
+        match store.run_migrations().await {
+            Ok(()) => Some(store),
+            Err(SessionStoreError::Sqlx(error)) => panic!("run migrations: {error}"),
+            Err(error) => panic!("run migrations: {error}"),
+        }
+    }
+
+    fn anthropic_test_app(store: PgSessionStore, script: Vec<String>) -> axum::Router {
+        let (app, _) = anthropic_test_app_with_backend(store, script);
+        app
+    }
+
+    fn anthropic_test_app_with_backend(
+        store: PgSessionStore,
+        script: Vec<String>,
+    ) -> (axum::Router, Arc<ScriptedStdoutBackend>) {
+        let backend = Arc::new(ScriptedStdoutBackend::new(script));
+        let app = build_router_with_runtime(
+            store,
+            SandboxRuntime::backend(backend.clone(), SandboxSpec::new("scripted")),
+        );
+        (app, backend)
+    }
+
+    fn env_value<'a>(spec: &'a SandboxSpec, name: &str) -> Option<&'a str> {
+        spec.env
+            .iter()
+            .find(|env| env.name == name)
+            .map(|env| env.value.as_str())
+    }
+
+    fn sse_event_names(body: &str) -> Vec<&str> {
+        body.lines()
+            .filter_map(|line| line.strip_prefix("event:"))
+            .map(str::trim)
+            .filter(|event| !event.is_empty())
+            .collect()
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -52,7 +52,7 @@ use tracing::Span;
 use uuid::Uuid;
 
 use crate::{
-    ApiError,
+    ApiError, anthropic,
     types::{
         AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
         EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
@@ -124,13 +124,13 @@ impl AppState {
         self.initialized().is_some()
     }
 
-    fn runtime(&self) -> Result<SessionRuntime, ApiError> {
+    pub(crate) fn runtime(&self) -> Result<SessionRuntime, ApiError> {
         self.initialized()
             .map(|initialized| initialized.runtime)
             .ok_or_else(|| ApiError::ServiceUnavailable("api-rs is still starting".to_owned()))
     }
 
-    fn workflows(&self) -> Result<WorkflowRuntime, ApiError> {
+    pub(crate) fn workflows(&self) -> Result<WorkflowRuntime, ApiError> {
         let initialized = self
             .initialized()
             .ok_or_else(|| ApiError::ServiceUnavailable("api-rs is still starting".to_owned()))?;
@@ -188,6 +188,10 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route("/readyz", get(readyz))
         .route("/metrics", get(metrics))
         .route("/api/personas", get(list_personas))
+        .route(
+            "/v1/messages",
+            post(anthropic::anthropic_messages).layer(DefaultBodyLimit::disable()),
+        )
         .route(
             "/api/session/{thread_key}",
             post(create_or_get_session).get(get_session_context),
@@ -418,6 +422,8 @@ async fn execute_session(
                 input_lines: request.input_lines,
                 idle_timeout_ms: request.idle_timeout_ms,
                 max_duration_ms: request.max_duration_ms,
+                model: None,
+                system_prompt: None,
             },
         )
         .await?;

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -234,6 +234,8 @@ pub struct ExecuteSessionInput {
     pub input_lines: Vec<String>,
     pub idle_timeout_ms: Option<u64>,
     pub max_duration_ms: Option<u64>,
+    pub model: Option<String>,
+    pub system_prompt: Option<String>,
 }
 
 #[derive(Clone)]
@@ -278,6 +280,29 @@ struct PersonaResolution {
     persona_id: Option<String>,
     context: Option<PersonaContext>,
     defaulted: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct SessionSandboxOverrides<'a> {
+    model: Option<&'a str>,
+    system_prompt: Option<&'a str>,
+}
+
+impl SessionSandboxOverrides<'_> {
+    fn has_overrides(self) -> bool {
+        self.model.is_some_and(|model| !model.trim().is_empty())
+            || self
+                .system_prompt
+                .is_some_and(|prompt| !prompt.trim().is_empty())
+    }
+}
+
+struct SessionSandboxRequest<'a> {
+    persona_id: Option<&'a str>,
+    existing_sandbox_id: Option<&'a str>,
+    iron_control_principal: Option<&'a str>,
+    execution_id: &'a str,
+    overrides: SessionSandboxOverrides<'a>,
 }
 
 impl SessionRuntime {
@@ -741,6 +766,8 @@ impl SessionRuntime {
             input_lines,
             idle_timeout_ms,
             max_duration_ms,
+            model,
+            system_prompt,
         } = input;
         let input_line_count = input_lines.len();
         let idempotency_key_present = idempotency_key.is_some();
@@ -852,10 +879,16 @@ impl SessionRuntime {
                 .ensure_session_sandbox(
                     thread_key,
                     &session.harness_type,
-                    session.persona_id.as_deref(),
-                    session.sandbox_id.as_deref(),
-                    session.iron_control_principal.as_deref(),
-                    &execution.execution_id,
+                    SessionSandboxRequest {
+                        persona_id: session.persona_id.as_deref(),
+                        existing_sandbox_id: session.sandbox_id.as_deref(),
+                        iron_control_principal: session.iron_control_principal.as_deref(),
+                        execution_id: &execution.execution_id,
+                        overrides: SessionSandboxOverrides {
+                            model: model.as_deref(),
+                            system_prompt: system_prompt.as_deref(),
+                        },
+                    },
                 )
                 .await
             {
@@ -1166,11 +1199,15 @@ impl SessionRuntime {
         &self,
         thread_key: &ThreadKey,
         harness_type: &HarnessType,
-        persona_id: Option<&str>,
-        existing_sandbox_id: Option<&str>,
-        iron_control_principal: Option<&str>,
-        execution_id: &str,
+        request: SessionSandboxRequest<'_>,
     ) -> Result<String, SessionRuntimeError> {
+        let SessionSandboxRequest {
+            persona_id,
+            existing_sandbox_id,
+            iron_control_principal,
+            execution_id,
+            overrides,
+        } = request;
         let span = info_span!(
             "centaur.api_rs.sandbox.ensure",
             component = COMPONENT_SESSION_RUNTIME,
@@ -1315,22 +1352,28 @@ impl SessionRuntime {
 
             // Warm sandboxes are pre-booted with the workload's default
             // harness; a session on any other harness needs a cold sandbox.
+            let has_sandbox_overrides = overrides.has_overrides();
             let warm_harness_matches = self
                 .sandbox_runtime
                 .warm_harness
                 .as_ref()
                 .is_none_or(|warm| warm == harness_type);
             let warm_persona_matches = persona_context.is_none();
-            if !warm_harness_matches && self.warm_pool.is_some() {
-                record_sandbox_warm_pool_claim("harness_mismatch");
-            }
-            if !warm_persona_matches && self.warm_pool.is_some() {
-                record_sandbox_warm_pool_claim("persona_specific");
+            if self.warm_pool.is_some() {
+                if has_sandbox_overrides {
+                    record_sandbox_warm_pool_claim("request_overrides");
+                } else if !warm_harness_matches {
+                    record_sandbox_warm_pool_claim("harness_mismatch");
+                } else if !warm_persona_matches {
+                    record_sandbox_warm_pool_claim("persona_specific");
+                }
             }
             if let Some(warm_pool) = self
                 .warm_pool
                 .as_ref()
-                .filter(|_| warm_harness_matches && warm_persona_matches)
+                .filter(|_| {
+                    warm_harness_matches && warm_persona_matches && !has_sandbox_overrides
+                })
             {
                 match warm_pool
                     .claim(thread_key.as_str(), iron_control_principal)
@@ -1394,6 +1437,7 @@ impl SessionRuntime {
                 harness_type,
                 persona_context.as_ref(),
             );
+            apply_session_sandbox_overrides(&mut spec, harness_type, overrides);
             if let Some(principal) = iron_control_principal {
                 spec.iron_control_principal = Some(principal.to_owned());
             }
@@ -2098,6 +2142,38 @@ fn harness_server_subcommand(harness: &HarnessType) -> &'static str {
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Amp => "amp",
     }
+}
+
+fn apply_session_sandbox_overrides(
+    spec: &mut SandboxSpec,
+    harness: &HarnessType,
+    overrides: SessionSandboxOverrides<'_>,
+) {
+    // PR A intentionally scopes request model/system to ClaudeCode. Codex and
+    // Amp request-level model/system handling need separate harness semantics.
+    if !matches!(harness, HarnessType::ClaudeCode) {
+        return;
+    }
+    if let Some(model) = overrides.model.and_then(non_empty_str) {
+        upsert_env(spec, "CLAUDE_MODEL", model);
+    }
+    if let Some(system_prompt) = overrides.system_prompt.and_then(non_empty_str) {
+        upsert_env(spec, "CENTAUR_EXTRA_SYSTEM_PROMPT", system_prompt);
+    }
+}
+
+fn upsert_env(spec: &mut SandboxSpec, name: &str, value: &str) {
+    if let Some(existing) = spec.env.iter_mut().find(|env| env.name == name) {
+        existing.value = value.to_owned();
+    } else {
+        spec.env
+            .push(centaur_sandbox_core::EnvVar::new(name, value));
+    }
+}
+
+fn non_empty_str(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
 }
 
 fn sandbox_spec_key(spec: &SandboxSpec) -> String {
@@ -2957,7 +3033,7 @@ fn tool_labels_from_item(item: &Value) -> Option<ToolCallLabels> {
             name: string_at_path(item, &["tool"]).unwrap_or_else(|| "agent".to_owned()),
             method: "call".to_owned(),
         }),
-        _ => None,
+        _ => centaur_call_labels_from_command_item(item),
     }
 }
 
@@ -3026,7 +3102,8 @@ fn progress_item_id(value: &Value) -> Option<String> {
     .next()
 }
 
-fn anthropic_tool_uses(value: &Value) -> Vec<&Value> {
+/// Extract Anthropic tool_use blocks; reused by api-server Anthropic translator.
+pub fn anthropic_tool_uses(value: &Value) -> Vec<&Value> {
     if value.get("type").and_then(Value::as_str) != Some("assistant") {
         return Vec::new();
     }
@@ -3036,7 +3113,8 @@ fn anthropic_tool_uses(value: &Value) -> Vec<&Value> {
         .collect()
 }
 
-fn anthropic_tool_results(value: &Value) -> Vec<&Value> {
+/// Extract Anthropic tool_result blocks; reused by api-server Anthropic translator.
+pub fn anthropic_tool_results(value: &Value) -> Vec<&Value> {
     if !matches!(
         value.get("type").and_then(Value::as_str),
         Some("user" | "tool")
@@ -3052,7 +3130,8 @@ fn anthropic_tool_results(value: &Value) -> Vec<&Value> {
         .collect()
 }
 
-fn content_blocks(value: &Value) -> Vec<&Value> {
+/// Extract Anthropic content blocks; reused by api-server Anthropic translator.
+pub fn content_blocks(value: &Value) -> Vec<&Value> {
     value
         .get("content")
         .or_else(|| {
@@ -3065,8 +3144,63 @@ fn content_blocks(value: &Value) -> Vec<&Value> {
         .unwrap_or_default()
 }
 
+fn centaur_call_labels_from_command_item(item: &Value) -> Option<ToolCallLabels> {
+    let command = string_at_path(item, &["command"])?;
+    let (name, method) = parse_centaur_call_command(&command)?;
+    Some(ToolCallLabels {
+        kind: "centaur_call".to_owned(),
+        name,
+        method,
+    })
+}
+
+fn parse_centaur_call_command(command: &str) -> Option<(String, String)> {
+    let call_start = command
+        .match_indices("call")
+        .find_map(|(index, _)| is_call_command_token(command, index).then_some(index))?;
+    let after_call = command[call_start + "call".len()..]
+        .trim_start_matches(|ch: char| ch.is_whitespace() || ch == '\'' || ch == '"');
+    let mut parts = after_call
+        .split(|ch: char| ch.is_whitespace() || matches!(ch, '\'' | '"' | ';'))
+        .filter(|part| !part.is_empty());
+    let first = parts.next()?;
+    match first {
+        "tools" => Some(("tools".to_owned(), "list".to_owned())),
+        "discover" => Some((
+            parts.next().unwrap_or("unknown").to_owned(),
+            "discover".to_owned(),
+        )),
+        "agent" => Some((
+            "agent".to_owned(),
+            parts.next().unwrap_or("unknown").to_owned(),
+        )),
+        tool => Some((
+            tool.to_owned(),
+            parts.next().unwrap_or("unknown").to_owned(),
+        )),
+    }
+}
+
+fn is_call_command_token(command: &str, index: usize) -> bool {
+    let before = command[..index].chars().next_back();
+    let after = command[index + "call".len()..].chars().next();
+
+    let before_is_boundary = before.is_none_or(|ch| {
+        ch.is_whitespace()
+            || matches!(
+                ch,
+                '\'' | '"' | '`' | ';' | '&' | '|' | '(' | ')' | '{' | '}' | '/'
+            )
+    });
+    let after_is_boundary =
+        after.is_some_and(|ch| ch.is_whitespace() || matches!(ch, '\'' | '"' | ';'));
+
+    before_is_boundary && after_is_boundary
+}
+
+/// Parsed terminal harness output; reused by api-server Anthropic translator.
 #[derive(Debug, Eq, PartialEq)]
-enum TerminalOutput {
+pub enum TerminalOutput {
     Completed {
         reason: &'static str,
         result_text: Option<String>,
@@ -3514,7 +3648,8 @@ fn is_event_stream_attach_race(error: &SessionRuntimeError) -> bool {
     )
 }
 
-fn terminal_output(value: &Value, prior_final_answer_text: &str) -> Option<TerminalOutput> {
+/// Parse terminal harness output; reused by api-server Anthropic translator.
+pub fn terminal_output(value: &Value, prior_final_answer_text: &str) -> Option<TerminalOutput> {
     let method = value.get("method").and_then(Value::as_str);
     let event_type = value.get("type").and_then(Value::as_str);
 
@@ -3607,12 +3742,15 @@ fn turn_completion_status(value: &Value) -> Option<String> {
     .next()
 }
 
-enum FinalAnswerTextUpdate {
+/// Parsed final-answer text update; reused by api-server Anthropic translator.
+#[derive(Debug, Eq, PartialEq)]
+pub enum FinalAnswerTextUpdate {
     Append(String),
     Replace(String),
 }
 
-fn output_line_final_answer_text(value: &Value) -> Option<FinalAnswerTextUpdate> {
+/// Parse final-answer text updates; reused by api-server Anthropic translator.
+pub fn output_line_final_answer_text(value: &Value) -> Option<FinalAnswerTextUpdate> {
     let method = value.get("method").and_then(Value::as_str);
     let event_type = value.get("type").and_then(Value::as_str);
     if matches!(method, Some("item/agentMessage/delta"))
@@ -3672,7 +3810,8 @@ fn item_ids(value: &Value) -> Vec<String> {
     .collect()
 }
 
-fn string_at_path(value: &Value, path: &[&str]) -> Option<String> {
+/// Read a non-empty string at a nested object path; reused by api-server Anthropic translator.
+pub fn string_at_path(value: &Value, path: &[&str]) -> Option<String> {
     let mut current = value;
     for key in path {
         current = current.get(*key)?;
@@ -3702,7 +3841,8 @@ fn terminal_error_text(value: &Value) -> String {
         .if_empty("terminal harness output reported failure")
 }
 
-fn terminal_payload_text(value: &Value) -> String {
+/// Extract text from common terminal payload shapes; reused by api-server Anthropic translator.
+pub fn terminal_payload_text(value: &Value) -> String {
     match value {
         Value::String(text) => text.clone(),
         Value::Array(values) => values

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -3209,6 +3209,8 @@ async fn run_agent_session_turn(
                 }))?],
                 idle_timeout_ms: Some(idle_timeout_ms),
                 max_duration_ms: Some(max_duration_ms),
+                model: None,
+                system_prompt: None,
             },
         )
         .await?;


### PR DESCRIPTION
## Summary

Exposes centaur's durable, thread-keyed session control plane behind an **Anthropic Messages-compatible `POST /v1/messages`**, so any Anthropic SDK client or `claude -p` (via `ANTHROPIC_BASE_URL`) can drive a fully-configured centaur thread (tools, sandbox, durability) through the standard Messages API.

**Now fully implemented and validated end-to-end on a live deployment.** This folds in the model/system support (previously a stacked follow-up) plus the harness-output and client-compatibility fixes found while validating with `claude -p`.

## What it does

- **Endpoint:** `POST /v1/messages` (Anthropic Messages shape), registered alongside `/api/session/*`; streaming (SSE) and non-streaming.
- **Thread continuity:** keyed on the client's Claude Code session id — the `X-Claude-Code-Session-Id` header (the same id it uses for `--resume`/`--continue`) → thread `api:claude:<session-id>`, so a resumed CLI session continues the same durable thread and warm sandbox. No custom header to manage; absent → a fresh `api:<uuid>` thread.
- **Honors `model` and `system`** (first-request-wins): threaded into the sandbox harness env (`CLAUDE_MODEL`; `CENTAUR_EXTRA_SYSTEM_PROMPT` appended after `AGENTS.md`). `tools` are accepted but centaur owns the in-sandbox tools.
- **`AnthropicTranslator`** maps harness output → Anthropic content-block stream events, handling both harness shapes:
  - **claude** (natively Anthropic-shaped `assistant`/`user` events);
  - **codex** — both the dotted `item.agentMessage.delta` shape *and* the Rust harness-server's **slash-method/`params`** events (`item/agentMessage/delta`, `item/reasoning/textDelta`, `item/completed`). Text + reasoning + `tool_use` + `tool_result` → content blocks.
- **Client compat:** drives the turn off the **last `user` message**, so clients like Claude Code that append a trailing `system`-role message in `messages[]` work.

## Validation

End-to-end against a live deployment with `claude -p` (`ANTHROPIC_BASE_URL` → the ingress):
- basic reply (`Reply PONG` → `PONG`);
- **tool use** — the inner agent runs shell commands and returns their output;
- **model selection** — a requested `model` lands as `CLAUDE_MODEL` in the spawned sandbox.

`cargo fmt --check` · `clippy -D warnings` · `cargo test` green (translator unit cases for both harness shapes + streaming/non-streaming integration via the stdout-scripting backend; harness-server system-prompt test).

## Follow-ups (out of scope)

- `x-api-key` auth on `/v1/messages` (currently network-gated like `/api/session/*`).
- Full-history replay (v1 appends only the latest user turn; centaur owns thread history).
- Real usage-token accounting (v1 reports zeros).
- **Client tools** round-trip (let the caller's `tools` execute caller-side via an MCP bridge) — designed, not in this PR.

