### PR TITLE
fix: unify tool overlay publishing

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.66
+version: 0.1.67
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -50,15 +50,15 @@ toolServer:
   ref: ""
   # Subdirectory in the repo holding the tools tree (mounted at /app/tools).
   subdir: tools
-  # Additional repo/subdir sources copied after the base tools source. Later
-  # sources shadow earlier ones when tool directory names collide. These repos
-  # are cached automatically when repoCache.enabled=true.
+  # Additional repo/subdir sources copied after the base tools source. Duplicate
+  # tool names are skipped by the sandbox copy helper. These repos are cached
+  # automatically when repoCache.enabled=true.
   extraSources: []
   # - repo: tempoxyz/centaur-tempo
   #   ref: ""
   #   subdir: tools
-  # Git-capable image the clone init container runs in; empty fields fall back to
-  # sandbox.image (which carries git).
+  # Image the tools-bootstrap init container runs in; empty fields fall back to
+  # sandbox.image, which carries git and install-tool-shims.
   runnerImage:
     repository: ""
     tag: ""

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
@@ -11,16 +11,16 @@
 //! trees api-rs's own `tool_discovery` scans, so the creds api-rs grants match
 //! the tools the agent installs:
 //!
-//! * a `tools-bootstrap` init container copies the tools repo's `source_subdir`
+//! * a `tools-bootstrap` init container publishes the tools repo's `source_subdir`
 //!   from the repo-cache DaemonSet's node-level cache when configured, otherwise
 //!   it git-clones the tools repo at a pinned ref into an emptyDir mounted at
 //!   `/app/tools`;
 //!
 //! `TOOL_DIRS` is set explicitly on the agent env to `/app/tools`, pointing at
-//! the path the init container populates in this pod. The copied tools tree keeps
-//! source metadata in a hidden file so `centaur-tools refresh` can either re-copy
-//! from repo-cache or fetch the configured ref, then reinstall shims without
-//! restarting the pod.
+//! the path the init container populates in this pod. The published tools tree
+//! keeps source metadata in a hidden file so `centaur-tools refresh` can either
+//! republish from repo-cache or fetch the configured ref, then reinstall shims
+//! without restarting the pod.
 
 use serde_json::{Value, json};
 
@@ -41,28 +41,30 @@ const GITHUB_TOKEN_FILE_PATH: &str = "/tools-github-token/token";
 const REPO_CACHE_VOLUME: &str = "tools-repo-cache";
 
 /// Git source for the base tools tree. When set, every sandbox gets a
-/// `tools-bootstrap` init container that clones `repo` at `git_ref` and copies
-/// its `source_subdir` into the agent's `/app/tools` — so adding a tool is a
-/// push to the repo, not an image rebuild.
+/// `tools-bootstrap` init container that clones `repo` at `git_ref` and
+/// publishes its `source_subdir` into the agent's `/app/tools` — so adding a
+/// tool is a push to the repo, not an image rebuild.
 #[derive(Clone, Debug)]
 pub struct ToolsConfig {
     /// `owner/name` GitHub repo carrying the tools tree.
     pub repo: String,
     /// Branch, tag, or commit to check out. `None` => the repo's default branch.
     pub git_ref: Option<String>,
-    /// Subdirectory within the repo holding the tools (copied to `/app/tools`).
+    /// Subdirectory within the repo holding the tools (published to `/app/tools`).
     pub source_subdir: String,
-    /// Git-capable image the clone init container runs (e.g. the sandbox image).
+    /// Image the clone init container runs. It must include git and
+    /// `install-tool-shims` (the default sandbox image does).
     pub image: String,
     pub image_pull_policy: Option<String>,
     /// GitHub token secret for private-repo clones. `None` => unauthenticated clone.
     pub github_token: Option<GitHubTokenRef>,
     /// Optional repo-cache root path mounted from the host. When set,
-    /// tools-bootstrap copies from `<repo_cache_path>/<repo>/<source_subdir>` and
-    /// `centaur-tools refresh` re-copies from the same cache instead of fetching.
+    /// tools-bootstrap publishes from `<repo_cache_path>/<repo>/<source_subdir>`
+    /// and `centaur-tools refresh` republishes from the same cache instead of
+    /// fetching.
     pub repo_cache_path: Option<String>,
-    /// Additional tool sources copied after the base tree. Later sources shadow
-    /// earlier ones when they contain the same tool directory name.
+    /// Additional tool sources copied after the base tree. Duplicate tool names
+    /// are skipped by the copy helper.
     pub extra_sources: Vec<ToolSource>,
 }
 
@@ -158,11 +160,9 @@ pub(crate) struct CloneProxy {
     pub ca_volume_mount: Value,
 }
 
-/// The `tools-bootstrap` init container: copies `repo`'s `source_subdir` from
-/// repo-cache when configured, otherwise clones `repo` at `git_ref` (sparse, on
-/// `source_subdir`) and copies that subtree into the shared `tools-root` emptyDir
-/// the agent mounts at `/app/tools`. With a `CloneProxy`, the clone fallback
-/// rides the per-sandbox iron-proxy like all other sandbox egress.
+/// The `tools-bootstrap` init container: resolves each configured source, then
+/// delegates copying to `install-tool-shims`. With a `CloneProxy`, the clone
+/// fallback rides the per-sandbox iron-proxy like all other sandbox egress.
 pub(crate) fn tools_init_container_json(
     tools: &ToolsConfig,
     clone_proxy: Option<&CloneProxy>,
@@ -200,9 +200,7 @@ pub(crate) fn tools_init_container_json(
     // clone must retry through the connection-refused window rather than die.
     // repo/ref/subdir are operator config, but quote them anyway so a stray
     // space or metacharacter breaks loudly in git instead of in the shell.
-    let mut publish_steps = String::from(
-        "find \"$target\" -mindepth 1 -maxdepth 1 ! -name '.centaur-source*' ! -name '.centaur-tools-source.json' -exec rm -rf {} +\n",
-    );
+    let mut publish_steps = String::new();
     let mut metadata_sources = Vec::new();
     for (index, source) in sources.iter().enumerate() {
         let subdir = &source.source_subdir;
@@ -214,9 +212,7 @@ pub(crate) fn tools_init_container_json(
                 source.repo.trim_start_matches('/')
             );
             // Wait only for the repo checkout itself; a source without the
-            // tools subdir (e.g. a workflows- or skills-only overlay using the
-            // chart's defaulted subdirs) is skipped instead of failing the
-            // sandbox, because an init failure is terminal for the Sandbox.
+            // tools subdir is skipped instead of failing the sandbox init.
             publish_steps.push_str(&format!(
                 "attempt=0\n\
                  cache_repo=\"{repo_cache_repo_path}\"\n\
@@ -226,7 +222,7 @@ pub(crate) fn tools_init_container_json(
                  sleep 2\n\
                  done\n\
                  if [ -d \"$cache_repo/{subdir}\" ]; then\n\
-                 cp -R \"$cache_repo/{subdir}/.\" \"$target\"/\n\
+                 install-tool-shims --copy-tools \"$cache_repo/{subdir}\" \"$target\"\n\
                  else\n\
                  echo \"skipping tools source {repo}: no {subdir}/ in repo-cache checkout\" >&2\n\
                  fi\n"
@@ -241,10 +237,11 @@ pub(crate) fn tools_init_container_json(
         } else {
             let repo_url = format!("https://github.com/{}.git", source.repo);
             let source_path = if index == 0 {
-                "$target/.centaur-source".to_owned()
+                ".centaur-source".to_owned()
             } else {
-                format!("$target/.centaur-source-{index}")
+                format!(".centaur-source-{index}")
             };
+            let source_target_path = format!("$target/{source_path}");
             let checkout = match &source.git_ref {
                 Some(git_ref) => format!(
                     "git -C \"$source\" -c gc.auto=0 fetch --quiet origin \"{git_ref}\" && \
@@ -257,7 +254,7 @@ pub(crate) fn tools_init_container_json(
             // sandbox (sparse-checkout of a missing path succeeds, so this is
             // only detectable after checkout).
             publish_steps.push_str(&format!(
-                "source=\"{source_path}\"\n\
+                "source=\"{source_target_path}\"\n\
                  rm -rf \"$source\"\n\
                  attempt=0\n\
                  until git clone --quiet --filter=blob:none --no-checkout \"{repo_url}\" \"$source\" && \
@@ -269,7 +266,7 @@ pub(crate) fn tools_init_container_json(
                  sleep 2\n\
                  done\n\
                  if [ -d \"$source/{subdir}\" ]; then\n\
-                 cp -R \"$source/{subdir}/.\" \"$target\"/\n\
+                 install-tool-shims --copy-tools \"$source/{subdir}\" \"$target\"\n\
                  else\n\
                  echo \"skipping tools source {repo}: no {subdir}/ at the configured ref\" >&2\n\
                  fi\n"
@@ -279,7 +276,7 @@ pub(crate) fn tools_init_container_json(
                 "source_subdir": subdir,
                 "git_ref": source.git_ref.as_deref(),
                 "source": "git",
-                "source_path": source_path.replace("$target", TOOLS_BOOTSTRAP_DIR),
+                "source_path": source_path,
             }));
         }
     }
@@ -423,14 +420,14 @@ mod tests {
         assert!(script.contains("sparse-checkout set \"tools\""));
         assert!(script.contains("fetch --quiet origin \"main\""));
         assert!(script.contains("source=\"$target/.centaur-source\""));
-        // The copy is conditional so a cloned source without the tools subdir
-        // is skipped rather than failing the sandbox init.
+        assert!(script.contains("\"source_path\":\".centaur-source\""));
         assert!(script.contains("if [ -d \"$source/tools\" ]; then"));
-        assert!(script.contains("cp -R \"$source/tools/.\" \"$target\"/"));
+        assert!(script.contains("install-tool-shims --copy-tools \"$source/tools\" \"$target\""));
         assert!(script.contains(
             "skipping tools source paradigmxyz/centaur: no tools/ at the configured ref"
         ));
         assert!(script.contains(".centaur-tools-source.json"));
+        assert!(!script.contains("cp -R"));
         // No token configured => no askpass, single (tools) volume mount.
         assert!(!script.contains("GIT_ASKPASS"));
         assert_eq!(c["volumeMounts"].as_array().unwrap().len(), 1);
@@ -453,7 +450,9 @@ mod tests {
         assert!(script.contains("checkout --quiet --detach FETCH_HEAD; do"));
         assert!(script.contains("if [ \"$attempt\" -ge 30 ]"));
         assert!(script.contains("sleep 2"));
-        assert!(script.find("done").unwrap() < script.find("cp -R").unwrap());
+        assert!(
+            script.find("done").unwrap() < script.find("install-tool-shims --copy-tools").unwrap()
+        );
     }
 
     #[test]
@@ -505,8 +504,12 @@ mod tests {
         let c = tools_init_container_json(&tools, None);
         let script = c["command"][2].as_str().unwrap();
         assert!(script.contains("cache_repo=\"/var/lib/centaur/repos/paradigmxyz/centaur\""));
-        assert!(script.contains("cp -R \"$cache_repo/tools/.\" \"$target\"/"));
+        assert!(script.contains("if [ -d \"$cache_repo/tools\" ]; then"));
+        assert!(
+            script.contains("install-tool-shims --copy-tools \"$cache_repo/tools\" \"$target\"")
+        );
         assert!(script.contains("\"source\":\"repo_cache\""));
+        assert!(!script.contains("cp -R"));
         assert!(!script.contains("git clone"));
         // The wait covers only the repo checkout; a source without the tools
         // subdir is skipped instead of failing the sandbox, so the chart can
@@ -515,7 +518,6 @@ mod tests {
         assert!(
             !script.contains("until [ -d \"$cache_repo/.git\" ] && [ -d \"$cache_repo/tools\" ]")
         );
-        assert!(script.contains("if [ -d \"$cache_repo/tools\" ]; then"));
         assert!(script.contains(
             "skipping tools source paradigmxyz/centaur: no tools/ in repo-cache checkout"
         ));

--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -14,6 +14,8 @@ import sys
 import tempfile
 import tomllib
 
+TOOLS_METADATA_NAME = ".centaur-tools-source.json"
+
 
 def _split_paths(value: str) -> list[Path]:
     return [Path(part) for part in value.split(":") if part]
@@ -56,33 +58,73 @@ def _git_env() -> tuple[dict[str, str], tempfile.TemporaryDirectory[str] | None]
     return env, temp_dir
 
 
+def _sorted_children(path: Path) -> list[Path]:
+    return sorted(path.iterdir(), key=lambda child: child.name)
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
 def _clear_published_tools(tool_dir: Path) -> None:
-    for child in tool_dir.iterdir():
-        if child.name in {".centaur-source", ".centaur-tools-source.json"} or child.name.startswith(
+    tool_dir.mkdir(parents=True, exist_ok=True)
+    for child in _sorted_children(tool_dir):
+        if child.name in {".centaur-source", TOOLS_METADATA_NAME} or child.name.startswith(
             ".centaur-source-"
         ):
             continue
-        if child.is_dir() and not child.is_symlink():
-            shutil.rmtree(child)
-        else:
-            child.unlink()
+        _remove_path(child)
 
 
 def _copy_published_tools(tool_dir: Path, published: Path) -> None:
     if not published.is_dir():
         raise RuntimeError(f"refreshed tools subdir does not exist: {published}")
 
-    for child in published.iterdir():
-        target = tool_dir / child.name
+    existing = {package_dir.name: package_dir for package_dir in _tool_package_dirs(tool_dir)}
+    for package_dir in _tool_package_dirs(published):
+        tool_name = package_dir.name
+        if tool_name in existing:
+            print(
+                f"skipping duplicate tool {tool_name}: {package_dir} conflicts with {existing[tool_name]}",
+                file=sys.stderr,
+            )
+            continue
+        relative_package_dir = package_dir.relative_to(published)
+        target = tool_dir / relative_package_dir
         if target.exists() or target.is_symlink():
-            if target.is_dir() and not target.is_symlink():
-                shutil.rmtree(target)
-            else:
-                target.unlink()
-        if child.is_dir() and not child.is_symlink():
-            shutil.copytree(child, target, symlinks=True)
-        else:
-            shutil.copy2(child, target, follow_symlinks=False)
+            _remove_path(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(package_dir, target, symlinks=True)
+        existing[tool_name] = target
+
+
+def _tool_package_dirs(published: Path) -> list[Path]:
+    if not published.is_dir():
+        return []
+
+    package_dirs: list[Path] = []
+    for child in _visible_dirs(published):
+        if (child / "pyproject.toml").is_file():
+            package_dirs.append(child)
+            continue
+        for grandchild in _visible_dirs(child):
+            if (grandchild / "pyproject.toml").is_file():
+                package_dirs.append(grandchild)
+    return package_dirs
+
+
+def _visible_dirs(path: Path) -> list[Path]:
+    return [
+        child
+        for child in _sorted_children(path)
+        if child.is_dir()
+        and not child.is_symlink()
+        and not child.name.startswith(".")
+        and not child.name.startswith("_")
+    ]
 
 
 def _publish_tools(tool_dir: Path, published: Path) -> None:
@@ -90,20 +132,25 @@ def _publish_tools(tool_dir: Path, published: Path) -> None:
     _copy_published_tools(tool_dir, published)
 
 
-def _refresh_source(tool_dir: Path, source_metadata: dict[str, object]) -> None:
-    subdir = str(source_metadata.get("source_subdir") or "tools")
-    if source_metadata.get("source") == "repo_cache":
-        repo_cache_repo_path = source_metadata.get("repo_cache_repo_path")
-        if not repo_cache_repo_path:
-            raise RuntimeError("repo-cache tools metadata is missing repo_cache_repo_path")
-        _copy_published_tools(tool_dir, Path(str(repo_cache_repo_path)) / subdir)
+def _source_checkout_path(tool_dir: Path, source_metadata: dict[str, object]) -> Path:
+    raw_source_path = source_metadata.get("source_path")
+    if not raw_source_path:
+        return tool_dir / ".centaur-source"
+
+    source_path = Path(str(raw_source_path))
+    if not source_path.is_absolute():
+        return tool_dir / source_path
+    return source_path
+
+
+def _copy_refreshed_source(tool_dir: Path, published: Path, label: str) -> None:
+    if not published.is_dir():
+        print(f"skipping tools source {label}: no tools tree at {published}", file=sys.stderr)
         return
+    _copy_published_tools(tool_dir, published)
 
-    source_path = Path(str(source_metadata.get("source_path") or tool_dir / ".centaur-source"))
-    if not source_path.is_dir():
-        raise RuntimeError(f"git tools source does not exist: {source_path}")
 
-    git_ref = source_metadata.get("git_ref")
+def _refresh_checkout(source_path: Path, git_ref: object | None) -> None:
     env, temp_dir = _git_env()
     try:
         if git_ref:
@@ -127,12 +174,34 @@ def _refresh_source(tool_dir: Path, source_metadata: dict[str, object]) -> None:
         if temp_dir is not None:
             temp_dir.cleanup()
 
-    _copy_published_tools(tool_dir, source_path / subdir)
+
+def _refresh_source(tool_dir: Path, source_metadata: dict[str, object]) -> None:
+    subdir = str(source_metadata.get("source_subdir") or "tools")
+    if source_metadata.get("source") == "repo_cache":
+        repo_cache_repo_path = source_metadata.get("repo_cache_repo_path")
+        if not repo_cache_repo_path:
+            raise RuntimeError("repo-cache tools metadata is missing repo_cache_repo_path")
+        _copy_refreshed_source(
+            tool_dir,
+            Path(str(repo_cache_repo_path)) / subdir,
+            f"{source_metadata.get('repo') or repo_cache_repo_path}:{subdir}",
+        )
+        return
+
+    source_path = _source_checkout_path(tool_dir, source_metadata)
+    if not source_path.is_dir():
+        raise RuntimeError(f"git tools source does not exist: {source_path}")
+
+    _refresh_checkout(source_path, source_metadata.get("git_ref"))
+    _copy_refreshed_source(
+        tool_dir,
+        source_path / subdir,
+        f"{source_metadata.get('repo') or source_path}:{subdir}",
+    )
 
 
 def _refresh_tool_dir(tool_dir: Path) -> bool:
-    source = tool_dir / ".centaur-source"
-    metadata_path = tool_dir / ".centaur-tools-source.json"
+    metadata_path = tool_dir / TOOLS_METADATA_NAME
     if not metadata_path.is_file():
         return False
 
@@ -142,7 +211,9 @@ def _refresh_tool_dir(tool_dir: Path) -> bool:
         _clear_published_tools(tool_dir)
         for source_metadata in sources:
             if not isinstance(source_metadata, dict):
-                raise RuntimeError(f"invalid tools source metadata in {metadata_path}: {source_metadata!r}")
+                raise RuntimeError(
+                    f"invalid tools source metadata in {metadata_path}: {source_metadata!r}"
+                )
             _refresh_source(tool_dir, source_metadata)
         return True
 
@@ -150,37 +221,17 @@ def _refresh_tool_dir(tool_dir: Path) -> bool:
     if metadata.get("source") == "repo_cache":
         repo_cache_repo_path = metadata.get("repo_cache_repo_path")
         if not repo_cache_repo_path:
-            raise RuntimeError(f"repo-cache tools metadata is missing repo_cache_repo_path: {metadata_path}")
+            raise RuntimeError(
+                f"repo-cache tools metadata is missing repo_cache_repo_path: {metadata_path}"
+            )
         _publish_tools(tool_dir, Path(repo_cache_repo_path) / subdir)
         return True
 
+    source = _source_checkout_path(tool_dir, metadata)
     if not source.is_dir():
         return False
 
-    git_ref = metadata.get("git_ref")
-    env, temp_dir = _git_env()
-    try:
-        if git_ref:
-            subprocess.run(
-                ["git", "-C", str(source), "-c", "gc.auto=0", "fetch", "--quiet", "origin", str(git_ref)],
-                check=True,
-                env=env,
-            )
-            subprocess.run(
-                ["git", "-C", str(source), "checkout", "--quiet", "--detach", "FETCH_HEAD"],
-                check=True,
-                env=env,
-            )
-        else:
-            subprocess.run(
-                ["git", "-C", str(source), "pull", "--ff-only", "--quiet"],
-                check=True,
-                env=env,
-            )
-    finally:
-        if temp_dir is not None:
-            temp_dir.cleanup()
-
+    _refresh_checkout(source, metadata.get("git_ref"))
     _publish_tools(tool_dir, source / subdir)
     return True
 
@@ -490,17 +541,33 @@ if __name__ == "__main__":
     _write_executable(path, content)
 
 
+def _option_values(argv: list[str], option: str, count: int) -> list[str] | None:
+    if option not in argv[1:]:
+        return None
+    index = argv.index(option)
+    if index + count >= len(argv):
+        raise RuntimeError(f"{option} requires {count} values")
+    return argv[index + 1 : index + 1 + count]
+
+
 def main(argv: list[str]) -> int:
     refresh = "--refresh" in argv[1:]
     refresh_skills_only = "--refresh-skills" in argv[1:]
+    copy_tools_args = _option_values(argv, "--copy-tools", 2)
     tool_dirs = _split_paths(os.environ.get("TOOL_DIRS", ""))
-    bin_dir = Path(os.environ.get("CENTAUR_TOOL_BIN_DIR", str(Path.home() / ".local/bin")))
-    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    if copy_tools_args:
+        source, target = copy_tools_args
+        _copy_published_tools(Path(target), Path(source))
+        return 0
 
     if refresh_skills_only:
         copied = _refresh_skill_dirs(_workspace_dir())
         print(f"reloaded {copied} Centaur skill entries", file=sys.stderr)
         return 0
+
+    bin_dir = Path(os.environ.get("CENTAUR_TOOL_BIN_DIR", str(Path.home() / ".local/bin")))
+    bin_dir.mkdir(parents=True, exist_ok=True)
 
     if refresh:
         refreshed = _refresh_tool_dirs(tool_dirs)

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+import install_tool_shims
+
+
+class CopyPublishedToolsTest(unittest.TestCase):
+    def test_copies_tool_dirs_and_skips_duplicate_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            published = root / "published"
+            target = root / "target"
+
+            (target / "research" / "sensortower").mkdir(parents=True)
+            (target / "research" / "sensortower" / "pyproject.toml").write_text("base\n")
+            (target / "research" / "websearch").mkdir(parents=True)
+            (target / "research" / "websearch" / "pyproject.toml").write_text("old project\n")
+            (target / "research" / "websearch" / "old.py").write_text("old\n")
+
+            (published / "research" / "websearch").mkdir(parents=True)
+            (published / "research" / "websearch" / "pyproject.toml").write_text("new project\n")
+            (published / "research" / "websearch" / "new.py").write_text("new\n")
+            (published / "research" / "company").mkdir(parents=True)
+            (published / "research" / "company" / "pyproject.toml").write_text("company\n")
+
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                install_tool_shims._copy_published_tools(target, published)
+
+            self.assertEqual(
+                (target / "research" / "sensortower" / "pyproject.toml").read_text(),
+                "base\n",
+            )
+            self.assertIn("skipping duplicate tool websearch", stderr.getvalue())
+            self.assertEqual(
+                (target / "research" / "websearch" / "pyproject.toml").read_text(),
+                "old project\n",
+            )
+            self.assertEqual((target / "research" / "websearch" / "old.py").read_text(), "old\n")
+            self.assertFalse((target / "research" / "websearch" / "new.py").exists())
+            self.assertEqual((target / "research" / "company" / "pyproject.toml").read_text(), "company\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Unifies sandbox tool publishing so bootstrap and refresh both copy package-level tool directories through install-tool-shims. This preserves base sibling tools when overlays add nested packages, skips duplicate tool names consistently, keeps multi-source refresh metadata usable, and bumps the Helm chart to 0.1.67.