### PR TITLE
fix(discordbot): inline image attachments instead of passing raw CDN URLs

### DIFF
--- a/services/discordbot/src/session-api.ts
+++ b/services/discordbot/src/session-api.ts
@@ -303,8 +303,18 @@ export function sessionStreamError(error: unknown): RustSessionStreamEvent {
 /** Largest attachment we are willing to buffer in memory and inline as base64. */
 export const MAX_INLINE_ATTACHMENT_BYTES = 100 * 1024 * 1024;
 
-async function serializeAttachment(
+/**
+ * Largest JSON codex input line we will emit. A `data:` URL inlined directly in
+ * the user message blows past this for larger images, so anything bigger is
+ * delivered out-of-band as `attachment.chunk` lines and referenced by a staged
+ * attachment id (mirrors slackbotv2).
+ */
+const MAX_CODEX_INPUT_LINE_CHARS = 900 * 1024;
+const STAGED_ATTACHMENT_CHUNK_CHARS = 700 * 1024;
+
+export async function serializeAttachment(
   attachment: Attachment,
+  fetchFn: typeof fetch = fetch,
 ): Promise<DiscordbotApiAttachment> {
   const serialized: DiscordbotApiAttachment = {
     fetchMetadata: attachment.fetchMetadata,
@@ -326,7 +336,15 @@ async function serializeAttachment(
   }
 
   try {
-    const data = attachment.data ?? (await attachment.fetchData?.());
+    // The Discord chat adapter hands us only a public (signed) CDN `url` — it
+    // provides neither `data` nor a `fetchData` closure — so download the bytes
+    // ourselves as a last resort. Without them we can only emit a raw remote
+    // `image_url`, which AWS Bedrock (mantle) rejects (it accepts only `data:`
+    // and `s3://` schemes); inlining as a `data:` URL works on every provider.
+    const data =
+      attachment.data ??
+      (await attachment.fetchData?.()) ??
+      (await fetchAttachmentData(attachment.url, fetchFn));
     if (data) {
       // Re-check the actual byte count: Discord size metadata can be absent.
       const byteLength = Buffer.isBuffer(data) ? data.length : data.size;
@@ -342,6 +360,20 @@ async function serializeAttachment(
   }
 
   return serialized;
+}
+
+async function fetchAttachmentData(
+  url: string | undefined,
+  fetchFn: typeof fetch,
+): Promise<Buffer | undefined> {
+  if (!url) return undefined;
+  const response = await fetchFn(url);
+  if (!response.ok) {
+    throw new Error(
+      `failed to download attachment (${response.status} ${response.statusText})`,
+    );
+  }
+  return Buffer.from(await response.arrayBuffer());
 }
 
 function attachmentTooLargeError(bytes: number): string {
@@ -408,7 +440,7 @@ async function executeSession(
   const body: DiscordbotExecuteSessionRequest = {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: "execute" }),
-    input_lines: [toCodexInputLine(message, threadId)],
+    input_lines: toCodexInputLines(message, threadId),
     ...(options.idleTimeoutMs === undefined
       ? {}
       : { idle_timeout_ms: options.idleTimeoutMs }),
@@ -522,13 +554,27 @@ function sessionMessageParts(message: DiscordbotApiMessage): JsonValue[] {
     parts.push({ type: "text", text: message.text });
   }
   for (const attachment of message.attachments) {
-    parts.push({
-      ...attachment,
-      attachment_type: attachment.type,
-      type: "attachment",
-    });
+    parts.push(sessionAttachmentPart(attachment));
   }
   return parts.length > 0 ? parts : [{ type: "text", text: "" }];
+}
+
+function sessionAttachmentPart(attachment: DiscordbotApiAttachment): JsonObject {
+  const part: JsonObject = {
+    ...attachment,
+    attachment_type: attachment.type,
+    type: "attachment",
+  };
+  // Don't persist megabytes of base64 in the stored session message; the
+  // executing turn delivers the bytes separately (inline or staged chunks).
+  if (
+    typeof attachment.dataBase64 === "string" &&
+    attachment.dataBase64.length > MAX_CODEX_INPUT_LINE_CHARS
+  ) {
+    delete part.dataBase64;
+    part.dataBase64Omitted = `${attachment.dataBase64.length} base64 chars omitted from stored session message`;
+  }
+  return part;
 }
 
 function sessionMetadata(
@@ -548,9 +594,39 @@ function sessionMetadata(
   };
 }
 
-function toCodexInputLine(
+/**
+ * Build the codex input lines for an execute turn. Attachments whose inlined
+ * `data:` URL would push the user-message line past `MAX_CODEX_INPUT_LINE_CHARS`
+ * are streamed ahead of it as `attachment.chunk` lines and referenced by a
+ * staged attachment id; everything else stays inline. Mirrors slackbotv2.
+ */
+export function toCodexInputLines(
   message: DiscordbotApiMessage,
   threadId: string,
+): string[] {
+  const staged = new Map<DiscordbotApiAttachment, string>();
+  const lines: string[] = [];
+  for (const attachment of message.attachments) {
+    if (!attachment.dataBase64) continue;
+    const inlineLine = toCodexInputLineWithStaged(message, threadId, staged);
+    if (
+      inlineLine.length <= MAX_CODEX_INPUT_LINE_CHARS &&
+      attachment.dataBase64.length <= MAX_CODEX_INPUT_LINE_CHARS
+    ) {
+      continue;
+    }
+    const stagedAttachmentId = `att-${message.id}-${staged.size + 1}`;
+    staged.set(attachment, stagedAttachmentId);
+    lines.push(...stagedAttachmentInputLines(attachment, stagedAttachmentId));
+  }
+  lines.push(toCodexInputLineWithStaged(message, threadId, staged));
+  return lines;
+}
+
+function toCodexInputLineWithStaged(
+  message: DiscordbotApiMessage,
+  threadId: string,
+  staged: Map<DiscordbotApiAttachment, string>,
 ): string {
   return JSON.stringify({
     type: "user",
@@ -558,23 +634,71 @@ function toCodexInputLine(
     trace_metadata: sessionMetadata(message, { action: "execute" }),
     message: {
       role: "user",
-      content: codexInputContent(message),
+      content: codexInputContent(message, staged),
     },
   });
 }
 
-function codexInputContent(message: DiscordbotApiMessage): JsonValue[] {
+function stagedAttachmentInputLines(
+  attachment: DiscordbotApiAttachment,
+  stagedAttachmentId: string,
+): string[] {
+  const dataBase64 = attachment.dataBase64;
+  if (!dataBase64) return [];
+  const lines: string[] = [];
+  // Keep chunks on a base64 boundary (multiple of 4) so each decodes cleanly.
+  const chunkSize =
+    STAGED_ATTACHMENT_CHUNK_CHARS - (STAGED_ATTACHMENT_CHUNK_CHARS % 4);
+  for (
+    let offset = 0, index = 0;
+    offset < dataBase64.length;
+    offset += chunkSize, index += 1
+  ) {
+    const chunk = dataBase64.slice(offset, offset + chunkSize);
+    lines.push(
+      JSON.stringify({
+        type: "attachment.chunk",
+        attachmentId: stagedAttachmentId,
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        attachmentType: attachment.type,
+        chunkIndex: index,
+        final: offset + chunkSize >= dataBase64.length,
+        dataBase64: chunk,
+      }),
+    );
+  }
+  return lines;
+}
+
+function codexInputContent(
+  message: DiscordbotApiMessage,
+  staged: Map<DiscordbotApiAttachment, string> = new Map(),
+): JsonValue[] {
   const content: JsonValue[] = [];
   if (message.text.trim()) {
     content.push({ type: "text", text: message.text });
   }
   for (const attachment of message.attachments) {
-    content.push(codexAttachmentInput(attachment));
+    content.push(codexAttachmentInput(attachment, staged.get(attachment)));
   }
   return content.length > 0 ? content : [{ type: "text", text: "continue" }];
 }
 
-function codexAttachmentInput(attachment: DiscordbotApiAttachment): JsonValue {
+export function codexAttachmentInput(
+  attachment: DiscordbotApiAttachment,
+  stagedAttachmentId?: string,
+): JsonValue {
+  if (stagedAttachmentId) {
+    return {
+      type: "attachment",
+      attachment_type: attachment.type,
+      stagedAttachmentId,
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      size: attachment.size,
+    };
+  }
   const dataUrl =
     attachment.dataBase64 && attachment.mimeType
       ? `data:${attachment.mimeType};base64,${attachment.dataBase64}`
@@ -585,6 +709,16 @@ function codexAttachmentInput(attachment: DiscordbotApiAttachment): JsonValue {
       url: dataUrl ?? attachment.url,
       detail: "auto",
       name: attachment.name,
+    };
+  }
+  if (attachment.dataBase64) {
+    return {
+      type: "attachment",
+      attachment_type: attachment.type,
+      dataBase64: attachment.dataBase64,
+      mimeType: attachment.mimeType,
+      name: attachment.name,
+      size: attachment.size,
     };
   }
   return {
@@ -599,7 +733,9 @@ function attachmentDescription(attachment: DiscordbotApiAttachment): string {
     `type=${attachment.type}`,
     attachment.mimeType ? `mime=${attachment.mimeType}` : undefined,
     attachment.url ? `url=${attachment.url}` : undefined,
-    attachment.dataBase64 ? `base64=${attachment.dataBase64}` : undefined,
+    attachment.dataBase64Omitted
+      ? `content=${attachment.dataBase64Omitted}`
+      : undefined,
     attachment.fetchError ? `fetch_error=${attachment.fetchError}` : undefined,
   ].filter(Boolean);
   return `[Discord attachment: ${fields.join(" ")}]`;

--- a/services/discordbot/src/types.ts
+++ b/services/discordbot/src/types.ts
@@ -17,6 +17,7 @@ export type DiscordbotApiAuthor = {
 
 export type DiscordbotApiAttachment = {
   dataBase64?: string;
+  dataBase64Omitted?: string;
   fetchError?: string;
   fetchMetadata?: Record<string, string>;
   height?: number;

--- a/services/discordbot/test/chat-sdk-emulate.test.ts
+++ b/services/discordbot/test/chat-sdk-emulate.test.ts
@@ -146,15 +146,15 @@ describe("discordbot", () => {
     expect(firstAttachment).toEqual(
       expect.objectContaining({
         attachment_type: "image",
+        // The Discord adapter exposes only a signed CDN url, so discordbot
+        // downloads the bytes and inlines them as base64 (parity with
+        // slackbotv2) rather than forwarding the raw remote url.
+        dataBase64: Buffer.from("fake-binary").toString("base64"),
         mimeType: "image/png",
         name: "captured.png",
         type: "attachment",
         url: fileUrl,
       }),
-    );
-    // Discord delta: attachments forward by URL, never inlined as base64.
-    expect((firstAttachment as Record<string, unknown>).dataBase64).toBe(
-      undefined,
     );
 
     const firstExecute = codexApi.executes[0]!;
@@ -166,7 +166,7 @@ describe("discordbot", () => {
     expect(firstInputLine).toEqual(
       expect.objectContaining({ type: "user", thread_key: key }),
     );
-    expect(JSON.stringify(firstInputLine)).toContain(fileUrl);
+    expect(JSON.stringify(firstInputLine)).toContain("data:image/png;base64");
 
     const followUpAppend = codexApi.appends[1]!;
     expect(followUpAppend.body.messages[0]?.client_message_id).toBe(followUpId);

--- a/services/discordbot/test/session-api.test.ts
+++ b/services/discordbot/test/session-api.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "bun:test";
+import type { Attachment } from "chat";
 import {
+  codexAttachmentInput,
   forwardToSessionApi,
   isContentlessApiMessage,
   isDiscordPermissionError,
   isRetryableSessionApiError,
+  MAX_INLINE_ATTACHMENT_BYTES,
+  serializeAttachment,
   SessionApiError,
+  toCodexInputLines,
 } from "../src/session-api";
 import type {
   DiscordbotApiMessage,
@@ -12,6 +17,12 @@ import type {
   DiscordbotOptions,
   ForwardSessionInput,
 } from "../src/types";
+
+type JsonRecord = Record<string, unknown>;
+
+function bytesResponse(body: Buffer): Response {
+  return new Response(new Uint8Array(body), { status: 200 });
+}
 
 function apiMessage(
   overrides: Partial<DiscordbotApiMessage> = {},
@@ -200,5 +211,171 @@ describe("isContentlessApiMessage", () => {
         apiMessage({ text: "", attachments: [{ type: "image" }] }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("serializeAttachment", () => {
+  it("downloads the CDN url and inlines as base64 when the adapter supplies no bytes", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]);
+    let requestedUrl: string | undefined;
+    const fetchFn = (async (url: string) => {
+      requestedUrl = url;
+      return bytesResponse(png);
+    }) as unknown as typeof fetch;
+    const attachment = {
+      type: "image",
+      url: "https://cdn.discordapp.com/attachments/1/2/image.png?ex=1&hm=2",
+      name: "image.png",
+      mimeType: "image/png",
+      size: png.length,
+    } as Attachment;
+
+    const result = await serializeAttachment(attachment, fetchFn);
+
+    expect(requestedUrl).toBe(attachment.url);
+    expect(result.dataBase64).toBe(png.toString("base64"));
+    expect(result.fetchError).toBeUndefined();
+  });
+
+  it("prefers adapter-provided bytes over a network fetch", async () => {
+    const data = Buffer.from("hello world");
+    let fetched = false;
+    const fetchFn = (async () => {
+      fetched = true;
+      return new Response("x", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await serializeAttachment(
+      { type: "image", mimeType: "image/png", data } as Attachment,
+      fetchFn,
+    );
+
+    expect(fetched).toBe(false);
+    expect(result.dataBase64).toBe(data.toString("base64"));
+  });
+
+  it("skips the download and records fetchError when over the size limit", async () => {
+    const fetchFn = (async () => {
+      throw new Error("should not be called");
+    }) as unknown as typeof fetch;
+
+    const result = await serializeAttachment(
+      {
+        type: "image",
+        url: "https://cdn.discordapp.com/x.png",
+        size: MAX_INLINE_ATTACHMENT_BYTES + 1,
+      } as Attachment,
+      fetchFn,
+    );
+
+    expect(result.dataBase64).toBeUndefined();
+    expect(result.fetchError).toContain("too large");
+  });
+
+  it("records fetchError when the download fails", async () => {
+    const fetchFn = (async () =>
+      new Response("nope", {
+        status: 403,
+        statusText: "Forbidden",
+      })) as unknown as typeof fetch;
+
+    const result = await serializeAttachment(
+      {
+        type: "image",
+        url: "https://cdn.discordapp.com/x.png",
+        mimeType: "image/png",
+      } as Attachment,
+      fetchFn,
+    );
+
+    expect(result.dataBase64).toBeUndefined();
+    expect(result.fetchError).toContain("403");
+  });
+});
+
+describe("codexAttachmentInput", () => {
+  it("inlines an image with bytes as a data: URL, never a remote url", () => {
+    const out = codexAttachmentInput({
+      type: "image",
+      mimeType: "image/png",
+      dataBase64: "QUJD",
+      url: "https://cdn.discordapp.com/x.png",
+      name: "image.png",
+    }) as JsonRecord;
+    expect(out.type).toBe("image");
+    expect(out.url).toBe("data:image/png;base64,QUJD");
+  });
+
+  it("references a staged attachment id instead of inlining", () => {
+    const out = codexAttachmentInput(
+      { type: "image", mimeType: "image/png", dataBase64: "QUJD" },
+      "att-m1-1",
+    ) as JsonRecord;
+    expect(out).toMatchObject({
+      type: "attachment",
+      stagedAttachmentId: "att-m1-1",
+    });
+    expect(out.dataBase64).toBeUndefined();
+    expect(out.url).toBeUndefined();
+  });
+
+  it("falls back to the raw url only when no bytes are available", () => {
+    const out = codexAttachmentInput({
+      type: "image",
+      url: "https://cdn.discordapp.com/x.png",
+    }) as JsonRecord;
+    expect(out.url).toBe("https://cdn.discordapp.com/x.png");
+  });
+});
+
+describe("toCodexInputLines", () => {
+  it("inlines a small image in a single user line as a data: URL", () => {
+    const message = apiMessage({
+      attachments: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          dataBase64: "QUJD",
+          name: "image.png",
+        },
+      ],
+    });
+
+    const lines = toCodexInputLines(message, message.threadId);
+
+    expect(lines).toHaveLength(1);
+    const content = JSON.parse(lines[0]!).message.content as JsonRecord[];
+    const image = content.find((part) => part.type === "image");
+    expect(image?.url).toBe("data:image/png;base64,QUJD");
+  });
+
+  it("stages a large image as chunk lines plus a referencing user line", () => {
+    const dataBase64 = Buffer.alloc(700 * 1024, 1).toString("base64");
+    const message = apiMessage({
+      attachments: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          dataBase64,
+          name: "image.png",
+        },
+      ],
+    });
+
+    const lines = toCodexInputLines(message, message.threadId);
+
+    expect(lines.length).toBeGreaterThan(1);
+    const chunks = lines.slice(0, -1).map((line) => JSON.parse(line));
+    expect(chunks.every((c) => c.type === "attachment.chunk")).toBe(true);
+    expect(chunks.at(-1).final).toBe(true);
+    // The chunks must reassemble to the original base64 payload.
+    expect(chunks.map((c) => c.dataBase64).join("")).toBe(dataBase64);
+
+    const lastLine = lines[lines.length - 1]!;
+    const content = JSON.parse(lastLine).message.content as JsonRecord[];
+    const ref = content.find((part) => part.type === "attachment");
+    expect(ref?.stagedAttachmentId).toBe(chunks[0].attachmentId);
+    // The huge payload must NOT also be inlined in the user line.
+    expect(lastLine.length).toBeLessThan(dataBase64.length);
   });
 });


### PR DESCRIPTION
## Summary

`slackbotv2` downloads attachment bytes and inlines them as a `data:` URL, but `discordbot` doesn't - it relies on `attachment.data` / `attachment.fetchData`, which the Discord chat adapter never populates. The adapter exposes only a public (signed) CDN `url`, so `serializeAttachment` never sets `dataBase64` and `codexAttachmentInput` always emits the raw `https://cdn.discordapp.com/...` URL as the model `image_url`.

That only works for model providers that fetch remote image URLs server-side, and even then it depends on a short-lived signed CDN link being reachable at request time. Providers that require inline image data reject it outright, including AWS Bedrock

This brings `discordbot` attachment handling to parity with `slackbotv2`.

## Testing
We currently have this deployed on our instance.

### Before:
<img width="1032" height="867" alt="Screenshot 2026-06-23 at 12 07 09 PM" src="https://github.com/user-attachments/assets/2e5f840b-7d0a-4eb2-92ab-b5f1121e4070" />

### After:
<img width="1219" height="571" alt="Screenshot 2026-06-23 at 12 05 51 PM" src="https://github.com/user-attachments/assets/511c9125-83fe-4de1-adaf-b46182db04c8" />