### PR TITLE
[codex] Seal rotated Slack progress segments

### DIFF
--- a/patches/@chat-adapter__slack@4.31.0.patch
+++ b/patches/@chat-adapter__slack@4.31.0.patch
@@ -572,7 +572,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +          continue;
 +        }
 +        try {
-+          await stopSegment(segment, void 0, false, false);
++          await stopSegment(segment, void 0, false, true);
 +        } catch (stopError) {
 +          if (segment.length > 0) {
 +            throw stopError;

--- a/patches/@chat-adapter__slack@4.31.0.patch
+++ b/patches/@chat-adapter__slack@4.31.0.patch
@@ -219,7 +219,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
  
  // src/cards.ts
  import {
-@@ -3434,26 +3644,216 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3452,26 +3662,251 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -239,6 +239,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +      stopped: false,
 +      taskChars: /* @__PURE__ */ new Map(),
 +      taskCharsTotal: 0,
++      tasks: /* @__PURE__ */ new Map(),
 +      streamer: this._client.chatStream({
 +        channel,
 +        thread_ts: threadTs,
@@ -264,12 +265,42 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
        wrapTablesForAppend: false
      });
 +    const isExpired = (segment) => Date.now() - segment.startedAt >= streamSegmentMaxAgeMs();
-+    const stopSegment = async (segment, blocks, force = false) => {
++    const taskIsOpen = (chunk) => chunk.type === "task_update" && (chunk.status === "in_progress" || chunk.status === "pending");
++    const appendSegmentTaskChunk = async (segment, chunk) => {
++      await segment.streamer.append({ chunks: [chunk], token });
++      segment.hasContent = true;
++      const key = chunk.id;
++      const size = taskChunkChars(chunk);
++      const previous = segment.taskChars.get(key) ?? 0;
++      if (size > previous) {
++        segment.taskCharsTotal += size - previous;
++        segment.taskChars.set(key, size);
++      }
++      segment.tasks.set(key, chunk);
++    };
++    const completeSegmentOpenTasks = async (segment) => {
++      if (segment.stopped) {
++        return;
++      }
++      for (const task of Array.from(segment.tasks.values())) {
++        if (!taskIsOpen(task)) {
++          continue;
++        }
++        await appendSegmentTaskChunk(segment, {
++          ...task,
++          status: "complete"
++        });
++      }
++    };
++    const stopSegment = async (segment, blocks, force = false, sealProgress = true) => {
 +      if (segment.stopped || !(segment.hasContent || force)) {
 +        return void 0;
 +      }
 +      let result;
 +      try {
++        if (sealProgress) {
++          await completeSegmentOpenTasks(segment);
++        }
 +        result = await segment.streamer.stop({
 +          token,
 +          ...blocks ? { blocks } : {}
@@ -394,6 +425,10 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
      };
      let structuredChunksSupported = true;
 +    const appendStructuredChunk = async (segment, chunk) => {
++      if (chunk.type === "task_update") {
++        await appendSegmentTaskChunk(segment, chunk);
++        return;
++      }
 +      await segment.streamer.append({ chunks: [chunk], token });
 +      segment.hasContent = true;
 +      if (chunk.type === "task_update" || chunk.type === "plan_update") {
@@ -445,7 +480,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
      const sendStructuredChunk = async (chunk) => {
        if (!structuredChunksSupported) {
          return;
-@@ -3463,8 +3863,45 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3481,8 +3916,45 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
@@ -492,7 +527,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
          structuredChunksSupported = false;
          this.logger.warn(
            "Structured streaming chunk failed, falling back to text-only streaming. Ensure your Slack app manifest includes assistant_view, assistant:write scope, and @slack/web-api >= 7.14.0",
-@@ -3479,31 +3916,91 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3497,31 +3969,91 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
      };
@@ -537,7 +572,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +          continue;
 +        }
 +        try {
-+          await stopSegment(segment);
++          await stopSegment(segment, void 0, false, false);
 +        } catch (stopError) {
 +          if (segment.length > 0) {
 +            throw stopError;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 8f4fbb770159f924570fbad681297fcb9f8f7a6353a705cfcb78e39ef9e3a3ab
     path: patches/@chat-adapter__discord@4.31.0.patch
   '@chat-adapter/slack@4.31.0':
-    hash: c6d5fad9bae6bed345249a5b0af50e549afc4a5f9c4edcbe99c51d166b0185c1
+    hash: 7da250cea3e8a84e3fc21314f7be2059496de2add5724287495c3a1b5b1ef21b
     path: patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
@@ -128,7 +128,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.31.0
-        version: 4.31.0(patch_hash=c6d5fad9bae6bed345249a5b0af50e549afc4a5f9c4edcbe99c51d166b0185c1)(zod@4.4.3)
+        version: 4.31.0(patch_hash=7da250cea3e8a84e3fc21314f7be2059496de2add5724287495c3a1b5b1ef21b)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
@@ -1279,7 +1279,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.31.0(patch_hash=c6d5fad9bae6bed345249a5b0af50e549afc4a5f9c4edcbe99c51d166b0185c1)(zod@4.4.3)':
+  '@chat-adapter/slack@4.31.0(patch_hash=7da250cea3e8a84e3fc21314f7be2059496de2add5724287495c3a1b5b1ef21b)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 8f4fbb770159f924570fbad681297fcb9f8f7a6353a705cfcb78e39ef9e3a3ab
     path: patches/@chat-adapter__discord@4.31.0.patch
   '@chat-adapter/slack@4.31.0':
-    hash: f656c319fc04061edbaf3a94ae5d46cbed31057d1057cad70748abb12ef4e151
+    hash: c6d5fad9bae6bed345249a5b0af50e549afc4a5f9c4edcbe99c51d166b0185c1
     path: patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
@@ -128,7 +128,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.31.0
-        version: 4.31.0(patch_hash=f656c319fc04061edbaf3a94ae5d46cbed31057d1057cad70748abb12ef4e151)(zod@4.4.3)
+        version: 4.31.0(patch_hash=c6d5fad9bae6bed345249a5b0af50e549afc4a5f9c4edcbe99c51d166b0185c1)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
@@ -1279,7 +1279,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.31.0(patch_hash=f656c319fc04061edbaf3a94ae5d46cbed31057d1057cad70748abb12ef4e151)(zod@4.4.3)':
+  '@chat-adapter/slack@4.31.0(patch_hash=c6d5fad9bae6bed345249a5b0af50e549afc4a5f9c4edcbe99c51d166b0185c1)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1567,6 +1567,99 @@ describe('slackbotv2', () => {
     }
   })
 
+  it('marks open tasks complete before rotating an aged progress segment', async () => {
+    process.env.SLACK_STREAM_SEGMENT_MAX_AGE_MS = '120'
+    try {
+      codexApi.autoRespond = false
+
+      const parent = await postUserMessage('Context before an aged open task.')
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> keep thinking`, parent.ts)
+      const key = threadKey(parent.ts)
+      const waits: Promise<unknown>[] = []
+      const response = await bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: 'Ev-slackbotv2-open-task-age-rotation',
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parent.ts,
+            text: `<@${BOT_USER_ID}> keep thinking`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+
+      expect(response.status).toBe(200)
+      await waitFor(() => codexApi.executes.length === 1)
+      await waitFor(() => codexApi.eventRequests.length === 1)
+      await waitFor(() => codexApi.streamCount === 1)
+
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.started',
+          item: {
+            id: 'cmd-aging-open',
+            type: 'commandExecution',
+            command: `sleep 1 # ${'x'.repeat(300)}`,
+            status: 'inProgress'
+          }
+        })
+      )
+      await waitFor(() =>
+        slackApi.calls.some(call =>
+          streamChunks(call.body.chunks).some(
+            chunk => chunk.id === 'cmd-aging-open' && chunk.status === 'in_progress'
+          )
+        )
+      )
+
+      await new Promise(resolve => setTimeout(resolve, 250))
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: 'cmd-aging-open',
+            type: 'commandExecution',
+            command: 'sleep 1',
+            status: 'completed',
+            aggregatedOutput: ''
+          }
+        })
+      )
+      codexApi.emitSessionEvent(key, 'session.execution_completed', {
+        execution_id: 'exe-open-task-age-rotation',
+        status: 'completed',
+        result_text: 'OPEN_TASK_AGE_ROTATION_OK'
+      })
+
+      await Promise.all(waits)
+      const transcripts = slackStreamTranscripts(slackApi.calls)
+      expect(transcripts.length).toBeGreaterThan(1)
+      const taskTranscripts = transcripts.filter(transcript =>
+        transcript.chunks.some(chunk => chunk.type === 'task_update' && chunk.id === 'cmd-aging-open')
+      )
+      expect(taskTranscripts.length).toBeGreaterThan(0)
+      for (const transcript of taskTranscripts) {
+        const statuses = transcript.chunks
+          .filter(chunk => chunk.type === 'task_update' && chunk.id === 'cmd-aging-open')
+          .map(chunk => stringField(chunk.status))
+        expect(statuses[statuses.length - 1]).toBe('complete')
+      }
+      const texts = await threadTexts(parent.ts)
+      expect(texts.some(text => text.includes(BROKEN_STREAM_TEXT))).toBe(false)
+      expect(texts.filter(text => text.includes('OPEN_TASK_AGE_ROTATION_OK'))).toHaveLength(1)
+    } finally {
+      delete process.env.SLACK_STREAM_SEGMENT_MAX_AGE_MS
+    }
+  })
+
   it('rotates structured plan segments before they exceed the task char budget', async () => {
     process.env.SLACK_STREAM_SEGMENT_TASK_CHAR_BUDGET = '400'
     try {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1736,6 +1736,101 @@ describe('slackbotv2', () => {
     }
   })
 
+  it('seals open tasks before stopping older structured progress segments', async () => {
+    process.env.SLACK_STREAM_SEGMENT_TASK_CHAR_BUDGET = '520'
+    try {
+      codexApi.autoRespond = false
+
+      const parent = await postUserMessage('Context before an open card spillover.')
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> keep one step open`, parent.ts)
+      const key = threadKey(parent.ts)
+      const waits: Promise<unknown>[] = []
+      const response = await bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: 'Ev-slackbotv2-open-task-structured-spillover',
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parent.ts,
+            text: `<@${BOT_USER_ID}> keep one step open`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+
+      expect(response.status).toBe(200)
+      await waitFor(() => codexApi.executes.length === 1)
+      await waitFor(() => codexApi.eventRequests.length === 1)
+      await waitFor(() => codexApi.streamCount === 1)
+
+      codexApi.emitOutputLine(
+        key,
+        JSON.stringify({
+          type: 'item.started',
+          item: {
+            id: 'cmd-open-spillover',
+            type: 'commandExecution',
+            command: `sleep 1 # ${'x'.repeat(220)}`,
+            status: 'inProgress'
+          }
+        })
+      )
+      await waitFor(() =>
+        slackApi.calls.some(call =>
+          streamChunks(call.body.chunks).some(
+            chunk => chunk.id === 'cmd-open-spillover' && chunk.status === 'in_progress'
+          )
+        )
+      )
+
+      for (let index = 1; index <= 4; index += 1) {
+        codexApi.emitOutputLine(
+          key,
+          JSON.stringify({
+            type: 'item.completed',
+            item: {
+              id: `cmd-spillover-${index}`,
+              type: 'commandExecution',
+              command: `printf spillover-${index} ${'x'.repeat(220)}`,
+              status: 'completed',
+              aggregatedOutput: ''
+            }
+          })
+        )
+      }
+      codexApi.emitSessionEvent(key, 'session.execution_completed', {
+        execution_id: 'exe-open-task-structured-spillover',
+        status: 'completed',
+        result_text: 'OPEN_TASK_STRUCTURED_SPILLOVER_OK'
+      })
+
+      await Promise.all(waits)
+      const transcripts = slackStreamTranscripts(slackApi.calls)
+      expect(transcripts.length).toBeGreaterThanOrEqual(2)
+      const taskTranscripts = transcripts.filter(transcript =>
+        transcript.chunks.some(
+          chunk => chunk.type === 'task_update' && chunk.id === 'cmd-open-spillover'
+        )
+      )
+      expect(taskTranscripts.length).toBeGreaterThan(0)
+      for (const transcript of taskTranscripts) {
+        const statuses = transcript.chunks
+          .filter(chunk => chunk.type === 'task_update' && chunk.id === 'cmd-open-spillover')
+          .map(chunk => stringField(chunk.status))
+        expect(statuses).toContain('in_progress')
+        expect(statuses[statuses.length - 1]).toBe('complete')
+      }
+      expect(await threadText(parent.ts)).toContain('OPEN_TASK_STRUCTURED_SPILLOVER_OK')
+    } finally {
+      delete process.env.SLACK_STREAM_SEGMENT_TASK_CHAR_BUDGET
+    }
+  })
+
   it('keeps card-heavy structured streams below Slack finalization payload limits', async () => {
     slackApi.failStreamStopsLongerThan(12_000)
     codexApi.autoRespond = false


### PR DESCRIPTION
## Summary
- Track task state per Slack streaming segment so aged progress messages know which tasks remain open.
- Before normal segment rotation/stop, append completion updates for any still-open tasks so retired progress cards do not show a false failure state.
- Preserve real failure behavior by skipping that sealing path during error cleanup.

## Root cause
A Slack stream segment could rotate while it still contained an in-progress task. The later completion update landed in the next segment, leaving the old progress-only message behind as `Something went wrong` even though the run completed and posted a final answer.

## Validation
- `pnpm install`
- `bun test test/chat-sdk-emulate.test.ts`
- `git diff --check`