### PR TITLE
[codex] Default Claude to Opus 4.8

### DIFF
--- a/harness/claude/settings.json
+++ b/harness/claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-fable-5",
+  "model": "claude-opus-4-8",
   "permissions": {
     "defaultMode": "bypassPermissions",
     "additionalDirectories": [


### PR DESCRIPTION
## Summary

Switches the baked Claude Code default model from `claude-fable-5` to `claude-opus-4-8` in `harness/claude/settings.json`.

## Impact

New sandbox images will default Claude Code turns to Opus 4.8 when no `CLAUDE_MODEL` override or per-turn model is supplied. Explicit Slack aliases and request-level model overrides are unchanged.

## Validation

- `jq . harness/claude/settings.json`
- `just build-one sandbox`
- `docker run --rm --entrypoint cat centaur-agent:latest /home/agent/harness/claude/settings.json`
- `kubectl --context orbstack -n centaur run claude-settings-check --image=centaur-agent:latest --restart=Never --image-pull-policy=IfNotPresent --attach --rm --quiet --command -- sh -lc 'jq -r .model /home/agent/harness/claude/settings.json'` -> `claude-opus-4-8`

Note: I did not run `just deploy` because the active kubectl context was `prd-centaur-na.tail388b2e.ts.net`; validation used explicit local `orbstack` context instead.
