### PR TITLE
[codex] Fix Twitter X API secret metadata

### DIFF
--- a/tools/comms/twitter/pyproject.toml
+++ b/tools/comms/twitter/pyproject.toml
@@ -25,4 +25,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "X_API_KEY", mode = "inject", inject_header = ["Authorization"], hosts = ["api.x.com"]}]
+secrets = [{type = "http", name = "X_API_KEY", mode = "inject", inject_header = "Authorization", hosts = ["api.x.com"]}]


### PR DESCRIPTION
## Summary

Fix the Twitter/X tool metadata so `X_API_KEY` is registered as an injected HTTP secret for `api.x.com`.

The Twitter tool was using `inject_header = ["Authorization"]`, but api-rs tool discovery expects `inject_header` to be a scalar string. Because of that shape mismatch, prod logged `api-rs tool invalid secret metadata` for the Twitter tool and skipped registering the X API secret/rule in iron-control.

## Impact

After rollout and reconciliation, sandboxes should get a proper proxy rule for `X_API_KEY` on `api.x.com` instead of sending the placeholder bearer token and receiving `401 Unauthorized` from X.

## Validation

- `python3 -c "import tomllib; tomllib.load(open('tools/comms/twitter/pyproject.toml','rb'))"`
- `git diff --check`

Prompted by: @Zygimantass