### PR TITLE
Fix Twitter X API bearer injection

### DIFF
--- a/tools/comms/twitter/pyproject.toml
+++ b/tools/comms/twitter/pyproject.toml
@@ -25,4 +25,4 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-secrets = [{type = "http", name = "X_API_KEY", mode = "inject", inject_header = "Authorization", hosts = ["api.x.com"]}]
+secrets = [{type = "http", name = "X_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.x.com"]}]


### PR DESCRIPTION
## Summary
- add the missing Bearer formatter for the Twitter/X API injected Authorization header
- keeps the follow-up scoped to tools/comms/twitter/pyproject.toml only

## Evidence
- Slack thread: https://tempoxyz.slack.com/archives/C0B1NNXKE4F/p1782216008206169?thread_ts=1782215948.100219&cid=C0B1NNXKE4F
- Live proxy audit after PR #711 showed `op://centaur-agent/X_API_KEY/credential` injected into `header:Authorization`, but X still returned 401.
- The Python client sends `Authorization: Bearer <X_API_KEY>`, so the proxy-injected raw value needs the same formatter.

## Validation
- Parsed `tools/comms/twitter/pyproject.toml` with Python `tomllib`.
- `git diff --check`

Prompted by: @Zygimantass