### PR TITLE
[codex] Fix Slack inbound display text fallback

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -22,6 +22,7 @@ import {
 } from '@centaur/rendering'
 import { conflateChatSdkStream } from './conflate'
 import { observeSeconds, slackbotMetrics } from './metrics'
+import { renderSlackDisplayText, slackMessagePromptText } from './slack-display-text'
 import {
   collectInitialContext,
   forwardToSessionApi,
@@ -540,7 +541,7 @@ async function syncThreadMessageToSession(
   const serializeStartedAtMs = nowMs()
   const serializedMessage = await serializeMessage(message)
   const overrides = extractMessageOverrides(serializedMessage.text)
-  serializedMessage.text = overrides.cleanedText
+  setMessageText(serializedMessage, overrides.cleanedText)
   if (overrides.harnessType || overrides.model || overrides.provider || overrides.reasoning) {
     traceLog(input.options, 'slackbotv2_forward_overrides_parsed', trace, {
       harness_type: overrides.harnessType,
@@ -551,6 +552,10 @@ async function syncThreadMessageToSession(
   }
   traceLog(input.options, 'slackbotv2_forward_message_serialized', trace, {
     attachment_count: serializedMessage.attachments.length,
+    raw_slack_attachment_count: serializedMessage.rawSlackAttachmentCount,
+    raw_slack_block_count: serializedMessage.rawSlackBlockCount,
+    slack_display_text_chars: slackMessagePromptText(serializedMessage).length,
+    slack_text_source: serializedMessage.displayTextSource,
     phase_ms: elapsedMs(serializeStartedAtMs)
   })
   let context: SlackbotV2ApiMessage[] | undefined
@@ -563,7 +568,7 @@ async function syncThreadMessageToSession(
     // collectInitialContext re-serializes the current message; mirror the
     // flag-stripped text on that copy too.
     for (const item of context) {
-      if (item.id === serializedMessage.id) item.text = serializedMessage.text
+      if (item.id === serializedMessage.id) copyMessageTextFields(item, serializedMessage)
     }
     traceLog(input.options, 'slackbotv2_forward_context_collected', trace, {
       message_count: context.length,
@@ -813,6 +818,23 @@ function scheduleExecutionRender(
     }
   })()
   backgroundWaitUntil(promise)
+}
+
+function setMessageText(message: SlackbotV2ApiMessage, text: string): void {
+  const displayText = renderSlackDisplayText({ raw: message.raw, text })
+  message.text = text
+  message.displayText = displayText.text
+  message.displayTextSource = displayText.source
+  message.rawSlackAttachmentCount = displayText.rawAttachmentCount
+  message.rawSlackBlockCount = displayText.rawBlockCount
+}
+
+function copyMessageTextFields(target: SlackbotV2ApiMessage, source: SlackbotV2ApiMessage): void {
+  target.text = source.text
+  target.displayText = source.displayText
+  target.displayTextSource = source.displayTextSource
+  target.rawSlackAttachmentCount = source.rawSlackAttachmentCount
+  target.rawSlackBlockCount = source.rawSlackBlockCount
 }
 
 async function renderExecutionAttempt(
@@ -1649,7 +1671,8 @@ async function renderExecutionStream(
   trace?: SlackbotV2Trace,
   assistantStatusVisible = false
 ): Promise<{ diverged: boolean; messageId?: string }> {
-  if (isPlainTextOnlyRequest(message.text)) {
+  const promptText = slackMessagePromptText(message)
+  if (isPlainTextOnlyRequest(promptText)) {
     await renderPlainTextExecutionStream(
       thread,
       stream,
@@ -1661,7 +1684,7 @@ async function renderExecutionStream(
     return { diverged: false }
   }
   const titleStartedAtMs = nowMs()
-  await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
+  await setAssistantTitle(thread, titleFromMessage(promptText, options.userName))
   if (!assistantStatusVisible) {
     await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   }
@@ -1705,12 +1728,13 @@ async function renderRecoveredExecutionStream(
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace
 ): Promise<{ diverged: boolean; messageId?: string }> {
-  if (isPlainTextOnlyRequest(message.text)) {
+  const promptText = slackMessagePromptText(message)
+  if (isPlainTextOnlyRequest(promptText)) {
     await renderPlainTextExecutionStream(thread, stream, message, options, trace)
     return { diverged: false }
   }
   const titleStartedAtMs = nowMs()
-  await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
+  await setAssistantTitle(thread, titleFromMessage(promptText, options.userName))
   await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   traceLog(options, 'slackbotv2_render_slack_metadata_set', trace, {
     phase_ms: elapsedMs(titleStartedAtMs)
@@ -1753,7 +1777,7 @@ async function renderPlainTextExecutionStream(
 ): Promise<void> {
   const fallback = new SlackRenderFallback()
   const titleStartedAtMs = nowMs()
-  await setAssistantTitle(thread, titleFromMessage(message.text, options.userName))
+  await setAssistantTitle(thread, titleFromMessage(slackMessagePromptText(message), options.userName))
   if (!assistantStatusVisible) {
     await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   }
@@ -2040,6 +2064,8 @@ async function slackApiMessageFromSlack(
   const id = stringField(message.ts) || randomUUID()
   const actorId = slackActorId(message)
   const isBot = Boolean(message.bot_id || message.bot_profile)
+  const text = normalizeSlackText(stringField(message.text))
+  const displayText = renderSlackDisplayText({ raw: message, text })
   return {
     attachments: await slackApiAttachmentsFromFiles(options, message, rawCurrent),
     author: {
@@ -2049,15 +2075,19 @@ async function slackApiMessageFromSlack(
       userId: actorId,
       userName: actorId
     },
+    displayText: displayText.text,
+    displayTextSource: displayText.source,
     id,
     isMention: id === currentMessage.id ? currentMessage.isMention === true : false,
     raw: message,
+    rawSlackAttachmentCount: displayText.rawAttachmentCount,
+    rawSlackBlockCount: displayText.rawBlockCount,
     teamId:
       stringField(message.team)
       || stringField(message.team_id)
       || stringField(rawCurrent.team)
       || stringField(rawCurrent.team_id),
-    text: normalizeSlackText(stringField(message.text)),
+    text,
     threadId: currentMessage.threadId,
     timestamp: slackTimestampToIso(id)
   }

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1,5 +1,6 @@
 import type { RustSessionStreamEvent } from '@centaur/harness-events'
 import type { Attachment, Message } from 'chat'
+import { renderSlackDisplayText, slackMessagePromptText } from './slack-display-text'
 import type {
   ForwardSessionInput,
   JsonObject,
@@ -127,6 +128,7 @@ export async function serializeMessage(message: Message): Promise<SlackbotV2ApiM
   for (const attachment of message.attachments) {
     attachments.push(await serializeAttachment(attachment))
   }
+  const displayText = renderSlackDisplayText({ raw: message.raw, text: message.text })
 
   return {
     attachments,
@@ -137,9 +139,13 @@ export async function serializeMessage(message: Message): Promise<SlackbotV2ApiM
       userId: message.author.userId,
       userName: message.author.userName
     },
+    displayText: displayText.text,
+    displayTextSource: displayText.source,
     id: message.id,
     isMention: message.isMention === true,
     raw: message.raw,
+    rawSlackAttachmentCount: displayText.rawAttachmentCount,
+    rawSlackBlockCount: displayText.rawBlockCount,
     teamId: slackTeamId(message.raw) as string,
     text: message.text,
     threadId: message.threadId,
@@ -264,7 +270,7 @@ export function harnessRestartPreamble(
   const lines: string[] = []
   for (const item of history) {
     if (item.id === currentMessageId) continue
-    const text = item.text.trim()
+    const text = slackMessagePromptText(item).trim()
     if (!text) continue
     const author = item.author.isMe
       ? 'assistant'
@@ -943,8 +949,9 @@ function sessionMessageParts(
   if (requesterContext) {
     parts.push({ type: 'text', text: requesterContext })
   }
-  if (message.text.trim()) {
-    parts.push({ type: 'text', text: message.text })
+  const promptText = slackMessagePromptText(message)
+  if (promptText.trim()) {
+    parts.push({ type: 'text', text: promptText })
   }
   for (const attachment of message.attachments) {
     parts.push(sessionAttachmentPart(attachment))
@@ -978,9 +985,24 @@ function sessionMetadata(
     timestamp: message.timestamp,
     user_id: message.author.userId,
     user_name: message.author.userName,
+    ...sessionSlackTextMetadata(message),
     ...sessionRequesterMetadata(message, requesterIdentity),
     ...extra
   }
+}
+
+function sessionSlackTextMetadata(message: SlackbotV2ApiMessage): JsonObject {
+  const fields: JsonObject = {}
+  if (message.displayTextSource) fields.slack_text_source = message.displayTextSource
+  const displayText = slackMessagePromptText(message)
+  if (message.displayTextSource) fields.slack_display_text_chars = displayText.length
+  if (typeof message.rawSlackBlockCount === 'number') {
+    fields.slack_raw_block_count = message.rawSlackBlockCount
+  }
+  if (typeof message.rawSlackAttachmentCount === 'number') {
+    fields.slack_raw_attachment_count = message.rawSlackAttachmentCount
+  }
+  return fields
 }
 
 function toCodexInputLines(
@@ -1179,8 +1201,9 @@ function codexInputContent(
       codexAttachmentInput(contextAttachment.attachment, staged.get(contextAttachment.attachment))
     )
   }
-  if (message.text.trim()) {
-    content.push({ type: 'text', text: message.text })
+  const promptText = slackMessagePromptText(message)
+  if (promptText.trim()) {
+    content.push({ type: 'text', text: promptText })
   }
   for (const attachment of message.attachments) {
     content.push(codexAttachmentInput(attachment, staged.get(attachment)))
@@ -1236,7 +1259,7 @@ function slackContextAuthor(message: SlackbotV2ApiMessage): string {
 }
 
 function slackContextMessageText(message: SlackbotV2ApiMessage): string {
-  const fields = [message.text.trim()]
+  const fields = [slackMessagePromptText(message).trim()]
   for (const attachment of message.attachments) {
     fields.push(attachmentDescription(attachment))
   }

--- a/services/slackbotv2/src/slack-display-text.ts
+++ b/services/slackbotv2/src/slack-display-text.ts
@@ -1,0 +1,322 @@
+export type SlackDisplayTextSource = 'text' | 'raw_blocks' | 'raw_attachments' | 'empty'
+
+export type SlackDisplayText = {
+  rawAttachmentCount: number
+  rawBlockCount: number
+  source: SlackDisplayTextSource
+  text: string
+}
+
+const MAX_RAW_DISPLAY_TEXT_CHARS = 24_000
+
+type UnknownRecord = Record<string, unknown>
+
+export function renderSlackDisplayText(input: { raw: unknown; text: string }): SlackDisplayText {
+  const records = slackMessageRecords(input.raw)
+  const rawBlockCount = countArrayFields(records, 'blocks')
+  const rawAttachmentCount = countArrayFields(records, 'attachments')
+
+  if (input.text.trim()) {
+    return {
+      rawAttachmentCount,
+      rawBlockCount,
+      source: 'text',
+      text: input.text
+    }
+  }
+
+  const blockText = finalizeDisplayLines(collectRawBlockLines(records))
+  if (blockText) {
+    return {
+      rawAttachmentCount,
+      rawBlockCount,
+      source: 'raw_blocks',
+      text: blockText
+    }
+  }
+
+  const attachmentText = finalizeDisplayLines(collectRawAttachmentLines(records))
+  if (attachmentText) {
+    return {
+      rawAttachmentCount,
+      rawBlockCount,
+      source: 'raw_attachments',
+      text: attachmentText
+    }
+  }
+
+  return {
+    rawAttachmentCount,
+    rawBlockCount,
+    source: 'empty',
+    text: ''
+  }
+}
+
+export function slackMessagePromptText(message: {
+  displayText?: string
+  displayTextSource?: SlackDisplayTextSource
+  text: string
+}): string {
+  const source = message.displayTextSource
+  if ((source === 'raw_blocks' || source === 'raw_attachments') && message.displayText) {
+    return message.displayText
+  }
+  return message.text
+}
+
+function slackMessageRecords(raw: unknown): UnknownRecord[] {
+  const records: UnknownRecord[] = []
+  const seen = new Set<UnknownRecord>()
+  const add = (value: unknown): void => {
+    if (!isRecord(value) || seen.has(value)) return
+    records.push(value)
+    seen.add(value)
+  }
+
+  add(raw)
+  if (isRecord(raw)) {
+    add(raw.event)
+    add(raw.message)
+    if (isRecord(raw.event)) add(raw.event.message)
+  }
+  return records
+}
+
+function countArrayFields(records: UnknownRecord[], key: string): number {
+  let count = 0
+  for (const record of records) {
+    const value = record[key]
+    if (Array.isArray(value)) count += value.length
+  }
+  return count
+}
+
+function collectRawBlockLines(records: UnknownRecord[]): string[] {
+  const lines: string[] = []
+  for (const record of records) {
+    const blocks = record.blocks
+    if (!Array.isArray(blocks)) continue
+    for (const block of blocks) collectSlackBlockText(block, lines)
+  }
+  return lines
+}
+
+function collectRawAttachmentLines(records: UnknownRecord[]): string[] {
+  const lines: string[] = []
+  for (const record of records) {
+    const attachments = record.attachments
+    if (!Array.isArray(attachments)) continue
+    for (const attachment of attachments) collectSlackAttachmentText(attachment, lines)
+  }
+  return lines
+}
+
+function collectSlackAttachmentText(value: unknown, lines: string[]): void {
+  if (!isRecord(value)) return
+  collectStringFields(value, lines, ['fallback', 'pretext', 'title', 'text'])
+
+  const fields = value.fields
+  if (Array.isArray(fields)) {
+    for (const field of fields) {
+      if (!isRecord(field)) continue
+      collectStringFields(field, lines, ['title', 'value'])
+    }
+  }
+
+  const blocks = value.blocks
+  if (Array.isArray(blocks)) {
+    for (const block of blocks) collectSlackBlockText(block, lines)
+  }
+}
+
+function collectSlackBlockText(value: unknown, lines: string[]): void {
+  if (!isRecord(value)) return
+  const type = stringField(value.type)
+
+  if (type === 'section') {
+    collectTextObject(value.text, lines)
+    collectTextObjects(value.fields, lines)
+    collectSlackElementText(value.accessory, lines)
+    return
+  }
+
+  if (type === 'context') {
+    collectSlackElementsText(value.elements, lines)
+    return
+  }
+
+  if (type === 'header') {
+    collectTextObject(value.text, lines)
+    return
+  }
+
+  if (type === 'rich_text') {
+    collectRichTextLines(value.elements, lines)
+    return
+  }
+
+  if (type === 'image') {
+    collectTextObject(value.title, lines)
+    collectStringFields(value, lines, ['alt_text'])
+    return
+  }
+
+  if (type === 'actions') {
+    collectSlackElementsText(value.elements, lines)
+    return
+  }
+
+  if (type === 'input') {
+    collectTextObject(value.label, lines)
+    collectTextObject(value.hint, lines)
+    collectSlackElementText(value.element, lines)
+    return
+  }
+
+  collectTextObject(value.text, lines)
+  collectTextObjects(value.fields, lines)
+  collectSlackElementsText(value.elements, lines)
+}
+
+function collectSlackElementsText(value: unknown, lines: string[]): void {
+  if (!Array.isArray(value)) return
+  for (const element of value) collectSlackElementText(element, lines)
+}
+
+function collectSlackElementText(value: unknown, lines: string[]): void {
+  if (!isRecord(value)) return
+  collectTextObject(value.text, lines)
+  collectTextObject(value.placeholder, lines)
+  collectTextObject(value.confirm, lines)
+  collectStringFields(value, lines, ['alt_text'])
+}
+
+function collectTextObjects(value: unknown, lines: string[]): void {
+  if (!Array.isArray(value)) return
+  for (const item of value) collectTextObject(item, lines)
+}
+
+function collectTextObject(value: unknown, lines: string[]): void {
+  if (typeof value === 'string') {
+    lines.push(value)
+    return
+  }
+  if (!isRecord(value)) return
+  const text = value.text
+  if (typeof text === 'string') lines.push(text)
+}
+
+function collectStringFields(
+  record: UnknownRecord,
+  lines: string[],
+  fields: string[]
+): void {
+  for (const field of fields) {
+    const value = record[field]
+    if (typeof value === 'string') lines.push(value)
+  }
+}
+
+function collectRichTextLines(value: unknown, lines: string[]): void {
+  if (!Array.isArray(value)) return
+  for (const element of value) {
+    const text = richTextElementText(element)
+    if (text) lines.push(text)
+  }
+}
+
+function richTextElementText(value: unknown): string {
+  if (!isRecord(value)) return ''
+  const type = stringField(value.type)
+
+  if (type === 'text') return stringField(value.text)
+  if (type === 'link') {
+    const text = stringField(value.text)
+    const url = stringField(value.url)
+    return text && url ? `${text} (${url})` : text || url
+  }
+  if (type === 'user') return slackRef('@', value.user_id)
+  if (type === 'channel') return slackRef('#', value.channel_id)
+  if (type === 'usergroup') return slackRef('@', value.usergroup_id)
+  if (type === 'emoji') {
+    const name = stringField(value.name)
+    return name ? `:${name}:` : ''
+  }
+
+  const children = richTextChildren(value.elements)
+  if (type === 'rich_text_section') return children.join('')
+  if (type === 'rich_text_list') return children.map(child => `- ${child}`).join('\n')
+  if (type === 'rich_text_quote') {
+    return children
+      .join('\n')
+      .split('\n')
+      .map(line => `> ${line}`)
+      .join('\n')
+  }
+  if (type === 'rich_text_preformatted') return children.join('')
+  return children.join('\n')
+}
+
+function richTextChildren(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.map(richTextElementText).filter(Boolean)
+}
+
+function slackRef(prefix: string, value: unknown): string {
+  const id = stringField(value)
+  return id ? `${prefix}${id}` : ''
+}
+
+function finalizeDisplayLines(lines: string[]): string {
+  const seen = new Set<string>()
+  const normalized: string[] = []
+  for (const line of lines) {
+    for (const part of normalizeSlackFallbackText(line).split('\n')) {
+      if (!part || seen.has(part)) continue
+      seen.add(part)
+      normalized.push(part)
+    }
+  }
+  return truncateRawDisplayText(normalized.join('\n'))
+}
+
+function normalizeSlackFallbackText(input: string): string {
+  return input
+    .replace(/<([a-z]+:\/\/[^>|]+)\|([^>]+)>/gi, '$2 ($1)')
+    .replace(/<([a-z]+:\/\/[^>]+)>/gi, '$1')
+    .replace(/<#([A-Z0-9]+)\|([^>]+)>/g, '#$2 ($1)')
+    .replace(/<#([A-Z0-9]+)>/g, '#$1')
+    .replace(/<@([A-Z0-9]+)>/g, '@$1')
+    .replace(/<!subteam\^([A-Z0-9]+)\|([^>]+)>/g, '@$2')
+    .replace(/<!(channel|here|everyone)>/g, '@$1')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .split('\n')
+    .map(line => line.replace(/[ \t]+/g, ' ').trim())
+    .filter(Boolean)
+    .join('\n')
+}
+
+function truncateRawDisplayText(text: string): string {
+  if (text.length <= MAX_RAW_DISPLAY_TEXT_CHARS) return text
+  let omitted = text.length - MAX_RAW_DISPLAY_TEXT_CHARS
+  while (true) {
+    const suffix = `\n[truncated ${omitted} chars from Slack display text]`
+    const keep = Math.max(0, MAX_RAW_DISPLAY_TEXT_CHARS - suffix.length)
+    const actualOmitted = text.length - keep
+    if (actualOmitted === omitted) return `${text.slice(0, keep).trimEnd()}${suffix}`
+    omitted = actualOmitted
+  }
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -2,6 +2,7 @@ import type { RustSessionStreamEvent } from '@centaur/harness-events'
 import type { CodexAppServerToChatStreamOptions } from '@centaur/rendering'
 import type { Attachment, Chat, Logger, StateAdapter } from 'chat'
 import type { Hono } from 'hono'
+import type { SlackDisplayTextSource } from './slack-display-text'
 
 export type JsonPrimitive = string | number | boolean | null
 export type JsonValue = JsonPrimitive | JsonObject | JsonValue[]
@@ -32,9 +33,13 @@ export type SlackbotV2ApiAttachment = {
 export type SlackbotV2ApiMessage = {
   attachments: SlackbotV2ApiAttachment[]
   author: SlackbotV2ApiAuthor
+  displayText?: string
+  displayTextSource?: SlackDisplayTextSource
   id: string
   isMention: boolean
   raw: unknown
+  rawSlackAttachmentCount?: number
+  rawSlackBlockCount?: number
   teamId: string
   text: string
   threadId: string

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -3,10 +3,14 @@ import {
   clearConversationNameCacheForTests,
   clearRequesterIdentityCacheForTests,
   forwardToSessionApi,
-  harnessRestartPreamble
+  harnessRestartPreamble,
+  serializeMessage
 } from '../src/session-api'
+import { renderSlackDisplayText } from '../src/slack-display-text'
 import type {
   ForwardSessionInput,
+  JsonObject,
+  JsonValue,
   SlackbotV2ApiMessage,
   SlackbotV2Options
 } from '../src/types'
@@ -16,7 +20,12 @@ type RecordedRequest = {
   url: string
 }
 
-function apiMessage(text: string): SlackbotV2ApiMessage {
+function apiMessage(
+  text: string,
+  overrides: Partial<SlackbotV2ApiMessage> = {}
+): SlackbotV2ApiMessage {
+  const raw = overrides.raw ?? {}
+  const displayText = renderSlackDisplayText({ raw, text })
   return {
     attachments: [],
     author: {
@@ -26,13 +35,18 @@ function apiMessage(text: string): SlackbotV2ApiMessage {
       userId: 'U1',
       userName: 'test'
     },
+    displayText: displayText.text,
+    displayTextSource: displayText.source,
     id: '1700000000.000100',
     isMention: true,
-    raw: {},
+    raw,
+    rawSlackAttachmentCount: displayText.rawAttachmentCount,
+    rawSlackBlockCount: displayText.rawBlockCount,
     teamId: 'T1',
     text,
     threadId: 'slack:C1:1700000000.000100',
-    timestamp: '2026-06-10T00:00:00.000Z'
+    timestamp: '2026-06-10T00:00:00.000Z',
+    ...overrides
   }
 }
 
@@ -83,6 +97,172 @@ function options(fetchFn: SlackbotV2Options['fetch']): SlackbotV2Options {
     signingSecret: 'secret'
   }
 }
+
+function executeLine(requests: RecordedRequest[]): JsonObject {
+  const execute = requests.find(request => request.url.endsWith('/execute'))
+  const inputLines = (execute?.body as { input_lines: string[] }).input_lines
+  return JSON.parse(inputLines[0]!) as JsonObject
+}
+
+function appendedTextParts(requests: RecordedRequest[]): string[] {
+  const append = requests.find(request => request.url.endsWith('/messages'))
+  const messages = ((append?.body as { messages?: Array<{ parts?: JsonValue[] }> }).messages ?? [])
+  return messages.flatMap(message =>
+    (message.parts ?? []).flatMap(part =>
+      isJsonRecord(part) && part.type === 'text' && typeof part.text === 'string'
+        ? [part.text]
+        : []
+    )
+  )
+}
+
+function lineContent(line: JsonObject): JsonObject[] {
+  const message = line.message
+  if (!isJsonRecord(message)) return []
+  return Array.isArray(message.content) ? message.content.filter(isJsonRecord) : []
+}
+
+function isJsonRecord(value: JsonValue | undefined): value is JsonObject {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+describe('Slack display text fallback', () => {
+  test('serializeMessage extracts raw Slack blocks when adapter text is empty', async () => {
+    const raw = {
+      blocks: [
+        {
+          text: { text: '*Alert:* <https://example.test/incident|prod down>', type: 'mrkdwn' },
+          type: 'section'
+        },
+        {
+          elements: [{ text: 'prd-centaur-na', type: 'mrkdwn' }],
+          type: 'context'
+        }
+      ],
+      team_id: 'T1'
+    }
+    const message = await serializeMessage({
+      attachments: [],
+      author: {
+        fullName: 'Test User',
+        isBot: false,
+        isMe: false,
+        userId: 'U1',
+        userName: 'test'
+      },
+      id: '1700000000.000100',
+      isMention: true,
+      metadata: { dateSent: new Date('2026-06-10T00:00:00.000Z') },
+      raw,
+      text: '',
+      threadId: 'slack:C1:1700000000.000100'
+    } as unknown as Parameters<typeof serializeMessage>[0])
+
+    expect(message.displayTextSource).toBe('raw_blocks')
+    expect(message.displayText).toBe(
+      '*Alert:* prod down (https://example.test/incident)\nprd-centaur-na'
+    )
+    expect(message.rawSlackBlockCount).toBe(2)
+  })
+
+  test('forwards raw Slack block text to session parts and Codex input', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const message = apiMessage('', {
+      raw: {
+        blocks: [
+          {
+            text: { text: '*Alert:* API errors above threshold', type: 'mrkdwn' },
+            type: 'section'
+          },
+          {
+            fields: [
+              { text: '*service*\ncodex-app-server', type: 'mrkdwn' },
+              { text: '*sandbox*\nprd-centaur-na', type: 'mrkdwn' }
+            ],
+            type: 'section'
+          }
+        ]
+      }
+    })
+
+    await forwardToSessionApi(options(fetchFn), forwardInput(message))
+
+    const expected = '*Alert:* API errors above threshold\n*service*\ncodex-app-server\n*sandbox*\nprd-centaur-na'
+    expect(appendedTextParts(requests)).toContain(expected)
+
+    const line = executeLine(requests)
+    expect(line.trace_metadata).toEqual(
+      expect.objectContaining({
+        slack_display_text_chars: expected.length,
+        slack_raw_block_count: 2,
+        slack_text_source: 'raw_blocks'
+      })
+    )
+    expect(lineContent(line).at(-1)).toEqual({ type: 'text', text: expected })
+  })
+
+  test('uses raw Slack block text in prior thread context instead of no text', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const root = apiMessage('', {
+      id: '1700000000.000001',
+      isMention: false,
+      raw: {
+        blocks: [
+          {
+            text: { text: 'Incident: queue stalled in prd-centaur-na', type: 'mrkdwn' },
+            type: 'section'
+          }
+        ]
+      }
+    })
+    const current = apiMessage('investigate', { id: '1700000000.000002' })
+
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(current, {
+        executeContextMessages: [root, current],
+        messages: [root, current]
+      })
+    )
+
+    const context = lineContent(executeLine(requests)).find(part =>
+      typeof part.text === 'string' && part.text.includes('# Slack Thread Context')
+    )
+    expect(context?.text).toContain('Incident: queue stalled in prd-centaur-na')
+    expect(context?.text).not.toContain('[no text]')
+  })
+
+  test('falls back to raw Slack attachment text when blocks are absent', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const message = apiMessage('', {
+      raw: {
+        attachments: [
+          {
+            fallback: 'Monitor alert fired',
+            fields: [
+              { title: 'Service', value: 'centaur-api-rs' },
+              { title: 'Cluster', value: 'prd-centaur-na' }
+            ],
+            title: 'High error rate'
+          }
+        ]
+      }
+    })
+
+    await forwardToSessionApi(options(fetchFn), forwardInput(message))
+
+    const expected = 'Monitor alert fired\nHigh error rate\nService\ncentaur-api-rs\nCluster\nprd-centaur-na'
+    expect(appendedTextParts(requests)).toContain(expected)
+    const line = executeLine(requests)
+    expect(line.trace_metadata).toEqual(
+      expect.objectContaining({
+        slack_raw_attachment_count: 1,
+        slack_text_source: 'raw_attachments'
+      })
+    )
+    expect(lineContent(line).at(-1)).toEqual({ type: 'text', text: expected })
+  })
+})
 
 describe('forwardToSessionApi overrides', () => {
   test('creates session with default codex harness', async () => {


### PR DESCRIPTION
## Summary

Fixes the Slackbot v2 inbound prompt path for Slack messages where the plain `text` field is empty but the visible content is present in raw Slack Block Kit or attachment payloads.

## Root Cause

Slack can deliver visible alert/card content in `blocks` or attachment fields while leaving the top-level `text` empty. Slackbot v2 was persisting and prompting from `message.text` directly, so those messages became empty session parts and Codex input. Prior thread context then rendered them as `[no text]`.

## Changes

- Add an inbound Slack display-text normalizer that extracts human-visible text from raw Slack blocks, rich text, context/header/section fields, and legacy attachment fallbacks.
- Store compact provenance on serialized Slack messages: source, extracted text length, raw block count, and raw attachment count.
- Use the normalized prompt text for session message parts, Codex input, Slack thread context, harness restart preambles, assistant titles, and fetched Slack thread replies.
- Preserve existing text behavior and directive stripping by only preferring `displayText` when it came from raw blocks or raw attachments.

## Validation

- `bun test services/slackbotv2/test/session-api.test.ts`
- `bun test services/slackbotv2/test`
- `pnpm --filter slackbotv2 check:types`
- `git diff --check`
