### PR TITLE
fix(iron-proxy): allow content-encoding header so private git clone works

### DIFF
--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -29,6 +29,7 @@ transforms:
         - "host"
         - "content-type"
         - "content-length"
+        - "content-encoding"
         - "accept"
         - "accept-encoding"
         - "accept-language"


### PR DESCRIPTION
Rebases the fix from paradigmxyz/centaur#403 onto latest main and applies it to the active iron-proxy config.

Validation:
- cargo test -p centaur-iron-proxy
- just build-one iron-proxy could not run locally because the Docker/OrbStack socket was unavailable.