### PR TITLE
feat: add Slack archive import ingestion

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -214,7 +214,7 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route("/api/workflows/events", post(emit_workflow_event))
         .route(
             "/api/admin/slack/archive-imports",
-            get(list_slack_archive_imports),
+            get(list_slack_archive_imports).post(presign_slack_archive_import),
         )
         .route(
             "/api/admin/slack/archive-imports/presign",
@@ -222,11 +222,19 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         )
         .route(
             "/api/admin/slack/archive-imports/{import_id}",
-            get(get_slack_archive_import),
+            get(get_slack_archive_import).delete(delete_slack_archive_import),
+        )
+        .route(
+            "/api/admin/slack/archive-imports/{import_id}/upload-url",
+            post(refresh_slack_archive_import_upload_url),
         )
         .route(
             "/api/admin/slack/archive-imports/{import_id}/start",
             post(start_slack_archive_import),
+        )
+        .route(
+            "/api/admin/slack/archive-imports/{import_id}/retry",
+            post(retry_slack_archive_import),
         )
         .route("/api/webhooks/{slug}", any(invoke_workflow_webhook))
         .layer(
@@ -705,16 +713,73 @@ async fn presign_slack_archive_import(
 
     Ok((
         StatusCode::CREATED,
-        Json(json!({
-            "ok": true,
-            "import": SlackArchiveImportResponse::from(row),
-            "upload": {
-                "archive_uri": archive_uri,
-                "upload_url": upload_url,
-                "expires_at": expires_at,
-            }
-        })),
+        Json(slack_archive_upload_response(row, upload_url, expires_at)),
     ))
+}
+
+async fn refresh_slack_archive_import_upload_url(
+    State(state): State<AppState>,
+    Path(import_id): Path<String>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    let pool = db_pool(&state)?;
+    let import = load_slack_archive_import(&pool, &import_id).await?;
+    ensure_archive_import_status(
+        &import.status,
+        &["upload_pending"],
+        "archive upload URL cannot be refreshed",
+    )?;
+    let config = slack_archive_upload_config()?;
+    ensure_archive_import_bucket_matches_config(&import, &config)?;
+    let upload_url = presign_s3_put_url(&config, &import.object_key, &import.content_type).await?;
+    let expires_at = OffsetDateTime::now_utc() + config.presign_ttl;
+    let sql = format!(
+        "UPDATE slack_archive_imports SET upload_url_expires_at = $2, updated_at = NOW() \
+         WHERE import_id = $1 RETURNING {SLACK_ARCHIVE_IMPORT_COLUMNS}"
+    );
+    let row = sqlx::query_as::<_, SlackArchiveImportRow>(&sql)
+        .bind(&import.import_id)
+        .bind(expires_at)
+        .fetch_one(&pool)
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(slack_archive_upload_response(row, upload_url, expires_at)),
+    ))
+}
+
+async fn delete_slack_archive_import(
+    State(state): State<AppState>,
+    Path(import_id): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let pool = db_pool(&state)?;
+    let import = load_slack_archive_import(&pool, &import_id).await?;
+    ensure_archive_import_status(
+        &import.status,
+        &["upload_pending", "uploaded", "failed", "cancelled"],
+        "archive import cannot be deleted",
+    )?;
+    let mut object_delete = json!({"attempted": false, "deleted": false});
+    if import.status != "cancelled" {
+        let config = slack_archive_upload_config()?;
+        ensure_archive_import_bucket_matches_config(&import, &config)?;
+        delete_s3_object(&config, &import.object_key).await?;
+        object_delete = json!({"attempted": true, "deleted": true});
+    }
+    let sql = format!(
+        "UPDATE slack_archive_imports SET status = 'cancelled', \
+         finished_at = COALESCE(finished_at, NOW()), error_text = '', updated_at = NOW() \
+         WHERE import_id = $1 RETURNING {SLACK_ARCHIVE_IMPORT_COLUMNS}"
+    );
+    let row = sqlx::query_as::<_, SlackArchiveImportRow>(&sql)
+        .bind(&import.import_id)
+        .fetch_one(&pool)
+        .await?;
+    Ok(Json(json!({
+        "ok": true,
+        "import": SlackArchiveImportResponse::from(row),
+        "archive_object": object_delete,
+    })))
 }
 
 async fn start_slack_archive_import(
@@ -723,36 +788,27 @@ async fn start_slack_archive_import(
 ) -> Result<(StatusCode, Json<Value>), ApiError> {
     let pool = db_pool(&state)?;
     let import = load_slack_archive_import(&pool, &import_id).await?;
-    if !matches!(import.status.as_str(), "upload_pending" | "failed") {
-        return Err(ApiError::BadRequest(format!(
-            "archive upload cannot be confirmed from status {}",
-            import.status
-        )));
-    }
+    ensure_archive_import_status(
+        &import.status,
+        &["upload_pending"],
+        "archive upload cannot be confirmed",
+    )?;
     let config = slack_archive_upload_config()?;
-    if import.object_bucket != config.bucket {
-        return Err(ApiError::BadRequest(
-            "archive import bucket no longer matches configured bucket".to_owned(),
-        ));
-    }
+    ensure_archive_import_bucket_matches_config(&import, &config)?;
     let head = head_s3_object(&config, &import.object_key).await?;
-    let sql = format!(
-        "UPDATE slack_archive_imports SET \
-         status = 'uploaded', \
-         file_size_bytes = $2, \
-         sha256 = COALESCE(sha256, $3), \
-         uploaded_at = COALESCE(uploaded_at, NOW()), \
-         error_text = '', \
-         updated_at = NOW() \
-         WHERE import_id = $1 \
-         RETURNING {SLACK_ARCHIVE_IMPORT_COLUMNS}"
-    );
-    let row = sqlx::query_as::<_, SlackArchiveImportRow>(&sql)
-        .bind(&import.import_id)
-        .bind(head.size_bytes)
-        .bind(head.sha256)
-        .fetch_one(&pool)
+    let workflows = workflow_runtime(&state)?;
+    let workflow = workflows
+        .create_run(CreateWorkflowRunRequest {
+            workflow_name: "slack_archive_import".to_owned(),
+            input: json!({ "import_id": import.import_id }),
+            idempotency_key: Some(format!("slack_archive_import:{}", import.import_id)),
+            harness_type: None,
+            max_attempts: Some(1),
+        })
         .await?;
+    let row =
+        mark_slack_archive_import_queued(&pool, &import, head, &workflow.run_id, &workflow.task_id)
+            .await?;
 
     Ok((
         StatusCode::OK,
@@ -760,8 +816,59 @@ async fn start_slack_archive_import(
             "ok": true,
             "import": SlackArchiveImportResponse::from(row),
             "ingestion": {
-                "status": "not_started",
-                "reason": "archive ingestion workflow is out of scope for this API-only change"
+                "status": workflow.status,
+                "workflow_name": "slack_archive_import",
+                "workflow_run_id": workflow.run_id,
+                "workflow_task_id": workflow.task_id,
+                "created": workflow.created
+            }
+        })),
+    ))
+}
+
+async fn retry_slack_archive_import(
+    State(state): State<AppState>,
+    Path(import_id): Path<String>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    let pool = db_pool(&state)?;
+    let import = load_slack_archive_import(&pool, &import_id).await?;
+    ensure_archive_import_status(
+        &import.status,
+        &["failed"],
+        "archive import cannot be retried",
+    )?;
+    let config = slack_archive_upload_config()?;
+    ensure_archive_import_bucket_matches_config(&import, &config)?;
+    let head = head_s3_object(&config, &import.object_key).await?;
+    let workflows = workflow_runtime(&state)?;
+    let workflow = workflows
+        .create_run(CreateWorkflowRunRequest {
+            workflow_name: "slack_archive_import".to_owned(),
+            input: json!({ "import_id": import.import_id }),
+            idempotency_key: Some(format!(
+                "slack_archive_import:{}:retry:{}",
+                import.import_id,
+                Uuid::new_v4().simple()
+            )),
+            harness_type: None,
+            max_attempts: Some(1),
+        })
+        .await?;
+    let row =
+        mark_slack_archive_import_queued(&pool, &import, head, &workflow.run_id, &workflow.task_id)
+            .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "import": SlackArchiveImportResponse::from(row),
+            "ingestion": {
+                "status": workflow.status,
+                "workflow_name": "slack_archive_import",
+                "workflow_run_id": workflow.run_id,
+                "workflow_task_id": workflow.task_id,
+                "created": workflow.created
             }
         })),
     ))
@@ -925,6 +1032,84 @@ async fn load_slack_archive_import(
         .ok_or_else(|| ApiError::NotFound("archive import not found".to_owned()))
 }
 
+fn slack_archive_upload_response(
+    row: SlackArchiveImportRow,
+    upload_url: String,
+    expires_at: OffsetDateTime,
+) -> Value {
+    let archive_uri = row.archive_uri.clone();
+    json!({
+        "ok": true,
+        "import": SlackArchiveImportResponse::from(row),
+        "upload": {
+            "archive_uri": archive_uri,
+            "upload_url": upload_url,
+            "expires_at": expires_at,
+        }
+    })
+}
+
+fn ensure_archive_import_status(
+    status: &str,
+    allowed: &[&str],
+    action: &str,
+) -> Result<(), ApiError> {
+    if allowed.contains(&status) {
+        return Ok(());
+    }
+    Err(ApiError::BadRequest(format!(
+        "{action} from status {status}"
+    )))
+}
+
+fn ensure_archive_import_bucket_matches_config(
+    import: &SlackArchiveImportRow,
+    config: &SlackArchiveUploadConfig,
+) -> Result<(), ApiError> {
+    if import.object_bucket == config.bucket {
+        return Ok(());
+    }
+    Err(ApiError::BadRequest(
+        "archive import bucket no longer matches configured bucket".to_owned(),
+    ))
+}
+
+async fn mark_slack_archive_import_queued(
+    pool: &PgPool,
+    import: &SlackArchiveImportRow,
+    head: S3ObjectHead,
+    workflow_run_id: &str,
+    workflow_task_id: &str,
+) -> Result<SlackArchiveImportRow, ApiError> {
+    let sql = format!(
+        "UPDATE slack_archive_imports SET \
+         status = 'uploaded', \
+         file_size_bytes = $2, \
+         sha256 = COALESCE(sha256, $3), \
+         uploaded_at = COALESCE(uploaded_at, NOW()), \
+         started_at = NULL, \
+         finished_at = NULL, \
+         workflow_run_id = $4, \
+         workflow_task_id = $5, \
+         channels_imported = 0, \
+         users_imported = 0, \
+         messages_imported = 0, \
+         error_text = '', \
+         updated_at = NOW() \
+         WHERE import_id = $1 \
+         RETURNING {SLACK_ARCHIVE_IMPORT_COLUMNS}"
+    );
+    sqlx::query_as::<_, SlackArchiveImportRow>(&sql)
+        .bind(&import.import_id)
+        .bind(head.size_bytes)
+        .bind(head.sha256)
+        .bind(workflow_run_id)
+        .bind(workflow_task_id)
+        .fetch_one(pool)
+        .await
+        .map_err(ApiError::from)
+}
+
 fn slack_archive_upload_config() -> Result<SlackArchiveUploadConfig, ApiError> {
     let bucket = env::var("SLACK_ARCHIVE_UPLOAD_BUCKET")
         .unwrap_or_default()
@@ -1086,6 +1271,23 @@ async fn head_s3_object(
         size_bytes: response.content_length(),
         sha256,
     })
+}
+
+async fn delete_s3_object(
+    config: &SlackArchiveUploadConfig,
+    object_key: &str,
+) -> Result<(), ApiError> {
+    let client = s3_client(config).await;
+    client
+        .delete_object()
+        .bucket(&config.bucket)
+        .key(object_key)
+        .send()
+        .await
+        .map_err(|error| {
+            ApiError::BadRequest(format!("archive object could not be deleted: {error}"))
+        })?;
+    Ok(())
 }
 
 fn content_type(headers: &HeaderMap) -> String {
@@ -1316,6 +1518,123 @@ fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
         .get(name)
         .and_then(|value| value.to_str().ok())
         .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod slack_archive_import_tests {
+    use super::*;
+
+    fn archive_row(status: &str) -> SlackArchiveImportRow {
+        let now = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+        SlackArchiveImportRow {
+            import_id: "sai_test".to_owned(),
+            workspace_id: "workspace".to_owned(),
+            mode: "public_channels".to_owned(),
+            archive_uri: "s3://bucket/prefix/workspace/sai_test/archive.zip".to_owned(),
+            object_bucket: "bucket".to_owned(),
+            object_key: "prefix/workspace/sai_test/archive.zip".to_owned(),
+            original_filename: "archive.zip".to_owned(),
+            content_type: "application/zip".to_owned(),
+            file_size_bytes: None,
+            sha256: None,
+            status: status.to_owned(),
+            workflow_run_id: None,
+            workflow_task_id: None,
+            channels_imported: 0,
+            users_imported: 0,
+            messages_imported: 0,
+            error_text: String::new(),
+            created_by: "tester".to_owned(),
+            uploaded_at: None,
+            started_at: None,
+            finished_at: None,
+            upload_url_expires_at: None,
+            created_at: now,
+            updated_at: now,
+            metadata: json!({}),
+        }
+    }
+
+    #[test]
+    fn archive_import_status_gate_allows_only_requested_statuses() {
+        assert!(
+            ensure_archive_import_status(
+                "upload_pending",
+                &["upload_pending"],
+                "archive upload URL cannot be refreshed",
+            )
+            .is_ok()
+        );
+        let error = ensure_archive_import_status(
+            "failed",
+            &["upload_pending"],
+            "archive upload URL cannot be refreshed",
+        )
+        .unwrap_err();
+        assert!(matches!(error, ApiError::BadRequest(_)));
+    }
+
+    #[test]
+    fn archive_import_delete_statuses_exclude_active_and_completed_imports() {
+        for status in ["upload_pending", "uploaded", "failed", "cancelled"] {
+            ensure_archive_import_status(
+                status,
+                &["upload_pending", "uploaded", "failed", "cancelled"],
+                "archive import cannot be deleted",
+            )
+            .unwrap();
+        }
+        for status in ["importing", "completed"] {
+            let error = ensure_archive_import_status(
+                status,
+                &["upload_pending", "uploaded", "failed", "cancelled"],
+                "archive import cannot be deleted",
+            )
+            .unwrap_err();
+            assert!(matches!(error, ApiError::BadRequest(_)));
+        }
+    }
+
+    #[test]
+    fn archive_import_bucket_must_match_current_upload_config() {
+        let import = archive_row("upload_pending");
+        let config = SlackArchiveUploadConfig {
+            bucket: "bucket".to_owned(),
+            prefix: "prefix".to_owned(),
+            region: Some("us-east-1".to_owned()),
+            endpoint: None,
+            presign_ttl: Duration::from_secs(900),
+        };
+        ensure_archive_import_bucket_matches_config(&import, &config).unwrap();
+
+        let config = SlackArchiveUploadConfig {
+            bucket: "other-bucket".to_owned(),
+            ..config
+        };
+        let error = ensure_archive_import_bucket_matches_config(&import, &config).unwrap_err();
+        assert!(matches!(error, ApiError::BadRequest(_)));
+    }
+
+    #[test]
+    fn archive_upload_response_includes_import_and_upload_contract() {
+        let expires_at = OffsetDateTime::from_unix_timestamp(1_700_000_900).unwrap();
+        let body = slack_archive_upload_response(
+            archive_row("upload_pending"),
+            "https://uploads.example/presigned".to_owned(),
+            expires_at,
+        );
+        assert_eq!(body["ok"], json!(true));
+        assert_eq!(body["import"]["import_id"], json!("sai_test"));
+        assert_eq!(
+            body["upload"]["archive_uri"],
+            json!("s3://bucket/prefix/workspace/sai_test/archive.zip")
+        );
+        assert_eq!(
+            body["upload"]["upload_url"],
+            json!("https://uploads.example/presigned")
+        );
+        assert!(body["upload"]["expires_at"].is_array());
+    }
 }
 
 #[cfg(test)]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -846,7 +846,7 @@ enum WorkflowQueueClass {
 fn workflow_queue_class(workflow_name: &str) -> WorkflowQueueClass {
     match workflow_name {
         "slack_sync" => WorkflowQueueClass::SlackLive,
-        "slack_backfill" => WorkflowQueueClass::EtlBackfill,
+        "slack_backfill" | "slack_archive_import" => WorkflowQueueClass::EtlBackfill,
         "google_calendar_sync"
         | "google_drive_sync"
         | "linear_sync"
@@ -3453,6 +3453,10 @@ mod tests {
         }
         assert_eq!(
             workflow_queue_class("slack_backfill"),
+            WorkflowQueueClass::EtlBackfill
+        );
+        assert_eq!(
+            workflow_queue_class("slack_archive_import"),
             WorkflowQueueClass::EtlBackfill
         );
         assert_eq!(

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -31,6 +31,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     python-pptx==1.0.2 openpyxl==3.1.5 PyMuPDF==1.27.2 mammoth==1.12.0 \
     faster-whisper \
     asyncpg==0.30.0 \
+    boto3>=1.40.0 \
     google-api-python-client>=2.100.0 \
     google-auth-httplib2>=0.2.0 \
     google-auth-oauthlib>=1.2.0 \

--- a/services/workflow-python/pyproject.toml
+++ b/services/workflow-python/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "asyncpg>=0.30.0",
+    "boto3>=1.40.0",
     "google-api-python-client>=2.100.0",
     "google-auth-httplib2>=0.2.0",
     "google-auth-oauthlib>=1.2.0",

--- a/workflows/slack/archive_import.py
+++ b/workflows/slack/archive_import.py
@@ -1,0 +1,665 @@
+"""Workflow: import a public-channel Slack export archive into Slack ETL tables."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import json
+import os
+import tempfile
+import urllib.parse
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from api.runtime_control import canonical_json
+from api.workflow_engine import WorkflowContext
+from workflows.slack.shared import record_run_finish, record_run_start
+
+WORKFLOW_NAME = "slack_archive_import"
+
+ARCHIVE_IMPORT_MODE = "archive_import"
+MESSAGE_BATCH_SIZE = 1_000
+ATTACHMENT_BATCH_SIZE = 1_000
+
+
+@dataclass
+class Input:
+    """Runtime options for importing an uploaded Slack export archive."""
+
+    import_id: str
+
+
+def _as_text(value: Any) -> str:
+    return str(value or "")
+
+
+def _topic_value(value: Any) -> str:
+    if isinstance(value, dict):
+        return _as_text(value.get("value"))
+    return _as_text(value)
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _slack_ts_to_datetime(ts: str | None) -> dt.datetime | None:
+    if not ts:
+        return None
+    try:
+        return dt.datetime.fromtimestamp(float(ts), tz=dt.timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _strip_sensitive_url_query(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value)
+    if parsed.scheme not in {"http", "https"}:
+        return value
+    if parsed.netloc.endswith("slack.com") or parsed.netloc.endswith("slack-edge.com"):
+        return urllib.parse.urlunsplit(
+            (parsed.scheme, parsed.netloc, parsed.path, "", "")
+        )
+    return value
+
+
+def _scrub_archive_payload(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _scrub_archive_payload(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_scrub_archive_payload(child) for child in value]
+    if isinstance(value, str):
+        return _strip_sensitive_url_query(value)
+    return value
+
+
+def _message_ts(message: dict[str, Any]) -> str:
+    if message.get("subtype") in {"message_changed", "message_deleted"}:
+        original = message.get("original")
+        if isinstance(original, dict) and original.get("ts"):
+            return _as_text(original.get("ts"))
+    return _as_text(message.get("ts"))
+
+
+def _message_thread_ts(message: dict[str, Any], message_ts: str) -> str | None:
+    raw = _as_text(message.get("thread_ts"))
+    if raw and raw != "0000000000.000000":
+        return raw
+    original = message.get("original")
+    if isinstance(original, dict):
+        raw = _as_text(original.get("thread_ts"))
+        if raw and raw != "0000000000.000000":
+            return raw
+    return message_ts if message.get("reply_count") else None
+
+
+def _archive_message_row(
+    channel_id: str,
+    message: dict[str, Any],
+    *,
+    run_id: str,
+    archive_file: str,
+) -> dict[str, Any] | None:
+    subtype = _as_text(message.get("subtype"))
+    if subtype == "message_deleted":
+        return None
+
+    message_ts = _message_ts(message)
+    if not message_ts:
+        return None
+
+    thread_ts = _message_thread_ts(message, message_ts)
+    parent_message_ts = thread_ts if thread_ts and thread_ts != message_ts else None
+    raw_payload = _scrub_archive_payload(message)
+    if isinstance(raw_payload, dict):
+        raw_payload.setdefault(
+            "archive_import",
+            {
+                "source": "slack_archive",
+                "archive_file": archive_file,
+                "original_event_ts": _as_text(message.get("ts")),
+            },
+        )
+
+    return {
+        "channel_id": channel_id,
+        "message_ts": message_ts,
+        "occurred_at": _slack_ts_to_datetime(message_ts),
+        "thread_ts": thread_ts,
+        "parent_message_ts": parent_message_ts,
+        "is_thread_root": bool(thread_ts and thread_ts == message_ts),
+        "user_id": _as_text(message.get("user")),
+        "bot_id": _as_text(message.get("bot_id")),
+        "message_type": _as_text(message.get("type")) or "message",
+        "message_subtype": subtype or None,
+        "text": _as_text(message.get("text")),
+        "permalink": _as_text(message.get("permalink")),
+        "reply_count": _safe_int(message.get("reply_count")),
+        "reply_users": message.get("reply_users") or [],
+        "latest_reply_ts": message.get("latest_reply"),
+        "raw_payload": raw_payload,
+        "attachments": message.get("files") or [],
+        "source_run_id": run_id,
+    }
+
+
+def _attachment_rows(row: dict[str, Any]) -> list[dict[str, Any]]:
+    attachments = row.get("attachments")
+    if not isinstance(attachments, list):
+        return []
+
+    result = []
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        slack_file_id = _as_text(attachment.get("id")).strip()
+        if not slack_file_id:
+            continue
+        raw_payload = _scrub_archive_payload(attachment)
+        result.append(
+            {
+                "channel_id": row["channel_id"],
+                "message_ts": row["message_ts"],
+                "slack_file_id": slack_file_id,
+                "name": _as_text(attachment.get("name")),
+                "title": _as_text(attachment.get("title")),
+                "mimetype": _as_text(attachment.get("mimetype")),
+                "filetype": _as_text(attachment.get("filetype")),
+                "size_bytes": _safe_int(attachment.get("size")),
+                "url_private": _as_text(raw_payload.get("url_private"))
+                if isinstance(raw_payload, dict)
+                else "",
+                "permalink": _as_text(attachment.get("permalink")),
+                "download_status": "metadata_only",
+                "download_error": "",
+                "content_sha256": None,
+                "content_bytes": None,
+                "raw_payload": raw_payload,
+                "source_run_id": row["source_run_id"],
+            }
+        )
+    return result
+
+
+def _json_member(zip_file: zipfile.ZipFile, name: str) -> Any:
+    try:
+        with zip_file.open(name) as handle:
+            return json.load(handle)
+    except KeyError as exc:
+        raise RuntimeError(f"Slack archive missing required {name}") from exc
+
+
+def _message_files(zip_file: zipfile.ZipFile) -> Iterable[str]:
+    for info in zip_file.infolist():
+        name = info.filename
+        if info.is_dir() or "/" not in name or not name.endswith(".json"):
+            continue
+        yield name
+
+
+def _archive_channel_refs(channels: list[dict[str, Any]]) -> list[dict[str, str]]:
+    refs = []
+    for channel in channels:
+        channel_id = _as_text(channel.get("id"))
+        if not channel_id:
+            continue
+        refs.append(
+            {
+                "channel_id": channel_id,
+                "channel_name": _as_text(channel.get("name")),
+            }
+        )
+    return refs
+
+
+async def _load_archive_import(pool, import_id: str) -> dict[str, Any]:
+    row = await pool.fetchrow(
+        "SELECT import_id, workspace_id, archive_uri, object_bucket, object_key, "
+        "status, workflow_run_id, workflow_task_id FROM slack_archive_imports "
+        "WHERE import_id = $1",
+        import_id,
+    )
+    if row is None:
+        raise RuntimeError(f"archive import not found: {import_id}")
+    return dict(row)
+
+
+async def _mark_import_running(pool, *, import_id: str, run_id: str) -> None:
+    await pool.execute(
+        "UPDATE slack_archive_imports SET status = 'importing', started_at = NOW(), "
+        "error_text = '', updated_at = NOW(), workflow_run_id = COALESCE(workflow_run_id, $2) "
+        "WHERE import_id = $1",
+        import_id,
+        run_id,
+    )
+
+
+async def _mark_import_completed(
+    pool,
+    *,
+    import_id: str,
+    counts: dict[str, int],
+) -> None:
+    await pool.execute(
+        "UPDATE slack_archive_imports SET status = 'completed', finished_at = NOW(), "
+        "channels_imported = $2, users_imported = $3, messages_imported = $4, "
+        "error_text = '', updated_at = NOW() WHERE import_id = $1",
+        import_id,
+        counts.get("channels_imported", 0),
+        counts.get("users_imported", 0),
+        counts.get("messages_imported", 0),
+    )
+
+
+async def _mark_import_failed(pool, *, import_id: str, error_text: str) -> None:
+    await pool.execute(
+        "UPDATE slack_archive_imports SET status = 'failed', finished_at = NOW(), "
+        "error_text = $2, updated_at = NOW() WHERE import_id = $1",
+        import_id,
+        error_text[:4000],
+    )
+
+
+async def _upsert_archive_channels(pool, channels: list[dict[str, Any]]) -> int:
+    rows = []
+    for channel in channels:
+        channel_id = _as_text(channel.get("id"))
+        if not channel_id:
+            continue
+        rows.append(
+            (
+                channel_id,
+                _as_text(channel.get("name")),
+                bool(channel.get("is_archived")),
+                _topic_value(channel.get("topic")),
+                _topic_value(channel.get("purpose")),
+                len(channel.get("members") or []),
+                canonical_json(_scrub_archive_payload(channel)),
+            )
+        )
+
+    if not rows:
+        return 0
+
+    async with pool.acquire() as conn:
+        await conn.executemany(
+            "INSERT INTO slack_sync_channels ("
+            "channel_id, channel_name, is_archived, is_syncable, topic, purpose, "
+            "member_count, raw_payload, last_seen_at, updated_at"
+            ") VALUES ($1, $2, $3, FALSE, $4, $5, $6, $7::jsonb, NOW(), NOW()) "
+            "ON CONFLICT (channel_id) DO UPDATE SET "
+            "channel_name = CASE WHEN slack_sync_channels.channel_name = '' "
+            "THEN EXCLUDED.channel_name ELSE slack_sync_channels.channel_name END, "
+            "topic = CASE WHEN slack_sync_channels.topic = '' "
+            "THEN EXCLUDED.topic ELSE slack_sync_channels.topic END, "
+            "purpose = CASE WHEN slack_sync_channels.purpose = '' "
+            "THEN EXCLUDED.purpose ELSE slack_sync_channels.purpose END, "
+            "member_count = CASE WHEN slack_sync_channels.member_count = 0 "
+            "THEN EXCLUDED.member_count ELSE slack_sync_channels.member_count END, "
+            "raw_payload = CASE WHEN slack_sync_channels.raw_payload = '{}'::jsonb "
+            "THEN EXCLUDED.raw_payload ELSE slack_sync_channels.raw_payload END, "
+            "last_seen_at = NOW(), updated_at = NOW()",
+            rows,
+        )
+    return len(rows)
+
+
+async def _upsert_archive_users(pool, users: list[dict[str, Any]]) -> int:
+    rows = []
+    for user in users:
+        user_id = _as_text(user.get("id"))
+        if not user_id:
+            continue
+        profile = user.get("profile") if isinstance(user.get("profile"), dict) else {}
+        rows.append(
+            (
+                user_id,
+                _as_text(user.get("name")),
+                _as_text(user.get("real_name")),
+                _as_text(user.get("display_name") or profile.get("display_name")),
+                bool(user.get("is_bot")),
+                bool(user.get("deleted") or user.get("is_deleted")),
+                _as_text(user.get("team_id") or user.get("team")),
+                canonical_json(_scrub_archive_payload(user)),
+            )
+        )
+
+    if not rows:
+        return 0
+
+    async with pool.acquire() as conn:
+        await conn.executemany(
+            "INSERT INTO slack_sync_users ("
+            "user_id, user_name, real_name, display_name, is_bot, is_deleted, "
+            "team_id, raw_payload, last_seen_at, updated_at"
+            ") VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, NOW(), NOW()) "
+            "ON CONFLICT (user_id) DO UPDATE SET "
+            "user_name = CASE WHEN slack_sync_users.user_name = '' "
+            "THEN EXCLUDED.user_name ELSE slack_sync_users.user_name END, "
+            "real_name = CASE WHEN slack_sync_users.real_name = '' "
+            "THEN EXCLUDED.real_name ELSE slack_sync_users.real_name END, "
+            "display_name = CASE WHEN slack_sync_users.display_name = '' "
+            "THEN EXCLUDED.display_name ELSE slack_sync_users.display_name END, "
+            "team_id = CASE WHEN slack_sync_users.team_id = '' "
+            "THEN EXCLUDED.team_id ELSE slack_sync_users.team_id END, "
+            "raw_payload = CASE WHEN slack_sync_users.raw_payload = '{}'::jsonb "
+            "THEN EXCLUDED.raw_payload ELSE slack_sync_users.raw_payload END, "
+            "last_seen_at = NOW(), updated_at = NOW()",
+            rows,
+        )
+    return len(rows)
+
+
+_MESSAGE_UPSERT_SQL = (
+    "INSERT INTO slack_sync_messages ("
+    "channel_id, message_ts, occurred_at, thread_ts, parent_message_ts, "
+    "is_thread_root, user_id, bot_id, message_type, message_subtype, text, "
+    "permalink, reply_count, reply_users, latest_reply_ts, raw_payload, "
+    "source_run_id, last_seen_at, updated_at"
+    ") VALUES ("
+    "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, "
+    "$14::jsonb, $15, $16::jsonb, $17, NOW(), NOW()"
+    ") ON CONFLICT (channel_id, message_ts) DO UPDATE SET "
+    "occurred_at = COALESCE(slack_sync_messages.occurred_at, EXCLUDED.occurred_at), "
+    "thread_ts = COALESCE(slack_sync_messages.thread_ts, EXCLUDED.thread_ts), "
+    "parent_message_ts = COALESCE("
+    "slack_sync_messages.parent_message_ts, EXCLUDED.parent_message_ts"
+    "), "
+    "is_thread_root = slack_sync_messages.is_thread_root OR EXCLUDED.is_thread_root, "
+    "user_id = CASE WHEN slack_sync_messages.user_id = '' "
+    "THEN EXCLUDED.user_id ELSE slack_sync_messages.user_id END, "
+    "bot_id = CASE WHEN slack_sync_messages.bot_id = '' "
+    "THEN EXCLUDED.bot_id ELSE slack_sync_messages.bot_id END, "
+    "message_type = CASE WHEN slack_sync_messages.message_type = '' "
+    "THEN EXCLUDED.message_type ELSE slack_sync_messages.message_type END, "
+    "message_subtype = COALESCE("
+    "slack_sync_messages.message_subtype, EXCLUDED.message_subtype"
+    "), "
+    "text = CASE WHEN slack_sync_messages.text = '' "
+    "THEN EXCLUDED.text ELSE slack_sync_messages.text END, "
+    "permalink = CASE WHEN slack_sync_messages.permalink = '' "
+    "THEN EXCLUDED.permalink ELSE slack_sync_messages.permalink END, "
+    "reply_count = GREATEST(slack_sync_messages.reply_count, EXCLUDED.reply_count), "
+    "reply_users = CASE WHEN slack_sync_messages.reply_users = '[]'::jsonb "
+    "THEN EXCLUDED.reply_users ELSE slack_sync_messages.reply_users END, "
+    "latest_reply_ts = COALESCE(slack_sync_messages.latest_reply_ts, EXCLUDED.latest_reply_ts), "
+    "raw_payload = CASE WHEN slack_sync_messages.raw_payload = '{}'::jsonb "
+    "THEN EXCLUDED.raw_payload ELSE slack_sync_messages.raw_payload END, "
+    "source_run_id = COALESCE(slack_sync_messages.source_run_id, EXCLUDED.source_run_id), "
+    "last_seen_at = NOW(), updated_at = NOW()"
+)
+
+
+def _message_params(row: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        row["channel_id"],
+        row["message_ts"],
+        row["occurred_at"],
+        row["thread_ts"],
+        row["parent_message_ts"],
+        row["is_thread_root"],
+        row["user_id"],
+        row["bot_id"],
+        row["message_type"],
+        row["message_subtype"],
+        row["text"],
+        row["permalink"],
+        row["reply_count"],
+        canonical_json(row["reply_users"]),
+        row["latest_reply_ts"],
+        canonical_json(row["raw_payload"]),
+        row["source_run_id"],
+    )
+
+
+_ATTACHMENT_UPSERT_SQL = (
+    "INSERT INTO slack_sync_message_attachments ("
+    "channel_id, message_ts, slack_file_id, name, title, mimetype, filetype, "
+    "size_bytes, url_private, permalink, download_status, download_error, "
+    "content_sha256, content_bytes, raw_payload, source_run_id, last_seen_at, updated_at"
+    ") VALUES ("
+    "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, "
+    "$15::jsonb, $16, NOW(), NOW()"
+    ") ON CONFLICT (channel_id, message_ts, slack_file_id) DO UPDATE SET "
+    "name = CASE WHEN slack_sync_message_attachments.name = '' "
+    "THEN EXCLUDED.name ELSE slack_sync_message_attachments.name END, "
+    "title = CASE WHEN slack_sync_message_attachments.title = '' "
+    "THEN EXCLUDED.title ELSE slack_sync_message_attachments.title END, "
+    "mimetype = CASE WHEN slack_sync_message_attachments.mimetype = '' "
+    "THEN EXCLUDED.mimetype ELSE slack_sync_message_attachments.mimetype END, "
+    "filetype = CASE WHEN slack_sync_message_attachments.filetype = '' "
+    "THEN EXCLUDED.filetype ELSE slack_sync_message_attachments.filetype END, "
+    "size_bytes = CASE WHEN slack_sync_message_attachments.size_bytes = 0 "
+    "THEN EXCLUDED.size_bytes ELSE slack_sync_message_attachments.size_bytes END, "
+    "url_private = CASE WHEN slack_sync_message_attachments.url_private = '' "
+    "THEN EXCLUDED.url_private ELSE slack_sync_message_attachments.url_private END, "
+    "permalink = CASE WHEN slack_sync_message_attachments.permalink = '' "
+    "THEN EXCLUDED.permalink ELSE slack_sync_message_attachments.permalink END, "
+    "download_status = CASE WHEN slack_sync_message_attachments.content_bytes IS NULL "
+    "AND slack_sync_message_attachments.download_status IN ('', 'metadata_only') "
+    "THEN EXCLUDED.download_status ELSE slack_sync_message_attachments.download_status END, "
+    "download_error = CASE WHEN slack_sync_message_attachments.download_error = '' "
+    "THEN EXCLUDED.download_error ELSE slack_sync_message_attachments.download_error END, "
+    "raw_payload = CASE WHEN slack_sync_message_attachments.raw_payload = '{}'::jsonb "
+    "THEN EXCLUDED.raw_payload ELSE slack_sync_message_attachments.raw_payload END, "
+    "source_run_id = COALESCE("
+    "slack_sync_message_attachments.source_run_id, EXCLUDED.source_run_id"
+    "), "
+    "last_seen_at = NOW(), updated_at = NOW()"
+)
+
+
+def _attachment_params(row: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        row["channel_id"],
+        row["message_ts"],
+        row["slack_file_id"],
+        row["name"],
+        row["title"],
+        row["mimetype"],
+        row["filetype"],
+        row["size_bytes"],
+        row["url_private"],
+        row["permalink"],
+        row["download_status"],
+        row["download_error"],
+        row["content_sha256"],
+        row["content_bytes"],
+        canonical_json(row["raw_payload"]),
+        row["source_run_id"],
+    )
+
+
+async def _flush_message_batch(pool, rows: list[dict[str, Any]]) -> int:
+    if not rows:
+        return 0
+    attachment_rows = [
+        attachment for row in rows for attachment in _attachment_rows(row)
+    ]
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.executemany(
+                _MESSAGE_UPSERT_SQL, [_message_params(row) for row in rows]
+            )
+            for start in range(0, len(attachment_rows), ATTACHMENT_BATCH_SIZE):
+                batch = attachment_rows[start : start + ATTACHMENT_BATCH_SIZE]
+                await conn.executemany(
+                    _ATTACHMENT_UPSERT_SQL,
+                    [_attachment_params(row) for row in batch],
+                )
+    return len(rows)
+
+
+async def import_archive_path(
+    pool,
+    archive_path: Path,
+    *,
+    import_id: str,
+    workflow_run_id: str,
+) -> dict[str, int]:
+    run_id = f"slack_archive_{import_id}"
+    counts = {
+        "channels_imported": 0,
+        "users_imported": 0,
+        "messages_imported": 0,
+        "messages_skipped": 0,
+        "message_files_skipped": 0,
+    }
+
+    with zipfile.ZipFile(archive_path) as zip_file:
+        channels = _json_member(zip_file, "channels.json")
+        users = _json_member(zip_file, "users.json")
+        if not isinstance(channels, list):
+            raise RuntimeError("Slack archive channels.json must be a list")
+        if not isinstance(users, list):
+            raise RuntimeError("Slack archive users.json must be a list")
+
+        channel_by_name = {
+            _as_text(channel.get("name")): channel
+            for channel in channels
+            if isinstance(channel, dict) and channel.get("id") and channel.get("name")
+        }
+        channel_id_by_name = {
+            name: _as_text(channel.get("id"))
+            for name, channel in channel_by_name.items()
+        }
+        requested = _archive_channel_refs([c for c in channels if isinstance(c, dict)])
+        await record_run_start(
+            pool,
+            run_id=run_id,
+            workflow_run_id=workflow_run_id,
+            mode=ARCHIVE_IMPORT_MODE,
+            requested=requested,
+            skipped=[],
+            metadata={
+                "source": "slack_archive_import",
+                "import_id": import_id,
+                "archive_path": str(archive_path),
+            },
+        )
+
+        counts["channels_imported"] = await _upsert_archive_channels(
+            pool,
+            [c for c in channels if isinstance(c, dict)],
+        )
+        counts["users_imported"] = await _upsert_archive_users(
+            pool,
+            [u for u in users if isinstance(u, dict)],
+        )
+
+        message_batch: list[dict[str, Any]] = []
+        for archive_file in _message_files(zip_file):
+            channel_name = archive_file.split("/", 1)[0]
+            channel_id = channel_id_by_name.get(channel_name)
+            if not channel_id:
+                counts["message_files_skipped"] += 1
+                continue
+            messages = _json_member(zip_file, archive_file)
+            if not isinstance(messages, list):
+                counts["message_files_skipped"] += 1
+                continue
+            for message in messages:
+                if not isinstance(message, dict):
+                    counts["messages_skipped"] += 1
+                    continue
+                row = _archive_message_row(
+                    channel_id,
+                    message,
+                    run_id=run_id,
+                    archive_file=archive_file,
+                )
+                if row is None:
+                    counts["messages_skipped"] += 1
+                    continue
+                message_batch.append(row)
+                if len(message_batch) >= MESSAGE_BATCH_SIZE:
+                    counts["messages_imported"] += await _flush_message_batch(
+                        pool,
+                        message_batch,
+                    )
+                    message_batch = []
+        counts["messages_imported"] += await _flush_message_batch(pool, message_batch)
+
+    await record_run_finish(
+        pool,
+        run_id=run_id,
+        status="completed",
+        synced=requested,
+        skipped=[],
+        failed=[],
+        counts={
+            "messages_fetched": counts["messages_imported"]
+            + counts["messages_skipped"],
+            "messages_upserted": counts["messages_imported"],
+        },
+    )
+    return counts
+
+
+def _s3_client():
+    import boto3
+    from botocore.config import Config
+
+    region = os.getenv("SLACK_ARCHIVE_UPLOAD_REGION") or "auto"
+    endpoint_url = os.getenv("SLACK_ARCHIVE_UPLOAD_ENDPOINT") or None
+    return boto3.client(
+        "s3",
+        region_name=region,
+        endpoint_url=endpoint_url,
+        config=Config(s3={"addressing_style": "path"}),
+    )
+
+
+def _download_s3_object(bucket: str, key: str, destination: Path) -> None:
+    with destination.open("wb") as handle:
+        _s3_client().download_fileobj(bucket, key, handle)
+
+
+async def _download_archive(import_row: dict[str, Any], destination: Path) -> None:
+    await asyncio.to_thread(
+        _download_s3_object,
+        _as_text(import_row.get("object_bucket")),
+        _as_text(import_row.get("object_key")),
+        destination,
+    )
+
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    if not inp.import_id:
+        raise RuntimeError("import_id is required")
+    import_row = await _load_archive_import(ctx._pool, inp.import_id)
+    if import_row.get("status") not in {"uploaded", "importing"}:
+        raise RuntimeError(
+            f"archive import {inp.import_id} must be uploaded before ingestion; "
+            f"got {import_row.get('status')}"
+        )
+
+    await _mark_import_running(ctx._pool, import_id=inp.import_id, run_id=ctx.run_id)
+    with tempfile.TemporaryDirectory(prefix="slack-archive-import-") as temp_dir:
+        archive_path = Path(temp_dir) / "archive.zip"
+        try:
+            await _download_archive(import_row, archive_path)
+            counts = await import_archive_path(
+                ctx._pool,
+                archive_path,
+                import_id=inp.import_id,
+                workflow_run_id=ctx.run_id,
+            )
+            await _mark_import_completed(
+                ctx._pool,
+                import_id=inp.import_id,
+                counts=counts,
+            )
+        except Exception as exc:
+            await _mark_import_failed(
+                ctx._pool, import_id=inp.import_id, error_text=str(exc)
+            )
+            raise
+
+    return {"status": "completed", "import_id": inp.import_id, "counts": counts}

--- a/workflows/slack/tests/test_archive_import.py
+++ b/workflows/slack/tests/test_archive_import.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+import types
+import zipfile
+from pathlib import Path
+
+
+def _load_archive_import():
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    api_module = sys.modules.setdefault("api", types.ModuleType("api"))
+
+    runtime_control = types.ModuleType("api.runtime_control")
+    runtime_control.canonical_json = lambda value: json.dumps(value, sort_keys=True)
+    api_module.runtime_control = runtime_control
+    sys.modules["api.runtime_control"] = runtime_control
+
+    workflow_engine = types.ModuleType("api.workflow_engine")
+    workflow_engine.WorkflowContext = object
+    api_module.workflow_engine = workflow_engine
+    sys.modules["api.workflow_engine"] = workflow_engine
+
+    vm_metrics = types.ModuleType("api.vm_metrics")
+    for name in (
+        "record_slack_etl_rate_limit",
+        "set_etl_active_scopes",
+        "set_etl_failed_scopes",
+        "set_etl_scope_sync_freshness_seconds",
+    ):
+        setattr(vm_metrics, name, lambda *_args, **_kwargs: None)
+    api_module.vm_metrics = vm_metrics
+    sys.modules["api.vm_metrics"] = vm_metrics
+
+    centaur_sdk = sys.modules.setdefault("centaur_sdk", types.ModuleType("centaur_sdk"))
+    centaur_sdk.secret = lambda _name, default=None: default
+
+    return importlib.import_module("workflows.slack.archive_import")
+
+
+archive_import = _load_archive_import()
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.executemany_calls: list[tuple[str, list[tuple]]] = []
+
+    async def executemany(self, sql, args_list):
+        self.executemany_calls.append((sql, list(args_list)))
+
+    def transaction(self):
+        conn = self
+
+        class _Txn:
+            async def __aenter__(self_):
+                return conn
+
+            async def __aexit__(self_, *_exc):
+                return False
+
+        return _Txn()
+
+
+class FakePool:
+    def __init__(self) -> None:
+        self.conn = FakeConn()
+
+    def acquire(self):
+        conn = self.conn
+
+        class _Acquire:
+            async def __aenter__(self_):
+                return conn
+
+            async def __aexit__(self_, *_exc):
+                return False
+
+        return _Acquire()
+
+
+def _write_dummy_archive(path: Path) -> None:
+    channels = [
+        {
+            "id": "CENG",
+            "name": "eng-test",
+            "is_archived": False,
+            "topic": {"value": "Archive topic"},
+            "purpose": {"value": "Archive purpose"},
+            "members": ["U123", "U234"],
+        },
+        {
+            "id": "CJP",
+            "name": "日本語",
+            "is_archived": True,
+            "topic": {"value": ""},
+            "purpose": {"value": ""},
+            "members": [],
+        },
+    ]
+    users = [
+        {
+            "id": "U123",
+            "team_id": "T123",
+            "name": "alice",
+            "real_name": "Alice Example",
+            "deleted": False,
+            "is_bot": False,
+            "profile": {"display_name": "alice"},
+        },
+        {
+            "id": "BUSER",
+            "team_id": "T123",
+            "name": "buildkite",
+            "real_name": "Build Kite",
+            "deleted": False,
+            "is_bot": True,
+            "profile": {"display_name": "buildkite"},
+        },
+    ]
+    messages = [
+        {
+            "user": "U123",
+            "type": "message",
+            "ts": "1770000000.000100",
+            "text": "thread root",
+            "thread_ts": "1770000000.000100",
+            "reply_count": 1,
+            "reply_users": ["U234"],
+            "reply_users_count": 1,
+            "latest_reply": "1770000001.000200",
+            "replies": [{"user": "U234", "ts": "1770000001.000200"}],
+            "blocks": [{"type": "rich_text"}],
+        },
+        {
+            "user": "U234",
+            "type": "message",
+            "ts": "1770000001.000200",
+            "text": "thread reply",
+            "thread_ts": "1770000000.000100",
+            "parent_user_id": "U123",
+            "blocks": [{"type": "rich_text"}],
+        },
+        {
+            "type": "message",
+            "user": "U123",
+            "upload": False,
+            "ts": "1770000003.000000",
+            "text": "edited text",
+            "subtype": "message_changed",
+            "thread_ts": "1770000002.000300",
+            "original": {
+                "user": "U123",
+                "type": "message",
+                "ts": "1770000002.000300",
+                "text": "old text",
+                "thread_ts": "1770000002.000300",
+            },
+            "edited_by": "U123",
+        },
+        {
+            "type": "message",
+            "user": "U123",
+            "upload": False,
+            "ts": "1770000004.000000",
+            "text": "",
+            "subtype": "message_deleted",
+            "thread_ts": "0000000000.000000",
+            "original": {
+                "user": "U123",
+                "type": "message",
+                "ts": "1770000004.000400",
+                "text": "delete me",
+            },
+            "deleted_by": "U123",
+        },
+        {
+            "user": "U123",
+            "type": "message",
+            "ts": "1770000005.000500",
+            "text": "uploaded a file",
+            "files": [
+                {
+                    "id": "F123",
+                    "name": "diagram.png",
+                    "title": "Diagram",
+                    "mimetype": "image/png",
+                    "filetype": "png",
+                    "size": 1234,
+                    "url_private": (
+                        "https://files.slack.com/files-pri/T123-F123/diagram.png"
+                        "?token=xoxe-secret"
+                    ),
+                    "url_private_download": (
+                        "https://files.slack.com/files-pri/T123-F123/download/diagram.png"
+                        "?token=xoxe-secret"
+                    ),
+                    "permalink": "https://example.slack.com/files/U123/F123/diagram.png",
+                }
+            ],
+        },
+        {
+            "user": "U123",
+            "type": "message",
+            "ts": "1770000006.000600",
+            "text": "link unfurl",
+            "attachments": [
+                {
+                    "id": 1,
+                    "from_url": "https://example.com/post",
+                    "title": "Unfurl",
+                    "text": "This is not a Slack file object.",
+                }
+            ],
+        },
+        {
+            "subtype": "bot_message",
+            "text": "build passed",
+            "username": "CI",
+            "type": "message",
+            "ts": "1770000007.000700",
+            "bot_id": "B123",
+            "app_id": "A123",
+            "blocks": [{"type": "section"}],
+        },
+    ]
+    unknown_messages = [
+        {
+            "user": "U123",
+            "type": "message",
+            "ts": "1770000008.000800",
+            "text": "unknown channel dir",
+        }
+    ]
+
+    with zipfile.ZipFile(path, "w") as zip_file:
+        zip_file.writestr("channels.json", json.dumps(channels))
+        zip_file.writestr("users.json", json.dumps(users))
+        zip_file.writestr("integration_logs.json", "[]")
+        zip_file.writestr("eng-test/2026-06-12.json", json.dumps(messages))
+        zip_file.writestr("garbled-name/2026-06-12.json", json.dumps(unknown_messages))
+
+
+def _executemany_calls_for(
+    pool: FakePool, table_name: str
+) -> list[tuple[str, list[tuple]]]:
+    return [
+        call
+        for call in pool.conn.executemany_calls
+        if f"INSERT INTO {table_name}" in call[0]
+    ]
+
+
+def test_import_archive_path_parses_public_export_shape_and_edges(
+    tmp_path, monkeypatch
+):
+    archive_path = tmp_path / "dummy-slack-export.zip"
+    _write_dummy_archive(archive_path)
+    pool = FakePool()
+    run_starts = []
+    run_finishes = []
+
+    async def fake_record_run_start(_pool, **kwargs):
+        run_starts.append(kwargs)
+
+    async def fake_record_run_finish(_pool, **kwargs):
+        run_finishes.append(kwargs)
+
+    monkeypatch.setattr(archive_import, "record_run_start", fake_record_run_start)
+    monkeypatch.setattr(archive_import, "record_run_finish", fake_record_run_finish)
+
+    counts = asyncio.run(
+        archive_import.import_archive_path(
+            pool,
+            archive_path,
+            import_id="sai_dummy",
+            workflow_run_id="wfr_dummy",
+        )
+    )
+
+    assert counts == {
+        "channels_imported": 2,
+        "users_imported": 2,
+        "messages_imported": 6,
+        "messages_skipped": 1,
+        "message_files_skipped": 1,
+    }
+    assert run_starts[0]["mode"] == "archive_import"
+    assert run_starts[0]["run_id"] == "slack_archive_sai_dummy"
+    assert run_finishes[0]["status"] == "completed"
+    assert run_finishes[0]["counts"]["messages_upserted"] == 6
+
+    channel_args = _executemany_calls_for(pool, "slack_sync_channels")[0][1]
+    assert channel_args[0][0:6] == (
+        "CENG",
+        "eng-test",
+        False,
+        "Archive topic",
+        "Archive purpose",
+        2,
+    )
+
+    user_args = _executemany_calls_for(pool, "slack_sync_users")[0][1]
+    assert user_args[0][0:4] == ("U123", "alice", "Alice Example", "alice")
+
+    message_args = _executemany_calls_for(pool, "slack_sync_messages")[0][1]
+    message_ts_values = {args[1] for args in message_args}
+    assert "1770000002.000300" in message_ts_values
+    assert "1770000004.000400" not in message_ts_values
+
+    changed_args = next(args for args in message_args if args[1] == "1770000002.000300")
+    assert changed_args[10] == "edited text"
+    assert changed_args[9] == "message_changed"
+
+    file_args = next(args for args in message_args if args[1] == "1770000005.000500")
+    raw_payload = json.loads(file_args[15])
+    assert raw_payload["files"][0]["url_private"].endswith("/diagram.png")
+    assert "token=" not in raw_payload["files"][0]["url_private"]
+    assert "token=" not in raw_payload["files"][0]["url_private_download"]
+
+    attachment_args = _executemany_calls_for(pool, "slack_sync_message_attachments")[0][
+        1
+    ]
+    assert len(attachment_args) == 1
+    assert attachment_args[0][2] == "F123"
+    assert attachment_args[0][8].endswith("/diagram.png")
+    assert "token=" not in attachment_args[0][8]
+
+
+def test_archive_upsert_sql_preserves_live_fields():
+    message_update = archive_import._MESSAGE_UPSERT_SQL.split(
+        "ON CONFLICT (channel_id, message_ts) DO UPDATE SET ",
+        1,
+    )[1]
+    attachment_update = archive_import._ATTACHMENT_UPSERT_SQL.split(
+        "ON CONFLICT (channel_id, message_ts, slack_file_id) DO UPDATE SET ",
+        1,
+    )[1]
+
+    assert "permalink = CASE WHEN slack_sync_messages.permalink = ''" in message_update
+    assert (
+        "source_run_id = COALESCE(slack_sync_messages.source_run_id" in message_update
+    )
+    assert "thread_refreshed_at" not in message_update
+    assert "content_bytes =" not in attachment_update
+    assert "content_sha256 =" not in attachment_update
+    assert "download_status = CASE WHEN" in attachment_update


### PR DESCRIPTION
## Summary
- add the Slack archive import workflow for public-channel exports and route it through the ETL backfill queue
- add the admin API control-panel surface for archive imports: create/presign, refresh upload URL, delete/cancel, start, retry, list, and get status
- add workflow runtime dependencies plus parser/upsert tests that use invented Slack export-shaped data

## Admin API endpoints
| UI action | Endpoint | Status |
| --- | --- | --- |
| Upload / create import | `POST /api/admin/slack/archive-imports` | Added |
| Existing presign alias | `POST /api/admin/slack/archive-imports/presign` | Existing, retained |
| Redo upload URL | `POST /api/admin/slack/archive-imports/{import_id}/upload-url` | Added |
| Delete uploaded archive | `DELETE /api/admin/slack/archive-imports/{import_id}` | Added |
| Track ingest status | `GET /api/admin/slack/archive-imports` and `GET /api/admin/slack/archive-imports/{import_id}` | Existing |
| Start ingest | `POST /api/admin/slack/archive-imports/{import_id}/start` | Updated to launch workflow |
| Retry failed ingest | `POST /api/admin/slack/archive-imports/{import_id}/retry` | Added |

## Validation
- `services/api/.venv/bin/pytest workflows/slack/tests`
- `cargo fmt --check`
- `cargo check -p centaur-api-server -p centaur-workflows`
- `cargo test -p centaur-api-server`
- `cargo test -p centaur-workflows`
- `just build-one api-rs`
- local Orbstack smoke against rebuilt API pod: create import -> refresh upload URL -> delete import -> GET confirmed `cancelled`
- earlier local Orbstack archive smoke: create/start completed 1 channel, 1 user, 1 message; upload-url + delete cancelled; retry completed 1 channel, 1 user, 1 message
- earlier local Orbstack full archive E2E: 309 channels, 343 users, 33,783 messages, 760 attachments

## Notes
- `just deploy` still hits the existing local Helm managed-fields conflict on API env vars that were set with `kubectl set env`; I rolled the local API deployment directly after rebuilding and verified the smoke against the rebuilt image.
