### PR TITLE
[codex] Add MCP persistent tool runners

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.80
+version: 0.1.81
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/values.dev.yaml
+++ b/contrib/chart/values.dev.yaml
@@ -32,6 +32,11 @@ apiRs:
   image:
     pullPolicy: IfNotPresent
 
+console:
+  enabled: true
+  image:
+    pullPolicy: IfNotPresent
+
 ironProxy:
   image:
     pullPolicy: IfNotPresent

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -11,7 +11,10 @@ use std::{
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
-use centaur_api_server::SandboxRuntime;
+use centaur_api_server::{
+    DiscoveredToolProxyFragment, SandboxRuntime, ToolDiscoveryConfig, discover_persona_registry,
+    discover_tool_proxy_fragment,
+};
 use centaur_iron_control::{
     IdentityInput, IronControlClient, IronControlError, RegisterError, RoleSpec, SessionRegistrar,
     register_role,
@@ -32,13 +35,7 @@ use centaur_workflows::WorkflowHostSandboxRuntime;
 use clap::{Args as ClapArgs, Parser, ValueEnum};
 use tracing::{error, info, warn};
 
-use crate::{
-    ServerError,
-    tool_discovery::{
-        DiscoveredToolProxyFragment, ToolDiscoveryConfig, discover_persona_registry,
-        discover_tool_proxy_fragment,
-    },
-};
+use crate::ServerError;
 
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
 

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod client;
 mod error;
+mod mcp;
 mod routes;
+mod tool_discovery;
 pub mod types;
 
 pub use centaur_session_runtime::{SandboxRuntime, SessionRuntime};
@@ -8,6 +10,10 @@ pub use error::ApiError;
 pub use routes::{
     AppState, build_router_with_app_state, build_router_with_runtime,
     build_router_with_session_and_workflow_runtime, build_router_with_session_runtime,
+};
+pub use tool_discovery::{
+    DiscoveredToolProxyFragment, ToolDiscoveryConfig, ToolDiscoveryError,
+    discover_persona_registry, discover_tool_proxy_fragment,
 };
 
 #[cfg(test)]
@@ -223,6 +229,35 @@ mod tests {
             let response = app.oneshot(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         }
+    }
+
+    #[tokio::test]
+    async fn mcp_initialize_is_available_without_auth_before_runtime_is_ready() {
+        let app = build_router_with_app_state(AppState::unready());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header(header::HOST, "centaur.local")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["result"]["serverInfo"]["name"], "centaur");
+        assert_eq!(
+            body["result"]["capabilities"]["tools"]["listChanged"],
+            false
+        );
     }
 
     #[tokio::test]

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -1,5 +1,4 @@
 mod args;
-mod tool_discovery;
 
 use centaur_api_server::{AppState, build_router_with_app_state};
 use centaur_session_runtime::SessionRuntime;
@@ -138,7 +137,7 @@ pub(crate) enum ServerError {
     #[error(transparent)]
     Telemetry(#[from] centaur_telemetry::TelemetryError),
     #[error(transparent)]
-    ToolDiscovery(#[from] tool_discovery::ToolDiscoveryError),
+    ToolDiscovery(#[from] centaur_api_server::ToolDiscoveryError),
     #[error("tool source error: {0}")]
     ToolSource(String),
     #[error("iron-proxy requires both firewall CA cert and key Secret names")]

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -1,0 +1,481 @@
+use std::{collections::BTreeSet, env, fs, path::PathBuf, time::Duration};
+
+use axum::{
+    Json,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use centaur_session_runtime::{PersistentToolCallInput, SessionRuntime};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::{
+    ApiError,
+    routes::AppState,
+    tool_discovery::{DiscoveredTool, ToolDiscoveryConfig, discover_tool_catalog},
+};
+
+pub(crate) async fn mcp_get() -> Response {
+    (
+        StatusCode::METHOD_NOT_ALLOWED,
+        Json(json!({
+            "ok": false,
+            "error": "MCP Streamable HTTP requests must use POST for this endpoint",
+        })),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct McpJsonRpcRequest {
+    jsonrpc: Option<String>,
+    #[serde(default)]
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpToolCallParams {
+    name: String,
+    #[serde(default)]
+    arguments: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct CentaurToolMcpArguments {
+    method: String,
+    #[serde(default)]
+    arguments: Value,
+}
+
+#[derive(Debug, Clone)]
+struct McpPrincipal {
+    principal_id: String,
+}
+
+pub(crate) async fn mcp_post(
+    State(state): State<AppState>,
+    Json(request): Json<McpJsonRpcRequest>,
+) -> Result<Response, ApiError> {
+    let principal = anonymous_mcp_principal();
+    if request.jsonrpc.as_deref().unwrap_or("2.0") != "2.0" {
+        return Ok(mcp_json_error(
+            request.id.unwrap_or(Value::Null),
+            -32600,
+            "invalid JSON-RPC version",
+        ));
+    }
+    let Some(id) = request.id.clone() else {
+        return Ok(StatusCode::NO_CONTENT.into_response());
+    };
+
+    let result = match request.method.as_str() {
+        "initialize" => json!({
+            "protocolVersion": requested_mcp_protocol_version(&request.params),
+            "capabilities": {
+                "tools": {
+                    "listChanged": false,
+                },
+            },
+            "serverInfo": {
+                "name": "centaur",
+                "version": env!("CARGO_PKG_VERSION"),
+            },
+        }),
+        "ping" => json!({}),
+        "tools/list" => {
+            let mut tools = vec![mcp_whoami_tool()];
+            tools.extend(mcp_centaur_tool_entries()?);
+            json!({
+                "tools": tools,
+            })
+        }
+        "tools/call" => {
+            let params = serde_json::from_value::<McpToolCallParams>(request.params.clone())
+                .map_err(|error| ApiError::BadRequest(error.to_string()))?;
+            if params.name == "centaur_whoami" {
+                mcp_whoami_result(&principal, params.arguments)?
+            } else {
+                let Some(tool) = mcp_find_centaur_tool(&params.name)? else {
+                    return Ok(mcp_json_error(id, -32602, "unknown tool"));
+                };
+                mcp_centaur_tool_result(&state, &principal, tool, params.arguments).await?
+            }
+        }
+        _ => return Ok(mcp_json_error(id, -32601, "method not found")),
+    };
+
+    Ok(Json(json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    }))
+    .into_response())
+}
+
+fn mcp_whoami_tool() -> Value {
+    json!({
+        "name": "centaur_whoami",
+        "description": "Show the Centaur MCP runner principal.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false,
+        },
+    })
+}
+
+fn mcp_centaur_tool_entries() -> Result<Vec<Value>, ApiError> {
+    let mut entries = Vec::new();
+    for tool in mcp_centaur_tool_catalog()? {
+        let methods = mcp_tool_method_names(&tool);
+        let mut description = tool
+            .description
+            .clone()
+            .unwrap_or_else(|| format!("Centaur tool package {}", tool.package));
+        if !methods.is_empty() {
+            description.push_str(" Available methods: ");
+            description.push_str(&methods.join(", "));
+            description.push_str(". Call method=help for this list.");
+        }
+        let mut method_schema = json!({
+            "type": "string",
+            "description": "Public method on the tool client to call. Use help to list available methods.",
+        });
+        if !methods.is_empty() {
+            method_schema["enum"] = json!(methods);
+        }
+        entries.push(json!({
+            "name": tool.name,
+            "description": description,
+            "inputSchema": {
+                "type": "object",
+                "required": ["method"],
+                "properties": {
+                    "method": method_schema,
+                    "arguments": {
+                        "type": "object",
+                        "description": "Keyword arguments passed to the selected method.",
+                        "additionalProperties": true,
+                    },
+                },
+                "additionalProperties": false,
+            },
+        }));
+    }
+    Ok(entries)
+}
+
+fn mcp_tool_method_names(tool: &DiscoveredTool) -> Vec<String> {
+    let path = tool.project_dir.join(&tool.client_module);
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return vec!["help".to_owned()];
+    };
+    let mut methods = BTreeSet::from(["help".to_owned()]);
+    for line in contents.lines() {
+        let indent = line.chars().take_while(|ch| *ch == ' ').count();
+        if indent != 0 && indent != 4 {
+            continue;
+        }
+        let trimmed = line.trim_start();
+        let signature = trimmed
+            .strip_prefix("def ")
+            .or_else(|| trimmed.strip_prefix("async def "));
+        let Some(signature) = signature else {
+            continue;
+        };
+        let Some(name) = signature.split_once('(').map(|(name, _)| name.trim()) else {
+            continue;
+        };
+        if name.is_empty() || name.starts_with('_') {
+            continue;
+        }
+        methods.insert(name.to_owned());
+    }
+    methods.into_iter().collect()
+}
+
+fn mcp_tool_help_result(tool: &DiscoveredTool) -> Result<Value, ApiError> {
+    Ok(mcp_text_result(
+        serde_json::to_string_pretty(&json!({
+            "tool": tool.name,
+            "description": tool.description,
+            "methods": mcp_tool_method_names(tool),
+        }))?,
+        false,
+    ))
+}
+
+fn mcp_centaur_tool_catalog() -> Result<Vec<DiscoveredTool>, ApiError> {
+    let dirs = ToolDiscoveryConfig {
+        tool_dirs: env::var("TOOL_DIRS").ok(),
+        tools_path: env::var("TOOLS_PATH").ok().map(PathBuf::from),
+        tools_overlay_path: env::var("TOOLS_OVERLAY_PATH").ok().map(PathBuf::from),
+        plugins_dir: env::var("PLUGINS_DIR").ok().map(PathBuf::from),
+        tools_config: env::var("TOOLS_CONFIG").ok().map(PathBuf::from),
+    }
+    .resolve_tool_dirs()
+    .map_err(|error| ApiError::Internal(error.to_string()))?;
+    Ok(discover_tool_catalog(&dirs)
+        .map_err(|error| ApiError::Internal(error.to_string()))?
+        .tools)
+}
+
+fn mcp_find_centaur_tool(name: &str) -> Result<Option<DiscoveredTool>, ApiError> {
+    Ok(mcp_centaur_tool_catalog()?
+        .into_iter()
+        .find(|tool| tool.name == name))
+}
+
+fn mcp_whoami_result(principal: &McpPrincipal, arguments: Value) -> Result<Value, ApiError> {
+    if !arguments.is_null() && !arguments.as_object().is_some_and(serde_json::Map::is_empty) {
+        return Err(ApiError::BadRequest(
+            "centaur_whoami does not accept arguments".to_owned(),
+        ));
+    }
+    Ok(mcp_text_result(
+        serde_json::to_string_pretty(&json!({
+            "principal_id": principal.principal_id,
+        }))?,
+        false,
+    ))
+}
+
+async fn mcp_centaur_tool_result(
+    state: &AppState,
+    principal: &McpPrincipal,
+    tool: DiscoveredTool,
+    arguments: Value,
+) -> Result<Value, ApiError> {
+    let params = serde_json::from_value::<CentaurToolMcpArguments>(arguments)
+        .map_err(|error| ApiError::BadRequest(error.to_string()))?;
+    if params.method.trim().is_empty() {
+        return Err(ApiError::BadRequest("method is required".to_owned()));
+    }
+    let method = params.method.trim().to_owned();
+    let methods = mcp_tool_method_names(&tool);
+    if method == "help" {
+        return mcp_tool_help_result(&tool);
+    }
+    if methods.len() > 1 && !methods.iter().any(|candidate| candidate == &method) {
+        return Ok(mcp_text_result(
+            format!(
+                "centaur tool {} has no method {method}. Available methods: {}",
+                tool.name,
+                methods.join(", ")
+            ),
+            true,
+        ));
+    }
+    run_persistent_centaur_tool(
+        state.runtime()?,
+        principal,
+        &tool,
+        &method,
+        params.arguments,
+    )
+    .await
+}
+
+async fn run_persistent_centaur_tool(
+    runtime: SessionRuntime,
+    principal: &McpPrincipal,
+    tool: &DiscoveredTool,
+    method: &str,
+    arguments: Value,
+) -> Result<Value, ApiError> {
+    let runner_principal_id = runtime
+        .register_mcp_runner_principal(&principal.principal_id)
+        .await?;
+    let output = runtime
+        .run_persistent_tool_call(PersistentToolCallInput {
+            principal_id: runner_principal_id,
+            token_id: None,
+            tool_name: tool.name.clone(),
+            method: method.to_owned(),
+            arguments,
+            timeout: Duration::from_secs(120),
+        })
+        .await?;
+    if output.timed_out {
+        return Ok(mcp_text_result(
+            format!(
+                "centaur tool {}.{method} timed out in sandbox {}: {}",
+                tool.name, output.sandbox_id, output.stderr
+            ),
+            true,
+        ));
+    }
+    if output.exit_status != Some(0) {
+        let detail = if output.stderr.is_empty() {
+            output.stdout.trim().to_owned()
+        } else {
+            output.stderr.trim().to_owned()
+        };
+        return Ok(mcp_text_result(
+            format!(
+                "centaur tool {}.{method} failed in sandbox {} with status {:?}: {detail}",
+                tool.name, output.sandbox_id, output.exit_status
+            ),
+            true,
+        ));
+    }
+    let stdout = output.stdout.trim();
+    if stdout.is_empty() {
+        return Ok(mcp_text_result("null".to_owned(), false));
+    }
+    match serde_json::from_str::<Value>(stdout) {
+        Ok(value) => Ok(mcp_text_result(
+            serde_json::to_string_pretty(&value)?,
+            false,
+        )),
+        Err(error) => Ok(mcp_text_result(
+            format!(
+                "centaur tool {}.{method} returned non-json output in sandbox {}: {error}: {stdout}",
+                tool.name, output.sandbox_id
+            ),
+            true,
+        )),
+    }
+}
+
+fn mcp_text_result(text: String, is_error: bool) -> Value {
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": text,
+            },
+        ],
+        "isError": is_error,
+    })
+}
+
+fn anonymous_mcp_principal() -> McpPrincipal {
+    McpPrincipal {
+        principal_id: "mcp-anonymous".to_owned(),
+    }
+}
+
+fn requested_mcp_protocol_version(params: &Value) -> &'static str {
+    const DEFAULT_PROTOCOL_VERSION: &str = "2025-06-18";
+    match params
+        .get("protocolVersion")
+        .and_then(Value::as_str)
+        .filter(|version| !version.trim().is_empty())
+    {
+        Some("2025-11-25") => "2025-11-25",
+        Some("2025-06-18") => "2025-06-18",
+        Some("2025-03-26") => "2025-03-26",
+        _ => DEFAULT_PROTOCOL_VERSION,
+    }
+}
+
+fn mcp_json_error(id: Value, code: i64, message: &str) -> Response {
+    Json(json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }))
+    .into_response()
+}
+
+#[cfg(test)]
+mod mcp_tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        env::temp_dir().join(format!("{prefix}-{}-{suffix}", std::process::id()))
+    }
+
+    fn test_tool(project_dir: PathBuf) -> DiscoveredTool {
+        DiscoveredTool {
+            name: "demo".to_owned(),
+            package: "demo".to_owned(),
+            description: Some("Demo tool".to_owned()),
+            client_module: "client.py".to_owned(),
+            project_dir,
+        }
+    }
+
+    #[test]
+    fn mcp_tool_method_names_include_public_client_methods_and_help() {
+        let temp = temp_dir("centaur-api-rs-mcp-methods");
+        fs::create_dir_all(&temp).unwrap();
+        fs::write(
+            temp.join("client.py"),
+            r#"
+def search(query, limit=20):
+    return []
+
+def _hidden():
+    return None
+
+class DemoClient:
+    def list_channels(self, limit=200):
+        def nested_helper():
+            return None
+        return []
+
+    async def search_messages(self, query):
+        return []
+"#,
+        )
+        .unwrap();
+
+        let methods = mcp_tool_method_names(&test_tool(temp.clone()));
+
+        assert!(methods.contains(&"help".to_owned()));
+        assert!(methods.contains(&"search".to_owned()));
+        assert!(methods.contains(&"list_channels".to_owned()));
+        assert!(methods.contains(&"search_messages".to_owned()));
+        assert!(!methods.contains(&"_hidden".to_owned()));
+        assert!(!methods.contains(&"nested_helper".to_owned()));
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[tokio::test]
+    async fn mcp_unknown_method_returns_available_methods_without_running_tool() {
+        let temp = temp_dir("centaur-api-rs-mcp-unknown-method");
+        fs::create_dir_all(&temp).unwrap();
+        fs::write(
+            temp.join("client.py"),
+            r#"
+def search(query, limit=20):
+    return []
+"#,
+        )
+        .unwrap();
+
+        let result = mcp_centaur_tool_result(
+            &AppState::unready(),
+            &McpPrincipal {
+                principal_id: "mcp-test".to_owned(),
+            },
+            test_tool(temp.clone()),
+            json!({"method": "missing", "arguments": {}}),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result["isError"], true);
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("has no method missing"));
+        assert!(text.contains("search"));
+
+        let _ = fs::remove_dir_all(temp);
+    }
+}

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -54,6 +54,7 @@ use uuid::Uuid;
 
 use crate::{
     ApiError,
+    mcp::{mcp_get, mcp_post},
     types::{
         AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
         EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
@@ -125,7 +126,7 @@ impl AppState {
         self.initialized().is_some()
     }
 
-    fn runtime(&self) -> Result<SessionRuntime, ApiError> {
+    pub(crate) fn runtime(&self) -> Result<SessionRuntime, ApiError> {
         self.initialized()
             .map(|initialized| initialized.runtime)
             .ok_or_else(|| ApiError::ServiceUnavailable("api-rs is still starting".to_owned()))
@@ -189,6 +190,7 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route("/readyz", get(readyz))
         .route("/metrics", get(metrics))
         .route("/api/personas", get(list_personas))
+        .route("/mcp", post(mcp_post).get(mcp_get))
         .route(
             "/api/session/{thread_key}",
             post(create_or_get_session).get(get_session_context),

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -38,23 +38,37 @@ const DEFAULT_MATCH_HEADERS: &[&str] = &[
 ];
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct ToolDiscoveryConfig {
-    pub(crate) tool_dirs: Option<String>,
-    pub(crate) tools_path: Option<PathBuf>,
-    pub(crate) tools_overlay_path: Option<PathBuf>,
-    pub(crate) plugins_dir: Option<PathBuf>,
-    pub(crate) tools_config: Option<PathBuf>,
+pub struct ToolDiscoveryConfig {
+    pub tool_dirs: Option<String>,
+    pub tools_path: Option<PathBuf>,
+    pub tools_overlay_path: Option<PathBuf>,
+    pub plugins_dir: Option<PathBuf>,
+    pub tools_config: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct DiscoveredToolProxyFragment {
-    pub(crate) fragment: ProxyFragment,
-    pub(crate) tool_count: usize,
-    pub(crate) secret_count: usize,
+pub struct DiscoveredToolProxyFragment {
+    pub fragment: ProxyFragment,
+    pub tool_count: usize,
+    pub secret_count: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DiscoveredToolCatalog {
+    pub(crate) tools: Vec<DiscoveredTool>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DiscoveredTool {
+    pub(crate) name: String,
+    pub(crate) package: String,
+    pub(crate) description: Option<String>,
+    pub(crate) client_module: String,
+    pub(crate) project_dir: PathBuf,
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum ToolDiscoveryError {
+pub enum ToolDiscoveryError {
     #[error("failed to read {path}: {source}")]
     Read {
         path: PathBuf,
@@ -72,7 +86,7 @@ pub(crate) enum ToolDiscoveryError {
 }
 
 impl ToolDiscoveryConfig {
-    pub(crate) fn resolve_tool_dirs(&self) -> Result<Vec<PathBuf>, ToolDiscoveryError> {
+    pub fn resolve_tool_dirs(&self) -> Result<Vec<PathBuf>, ToolDiscoveryError> {
         if let Some(tool_dirs) = clean_optional_str(self.tool_dirs.as_deref()) {
             return Ok(split_tool_dirs(&tool_dirs));
         }
@@ -113,7 +127,7 @@ impl ToolDiscoveryConfig {
     }
 }
 
-pub(crate) fn discover_tool_proxy_fragment(
+pub fn discover_tool_proxy_fragment(
     tool_dirs: &[PathBuf],
 ) -> Result<DiscoveredToolProxyFragment, ToolDiscoveryError> {
     let tools = collect_plugin_metadata(tool_dirs)?.tools;
@@ -136,13 +150,32 @@ pub(crate) fn discover_tool_proxy_fragment(
     })
 }
 
-pub(crate) fn discover_persona_registry(
+pub fn discover_persona_registry(
     tool_dirs: &[PathBuf],
     default_persona_id: Option<String>,
 ) -> Result<PersonaRegistry, ToolDiscoveryError> {
     let plugins = collect_plugin_metadata(tool_dirs)?;
     PersonaRegistry::new(plugins.personas, default_persona_id, plugins.overlay_chain)
         .map_err(ToolDiscoveryError::Invalid)
+}
+
+pub(crate) fn discover_tool_catalog(
+    tool_dirs: &[PathBuf],
+) -> Result<DiscoveredToolCatalog, ToolDiscoveryError> {
+    let mut tools = Vec::new();
+    for tool in collect_plugin_metadata(tool_dirs)?.tools {
+        for script_name in tool.script_names {
+            tools.push(DiscoveredTool {
+                name: script_name,
+                package: tool.package.clone(),
+                description: tool.description.clone(),
+                client_module: tool.client_module.clone(),
+                project_dir: tool.dir.clone(),
+            });
+        }
+    }
+    tools.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(DiscoveredToolCatalog { tools })
 }
 
 fn split_tool_dirs(value: &str) -> Vec<PathBuf> {
@@ -281,6 +314,11 @@ fn parse_toml(path: &Path, contents: &str) -> Result<TomlValue, ToolDiscoveryErr
 #[derive(Clone, Debug)]
 struct LoadedToolMeta {
     name: String,
+    dir: PathBuf,
+    package: String,
+    description: Option<String>,
+    client_module: String,
+    script_names: Vec<String>,
     secrets: Vec<ToolSecret>,
 }
 
@@ -436,7 +474,7 @@ fn load_plugin_meta(
         .and_then(|value| value.get("centaur"))
         .unwrap_or(&default_tool_conf);
     if tool_conf.get("type").and_then(TomlValue::as_str) != Some("persona") {
-        return load_tool_meta(source_root, plugin_dir, tool_conf)
+        return load_tool_meta(source_root, plugin_dir, &pyproject, tool_conf)
             .map(|meta| meta.map(LoadedPluginMeta::Tool));
     }
     let id = plugin_dir
@@ -473,6 +511,7 @@ fn load_plugin_meta(
 fn load_tool_meta(
     source_root: &Path,
     tool_dir: &Path,
+    pyproject: &TomlValue,
     tool_conf: &TomlValue,
 ) -> Result<Option<LoadedToolMeta>, ToolDiscoveryError> {
     let name = tool_dir
@@ -482,6 +521,40 @@ fn load_tool_meta(
             ToolDiscoveryError::Invalid(format!("invalid tool path {}", tool_dir.display()))
         })?
         .to_owned();
+    let default_project_conf = TomlValue::Table(Default::default());
+    let project_conf = pyproject.get("project").unwrap_or(&default_project_conf);
+    let package = project_conf
+        .get("name")
+        .and_then(TomlValue::as_str)
+        .map(str::to_owned)
+        .unwrap_or_else(|| name.clone());
+    let description = project_conf
+        .get("description")
+        .and_then(TomlValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    let client_module = tool_conf
+        .get("module")
+        .and_then(TomlValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("client.py")
+        .to_owned();
+    let script_names = project_conf
+        .get("scripts")
+        .and_then(TomlValue::as_table)
+        .map(|scripts| {
+            let mut names = scripts
+                .keys()
+                .filter(|script| !script.contains('/') && !script.contains('\0'))
+                .cloned()
+                .collect::<Vec<_>>();
+            names.sort();
+            names
+        })
+        .filter(|names| !names.is_empty())
+        .unwrap_or_else(|| vec![name.clone()]);
     let default_hosts = string_array(tool_conf.get("hosts"));
     let labels = tool_labels(&name, &overlay_name_for_root(source_root));
     let secrets = match parse_secret_list(tool_conf.get("secrets"), &default_hosts, &labels)
@@ -503,7 +576,15 @@ fn load_tool_meta(
             return Ok(None);
         }
     };
-    Ok(Some(LoadedToolMeta { name, secrets }))
+    Ok(Some(LoadedToolMeta {
+        name,
+        dir: tool_dir.to_path_buf(),
+        package,
+        description,
+        client_module,
+        script_names,
+        secrets,
+    }))
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -36,10 +36,11 @@ use thiserror::Error;
 use tokio::{
     io,
     sync::Mutex,
-    time::{Instant, Interval, MissedTickBehavior, interval_at, sleep},
+    time::{Instant, Interval, MissedTickBehavior, interval_at, sleep, timeout},
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
 use tracing::{Instrument, Span, error, info, info_span, warn};
+use uuid::Uuid;
 
 pub use cleanup::SessionSandboxCleanupConfig;
 
@@ -63,6 +64,8 @@ type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
 type ExecutionSpanRegistry = Arc<Mutex<HashMap<String, Span>>>;
 type SessionPipeMap = Arc<DashMap<String, SessionPipe>>;
 type SessionPipeOpenLocks = Arc<DashMap<String, Arc<Mutex<()>>>>;
+type ToolRunnerMap = Arc<DashMap<String, Arc<PersistentToolRunner>>>;
+type ToolRunnerOpenLocks = Arc<DashMap<String, Arc<Mutex<()>>>>;
 
 #[derive(Clone)]
 pub struct SessionRuntime {
@@ -70,6 +73,8 @@ pub struct SessionRuntime {
     sandbox_runtime: SandboxRuntime,
     sandbox_pipes: SessionPipeMap,
     sandbox_pipe_open_locks: SessionPipeOpenLocks,
+    tool_runners: ToolRunnerMap,
+    tool_runner_open_locks: ToolRunnerOpenLocks,
     execution_spans: ExecutionSpanRegistry,
     iron_control: Option<SessionRegistrar>,
     warm_pool: Option<Arc<WarmPoolManager>>,
@@ -253,9 +258,62 @@ pub struct ExecuteSessionInput {
     pub max_duration_ms: Option<u64>,
 }
 
+#[derive(Debug)]
+pub struct PersistentToolCallInput {
+    pub principal_id: String,
+    pub token_id: Option<String>,
+    pub tool_name: String,
+    pub method: String,
+    pub arguments: Value,
+    pub timeout: Duration,
+}
+
+#[derive(Debug)]
+pub struct PersistentToolCallOutput {
+    pub sandbox_id: String,
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_status: Option<i32>,
+    pub timed_out: bool,
+}
+
 #[derive(Clone)]
 struct SessionPipe {
     stdin: Arc<Mutex<SessionInputSink>>,
+}
+
+struct PersistentToolRunner {
+    sandbox_id: SandboxId,
+    io: Mutex<PersistentToolRunnerIo>,
+}
+
+struct PersistentToolRunnerIo {
+    stdin: FramedWrite<SandboxWrite, LinesCodec>,
+    stdout: FramedRead<SandboxRead, LinesCodec>,
+    _guard: SandboxIoGuard,
+}
+
+#[derive(Serialize)]
+struct PersistentToolRunnerRequest {
+    id: String,
+    tool: String,
+    method: String,
+    arguments: Value,
+    principal_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token_id: Option<String>,
+    timeout_seconds: u64,
+}
+
+#[derive(Deserialize)]
+struct PersistentToolRunnerResponse {
+    status: Option<i32>,
+    #[serde(default)]
+    stdout: String,
+    #[serde(default)]
+    stderr: String,
+    #[serde(default)]
+    timed_out: bool,
 }
 
 /// Shared handles threaded through background session tasks (stdout pump,
@@ -315,6 +373,8 @@ impl SessionRuntime {
             sandbox_runtime,
             sandbox_pipes: Arc::new(DashMap::new()),
             sandbox_pipe_open_locks: Arc::new(DashMap::new()),
+            tool_runners: Arc::new(DashMap::new()),
+            tool_runner_open_locks: Arc::new(DashMap::new()),
             execution_spans: Arc::new(Mutex::new(HashMap::new())),
             iron_control: None,
             warm_pool: None,
@@ -391,11 +451,225 @@ impl SessionRuntime {
         }
     }
 
+    pub async fn run_persistent_tool_call(
+        &self,
+        input: PersistentToolCallInput,
+    ) -> Result<PersistentToolCallOutput, SessionRuntimeError> {
+        if input.principal_id.trim().is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "persistent tool runner principal_id is required".to_owned(),
+            ));
+        }
+        if input.tool_name.trim().is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "persistent tool runner tool_name is required".to_owned(),
+            ));
+        }
+        if input.method.trim().is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "persistent tool runner method is required".to_owned(),
+            ));
+        }
+        if input.timeout.is_zero() {
+            return Err(SessionRuntimeError::BadRequest(
+                "persistent tool runner timeout must be non-zero".to_owned(),
+            ));
+        }
+
+        let runner = self
+            .ensure_persistent_tool_runner(input.principal_id.trim())
+            .await?;
+        match runner.call(&input).await {
+            Ok(output) => Ok(output),
+            Err(error) => {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "persistent_tool_runner_call_failed",
+                    principal_id = input.principal_id.trim(),
+                    sandbox_id = %runner.sandbox_id.as_str(),
+                    %error,
+                    "persistent tool runner call failed; recreating runner and retrying once"
+                );
+                self.discard_persistent_tool_runner(input.principal_id.trim(), &runner)
+                    .await;
+                let retry_runner = self
+                    .ensure_persistent_tool_runner(input.principal_id.trim())
+                    .await?;
+                retry_runner.call(&input).await
+            }
+        }
+    }
+
+    async fn ensure_persistent_tool_runner(
+        &self,
+        principal_id: &str,
+    ) -> Result<Arc<PersistentToolRunner>, SessionRuntimeError> {
+        if let Some(runner) = self.cached_persistent_tool_runner(principal_id) {
+            return Ok(runner);
+        }
+
+        let open_lock = {
+            let entry = self
+                .tool_runner_open_locks
+                .entry(principal_id.to_owned())
+                .or_insert_with(|| Arc::new(Mutex::new(())));
+            entry.clone()
+        };
+        let _open_guard = open_lock.lock().await;
+
+        if let Some(runner) = self.cached_persistent_tool_runner(principal_id) {
+            return Ok(runner);
+        }
+
+        let runner = Arc::new(self.create_persistent_tool_runner(principal_id).await?);
+        self.tool_runners
+            .insert(principal_id.to_owned(), runner.clone());
+        Ok(runner)
+    }
+
+    fn cached_persistent_tool_runner(
+        &self,
+        principal_id: &str,
+    ) -> Option<Arc<PersistentToolRunner>> {
+        self.tool_runners
+            .get(principal_id)
+            .map(|entry| entry.clone())
+    }
+
+    async fn create_persistent_tool_runner(
+        &self,
+        principal_id: &str,
+    ) -> Result<PersistentToolRunner, SessionRuntimeError> {
+        let thread_key = ThreadKey::parse(format!("mcp:{principal_id}"))
+            .map_err(|error| SessionRuntimeError::BadRequest(error.to_string()))?;
+        let harness = self
+            .sandbox_runtime
+            .warm_harness
+            .clone()
+            .unwrap_or(HarnessType::Codex);
+        let execution_id = format!("mcp-runner-{}", Uuid::new_v4().simple());
+        let mut spec =
+            (self.sandbox_runtime.spec_factory)(&thread_key, &execution_id, &harness, None);
+        spec.labels.insert(
+            "centaur.ai/component".to_owned(),
+            "mcp-tool-runner".to_owned(),
+        );
+        spec.labels.insert(
+            "centaur.ai/workload".to_owned(),
+            "persistent-tool-runner".to_owned(),
+        );
+        spec.iron_control_principal = Some(principal_id.to_owned());
+        upsert_spec_env(
+            &mut spec,
+            "CENTAUR_MCP_PRINCIPAL_ID",
+            principal_id.to_owned(),
+        );
+        configure_persistent_tool_runner_command(&mut spec);
+
+        let handle = self.sandbox_runtime.manager.create_running(spec).await?;
+        let sandbox_id = handle.id.clone();
+        let io = self
+            .sandbox_runtime
+            .manager
+            .open_io(&sandbox_id)
+            .await?
+            .into_parts();
+        let stdin = io.stdin;
+        let stdout = io.stdout;
+        let stderr = io.stderr;
+        let guard = io.guard;
+        let stderr_sandbox_id = sandbox_id.clone();
+        tokio::spawn(async move {
+            if let Err(error) = drain_stderr(stderr).await {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "persistent_tool_runner_stderr_drain_failed",
+                    sandbox_id = %stderr_sandbox_id.as_str(),
+                    %error,
+                    "persistent tool runner stderr drain failed"
+                );
+            }
+        });
+
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "persistent_tool_runner_created",
+            principal_id,
+            sandbox_id = %handle.id.as_str(),
+            "persistent tool runner created"
+        );
+
+        Ok(PersistentToolRunner {
+            sandbox_id: handle.id,
+            io: Mutex::new(PersistentToolRunnerIo {
+                stdin: FramedWrite::new(stdin, LinesCodec::new()),
+                stdout: FramedRead::new(stdout, LinesCodec::new()),
+                _guard: guard,
+            }),
+        })
+    }
+
+    async fn discard_persistent_tool_runner(
+        &self,
+        principal_id: &str,
+        runner: &Arc<PersistentToolRunner>,
+    ) {
+        let removed = self
+            .tool_runners
+            .remove_if(principal_id, |_key, current| Arc::ptr_eq(current, runner));
+        if removed.is_none() {
+            return;
+        }
+        if let Err(error) = self.sandbox_runtime.stop_sandbox(&runner.sandbox_id).await {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "persistent_tool_runner_stop_failed",
+                principal_id,
+                sandbox_id = %runner.sandbox_id.as_str(),
+                %error,
+                "failed to stop discarded persistent tool runner"
+            );
+        }
+    }
+
     /// Attach an iron-control registrar so each new session upserts its
-    /// principal and assigns the configured roles.
+    /// principal and assigns it the configured roles.
     pub fn with_iron_control(mut self, registrar: SessionRegistrar) -> Self {
         self.iron_control = Some(registrar);
         self
+    }
+
+    /// Register the shared unauthenticated MCP runner principal when
+    /// iron-control is enabled, so proxy-backed tool calls can resolve an
+    /// effective config without minting per-user credentials in this layer.
+    pub async fn register_mcp_runner_principal(
+        &self,
+        principal_id: &str,
+    ) -> Result<String, SessionRuntimeError> {
+        let principal_id = principal_id.trim();
+        if principal_id.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "mcp runner principal_id is required".to_owned(),
+            ));
+        }
+        if principal_id.contains(':') {
+            return Err(SessionRuntimeError::BadRequest(
+                "mcp runner principal_id must not contain ':'".to_owned(),
+            ));
+        }
+        let thread_key = ThreadKey::parse(format!("mcp:{principal_id}"))
+            .map_err(|error| SessionRuntimeError::BadRequest(error.to_string()))?;
+        if let Some(registrar) = &self.iron_control {
+            let metadata = json!({
+                "mcp_runner": true,
+                "mcp_principal_id": principal_id,
+            });
+            let principal = registrar
+                .register_session(thread_key.as_str(), Some(&metadata))
+                .await?;
+            return Ok(principal.id);
+        }
+        Ok(principal_id.to_owned())
     }
 
     pub fn with_warm_pool(mut self, config: WarmPoolConfig) -> Self {
@@ -2093,6 +2367,92 @@ impl SessionRuntime {
                 "failed to record orphaned execution failure"
             );
         }
+    }
+}
+
+impl PersistentToolRunner {
+    async fn call(
+        &self,
+        input: &PersistentToolCallInput,
+    ) -> Result<PersistentToolCallOutput, SessionRuntimeError> {
+        let request_id = format!("mcp-call-{}", Uuid::new_v4().simple());
+        let request = PersistentToolRunnerRequest {
+            id: request_id.clone(),
+            tool: input.tool_name.trim().to_owned(),
+            method: input.method.trim().to_owned(),
+            arguments: input.arguments.clone(),
+            principal_id: input.principal_id.trim().to_owned(),
+            token_id: input.token_id.clone(),
+            timeout_seconds: input.timeout.as_secs().max(1),
+        };
+        let line = serde_json::to_string(&request).map_err(|error| {
+            SessionRuntimeError::Sandbox(SandboxError::io_source(
+                "encode persistent tool runner request",
+                error,
+            ))
+        })?;
+        let response_timeout = input.timeout.saturating_add(Duration::from_secs(5));
+        let mut io = self.io.lock().await;
+        io.stdin.send(line).await.map_err(|error| {
+            SessionRuntimeError::Sandbox(SandboxError::io_source(
+                "write persistent tool runner request",
+                error,
+            ))
+        })?;
+
+        let response = match timeout(response_timeout, async {
+            loop {
+                let Some(line) = io.stdout.next().await else {
+                    return Err(SessionRuntimeError::Sandbox(SandboxError::io(
+                        "persistent tool runner stdout closed",
+                    )));
+                };
+                let line = line.map_err(|error| {
+                    SessionRuntimeError::Sandbox(SandboxError::io_source(
+                        "read persistent tool runner response",
+                        error,
+                    ))
+                })?;
+                let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+                if value.get("id").and_then(Value::as_str) != Some(request_id.as_str()) {
+                    continue;
+                }
+                return serde_json::from_value::<PersistentToolRunnerResponse>(value).map_err(
+                    |error| {
+                        SessionRuntimeError::Sandbox(SandboxError::io_source(
+                            "decode persistent tool runner response",
+                            error,
+                        ))
+                    },
+                );
+            }
+        })
+        .await
+        {
+            Ok(result) => result?,
+            Err(_) => {
+                return Ok(PersistentToolCallOutput {
+                    sandbox_id: self.sandbox_id.as_str().to_owned(),
+                    stdout: String::new(),
+                    stderr: format!(
+                        "persistent tool runner timed out after {} ms",
+                        response_timeout.as_millis()
+                    ),
+                    exit_status: None,
+                    timed_out: true,
+                });
+            }
+        };
+
+        Ok(PersistentToolCallOutput {
+            sandbox_id: self.sandbox_id.as_str().to_owned(),
+            stdout: response.stdout,
+            stderr: response.stderr,
+            exit_status: response.status,
+            timed_out: response.timed_out,
+        })
     }
 }
 
@@ -4785,6 +5145,98 @@ fn nonzero_duration_millis(value: u64) -> Result<Duration, SessionRuntimeError> 
     Ok(Duration::from_millis(value))
 }
 
+const PERSISTENT_TOOL_RUNNER_SCRIPT: &str = r#"
+import json
+import os
+import subprocess
+import sys
+import traceback
+
+print("__CENTAUR_TOOL_RUNNER_READY", flush=True)
+
+for raw_line in sys.stdin:
+    raw_line = raw_line.strip()
+    if not raw_line:
+        continue
+    request_id = None
+    try:
+        request = json.loads(raw_line)
+        request_id = request.get("id")
+        tool = request["tool"]
+        method = request["method"]
+        arguments = request.get("arguments", {})
+        timeout_seconds = max(1, int(request.get("timeout_seconds") or 120))
+        env = os.environ.copy()
+        principal_id = request.get("principal_id")
+        token_id = request.get("token_id")
+        if principal_id:
+            env["CENTAUR_MCP_PRINCIPAL_ID"] = str(principal_id)
+        if token_id:
+            env["CENTAUR_MCP_TOKEN_ID"] = str(token_id)
+        try:
+            completed = subprocess.run(
+                [
+                    "centaur-tools",
+                    "call",
+                    str(tool),
+                    str(method),
+                    json.dumps(arguments, separators=(",", ":")),
+                ],
+                check=False,
+                text=True,
+                capture_output=True,
+                timeout=timeout_seconds,
+                env=env,
+            )
+            response = {
+                "id": request_id,
+                "status": completed.returncode,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+                "timed_out": False,
+            }
+        except subprocess.TimeoutExpired as exc:
+            response = {
+                "id": request_id,
+                "status": None,
+                "stdout": exc.stdout or "",
+                "stderr": (exc.stderr or "") + f"\ncentaur tool call timed out after {timeout_seconds}s",
+                "timed_out": True,
+            }
+    except Exception:
+        response = {
+            "id": request_id,
+            "status": 1,
+            "stdout": "",
+            "stderr": traceback.format_exc(),
+            "timed_out": False,
+        }
+    print(json.dumps(response, separators=(",", ":")), flush=True)
+"#;
+
+fn configure_persistent_tool_runner_command(spec: &mut SandboxSpec) {
+    if should_preserve_entrypoint_for_tool_runner(spec) {
+        spec.command = Some(vec!["/entrypoint.sh".to_owned()]);
+        spec.args = vec![
+            "python3".to_owned(),
+            "-u".to_owned(),
+            "-c".to_owned(),
+            PERSISTENT_TOOL_RUNNER_SCRIPT.to_owned(),
+        ];
+    } else {
+        spec.command = Some(vec!["python3".to_owned(), "-u".to_owned(), "-c".to_owned()]);
+        spec.args = vec![PERSISTENT_TOOL_RUNNER_SCRIPT.to_owned()];
+    }
+}
+
+fn should_preserve_entrypoint_for_tool_runner(spec: &SandboxSpec) -> bool {
+    spec.command
+        .as_ref()
+        .and_then(|command| command.first())
+        .is_some_and(|program| program == "/entrypoint.sh")
+        || spec.args.first().is_some_and(|arg| arg == "harness-server")
+}
+
 fn execution_metadata(
     metadata: Option<Value>,
     idle_timeout_ms: Option<u64>,
@@ -4889,6 +5341,26 @@ mod tests {
                 .is_none()
         );
         assert!(PersonaRegistry::new(Vec::new(), Some("missing".to_owned()), Vec::new()).is_err());
+    }
+
+    #[test]
+    fn persistent_tool_runner_command_preserves_sandbox_entrypoint_for_tool_setup() {
+        let thread_key = ThreadKey::parse("mcp:test").unwrap();
+        let workload = SandboxWorkloadMode::codex_app_server(
+            "centaur-agent:latest",
+            [("TOOL_DIRS".to_owned(), "/app/tools".to_owned())],
+            HarnessType::Codex,
+        );
+        let mut spec = workload.spec(&thread_key, &HarnessType::Codex, None);
+
+        configure_persistent_tool_runner_command(&mut spec);
+
+        assert_eq!(spec.command, Some(vec!["/entrypoint.sh".to_owned()]));
+        assert_eq!(spec.args[0], "python3");
+        assert_eq!(spec.args[1], "-u");
+        assert_eq!(spec.args[2], "-c");
+        assert!(spec.args[3].contains("__CENTAUR_TOOL_RUNNER_READY"));
+        assert_eq!(env_value(&spec, "TOOL_DIRS"), Some("/app/tools"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This keeps PR #718 focused on the authless MCP transport and persistent tool-runner runtime. User auth/token issuance stays out of this base PR; the console OAuth/JWT work remains stacked separately.

- Add a Streamable HTTP `/mcp` endpoint in `api-rs` for `initialize`, `ping`, `tools/list`, and `tools/call`.
- Keep the MCP endpoint implementation in `src/mcp.rs`, with `routes.rs` only wiring the handlers.
- Discover Centaur tool scripts from existing tool metadata and expose them as MCP tools with a `method` argument.
- Route real tool calls through one persistent sandbox per MCP principal, keeping the sandbox on the existing iron-proxy/iron-control path instead of one sandbox per tool call.
- Keep `tool_discovery` mostly private: only the startup-facing discovery types/functions are exported for the binary; MCP catalog structs stay crate-local.
- Enable the local dev console in `values.dev.yaml`, because dev `toolServer.enabled` plus tool proxy fragments require iron-control wiring for api-rs to start.
- Bump the chart version for the dev-values chart change.

## ELI10

Centaur now speaks MCP. A client can ask Centaur what tools exist, then call one of those tools.

The first real tool call starts a small sandbox that knows how to run Centaur tools. Centaur keeps that sandbox open for the same MCP principal, so later calls do not pay the full startup cost again. This PR does not decide who the human user is yet; the stacked auth PR adds that.

## Validation

- `cargo fmt --all --check`
- `cargo test -p centaur-api-server`
- `helm lint contrib/chart -f contrib/chart/values.dev.yaml`
- Earlier local OrbStack validation before the rebase/module extraction: `just build-one api-rs`, `just deploy`, then MCP smoke from inside the api-rs pod:
  - `initialize` returned Centaur server info and tools capability
  - `centaur_whoami` returned `mcp-anonymous`
  - `tools/list` returned 79 tools
  - `coindesk.search` succeeded through `/mcp` in 15s, creating persistent runner sandbox `asbx-1782855102288-4`
