### PR TITLE
fix: preserve manual iron-control role revocations

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -844,6 +844,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
+ "tokio",
  "urlencoding",
 ]
 

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -677,10 +677,11 @@ impl SandboxArgs {
         }))
     }
 
-    /// Background registration for git/volume-backed tool updates. The startup
-    /// registrar grants every principal the stable infra role; re-upserting that
-    /// role here adds newly discovered tool secrets to existing and future
-    /// principals without restarting api-rs or sandboxes.
+    /// Background registration for git/volume-backed tool updates. Startup
+    /// registration keeps the stable infra role current; re-upserting that role
+    /// here adds newly discovered tool secrets to principals that hold the role
+    /// without restarting api-rs or sandboxes. Session registration only seeds
+    /// this role onto brand-new principals, so operator revocations stay sticky.
     fn iron_control_tool_reconciler(
         &self,
     ) -> Result<Option<IronControlToolReconciler>, ServerError> {

--- a/services/api-rs/crates/centaur-iron-control/Cargo.toml
+++ b/services/api-rs/crates/centaur-iron-control/Cargo.toml
@@ -14,5 +14,8 @@ serde_yaml.workspace = true
 thiserror.workspace = true
 urlencoding.workspace = true
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread"] }
+
 [lints]
 workspace = true

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -2,11 +2,13 @@
 //!
 //! Roles are registered once at startup (see [`crate::register_role`]); a
 //! [`SessionRegistrar`] carries the resulting role OIDs and, when a session
-//! starts, upserts the session's principal and assigns it those roles. The
+//! starts, upserts the session's principal. Brand-new principals receive the
+//! default roles once; existing principals keep their current assignments so
+//! operator revocations in console or ``centaur-perms`` remain sticky. The
 //! principal is derived from the thread key (see [`crate::derive_principal`]).
 
 use crate::IronControlClient;
-use crate::error::Result;
+use crate::error::{IronControlError, Result};
 use crate::models::Principal;
 use crate::principal::derive_principal;
 
@@ -36,13 +38,17 @@ impl SessionRegistrar {
         }
     }
 
-    /// Upsert the principal for ``thread_key`` and assign it the configured
-    /// roles. ``slack_user_id`` keys a 1:1 DM principal; it is ignored for
-    /// channel threads. ``conversation_name`` is the human-readable channel/DM
-    /// name (when the slackbot resolved one) used as the principal's display
-    /// name. Returns the upserted principal record (its ``id`` is the OID) so
-    /// callers can bind the session's egress proxy to the same identity.
-    /// Idempotent.
+    /// Upsert the principal for ``thread_key``. ``slack_user_id`` keys a 1:1
+    /// DM principal; it is ignored for channel threads. ``conversation_name``
+    /// is the human-readable channel/DM name (when the slackbot resolved one)
+    /// used as the principal's display name. Returns the upserted principal
+    /// record (its ``id`` is the OID) so callers can bind the session's egress
+    /// proxy to the same identity.
+    ///
+    /// Default roles are assigned only when the principal does not already
+    /// exist. Re-registering an existing channel/user still refreshes identity
+    /// metadata, but it must not restore roles that an operator manually
+    /// removed.
     pub async fn register_session(
         &self,
         thread_key: &str,
@@ -50,13 +56,164 @@ impl SessionRegistrar {
         conversation_name: Option<&str>,
     ) -> Result<Principal> {
         let principal = derive_principal(thread_key, slack_user_id, conversation_name);
-        let record = self
+        let input = principal.to_identity_input(&self.namespace);
+        let exists = match self
             .client
-            .upsert_principal(&principal.to_identity_input(&self.namespace))
-            .await?;
-        for role_id in &self.assign_role_ids {
-            self.client.assign_role(&record.id, role_id).await?;
+            .get_principal(&self.namespace, &input.foreign_id)
+            .await
+        {
+            Ok(_) => true,
+            Err(error) if is_status(&error, 404) => false,
+            Err(error) => return Err(error),
+        };
+        let record = self.client.upsert_principal(&input).await?;
+        if !exists {
+            for role_id in &self.assign_role_ids {
+                match self.client.assign_role(&record.id, role_id).await {
+                    Ok(()) => {}
+                    Err(error) if is_status(&error, 409) || is_status(&error, 422) => {}
+                    Err(error) => return Err(error),
+                }
+            }
         }
         Ok(record)
+    }
+}
+
+fn is_status(err: &IronControlError, code: u16) -> bool {
+    matches!(err, IronControlError::Status { status, .. } if *status == code)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn register_session_seeds_roles_for_new_principal() {
+        let (base_url, requests, server) = spawn_iron_control_stub(false).await;
+        let registrar = SessionRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+            vec!["role_infra".to_owned()],
+        );
+
+        registrar
+            .register_session(
+                "slack:T123:C123:1773364194.179929",
+                Some("U123"),
+                Some("general"),
+            )
+            .await
+            .unwrap();
+
+        let requests = requests.lock().unwrap();
+        assert!(
+            requests.contains(
+                &"GET /api/v1/principals/lookup/default/slack-channel-t123-c123".to_owned()
+            )
+        );
+        assert!(requests.contains(&"PUT /api/v1/principals/slack-channel-t123-c123".to_owned()));
+        assert!(requests.contains(&"POST /api/v1/principals/prn_channel/roles".to_owned()));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn register_session_does_not_restore_roles_for_existing_principal() {
+        let (base_url, requests, server) = spawn_iron_control_stub(true).await;
+        let registrar = SessionRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+            vec!["role_infra".to_owned()],
+        );
+
+        registrar
+            .register_session(
+                "slack:T123:C123:1773364194.179929",
+                Some("U123"),
+                Some("general"),
+            )
+            .await
+            .unwrap();
+
+        let requests = requests.lock().unwrap();
+        assert!(
+            requests.contains(
+                &"GET /api/v1/principals/lookup/default/slack-channel-t123-c123".to_owned()
+            )
+        );
+        assert!(requests.contains(&"PUT /api/v1/principals/slack-channel-t123-c123".to_owned()));
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request == "POST /api/v1/principals/prn_channel/roles"),
+            "existing principals must not have manually removed roles restored"
+        );
+        server.abort();
+    }
+
+    async fn spawn_iron_control_stub(
+        principal_exists: bool,
+    ) -> (String, Arc<Mutex<Vec<String>>>, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let seen = requests.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut request = Vec::new();
+                let mut buf = [0u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => request.extend_from_slice(&buf[..read]),
+                    }
+                }
+                let request = String::from_utf8_lossy(&request);
+                let first_line = request.lines().next().unwrap_or_default();
+                let mut parts = first_line.split_whitespace();
+                let method = parts.next().unwrap_or_default();
+                let path = parts.next().unwrap_or_default();
+                seen.lock().unwrap().push(format!("{method} {path}"));
+
+                let (status_line, body) = match (method, path) {
+                    ("GET", "/api/v1/principals/lookup/default/slack-channel-t123-c123")
+                        if principal_exists =>
+                    {
+                        ("200 OK", principal_body())
+                    }
+                    ("GET", "/api/v1/principals/lookup/default/slack-channel-t123-c123") => {
+                        ("404 Not Found", r#"{"error":"not found"}"#.to_owned())
+                    }
+                    ("PUT", "/api/v1/principals/slack-channel-t123-c123") => {
+                        ("200 OK", principal_body())
+                    }
+                    ("POST", "/api/v1/principals/prn_channel/roles") => {
+                        ("200 OK", r#"{"data":{"ok":true}}"#.to_owned())
+                    }
+                    _ => (
+                        "500 Internal Server Error",
+                        r#"{"error":"unexpected"}"#.to_owned(),
+                    ),
+                };
+                let response = format!(
+                    "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+        (base_url, requests, handle)
+    }
+
+    fn principal_body() -> String {
+        r#"{"data":{"id":"prn_channel","namespace":"default","foreign_id":"slack-channel-t123-c123","name":"Slack Channel #general","labels":{}}}"#.to_owned()
     }
 }


### PR DESCRIPTION
## Summary

- Change session principal registration so default iron-control roles are seeded only for brand-new principals.
- Keep existing principal role assignments intact when a Slack channel/user is mentioned again, so console or `centaur-perms` revocations remain sticky.
- Add focused HTTP-level regression coverage for new versus existing principal registration.

## Root Cause

`SessionRegistrar::register_session` upserted the principal and then unconditionally assigned the configured infra role on every session start. Channel mentions run through this path, so manually removing `infra` from a channel principal was undone on the next mention.

## Validation

- `cargo test -p centaur-iron-control`
- `cargo test -p centaur-api-server`
