### PR TITLE
feat(discord): add thread creation

### DIFF
--- a/tools/comms/discord/cli.py
+++ b/tools/comms/discord/cli.py
@@ -190,5 +190,32 @@ def post(
     console.print(f"[green]Sent[/] message {result.get('id')} to channel {result.get('channel_id')}")
 
 
+@app.command("create-thread")
+def create_thread(
+    channel: str = typer.Argument(..., help="Channel name or ID"),
+    name: str = typer.Argument(..., help="Thread name"),
+    from_message: str = typer.Option(
+        None, "--from-message", "-m", help="Message ID to branch the thread from"
+    ),
+    content: str = typer.Option(
+        None, "--content", "-c", help="First message to post in a standalone thread"
+    ),
+    private: bool = typer.Option(False, "--private", help="Create a private thread"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Create a thread in a channel."""
+    result = _get_client().create_thread(
+        channel=channel,
+        name=name,
+        from_message_id=from_message,
+        content=content,
+        private=private,
+    )
+    if _emit(result, json_output):
+        return
+    console.print(f"[green]Created thread[/] {result.get('name')} ({result.get('id')})")
+    console.print(f"[dim]{result.get('url')}[/]")
+
+
 if __name__ == "__main__":
     app()

--- a/tools/comms/discord/client.py
+++ b/tools/comms/discord/client.py
@@ -200,6 +200,37 @@ class DiscordClient:
 
         return _run(self._with_client(action))
 
+    def create_thread(
+        self,
+        channel: str,
+        name: str,
+        from_message_id: str | None = None,
+        content: str | None = None,
+        private: bool = False,
+    ) -> dict[str, Any]:
+        """Create a thread in a channel by name or ID.
+
+        Pass from_message_id to branch a public thread off an existing message.
+        Otherwise a standalone thread is created (public by default, or private
+        when private is set), and content, if given, is posted as its first message.
+        """
+
+        async def action(client):
+            resolved = self._find_channel(client, channel)
+            if from_message_id:
+                starter = await resolved.fetch_message(int(from_message_id))
+                thread = await resolved.create_thread(name=name, message=starter)
+            else:
+                thread_type = (
+                    discord.ChannelType.private_thread if private else discord.ChannelType.public_thread
+                )
+                thread = await resolved.create_thread(name=name, type=thread_type)
+                if content:
+                    await thread.send(content)
+            return self._format_thread(thread)
+
+        return _run(self._with_client(action))
+
     def _find_guild(self, client, guild_str: str):
         if guild_str.isdigit():
             guild = client.get_guild(int(guild_str))
@@ -239,6 +270,18 @@ class DiscordClient:
             "timestamp": msg.created_at.isoformat(),
             "content": msg.content or "",
             "reply_to": str(msg.reference.message_id) if msg.reference else None,
+        }
+
+    def _format_thread(self, thread) -> dict[str, Any]:
+        return {
+            "id": str(thread.id),
+            "name": thread.name,
+            "parent_id": str(thread.parent_id),
+            "guild_id": str(thread.guild.id),
+            "owner_id": str(thread.owner_id),
+            "type": thread.type.name if thread.type else None,
+            "archived": thread.archived,
+            "url": thread.jump_url,
         }
 
 

--- a/tools/comms/discord/tests/test_client.py
+++ b/tools/comms/discord/tests/test_client.py
@@ -44,3 +44,76 @@ def test_find_channel_supports_hash_prefix_and_partial_name():
 
     assert client._find_channel(discord_client, "#announcements").id == 11
     assert client._find_channel(discord_client, "announce").id == 11
+
+
+def _stub_channel(client, monkeypatch, calls):
+    async def thread_send(content):
+        calls.setdefault("sent", []).append(content)
+
+    thread = SimpleNamespace(
+        id=99,
+        name="design chat",
+        parent_id=11,
+        owner_id=5,
+        archived=False,
+        guild=SimpleNamespace(id=1),
+        type=SimpleNamespace(name="public_thread"),
+        jump_url="https://discord.com/channels/1/99",
+        send=thread_send,
+    )
+
+    class FakeChannel:
+        id = 11
+
+        async def fetch_message(self, message_id):
+            calls["fetched"] = message_id
+            return SimpleNamespace(id=message_id)
+
+        async def create_thread(self, **kwargs):
+            calls["create"] = kwargs
+            return thread
+
+    monkeypatch.setattr(client, "_find_channel", lambda discord_client, name: FakeChannel())
+
+    async def fake_with_client(action):
+        return await action(object())
+
+    monkeypatch.setattr(client, "_with_client", fake_with_client)
+
+
+def test_create_thread_from_message_branches_off_starter(monkeypatch):
+    client = DiscordClient(token="unused")
+    calls = {}
+    _stub_channel(client, monkeypatch, calls)
+
+    result = client.create_thread("general", "design chat", from_message_id="123")
+
+    assert calls["fetched"] == 123
+    assert calls["create"]["message"].id == 123
+    assert "type" not in calls["create"]
+    assert "sent" not in calls
+    assert result == {
+        "id": "99",
+        "name": "design chat",
+        "parent_id": "11",
+        "guild_id": "1",
+        "owner_id": "5",
+        "type": "public_thread",
+        "archived": False,
+        "url": "https://discord.com/channels/1/99",
+    }
+
+
+def test_create_thread_standalone_posts_initial_content(monkeypatch):
+    import discord
+
+    client = DiscordClient(token="unused")
+    calls = {}
+    _stub_channel(client, monkeypatch, calls)
+
+    result = client.create_thread("general", "design chat", content="kickoff", private=True)
+
+    assert calls["create"]["type"] == discord.ChannelType.private_thread
+    assert "message" not in calls["create"]
+    assert calls["sent"] == ["kickoff"]
+    assert result["id"] == "99"


### PR DESCRIPTION
Adds the ability to start threads through the Discord tool. You can branch a thread off an existing message, or open a fresh standalone thread and optionally seed it with an opening message. Available to agents as a client operation and from the CLI.