### PR TITLE
[codex] Fix workflow task claim timeout

### DIFF
--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -46,7 +46,7 @@ const PYTHON_HOST_INTERPRETER_ENV: &str = "PYTHON_WORKFLOW_HOST_PYTHON";
 const WORKFLOW_TOOL_API_URL_ENV: &str = "WORKFLOW_TOOL_API_URL";
 const DEFAULT_AGENT_IDLE_TIMEOUT_MS: u64 = 60_000;
 const DEFAULT_AGENT_MAX_DURATION_MS: u64 = 30 * 60 * 1_000;
-const WORKFLOW_HOST_CLAIM_EXTENSION: Duration = Duration::from_secs(5 * 60);
+const WORKFLOW_TASK_CLAIM_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 const WORKFLOW_HOST_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 const WORKFLOW_RECONCILE_INTERVAL_SECS_ENV: &str = "WORKFLOW_RECONCILE_INTERVAL_SECS";
 const DEFAULT_WORKFLOW_RECONCILE_INTERVAL_SECS: u64 = 60;
@@ -515,6 +515,7 @@ impl WorkflowRuntime {
 
         let worker = client.start_worker(WorkerOptions {
             worker_id: Some("centaur-api-rs-workflow-worker".to_owned()),
+            claim_timeout: WORKFLOW_TASK_CLAIM_TIMEOUT,
             concurrency: worker_concurrency(
                 WORKFLOW_WORKER_CONCURRENCY_ENV,
                 DEFAULT_WORKFLOW_WORKER_CONCURRENCY,
@@ -526,6 +527,7 @@ impl WorkflowRuntime {
         });
         let slack_live_worker = slack_live_client.start_worker(WorkerOptions {
             worker_id: Some("centaur-api-rs-workflow-slack-live-worker".to_owned()),
+            claim_timeout: WORKFLOW_TASK_CLAIM_TIMEOUT,
             concurrency: 1,
             on_error: Some(Arc::new(|error| {
                 warn!(%error, "absurd workflow slack live worker error");
@@ -534,6 +536,7 @@ impl WorkflowRuntime {
         });
         let etl_worker = etl_client.start_worker(WorkerOptions {
             worker_id: Some("centaur-api-rs-workflow-etl-worker".to_owned()),
+            claim_timeout: WORKFLOW_TASK_CLAIM_TIMEOUT,
             concurrency: worker_concurrency(
                 WORKFLOW_ETL_WORKER_CONCURRENCY_ENV,
                 DEFAULT_WORKFLOW_ETL_WORKER_CONCURRENCY,
@@ -545,6 +548,7 @@ impl WorkflowRuntime {
         });
         let etl_backfill_worker = etl_backfill_client.start_worker(WorkerOptions {
             worker_id: Some("centaur-api-rs-workflow-etl-backfill-worker".to_owned()),
+            claim_timeout: WORKFLOW_TASK_CLAIM_TIMEOUT,
             concurrency: worker_concurrency(
                 WORKFLOW_ETL_BACKFILL_WORKER_CONCURRENCY_ENV,
                 DEFAULT_WORKFLOW_ETL_BACKFILL_WORKER_CONCURRENCY,
@@ -556,6 +560,7 @@ impl WorkflowRuntime {
         });
         let schedule_worker = schedule_client.start_worker(WorkerOptions {
             worker_id: Some("centaur-api-rs-workflow-schedule-worker".to_owned()),
+            claim_timeout: WORKFLOW_TASK_CLAIM_TIMEOUT,
             concurrency: worker_concurrency(
                 WORKFLOW_SCHEDULE_WORKER_CONCURRENCY_ENV,
                 DEFAULT_WORKFLOW_SCHEDULE_WORKER_CONCURRENCY,
@@ -2326,11 +2331,11 @@ async fn run_python_workflow_host(
 async fn start_workflow_task_heartbeat(
     ctx: TaskContext,
 ) -> Result<WorkflowTaskHeartbeatGuard, WorkflowRuntimeError> {
-    ctx.heartbeat(Some(WORKFLOW_HOST_CLAIM_EXTENSION)).await?;
+    ctx.heartbeat(Some(WORKFLOW_TASK_CLAIM_TIMEOUT)).await?;
     let task = tokio::spawn(async move {
         loop {
             tokio::time::sleep(WORKFLOW_HOST_HEARTBEAT_INTERVAL).await;
-            if let Err(error) = ctx.heartbeat(Some(WORKFLOW_HOST_CLAIM_EXTENSION)).await {
+            if let Err(error) = ctx.heartbeat(Some(WORKFLOW_TASK_CLAIM_TIMEOUT)).await {
                 warn!(%error, "failed to extend workflow task claim");
             }
         }
@@ -3354,6 +3359,13 @@ mod tests {
         assert_eq!(parse_worker_concurrency(Some("lots"), 4), 4);
         assert_eq!(parse_worker_concurrency(Some("0"), 4), 4);
         assert_eq!(parse_worker_concurrency(Some("-2"), 1), 1);
+    }
+
+    #[test]
+    fn workflow_task_claim_timeout_exceeds_long_agent_turns() {
+        assert_eq!(WORKFLOW_TASK_CLAIM_TIMEOUT, Duration::from_secs(30 * 60));
+        assert!(WORKFLOW_TASK_CLAIM_TIMEOUT > Duration::from_secs(5 * 60));
+        assert!(WORKFLOW_HOST_HEARTBEAT_INTERVAL < WORKFLOW_TASK_CLAIM_TIMEOUT / 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Increase Centaur workflow task claim timeout from 5 minutes to 30 minutes.
- Apply the same timeout to every api-rs workflow worker queue through `WorkerOptions.claim_timeout`.
- Heartbeat workflow tasks with the 30-minute extension so long bounded agent turns do not fail with `$ClaimTimeout` before they can finish.
- Add a regression test that keeps the task claim timeout above the old 5-minute boundary and below the heartbeat cadence risk.

## Root Cause

Agent-backed workflows such as `agent_surface_sync` can legitimately run for longer than 5 minutes while still being bounded by the agent turn timeout. The api-rs worker was still using the platform default task-claim window, so a valid workflow could be killed with `$ClaimTimeout` before the agent turn finished or reported.

## Validation

- `cargo test -p centaur-workflows`
- PR CI: `Rust API fmt, clippy, and tests` passed.
- Deployed equivalent patch on `auto-research-centaur-v1` and verified a manual `agent_surface_sync` run completed without recent claim-timeout logs.

## CI Note

The `Publish Images` matrix fails on this fork PR because GitHub reports `Secret source: None` and Depot returns `permission_denied: Invalid token`. That is a fork-permission/publishing-token limitation, not a Rust build/test failure.
