### PR TITLE
fix: clean up session sandboxes

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.70
+version: 0.1.71
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -195,6 +195,10 @@ spec:
               value: {{ .Values.apiRs.sandboxMaxLifetimeSecs | quote }}
             - name: SESSION_SANDBOX_REAP_INTERVAL_SECS
               value: {{ .Values.apiRs.sandboxReapIntervalSecs | quote }}
+            - name: SESSION_SANDBOX_CLEANUP_INTERVAL_SECS
+              value: {{ .Values.apiRs.sandboxCleanupIntervalSecs | quote }}
+            - name: SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS
+              value: {{ .Values.apiRs.sandboxIdleCleanupBackstopSecs | quote }}
             - name: SESSION_SANDBOX_K8S_NAMESPACE
               value: {{ .Release.Namespace | quote }}
             - name: SESSION_SANDBOX_IMAGE

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -295,6 +295,11 @@ apiRs:
   sandboxIdleStopTtlSecs: 10800 # 3 hours
   sandboxMaxLifetimeSecs: 259200 # 3 days
   sandboxReapIntervalSecs: 300
+  # Cleanup worker: stop unreferenced session/warm-pool sandboxes after two
+  # consecutive sweeps and restore idle-pauses lost across api-rs restarts.
+  # 0 disables the corresponding arm.
+  sandboxCleanupIntervalSecs: 300
+  sandboxIdleCleanupBackstopSecs: 21600 # 6 hours
   ironProxy:
     mode: enabled
   metrics:

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -163,6 +163,7 @@ Kubernetes backend:
 | `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME`, `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.runtimeClassName`, `api.extraEnv`. | Pod runtime class and service account. |
 | `KUBERNETES_SANDBOX_CPU_LIMIT`, `KUBERNETES_SANDBOX_MEMORY_LIMIT`, `KUBERNETES_SANDBOX_CPU_REQUEST`, `KUBERNETES_SANDBOX_MEMORY_REQUEST` | `sandbox.resources.*`. | Sandbox pod resources. |
 | `KUBERNETES_SANDBOX_READY_TIMEOUT_S`, `KUBERNETES_ATTACH_LOG_TAIL_LINES` | `api.extraEnv`. | Sandbox readiness and attach diagnostics. |
+| `SESSION_SANDBOX_CLEANUP_INTERVAL_SECS`, `SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS` | `apiRs.sandboxCleanupIntervalSecs`, `apiRs.sandboxIdleCleanupBackstopSecs`. | DB-aware cleanup of unreferenced sandboxes and idle-pause backstop after API restarts. |
 | `KUBERNETES_SANDBOX_EXTRA_ENV` | `sandbox.extraEnv`. | JSON list copied into each sandbox. |
 | `KUBERNETES_WORKFLOW_DIRS` | Chart-rendered from `overlays.sources[*].workflowsSubdir` (default `workflows`) using the sandbox repo-cache mount prefix. | Workflow-host sandbox discovery paths. |
 | `KUBERNETES_FIREWALL_CA_SECRET_NAME`, `KUBERNETES_FIREWALL_CA_KEY_SECRET_NAME` | `firewall.existingCa*` or generated CA Secrets. | CA material for sandbox/proxy TLS interception. |

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -163,6 +163,7 @@ Kubernetes backend:
 | `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME`, `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.runtimeClassName`, `api.extraEnv`. | Pod runtime class and service account. |
 | `KUBERNETES_SANDBOX_CPU_LIMIT`, `KUBERNETES_SANDBOX_MEMORY_LIMIT`, `KUBERNETES_SANDBOX_CPU_REQUEST`, `KUBERNETES_SANDBOX_MEMORY_REQUEST` | `sandbox.resources.*`. | Sandbox pod resources. |
 | `KUBERNETES_SANDBOX_READY_TIMEOUT_S`, `KUBERNETES_ATTACH_LOG_TAIL_LINES` | `api.extraEnv`. | Sandbox readiness and attach diagnostics. |
+| `SESSION_SANDBOX_CLEANUP_INTERVAL_SECS`, `SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS` | `apiRs.sandboxCleanupIntervalSecs`, `apiRs.sandboxIdleCleanupBackstopSecs`. | DB-aware cleanup of unreferenced sandboxes and idle-pause backstop after API restarts. |
 | `KUBERNETES_SANDBOX_EXTRA_ENV` | `sandbox.extraEnv`. | JSON list copied into each sandbox. |
 | `KUBERNETES_WORKFLOW_DIRS` | Chart-rendered from `overlays.sources[*].workflowsSubdir` (default `workflows`) using the sandbox repo-cache mount prefix. | Workflow-host sandbox discovery paths. |
 | `KUBERNETES_FIREWALL_CA_SECRET_NAME`, `KUBERNETES_FIREWALL_CA_KEY_SECRET_NAME` | `firewall.existingCa*` or generated CA Secrets. | CA material for sandbox/proxy TLS interception. |

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -27,7 +27,7 @@ use centaur_sandbox_core::{Mount, MountKind, SandboxSpec};
 use centaur_sandbox_local::LocalSandboxBackend;
 use centaur_sandbox_manager::{SandboxReaperConfig, WarmPoolConfig};
 use centaur_session_core::HarnessType;
-use centaur_session_runtime::{PersonaRegistry, SandboxWorkloadMode};
+use centaur_session_runtime::{PersonaRegistry, SandboxWorkloadMode, SessionSandboxCleanupConfig};
 use centaur_workflows::WorkflowHostSandboxRuntime;
 use clap::{Args as ClapArgs, Parser, ValueEnum};
 use tracing::{error, info, warn};
@@ -89,6 +89,10 @@ impl Args {
 
     pub(crate) fn sandbox_reaper_config(&self) -> SandboxReaperConfig {
         self.sandbox.sandbox_reaper_config()
+    }
+
+    pub(crate) fn sandbox_cleanup_config(&self) -> SessionSandboxCleanupConfig {
+        self.sandbox.sandbox_cleanup_config()
     }
 
     pub(crate) async fn workflow_host_sandbox_runtime(
@@ -549,6 +553,18 @@ struct SandboxArgs {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     sandbox_reap_interval_secs: u64,
+    #[arg(
+        long = "session-sandbox-cleanup-interval-secs",
+        env = "SESSION_SANDBOX_CLEANUP_INTERVAL_SECS",
+        default_value_t = 300
+    )]
+    sandbox_cleanup_interval_secs: u64,
+    #[arg(
+        long = "session-sandbox-idle-cleanup-backstop-secs",
+        env = "SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS",
+        default_value_t = 21_600
+    )]
+    sandbox_idle_cleanup_backstop_secs: u64,
     #[arg(
         long = "session-sandbox-k8s-context",
         alias = "kubernetes-context",
@@ -1210,6 +1226,14 @@ impl SandboxArgs {
             interval: Duration::from_secs(self.sandbox_reap_interval_secs),
             idle_ttl: ttl(self.sandbox_idle_stop_ttl_secs),
             max_lifetime: ttl(self.sandbox_max_lifetime_secs),
+        }
+    }
+
+    fn sandbox_cleanup_config(&self) -> SessionSandboxCleanupConfig {
+        let duration = |secs: u64| (secs > 0).then(|| Duration::from_secs(secs));
+        SessionSandboxCleanupConfig {
+            interval: duration(self.sandbox_cleanup_interval_secs),
+            idle_backstop: duration(self.sandbox_idle_cleanup_backstop_secs),
         }
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -79,6 +79,7 @@ async fn initialize_runtime(args: Args, app_state: AppState) -> Result<(), Serve
         runtime = runtime.with_warm_pool(config);
     }
     runtime = runtime.with_sandbox_reaper(args.sandbox_reaper_config());
+    runtime = runtime.with_sandbox_cleanup(args.sandbox_cleanup_config());
     let workflow_host_sandbox = args
         .workflow_host_sandbox_runtime(workflow_host_principal.as_deref())
         .await?;

--- a/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
@@ -1,0 +1,262 @@
+use std::{collections::BTreeSet, time::Duration};
+
+use centaur_sandbox_core::{ObservedSandbox, SandboxError, SandboxId, SandboxStatus};
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::{info, warn};
+
+use crate::{RuntimeContext, SessionRuntimeError, record_idle_pause};
+
+#[derive(Clone, Copy, Debug)]
+pub struct SessionSandboxCleanupConfig {
+    /// How often to sweep. `None` disables the cleanup worker entirely.
+    pub interval: Option<Duration>,
+    /// Pause session sandboxes whose latest execution has been terminal longer
+    /// than this. `None` disables the idle backstop arm.
+    pub idle_backstop: Option<Duration>,
+}
+
+impl SessionSandboxCleanupConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.interval.is_some()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SessionSandboxCleanupReport {
+    pub stopped_orphans: usize,
+    pub failed_orphans: usize,
+    pub idle_pause_attempts: usize,
+    pub failed_idle_pauses: usize,
+}
+
+pub struct SessionSandboxCleanupWorker {
+    ctx: RuntimeContext,
+    config: SessionSandboxCleanupConfig,
+    pending_orphans: BTreeSet<String>,
+}
+
+impl SessionSandboxCleanupWorker {
+    pub(crate) fn new(ctx: RuntimeContext, config: SessionSandboxCleanupConfig) -> Self {
+        Self {
+            ctx,
+            config,
+            pending_orphans: BTreeSet::new(),
+        }
+    }
+
+    pub(crate) fn spawn(mut self) {
+        let Some(interval_duration) = self.config.interval else {
+            return;
+        };
+        tokio::spawn(async move {
+            let mut tick = interval(interval_duration);
+            tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            loop {
+                tick.tick().await;
+                if let Err(error) = self.reap_once().await {
+                    warn!(%error, "session sandbox cleanup worker sweep failed");
+                }
+            }
+        });
+    }
+
+    pub(crate) async fn reap_once(
+        &mut self,
+    ) -> Result<SessionSandboxCleanupReport, SessionRuntimeError> {
+        let mut report = SessionSandboxCleanupReport::default();
+        self.reap_unreferenced_sandboxes(&mut report).await?;
+        self.pause_idle_sandboxes(&mut report).await?;
+        Ok(report)
+    }
+
+    async fn reap_unreferenced_sandboxes(
+        &mut self,
+        report: &mut SessionSandboxCleanupReport,
+    ) -> Result<(), SessionRuntimeError> {
+        let referenced = self
+            .ctx
+            .store
+            .list_referenced_sandbox_ids()
+            .await?
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let observed = self.ctx.manager.list_observed().await?;
+        let candidates =
+            select_orphan_reap_candidates(&observed, &referenced, &mut self.pending_orphans);
+
+        for sandbox_id in candidates {
+            let id = SandboxId::new(sandbox_id.clone());
+            match self.ctx.manager.stop(&id).await {
+                Ok(()) | Err(SandboxError::NotFound(_)) => {
+                    self.ctx.sandbox_pipes.remove(&sandbox_id);
+                    self.pending_orphans.remove(&sandbox_id);
+                    report.stopped_orphans += 1;
+                    info!(
+                        sandbox_id,
+                        reason = "unreferenced",
+                        "session sandbox cleanup worker stopped orphaned sandbox"
+                    );
+                }
+                Err(error) => {
+                    report.failed_orphans += 1;
+                    warn!(
+                        sandbox_id,
+                        %error,
+                        "session sandbox cleanup worker failed to stop orphaned sandbox"
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn pause_idle_sandboxes(
+        &self,
+        report: &mut SessionSandboxCleanupReport,
+    ) -> Result<(), SessionRuntimeError> {
+        let Some(idle_backstop) = self.config.idle_backstop else {
+            return Ok(());
+        };
+        for candidate in self
+            .ctx
+            .store
+            .list_idle_sandbox_candidates(idle_backstop)
+            .await?
+        {
+            report.idle_pause_attempts += 1;
+            if let Err(error) = record_idle_pause(
+                &self.ctx,
+                &candidate.thread_key,
+                &candidate.execution_id,
+                &candidate.sandbox_id,
+                idle_backstop,
+            )
+            .await
+            {
+                report.failed_idle_pauses += 1;
+                warn!(
+                    thread_key = %candidate.thread_key,
+                    execution_id = %candidate.execution_id,
+                    sandbox_id = %candidate.sandbox_id,
+                    %error,
+                    "session sandbox cleanup worker failed to pause idle sandbox"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+fn select_orphan_reap_candidates(
+    observed: &[ObservedSandbox],
+    referenced: &BTreeSet<String>,
+    pending_orphans: &mut BTreeSet<String>,
+) -> Vec<String> {
+    let current_orphans = observed
+        .iter()
+        .filter(|sandbox| orphan_reap_eligible(sandbox, referenced))
+        .map(|sandbox| sandbox.id.as_str().to_owned())
+        .collect::<BTreeSet<_>>();
+
+    let candidates = current_orphans
+        .intersection(pending_orphans)
+        .cloned()
+        .collect::<Vec<_>>();
+    *pending_orphans = current_orphans;
+    candidates
+}
+
+fn orphan_reap_eligible(sandbox: &ObservedSandbox, referenced: &BTreeSet<String>) -> bool {
+    if referenced.contains(sandbox.id.as_str()) {
+        return false;
+    }
+    !matches!(
+        sandbox.status,
+        SandboxStatus::Created | SandboxStatus::Stopped | SandboxStatus::Gone
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn observed(id: &str, status: SandboxStatus) -> ObservedSandbox {
+        ObservedSandbox::new(SandboxId::new(id), "test", status)
+    }
+
+    fn referenced(ids: &[&str]) -> BTreeSet<String> {
+        ids.iter().map(|id| (*id).to_owned()).collect()
+    }
+
+    #[test]
+    fn orphan_reap_requires_two_consecutive_passes() {
+        let observed = [observed("asbx-1", SandboxStatus::Running)];
+        let mut pending = BTreeSet::new();
+
+        assert_eq!(
+            select_orphan_reap_candidates(&observed, &referenced(&[]), &mut pending),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            select_orphan_reap_candidates(&observed, &referenced(&[]), &mut pending),
+            vec!["asbx-1".to_owned()]
+        );
+    }
+
+    #[test]
+    fn referenced_sandbox_rescues_pending_orphan() {
+        let observed = [observed("asbx-1", SandboxStatus::Running)];
+        let mut pending = BTreeSet::new();
+
+        select_orphan_reap_candidates(&observed, &referenced(&[]), &mut pending);
+        assert_eq!(
+            select_orphan_reap_candidates(&observed, &referenced(&["asbx-1"]), &mut pending),
+            Vec::<String>::new()
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn created_and_terminal_sandboxes_are_not_reaped() {
+        let observed = [
+            observed("asbx-created", SandboxStatus::Created),
+            observed("asbx-stopped", SandboxStatus::Stopped),
+            observed("asbx-gone", SandboxStatus::Gone),
+        ];
+        let mut pending = BTreeSet::from([
+            "asbx-created".to_owned(),
+            "asbx-stopped".to_owned(),
+            "asbx-gone".to_owned(),
+        ]);
+
+        assert_eq!(
+            select_orphan_reap_candidates(&observed, &referenced(&[]), &mut pending),
+            Vec::<String>::new()
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn failed_stop_stays_pending_for_retry() {
+        let observed = [observed("asbx-1", SandboxStatus::Running)];
+        let mut pending = BTreeSet::from(["asbx-1".to_owned()]);
+
+        assert_eq!(
+            select_orphan_reap_candidates(&observed, &referenced(&[]), &mut pending),
+            vec!["asbx-1".to_owned()]
+        );
+        assert!(pending.contains("asbx-1"));
+    }
+
+    #[test]
+    fn vanished_pending_orphan_is_dropped() {
+        let mut pending = BTreeSet::from(["asbx-1".to_owned()]);
+
+        assert_eq!(
+            select_orphan_reap_candidates(&[], &referenced(&[]), &mut pending),
+            Vec::<String>::new()
+        );
+        assert!(pending.is_empty());
+    }
+}

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1,3 +1,5 @@
+mod cleanup;
+
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     sync::Arc,
@@ -37,6 +39,8 @@ use tokio::{
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
 use tracing::{Instrument, Span, error, info, info_span, warn};
+
+pub use cleanup::SessionSandboxCleanupConfig;
 
 pub const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 pub const SESSION_FIRST_TOKEN_EVENT: &str = "session.first_token";
@@ -227,6 +231,13 @@ pub struct DrainFailure {
     pub error: String,
 }
 
+#[derive(Debug, Default)]
+pub struct WorkflowSandboxCleanupReport {
+    pub stopped: Vec<String>,
+    pub missing: Vec<String>,
+    pub failed: Vec<DrainFailure>,
+}
+
 #[derive(Debug)]
 pub struct ExecuteSessionInput {
     pub idempotency_key: Option<String>,
@@ -405,6 +416,17 @@ impl SessionRuntime {
             return self;
         }
         SandboxReaper::new(self.sandbox_runtime.manager.clone(), config).spawn();
+        self
+    }
+
+    /// Spawn the DB-aware cleanup worker that reaps backend sandboxes no durable
+    /// session/warm-pool row references and restores idle pauses lost across
+    /// control-plane restarts.
+    pub fn with_sandbox_cleanup(self, config: SessionSandboxCleanupConfig) -> Self {
+        if !config.is_enabled() {
+            return self;
+        }
+        cleanup::SessionSandboxCleanupWorker::new(self.context(), config).spawn();
         self
     }
 
@@ -703,6 +725,119 @@ impl SessionRuntime {
                 }
             }
         }
+        Ok(report)
+    }
+
+    pub async fn stop_workflow_owned_sandboxes(
+        &self,
+        workflow_run_id: &str,
+        reason: &str,
+    ) -> Result<WorkflowSandboxCleanupReport, SessionRuntimeError> {
+        let sandboxes = self
+            .store
+            .list_workflow_owned_sandboxes(workflow_run_id)
+            .await?;
+        let mut report = WorkflowSandboxCleanupReport::default();
+
+        for sandbox in sandboxes {
+            let sandbox_id = sandbox.sandbox_id;
+            let thread_key = sandbox.thread_key;
+            self.sandbox_pipes.remove(&sandbox_id);
+            let id = SandboxId::new(sandbox_id.clone());
+            let mut missing = false;
+            match self.sandbox_runtime.manager.stop(&id).await {
+                Ok(()) => report.stopped.push(sandbox_id.clone()),
+                Err(SandboxError::NotFound(_)) => {
+                    missing = true;
+                    report.missing.push(sandbox_id.clone());
+                }
+                Err(error) => {
+                    let error = error.to_string();
+                    warn!(
+                        thread_key = %thread_key,
+                        sandbox_id,
+                        workflow_run_id,
+                        reason,
+                        %error,
+                        "failed to stop workflow-owned sandbox"
+                    );
+                    report.failed.push(DrainFailure {
+                        sandbox_id: sandbox_id.clone(),
+                        error: error.clone(),
+                    });
+                    if let Err(event_error) = self
+                        .store
+                        .append_event(
+                            &thread_key,
+                            None,
+                            "session.workflow_sandbox_stop_failed",
+                            json!({
+                                "thread_key": thread_key.as_str(),
+                                "sandbox_id": sandbox_id,
+                                "workflow_run_id": workflow_run_id,
+                                "reason": reason,
+                                "error": error,
+                            }),
+                        )
+                        .await
+                    {
+                        warn!(
+                            thread_key = %thread_key,
+                            sandbox_id,
+                            workflow_run_id,
+                            %event_error,
+                            "failed to append workflow sandbox stop failure event"
+                        );
+                    }
+                    continue;
+                }
+            }
+
+            if let Err(error) = self
+                .store
+                .mark_warm_sandbox_failed(&sandbox_id, "workflow-owned sandbox stopped")
+                .await
+            {
+                warn!(
+                    thread_key = %thread_key,
+                    sandbox_id,
+                    workflow_run_id,
+                    %error,
+                    "failed to mark workflow-owned warm sandbox failed"
+                );
+            }
+
+            let cleared = self
+                .store
+                .clear_sandbox_id_if_matches(&thread_key, &sandbox_id)
+                .await?;
+            if let Err(error) = self
+                .store
+                .append_event(
+                    &thread_key,
+                    None,
+                    "session.workflow_sandbox_stopped",
+                    json!({
+                        "thread_key": thread_key.as_str(),
+                        "sandbox_id": sandbox_id,
+                        "workflow_run_id": workflow_run_id,
+                        "reason": reason,
+                        "missing": missing,
+                        "cleared": cleared,
+                    }),
+                )
+                .await
+            {
+                warn!(
+                    thread_key = %thread_key,
+                    sandbox_id,
+                    workflow_run_id,
+                    %error,
+                    "failed to append workflow sandbox cleanup event"
+                );
+            }
+        }
+
         Ok(report)
     }
 
@@ -5181,7 +5316,10 @@ mod tests {
 /// silently otherwise, mirroring `ABSURD_TEST_DATABASE_URL` in absurd-sdk).
 #[cfg(test)]
 mod adoption_tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::{
+        collections::BTreeSet,
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
 
     use centaur_sandbox_core::{ObservedSandbox, SandboxHandle, SandboxIo, SandboxResult};
     use tokio::io::{AsyncWriteExt, DuplexStream};
@@ -5198,6 +5336,10 @@ mod adoption_tests {
         recorded_output: Vec<String>,
         open_count: AtomicUsize,
         status: std::sync::Mutex<SandboxStatus>,
+        create_id: String,
+        resume_fails: AtomicBool,
+        stopped: std::sync::Mutex<Vec<String>>,
+        missing_on_stop: std::sync::Mutex<BTreeSet<String>>,
     }
 
     impl MockBackend {
@@ -5207,6 +5349,10 @@ mod adoption_tests {
                 recorded_output,
                 open_count: AtomicUsize::new(0),
                 status: std::sync::Mutex::new(status),
+                create_id: "mock-sbx".to_owned(),
+                resume_fails: AtomicBool::new(false),
+                stopped: std::sync::Mutex::new(Vec::new()),
+                missing_on_stop: std::sync::Mutex::new(BTreeSet::new()),
             }
         }
 
@@ -5217,6 +5363,21 @@ mod adoption_tests {
         fn opens(&self) -> usize {
             self.open_count.load(Ordering::SeqCst)
         }
+
+        fn fail_resume(&self) {
+            self.resume_fails.store(true, Ordering::SeqCst);
+        }
+
+        fn mark_stop_missing(&self, sandbox_id: &str) {
+            self.missing_on_stop
+                .lock()
+                .unwrap()
+                .insert(sandbox_id.to_owned());
+        }
+
+        fn stopped(&self) -> Vec<String> {
+            self.stopped.lock().unwrap().clone()
+        }
     }
 
     #[async_trait::async_trait]
@@ -5226,7 +5387,10 @@ mod adoption_tests {
         }
 
         async fn create(&self, _spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
-            Ok(SandboxHandle::new(SandboxId::new("mock-sbx"), "mock"))
+            Ok(SandboxHandle::new(
+                SandboxId::new(self.create_id.clone()),
+                "mock",
+            ))
         }
 
         async fn open_io(&self, _id: &SandboxId) -> SandboxResult<SandboxIo> {
@@ -5259,7 +5423,11 @@ mod adoption_tests {
             Ok(Vec::new())
         }
 
-        async fn stop(&self, _id: &SandboxId) -> SandboxResult<()> {
+        async fn stop(&self, id: &SandboxId) -> SandboxResult<()> {
+            if self.missing_on_stop.lock().unwrap().contains(id.as_str()) {
+                return Err(SandboxError::NotFound(id.as_str().to_owned()));
+            }
+            self.stopped.lock().unwrap().push(id.as_str().to_owned());
             Ok(())
         }
 
@@ -5268,6 +5436,9 @@ mod adoption_tests {
         }
 
         async fn resume(&self, _id: &SandboxId) -> SandboxResult<()> {
+            if self.resume_fails.load(Ordering::SeqCst) {
+                return Err(SandboxError::NotFound(_id.as_str().to_owned()));
+            }
             Ok(())
         }
     }
@@ -5356,6 +5527,218 @@ mod adoption_tests {
             store.clone(),
             SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
         )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn workflow_cleanup_stops_and_clears_owned_sandbox() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let workflow_run_id = format!("run-{}", uuid::Uuid::new_v4());
+        let thread_key =
+            ThreadKey::parse(format!("test:wf-cleanup-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({
+                    "source": "absurd_workflow",
+                    "workflow_run_id": workflow_run_id,
+                    "workflow_owned_thread": true,
+                }),
+            )
+            .await
+            .expect("create session");
+        store
+            .update_sandbox_id(&thread_key, Some("sbx-owned"))
+            .await
+            .expect("set sandbox id");
+        store
+            .insert_ready_warm_sandbox("sbx-owned", "test-workload")
+            .await
+            .expect("insert warm sandbox");
+        assert_eq!(
+            store
+                .claim_ready_warm_sandbox("test-workload", thread_key.as_str())
+                .await
+                .expect("claim warm sandbox"),
+            Some("sbx-owned".to_owned())
+        );
+        assert!(
+            store
+                .list_referenced_sandbox_ids()
+                .await
+                .expect("list referenced sandboxes")
+                .contains(&"sbx-owned".to_owned())
+        );
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        let report = runtime
+            .stop_workflow_owned_sandboxes(&workflow_run_id, "test")
+            .await
+            .expect("cleanup workflow sandboxes");
+
+        assert_eq!(report.stopped, vec!["sbx-owned".to_owned()]);
+        assert_eq!(backend.stopped(), vec!["sbx-owned".to_owned()]);
+        assert_eq!(
+            store.get_session(&thread_key).await.unwrap().sandbox_id,
+            None
+        );
+        assert!(
+            !store
+                .list_referenced_sandbox_ids()
+                .await
+                .expect("list referenced sandboxes")
+                .contains(&"sbx-owned".to_owned())
+        );
+        let all = events(&store, &thread_key).await;
+        assert!(all.iter().any(|event| {
+            event.event_type == "session.workflow_sandbox_stopped"
+                && event.payload["workflow_run_id"] == json!(workflow_run_id)
+                && event.payload["cleared"] == json!(true)
+        }));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn workflow_cleanup_preserves_explicit_unowned_thread_key() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let workflow_run_id = format!("run-{}", uuid::Uuid::new_v4());
+        let thread_key =
+            ThreadKey::parse(format!("test:wf-explicit-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({
+                    "source": "absurd_workflow",
+                    "workflow_run_id": workflow_run_id,
+                }),
+            )
+            .await
+            .expect("create session");
+        store
+            .update_sandbox_id(&thread_key, Some("sbx-explicit"))
+            .await
+            .expect("set sandbox id");
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        let report = runtime
+            .stop_workflow_owned_sandboxes(&workflow_run_id, "test")
+            .await
+            .expect("cleanup workflow sandboxes");
+
+        assert!(report.stopped.is_empty());
+        assert!(backend.stopped().is_empty());
+        assert_eq!(
+            store.get_session(&thread_key).await.unwrap().sandbox_id,
+            Some("sbx-explicit".to_owned())
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn workflow_cleanup_clears_owned_sandbox_when_backend_reports_missing() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let workflow_run_id = format!("run-{}", uuid::Uuid::new_v4());
+        let thread_key =
+            ThreadKey::parse(format!("test:wf-missing-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({
+                    "source": "absurd_workflow",
+                    "workflow_run_id": workflow_run_id,
+                    "workflow_owned_thread": true,
+                }),
+            )
+            .await
+            .expect("create session");
+        store
+            .update_sandbox_id(&thread_key, Some("sbx-missing"))
+            .await
+            .expect("set sandbox id");
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        backend.mark_stop_missing("sbx-missing");
+        let runtime = runtime_with(&store, backend);
+        let report = runtime
+            .stop_workflow_owned_sandboxes(&workflow_run_id, "test")
+            .await
+            .expect("cleanup workflow sandboxes");
+
+        assert_eq!(report.missing, vec!["sbx-missing".to_owned()]);
+        assert_eq!(
+            store.get_session(&thread_key).await.unwrap().sandbox_id,
+            None
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resume_failure_replaces_sandbox_and_preserves_harness_thread_id() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:resume-failed-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        store
+            .update_sandbox_id(&thread_key, Some("sbx-old"))
+            .await
+            .expect("set sandbox id");
+        store
+            .update_harness_thread_id(&thread_key, Some("harness-thread-1"))
+            .await
+            .expect("set harness thread id");
+        let execution_id = store
+            .create_execution(&thread_key, None, json!({}))
+            .await
+            .expect("create execution")
+            .execution
+            .execution_id;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Suspended, Vec::new()));
+        backend.fail_resume();
+        let runtime = runtime_with(&store, backend);
+        let sandbox_id = runtime
+            .ensure_session_sandbox(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some("sbx-old"),
+                None,
+                &execution_id,
+            )
+            .await
+            .expect("resume failure should fall through to replacement");
+
+        assert_eq!(sandbox_id, "mock-sbx");
+        let session = store.get_session(&thread_key).await.unwrap();
+        assert_eq!(session.sandbox_id, Some("mock-sbx".to_owned()));
+        assert_eq!(
+            session.harness_thread_id,
+            Some("harness-thread-1".to_owned())
+        );
+        let all = events(&store, &thread_key).await;
+        assert!(
+            all.iter()
+                .any(|event| event.event_type == "session.sandbox_resume_failed")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -37,6 +37,19 @@ pub struct ClaimExecutionResult {
     pub claimed: bool,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IdleSandboxCandidate {
+    pub thread_key: ThreadKey,
+    pub sandbox_id: String,
+    pub execution_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkflowOwnedSandbox {
+    pub thread_key: ThreadKey,
+    pub sandbox_id: String,
+}
+
 #[derive(Clone)]
 pub struct PgSessionStore {
     pool: PgPool,
@@ -509,6 +522,88 @@ impl PgSessionStore {
         Ok(exists)
     }
 
+    pub async fn list_referenced_sandbox_ids(&self) -> Result<Vec<String>, SessionStoreError> {
+        let rows = sqlx::query_scalar::<_, String>(
+            r#"
+            select sandbox_id
+            from sessions
+            where sandbox_id is not null
+
+            union
+
+            select sandbox_id
+            from session_warm_sandboxes
+            where status in ('ready', 'claimed')
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    pub async fn list_idle_sandbox_candidates(
+        &self,
+        idle_backstop: std::time::Duration,
+    ) -> Result<Vec<IdleSandboxCandidate>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, IdleSandboxCandidateRow>(
+            r#"
+            with latest as (
+                select distinct on (thread_key)
+                    execution_id,
+                    thread_key,
+                    status,
+                    completed_at
+                from session_executions
+                order by thread_key, created_at desc, execution_id desc
+            )
+            select
+                s.thread_key,
+                s.sandbox_id as sandbox_id,
+                latest.execution_id
+            from sessions s
+            join latest on latest.thread_key = s.thread_key
+            where s.sandbox_id is not null
+              and latest.status in ('completed', 'failed', 'cancelled')
+              and latest.completed_at is not null
+              and latest.completed_at <= now() - ($1::float8 * interval '1 second')
+              and not exists (
+                  select 1
+                  from session_executions active
+                  where active.thread_key = s.thread_key
+                    and active.status in ('queued', 'running')
+              )
+            order by latest.completed_at, s.thread_key
+            "#,
+        )
+        .bind(idle_backstop.as_secs_f64())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    pub async fn list_workflow_owned_sandboxes(
+        &self,
+        workflow_run_id: &str,
+    ) -> Result<Vec<WorkflowOwnedSandbox>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, WorkflowOwnedSandboxRow>(
+            r#"
+            select thread_key, sandbox_id as sandbox_id
+            from sessions
+            where sandbox_id is not null
+              and metadata->>'workflow_owned_thread' = 'true'
+              and metadata->>'workflow_run_id' = $1
+            order by thread_key
+            "#,
+        )
+        .bind(workflow_run_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
     pub async fn update_sandbox_id(
         &self,
         thread_key: &ThreadKey,
@@ -528,6 +623,26 @@ impl PgSessionStore {
         .await?;
 
         row.try_into()
+    }
+
+    pub async fn clear_sandbox_id_if_matches(
+        &self,
+        thread_key: &ThreadKey,
+        sandbox_id: &str,
+    ) -> Result<bool, SessionStoreError> {
+        let result = sqlx::query(
+            r#"
+            update sessions
+            set sandbox_id = null, updated_at = now()
+            where thread_key = $1 and sandbox_id = $2
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(sandbox_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     /// Move an existing session onto a different harness. Clears the sandbox
@@ -849,6 +964,42 @@ struct SessionExecutionRow {
     updated_at: OffsetDateTime,
     started_at: Option<OffsetDateTime>,
     completed_at: Option<OffsetDateTime>,
+}
+
+#[derive(Debug, FromRow)]
+struct IdleSandboxCandidateRow {
+    thread_key: String,
+    sandbox_id: String,
+    execution_id: String,
+}
+
+impl TryFrom<IdleSandboxCandidateRow> for IdleSandboxCandidate {
+    type Error = SessionStoreError;
+
+    fn try_from(row: IdleSandboxCandidateRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            thread_key: parse_persisted(row.thread_key)?,
+            sandbox_id: row.sandbox_id,
+            execution_id: row.execution_id,
+        })
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct WorkflowOwnedSandboxRow {
+    thread_key: String,
+    sandbox_id: String,
+}
+
+impl TryFrom<WorkflowOwnedSandboxRow> for WorkflowOwnedSandbox {
+    type Error = SessionStoreError;
+
+    fn try_from(row: WorkflowOwnedSandboxRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            thread_key: parse_persisted(row.thread_key)?,
+            sandbox_id: row.sandbox_id,
+        })
+    }
 }
 
 impl TryFrom<SessionExecutionRow> for SessionExecution {

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -2142,6 +2142,33 @@ async fn run_centaur_workflow(
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
 ) -> absurd::Result<WorkflowResult> {
+    let mut cleanup_guard =
+        WorkflowSandboxCleanupGuard::new(session_runtime.clone(), ctx.run_id().to_owned());
+    let result =
+        run_centaur_workflow_inner(input, ctx, session_runtime, workflow_host_sandbox).await;
+    if let Some(reason) = workflow_cleanup_reason(&result) {
+        cleanup_guard.cleanup(reason).await;
+    } else {
+        cleanup_guard.disarm();
+    }
+    result
+}
+
+fn workflow_cleanup_reason(result: &absurd::Result<WorkflowResult>) -> Option<&'static str> {
+    match result {
+        Ok(_) => Some("workflow_completed"),
+        Err(absurd::Error::Suspend) => None,
+        Err(absurd::Error::Cancelled) => Some("workflow_cancelled"),
+        Err(_) => Some("workflow_failed"),
+    }
+}
+
+async fn run_centaur_workflow_inner(
+    input: WorkflowTaskInput,
+    ctx: TaskContext,
+    session_runtime: SessionRuntime,
+    workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
+) -> absurd::Result<WorkflowResult> {
     let _heartbeat_guard = start_workflow_task_heartbeat(ctx.clone())
         .await
         .map_err(absurd_error)?;
@@ -2233,6 +2260,7 @@ async fn run_centaur_workflow(
                                 execution_idempotency_key: format!(
                                     "absurd-workflow-agent-turn:{client_message_id}"
                                 ),
+                                workflow_owned_thread: true,
                                 idle_timeout_ms,
                                 max_duration_ms,
                             },
@@ -2308,6 +2336,64 @@ async fn run_centaur_workflow(
                 output,
             })
         }
+    }
+}
+
+struct WorkflowSandboxCleanupGuard {
+    session_runtime: Option<SessionRuntime>,
+    workflow_run_id: String,
+}
+
+impl WorkflowSandboxCleanupGuard {
+    fn new(session_runtime: SessionRuntime, workflow_run_id: String) -> Self {
+        Self {
+            session_runtime: Some(session_runtime),
+            workflow_run_id,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.session_runtime = None;
+    }
+
+    async fn cleanup(&mut self, reason: &'static str) {
+        let Some(session_runtime) = self.session_runtime.as_ref().cloned() else {
+            return;
+        };
+        if let Err(error) = session_runtime
+            .stop_workflow_owned_sandboxes(&self.workflow_run_id, reason)
+            .await
+        {
+            warn!(
+                workflow_run_id = %self.workflow_run_id,
+                reason,
+                %error,
+                "failed to clean up workflow-owned sandboxes"
+            );
+            return;
+        }
+        self.session_runtime = None;
+    }
+}
+
+impl Drop for WorkflowSandboxCleanupGuard {
+    fn drop(&mut self) {
+        let Some(session_runtime) = self.session_runtime.take() else {
+            return;
+        };
+        let workflow_run_id = self.workflow_run_id.clone();
+        tokio::spawn(async move {
+            if let Err(error) = session_runtime
+                .stop_workflow_owned_sandboxes(&workflow_run_id, "workflow_cancelled_or_dropped")
+                .await
+            {
+                warn!(
+                    workflow_run_id,
+                    %error,
+                    "failed to clean up dropped workflow-owned sandboxes"
+                );
+            }
+        });
     }
 }
 
@@ -2813,17 +2899,18 @@ async fn run_python_agent_turn(
             "ctx.agent_turn requires text, prompt, content, or parts".to_owned(),
         ));
     }
-    let thread_key = args
+    let explicit_thread_key = args
         .get("thread_key")
         .and_then(Value::as_str)
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| {
-            format!(
-                "wf:{}:agent:{}",
-                ctx.task_id().replace('-', ""),
-                input.workflow_name
-            )
-        });
+        .map(ToOwned::to_owned);
+    let workflow_owned_thread = explicit_thread_key.is_none();
+    let thread_key = explicit_thread_key.unwrap_or_else(|| {
+        format!(
+            "wf:{}:agent:{}",
+            ctx.task_id().replace('-', ""),
+            input.workflow_name
+        )
+    });
     let harness_type = parse_agent_harness(&args)?.unwrap_or_else(|| input.harness_type.clone());
     let persona_id = args
         .get("persona_id")
@@ -2885,6 +2972,7 @@ async fn run_python_agent_turn(
             message_metadata,
             execution_metadata,
             execution_idempotency_key,
+            workflow_owned_thread,
             idle_timeout_ms,
             max_duration_ms,
         },
@@ -3153,6 +3241,7 @@ struct AgentTurnRequest {
     message_metadata: Value,
     execution_metadata: Value,
     execution_idempotency_key: String,
+    workflow_owned_thread: bool,
     idle_timeout_ms: u64,
     max_duration_ms: u64,
 }
@@ -3171,10 +3260,15 @@ async fn run_agent_session_turn(
         message_metadata,
         execution_metadata,
         execution_idempotency_key,
+        workflow_owned_thread,
         idle_timeout_ms,
         max_duration_ms,
     } = turn;
     let thread_key = ThreadKey::parse(thread_key)?;
+    let mut session_metadata = session_metadata;
+    if workflow_owned_thread {
+        object_insert(&mut session_metadata, "workflow_owned_thread", json!(true));
+    }
     session_runtime
         .create_or_get_session(
             &thread_key,
@@ -3654,6 +3748,33 @@ mod tests {
             .ensure_enabled("slack_sync")
             .unwrap_err();
         assert!(matches!(error, WorkflowRuntimeError::Disabled(_)));
+    }
+
+    #[test]
+    fn workflow_cleanup_reason_skips_suspended_runs() {
+        let completed: absurd::Result<WorkflowResult> = Ok(WorkflowResult {
+            workflow_name: "test".to_owned(),
+            run_id: "run-1".to_owned(),
+            task_id: "task-1".to_owned(),
+            steps: Vec::new(),
+            output: json!({}),
+        });
+        assert_eq!(
+            workflow_cleanup_reason(&completed),
+            Some("workflow_completed")
+        );
+
+        let suspended: absurd::Result<WorkflowResult> = Err(absurd::Error::Suspend);
+        assert_eq!(workflow_cleanup_reason(&suspended), None);
+
+        let cancelled: absurd::Result<WorkflowResult> = Err(absurd::Error::Cancelled);
+        assert_eq!(
+            workflow_cleanup_reason(&cancelled),
+            Some("workflow_cancelled")
+        );
+
+        let failed: absurd::Result<WorkflowResult> = Err(absurd::Error::Timeout("boom".to_owned()));
+        assert_eq!(workflow_cleanup_reason(&failed), Some("workflow_failed"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a DB-aware session sandbox cleanup worker that compares observed
  sandboxes against durable session and warm-pool references
- stop workflow-owned agent sandboxes after terminal workflow runs while
  preserving explicit workflow `thread_key` sessions
- add env/Helm/docs wiring for the session sandbox cleanup interval and idle
  cleanup backstop settings
- add regression coverage for orphan reaping, workflow cleanup, stale warm-pool
  rows, and resume-failed sandbox replacement

## Validation

- `cargo fmt --manifest-path services/api-rs/Cargo.toml --all --check`
- `cargo check --manifest-path services/api-rs/Cargo.toml -p centaur-api-server`
- `cargo test --manifest-path services/api-rs/Cargo.toml -p centaur-session-runtime -p centaur-session-sqlx -p centaur-sandbox-manager -p centaur-workflows`
- `git diff --check`
- `helm lint contrib/chart`
- `just build-one api-rs`
- local deploy with existing local overrides:
  `helm upgrade --install centaur contrib/chart -n centaur --create-namespace -f contrib/chart/values.dev.yaml --force-conflicts --set apiRs.runMigrations=false --set apiRs.ironProxy.mode=disabled`
- verified the local deployment renders the renamed env vars:
  - `SESSION_SANDBOX_CLEANUP_INTERVAL_SECS`
  - `SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS`
- local `agent_turn` workflow smoke verified:
  - workflow-owned session `sandbox_id` cleared
  - `session.workflow_sandbox_stopped` emitted with `cleared: true`
  - claimed warm sandbox row marked `failed`
  - warm pool replenished with running ready sandboxes

The local workflow reached terminal `failed` because this local stack lacks the
LLM proxy/Iron Control credentials needed for the harness call, but the terminal
cleanup path was exercised and verified against Postgres and Kubernetes pods.

Closes paradigmxyz/centaur#524
Closes paradigmxyz/centaur#570
Closes paradigmxyz/centaur#420
Closes paradigmxyz/centaur#211
Closes paradigmxyz/centaur#172
Closes paradigmxyz/centaur#171