### PR TITLE
feat: add gcp id token secret support

### DIFF
--- a/services/api-rs/crates/centaur-iron-control/src/client.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/client.rs
@@ -14,9 +14,9 @@ use serde_json::{Value, json};
 use crate::error::{IronControlError, Result};
 use crate::models::{
     AwsAuthSecretInput, BrokerCredentialInput, BrokerCredentialRecord, DataEnvelope,
-    EffectiveConfig, GcpAuthSecretInput, Grant, GrantSecret, Grantee, HmacSecretInput,
-    IdentityInput, OAuthTokenSecretInput, PgDsnSecretInput, Principal, Proxy, ProxyInput, Role,
-    SecretRecord, StaticSecretInput,
+    EffectiveConfig, GcpAuthSecretInput, GcpIdTokenSecretInput, Grant, GrantSecret, Grantee,
+    HmacSecretInput, IdentityInput, OAuthTokenSecretInput, PgDsnSecretInput, Principal, Proxy,
+    ProxyInput, Role, SecretRecord, StaticSecretInput,
 };
 
 const API_PREFIX: &str = "/api/v1";
@@ -245,6 +245,19 @@ impl IronControlClient {
         }
     }
 
+    /// Upsert a GCP ID token secret by ``foreign_id``.
+    pub async fn upsert_gcp_id_token_secret(
+        &self,
+        input: &GcpIdTokenSecretInput,
+    ) -> Result<SecretRecord> {
+        self.write(
+            Method::PUT,
+            &upsert_path("gcp_id_token_secrets", &input.foreign_id),
+            input,
+        )
+        .await
+    }
+
     /// Upsert a Postgres DSN secret by ``foreign_id``.
     pub async fn upsert_pg_dsn_secret(&self, input: &PgDsnSecretInput) -> Result<SecretRecord> {
         self.write(
@@ -278,7 +291,8 @@ impl IronControlClient {
     /// Fetch a secret's identity (id, ``foreign_id``, ``name``) by OID. The
     /// ``collection`` is the resource path segment for the secret's type
     /// (``static_secrets``, ``oauth_token_secrets``, ``gcp_auth_secrets``,
-    /// ``pg_dsn_secrets``, ``hmac_secrets``, ``aws_auth_secrets``) — see
+    /// ``gcp_id_token_secrets``, ``pg_dsn_secrets``, ``hmac_secrets``,
+    /// ``aws_auth_secrets``) — see
     /// [`Grant::secret_target`].
     pub async fn get_secret(&self, collection: &str, oid: &str) -> Result<SecretRecord> {
         let path = format!("{API_PREFIX}/{collection}/{}", urlencoding::encode(oid));
@@ -494,6 +508,7 @@ fn grant_body(grantee: &Grantee, secret: &GrantSecret) -> Value {
     let (key, id) = match secret {
         GrantSecret::Static(id) => ("static_secret_id", id),
         GrantSecret::GcpAuth(id) => ("gcp_auth_secret_id", id),
+        GrantSecret::GcpIdToken(id) => ("gcp_id_token_secret_id", id),
         GrantSecret::OAuthToken(id) => ("oauth_token_secret_id", id),
         GrantSecret::PgDsn(id) => ("pg_dsn_secret_id", id),
         GrantSecret::Hmac(id) => ("hmac_secret_id", id),
@@ -609,6 +624,18 @@ mod tests {
         assert_eq!(
             body,
             json!({ "role_id": "role_cw", "aws_auth_secret_id": "aas_cloudwatch" })
+        );
+    }
+
+    #[test]
+    fn grant_body_role_gcp_id_token() {
+        let body = grant_body(
+            &Grantee::Role("role_cloud_run".to_owned()),
+            &GrantSecret::GcpIdToken("gid_cloudrun".to_owned()),
+        );
+        assert_eq!(
+            body,
+            json!({ "role_id": "role_cloud_run", "gcp_id_token_secret_id": "gid_cloudrun" })
         );
     }
 

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -18,10 +18,11 @@ pub use client::IronControlClient;
 pub use error::{IronControlError, Result};
 pub use models::{
     AwsAuthSecretInput, BrokerCredentialInput, BrokerCredentialRecord, EffectiveConfig,
-    EffectivePgDsn, EffectiveReplace, EffectiveSecret, GcpAuthSecretInput, Grant, GrantSecret,
-    Grantee, HmacSecretHeader, HmacSecretInput, IdentityInput, InjectConfig, OAuthTokenSecretInput,
-    PgDsnSecretInput, PgDsnSettingInput, PgDsnSettingValueFromInput, Principal, Proxy, ProxyInput,
-    ReplaceConfig, RequestRule, Role, SECRET_TYPES, SecretRecord, SecretSource, StaticSecretInput,
+    EffectivePgDsn, EffectiveReplace, EffectiveSecret, GcpAuthSecretInput, GcpIdTokenSecretInput,
+    Grant, GrantSecret, Grantee, HmacSecretHeader, HmacSecretInput, IdentityInput, InjectConfig,
+    OAuthTokenSecretInput, PgDsnSecretInput, PgDsnSettingInput, PgDsnSettingValueFromInput,
+    Principal, Proxy, ProxyInput, ReplaceConfig, RequestRule, Role, SECRET_TYPES, SecretRecord,
+    SecretSource, StaticSecretInput,
 };
 pub use principal::{PrincipalRef, derive_principal};
 pub use registry::{

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -222,6 +222,32 @@ pub struct GcpAuthSecretInput {
 }
 
 // ---------------------------------------------------------------------------
+// GCP ID token secrets
+// ---------------------------------------------------------------------------
+
+/// Request body for ``POST``/``PUT /api/v1/gcp_id_token_secrets``. iron-proxy
+/// mints a Google-signed OIDC ID token for ``audience`` from the service-account
+/// ``keyfile`` and injects it into ``Authorization`` by default, or
+/// ``X-Serverless-Authorization`` when ``header`` is set accordingly.
+// Not `Eq`: holds a `SecretSource` (arbitrary `Value` config).
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct GcpIdTokenSecretInput {
+    pub namespace: String,
+    pub foreign_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
+    pub audience: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header: Option<String>,
+    pub keyfile: SecretSource,
+    pub rules: Vec<RequestRule>,
+}
+
+// ---------------------------------------------------------------------------
 // AWS auth secrets
 // ---------------------------------------------------------------------------
 
@@ -501,6 +527,7 @@ pub const SECRET_TYPES: &[(&str, &str, &str)] = &[
     ("static", "static_secrets", "ssr_"),
     ("oauth_token", "oauth_token_secrets", "ots_"),
     ("gcp_auth", "gcp_auth_secrets", "gas_"),
+    ("gcp_id_token", "gcp_id_token_secrets", "gid_"),
     ("pg_dsn", "pg_dsn_secrets", "pgs_"),
     ("hmac", "hmac_secrets", "hms_"),
     ("aws_auth", "aws_auth_secrets", "aas_"),
@@ -522,6 +549,7 @@ pub enum Grantee {
 pub enum GrantSecret {
     Static(String),
     GcpAuth(String),
+    GcpIdToken(String),
     OAuthToken(String),
     PgDsn(String),
     Hmac(String),
@@ -534,6 +562,7 @@ impl GrantSecret {
         match self {
             Self::Static(id)
             | Self::GcpAuth(id)
+            | Self::GcpIdToken(id)
             | Self::OAuthToken(id)
             | Self::PgDsn(id)
             | Self::Hmac(id)
@@ -552,6 +581,7 @@ impl GrantSecret {
             "static" => Self::Static(id),
             "oauth_token" => Self::OAuthToken(id),
             "gcp_auth" => Self::GcpAuth(id),
+            "gcp_id_token" => Self::GcpIdToken(id),
             "pg_dsn" => Self::PgDsn(id),
             "hmac" => Self::Hmac(id),
             "aws_auth" => Self::AwsAuth(id),
@@ -577,6 +607,8 @@ pub struct Grant {
     #[serde(default)]
     pub gcp_auth_secret_id: Option<String>,
     #[serde(default)]
+    pub gcp_id_token_secret_id: Option<String>,
+    #[serde(default)]
     pub pg_dsn_secret_id: Option<String>,
     #[serde(default)]
     pub hmac_secret_id: Option<String>,
@@ -591,6 +623,7 @@ impl Grant {
             .as_deref()
             .or(self.oauth_token_secret_id.as_deref())
             .or(self.gcp_auth_secret_id.as_deref())
+            .or(self.gcp_id_token_secret_id.as_deref())
             .or(self.pg_dsn_secret_id.as_deref())
             .or(self.hmac_secret_id.as_deref())
             .or(self.aws_auth_secret_id.as_deref())
@@ -606,6 +639,8 @@ impl Grant {
             Some(("oauth_token", "oauth_token_secrets", id))
         } else if let Some(id) = &self.gcp_auth_secret_id {
             Some(("gcp_auth", "gcp_auth_secrets", id))
+        } else if let Some(id) = &self.gcp_id_token_secret_id {
+            Some(("gcp_id_token", "gcp_id_token_secrets", id))
         } else if let Some(id) = &self.pg_dsn_secret_id {
             Some(("pg_dsn", "pg_dsn_secrets", id))
         } else if let Some(id) = &self.hmac_secret_id {

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -24,9 +24,10 @@ use serde_yaml::Value as YamlValue;
 use crate::client::IronControlClient;
 use crate::error::IronControlError;
 use crate::models::{
-    AwsAuthSecretInput, GcpAuthSecretInput, GrantSecret, Grantee, HmacSecretInput, IdentityInput,
-    InjectConfig, OAuthTokenSecretInput, PgDsnSecretInput, PgDsnSettingInput,
-    PgDsnSettingValueFromInput, ReplaceConfig, RequestRule, SecretSource, StaticSecretInput,
+    AwsAuthSecretInput, GcpAuthSecretInput, GcpIdTokenSecretInput, GrantSecret, Grantee,
+    HmacSecretInput, IdentityInput, InjectConfig, OAuthTokenSecretInput, PgDsnSecretInput,
+    PgDsnSettingInput, PgDsnSettingValueFromInput, ReplaceConfig, RequestRule, SecretSource,
+    StaticSecretInput,
 };
 use crate::util::{managed_labels, slugify};
 
@@ -63,6 +64,7 @@ pub enum SecretInput {
     Static(StaticSecretInput),
     OAuthToken(OAuthTokenSecretInput),
     GcpAuth(GcpAuthSecretInput),
+    GcpIdToken(GcpIdTokenSecretInput),
     PgDsn(PgDsnSecretInput),
     Hmac(HmacSecretInput),
     AwsAuth(AwsAuthSecretInput),
@@ -149,6 +151,9 @@ pub async fn grant_inputs_to_role(
             }
             SecretInput::GcpAuth(input) => {
                 GrantSecret::GcpAuth(client.upsert_gcp_auth_secret(&input).await?.id)
+            }
+            SecretInput::GcpIdToken(input) => {
+                GrantSecret::GcpIdToken(client.upsert_gcp_id_token_secret(&input).await?.id)
             }
             SecretInput::PgDsn(input) => {
                 GrantSecret::PgDsn(client.upsert_pg_dsn_secret(&input).await?.id)

--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -31,6 +31,10 @@ fn secret_type_routes_by_oid_prefix() {
         secret_type_for_oid("gas_3").map(|t| t.1),
         Some("gcp_auth_secrets")
     );
+    assert_eq!(
+        secret_type_for_oid("gid_7").map(|t| t.1),
+        Some("gcp_id_token_secrets")
+    );
     assert_eq!(secret_type_for_oid("pgs_4").map(|t| t.0), Some("pg_dsn"));
     assert_eq!(secret_type_for_oid("hms_5").map(|t| t.0), Some("hmac"));
     assert_eq!(

--- a/services/console/app/controllers/api/base_controller.rb
+++ b/services/console/app/controllers/api/base_controller.rb
@@ -102,6 +102,22 @@ module Api
       model.find_by!(namespace: params.require(:namespace), foreign_id: params.require(:foreign_id))
     end
 
+    def build_rules(attrs)
+      request_rule_attributes(attrs).map { |rule_attrs| RequestRule.new(rule_attrs) }
+    end
+
+    def request_rule_attributes(attrs)
+      Array(attrs[:rules]).each_with_index.map do |rule, position|
+        rule_params = if rule.is_a?(ActionController::Parameters)
+          rule
+        else
+          ActionController::Parameters.new(rule || {})
+        end
+
+        rule_params.permit(:host, :cidr, http_methods: [], paths: []).to_h.merge(position: position)
+      end
+    end
+
     DEFAULT_PAGE_LIMIT = 50
     MAX_PAGE_LIMIT = 200
 

--- a/services/console/app/controllers/api/v1/aws_auth_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/aws_auth_secrets_controller.rb
@@ -82,13 +82,6 @@ module Api
         params.permit(:source_type, :secret, config: {}).to_h
       end
 
-      def build_rules(attrs)
-        Array(attrs[:rules]).each_with_index.map do |r, i|
-          permitted = ActionController::Parameters.new(r.to_unsafe_h).permit(:host, :cidr, http_methods: [], paths: [])
-          RequestRule.new(permitted.to_h.merge(position: i))
-        end
-      end
-
       def record_payload(ref)
         by_role = ref.sources.index_by(&:role)
         {

--- a/services/console/app/controllers/api/v1/gcp_auth_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/gcp_auth_secrets_controller.rb
@@ -68,13 +68,6 @@ module Api
         end
       end
 
-      def build_rules(attrs)
-        Array(attrs[:rules]).each_with_index.map do |r, i|
-          permitted = ActionController::Parameters.new(r.to_unsafe_h).permit(:host, :cidr, http_methods: [], paths: [])
-          RequestRule.new(permitted.to_h.merge(position: i))
-        end
-      end
-
       def record_payload(ref)
         {
           id: ref.oid,

--- a/services/console/app/controllers/api/v1/gcp_id_token_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/gcp_id_token_secrets_controller.rb
@@ -1,0 +1,91 @@
+module Api
+  module V1
+    class GcpIdTokenSecretsController < Api::BaseController
+      def index
+        records, meta = paginated_label_search(GcpIdTokenSecret.all)
+        render json: { data: records.map { |r| record_payload(r) }, meta: meta }
+      end
+
+      def show
+        ref = GcpIdTokenSecret.find_by_oid!(params[:id])
+        render json: { data: record_payload(ref) }
+      end
+
+      def lookup
+        render json: { data: record_payload(find_by_foreign_id!(GcpIdTokenSecret)) }
+      end
+
+      def create
+        ref = GcpIdTokenSecret.new(created_by: current_user)
+        assign_and_save!(ref, data_params)
+        render status: :created, json: { data: record_payload(ref) }
+      rescue ActiveRecord::RecordInvalid => e
+        render_validation_error(e.record)
+      end
+
+      def update
+        ref = resolve_for_upsert(GcpIdTokenSecret)
+        was_new = ref.new_record?
+        assign_and_save!(ref, data_params)
+        render status: (was_new ? :created : :ok), json: { data: record_payload(ref) }
+      rescue ActiveRecord::RecordInvalid => e
+        render_validation_error(e.record)
+      end
+
+      def destroy
+        ref = GcpIdTokenSecret.find_by_oid!(params[:id])
+        ref.destroy!
+        head :no_content
+      end
+
+      private
+
+      def assign_and_save!(ref, attrs)
+        base = permit_document(ref, attrs, :name, :description, :audience, :header, labels: {})
+
+        keyfile_attrs = if attrs.key?(:keyfile) && attrs[:keyfile].present?
+          attrs.require(:keyfile).permit(:source_type, :secret, config: {})
+        end
+
+        rules_attrs = build_rules(attrs)
+
+        GcpIdTokenSecret.transaction do
+          ref.assign_attributes(base)
+          ref.keyfile_source = keyfile_attrs ? SecretSource.new(keyfile_attrs.to_h) : nil
+          ref.rules = rules_attrs
+          ref.save!
+          ref.reload
+        end
+      end
+
+      def build_rules(attrs)
+        Array(attrs[:rules]).each_with_index.map do |r, i|
+          permitted = ActionController::Parameters.new(r.to_unsafe_h).permit(:host, :cidr, http_methods: [], paths: [])
+          RequestRule.new(permitted.to_h.merge(position: i))
+        end
+      end
+
+      def record_payload(ref)
+        {
+          id: ref.oid,
+          namespace: ref.namespace,
+          foreign_id: ref.foreign_id,
+          name: ref.name,
+          description: ref.description,
+          labels: ref.labels,
+          audience: ref.audience,
+          header: ref.header,
+          keyfile: ref.keyfile_source && {
+            source_type: ref.keyfile_source.source_type,
+            config: ref.keyfile_source.config
+          },
+          rules: ref.rules.map do |r|
+            { host: r.host, cidr: r.cidr, position: r.position, http_methods: r.http_methods, paths: r.paths }
+          end,
+          created_at: ref.created_at,
+          updated_at: ref.updated_at
+        }
+      end
+    end
+  end
+end

--- a/services/console/app/controllers/api/v1/gcp_id_token_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/gcp_id_token_secrets_controller.rb
@@ -58,13 +58,6 @@ module Api
         end
       end
 
-      def build_rules(attrs)
-        Array(attrs[:rules]).each_with_index.map do |r, i|
-          permitted = ActionController::Parameters.new(r.to_unsafe_h).permit(:host, :cidr, http_methods: [], paths: [])
-          RequestRule.new(permitted.to_h.merge(position: i))
-        end
-      end
-
       def record_payload(ref)
         {
           id: ref.oid,

--- a/services/console/app/controllers/api/v1/grants_controller.rb
+++ b/services/console/app/controllers/api/v1/grants_controller.rb
@@ -14,6 +14,7 @@ module Api
       GRANTABLE_TYPES = {
         static_secret_id: StaticSecret,
         gcp_auth_secret_id: GcpAuthSecret,
+        gcp_id_token_secret_id: GcpIdTokenSecret,
         aws_auth_secret_id: AwsAuthSecret,
         oauth_token_secret_id: OauthTokenSecret,
         pg_dsn_secret_id: PgDsnSecret,

--- a/services/console/app/controllers/api/v1/hmac_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/hmac_secrets_controller.rb
@@ -80,13 +80,6 @@ module Api
         params.permit(:source_type, :secret, config: {}).to_h
       end
 
-      def build_rules(attrs)
-        Array(attrs[:rules]).each_with_index.map do |r, i|
-          permitted = ActionController::Parameters.new(r.to_unsafe_h).permit(:host, :cidr, http_methods: [], paths: [])
-          RequestRule.new(permitted.to_h.merge(position: i))
-        end
-      end
-
       def record_payload(ref)
         {
           id: ref.oid,

--- a/services/console/app/controllers/api/v1/oauth_token_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/oauth_token_secrets_controller.rb
@@ -87,13 +87,6 @@ module Api
         params.permit(:source_type, :secret, config: {}).to_h
       end
 
-      def build_rules(attrs)
-        Array(attrs[:rules]).each_with_index.map do |r, i|
-          permitted = ActionController::Parameters.new(r.to_unsafe_h).permit(:host, :cidr, http_methods: [], paths: [])
-          RequestRule.new(permitted.to_h.merge(position: i))
-        end
-      end
-
       def record_payload(ref)
         cred = ref.sources.select(&:credential_field?)
         headers = ref.sources.select(&:endpoint_header?)

--- a/services/console/app/controllers/api/v1/proxy_sync_controller.rb
+++ b/services/console/app/controllers/api/v1/proxy_sync_controller.rb
@@ -8,9 +8,9 @@ module Api
     # full `secrets` and `transforms` payload.
     #
     # `secrets` populates the proxy's `secrets` transform. `transforms` carries
-    # whole transforms the proxy splices into its pipeline: a gcp_auth transform
-    # per granted GcpAuthSecret, an hmac_sign transform per granted HmacSecret,
-    # and one bundled oauth_token transform. `postgres` carries one upstream-DSN
+    # whole transforms the proxy splices into its pipeline: one gcp_auth,
+    # gcp_id_token, hmac_sign, or aws_auth transform per granted secret, and one
+    # bundled oauth_token transform. `postgres` carries one upstream-DSN
     # entry per granted PgDsnSecret, keyed by foreign_id; the proxy's
     # locally-defined listeners bind to these by foreign_id.
     #

--- a/services/console/app/controllers/api/v1/static_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/static_secrets_controller.rb
@@ -71,11 +71,7 @@ module Api
           attrs.require(:source).permit(:source_type, :secret, config: {})
         end
 
-        rules_attrs = Array(attrs[:rules]).map do |r|
-          ActionController::Parameters.new(r.to_unsafe_h).permit(
-            :host, :cidr, http_methods: [], paths: []
-          )
-        end
+        rules_attrs = request_rule_attributes(attrs)
 
         StaticSecret.transaction do
           ref.lock! unless ref.new_record?
@@ -88,8 +84,8 @@ module Api
           end
 
           ref.rules.destroy_all
-          rules_attrs.each_with_index do |r, i|
-            RequestRule.create!(r.to_h.merge(position: i, static_secret: ref))
+          rules_attrs.each do |r|
+            RequestRule.create!(r.merge(static_secret: ref))
           end
 
           ref.reload

--- a/services/console/app/controllers/concerns/secret_kinds.rb
+++ b/services/console/app/controllers/concerns/secret_kinds.rb
@@ -11,6 +11,7 @@ module SecretKinds
   SECRET_KINDS = {
     "static" => { model: StaticSecret, label: "Static", includes: :source, form: true },
     "gcp_auth" => { model: GcpAuthSecret, label: "GCP Auth", includes: :keyfile_source, form: true },
+    "gcp_id_token" => { model: GcpIdTokenSecret, label: "GCP ID Token", includes: :keyfile_source, form: true },
     "aws_auth" => { model: AwsAuthSecret, label: "AWS Auth", includes: :sources, form: false },
     "oauth_token" => { model: OauthTokenSecret, label: "OAuth Token", includes: :sources, form: false },
     "pg_dsn" => { model: PgDsnSecret, label: "Postgres DSN", includes: :dsn_source, form: true },

--- a/services/console/app/controllers/console/gcp_id_token_secrets_controller.rb
+++ b/services/console/app/controllers/console/gcp_id_token_secrets_controller.rb
@@ -1,0 +1,28 @@
+module Console
+  # Create/edit form for GcpIdTokenSecret: mints a Google-signed OIDC ID token
+  # from a service-account keyfile and injects it into Authorization, or
+  # X-Serverless-Authorization for Cloud Run apps that need Authorization for
+  # their own application auth.
+  class GcpIdTokenSecretsController < BaseSecretsController
+    include RuleParams
+
+    private
+
+    def model
+      GcpIdTokenSecret
+    end
+
+    def kind
+      "gcp_id_token"
+    end
+
+    def assign_form(secret)
+      assign_identity(secret)
+      gcp = params.fetch(:gcp_id_token, ActionController::Parameters.new)
+      secret.audience = gcp[:audience].to_s.strip.presence
+      secret.header = gcp[:header].to_s.strip.presence
+      secret.keyfile_source = build_source
+      assign_rules(secret)
+    end
+  end
+end

--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -26,6 +26,7 @@ class ConsoleController < ApplicationController
     @granted = {
       "static" => @principal.granted_static_secrets,
       "gcp_auth" => @principal.granted_gcp_auth_secrets,
+      "gcp_id_token" => @principal.granted_gcp_id_token_secrets,
       "aws_auth" => @principal.granted_aws_auth_secrets,
       "oauth_token" => @principal.granted_oauth_token_secrets,
       "pg_dsn" => @principal.granted_pg_dsn_secrets,
@@ -129,6 +130,7 @@ class ConsoleController < ApplicationController
     case record
     when StaticSecret then [ source_segment(record.source) ].compact
     when PgDsnSecret  then [ source_segment(record.dsn_source) ].compact
+    when GcpIdTokenSecret then [ source_segment(record.keyfile_source) ].compact
     when GcpAuthSecret
       if record.keyfile_source
         [ source_segment(record.keyfile_source) ].compact
@@ -169,6 +171,9 @@ class ConsoleController < ApplicationController
     case record
     when StaticSecret  then static_injection(record)
     when GcpAuthSecret  then "Authorization: Bearer"
+    when GcpIdTokenSecret
+      header = record.header.presence || "authorization"
+      "#{header}: Bearer"
     when AwsAuthSecret  then "Authorization: AWS4-HMAC-SHA256"
     when OauthTokenSecret
       header = record.header.presence || "Authorization"

--- a/services/console/app/helpers/console_form_helper.rb
+++ b/services/console/app/helpers/console_form_helper.rb
@@ -35,7 +35,9 @@ module ConsoleFormHelper
   # detailed messages, prefixed by which record they came from.
   def secret_error_messages(secret)
     nested_attrs = %i[source dsn_source keyfile_source rules]
-    messages = secret.errors.reject { |e| nested_attrs.include?(e.attribute) }.map(&:full_message)
+    messages = secret.errors.reject do |e|
+      nested_attrs.include?(e.attribute) && e.message == "is invalid"
+    end.map(&:full_message)
 
     %i[source dsn_source keyfile_source].each do |assoc|
       next unless secret.respond_to?(assoc)

--- a/services/console/app/models/gcp_id_token_secret.rb
+++ b/services/console/app/models/gcp_id_token_secret.rb
@@ -1,0 +1,67 @@
+class GcpIdTokenSecret < ApplicationRecord
+  oid_prefix "gid"
+
+  include ForeignIdCollisionGuard
+  include SyncConfigCacheInvalidation
+
+  URL_SAFE_FORMAT = /\A[A-Za-z0-9\-._~]+\z/
+  URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"
+
+  HEADERS = %w[authorization x-serverless-authorization].freeze
+  DEFAULT_HEADER = "authorization".freeze
+
+  has_one :keyfile_source, class_name: "SecretSource", dependent: :destroy
+  has_many :rules, class_name: "RequestRule", dependent: :destroy
+  has_many :grants, dependent: :destroy
+  belongs_to :created_by, class_name: "User"
+
+  before_validation :normalize_header
+
+  # Maps to one entry in the iron-proxy `transforms` array as a gcp_id_token
+  # transform. The proxy defaults to Authorization when header is omitted.
+  def to_proxy_transform
+    config = {
+      "keyfile" => keyfile_source.to_proxy_source,
+      "audience" => audience,
+      "rules" => rules.map(&:to_proxy_rule)
+    }
+    config["header"] = header if header.present?
+    { "name" => "gcp_id_token", "config" => config }
+  end
+
+  def proxy_conflict_targets
+    [ "header:#{header.presence || DEFAULT_HEADER}" ]
+  end
+
+  validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
+  validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
+            format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true
+  validates :audience, presence: true
+  validate :labels_is_a_hash
+  validate :keyfile_source_present
+  validate :header_is_supported
+  validate :at_least_one_rule
+
+  private
+
+  def normalize_header
+    self.header = header.to_s.strip.downcase.presence
+  end
+
+  def labels_is_a_hash
+    errors.add(:labels, "must be a hash") unless labels.is_a?(Hash)
+  end
+
+  def keyfile_source_present
+    errors.add(:keyfile_source, "can't be blank") unless keyfile_source
+  end
+
+  def header_is_supported
+    return if header.blank? || HEADERS.include?(header)
+    errors.add(:header, "must be one of #{HEADERS.join(", ")}")
+  end
+
+  def at_least_one_rule
+    errors.add(:rules, "must include at least one rule") if rules.empty?
+  end
+end

--- a/services/console/app/models/grant.rb
+++ b/services/console/app/models/grant.rb
@@ -4,7 +4,9 @@ class Grant < ApplicationRecord
   include SyncConfigCacheInvalidation
 
   GRANTEE_ASSOCIATIONS = %i[principal role].freeze
-  GRANTABLE_ASSOCIATIONS = %i[static_secret gcp_auth_secret aws_auth_secret oauth_token_secret pg_dsn_secret hmac_secret].freeze
+  GRANTABLE_ASSOCIATIONS = %i[
+    static_secret gcp_auth_secret gcp_id_token_secret aws_auth_secret oauth_token_secret pg_dsn_secret hmac_secret
+  ].freeze
 
   # Higher priority wins. When two granted secrets collide at the proxy (iron-proxy
   # applies the last matching transform), the one with the higher priority is
@@ -15,12 +17,14 @@ class Grant < ApplicationRecord
   DEFAULT_ROLE_PRIORITY = 0
 
   attr_readonly :principal_id, :role_id, :static_secret_id, :gcp_auth_secret_id,
-                :aws_auth_secret_id, :oauth_token_secret_id, :pg_dsn_secret_id, :hmac_secret_id
+                :gcp_id_token_secret_id, :aws_auth_secret_id, :oauth_token_secret_id,
+                :pg_dsn_secret_id, :hmac_secret_id
 
   belongs_to :principal, optional: true
   belongs_to :role, optional: true
   belongs_to :static_secret, optional: true
   belongs_to :gcp_auth_secret, optional: true
+  belongs_to :gcp_id_token_secret, optional: true
   belongs_to :aws_auth_secret, optional: true
   belongs_to :oauth_token_secret, optional: true
   belongs_to :pg_dsn_secret, optional: true

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -48,6 +48,11 @@ class Principal < ApplicationRecord
     granted_secrets_by_priority(GcpAuthSecret, :gcp_auth_secret_id, includes: %i[keyfile_source rules])
   end
 
+  # gcp_id_token credentials this principal resolves to, via its effective grants.
+  def granted_gcp_id_token_secrets
+    granted_secrets_by_priority(GcpIdTokenSecret, :gcp_id_token_secret_id, includes: %i[keyfile_source rules])
+  end
+
   # aws_auth credentials this principal resolves to, via its effective grants.
   def granted_aws_auth_secrets
     granted_secrets_by_priority(AwsAuthSecret, :aws_auth_secret_id, includes: %i[sources rules])
@@ -76,9 +81,8 @@ class Principal < ApplicationRecord
     proxy_secrets_for(served_credentials)
   end
 
-  # The `transforms` array delivered to iron-proxy: one gcp_auth transform per
-  # granted GcpAuthSecret, one aws_auth transform per granted AwsAuthSecret, one
-  # hmac_sign transform per granted HmacSecret, plus a single oauth_token
+  # The `transforms` array delivered to iron-proxy: one gcp_auth/gcp_id_token/
+  # aws_auth/hmac_sign transform per granted secret, plus a single oauth_token
   # transform bundling every granted OauthTokenSecret as one `tokens` entry.
   # Credentials that lost a cross-type conflict are omitted (see
   # #served_credentials).
@@ -157,15 +161,17 @@ class Principal < ApplicationRecord
   def served_credentials
     static = granted_static_secrets.select { |ss| ss.source&.deliverable? }
     gcp_auth = granted_gcp_auth_secrets.to_a
+    gcp_id_token = granted_gcp_id_token_secrets.to_a
     aws_auth = granted_aws_auth_secrets.to_a
     hmac = granted_hmac_secrets.to_a
     oauth = granted_oauth_token_secrets.to_a
 
-    suppressed = suppressed_conflict_credentials(static + gcp_auth + aws_auth + hmac + oauth)
+    suppressed = suppressed_conflict_credentials(static + gcp_auth + gcp_id_token + aws_auth + hmac + oauth)
 
     {
       static: static - suppressed,
       gcp_auth: gcp_auth - suppressed,
+      gcp_id_token: gcp_id_token - suppressed,
       aws_auth: aws_auth - suppressed,
       hmac: hmac - suppressed,
       oauth: oauth - suppressed
@@ -178,6 +184,7 @@ class Principal < ApplicationRecord
 
   def proxy_transforms_for(served)
     transforms = served[:gcp_auth].map(&:to_proxy_transform)
+    transforms += served[:gcp_id_token].map(&:to_proxy_transform)
     transforms += served[:aws_auth].map(&:to_proxy_transform)
     transforms += served[:hmac].map(&:to_proxy_transform)
 

--- a/services/console/app/models/request_rule.rb
+++ b/services/console/app/models/request_rule.rb
@@ -11,11 +11,14 @@ class RequestRule < ApplicationRecord
   # A rule hangs off exactly one credential type.
   belongs_to :static_secret, optional: true
   belongs_to :gcp_auth_secret, optional: true
+  belongs_to :gcp_id_token_secret, optional: true
   belongs_to :aws_auth_secret, optional: true
   belongs_to :oauth_token_secret, optional: true
   belongs_to :hmac_secret, optional: true
 
-  OWNER_ASSOCIATIONS = %i[static_secret gcp_auth_secret aws_auth_secret oauth_token_secret hmac_secret].freeze
+  OWNER_ASSOCIATIONS = %i[
+    static_secret gcp_auth_secret gcp_id_token_secret aws_auth_secret oauth_token_secret hmac_secret
+  ].freeze
 
   default_scope { order(:position) }
 

--- a/services/console/app/models/secret_source.rb
+++ b/services/console/app/models/secret_source.rb
@@ -20,10 +20,12 @@ class SecretSource < ApplicationRecord
   # A source belongs to exactly one owner. static_secret feeds the `secrets`
   # transform; gcp_auth_secret is a gcp_auth keyfile; oauth_token_secret holds
   # one oauth_token entry's credential fields and token-endpoint headers;
+  # gcp_id_token_secret is a gcp_id_token keyfile;
   # pg_dsn_secret is a Postgres upstream's connection string; hmac_secret holds
   # one hmac_sign entry's HMAC key and any additional named credentials.
   belongs_to :static_secret, optional: true
   belongs_to :gcp_auth_secret, optional: true
+  belongs_to :gcp_id_token_secret, optional: true
   belongs_to :aws_auth_secret, optional: true
   belongs_to :oauth_token_secret, optional: true
   belongs_to :pg_dsn_secret, optional: true
@@ -78,7 +80,9 @@ class SecretSource < ApplicationRecord
     )
   end
 
-  OWNER_ASSOCIATIONS = %i[static_secret gcp_auth_secret aws_auth_secret oauth_token_secret pg_dsn_secret hmac_secret].freeze
+  OWNER_ASSOCIATIONS = %i[
+    static_secret gcp_auth_secret gcp_id_token_secret aws_auth_secret oauth_token_secret pg_dsn_secret hmac_secret
+  ].freeze
 
   # Owners whose sources fill a named role (credential field or endpoint header).
   # aws_auth's sources are credential fields (access_key_id, secret_access_key,

--- a/services/console/app/views/console/base_secrets/_form_gcp_id_token.html.erb
+++ b/services/console/app/views/console/base_secrets/_form_gcp_id_token.html.erb
@@ -1,0 +1,45 @@
+<%
+  header = secret.header.presence || ""
+%>
+<%= form_with model: [ :console, secret ], data: { turbo: false } do %>
+  <div class="space-y-6">
+    <%= render "identity_fields", secret: secret %>
+
+    <section class="form-section">
+      <h2 class="form-section-heading">Token</h2>
+      <div class="grid gap-5 sm:grid-cols-2">
+        <div>
+          <label class="form-label" for="gcp_id_token_audience">Audience</label>
+          <%= text_field_tag "gcp_id_token[audience]", secret.audience, id: "gcp_id_token_audience", class: "form-input #{field_error_class(secret, :audience)}", placeholder: "https://my-service-abc123-uc.a.run.app" %>
+          <%= field_error(secret, :audience) %>
+        </div>
+
+        <div>
+          <label class="form-label" for="gcp_id_token_header">Header</label>
+          <%= select_tag "gcp_id_token[header]",
+                options_for_select([
+                  [ "Authorization", "" ],
+                  [ "X-Serverless-Authorization", "x-serverless-authorization" ]
+                ], header),
+                id: "gcp_id_token_header",
+                class: "form-input #{field_error_class(secret, :header)}" %>
+          <%= field_error(secret, :header) %>
+        </div>
+      </div>
+    </section>
+
+    <section class="form-section">
+      <h2 class="form-section-heading">Credentials</h2>
+      <%= render "source_fields", secret: secret, source: secret.keyfile_source, heading: "Keyfile Source", bare: true %>
+    </section>
+
+    <%= render "rules_fields", secret: secret,
+          hint: "Each rule matches by host or CIDR. GCP ID token secrets require at least one rule." %>
+    <%= render "labels_fields", secret: secret %>
+
+    <div class="flex items-center gap-3">
+      <%= submit_tag(secret.new_record? ? "Create secret" : "Save changes", class: "btn-primary") %>
+      <a href="<%= console_secrets_path %>" class="btn-secondary">Cancel</a>
+    </div>
+  </div>
+<% end %>

--- a/services/console/app/views/console/base_secrets/_rules_fields.html.erb
+++ b/services/console/app/views/console/base_secrets/_rules_fields.html.erb
@@ -1,12 +1,16 @@
 <%# Reusable request-rule editor. The nested-fields controller clones the hidden
     template to add rows; positions are reassigned server-side on save. %>
 <% hint = local_assigns.fetch(:hint, "Each rule matches by host or CIDR. With no rules, the secret applies with no request matching.") %>
+<% rule_messages = secret.errors[:rules].reject { |message| message == "is invalid" } %>
 <section data-controller="nested-fields" class="form-section">
   <div class="mb-2 flex items-center justify-between">
     <h2 class="form-section-heading mb-0">Request Rules</h2>
     <button type="button" data-action="nested-fields#add" class="btn-secondary">Add rule</button>
   </div>
   <p class="form-hint mb-3"><%= hint %></p>
+  <% if rule_messages.any? %>
+    <p class="field-error"><%= rule_messages.to_sentence %></p>
+  <% end %>
 
   <div class="space-y-3" data-nested-fields-target="container">
     <% secret.rules.each_with_index do |rule, i| %>

--- a/services/console/app/views/console/base_secrets/_rules_fields.html.erb
+++ b/services/console/app/views/console/base_secrets/_rules_fields.html.erb
@@ -1,11 +1,12 @@
 <%# Reusable request-rule editor. The nested-fields controller clones the hidden
     template to add rows; positions are reassigned server-side on save. %>
+<% hint = local_assigns.fetch(:hint, "Each rule matches by host or CIDR. With no rules, the secret applies with no request matching.") %>
 <section data-controller="nested-fields" class="form-section">
   <div class="mb-2 flex items-center justify-between">
     <h2 class="form-section-heading mb-0">Request Rules</h2>
     <button type="button" data-action="nested-fields#add" class="btn-secondary">Add rule</button>
   </div>
-  <p class="form-hint mb-3">Each rule matches by host or CIDR. With no rules, the secret applies with no request matching.</p>
+  <p class="form-hint mb-3"><%= hint %></p>
 
   <div class="space-y-3" data-nested-fields-target="container">
     <% secret.rules.each_with_index do |rule, i| %>

--- a/services/console/app/views/console/secret.html.erb
+++ b/services/console/app/views/console/secret.html.erb
@@ -152,6 +152,9 @@
   when GcpAuthSecret
     rows << [ "Subject", @secret.subject ] if @secret.subject.present?
     rows << [ "Scopes", Array(@secret.scopes).join("\n") ] if @secret.scopes.present?
+  when GcpIdTokenSecret
+    rows << [ "Audience", @secret.audience ]
+    rows << [ "Header", @secret.header.presence || "authorization" ]
   when AwsAuthSecret
     rows << [ "Allowed regions", Array(@secret.allowed_regions).join("\n") ] if @secret.allowed_regions.present?
     rows << [ "Allowed services", Array(@secret.allowed_services).join("\n") ] if @secret.allowed_services.present?

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
     resources :static_secrets, only: %i[new create edit update destroy], path: "secrets/static"
     resources :pg_dsn_secrets, only: %i[new create edit update destroy], path: "secrets/pg_dsn"
     resources :gcp_auth_secrets, only: %i[new create edit update destroy], path: "secrets/gcp_auth"
+    resources :gcp_id_token_secrets, only: %i[new create edit update destroy], path: "secrets/gcp_id_token"
     post   "secrets/:kind/:id/roles",           to: "secrets#grant_role",        as: :secret_grant_role
     delete "secrets/:kind/:id/roles/:grant_id", to: "secrets#revoke_role_grant", as: :secret_revoke_role_grant
   end
@@ -105,6 +106,9 @@ Rails.application.routes.draw do
         collection { get "lookup/:namespace/:foreign_id", action: :lookup, as: :lookup }
       end
       resources :gcp_auth_secrets, only: %i[index show create update destroy] do
+        collection { get "lookup/:namespace/:foreign_id", action: :lookup, as: :lookup }
+      end
+      resources :gcp_id_token_secrets, only: %i[index show create update destroy] do
         collection { get "lookup/:namespace/:foreign_id", action: :lookup, as: :lookup }
       end
       resources :aws_auth_secrets, only: %i[index show create update destroy] do

--- a/services/console/db/migrate/20260623231029_create_gcp_id_token_secrets.rb
+++ b/services/console/db/migrate/20260623231029_create_gcp_id_token_secrets.rb
@@ -1,0 +1,19 @@
+class CreateGcpIdTokenSecrets < ActiveRecord::Migration[8.1]
+  def change
+    create_table :gcp_id_token_secrets do |t|
+      t.string :namespace, null: false, default: "default"
+      t.string :foreign_id
+      t.string :name
+      t.string :description
+      t.jsonb :labels, null: false, default: {}
+      t.string :audience, null: false
+      t.string :header
+      t.references :created_by, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :gcp_id_token_secrets, [ :namespace, :foreign_id ], unique: true
+    add_index :gcp_id_token_secrets, :labels, using: :gin
+  end
+end

--- a/services/console/db/migrate/20260623231036_add_gcp_id_token_secret_to_owners.rb
+++ b/services/console/db/migrate/20260623231036_add_gcp_id_token_secret_to_owners.rb
@@ -1,0 +1,7 @@
+class AddGcpIdTokenSecretToOwners < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :secret_sources, :gcp_id_token_secret, null: true, foreign_key: true, index: { unique: true }
+    add_reference :request_rules, :gcp_id_token_secret, null: true, foreign_key: true
+    add_reference :grants, :gcp_id_token_secret, null: true, foreign_key: true
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_23_231036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -97,11 +97,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
     t.index ["namespace", "foreign_id"], name: "index_gcp_auth_secrets_on_namespace_and_foreign_id", unique: true
   end
 
+  create_table "gcp_id_token_secrets", force: :cascade do |t|
+    t.string "audience", null: false
+    t.datetime "created_at", null: false
+    t.bigint "created_by_id", null: false
+    t.string "description"
+    t.string "foreign_id"
+    t.string "header"
+    t.jsonb "labels", default: {}, null: false
+    t.string "name"
+    t.string "namespace", default: "default", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_by_id"], name: "index_gcp_id_token_secrets_on_created_by_id"
+    t.index ["labels"], name: "index_gcp_id_token_secrets_on_labels", using: :gin
+    t.index ["namespace", "foreign_id"], name: "index_gcp_id_token_secrets_on_namespace_and_foreign_id", unique: true
+  end
+
   create_table "grants", force: :cascade do |t|
     t.bigint "aws_auth_secret_id"
     t.datetime "created_at", null: false
     t.bigint "created_by_id", null: false
     t.bigint "gcp_auth_secret_id"
+    t.bigint "gcp_id_token_secret_id"
     t.bigint "hmac_secret_id"
     t.bigint "oauth_token_secret_id"
     t.bigint "pg_dsn_secret_id"
@@ -113,6 +130,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
     t.index ["aws_auth_secret_id"], name: "index_grants_on_aws_auth_secret_id"
     t.index ["created_by_id"], name: "index_grants_on_created_by_id"
     t.index ["gcp_auth_secret_id"], name: "index_grants_on_gcp_auth_secret_id"
+    t.index ["gcp_id_token_secret_id"], name: "index_grants_on_gcp_id_token_secret_id"
     t.index ["hmac_secret_id"], name: "index_grants_on_hmac_secret_id"
     t.index ["oauth_token_secret_id"], name: "index_grants_on_oauth_token_secret_id"
     t.index ["pg_dsn_secret_id"], name: "index_grants_on_pg_dsn_secret_id"
@@ -259,6 +277,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
     t.string "cidr"
     t.datetime "created_at", null: false
     t.bigint "gcp_auth_secret_id"
+    t.bigint "gcp_id_token_secret_id"
     t.bigint "hmac_secret_id"
     t.string "host"
     t.jsonb "http_methods", default: [], null: false
@@ -269,6 +288,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
     t.datetime "updated_at", null: false
     t.index ["aws_auth_secret_id"], name: "index_request_rules_on_aws_auth_secret_id"
     t.index ["gcp_auth_secret_id"], name: "index_request_rules_on_gcp_auth_secret_id"
+    t.index ["gcp_id_token_secret_id"], name: "index_request_rules_on_gcp_id_token_secret_id"
     t.index ["hmac_secret_id"], name: "index_request_rules_on_hmac_secret_id"
     t.index ["host"], name: "index_request_rules_on_host"
     t.index ["oauth_token_secret_id"], name: "index_request_rules_on_oauth_token_secret_id"
@@ -294,6 +314,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
     t.jsonb "config", default: {}, null: false
     t.datetime "created_at", null: false
     t.bigint "gcp_auth_secret_id"
+    t.bigint "gcp_id_token_secret_id"
     t.bigint "hmac_secret_id"
     t.bigint "oauth_token_secret_id"
     t.bigint "pg_dsn_secret_id"
@@ -306,6 +327,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
     t.index ["aws_auth_secret_id", "role", "role_kind"], name: "index_secret_sources_on_aws_owner_and_role", unique: true
     t.index ["aws_auth_secret_id"], name: "index_secret_sources_on_aws_auth_secret_id"
     t.index ["gcp_auth_secret_id"], name: "index_secret_sources_on_gcp_auth_secret_id", unique: true
+    t.index ["gcp_id_token_secret_id"], name: "index_secret_sources_on_gcp_id_token_secret_id", unique: true
     t.index ["hmac_secret_id", "role", "role_kind"], name: "index_secret_sources_on_hmac_owner_and_role", unique: true
     t.index ["hmac_secret_id"], name: "index_secret_sources_on_hmac_secret_id"
     t.index ["oauth_token_secret_id", "role", "role_kind"], name: "index_secret_sources_on_oauth_owner_and_role", unique: true
@@ -364,8 +386,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
   add_foreign_key "broker_credentials", "oauth_apps"
   add_foreign_key "broker_credentials", "users", column: "created_by_id"
   add_foreign_key "gcp_auth_secrets", "users", column: "created_by_id"
+  add_foreign_key "gcp_id_token_secrets", "users", column: "created_by_id"
   add_foreign_key "grants", "aws_auth_secrets"
   add_foreign_key "grants", "gcp_auth_secrets"
+  add_foreign_key "grants", "gcp_id_token_secrets"
   add_foreign_key "grants", "hmac_secrets"
   add_foreign_key "grants", "oauth_token_secrets"
   add_foreign_key "grants", "pg_dsn_secrets"
@@ -384,12 +408,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_170000) do
   add_foreign_key "proxies", "principals", on_delete: :nullify
   add_foreign_key "request_rules", "aws_auth_secrets"
   add_foreign_key "request_rules", "gcp_auth_secrets"
+  add_foreign_key "request_rules", "gcp_id_token_secrets"
   add_foreign_key "request_rules", "hmac_secrets"
   add_foreign_key "request_rules", "oauth_token_secrets"
   add_foreign_key "request_rules", "static_secrets"
   add_foreign_key "roles", "users", column: "created_by_id"
   add_foreign_key "secret_sources", "aws_auth_secrets"
   add_foreign_key "secret_sources", "gcp_auth_secrets"
+  add_foreign_key "secret_sources", "gcp_id_token_secrets"
   add_foreign_key "secret_sources", "hmac_secrets"
   add_foreign_key "secret_sources", "oauth_token_secrets"
   add_foreign_key "secret_sources", "pg_dsn_secrets"

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -10,6 +10,7 @@
   - [Request rules](#request-rules)
 - [Static secrets](#static-secrets)
 - [GCP auth secrets](#gcp-auth-secrets)
+- [GCP ID token secrets](#gcp-id-token-secrets)
 - [AWS auth secrets](#aws-auth-secrets)
 - [OAuth token secrets](#oauth-token-secrets)
 - [PG DSN secrets](#pg-dsn-secrets)
@@ -54,14 +55,14 @@ A missing or invalid token returns `401`:
   ```
 
 - **Pagination** uses the `page` (default `1`) and `limit` (default `50`, max `200`) query parameters. Values are clamped into range; a non-integer value returns `400`.
-- **Namespaced list filtering** (static secrets, GCP auth secrets, OAuth token secrets, principals, roles) requires a `namespace` query parameter and accepts an optional `labels[key]=value` filter that matches by JSONB containment (all supplied pairs must be present). Label values must be scalars.
-- **Object IDs** are prefixed by type: `ssr_` (static secret), `gas_` (GCP auth secret), `ots_` (OAuth token secret), `prn_` (principal), `role_` (role), `grant_` (grant), `ak_` (API key), `prx_` (proxy).
+- **Namespaced list filtering** (static secrets, GCP auth secrets, GCP ID token secrets, OAuth token secrets, principals, roles) requires a `namespace` query parameter and accepts an optional `labels[key]=value` filter that matches by JSONB containment (all supplied pairs must be present). Label values must be scalars.
+- **Object IDs** are prefixed by type: `ssr_` (static secret), `gas_` (GCP auth secret), `gid_` (GCP ID token secret), `ots_` (OAuth token secret), `prn_` (principal), `role_` (role), `grant_` (grant), `ak_` (API key), `prx_` (proxy).
 - **`namespace`** defaults to `"default"` when omitted on create. Once set, `namespace` and `foreign_id` are immutable.
 - **`namespace` and `foreign_id`** must be URL-safe: only `A-Z a-z 0-9 - . _ ~`. `foreign_id` is optional and, when set, must be unique within its namespace. A `foreign_id` may not start with the resource's opaque-id prefix (e.g. `ssr_`), so it can never be mistaken for an OID.
 
 ### Upsert (`PUT` / `PATCH`)
 
-For the resources with a `foreign_id` (static secrets, GCP auth secrets, OAuth token secrets, principals, roles), `PUT`/`PATCH /api/v1/<resource>/:id` is an **upsert**, and `:id` may be either an OID or a `foreign_id`:
+For the resources with a `foreign_id` (static secrets, GCP auth secrets, GCP ID token secrets, OAuth token secrets, principals, roles), `PUT`/`PATCH /api/v1/<resource>/:id` is an **upsert**, and `:id` may be either an OID or a `foreign_id`:
 
 - **`:id` is an OID** (it starts with the resource's prefix, e.g. `ssr_…`): updates that record. `404` if it does not exist — an OID is server-assigned, so it can't be created at a chosen value.
 - **`:id` is anything else**: it is treated as a `foreign_id` within the body `namespace` (default `"default"`). The record is **updated if it exists, created if it does not**. Creation responds `201`; update responds `200`.
@@ -100,7 +101,7 @@ Errors return an `error` object with a `message` and, for validation failures, a
 
 ### Secret sources
 
-A secret source describes where a credential value is resolved from. It appears as the `source` of a static secret, the `keyfile` of a GCP auth secret, and each entry in an OAuth token secret's `credentials` and `token_endpoint_headers` maps.
+A secret source describes where a credential value is resolved from. It appears as the `source` of a static secret, the `keyfile` of a GCP auth or GCP ID token secret, and each entry in an OAuth token secret's `credentials` and `token_endpoint_headers` maps.
 
 Shape:
 
@@ -149,7 +150,7 @@ The `secret` field is encrypted at rest, is write-only, and is never returned in
 
 ### Request rules
 
-A rule scopes a credential to matching outbound requests. Rules appear as the `rules` array of static, GCP, and OAuth secrets.
+A rule scopes a credential to matching outbound requests. Rules appear as the `rules` array of static, GCP auth, GCP ID token, and OAuth secrets.
 
 ```json
 {
@@ -350,6 +351,77 @@ Returns `201`. Response shape:
 | `GET`  | `/api/v1/gcp_auth_secrets/lookup/:namespace/:foreign_id` | Fetch by namespace + foreign id. `404` if missing. |
 | `PUT`/`PATCH` | `/api/v1/gcp_auth_secrets/:id` | [Upsert](#upsert-put--patch) by OID or `foreign_id`; same body as create. |
 | `DELETE` | `/api/v1/gcp_auth_secrets/:id` | Delete. Returns `204`; `404` if missing. Cascades: the secret's sources, rules, and any grants that reference it are removed. The granted roles and principals are not deleted. |
+
+## GCP ID token secrets
+
+A GCP ID token secret mints Google-signed OIDC ID tokens for an audience and injects them as a bearer header. It is used for private Cloud Run services, Cloud Run functions, IAP, API Gateway, and other Google audience-authenticated targets. It requires a service-account `keyfile` [secret source](#secret-sources) and at least one [rule](#request-rules).
+
+### Attributes
+
+| Field                 | In requests | Notes |
+| --------------------- | ----------- | ----- |
+| `namespace`           | optional    | Defaults to `"default"`. Immutable. |
+| `foreign_id`          | optional    | Unique per namespace. Immutable. |
+| `name`, `description` | optional    | |
+| `labels`              | optional    | Object; defaults to `{}`. |
+| `audience`            | required    | ID token `aud` claim. For Cloud Run, use the service URL or configured custom audience. |
+| `header`              | optional    | Omit or use `authorization` for `Authorization`; use `x-serverless-authorization` when the upstream app owns `Authorization`. |
+| `keyfile`             | required    | A [secret source](#secret-sources) resolving the service account JSON. |
+| `rules`               | required    | At least one [rule](#request-rules). |
+
+### Create
+
+`POST /api/v1/gcp_id_token_secrets`
+
+```json
+{
+  "data": {
+    "namespace": "default",
+    "foreign_id": "cloud-run-caller",
+    "name": "Cloud Run Caller",
+    "audience": "https://my-service-abc123-uc.a.run.app",
+    "header": "x-serverless-authorization",
+    "keyfile": {
+      "source_type": "1password_connect",
+      "config": { "secret_ref": "op://Engineering/Cloud-Run-Caller/credential" }
+    },
+    "rules": [ { "host": "my-service-abc123-uc.a.run.app" } ]
+  }
+}
+```
+
+Returns `201`. Response shape:
+
+```json
+{
+  "data": {
+    "id": "gid_...",
+    "namespace": "default",
+    "foreign_id": "cloud-run-caller",
+    "name": "Cloud Run Caller",
+    "description": null,
+    "labels": {},
+    "audience": "https://my-service-abc123-uc.a.run.app",
+    "header": "x-serverless-authorization",
+    "keyfile": { "source_type": "1password_connect", "config": { "secret_ref": "op://Engineering/Cloud-Run-Caller/credential" } },
+    "rules": [ { "host": "my-service-abc123-uc.a.run.app", "cidr": null, "position": 0, "http_methods": [], "paths": [] } ],
+    "created_at": "2026-06-01T10:00:00Z",
+    "updated_at": "2026-06-01T10:00:00Z"
+  }
+}
+```
+
+The `keyfile` in responses never includes a `control_plane` `secret` value.
+
+### Other operations
+
+| Method | Path | Notes |
+| ------ | ---- | ----- |
+| `GET`  | `/api/v1/gcp_id_token_secrets?namespace=default` | List. |
+| `GET`  | `/api/v1/gcp_id_token_secrets/:id` | Fetch one. |
+| `GET`  | `/api/v1/gcp_id_token_secrets/lookup/:namespace/:foreign_id` | Fetch by namespace + foreign id. `404` if missing. |
+| `PUT`/`PATCH` | `/api/v1/gcp_id_token_secrets/:id` | [Upsert](#upsert-put--patch) by OID or `foreign_id`; same body as create. |
+| `DELETE` | `/api/v1/gcp_id_token_secrets/:id` | Delete. Returns `204`; `404` if missing. Cascades: the secret's source, rules, and any grants that reference it are removed. The granted roles and principals are not deleted. |
 
 ## AWS auth secrets
 

--- a/services/console/test/controllers/api/v1/gcp_id_token_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/gcp_id_token_secrets_controller_test.rb
@@ -1,0 +1,161 @@
+require "test_helper"
+
+module Api
+  module V1
+    class GcpIdTokenSecretsControllerTest < ActionDispatch::IntegrationTest
+      ACME_TOKEN = "iak_acme-ci-token".freeze
+
+      def auth_headers(token = ACME_TOKEN)
+        { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" }
+      end
+
+      def json_body
+        JSON.parse(response.body)
+      end
+
+      test "rejects requests without an Authorization header" do
+        get api_v1_gcp_id_token_secret_url(id: "gid_unknown")
+        assert_response :unauthorized
+      end
+
+      test "GET returns a gcp_id_token secret with its keyfile and rules" do
+        secret = gcp_id_token_secrets(:acme_cloud_run)
+        get api_v1_gcp_id_token_secret_url(id: secret.oid), headers: auth_headers
+        assert_response :ok
+
+        data = json_body.fetch("data")
+        assert_equal secret.oid, data["id"]
+        assert_equal "https://my-service-abc123-uc.a.run.app", data["audience"]
+        assert_equal "x-serverless-authorization", data["header"]
+        assert_equal({ "source_type" => "env", "config" => { "var" => "CLOUD_RUN_SA_KEYFILE" } },
+                     data["keyfile"])
+        assert_equal 1, data["rules"].length
+      end
+
+      test "GET lookup finds a gcp_id_token secret by namespace and foreign_id" do
+        secret = gcp_id_token_secrets(:acme_cloud_run)
+        get lookup_api_v1_gcp_id_token_secrets_url(namespace: secret.namespace, foreign_id: secret.foreign_id),
+            headers: auth_headers
+        assert_response :ok
+        assert_equal secret.oid, json_body.dig("data", "id")
+      end
+
+      test "GET lookup returns 404 when no gcp_id_token secret matches" do
+        get lookup_api_v1_gcp_id_token_secrets_url(namespace: "acme", foreign_id: "does-not-exist"),
+            headers: auth_headers
+        assert_response :not_found
+      end
+
+      test "POST creates a gcp_id_token secret" do
+        body = {
+          data: {
+            namespace: "acme",
+            foreign_id: "new-cloud-run",
+            name: "new cloud run",
+            audience: "https://new-service-abc123-uc.a.run.app",
+            header: "X-Serverless-Authorization",
+            keyfile: { source_type: "env", config: { var: "NEW_CLOUD_RUN_KEYFILE" } },
+            rules: [ { host: "new-service-abc123-uc.a.run.app" } ]
+          }
+        }
+
+        assert_difference -> { GcpIdTokenSecret.count } => 1,
+                          -> { SecretSource.count } => 1,
+                          -> { RequestRule.count } => 1 do
+          post api_v1_gcp_id_token_secrets_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :created
+
+        secret = GcpIdTokenSecret.find_by_oid(json_body.dig("data", "id"))
+        assert_equal "x-serverless-authorization", secret.header
+        assert_equal "NEW_CLOUD_RUN_KEYFILE", secret.keyfile_source.config["var"]
+      end
+
+      test "POST never echoes a control_plane keyfile secret back" do
+        body = {
+          data: {
+            namespace: "acme",
+            foreign_id: "inline-cloud-run",
+            audience: "https://inline-service-abc123-uc.a.run.app",
+            keyfile: { source_type: "control_plane", secret: "{\"client_email\":\"x\"}" },
+            rules: [ { host: "inline-service-abc123-uc.a.run.app" } ]
+          }
+        }
+
+        post api_v1_gcp_id_token_secrets_url, params: body.to_json, headers: auth_headers
+        assert_response :created
+        refute_includes response.body, "client_email"
+      end
+
+      test "POST rejects missing rules" do
+        body = {
+          data: {
+            namespace: "acme",
+            foreign_id: "no-rules",
+            audience: "https://no-rules-abc123-uc.a.run.app",
+            keyfile: { source_type: "env", config: { var: "CLOUD_RUN_KEYFILE" } }
+          }
+        }
+
+        assert_no_difference -> { GcpIdTokenSecret.count } do
+          post api_v1_gcp_id_token_secrets_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :unprocessable_entity
+      end
+
+      test "PUT replaces rules and keyfile" do
+        secret = gcp_id_token_secrets(:acme_cloud_run)
+        body = {
+          data: {
+            audience: "https://rotated-service-abc123-uc.a.run.app",
+            header: "",
+            keyfile: { source_type: "env", config: { var: "ROTATED_CLOUD_RUN_KEYFILE" } },
+            rules: [ { host: "rotated-service-abc123-uc.a.run.app", http_methods: [ "POST" ] } ]
+          }
+        }
+
+        put api_v1_gcp_id_token_secret_url(id: secret.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        secret.reload
+        assert_equal "https://rotated-service-abc123-uc.a.run.app", secret.audience
+        assert_nil secret.header
+        assert_equal "ROTATED_CLOUD_RUN_KEYFILE", secret.keyfile_source.config["var"]
+        assert_equal [ "rotated-service-abc123-uc.a.run.app" ], secret.rules.map(&:host)
+      end
+
+      test "PUT upserts a new gcp_id_token secret by foreign_id" do
+        body = {
+          data: {
+            namespace: "acme",
+            audience: "https://upsert-service-abc123-uc.a.run.app",
+            keyfile: { source_type: "env", config: { var: "UPSERT_CLOUD_RUN_KEYFILE" } },
+            rules: [ { host: "upsert-service-abc123-uc.a.run.app" } ]
+          }
+        }
+
+        assert_difference -> { GcpIdTokenSecret.count } => 1 do
+          put api_v1_gcp_id_token_secret_url(id: "cloud-run-upsert"), params: body.to_json, headers: auth_headers
+        end
+        assert_response :created
+        assert_equal "cloud-run-upsert", json_body.dig("data", "foreign_id")
+      end
+
+      test "GET index is scoped by namespace" do
+        get api_v1_gcp_id_token_secrets_url, params: { namespace: "acme" }, headers: auth_headers
+        assert_response :ok
+        ids = json_body.fetch("data").map { |r| r["id"] }
+        assert_includes ids, gcp_id_token_secrets(:acme_cloud_run).oid
+      end
+
+      test "DELETE removes a gcp_id_token secret" do
+        secret = gcp_id_token_secrets(:acme_cloud_run)
+        assert_difference -> { GcpIdTokenSecret.count } => -1 do
+          delete api_v1_gcp_id_token_secret_url(id: secret.oid), headers: auth_headers
+        end
+        assert_response :no_content
+        assert_nil GcpIdTokenSecret.find_by_oid(secret.oid)
+      end
+    end
+  end
+end

--- a/services/console/test/controllers/api/v1/grants_controller_test.rb
+++ b/services/console/test/controllers/api/v1/grants_controller_test.rb
@@ -83,6 +83,19 @@ module Api
         assert_equal secret.oid, json_body.dig("data", "gcp_auth_secret_id")
       end
 
+      test "POST creates a Grant for a gcp_id_token secret" do
+        principal = principals(:globex_user)
+        secret = gcp_id_token_secrets(:acme_cloud_run)
+
+        body = { data: { principal_id: principal.oid, gcp_id_token_secret_id: secret.oid } }
+
+        assert_difference -> { Grant.count } => 1 do
+          post api_v1_grants_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :created
+        assert_equal secret.oid, json_body.dig("data", "gcp_id_token_secret_id")
+      end
+
       test "POST creates a Grant for an oauth_token secret" do
         principal = principals(:globex_user)
         secret = oauth_token_secrets(:acme_gmail_oauth)

--- a/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
@@ -174,6 +174,43 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, oauth.dig("config", "tokens").length
   end
 
+  test "cached proxy snapshot carries gcp_id_token and invalidates when it changes" do
+    admin = users(:acme_admin)
+    secret = gcp_id_token_secrets(:acme_cloud_run)
+    Grant.create!(principal: @proxy.principal, gcp_id_token_secret: secret, created_by: admin)
+
+    assert_difference -> { PrincipalSyncConfigSnapshot.count }, 1 do
+      post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
+    end
+    assert_response :ok
+
+    original_hash = json_body.fetch("config_hash")
+    snapshot = PrincipalSyncConfigSnapshot.find_by!(principal: @proxy.principal)
+    transform = snapshot.payload.fetch("transforms").find { |t| t["name"] == "gcp_id_token" }
+    assert_equal secret.audience, transform.dig("config", "audience")
+    assert_equal "CLOUD_RUN_SA_KEYFILE", transform.dig("config", "keyfile", "var")
+
+    assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
+      post api_v1_proxy_sync_url, params: { config_hash: "sha256:#{'0' * 64}" }.to_json,
+                                 headers: auth_headers
+    end
+    assert_response :ok
+    transform = json_body.fetch("transforms").find { |t| t["name"] == "gcp_id_token" }
+    assert_equal secret.audience, transform.dig("config", "audience")
+
+    original_version = @proxy.principal.reload.sync_config_cache_version
+    secret.update!(audience: "https://updated-service-abc123-uc.a.run.app")
+
+    assert_operator @proxy.principal.reload.sync_config_cache_version, :>, original_version
+    assert_difference -> { PrincipalSyncConfigSnapshot.count }, 1 do
+      post api_v1_proxy_sync_url, params: { config_hash: original_hash }.to_json, headers: auth_headers
+    end
+    assert_response :ok
+    refute_equal original_hash, json_body.fetch("config_hash")
+    transform = json_body.fetch("transforms").find { |t| t["name"] == "gcp_id_token" }
+    assert_equal "https://updated-service-abc123-uc.a.run.app", transform.dig("config", "audience")
+  end
+
   test "transforms carries one hmac_sign transform per granted HmacSecret" do
     admin = users(:acme_admin)
     Grant.create!(principal: @proxy.principal, hmac_secret: hmac_secrets(:acme_webhook_hmac), created_by: admin)

--- a/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
@@ -150,9 +150,11 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     assert_equal first, second
   end
 
-  test "transforms carries gcp_auth per grant and a single bundled oauth_token" do
+  test "transforms carries gcp auth transforms per grant and a single bundled oauth_token" do
     admin = users(:acme_admin)
     Grant.create!(principal: @proxy.principal, gcp_auth_secret: gcp_auth_secrets(:acme_bigquery), created_by: admin)
+    Grant.create!(principal: @proxy.principal, gcp_id_token_secret: gcp_id_token_secrets(:acme_cloud_run),
+                  created_by: admin)
     Grant.create!(principal: @proxy.principal, oauth_token_secret: oauth_token_secrets(:acme_gmail_oauth), created_by: admin)
 
     post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
@@ -161,7 +163,12 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     transforms = json_body.fetch("transforms")
     names = transforms.map { |t| t["name"] }
     assert_equal 1, names.count("gcp_auth")
+    assert_equal 1, names.count("gcp_id_token")
     assert_equal 1, names.count("oauth_token")
+
+    gcp_id = transforms.find { |t| t["name"] == "gcp_id_token" }
+    assert_equal "https://my-service-abc123-uc.a.run.app", gcp_id.dig("config", "audience")
+    assert_equal "x-serverless-authorization", gcp_id.dig("config", "header")
 
     oauth = transforms.find { |t| t["name"] == "oauth_token" }
     assert_equal 1, oauth.dig("config", "tokens").length

--- a/services/console/test/controllers/console/secrets_controller_test.rb
+++ b/services/console/test/controllers/console/secrets_controller_test.rb
@@ -337,6 +337,70 @@ module Console
       assert_equal({ "type" => "workload_identity" }, secret.credentials_provider)
     end
 
+    # --- gcp_id_token -----------------------------------------------------
+
+    test "GET new and edit render without error for gcp_id_token" do
+      get new_console_gcp_id_token_secret_url
+      assert_response :ok
+      get edit_console_gcp_id_token_secret_url(gcp_id_token_secrets(:acme_cloud_run).oid)
+      assert_response :ok
+    end
+
+    test "POST create builds a gcp_id_token secret with a keyfile source and rule" do
+      assert_difference -> { GcpIdTokenSecret.count } => 1,
+                        -> { SecretSource.count } => 1,
+                        -> { RequestRule.count } => 1 do
+        post console_gcp_id_token_secrets_url, params: {
+          secret: { namespace: "acme", foreign_id: "ui-cloud-run", name: "ui cloud run" },
+          gcp_id_token: {
+            audience: "https://ui-service-abc123-uc.a.run.app",
+            header: "x-serverless-authorization"
+          },
+          source: { source_type: "env", reference: "UI_CLOUD_RUN_KEYFILE" },
+          rules: { "0" => { host: "ui-service-abc123-uc.a.run.app", http_methods: "GET", paths: "/" } }
+        }
+      end
+
+      secret = GcpIdTokenSecret.find_by!(namespace: "acme", foreign_id: "ui-cloud-run")
+      assert_redirected_to console_secret_path("gcp_id_token", secret.oid)
+      assert_equal "https://ui-service-abc123-uc.a.run.app", secret.audience
+      assert_equal "x-serverless-authorization", secret.header
+      assert_equal({ "var" => "UI_CLOUD_RUN_KEYFILE" }, secret.keyfile_source.config)
+      assert_equal [ "ui-service-abc123-uc.a.run.app" ], secret.rules.map(&:host)
+    end
+
+    test "POST create gcp_id_token without rules is rejected without writing" do
+      assert_no_difference [ "GcpIdTokenSecret.count", "SecretSource.count", "RequestRule.count" ] do
+        post console_gcp_id_token_secrets_url, params: {
+          secret: { namespace: "acme", foreign_id: "ui-cloud-run-no-rules" },
+          gcp_id_token: { audience: "https://ui-service-abc123-uc.a.run.app" },
+          source: { source_type: "env", reference: "UI_CLOUD_RUN_KEYFILE" }
+        }
+      end
+      assert_response :unprocessable_entity
+    end
+
+    test "PATCH update changes a gcp_id_token secret keyfile audience header and rules" do
+      secret = gcp_id_token_secrets(:acme_cloud_run)
+
+      patch console_gcp_id_token_secret_url(secret.oid), params: {
+        secret: { namespace: secret.namespace, foreign_id: secret.foreign_id },
+        gcp_id_token: {
+          audience: "https://updated-service-abc123-uc.a.run.app",
+          header: ""
+        },
+        source: { source_type: "env", reference: "UPDATED_CLOUD_RUN_KEYFILE" },
+        rules: { "0" => { host: "updated-service-abc123-uc.a.run.app", http_methods: "POST", paths: "" } }
+      }
+
+      assert_redirected_to console_secret_path("gcp_id_token", secret.oid)
+      secret.reload
+      assert_equal "https://updated-service-abc123-uc.a.run.app", secret.audience
+      assert_nil secret.header
+      assert_equal "UPDATED_CLOUD_RUN_KEYFILE", secret.keyfile_source.config["var"]
+      assert_equal [ "updated-service-abc123-uc.a.run.app" ], secret.rules.map(&:host)
+    end
+
     # --- role grants ------------------------------------------------------
 
     test "POST grant_role grants the secret to a role at the default role priority" do

--- a/services/console/test/controllers/console/secrets_controller_test.rb
+++ b/services/console/test/controllers/console/secrets_controller_test.rb
@@ -378,6 +378,8 @@ module Console
         }
       end
       assert_response :unprocessable_entity
+      assert_match "Rules must include at least one rule", response.body
+      assert_match "must include at least one rule", response.body
     end
 
     test "PATCH update changes a gcp_id_token secret keyfile audience header and rules" do

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -74,6 +74,7 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
       [ "static", static_secrets(:github_token_inject) ],
       [ "gcp_auth", gcp_auth_secrets(:acme_gcs_keyfile) ],   # keyfile source
       [ "gcp_auth", gcp_auth_secrets(:acme_bigquery) ],      # workload_identity provider
+      [ "gcp_id_token", gcp_id_token_secrets(:acme_cloud_run) ],
       [ "oauth_token", oauth_token_secrets(:acme_gmail_oauth) ],
       [ "pg_dsn", pg_dsn_secrets(:acme_analytics_pg) ],
       [ "hmac", hmac_secrets(:acme_webhook_hmac) ]
@@ -81,6 +82,17 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
       get console_secret_url(kind, secret.oid)
       assert_response :ok, "expected #{kind} detail page for #{secret.oid} to render"
     end
+  end
+
+  test "gcp_id_token detail page lists audience header and keyfile source" do
+    secret = gcp_id_token_secrets(:acme_cloud_run)
+    get console_secret_url("gcp_id_token", secret.oid)
+    assert_response :ok
+    assert_select "dt", text: "Audience"
+    assert_select "dd", text: secret.audience
+    assert_select "dt", text: "Header"
+    assert_select "dd", text: "x-serverless-authorization"
+    assert_select "td", text: "CLOUD_RUN_SA_KEYFILE"
   end
 
   test "pg_dsn detail page lists configured session settings" do
@@ -246,6 +258,8 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     # A kind with no direct grant on this principal still lists all its secrets.
     gcp = gcp_auth_secrets(:acme_bigquery)
     assert_select "select[name=grantable] option[value=?]", "gcp_auth:#{gcp.oid}"
+    gcp_id = gcp_id_token_secrets(:acme_cloud_run)
+    assert_select "select[name=grantable] option[value=?]", "gcp_id_token:#{gcp_id.oid}"
   end
 
   test "header shows the signed-in operator and a sign-out control" do

--- a/services/console/test/fixtures/gcp_id_token_secrets.yml
+++ b/services/console/test/fixtures/gcp_id_token_secrets.yml
@@ -1,0 +1,9 @@
+acme_cloud_run:
+  namespace: acme
+  foreign_id: cloud-run-caller
+  name: cloud run caller
+  labels:
+    team: platform
+  audience: https://my-service-abc123-uc.a.run.app
+  header: x-serverless-authorization
+  created_by: acme_admin

--- a/services/console/test/fixtures/request_rules.yml
+++ b/services/console/test/fixtures/request_rules.yml
@@ -19,6 +19,13 @@ gcp_googleapis:
   paths: []
   gcp_auth_secret: acme_bigquery
 
+gcp_id_token_cloud_run:
+  host: my-service-abc123-uc.a.run.app
+  http_methods: []
+  paths: []
+  position: 0
+  gcp_id_token_secret: acme_cloud_run
+
 oauth_gmail_host:
   host: gmail.googleapis.com
   http_methods: ["GET"]

--- a/services/console/test/fixtures/secret_sources.yml
+++ b/services/console/test/fixtures/secret_sources.yml
@@ -41,6 +41,13 @@ gcp_keyfile:
     var: GCP_SA_KEYFILE
   gcp_auth_secret: acme_gcs_keyfile
 
+# Service-account keyfile source for the acme_cloud_run gcp_id_token secret.
+gcp_id_token_keyfile:
+  source_type: env
+  config:
+    var: CLOUD_RUN_SA_KEYFILE
+  gcp_id_token_secret: acme_cloud_run
+
 # Credential fields for the acme_gmail_oauth oauth_token secret.
 oauth_gmail_refresh:
   source_type: 1password

--- a/services/console/test/lib/iron/bootstrap_test.rb
+++ b/services/console/test/lib/iron/bootstrap_test.rb
@@ -18,6 +18,7 @@ class Iron::BootstrapTest < ActiveSupport::TestCase
     BrokerCredential.delete_all
     OauthApp.delete_all
     GcpAuthSecret.delete_all
+    GcpIdTokenSecret.delete_all
     AwsAuthSecret.delete_all
     OauthTokenSecret.delete_all
     PgDsnSecret.delete_all

--- a/services/console/test/models/gcp_id_token_secret_test.rb
+++ b/services/console/test/models/gcp_id_token_secret_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class GcpIdTokenSecretTest < ActiveSupport::TestCase
+  def base_attrs(overrides = {})
+    {
+      namespace: "acme",
+      foreign_id: "new-cloud-run",
+      audience: "https://service-abc123-uc.a.run.app",
+      created_by: users(:acme_admin)
+    }.merge(overrides)
+  end
+
+  def with_keyfile_and_rule(secret = nil)
+    secret ||= GcpIdTokenSecret.new(base_attrs)
+    secret.keyfile_source = SecretSource.new(source_type: "env", config: { "var" => "GCP_ID_TOKEN_KEYFILE" })
+    secret.rules.build(host: "service-abc123-uc.a.run.app", position: 0)
+    secret
+  end
+
+  test "is valid with a keyfile source audience and rule" do
+    assert with_keyfile_and_rule.valid?
+  end
+
+  test "requires a keyfile source" do
+    secret = GcpIdTokenSecret.new(base_attrs)
+    secret.rules.build(host: "service-abc123-uc.a.run.app", position: 0)
+    assert_not secret.valid?
+    assert_includes secret.errors[:keyfile_source], "can't be blank"
+  end
+
+  test "requires an audience" do
+    secret = with_keyfile_and_rule(GcpIdTokenSecret.new(base_attrs(audience: "")))
+    assert_not secret.valid?
+    assert_includes secret.errors[:audience], "can't be blank"
+  end
+
+  test "requires at least one rule" do
+    secret = GcpIdTokenSecret.new(base_attrs)
+    secret.keyfile_source = SecretSource.new(source_type: "env", config: { "var" => "GCP_ID_TOKEN_KEYFILE" })
+    assert_not secret.valid?
+    assert_includes secret.errors[:rules], "must include at least one rule"
+  end
+
+  test "normalizes supported headers" do
+    secret = with_keyfile_and_rule(GcpIdTokenSecret.new(base_attrs(header: " X-Serverless-Authorization ")))
+    assert secret.valid?, secret.errors.full_messages.inspect
+    assert_equal "x-serverless-authorization", secret.header
+  end
+
+  test "rejects unsupported headers" do
+    secret = with_keyfile_and_rule(GcpIdTokenSecret.new(base_attrs(header: "X-Other")))
+    assert_not secret.valid?
+    assert_includes secret.errors[:header], "must be one of authorization, x-serverless-authorization"
+  end
+
+  test "to_proxy_transform emits gcp_id_token config" do
+    config = gcp_id_token_secrets(:acme_cloud_run).to_proxy_transform["config"]
+    assert_equal({ "type" => "env", "var" => "CLOUD_RUN_SA_KEYFILE" }, config["keyfile"])
+    assert_equal "https://my-service-abc123-uc.a.run.app", config["audience"]
+    assert_equal "x-serverless-authorization", config["header"]
+    assert_equal [ { "host" => "my-service-abc123-uc.a.run.app" } ], config["rules"]
+  end
+
+  test "to_proxy_transform omits the default header" do
+    secret = with_keyfile_and_rule
+    config = secret.to_proxy_transform["config"]
+    refute config.key?("header")
+  end
+
+  test "proxy_conflict_targets follows the configured header" do
+    assert_equal [ "header:x-serverless-authorization" ],
+                 gcp_id_token_secrets(:acme_cloud_run).proxy_conflict_targets
+    assert_equal [ "header:authorization" ], with_keyfile_and_rule.proxy_conflict_targets
+  end
+
+  test "declares gid as its oid prefix" do
+    assert_equal "gid", GcpIdTokenSecret.oid_prefix
+  end
+end

--- a/services/console/test/models/grant_test.rb
+++ b/services/console/test/models/grant_test.rb
@@ -47,13 +47,13 @@ class GrantTest < ActiveSupport::TestCase
   test "requires exactly one grantable" do
     grant = Grant.new(valid_attrs(static_secret: nil))
     assert_not grant.valid?
-    assert_includes grant.errors[:base], "must reference exactly one of static_secret, gcp_auth_secret, aws_auth_secret, oauth_token_secret, pg_dsn_secret, hmac_secret"
+    assert_includes grant.errors[:base], "must reference exactly one of static_secret, gcp_auth_secret, gcp_id_token_secret, aws_auth_secret, oauth_token_secret, pg_dsn_secret, hmac_secret"
   end
 
   test "rejects more than one grantable" do
     grant = Grant.new(valid_attrs(gcp_auth_secret: gcp_auth_secrets(:acme_bigquery)))
     assert_not grant.valid?
-    assert_includes grant.errors[:base], "must reference exactly one of static_secret, gcp_auth_secret, aws_auth_secret, oauth_token_secret, pg_dsn_secret, hmac_secret"
+    assert_includes grant.errors[:base], "must reference exactly one of static_secret, gcp_auth_secret, gcp_id_token_secret, aws_auth_secret, oauth_token_secret, pg_dsn_secret, hmac_secret"
   end
 
   test "principal is immutable after creation" do

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -153,6 +153,16 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal({ "type" => "workload_identity" }, transforms.first.dig("config", "credentials_provider"))
   end
 
+  test "sync_transforms emits a gcp_id_token transform per granted GcpIdTokenSecret" do
+    transforms = principal_with_grants(gcp_id_token_secrets(:acme_cloud_run)).sync_transforms
+    assert_equal 1, transforms.length
+    transform = transforms.first
+    assert_equal "gcp_id_token", transform["name"]
+    assert_equal({ "type" => "env", "var" => "CLOUD_RUN_SA_KEYFILE" }, transform.dig("config", "keyfile"))
+    assert_equal "https://my-service-abc123-uc.a.run.app", transform.dig("config", "audience")
+    assert_equal "x-serverless-authorization", transform.dig("config", "header")
+  end
+
   test "sync_transforms emits an aws_auth transform per granted AwsAuthSecret" do
     transforms = principal_with_grants(aws_auth_secrets(:acme_cloudwatch_aws)).sync_transforms
     aws = transforms.find { |t| t["name"] == "aws_auth" }

--- a/services/console/test/models/request_rule_test.rb
+++ b/services/console/test/models/request_rule_test.rb
@@ -121,6 +121,6 @@ class RequestRuleTest < ActiveSupport::TestCase
                  static_secret: static_secrets(:github_token_inject),
                  oauth_token_secret: oauth_token_secrets(:acme_gmail_oauth))
     assert_not r.valid?
-    assert_includes r.errors[:base], "must belong to at most one of static_secret, gcp_auth_secret, aws_auth_secret, oauth_token_secret, hmac_secret"
+    assert_includes r.errors[:base], "must belong to at most one of static_secret, gcp_auth_secret, gcp_id_token_secret, aws_auth_secret, oauth_token_secret, hmac_secret"
   end
 end

--- a/services/console/test/models/secret_source_test.rb
+++ b/services/console/test/models/secret_source_test.rb
@@ -218,7 +218,7 @@ class SecretSourceTest < ActiveSupport::TestCase
                    static_secret: static_secrets(:github_token_inject),
                    gcp_auth_secret: gcp_auth_secrets(:acme_bigquery))
     assert_not s.valid?
-    assert_includes s.errors[:base], "must belong to at most one of static_secret, gcp_auth_secret, aws_auth_secret, oauth_token_secret, pg_dsn_secret, hmac_secret"
+    assert_includes s.errors[:base], "must belong to at most one of static_secret, gcp_auth_secret, gcp_id_token_secret, aws_auth_secret, oauth_token_secret, pg_dsn_secret, hmac_secret"
   end
 
   test "role is only allowed for an oauth_token_secret or hmac_secret source" do

--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM ironsh/iron-proxy:0.45.0@sha256:fffd1d72f9631fa3a0e54afea1b9ee8c125de94559134acabe97b6e12077865d
+FROM ironsh/iron-proxy:0.46.0-rc.1@sha256:8d78eb486e4298078fe0fa19803094dd6cf1b8ca12d956ae5e1cdfcac0f5e5c2
 
 USER root
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \


### PR DESCRIPTION
Adds console and API support for the `gcp_id_token` secret type introduced in iron-proxy v0.46.0-rc.1, including persistence, forms, proxy sync output, grants, docs, and Rails coverage. Extends the Rust iron-control client and centaur-perms routing so `gid_` secrets can be addressed by grant tooling.