### PR TITLE
Scope YouTube API key injection

### DIFF
--- a/tools/research/youtube/pyproject.toml
+++ b/tools/research/youtube/pyproject.toml
@@ -28,5 +28,4 @@ build-backend = "hatchling.build"
 module = "client.py"
 secrets = [
     {type = "http", name = "YOUTUBE_API_KEY", mode = "inject", inject_query_param = "key", hosts = ["www.googleapis.com"]},
-    {type = "http", name = "GOOGLE_API_KEY", mode = "inject", inject_query_param = "key", hosts = ["www.googleapis.com"]},
 ]


### PR DESCRIPTION
## Summary
- remove the broad GOOGLE_API_KEY fallback from the YouTube tool on www.googleapis.com
- prevent YouTube credentials from being injected into unrelated Google APIs such as Calendar

## Root cause
Calendar requests to www.googleapis.com were receiving a query key from the YouTube tool's GOOGLE_API_KEY fallback. Google rejected the request with 'API key not valid' before OAuth could authorize it.

## Test plan
- cargo test -p centaur-perms youtube -- --nocapture
- cargo test -p centaur-api-server tool_discovery -- --nocapture