### PR TITLE
fix: reconcile gcp id token secrets

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use centaur_iron_control::{GCP_ID_TOKEN_ALLOWED_HEADERS, normalize_gcp_id_token_header};
 use centaur_iron_proxy::{
     PgDsnSetting, PgDsnSettingValueFrom, PostgresListener, PostgresUpstream, ProxyFragment,
     SandboxEnv, Secret, SecretReplace, Transform, TransformConfig,
@@ -819,7 +820,7 @@ fn parse_gcp_id_token_secret(
     }
     let audience = required_str(table, "audience")?.to_owned();
     let header = optional_str(table, "header")
-        .map(|value| value.to_ascii_lowercase())
+        .map(ToOwned::to_owned)
         .map(validate_gcp_id_token_header)
         .transpose()?;
     Ok(ToolSecret::GcpIdToken(GcpIdTokenSecret {
@@ -1461,12 +1462,12 @@ fn optional_bool(table: &toml::Table, key: &str) -> Result<Option<bool>, ToolDis
 }
 
 fn validate_gcp_id_token_header(value: String) -> Result<String, ToolDiscoveryError> {
-    match value.as_str() {
-        "authorization" | "x-serverless-authorization" => Ok(value),
-        _ => Err(ToolDiscoveryError::Invalid(format!(
-            "gcp_id_token header must be one of authorization, x-serverless-authorization, got {value:?}"
-        ))),
-    }
+    normalize_gcp_id_token_header(&value).ok_or_else(|| {
+        ToolDiscoveryError::Invalid(format!(
+            "gcp_id_token header must be one of {}, got {value:?}",
+            GCP_ID_TOKEN_ALLOWED_HEADERS.join(", ")
+        ))
+    })
 }
 
 #[cfg(test)]

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -510,6 +510,7 @@ enum ToolSecret {
     Http(HttpSecret),
     OAuthToken(OAuthTokenSecret),
     GcpAuth(GcpAuthSecret),
+    GcpIdToken(GcpIdTokenSecret),
     PgDsn(PgDsnSecret),
     AwsAuth(AwsAuthSecret),
 }
@@ -562,6 +563,18 @@ struct GcpAuthSecret {
     labels: BTreeMap<String, String>,
     hosts: Vec<String>,
     scopes: Vec<String>,
+}
+
+/// A `type = "gcp_id_token"` secret. The proxy mints a Google-signed OIDC ID
+/// token from the service-account keyfile and injects it into Authorization by
+/// default, or into `x-serverless-authorization` when configured for Cloud Run.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct GcpIdTokenSecret {
+    secret_ref: String,
+    labels: BTreeMap<String, String>,
+    hosts: Vec<String>,
+    audience: String,
+    header: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -652,6 +665,7 @@ fn parse_secret(
         "http" | "header" => parse_http_secret(table, name, secret_ref, default_hosts, labels),
         "oauth_token" => parse_oauth_token_secret(table, name, labels),
         "gcp_auth" => parse_gcp_auth_secret(table, name, secret_ref, labels),
+        "gcp_id_token" => parse_gcp_id_token_secret(table, name, secret_ref, labels),
         "pg_dsn" => parse_pg_dsn_secret(table, name, secret_ref, labels),
         "aws_auth" => parse_aws_auth_secret(table, name, labels),
         "brokered_token" | "hmac_sign" => Err(ToolDiscoveryError::Invalid(format!(
@@ -788,6 +802,32 @@ fn parse_gcp_auth_secret(
         labels: labels.clone(),
         hosts: optional_string_array(table.get("hosts"))?.unwrap_or_default(),
         scopes: optional_string_array(table.get("scopes"))?.unwrap_or_default(),
+    }))
+}
+
+fn parse_gcp_id_token_secret(
+    table: &toml::Table,
+    _name: String,
+    secret_ref: String,
+    labels: &BTreeMap<String, String>,
+) -> Result<ToolSecret, ToolDiscoveryError> {
+    let hosts = required_string_array(table.get("hosts"), "hosts")?;
+    if hosts.is_empty() {
+        return Err(ToolDiscoveryError::Invalid(
+            "gcp_id_token hosts must be non-empty".to_owned(),
+        ));
+    }
+    let audience = required_str(table, "audience")?.to_owned();
+    let header = optional_str(table, "header")
+        .map(|value| value.to_ascii_lowercase())
+        .map(validate_gcp_id_token_header)
+        .transpose()?;
+    Ok(ToolSecret::GcpIdToken(GcpIdTokenSecret {
+        secret_ref,
+        labels: labels.clone(),
+        hosts,
+        audience,
+        header,
     }))
 }
 
@@ -936,6 +976,9 @@ fn fragment_from_secrets(secrets: Vec<ToolSecret>) -> Result<ProxyFragment, Tool
         fragment.transforms.push(transform);
     }
     fragment.transforms.extend(gcp_auth_transforms(&secrets)?);
+    fragment
+        .transforms
+        .extend(gcp_id_token_transforms(&secrets)?);
     fragment.transforms.extend(aws_auth_transforms(&secrets)?);
     if let Some(transform) = oauth_token_transform(&secrets)? {
         fragment.transforms.push(transform);
@@ -1075,6 +1118,50 @@ fn gcp_auth_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDis
         config.insert("labels".to_owned(), yaml_value(labels)?);
         transforms.push(Transform {
             name: "gcp_auth".to_owned(),
+            config: TransformConfig {
+                extra: config,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+    }
+    Ok(transforms)
+}
+
+fn gcp_id_token_transforms(secrets: &[ToolSecret]) -> Result<Vec<Transform>, ToolDiscoveryError> {
+    type GcpIdTokenKey = (String, String, Option<String>);
+    let mut by_identity =
+        BTreeMap::<GcpIdTokenKey, (BTreeSet<String>, BTreeMap<String, String>)>::new();
+    for secret in secrets {
+        let ToolSecret::GcpIdToken(secret) = secret else {
+            continue;
+        };
+        let entry = by_identity
+            .entry((
+                secret.secret_ref.clone(),
+                secret.audience.clone(),
+                secret.header.clone(),
+            ))
+            .or_default();
+        entry.0.extend(secret.hosts.iter().cloned());
+        merge_tool_labels(&mut entry.1, &secret.labels);
+    }
+
+    let mut transforms = Vec::new();
+    for ((secret_ref, audience, header), (hosts, labels)) in by_identity {
+        let mut config = BTreeMap::new();
+        config.insert(
+            "keyfile".to_owned(),
+            yaml_map([("placeholder", yaml_string(&secret_ref))])?,
+        );
+        config.insert("audience".to_owned(), yaml_string(&audience));
+        if let Some(header) = &header {
+            config.insert("header".to_owned(), yaml_string(header));
+        }
+        config.insert("rules".to_owned(), yaml_value(host_rules(hosts)?)?);
+        config.insert("labels".to_owned(), yaml_value(labels)?);
+        transforms.push(Transform {
+            name: "gcp_id_token".to_owned(),
             config: TransformConfig {
                 extra: config,
                 ..Default::default()
@@ -1373,6 +1460,15 @@ fn optional_bool(table: &toml::Table, key: &str) -> Result<Option<bool>, ToolDis
     }
 }
 
+fn validate_gcp_id_token_header(value: String) -> Result<String, ToolDiscoveryError> {
+    match value.as_str() {
+        "authorization" | "x-serverless-authorization" => Ok(value),
+        _ => Err(ToolDiscoveryError::Invalid(format!(
+            "gcp_id_token header must be one of authorization, x-serverless-authorization, got {value:?}"
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1605,6 +1701,56 @@ secrets = [
 
         // No sandbox env rides along: the tool embeds its own throwaway SigV4
         // credentials, so aws_auth contributes nothing to placeholder env.
+        let placeholders =
+            centaur_iron_proxy::placeholder_env(std::slice::from_ref(&discovered.fragment));
+        assert!(placeholders.is_empty());
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn discovers_gcp_id_token_tool_as_transform() {
+        let temp = temp_dir("api-rs-tools-gcp-id-token");
+        let base = temp.join("base");
+        write_tool(
+            &base.join("infra").join("cloudrun"),
+            r#"
+[project]
+description = "cloudrun"
+
+[tool.centaur]
+secrets = [
+  { type = "gcp_id_token", name = "CLOUD_RUN_KEYFILE", audience = "https://my-service-abc123-uc.a.run.app", header = "X-Serverless-Authorization", hosts = ["my-service-abc123-uc.a.run.app"] },
+]
+"#,
+        );
+
+        let discovered = discover_tool_proxy_fragment(std::slice::from_ref(&base)).unwrap();
+
+        assert_eq!(discovered.tool_count, 1);
+        assert_eq!(discovered.secret_count, 1);
+        let transform = discovered
+            .fragment
+            .transforms
+            .iter()
+            .find(|transform| transform.name == "gcp_id_token")
+            .expect("gcp_id_token transform present");
+        let config = &transform.config.extra;
+        assert_eq!(
+            config["keyfile"]["placeholder"].as_str(),
+            Some("CLOUD_RUN_KEYFILE")
+        );
+        assert_eq!(
+            config["audience"].as_str(),
+            Some("https://my-service-abc123-uc.a.run.app")
+        );
+        assert_eq!(
+            config["header"].as_str(),
+            Some("x-serverless-authorization")
+        );
+        assert_eq!(config["rules"].as_sequence().unwrap().len(), 1);
+        assert_eq!(config["labels"]["centaur-tool"].as_str(), Some("cloudrun"));
+
         let placeholders =
             centaur_iron_proxy::placeholder_env(std::slice::from_ref(&discovered.fragment));
         assert!(placeholders.is_empty());

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -18,11 +18,12 @@ pub use client::IronControlClient;
 pub use error::{IronControlError, Result};
 pub use models::{
     AwsAuthSecretInput, BrokerCredentialInput, BrokerCredentialRecord, EffectiveConfig,
-    EffectivePgDsn, EffectiveReplace, EffectiveSecret, GcpAuthSecretInput, GcpIdTokenSecretInput,
-    Grant, GrantSecret, Grantee, HmacSecretHeader, HmacSecretInput, IdentityInput, InjectConfig,
-    OAuthTokenSecretInput, PgDsnSecretInput, PgDsnSettingInput, PgDsnSettingValueFromInput,
-    Principal, Proxy, ProxyInput, ReplaceConfig, RequestRule, Role, SECRET_TYPES, SecretRecord,
-    SecretSource, StaticSecretInput,
+    EffectivePgDsn, EffectiveReplace, EffectiveSecret, GCP_ID_TOKEN_ALLOWED_HEADERS,
+    GcpAuthSecretInput, GcpIdTokenSecretInput, Grant, GrantSecret, Grantee, HmacSecretHeader,
+    HmacSecretInput, IdentityInput, InjectConfig, OAuthTokenSecretInput, PgDsnSecretInput,
+    PgDsnSettingInput, PgDsnSettingValueFromInput, Principal, Proxy, ProxyInput, ReplaceConfig,
+    RequestRule, Role, SECRET_TYPES, SecretRecord, SecretSource, StaticSecretInput,
+    normalize_gcp_id_token_header,
 };
 pub use principal::{PrincipalRef, derive_principal};
 pub use registry::{

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -225,6 +225,18 @@ pub struct GcpAuthSecretInput {
 // GCP ID token secrets
 // ---------------------------------------------------------------------------
 
+/// Headers supported by iron-proxy's ``gcp_id_token`` transform.
+pub const GCP_ID_TOKEN_ALLOWED_HEADERS: &[&str] = &["authorization", "x-serverless-authorization"];
+
+/// Return the canonical lower-case header name when ``value`` is a supported
+/// ``gcp_id_token`` injection header.
+pub fn normalize_gcp_id_token_header(value: &str) -> Option<String> {
+    let normalized = value.trim().to_ascii_lowercase();
+    GCP_ID_TOKEN_ALLOWED_HEADERS
+        .contains(&normalized.as_str())
+        .then_some(normalized)
+}
+
 /// Request body for ``POST``/``PUT /api/v1/gcp_id_token_secrets``. iron-proxy
 /// mints a Google-signed OIDC ID token for ``audience`` from the service-account
 /// ``keyfile`` and injects it into ``Authorization`` by default, or
@@ -673,4 +685,22 @@ pub struct Proxy {
     pub principal_id: String,
     #[serde(default)]
     pub token: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_gcp_id_token_header;
+
+    #[test]
+    fn normalizes_supported_gcp_id_token_headers() {
+        assert_eq!(
+            normalize_gcp_id_token_header("Authorization").as_deref(),
+            Some("authorization")
+        );
+        assert_eq!(
+            normalize_gcp_id_token_header(" X-Serverless-Authorization ").as_deref(),
+            Some("x-serverless-authorization")
+        );
+        assert_eq!(normalize_gcp_id_token_header("x-other"), None);
+    }
 }

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -184,12 +184,13 @@ pub async fn grant_inputs_to_role(
 ///
 /// Only the transform shapes Centaur uses are translated: the ``secrets``
 /// transform (replace and inject, including ``token_broker`` sources),
-/// ``oauth_token``, ``gcp_auth``, and ``aws_auth``. Postgres listeners translate
-/// to ``pg_dsn`` secrets (one per listener). ``hmac_sign`` errors out here: it
-/// is represented in iron-control (see [`HmacSecretInput`]), but only the infra
-/// and harness fragments flow through this fragment translator and none sign
-/// requests — tool ``hmac_sign`` secrets are operator-managed via the
-/// ``centaur-perms`` CLI, which parses ``pyproject.toml`` directly.
+/// ``oauth_token``, ``gcp_auth``, ``gcp_id_token``, and ``aws_auth``. Postgres
+/// listeners translate to ``pg_dsn`` secrets (one per listener). ``hmac_sign``
+/// errors out here: it is represented in iron-control (see [`HmacSecretInput`]),
+/// but only the infra and harness fragments flow through this fragment
+/// translator and none sign requests — tool ``hmac_sign`` secrets are
+/// operator-managed via the ``centaur-perms`` CLI, which parses
+/// ``pyproject.toml`` directly.
 pub fn secret_inputs_from_fragment(
     namespace: &str,
     role_foreign_id: &str,
@@ -229,6 +230,12 @@ pub fn secret_inputs_from_fragment(
                     input.foreign_id = Some(unique_foreign_id(foreign_id, &mut used_foreign_ids));
                 }
                 inputs.push(SecretInput::GcpAuth(input));
+            }
+            "gcp_id_token" => {
+                let mut input =
+                    gcp_id_token_from_transform(namespace, role_foreign_id, transform, policy)?;
+                input.foreign_id = unique_foreign_id(input.foreign_id, &mut used_foreign_ids);
+                inputs.push(SecretInput::GcpIdToken(input));
             }
             "hmac_sign" => {
                 // Representable in iron-control, but never reached: only infra/
@@ -746,6 +753,63 @@ fn gcp_auth_from_transform(
 }
 
 // ---------------------------------------------------------------------------
+// GCP ID token secrets
+// ---------------------------------------------------------------------------
+
+fn gcp_id_token_from_transform(
+    namespace: &str,
+    role: &str,
+    transform: &centaur_iron_proxy::Transform,
+    policy: &SourcePolicy,
+) -> Result<GcpIdTokenSecretInput, TranslateError> {
+    let config = &transform.config.extra;
+    let audience = config
+        .get("audience")
+        .and_then(YamlValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| malformed(role, "gcp_id_token missing audience"))?;
+    let keyfile_value = config
+        .get("keyfile")
+        .ok_or_else(|| malformed(role, "gcp_id_token missing keyfile"))?;
+    let placeholder = yaml_str(keyfile_value, "placeholder")
+        .or_else(|| keyfile_value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| malformed(role, "gcp_id_token keyfile must be a placeholder"))?;
+    let rules = rules_from_values(role, &sequence(config.get("rules")))?;
+    if rules.is_empty() {
+        return Err(malformed(
+            role,
+            "gcp_id_token must declare at least one rule",
+        ));
+    }
+    let header = config
+        .get("header")
+        .and_then(YamlValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+
+    let mut identity = format!("{placeholder}-{audience}");
+    if let Some(header) = &header {
+        identity.push('-');
+        identity.push_str(header);
+    }
+    Ok(GcpIdTokenSecretInput {
+        namespace: namespace.to_owned(),
+        foreign_id: format!("{role}-gcp-id-token-{}", slugify(&identity)),
+        name: Some(format!("GCP ID Token ({role})")),
+        description: None,
+        labels: resource_labels(config.get("labels")),
+        audience: audience.to_owned(),
+        header,
+        keyfile: source_from_placeholder(policy, placeholder, None),
+        rules,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // AWS auth secrets
 // ---------------------------------------------------------------------------
 
@@ -1142,6 +1206,73 @@ transforms:
             input.rules[0].host.as_deref(),
             Some("logs.us-east-1.amazonaws.com")
         );
+    }
+
+    #[test]
+    fn translates_gcp_id_token_transform() {
+        let fragment = load_fragment_str(
+            r#"
+transforms:
+  - name: gcp_id_token
+    config:
+      keyfile: { placeholder: CLOUD_RUN_KEYFILE }
+      audience: https://my-service-abc123-uc.a.run.app
+      header: x-serverless-authorization
+      labels:
+        centaur-tool: cloud-run
+      rules:
+        - { host: my-service-abc123-uc.a.run.app, http_methods: [POST] }
+"#,
+        )
+        .unwrap();
+        let inputs =
+            secret_inputs_from_fragment("default", "infra", &fragment, &env_policy()).unwrap();
+        let SecretInput::GcpIdToken(input) = &inputs[0] else {
+            panic!("expected a gcp_id_token secret");
+        };
+        assert_eq!(
+            input.foreign_id,
+            "infra-gcp-id-token-cloud-run-keyfile-https-my-service-abc123-uc-a-run-app-x-serverless-authorization"
+        );
+        assert_eq!(input.name.as_deref(), Some("GCP ID Token (infra)"));
+        assert_eq!(
+            input.audience,
+            "https://my-service-abc123-uc.a.run.app".to_owned()
+        );
+        assert_eq!(input.header.as_deref(), Some("x-serverless-authorization"));
+        assert_eq!(input.keyfile.source_type, "env");
+        assert_eq!(input.keyfile.config, json!({ "var": "CLOUD_RUN_KEYFILE" }));
+        assert_eq!(
+            input.labels.get("managed-by").map(String::as_str),
+            Some("centaur")
+        );
+        assert_eq!(
+            input.labels.get("centaur-tool").map(String::as_str),
+            Some("cloud-run")
+        );
+        assert_eq!(input.rules.len(), 1);
+        assert_eq!(
+            input.rules[0].host.as_deref(),
+            Some("my-service-abc123-uc.a.run.app")
+        );
+        assert_eq!(input.rules[0].http_methods, vec!["POST".to_owned()]);
+    }
+
+    #[test]
+    fn gcp_id_token_requires_rules() {
+        let fragment = load_fragment_str(
+            r#"
+transforms:
+  - name: gcp_id_token
+    config:
+      keyfile: { placeholder: CLOUD_RUN_KEYFILE }
+      audience: https://my-service-abc123-uc.a.run.app
+"#,
+        )
+        .unwrap();
+        let err =
+            secret_inputs_from_fragment("default", "infra", &fragment, &env_policy()).unwrap_err();
+        assert!(matches!(err, TranslateError::Malformed { .. }), "{err:?}");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-perms/src/main.rs
+++ b/services/api-rs/crates/centaur-perms/src/main.rs
@@ -125,8 +125,8 @@ enum SecretsCmd {
 
 #[derive(Args, Debug)]
 struct SecretSelector {
-    /// Secret OID (`ssr_`/`ots_`/`gas_`/`pgs_`/`hms_`/`aas_`) or `foreign_id`. A
-    /// `foreign_id` is resolved by trying each secret type in turn.
+    /// Secret OID (`ssr_`/`ots_`/`gas_`/`gid_`/`pgs_`/`hms_`/`aas_`) or
+    /// `foreign_id`. A `foreign_id` is resolved by trying each secret type in turn.
     secret: String,
 }
 
@@ -255,7 +255,8 @@ struct PrincipalGrantArgs {
     #[arg(long = "role", value_name = "FOREIGN_ID")]
     roles: Vec<String>,
 
-    /// Secret OID (`ssr_`/`ots_`/`gas_`/`hms_`) to grant/revoke directly. Repeatable.
+    /// Secret OID (`ssr_`/`ots_`/`gas_`/`gid_`/`pgs_`/`hms_`/`aas_`) to
+    /// grant/revoke directly. Repeatable.
     #[arg(long = "secret", value_name = "OID")]
     secrets: Vec<String>,
 
@@ -275,7 +276,8 @@ struct RoleSecretArgs {
     /// Role `foreign_id` (e.g. `infra`, `tools`, `tool-github`) or OID.
     role: String,
 
-    /// Secret OID (`ssr_`/`ots_`/`gas_`/`hms_`) to grant/revoke. Repeatable.
+    /// Secret OID (`ssr_`/`ots_`/`gas_`/`gid_`/`pgs_`/`hms_`/`aas_`) to
+    /// grant/revoke. Repeatable.
     #[arg(long = "secret", value_name = "OID", required = true)]
     secrets: Vec<String>,
 }
@@ -285,7 +287,8 @@ struct RoleGrantArgs {
     /// Role `foreign_id` (e.g. `infra`, `tools`, `tool-github`) or OID.
     role: String,
 
-    /// Existing secret OID (`ssr_`/`ots_`/`gas_`/`hms_`) to grant. Repeatable.
+    /// Existing secret OID (`ssr_`/`ots_`/`gas_`/`gid_`/`pgs_`/`hms_`/`aas_`) to
+    /// grant. Repeatable.
     #[arg(long = "secret", value_name = "OID")]
     secrets: Vec<String>,
 
@@ -1002,7 +1005,7 @@ fn grant_secret_from_oid(oid: &str) -> Result<GrantSecret> {
     match GrantSecret::from_oid(oid) {
         Some(secret) => Ok(secret),
         None => {
-            bail!("--secret expects a secret OID (ssr_/ots_/gas_/pgs_/hms_/aas_), got {oid:?}")
+            bail!("--secret expects a secret OID (ssr_/ots_/gas_/gid_/pgs_/hms_/aas_), got {oid:?}")
         }
     }
 }

--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -308,6 +308,37 @@ fn parses_aws_auth_with_session_token_and_regions() {
 }
 
 #[test]
+fn parses_gcp_id_token_secret() {
+    let parsed = tools::parse_secret(
+        &entry(
+            r#"{ type = "gcp_id_token", name = "CLOUD_RUN_KEYFILE", audience = "https://my-service-abc123-uc.a.run.app", header = "X-Serverless-Authorization", hosts = ["my-service-abc123-uc.a.run.app"] }"#,
+        ),
+        &[],
+    )
+    .unwrap();
+    let ParsedSecret::GcpIdToken(gcp) = parsed else {
+        panic!("expected gcp_id_token")
+    };
+    assert_eq!(gcp.name, "CLOUD_RUN_KEYFILE");
+    assert_eq!(gcp.secret_ref, "CLOUD_RUN_KEYFILE");
+    assert_eq!(gcp.audience, "https://my-service-abc123-uc.a.run.app");
+    assert_eq!(gcp.header.as_deref(), Some("x-serverless-authorization"));
+    assert_eq!(gcp.hosts, vec!["my-service-abc123-uc.a.run.app"]);
+}
+
+#[test]
+fn gcp_id_token_requires_audience() {
+    let err = tools::parse_secret(
+        &entry(
+            r#"{ type = "gcp_id_token", name = "CLOUD_RUN_KEYFILE", hosts = ["my-service-abc123-uc.a.run.app"] }"#,
+        ),
+        &[],
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("audience"), "{err}");
+}
+
+#[test]
 fn aws_auth_requires_access_key_id() {
     let err = tools::parse_secret(
         &entry(
@@ -438,6 +469,43 @@ fn translates_gcp_auth_defaults_scopes_when_unset() {
     assert_eq!(
         input.scopes,
         vec!["https://www.googleapis.com/auth/cloud-platform".to_owned()]
+    );
+}
+
+#[test]
+fn translates_gcp_id_token_to_input() {
+    let secrets = vec![
+        tools::parse_secret(
+            &entry(
+                r#"{ type = "gcp_id_token", name = "CLOUD_RUN_KEYFILE", audience = "https://my-service-abc123-uc.a.run.app", header = "x-serverless-authorization", hosts = ["my-service-abc123-uc.a.run.app"] }"#,
+            ),
+            &[],
+        )
+        .unwrap(),
+    ];
+    let out = translate::translate("default", "tool-cloudrun", &secrets, &SourcePolicy::env());
+    let SecretInput::GcpIdToken(input) = &out.inputs[0] else {
+        panic!("expected gcp_id_token")
+    };
+    assert_eq!(
+        input.foreign_id,
+        "tool-cloudrun-gcp-id-token-cloud-run-keyfile-https-my-service-abc123-uc-a-run-app-x-serverless-authorization"
+    );
+    assert_eq!(input.name.as_deref(), Some("GCP ID Token (tool-cloudrun)"));
+    assert_eq!(
+        input.audience,
+        "https://my-service-abc123-uc.a.run.app".to_owned()
+    );
+    assert_eq!(input.header.as_deref(), Some("x-serverless-authorization"));
+    assert_eq!(input.keyfile.source_type, "env");
+    assert_eq!(
+        input.keyfile.config,
+        serde_json::json!({ "var": "CLOUD_RUN_KEYFILE" })
+    );
+    assert_eq!(input.rules.len(), 1);
+    assert_eq!(
+        input.rules[0].host.as_deref(),
+        Some("my-service-abc123-uc.a.run.app")
     );
 }
 

--- a/services/api-rs/crates/centaur-perms/src/tools.rs
+++ b/services/api-rs/crates/centaur-perms/src/tools.rs
@@ -125,6 +125,16 @@ pub struct GcpAuthSecret {
     pub scopes: Vec<String>,
 }
 
+/// A `type = "gcp_id_token"` secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcpIdTokenSecret {
+    pub name: String,
+    pub secret_ref: String,
+    pub hosts: Vec<String>,
+    pub audience: String,
+    pub header: Option<String>,
+}
+
 /// A `type = "pg_dsn"` secret: a Postgres upstream the proxy fronts. `name` is
 /// the DSN env var the sandbox reads, `secret_ref` resolves the upstream
 /// connection string, and `database` is the database to connect to. pg_dsn
@@ -208,6 +218,7 @@ pub enum ParsedSecret {
     Http(HttpSecret),
     OAuthToken(OAuthTokenSecret),
     GcpAuth(GcpAuthSecret),
+    GcpIdToken(GcpIdTokenSecret),
     PgDsn(PgDsnSecret),
     Hmac(HmacSignSecret),
     BrokerToken(BrokerTokenSecret),
@@ -221,6 +232,7 @@ impl ParsedSecret {
             ParsedSecret::Http(s) => &s.name,
             ParsedSecret::OAuthToken(s) => &s.name,
             ParsedSecret::GcpAuth(s) => &s.name,
+            ParsedSecret::GcpIdToken(s) => &s.name,
             ParsedSecret::PgDsn(s) => &s.name,
             ParsedSecret::Hmac(s) => &s.name,
             ParsedSecret::BrokerToken(s) => &s.name,
@@ -451,6 +463,11 @@ pub fn parse_secret(entry: &Value, default_hosts: &[String]) -> Result<ParsedSec
         )?)),
         "oauth_token" => Ok(ParsedSecret::OAuthToken(parse_oauth(table, &name)?)),
         "gcp_auth" => Ok(ParsedSecret::GcpAuth(parse_gcp(table, &name, &secret_ref)?)),
+        "gcp_id_token" => Ok(ParsedSecret::GcpIdToken(parse_gcp_id_token(
+            table,
+            &name,
+            &secret_ref,
+        )?)),
         "pg_dsn" => Ok(ParsedSecret::PgDsn(parse_pg_dsn(
             table,
             &name,
@@ -646,6 +663,30 @@ fn parse_gcp(table: &toml::Table, name: &str, secret_ref: &str) -> Result<GcpAut
         secret_ref: secret_ref.to_owned(),
         hosts,
         scopes,
+    })
+}
+
+fn parse_gcp_id_token(
+    table: &toml::Table,
+    name: &str,
+    secret_ref: &str,
+) -> Result<GcpIdTokenSecret> {
+    let hosts = non_empty_str_array(table.get("hosts")).ok_or_else(|| {
+        eyre!("gcp_id_token entry {name:?} 'hosts' must be a non-empty array of non-empty strings")
+    })?;
+    let audience = req_str(table, "audience")
+        .wrap_err_with(|| format!("gcp_id_token entry {name:?} requires a non-empty 'audience'"))?;
+    let header = opt_str(table, "header")
+        .map(|value| value.to_ascii_lowercase())
+        .map(validate_gcp_id_token_header)
+        .transpose()
+        .wrap_err_with(|| format!("gcp_id_token entry {name:?}"))?;
+    Ok(GcpIdTokenSecret {
+        name: name.to_owned(),
+        secret_ref: secret_ref.to_owned(),
+        hosts,
+        audience,
+        header,
     })
 }
 
@@ -1011,6 +1052,15 @@ fn non_empty_str_array(value: Option<&Value>) -> Option<Vec<String>> {
         out.push(s.to_owned());
     }
     Some(out)
+}
+
+fn validate_gcp_id_token_header(value: String) -> Result<String> {
+    match value.as_str() {
+        "authorization" | "x-serverless-authorization" => Ok(value),
+        _ => {
+            bail!("header must be one of authorization, x-serverless-authorization, got {value:?}")
+        }
+    }
 }
 
 fn reject_keys(table: &toml::Table, name: &str, mode: &str, keys: &[&str]) -> Result<()> {

--- a/services/api-rs/crates/centaur-perms/src/tools.rs
+++ b/services/api-rs/crates/centaur-perms/src/tools.rs
@@ -10,6 +10,7 @@
 
 use std::path::{Path, PathBuf};
 
+use centaur_iron_control::{GCP_ID_TOKEN_ALLOWED_HEADERS, normalize_gcp_id_token_header};
 use centaur_iron_proxy::{PgDsnSetting, PgDsnSettingValueFrom};
 use eyre::{Context, Result, bail, eyre};
 use toml::Value;
@@ -677,7 +678,6 @@ fn parse_gcp_id_token(
     let audience = req_str(table, "audience")
         .wrap_err_with(|| format!("gcp_id_token entry {name:?} requires a non-empty 'audience'"))?;
     let header = opt_str(table, "header")
-        .map(|value| value.to_ascii_lowercase())
         .map(validate_gcp_id_token_header)
         .transpose()
         .wrap_err_with(|| format!("gcp_id_token entry {name:?}"))?;
@@ -1055,12 +1055,12 @@ fn non_empty_str_array(value: Option<&Value>) -> Option<Vec<String>> {
 }
 
 fn validate_gcp_id_token_header(value: String) -> Result<String> {
-    match value.as_str() {
-        "authorization" | "x-serverless-authorization" => Ok(value),
-        _ => {
-            bail!("header must be one of authorization, x-serverless-authorization, got {value:?}")
-        }
-    }
+    normalize_gcp_id_token_header(&value).ok_or_else(|| {
+        eyre!(
+            "header must be one of {}, got {value:?}",
+            GCP_ID_TOKEN_ALLOWED_HEADERS.join(", ")
+        )
+    })
 }
 
 fn reject_keys(table: &toml::Table, name: &str, mode: &str, keys: &[&str]) -> Result<()> {

--- a/services/api-rs/crates/centaur-perms/src/translate.rs
+++ b/services/api-rs/crates/centaur-perms/src/translate.rs
@@ -10,18 +10,18 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use centaur_iron_control::{
-    AwsAuthSecretInput, GcpAuthSecretInput, HmacSecretHeader, HmacSecretInput, InjectConfig,
-    OAuthTokenSecretInput, PgDsnSecretInput, PgDsnSettingInput, PgDsnSettingValueFromInput,
-    ReplaceConfig, RequestRule, SecretInput, SecretSource, StaticSecretInput,
-    gcp_auth_scopes_or_default, managed_labels, slugify, source_from_placeholder,
-    unique_foreign_id,
+    AwsAuthSecretInput, GcpAuthSecretInput, GcpIdTokenSecretInput, HmacSecretHeader,
+    HmacSecretInput, InjectConfig, OAuthTokenSecretInput, PgDsnSecretInput, PgDsnSettingInput,
+    PgDsnSettingValueFromInput, ReplaceConfig, RequestRule, SecretInput, SecretSource,
+    StaticSecretInput, gcp_auth_scopes_or_default, managed_labels, slugify,
+    source_from_placeholder, unique_foreign_id,
 };
 use centaur_iron_proxy::SourcePolicy;
 use centaur_iron_proxy::{PgDsnSetting, PgDsnSettingValueFrom};
 
 use crate::tools::{
-    AwsAuthSecret, BrokerTokenSecret, FieldSource, GcpAuthSecret, HmacSignSecret, HttpSecret,
-    OAuthTokenSecret, ParsedSecret, PgDsnSecret, SecretMode,
+    AwsAuthSecret, BrokerTokenSecret, FieldSource, GcpAuthSecret, GcpIdTokenSecret, HmacSignSecret,
+    HttpSecret, OAuthTokenSecret, ParsedSecret, PgDsnSecret, SecretMode,
 };
 
 /// The result of translating a tool's secrets: the iron-control inputs to upsert.
@@ -107,6 +107,16 @@ fn translate_with_labels(
             }
             ParsedSecret::GcpAuth(gcp) => {
                 out.inputs.push(SecretInput::GcpAuth(gcp_input(
+                    namespace,
+                    role_foreign_id,
+                    gcp,
+                    policy,
+                    labels,
+                    &mut used,
+                )));
+            }
+            ParsedSecret::GcpIdToken(gcp) => {
+                out.inputs.push(SecretInput::GcpIdToken(gcp_id_token_input(
                     namespace,
                     role_foreign_id,
                     gcp,
@@ -247,6 +257,32 @@ fn gcp_input(
         subject: None,
         keyfile: Some(source_from_placeholder(policy, &gcp.secret_ref, None)),
         credentials_provider: None,
+        rules: rules_from_hosts(&gcp.hosts),
+    }
+}
+
+fn gcp_id_token_input(
+    namespace: &str,
+    role: &str,
+    gcp: &GcpIdTokenSecret,
+    policy: &SourcePolicy,
+    labels: &BTreeMap<String, String>,
+    used: &mut BTreeSet<String>,
+) -> GcpIdTokenSecretInput {
+    let mut identity = format!("{}-{}", gcp.secret_ref, gcp.audience);
+    if let Some(header) = &gcp.header {
+        identity.push('-');
+        identity.push_str(header);
+    }
+    GcpIdTokenSecretInput {
+        namespace: namespace.to_owned(),
+        foreign_id: unique_foreign_id(format!("{role}-gcp-id-token-{}", slugify(&identity)), used),
+        name: Some(format!("GCP ID Token ({role})")),
+        description: None,
+        labels: labels.clone(),
+        audience: gcp.audience.clone(),
+        header: gcp.header.clone(),
+        keyfile: source_from_placeholder(policy, &gcp.secret_ref, None),
         rules: rules_from_hosts(&gcp.hosts),
     }
 }


### PR DESCRIPTION
Adds gcp_id_token manifest support to API tool discovery and the iron-control registry so discovered tool secrets are reconciled into the infra role. Mirrors the parser and translator in centaur-perms so manual role grants can register the same secret shape.