### PR TITLE
fix: preserve hidden Slack links in agent prompts

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -30,6 +30,7 @@ import {
   isRetryableSessionApiError,
   openSessionEventStream,
   serializeAttachment,
+  serializeMessageLinks,
   serializeMessage,
   sessionStreamError
 } from './session-api'
@@ -2079,6 +2080,7 @@ async function slackApiMessageFromSlack(
     displayTextSource: displayText.source,
     id,
     isMention: id === currentMessage.id ? currentMessage.isMention === true : false,
+    links: serializeMessageLinks(undefined, message),
     raw: message,
     rawSlackAttachmentCount: displayText.rawAttachmentCount,
     rawSlackBlockCount: displayText.rawBlockCount,

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1,11 +1,12 @@
 import type { RustSessionStreamEvent } from '@centaur/harness-events'
-import type { Attachment, Message } from 'chat'
+import type { Attachment, LinkPreview, Message } from 'chat'
 import { renderSlackDisplayText, slackMessagePromptText } from './slack-display-text'
 import type {
   ForwardSessionInput,
   JsonObject,
   JsonValue,
   SlackbotV2ApiAttachment,
+  SlackbotV2ApiMessageLink,
   SlackbotV2ApiMessage,
   SlackbotV2AppendMessagesRequest,
   SlackbotV2CreateSessionRequest,
@@ -214,6 +215,7 @@ export async function serializeMessage(message: Message): Promise<SlackbotV2ApiM
     displayTextSource: displayText.source,
     id: message.id,
     isMention: message.isMention === true,
+    links: serializeMessageLinks(message.links, message.raw),
     raw: message.raw,
     rawSlackAttachmentCount: displayText.rawAttachmentCount,
     rawSlackBlockCount: displayText.rawBlockCount,
@@ -222,6 +224,133 @@ export async function serializeMessage(message: Message): Promise<SlackbotV2ApiM
     threadId: message.threadId,
     timestamp: message.metadata.dateSent.toISOString()
   }
+}
+
+const SLACK_MESSAGE_URL_PATTERN = /^https:\/\/[^/\s]+\.slack\.com\/archives\/[A-Z0-9]+\/p\d+/i
+
+export function serializeMessageLinks(
+  links: readonly LinkPreview[] | undefined,
+  raw: unknown
+): SlackbotV2ApiMessageLink[] | undefined {
+  return normalizeApiLinks([
+    ...(links ?? []).map(serializeLinkPreview),
+    ...extractRawSlackLinks(raw)
+  ])
+}
+
+function serializeLinkPreview(link: LinkPreview): SlackbotV2ApiMessageLink {
+  return {
+    description: link.description,
+    imageUrl: link.imageUrl,
+    isSlackMessage: Boolean(link.fetchMessage) || isSlackMessageUrl(link.url),
+    siteName: link.siteName,
+    title: link.title,
+    url: link.url
+  }
+}
+
+function extractRawSlackLinks(raw: unknown): SlackbotV2ApiMessageLink[] {
+  const links: SlackbotV2ApiMessageLink[] = []
+  for (const record of slackRawRecords(raw)) {
+    extractRawSlackBlockLinks(record.blocks, links)
+    extractRawSlackTextLinks(record.text, links)
+    extractRawSlackAttachmentLinks(record.attachments, links)
+  }
+  return links
+}
+
+function slackRawRecords(raw: unknown): JsonObject[] {
+  const records: JsonObject[] = []
+  const seen = new Set<JsonObject>()
+  const add = (value: unknown): void => {
+    if (!isJsonObject(value) || seen.has(value)) return
+    records.push(value)
+    seen.add(value)
+  }
+
+  add(raw)
+  if (isJsonObject(raw)) {
+    add(raw.event)
+    add(raw.message)
+    if (isJsonObject(raw.event)) add(raw.event.message)
+  }
+  return records
+}
+
+function extractRawSlackBlockLinks(
+  value: JsonValue | undefined,
+  links: SlackbotV2ApiMessageLink[]
+): void {
+  if (!Array.isArray(value)) return
+  for (const block of value) extractRawSlackElementLinks(block, links)
+}
+
+function extractRawSlackElementLinks(
+  value: JsonValue | undefined,
+  links: SlackbotV2ApiMessageLink[]
+): void {
+  if (!isJsonObject(value)) return
+  if (value.type === 'link') {
+    const url = stringValue(value.url)
+    if (url) links.push({ isSlackMessage: isSlackMessageUrl(url), url })
+  }
+  for (const key of ['elements', 'fields']) {
+    const children = value[key]
+    if (Array.isArray(children)) {
+      for (const child of children) extractRawSlackElementLinks(child, links)
+    }
+  }
+  extractRawSlackElementLinks(value.text, links)
+  extractRawSlackElementLinks(value.accessory, links)
+}
+
+function extractRawSlackTextLinks(
+  value: JsonValue | undefined,
+  links: SlackbotV2ApiMessageLink[]
+): void {
+  const text = stringValue(value)
+  if (!text) return
+  for (const match of text.matchAll(/<([a-z]+:\/\/[^>|]+)(?:\|[^>]+)?>/gi)) {
+    const url = match[1]
+    if (url) links.push({ isSlackMessage: isSlackMessageUrl(url), url })
+  }
+}
+
+function extractRawSlackAttachmentLinks(
+  value: JsonValue | undefined,
+  links: SlackbotV2ApiMessageLink[]
+): void {
+  if (!Array.isArray(value)) return
+  for (const attachment of value) {
+    if (!isJsonObject(attachment)) continue
+    const url = stringValue(attachment.from_url) ?? stringValue(attachment.original_url)
+    if (!url) continue
+    links.push({
+      description: stringValue(attachment.text),
+      isSlackMessage: isSlackMessageUrl(url),
+      siteName: stringValue(attachment.service_name),
+      title: stringValue(attachment.title),
+      url
+    })
+  }
+}
+
+function normalizeApiLinks(
+  links: SlackbotV2ApiMessageLink[]
+): SlackbotV2ApiMessageLink[] | undefined {
+  const seen = new Set<string>()
+  const normalized: SlackbotV2ApiMessageLink[] = []
+  for (const link of links) {
+    const url = link.url.trim()
+    if (!url || seen.has(url)) continue
+    seen.add(url)
+    normalized.push({ ...link, url })
+  }
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function isSlackMessageUrl(url: string): boolean {
+  return SLACK_MESSAGE_URL_PATTERN.test(url)
 }
 
 function slackTeamId(raw: unknown): string | undefined {
@@ -1131,6 +1260,7 @@ function sessionSlackTextMetadata(message: SlackbotV2ApiMessage): JsonObject {
   if (typeof message.rawSlackAttachmentCount === 'number') {
     fields.slack_raw_attachment_count = message.rawSlackAttachmentCount
   }
+  if (message.links?.length) fields.slack_link_count = message.links.length
   return fields
 }
 

--- a/services/slackbotv2/src/slack-display-text.ts
+++ b/services/slackbotv2/src/slack-display-text.ts
@@ -56,13 +56,68 @@ export function renderSlackDisplayText(input: { raw: unknown; text: string }): S
 export function slackMessagePromptText(message: {
   displayText?: string
   displayTextSource?: SlackDisplayTextSource
+  links?: PromptLink[]
   text: string
 }): string {
   const source = message.displayTextSource
-  if ((source === 'raw_blocks' || source === 'raw_attachments') && message.displayText) {
-    return message.displayText
+  const text =
+    (source === 'raw_blocks' || source === 'raw_attachments') && message.displayText
+      ? message.displayText
+      : message.text
+  const links = promptLinksText(message.links, text)
+  return [text, links].filter(part => part.trim()).join('\n\n')
+}
+
+type PromptLink = {
+  description?: string
+  isSlackMessage?: boolean
+  siteName?: string
+  title?: string
+  url: string
+}
+
+function promptLinksText(
+  links: readonly PromptLink[] | undefined,
+  existingText: string
+): string {
+  const normalized = normalizePromptLinks(links).filter(link => !existingText.includes(link.url))
+  if (normalized.length === 0) return ''
+
+  const hasSlackMessageLink = normalized.some(link => link.isSlackMessage)
+  const lines = ['Links included in the Slack message:']
+  if (hasSlackMessageLink) {
+    lines.push(
+      'If the request is context-dependent, inspect linked Slack message/thread links before responding.'
+    )
   }
-  return message.text
+  for (const link of normalized) {
+    lines.push(`- ${promptLinkLine(link)}`)
+  }
+  return lines.join('\n')
+}
+
+function normalizePromptLinks(
+  links: readonly PromptLink[] | undefined
+): PromptLink[] {
+  const seen = new Set<string>()
+  const normalized: PromptLink[] = []
+  for (const link of links ?? []) {
+    const url = link.url.trim()
+    if (!url || seen.has(url)) continue
+    seen.add(url)
+    normalized.push({ ...link, url })
+  }
+  return normalized
+}
+
+function promptLinkLine(link: PromptLink): string {
+  const fields = [
+    link.isSlackMessage ? `Slack message/thread: ${link.url}` : link.url,
+    link.title ? `Title: ${link.title}` : undefined,
+    link.description ? `Description: ${link.description}` : undefined,
+    link.siteName ? `Site: ${link.siteName}` : undefined
+  ].filter(Boolean)
+  return fields.join(' | ')
 }
 
 function slackMessageRecords(raw: unknown): UnknownRecord[] {

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -30,6 +30,15 @@ export type SlackbotV2ApiAttachment = {
   width?: number
 }
 
+export type SlackbotV2ApiMessageLink = {
+  description?: string
+  imageUrl?: string
+  isSlackMessage?: boolean
+  siteName?: string
+  title?: string
+  url: string
+}
+
 export type SlackbotV2ApiMessage = {
   attachments: SlackbotV2ApiAttachment[]
   author: SlackbotV2ApiAuthor
@@ -37,6 +46,7 @@ export type SlackbotV2ApiMessage = {
   displayTextSource?: SlackDisplayTextSource
   id: string
   isMention: boolean
+  links?: SlackbotV2ApiMessageLink[]
   raw: unknown
   rawSlackAttachmentCount?: number
   rawSlackBlockCount?: number

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -262,6 +262,78 @@ describe('Slack display text fallback', () => {
     )
     expect(lineContent(line).at(-1)).toEqual({ type: 'text', text: expected })
   })
+
+  test('forwards hidden Slack message links with non-empty adapter text', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const slackUrl = 'https://acme.slack.com/archives/C1234567890/p1700000000000100'
+    const serialized = await serializeMessage({
+      attachments: [],
+      author: {
+        fullName: 'Test User',
+        isBot: false,
+        isMe: false,
+        userId: 'U1',
+        userName: 'test'
+      },
+      id: '1700000000.000100',
+      isMention: true,
+      links: [],
+      metadata: { dateSent: new Date('2026-06-10T00:00:00.000Z') },
+      raw: {
+        blocks: [
+          {
+            elements: [
+              {
+                elements: [
+                  { text: 'continue', type: 'text' },
+                  { text: 'source thread', type: 'link', url: slackUrl }
+                ],
+                type: 'rich_text_section'
+              }
+            ],
+            type: 'rich_text'
+          }
+        ],
+        team_id: 'T1'
+      },
+      text: 'continue',
+      threadId: 'slack:C1:1700000000.000100'
+    } as unknown as Parameters<typeof serializeMessage>[0])
+
+    await forwardToSessionApi(options(fetchFn), forwardInput(serialized))
+
+    expect(serialized.links).toEqual([{ isSlackMessage: true, url: slackUrl }])
+    const expected = [
+      'continue',
+      '',
+      'Links included in the Slack message:',
+      'If the request is context-dependent, inspect linked Slack message/thread links before responding.',
+      `- Slack message/thread: ${slackUrl}`
+    ].join('\n')
+    expect(appendedTextParts(requests)).toContain(expected)
+
+    const line = executeLine(requests)
+    expect(line.trace_metadata).toEqual(
+      expect.objectContaining({
+        slack_link_count: 1,
+        slack_text_source: 'text'
+      })
+    )
+    expect(lineContent(line).at(-1)).toEqual({ type: 'text', text: expected })
+  })
+
+  test('does not duplicate links already visible in Slack text', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const slackUrl = 'https://acme.slack.com/archives/C1234567890/p1700000000000100'
+    const message = apiMessage(`continue (${slackUrl})`, {
+      links: [{ isSlackMessage: true, url: slackUrl }]
+    })
+
+    await forwardToSessionApi(options(fetchFn), forwardInput(message))
+
+    expect(appendedTextParts(requests)).toContain(`continue (${slackUrl})`)
+    expect(appendedTextParts(requests).join('\n')).not.toContain('Links included in the Slack message')
+  })
 })
 
 describe('forwardToSessionApi overrides', () => {


### PR DESCRIPTION
## Summary

- Preserve Slack links when serializing Slackbot messages into the session API payload.
- Extract rich-text links from raw Slack blocks as a fallback, including hidden links behind visible text like `continue`.
- Append a compact `Links included in the Slack message` section to the agent prompt so linked Slack threads are visible to the agent.
- Add regression coverage for hidden Slack message links and duplicate-link avoidance.

## Root Cause

Slack messages with manually hyperlinked words can arrive with plain adapter text such as `continue` while the URL lives in Slack rich-text blocks or adapter link metadata. Slackbot was forwarding only the plain text when it was non-empty, so the agent had no way to know a linked thread existed.

## Validation

- `bun test test/session-api.test.ts`
- `pnpm --filter slackbotv2 check:types`

Note: the clean PR worktree does not have Node dependencies installed; validation was run in the main checkout against the same patch before creating the PR branch.
