### PR TITLE
Fix Codex OpenAI API key proxy transform

### DIFF
--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -162,11 +162,9 @@ transforms:
     config:
       secrets:
         - id: OPENAI_API_KEY_AUTHORIZATION
-          source:
-            placeholder: OPENAI_API_KEY
-          inject:
-            header: Authorization
-            formatter: "Bearer {{.Value}}"
+          replace:
+            proxy_value: OPENAI_API_KEY
+            match_headers: ["Authorization"]
           rules: [{ host: api.openai.com }]
 "#;
 

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -3,7 +3,11 @@ use super::*;
 #[test]
 fn harness_auth_fragments_are_baked_in() {
     let codex = harness_auth_fragment("codex", "api_key").unwrap().unwrap();
-    assert!(placeholder_env(&[codex]).is_empty());
+    let codex_placeholders = placeholder_env(&[codex]);
+    assert_eq!(
+        codex_placeholders.get("OPENAI_API_KEY").map(String::as_str),
+        Some("OPENAI_API_KEY")
+    );
 
     // access_token carries the token-broker credential, not a replace
     // placeholder, so it contributes no sandbox placeholder env.


### PR DESCRIPTION
## Summary
- change Codex OpenAI API-key proxy auth from header injection to placeholder replacement on Authorization
- assert Codex API-key auth contributes the OPENAI_API_KEY placeholder env

## Evidence
- Live failure: sandbox pod logged repeated 401s to wss://api.openai.com/v1/responses while OPENAI_API_KEY was set to the literal placeholder
- Proxy auth logs showed no separate proxy-side secret-resolution failure

## Tests
- cargo test -p centaur-iron-proxy harness_auth_fragments_are_baked_in
- cargo test -p centaur-api-server codex_app_server_env_template_injects_auth_mode_and_placeholder
- cargo fmt --check