### PR TITLE
feat: add principal sandbox access toggles

### DIFF
--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -29,6 +29,10 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
+fn default_true() -> bool {
+    true
+}
+
 // ---------------------------------------------------------------------------
 // Secret sources
 // ---------------------------------------------------------------------------
@@ -470,6 +474,10 @@ pub struct Principal {
     pub name: String,
     #[serde(default)]
     pub labels: BTreeMap<String, String>,
+    #[serde(default = "default_true")]
+    pub sandbox_repo_cache_enabled: bool,
+    #[serde(default = "default_true")]
+    pub sandbox_observability_enabled: bool,
 }
 
 /// A principal's effective config — the same secrets/postgres the principal's

--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -24,7 +24,7 @@ module Api
       def create
         principal = Principal.new(namespace: upsert_namespace, foreign_id: data_params[:foreign_id],
                                   created_by: current_user)
-        principal.assign_attributes(data_params.permit(:name, labels: {}))
+        principal.assign_attributes(principal_params)
         principal.save!
         render status: :created, json: { data: record_payload(principal) }
       rescue ActiveRecord::RecordInvalid => e
@@ -37,7 +37,7 @@ module Api
       def update
         principal = resolve_for_upsert(Principal)
         was_new = principal.new_record?
-        principal.assign_attributes(data_params.permit(:name, labels: {}))
+        principal.assign_attributes(principal_params)
         principal.save!
         render status: (was_new ? :created : :ok), json: { data: record_payload(principal) }
       rescue ActiveRecord::RecordInvalid => e
@@ -74,9 +74,20 @@ module Api
           foreign_id: principal.foreign_id,
           name: principal.name,
           labels: principal.labels,
+          sandbox_repo_cache_enabled: principal.sandbox_repo_cache_enabled,
+          sandbox_observability_enabled: principal.sandbox_observability_enabled,
           created_at: principal.created_at,
           updated_at: principal.updated_at
         }
+      end
+
+      def principal_params
+        data_params.permit(
+          :name,
+          :sandbox_repo_cache_enabled,
+          :sandbox_observability_enabled,
+          labels: {}
+        )
       end
     end
   end

--- a/services/console/app/controllers/console/principals_controller.rb
+++ b/services/console/app/controllers/console/principals_controller.rb
@@ -10,6 +10,16 @@ module Console
 
     before_action :set_principal
 
+    def update_sandbox_access
+      @principal.update!(
+        sandbox_repo_cache_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_repo_cache_enabled]),
+        sandbox_observability_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_observability_enabled])
+      )
+      redirect_to console_principal_path(@principal.oid), notice: "Updated sandbox access."
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to console_principal_path(@principal.oid), alert: e.record.errors.full_messages.to_sentence
+    end
+
     def assign_role
       role = Role.find_by_oid!(params[:role_id])
       @principal.principal_roles.find_or_create_by!(role: role)

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -23,6 +23,46 @@
   <% end %>
 </div>
 
+<!-- Sandbox access -->
+<section class="mb-8">
+  <div class="mb-4">
+    <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Sandbox Access</h2>
+  </div>
+  <div class="console-panel p-5">
+    <% checkbox_class = "mt-1 h-4 w-4 rounded border-ink-500 bg-ink-800 text-centaur-500 focus:ring-centaur-500" %>
+    <%= form_with url: console_principal_sandbox_access_path(@principal.oid),
+                  method: :patch,
+                  data: { turbo: false },
+                  class: "space-y-4" do %>
+      <label class="flex items-start gap-3">
+        <%= hidden_field_tag :sandbox_repo_cache_enabled, "0" %>
+        <%= check_box_tag :sandbox_repo_cache_enabled,
+                          "1",
+                          @principal.sandbox_repo_cache_enabled,
+                          class: checkbox_class %>
+        <span>
+          <span class="block text-sm font-medium text-zinc-100">Repo cache</span>
+          <span class="block text-xs text-zinc-500">Mount repo-cache backed workspace and tool sources.</span>
+        </span>
+      </label>
+      <label class="flex items-start gap-3">
+        <%= hidden_field_tag :sandbox_observability_enabled, "0" %>
+        <%= check_box_tag :sandbox_observability_enabled,
+                          "1",
+                          @principal.sandbox_observability_enabled,
+                          class: checkbox_class %>
+        <span>
+          <span class="block text-sm font-medium text-zinc-100">Observability</span>
+          <span class="block text-xs text-zinc-500">Allow sandbox access to logs and metrics surfaces.</span>
+        </span>
+      </label>
+      <div>
+        <%= submit_tag "Save sandbox access", class: "btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</section>
+
 <!-- Roles -->
 <section class="mb-8">
   <div class="mb-4 flex flex-wrap items-end justify-between gap-3">

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
   # extra /roles and /grants path segments keep these clear of the show route above
   # and avoid clobbering the console_principal_path helper.
   namespace :console do
+    patch  "principals/:id/sandbox_access",   to: "principals#update_sandbox_access", as: :principal_sandbox_access
     post   "principals/:id/roles",            to: "principals#assign_role",   as: :principal_assign_role
     delete "principals/:id/roles/:role_id",   to: "principals#unassign_role", as: :principal_unassign_role
     post   "principals/:id/grants",           to: "principals#grant_secret",  as: :principal_grant_secret

--- a/services/console/db/migrate/20260625030000_add_sandbox_capabilities_to_principals.rb
+++ b/services/console/db/migrate/20260625030000_add_sandbox_capabilities_to_principals.rb
@@ -1,0 +1,6 @@
+class AddSandboxCapabilitiesToPrincipals < ActiveRecord::Migration[8.1]
+  def change
+    add_column :principals, :sandbox_repo_cache_enabled, :boolean, null: false, default: true
+    add_column :principals, :sandbox_observability_enabled, :boolean, null: false, default: true
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_25_002334) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_25_030000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -259,6 +259,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_002334) do
     t.jsonb "labels", default: {}, null: false
     t.string "name"
     t.string "namespace", default: "default", null: false
+    t.boolean "sandbox_observability_enabled", default: true, null: false
+    t.boolean "sandbox_repo_cache_enabled", default: true, null: false
     t.bigint "sync_config_cache_version", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["created_by_id"], name: "index_principals_on_created_by_id"

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -42,6 +42,8 @@ module Api
         assert_equal "acme", data["namespace"]
         assert_equal "C0123456789", data["foreign_id"]
         assert_equal({ "kind" => "slack_channel", "team" => "platform" }, data["labels"])
+        assert_equal true, data["sandbox_repo_cache_enabled"]
+        assert_equal true, data["sandbox_observability_enabled"]
       end
 
       test "GET returns 404 for an unknown oid" do
@@ -75,6 +77,8 @@ module Api
         assert_equal "acme", data["namespace"]
         assert_equal "U-new-id", data["foreign_id"]
         assert_equal({ "kind" => "user", "team" => "platform" }, data["labels"])
+        assert_equal true, data["sandbox_repo_cache_enabled"]
+        assert_equal true, data["sandbox_observability_enabled"]
       end
 
       test "POST creates a Principal with only a human-readable name" do
@@ -93,12 +97,40 @@ module Api
 
       test "PUT updates the human-readable name" do
         principal = principals(:acme_channel)
+        principal.update!(
+          sandbox_repo_cache_enabled: false,
+          sandbox_observability_enabled: false
+        )
         body = { data: { name: "Acme Slack channel" } }
 
         put api_v1_principal_url(id: principal.oid), params: body.to_json, headers: auth_headers
         assert_response :ok
 
-        assert_equal "Acme Slack channel", principal.reload.name
+        principal.reload
+        assert_equal "Acme Slack channel", principal.name
+        assert_equal false, principal.sandbox_repo_cache_enabled
+        assert_equal false, principal.sandbox_observability_enabled
+      end
+
+      test "PUT updates sandbox access flags" do
+        principal = principals(:acme_channel)
+        body = {
+          data: {
+            sandbox_repo_cache_enabled: false,
+            sandbox_observability_enabled: false
+          }
+        }
+
+        put api_v1_principal_url(id: principal.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        principal.reload
+        assert_equal false, principal.sandbox_repo_cache_enabled
+        assert_equal false, principal.sandbox_observability_enabled
+
+        data = json_body.fetch("data")
+        assert_equal false, data["sandbox_repo_cache_enabled"]
+        assert_equal false, data["sandbox_observability_enabled"]
       end
 
       test "POST returns 422 when (namespace, foreign_id) already exists" do

--- a/services/console/test/controllers/console/principals_controller_test.rb
+++ b/services/console/test/controllers/console/principals_controller_test.rb
@@ -17,6 +17,22 @@ module Console
       assert_redirected_to login_path
     end
 
+    test "update_sandbox_access toggles repo cache and observability access" do
+      principal = principals(:acme_user_bob)
+
+      patch console_principal_sandbox_access_url(principal.oid),
+            params: {
+              sandbox_repo_cache_enabled: "0",
+              sandbox_observability_enabled: "0"
+            }
+
+      assert_redirected_to console_principal_path(principal.oid)
+      assert_equal "Updated sandbox access.", flash[:notice]
+      principal.reload
+      assert_equal false, principal.sandbox_repo_cache_enabled
+      assert_equal false, principal.sandbox_observability_enabled
+    end
+
     test "assign_role attaches the role and redirects with a notice" do
       principal = principals(:acme_user_bob)
       role = roles(:acme_admin_role)

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -50,6 +50,14 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal({}, principal.reload.labels)
   end
 
+  test "sandbox access defaults to enabled" do
+    principal = Principal.create!(default_attrs(namespace: "acme", foreign_id: "C-default-sandbox-access"))
+    principal.reload
+
+    assert_predicate principal, :sandbox_repo_cache_enabled
+    assert_predicate principal, :sandbox_observability_enabled
+  end
+
   test "labels accepts arbitrary string map" do
     principal = Principal.create!(default_attrs(
       namespace: "acme",


### PR DESCRIPTION
## Summary
- add default-enabled principal fields for sandbox repo-cache and observability access
- expose the fields through the principal API payload/update path
- add console checkboxes on the principal detail page to update those fields
- update the Rust iron-control principal model to default missing fields to enabled

## Not included
- no sandbox runtime enforcement yet
- no warm sandbox capability matching yet
- no repo-cache or vlogs/vmetrics server-side gating yet

Those server-side capability checks will come in a follow-up PR.

## Validation
- Rails focused tests: 95 runs, 272 assertions, 0 failures
- `cargo test -p centaur-iron-control --lib`: 49 passed
- `just build-one console`
- `just deploy` locally
- `centaur-console:latest` smoke: `GET /up` -> 200