### PR TITLE
fix: install workflow python deps in api image

### DIFF
--- a/services/api-rs/Dockerfile
+++ b/services/api-rs/Dockerfile
@@ -26,13 +26,17 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 FROM debian:bookworm-slim
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends ca-certificates python3
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates python3 python3-pip
 COPY --from=builder /usr/local/bin/centaur-api-server /usr/local/bin/centaur-api-server
 WORKDIR /app
+COPY services/workflow-python/ /app/workflow-python/
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip3 install --break-system-packages --no-compile /app/workflow-python \
+    && python3 -c "import boto3, botocore" \
+    && rm -rf /usr/share/doc /usr/share/man /usr/share/info
 # api-rs discovers tool secret metadata from pyproject.toml at startup so it can
 # register the full tool secret set with iron-control before sandboxes claim.
 COPY tools/ /app/tools/
-COPY services/workflow-python/ /app/workflow-python/
 COPY workflows/ /app/workflows/
 ENV PYTHON_WORKFLOW_HOST_PATH=/app/workflow-python/workflow_host.py
 ENV WORKFLOW_DIRS=/app/workflows


### PR DESCRIPTION
## Summary
- install the workflow Python host package into the centaur-api-rs runtime image
- add a Docker build-time import check for boto3 and botocore
- keep the existing workflow host source copied into /app/workflow-python for local workflow execution

## Why
Slack archive import failed on staging because the non-sandbox Python workflow host path in the API image could not import boto3 when downloading the uploaded archive from S3/R2.

## Validation
- installed services/workflow-python locally in a Python 3.13 venv and imported boto3/botocore
- built centaur-api-rs:latest with docker build -t centaur-api-rs:latest -f services/api-rs/Dockerfile .
- ran docker run --rm --entrypoint python3 centaur-api-rs:latest -c "import boto3, botocore; ..."

Note: just build-one api-rs was blocked before invoking the build because a parent .env file has an unparsable bare token line, so I ran the equivalent docker build command directly.