### PR TITLE
feat: support Password Grant broker credentials

### DIFF
--- a/services/console/app/controllers/api/v1/broker_credentials_controller.rb
+++ b/services/console/app/controllers/api/v1/broker_credentials_controller.rb
@@ -2,8 +2,8 @@ module Api
   module V1
     # Operator CRUD for managed broker credentials. Mirrors the secret
     # controllers (oid/foreign_id addressing, label search, PUT-upsert), with two
-    # differences: the initial refresh_token is a write-only seed, and the
-    # rotating token blob (access_token/refresh_token) is NEVER serialized back.
+    # differences: bootstrap fields are write-only, and the rotating token blob
+    # (access_token/refresh_token) is NEVER serialized back.
     class BrokerCredentialsController < Api::BaseController
       def index
         records, meta = paginated_label_search(BrokerCredential.all)
@@ -49,7 +49,7 @@ module Api
 
       def assign_and_save!(ref, attrs)
         base = attrs.permit(:namespace, :foreign_id, :name, :description, :token_endpoint,
-                            :client_id, :client_secret,
+                            :grant, :client_id,
                             :early_refresh_slack_seconds, :early_refresh_fraction,
                             :max_refresh_interval_seconds, :refresh_timeout_seconds,
                             labels: {}, scopes: [])
@@ -61,8 +61,9 @@ module Api
 
         BrokerCredential.transaction do
           ref.assign_attributes(base)
+          apply_write_only_field(ref, attrs, :client_secret)
           apply_token_endpoint_headers(ref, attrs)
-          apply_refresh_token_seed(ref, attrs)
+          apply_bootstrap_fields(ref, attrs)
           ref.save!
           ref.reload
         end
@@ -77,24 +78,36 @@ module Api
         ref.token_endpoint_headers = raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw
       end
 
-      # The refresh_token is a write-only bootstrap/re-auth seed. Supplying a new
-      # one resets the credential to "due now" and clears any dead state, so the
-      # next poll re-bootstraps it. A blank/absent value leaves the existing seed
-      # (and rotation state) untouched.
-      def apply_refresh_token_seed(ref, attrs)
-        seed = attrs[:refresh_token]
-        return if seed.blank?
+      def apply_write_only_field(ref, attrs, field)
+        value = attrs[field]
+        ref.public_send("#{field}=", value) if value.present?
+      end
 
-        ref.refresh_token = seed
+      # These fields are write-only bootstrap/re-auth material. Supplying any
+      # fresh value resets the credential to "due now" and clears dead state, so
+      # the next poll re-bootstraps it. Blank/absent values leave stored material
+      # and rotation state untouched.
+      def apply_bootstrap_fields(ref, attrs)
+        changed = false
+        %i[refresh_token username password].each do |field|
+          value = attrs[field]
+          next if value.blank?
+
+          ref.public_send("#{field}=", value)
+          changed = true
+        end
+        return unless changed
+
         ref.dead = false
         ref.dead_reason = nil
         ref.failure_count = 0
         ref.next_attempt_at = Time.current
       end
 
-      # Observability only. The client_secret, the token_endpoint_headers values,
-      # the minted access_token, and the refresh_token are deliberately never
-      # included; only the header names are surfaced.
+      # Observability only. The client_secret, username/password, the
+      # token_endpoint_headers values, the minted access_token, and the
+      # refresh_token are deliberately never included; only the header names are
+      # surfaced.
       def record_payload(ref)
         {
           id: ref.oid,
@@ -103,6 +116,7 @@ module Api
           name: ref.name,
           description: ref.description,
           labels: ref.labels,
+          grant: ref.grant,
           token_endpoint: ref.token_endpoint,
           scopes: ref.scopes,
           client_id: ref.client_id,

--- a/services/console/app/controllers/api/v1/broker_credentials_controller.rb
+++ b/services/console/app/controllers/api/v1/broker_credentials_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     # Operator CRUD for managed broker credentials. Mirrors the secret
     # controllers (oid/foreign_id addressing, label search, PUT-upsert), with two
-    # differences: bootstrap fields are write-only, and the rotating token blob
+    # differences: initial values are write-only, and the rotating token blob
     # (access_token/refresh_token) is NEVER serialized back.
     class BrokerCredentialsController < Api::BaseController
       def index
@@ -61,9 +61,9 @@ module Api
 
         BrokerCredential.transaction do
           ref.assign_attributes(base)
-          apply_write_only_field(ref, attrs, :client_secret)
+          apply_client_secret(ref, attrs)
           apply_token_endpoint_headers(ref, attrs)
-          apply_bootstrap_fields(ref, attrs)
+          apply_initial_values(ref, attrs)
           ref.save!
           ref.reload
         end
@@ -78,16 +78,16 @@ module Api
         ref.token_endpoint_headers = raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw
       end
 
-      def apply_write_only_field(ref, attrs, field)
-        value = attrs[field]
-        ref.public_send("#{field}=", value) if value.present?
+      def apply_client_secret(ref, attrs)
+        secret = attrs[:client_secret]
+        ref.client_secret = secret if secret.present?
       end
 
-      # These fields are write-only bootstrap/re-auth material. Supplying any
+      # These fields are write-only initial/re-auth values. Supplying any
       # fresh value resets the credential to "due now" and clears dead state, so
-      # the next poll re-bootstraps it. Blank/absent values leave stored material
+      # the next poll refreshes it. Blank/absent values leave stored material
       # and rotation state untouched.
-      def apply_bootstrap_fields(ref, attrs)
+      def apply_initial_values(ref, attrs)
         changed = false
         %i[refresh_token username password].each do |field|
           value = attrs[field]

--- a/services/console/app/controllers/console/broker_credentials_controller.rb
+++ b/services/console/app/controllers/console/broker_credentials_controller.rb
@@ -2,7 +2,7 @@ module Console
   # Create/edit form for managed broker credentials: identity, the OAuth client
   # config it refreshes with (token endpoint, client id/secret, scopes, token-
   # endpoint headers), the refresh-policy knobs, and grant-specific write-only
-  # bootstrap fields. Mirrors the per-type secret form controllers, but a broker
+  # initial values. Mirrors the per-type secret form controllers, but a broker
   # credential is not a secret (it is referenced by a token_broker source, not
   # granted), so it lives on its own rather than under BaseSecretsController.
   class BrokerCredentialsController < ApplicationController
@@ -53,8 +53,8 @@ module Console
 
     # Map the form params onto the credential. Encrypted write-only fields are
     # only assigned when non-blank, so editing without re-entering them leaves the
-    # stored values in place. Fresh bootstrap material re-bootstraps the
-    # credential and mirrors the API controller's seed handling.
+    # stored values in place. Fresh initial values reschedule the credential and
+    # mirror the API controller's handling.
     def assign_form(credential)
       fields = credential_params.permit(:namespace, :foreign_id, :name, :description,
                                         :grant, :token_endpoint, :client_id,
@@ -69,10 +69,10 @@ module Console
 
       secret = credential_params[:client_secret]
       credential.client_secret = secret if secret.present?
-      apply_bootstrap_fields(credential)
+      apply_initial_values(credential)
     end
 
-    def apply_bootstrap_fields(credential)
+    def apply_initial_values(credential)
       changed = false
       %i[refresh_token username password].each do |field|
         value = credential_params[field]

--- a/services/console/app/controllers/console/broker_credentials_controller.rb
+++ b/services/console/app/controllers/console/broker_credentials_controller.rb
@@ -1,10 +1,10 @@
 module Console
   # Create/edit form for managed broker credentials: identity, the OAuth client
   # config it refreshes with (token endpoint, client id/secret, scopes, token-
-  # endpoint headers), the refresh-policy knobs, and a write-only refresh_token
-  # seed. Mirrors the per-type secret form controllers, but a broker credential is
-  # not a secret (it is referenced by a token_broker source, not granted), so it
-  # lives on its own rather than under BaseSecretsController.
+  # endpoint headers), the refresh-policy knobs, and grant-specific write-only
+  # bootstrap fields. Mirrors the per-type secret form controllers, but a broker
+  # credential is not a secret (it is referenced by a token_broker source, not
+  # granted), so it lives on its own rather than under BaseSecretsController.
   class BrokerCredentialsController < ApplicationController
     include KvRowParams
 
@@ -51,14 +51,13 @@ module Console
 
     private
 
-    # Map the form params onto the credential. The encrypted write-only fields --
-    # client_secret and the refresh_token seed -- are only assigned when the field
-    # is non-blank, so editing without re-entering them leaves the stored value in
-    # place. A blank refresh_token also leaves rotation state untouched; a fresh one
-    # re-bootstraps the credential (mirrors the API controller's seed handling).
+    # Map the form params onto the credential. Encrypted write-only fields are
+    # only assigned when non-blank, so editing without re-entering them leaves the
+    # stored values in place. Fresh bootstrap material re-bootstraps the
+    # credential and mirrors the API controller's seed handling.
     def assign_form(credential)
       fields = credential_params.permit(:namespace, :foreign_id, :name, :description,
-                                        :token_endpoint, :client_id,
+                                        :grant, :token_endpoint, :client_id,
                                         :early_refresh_slack_seconds, :early_refresh_fraction,
                                         :max_refresh_interval_seconds, :refresh_timeout_seconds)
       fields[:namespace] = fields[:namespace].presence || "default"
@@ -70,12 +69,20 @@ module Console
 
       secret = credential_params[:client_secret]
       credential.client_secret = secret if secret.present?
-      apply_refresh_token_seed(credential, credential_params[:refresh_token])
+      apply_bootstrap_fields(credential)
     end
 
-    def apply_refresh_token_seed(credential, seed)
-      return if seed.blank?
-      credential.refresh_token = seed
+    def apply_bootstrap_fields(credential)
+      changed = false
+      %i[refresh_token username password].each do |field|
+        value = credential_params[field]
+        next if value.blank?
+
+        credential.public_send("#{field}=", value)
+        changed = true
+      end
+      return unless changed
+
       credential.dead = false
       credential.dead_reason = nil
       credential.failure_count = 0

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -164,7 +164,7 @@ class BrokerCredential < ApplicationRecord
 
   def perform_refresh_token_refresh
     if refresh_token.blank?
-      mark_dead!("blob_not_bootstrapped")
+      mark_dead!("missing_initial_refresh_token")
       return nil
     end
 
@@ -206,8 +206,8 @@ class BrokerCredential < ApplicationRecord
       end
     end
 
-    unless password_grant_bootstrapped?
-      mark_dead!("password_grant_not_bootstrapped")
+    unless password_grant_initial_values_present?
+      mark_dead!("password_grant_missing_initial_values")
       return nil
     end
 
@@ -307,7 +307,7 @@ class BrokerCredential < ApplicationRecord
     errors.add(:password, "can't be blank for the password grant") if password.blank?
   end
 
-  def password_grant_bootstrapped?
+  def password_grant_initial_values_present?
     username.present? && password.present?
   end
 

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -1,7 +1,7 @@
-# A managed OAuth credential whose refresh-token lifecycle centaur-console owns
-# itself: the in-control port of iron-token-broker. control drives a refresh loop
-# (Broker::PollRefreshJob -> Broker::RefreshCredentialJob -> #refresh!) that mints
-# fresh access tokens before expiry.
+# A managed OAuth credential whose token lifecycle centaur-console owns itself:
+# the in-control port of iron-token-broker. control drives a refresh loop
+# (Broker::PollRefreshJob -> Broker::RefreshCredentialJob -> #refresh!) that
+# mints fresh access tokens before expiry.
 #
 # The minted access token reaches iron-proxy through the normal /sync path: a
 # `token_broker` SecretSource on some grantable secret references this credential
@@ -9,10 +9,10 @@
 # the current access token, delivered inline like a control_plane value. A
 # BrokerCredential is itself NOT synced and NOT grantable.
 #
-# The OAuth client credentials it refreshes with -- client_id, optional
-# client_secret, and any token-endpoint headers -- are fields on the credential,
-# resolved by control itself. client_id is not secret; client_secret and the
-# header values are encrypted at rest.
+# The OAuth credentials it refreshes with -- client_id, optional client_secret,
+# optional username/password, and any token-endpoint headers -- are fields on the
+# credential, resolved by control itself. client_id is not secret; every other
+# credential value is encrypted at rest.
 class BrokerCredential < ApplicationRecord
   oid_prefix "bcr"
 
@@ -20,6 +20,9 @@ class BrokerCredential < ApplicationRecord
 
   URL_SAFE_FORMAT = /\A[A-Za-z0-9\-._~]+\z/
   URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"
+
+  GRANTS = %w[refresh_token password].freeze
+  RefreshAttempt = Data.define(:result, :clear_refresh_token)
 
   # The access token must keep at least this much life past the scheduled
   # refresh, regardless of slack/fraction. Mirrors the 60s floor in
@@ -56,14 +59,20 @@ class BrokerCredential < ApplicationRecord
   encrypts :access_token
   encrypts :refresh_token
   encrypts :client_secret
+  encrypts :username
+  encrypts :password
   encrypts :token_endpoint_headers
 
   scope :refreshable, -> {
     where(dead: false)
-      .where("last_refresh IS NULL OR refresh_token IS NOT NULL")
+      .where("(\"broker_credentials\".\"grant\" = ? AND " \
+             "(last_refresh IS NULL OR refresh_token IS NOT NULL)) OR " \
+             "\"broker_credentials\".\"grant\" = ?",
+             "refresh_token", "password")
       .where("next_attempt_at IS NULL OR next_attempt_at <= ?", Time.current)
   }
 
+  validates :grant, inclusion: { in: GRANTS, message: "must be one of #{GRANTS.join(", ")}" }
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true
@@ -79,6 +88,7 @@ class BrokerCredential < ApplicationRecord
             numericality: { only_integer: true, greater_than: 0 }
   validate :labels_is_a_hash
   validate :scopes_is_an_array
+  validate :password_grant_credentials_present
   validate :token_endpoint_headers_valid
 
   # OAuth client identity used for refresh. Flow-minted credentials delegate to
@@ -125,13 +135,9 @@ class BrokerCredential < ApplicationRecord
   def refresh!(now: Time.current)
     with_lock do
       return if dead?
-      if refresh_token.blank?
-        mark_dead!("blob_not_bootstrapped")
-        return
-      end
 
-      result = perform_refresh(now: now)
-      apply_success!(result, now: now)
+      attempt = perform_refresh
+      apply_success!(attempt, now: now) if attempt
     rescue Broker::RefreshError => e
       if e.retryable?
         record_retryable_failure(e.message, now: now)
@@ -147,23 +153,84 @@ class BrokerCredential < ApplicationRecord
     @refresh_client ||= Broker::RefreshClient.new
   end
 
-  def perform_refresh(now:)
-    refresh_client.refresh(
+  def perform_refresh
+    case grant
+    when "password"
+      perform_password_grant_refresh
+    else
+      perform_refresh_token_refresh
+    end
+  end
+
+  def perform_refresh_token_refresh
+    if refresh_token.blank?
+      mark_dead!("blob_not_bootstrapped")
+      return nil
+    end
+
+    RefreshAttempt.new(refresh_client.refresh(
       token_endpoint: token_endpoint,
+      grant: "refresh_token",
       client_id: effective_client_id,
       client_secret: effective_client_secret,
       refresh_token: refresh_token,
       scopes: refresh_scopes_for_provider,
       headers: token_endpoint_headers || {},
       timeout: refresh_timeout_seconds
+    ), false)
+  end
+
+  def perform_password_grant_refresh
+    clear_stale_refresh_token = false
+
+    if refresh_token.present?
+      begin
+        return RefreshAttempt.new(refresh_client.refresh(
+          token_endpoint: token_endpoint,
+          grant: "refresh_token",
+          client_id: effective_client_id,
+          client_secret: effective_client_secret,
+          refresh_token: refresh_token,
+          scopes: refresh_scopes_for_provider,
+          headers: token_endpoint_headers || {},
+          timeout: refresh_timeout_seconds
+        ), false)
+      rescue Broker::RefreshError => e
+        raise if e.retryable?
+
+        Rails.logger.warn do
+          "broker credential #{oid} refresh_token grant failed with #{e.reason}; " \
+            "falling back to password grant"
+        end
+        clear_stale_refresh_token = true
+      end
+    end
+
+    unless password_grant_bootstrapped?
+      mark_dead!("password_grant_not_bootstrapped")
+      return nil
+    end
+
+    result = refresh_client.refresh(
+      token_endpoint: token_endpoint,
+      grant: "password",
+      client_id: effective_client_id,
+      client_secret: effective_client_secret,
+      username: username,
+      password: password,
+      scopes: refresh_scopes_for_provider,
+      headers: token_endpoint_headers || {},
+      timeout: refresh_timeout_seconds
     )
+    RefreshAttempt.new(result, clear_stale_refresh_token && result.refresh_token.blank?)
   end
 
   def refresh_scopes_for_provider
     oauth_app&.provider_strategy&.refresh_scopes(scopes) || scopes
   end
 
-  def apply_success!(result, now:)
+  def apply_success!(attempt, now:)
+    result = attempt.result
     expires_in = result.expires_in&.positive? ? result.expires_in : DEFAULT_EXPIRES_IN_SECONDS
     attrs = {
       access_token: result.access_token,
@@ -174,7 +241,11 @@ class BrokerCredential < ApplicationRecord
       dead_reason: nil
     }
     # Carry the previous refresh_token forward when the IdP did not rotate.
-    attrs[:refresh_token] = result.refresh_token if result.refresh_token.present?
+    if result.refresh_token.present?
+      attrs[:refresh_token] = result.refresh_token
+    elsif attempt.clear_refresh_token
+      attrs[:refresh_token] = nil
+    end
     assign_attributes(attrs)
     self.next_attempt_at = compute_next_attempt_at(now: now)
     save!
@@ -189,7 +260,8 @@ class BrokerCredential < ApplicationRecord
   end
 
   def mark_dead!(reason)
-    update!(dead: true, dead_reason: reason)
+    assign_attributes(dead: true, dead_reason: reason)
+    save!(validate: false)
     Rails.logger.error { "broker credential #{oid} marked dead; human re-auth required: reason=#{reason}" }
   end
 
@@ -226,6 +298,17 @@ class BrokerCredential < ApplicationRecord
   def scopes_is_an_array
     return if scopes.is_a?(Array) && scopes.all?(String)
     errors.add(:scopes, "must be an array of strings")
+  end
+
+  def password_grant_credentials_present
+    return unless grant == "password"
+
+    errors.add(:username, "can't be blank for the password grant") if username.blank?
+    errors.add(:password, "can't be blank for the password grant") if password.blank?
+  end
+
+  def password_grant_bootstrapped?
+    username.present? && password.present?
   end
 
   def token_endpoint_headers_valid

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -167,19 +167,20 @@ class BrokerCredential < ApplicationRecord
       return nil
     end
 
-    [
-      refresh_client.refresh(
-        token_endpoint: token_endpoint,
-        grant: "refresh_token",
-        client_id: effective_client_id,
-        client_secret: effective_client_secret,
-        refresh_token: refresh_token,
-        scopes: refresh_scopes_for_provider,
-        headers: token_endpoint_headers || {},
-        timeout: refresh_timeout_seconds
-      ),
-      false
-    ]
+    [ refresh_with_stored_token, false ]
+  end
+
+  def refresh_with_stored_token
+    refresh_client.refresh(
+      token_endpoint: token_endpoint,
+      grant: "refresh_token",
+      client_id: effective_client_id,
+      client_secret: effective_client_secret,
+      refresh_token: refresh_token,
+      scopes: refresh_scopes_for_provider,
+      headers: token_endpoint_headers || {},
+      timeout: refresh_timeout_seconds
+    )
   end
 
   def perform_password_grant_refresh
@@ -187,19 +188,7 @@ class BrokerCredential < ApplicationRecord
 
     if refresh_token.present?
       begin
-        return [
-          refresh_client.refresh(
-            token_endpoint: token_endpoint,
-            grant: "refresh_token",
-            client_id: effective_client_id,
-            client_secret: effective_client_secret,
-            refresh_token: refresh_token,
-            scopes: refresh_scopes_for_provider,
-            headers: token_endpoint_headers || {},
-            timeout: refresh_timeout_seconds
-          ),
-          false
-        ]
+        return [ refresh_with_stored_token, false ]
       rescue Broker::RefreshError => e
         raise if e.retryable?
 

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -22,7 +22,6 @@ class BrokerCredential < ApplicationRecord
   URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"
 
   GRANTS = %w[refresh_token password].freeze
-  RefreshAttempt = Data.define(:result, :clear_refresh_token)
 
   # The access token must keep at least this much life past the scheduled
   # refresh, regardless of slack/fraction. Mirrors the 60s floor in
@@ -136,8 +135,8 @@ class BrokerCredential < ApplicationRecord
     with_lock do
       return if dead?
 
-      attempt = perform_refresh
-      apply_success!(attempt, now: now) if attempt
+      result, clear_refresh_token = perform_refresh
+      apply_success!(result, now: now, clear_refresh_token: clear_refresh_token) if result
     rescue Broker::RefreshError => e
       if e.retryable?
         record_retryable_failure(e.message, now: now)
@@ -168,16 +167,19 @@ class BrokerCredential < ApplicationRecord
       return nil
     end
 
-    RefreshAttempt.new(refresh_client.refresh(
-      token_endpoint: token_endpoint,
-      grant: "refresh_token",
-      client_id: effective_client_id,
-      client_secret: effective_client_secret,
-      refresh_token: refresh_token,
-      scopes: refresh_scopes_for_provider,
-      headers: token_endpoint_headers || {},
-      timeout: refresh_timeout_seconds
-    ), false)
+    [
+      refresh_client.refresh(
+        token_endpoint: token_endpoint,
+        grant: "refresh_token",
+        client_id: effective_client_id,
+        client_secret: effective_client_secret,
+        refresh_token: refresh_token,
+        scopes: refresh_scopes_for_provider,
+        headers: token_endpoint_headers || {},
+        timeout: refresh_timeout_seconds
+      ),
+      false
+    ]
   end
 
   def perform_password_grant_refresh
@@ -185,16 +187,19 @@ class BrokerCredential < ApplicationRecord
 
     if refresh_token.present?
       begin
-        return RefreshAttempt.new(refresh_client.refresh(
-          token_endpoint: token_endpoint,
-          grant: "refresh_token",
-          client_id: effective_client_id,
-          client_secret: effective_client_secret,
-          refresh_token: refresh_token,
-          scopes: refresh_scopes_for_provider,
-          headers: token_endpoint_headers || {},
-          timeout: refresh_timeout_seconds
-        ), false)
+        return [
+          refresh_client.refresh(
+            token_endpoint: token_endpoint,
+            grant: "refresh_token",
+            client_id: effective_client_id,
+            client_secret: effective_client_secret,
+            refresh_token: refresh_token,
+            scopes: refresh_scopes_for_provider,
+            headers: token_endpoint_headers || {},
+            timeout: refresh_timeout_seconds
+          ),
+          false
+        ]
       rescue Broker::RefreshError => e
         raise if e.retryable?
 
@@ -222,15 +227,14 @@ class BrokerCredential < ApplicationRecord
       headers: token_endpoint_headers || {},
       timeout: refresh_timeout_seconds
     )
-    RefreshAttempt.new(result, clear_stale_refresh_token && result.refresh_token.blank?)
+    [ result, clear_stale_refresh_token && result.refresh_token.blank? ]
   end
 
   def refresh_scopes_for_provider
     oauth_app&.provider_strategy&.refresh_scopes(scopes) || scopes
   end
 
-  def apply_success!(attempt, now:)
-    result = attempt.result
+  def apply_success!(result, now:, clear_refresh_token:)
     expires_in = result.expires_in&.positive? ? result.expires_in : DEFAULT_EXPIRES_IN_SECONDS
     attrs = {
       access_token: result.access_token,
@@ -243,7 +247,7 @@ class BrokerCredential < ApplicationRecord
     # Carry the previous refresh_token forward when the IdP did not rotate.
     if result.refresh_token.present?
       attrs[:refresh_token] = result.refresh_token
-    elsif attempt.clear_refresh_token
+    elsif clear_refresh_token
       attrs[:refresh_token] = nil
     end
     assign_attributes(attrs)

--- a/services/console/app/views/console/broker_credentials/_form.html.erb
+++ b/services/console/app/views/console/broker_credentials/_form.html.erb
@@ -97,16 +97,16 @@
           <label class="inline-flex items-center gap-2 rounded border border-ink-600 px-3 py-2 text-sm text-zinc-200">
             <%= radio_button_tag "credential[grant]", grant, selected_grant == grant,
                   data: { action: "toggle#update" } %>
-            <span><%= grant.tr("_", " ") %></span>
+            <span><%= grant.tr("_", " ").titleize %></span>
           </label>
         <% end %>
       </div>
       <%= field_error(credential, :grant) %>
 
       <div data-toggle-target="panel" data-toggle-key="refresh_token">
-        <label class="form-label" for="credential_refresh_token">Refresh token</label>
-        <%= text_area_tag "credential[refresh_token]", nil, id: "credential_refresh_token", rows: 3, class: "form-input", autocomplete: "off", placeholder: credential.new_record? ? "the initial refresh token to seed the loop" : "•••••••• (unchanged)" %>
-        <p class="form-hint">Write-only seed, stored encrypted. Leave blank to keep the current token; entering a new one re-bootstraps the credential and clears any dead state.</p>
+        <label class="form-label" for="credential_refresh_token">Refresh Token</label>
+        <%= text_area_tag "credential[refresh_token]", nil, id: "credential_refresh_token", rows: 3, class: "form-input", autocomplete: "off", placeholder: credential.new_record? ? "initial refresh token for the loop" : "•••••••• (unchanged)" %>
+        <p class="form-hint">Write-only initial value, stored encrypted. Leave blank to keep the current token; entering a new one reschedules the credential and clears any dead state.</p>
       </div>
 
       <div data-toggle-target="panel" data-toggle-key="password" class="grid gap-5 sm:grid-cols-2">

--- a/services/console/app/views/console/broker_credentials/_form.html.erb
+++ b/services/console/app/views/console/broker_credentials/_form.html.erb
@@ -1,3 +1,5 @@
+<% selected_grant = credential.grant.presence || "refresh_token" %>
+
 <%= form_with model: [ :console, credential ], data: { turbo: false } do %>
   <div class="space-y-6">
     <section class="form-section">
@@ -88,19 +90,38 @@
       </div>
     </section>
 
-    <section class="form-section">
+    <section class="form-section" data-controller="toggle">
       <h2 class="form-section-heading">Bootstrap</h2>
-      <div>
-        <label class="form-label" for="credential_refresh_token">Refresh token<%= " *".html_safe if credential.new_record? %></label>
+      <div class="mb-4 flex flex-wrap gap-3">
+        <% BrokerCredential::GRANTS.each do |grant| %>
+          <label class="inline-flex items-center gap-2 rounded border border-ink-600 px-3 py-2 text-sm text-zinc-200">
+            <%= radio_button_tag "credential[grant]", grant, selected_grant == grant,
+                  data: { action: "toggle#update" } %>
+            <span><%= grant.tr("_", " ") %></span>
+          </label>
+        <% end %>
+      </div>
+      <%= field_error(credential, :grant) %>
+
+      <div data-toggle-target="panel" data-toggle-key="refresh_token">
+        <label class="form-label" for="credential_refresh_token">Refresh token</label>
         <%= text_area_tag "credential[refresh_token]", nil, id: "credential_refresh_token", rows: 3, class: "form-input", autocomplete: "off", placeholder: credential.new_record? ? "the initial refresh token to seed the loop" : "•••••••• (unchanged)" %>
-        <p class="form-hint">
-          Write-only seed, stored encrypted. The refresh loop rotates it from here.
-          <% if credential.new_record? %>
-            Required to leave bootstrapping.
-          <% else %>
-            Leave blank to keep the current token; entering a new one re-bootstraps the credential and clears any dead state.
-          <% end %>
-        </p>
+        <p class="form-hint">Write-only seed, stored encrypted. Leave blank to keep the current token; entering a new one re-bootstraps the credential and clears any dead state.</p>
+      </div>
+
+      <div data-toggle-target="panel" data-toggle-key="password" class="grid gap-5 sm:grid-cols-2">
+        <div>
+          <label class="form-label" for="credential_username">Username *</label>
+          <%= text_field_tag "credential[username]", nil, id: "credential_username", class: "form-input #{field_error_class(credential, :username)}", autocomplete: "off", placeholder: credential.new_record? ? nil : "•••••••• (unchanged)" %>
+          <%= field_error(credential, :username) %>
+          <p class="form-hint">Stored encrypted. Leave blank to keep the current username.</p>
+        </div>
+        <div>
+          <label class="form-label" for="credential_password">Password *</label>
+          <%= password_field_tag "credential[password]", nil, id: "credential_password", class: "form-input #{field_error_class(credential, :password)}", autocomplete: "off", placeholder: credential.new_record? ? nil : "•••••••• (unchanged)" %>
+          <%= field_error(credential, :password) %>
+          <p class="form-hint">Stored encrypted. Leave blank to keep the current password.</p>
+        </div>
       </div>
     </section>
 

--- a/services/console/app/views/console/credential.html.erb
+++ b/services/console/app/views/console/credential.html.erb
@@ -63,9 +63,12 @@
 ].compact) %>
 
 <%= def_section.call("OAuth Client", [
+  [ "Grant", @credential.grant ],
   [ "Client ID", @credential.effective_client_id ],
   [ "Token endpoint", @credential.token_endpoint ],
   [ "Scopes", Array(@credential.scopes).join("\n") ],
+  ([ "Username", "[redacted]" ] if @credential.grant == "password" && @credential.username.present?),
+  ([ "Password", "[redacted]" ] if @credential.grant == "password" && @credential.password.present?),
   ([ "Token endpoint headers", Array(@credential.token_endpoint_headers&.keys).map { |k| "#{k}: [redacted]" }.join("\n") ] if @credential.token_endpoint_headers.present?)
 ].compact) %>
 

--- a/services/console/db/migrate/20260624000100_add_password_grant_to_broker_credentials.rb
+++ b/services/console/db/migrate/20260624000100_add_password_grant_to_broker_credentials.rb
@@ -1,0 +1,7 @@
+class AddPasswordGrantToBrokerCredentials < ActiveRecord::Migration[8.1]
+  def change
+    add_column :broker_credentials, :grant, :string, null: false, default: "refresh_token"
+    add_column :broker_credentials, :username, :text
+    add_column :broker_credentials, :password, :text
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_23_231036) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_24_000100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -72,6 +72,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_231036) do
     t.string "token_endpoint", null: false
     t.text "token_endpoint_headers"
     t.datetime "updated_at", null: false
+    t.string "grant", default: "refresh_token", null: false
+    t.text "username"
+    t.text "password"
     t.index ["created_by_id"], name: "index_broker_credentials_on_created_by_id"
     t.index ["labels"], name: "index_broker_credentials_on_labels", using: :gin
     t.index ["namespace", "foreign_id"], name: "index_broker_credentials_on_namespace_and_foreign_id", unique: true

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -57,6 +57,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_000100) do
     t.string "external_user_key"
     t.integer "failure_count", default: 0, null: false
     t.string "foreign_id"
+    t.string "grant", default: "refresh_token", null: false
     t.jsonb "labels", default: {}, null: false
     t.datetime "last_refresh"
     t.integer "max_refresh_interval_seconds", default: 86400, null: false
@@ -64,6 +65,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_000100) do
     t.string "namespace", default: "default", null: false
     t.datetime "next_attempt_at"
     t.bigint "oauth_app_id"
+    t.text "password"
     t.string "provider_email"
     t.string "provider_subject"
     t.integer "refresh_timeout_seconds", default: 30, null: false
@@ -72,9 +74,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_000100) do
     t.string "token_endpoint", null: false
     t.text "token_endpoint_headers"
     t.datetime "updated_at", null: false
-    t.string "grant", default: "refresh_token", null: false
     t.text "username"
-    t.text "password"
     t.index ["created_by_id"], name: "index_broker_credentials_on_created_by_id"
     t.index ["labels"], name: "index_broker_credentials_on_labels", using: :gin
     t.index ["namespace", "foreign_id"], name: "index_broker_credentials_on_namespace_and_foreign_id", unique: true

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -802,11 +802,11 @@ Returns `201`. Response shape (note that `credentials` echoes each source as `{ 
 
 ## Broker credentials
 
-A broker credential is an OAuth credential whose refresh-token lifecycle iron-control manages itself. iron-control runs the refresh loop, mints fresh access tokens before they expire, and delivers the current access token to `iron-proxy` inline through [proxy sync](#proxy-sync) wherever a [`token_broker` secret source](#secret-sources) references the credential by its `id`.
+A broker credential is an OAuth credential whose token lifecycle iron-control manages itself. iron-control runs the refresh loop, mints fresh access tokens before they expire, and delivers the current access token to `iron-proxy` inline through [proxy sync](#proxy-sync) wherever a [`token_broker` secret source](#secret-sources) references the credential by its `id`.
 
-Unlike the secret types above, a broker credential is not granted directly and is not injected on its own. It is referenced by a `token_broker` source on a grantable secret (typically a [static secret](#static-secrets)), which carries the rules and injection config. The `refresh_token` never leaves iron-control.
+Unlike the secret types above, a broker credential is not granted directly and is not injected on its own. It is referenced by a `token_broker` source on a grantable secret (typically a [static secret](#static-secrets)), which carries the rules and injection config. Refresh tokens, usernames, and passwords never leave iron-control.
 
-The OAuth client credentials it refreshes with are fields on the credential, resolved by iron-control itself. `client_id` is not secret and is returned in responses; `client_secret` and the `token_endpoint_headers` values are encrypted at rest and never returned.
+The OAuth client credentials it refreshes with are fields on the credential, resolved by iron-control itself. `client_id` is not secret and is returned in responses; `client_secret`, password-grant fields, and the `token_endpoint_headers` values are encrypted at rest and never returned.
 
 ### Attributes
 
@@ -816,12 +816,15 @@ The OAuth client credentials it refreshes with are fields on the credential, res
 | `foreign_id`                   | optional    | Unique per namespace. Immutable. |
 | `name`, `description`          | optional    | |
 | `labels`                       | optional    | |
+| `grant`                        | optional    | One of `refresh_token` or `password`. Defaults to `refresh_token`. |
 | `token_endpoint`               | required    | OAuth token endpoint the refresh request is sent to. |
 | `scopes`                       | optional    | Array of strings. |
 | `client_id`                    | required    | OAuth client id. Returned in responses. |
 | `client_secret`                | optional    | OAuth client secret. Write-only and encrypted at rest; omit for public clients. Never returned. |
 | `token_endpoint_headers`       | optional    | Object mapping header name to a string value, sent on the refresh request. Values are write-only and encrypted; only the header names are returned (as `token_endpoint_header_names`). |
-| `refresh_token`                | optional    | Write-only seed. Supplying a value (re)bootstraps the credential: it is scheduled to refresh immediately and any dead state is cleared. Never returned. |
+| `refresh_token`                | optional    | Write-only seed for `refresh_token` credentials. Also used by `password` credentials when the provider returns one. Supplying a value schedules the credential immediately and clears dead state. Never returned. |
+| `username`                     | conditional | Required for `password` credentials. Write-only and encrypted at rest. Never returned. |
+| `password`                     | conditional | Required for `password` credentials. Write-only and encrypted at rest. Never returned. |
 | `early_refresh_slack_seconds`  | optional    | Refresh this many seconds before expiry. Defaults to `300`. |
 | `early_refresh_fraction`       | optional    | Refresh once this fraction of the token's lifetime remains, when that is larger than the slack. In `[0, 1)`. Defaults to `0.2`. |
 | `max_refresh_interval_seconds` | optional    | Refresh at least this often, even for long-lived tokens. Defaults to `86400`. |
@@ -844,7 +847,9 @@ Read-only fields are returned but never accepted in requests:
 | `provider_email`              | The account email captured at consent time. |
 | `external_user_key`           | An opaque key generated for the credential when it is minted by the consent flow. |
 
-The minted `access_token`, the `refresh_token`, the `client_secret`, and the `token_endpoint_headers` values are never returned in any response.
+The minted `access_token`, the `refresh_token`, `username`, `password`, the `client_secret`, and the `token_endpoint_headers` values are never returned in any response.
+
+Password-grant credentials first bootstrap with `grant_type=password`. If the token endpoint returns a `refresh_token`, iron-control stores it and uses `grant_type=refresh_token` on later scheduled refreshes. If that stored refresh token is rejected with an unrecoverable OAuth error, iron-control retries once with `grant_type=password`; retryable network, 5xx, rate-limit, and parse failures keep the existing backoff behavior and do not fall back to password.
 
 Credentials minted by the [OAuth consent flow](#oauth-consent-flow) are linked to an OAuth app and delegate their `client_id` and `client_secret` to it: rotating the app's secret applies to every credential it minted. Such a credential needs no `client_id`/`client_secret` of its own, and its `scopes` reflect exactly what the IdP granted.
 
@@ -858,6 +863,7 @@ Credentials minted by the [OAuth consent flow](#oauth-consent-flow) are linked t
     "namespace": "default",
     "foreign_id": "gmail",
     "name": "Gmail",
+    "grant": "refresh_token",
     "token_endpoint": "https://oauth2.googleapis.com/token",
     "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
     "client_id": "1234.apps.googleusercontent.com",
@@ -878,6 +884,7 @@ Returns `201`. The token blob, the `refresh_token` seed, and the `client_secret`
     "name": "Gmail",
     "description": null,
     "labels": {},
+    "grant": "refresh_token",
     "token_endpoint": "https://oauth2.googleapis.com/token",
     "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
     "client_id": "1234.apps.googleusercontent.com",
@@ -899,6 +906,27 @@ Returns `201`. The token blob, the `refresh_token` seed, and the `client_secret`
 }
 ```
 
+Password-grant providers use the same endpoint with `grant: "password"`:
+
+```json
+{
+  "data": {
+    "namespace": "default",
+    "foreign_id": "alphasense",
+    "name": "AlphaSense",
+    "grant": "password",
+    "token_endpoint": "https://api.alpha-sense.com/auth",
+    "client_id": "client-id",
+    "client_secret": "client-secret",
+    "username": "user@example.com",
+    "password": "account-password",
+    "token_endpoint_headers": { "x-api-key": "api-key" }
+  }
+}
+```
+
+For AlphaSense API calls, grant static secrets alongside the broker token so the proxy also injects the required `x-api-key` and `clientid` headers on `api.alpha-sense.com`. The broker credential itself only supplies the current bearer token through a `token_broker` source.
+
 To put the credential to use, reference it from a grantable secret's `token_broker` source, then grant that secret to a principal:
 
 ```json
@@ -914,7 +942,7 @@ To put the credential to use, reference it from a grantable secret's `token_brok
 
 ### Re-authenticating a dead credential
 
-When a refresh fails unrecoverably (for example the IdP returns `invalid_grant` because the refresh token was revoked), the credential's `status` becomes `dead` and it stops minting tokens. Supply a fresh `refresh_token` via `PUT` / `PATCH` to clear the dead state and reschedule it:
+When a refresh fails unrecoverably (for example the IdP returns `invalid_grant` because the refresh token was revoked), the credential's `status` becomes `dead` and it stops minting tokens. Supply a fresh `refresh_token` for a `refresh_token` credential, or fresh `username` / `password` fields for a `password` credential, via `PUT` / `PATCH` to clear the dead state and reschedule it:
 
 ```json
 { "data": { "refresh_token": "1//0gNEW..." } }
@@ -927,7 +955,7 @@ When a refresh fails unrecoverably (for example the IdP returns `invalid_grant` 
 | `GET`  | `/api/v1/broker_credentials?namespace=default` | List. `namespace` required; `labels[k]=v` and pagination optional. |
 | `GET`  | `/api/v1/broker_credentials/:id` | Fetch one. `404` if missing. |
 | `GET`  | `/api/v1/broker_credentials/lookup/:namespace/:foreign_id` | Fetch by namespace + foreign id. `404` if missing. |
-| `PUT`/`PATCH` | `/api/v1/broker_credentials/:id` | [Upsert](#upsert-put--patch) by OID or `foreign_id`. A `refresh_token` reseeds and clears dead state. Omitted fields are preserved; `client_secret` and `token_endpoint_headers` are only changed when supplied. |
+| `PUT`/`PATCH` | `/api/v1/broker_credentials/:id` | [Upsert](#upsert-put--patch) by OID or `foreign_id`. Fresh bootstrap fields reseed and clear dead state. Omitted fields are preserved; write-only fields are only changed when supplied. |
 | `DELETE` | `/api/v1/broker_credentials/:id` | Delete. Returns `204`; `404` if missing. Returns `409` if any `token_broker` secret source still references the credential (remove those references first). |
 
 ## OAuth apps

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -822,7 +822,7 @@ The OAuth client credentials it refreshes with are fields on the credential, res
 | `client_id`                    | required    | OAuth client id. Returned in responses. |
 | `client_secret`                | optional    | OAuth client secret. Write-only and encrypted at rest; omit for public clients. Never returned. |
 | `token_endpoint_headers`       | optional    | Object mapping header name to a string value, sent on the refresh request. Values are write-only and encrypted; only the header names are returned (as `token_endpoint_header_names`). |
-| `refresh_token`                | optional    | Write-only seed for `refresh_token` credentials. Also used by `password` credentials when the provider returns one. Supplying a value schedules the credential immediately and clears dead state. Never returned. |
+| `refresh_token`                | optional    | Write-only initial value for `refresh_token` credentials. Also used by `password` credentials when the provider returns one. Supplying a value schedules the credential immediately and clears dead state. Never returned. |
 | `username`                     | conditional | Required for `password` credentials. Write-only and encrypted at rest. Never returned. |
 | `password`                     | conditional | Required for `password` credentials. Write-only and encrypted at rest. Never returned. |
 | `early_refresh_slack_seconds`  | optional    | Refresh this many seconds before expiry. Defaults to `300`. |
@@ -849,7 +849,7 @@ Read-only fields are returned but never accepted in requests:
 
 The minted `access_token`, the `refresh_token`, `username`, `password`, the `client_secret`, and the `token_endpoint_headers` values are never returned in any response.
 
-Password-grant credentials first bootstrap with `grant_type=password`. If the token endpoint returns a `refresh_token`, iron-control stores it and uses `grant_type=refresh_token` on later scheduled refreshes. If that stored refresh token is rejected with an unrecoverable OAuth error, iron-control retries once with `grant_type=password`; retryable network, 5xx, rate-limit, and parse failures keep the existing backoff behavior and do not fall back to password.
+Password-grant credentials first use the stored initial values with `grant_type=password`. If the token endpoint returns a `refresh_token`, iron-control stores it and uses `grant_type=refresh_token` on later scheduled refreshes. If that stored refresh token is rejected with an unrecoverable OAuth error, iron-control retries once with `grant_type=password`; retryable network, 5xx, rate-limit, and parse failures keep the existing backoff behavior and do not fall back to password.
 
 Credentials minted by the [OAuth consent flow](#oauth-consent-flow) are linked to an OAuth app and delegate their `client_id` and `client_secret` to it: rotating the app's secret applies to every credential it minted. Such a credential needs no `client_id`/`client_secret` of its own, and its `scopes` reflect exactly what the IdP granted.
 
@@ -955,7 +955,7 @@ When a refresh fails unrecoverably (for example the IdP returns `invalid_grant` 
 | `GET`  | `/api/v1/broker_credentials?namespace=default` | List. `namespace` required; `labels[k]=v` and pagination optional. |
 | `GET`  | `/api/v1/broker_credentials/:id` | Fetch one. `404` if missing. |
 | `GET`  | `/api/v1/broker_credentials/lookup/:namespace/:foreign_id` | Fetch by namespace + foreign id. `404` if missing. |
-| `PUT`/`PATCH` | `/api/v1/broker_credentials/:id` | [Upsert](#upsert-put--patch) by OID or `foreign_id`. Fresh bootstrap fields reseed and clear dead state. Omitted fields are preserved; write-only fields are only changed when supplied. |
+| `PUT`/`PATCH` | `/api/v1/broker_credentials/:id` | [Upsert](#upsert-put--patch) by OID or `foreign_id`. Fresh initial values reseed and clear dead state. Omitted fields are preserved; write-only fields are only changed when supplied. |
 | `DELETE` | `/api/v1/broker_credentials/:id` | Delete. Returns `204`; `404` if missing. Returns `409` if any `token_broker` secret source still references the credential (remove those references first). |
 
 ## OAuth apps

--- a/services/console/lib/broker/refresh_client.rb
+++ b/services/console/lib/broker/refresh_client.rb
@@ -3,10 +3,11 @@ require "json"
 require "uri"
 
 module Broker
-  # RefreshClient performs the raw RFC 6749 4.5 refresh_token grant POST against a
-  # token endpoint and returns the parsed response. It owns no retry/backoff
-  # state -- BrokerCredential drives that. Ported from iron-token-broker's
-  # internal/broker/refresh.go.
+  # RefreshClient performs raw RFC 6749 token grant POSTs against a token
+  # endpoint and returns the parsed response. It owns no retry/backoff state --
+  # BrokerCredential drives that. Ported from iron-token-broker's
+  # internal/broker/refresh.go, with password-grant support added for providers
+  # that still require it.
   #
   # SECURITY: this class never logs the refresh_token, client_secret, the
   # response body, or any decoded token. Callers must keep the same discipline.
@@ -29,20 +30,22 @@ module Broker
       @http = http
     end
 
-    # Performs one refresh. Raises Broker::RefreshError on any failure (classified
-    # retryable vs. unrecoverable). scopes is an array; headers is a name=>value
-    # hash applied verbatim to the token POST.
-    def refresh(token_endpoint:, client_id:, refresh_token:, client_secret: nil,
+    # Performs one token exchange. Raises Broker::RefreshError on any failure
+    # (classified retryable vs. unrecoverable). scopes is an array; headers is a
+    # name=>value hash applied verbatim to the token POST.
+    def refresh(token_endpoint:, client_id:, grant: "refresh_token", refresh_token: nil,
+                username: nil, password: nil, client_secret: nil,
                 scopes: [], headers: {}, timeout: DEFAULT_TIMEOUT)
       raise ArgumentError, "token endpoint is required" if token_endpoint.blank?
       raise ArgumentError, "client_id is required" if client_id.blank?
-      raise ArgumentError, "refresh_token is required" if refresh_token.blank?
 
-      form = {
-        "grant_type" => "refresh_token",
-        "refresh_token" => refresh_token,
-        "client_id" => client_id
-      }
+      form = form_for_grant(
+        grant: grant,
+        client_id: client_id,
+        refresh_token: refresh_token,
+        username: username,
+        password: password
+      )
       form["client_secret"] = client_secret if client_secret.present?
       form["scope"] = scopes.join(" ") if scopes.present?
 
@@ -54,6 +57,31 @@ module Broker
     end
 
     private
+
+    def form_for_grant(grant:, client_id:, refresh_token:, username:, password:)
+      case grant
+      when "refresh_token"
+        raise ArgumentError, "refresh_token is required" if refresh_token.blank?
+
+        {
+          "grant_type" => "refresh_token",
+          "refresh_token" => refresh_token,
+          "client_id" => client_id
+        }
+      when "password"
+        raise ArgumentError, "username is required" if username.blank?
+        raise ArgumentError, "password is required" if password.blank?
+
+        {
+          "grant_type" => "password",
+          "username" => username,
+          "password" => password,
+          "client_id" => client_id
+        }
+      else
+        raise ArgumentError, "unsupported grant #{grant.inspect}"
+      end
+    end
 
     def perform(url, form, headers, timeout)
       if @http

--- a/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
@@ -85,7 +85,7 @@ module Api
         assert_equal({ "X-Api-Key" => "k" }, created.token_endpoint_headers)
       end
 
-      test "create password grant stores bootstrap fields and redacts secrets" do
+      test "create password grant stores initial values and redacts secrets" do
         body = {
           data: {
             namespace: "acme", foreign_id: "alphasense",
@@ -180,7 +180,7 @@ module Api
         assert_equal "pass", bc.password
       end
 
-      test "password bootstrap update clears dead state and reschedules" do
+      test "password initial values update clears dead state and reschedules" do
         bc = BrokerCredential.create!(namespace: "acme", foreign_id: "password-dead",
                                       grant: "password", token_endpoint: "https://idp.example/token",
                                       client_id: "cid", username: "old", password: "old",

--- a/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
@@ -32,7 +32,10 @@ module Api
         data = json_body.fetch("data")
         assert_equal "https://oauth2.googleapis.com/token", data["token_endpoint"]
         assert_equal "gmail-client-id", data["client_id"]
+        assert_equal "refresh_token", data["grant"]
         refute data.key?("client_secret")
+        refute data.key?("username")
+        refute data.key?("password")
         refute data.key?("access_token")
         refute data.key?("refresh_token")
       end
@@ -82,6 +85,39 @@ module Api
         assert_equal({ "X-Api-Key" => "k" }, created.token_endpoint_headers)
       end
 
+      test "create password grant stores bootstrap fields and redacts secrets" do
+        body = {
+          data: {
+            namespace: "acme", foreign_id: "alphasense",
+            grant: "password",
+            token_endpoint: "https://api.alpha-sense.com/auth",
+            client_id: "alpha-client",
+            client_secret: "alpha-secret",
+            username: "alpha-user",
+            password: "alpha-password",
+            token_endpoint_headers: { "x-api-key" => "alpha-key" }
+          }
+        }
+
+        assert_difference -> { BrokerCredential.count } => 1 do
+          post api_v1_broker_credentials_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :created
+        data = json_body.fetch("data")
+        assert_equal "password", data["grant"]
+        refute data.key?("client_secret")
+        refute data.key?("username")
+        refute data.key?("password")
+        assert_equal [ "x-api-key" ], data["token_endpoint_header_names"]
+
+        created = BrokerCredential.find_by_oid(data["id"])
+        assert_equal "alpha-user", created.username
+        assert_equal "alpha-password", created.password
+        assert_equal "alpha-secret", created.client_secret
+        assert_equal({ "x-api-key" => "alpha-key" }, created.token_endpoint_headers)
+        assert created.next_attempt_at.present?
+      end
+
       test "create rejects a missing client_id" do
         body = {
           data: {
@@ -94,6 +130,23 @@ module Api
           post api_v1_broker_credentials_url, params: body.to_json, headers: auth_headers
         end
         assert_response :unprocessable_entity
+      end
+
+      test "create password grant rejects missing password" do
+        body = {
+          data: {
+            namespace: "acme", foreign_id: "password-incomplete",
+            grant: "password",
+            token_endpoint: "https://idp.example/token",
+            client_id: "cid",
+            username: "user"
+          }
+        }
+        assert_no_difference -> { BrokerCredential.count } do
+          post api_v1_broker_credentials_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :unprocessable_entity
+        assert json_body.dig("error", "details", "password").present?
       end
 
       test "re-auth via PUT clears dead state and reschedules" do
@@ -109,6 +162,42 @@ module Api
         assert_nil bc.dead_reason
         assert_equal 0, bc.failure_count
         assert_equal "fresh-seed", bc.refresh_token
+      end
+
+      test "blank write-only fields preserve existing password grant material" do
+        bc = BrokerCredential.create!(namespace: "acme", foreign_id: "password-preserve",
+                                      grant: "password", token_endpoint: "https://idp.example/token",
+                                      client_id: "cid", client_secret: "secret",
+                                      username: "user", password: "pass", created_by: users(:acme_admin))
+
+        body = { data: { client_secret: "", username: "", password: "" } }
+        patch api_v1_broker_credential_url(id: bc.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        bc.reload
+        assert_equal "secret", bc.client_secret
+        assert_equal "user", bc.username
+        assert_equal "pass", bc.password
+      end
+
+      test "password bootstrap update clears dead state and reschedules" do
+        bc = BrokerCredential.create!(namespace: "acme", foreign_id: "password-dead",
+                                      grant: "password", token_endpoint: "https://idp.example/token",
+                                      client_id: "cid", username: "old", password: "old",
+                                      dead: true, dead_reason: "invalid_grant", failure_count: 3,
+                                      created_by: users(:acme_admin))
+
+        body = { data: { username: "new-user", password: "new-pass" } }
+        patch api_v1_broker_credential_url(id: bc.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        bc.reload
+        assert_equal "new-user", bc.username
+        assert_equal "new-pass", bc.password
+        refute bc.dead?
+        assert_nil bc.dead_reason
+        assert_equal 0, bc.failure_count
+        assert bc.next_attempt_at.present?
       end
 
       test "destroy removes the credential" do

--- a/services/console/test/controllers/console/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/console/broker_credentials_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 module Console
   # Covers the broker credential create/edit form controller: what gets built and
   # persisted (identity, OAuth config, scopes, headers, refresh policy, write-
-  # only bootstrap fields), redirects, that blank write-only fields leave the
+  # only initial values), redirects, that blank write-only fields leave the
   # stored values in place, and that invalid input is rejected (422) without writing.
   class BrokerCredentialsControllerTest < ActionDispatch::IntegrationTest
     setup do
@@ -56,7 +56,7 @@ module Console
       assert_equal @operator, cred.created_by
     end
 
-    test "POST create builds a password grant credential with write-only bootstrap fields" do
+    test "POST create builds a password grant credential with write-only initial values" do
       assert_difference -> { BrokerCredential.count } => 1 do
         post console_broker_credentials_url, params: {
           credential: {
@@ -132,7 +132,7 @@ module Console
       cred.reload
       assert_equal "original-secret", cred.client_secret
       assert_equal "original-token", cred.refresh_token
-      # A blank seed must not re-bootstrap: dead state is untouched.
+      # A blank seed must not reschedule: dead state is untouched.
       assert cred.dead?
     end
 
@@ -160,7 +160,7 @@ module Console
       assert_equal "pass", cred.password
     end
 
-    test "PATCH update with a fresh refresh_token re-bootstraps the credential" do
+    test "PATCH update with a fresh refresh_token reschedules the credential" do
       cred = broker_credentials(:acme_managed_gmail)
       cred.update!(refresh_token: "old", dead: true, dead_reason: "stale", failure_count: 3)
 

--- a/services/console/test/controllers/console/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/console/broker_credentials_controller_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 module Console
   # Covers the broker credential create/edit form controller: what gets built and
-  # persisted (identity, OAuth config, scopes, headers, refresh policy, the write-
-  # only refresh_token seed), redirects, that blank write-only fields leave the
+  # persisted (identity, OAuth config, scopes, headers, refresh policy, write-
+  # only bootstrap fields), redirects, that blank write-only fields leave the
   # stored values in place, and that invalid input is rejected (422) without writing.
   class BrokerCredentialsControllerTest < ActionDispatch::IntegrationTest
     setup do
@@ -54,6 +54,30 @@ module Console
       assert_equal 0.5, cred.early_refresh_fraction
       assert_equal 120, cred.early_refresh_slack_seconds
       assert_equal @operator, cred.created_by
+    end
+
+    test "POST create builds a password grant credential with write-only bootstrap fields" do
+      assert_difference -> { BrokerCredential.count } => 1 do
+        post console_broker_credentials_url, params: {
+          credential: {
+            namespace: "acme", foreign_id: "alphasense", name: "AlphaSense",
+            grant: "password", token_endpoint: "https://api.alpha-sense.com/auth",
+            client_id: "alpha-client", client_secret: "alpha-secret",
+            username: "alpha-user", password: "alpha-password",
+            early_refresh_fraction: "0.5", early_refresh_slack_seconds: "120",
+            max_refresh_interval_seconds: "3600", refresh_timeout_seconds: "10"
+          },
+          headers: { "0" => { key: "x-api-key", value: "alpha-key" } }
+        }
+      end
+
+      cred = BrokerCredential.find_by!(namespace: "acme", foreign_id: "alphasense")
+      assert_redirected_to console_credential_path(cred.oid)
+      assert_equal "password", cred.grant
+      assert_equal "alpha-user", cred.username
+      assert_equal "alpha-password", cred.password
+      assert_equal "alpha-secret", cred.client_secret
+      assert_equal({ "x-api-key" => "alpha-key" }, cred.token_endpoint_headers)
     end
 
     test "POST create without a token endpoint or client id is rejected without writing" do
@@ -110,6 +134,30 @@ module Console
       assert_equal "original-token", cred.refresh_token
       # A blank seed must not re-bootstrap: dead state is untouched.
       assert cred.dead?
+    end
+
+    test "PATCH update with blank password grant fields leaves them in place" do
+      cred = BrokerCredential.create!(namespace: "acme", foreign_id: "password-console",
+                                      grant: "password", token_endpoint: "https://idp.example/token",
+                                      client_id: "cid", client_secret: "secret",
+                                      username: "user", password: "pass", created_by: @operator)
+
+      patch console_broker_credential_url(cred.oid), params: {
+        credential: {
+          namespace: cred.namespace, foreign_id: cred.foreign_id,
+          grant: "password", token_endpoint: cred.token_endpoint, client_id: cred.client_id,
+          client_secret: "", username: "", password: "",
+          early_refresh_fraction: cred.early_refresh_fraction,
+          early_refresh_slack_seconds: cred.early_refresh_slack_seconds,
+          max_refresh_interval_seconds: cred.max_refresh_interval_seconds,
+          refresh_timeout_seconds: cred.refresh_timeout_seconds
+        }
+      }
+      assert_redirected_to console_credential_path(cred.oid)
+      cred.reload
+      assert_equal "secret", cred.client_secret
+      assert_equal "user", cred.username
+      assert_equal "pass", cred.password
     end
 
     test "PATCH update with a fresh refresh_token re-bootstraps the credential" do

--- a/services/console/test/jobs/broker/jobs_test.rb
+++ b/services/console/test/jobs/broker/jobs_test.rb
@@ -25,6 +25,18 @@ module Broker
       refute_includes enqueued_ids, future.id
     end
 
+    test "PollRefreshJob enqueues due password grant credentials without refresh tokens" do
+      due = make_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
+      due.update_columns(last_refresh: 1.hour.ago, next_attempt_at: 1.minute.ago)
+
+      Broker::PollRefreshJob.perform_now
+
+      enqueued_ids = enqueued_jobs
+        .select { |j| j[:job] == Broker::RefreshCredentialJob }
+        .map { |j| j[:args].first }
+      assert_includes enqueued_ids, due.id
+    end
+
     test "RefreshCredentialJob drives the credential refresh" do
       # No refresh_token seed: refresh! marks the credential dead without any
       # network call, proving the job invoked it.

--- a/services/console/test/jobs/broker/jobs_test.rb
+++ b/services/console/test/jobs/broker/jobs_test.rb
@@ -44,7 +44,7 @@ module Broker
       Broker::RefreshCredentialJob.perform_now(bc.id)
       bc.reload
       assert bc.dead?
-      assert_equal "blob_not_bootstrapped", bc.dead_reason
+      assert_equal "missing_initial_refresh_token", bc.dead_reason
     end
 
     test "RefreshCredentialJob is a no-op for a missing credential" do

--- a/services/console/test/lib/broker/refresh_client_test.rb
+++ b/services/console/test/lib/broker/refresh_client_test.rb
@@ -51,6 +51,28 @@ module Broker
       assert_equal "k", http.captured[:headers]["X-Api-Key"]
     end
 
+    test "form carries the password grant and optional fields" do
+      client, http = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 60 }.to_json)
+      client.refresh(
+        token_endpoint: "https://idp.example/token",
+        grant: "password",
+        client_id: "cid",
+        client_secret: "sec",
+        username: "user",
+        password: "pass",
+        scopes: %w[a b],
+        headers: { "X-Api-Key" => "k" }
+      )
+      form = http.captured[:form]
+      assert_equal "password", form["grant_type"]
+      assert_equal "user", form["username"]
+      assert_equal "pass", form["password"]
+      assert_equal "cid", form["client_id"]
+      assert_equal "sec", form["client_secret"]
+      assert_equal "a b", form["scope"]
+      assert_equal "k", http.captured[:headers]["X-Api-Key"]
+    end
+
     test "absent refresh_token in response means no rotation" do
       client, _ = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
       result = client.refresh(**base_args)
@@ -107,6 +129,14 @@ module Broker
       client, _ = client_with(status: 200, body: "{}")
       assert_raises(ArgumentError) { client.refresh(**base_args(refresh_token: "")) }
       assert_raises(ArgumentError) { client.refresh(**base_args(client_id: "")) }
+      assert_raises(ArgumentError) do
+        client.refresh(token_endpoint: "https://idp.example/token", grant: "password",
+                       client_id: "cid", username: "", password: "pass")
+      end
+      assert_raises(ArgumentError) do
+        client.refresh(token_endpoint: "https://idp.example/token", grant: "device_code",
+                       client_id: "cid")
+      end
     end
   end
 end

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -239,7 +239,7 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert_equal({ "X-Api-Key" => "k" }, captured[:headers])
   end
 
-  test "password grant bootstraps with username and password and stores returned refresh_token" do
+  test "password grant uses initial values and stores returned refresh_token" do
     captured = {}
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
     bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: "RT-new") }
@@ -309,24 +309,24 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert_equal 1, bc.failure_count
   end
 
-  test "refresh with no seed marks dead as not bootstrapped" do
+  test "refresh with no seed marks dead as missing a seed" do
     bc = create_credential(refresh_token: "seed")
     bc.update_columns(refresh_token: nil)
     bc.reload
     bc.refresh!
     bc.reload
     assert bc.dead?
-    assert_equal "blob_not_bootstrapped", bc.dead_reason
+    assert_equal "missing_initial_refresh_token", bc.dead_reason
   end
 
-  test "password grant with missing bootstrap fields marks dead" do
+  test "password grant with missing initial values marks dead" do
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
     bc.update_columns(username: nil)
     bc.reload
     bc.refresh!
     bc.reload
     assert bc.dead?
-    assert_equal "password_grant_not_bootstrapped", bc.dead_reason
+    assert_equal "password_grant_missing_initial_values", bc.dead_reason
   end
 
   # --- scope ----------------------------------------------------------------

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -282,8 +282,10 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   end
 
   test "password grant clears stale refresh_token when password fallback succeeds without rotation" do
+    grants = []
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-bad")
     bc.refresh_client = StubClient.new do |**kw|
+      grants << kw[:grant]
       if kw[:grant] == "refresh_token"
         raise Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false)
       end
@@ -291,6 +293,7 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     end
     bc.refresh!
     bc.reload
+    assert_equal %w[refresh_token password], grants
     assert_nil bc.refresh_token
     assert_equal "AT-password", bc.access_token
   end

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -47,6 +47,17 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert bc.errors[:client_id].any?
   end
 
+  test "password grant is valid with username and password" do
+    bc = build_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
+    assert bc.valid?, bc.errors.full_messages.to_sentence
+  end
+
+  test "password grant requires username and password" do
+    bc = build_credential(grant: "password", username: "user", password: nil, refresh_token: nil)
+    refute bc.valid?
+    assert bc.errors[:password].any? { |m| m.include?("password grant") }
+  end
+
   # --- oauth_app provenance (flow-minted credentials) -----------------------
 
   def build_app(**overrides)
@@ -118,13 +129,18 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert bc.valid?, bc.errors.full_messages.to_sentence
   end
 
-  test "client_secret and token_endpoint_headers are encrypted at rest" do
-    bc = create_credential(client_secret: "shh", token_endpoint_headers: { "X-Api-Key" => "k" })
+  test "client_secret, password grant fields, and token_endpoint_headers are encrypted at rest" do
+    bc = create_credential(client_secret: "shh", username: "alice", password: "p4ss",
+                           token_endpoint_headers: { "X-Api-Key" => "k" })
     raw = BrokerCredential.connection.select_one(
-      "SELECT client_secret, token_endpoint_headers FROM broker_credentials WHERE id = #{bc.id}"
+      "SELECT client_secret, username, password, token_endpoint_headers FROM broker_credentials WHERE id = #{bc.id}"
     )
     refute_includes raw["client_secret"].to_s, "shh"
+    refute_includes raw["username"].to_s, "alice"
+    refute_includes raw["password"].to_s, "p4ss"
     refute_includes raw["token_endpoint_headers"].to_s, "X-Api-Key"
+    assert_equal "alice", bc.reload.username
+    assert_equal "p4ss", bc.password
     assert_equal({ "X-Api-Key" => "k" }, bc.reload.token_endpoint_headers)
   end
 
@@ -223,6 +239,76 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert_equal({ "X-Api-Key" => "k" }, captured[:headers])
   end
 
+  test "password grant bootstraps with username and password and stores returned refresh_token" do
+    captured = {}
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
+    bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: "RT-new") }
+    bc.refresh!
+    bc.reload
+    assert_equal "password", captured[:grant]
+    assert_equal "user", captured[:username]
+    assert_equal "pass", captured[:password]
+    assert_equal "RT-new", bc.refresh_token
+    assert_equal "AT", bc.access_token
+  end
+
+  test "password grant prefers a stored refresh_token" do
+    captured = {}
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-old")
+    bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: nil) }
+    bc.refresh!
+    bc.reload
+    assert_equal "refresh_token", captured[:grant]
+    assert_equal "RT-old", captured[:refresh_token]
+    assert_equal "RT-old", bc.refresh_token
+  end
+
+  test "password grant falls back to password when stored refresh_token is rejected" do
+    grants = []
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-bad")
+    bc.refresh_client = StubClient.new do |**kw|
+      grants << kw[:grant]
+      if kw[:grant] == "refresh_token"
+        raise Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false)
+      end
+      result(access_token: "AT-password", refresh_token: "RT-good")
+    end
+    bc.refresh!
+    bc.reload
+    assert_equal %w[refresh_token password], grants
+    assert_equal "AT-password", bc.access_token
+    assert_equal "RT-good", bc.refresh_token
+    refute bc.dead?
+  end
+
+  test "password grant clears stale refresh_token when password fallback succeeds without rotation" do
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-bad")
+    bc.refresh_client = StubClient.new do |**kw|
+      if kw[:grant] == "refresh_token"
+        raise Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false)
+      end
+      result(access_token: "AT-password", refresh_token: nil)
+    end
+    bc.refresh!
+    bc.reload
+    assert_nil bc.refresh_token
+    assert_equal "AT-password", bc.access_token
+  end
+
+  test "password grant does not fall back on retryable refresh_token failure" do
+    grants = []
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-old")
+    bc.refresh_client = StubClient.new do |**kw|
+      grants << kw[:grant]
+      raise Broker::RefreshError.new("net", stage: "network", retryable: true)
+    end
+    bc.refresh!
+    bc.reload
+    assert_equal [ "refresh_token" ], grants
+    refute bc.dead?
+    assert_equal 1, bc.failure_count
+  end
+
   test "refresh with no seed marks dead as not bootstrapped" do
     bc = create_credential(refresh_token: "seed")
     bc.update_columns(refresh_token: nil)
@@ -231,6 +317,16 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc.reload
     assert bc.dead?
     assert_equal "blob_not_bootstrapped", bc.dead_reason
+  end
+
+  test "password grant with missing bootstrap fields marks dead" do
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
+    bc.update_columns(username: nil)
+    bc.reload
+    bc.refresh!
+    bc.reload
+    assert bc.dead?
+    assert_equal "password_grant_not_bootstrapped", bc.dead_reason
   end
 
   # --- scope ----------------------------------------------------------------
@@ -249,6 +345,13 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert_includes ids, never.id
     refute_includes ids, future.id
     refute_includes ids, dead.id
+  end
+
+  test "refreshable includes password grant credentials without a refresh_token" do
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
+    bc.update_columns(last_refresh: 1.hour.ago, next_attempt_at: 1.minute.ago)
+
+    assert_includes BrokerCredential.refreshable.pluck(:id), bc.id
   end
 
   # --- delete guard ---------------------------------------------------------


### PR DESCRIPTION
Adds Password Grant support to managed broker credentials so providers like AlphaSense can use username/password initial values and then reuse returned Refresh Token values. The broker now records grant type and encrypted username/password fields, preserves write-only handling in the API and console, and documents the AlphaSense setup.