### PR TITLE
Fix Discord CLI read commands hanging

### DIFF
--- a/tools/comms/discord/client.py
+++ b/tools/comms/discord/client.py
@@ -1,20 +1,16 @@
 """Discord self-token client."""
 
-import asyncio
 import re
+import time
+from datetime import datetime, timezone
 from typing import Any
 
 import httpx
 
-import discord
 from centaur_sdk import secret
 
 BASE_URL = "https://discord.com/api/v10"
 INVITE_RE = re.compile(r"(?:https?://)?(?:discord(?:\.gg|\.com/invite)/)?([A-Za-z0-9-]+)")
-
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 class DiscordClient:
@@ -41,6 +37,14 @@ class DiscordClient:
         }
         with httpx.Client(timeout=self.timeout) as client:
             response = client.request(method, f"{BASE_URL}{endpoint}", headers=headers, **kwargs)
+            if response.status_code == 429:
+                try:
+                    retry_after = float(response.json().get("retry_after", 0))
+                except Exception:
+                    retry_after = 0
+                if 0 < retry_after <= self.timeout:
+                    time.sleep(retry_after)
+                    response = client.request(method, f"{BASE_URL}{endpoint}", headers=headers, **kwargs)
         if response.status_code == 204:
             return {}
         if response.status_code >= 400:
@@ -50,29 +54,6 @@ class DiscordClient:
                 message = response.text
             raise RuntimeError(f"Discord API error ({response.status_code}): {message}")
         return response.json()
-
-    async def _with_client(self, action):
-        client = discord.Client()
-        done = asyncio.Event()
-        result: Any = None
-        error: BaseException | None = None
-
-        @client.event
-        async def on_ready():
-            nonlocal result, error
-            try:
-                result = await action(client)
-            except BaseException as exc:
-                error = exc
-            finally:
-                done.set()
-                await client.close()
-
-        await client.start(self._get_token())
-        await done.wait()
-        if error:
-            raise error
-        return result
 
     def get_me(self) -> dict[str, Any]:
         """Get the current Discord user."""
@@ -93,76 +74,80 @@ class DiscordClient:
 
     def list_servers(self, query: str = "", limit: int = 100) -> list[dict[str, Any]]:
         """List joined servers/guilds."""
-
-        async def action(client):
-            rows = []
-            for guild in client.guilds:
-                if query and query.lower() not in guild.name.lower():
-                    continue
-                rows.append({"id": str(guild.id), "name": guild.name, "member_count": guild.member_count})
-                if len(rows) >= limit:
-                    break
-            return rows
-
-        return _run(self._with_client(action))
+        rows = []
+        for guild in self._request("GET", "/users/@me/guilds"):
+            if query and query.lower() not in guild.get("name", "").lower():
+                continue
+            rows.append(
+                {
+                    "id": str(guild.get("id", "")),
+                    "name": guild.get("name", ""),
+                    "member_count": guild.get("approximate_member_count"),
+                }
+            )
+            if len(rows) >= limit:
+                break
+        return rows
 
     def list_channels(self, guild: str, query: str = "") -> list[dict[str, Any]]:
         """List text channels in a server by name or ID."""
-
-        async def action(client):
-            resolved = self._find_guild(client, guild)
-            rows = []
-            for channel in resolved.text_channels:
-                if query and query.lower().lstrip("#") not in channel.name.lower():
-                    continue
-                rows.append(
-                    {
-                        "id": str(channel.id),
-                        "name": channel.name,
-                        "guild_id": str(resolved.id),
-                        "guild_name": resolved.name,
-                    }
-                )
-            return rows
-
-        return _run(self._with_client(action))
+        resolved = self._find_guild(guild)
+        rows = []
+        needle = query.lower().lstrip("#")
+        for channel in self._guild_channels(resolved["id"]):
+            if channel.get("type") != 0:
+                continue
+            if needle and needle not in channel.get("name", "").lower():
+                continue
+            rows.append(
+                {
+                    "id": str(channel.get("id", "")),
+                    "name": channel.get("name", ""),
+                    "guild_id": str(resolved["id"]),
+                    "guild_name": resolved["name"],
+                }
+            )
+        return rows
 
     def get_messages(self, channel: str, limit: int = 50) -> list[dict[str, Any]]:
         """Get recent messages from a channel by name or ID."""
-
-        async def action(client):
-            resolved = self._find_channel(client, channel)
-            messages = [self._format_message(msg) async for msg in resolved.history(limit=limit)]
-            return list(reversed(messages))
-
-        return _run(self._with_client(action))
+        resolved = self._find_channel(channel)
+        messages = self._request("GET", f"/channels/{resolved['id']}/messages", params={"limit": min(limit, 100)})
+        return list(reversed([self._format_message(msg, resolved.get("name")) for msg in messages]))
 
     def search_messages(self, query: str, channel: str, limit: int = 50) -> list[dict[str, Any]]:
         """Search recent messages in one channel by name or ID."""
-
-        async def action(client):
-            resolved = self._find_channel(client, channel)
-            rows = []
-            async for msg in resolved.history(limit=500):
-                if query.lower() in (msg.content or "").lower():
-                    rows.append(self._format_message(msg))
+        resolved = self._find_channel(channel)
+        rows = []
+        before = None
+        while len(rows) < limit:
+            params: dict[str, Any] = {"limit": 100}
+            if before:
+                params["before"] = before
+            messages = self._request("GET", f"/channels/{resolved['id']}/messages", params=params)
+            if not messages:
+                break
+            for msg in messages:
+                if query.lower() in (msg.get("content") or "").lower():
+                    rows.append(self._format_message(msg, resolved.get("name")))
                     if len(rows) >= limit:
                         break
-            return list(reversed(rows))
-
-        return _run(self._with_client(action))
+            before = messages[-1].get("id")
+        return list(reversed(rows))
 
     def search_all(self, guild: str, query: str, limit: int = 50) -> list[dict[str, Any]]:
         """Search messages across a server by name or ID."""
-
-        async def action(client):
-            resolved = self._find_guild(client, guild)
-            rows = []
-            async for msg in resolved.search(query, limit=limit):
-                rows.append(self._format_message(msg, channel_name=f"#{msg.channel.name}"))
-            return rows
-
-        return _run(self._with_client(action))
+        resolved = self._find_guild(guild)
+        channels = [c for c in self._guild_channels(resolved["id"]) if c.get("type") == 0]
+        rows = []
+        for channel in channels:
+            try:
+                rows.extend(self.search_messages(query, channel["id"], limit=limit - len(rows)))
+            except RuntimeError:
+                continue
+            if len(rows) >= limit:
+                break
+        return rows
 
     def get_context(
         self,
@@ -172,15 +157,20 @@ class DiscordClient:
         after: int = 10,
     ) -> list[dict[str, Any]]:
         """Get messages around a specific message."""
-
-        async def action(client):
-            resolved = self._find_channel(client, channel)
-            target = await resolved.fetch_message(int(message_id))
-            after_msgs = [msg async for msg in resolved.history(limit=after, after=target)]
-            before_msgs = [msg async for msg in resolved.history(limit=before, before=target)]
-            return [self._format_message(msg) for msg in [*reversed(after_msgs), target, *before_msgs]]
-
-        return _run(self._with_client(action))
+        resolved = self._find_channel(channel)
+        target = self._request("GET", f"/channels/{resolved['id']}/messages/{message_id}")
+        before_msgs = self._request(
+            "GET",
+            f"/channels/{resolved['id']}/messages",
+            params={"limit": min(before, 100), "before": message_id},
+        )
+        after_msgs = self._request(
+            "GET",
+            f"/channels/{resolved['id']}/messages",
+            params={"limit": min(after, 100), "after": message_id},
+        )
+        messages = [*reversed(after_msgs), target, *before_msgs]
+        return [self._format_message(msg, resolved.get("name")) for msg in messages]
 
     def post_message(
         self,
@@ -189,58 +179,88 @@ class DiscordClient:
         reply_to_message_id: str | None = None,
     ) -> dict[str, Any]:
         """Post a message to a channel by name or ID."""
+        resolved = self._find_channel(channel)
+        payload: dict[str, Any] = {"content": content}
+        if reply_to_message_id:
+            payload["message_reference"] = {"message_id": reply_to_message_id}
+        msg = self._request("POST", f"/channels/{resolved['id']}/messages", json=payload)
+        return self._format_message(msg, resolved.get("name"))
 
-        async def action(client):
-            resolved = self._find_channel(client, channel)
-            reference = None
-            if reply_to_message_id:
-                reference = await resolved.fetch_message(int(reply_to_message_id))
-            msg = await resolved.send(content, reference=reference)
-            return self._format_message(msg)
+    def _guild_channels(self, guild_id: str) -> list[dict[str, Any]]:
+        return list(self._request("GET", f"/guilds/{guild_id}/channels"))
 
-        return _run(self._with_client(action))
-
-    def _find_guild(self, client, guild_str: str):
+    def _find_guild(self, guild_str: str) -> dict[str, Any]:
+        guilds = list(self._request("GET", "/users/@me/guilds"))
         if guild_str.isdigit():
-            guild = client.get_guild(int(guild_str))
-            if guild:
-                return guild
-        for guild in client.guilds:
-            if guild.name.lower() == guild_str.lower():
-                return guild
-        for guild in client.guilds:
-            if guild_str.lower() in guild.name.lower():
-                return guild
+            for guild in guilds:
+                if guild.get("id") == guild_str:
+                    return {"id": str(guild["id"]), "name": guild.get("name", "")}
+        for guild in guilds:
+            if guild.get("name", "").lower() == guild_str.lower():
+                return {"id": str(guild["id"]), "name": guild.get("name", "")}
+        for guild in guilds:
+            if guild_str.lower() in guild.get("name", "").lower():
+                return {"id": str(guild["id"]), "name": guild.get("name", "")}
         raise RuntimeError(f"Guild not found: {guild_str}")
 
-    def _find_channel(self, client, channel_str: str):
+    def _find_channel(self, channel_str: str) -> dict[str, Any]:
         if channel_str.isdigit():
-            channel = client.get_channel(int(channel_str))
-            if channel:
-                return channel
+            channel = dict(self._request("GET", f"/channels/{channel_str}"))
+            return {
+                "id": str(channel["id"]),
+                "name": channel.get("name"),
+                "guild_id": str(channel.get("guild_id", "")),
+                "guild_name": None,
+            }
         needle = channel_str.lstrip("#").lower()
-        for guild in client.guilds:
-            for channel in guild.text_channels:
-                if channel.name.lower() == needle:
-                    return channel
-        for guild in client.guilds:
-            for channel in guild.text_channels:
-                if needle in channel.name.lower():
-                    return channel
+        partial = None
+        for guild in self._request("GET", "/users/@me/guilds"):
+            for channel in self._guild_channels(guild["id"]):
+                if channel.get("type") != 0:
+                    continue
+                name = channel.get("name", "")
+                if name.lower() == needle:
+                    return {
+                        "id": str(channel["id"]),
+                        "name": name,
+                        "guild_id": str(guild["id"]),
+                        "guild_name": guild.get("name"),
+                    }
+                if partial is None and needle in name.lower():
+                    partial = {
+                        "id": str(channel["id"]),
+                        "name": name,
+                        "guild_id": str(guild["id"]),
+                        "guild_name": guild.get("name"),
+                    }
+        if partial:
+            return partial
         raise RuntimeError(f"Channel not found: {channel_str}")
 
-    def _format_message(self, msg, channel_name: str | None = None) -> dict[str, Any]:
+    def _format_message(self, msg: dict[str, Any], channel_name: str | None = None) -> dict[str, Any]:
+        author = msg.get("author") or {}
         return {
-            "id": str(msg.id),
-            "channel_id": str(msg.channel.id),
-            "channel_name": channel_name or getattr(msg.channel, "name", None),
-            "author": getattr(msg.author, "display_name", None) or str(msg.author),
-            "author_id": str(msg.author.id),
-            "timestamp": msg.created_at.isoformat(),
-            "content": msg.content or "",
-            "reply_to": str(msg.reference.message_id) if msg.reference else None,
+            "id": str(msg.get("id", "")),
+            "channel_id": str(msg.get("channel_id", "")),
+            "channel_name": channel_name,
+            "author": author.get("global_name") or author.get("username") or "",
+            "author_id": str(author.get("id", "")),
+            "timestamp": _format_timestamp(msg),
+            "content": msg.get("content") or "",
+            "reply_to": ((msg.get("message_reference") or {}).get("message_id")),
         }
 
 
 def _client() -> DiscordClient:
     return DiscordClient()
+
+
+def _format_timestamp(msg: dict[str, Any]) -> str:
+    timestamp = msg.get("timestamp")
+    if timestamp:
+        return str(timestamp)
+    snowflake = msg.get("id")
+    if not snowflake:
+        return ""
+    created_ms = (int(snowflake) >> 22) + 1420070400000
+    return datetime.fromtimestamp(created_ms / 1000, tz=timezone.utc).isoformat()

--- a/tools/comms/discord/pyproject.toml
+++ b/tools/comms/discord/pyproject.toml
@@ -4,7 +4,6 @@ description = "Discord self-token CLI for AI agents - guilds, channels, search, 
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "discord.py-self>=2.1",
     "httpx>=0.27.0",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/tools/comms/discord/tests/test_client.py
+++ b/tools/comms/discord/tests/test_client.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -20,27 +19,69 @@ def test_join_server_posts_invite_code(monkeypatch):
     assert client.join_server("https://discord.gg/abc123")["guild"]["name"] == "Test"
 
 
-def test_find_guild_exact_then_partial_name():
+def test_list_servers_uses_rest(monkeypatch):
     client = DiscordClient(token="unused")
-    discord_client = SimpleNamespace(
-        guilds=[
-            SimpleNamespace(id=1, name="General"),
-            SimpleNamespace(id=2, name="Eth R&D"),
-        ],
-        get_guild=lambda guild_id: None,
-    )
 
-    assert client._find_guild(discord_client, "Eth R&D").id == 2
-    assert client._find_guild(discord_client, "eth").id == 2
+    def fake_request(method, endpoint, **kwargs):
+        assert method == "GET"
+        assert endpoint == "/users/@me/guilds"
+        return [
+            {"id": "1", "name": "General", "approximate_member_count": 10},
+            {"id": "2", "name": "Eth R&D", "approximate_member_count": 20},
+        ]
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    assert client.list_servers("eth") == [{"id": "2", "name": "Eth R&D", "member_count": 20}]
 
 
-def test_find_channel_supports_hash_prefix_and_partial_name():
+def test_find_guild_exact_then_partial_name(monkeypatch):
     client = DiscordClient(token="unused")
-    channel = SimpleNamespace(id=11, name="announcements")
-    discord_client = SimpleNamespace(
-        guilds=[SimpleNamespace(text_channels=[channel])],
-        get_channel=lambda channel_id: None,
-    )
 
-    assert client._find_channel(discord_client, "#announcements").id == 11
-    assert client._find_channel(discord_client, "announce").id == 11
+    def fake_request(method, endpoint, **kwargs):
+        assert method == "GET"
+        assert endpoint == "/users/@me/guilds"
+        return [
+            {"id": "1", "name": "General"},
+            {"id": "2", "name": "Eth R&D"},
+        ]
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    assert client._find_guild("Eth R&D")["id"] == "2"
+    assert client._find_guild("eth")["id"] == "2"
+
+
+def test_find_channel_supports_hash_prefix_and_partial_name(monkeypatch):
+    client = DiscordClient(token="unused")
+
+    def fake_request(method, endpoint, **kwargs):
+        assert method == "GET"
+        if endpoint == "/users/@me/guilds":
+            return [{"id": "1", "name": "General"}]
+        if endpoint == "/guilds/1/channels":
+            return [{"id": "11", "name": "announcements", "type": 0}]
+        raise AssertionError(endpoint)
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    assert client._find_channel("#announcements")["id"] == "11"
+    assert client._find_channel("announce")["id"] == "11"
+
+
+def test_find_channel_by_id_uses_channel_endpoint(monkeypatch):
+    client = DiscordClient(token="unused")
+
+    def fake_request(method, endpoint, **kwargs):
+        assert method == "GET"
+        assert endpoint == "/channels/11"
+        return {"id": "11", "name": "announcements", "guild_id": "1"}
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    assert client._find_channel("11") == {
+        "id": "11",
+        "name": "announcements",
+        "guild_id": "1",
+        "guild_name": None,
+    }


### PR DESCRIPTION
## Summary
- replace short-lived discord.py-self Gateway clients with Discord REST API calls for read/search/post CLI operations
- add bounded retry handling for Discord 429 responses
- remove the now-unused discord.py-self dependency and update focused client tests

## Verification
- `PYTHONPATH=/home/agent/branches/paradigmxyz/centaur:/home/agent/branches/paradigmxyz/centaur/tools/comms/discord UV_PROJECT_ENVIRONMENT=/tmp/discord-test-venv uv run --with httpx --with typer --with rich --with python-dotenv --with pytest pytest -q tools/comms/discord/tests/test_client.py`
- `UV_PROJECT_ENVIRONMENT=/tmp/discord-live-venv3 uv run --project tools/comms/discord --no-editable discord servers --limit 5 --json`
- `UV_PROJECT_ENVIRONMENT=/tmp/discord-live-venv3 uv run --project tools/comms/discord --no-editable discord channels 595666850260713488 --json`
- `UV_PROJECT_ENVIRONMENT=/tmp/discord-live-venv4 uv run --project tools/comms/discord --no-editable discord messages 595701895700676644 --limit 2 --json`

Prompted by: @Zygimantass