### PR TITLE
Suppress reasoning cards in Slack streams

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -152,6 +152,23 @@ describe('CodexAppServerRendererEventMapper', () => {
     })
   })
 
+  it('can omit reasoning Thinking tasks for Slack surfaces', () => {
+    const mapper = new CodexAppServerRendererEventMapper({ reasoningTasks: 'omit' })
+
+    const first = mapper.process({
+      type: 'item.reasoning.textDelta',
+      itemId: 'reasoning-1',
+      delta: 'Inspecting the event stream'
+    })
+    expect(first.find(event => event.type === 'renderer.task.update')).toBeUndefined()
+
+    const sealed = mapper.process({
+      type: 'item.completed',
+      item: { id: 'reasoning-1', type: 'reasoning', content: ['Inspecting the event stream'] }
+    })
+    expect(sealed.find(event => event.type === 'renderer.task.update')).toBeUndefined()
+  })
+
   it('holds the last finished task in_progress so the Slack header never claims completion mid-turn', () => {
     const mapper = new CodexAppServerRendererEventMapper()
 
@@ -470,6 +487,33 @@ describe('CodexAppServerRendererEventMapper', () => {
       title: 'Thinking',
       status: 'complete'
     })
+  })
+
+  it('omits reasoning chunks when configured for Slack', async () => {
+    const chunks = await collect(
+      codexAppServerToChatSdkStream(
+        toAsyncIterable([
+          {
+            method: 'item/reasoning/summaryTextDelta',
+            params: {
+              itemId: 'reasoning-1',
+              delta: 'Inspecting the event stream'
+            }
+          },
+          {
+            method: 'turn/completed',
+            params: {
+              turn: { id: 'turn-1', items: [], status: 'completed' }
+            }
+          }
+        ]),
+        { reasoningTasks: 'omit' }
+      )
+    )
+
+    expect(
+      chunks.some(chunk => chunk.type === 'task_update' && chunk.title === 'Thinking')
+    ).toBe(false)
   })
 
   it('streams command details once and command output incrementally', async () => {

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -73,6 +73,7 @@ export type CodexAppServerRendererEventMapperOptions = {
   sessionId?: string
   logInfo?: RendererLogInfo
   unknownAgentMessagePhase?: AgentMessagePhase
+  reasoningTasks?: 'visible' | 'omit'
   taskOutput?: 'full' | 'omit'
 }
 
@@ -89,12 +90,14 @@ export class CodexAppServerRendererEventMapper
   private readonly logInfo?: RendererLogInfo
   private readonly unknownAgentMessagePhase: AgentMessagePhase
   private readonly includeTaskOutput: boolean
+  private readonly includeReasoningTasks: boolean
 
   constructor(options: CodexAppServerRendererEventMapperOptions = {}) {
     this.sessionId = options.sessionId ?? ''
     this.logInfo = options.logInfo
     this.unknownAgentMessagePhase = options.unknownAgentMessagePhase ?? 'final_answer'
     this.includeTaskOutput = options.taskOutput === 'full'
+    this.includeReasoningTasks = options.reasoningTasks !== 'omit'
   }
 
   process(source: ServerNotification | RustSessionStreamEvent | unknown): RendererEvent[] {
@@ -302,7 +305,7 @@ export class CodexAppServerRendererEventMapper
     }
 
     const reasoningMessage = reasoningText(event)
-    if (reasoningMessage.trim()) {
+    if (reasoningMessage.trim() && this.includeReasoningTasks) {
       const itemId = reasoningEventItemId(event)
       if (isReasoningDeltaEvent(event) && itemId) {
         // Accumulate deltas into one task per reasoning item and keep it
@@ -343,7 +346,7 @@ export class CodexAppServerRendererEventMapper
     }
 
     const sealedReasoning = completedReasoningItem(event)
-    if (sealedReasoning) {
+    if (sealedReasoning && this.includeReasoningTasks) {
       const id = String(sealedReasoning.id ?? '')
       const accumulated = id ? this.state.reasoningTextByItemId.get(id) ?? '' : ''
       const finalText = (reasoningItemText(sealedReasoning) || accumulated).trim()

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -2263,6 +2263,7 @@ function rendererOptions(
   const mapper = options.mapper
   return {
     ...mapper,
+    reasoningTasks: mapper?.reasoningTasks ?? 'omit',
     logInfo: rendererLogInfo(options, capture),
     async onRendererEvent(event: RendererEvent) {
       await mapper?.onRendererEvent?.(event)
@@ -2282,6 +2283,7 @@ function fallbackRendererOptions(options: SlackbotV2Options): CodexAppServerToCh
   const mapper = options.mapper
   return {
     ...mapper,
+    reasoningTasks: mapper?.reasoningTasks ?? 'omit',
     logInfo: rendererLogInfo(options),
     async onRendererEvent(event: RendererEvent) {
       try {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -302,7 +302,7 @@ describe('slackbotv2', () => {
     expect(text).toContain('Implementation plan')
     expect(text).toContain('Inspect App Server events')
     expect(text).toContain('Checking the command output')
-    expect(text).toContain('Inspecting the event stream')
+    expect(text).not.toContain('Inspecting the event stream')
     expect(text).toContain('Command execution')
     expect(text).toContain('pnpm test')
     expect(text).not.toContain('tests passed')
@@ -4570,12 +4570,11 @@ function expectSlackPlanStreamShape(
         status: 'complete'
       })
     )
-    expect(progressChunks).toContainEqual(
+    expect(progressChunks).not.toContainEqual(
       expect.objectContaining({
         type: 'task_update',
         id: 'reasoning-1',
-        title: 'Thinking',
-        status: 'complete'
+        title: 'Thinking'
       })
     )
     expect(progressChunks).toContainEqual(
@@ -4600,7 +4599,7 @@ function expectSlackPlanStreamShape(
     expect(renderedText).toContain('Inspect App Server events')
     expect(renderedText).toContain('Stream Chat SDK chunks')
     expect(renderedText).toContain('Checking the command output')
-    expect(renderedText).toContain('Inspecting the event stream')
+    expect(renderedText).not.toContain('Inspecting the event stream')
     expect(renderedText).toContain('Command execution')
     expect(renderedText).toContain('pnpm test')
     expect(renderedText).not.toContain('tests passed')
@@ -4614,7 +4613,7 @@ function expectSlackRenderedReply(text: string, answer: string): void {
   expect(text).toContain('Stream Chat SDK chunks')
   expect(text).toContain('Thinking')
   expect(text).toContain('Checking the command output')
-  expect(text).toContain('Inspecting the event stream')
+  expect(text).not.toContain('Inspecting the event stream')
   expect(text).toContain('Command execution')
   expect(text).toContain('pnpm test')
   expect(text).not.toContain('tests passed')


### PR DESCRIPTION
## Summary
- add a renderer option to omit reasoning-derived Thinking task cards
- default Slackbot rendering and recovery to omit those reasoning cards while preserving commentary, plan, command progress, and final answer rendering
- update Slackbot stream expectations for the quieter Slack surface

Prompted by: @DaniPopes

## Tests
- bun test packages/rendering/src/codex-app-server.test.ts
- bun test services/slackbotv2/test/chat-sdk-emulate.test.ts
- pnpm --filter @centaur/rendering typecheck
- pnpm --filter slackbotv2 check:types