### PR TITLE
[codex] default sandbox lifecycle cleanup

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -242,8 +242,6 @@ spec:
               value: {{ .Values.apiRs.sandboxWarmPoolSize | quote }}
             - name: SESSION_SANDBOX_WARM_POOL_REPLENISH_INTERVAL_SECS
               value: {{ .Values.apiRs.sandboxWarmPoolReplenishIntervalSecs | quote }}
-            - name: SESSION_SANDBOX_IDLE_STOP_TTL_SECS
-              value: {{ .Values.apiRs.sandboxIdleStopTtlSecs | quote }}
             - name: SESSION_SANDBOX_MAX_LIFETIME_SECS
               value: {{ .Values.apiRs.sandboxMaxLifetimeSecs | quote }}
             - name: SESSION_SANDBOX_REAP_INTERVAL_SECS

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -350,7 +350,8 @@ apiRs:
   sandboxReapIntervalSecs: 300
   # Cleanup worker: stop unreferenced session/warm-pool sandboxes after two
   # consecutive sweeps and restore idle-pauses lost across api-rs restarts.
-  # 0 disables the corresponding arm.
+  # The idle backstop is only used when older execution rows have no persisted
+  # idle_timeout_ms. 0 disables the corresponding arm.
   sandboxCleanupIntervalSecs: 300
   sandboxIdleCleanupBackstopSecs: 21600 # 6 hours
   ironProxy:

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -344,9 +344,10 @@ apiRs:
     companyContextDocuments:
       enabled: true
       intervalSeconds: 14400
-  # Reaper: stop sandboxes idle-paused longer than the idle TTL or older than
-  # the max lifetime. 0 disables that sweep. Interval must be >= 1.
-  sandboxIdleStopTtlSecs: 10800 # 3 hours
+  # Reaper: stop sandboxes older than the max lifetime. The suspended-idle
+  # deletion sweep is opt-in so pause and deletion policy stay separate.
+  # 0 disables that sweep. Interval must be >= 1.
+  sandboxIdleStopTtlSecs: 0
   sandboxMaxLifetimeSecs: 259200 # 3 days
   sandboxReapIntervalSecs: 300
   # Cleanup worker: stop unreferenced session/warm-pool sandboxes after two

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -344,10 +344,8 @@ apiRs:
     companyContextDocuments:
       enabled: true
       intervalSeconds: 14400
-  # Reaper: stop sandboxes older than the max lifetime. The suspended-idle
-  # deletion sweep is opt-in so pause and deletion policy stay separate.
-  # 0 disables that sweep. Interval must be >= 1.
-  sandboxIdleStopTtlSecs: 0
+  # Reaper: stop sandboxes older than the max lifetime, regardless of whether
+  # they are running or suspended. 0 disables the sweep. Interval must be >= 1.
   sandboxMaxLifetimeSecs: 259200 # 3 days
   sandboxReapIntervalSecs: 300
   # Cleanup worker: stop unreferenced session/warm-pool sandboxes after two

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -238,6 +238,10 @@ ironProxy:
   secretSource: onepassword-connect
   secretTtl: 10m
 
+apiRs:
+  # Delete any sandbox older than this, running or suspended.
+  sandboxMaxLifetimeSecs: 259200
+
 onepasswordConnect:
   connect:
     create: true
@@ -254,6 +258,17 @@ sandbox:
 
 The Kubernetes sandbox backend is the active runtime backend; there is no chart
 switch named `api.sandboxBackend`.
+
+Sandbox lifecycle has two separate timers:
+
+- Slackbot v2 sends `idle_timeout_ms` on execute requests, defaulting to up to
+  3 hours, so api-rs can pause an idle sandbox after a turn finishes.
+- api-rs deletes old sandboxes through `apiRs.sandboxMaxLifetimeSecs`, default
+  72 hours, regardless of whether the sandbox is still running or already
+  suspended.
+
+There is no suspended-only delete setting. If you want sandboxes gone after N
+hours, set `apiRs.sandboxMaxLifetimeSecs` to N hours in seconds.
 
 Install or upgrade:
 

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -85,6 +85,18 @@ Optional required-by-mode variables:
 | `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
 | `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
 
+Sandbox lifecycle:
+
+| Env var or value | Set from | Controls |
+| --- | --- | --- |
+| `SESSION_IDLE_TIMEOUT_MS` | `slackbotv2.extraEnv`; default is up to 3 hours. | Slackbot v2 execute idle timeout. After an execution reaches a terminal state, api-rs pauses the sandbox if no newer execution has used that sandbox. If `SESSION_MAX_DURATION_MS` is lower than 3 hours and this value is unset, Slackbot v2 caps the default idle timeout to the max duration. |
+| `SESSION_MAX_DURATION_MS` | `slackbotv2.extraEnv`. | Optional per-execution max duration forwarded to api-rs. api-rs rejects requests where `idle_timeout_ms` is greater than `max_duration_ms`. |
+| `apiRs.sandboxMaxLifetimeSecs` / `SESSION_SANDBOX_MAX_LIFETIME_SECS` | Helm value, default `259200` (72 hours). | Restart-surviving sandbox deletion backstop. The reaper stops any non-terminal sandbox older than this, regardless of whether it is running or suspended. Set `0` to disable max-lifetime reaping. |
+| `apiRs.sandboxReapIntervalSecs` / `SESSION_SANDBOX_REAP_INTERVAL_SECS` | Helm value, default `300`. | How often api-rs sweeps observed sandboxes for max-lifetime expiry. |
+
+There is no separate suspended-only delete timer. Pausing is controlled by the
+per-execution idle timeout; deletion is controlled by sandbox max lifetime.
+
 Execution tuning:
 
 | Env var | Set from | Controls |

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -175,7 +175,7 @@ Kubernetes backend:
 | `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME`, `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.runtimeClassName`, `api.extraEnv`. | Pod runtime class and service account. |
 | `KUBERNETES_SANDBOX_CPU_LIMIT`, `KUBERNETES_SANDBOX_MEMORY_LIMIT`, `KUBERNETES_SANDBOX_CPU_REQUEST`, `KUBERNETES_SANDBOX_MEMORY_REQUEST` | `sandbox.resources.*`. | Sandbox pod resources. |
 | `KUBERNETES_SANDBOX_READY_TIMEOUT_S`, `KUBERNETES_ATTACH_LOG_TAIL_LINES` | `api.extraEnv`. | Sandbox readiness and attach diagnostics. |
-| `SESSION_SANDBOX_CLEANUP_INTERVAL_SECS`, `SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS` | `apiRs.sandboxCleanupIntervalSecs`, `apiRs.sandboxIdleCleanupBackstopSecs`. | DB-aware cleanup of unreferenced sandboxes and idle-pause backstop after API restarts. |
+| `SESSION_SANDBOX_CLEANUP_INTERVAL_SECS`, `SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS` | `apiRs.sandboxCleanupIntervalSecs`, `apiRs.sandboxIdleCleanupBackstopSecs`. | DB-aware cleanup of unreferenced sandboxes and restart recovery for idle pauses. Persisted `idle_timeout_ms` is honored after restart; the backstop is the fallback for older execution rows without that metadata. |
 | `KUBERNETES_SANDBOX_EXTRA_ENV` | `sandbox.extraEnv`. | JSON list copied into each sandbox. |
 | `KUBERNETES_WORKFLOW_DIRS` | Chart-rendered from `overlays.sources[*].workflowsSubdir` (default `workflows`) using the sandbox repo-cache mount prefix. | Workflow-host sandbox discovery paths. |
 | `KUBERNETES_FIREWALL_CA_SECRET_NAME`, `KUBERNETES_FIREWALL_CA_KEY_SECRET_NAME` | `firewall.existingCa*` or generated CA Secrets. | CA material for sandbox/proxy TLS interception. |

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -238,6 +238,10 @@ ironProxy:
   secretSource: onepassword-connect
   secretTtl: 10m
 
+apiRs:
+  # Delete any sandbox older than this, running or suspended.
+  sandboxMaxLifetimeSecs: 259200
+
 onepasswordConnect:
   connect:
     create: true
@@ -254,6 +258,17 @@ sandbox:
 
 The Kubernetes sandbox backend is the active runtime backend; there is no chart
 switch named `api.sandboxBackend`.
+
+Sandbox lifecycle has two separate timers:
+
+- Slackbot v2 sends `idle_timeout_ms` on execute requests, defaulting to up to
+  3 hours, so api-rs can pause an idle sandbox after a turn finishes.
+- api-rs deletes old sandboxes through `apiRs.sandboxMaxLifetimeSecs`, default
+  72 hours, regardless of whether the sandbox is still running or already
+  suspended.
+
+There is no suspended-only delete setting. If you want sandboxes gone after N
+hours, set `apiRs.sandboxMaxLifetimeSecs` to N hours in seconds.
 
 Install or upgrade:
 

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -85,6 +85,18 @@ Optional required-by-mode variables:
 | `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
 | `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
 
+Sandbox lifecycle:
+
+| Env var or value | Set from | Controls |
+| --- | --- | --- |
+| `SESSION_IDLE_TIMEOUT_MS` | `slackbotv2.extraEnv`; default is up to 3 hours. | Slackbot v2 execute idle timeout. After an execution reaches a terminal state, api-rs pauses the sandbox if no newer execution has used that sandbox. If `SESSION_MAX_DURATION_MS` is lower than 3 hours and this value is unset, Slackbot v2 caps the default idle timeout to the max duration. |
+| `SESSION_MAX_DURATION_MS` | `slackbotv2.extraEnv`. | Optional per-execution max duration forwarded to api-rs. api-rs rejects requests where `idle_timeout_ms` is greater than `max_duration_ms`. |
+| `apiRs.sandboxMaxLifetimeSecs` / `SESSION_SANDBOX_MAX_LIFETIME_SECS` | Helm value, default `259200` (72 hours). | Restart-surviving sandbox deletion backstop. The reaper stops any non-terminal sandbox older than this, regardless of whether it is running or suspended. Set `0` to disable max-lifetime reaping. |
+| `apiRs.sandboxReapIntervalSecs` / `SESSION_SANDBOX_REAP_INTERVAL_SECS` | Helm value, default `300`. | How often api-rs sweeps observed sandboxes for max-lifetime expiry. |
+
+There is no separate suspended-only delete timer. Pausing is controlled by the
+per-execution idle timeout; deletion is controlled by sandbox max lifetime.
+
 Execution tuning:
 
 | Env var | Set from | Controls |

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -175,7 +175,7 @@ Kubernetes backend:
 | `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME`, `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.runtimeClassName`, `api.extraEnv`. | Pod runtime class and service account. |
 | `KUBERNETES_SANDBOX_CPU_LIMIT`, `KUBERNETES_SANDBOX_MEMORY_LIMIT`, `KUBERNETES_SANDBOX_CPU_REQUEST`, `KUBERNETES_SANDBOX_MEMORY_REQUEST` | `sandbox.resources.*`. | Sandbox pod resources. |
 | `KUBERNETES_SANDBOX_READY_TIMEOUT_S`, `KUBERNETES_ATTACH_LOG_TAIL_LINES` | `api.extraEnv`. | Sandbox readiness and attach diagnostics. |
-| `SESSION_SANDBOX_CLEANUP_INTERVAL_SECS`, `SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS` | `apiRs.sandboxCleanupIntervalSecs`, `apiRs.sandboxIdleCleanupBackstopSecs`. | DB-aware cleanup of unreferenced sandboxes and idle-pause backstop after API restarts. |
+| `SESSION_SANDBOX_CLEANUP_INTERVAL_SECS`, `SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS` | `apiRs.sandboxCleanupIntervalSecs`, `apiRs.sandboxIdleCleanupBackstopSecs`. | DB-aware cleanup of unreferenced sandboxes and restart recovery for idle pauses. Persisted `idle_timeout_ms` is honored after restart; the backstop is the fallback for older execution rows without that metadata. |
 | `KUBERNETES_SANDBOX_EXTRA_ENV` | `sandbox.extraEnv`. | JSON list copied into each sandbox. |
 | `KUBERNETES_WORKFLOW_DIRS` | Chart-rendered from `overlays.sources[*].workflowsSubdir` (default `workflows`) using the sandbox repo-cache mount prefix. | Workflow-host sandbox discovery paths. |
 | `KUBERNETES_FIREWALL_CA_SECRET_NAME`, `KUBERNETES_FIREWALL_CA_KEY_SECRET_NAME` | `firewall.existingCa*` or generated CA Secrets. | CA material for sandbox/proxy TLS interception. |

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -529,12 +529,12 @@ struct SandboxArgs {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     warm_pool_replenish_interval_secs: u64,
-    /// Stop sandboxes that have been idle-paused longer than this. 0 disables
-    /// the idle sweep.
+    /// Stop sandboxes that have been idle-paused longer than this. Defaults to
+    /// disabled so pause and deletion policy stay separate.
     #[arg(
         long = "session-sandbox-idle-stop-ttl-secs",
         env = "SESSION_SANDBOX_IDLE_STOP_TTL_SECS",
-        default_value_t = 3600
+        default_value_t = 0
     )]
     sandbox_idle_stop_ttl_secs: u64,
     /// Stop any sandbox older than this regardless of status; sessions replace
@@ -543,7 +543,7 @@ struct SandboxArgs {
     #[arg(
         long = "session-sandbox-max-lifetime-secs",
         env = "SESSION_SANDBOX_MAX_LIFETIME_SECS",
-        default_value_t = 86_400
+        default_value_t = 259_200
     )]
     sandbox_max_lifetime_secs: u64,
     #[arg(
@@ -2039,6 +2039,20 @@ mod tests {
         assert_eq!(args.sandbox.k8s_namespace, "centaur-test");
         assert_eq!(args.sandbox.ready_timeout_secs, 17);
         assert_eq!(args.sandbox.k8s_context.as_deref(), Some("kind-test"));
+    }
+
+    #[test]
+    fn sandbox_reaper_defaults_pause_after_execution_and_delete_after_max_lifetime() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+        ])
+        .unwrap();
+
+        let config = args.sandbox_reaper_config();
+        assert_eq!(config.idle_ttl, None);
+        assert_eq!(config.max_lifetime, Some(Duration::from_secs(259_200)));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -529,14 +529,6 @@ struct SandboxArgs {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     warm_pool_replenish_interval_secs: u64,
-    /// Stop sandboxes that have been idle-paused longer than this. Defaults to
-    /// disabled so pause and deletion policy stay separate.
-    #[arg(
-        long = "session-sandbox-idle-stop-ttl-secs",
-        env = "SESSION_SANDBOX_IDLE_STOP_TTL_SECS",
-        default_value_t = 0
-    )]
-    sandbox_idle_stop_ttl_secs: u64,
     /// Stop any sandbox older than this regardless of status; sessions replace
     /// reaped sandboxes on their next message. 0 disables the max-lifetime
     /// sweep.
@@ -1225,7 +1217,6 @@ impl SandboxArgs {
         let ttl = |secs: u64| (secs > 0).then(|| Duration::from_secs(secs));
         SandboxReaperConfig {
             interval: Duration::from_secs(self.sandbox_reap_interval_secs),
-            idle_ttl: ttl(self.sandbox_idle_stop_ttl_secs),
             max_lifetime: ttl(self.sandbox_max_lifetime_secs),
         }
     }
@@ -2042,7 +2033,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_reaper_defaults_pause_after_execution_and_delete_after_max_lifetime() {
+    fn sandbox_reaper_defaults_delete_after_max_lifetime() {
         let args = Args::try_parse_from([
             "centaur-api-server",
             "--database-url",
@@ -2051,7 +2042,6 @@ mod tests {
         .unwrap();
 
         let config = args.sandbox_reaper_config();
-        assert_eq!(config.idle_ttl, None);
         assert_eq!(config.max_lifetime, Some(Duration::from_secs(259_200)));
     }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -42,10 +42,8 @@ const MANAGED_BY_VALUE: &str = "api-rs";
 // so resume (which has only the sandbox id) can rebind without the spec or any
 // in-memory state. Survives pause and api-rs restarts.
 const IRON_CONTROL_PRINCIPAL_ANNOTATION: &str = "centaur.ai/iron-control-principal";
-// RFC 3339 instant stamped when the sandbox is paused for idleness and
-// cleared on resume. The reaper uses it to stop sandboxes whose pause
-// outlived the idle TTL, surviving api-rs restarts (the pause timer is
-// otherwise in-memory only).
+// RFC 3339 instant stamped when the sandbox is paused for idleness and cleared
+// on resume. This keeps suspended status observable across api-rs restarts.
 const PAUSED_AT_ANNOTATION: &str = "centaur.ai/paused-at";
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);

--- a/services/api-rs/crates/centaur-sandbox-manager/src/reaper.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/reaper.rs
@@ -1,18 +1,18 @@
 //! Background garbage collection for leaked sandboxes.
 //!
-//! Sessions pause idle sandboxes (replicas to zero) but nothing stops them:
-//! the pause timer lives in process memory and dies with the deploy, and
-//! sandboxes whose sessions never go idle are retained forever. The reaper is
-//! the restart-surviving backstop: it sweeps the backend's observed sandboxes
-//! and stops any that outlived their welcome, releasing the sandbox, its
-//! proxy resources, and its node pod slots.
+//! Sessions pause idle sandboxes (replicas to zero), but paused sandboxes and
+//! sandboxes whose sessions never go idle still need a restart-surviving
+//! backstop. The reaper sweeps the backend's observed sandboxes and stops any
+//! that exceed the configured max lifetime, releasing the sandbox, its proxy
+//! resources, and its node pod slots.
 
 use std::{
     sync::Arc,
     time::{Duration, SystemTime},
 };
 
-use centaur_sandbox_core::{ObservedSandbox, SandboxResult, SandboxStatus};
+use centaur_sandbox_core::ObservedSandbox;
+use centaur_sandbox_core::SandboxResult;
 use tokio::time::{MissedTickBehavior, interval};
 use tracing::{info, warn};
 
@@ -22,9 +22,6 @@ use crate::SandboxManager;
 pub struct SandboxReaperConfig {
     /// How often to sweep.
     pub interval: Duration,
-    /// Stop sandboxes that have been suspended longer than this. `None`
-    /// disables the idle sweep.
-    pub idle_ttl: Option<Duration>,
     /// Stop any sandbox older than this regardless of status. `None` disables
     /// the max-lifetime sweep.
     pub max_lifetime: Option<Duration>,
@@ -32,7 +29,7 @@ pub struct SandboxReaperConfig {
 
 impl SandboxReaperConfig {
     pub fn is_enabled(&self) -> bool {
-        self.idle_ttl.is_some() || self.max_lifetime.is_some()
+        self.max_lifetime.is_some()
     }
 }
 
@@ -99,14 +96,6 @@ fn reap_reason(
     if observed.status.is_terminal() {
         return None;
     }
-    if let (Some(idle_ttl), Some(suspended_since)) = (config.idle_ttl, observed.suspended_since)
-        && matches!(observed.status, SandboxStatus::Suspended)
-        && now
-            .duration_since(suspended_since)
-            .is_ok_and(|age| age >= idle_ttl)
-    {
-        return Some("idle_ttl");
-    }
     if let (Some(max_lifetime), Some(created_at)) = (config.max_lifetime, observed.created_at)
         && now
             .duration_since(created_at)
@@ -121,73 +110,36 @@ fn reap_reason(
 mod tests {
     use super::*;
 
-    fn config(idle_ttl: Option<Duration>, max_lifetime: Option<Duration>) -> SandboxReaperConfig {
+    fn config(max_lifetime: Option<Duration>) -> SandboxReaperConfig {
         SandboxReaperConfig {
             interval: Duration::from_secs(60),
-            idle_ttl,
             max_lifetime,
         }
     }
 
-    fn observed(status: SandboxStatus) -> ObservedSandbox {
+    fn observed(status: centaur_sandbox_core::SandboxStatus) -> ObservedSandbox {
         ObservedSandbox::new("sandbox-1", "fake", status)
-    }
-
-    #[test]
-    fn reaps_suspended_sandbox_past_idle_ttl() {
-        let now = SystemTime::now();
-        let sandbox = observed(SandboxStatus::Suspended)
-            .with_suspended_since(Some(now - Duration::from_secs(7200)));
-
-        let reason = reap_reason(
-            &sandbox,
-            now,
-            &config(Some(Duration::from_secs(3600)), None),
-        );
-
-        assert_eq!(reason, Some("idle_ttl"));
-    }
-
-    #[test]
-    fn keeps_suspended_sandbox_within_idle_ttl() {
-        let now = SystemTime::now();
-        let sandbox = observed(SandboxStatus::Suspended)
-            .with_suspended_since(Some(now - Duration::from_secs(60)));
-
-        let reason = reap_reason(
-            &sandbox,
-            now,
-            &config(Some(Duration::from_secs(3600)), None),
-        );
-
-        assert_eq!(reason, None);
-    }
-
-    #[test]
-    fn keeps_suspended_sandbox_without_pause_timestamp() {
-        let now = SystemTime::now();
-        let sandbox = observed(SandboxStatus::Suspended);
-
-        let reason = reap_reason(
-            &sandbox,
-            now,
-            &config(Some(Duration::from_secs(3600)), None),
-        );
-
-        assert_eq!(reason, None);
     }
 
     #[test]
     fn reaps_running_sandbox_past_max_lifetime() {
         let now = SystemTime::now();
-        let sandbox = observed(SandboxStatus::Running)
+        let sandbox = observed(centaur_sandbox_core::SandboxStatus::Running)
             .with_created_at(Some(now - Duration::from_secs(100_000)));
 
-        let reason = reap_reason(
-            &sandbox,
-            now,
-            &config(None, Some(Duration::from_secs(86_400))),
-        );
+        let reason = reap_reason(&sandbox, now, &config(Some(Duration::from_secs(86_400))));
+
+        assert_eq!(reason, Some("max_lifetime"));
+    }
+
+    #[test]
+    fn reaps_suspended_sandbox_past_max_lifetime() {
+        let now = SystemTime::now();
+        let sandbox = observed(centaur_sandbox_core::SandboxStatus::Suspended)
+            .with_created_at(Some(now - Duration::from_secs(100_000)))
+            .with_suspended_since(Some(now - Duration::from_secs(60)));
+
+        let reason = reap_reason(&sandbox, now, &config(Some(Duration::from_secs(86_400))));
 
         assert_eq!(reason, Some("max_lifetime"));
     }
@@ -195,14 +147,10 @@ mod tests {
     #[test]
     fn keeps_running_sandbox_within_max_lifetime() {
         let now = SystemTime::now();
-        let sandbox =
-            observed(SandboxStatus::Running).with_created_at(Some(now - Duration::from_secs(60)));
+        let sandbox = observed(centaur_sandbox_core::SandboxStatus::Running)
+            .with_created_at(Some(now - Duration::from_secs(60)));
 
-        let reason = reap_reason(
-            &sandbox,
-            now,
-            &config(None, Some(Duration::from_secs(86_400))),
-        );
+        let reason = reap_reason(&sandbox, now, &config(Some(Duration::from_secs(86_400))));
 
         assert_eq!(reason, None);
     }
@@ -210,17 +158,10 @@ mod tests {
     #[test]
     fn ignores_terminal_sandboxes() {
         let now = SystemTime::now();
-        let sandbox =
-            observed(SandboxStatus::Gone).with_created_at(Some(now - Duration::from_secs(100_000)));
+        let sandbox = observed(centaur_sandbox_core::SandboxStatus::Gone)
+            .with_created_at(Some(now - Duration::from_secs(100_000)));
 
-        let reason = reap_reason(
-            &sandbox,
-            now,
-            &config(
-                Some(Duration::from_secs(3600)),
-                Some(Duration::from_secs(86_400)),
-            ),
-        );
+        let reason = reap_reason(&sandbox, now, &config(Some(Duration::from_secs(86_400))));
 
         assert_eq!(reason, None);
     }
@@ -228,10 +169,10 @@ mod tests {
     #[test]
     fn disabled_config_reaps_nothing() {
         let now = SystemTime::now();
-        let sandbox = observed(SandboxStatus::Suspended)
+        let sandbox = observed(centaur_sandbox_core::SandboxStatus::Suspended)
             .with_created_at(Some(now - Duration::from_secs(100_000)))
             .with_suspended_since(Some(now - Duration::from_secs(100_000)));
-        let config = config(None, None);
+        let config = config(None);
 
         assert!(!config.is_enabled());
         assert_eq!(reap_reason(&sandbox, now, &config), None);

--- a/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
@@ -115,6 +115,8 @@ impl WarmPoolManager {
     }
 
     async fn replenish_once(&self) -> Result<(), WarmPoolError> {
+        self.prune_stale_ready_sandboxes().await?;
+
         let needed = self.config.target_size.saturating_sub(
             self.store
                 .count_ready_warm_sandboxes(self.workload_key.as_str())
@@ -140,6 +142,31 @@ impl WarmPoolManager {
 
         Ok(())
     }
+
+    async fn prune_stale_ready_sandboxes(&self) -> Result<(), WarmPoolError> {
+        for sandbox_id in self
+            .store
+            .list_ready_warm_sandbox_ids(self.workload_key.as_str())
+            .await?
+        {
+            let id = SandboxId::new(sandbox_id.as_str());
+            let failure = match self.manager.status(&id).await {
+                Ok(SandboxStatus::Running) => continue,
+                Ok(status) => format!("ready warm sandbox was not running: {status:?}"),
+                Err(SandboxError::NotFound(_)) => "ready warm sandbox was not found".to_owned(),
+                Err(error) => {
+                    let error_message = error.to_string();
+                    warn!(%sandbox_id, error = %error_message);
+                    return Err(WarmPoolError::Sandbox(error));
+                }
+            };
+            warn!(%sandbox_id, error = %failure, "marking stale ready warm sandbox failed");
+            self.store
+                .mark_warm_sandbox_failed(&sandbox_id, &failure)
+                .await?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Error)]
@@ -148,4 +175,192 @@ pub enum WarmPoolError {
     Store(#[from] SessionStoreError),
     #[error(transparent)]
     Sandbox(#[from] SandboxError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::{Arc, Mutex},
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+
+    use async_trait::async_trait;
+    use centaur_sandbox_core::{
+        ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
+        SandboxResult, SandboxSpec, SandboxStatus,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn replenisher_prunes_missing_ready_rows_before_counting() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let suffix = unique_suffix();
+        let workload_key = format!("test-prune-{suffix}");
+        let stale_sandbox = format!("stale-{suffix}");
+        let fresh_sandbox = format!("fresh-{suffix}");
+
+        store
+            .insert_ready_warm_sandbox(&stale_sandbox, &workload_key)
+            .await
+            .expect("insert stale warm sandbox row");
+        assert_eq!(
+            store
+                .count_ready_warm_sandboxes(&workload_key)
+                .await
+                .expect("count ready warm sandboxes"),
+            1
+        );
+
+        let backend = Arc::new(TestBackend::new(fresh_sandbox.clone()));
+        let pool = WarmPoolManager::new(
+            Arc::new(SandboxManager::new(backend.clone())),
+            store.clone(),
+            Arc::new(|| SandboxSpec::new("image")),
+            workload_key.clone(),
+            WarmPoolConfig {
+                target_size: 1,
+                replenish_interval: Duration::from_secs(60),
+                bootstrap_iron_control_principal: None,
+            },
+        );
+
+        pool.replenish_once().await.expect("replenish warm pool");
+
+        assert_eq!(backend.created(), vec![fresh_sandbox.clone()]);
+        assert_eq!(
+            store
+                .count_ready_warm_sandboxes(&workload_key)
+                .await
+                .expect("count ready warm sandboxes"),
+            1
+        );
+        assert_eq!(
+            store
+                .claim_ready_warm_sandbox(&workload_key, "test-thread")
+                .await
+                .expect("claim ready warm sandbox"),
+            Some(fresh_sandbox)
+        );
+    }
+
+    async fn test_store() -> Option<PgSessionStore> {
+        let Ok(url) = std::env::var("SESSION_RUNTIME_TEST_DATABASE_URL") else {
+            eprintln!("skipping: SESSION_RUNTIME_TEST_DATABASE_URL not set");
+            return None;
+        };
+        let store = PgSessionStore::connect(&url)
+            .await
+            .expect("connect test db");
+        store.run_migrations().await.expect("run migrations");
+        Some(store)
+    }
+
+    fn unique_suffix() -> String {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos()
+            .to_string()
+    }
+
+    struct TestBackend {
+        create_id: String,
+        statuses: Mutex<BTreeMap<String, SandboxStatus>>,
+        created: Mutex<Vec<String>>,
+    }
+
+    impl TestBackend {
+        fn new(create_id: String) -> Self {
+            Self {
+                create_id,
+                statuses: Mutex::new(BTreeMap::new()),
+                created: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn created(&self) -> Vec<String> {
+            self.created.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl SandboxBackend for TestBackend {
+        fn name(&self) -> &'static str {
+            "test"
+        }
+
+        async fn create(&self, _spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
+            self.statuses
+                .lock()
+                .unwrap()
+                .insert(self.create_id.clone(), SandboxStatus::Running);
+            self.created.lock().unwrap().push(self.create_id.clone());
+            Ok(SandboxHandle::new(
+                SandboxId::new(self.create_id.clone()),
+                self.name(),
+            ))
+        }
+
+        async fn open_io(&self, _id: &SandboxId) -> SandboxResult<SandboxIo> {
+            Err(SandboxError::Unsupported {
+                backend: self.name(),
+                operation: "open_io",
+            })
+        }
+
+        async fn status(&self, id: &SandboxId) -> SandboxResult<SandboxStatus> {
+            self.statuses
+                .lock()
+                .unwrap()
+                .get(id.as_str())
+                .cloned()
+                .ok_or_else(|| SandboxError::NotFound(id.as_str().to_owned()))
+        }
+
+        async fn observe(&self, id: &SandboxId) -> SandboxResult<ObservedSandbox> {
+            Ok(ObservedSandbox::new(
+                id.clone(),
+                self.name(),
+                self.status(id).await?,
+            ))
+        }
+
+        async fn list_observed(&self) -> SandboxResult<Vec<ObservedSandbox>> {
+            Ok(self
+                .statuses
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(id, status)| ObservedSandbox::new(id.clone(), self.name(), status.clone()))
+                .collect())
+        }
+
+        async fn stop(&self, id: &SandboxId) -> SandboxResult<()> {
+            self.statuses
+                .lock()
+                .unwrap()
+                .insert(id.as_str().to_owned(), SandboxStatus::Stopped);
+            Ok(())
+        }
+
+        async fn pause(&self, id: &SandboxId) -> SandboxResult<()> {
+            self.statuses
+                .lock()
+                .unwrap()
+                .insert(id.as_str().to_owned(), SandboxStatus::Suspended);
+            Ok(())
+        }
+
+        async fn resume(&self, id: &SandboxId) -> SandboxResult<()> {
+            self.statuses
+                .lock()
+                .unwrap()
+                .insert(id.as_str().to_owned(), SandboxStatus::Running);
+            Ok(())
+        }
+    }
 }

--- a/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
@@ -144,11 +144,7 @@ impl WarmPoolManager {
     }
 
     async fn prune_stale_ready_sandboxes(&self) -> Result<(), WarmPoolError> {
-        for sandbox_id in self
-            .store
-            .list_ready_warm_sandbox_ids(self.workload_key.as_str())
-            .await?
-        {
+        for sandbox_id in self.store.list_ready_warm_sandbox_ids().await? {
             let id = SandboxId::new(sandbox_id.as_str());
             let failure = match self.manager.status(&id).await {
                 Ok(SandboxStatus::Running) => continue,
@@ -200,18 +196,31 @@ mod tests {
         };
         let suffix = unique_suffix();
         let workload_key = format!("test-prune-{suffix}");
+        let old_workload_key = format!("test-prune-old-{suffix}");
         let stale_sandbox = format!("stale-{suffix}");
+        let old_stale_sandbox = format!("old-stale-{suffix}");
         let fresh_sandbox = format!("fresh-{suffix}");
 
         store
             .insert_ready_warm_sandbox(&stale_sandbox, &workload_key)
             .await
             .expect("insert stale warm sandbox row");
+        store
+            .insert_ready_warm_sandbox(&old_stale_sandbox, &old_workload_key)
+            .await
+            .expect("insert stale warm sandbox row for old workload");
         assert_eq!(
             store
                 .count_ready_warm_sandboxes(&workload_key)
                 .await
                 .expect("count ready warm sandboxes"),
+            1
+        );
+        assert_eq!(
+            store
+                .count_ready_warm_sandboxes(&old_workload_key)
+                .await
+                .expect("count ready warm sandboxes for old workload"),
             1
         );
 
@@ -244,6 +253,13 @@ mod tests {
                 .await
                 .expect("claim ready warm sandbox"),
             Some(fresh_sandbox)
+        );
+        assert_eq!(
+            store
+                .count_ready_warm_sandboxes(&old_workload_key)
+                .await
+                .expect("count ready warm sandboxes for old workload"),
+            0
         );
     }
 

--- a/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
@@ -130,7 +130,7 @@ impl SessionSandboxCleanupWorker {
                 &candidate.thread_key,
                 &candidate.execution_id,
                 &candidate.sandbox_id,
-                idle_backstop,
+                candidate.idle_timeout,
             )
             .await
             {

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -469,8 +469,8 @@ impl SessionRuntime {
         self
     }
 
-    /// Spawn the background reaper that stops sandboxes whose idle pause or
-    /// total lifetime expired. No-op when both TTLs are disabled.
+    /// Spawn the background reaper that stops sandboxes whose total lifetime
+    /// expired. No-op when max-lifetime reaping is disabled.
     pub fn with_sandbox_reaper(self, config: SandboxReaperConfig) -> Self {
         if !config.is_enabled() {
             return self;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -843,19 +843,15 @@ impl PgSessionStore {
         Ok(count)
     }
 
-    pub async fn list_ready_warm_sandbox_ids(
-        &self,
-        workload_key: &str,
-    ) -> Result<Vec<String>, SessionStoreError> {
+    pub async fn list_ready_warm_sandbox_ids(&self) -> Result<Vec<String>, SessionStoreError> {
         let sandbox_ids = sqlx::query_scalar::<_, String>(
             r#"
             select sandbox_id
             from session_warm_sandboxes
-            where workload_key = $1 and status = 'ready'
+            where status = 'ready'
             order by created_at, sandbox_id
             "#,
         )
-        .bind(workload_key)
         .fetch_all(&self.pool)
         .await?;
         Ok(sandbox_ids)

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -630,53 +630,34 @@ impl PgSessionStore {
                     metadata
                 from session_executions
                 order by thread_key, created_at desc, execution_id desc
-            ),
-            eligible as (
-                select
-                    s.thread_key,
-                    s.sandbox_id as sandbox_id,
-                    latest.execution_id,
-                    latest.completed_at,
-                    coalesce(
-                        nullif(
-                            case
-                                when latest.metadata ->> 'idle_timeout_ms' ~ '^[0-9]+$'
-                                then least(
-                                    (latest.metadata ->> 'idle_timeout_ms')::numeric,
-                                    9223372036854775807
-                                )::bigint
-                            end,
-                            0
-                        ),
-                        greatest(ceil($1::float8 * 1000.0), 1.0)::bigint
-                    ) as idle_timeout_ms
-                from sessions s
-                join latest on latest.thread_key = s.thread_key
-                where s.sandbox_id is not null
-                  and latest.status in ('completed', 'failed', 'cancelled')
-                  and latest.completed_at is not null
-                  and not exists (
-                      select 1
-                      from session_executions active
-                      where active.thread_key = s.thread_key
-                        and active.status in ('queued', 'running')
-                  )
             )
             select
-                thread_key,
-                sandbox_id,
-                execution_id,
-                idle_timeout_ms
-            from eligible
-            where completed_at <= now() - ((idle_timeout_ms::float8 / 1000.0) * interval '1 second')
-            order by completed_at, thread_key
+                s.thread_key,
+                s.sandbox_id as sandbox_id,
+                latest.execution_id,
+                latest.completed_at,
+                latest.metadata
+            from sessions s
+            join latest on latest.thread_key = s.thread_key
+            where s.sandbox_id is not null
+              and latest.status in ('completed', 'failed', 'cancelled')
+              and latest.completed_at is not null
+              and not exists (
+                  select 1
+                  from session_executions active
+                  where active.thread_key = s.thread_key
+                    and active.status in ('queued', 'running')
+              )
+            order by latest.completed_at, s.thread_key
             "#,
         )
-        .bind(idle_backstop.as_secs_f64())
         .fetch_all(&self.pool)
         .await?;
 
-        rows.into_iter().map(TryInto::try_into).collect()
+        let now = OffsetDateTime::now_utc();
+        rows.into_iter()
+            .filter_map(|row| idle_candidate_from_row(row, idle_backstop, now).transpose())
+            .collect()
     }
 
     pub async fn list_workflow_owned_sandboxes(
@@ -1135,26 +1116,46 @@ struct IdleSandboxCandidateRow {
     thread_key: String,
     sandbox_id: String,
     execution_id: String,
-    idle_timeout_ms: i64,
+    completed_at: OffsetDateTime,
+    metadata: Value,
 }
 
-impl TryFrom<IdleSandboxCandidateRow> for IdleSandboxCandidate {
-    type Error = SessionStoreError;
-
-    fn try_from(row: IdleSandboxCandidateRow) -> Result<Self, Self::Error> {
-        let idle_timeout_ms = u64::try_from(row.idle_timeout_ms).map_err(|_| {
-            SessionStoreError::InvalidPersistedValue(format!(
-                "idle_timeout_ms must be non-negative: {}",
-                row.idle_timeout_ms
-            ))
-        })?;
-        Ok(Self {
-            thread_key: parse_persisted(row.thread_key)?,
-            sandbox_id: row.sandbox_id,
-            execution_id: row.execution_id,
-            idle_timeout: Duration::from_millis(idle_timeout_ms),
-        })
+fn idle_candidate_from_row(
+    row: IdleSandboxCandidateRow,
+    idle_backstop: Duration,
+    now: OffsetDateTime,
+) -> Result<Option<IdleSandboxCandidate>, SessionStoreError> {
+    let idle_timeout = effective_idle_timeout(&row.metadata, idle_backstop);
+    if !idle_deadline_elapsed(row.completed_at, idle_timeout, now) {
+        return Ok(None);
     }
+    Ok(Some(IdleSandboxCandidate {
+        thread_key: parse_persisted(row.thread_key)?,
+        sandbox_id: row.sandbox_id,
+        execution_id: row.execution_id,
+        idle_timeout,
+    }))
+}
+
+fn effective_idle_timeout(metadata: &Value, idle_backstop: Duration) -> Duration {
+    metadata
+        .get("idle_timeout_ms")
+        .and_then(Value::as_u64)
+        .filter(|value| *value > 0)
+        .map(Duration::from_millis)
+        .unwrap_or_else(|| std::cmp::max(idle_backstop, Duration::from_millis(1)))
+}
+
+fn idle_deadline_elapsed(
+    completed_at: OffsetDateTime,
+    idle_timeout: Duration,
+    now: OffsetDateTime,
+) -> bool {
+    let elapsed = now - completed_at;
+    if elapsed.is_negative() {
+        return false;
+    }
+    elapsed.whole_nanoseconds() >= idle_timeout.as_nanos() as i128
 }
 
 #[derive(Debug, FromRow)]
@@ -1280,9 +1281,10 @@ mod tests {
 
     use centaur_session_core::{HarnessType, ThreadKey};
     use serde_json::json;
+    use time::{Duration as TimeDuration, OffsetDateTime};
     use uuid::Uuid;
 
-    use super::{PgSessionStore, SessionEventNotification};
+    use super::{IdleSandboxCandidateRow, PgSessionStore, SessionEventNotification};
 
     async fn test_store() -> Option<PgSessionStore> {
         let Ok(url) = std::env::var("SESSION_RUNTIME_TEST_DATABASE_URL") else {
@@ -1308,6 +1310,69 @@ mod tests {
                 event_id: 42,
             }
         );
+    }
+
+    fn idle_row(
+        metadata: serde_json::Value,
+        completed_at: OffsetDateTime,
+    ) -> IdleSandboxCandidateRow {
+        IdleSandboxCandidateRow {
+            thread_key: "test:idle-row".to_owned(),
+            sandbox_id: "sbx-idle-row".to_owned(),
+            execution_id: "exe-idle-row".to_owned(),
+            completed_at,
+            metadata,
+        }
+    }
+
+    #[test]
+    fn idle_candidate_uses_persisted_timeout_deadline() {
+        let now = OffsetDateTime::now_utc();
+        let candidate = super::idle_candidate_from_row(
+            idle_row(
+                json!({"idle_timeout_ms": 1000}),
+                now - TimeDuration::seconds(2),
+            ),
+            Duration::from_secs(3600),
+            now,
+        )
+        .unwrap()
+        .expect("candidate should use persisted timeout");
+
+        assert_eq!(candidate.idle_timeout, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn idle_candidate_waits_for_persisted_timeout_even_when_backstop_elapsed() {
+        let now = OffsetDateTime::now_utc();
+        let candidate = super::idle_candidate_from_row(
+            idle_row(
+                json!({"idle_timeout_ms": 10_000}),
+                now - TimeDuration::seconds(2),
+            ),
+            Duration::from_secs(1),
+            now,
+        )
+        .unwrap();
+
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn idle_candidate_falls_back_to_backstop_for_missing_or_invalid_timeout() {
+        let now = OffsetDateTime::now_utc();
+        let candidate = super::idle_candidate_from_row(
+            idle_row(
+                json!({"idle_timeout_ms": "not-a-number"}),
+                now - TimeDuration::seconds(2),
+            ),
+            Duration::from_secs(1),
+            now,
+        )
+        .unwrap()
+        .expect("candidate should use backstop");
+
+        assert_eq!(candidate.idle_timeout, Duration::from_secs(1));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -1,6 +1,6 @@
 //! SQLx-backed session repository.
 
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
 use centaur_session_core::{
     ExecutionStatus, HarnessType, MessageRole, SandboxCapabilities, Session, SessionEvent,
@@ -42,6 +42,7 @@ pub struct IdleSandboxCandidate {
     pub thread_key: ThreadKey,
     pub sandbox_id: String,
     pub execution_id: String,
+    pub idle_timeout: Duration,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -616,7 +617,7 @@ impl PgSessionStore {
 
     pub async fn list_idle_sandbox_candidates(
         &self,
-        idle_backstop: std::time::Duration,
+        idle_backstop: Duration,
     ) -> Result<Vec<IdleSandboxCandidate>, SessionStoreError> {
         let rows = sqlx::query_as::<_, IdleSandboxCandidateRow>(
             r#"
@@ -625,27 +626,50 @@ impl PgSessionStore {
                     execution_id,
                     thread_key,
                     status,
-                    completed_at
+                    completed_at,
+                    metadata
                 from session_executions
                 order by thread_key, created_at desc, execution_id desc
+            ),
+            eligible as (
+                select
+                    s.thread_key,
+                    s.sandbox_id as sandbox_id,
+                    latest.execution_id,
+                    latest.completed_at,
+                    coalesce(
+                        nullif(
+                            case
+                                when latest.metadata ->> 'idle_timeout_ms' ~ '^[0-9]+$'
+                                then least(
+                                    (latest.metadata ->> 'idle_timeout_ms')::numeric,
+                                    9223372036854775807
+                                )::bigint
+                            end,
+                            0
+                        ),
+                        greatest(ceil($1::float8 * 1000.0), 1.0)::bigint
+                    ) as idle_timeout_ms
+                from sessions s
+                join latest on latest.thread_key = s.thread_key
+                where s.sandbox_id is not null
+                  and latest.status in ('completed', 'failed', 'cancelled')
+                  and latest.completed_at is not null
+                  and not exists (
+                      select 1
+                      from session_executions active
+                      where active.thread_key = s.thread_key
+                        and active.status in ('queued', 'running')
+                  )
             )
             select
-                s.thread_key,
-                s.sandbox_id as sandbox_id,
-                latest.execution_id
-            from sessions s
-            join latest on latest.thread_key = s.thread_key
-            where s.sandbox_id is not null
-              and latest.status in ('completed', 'failed', 'cancelled')
-              and latest.completed_at is not null
-              and latest.completed_at <= now() - ($1::float8 * interval '1 second')
-              and not exists (
-                  select 1
-                  from session_executions active
-                  where active.thread_key = s.thread_key
-                    and active.status in ('queued', 'running')
-              )
-            order by latest.completed_at, s.thread_key
+                thread_key,
+                sandbox_id,
+                execution_id,
+                idle_timeout_ms
+            from eligible
+            where completed_at <= now() - ((idle_timeout_ms::float8 / 1000.0) * interval '1 second')
+            order by completed_at, thread_key
             "#,
         )
         .bind(idle_backstop.as_secs_f64())
@@ -1111,16 +1135,24 @@ struct IdleSandboxCandidateRow {
     thread_key: String,
     sandbox_id: String,
     execution_id: String,
+    idle_timeout_ms: i64,
 }
 
 impl TryFrom<IdleSandboxCandidateRow> for IdleSandboxCandidate {
     type Error = SessionStoreError;
 
     fn try_from(row: IdleSandboxCandidateRow) -> Result<Self, Self::Error> {
+        let idle_timeout_ms = u64::try_from(row.idle_timeout_ms).map_err(|_| {
+            SessionStoreError::InvalidPersistedValue(format!(
+                "idle_timeout_ms must be non-negative: {}",
+                row.idle_timeout_ms
+            ))
+        })?;
         Ok(Self {
             thread_key: parse_persisted(row.thread_key)?,
             sandbox_id: row.sandbox_id,
             execution_id: row.execution_id,
+            idle_timeout: Duration::from_millis(idle_timeout_ms),
         })
     }
 }
@@ -1244,7 +1276,25 @@ pub fn default_metadata(metadata: Option<Value>) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::SessionEventNotification;
+    use std::time::Duration;
+
+    use centaur_session_core::{HarnessType, ThreadKey};
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use super::{PgSessionStore, SessionEventNotification};
+
+    async fn test_store() -> Option<PgSessionStore> {
+        let Ok(url) = std::env::var("SESSION_RUNTIME_TEST_DATABASE_URL") else {
+            eprintln!("skipping: SESSION_RUNTIME_TEST_DATABASE_URL not set");
+            return None;
+        };
+        let store = PgSessionStore::connect(&url)
+            .await
+            .expect("connect test db");
+        store.run_migrations().await.expect("run migrations");
+        Some(store)
+    }
 
     #[test]
     fn parses_session_event_notification_payload() {
@@ -1258,5 +1308,56 @@ mod tests {
                 event_id: 42,
             }
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn idle_candidates_use_persisted_execution_idle_timeout() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key = ThreadKey::parse(format!("test:idle-cleanup-{}", Uuid::new_v4())).unwrap();
+        let sandbox_id = format!("sbx-idle-{}", Uuid::new_v4());
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        store
+            .update_sandbox_id(&thread_key, Some(&sandbox_id))
+            .await
+            .expect("set sandbox id");
+        let execution_id = store
+            .create_execution(&thread_key, None, json!({"idle_timeout_ms": 1000}))
+            .await
+            .expect("create execution")
+            .execution
+            .execution_id;
+        store
+            .complete_execution(&execution_id)
+            .await
+            .expect("complete execution");
+        sqlx::query(
+            r#"
+            update session_executions
+            set completed_at = now() - interval '2 seconds', updated_at = now()
+            where execution_id = $1
+            "#,
+        )
+        .bind(&execution_id)
+        .execute(store.pool())
+        .await
+        .expect("age execution");
+
+        let candidates = store
+            .list_idle_sandbox_candidates(Duration::from_secs(3600))
+            .await
+            .expect("list idle sandbox candidates");
+        let candidate = candidates
+            .iter()
+            .find(|candidate| candidate.thread_key == thread_key)
+            .expect("candidate should use execution idle timeout, not backstop");
+
+        assert_eq!(candidate.sandbox_id, sandbox_id);
+        assert_eq!(candidate.execution_id, execution_id);
+        assert_eq!(candidate.idle_timeout, Duration::from_secs(1));
     }
 }

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -843,6 +843,24 @@ impl PgSessionStore {
         Ok(count)
     }
 
+    pub async fn list_ready_warm_sandbox_ids(
+        &self,
+        workload_key: &str,
+    ) -> Result<Vec<String>, SessionStoreError> {
+        let sandbox_ids = sqlx::query_scalar::<_, String>(
+            r#"
+            select sandbox_id
+            from session_warm_sandboxes
+            where workload_key = $1 and status = 'ready'
+            order by created_at, sandbox_id
+            "#,
+        )
+        .bind(workload_key)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(sandbox_ids)
+    }
+
     pub async fn claim_ready_warm_sandbox(
         &self,
         workload_key: &str,

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -66,6 +66,14 @@ export const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 3 * 60 * 60 * 1000
 const DEFAULT_SESSION_API_TIMEOUT_MS = 30_000
 const DEFAULT_SLACK_API_TIMEOUT_MS = 5_000
 
+function sessionIdleTimeoutMs(options: SlackbotV2Options): number {
+  if (options.idleTimeoutMs !== undefined) return options.idleTimeoutMs
+  if (options.maxDurationMs !== undefined) {
+    return Math.min(DEFAULT_SESSION_IDLE_TIMEOUT_MS, options.maxDurationMs)
+  }
+  return DEFAULT_SESSION_IDLE_TIMEOUT_MS
+}
+
 class FetchTimeoutError extends Error {
   constructor(action: string, timeoutMs: number) {
     super(`${action} timed out after ${timeoutMs}ms`)
@@ -1167,7 +1175,7 @@ async function executeSession(
 ): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
   const requesterIdentity = await resolveRequesterIdentity(options, message)
-  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_SESSION_IDLE_TIMEOUT_MS
+  const idleTimeoutMs = sessionIdleTimeoutMs(options)
   const body: SlackbotV2ExecuteSessionRequest = {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -62,6 +62,7 @@ export function isRetryableSessionApiError(error: unknown): boolean {
   return error.name === 'AbortError' || error.name === 'TypeError'
 }
 
+export const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 3 * 60 * 60 * 1000
 const DEFAULT_SESSION_API_TIMEOUT_MS = 30_000
 const DEFAULT_SLACK_API_TIMEOUT_MS = 5_000
 
@@ -1166,6 +1167,7 @@ async function executeSession(
 ): Promise<SlackbotV2ExecuteSessionResponse> {
   const fetchFn = options.fetch ?? fetch
   const requesterIdentity = await resolveRequesterIdentity(options, message)
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_SESSION_IDLE_TIMEOUT_MS
   const body: SlackbotV2ExecuteSessionRequest = {
     idempotency_key: message.id,
     metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),
@@ -1179,7 +1181,7 @@ async function executeSession(
       reasoning,
       provider
     ),
-    ...(options.idleTimeoutMs === undefined ? {} : { idle_timeout_ms: options.idleTimeoutMs }),
+    idle_timeout_ms: idleTimeoutMs,
     ...(options.maxDurationMs === undefined ? {} : { max_duration_ms: options.maxDurationMs })
   }
   const response = await fetchWithTimeout(

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -106,6 +106,7 @@ export type SlackbotV2Options = {
    */
   defaultHarnessType?: string
   fetch?: SlackbotV2Fetch
+  /** Milliseconds before an idle execution pauses its sandbox. Defaults to 3h. */
   idleTimeoutMs?: number
   logger?: Logger
   maxDurationMs?: number

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -106,7 +106,7 @@ export type SlackbotV2Options = {
    */
   defaultHarnessType?: string
   fetch?: SlackbotV2Fetch
-  /** Milliseconds before an idle execution pauses its sandbox. Defaults to 3h. */
+  /** Milliseconds before an idle execution pauses its sandbox. Defaults to up to 3h. */
   idleTimeoutMs?: number
   logger?: Logger
   maxDurationMs?: number

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   clearConversationNameCacheForTests,
   clearRequesterIdentityCacheForTests,
+  DEFAULT_SESSION_IDLE_TIMEOUT_MS,
   forwardToSessionApi,
   harnessRestartPreamble,
   serializeAttachment,
@@ -99,9 +100,13 @@ function options(fetchFn: SlackbotV2Options['fetch']): SlackbotV2Options {
   }
 }
 
-function executeLine(requests: RecordedRequest[]): JsonObject {
+function executeBody(requests: RecordedRequest[]): Record<string, unknown> {
   const execute = requests.find(request => request.url.endsWith('/execute'))
-  const inputLines = (execute?.body as { input_lines: string[] }).input_lines
+  return (execute?.body ?? {}) as Record<string, unknown>
+}
+
+function executeLine(requests: RecordedRequest[]): JsonObject {
+  const inputLines = (executeBody(requests) as { input_lines: string[] }).input_lines
   return JSON.parse(inputLines[0]!) as JsonObject
 }
 
@@ -450,6 +455,21 @@ describe('forwardToSessionApi overrides', () => {
     const execute = requests.find(request => request.url.endsWith('/execute'))
     const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
     expect('reasoning' in line).toBe(false)
+  })
+
+  test('includes default idle timeout on execute requests', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hi')))
+    expect(executeBody(requests).idle_timeout_ms).toBe(DEFAULT_SESSION_IDLE_TIMEOUT_MS)
+  })
+
+  test('allows idle timeout override on execute requests', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      { ...options(fetchFn), idleTimeoutMs: 12_345 },
+      forwardInput(apiMessage('hi'))
+    )
+    expect(executeBody(requests).idle_timeout_ms).toBe(12_345)
   })
 
   test('retries session creation with existing harness on 409 conflict', async () => {

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -463,6 +463,16 @@ describe('forwardToSessionApi overrides', () => {
     expect(executeBody(requests).idle_timeout_ms).toBe(DEFAULT_SESSION_IDLE_TIMEOUT_MS)
   })
 
+  test('caps default idle timeout to max duration on execute requests', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      { ...options(fetchFn), maxDurationMs: 60_000 },
+      forwardInput(apiMessage('hi'))
+    )
+    expect(executeBody(requests).idle_timeout_ms).toBe(60_000)
+    expect(executeBody(requests).max_duration_ms).toBe(60_000)
+  })
+
   test('allows idle timeout override on execute requests', async () => {
     const { fetchFn, requests } = fakeApi()
     await forwardToSessionApi(


### PR DESCRIPTION
## Summary

- Make the intended sandbox lifecycle policy the upstream default: Slackbot executions pause idle sandboxes after up to 3h, and max-lifetime deletion defaults to 72h regardless of sandbox state.
- Remove the suspended-idle delete TTL surface so deletion is controlled by one max-lifetime knob.
- Add DB-aware cleanup for unreferenced session/warm-pool sandboxes and restore idle pauses after api-rs restarts using persisted execution `idle_timeout_ms`.
- Keep idle cleanup SQL focused on latest terminal candidate selection; timeout parsing and deadline filtering now live in Rust with direct unit coverage.
- Prune stale warm-pool rows across workloads before replenishing so max-lifetime reaped warm sandboxes are replaced correctly.
- Document the pause-vs-delete lifecycle in production and configuration docs.

## Why

The previous defaults split cleanup across an in-memory idle pause timer, a suspended-only delete TTL, and a max-lifetime delete timer. That made the operator contract ambiguous: a sandbox could pause after one duration, delete after another only if already suspended, and survive longer after an api-rs restart because the pause sleep was process-local.

This PR makes the policy explicit and durable: pause is controlled by the execution idle timeout, delete is controlled by max lifetime, and restart recovery uses database state instead of starting the pause clock over. Warm-pool bookkeeping now also catches up when a live warm sandbox is reaped outside the normal claim path.

## Validation

- `helm template centaur contrib/chart >/tmp/centaur-pr739-template.yaml`
- Render check confirmed no `priorityClassName` or `SESSION_SANDBOX_PRIORITY_CLASS_NAME` in default manifests.
- `helm lint contrib/chart`
- `cargo test -p centaur-session-sqlx`
- `cargo test -p centaur-session-runtime -p centaur-sandbox-manager`
- `cargo clippy -p centaur-session-sqlx -p centaur-session-runtime -p centaur-sandbox-manager --all-targets -- -D warnings`
- Previous post-rebase checks: `cargo test -p centaur-api-server -p centaur-sandbox-agent-k8s -p centaur-sandbox-core -p centaur-session-runtime`, `cargo clippy -p centaur-api-server -p centaur-sandbox-agent-k8s -p centaur-sandbox-core -p centaur-session-runtime --all-targets -- -D warnings`
- Preview Helm test with `SESSION_SANDBOX_MAX_LIFETIME_SECS=120` and `SESSION_SANDBOX_REAP_INTERVAL_SECS=30` verified max-lifetime reaping and warm-pool row pruning/replenishment.
