### PR TITLE
Rename tool call docs to direct CLI syntax

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,14 +446,14 @@ The sandbox image bakes `services/sandbox/SYSTEM_PROMPT.md` into `~/AGENTS.md` a
 The system prompt tells the agent:
 - **Identity**: it's running inside a Kubernetes sandbox pod, calling back to the API for tool access
 - **Tools**: three kinds — harness built-ins (Read, Bash, etc.), API tools exposed as shell CLI shims, and a headless browser
-- **Tool CLIs**: each tool is installed as a shell command at container startup by `services/sandbox/install_tool_shims.py`, which scans `TOOL_DIRS` for `pyproject.toml [project.scripts]` and `uvx`-installs each. Agents call tools directly (`slack get_channel_history '{"channel":"general"}'`, `<tool> --help` to discover) — there is no `call` helper.
+- **Tool CLIs**: each tool is installed as a shell command at container startup by `services/sandbox/install_tool_shims.py`, which scans `TOOL_DIRS` for `pyproject.toml [project.scripts]` and `uvx`-installs each. Agents call tools directly (`slack get_channel_history '{"channel":"general"}'`, `<tool> --help` to discover).
 - **Slack messaging**: the agent's stdout IS the Slack reply — never call `send_message` on the active thread
 - **Rules**: never display secrets, show your work, lead with the answer
 
 `centaur-tools` is the generated catalog CLI emitted by the same installer:
 - `centaur-tools list` → list available tool CLIs
 - `centaur-tools run <tool> [args]` → run a tool CLI
-- `centaur-tools call <tool> <method> [json]` → internal method bridge kept only for the Python workflow host's `ctx.call_tool(...)`; interactive agents use the direct tool CLIs above.
+- `<tool> --help` → discover one tool's direct CLI; the internal method bridge is kept only for the Python workflow host's `ctx.call_tool(...)`.
 
 ### Persona System
 

--- a/contrib/MIGRATING_TO_RS.md
+++ b/contrib/MIGRATING_TO_RS.md
@@ -76,13 +76,11 @@ Legacy sandboxes often called tools through HTTP routes on the API service. In
 api-rs-managed sandboxes, prefer the local tool shim path when a dedicated tool
 server URL is not present.
 
-The expected `call` helper behavior is:
+The expected direct CLI behavior is:
 
-- if `CENTAUR_TOOLS_URL` is set, call the tool server;
-- otherwise, if `centaur-tools` is available, use local shims for:
-  - `call tools`
-  - `call discover <tool>`
-  - `call <tool> <method> [json]`
+- list installed tools with `centaur-tools list`;
+- discover one tool with `<tool> --help`;
+- invoke tools through their direct CLI, such as `<tool> ...`;
 - do not fall back to deprecated `/tools/...` HTTP routes on `CENTAUR_API_URL`.
 
 From inside a sandbox, validate:
@@ -216,9 +214,8 @@ the secret manager token path, the Kubernetes Secret, or the console grant.
 
 ### `404` from `/tools/...`
 
-The sandbox is using the deprecated API tool route. Update the `call` helper or
-the sandbox image so local `centaur-tools` shims are used when
-`CENTAUR_TOOLS_URL` is unset.
+The sandbox is using the deprecated API tool route. Update the tool invocation
+path or the sandbox image so local direct CLI shims are used.
 
 ### Tool appears in the overlay but not in `centaur-tools list`
 


### PR DESCRIPTION
## Summary
- replace remaining user-facing `call <tool>` guidance with direct CLI discovery via `<tool> --help`
- keep internal workflow compatibility wording while removing old invocation examples

## Verification
- `rg -n 'call <tool>|call discover <tool>|centaur-tools call <tool>|`call` helper|there is no `call` helper' .`\n- `git diff --check`\n\nPrompted by: @Zygimantass