### PR TITLE
revert: undo slack upload default context change

### DIFF
--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -3838,7 +3838,64 @@ fn input_line_with_session_context(
         map.entry("traceparent")
             .or_insert_with(|| Value::String(traceparent.clone()));
     }
+    merge_session_context(map, session_context_for_thread(thread_key));
     serde_json::to_string(&value).unwrap_or_else(|_| line.to_owned())
+}
+
+fn merge_session_context(
+    map: &mut serde_json::Map<String, Value>,
+    context: Option<serde_json::Map<String, Value>>,
+) {
+    let Some(context) = context else {
+        return;
+    };
+    let entry = map
+        .entry("session_context")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Value::Object(existing) = entry else {
+        return;
+    };
+    for (key, value) in context {
+        existing.entry(key).or_insert(value);
+    }
+}
+
+fn session_context_for_thread(thread_key: &ThreadKey) -> Option<serde_json::Map<String, Value>> {
+    let slack = slack_context_for_thread(thread_key)?;
+    let mut context = serde_json::Map::new();
+    context.insert("platform".to_owned(), Value::String("slack".to_owned()));
+    context.insert("slack".to_owned(), Value::Object(slack));
+    Some(context)
+}
+
+fn slack_context_for_thread(thread_key: &ThreadKey) -> Option<serde_json::Map<String, Value>> {
+    let parts = thread_key.as_str().split(':').collect::<Vec<_>>();
+    let (team_id, channel_id, thread_ts) = match parts.as_slice() {
+        ["slack", channel_id, thread_ts] => (None, *channel_id, *thread_ts),
+        ["slack", team_id, channel_id, thread_ts] => (Some(*team_id), *channel_id, *thread_ts),
+        [channel_id, thread_ts] if is_slack_conversation_id(channel_id) => {
+            (None, *channel_id, *thread_ts)
+        }
+        _ => return None,
+    };
+    if channel_id.is_empty() || thread_ts.is_empty() {
+        return None;
+    }
+
+    let mut slack = serde_json::Map::new();
+    if let Some(team_id) = team_id.filter(|value| !value.is_empty()) {
+        slack.insert("team_id".to_owned(), Value::String(team_id.to_owned()));
+    }
+    slack.insert(
+        "channel_id".to_owned(),
+        Value::String(channel_id.to_owned()),
+    );
+    slack.insert("thread_ts".to_owned(), Value::String(thread_ts.to_owned()));
+    Some(slack)
+}
+
+fn is_slack_conversation_id(value: &str) -> bool {
+    matches!(value.as_bytes().first(), Some(b'C' | b'D' | b'G'))
 }
 
 fn steering_input_lines(
@@ -5009,6 +5066,44 @@ mod tests {
         assert_eq!(value["trace_id"], trace.trace_id);
         // Without an OpenTelemetry layer there is no traceparent to forward.
         assert!(value.get("traceparent").is_none());
+        assert!(value.get("session_context").is_none());
+    }
+
+    #[test]
+    fn input_line_with_session_context_adds_slack_thread_context() {
+        let thread_key = ThreadKey::parse("slack:T123:C123:1780000000.000000").unwrap();
+        let trace = SessionTraceContext::new(&thread_key, None);
+
+        let line = input_line_with_session_context(&thread_key, &trace, r#"{"type":"user"}"#);
+        let value: Value = serde_json::from_str(&line).unwrap();
+
+        assert_eq!(value["session_context"]["platform"], "slack");
+        assert_eq!(value["session_context"]["slack"]["team_id"], "T123");
+        assert_eq!(value["session_context"]["slack"]["channel_id"], "C123");
+        assert_eq!(
+            value["session_context"]["slack"]["thread_ts"],
+            "1780000000.000000"
+        );
+    }
+
+    #[test]
+    fn input_line_with_session_context_preserves_existing_session_context() {
+        let thread_key = ThreadKey::parse("slack:T123:C123:1780000000.000000").unwrap();
+        let trace = SessionTraceContext::new(&thread_key, None);
+
+        let line = input_line_with_session_context(
+            &thread_key,
+            &trace,
+            r#"{"type":"user","session_context":{"requester":{"github_handle":"@ada"},"platform":"custom"}}"#,
+        );
+        let value: Value = serde_json::from_str(&line).unwrap();
+
+        assert_eq!(
+            value["session_context"]["requester"]["github_handle"],
+            "@ada"
+        );
+        assert_eq!(value["session_context"]["platform"], "custom");
+        assert_eq!(value["session_context"]["slack"]["channel_id"], "C123");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -2056,13 +2056,6 @@ impl SandboxWorkloadMode {
                     .args(["harness-server", harness_server_subcommand(harness)]);
                 if let Some(thread_key) = thread_key {
                     spec = spec.env("CENTAUR_THREAD_KEY", thread_key.as_str());
-                    if let Some((channel_id, thread_ts)) =
-                        slack_destination_from_thread_key(thread_key.as_str())
-                    {
-                        spec = spec
-                            .env("SLACK_CHANNEL_ID", channel_id)
-                            .env("SLACK_THREAD_TS", thread_ts);
-                    }
                 }
                 for mount in mounts {
                     spec = spec.mount(mount.clone());
@@ -2073,21 +2066,6 @@ impl SandboxWorkloadMode {
                 apply_persona_spec_env(spec, persona)
             }
         }
-    }
-}
-
-fn slack_destination_from_thread_key(thread_key: &str) -> Option<(&str, &str)> {
-    let parts = thread_key.split(':').collect::<Vec<_>>();
-    match parts.as_slice() {
-        ["slack", channel_id, thread_ts] if !channel_id.is_empty() && !thread_ts.is_empty() => {
-            Some((*channel_id, *thread_ts))
-        }
-        ["slack", _team_id, channel_id, thread_ts]
-            if !channel_id.is_empty() && !thread_ts.is_empty() =>
-        {
-            Some((*channel_id, *thread_ts))
-        }
-        _ => None,
     }
 }
 
@@ -4931,27 +4909,6 @@ mod tests {
             Some(thread_key.as_str())
         );
         assert_eq!(env_value(&warm_spec, "CENTAUR_THREAD_KEY"), None);
-    }
-
-    #[test]
-    fn codex_claimed_slack_spec_exports_upload_destination() {
-        let workload = SandboxWorkloadMode::codex_app_server(
-            "centaur-agent:latest",
-            [("CENTAUR_API_URL".to_owned(), "http://api:8000".to_owned())],
-            HarnessType::Codex,
-        );
-        let thread_key = ThreadKey::parse("slack:T123:C123:1780000000.000000").unwrap();
-
-        let claimed_spec = workload.spec(&thread_key, &HarnessType::Codex, None);
-        let warm_spec = workload.warm_spec();
-
-        assert_eq!(env_value(&claimed_spec, "SLACK_CHANNEL_ID"), Some("C123"));
-        assert_eq!(
-            env_value(&claimed_spec, "SLACK_THREAD_TS"),
-            Some("1780000000.000000")
-        );
-        assert_eq!(env_value(&warm_spec, "SLACK_CHANNEL_ID"), None);
-        assert_eq!(env_value(&warm_spec, "SLACK_THREAD_TS"), None);
     }
 
     #[test]

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -519,7 +519,6 @@ def upload(
     from .client import upload_file
 
     channel, upload_paths = _upload_target_and_files(target_or_file, files or [])
-    first_upload_path = upload_paths[0] if upload_paths else None
 
     for file_path in upload_paths:
         path = Path(file_path)
@@ -535,7 +534,7 @@ def upload(
                 content_base64=base64.b64encode(path.read_bytes()).decode(),
                 filename=path.name,
                 title=path.name,
-                comment=comment if file_path == first_upload_path else None,  # Only comment on first file
+                comment=comment if file_path == files[0] else None,  # Only comment on first file
                 thread_ts=thread,
             )
             console.print(f"[green]✓ Uploaded {path.name}[/]")

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1518,11 +1518,6 @@ class SlackClient:
         except Exception:
             pass
 
-        env_channel = os.environ.get("SLACK_CHANNEL_ID", "").strip()
-        env_thread_ts = os.environ.get("SLACK_THREAD_TS", "").strip()
-        if env_channel and env_thread_ts:
-            return env_channel, env_thread_ts
-
         try:
             thread_key = get_tool_context().thread_key or ""
         except LookupError:

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -1,10 +1,6 @@
-import sys
-import types
 from pathlib import Path
 
-from typer.testing import CliRunner
-
-from slack.cli import _channel_arg_is_id, _upload_target_and_files, app
+from slack.cli import _channel_arg_is_id, _upload_target_and_files
 
 
 def test_channel_arg_is_id_accepts_channel_id_forms() -> None:
@@ -45,32 +41,3 @@ def test_upload_target_single_missing_path_uses_default_context() -> None:
 
     assert channel is None
     assert files == ["chart.png"]
-
-
-def test_upload_single_file_uses_default_context_without_files_arg(
-    monkeypatch, tmp_path: Path
-) -> None:
-    upload = tmp_path / "chart.png"
-    upload.write_bytes(b"png")
-    calls = []
-
-    def fake_upload_file(**kwargs):
-        calls.append(kwargs)
-        return {"permalink": "https://slack.example/files/chart.png"}
-
-    fake_client = types.SimpleNamespace(upload_file=fake_upload_file)
-    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
-
-    result = CliRunner().invoke(app, ["upload", str(upload), "--comment", "chart"])
-
-    assert result.exit_code == 0
-    assert calls == [
-        {
-            "channel": None,
-            "content_base64": "cG5n",
-            "filename": "chart.png",
-            "title": "chart.png",
-            "comment": "chart",
-            "thread_ts": None,
-        }
-    ]

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -670,26 +670,6 @@ def test_upload_file_explicit_destination_overrides_api_context(monkeypatch) -> 
     assert fake_web_client.last_kwargs["thread_ts"] == "201.000000"
 
 
-def test_upload_file_defaults_to_slack_env_context(monkeypatch) -> None:
-    import slack.client as slack_client_module
-
-    client, fake_web_client = _make_client()
-    monkeypatch.setattr(
-        slack_client_module,
-        "current_slack_thread",
-        lambda: (_ for _ in ()).throw(RuntimeError("no tool context")),
-    )
-    monkeypatch.setenv("SLACK_CHANNEL_ID", "C-env")
-    monkeypatch.setenv("SLACK_THREAD_TS", "202.000000")
-    client._resolve_channel = lambda channel: channel  # type: ignore[method-assign]
-
-    client.upload_file(content_base64="dGVzdA==", filename="chart.png")
-
-    assert fake_web_client.last_kwargs is not None
-    assert fake_web_client.last_kwargs["channel"] == "C-env"
-    assert fake_web_client.last_kwargs["thread_ts"] == "202.000000"
-
-
 def test_upload_file_infers_destination_from_team_scoped_thread_key() -> None:
     """The slackbot emits slack:<team>:<channel>:<thread_ts>; upload_file must
     infer the channel and thread from that 4-part key, not just the legacy


### PR DESCRIPTION
## Summary

Reverts the changes from #699 / 1233ff73cced109cb3f907c57cb53e5394d37d82.

This removes the Slack upload default channel/thread context behavior added in that PR and drops its associated tests.

## Validation

Stopped additional local validation per follow-up request.
