### PR TITLE
fix: use presigned archive downloads

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -230,6 +230,10 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
             post(refresh_slack_archive_import_upload_url),
         )
         .route(
+            "/api/admin/slack/archive-imports/{import_id}/download-url",
+            post(create_slack_archive_import_download_url),
+        )
+        .route(
             "/api/admin/slack/archive-imports/{import_id}/start",
             post(start_slack_archive_import),
         )
@@ -740,6 +744,28 @@ async fn refresh_slack_archive_import_upload_url(
     ))
 }
 
+async fn create_slack_archive_import_download_url(
+    State(state): State<AppState>,
+    Path(import_id): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let pool = db_pool(&state)?;
+    let import = load_slack_archive_import(&pool, &import_id).await?;
+    ensure_archive_import_status(
+        &import.status,
+        &["uploaded", "importing", "failed"],
+        "archive download URL cannot be created",
+    )?;
+    let config = slack_archive_upload_config()?;
+    ensure_archive_import_bucket_matches_config(&import, &config)?;
+    let download_url = presign_s3_get_url(&config, &import.object_key).await?;
+    let expires_at = OffsetDateTime::now_utc() + config.presign_ttl;
+    Ok(Json(slack_archive_download_response(
+        import,
+        download_url,
+        expires_at,
+    )))
+}
+
 async fn delete_slack_archive_import(
     State(state): State<AppState>,
     Path(import_id): Path<String>,
@@ -1041,6 +1067,23 @@ fn slack_archive_upload_response(
     })
 }
 
+fn slack_archive_download_response(
+    row: SlackArchiveImportRow,
+    download_url: String,
+    expires_at: OffsetDateTime,
+) -> Value {
+    let archive_uri = row.archive_uri.clone();
+    json!({
+        "ok": true,
+        "import": SlackArchiveImportResponse::from(row),
+        "download": {
+            "archive_uri": archive_uri,
+            "download_url": download_url,
+            "expires_at": expires_at,
+        }
+    })
+}
+
 fn ensure_archive_import_status(
     status: &str,
     allowed: &[&str],
@@ -1218,6 +1261,23 @@ async fn presign_s3_put_url(
         .bucket(&config.bucket)
         .key(object_key)
         .content_type(content_type)
+        .presigned(presigning)
+        .await
+        .map_err(|error| ApiError::Internal(error.to_string()))?;
+    Ok(request.uri().to_string())
+}
+
+async fn presign_s3_get_url(
+    config: &SlackArchiveUploadConfig,
+    object_key: &str,
+) -> Result<String, ApiError> {
+    let client = s3_client(config).await;
+    let presigning = PresigningConfig::expires_in(config.presign_ttl)
+        .map_err(|error| ApiError::Internal(error.to_string()))?;
+    let request = client
+        .get_object()
+        .bucket(&config.bucket)
+        .key(object_key)
         .presigned(presigning)
         .await
         .map_err(|error| ApiError::Internal(error.to_string()))?;
@@ -1574,6 +1634,27 @@ mod slack_archive_import_tests {
     }
 
     #[test]
+    fn archive_import_download_url_statuses_exclude_unuploaded_or_terminal_imports() {
+        for status in ["uploaded", "importing", "failed"] {
+            ensure_archive_import_status(
+                status,
+                &["uploaded", "importing", "failed"],
+                "archive download URL cannot be created",
+            )
+            .unwrap();
+        }
+        for status in ["upload_pending", "completed", "cancelled"] {
+            let error = ensure_archive_import_status(
+                status,
+                &["uploaded", "importing", "failed"],
+                "archive download URL cannot be created",
+            )
+            .unwrap_err();
+            assert!(matches!(error, ApiError::BadRequest(_)));
+        }
+    }
+
+    #[test]
     fn archive_import_bucket_must_match_current_upload_config() {
         let import = archive_row("upload_pending");
         let config = SlackArchiveUploadConfig {
@@ -1613,6 +1694,28 @@ mod slack_archive_import_tests {
             json!("https://uploads.example/presigned")
         );
         assert!(body["upload"]["expires_at"].is_array());
+    }
+
+    #[test]
+    fn archive_download_response_includes_import_and_download_contract() {
+        let expires_at = OffsetDateTime::from_unix_timestamp(1_700_000_900).unwrap();
+        let body = slack_archive_download_response(
+            archive_row("uploaded"),
+            "https://uploads.example/presigned-download".to_owned(),
+            expires_at,
+        );
+        assert_eq!(body["ok"], json!(true));
+        assert_eq!(body["import"]["import_id"], json!("sai_test"));
+        assert_eq!(
+            body["download"]["archive_uri"],
+            json!("s3://bucket/prefix/sai_test/archive.zip")
+        );
+        assert_eq!(
+            body["download"]["download_url"],
+            json!("https://uploads.example/presigned-download")
+        );
+        assert!(body["download"]["expires_at"].is_array());
+        assert!(body.get("upload").is_none());
     }
 }
 

--- a/workflows/slack/archive_import.py
+++ b/workflows/slack/archive_import.py
@@ -6,8 +6,10 @@ import asyncio
 import datetime as dt
 import json
 import os
+import shutil
 import tempfile
 import urllib.parse
+import urllib.request
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -602,32 +604,49 @@ async def import_archive_path(
     return counts
 
 
-def _s3_client():
-    import boto3
-    from botocore.config import Config
+def _api_base_url() -> str:
+    value = _as_text(
+        os.environ.get("CENTAUR_API_URL")
+        or os.environ.get("SESSION_SANDBOX_CENTAUR_API_URL")
+    ).rstrip("/")
+    if not value:
+        raise RuntimeError("CENTAUR_API_URL is required to download Slack archive")
+    return value
 
-    region = os.getenv("SLACK_ARCHIVE_UPLOAD_REGION") or "auto"
-    endpoint_url = os.getenv("SLACK_ARCHIVE_UPLOAD_ENDPOINT") or None
-    return boto3.client(
-        "s3",
-        region_name=region,
-        endpoint_url=endpoint_url,
-        config=Config(s3={"addressing_style": "path"}),
+
+def _request_archive_download_url(import_id: str) -> str:
+    quoted_import_id = urllib.parse.quote(import_id, safe="")
+    request = urllib.request.Request(
+        f"{_api_base_url()}/api/admin/slack/archive-imports/{quoted_import_id}/download-url",
+        data=b"",
+        method="POST",
+        headers={"Content-Type": "application/json"},
     )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    download = payload.get("download") if isinstance(payload, dict) else None
+    download_url = download.get("download_url") if isinstance(download, dict) else None
+    if not download_url:
+        raise RuntimeError(
+            "Slack archive download URL response is missing download_url"
+        )
+    return _as_text(download_url)
 
 
-def _download_s3_object(bucket: str, key: str, destination: Path) -> None:
-    with destination.open("wb") as handle:
-        _s3_client().download_fileobj(bucket, key, handle)
+def _download_url_to_path(download_url: str, destination: Path) -> None:
+    request = urllib.request.Request(
+        download_url,
+        headers={"User-Agent": "centaur-slack-archive-import/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=300) as response:
+        with destination.open("wb") as handle:
+            shutil.copyfileobj(response, handle)
 
 
 async def _download_archive(import_row: dict[str, Any], destination: Path) -> None:
-    await asyncio.to_thread(
-        _download_s3_object,
-        _as_text(import_row.get("object_bucket")),
-        _as_text(import_row.get("object_key")),
-        destination,
-    )
+    import_id = _as_text(import_row.get("import_id"))
+    download_url = await asyncio.to_thread(_request_archive_download_url, import_id)
+    await asyncio.to_thread(_download_url_to_path, download_url, destination)
 
 
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:

--- a/workflows/slack/tests/test_archive_import.py
+++ b/workflows/slack/tests/test_archive_import.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import io
 import json
 import sys
 import types
+import urllib.request
 import zipfile
 from pathlib import Path
 
@@ -349,3 +351,76 @@ def test_archive_upsert_sql_preserves_live_fields():
     assert "content_bytes =" not in attachment_update
     assert "content_sha256 =" not in attachment_update
     assert "download_status = CASE WHEN" in attachment_update
+
+
+def test_request_archive_download_url_uses_api_presign_endpoint(monkeypatch):
+    opened_requests = []
+
+    class FakeResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    def fake_urlopen(request, timeout):
+        opened_requests.append((request, timeout))
+        return FakeResponse(
+            json.dumps(
+                {
+                    "ok": True,
+                    "download": {
+                        "download_url": "https://r2.example/presigned-download"
+                    },
+                }
+            ).encode()
+        )
+
+    monkeypatch.setenv("CENTAUR_API_URL", "http://centaur-api-rs:8080/")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    download_url = archive_import._request_archive_download_url("sai id/with/slash")
+
+    assert download_url == "https://r2.example/presigned-download"
+    request, timeout = opened_requests[0]
+    assert timeout == 30
+    assert request.get_method() == "POST"
+    assert (
+        request.full_url
+        == "http://centaur-api-rs:8080/api/admin/slack/archive-imports/"
+        "sai%20id%2Fwith%2Fslash/download-url"
+    )
+
+
+def test_download_archive_streams_api_presigned_url(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_request_archive_download_url(import_id):
+        calls.append(("presign", import_id))
+        return "https://r2.example/presigned-download"
+
+    def fake_download_url_to_path(download_url, destination):
+        calls.append(("download", download_url, destination))
+        destination.write_bytes(b"zip bytes")
+
+    monkeypatch.setattr(
+        archive_import,
+        "_request_archive_download_url",
+        fake_request_archive_download_url,
+    )
+    monkeypatch.setattr(
+        archive_import,
+        "_download_url_to_path",
+        fake_download_url_to_path,
+    )
+
+    destination = tmp_path / "archive.zip"
+    asyncio.run(
+        archive_import._download_archive({"import_id": "sai_dummy"}, destination)
+    )
+
+    assert calls == [
+        ("presign", "sai_dummy"),
+        ("download", "https://r2.example/presigned-download", destination),
+    ]
+    assert destination.read_bytes() == b"zip bytes"


### PR DESCRIPTION
## Summary
- add an admin archive-import endpoint that returns a short-lived presigned download URL for uploaded/importing/failed archives
- switch the Slack archive import workflow to request that URL from the API and stream the archive without S3/R2 credentials in the sandbox
- add unit tests for the download URL contract and workflow download behavior

## Tests
- uv run --with pytest pytest workflows/slack/tests/test_archive_import.py
- uv run --with ruff ruff check workflows/slack/archive_import.py workflows/slack/tests/test_archive_import.py
- uv run --with ruff ruff format --check workflows/slack/archive_import.py workflows/slack/tests/test_archive_import.py
- cargo fmt --all --check (services/api-rs)
- cargo test -p centaur-api-server slack_archive_import_tests (services/api-rs)
- git diff --check
- docker build -t centaur-api-rs:latest -f services/api-rs/Dockerfile .