### PR TITLE
fix: pass api url to workflow host sandboxes

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -919,14 +919,7 @@ impl SandboxArgs {
     }
 
     fn codex_app_server_env_template(&self) -> Result<Vec<(String, String)>, ServerError> {
-        let mut envs = vec![(
-            "CENTAUR_API_URL".to_owned(),
-            self.centaur_api_url_override
-                .as_deref()
-                .or(self.centaur_api_url.as_deref())
-                .unwrap_or("http://api:8000")
-                .to_owned(),
-        )];
+        let mut envs = vec![("CENTAUR_API_URL".to_owned(), self.centaur_api_url())];
 
         // Single source of truth: propagate this control plane's harness auth
         // modes into the sandbox so the agent's auth.json matches the
@@ -1109,7 +1102,7 @@ impl SandboxArgs {
     }
 
     fn workflow_host_env_template(&self) -> Result<Vec<(String, String)>, ServerError> {
-        let mut envs = Vec::new();
+        let mut envs = vec![("CENTAUR_API_URL".to_owned(), self.centaur_api_url())];
 
         for (name, value) in self.iron_proxy.sandbox_placeholder_env()? {
             envs.push((name, value));
@@ -1151,6 +1144,14 @@ impl SandboxArgs {
         }
 
         Ok(envs)
+    }
+
+    fn centaur_api_url(&self) -> String {
+        self.centaur_api_url_override
+            .as_deref()
+            .or(self.centaur_api_url.as_deref())
+            .unwrap_or("http://api:8000")
+            .to_owned()
     }
 
     fn passthrough_env_names(&self) -> impl Iterator<Item = &str> {
@@ -2209,6 +2210,8 @@ mod tests {
             "postgres://postgres:postgres@localhost/centaur",
             "--session-sandbox-backend",
             "agent-k8s",
+            "--session-sandbox-centaur-api-url",
+            "http://centaur-api-rs:8080",
             "--kubernetes-sandbox-iron-proxy-mode",
             "disabled",
         ])
@@ -2216,6 +2219,13 @@ mod tests {
 
         let spec = args.sandbox.workflow_host_spec(None).unwrap();
 
+        assert_eq!(
+            spec.env
+                .iter()
+                .find(|env| env.name == "CENTAUR_API_URL")
+                .map(|env| env.value.as_str()),
+            Some("http://centaur-api-rs:8080")
+        );
         assert_eq!(
             spec.env
                 .iter()


### PR DESCRIPTION
## Summary
- pass `CENTAUR_API_URL` into workflow-host sandbox specs using the same URL precedence as normal codex sandboxes
- reuse the shared URL helper so `SESSION_SANDBOX_CENTAUR_API_URL` drives both sandbox types
- add a regression assertion that workflow-host specs include the API URL override

## Why
Workflow-host pods call back to the Rust API for Slack archive presigned download URLs. They already receive `HTTP_PROXY`, and the K8s proxy env builder only adds the internal API host to `NO_PROXY` when the spec has `CENTAUR_API_URL`. Workflow-host specs only had `SESSION_SANDBOX_CENTAUR_API_URL`, so calls to `centaur-api-rs` could be routed through iron-proxy and fail with `405 Method Not Allowed`.

## Validation
- `cargo test --manifest-path services/api-rs/Cargo.toml -p centaur-api-server workflow_host_env_template_splits_passthrough_env_from_environment`
- `cargo test --manifest-path services/api-rs/Cargo.toml -p centaur-api-server args::tests`