### PR TITLE
Fix Slack bot-authored mention handling

### DIFF
--- a/patches/@chat-adapter__slack@4.31.0.patch
+++ b/patches/@chat-adapter__slack@4.31.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.js b/dist/index.js
-index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22eed819d8e 100644
+index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818ff52ce63 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -31,6 +31,216 @@ import {
@@ -219,7 +219,18 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
  
  // src/cards.ts
  import {
-@@ -3452,26 +3662,251 @@ var SlackAdapter = class _SlackAdapter {
+@@ -2004,7 +2214,9 @@ var SlackAdapter = class _SlackAdapter {
+       channel: event.channel,
+       threadTs
+     });
+-    const isMention = event.type === "app_mention";
++    const isMention = event.type === "app_mention" || Boolean(
++      this._botUserId && typeof event.text === "string" && event.text.includes(`<@${this._botUserId}>`) && (event.bot_id || event.subtype === "bot_message")
++    );
+     const factory = async () => {
+       const msg = await this.parseSlackMessage(event, threadId);
+       if (isMention) {
+@@ -3452,26 +3664,251 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -480,7 +491,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
      const sendStructuredChunk = async (chunk) => {
        if (!structuredChunksSupported) {
          return;
-@@ -3481,8 +3916,45 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3481,8 +3918,45 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
@@ -527,7 +538,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
          structuredChunksSupported = false;
          this.logger.warn(
            "Structured streaming chunk failed, falling back to text-only streaming. Ensure your Slack app manifest includes assistant_view, assistant:write scope, and @slack/web-api >= 7.14.0",
-@@ -3497,31 +3969,91 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3497,31 +3971,91 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
      };
@@ -547,7 +558,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +        } else {
 +          await sendStructuredChunk(chunk);
 +        }
-+      }
+       }
 +      renderer.finish();
 +      const finalCommittable = renderer.getCommittableText();
 +      const finalDelta = finalCommittable.slice(lastAppended.length);
@@ -610,7 +621,7 @@ index 53a35e40d7dc03dea57f965325728761467ad7c7..d960b5a2daa267af4f860f787261a22e
 +            error: stopError
 +          });
 +        }
-       }
++      }
 +      annotateSlackAnswerLost(error, !sourceConsumed || answerStopFailed);
 +      throw error;
      }

--- a/patches/@chat-adapter__slack@4.31.0.patch
+++ b/patches/@chat-adapter__slack@4.31.0.patch
@@ -219,14 +219,15 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
  
  // src/cards.ts
  import {
-@@ -2004,7 +2214,9 @@ var SlackAdapter = class _SlackAdapter {
+@@ -2004,7 +2214,10 @@ var SlackAdapter = class _SlackAdapter {
        channel: event.channel,
        threadTs
      });
 -    const isMention = event.type === "app_mention";
-+    const isMention = event.type === "app_mention" || Boolean(
-+      this._botUserId && typeof event.text === "string" && event.text.includes(`<@${this._botUserId}>`) && (event.bot_id || event.subtype === "bot_message")
++    const botMentioned = Boolean(
++      this._botUserId && typeof event.text === "string" && (event.text.includes(`<@${this._botUserId}>`) || event.text.includes(`<@${this._botUserId}|`))
 +    );
++    const isMention = event.type === "app_mention" || botMentioned && (event.bot_id || event.subtype === "bot_message");
      const factory = async () => {
        const msg = await this.parseSlackMessage(event, threadId);
        if (isMention) {

--- a/patches/@chat-adapter__slack@4.31.0.patch
+++ b/patches/@chat-adapter__slack@4.31.0.patch
@@ -230,6 +230,19 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
      const factory = async () => {
        const msg = await this.parseSlackMessage(event, threadId);
        if (isMention) {
+@@ -2520,10 +2732,10 @@ var SlackAdapter = class _SlackAdapter {
+       formatted: this.formatConverter.toAst(text),
+       raw: event,
+       author: {
+-        userId: event.user || event.bot_id || "unknown",
++        userId: event.user || event.bot_profile?.user_id || event.bot_id || "unknown",
+         userName,
+         fullName,
+-        isBot: !!event.bot_id,
++        isBot: Boolean(event.bot_id || event.bot_profile || event.subtype === "bot_message"),
+         isMe
+       },
+       metadata: {
 @@ -3452,26 +3664,251 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
@@ -649,3 +662,16 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
      };
    }
    /**
+@@ -3798,10 +4332,10 @@ var SlackAdapter = class _SlackAdapter {
+       formatted: this.formatConverter.toAst(text),
+       raw: event,
+       author: {
+-        userId: event.user || event.bot_id || "unknown",
++        userId: event.user || event.bot_profile?.user_id || event.bot_id || "unknown",
+         userName,
+         fullName,
+-        isBot: !!event.bot_id,
++        isBot: Boolean(event.bot_id || event.bot_profile || event.subtype === "bot_message"),
+         isMe
+       },
+       metadata: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fce7a692b030cfe3d325b020a4472b9424b8976aa2f7faded6ad4c83421e9132
     path: patches/@chat-adapter__linear@4.31.0.patch
   '@chat-adapter/slack@4.31.0':
-    hash: 248157ef9831daf2fbfa0f6c90d4f6fc7fdc1bad66937d54577f75fd6d007ef8
+    hash: 4a13e39aa1f023696e9b930391146ffcb8ac50adfcf394dcf1905e4e445213f7
     path: patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
@@ -177,7 +177,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.31.0
-        version: 4.31.0(patch_hash=248157ef9831daf2fbfa0f6c90d4f6fc7fdc1bad66937d54577f75fd6d007ef8)(zod@4.4.3)
+        version: 4.31.0(patch_hash=4a13e39aa1f023696e9b930391146ffcb8ac50adfcf394dcf1905e4e445213f7)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
@@ -1356,7 +1356,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.31.0(patch_hash=248157ef9831daf2fbfa0f6c90d4f6fc7fdc1bad66937d54577f75fd6d007ef8)(zod@4.4.3)':
+  '@chat-adapter/slack@4.31.0(patch_hash=4a13e39aa1f023696e9b930391146ffcb8ac50adfcf394dcf1905e4e445213f7)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fce7a692b030cfe3d325b020a4472b9424b8976aa2f7faded6ad4c83421e9132
     path: patches/@chat-adapter__linear@4.31.0.patch
   '@chat-adapter/slack@4.31.0':
-    hash: 7216033563a8409e8dce41f10a01334c50c1c7594bd3ba5fe91e8f2824a58728
+    hash: 248157ef9831daf2fbfa0f6c90d4f6fc7fdc1bad66937d54577f75fd6d007ef8
     path: patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
@@ -177,7 +177,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.31.0
-        version: 4.31.0(patch_hash=7216033563a8409e8dce41f10a01334c50c1c7594bd3ba5fe91e8f2824a58728)(zod@4.4.3)
+        version: 4.31.0(patch_hash=248157ef9831daf2fbfa0f6c90d4f6fc7fdc1bad66937d54577f75fd6d007ef8)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
@@ -1356,7 +1356,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.31.0(patch_hash=7216033563a8409e8dce41f10a01334c50c1c7594bd3ba5fe91e8f2824a58728)(zod@4.4.3)':
+  '@chat-adapter/slack@4.31.0(patch_hash=248157ef9831daf2fbfa0f6c90d4f6fc7fdc1bad66937d54577f75fd6d007ef8)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fce7a692b030cfe3d325b020a4472b9424b8976aa2f7faded6ad4c83421e9132
     path: patches/@chat-adapter__linear@4.31.0.patch
   '@chat-adapter/slack@4.31.0':
-    hash: 7da250cea3e8a84e3fc21314f7be2059496de2add5724287495c3a1b5b1ef21b
+    hash: 7216033563a8409e8dce41f10a01334c50c1c7594bd3ba5fe91e8f2824a58728
     path: patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
@@ -177,7 +177,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.31.0
-        version: 4.31.0(patch_hash=7da250cea3e8a84e3fc21314f7be2059496de2add5724287495c3a1b5b1ef21b)(zod@4.4.3)
+        version: 4.31.0(patch_hash=7216033563a8409e8dce41f10a01334c50c1c7594bd3ba5fe91e8f2824a58728)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
@@ -1356,7 +1356,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.31.0(patch_hash=7da250cea3e8a84e3fc21314f7be2059496de2add5724287495c3a1b5b1ef21b)(zod@4.4.3)':
+  '@chat-adapter/slack@4.31.0(patch_hash=7216033563a8409e8dce41f10a01334c50c1c7594bd3ba5fe91e8f2824a58728)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3297,7 +3297,8 @@ describe('slackbotv2', () => {
 
     bot = createTestBot({ triggerBotAllowlist: ['bot:BOTHERBOT'] })
     codexApi.reset()
-    const allowedBotChannelMessage = await postUserMessage(`<@${BOT_USER_ID}> from allowed bot message`)
+    const labeledBotMention = `<@${BOT_USER_ID}|centaur> from allowed bot message`
+    const allowedBotChannelMessage = await postUserMessage(labeledBotMention)
     slackApi.reset()
     const allowedBotChannelWaits: Promise<unknown>[] = []
     const allowedBotChannelResponse = await bot.app.request(
@@ -3316,7 +3317,7 @@ describe('slackbotv2', () => {
           channel: CHANNEL_ID,
           subtype: 'bot_message',
           team: TEAM_ID,
-          text: `<@${BOT_USER_ID}> from allowed bot message`,
+          text: labeledBotMention,
           ts: allowedBotChannelMessage.ts,
           username: 'otherbot'
         }

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3298,6 +3298,7 @@ describe('slackbotv2', () => {
     bot = createTestBot({ triggerBotAllowlist: ['bot:BOTHERBOT'] })
     codexApi.reset()
     const allowedBotChannelMessage = await postUserMessage(`<@${BOT_USER_ID}> from allowed bot message`)
+    slackApi.reset()
     const allowedBotChannelWaits: Promise<unknown>[] = []
     const allowedBotChannelResponse = await bot.app.request(
       '/api/webhooks/slack',
@@ -3327,6 +3328,14 @@ describe('slackbotv2', () => {
     await Promise.all(allowedBotChannelWaits)
     expect(codexApi.appends).toHaveLength(1)
     expect(codexApi.executes).toHaveLength(1)
+    const allowedBotChannelTranscripts = slackStreamTranscripts(slackApi.calls)
+    expect(allowedBotChannelTranscripts).toHaveLength(1)
+    expect(allowedBotChannelTranscripts[0]!.start.body).toEqual(
+      expect.objectContaining({
+        recipient_team_id: TEAM_ID,
+        recipient_user_id: 'UOTHERBOT'
+      })
+    )
   })
 })
 

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3294,6 +3294,39 @@ describe('slackbotv2', () => {
     await Promise.all(allowedBotWaits)
     expect(codexApi.appends).toHaveLength(1)
     expect(codexApi.executes).toHaveLength(1)
+
+    bot = createTestBot({ triggerBotAllowlist: ['bot:BOTHERBOT'] })
+    codexApi.reset()
+    const allowedBotChannelMessage = await postUserMessage(`<@${BOT_USER_ID}> from allowed bot message`)
+    const allowedBotChannelWaits: Promise<unknown>[] = []
+    const allowedBotChannelResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-bot-message-allowed',
+        event: {
+          type: 'message',
+          app_id: 'AOTHERBOT',
+          bot_id: 'BOTHERBOT',
+          bot_profile: {
+            app_id: 'AOTHERBOT',
+            id: 'BOTHERBOT',
+            user_id: 'UOTHERBOT'
+          },
+          channel: CHANNEL_ID,
+          subtype: 'bot_message',
+          team: TEAM_ID,
+          text: `<@${BOT_USER_ID}> from allowed bot message`,
+          ts: allowedBotChannelMessage.ts,
+          username: 'otherbot'
+        }
+      }),
+      {},
+      waitUntilContext(allowedBotChannelWaits)
+    )
+    expect(allowedBotChannelResponse.status).toBe(200)
+    await Promise.all(allowedBotChannelWaits)
+    expect(codexApi.appends).toHaveLength(1)
+    expect(codexApi.executes).toHaveLength(1)
   })
 })
 


### PR DESCRIPTION
## Summary
- Treat allowlisted bot-authored Slack channel messages that explicitly mention the bot as mentions
- Add regression coverage for `message` + `subtype=bot_message` events from allowlisted bots
- Refresh the PNPM patch hash for `@chat-adapter/slack`

## Test
- `pnpm install --frozen-lockfile && pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts`