### PR TITLE
Wait for iron-proxy principal before cold sandbox startup

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -312,7 +312,9 @@ impl AgentSandboxBackend {
             )
             .await
             .map_err(|err| map_kube_error("create iron-proxy pod", err))?;
-        self.wait_until_proxy_running(resolved).await
+        self.wait_until_proxy_running(resolved).await?;
+        self.require_proxy_principal_applied(id, &resolved.principal_id)
+            .await
     }
 
     /// Register a per-sandbox proxy in iron-control and return the env (URL +
@@ -477,28 +479,49 @@ impl AgentSandboxBackend {
     /// claim: managed proxies fail closed until synced, so the worst case is a
     /// brief 503 window rather than a failed execution.
     async fn wait_for_proxy_principal_applied(&self, id: &SandboxId, principal_id: &str) {
+        if let Err(error) = self
+            .proxy_principal_ack(id, principal_id, "claim barrier")
+            .await
+        {
+            tracing::info!(
+                sandbox_id = id.as_str(),
+                %error,
+                "iron-proxy management API is unavailable (image without \
+                 managed status support?); using the fixed reassign delay"
+            );
+            sleep(PROXY_REASSIGN_FALLBACK_DELAY).await;
+        }
+    }
+
+    /// Cold-created sandboxes do not go through the warm-pool claim barrier,
+    /// but the harness can make credentialed calls immediately after create
+    /// returns. Require the proxy to report the requested principal's config
+    /// before creating the sandbox pod, so first traffic cannot race ahead of
+    /// secret injection.
+    async fn require_proxy_principal_applied(
+        &self,
+        id: &SandboxId,
+        principal_id: &str,
+    ) -> SandboxResult<()> {
+        self.proxy_principal_ack(id, principal_id, "cold create barrier")
+            .await
+    }
+
+    async fn proxy_principal_ack(
+        &self,
+        id: &SandboxId,
+        principal_id: &str,
+        barrier: &'static str,
+    ) -> SandboxResult<()> {
         let started = Instant::now();
         let endpoint = match self.proxy_management_endpoint(id).await {
             Ok(Some(endpoint)) => endpoint,
             Ok(None) => {
-                tracing::warn!(
-                    sandbox_id = id.as_str(),
-                    "no running iron-proxy pod found for the claim barrier; \
-                     using the fixed reassign delay"
-                );
-                sleep(PROXY_REASSIGN_FALLBACK_DELAY).await;
-                return;
+                return Err(SandboxError::NotReady(format!(
+                    "no running iron-proxy pod found for the {barrier}"
+                )));
             }
-            Err(error) => {
-                tracing::warn!(
-                    sandbox_id = id.as_str(),
-                    %error,
-                    "failed to look up the iron-proxy management endpoint; \
-                     using the fixed reassign delay"
-                );
-                sleep(PROXY_REASSIGN_FALLBACK_DELAY).await;
-                return;
-            }
+            Err(error) => return Err(error),
         };
         let Ok(client) = reqwest::Client::builder()
             // Pod-IP call inside the cluster: never route via env-configured
@@ -508,8 +531,9 @@ impl AgentSandboxBackend {
             .timeout(Duration::from_secs(2))
             .build()
         else {
-            sleep(PROXY_REASSIGN_FALLBACK_DELAY).await;
-            return;
+            return Err(SandboxError::backend(
+                "failed to build iron-proxy management client",
+            ));
         };
         match wait_for_proxy_ack(
             &client,
@@ -525,27 +549,18 @@ impl AgentSandboxBackend {
                 tracing::info!(
                     sandbox_id = id.as_str(),
                     principal_id,
+                    barrier,
                     elapsed_ms = started.elapsed().as_millis() as u64,
                     "iron-proxy acknowledged the claimed principal's config"
                 );
+                Ok(())
             }
-            ProxyAck::ManagementUnavailable => {
-                tracing::info!(
-                    sandbox_id = id.as_str(),
-                    "iron-proxy management API is unavailable (image without \
-                     managed status support?); using the fixed reassign delay"
-                );
-                sleep(PROXY_REASSIGN_FALLBACK_DELAY.saturating_sub(started.elapsed())).await;
-            }
-            ProxyAck::TimedOut => {
-                tracing::warn!(
-                    sandbox_id = id.as_str(),
-                    principal_id,
-                    "iron-proxy did not acknowledge the claimed principal's \
-                     config before the deadline; proceeding (managed proxies \
-                     fail closed until synced)"
-                );
-            }
+            ProxyAck::ManagementUnavailable => Err(SandboxError::NotReady(format!(
+                "iron-proxy management API did not answer for the {barrier}"
+            ))),
+            ProxyAck::TimedOut => Err(SandboxError::NotReady(format!(
+                "iron-proxy did not acknowledge principal {principal_id:?} for the {barrier} before the deadline"
+            ))),
         }
     }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -313,8 +313,9 @@ impl AgentSandboxBackend {
             .await
             .map_err(|err| map_kube_error("create iron-proxy pod", err))?;
         self.wait_until_proxy_running(resolved).await?;
-        self.require_proxy_principal_applied(id, &resolved.principal_id)
-            .await
+        self.wait_for_cold_proxy_principal_applied(id, &resolved.principal_id)
+            .await;
+        Ok(())
     }
 
     /// Register a per-sandbox proxy in iron-control and return the env (URL +
@@ -479,32 +480,100 @@ impl AgentSandboxBackend {
     /// claim: managed proxies fail closed until synced, so the worst case is a
     /// brief 503 window rather than a failed execution.
     async fn wait_for_proxy_principal_applied(&self, id: &SandboxId, principal_id: &str) {
-        if let Err(error) = self
+        let started = Instant::now();
+        match self
             .proxy_principal_ack(id, principal_id, "claim barrier")
             .await
         {
-            tracing::info!(
-                sandbox_id = id.as_str(),
-                %error,
-                "iron-proxy management API is unavailable (image without \
-                 managed status support?); using the fixed reassign delay"
-            );
-            sleep(PROXY_REASSIGN_FALLBACK_DELAY).await;
+            Ok(ProxyAck::Applied) => {
+                tracing::info!(
+                    sandbox_id = id.as_str(),
+                    principal_id,
+                    barrier = "claim barrier",
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "iron-proxy acknowledged the claimed principal's config"
+                );
+            }
+            Ok(ProxyAck::ManagementUnavailable) => {
+                tracing::info!(
+                    sandbox_id = id.as_str(),
+                    "iron-proxy management API is unavailable (image without \
+                     managed status support?); using the fixed reassign delay"
+                );
+                sleep(proxy_fallback_delay_remaining(started.elapsed())).await;
+            }
+            Ok(ProxyAck::TimedOut) => {
+                // The ack timeout already waited longer than the fixed
+                // fallback delay, so do not add another sleep here.
+                tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    principal_id,
+                    "iron-proxy did not acknowledge the claimed principal's \
+                     config before the deadline; proceeding (managed proxies \
+                     fail closed until synced)"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    %error,
+                    "failed to check the iron-proxy management API for the \
+                     claim barrier; using the fixed reassign delay"
+                );
+                sleep(proxy_fallback_delay_remaining(started.elapsed())).await;
+            }
         }
     }
 
     /// Cold-created sandboxes do not go through the warm-pool claim barrier,
     /// but the harness can make credentialed calls immediately after create
-    /// returns. Require the proxy to report the requested principal's config
-    /// before creating the sandbox pod, so first traffic cannot race ahead of
-    /// secret injection.
-    async fn require_proxy_principal_applied(
-        &self,
-        id: &SandboxId,
-        principal_id: &str,
-    ) -> SandboxResult<()> {
-        self.proxy_principal_ack(id, principal_id, "cold create barrier")
+    /// returns. Ask the proxy to report the requested principal's config before
+    /// creating the sandbox pod. If the management API cannot prove readiness,
+    /// fall back to the fixed delay instead of failing the sandbox create.
+    async fn wait_for_cold_proxy_principal_applied(&self, id: &SandboxId, principal_id: &str) {
+        let started = Instant::now();
+        match self
+            .proxy_principal_ack(id, principal_id, "cold create barrier")
             .await
+        {
+            Ok(ProxyAck::Applied) => {
+                tracing::info!(
+                    sandbox_id = id.as_str(),
+                    principal_id,
+                    barrier = "cold create barrier",
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "iron-proxy acknowledged the claimed principal's config"
+                );
+            }
+            Ok(ProxyAck::ManagementUnavailable) => {
+                tracing::info!(
+                    sandbox_id = id.as_str(),
+                    "iron-proxy management API is unavailable (image without \
+                     managed status support?); using the fixed cold-create delay"
+                );
+                sleep(proxy_fallback_delay_remaining(started.elapsed())).await;
+            }
+            Ok(ProxyAck::TimedOut) => {
+                // The ack timeout already waited longer than the fixed
+                // fallback delay, so do not add another sleep here.
+                tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    principal_id,
+                    "iron-proxy did not acknowledge the cold-created principal's \
+                     config before the deadline; proceeding (managed proxies \
+                     fail closed until synced)"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    %error,
+                    "failed to check the iron-proxy management API for the \
+                     cold create barrier; using the fixed cold-create delay"
+                );
+                sleep(proxy_fallback_delay_remaining(started.elapsed())).await;
+            }
+        }
     }
 
     async fn proxy_principal_ack(
@@ -512,8 +581,7 @@ impl AgentSandboxBackend {
         id: &SandboxId,
         principal_id: &str,
         barrier: &'static str,
-    ) -> SandboxResult<()> {
-        let started = Instant::now();
+    ) -> SandboxResult<ProxyAck> {
         let endpoint = match self.proxy_management_endpoint(id).await {
             Ok(Some(endpoint)) => endpoint,
             Ok(None) => {
@@ -535,7 +603,7 @@ impl AgentSandboxBackend {
                 "failed to build iron-proxy management client",
             ));
         };
-        match wait_for_proxy_ack(
+        Ok(wait_for_proxy_ack(
             &client,
             &endpoint,
             principal_id,
@@ -543,25 +611,7 @@ impl AgentSandboxBackend {
             PROXY_ACK_PROBE_WINDOW,
             PROXY_ACK_POLL_INTERVAL,
         )
-        .await
-        {
-            ProxyAck::Applied => {
-                tracing::info!(
-                    sandbox_id = id.as_str(),
-                    principal_id,
-                    barrier,
-                    elapsed_ms = started.elapsed().as_millis() as u64,
-                    "iron-proxy acknowledged the claimed principal's config"
-                );
-                Ok(())
-            }
-            ProxyAck::ManagementUnavailable => Err(SandboxError::NotReady(format!(
-                "iron-proxy management API did not answer for the {barrier}"
-            ))),
-            ProxyAck::TimedOut => Err(SandboxError::NotReady(format!(
-                "iron-proxy did not acknowledge principal {principal_id:?} for the {barrier} before the deadline"
-            ))),
-        }
+        .await)
     }
 
     /// Locate the management API of the sandbox's running proxy pod. The
@@ -723,6 +773,10 @@ enum ProxyAck {
     /// The management API answered but the expected principal's config was
     /// not applied before the deadline.
     TimedOut,
+}
+
+fn proxy_fallback_delay_remaining(elapsed: Duration) -> Duration {
+    PROXY_REASSIGN_FALLBACK_DELAY.saturating_sub(elapsed)
 }
 
 /// Poll the proxy's management API until it reports `principal_id`'s config
@@ -1873,6 +1927,18 @@ mod tests {
         .await;
 
         assert_eq!(ack, ProxyAck::ManagementUnavailable);
+    }
+
+    #[test]
+    fn proxy_fallback_delay_subtracts_elapsed_probe_time() {
+        assert_eq!(
+            proxy_fallback_delay_remaining(Duration::from_secs(2)),
+            Duration::from_secs(4)
+        );
+        assert_eq!(
+            proxy_fallback_delay_remaining(Duration::from_secs(10)),
+            Duration::ZERO
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -460,8 +460,13 @@ impl SandboxBackend for AgentSandboxBackend {
         // Resume only has the sandbox id, not the spec, so rebind the proxy to
         // the principal recorded at create rather than re-resolving from spec.
         let resolved_iron_proxy = self.resolve_iron_proxy_for_resume(id).await?;
-        self.create_iron_proxy_resources(id, resolved_iron_proxy.as_ref())
-            .await?;
+        if let Err(err) = self
+            .create_iron_proxy_resources(id, resolved_iron_proxy.as_ref())
+            .await
+        {
+            let _ = self.delete_iron_proxy_resources(id).await;
+            return Err(err);
+        }
         // The proxy resources were recreated, so re-bind them to the sandbox
         // for cascade deletion.
         if let Some(sandbox) = self.get_sandbox(id).await?


### PR DESCRIPTION
## Summary
- add a cold-create iron-proxy principal barrier after the proxy pod reaches Running
- require the proxy management API to acknowledge the requested principal before creating the sandbox pod
- keep warm-pool claim behavior on the existing fixed-delay fallback path

## Context
Incident logs showed cold-created sandboxes could make OpenAI calls before iron-proxy reloaded the principal config, so requests saw only the secrets transform without OPENAI_API_KEY injection.

## Test
- cargo test -p centaur-sandbox-agent-k8s
- cargo test -p centaur-sandbox-agent-k8s proxy_ack