### PR TITLE
Fix Preqin credential handling

### DIFF
--- a/tools/research/preqin/centaur_tool_preqin/cli.py
+++ b/tools/research/preqin/centaur_tool_preqin/cli.py
@@ -8,8 +8,11 @@ import json
 from typing import Any
 
 import typer
+from centaur_sdk.backends import EnvBackend, configure
 from rich.console import Console
 from rich.table import Table
+
+configure(EnvBackend())
 
 app = typer.Typer(name="preqin", help="Preqin Operational API and Feeds API CLI")
 console = Console()

--- a/tools/research/preqin/centaur_tool_preqin/client.py
+++ b/tools/research/preqin/centaur_tool_preqin/client.py
@@ -12,6 +12,7 @@ from centaur_sdk import secret
 OPERATIONAL_BASE_URL = "https://api.preqin.com"
 IDENTITY_BASE_URL = "https://id.preqin.com"
 FEEDS_BASE_URL = "https://feeds.preqin.com"
+OPERATIONAL_TOKEN_PLACEHOLDER = "PREQIN_OPERATIONAL_TOKEN"
 
 
 def _clean_secret(value: str | None) -> str | None:
@@ -70,7 +71,7 @@ class PreqinClient:
         return self._api_key or _clean_secret(secret("PREQIN_API_KEY", ""))
 
     def _password_value(self) -> str | None:
-        return self._password or _clean_secret(secret("PREQIN_PASSWORD", "")) or self._api_key_value()
+        return self._password or _clean_secret(secret("PREQIN_PASSWORD", ""))
 
     def _client_id_value(self) -> str | None:
         return self._client_id or _clean_secret(secret("PREQIN_CLIENT_ID", ""))
@@ -84,32 +85,38 @@ class PreqinClient:
             "PREQIN_USERNAME": self._username_value(),
             "PREQIN_API_KEY": self._api_key_value(),
             "PREQIN_PASSWORD": self._password_value(),
-            "PREQIN_CLIENT_ID": self._client_id_value(),
-            "PREQIN_CLIENT_SECRET": self._client_secret_value(),
         }
         return {
             name: {
-                "present": bool(value),
+                "present": bool(value) and value != name,
                 "length": len(value or ""),
             }
             for name, value in fields.items()
         }
 
     def _operational_access_token(self, force_refresh: bool = False) -> str:
-        """Acquire a bearer token from Preqin's documented Operational API token endpoint."""
+        """Acquire a bearer token from Preqin's Operational API token endpoint."""
         if self._operational_token and not force_refresh:
             return self._operational_token
 
         username = self._username_value()
         api_key = self._api_key_value()
+        password = self._password_value()
         if not username:
             raise RuntimeError("PREQIN_USERNAME not set.")
         if not api_key:
             raise RuntimeError("PREQIN_API_KEY not set.")
+        if not password:
+            raise RuntimeError("PREQIN_PASSWORD not set.")
 
         response = self.client.post(
             f"{OPERATIONAL_BASE_URL}/connect/token",
-            files={"username": (None, username), "apikey": (None, api_key)},
+            data={
+                "grant_type": "password",
+                "username": username,
+                "password": password,
+                "client_id": api_key,
+            },
             headers={"Accept": "application/json"},
         )
         if response.status_code >= 400:
@@ -117,7 +124,7 @@ class PreqinClient:
             detail = f" - {body}" if body else ""
             raise RuntimeError(
                 "Preqin Operational API auth failed "
-                f"({response.status_code}) at /connect/token using username+apikey{detail}"
+                f"({response.status_code}) at /connect/token using password grant{detail}"
             )
 
         data = response.json()
@@ -137,20 +144,22 @@ class PreqinClient:
             return {
                 "ok": True,
                 "auth_url": f"{OPERATIONAL_BASE_URL}/connect/token",
-                "method": "multipart username+apikey",
+                "method": "password grant",
                 "token_length": len(token),
             }
         except Exception as exc:
             return {
                 "ok": False,
                 "auth_url": f"{OPERATIONAL_BASE_URL}/connect/token",
-                "method": "multipart username+apikey",
+                "method": "password grant",
                 "error": str(exc),
                 "credentials": self.credential_status(),
             }
 
     def _operational_get(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-        token = self._operational_access_token()
+        token = self._operational_token or _clean_secret(secret(OPERATIONAL_TOKEN_PLACEHOLDER, ""))
+        if not token:
+            token = self._operational_access_token()
         response = self.client.get(
             f"{OPERATIONAL_BASE_URL}{endpoint}",
             params={key: value for key, value in (params or {}).items() if value is not None},

--- a/tools/research/preqin/pyproject.toml
+++ b/tools/research/preqin/pyproject.toml
@@ -23,10 +23,8 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 hosts = ["api.preqin.com", "id.preqin.com", "feeds.preqin.com"]
-optional_secrets = [
-    "PREQIN_USERNAME",
-    "PREQIN_API_KEY",
-    "PREQIN_PASSWORD",
-    "PREQIN_CLIENT_ID",
-    "PREQIN_CLIENT_SECRET",
+secrets = [
+    { type = "oauth_token", name = "PREQIN_OPERATIONAL_TOKEN", grant = "password", token_endpoint = "https://api.preqin.com/connect/token", hosts = [
+        "api.preqin.com",
+    ], fields = { username = "PREQIN_USERNAME", password = "PREQIN_PASSWORD", client_id = "PREQIN_API_KEY" } },
 ]

--- a/tools/research/preqin/tests/test_client.py
+++ b/tools/research/preqin/tests/test_client.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from centaur_sdk.backends import StubBackend, configure
+
+from centaur_tool_preqin.client import OPERATIONAL_TOKEN_PLACEHOLDER, PreqinClient
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = ""
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(self.status_code)
+
+
+class FakeHttpClient:
+    def __init__(self):
+        self.posts: list[dict] = []
+        self.gets: list[dict] = []
+
+    def post(self, url: str, **kwargs):
+        self.posts.append({"url": url, **kwargs})
+        return FakeResponse({"access_token": "token-123"})
+
+    def get(self, url: str, **kwargs):
+        self.gets.append({"url": url, **kwargs})
+        return FakeResponse({"data": []})
+
+
+def test_credential_status_does_not_treat_stub_placeholders_as_present():
+    configure(StubBackend())
+    status = PreqinClient().credential_status()
+
+    assert status["PREQIN_USERNAME"]["present"] is False
+    assert status["PREQIN_API_KEY"]["present"] is False
+    assert status["PREQIN_PASSWORD"]["present"] is False
+
+
+def test_auth_uses_password_grant_with_username_password_and_api_key():
+    fake = FakeHttpClient()
+    client = PreqinClient(username="user", password="pass", api_key="api-key")
+    client._client = fake
+
+    assert client._operational_access_token(force_refresh=True) == "token-123"
+
+    request = fake.posts[0]
+    assert request["url"] == "https://api.preqin.com/connect/token"
+    assert request["data"] == {
+        "grant_type": "password",
+        "username": "user",
+        "password": "pass",
+        "client_id": "api-key",
+    }
+
+
+def test_operational_get_uses_proxy_token_placeholder_before_direct_auth():
+    configure(StubBackend())
+    fake = FakeHttpClient()
+    client = PreqinClient()
+    client._client = fake
+
+    client.get_funds(fund_name="Paradigm", size=1)
+
+    assert not fake.posts
+    assert fake.gets[0]["headers"]["Authorization"] == f"Bearer {OPERATIONAL_TOKEN_PLACEHOLDER}"


### PR DESCRIPTION
## Summary
- configure the Preqin CLI to use env-backed secrets for standalone smoke tests
- switch Operational API auth to the required username/password/API-key password grant
- declare `PREQIN_OPERATIONAL_TOKEN` as an OAuth password-token secret so deployed requests use proxy-injected bearer auth
- add regression tests for placeholder credentials, token exchange fields, and proxy placeholder usage

## Tests
- `uv run --project tools/research/preqin --with pytest pytest tools/research/preqin/tests/test_client.py`
- `uv run --project tools/research/preqin preqin credential-status --json`
- `cargo test -q -p centaur-perms`