### PR TITLE
feat: add validated workflow webhook edge filters

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -993,13 +993,13 @@ async fn invoke_workflow_webhook(
 
     // Edge pre-filter: drop events no handler could match, in-process, before
     // spawning a sandbox-backed run. Keeps org-wide webhooks cheap.
-    if let Some(filter) = &spec.filter {
-        if !webhook_filter_matches(filter, &headers, &body) {
-            return Ok((
-                StatusCode::OK,
-                Json(json!({ "ok": true, "filtered": true })),
-            ));
-        }
+    if let Some(filter) = &spec.filter
+        && !webhook_filter_matches(filter, &headers, &body)
+    {
+        return Ok((
+            StatusCode::OK,
+            Json(json!({ "ok": true, "filtered": true })),
+        ));
     }
 
     let trigger_key = webhook_trigger_key(&slug, &raw_body_sha256, spec, &headers);
@@ -1598,8 +1598,9 @@ fn webhook_filter_matches(filter: &WebhookFilter, headers: &HeaderMap, body: &Va
             .as_deref()
             .and_then(|key| webhook_body_path(body, key))
             .and_then(|value| value.as_str().map(ToOwned::to_owned)),
-        // An empty node is a no-op, but unknown sources should not match.
-        None => return true,
+        // Registry validation rejects empty nodes; fail closed if one reaches
+        // the evaluator anyway.
+        None => return false,
         Some(_) => return false,
     };
     let Some(actual) = actual else {
@@ -1908,7 +1909,7 @@ mod webhook_tests {
         }));
         assert!(!webhook_filter_matches(&repo_filter, &headers, &other));
 
-        // missing field -> no match; empty node -> pass-through.
+        // missing field -> no match.
         let missing = webhook_filter(json!({
             "source": "body",
             "key": "a.b",
@@ -1934,7 +1935,7 @@ mod webhook_tests {
         assert!(!webhook_filter_matches(&unknown_op, &headers, &body));
 
         let empty = webhook_filter(json!({}));
-        assert!(webhook_filter_matches(&empty, &headers, &body));
+        assert!(!webhook_filter_matches(&empty, &headers, &body));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -37,8 +37,8 @@ use centaur_telemetry::{
     record_http_request_started,
 };
 use centaur_workflows::{
-    CreateWorkflowRunRequest, WorkflowRuntime, WorkflowWebhookAuth, WorkflowWebhookSpec,
-    WorkflowWebhookTriggerKey,
+    CreateWorkflowRunRequest, WebhookFilter, WorkflowRuntime, WorkflowWebhookAuth,
+    WorkflowWebhookSpec, WorkflowWebhookTriggerKey,
 };
 use futures_util::{Stream, StreamExt};
 use hmac::{Hmac, Mac};
@@ -990,6 +990,18 @@ async fn invoke_workflow_webhook(
 
     let raw_body_sha256 = hex::encode(Sha256::digest(&raw_body));
     let body = parse_webhook_body(&headers, &raw_body)?;
+
+    // Edge pre-filter: drop events no handler could match, in-process, before
+    // spawning a sandbox-backed run. Keeps org-wide webhooks cheap.
+    if let Some(filter) = &spec.filter {
+        if !webhook_filter_matches(filter, &headers, &body) {
+            return Ok((
+                StatusCode::OK,
+                Json(json!({ "ok": true, "filtered": true })),
+            ));
+        }
+    }
+
     let trigger_key = webhook_trigger_key(&slug, &raw_body_sha256, spec, &headers);
     let request = CreateWorkflowRunRequest {
         workflow_name: registered.workflow_name.clone(),
@@ -1559,6 +1571,58 @@ fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+/// Read a dot-path (e.g. "repository.full_name") out of a JSON body.
+fn webhook_body_path<'a>(body: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = body;
+    for part in path.split('.') {
+        current = current.get(part)?;
+    }
+    Some(current)
+}
+
+/// Evaluate a declarative webhook pre-filter against the event.
+fn webhook_filter_matches(filter: &WebhookFilter, headers: &HeaderMap, body: &Value) -> bool {
+    if let Some(any) = &filter.any {
+        return any.iter().any(|f| webhook_filter_matches(f, headers, body));
+    }
+    if let Some(all) = &filter.all {
+        return all.iter().all(|f| webhook_filter_matches(f, headers, body));
+    }
+    let actual = match filter.source.as_deref() {
+        Some("header") => filter
+            .key
+            .as_deref()
+            .and_then(|key| header_value(headers, key)),
+        Some("body") => filter
+            .key
+            .as_deref()
+            .and_then(|key| webhook_body_path(body, key))
+            .and_then(|value| value.as_str().map(ToOwned::to_owned)),
+        // An empty node is a no-op, but unknown sources should not match.
+        None => return true,
+        Some(_) => return false,
+    };
+    let Some(actual) = actual else {
+        return false;
+    };
+    match filter.op.as_deref() {
+        Some("equals") => filter.value.as_deref() == Some(actual.as_str()),
+        Some("in") => filter
+            .values
+            .as_ref()
+            .is_some_and(|values| values.iter().any(|v| v == &actual)),
+        Some("contains") => filter
+            .value
+            .as_deref()
+            .is_some_and(|needle| actual.contains(needle)),
+        Some("prefix") => filter
+            .value
+            .as_deref()
+            .is_some_and(|prefix| actual.trim_start().starts_with(prefix)),
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod slack_archive_import_tests {
     use super::*;
@@ -1755,6 +1819,7 @@ mod webhook_tests {
             trigger_key: None,
             allowed_methods: vec!["POST".to_owned()],
             allowed_content_types: vec!["application/json".to_owned()],
+            filter: None,
         };
         let safe = safe_webhook_headers(&headers, &spec);
         assert_eq!(safe, json!({"x-test-delivery": "delivery-1"}));
@@ -1773,6 +1838,7 @@ mod webhook_tests {
             }),
             allowed_methods: vec!["POST".to_owned()],
             allowed_content_types: vec!["application/json".to_owned()],
+            filter: None,
         };
         assert_eq!(
             webhook_trigger_key("unit", "abc", &spec, &headers),
@@ -1801,6 +1867,74 @@ mod webhook_tests {
             raw_body,
         )
         .unwrap();
+    }
+
+    fn webhook_filter(value: Value) -> WebhookFilter {
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn webhook_filter_evaluates() {
+        let body = json!({
+            "repository": {"full_name": "ethereum-optimism/ethereum-optimism.github.io"},
+            "comment": {"body": "/review claude please"}
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert("x-github-event", "issue_comment".parse().unwrap());
+
+        // union: a /review comment on any repo matches the command branch
+        let filter = webhook_filter(json!({
+            "any": [
+                {"source": "header", "key": "x-github-event", "op": "equals", "value": "pull_request"},
+                {"all": [
+                    {"source": "header", "key": "x-github-event", "op": "equals", "value": "issue_comment"},
+                    {"source": "body", "key": "comment.body", "op": "contains", "value": "/review"}
+                ]}
+            ]
+        }));
+        assert!(webhook_filter_matches(&filter, &headers, &body));
+
+        // a plain comment on an unrelated repo doesn't match a repo-scoped filter
+        let other = json!({
+            "repository": {"full_name": "ethereum-optimism/k8s"},
+            "comment": {"body": "lgtm"}
+        });
+        let repo_filter = webhook_filter(json!({
+            "all": [
+                {"source": "header", "key": "x-github-event", "op": "equals", "value": "issue_comment"},
+                {"source": "body", "key": "repository.full_name", "op": "in",
+                 "values": ["ethereum-optimism/ethereum-optimism.github.io"]}
+            ]
+        }));
+        assert!(!webhook_filter_matches(&repo_filter, &headers, &other));
+
+        // missing field -> no match; empty node -> pass-through.
+        let missing = webhook_filter(json!({
+            "source": "body",
+            "key": "a.b",
+            "op": "equals",
+            "value": "x"
+        }));
+        assert!(!webhook_filter_matches(&missing, &headers, &body));
+
+        let unknown_source = webhook_filter(json!({
+            "source": "query",
+            "key": "event",
+            "op": "equals",
+            "value": "issue_comment"
+        }));
+        assert!(!webhook_filter_matches(&unknown_source, &headers, &body));
+
+        let unknown_op = webhook_filter(json!({
+            "source": "body",
+            "key": "comment.body",
+            "op": "regex",
+            "value": "/review"
+        }));
+        assert!(!webhook_filter_matches(&unknown_op, &headers, &body));
+
+        let empty = webhook_filter(json!({}));
+        assert!(webhook_filter_matches(&empty, &headers, &body));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -267,6 +267,33 @@ pub struct WorkflowWebhookSpec {
     pub allowed_methods: Vec<String>,
     #[serde(default = "default_webhook_content_types")]
     pub allowed_content_types: Vec<String>,
+    /// Optional edge pre-filter. When set, the API evaluates it against the
+    /// parsed event (headers + JSON body) and only creates a workflow run when
+    /// it matches. This keeps org-wide webhooks from spawning a sandbox per event.
+    #[serde(default)]
+    pub filter: Option<WebhookFilter>,
+}
+
+/// A declarative webhook pre-filter, evaluated in-process before a run is
+/// created. A node is either a boolean combinator (`any`/`all`) or a leaf that
+/// reads a `header` or a dot-path into the JSON `body` and applies `op`
+/// (`equals` | `in` | `contains` | `prefix`).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct WebhookFilter {
+    #[serde(default)]
+    pub any: Option<Vec<WebhookFilter>>,
+    #[serde(default)]
+    pub all: Option<Vec<WebhookFilter>>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub key: Option<String>,
+    #[serde(default)]
+    pub op: Option<String>,
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default)]
+    pub values: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1237,6 +1264,7 @@ fn default_workflow_webhooks() -> Vec<RegisteredWorkflowWebhook> {
                     "application/json".to_owned(),
                     "application/x-www-form-urlencoded".to_owned(),
                 ],
+                filter: None,
             },
         },
         RegisteredWorkflowWebhook {
@@ -1256,6 +1284,7 @@ fn default_workflow_webhooks() -> Vec<RegisteredWorkflowWebhook> {
                     "application/json".to_owned(),
                     "application/x-www-form-urlencoded".to_owned(),
                 ],
+                filter: None,
             },
         },
         RegisteredWorkflowWebhook {
@@ -1270,6 +1299,7 @@ fn default_workflow_webhooks() -> Vec<RegisteredWorkflowWebhook> {
                 trigger_key: None,
                 allowed_methods: vec!["POST".to_owned()],
                 allowed_content_types: vec!["application/json".to_owned()],
+                filter: None,
             },
         },
     ]
@@ -3669,6 +3699,55 @@ mod tests {
             metadata.schedules[0].get("workflow_name"),
             Some(&json!("scheduled_workflow"))
         );
+    }
+
+    #[test]
+    fn discovery_metadata_preserves_webhook_filter() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [
+                {
+                    "workflow_name": "github_issue_triage",
+                    "source_path": "workflows/github_issue_triage.py",
+                    "webhooks": [
+                        {
+                            "workflow_name": "github_issue_triage",
+                            "source_path": "workflows/github_issue_triage.py",
+                            "spec": {
+                                "slug": "github-issue-triage",
+                                "auth": {
+                                    "type": "github",
+                                    "secret_ref": "GITHUB_WEBHOOK_SECRET"
+                                },
+                                "filter": {
+                                    "all": [
+                                        {
+                                            "source": "header",
+                                            "key": "x-github-event",
+                                            "op": "equals",
+                                            "value": "issue_comment"
+                                        },
+                                        {
+                                            "source": "body",
+                                            "key": "repository.full_name",
+                                            "op": "in",
+                                            "values": ["ethereum-optimism/optimism"]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+        }))
+        .unwrap();
+
+        let metadata = metadata_from_discovery_payload(payload);
+        let filter = metadata.webhooks[0].spec.filter.as_ref().unwrap();
+        let all = filter.all.as_ref().unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].source.as_deref(), Some("header"));
+        assert_eq!(all[1].key.as_deref(), Some("repository.full_name"));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -1083,7 +1083,145 @@ fn normalize_webhook(webhook: &mut RegisteredWorkflowWebhook) -> Result<(), Work
             }
         }
     }
+    if let Some(filter) = &mut webhook.spec.filter {
+        normalize_webhook_filter(&webhook.spec.slug, filter)?;
+    }
     Ok(())
+}
+
+fn normalize_webhook_filter(
+    slug: &str,
+    filter: &mut WebhookFilter,
+) -> Result<(), WorkflowRuntimeError> {
+    normalize_webhook_filter_node(slug, filter, "filter")
+}
+
+fn normalize_webhook_filter_node(
+    slug: &str,
+    filter: &mut WebhookFilter,
+    path: &str,
+) -> Result<(), WorkflowRuntimeError> {
+    let has_any = filter.any.is_some();
+    let has_all = filter.all.is_some();
+    let has_leaf = filter.source.is_some()
+        || filter.key.is_some()
+        || filter.op.is_some()
+        || filter.value.is_some()
+        || filter.values.is_some();
+    if usize::from(has_any) + usize::from(has_all) + usize::from(has_leaf) != 1 {
+        return Err(invalid_webhook_filter(
+            slug,
+            path,
+            "node must be exactly one of any, all, or a leaf predicate",
+        ));
+    }
+
+    if let Some(any) = &mut filter.any {
+        if any.is_empty() {
+            return Err(invalid_webhook_filter(slug, path, "any must not be empty"));
+        }
+        for (index, child) in any.iter_mut().enumerate() {
+            normalize_webhook_filter_node(slug, child, &format!("{path}.any[{index}]"))?;
+        }
+        return Ok(());
+    }
+    if let Some(all) = &mut filter.all {
+        if all.is_empty() {
+            return Err(invalid_webhook_filter(slug, path, "all must not be empty"));
+        }
+        for (index, child) in all.iter_mut().enumerate() {
+            normalize_webhook_filter_node(slug, child, &format!("{path}.all[{index}]"))?;
+        }
+        return Ok(());
+    }
+
+    let source = normalize_required_filter_string(&mut filter.source)
+        .ok_or_else(|| invalid_webhook_filter(slug, path, "leaf requires source"))?;
+    let key = normalize_required_filter_string(&mut filter.key)
+        .ok_or_else(|| invalid_webhook_filter(slug, path, "leaf requires key"))?;
+    let op = normalize_required_filter_string(&mut filter.op)
+        .ok_or_else(|| invalid_webhook_filter(slug, path, "leaf requires op"))?;
+    filter.source = Some(source.to_ascii_lowercase());
+    filter.op = Some(op.to_ascii_lowercase());
+    let source = filter.source.as_deref().unwrap_or_default();
+    let op = filter.op.as_deref().unwrap_or_default();
+    if !matches!(source, "header" | "body") {
+        return Err(invalid_webhook_filter(
+            slug,
+            path,
+            "source must be header or body",
+        ));
+    }
+    if source == "body" && key.split('.').any(|part| part.trim().is_empty()) {
+        return Err(invalid_webhook_filter(
+            slug,
+            path,
+            "body key must be a non-empty dot path",
+        ));
+    }
+    match op {
+        "equals" | "contains" | "prefix" => {
+            if filter.values.is_some() {
+                return Err(invalid_webhook_filter(
+                    slug,
+                    path,
+                    "values is only valid with op in",
+                ));
+            }
+            normalize_required_filter_string(&mut filter.value).ok_or_else(|| {
+                invalid_webhook_filter(slug, path, "op requires a non-empty value")
+            })?;
+        }
+        "in" => {
+            if filter.value.is_some() {
+                return Err(invalid_webhook_filter(
+                    slug,
+                    path,
+                    "value is not valid with op in",
+                ));
+            }
+            let Some(values) = &mut filter.values else {
+                return Err(invalid_webhook_filter(
+                    slug,
+                    path,
+                    "op in requires non-empty values",
+                ));
+            };
+            for value in values.iter_mut() {
+                *value = value.trim().to_owned();
+            }
+            if values.is_empty() || values.iter().any(String::is_empty) {
+                return Err(invalid_webhook_filter(
+                    slug,
+                    path,
+                    "op in requires non-empty values",
+                ));
+            }
+        }
+        _ => {
+            return Err(invalid_webhook_filter(
+                slug,
+                path,
+                "op must be equals, in, contains, or prefix",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn normalize_required_filter_string(value: &mut Option<String>) -> Option<String> {
+    let normalized = value.as_ref()?.trim().to_owned();
+    if normalized.is_empty() {
+        return None;
+    }
+    *value = Some(normalized.clone());
+    Some(normalized)
+}
+
+fn invalid_webhook_filter(slug: &str, path: &str, reason: &str) -> WorkflowRuntimeError {
+    WorkflowRuntimeError::BadRequest(format!(
+        "workflow webhook {slug:?} has invalid filter at {path}: {reason}"
+    ))
 }
 
 fn valid_webhook_slug(slug: &str) -> bool {
@@ -3748,6 +3886,84 @@ mod tests {
         assert_eq!(all.len(), 2);
         assert_eq!(all[0].source.as_deref(), Some("header"));
         assert_eq!(all[1].key.as_deref(), Some("repository.full_name"));
+    }
+
+    fn webhook_with_filter(filter: Value) -> RegisteredWorkflowWebhook {
+        RegisteredWorkflowWebhook {
+            workflow_name: "github_issue_triage".to_owned(),
+            source_path: "workflows/github_issue_triage.py".to_owned(),
+            spec: WorkflowWebhookSpec {
+                slug: "github-issue-triage".to_owned(),
+                provider: Some("github".to_owned()),
+                auth: WorkflowWebhookAuth::Github {
+                    secret_ref: "GITHUB_WEBHOOK_SECRET".to_owned(),
+                },
+                trigger_key: Some(WorkflowWebhookTriggerKey::Header {
+                    header: "X-GitHub-Delivery".to_owned(),
+                }),
+                allowed_methods: vec!["POST".to_owned()],
+                allowed_content_types: vec!["application/json".to_owned()],
+                filter: Some(serde_json::from_value(filter).unwrap()),
+            },
+        }
+    }
+
+    #[test]
+    fn normalize_webhook_accepts_and_normalizes_filter() {
+        let mut webhook = webhook_with_filter(json!({
+            "all": [
+                {
+                    "source": " Header ",
+                    "key": " x-github-event ",
+                    "op": " EQUALS ",
+                    "value": " issue_comment "
+                },
+                {
+                    "source": "body",
+                    "key": "repository.full_name",
+                    "op": "in",
+                    "values": [" ethereum-optimism/optimism "]
+                }
+            ]
+        }));
+
+        normalize_webhook(&mut webhook).unwrap();
+
+        let all = webhook.spec.filter.unwrap().all.unwrap();
+        assert_eq!(all[0].source.as_deref(), Some("header"));
+        assert_eq!(all[0].key.as_deref(), Some("x-github-event"));
+        assert_eq!(all[0].op.as_deref(), Some("equals"));
+        assert_eq!(all[0].value.as_deref(), Some("issue_comment"));
+        assert_eq!(
+            all[1].values.as_ref().unwrap(),
+            &vec!["ethereum-optimism/optimism".to_owned()]
+        );
+    }
+
+    #[test]
+    fn normalize_webhook_rejects_malformed_filters() {
+        for filter in [
+            json!({}),
+            json!({"any": []}),
+            json!({
+                "any": [{"source": "header", "key": "x-github-event", "op": "equals", "value": "issues"}],
+                "source": "header",
+                "key": "x-github-event",
+                "op": "equals",
+                "value": "issues"
+            }),
+            json!({"source": "headers", "key": "x-github-event", "op": "equals", "value": "issues"}),
+            json!({"source": "body", "key": "repository..full_name", "op": "equals", "value": "repo"}),
+            json!({"source": "body", "key": "repository.full_name", "op": "regex", "value": "repo"}),
+            json!({"source": "body", "key": "repository.full_name", "op": "equals", "values": ["repo"]}),
+            json!({"source": "body", "key": "repository.full_name", "op": "in", "value": "repo"}),
+            json!({"source": "body", "key": "repository.full_name", "op": "in", "values": []}),
+            json!({"source": "body", "key": "repository.full_name", "op": "in", "values": [""]}),
+        ] {
+            let mut webhook = webhook_with_filter(filter);
+            let error = normalize_webhook(&mut webhook).unwrap_err();
+            assert!(matches!(error, WorkflowRuntimeError::BadRequest(_)));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- rebase PR #627 onto current main
- add optional declarative filters to workflow webhook specs
- evaluate matching webhooks at the API edge before creating workflow runs
- validate filters during webhook normalization so malformed specs fail fast instead of silently matching or dropping events
- make the request-path evaluator fail closed for unvalidated empty filter nodes

Closes paradigmxyz/centaur#627

## Tests
- cargo fmt --check -p centaur-api-server -p centaur-workflows
- cargo test -p centaur-api-server webhook_filter_evaluates
- cargo test -p centaur-workflows normalize_webhook
- cargo test -p centaur-workflows discovery_metadata