### PR TITLE
Allow api-rs egress to iron-proxy management port

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.71
+version: 0.1.72
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -197,7 +197,7 @@ spec:
         - protocol: TCP
           port: 5432
 {{- end }}
-    # Per-sandbox iron-proxy listeners (HTTP proxy + postgres port).
+    # Per-sandbox iron-proxy listeners (HTTP proxy + postgres + management API).
     - to:
         - podSelector:
             matchLabels:
@@ -207,6 +207,8 @@ spec:
           port: {{ .Values.ironProxy.service.proxyPort }}
         - protocol: TCP
           port: {{ .Values.ironProxy.service.pgPort }}
+        - protocol: TCP
+          port: {{ .Values.ironProxy.service.managementPort }}
 {{- if $console.enabled }}
     # console control plane: register principals/roles/grants and per-sandbox proxies.
     - to:


### PR DESCRIPTION
## Summary
- add iron-proxy management port to api-rs NetworkPolicy egress
- keep the port sourced from `.Values.ironProxy.service.managementPort`

## Context
api-rs calls per-sandbox iron-proxy directly on `:9092` for the claim/cold-create management barrier. The per-sandbox proxy NetworkPolicy already allowed ingress on `:9092`, but the api-rs NetworkPolicy only allowed egress to iron-proxy on `:8080` and `:5432`, causing the barrier to fall back to fixed sleeps.

## Testing
- `git diff --check`
- Could not run `helm template`: `helm` is not installed in this sandbox.
