### PR TITLE
fix(sandbox): honor TOOL_ALLOWLIST when installing/shimming tools

### DIFF
--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -21,6 +21,20 @@ def _split_paths(value: str) -> list[Path]:
     return [Path(part) for part in value.split(":") if part]
 
 
+def _tool_allowlist() -> set[str] | None:
+    """Tool package names to install, from ``TOOL_ALLOWLIST``.
+
+    Returns ``None`` when unset/empty -> install every mounted tool (backward
+    compatible). When set, only tools whose package name is listed are installed,
+    so the sandbox catalog is exactly the configured tools and the agent neither
+    sees nor wastes context on unconfigured ones (which also lack credentials).
+    """
+    raw = os.environ.get("TOOL_ALLOWLIST", "").strip()
+    if not raw:
+        return None
+    return {name.strip() for name in raw.split(",") if name.strip()}
+
+
 def _home_dir() -> Path:
     return Path.home()
 
@@ -83,9 +97,14 @@ def _copy_published_tools(tool_dir: Path, published: Path) -> None:
     if not published.is_dir():
         raise RuntimeError(f"refreshed tools subdir does not exist: {published}")
 
+    allowlist = _tool_allowlist()
     existing = {package_dir.name: package_dir for package_dir in _tool_package_dirs(tool_dir)}
     for package_dir in _tool_package_dirs(published):
         tool_name = package_dir.name
+        if allowlist is not None and tool_name not in allowlist:
+            # Not in TOOL_ALLOWLIST -> don't install; keeps the agent's catalog
+            # to configured tools (no phantom, credential-less tools).
+            continue
         if tool_name in existing:
             print(
                 f"skipping duplicate tool {tool_name}: {package_dir} conflicts with {existing[tool_name]}",
@@ -317,6 +336,7 @@ def _refresh_skill_dirs(workspace_dir: Path) -> int:
 
 
 def _discover_scripts(tool_dirs: list[Path]) -> dict[str, dict[str, str]]:
+    allowlist = _tool_allowlist()
     scripts: dict[str, dict[str, str]] = {}
     for tool_dir in tool_dirs:
         if not tool_dir.is_dir():
@@ -333,6 +353,12 @@ def _discover_scripts(tool_dirs: list[Path]) -> dict[str, dict[str, str]]:
                 print(f"warning: failed to read {pyproject}: {exc}", file=sys.stderr)
                 continue
             project = data.get("project") or {}
+            # Only shim allowlisted tools (by package dir or project name) so the
+            # agent's catalog is exactly the configured tools. Unset -> shim all.
+            if allowlist is not None and allowlist.isdisjoint(
+                {pyproject.parent.name, str(project.get("name") or "")}
+            ):
+                continue
             project_scripts = project.get("scripts") or {}
             if not isinstance(project_scripts, dict):
                 continue

--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -355,8 +355,12 @@ def _discover_scripts(tool_dirs: list[Path]) -> dict[str, dict[str, str]]:
             project = data.get("project") or {}
             # Only shim allowlisted tools (by package dir or project name) so the
             # agent's catalog is exactly the configured tools. Unset -> shim all.
-            if allowlist is not None and allowlist.isdisjoint(
-                {pyproject.parent.name, str(project.get("name") or "")}
+            package_dir = pyproject.parent.name
+            project_name = str(project.get("name") or "")
+            if (
+                allowlist is not None
+                and package_dir not in allowlist
+                and project_name not in allowlist
             ):
                 continue
             project_scripts = project.get("scripts") or {}

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -5,6 +5,7 @@ import io
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import install_tool_shims
 
@@ -44,6 +45,60 @@ class CopyPublishedToolsTest(unittest.TestCase):
             self.assertEqual((target / "research" / "websearch" / "old.py").read_text(), "old\n")
             self.assertFalse((target / "research" / "websearch" / "new.py").exists())
             self.assertEqual((target / "research" / "company" / "pyproject.toml").read_text(), "company\n")
+
+    def test_tool_allowlist_restricts_installed_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            published = root / "published"
+            target = root / "target"
+
+            for category, name in (("research", "websearch"), ("productivity", "linear")):
+                (published / category / name).mkdir(parents=True)
+                (published / category / name / "pyproject.toml").write_text(f"{name}\n")
+
+            with mock.patch.dict("os.environ", {"TOOL_ALLOWLIST": "websearch,posthog"}):
+                install_tool_shims._copy_published_tools(target, published)
+
+            # Allowlisted tool installed; unconfigured tool skipped.
+            self.assertTrue((target / "research" / "websearch" / "pyproject.toml").exists())
+            self.assertFalse((target / "productivity" / "linear").exists())
+
+    def test_unset_allowlist_installs_all_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            published = root / "published"
+            target = root / "target"
+
+            for category, name in (("research", "websearch"), ("productivity", "linear")):
+                (published / category / name).mkdir(parents=True)
+                (published / category / name / "pyproject.toml").write_text(f"{name}\n")
+
+            with mock.patch.dict("os.environ", {"TOOL_ALLOWLIST": ""}):
+                install_tool_shims._copy_published_tools(target, published)
+
+            self.assertTrue((target / "research" / "websearch" / "pyproject.toml").exists())
+            self.assertTrue((target / "productivity" / "linear" / "pyproject.toml").exists())
+
+
+    def test_discover_scripts_respects_allowlist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "tools"
+            for category, name in (("research", "websearch"), ("productivity", "linear")):
+                d = root / category / name
+                d.mkdir(parents=True)
+                (d / "pyproject.toml").write_text(
+                    f'[project]\nname = "{name}"\n\n[project.scripts]\n{name} = "client:main"\n'
+                )
+
+            with mock.patch.dict("os.environ", {"TOOL_ALLOWLIST": "websearch,posthog"}):
+                scripts = install_tool_shims._discover_scripts([root])
+            self.assertIn("websearch", scripts)
+            self.assertNotIn("linear", scripts)
+
+            with mock.patch.dict("os.environ", {"TOOL_ALLOWLIST": ""}):
+                scripts_all = install_tool_shims._discover_scripts([root])
+            self.assertIn("websearch", scripts_all)
+            self.assertIn("linear", scripts_all)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`services/sandbox/install_tool_shims.py` now honors `TOOL_ALLOWLIST` in **both** the install path (`_copy_published_tools`) and the shim-generation path (`_discover_scripts`). When `TOOL_ALLOWLIST` is set, only the listed tools are installed and shimmed; unset/empty preserves today's behavior (install all) — fully backward compatible. Test added.

## Why

`TOOL_ALLOWLIST` already scopes the agent's tool catalog elsewhere, but the sandbox shim installer ignored it — every mounted tool was installed and shimmed regardless of the allowlist. Consequences:

- **Phantom, credential-less tools in the catalog.** Tools the deployment never configured still show up to the agent, but they have no secrets provisioned, so they surface as broken options that mislead the model and waste its context.
- **Wasted setup.** Each tool's wheel builds lazily on first use via `uvx --from`; installing/shimming tools nobody enabled is work the deployment didn't ask for.

This makes the sandbox catalog exactly the configured tools.

## Test

`services/sandbox/test_install_tool_shims.py::...test_tool_allowlist_restricts_installed_tools` — allowlisted tool installed, unconfigured tool skipped.