### PR TITLE
feat(api-rs): set CENTAUR_OVERLAY_DIR for repo-cache overlay delivery

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -175,6 +175,17 @@ spec:
             - name: CENTAUR_OVERLAY_DIR
               value: {{ .Values.overlay.mountPath | quote }}
 {{- end }}
+{{- if $useOverlayRepoCache }}
+            # Point the sandbox CENTAUR_OVERLAY_DIR at the org overlay clone
+            # under the repos mount (/home/agent/github/<repo>). The org overlay
+            # is the highest-priority (last) repo-cache overlay source -- the one
+            # that shadows the base and carries the org's services/sandbox/
+            # SYSTEM_PROMPT.md and .agents/skills. api-rs derives the sandbox env
+            # from this slug. Repo-cache delivery only (overlay-image mode sets
+            # CENTAUR_OVERLAY_DIR above from overlay.mountPath).
+            - name: CENTAUR_OVERLAY_REPO
+              value: {{ (last $overlaySources).repo | quote }}
+{{- end }}
             - name: SESSION_SANDBOX_BACKEND
               value: {{ .Values.apiRs.sandboxBackend | quote }}
             - name: SESSION_SANDBOX_WORKLOAD

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -578,6 +578,10 @@ struct SandboxArgs {
     centaur_api_url_override: Option<String>,
     #[arg(long, env = "CENTAUR_API_URL")]
     centaur_api_url: Option<String>,
+    /// Owner/repo slug for org overlay delivery through repo-cache. When set,
+    /// sandboxes read overlay prompts and skills from the mounted checkout.
+    #[arg(long = "overlay-repo", env = "CENTAUR_OVERLAY_REPO")]
+    overlay_repo: Option<String>,
     #[arg(long = "repos-path", env = "REPOS_PATH")]
     repos_path: Option<String>,
     #[arg(
@@ -872,6 +876,15 @@ impl SandboxArgs {
         "/opt/centaur/workflows".to_owned()
     }
 
+    fn overlay_dir_in_repo_cache(&self) -> Option<String> {
+        let slug = clean_optional_value(self.overlay_repo.as_deref())?;
+        let slug = slug.trim_matches('/');
+        if slug.is_empty() {
+            return None;
+        }
+        Some(format!("{SANDBOX_REPOS_MOUNT_PATH}/{slug}"))
+    }
+
     fn default_workflow_host_path(&self) -> String {
         match self.backend {
             SandboxBackendKind::Local => default_workflow_host_path(),
@@ -1013,6 +1026,14 @@ impl SandboxArgs {
                     envs.push((name.to_owned(), value));
                 }
             }
+        }
+
+        if let Some(overlay_dir) = self.overlay_dir_in_repo_cache()
+            && !envs
+                .iter()
+                .any(|(existing, _)| existing == "CENTAUR_OVERLAY_DIR")
+        {
+            envs.push(("CENTAUR_OVERLAY_DIR".to_owned(), overlay_dir));
         }
 
         // Operator extra env wins over template defaults (same precedence as
@@ -1954,6 +1975,22 @@ mod tests {
             }
             Self { saved }
         }
+
+        fn clear(vars: &[&'static str]) -> Self {
+            let saved = vars
+                .iter()
+                .map(|name| (*name, env::var(name).ok()))
+                .collect();
+            for name in vars {
+                // SAFETY: tests that mutate process env hold ENV_LOCK for the
+                // duration of the guard, so concurrent tests in this module
+                // cannot observe partial mutations.
+                unsafe {
+                    env::remove_var(name);
+                }
+            }
+            Self { saved }
+        }
     }
 
     impl Drop for EnvGuard {
@@ -1969,6 +2006,80 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[derive(Debug, Parser)]
+    struct SandboxArgsWrapper {
+        #[command(flatten)]
+        sandbox: SandboxArgs,
+    }
+
+    #[test]
+    fn overlay_dir_in_repo_cache_parses_overlay_repo() {
+        let args = SandboxArgsWrapper::parse_from(["test", "--overlay-repo", "owner/repo"]).sandbox;
+        assert_eq!(
+            args.overlay_dir_in_repo_cache().as_deref(),
+            Some("/home/agent/github/owner/repo")
+        );
+
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[("CENTAUR_OVERLAY_REPO", "env-owner/env-repo")]);
+        let args = SandboxArgsWrapper::parse_from(["test"]).sandbox;
+        assert_eq!(
+            args.overlay_dir_in_repo_cache().as_deref(),
+            Some("/home/agent/github/env-owner/env-repo")
+        );
+    }
+
+    #[test]
+    fn overlay_dir_in_repo_cache_ignores_empty_values() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::clear(&["CENTAUR_OVERLAY_REPO"]);
+
+        let args = SandboxArgsWrapper::parse_from(["test"]).sandbox;
+        assert_eq!(args.overlay_dir_in_repo_cache(), None);
+
+        let args = SandboxArgsWrapper::parse_from(["test", "--overlay-repo", ""]).sandbox;
+        assert_eq!(args.overlay_dir_in_repo_cache(), None);
+
+        let args = SandboxArgsWrapper::parse_from(["test", "--overlay-repo", "///"]).sandbox;
+        assert_eq!(args.overlay_dir_in_repo_cache(), None);
+    }
+
+    #[test]
+    fn codex_app_server_env_template_injects_repo_cache_overlay_dir() {
+        let args = SandboxArgsWrapper::parse_from([
+            "test",
+            "--session-sandbox-workload",
+            "codex-app-server",
+            "--kubernetes-sandbox-iron-proxy-mode",
+            "disabled",
+            "--overlay-repo",
+            "owner/repo",
+        ])
+        .sandbox;
+
+        let env = args.codex_app_server_env_template().unwrap();
+        assert!(env.iter().any(|(name, value)| {
+            name == "CENTAUR_OVERLAY_DIR" && value == "/home/agent/github/owner/repo"
+        }));
+    }
+
+    #[test]
+    fn codex_app_server_env_template_omits_overlay_dir_when_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::clear(&["CENTAUR_OVERLAY_REPO"]);
+        let args = SandboxArgsWrapper::parse_from([
+            "test",
+            "--session-sandbox-workload",
+            "codex-app-server",
+            "--kubernetes-sandbox-iron-proxy-mode",
+            "disabled",
+        ])
+        .sandbox;
+
+        let env = args.codex_app_server_env_template().unwrap();
+        assert!(!env.iter().any(|(name, _)| name == "CENTAUR_OVERLAY_DIR"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Under repo-cache overlay delivery (the `overlays.sources` model, no overlay-image mount), api-rs now injects `CENTAUR_OVERLAY_DIR=/home/agent/github/<owner>/<repo>` into the sandbox env, derived from the overlay repo slug. The chart sets a new `CENTAUR_OVERLAY_REPO` from the highest-priority (last) overlay source; api-rs turns the slug into the clone path under the repos mount.

## Why

With repo-cache delivery the overlay repo is cloned at `/home/agent/github/<owner>/<repo>`, but `CENTAUR_OVERLAY_DIR` was only ever set in **overlay-image** mode (from `overlay.mountPath`). So in repo-cache mode it was **never set**, and the sandbox entrypoint's overlay branches were silently skipped — the org's `services/sandbox/SYSTEM_PROMPT.md` and `.agents/skills/` simply didn't apply. The overlay was delivered to the filesystem but never activated.

This wires `CENTAUR_OVERLAY_DIR` to the actual clone path so repo-cache overlay delivery works end-to-end (prompts + skills applied). Overlay-image mode is unchanged (it still sets `CENTAUR_OVERLAY_DIR` from `overlay.mountPath`, and api-rs no-clobbers when it's already present).

## Test

`centaur-api-server` args tests cover the slug→dir derivation (`/home/agent/github/owner/repo`), the `CENTAUR_OVERLAY_REPO` env override, and the no-clobber-when-already-set behavior.