### PR TITLE
feat: sync Slack DMs from OAuth credentials

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -46,7 +46,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
-use time::OffsetDateTime;
+use time::{Duration as TimeDuration, OffsetDateTime};
 use tower_http::trace::TraceLayer;
 use tracing::Span;
 use uuid::Uuid;
@@ -240,6 +240,14 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route(
             "/api/admin/slack/archive-imports/{import_id}/retry",
             post(retry_slack_archive_import),
+        )
+        .route(
+            "/api/admin/slack/dm-sync/checkpoints",
+            get(list_slack_dm_sync_checkpoints),
+        )
+        .route(
+            "/api/admin/slack/dm-sync/batch",
+            post(ingest_slack_dm_sync_batch).layer(DefaultBodyLimit::disable()),
         )
         .route("/api/webhooks/{slug}", any(invoke_workflow_webhook))
         .layer(
@@ -579,6 +587,184 @@ workflow_run_id, workflow_task_id, channels_imported, users_imported, messages_i
 error_text, created_by, uploaded_at, started_at, finished_at, upload_url_expires_at, created_at, \
 updated_at, metadata";
 
+#[derive(Debug, Deserialize)]
+struct ListSlackDmSyncCheckpointsQuery {
+    broker_credential_id: String,
+    #[serde(default)]
+    home_team_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+struct SlackDmSyncCheckpointResponse {
+    broker_credential_id: String,
+    home_team_id: String,
+    conversation_id: String,
+    watermark_ts: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackDmSyncBatchRequest {
+    #[serde(default)]
+    run: Option<SlackDmSyncRunPayload>,
+    #[serde(default)]
+    replace_memberships: bool,
+    #[serde(default)]
+    conversations: Vec<SlackDmSyncConversationPayload>,
+    #[serde(default)]
+    members: Vec<SlackDmSyncMemberPayload>,
+    #[serde(default)]
+    messages: Vec<SlackDmSyncMessagePayload>,
+    #[serde(default)]
+    attachments: Vec<SlackDmSyncAttachmentPayload>,
+    #[serde(default)]
+    checkpoints: Vec<SlackDmSyncCheckpointPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackDmSyncRunPayload {
+    run_id: String,
+    #[serde(default)]
+    workflow_run_id: Option<String>,
+    #[serde(default = "default_slack_dm_sync_mode")]
+    mode: String,
+    status: String,
+    broker_credential_id: String,
+    source_user_id: String,
+    home_team_id: String,
+    #[serde(default)]
+    conversations_requested: i32,
+    #[serde(default)]
+    conversations_synced: i32,
+    #[serde(default)]
+    conversations_failed: i32,
+    #[serde(default)]
+    messages_fetched: i32,
+    #[serde(default)]
+    messages_upserted: i32,
+    #[serde(default)]
+    replies_fetched: i32,
+    #[serde(default)]
+    replies_upserted: i32,
+    #[serde(default)]
+    finished: bool,
+    #[serde(default)]
+    error_text: String,
+    #[serde(default = "empty_object")]
+    metadata: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackDmSyncConversationPayload {
+    home_team_id: String,
+    conversation_id: String,
+    conversation_type: String,
+    #[serde(default)]
+    is_archived: bool,
+    #[serde(default)]
+    is_ext_shared: bool,
+    #[serde(default = "empty_object")]
+    raw_payload: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackDmSyncMemberPayload {
+    home_team_id: String,
+    conversation_id: String,
+    user_id: String,
+    #[serde(default)]
+    user_team_id: Option<String>,
+    #[serde(default)]
+    is_external: bool,
+    #[serde(default = "default_true")]
+    is_current_member: bool,
+    #[serde(default = "empty_object")]
+    raw_payload: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackDmSyncMessagePayload {
+    home_team_id: String,
+    conversation_id: String,
+    message_ts: String,
+    #[serde(default)]
+    thread_ts: Option<String>,
+    #[serde(default)]
+    parent_message_ts: Option<String>,
+    #[serde(default)]
+    is_thread_root: bool,
+    #[serde(default)]
+    user_id: String,
+    #[serde(default)]
+    user_team_id: Option<String>,
+    #[serde(default)]
+    bot_id: String,
+    #[serde(default = "default_slack_message_type")]
+    message_type: String,
+    #[serde(default)]
+    message_subtype: Option<String>,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    permalink: String,
+    #[serde(default)]
+    reply_count: i32,
+    #[serde(default = "empty_array")]
+    reply_users: Value,
+    #[serde(default)]
+    latest_reply_ts: Option<String>,
+    #[serde(default)]
+    thread_refreshed: bool,
+    #[serde(default = "empty_object")]
+    raw_payload: Value,
+    #[serde(default)]
+    source_run_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackDmSyncAttachmentPayload {
+    home_team_id: String,
+    conversation_id: String,
+    message_ts: String,
+    slack_file_id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    mimetype: String,
+    #[serde(default)]
+    filetype: String,
+    #[serde(default)]
+    size_bytes: i64,
+    #[serde(default)]
+    url_private: String,
+    #[serde(default)]
+    permalink: String,
+    #[serde(default = "default_attachment_download_status")]
+    download_status: String,
+    #[serde(default)]
+    download_error: String,
+    #[serde(default)]
+    content_sha256: Option<String>,
+    #[serde(default = "empty_object")]
+    raw_payload: Value,
+    #[serde(default)]
+    source_run_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackDmSyncCheckpointPayload {
+    broker_credential_id: String,
+    home_team_id: String,
+    conversation_id: String,
+    #[serde(default)]
+    watermark_ts: Option<String>,
+    #[serde(default)]
+    last_run_id: Option<String>,
+    #[serde(default)]
+    last_error: String,
+}
+
 impl From<SlackArchiveImportRow> for SlackArchiveImportResponse {
     fn from(row: SlackArchiveImportRow) -> Self {
         Self {
@@ -892,6 +1078,265 @@ async fn retry_slack_archive_import(
     ))
 }
 
+async fn list_slack_dm_sync_checkpoints(
+    State(state): State<AppState>,
+    Query(query): Query<ListSlackDmSyncCheckpointsQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let pool = db_pool(&state)?;
+    require_non_empty("broker_credential_id", &query.broker_credential_id)?;
+    let rows = sqlx::query_as::<_, SlackDmSyncCheckpointResponse>(
+        "SELECT broker_credential_id, home_team_id, conversation_id, watermark_ts \
+         FROM slack_dm_sync_checkpoints \
+         WHERE broker_credential_id = $1 \
+         AND ($2::text IS NULL OR home_team_id = $2) \
+         ORDER BY home_team_id, conversation_id",
+    )
+    .bind(&query.broker_credential_id)
+    .bind(
+        query
+            .home_team_id
+            .as_deref()
+            .filter(|value| !value.is_empty()),
+    )
+    .fetch_all(&pool)
+    .await?;
+
+    Ok(Json(json!({ "ok": true, "checkpoints": rows })))
+}
+
+async fn ingest_slack_dm_sync_batch(
+    State(state): State<AppState>,
+    Json(request): Json<SlackDmSyncBatchRequest>,
+) -> Result<Json<Value>, ApiError> {
+    validate_slack_dm_sync_batch(&request)?;
+    let pool = db_pool(&state)?;
+    let mut tx = pool.begin().await?;
+
+    if let Some(run) = &request.run {
+        upsert_slack_dm_sync_run(&mut tx, run).await?;
+    }
+
+    for conversation in &request.conversations {
+        sqlx::query(
+            "INSERT INTO slack_dm_sync_conversations (\
+             home_team_id, conversation_id, conversation_type, is_archived, is_ext_shared, \
+             raw_payload, last_seen_at, updated_at\
+             ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, NOW(), NOW()) \
+             ON CONFLICT (home_team_id, conversation_id) DO UPDATE SET \
+             conversation_type = EXCLUDED.conversation_type, \
+             is_archived = EXCLUDED.is_archived, \
+             is_ext_shared = EXCLUDED.is_ext_shared, \
+             raw_payload = EXCLUDED.raw_payload, \
+             last_seen_at = NOW(), \
+             updated_at = NOW()",
+        )
+        .bind(&conversation.home_team_id)
+        .bind(&conversation.conversation_id)
+        .bind(&conversation.conversation_type)
+        .bind(conversation.is_archived)
+        .bind(conversation.is_ext_shared)
+        .bind(&conversation.raw_payload)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    if request.replace_memberships {
+        let mut conversations = BTreeMap::new();
+        for member in &request.members {
+            conversations.insert(
+                (member.home_team_id.clone(), member.conversation_id.clone()),
+                true,
+            );
+        }
+        for ((home_team_id, conversation_id), _) in conversations {
+            sqlx::query(
+                "UPDATE slack_dm_sync_conversation_members \
+                 SET is_current_member = false, updated_at = NOW() \
+                 WHERE home_team_id = $1 AND conversation_id = $2",
+            )
+            .bind(home_team_id)
+            .bind(conversation_id)
+            .execute(&mut *tx)
+            .await?;
+        }
+    }
+
+    for member in &request.members {
+        sqlx::query(
+            "INSERT INTO slack_dm_sync_conversation_members (\
+             home_team_id, conversation_id, user_id, user_team_id, is_external, \
+             is_current_member, raw_payload, last_seen_at, updated_at\
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, NOW(), NOW()) \
+             ON CONFLICT (home_team_id, conversation_id, user_id) DO UPDATE SET \
+             user_team_id = EXCLUDED.user_team_id, \
+             is_external = EXCLUDED.is_external, \
+             is_current_member = EXCLUDED.is_current_member, \
+             raw_payload = EXCLUDED.raw_payload, \
+             last_seen_at = NOW(), \
+             updated_at = NOW()",
+        )
+        .bind(&member.home_team_id)
+        .bind(&member.conversation_id)
+        .bind(&member.user_id)
+        .bind(&member.user_team_id)
+        .bind(member.is_external)
+        .bind(member.is_current_member)
+        .bind(&member.raw_payload)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    for message in &request.messages {
+        let occurred_at = slack_ts_to_datetime(Some(&message.message_ts))?;
+        let thread_refreshed_at = if message.thread_refreshed {
+            Some(OffsetDateTime::now_utc())
+        } else {
+            None
+        };
+        sqlx::query(
+            "INSERT INTO slack_dm_sync_messages (\
+             home_team_id, conversation_id, message_ts, occurred_at, thread_ts, \
+             parent_message_ts, is_thread_root, user_id, user_team_id, bot_id, \
+             message_type, message_subtype, text, permalink, reply_count, reply_users, \
+             latest_reply_ts, thread_refreshed_at, raw_payload, source_run_id, \
+             last_seen_at, updated_at\
+             ) VALUES (\
+             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, \
+             $11, $12, $13, $14, $15, $16::jsonb, $17, $18, $19::jsonb, $20, \
+             NOW(), NOW()) \
+             ON CONFLICT (home_team_id, conversation_id, message_ts) DO UPDATE SET \
+             occurred_at = EXCLUDED.occurred_at, \
+             thread_ts = EXCLUDED.thread_ts, \
+             parent_message_ts = EXCLUDED.parent_message_ts, \
+             is_thread_root = EXCLUDED.is_thread_root, \
+             user_id = EXCLUDED.user_id, \
+             user_team_id = EXCLUDED.user_team_id, \
+             bot_id = EXCLUDED.bot_id, \
+             message_type = EXCLUDED.message_type, \
+             message_subtype = EXCLUDED.message_subtype, \
+             text = EXCLUDED.text, \
+             permalink = EXCLUDED.permalink, \
+             reply_count = EXCLUDED.reply_count, \
+             reply_users = EXCLUDED.reply_users, \
+             latest_reply_ts = EXCLUDED.latest_reply_ts, \
+             thread_refreshed_at = COALESCE(EXCLUDED.thread_refreshed_at, slack_dm_sync_messages.thread_refreshed_at), \
+             raw_payload = EXCLUDED.raw_payload, \
+             source_run_id = COALESCE(EXCLUDED.source_run_id, slack_dm_sync_messages.source_run_id), \
+             last_seen_at = NOW(), \
+             updated_at = NOW()",
+        )
+        .bind(&message.home_team_id)
+        .bind(&message.conversation_id)
+        .bind(&message.message_ts)
+        .bind(occurred_at)
+        .bind(empty_to_none(message.thread_ts.as_deref()))
+        .bind(empty_to_none(message.parent_message_ts.as_deref()))
+        .bind(message.is_thread_root)
+        .bind(&message.user_id)
+        .bind(&message.user_team_id)
+        .bind(&message.bot_id)
+        .bind(&message.message_type)
+        .bind(&message.message_subtype)
+        .bind(&message.text)
+        .bind(&message.permalink)
+        .bind(message.reply_count)
+        .bind(&message.reply_users)
+        .bind(empty_to_none(message.latest_reply_ts.as_deref()))
+        .bind(thread_refreshed_at)
+        .bind(&message.raw_payload)
+        .bind(empty_to_none(message.source_run_id.as_deref()))
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    for attachment in &request.attachments {
+        sqlx::query(
+            "INSERT INTO slack_dm_sync_message_attachments (\
+             home_team_id, conversation_id, message_ts, slack_file_id, name, title, \
+             mimetype, filetype, size_bytes, url_private, permalink, download_status, \
+             download_error, content_sha256, raw_payload, source_run_id, last_seen_at, updated_at\
+             ) VALUES (\
+             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, \
+             $13, $14, $15::jsonb, $16, NOW(), NOW()) \
+             ON CONFLICT (home_team_id, conversation_id, message_ts, slack_file_id) DO UPDATE SET \
+             name = EXCLUDED.name, \
+             title = EXCLUDED.title, \
+             mimetype = EXCLUDED.mimetype, \
+             filetype = EXCLUDED.filetype, \
+             size_bytes = EXCLUDED.size_bytes, \
+             url_private = EXCLUDED.url_private, \
+             permalink = EXCLUDED.permalink, \
+             download_status = EXCLUDED.download_status, \
+             download_error = EXCLUDED.download_error, \
+             content_sha256 = EXCLUDED.content_sha256, \
+             raw_payload = EXCLUDED.raw_payload, \
+             source_run_id = COALESCE(EXCLUDED.source_run_id, slack_dm_sync_message_attachments.source_run_id), \
+             last_seen_at = NOW(), \
+             updated_at = NOW()",
+        )
+        .bind(&attachment.home_team_id)
+        .bind(&attachment.conversation_id)
+        .bind(&attachment.message_ts)
+        .bind(&attachment.slack_file_id)
+        .bind(&attachment.name)
+        .bind(&attachment.title)
+        .bind(&attachment.mimetype)
+        .bind(&attachment.filetype)
+        .bind(attachment.size_bytes)
+        .bind(&attachment.url_private)
+        .bind(&attachment.permalink)
+        .bind(&attachment.download_status)
+        .bind(&attachment.download_error)
+        .bind(&attachment.content_sha256)
+        .bind(&attachment.raw_payload)
+        .bind(empty_to_none(attachment.source_run_id.as_deref()))
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    for checkpoint in &request.checkpoints {
+        let last_success_at = if checkpoint.last_error.trim().is_empty() {
+            Some(OffsetDateTime::now_utc())
+        } else {
+            None
+        };
+        sqlx::query(
+            "INSERT INTO slack_dm_sync_checkpoints (\
+             broker_credential_id, home_team_id, conversation_id, watermark_ts, \
+             last_run_id, last_success_at, last_error, updated_at\
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW()) \
+             ON CONFLICT (broker_credential_id, home_team_id, conversation_id) DO UPDATE SET \
+             watermark_ts = EXCLUDED.watermark_ts, \
+             last_run_id = EXCLUDED.last_run_id, \
+             last_success_at = COALESCE(EXCLUDED.last_success_at, slack_dm_sync_checkpoints.last_success_at), \
+             last_error = EXCLUDED.last_error, \
+             updated_at = NOW()",
+        )
+        .bind(&checkpoint.broker_credential_id)
+        .bind(&checkpoint.home_team_id)
+        .bind(&checkpoint.conversation_id)
+        .bind(empty_to_none(checkpoint.watermark_ts.as_deref()))
+        .bind(empty_to_none(checkpoint.last_run_id.as_deref()))
+        .bind(last_success_at)
+        .bind(&checkpoint.last_error)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    tx.commit().await?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "counts": {
+            "conversations": request.conversations.len(),
+            "members": request.members.len(),
+            "messages": request.messages.len(),
+            "attachments": request.attachments.len(),
+            "checkpoints": request.checkpoints.len(),
+        }
+    })))
+}
+
 async fn create_workflow_run(
     State(state): State<AppState>,
     Json(request): Json<CreateWorkflowRunRequest>,
@@ -1145,6 +1590,64 @@ async fn mark_slack_archive_import_queued(
         .map_err(ApiError::from)
 }
 
+async fn upsert_slack_dm_sync_run(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    run: &SlackDmSyncRunPayload,
+) -> Result<(), ApiError> {
+    let finished_at = if run.finished {
+        Some(OffsetDateTime::now_utc())
+    } else {
+        None
+    };
+    sqlx::query(
+        "INSERT INTO slack_dm_sync_runs (\
+         run_id, workflow_run_id, mode, status, broker_credential_id, source_user_id, \
+         home_team_id, conversations_requested, conversations_synced, conversations_failed, \
+         messages_fetched, messages_upserted, replies_fetched, replies_upserted, \
+         finished_at, error_text, metadata\
+         ) VALUES (\
+         $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, \
+         $11, $12, $13, $14, $15, $16, $17::jsonb) \
+         ON CONFLICT (run_id) DO UPDATE SET \
+         workflow_run_id = EXCLUDED.workflow_run_id, \
+         mode = EXCLUDED.mode, \
+         status = EXCLUDED.status, \
+         broker_credential_id = EXCLUDED.broker_credential_id, \
+         source_user_id = EXCLUDED.source_user_id, \
+         home_team_id = EXCLUDED.home_team_id, \
+         conversations_requested = EXCLUDED.conversations_requested, \
+         conversations_synced = EXCLUDED.conversations_synced, \
+         conversations_failed = EXCLUDED.conversations_failed, \
+         messages_fetched = EXCLUDED.messages_fetched, \
+         messages_upserted = EXCLUDED.messages_upserted, \
+         replies_fetched = EXCLUDED.replies_fetched, \
+         replies_upserted = EXCLUDED.replies_upserted, \
+         finished_at = COALESCE(EXCLUDED.finished_at, slack_dm_sync_runs.finished_at), \
+         error_text = EXCLUDED.error_text, \
+         metadata = EXCLUDED.metadata",
+    )
+    .bind(&run.run_id)
+    .bind(&run.workflow_run_id)
+    .bind(&run.mode)
+    .bind(&run.status)
+    .bind(&run.broker_credential_id)
+    .bind(&run.source_user_id)
+    .bind(&run.home_team_id)
+    .bind(run.conversations_requested)
+    .bind(run.conversations_synced)
+    .bind(run.conversations_failed)
+    .bind(run.messages_fetched)
+    .bind(run.messages_upserted)
+    .bind(run.replies_fetched)
+    .bind(run.replies_upserted)
+    .bind(finished_at)
+    .bind(&run.error_text)
+    .bind(&run.metadata)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
 fn slack_archive_upload_config() -> Result<SlackArchiveUploadConfig, ApiError> {
     let bucket = env::var("SLACK_ARCHIVE_UPLOAD_BUCKET")
         .unwrap_or_default()
@@ -1188,6 +1691,129 @@ fn positive_env_u64(name: &str, default: u64) -> u64 {
 
 fn prefixed_id(prefix: &str) -> String {
     format!("{prefix}_{}", Uuid::new_v4().simple())
+}
+
+fn default_slack_dm_sync_mode() -> String {
+    "incremental".to_owned()
+}
+
+fn default_slack_message_type() -> String {
+    "message".to_owned()
+}
+
+fn default_attachment_download_status() -> String {
+    "metadata_only".to_owned()
+}
+
+fn empty_object() -> Value {
+    json!({})
+}
+
+fn empty_array() -> Value {
+    json!([])
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn empty_to_none(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), ApiError> {
+    if value.trim().is_empty() {
+        return Err(ApiError::BadRequest(format!("{field} must not be empty")));
+    }
+    Ok(())
+}
+
+fn slack_ts_to_datetime(value: Option<&str>) -> Result<Option<OffsetDateTime>, ApiError> {
+    let Some(value) = empty_to_none(value) else {
+        return Ok(None);
+    };
+    let (seconds, micros) = value.split_once('.').unwrap_or((value, "0"));
+    let seconds = seconds
+        .parse::<i64>()
+        .map_err(|_| ApiError::BadRequest(format!("invalid Slack timestamp {value}")))?;
+    let micros = format!("{micros:0<6}");
+    let micros = micros[..micros.len().min(6)]
+        .parse::<i64>()
+        .map_err(|_| ApiError::BadRequest(format!("invalid Slack timestamp {value}")))?;
+    let timestamp = OffsetDateTime::from_unix_timestamp(seconds)
+        .map_err(|_| ApiError::BadRequest(format!("invalid Slack timestamp {value}")))?
+        .checked_add(TimeDuration::microseconds(micros))
+        .ok_or_else(|| ApiError::BadRequest(format!("invalid Slack timestamp {value}")))?;
+    Ok(Some(timestamp))
+}
+
+fn validate_json_shape(field: &str, value: &Value, object: bool) -> Result<(), ApiError> {
+    let valid = if object {
+        value.is_object()
+    } else {
+        value.is_array()
+    };
+    if valid {
+        return Ok(());
+    }
+    let expected = if object { "object" } else { "array" };
+    Err(ApiError::BadRequest(format!(
+        "{field} must be a JSON {expected}"
+    )))
+}
+
+fn validate_slack_dm_sync_batch(request: &SlackDmSyncBatchRequest) -> Result<(), ApiError> {
+    if let Some(run) = &request.run {
+        require_non_empty("run.run_id", &run.run_id)?;
+        require_non_empty("run.status", &run.status)?;
+        require_non_empty("run.broker_credential_id", &run.broker_credential_id)?;
+        require_non_empty("run.source_user_id", &run.source_user_id)?;
+        require_non_empty("run.home_team_id", &run.home_team_id)?;
+        validate_json_shape("run.metadata", &run.metadata, true)?;
+    }
+    for conversation in &request.conversations {
+        require_non_empty("conversation.home_team_id", &conversation.home_team_id)?;
+        require_non_empty(
+            "conversation.conversation_id",
+            &conversation.conversation_id,
+        )?;
+        if !matches!(conversation.conversation_type.as_str(), "im" | "mpim") {
+            return Err(ApiError::BadRequest(
+                "conversation.conversation_type must be im or mpim".to_owned(),
+            ));
+        }
+        validate_json_shape("conversation.raw_payload", &conversation.raw_payload, true)?;
+    }
+    for member in &request.members {
+        require_non_empty("member.home_team_id", &member.home_team_id)?;
+        require_non_empty("member.conversation_id", &member.conversation_id)?;
+        require_non_empty("member.user_id", &member.user_id)?;
+        validate_json_shape("member.raw_payload", &member.raw_payload, true)?;
+    }
+    for message in &request.messages {
+        require_non_empty("message.home_team_id", &message.home_team_id)?;
+        require_non_empty("message.conversation_id", &message.conversation_id)?;
+        require_non_empty("message.message_ts", &message.message_ts)?;
+        validate_json_shape("message.reply_users", &message.reply_users, false)?;
+        validate_json_shape("message.raw_payload", &message.raw_payload, true)?;
+        slack_ts_to_datetime(Some(&message.message_ts))?;
+    }
+    for attachment in &request.attachments {
+        require_non_empty("attachment.home_team_id", &attachment.home_team_id)?;
+        require_non_empty("attachment.conversation_id", &attachment.conversation_id)?;
+        require_non_empty("attachment.message_ts", &attachment.message_ts)?;
+        require_non_empty("attachment.slack_file_id", &attachment.slack_file_id)?;
+        validate_json_shape("attachment.raw_payload", &attachment.raw_payload, true)?;
+    }
+    for checkpoint in &request.checkpoints {
+        require_non_empty(
+            "checkpoint.broker_credential_id",
+            &checkpoint.broker_credential_id,
+        )?;
+        require_non_empty("checkpoint.home_team_id", &checkpoint.home_team_id)?;
+        require_non_empty("checkpoint.conversation_id", &checkpoint.conversation_id)?;
+    }
+    Ok(())
 }
 
 fn sanitize_path_segment(value: &str) -> String {

--- a/services/console/app/jobs/slack_dm/poll_sync_job.rb
+++ b/services/console/app/jobs/slack_dm/poll_sync_job.rb
@@ -1,0 +1,24 @@
+module SlackDm
+  class PollSyncJob < ApplicationJob
+    queue_as :default
+
+    def perform(oauth_app_slug = SlackDm::SyncCredential.oauth_app_slug)
+      credentials = BrokerCredential
+        .includes(:oauth_app)
+        .joins(:oauth_app)
+        .where(dead: false)
+        .where(oauth_apps: {
+          provider: Oauth::Providers::Slack::KEY,
+          slug: oauth_app_slug,
+          enabled: true
+        })
+
+      credentials.find_each do |credential|
+        next if credential.access_token.blank?
+        next unless SlackDm::SyncCredential.required_scopes_granted?(credential.scopes)
+
+        SlackDm::SyncCredentialJob.perform_later(credential.id)
+      end
+    end
+  end
+end

--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -1,0 +1,18 @@
+module SlackDm
+  class SyncCredentialJob < ApplicationJob
+    queue_as :default
+
+    limits_concurrency to: 1, key: ->(credential_id) { "slack_dm_sync_#{credential_id}" }
+
+    def perform(credential_id)
+      credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
+      return unless credential
+      return if credential.dead?
+      return if credential.access_token.blank?
+      return unless credential.oauth_app&.provider == Oauth::Providers::Slack::KEY
+      return unless SlackDm::SyncCredential.required_scopes_granted?(credential.scopes)
+
+      SlackDm::SyncCredential.new(credential).call
+    end
+  end
+end

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -46,6 +46,18 @@ class CentaurApiClient
     request(:delete, "/api/admin/slack/archive-imports/#{escape_path(import_id)}")
   end
 
+  def list_slack_dm_sync_checkpoints(broker_credential_id:, home_team_id: nil)
+    get(
+      "/api/admin/slack/dm-sync/checkpoints",
+      broker_credential_id: broker_credential_id,
+      home_team_id: home_team_id
+    )
+  end
+
+  def ingest_slack_dm_sync_batch(payload)
+    post("/api/admin/slack/dm-sync/batch", payload)
+  end
+
   private
 
   def get(path, params = {})

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -1,0 +1,341 @@
+require "json"
+require "net/http"
+require "uri"
+
+module SlackDm
+  class SyncCredential
+    REQUIRED_SCOPES = %w[im:read im:history mpim:read mpim:history].freeze
+
+    AUTH_TEST_ENDPOINT = "https://slack.com/api/auth.test"
+    CONVERSATIONS_LIST_ENDPOINT = "https://slack.com/api/conversations.list"
+    CONVERSATIONS_MEMBERS_ENDPOINT = "https://slack.com/api/conversations.members"
+    CONVERSATIONS_HISTORY_ENDPOINT = "https://slack.com/api/conversations.history"
+    CONVERSATIONS_REPLIES_ENDPOINT = "https://slack.com/api/conversations.replies"
+
+    SlackApiError = Class.new(StandardError)
+
+    class << self
+      attr_accessor :slack_api_http
+
+      def oauth_app_slug
+        ConsoleEnv["SLACK_DM_SYNC_OAUTH_APP_SLUG"].presence || "slack-dms"
+      end
+
+      def required_scopes_granted?(scopes)
+        (REQUIRED_SCOPES - Array(scopes)).empty?
+      end
+    end
+
+    def initialize(credential, api_client: CentaurApiClient.new, slack_api_http: nil)
+      @credential = credential
+      @api_client = api_client
+      @slack_api_http = slack_api_http || self.class.slack_api_http
+      @run_id = "sdms_#{SecureRandom.hex(16)}"
+      @messages_fetched = 0
+      @replies_fetched = 0
+    end
+
+    def call
+      auth = slack_api(AUTH_TEST_ENDPOINT)
+      home_team_id = auth.fetch("team_id")
+      source_user_id = auth["user_id"].presence || @credential.provider_subject.to_s
+      checkpoints = load_checkpoints(home_team_id)
+      batch = empty_batch(home_team_id, source_user_id)
+
+      conversations = list_conversations
+      batch[:run][:conversations_requested] = conversations.length
+
+      conversations.each do |conversation|
+        normalize_conversation(conversation, home_team_id, batch)
+        normalize_members(conversation, home_team_id, batch)
+        sync_history(conversation, home_team_id, checkpoints[conversation.fetch("id")], batch)
+        batch[:run][:conversations_synced] += 1
+      rescue StandardError => e
+        batch[:run][:conversations_failed] += 1
+        Rails.logger.warn do
+          "slack DM sync failed for conversation #{conversation['id']}: #{e.class}: #{e.message}"
+        end
+      end
+
+      batch[:run][:status] = batch[:run][:conversations_failed].positive? ? "partial" : "completed"
+      batch[:run][:messages_fetched] = @messages_fetched
+      batch[:run][:messages_upserted] = batch[:messages].length
+      batch[:run][:replies_fetched] = @replies_fetched
+      batch[:run][:replies_upserted] = batch[:messages].count { |message| message[:parent_message_ts].present? }
+      batch[:run][:finished] = true
+      @api_client.ingest_slack_dm_sync_batch(batch)
+    end
+
+    private
+
+    def load_checkpoints(home_team_id)
+      response = @api_client.list_slack_dm_sync_checkpoints(
+        broker_credential_id: @credential.oid,
+        home_team_id: home_team_id
+      )
+      Array(response["checkpoints"]).to_h do |checkpoint|
+        [ checkpoint.fetch("conversation_id"), checkpoint["watermark_ts"] ]
+      end
+    end
+
+    def empty_batch(home_team_id, source_user_id)
+      {
+        run: {
+          run_id: @run_id,
+          mode: "incremental",
+          status: "running",
+          broker_credential_id: @credential.oid,
+          source_user_id: source_user_id,
+          home_team_id: home_team_id,
+          conversations_requested: 0,
+          conversations_synced: 0,
+          conversations_failed: 0,
+          messages_fetched: 0,
+          messages_upserted: 0,
+          replies_fetched: 0,
+          replies_upserted: 0,
+          metadata: {
+            oauth_app_slug: @credential.oauth_app&.slug,
+            credential_id: @credential.oid
+          }
+        },
+        replace_memberships: true,
+        conversations: [],
+        members: [],
+        messages: [],
+        attachments: [],
+        checkpoints: []
+      }
+    end
+
+    def list_conversations
+      each_page(
+        CONVERSATIONS_LIST_ENDPOINT,
+        { "types" => "im,mpim", "exclude_archived" => "false", "limit" => list_page_size },
+        max_pages: list_max_pages
+      ).flat_map { |page| Array(page["channels"]) }
+    end
+
+    def normalize_conversation(conversation, home_team_id, batch)
+      batch[:conversations] << {
+        home_team_id: home_team_id,
+        conversation_id: conversation.fetch("id"),
+        conversation_type: conversation["is_mpim"] ? "mpim" : "im",
+        is_archived: conversation["is_archived"] == true,
+        is_ext_shared: conversation["is_ext_shared"] == true,
+        raw_payload: conversation
+      }
+    end
+
+    def normalize_members(conversation, home_team_id, batch)
+      conversation_id = conversation.fetch("id")
+      members = conversation_members(conversation)
+      members.each do |member_id|
+        batch[:members] << {
+          home_team_id: home_team_id,
+          conversation_id: conversation_id,
+          user_id: member_id,
+          is_external: false,
+          is_current_member: true,
+          raw_payload: { source: "conversations.members" }
+        }
+      end
+    end
+
+    def conversation_members(conversation)
+      if conversation["is_im"] && conversation["user"].present?
+        members = [ conversation["user"] ]
+        members << @credential.provider_subject if @credential.provider_subject.present?
+        return members.uniq
+      end
+
+      pages = each_page(
+        CONVERSATIONS_MEMBERS_ENDPOINT,
+        { "channel" => conversation.fetch("id"), "limit" => members_page_size },
+        max_pages: members_max_pages
+      )
+      members = pages.flat_map { |page| Array(page["members"]) }.compact
+      members << @credential.provider_subject if @credential.provider_subject.present?
+      members.uniq
+    end
+
+    def sync_history(conversation, home_team_id, checkpoint, batch)
+      conversation_id = conversation.fetch("id")
+      max_message_ts = checkpoint
+      completed = true
+      pages = each_page(
+        CONVERSATIONS_HISTORY_ENDPOINT,
+        history_params(conversation_id, checkpoint),
+        max_pages: history_max_pages
+      ) do |_page, truncated|
+        completed = false if truncated
+      end
+
+      pages.each do |page|
+        Array(page["messages"]).each do |message|
+          @messages_fetched += 1
+          max_message_ts = max_slack_ts(max_message_ts, message["ts"])
+          normalize_message(message, home_team_id, conversation_id, nil, batch)
+          normalize_files(message, home_team_id, conversation_id, batch)
+          sync_replies(message, home_team_id, conversation_id, batch) if message["reply_count"].to_i.positive?
+        end
+      end
+
+      return unless completed
+
+      batch[:checkpoints] << {
+        broker_credential_id: @credential.oid,
+        home_team_id: home_team_id,
+        conversation_id: conversation_id,
+        watermark_ts: max_message_ts,
+        last_run_id: @run_id
+      }
+    end
+
+    def sync_replies(root_message, home_team_id, conversation_id, batch)
+      thread_ts = root_message["thread_ts"].presence || root_message["ts"]
+      pages = each_page(
+        CONVERSATIONS_REPLIES_ENDPOINT,
+        { "channel" => conversation_id, "ts" => thread_ts, "limit" => replies_page_size },
+        max_pages: replies_max_pages
+      )
+
+      pages.each do |page|
+        Array(page["messages"]).each do |reply|
+          next if reply["ts"] == root_message["ts"]
+
+          @replies_fetched += 1
+          normalize_message(reply, home_team_id, conversation_id, root_message["ts"], batch)
+          normalize_files(reply, home_team_id, conversation_id, batch)
+        end
+      end
+    end
+
+    def normalize_message(message, home_team_id, conversation_id, parent_message_ts, batch)
+      ts = message.fetch("ts")
+      thread_ts = message["thread_ts"].presence || parent_message_ts
+      batch[:messages] << {
+        home_team_id: home_team_id,
+        conversation_id: conversation_id,
+        message_ts: ts,
+        thread_ts: thread_ts,
+        parent_message_ts: parent_message_ts,
+        is_thread_root: thread_ts.present? && thread_ts == ts,
+        user_id: message["user"].to_s,
+        user_team_id: message["user_team"],
+        bot_id: message["bot_id"].to_s,
+        message_type: message["type"].presence || "message",
+        message_subtype: message["subtype"],
+        text: message["text"].to_s,
+        permalink: message["permalink"].to_s,
+        reply_count: message["reply_count"].to_i,
+        reply_users: Array(message["reply_users"]),
+        latest_reply_ts: message["latest_reply"],
+        thread_refreshed: parent_message_ts.present?,
+        raw_payload: message,
+        source_run_id: @run_id
+      }
+    end
+
+    def normalize_files(message, home_team_id, conversation_id, batch)
+      Array(message["files"]).each do |file|
+        next if file["id"].blank?
+
+        batch[:attachments] << {
+          home_team_id: home_team_id,
+          conversation_id: conversation_id,
+          message_ts: message.fetch("ts"),
+          slack_file_id: file.fetch("id"),
+          name: file["name"].to_s,
+          title: file["title"].to_s,
+          mimetype: file["mimetype"].to_s,
+          filetype: file["filetype"].to_s,
+          size_bytes: file["size"].to_i,
+          url_private: file["url_private"].to_s,
+          permalink: file["permalink"].to_s,
+          raw_payload: file,
+          source_run_id: @run_id
+        }
+      end
+    end
+
+    def history_params(conversation_id, checkpoint)
+      params = { "channel" => conversation_id, "limit" => history_page_size }
+      params["oldest"] = checkpoint if checkpoint.present?
+      params["inclusive"] = "false" if checkpoint.present?
+      params
+    end
+
+    def each_page(endpoint, params, max_pages:)
+      pages = []
+      cursor = nil
+      max_pages.times do |index|
+        page = slack_api(endpoint, params.merge("cursor" => cursor).compact)
+        pages << page
+        cursor = page.dig("response_metadata", "next_cursor").presence
+        has_more = cursor.present?
+        truncated = has_more && index == max_pages - 1
+        yield page, truncated if block_given?
+        break unless has_more
+        break if truncated
+      end
+      pages
+    end
+
+    def slack_api(endpoint, params = {})
+      if @slack_api_http
+        return @slack_api_http.call(
+          endpoint: endpoint,
+          params: params,
+          access_token: @credential.access_token
+        )
+      end
+
+      uri = URI.parse(endpoint)
+      uri.query = URI.encode_www_form(params) if params.any?
+      request = Net::HTTP::Get.new(uri)
+      request["Authorization"] = "Bearer #{@credential.access_token}"
+      request["Accept"] = "application/json"
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = slack_timeout
+      http.read_timeout = slack_timeout
+      response = http.request(request)
+      raise SlackApiError, "Slack API rate limited" if response.code.to_i == 429
+
+      parsed = JSON.parse(response.body.to_s)
+      raise SlackApiError, "Slack API returned HTTP #{response.code}" unless response.code.to_i.between?(200, 299)
+      raise SlackApiError, "Slack API returned #{parsed['error']}" unless parsed["ok"] == true
+
+      parsed
+    end
+
+    def max_slack_ts(left, right)
+      return right if left.blank?
+      return left if right.blank?
+
+      slack_ts_sort_key(right) > slack_ts_sort_key(left) ? right : left
+    end
+
+    def slack_ts_sort_key(value)
+      seconds, micros = value.to_s.split(".", 2)
+      [ seconds.to_i, micros.to_s.ljust(6, "0")[0, 6].to_i ]
+    end
+
+    def slack_timeout = positive_env("SLACK_DM_SYNC_TIMEOUT_SECONDS", 20)
+    def list_page_size = positive_env("SLACK_DM_SYNC_LIST_PAGE_SIZE", 200)
+    def list_max_pages = positive_env("SLACK_DM_SYNC_LIST_MAX_PAGES", 10)
+    def members_page_size = positive_env("SLACK_DM_SYNC_MEMBERS_PAGE_SIZE", 200)
+    def members_max_pages = positive_env("SLACK_DM_SYNC_MEMBERS_MAX_PAGES", 10)
+    def history_page_size = positive_env("SLACK_DM_SYNC_HISTORY_PAGE_SIZE", 200)
+    def history_max_pages = positive_env("SLACK_DM_SYNC_HISTORY_MAX_PAGES", 5)
+    def replies_page_size = positive_env("SLACK_DM_SYNC_REPLIES_PAGE_SIZE", 200)
+    def replies_max_pages = positive_env("SLACK_DM_SYNC_REPLIES_MAX_PAGES", 5)
+
+    def positive_env(name, default)
+      value = ConsoleEnv[name].to_i
+      value.positive? ? value : default
+    end
+  end
+end

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -51,6 +51,8 @@ module SlackDm
         sync_history(conversation, home_team_id, checkpoints[conversation.fetch("id")], batch)
         batch[:run][:conversations_synced] += 1
       rescue StandardError => e
+        raise if Rails.env.test?
+
         batch[:run][:conversations_failed] += 1
         Rails.logger.warn do
           "slack DM sync failed for conversation #{conversation['id']}: #{e.class}: #{e.message}"

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -317,7 +317,7 @@ module SlackDm
       return right if left.blank?
       return left if right.blank?
 
-      slack_ts_sort_key(right) > slack_ts_sort_key(left) ? right : left
+      (slack_ts_sort_key(right) <=> slack_ts_sort_key(left)).positive? ? right : left
     end
 
     def slack_ts_sort_key(value)

--- a/services/console/config/recurring.yml
+++ b/services/console/config/recurring.yml
@@ -19,6 +19,9 @@ production:
   broker_poll_refresh:
     class: "Broker::PollRefreshJob"
     schedule: every minute
+  slack_dm_poll_sync:
+    class: "SlackDm::PollSyncJob"
+    schedule: every 10 minutes
   prune_principal_sync_config_snapshots:
     class: "PrunePrincipalSyncConfigSnapshotsJob"
     schedule: every 10 minutes

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -14,7 +14,12 @@ module SlackDm
       )
     end
 
-    def slack_credential(app:, scopes: SlackDm::SyncCredential::REQUIRED_SCOPES, access_token: "xoxp-live")
+    def slack_credential(
+      app:,
+      scopes: SlackDm::SyncCredential::REQUIRED_SCOPES,
+      access_token: "xoxp-live",
+      provider_subject: "U#{SecureRandom.hex(4).upcase}"
+    )
       BrokerCredential.create!(
         oauth_app: app,
         namespace: "acme",
@@ -25,7 +30,7 @@ module SlackDm
         last_refresh: Time.current,
         expires_at: 1.hour.from_now,
         scopes: scopes,
-        provider_subject: "U123"
+        provider_subject: provider_subject
       )
     end
 

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+module SlackDm
+  class JobsTest < ActiveJob::TestCase
+    def slack_app(slug: "slack-dms")
+      OauthApp.create!(
+        provider: "slack",
+        slug: slug,
+        client_id: "slack-client-#{SecureRandom.hex(4)}",
+        client_secret: "secret",
+        allowed_scopes: SlackDm::SyncCredential::REQUIRED_SCOPES,
+        credential_namespace: "acme",
+        created_by: users(:acme_admin)
+      )
+    end
+
+    def slack_credential(app:, scopes: SlackDm::SyncCredential::REQUIRED_SCOPES, access_token: "xoxp-live")
+      BrokerCredential.create!(
+        oauth_app: app,
+        namespace: "acme",
+        foreign_id: "slack-dms-#{SecureRandom.hex(6)}",
+        token_endpoint: "https://slack.com/api/oauth.v2.access",
+        access_token: access_token,
+        refresh_token: "refresh",
+        last_refresh: Time.current,
+        expires_at: 1.hour.from_now,
+        scopes: scopes,
+        provider_subject: "U123"
+      )
+    end
+
+    test "PollSyncJob enqueues credentials for the configured Slack OAuth app with required scopes" do
+      app = slack_app
+      good = slack_credential(app: app)
+      missing_scope = slack_credential(app: app, scopes: %w[im:read im:history])
+      no_token = slack_credential(app: app, access_token: nil)
+      other_app = slack_app(slug: "other-slack")
+      other = slack_credential(app: other_app)
+
+      SlackDm::PollSyncJob.perform_now("slack-dms")
+
+      enqueued_ids = enqueued_jobs
+        .select { |job| job[:job] == SlackDm::SyncCredentialJob }
+        .map { |job| job[:args].first }
+      assert_includes enqueued_ids, good.id
+      refute_includes enqueued_ids, missing_scope.id
+      refute_includes enqueued_ids, no_token.id
+      refute_includes enqueued_ids, other.id
+    end
+
+    test "SyncCredentialJob is a no-op for missing credentials" do
+      assert_nothing_raised { SlackDm::SyncCredentialJob.perform_now(-1) }
+    end
+  end
+end

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -59,4 +59,33 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     end
     assert_equal "bad archive", error.message
   end
+
+  test "lists Slack DM sync checkpoints for a broker credential" do
+    http = StubHTTP.new(status: 200, body: { checkpoints: [] }.to_json)
+    client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
+
+    client.list_slack_dm_sync_checkpoints(
+      broker_credential_id: "bcr_123",
+      home_team_id: "T123"
+    )
+
+    request = http.requests.first
+    assert_equal :get, request[:method]
+    assert_equal(
+      "http://api.internal:8080/api/admin/slack/dm-sync/checkpoints?broker_credential_id=bcr_123&home_team_id=T123",
+      request[:url]
+    )
+  end
+
+  test "posts Slack DM sync batches" do
+    http = StubHTTP.new(status: 200, body: { ok: true }.to_json)
+    client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
+
+    client.ingest_slack_dm_sync_batch(run: { run_id: "sdms_1" }, messages: [])
+
+    request = http.requests.first
+    assert_equal :post, request[:method]
+    assert_equal "http://api.internal:8080/api/admin/slack/dm-sync/batch", request[:url]
+    assert_equal({ "run" => { "run_id" => "sdms_1" }, "messages" => [] }, JSON.parse(request[:body]))
+  end
 end

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -27,7 +27,7 @@ module SlackDm
     def slack_app
       OauthApp.create!(
         provider: "slack",
-        slug: "slack-dms",
+        slug: "slack-dms-#{SecureRandom.hex(6)}",
         client_id: "slack-client-#{SecureRandom.hex(4)}",
         client_secret: "secret",
         allowed_scopes: SlackDm::SyncCredential::REQUIRED_SCOPES,

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -37,7 +37,7 @@ module SlackDm
     end
 
     def credential
-      BrokerCredential.create!(
+      @credential ||= BrokerCredential.create!(
         oauth_app: slack_app,
         namespace: "acme",
         foreign_id: "slack-dms-#{SecureRandom.hex(6)}",

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -1,0 +1,134 @@
+require "test_helper"
+
+module SlackDm
+  class SyncCredentialTest < ActiveSupport::TestCase
+    class FakeApiClient
+      attr_reader :batch
+
+      def list_slack_dm_sync_checkpoints(broker_credential_id:, home_team_id:)
+        {
+          "checkpoints" => [
+            {
+              "broker_credential_id" => broker_credential_id,
+              "home_team_id" => home_team_id,
+              "conversation_id" => "D123",
+              "watermark_ts" => "1700000000.000001"
+            }
+          ]
+        }
+      end
+
+      def ingest_slack_dm_sync_batch(payload)
+        @batch = payload
+        { "ok" => true }
+      end
+    end
+
+    def slack_app
+      OauthApp.create!(
+        provider: "slack",
+        slug: "slack-dms",
+        client_id: "slack-client-#{SecureRandom.hex(4)}",
+        client_secret: "secret",
+        allowed_scopes: SlackDm::SyncCredential::REQUIRED_SCOPES,
+        credential_namespace: "acme",
+        created_by: users(:acme_admin)
+      )
+    end
+
+    def credential
+      BrokerCredential.create!(
+        oauth_app: slack_app,
+        namespace: "acme",
+        foreign_id: "slack-dms-#{SecureRandom.hex(6)}",
+        token_endpoint: "https://slack.com/api/oauth.v2.access",
+        access_token: "xoxp-live",
+        refresh_token: "refresh",
+        last_refresh: Time.current,
+        expires_at: 1.hour.from_now,
+        scopes: SlackDm::SyncCredential::REQUIRED_SCOPES,
+        provider_subject: "U_ME"
+      )
+    end
+
+    test "sync normalizes conversations members messages files and checkpoints" do
+      api_client = FakeApiClient.new
+      slack_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "xoxp-live", access_token
+        case endpoint
+        when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
+          { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
+        when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          {
+            "ok" => true,
+            "channels" => [
+              { "id" => "D123", "is_im" => true, "user" => "U_OTHER", "is_archived" => false }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_HISTORY_ENDPOINT
+          assert_equal "D123", params["channel"]
+          assert_equal "1700000000.000001", params["oldest"]
+          {
+            "ok" => true,
+            "messages" => [
+              {
+                "type" => "message",
+                "ts" => "1700000000.000002",
+                "thread_ts" => "1700000000.000002",
+                "user" => "U_OTHER",
+                "text" => "hello",
+                "reply_count" => 1,
+                "reply_users" => [ "U_ME" ],
+                "latest_reply" => "1700000000.000003",
+                "files" => [
+                  {
+                    "id" => "F123",
+                    "name" => "note.txt",
+                    "title" => "Note",
+                    "mimetype" => "text/plain",
+                    "filetype" => "text",
+                    "size" => 42,
+                    "url_private" => "https://files.example/private",
+                    "permalink" => "https://slack.example/file"
+                  }
+                ]
+              }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_REPLIES_ENDPOINT
+          assert_equal "1700000000.000002", params["ts"]
+          {
+            "ok" => true,
+            "messages" => [
+              { "type" => "message", "ts" => "1700000000.000002", "user" => "U_OTHER", "text" => "hello" },
+              { "type" => "message", "ts" => "1700000000.000003", "user" => "U_ME", "text" => "reply" }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        else
+          flunk "unexpected Slack endpoint #{endpoint}"
+        end
+      end
+
+      SlackDm::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        slack_api_http: slack_http
+      ).call
+
+      batch = api_client.batch
+      assert_equal "completed", batch[:run][:status]
+      assert_equal credential.oid, batch[:run][:broker_credential_id]
+      assert_equal 1, batch[:conversations].length
+      assert_equal "im", batch[:conversations].first[:conversation_type]
+      assert_equal %w[U_OTHER U_ME], batch[:members].map { |member| member[:user_id] }
+      assert_equal 2, batch[:messages].length
+      assert_equal "hello", batch[:messages].first[:text]
+      assert_equal "1700000000.000002", batch[:messages].last[:parent_message_ts]
+      assert_equal "F123", batch[:attachments].first[:slack_file_id]
+      assert_equal "1700000000.000002", batch[:checkpoints].first[:watermark_ts]
+    end
+  end
+end

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -62,8 +62,20 @@ module SlackDm
           {
             "ok" => true,
             "channels" => [
-              { "id" => "D123", "is_im" => true, "user" => "U_OTHER", "is_archived" => false }
+              {
+                "id" => "D123",
+                "is_im" => true,
+                "is_mpim" => false,
+                "user" => "U_OTHER",
+                "is_archived" => false
+              }
             ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_MEMBERS_ENDPOINT
+          {
+            "ok" => true,
+            "members" => [ "U_OTHER", "U_ME" ],
             "response_metadata" => { "next_cursor" => "" }
           }
         when SlackDm::SyncCredential::CONVERSATIONS_HISTORY_ENDPOINT
@@ -102,8 +114,18 @@ module SlackDm
           {
             "ok" => true,
             "messages" => [
-              { "type" => "message", "ts" => "1700000000.000002", "user" => "U_OTHER", "text" => "hello" },
-              { "type" => "message", "ts" => "1700000000.000003", "user" => "U_ME", "text" => "reply" }
+              {
+                "type" => "message",
+                "ts" => "1700000000.000002",
+                "user" => "U_OTHER",
+                "text" => "hello"
+              },
+              {
+                "type" => "message",
+                "ts" => "1700000000.000003",
+                "user" => "U_ME",
+                "text" => "reply"
+              }
             ],
             "response_metadata" => { "next_cursor" => "" }
           }


### PR DESCRIPTION
## Summary
- add API-RS admin endpoints for Slack DM sync checkpoints and normalized batch ingestion into the DM ETL tables
- add Console recurring jobs that discover live Slack OAuth broker credentials for the configured DM app slug and sync each credential
- fetch IM/MPIM conversations, members, message history, thread replies, file metadata, and checkpoints using each user token
- add Console client/job/service tests for the new sync flow

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p centaur-api-server
- cargo test -p centaur-session-sqlx

## Notes
- Rails tests were added but not run locally because this shell only has system Ruby 2.6/Bundler 1.17; services/console requires ruby-3.4.8 and Bundler 4.0.10.