### PR TITLE
fix: allow console access to api-rs

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.72
+version: 0.1.73
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -173,6 +173,12 @@ spec:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "teamsbot") | nindent 14 }}
 {{- end }}
+{{- if $console.enabled }}
+        # Console pages call api-rs for admin-backed views such as ETLs.
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console") | nindent 14 }}
+{{- end }}
         # Sandboxes call back into the control plane. agent-k8s labels its pods
         # centaur.ai/managed-by=api-rs (MANAGED_BY_VALUE in centaur-sandbox-agent-k8s),
         # which also covers the per-sandbox iron-proxy pods.


### PR DESCRIPTION
## Summary

- Allow console pods to reach the `api-rs` NetworkPolicy ingress when the console is enabled.
- Preserve the default-deny posture by targeting only the console pod selector on the existing API port.

## Root Cause

The console ETL page calls `api-rs` to list Slack archive imports. Console egress to `api-rs` is already rendered on `main`, but `api-rs` ingress did not admit console pods, so TCP connects from console to `centaur-api-rs:8080` timed out and Rails returned a 500.

## Validation

- `helm lint contrib/chart --set console.enabled=true`
- `helm template centaur contrib/chart --set console.enabled=true` and confirmed the rendered `centaur-centaur-api-rs` NetworkPolicy includes the console pod selector under ingress.
