### PR TITLE
feat: add shared centaur image tag

### DIFF
--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -39,6 +39,10 @@ app.kubernetes.io/component: {{ .component }}
 {{- printf "%s-%s" (include "centaur.fullname" .root) .component | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "centaur.centaurImageTag" -}}
+{{- default .componentTag .root.Values.global.centaurImageTag -}}
+{{- end -}}
+
 {{- define "centaur.secretEnvName" -}}
 {{- required "secretManager.existingSecretName is required" .Values.secretManager.existingSecretName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.apiRs.enabled }}
 {{- $console := include "centaur.consoleValues" . | fromYaml -}}
 {{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") -}}
+{{- $apiRsImageTag := include "centaur.centaurImageTag" (dict "root" . "componentTag" .Values.apiRs.image.tag) -}}
+{{- $sandboxImageTag := include "centaur.centaurImageTag" (dict "root" . "componentTag" .Values.sandbox.image.tag) -}}
+{{- $toolRunnerImageTag := include "centaur.centaurImageTag" (dict "root" . "componentTag" (default .Values.sandbox.image.tag .Values.toolServer.runnerImage.tag)) -}}
 {{- $reposPath := .Values.sandbox.reposPath -}}
 {{- if and .Values.repoCache.enabled (not $reposPath) -}}
 {{- $reposPath = .Values.repoCache.hostPath -}}
@@ -139,7 +142,7 @@ spec:
       {{- end }}
       containers:
         - name: api-rs
-          image: {{ printf "%s:%s" .Values.apiRs.image.repository .Values.apiRs.image.tag | quote }}
+          image: {{ printf "%s:%s" .Values.apiRs.image.repository $apiRsImageTag | quote }}
           imagePullPolicy: {{ .Values.apiRs.image.pullPolicy }}
           env:
             - name: DATABASE_URL
@@ -202,7 +205,7 @@ spec:
             - name: SESSION_SANDBOX_K8S_NAMESPACE
               value: {{ .Release.Namespace | quote }}
             - name: SESSION_SANDBOX_IMAGE
-              value: {{ printf "%s:%s" .Values.sandbox.image.repository .Values.sandbox.image.tag | quote }}
+              value: {{ printf "%s:%s" .Values.sandbox.image.repository $sandboxImageTag | quote }}
             - name: SESSION_SANDBOX_IMAGE_PULL_POLICY
               value: {{ .Values.sandbox.image.pullPolicy | quote }}
 {{- if .Values.global.imagePullSecrets }}
@@ -323,7 +326,7 @@ spec:
               value: {{ .Values.repoCache.hostPath | quote }}
 {{- end }}
             - name: KUBERNETES_TOOLS_RUNNER_IMAGE
-              value: {{ printf "%s:%s" (default .Values.sandbox.image.repository .Values.toolServer.runnerImage.repository) (default .Values.sandbox.image.tag .Values.toolServer.runnerImage.tag) | quote }}
+              value: {{ printf "%s:%s" (default .Values.sandbox.image.repository .Values.toolServer.runnerImage.repository) $toolRunnerImageTag | quote }}
             - name: KUBERNETES_TOOLS_RUNNER_IMAGE_PULL_POLICY
               value: {{ default .Values.sandbox.image.pullPolicy .Values.toolServer.runnerImage.pullPolicy | quote }}
 {{- if and .Values.toolServer.githubToken.existingSecretName (not $toolsUseRepoCache) }}

--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -13,7 +13,7 @@
 {{- if $repoCacheRepositories }}
 {{- $repoCacheHasGithubToken := or .Values.repoCache.githubToken.existingSecretName .Values.repoCache.githubToken.token -}}
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
-{{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
+{{- $repoCacheImageTag := include "centaur.centaurImageTag" (dict "root" . "componentTag" (default .Values.sandbox.image.tag .Values.repoCache.image.tag)) -}}
 {{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
 {{- $repoCacheRepositoryRefs := list -}}
 {{- $repoCacheRepositoryRefRepos := list -}}

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.slackbotv2.enabled }}
 {{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") -}}
+{{- $slackbotV2ImageTag := include "centaur.centaurImageTag" (dict "root" . "componentTag" .Values.slackbotv2.image.tag) -}}
 {{- $slackbotV2MetricsAnnotations := dict -}}
 {{- if .Values.slackbotv2.metrics.scrapeAnnotations -}}
 {{- $slackbotV2MetricsAnnotations = dict "prometheus.io/scrape" "true" "prometheus.io/path" .Values.slackbotv2.metrics.path "prometheus.io/port" "3001" -}}
@@ -34,7 +35,7 @@ spec:
       {{- end }}
       containers:
         - name: slackbotv2
-          image: {{ printf "%s:%s" .Values.slackbotv2.image.repository .Values.slackbotv2.image.tag | quote }}
+          image: {{ printf "%s:%s" .Values.slackbotv2.image.repository $slackbotV2ImageTag | quote }}
           imagePullPolicy: {{ .Values.slackbotv2.image.pullPolicy }}
           env:
             - name: PORT

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -3,6 +3,10 @@ fullnameOverride: ""
 
 global:
   imagePullSecrets: []
+  # Optional shared tag for Centaur images that must move together. When set,
+  # this overrides apiRs, sandbox, repoCache, toolServer runner, and slackbotv2
+  # image tags while leaving separately versioned images such as ironProxy alone.
+  centaurImageTag: ""
 
 secretManager:
   envPrefix: ""


### PR DESCRIPTION
## Summary
- add `global.centaurImageTag` as an optional shared tag for coupled Centaur-built images
- apply the shared tag to api-rs, sandbox agent, repo-cache/tool-runner, and slackbotv2
- leave iron-proxy on its existing independent image tag path

## Why
Staging can currently auto-update api-rs, sandbox, repo-cache, and slackbotv2 independently. That allows runtime contract skew, such as api-rs emitting sandbox bootstrap commands that the older sandbox image does not support. A single chart value lets deployment config update one Centaur tag and have Helm fan it out consistently.

## Validation
- `helm dependency build contrib/chart`
- `helm lint contrib/chart -f /Users/akshaan/Desktop/prd-centaur-infra/clusters/centaur-na/argocd/values/centaur-staging.yaml`
- `helm template centaur contrib/chart -n stg-centaur-system -f /Users/akshaan/Desktop/prd-centaur-infra/clusters/centaur-na/argocd/values/centaur-staging.yaml --set global.centaurImageTag=main-sha-shared --set apiRs.image.tag=main-sha-api --set sandbox.image.tag=main-sha-agent --set repoCache.image.tag=main-sha-cache --set slackbotv2.image.tag=main-sha-slack --set ironProxy.image.tag=main-sha-iron`

The rendered manifests use `main-sha-shared` for api-rs, sandbox agent, repo-cache/tool-runner, and slackbotv2, while iron-proxy remains `main-sha-iron`.
