### PR TITLE
Fix Preqin no-password auth

### DIFF
--- a/tools/research/preqin/centaur_tool_preqin/client.py
+++ b/tools/research/preqin/centaur_tool_preqin/client.py
@@ -84,7 +84,6 @@ class PreqinClient:
         fields = {
             "PREQIN_USERNAME": self._username_value(),
             "PREQIN_API_KEY": self._api_key_value(),
-            "PREQIN_PASSWORD": self._password_value(),
         }
         return {
             name: {
@@ -101,30 +100,30 @@ class PreqinClient:
 
         username = self._username_value()
         api_key = self._api_key_value()
-        password = self._password_value()
         if not username:
             raise RuntimeError("PREQIN_USERNAME not set.")
         if not api_key:
             raise RuntimeError("PREQIN_API_KEY not set.")
-        if not password:
-            raise RuntimeError("PREQIN_PASSWORD not set.")
 
+        # Preqin's Operational API token endpoint does not use a standard OAuth2
+        # password grant. It expects these exact form fields.
         response = self.client.post(
             f"{OPERATIONAL_BASE_URL}/connect/token",
             data={
-                "grant_type": "password",
-                "username": username,
-                "password": password,
-                "client_id": api_key,
+                "Username": username,
+                "APIKey": api_key,
             },
-            headers={"Accept": "application/json"},
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
         )
         if response.status_code >= 400:
             body = response.text.strip()
             detail = f" - {body}" if body else ""
             raise RuntimeError(
                 "Preqin Operational API auth failed "
-                f"({response.status_code}) at /connect/token using password grant{detail}"
+                f"({response.status_code}) at /connect/token{detail}"
             )
 
         data = response.json()
@@ -144,14 +143,14 @@ class PreqinClient:
             return {
                 "ok": True,
                 "auth_url": f"{OPERATIONAL_BASE_URL}/connect/token",
-                "method": "password grant",
+                "method": "username+apikey form",
                 "token_length": len(token),
             }
         except Exception as exc:
             return {
                 "ok": False,
                 "auth_url": f"{OPERATIONAL_BASE_URL}/connect/token",
-                "method": "password grant",
+                "method": "username+apikey form",
                 "error": str(exc),
                 "credentials": self.credential_status(),
             }

--- a/tools/research/preqin/pyproject.toml
+++ b/tools/research/preqin/pyproject.toml
@@ -23,8 +23,8 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 hosts = ["api.preqin.com", "id.preqin.com", "feeds.preqin.com"]
-secrets = [
-    { type = "oauth_token", name = "PREQIN_OPERATIONAL_TOKEN", grant = "password", token_endpoint = "https://api.preqin.com/connect/token", hosts = [
-        "api.preqin.com",
-    ], fields = { username = "PREQIN_USERNAME", password = "PREQIN_PASSWORD", client_id = "PREQIN_API_KEY" } },
-]
+# Preqin's /connect/token does not use a standard OAuth2 grant - it expects the
+# form fields `Username` and `APIKey` (no grant_type/password/client_id), which
+# the oauth_token proxy type cannot express. So we expose the raw secrets and let
+# the client mint the bearer token itself (see client.py _operational_access_token).
+secrets = ["PREQIN_USERNAME", "PREQIN_API_KEY"]

--- a/tools/research/preqin/tests/test_client.py
+++ b/tools/research/preqin/tests/test_client.py
@@ -39,12 +39,11 @@ def test_credential_status_does_not_treat_stub_placeholders_as_present():
 
     assert status["PREQIN_USERNAME"]["present"] is False
     assert status["PREQIN_API_KEY"]["present"] is False
-    assert status["PREQIN_PASSWORD"]["present"] is False
 
 
-def test_auth_uses_password_grant_with_username_password_and_api_key():
+def test_auth_uses_username_and_apikey_form_fields():
     fake = FakeHttpClient()
-    client = PreqinClient(username="user", password="pass", api_key="api-key")
+    client = PreqinClient(username="user", api_key="api-key")
     client._client = fake
 
     assert client._operational_access_token(force_refresh=True) == "token-123"
@@ -52,10 +51,8 @@ def test_auth_uses_password_grant_with_username_password_and_api_key():
     request = fake.posts[0]
     assert request["url"] == "https://api.preqin.com/connect/token"
     assert request["data"] == {
-        "grant_type": "password",
-        "username": "user",
-        "password": "pass",
-        "client_id": "api-key",
+        "Username": "user",
+        "APIKey": "api-key",
     }
 
 


### PR DESCRIPTION
## Summary
- remove obsolete PREQIN_PASSWORD requirement from the Preqin tool
- send Preqin /connect/token requests with Username and APIKey form fields
- update credential-status and tests for the two-secret flow

## Tests
- uv run --with pytest pytest tests