### PR TITLE
feat: add Preqin broker credential grant

### DIFF
--- a/services/console/app/controllers/api/v1/broker_credentials_controller.rb
+++ b/services/console/app/controllers/api/v1/broker_credentials_controller.rb
@@ -89,7 +89,7 @@ module Api
       # and rotation state untouched.
       def apply_initial_values(ref, attrs)
         changed = false
-        %i[refresh_token username password].each do |field|
+        %i[refresh_token username password api_key].each do |field|
           value = attrs[field]
           next if value.blank?
 
@@ -104,7 +104,7 @@ module Api
         ref.next_attempt_at = Time.current
       end
 
-      # Observability only. The client_secret, username/password, the
+      # Observability only. The client_secret, username/password/api_key, the
       # token_endpoint_headers values, the minted access_token, and the
       # refresh_token are deliberately never included; only the header names are
       # surfaced.

--- a/services/console/app/controllers/console/broker_credentials_controller.rb
+++ b/services/console/app/controllers/console/broker_credentials_controller.rb
@@ -74,13 +74,18 @@ module Console
 
     def apply_initial_values(credential)
       changed = false
-      preqin_username = credential_params[:preqin_username]
-      if preqin_username.present?
-        credential.username = preqin_username
-        changed = true
+
+      if credential.grant == "preqin"
+        preqin_username = credential_params[:preqin_username]
+        if preqin_username.present?
+          credential.username = preqin_username
+          changed = true
+        end
       end
 
       %i[refresh_token username password api_key].each do |field|
+        next if field == :username && credential.grant == "preqin"
+
         value = credential_params[field]
         next if value.blank?
 

--- a/services/console/app/controllers/console/broker_credentials_controller.rb
+++ b/services/console/app/controllers/console/broker_credentials_controller.rb
@@ -74,7 +74,13 @@ module Console
 
     def apply_initial_values(credential)
       changed = false
-      %i[refresh_token username password].each do |field|
+      preqin_username = credential_params[:preqin_username]
+      if preqin_username.present?
+        credential.username = preqin_username
+        changed = true
+      end
+
+      %i[refresh_token username password api_key].each do |field|
         value = credential_params[field]
         next if value.blank?
 

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -10,9 +10,9 @@
 # BrokerCredential is itself NOT synced and NOT grantable.
 #
 # The OAuth credentials it refreshes with -- client_id, optional client_secret,
-# optional username/password, and any token-endpoint headers -- are fields on the
-# credential, resolved by control itself. client_id is not secret; every other
-# credential value is encrypted at rest.
+# optional username/password/api_key, and any token-endpoint headers -- are fields
+# on the credential, resolved by control itself. client_id is not secret; every
+# other credential value is encrypted at rest.
 class BrokerCredential < ApplicationRecord
   oid_prefix "bcr"
 
@@ -21,7 +21,8 @@ class BrokerCredential < ApplicationRecord
   URL_SAFE_FORMAT = /\A[A-Za-z0-9\-._~]+\z/
   URL_SAFE_MESSAGE = "must contain only URL-safe characters (A-Z, a-z, 0-9, -, ., _, ~)"
 
-  GRANTS = %w[refresh_token password].freeze
+  PREQIN_TOKEN_ENDPOINT = Broker::CredentialGrants::PREQIN_TOKEN_ENDPOINT
+  GRANTS = Broker::CredentialGrants::GRANTS
 
   # The access token must keep at least this much life past the scheduled
   # refresh, regardless of slack/fraction. Mirrors the 60s floor in
@@ -53,6 +54,7 @@ class BrokerCredential < ApplicationRecord
   # undeliverable. The operator must remove the references first.
   before_destroy :ensure_not_referenced
   after_commit :auto_grant_matching_principals, on: %i[create update], if: :oauth_app_id?
+  before_validation :default_preqin_token_endpoint
   before_commit :bump_referencing_principal_sync_config_versions, if: :sync_config_relevant_change?
 
   serialize :token_endpoint_headers, coder: JSON
@@ -61,14 +63,15 @@ class BrokerCredential < ApplicationRecord
   encrypts :client_secret
   encrypts :username
   encrypts :password
+  encrypts :api_key
   encrypts :token_endpoint_headers
 
   scope :refreshable, -> {
     where(dead: false)
       .where("(\"broker_credentials\".\"grant\" = ? AND " \
              "(last_refresh IS NULL OR refresh_token IS NOT NULL)) OR " \
-             "\"broker_credentials\".\"grant\" = ?",
-             "refresh_token", "password")
+             "\"broker_credentials\".\"grant\" IN (?)",
+             "refresh_token", Broker::CredentialGrants::REFRESHABLE_WITHOUT_TOKEN_GRANTS)
       .where("next_attempt_at IS NULL OR next_attempt_at <= ?", Time.current)
   }
 
@@ -78,8 +81,8 @@ class BrokerCredential < ApplicationRecord
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true
   validates :token_endpoint, presence: true
   # client_id is sourced from the linked OauthApp for flow-minted credentials, so
-  # it is only required on standalone (operator-authored) credentials.
-  validates :client_id, presence: true, unless: :oauth_app_id?
+  # it is only required for standalone grants whose strategy uses it.
+  validates :client_id, presence: true, if: -> { Broker::CredentialGrants.client_id_required?(self) }
   validates :external_user_key, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE },
             length: { maximum: 128 }, allow_nil: true
   validates :early_refresh_fraction,
@@ -88,7 +91,7 @@ class BrokerCredential < ApplicationRecord
             numericality: { only_integer: true, greater_than: 0 }
   validate :labels_is_a_hash
   validate :scopes_is_an_array
-  validate :password_grant_credentials_present
+  validate :grant_credentials_present
   validate :token_endpoint_headers_valid
 
   # OAuth client identity used for refresh. Flow-minted credentials delegate to
@@ -103,6 +106,18 @@ class BrokerCredential < ApplicationRecord
     return "dead" if dead?
     return "bootstrapping" if last_refresh.nil?
     "live"
+  end
+
+  def preqin? = grant == "preqin"
+
+  # Used by broker grant strategies. Kept public so tests can inject a stub via
+  # attr_writer and the strategy registry can stay outside the ActiveRecord model.
+  def refresh_client
+    @refresh_client ||= Broker::RefreshClient.new
+  end
+
+  def refresh_scopes_for_provider
+    oauth_app&.provider_strategy&.refresh_scopes(scopes) || scopes
   end
 
   # --- Refresh state machine (ported from iron-token-broker credential.go) ----
@@ -136,8 +151,16 @@ class BrokerCredential < ApplicationRecord
     with_lock do
       return if dead?
 
-      result, clear_refresh_token = perform_refresh
-      apply_success!(result, now: now, clear_refresh_token: clear_refresh_token) if result
+      outcome = perform_refresh
+      if outcome.dead_reason
+        mark_dead!(outcome.dead_reason)
+      elsif outcome.result
+        apply_success!(
+          outcome.result,
+          now: now,
+          clear_refresh_token: outcome.clear_refresh_token
+        )
+      end
     rescue Broker::RefreshError => e
       if e.retryable?
         record_retryable_failure(e.message, now: now)
@@ -153,79 +176,8 @@ class BrokerCredential < ApplicationRecord
     PrincipalCredentialReconciliation.new.apply_for_credential(self)
   end
 
-  def refresh_client
-    @refresh_client ||= Broker::RefreshClient.new
-  end
-
   def perform_refresh
-    case grant
-    when "password"
-      perform_password_grant_refresh
-    else
-      perform_refresh_token_refresh
-    end
-  end
-
-  def perform_refresh_token_refresh
-    if refresh_token.blank?
-      mark_dead!("missing_initial_refresh_token")
-      return nil
-    end
-
-    [ refresh_with_stored_token, false ]
-  end
-
-  def refresh_with_stored_token
-    refresh_client.refresh(
-      token_endpoint: token_endpoint,
-      grant: "refresh_token",
-      client_id: effective_client_id,
-      client_secret: effective_client_secret,
-      refresh_token: refresh_token,
-      scopes: refresh_scopes_for_provider,
-      headers: token_endpoint_headers || {},
-      timeout: refresh_timeout_seconds
-    )
-  end
-
-  def perform_password_grant_refresh
-    clear_stale_refresh_token = false
-
-    if refresh_token.present?
-      begin
-        return [ refresh_with_stored_token, false ]
-      rescue Broker::RefreshError => e
-        raise if e.retryable?
-
-        Rails.logger.warn do
-          "broker credential #{oid} refresh_token grant failed with #{e.reason}; " \
-            "falling back to password grant"
-        end
-        clear_stale_refresh_token = true
-      end
-    end
-
-    unless password_grant_initial_values_present?
-      mark_dead!("password_grant_missing_initial_values")
-      return nil
-    end
-
-    result = refresh_client.refresh(
-      token_endpoint: token_endpoint,
-      grant: "password",
-      client_id: effective_client_id,
-      client_secret: effective_client_secret,
-      username: username,
-      password: password,
-      scopes: refresh_scopes_for_provider,
-      headers: token_endpoint_headers || {},
-      timeout: refresh_timeout_seconds
-    )
-    [ result, clear_stale_refresh_token && result.refresh_token.blank? ]
-  end
-
-  def refresh_scopes_for_provider
-    oauth_app&.provider_strategy&.refresh_scopes(scopes) || scopes
+    Broker::CredentialGrants.refresh(self)
   end
 
   def apply_success!(result, now:, clear_refresh_token:)
@@ -298,15 +250,8 @@ class BrokerCredential < ApplicationRecord
     errors.add(:scopes, "must be an array of strings")
   end
 
-  def password_grant_credentials_present
-    return unless grant == "password"
-
-    errors.add(:username, "can't be blank for the password grant") if username.blank?
-    errors.add(:password, "can't be blank for the password grant") if password.blank?
-  end
-
-  def password_grant_initial_values_present?
-    username.present? && password.present?
+  def grant_credentials_present
+    Broker::CredentialGrants.validate(self)
   end
 
   def token_endpoint_headers_valid
@@ -314,5 +259,11 @@ class BrokerCredential < ApplicationRecord
     valid = token_endpoint_headers.is_a?(Hash) &&
             token_endpoint_headers.all? { |k, v| k.is_a?(String) && v.is_a?(String) }
     errors.add(:token_endpoint_headers, "must be an object mapping header names to string values") unless valid
+  end
+
+  def default_preqin_token_endpoint
+    return unless grant == "preqin"
+
+    self.token_endpoint = Broker::CredentialGrants.default_token_endpoint(grant)
   end
 end

--- a/services/console/app/views/console/broker_credentials/_form.html.erb
+++ b/services/console/app/views/console/broker_credentials/_form.html.erb
@@ -30,30 +30,30 @@
     </section>
 
     <section class="form-section">
-      <h2 class="form-section-heading">OAuth Client</h2>
+      <h2 class="form-section-heading">Token Client</h2>
       <div class="grid gap-5 sm:grid-cols-2">
         <div>
           <label class="form-label" for="credential_token_endpoint">Token endpoint *</label>
-          <%= text_field_tag "credential[token_endpoint]", credential.token_endpoint, id: "credential_token_endpoint", class: "form-input #{field_error_class(credential, :token_endpoint)}", placeholder: "https://oauth2.googleapis.com/token" %>
+          <%= text_field_tag "credential[token_endpoint]", credential.token_endpoint, id: "credential_token_endpoint", class: "form-input #{field_error_class(credential, :token_endpoint)}", placeholder: selected_grant == "preqin" ? BrokerCredential::PREQIN_TOKEN_ENDPOINT : "https://oauth2.googleapis.com/token" %>
           <%= field_error(credential, :token_endpoint) %>
-          <p class="form-hint">The IdP endpoint control refreshes against.</p>
+          <p class="form-hint">The token endpoint control refreshes against. Preqin uses its fixed Operational API endpoint.</p>
         </div>
         <div>
-          <label class="form-label" for="credential_client_id">Client ID *</label>
+          <label class="form-label" for="credential_client_id">Client ID<%= " *" unless selected_grant == "preqin" %></label>
           <%= text_field_tag "credential[client_id]", credential.client_id, id: "credential_client_id", class: "form-input #{field_error_class(credential, :client_id)}" %>
           <%= field_error(credential, :client_id) %>
-          <p class="form-hint">Not secret. Sent on every refresh.</p>
+          <p class="form-hint">Not secret. Not used for Preqin.</p>
         </div>
         <div>
           <label class="form-label" for="credential_client_secret">Client secret</label>
           <%= password_field_tag "credential[client_secret]", nil, id: "credential_client_secret", class: "form-input", autocomplete: "off", placeholder: credential.new_record? ? nil : "•••••••• (unchanged)" %>
-          <p class="form-hint">Stored encrypted.<%= " Leave blank to keep the current secret." unless credential.new_record? %></p>
+          <p class="form-hint">Stored encrypted. Not used for Preqin.<%= " Leave blank to keep the current secret." unless credential.new_record? %></p>
         </div>
         <div>
           <label class="form-label" for="credential_scopes">Scopes</label>
           <%= text_area_tag "credential[scopes]", Array(credential.scopes).join("\n"), id: "credential_scopes", rows: 3, class: "form-input #{field_error_class(credential, :scopes)}", placeholder: "https://www.googleapis.com/auth/gmail.readonly" %>
           <%= field_error(credential, :scopes) %>
-          <p class="form-hint">One scope per line.</p>
+          <p class="form-hint">One scope per line. Not used for Preqin.</p>
         </div>
       </div>
     </section>
@@ -121,6 +121,21 @@
           <%= password_field_tag "credential[password]", nil, id: "credential_password", class: "form-input #{field_error_class(credential, :password)}", autocomplete: "off", placeholder: credential.new_record? ? nil : "•••••••• (unchanged)" %>
           <%= field_error(credential, :password) %>
           <p class="form-hint">Stored encrypted. Leave blank to keep the current password.</p>
+        </div>
+      </div>
+
+      <div data-toggle-target="panel" data-toggle-key="preqin" class="grid gap-5 sm:grid-cols-2">
+        <div>
+          <label class="form-label" for="credential_preqin_username">Username *</label>
+          <%= text_field_tag "credential[preqin_username]", nil, id: "credential_preqin_username", class: "form-input #{field_error_class(credential, :username)}", autocomplete: "off", placeholder: credential.new_record? ? nil : "•••••••• (unchanged)" %>
+          <%= field_error(credential, :username) %>
+          <p class="form-hint">Stored encrypted. Leave blank to keep the current username.</p>
+        </div>
+        <div>
+          <label class="form-label" for="credential_api_key">API key *</label>
+          <%= password_field_tag "credential[api_key]", nil, id: "credential_api_key", class: "form-input #{field_error_class(credential, :api_key)}", autocomplete: "off", placeholder: credential.new_record? ? nil : "•••••••• (unchanged)" %>
+          <%= field_error(credential, :api_key) %>
+          <p class="form-hint">Stored encrypted. Leave blank to keep the current API key.</p>
         </div>
       </div>
     </section>

--- a/services/console/app/views/console/credential.html.erb
+++ b/services/console/app/views/console/credential.html.erb
@@ -62,13 +62,15 @@
   ([ "Dead reason", @credential.dead_reason ] if @credential.dead?)
 ].compact) %>
 
-<%= def_section.call("OAuth Client", [
+<%= def_section.call("Token Client", [
   [ "Grant", @credential.grant ],
-  [ "Client ID", @credential.effective_client_id ],
+  ([ "Client ID", @credential.effective_client_id ] if @credential.effective_client_id.present?),
   [ "Token endpoint", @credential.token_endpoint ],
   [ "Scopes", Array(@credential.scopes).join("\n") ],
   ([ "Username", "[redacted]" ] if @credential.grant == "password" && @credential.username.present?),
   ([ "Password", "[redacted]" ] if @credential.grant == "password" && @credential.password.present?),
+  ([ "Username", "[redacted]" ] if @credential.grant == "preqin" && @credential.username.present?),
+  ([ "API key", "[redacted]" ] if @credential.grant == "preqin" && @credential.api_key.present?),
   ([ "Token endpoint headers", Array(@credential.token_endpoint_headers&.keys).map { |k| "#{k}: [redacted]" }.join("\n") ] if @credential.token_endpoint_headers.present?)
 ].compact) %>
 

--- a/services/console/db/migrate/20260625002334_add_api_key_to_broker_credentials.rb
+++ b/services/console/db/migrate/20260625002334_add_api_key_to_broker_credentials.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToBrokerCredentials < ActiveRecord::Migration[8.1]
+  def change
+    add_column :broker_credentials, :api_key, :text
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_24_000100) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_25_002334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -44,6 +44,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_000100) do
 
   create_table "broker_credentials", force: :cascade do |t|
     t.text "access_token"
+    t.text "api_key"
     t.string "client_id"
     t.text "client_secret"
     t.datetime "created_at", null: false

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -804,9 +804,9 @@ Returns `201`. Response shape (note that `credentials` echoes each source as `{ 
 
 A broker credential is an OAuth credential whose token lifecycle iron-control manages itself. iron-control runs the refresh loop, mints fresh access tokens before they expire, and delivers the current access token to `iron-proxy` inline through [proxy sync](#proxy-sync) wherever a [`token_broker` secret source](#secret-sources) references the credential by its `id`.
 
-Unlike the secret types above, a broker credential is not granted directly and is not injected on its own. It is referenced by a `token_broker` source on a grantable secret (typically a [static secret](#static-secrets)), which carries the rules and injection config. Refresh tokens, usernames, and passwords never leave iron-control.
+Unlike the secret types above, a broker credential is not granted directly and is not injected on its own. It is referenced by a `token_broker` source on a grantable secret (typically a [static secret](#static-secrets)), which carries the rules and injection config. Refresh tokens, usernames, passwords, and API keys never leave iron-control.
 
-The OAuth client credentials it refreshes with are fields on the credential, resolved by iron-control itself. `client_id` is not secret and is returned in responses; `client_secret`, password-grant fields, and the `token_endpoint_headers` values are encrypted at rest and never returned.
+The token credentials it refreshes with are fields on the credential, resolved by iron-control itself. `client_id` is not secret and is returned in responses; `client_secret`, password-grant fields, Preqin API keys, and the `token_endpoint_headers` values are encrypted at rest and never returned.
 
 ### Attributes
 
@@ -816,15 +816,16 @@ The OAuth client credentials it refreshes with are fields on the credential, res
 | `foreign_id`                   | optional    | Unique per namespace. Immutable. |
 | `name`, `description`          | optional    | |
 | `labels`                       | optional    | |
-| `grant`                        | optional    | One of `refresh_token` or `password`. Defaults to `refresh_token`. |
-| `token_endpoint`               | required    | OAuth token endpoint the refresh request is sent to. |
+| `grant`                        | optional    | One of `refresh_token`, `password`, or `preqin`. Defaults to `refresh_token`. |
+| `token_endpoint`               | conditional | Token endpoint the refresh request is sent to. Required except `preqin`, which uses the fixed `https://api.preqin.com/connect/token` endpoint. |
 | `scopes`                       | optional    | Array of strings. |
-| `client_id`                    | required    | OAuth client id. Returned in responses. |
+| `client_id`                    | conditional | OAuth client id. Required for standalone `refresh_token` and `password` credentials. Returned in responses. Not used for `preqin`. |
 | `client_secret`                | optional    | OAuth client secret. Write-only and encrypted at rest; omit for public clients. Never returned. |
 | `token_endpoint_headers`       | optional    | Object mapping header name to a string value, sent on the refresh request. Values are write-only and encrypted; only the header names are returned (as `token_endpoint_header_names`). |
 | `refresh_token`                | optional    | Write-only initial value for `refresh_token` credentials. Also used by `password` credentials when the provider returns one. Supplying a value schedules the credential immediately and clears dead state. Never returned. |
 | `username`                     | conditional | Required for `password` credentials. Write-only and encrypted at rest. Never returned. |
 | `password`                     | conditional | Required for `password` credentials. Write-only and encrypted at rest. Never returned. |
+| `api_key`                      | conditional | Required for `preqin` credentials. Write-only and encrypted at rest. Never returned. |
 | `early_refresh_slack_seconds`  | optional    | Refresh this many seconds before expiry. Defaults to `300`. |
 | `early_refresh_fraction`       | optional    | Refresh once this fraction of the token's lifetime remains, when that is larger than the slack. In `[0, 1)`. Defaults to `0.2`. |
 | `max_refresh_interval_seconds` | optional    | Refresh at least this often, even for long-lived tokens. Defaults to `86400`. |
@@ -834,7 +835,7 @@ Read-only fields are returned but never accepted in requests:
 
 | Field                         | Notes |
 | ----------------------------- | ----- |
-| `status`                      | `bootstrapping` (no token minted yet), `live`, or `dead` (an unrecoverable refresh failure; needs a new `refresh_token`). |
+| `status`                      | `bootstrapping` (no token minted yet), `live`, or `dead` (an unrecoverable refresh failure; needs fresh initial values). |
 | `token_endpoint_header_names` | The configured header names (values are not returned). |
 | `expires_at`                  | When the current access token expires. |
 | `last_refresh`                | When the last successful refresh completed. |
@@ -847,7 +848,7 @@ Read-only fields are returned but never accepted in requests:
 | `provider_email`              | The account email captured at consent time. |
 | `external_user_key`           | An opaque key generated for the credential when it is minted by the consent flow. |
 
-The minted `access_token`, the `refresh_token`, `username`, `password`, the `client_secret`, and the `token_endpoint_headers` values are never returned in any response.
+The minted `access_token`, the `refresh_token`, `username`, `password`, `api_key`, the `client_secret`, and the `token_endpoint_headers` values are never returned in any response.
 
 Password-grant credentials first use the stored initial values with `grant_type=password`. If the token endpoint returns a `refresh_token`, iron-control stores it and uses `grant_type=refresh_token` on later scheduled refreshes. If that stored refresh token is rejected with an unrecoverable OAuth error, iron-control retries once with `grant_type=password`; retryable network, 5xx, rate-limit, and parse failures keep the existing backoff behavior and do not fall back to password.
 
@@ -927,6 +928,37 @@ Password-grant providers use the same endpoint with `grant: "password"`:
 
 For AlphaSense API calls, grant static secrets alongside the broker token so the proxy also injects the required `x-api-key` and `clientid` headers on `api.alpha-sense.com`. The broker credential itself only supplies the current bearer token through a `token_broker` source.
 
+Preqin Operational API credentials use the provider-specific `preqin` grant. iron-control submits Preqin's multipart `username` and `apikey` form, stores any returned `refresh_token`, and later uses Preqin's refresh endpoint when possible:
+
+```json
+{
+  "data": {
+    "namespace": "default",
+    "foreign_id": "preqin-operational",
+    "name": "Preqin Operational",
+    "grant": "preqin",
+    "username": "preqinapiuser@example.com",
+    "api_key": "preqin-api-key"
+  }
+}
+```
+
+The token is still consumed like any other broker token:
+
+```json
+{
+  "data": {
+    "foreign_id": "preqin-operational-auth",
+    "inject_config": { "header": "Authorization", "formatter": "Bearer {{ .Value }}" },
+    "source": {
+      "source_type": "token_broker",
+      "config": { "credential_id": "preqin-operational", "credential_namespace": "default" }
+    },
+    "rules": [ { "host": "api.preqin.com" } ]
+  }
+}
+```
+
 To put the credential to use, reference it from a grantable secret's `token_broker` source, then grant that secret to a principal:
 
 ```json
@@ -942,7 +974,7 @@ To put the credential to use, reference it from a grantable secret's `token_brok
 
 ### Re-authenticating a dead credential
 
-When a refresh fails unrecoverably (for example the IdP returns `invalid_grant` because the refresh token was revoked), the credential's `status` becomes `dead` and it stops minting tokens. Supply a fresh `refresh_token` for a `refresh_token` credential, or fresh `username` / `password` fields for a `password` credential, via `PUT` / `PATCH` to clear the dead state and reschedule it:
+When a refresh fails unrecoverably (for example the IdP returns `invalid_grant` because the refresh token was revoked), the credential's `status` becomes `dead` and it stops minting tokens. Supply a fresh `refresh_token` for a `refresh_token` credential, fresh `username` / `password` fields for a `password` credential, or fresh `username` / `api_key` fields for a `preqin` credential, via `PUT` / `PATCH` to clear the dead state and reschedule it:
 
 ```json
 { "data": { "refresh_token": "1//0gNEW..." } }

--- a/services/console/lib/broker/credential_grants.rb
+++ b/services/console/lib/broker/credential_grants.rb
@@ -1,0 +1,161 @@
+module Broker
+  # Registry for broker credential token-exchange strategies. BrokerCredential
+  # owns persistence and scheduling; these strategies own provider-specific
+  # request shapes and bootstrap validation.
+  module CredentialGrants
+    PREQIN_TOKEN_ENDPOINT = "https://api.preqin.com/connect/token".freeze
+    PREQIN_REFRESH_TOKEN_ENDPOINT = "https://api.preqin.com/connect/refresh_token".freeze
+
+    GRANTS = %w[refresh_token password preqin].freeze
+    REFRESHABLE_WITHOUT_TOKEN_GRANTS = %w[password preqin].freeze
+
+    Outcome = Data.define(:result, :clear_refresh_token, :dead_reason)
+
+    class << self
+      def default_token_endpoint(grant)
+        PREQIN_TOKEN_ENDPOINT if grant == "preqin"
+      end
+
+      def client_id_required?(credential)
+        credential.grant != "preqin" && !credential.oauth_app_id?
+      end
+
+      def validate(credential)
+        case credential.grant
+        when "password"
+          validate_password(credential)
+        when "preqin"
+          validate_preqin(credential)
+        end
+      end
+
+      def refresh(credential)
+        case credential.grant
+        when "password"
+          refresh_password(credential)
+        when "preqin"
+          refresh_preqin(credential)
+        else
+          refresh_token(credential)
+        end
+      end
+
+      private
+
+      def success(result, clear_refresh_token: false)
+        Outcome.new(result: result, clear_refresh_token: clear_refresh_token, dead_reason: nil)
+      end
+
+      def dead(reason)
+        Outcome.new(result: nil, clear_refresh_token: false, dead_reason: reason)
+      end
+
+      def refresh_token(credential)
+        return dead("missing_initial_refresh_token") if credential.refresh_token.blank?
+
+        success(oauth_refresh_token(credential))
+      end
+
+      def refresh_password(credential)
+        clear_stale_refresh_token = false
+
+        if credential.refresh_token.present?
+          begin
+            return success(oauth_refresh_token(credential))
+          rescue Broker::RefreshError => e
+            raise if e.retryable?
+
+            Rails.logger.warn do
+              "broker credential #{credential.oid} refresh_token grant failed with #{e.reason}; " \
+                "falling back to password grant"
+            end
+            clear_stale_refresh_token = true
+          end
+        end
+
+        return dead("password_grant_missing_initial_values") unless password_values_present?(credential)
+
+        result = credential.refresh_client.refresh(
+          token_endpoint: credential.token_endpoint,
+          grant: "password",
+          client_id: credential.effective_client_id,
+          client_secret: credential.effective_client_secret,
+          username: credential.username,
+          password: credential.password,
+          scopes: credential.refresh_scopes_for_provider,
+          headers: credential.token_endpoint_headers || {},
+          timeout: credential.refresh_timeout_seconds
+        )
+        success(result, clear_refresh_token: clear_stale_refresh_token && result.refresh_token.blank?)
+      end
+
+      def refresh_preqin(credential)
+        clear_stale_refresh_token = false
+
+        if credential.refresh_token.present?
+          begin
+            result = credential.refresh_client.refresh(
+              token_endpoint: PREQIN_REFRESH_TOKEN_ENDPOINT,
+              grant: "preqin_refresh_token",
+              refresh_token: credential.refresh_token,
+              headers: credential.token_endpoint_headers || {},
+              timeout: credential.refresh_timeout_seconds
+            )
+            return success(result)
+          rescue Broker::RefreshError => e
+            raise if e.retryable?
+
+            Rails.logger.warn do
+              "broker credential #{credential.oid} preqin refresh_token failed with #{e.reason}; " \
+                "falling back to username/api key"
+            end
+            clear_stale_refresh_token = true
+          end
+        end
+
+        return dead("preqin_missing_initial_values") unless preqin_values_present?(credential)
+
+        result = credential.refresh_client.refresh(
+          token_endpoint: credential.token_endpoint,
+          grant: "preqin",
+          username: credential.username,
+          api_key: credential.api_key,
+          headers: credential.token_endpoint_headers || {},
+          timeout: credential.refresh_timeout_seconds
+        )
+        success(result, clear_refresh_token: clear_stale_refresh_token && result.refresh_token.blank?)
+      end
+
+      def oauth_refresh_token(credential)
+        credential.refresh_client.refresh(
+          token_endpoint: credential.token_endpoint,
+          grant: "refresh_token",
+          client_id: credential.effective_client_id,
+          client_secret: credential.effective_client_secret,
+          refresh_token: credential.refresh_token,
+          scopes: credential.refresh_scopes_for_provider,
+          headers: credential.token_endpoint_headers || {},
+          timeout: credential.refresh_timeout_seconds
+        )
+      end
+
+      def validate_password(credential)
+        credential.errors.add(:username, "can't be blank for the password grant") if credential.username.blank?
+        credential.errors.add(:password, "can't be blank for the password grant") if credential.password.blank?
+      end
+
+      def validate_preqin(credential)
+        credential.errors.add(:username, "can't be blank for the Preqin broker grant") if credential.username.blank?
+        credential.errors.add(:api_key, "can't be blank for the Preqin broker grant") if credential.api_key.blank?
+      end
+
+      def password_values_present?(credential)
+        credential.username.present? && credential.password.present?
+      end
+
+      def preqin_values_present?(credential)
+        credential.username.present? && credential.api_key.present?
+      end
+    end
+  end
+end

--- a/services/console/lib/broker/credential_grants.rb
+++ b/services/console/lib/broker/credential_grants.rb
@@ -75,17 +75,8 @@ module Broker
 
         return dead("password_grant_missing_initial_values") unless password_values_present?(credential)
 
-        result = credential.refresh_client.refresh(
-          token_endpoint: credential.token_endpoint,
-          grant: "password",
-          client_id: credential.effective_client_id,
-          client_secret: credential.effective_client_secret,
-          username: credential.username,
-          password: credential.password,
-          scopes: credential.refresh_scopes_for_provider,
-          headers: credential.token_endpoint_headers || {},
-          timeout: credential.refresh_timeout_seconds
-        )
+        result = post_token_form(credential, url: credential.token_endpoint,
+                                             form: password_form(credential))
         success(result, clear_refresh_token: clear_stale_refresh_token && result.refresh_token.blank?)
       end
 
@@ -94,12 +85,12 @@ module Broker
 
         if credential.refresh_token.present?
           begin
-            result = credential.refresh_client.refresh(
-              token_endpoint: PREQIN_REFRESH_TOKEN_ENDPOINT,
-              grant: "preqin_refresh_token",
-              refresh_token: credential.refresh_token,
-              headers: credential.token_endpoint_headers || {},
-              timeout: credential.refresh_timeout_seconds
+            result = post_token_form(
+              credential,
+              url: PREQIN_REFRESH_TOKEN_ENDPOINT,
+              form: preqin_refresh_token_form(credential),
+              form_encoding: :multipart,
+              strict_4xx: true
             )
             return success(result)
           rescue Broker::RefreshError => e
@@ -115,28 +106,87 @@ module Broker
 
         return dead("preqin_missing_initial_values") unless preqin_values_present?(credential)
 
-        result = credential.refresh_client.refresh(
-          token_endpoint: credential.token_endpoint,
-          grant: "preqin",
-          username: credential.username,
-          api_key: credential.api_key,
-          headers: credential.token_endpoint_headers || {},
-          timeout: credential.refresh_timeout_seconds
+        result = post_token_form(
+          credential,
+          url: credential.token_endpoint,
+          form: preqin_token_form(credential),
+          form_encoding: :multipart,
+          strict_4xx: true
         )
         success(result, clear_refresh_token: clear_stale_refresh_token && result.refresh_token.blank?)
       end
 
       def oauth_refresh_token(credential)
-        credential.refresh_client.refresh(
-          token_endpoint: credential.token_endpoint,
-          grant: "refresh_token",
-          client_id: credential.effective_client_id,
-          client_secret: credential.effective_client_secret,
-          refresh_token: credential.refresh_token,
-          scopes: credential.refresh_scopes_for_provider,
-          headers: credential.token_endpoint_headers || {},
-          timeout: credential.refresh_timeout_seconds
+        post_token_form(
+          credential,
+          url: credential.token_endpoint,
+          form: refresh_token_form(credential)
         )
+      end
+
+      def post_token_form(credential, url:, form:, form_encoding: :urlencoded, strict_4xx: false)
+        credential.refresh_client.refresh(
+          url: url,
+          form: form,
+          form_encoding: form_encoding,
+          headers: credential.token_endpoint_headers || {},
+          timeout: credential.refresh_timeout_seconds,
+          strict_4xx: strict_4xx
+        )
+      end
+
+      def refresh_token_form(credential)
+        require_value!("client_id", credential.effective_client_id)
+        require_value!("refresh_token", credential.refresh_token)
+
+        form = {
+          "grant_type" => "refresh_token",
+          "refresh_token" => credential.refresh_token,
+          "client_id" => credential.effective_client_id
+        }
+        add_oauth_optional_fields(form, credential)
+      end
+
+      def password_form(credential)
+        require_value!("client_id", credential.effective_client_id)
+        require_value!("username", credential.username)
+        require_value!("password", credential.password)
+
+        form = {
+          "grant_type" => "password",
+          "username" => credential.username,
+          "password" => credential.password,
+          "client_id" => credential.effective_client_id
+        }
+        add_oauth_optional_fields(form, credential)
+      end
+
+      def preqin_token_form(credential)
+        require_value!("username", credential.username)
+        require_value!("api_key", credential.api_key)
+
+        {
+          "username" => credential.username,
+          "apikey" => credential.api_key
+        }
+      end
+
+      def preqin_refresh_token_form(credential)
+        require_value!("refresh_token", credential.refresh_token)
+
+        { "refresh_token" => credential.refresh_token }
+      end
+
+      def add_oauth_optional_fields(form, credential)
+        form["client_secret"] = credential.effective_client_secret if credential.effective_client_secret.present?
+
+        scopes = credential.refresh_scopes_for_provider
+        form["scope"] = scopes.join(" ") if scopes.present?
+        form
+      end
+
+      def require_value!(name, value)
+        raise ArgumentError, "#{name} is required" if value.blank?
       end
 
       def validate_password(credential)

--- a/services/console/lib/broker/refresh_client.rb
+++ b/services/console/lib/broker/refresh_client.rb
@@ -24,7 +24,7 @@ module Broker
     MAX_BODY_BYTES = 64 * 1024
 
     # http: an optional callable for testing, invoked as
-    #   http.call(url:, form:, headers:, timeout:) -> Response
+    #   http.call(url:, form:, headers:, timeout:, form_encoding:) -> Response
     # When nil, a Net::HTTP-backed implementation is used.
     def initialize(http: nil)
       @http = http
@@ -33,65 +33,99 @@ module Broker
     # Performs one token exchange. Raises Broker::RefreshError on any failure
     # (classified retryable vs. unrecoverable). scopes is an array; headers is a
     # name=>value hash applied verbatim to the token POST.
-    def refresh(token_endpoint:, client_id:, grant: "refresh_token", refresh_token: nil,
-                username: nil, password: nil, client_secret: nil,
+    def refresh(token_endpoint:, client_id: nil, grant: "refresh_token", refresh_token: nil,
+                username: nil, password: nil, api_key: nil, client_secret: nil,
                 scopes: [], headers: {}, timeout: DEFAULT_TIMEOUT)
       raise ArgumentError, "token endpoint is required" if token_endpoint.blank?
-      raise ArgumentError, "client_id is required" if client_id.blank?
+      raise ArgumentError, "client_id is required" if client_id.blank? && requires_client_id?(grant)
 
-      form = form_for_grant(
+      form, form_encoding = form_for_grant(
         grant: grant,
         client_id: client_id,
         refresh_token: refresh_token,
         username: username,
-        password: password
+        password: password,
+        api_key: api_key
       )
-      form["client_secret"] = client_secret if client_secret.present?
-      form["scope"] = scopes.join(" ") if scopes.present?
+      unless preqin_grant?(grant)
+        form["client_secret"] = client_secret if client_secret.present?
+        form["scope"] = scopes.join(" ") if scopes.present?
+      end
 
-      response = perform(token_endpoint, form, headers, timeout)
+      response = perform(token_endpoint, form, headers, timeout, form_encoding: form_encoding)
 
-      return classify_error(response.status, response.body) if response.status / 100 != 2
+      if response.status / 100 != 2
+        return classify_error(
+          response.status,
+          response.body,
+          strict_4xx: preqin_grant?(grant)
+        )
+      end
 
       parse_success(response)
     end
 
     private
 
-    def form_for_grant(grant:, client_id:, refresh_token:, username:, password:)
+    def requires_client_id?(grant)
+      !preqin_grant?(grant)
+    end
+
+    def preqin_grant?(grant)
+      %w[preqin preqin_refresh_token].include?(grant)
+    end
+
+    def form_for_grant(grant:, client_id:, refresh_token:, username:, password:, api_key:)
       case grant
       when "refresh_token"
         raise ArgumentError, "refresh_token is required" if refresh_token.blank?
 
-        {
+        [ {
           "grant_type" => "refresh_token",
           "refresh_token" => refresh_token,
           "client_id" => client_id
-        }
+        }, :urlencoded ]
       when "password"
         raise ArgumentError, "username is required" if username.blank?
         raise ArgumentError, "password is required" if password.blank?
 
-        {
+        [ {
           "grant_type" => "password",
           "username" => username,
           "password" => password,
           "client_id" => client_id
-        }
+        }, :urlencoded ]
+      when "preqin"
+        raise ArgumentError, "username is required" if username.blank?
+        raise ArgumentError, "api_key is required" if api_key.blank?
+
+        [ {
+          "username" => username,
+          "apikey" => api_key
+        }, :multipart ]
+      when "preqin_refresh_token"
+        raise ArgumentError, "refresh_token is required" if refresh_token.blank?
+
+        [ { "refresh_token" => refresh_token }, :multipart ]
       else
         raise ArgumentError, "unsupported grant #{grant.inspect}"
       end
     end
 
-    def perform(url, form, headers, timeout)
+    def perform(url, form, headers, timeout, form_encoding:)
       if @http
-        return @http.call(url: url, form: form, headers: headers, timeout: timeout)
+        return @http.call(url: url, form: form, headers: headers, timeout: timeout,
+                          form_encoding: form_encoding)
       end
 
       uri = URI.parse(url)
       req = Net::HTTP::Post.new(uri)
-      req.set_form_data(form)
-      req["Content-Type"] = "application/x-www-form-urlencoded"
+      if form_encoding == :multipart
+        req.set_form(form.to_a, "multipart/form-data")
+      else
+        req.set_form_data(form)
+        req["Content-Type"] = "application/x-www-form-urlencoded"
+      end
       req["Accept"] = "application/json"
       headers.each { |name, value| req[name] = value }
 
@@ -140,19 +174,24 @@ module Broker
     # side: any RFC 6749 5.2 error code is structural and means the credential is
     # dead until a human acts. Transport-shaped failures (5xx, bodyless 4xx) are
     # retryable.
-    def classify_error(status, body)
+    def classify_error(status, body, strict_4xx: false)
       oauth_error = begin
         JSON.parse(body.to_s)["error"]
       rescue JSON::ParserError, TypeError
         nil
       end
 
-      if status / 100 == 5
+      if status / 100 == 5 || status == 429
         raise RefreshError.new("token endpoint http #{status}",
                                stage: "http", code: oauth_error.presence, status: status, retryable: true)
       end
 
       if oauth_error.blank?
+        if strict_4xx
+          raise RefreshError.new("token endpoint http #{status}",
+                                 stage: "http", code: "http_#{status}",
+                                 status: status, retryable: false)
+        end
         # 4xx with no OAuth body: most likely a gateway/rate-limiter, not the IdP.
         raise RefreshError.new("token endpoint http #{status}",
                                stage: "http", status: status, retryable: true)

--- a/services/console/lib/broker/refresh_client.rb
+++ b/services/console/lib/broker/refresh_client.rb
@@ -3,11 +3,10 @@ require "json"
 require "uri"
 
 module Broker
-  # RefreshClient performs raw RFC 6749 token grant POSTs against a token
-  # endpoint and returns the parsed response. It owns no retry/backoff state --
-  # BrokerCredential drives that. Ported from iron-token-broker's
-  # internal/broker/refresh.go, with password-grant support added for providers
-  # that still require it.
+  # RefreshClient performs raw token POSTs and returns the parsed response. It
+  # owns no grant-specific request shape and no retry/backoff state:
+  # BrokerCredential drives scheduling, while Broker::CredentialGrants builds the
+  # provider form body.
   #
   # SECURITY: this class never logs the refresh_token, client_secret, the
   # response body, or any decoded token. Callers must keep the same discipline.
@@ -31,34 +30,23 @@ module Broker
     end
 
     # Performs one token exchange. Raises Broker::RefreshError on any failure
-    # (classified retryable vs. unrecoverable). scopes is an array; headers is a
-    # name=>value hash applied verbatim to the token POST.
-    def refresh(token_endpoint:, client_id: nil, grant: "refresh_token", refresh_token: nil,
-                username: nil, password: nil, api_key: nil, client_secret: nil,
-                scopes: [], headers: {}, timeout: DEFAULT_TIMEOUT)
-      raise ArgumentError, "token endpoint is required" if token_endpoint.blank?
-      raise ArgumentError, "client_id is required" if client_id.blank? && requires_client_id?(grant)
-
-      form, form_encoding = form_for_grant(
-        grant: grant,
-        client_id: client_id,
-        refresh_token: refresh_token,
-        username: username,
-        password: password,
-        api_key: api_key
-      )
-      unless preqin_grant?(grant)
-        form["client_secret"] = client_secret if client_secret.present?
-        form["scope"] = scopes.join(" ") if scopes.present?
+    # (classified retryable vs. unrecoverable). `form` is posted exactly as
+    # supplied by the caller, encoded as either URL-encoded or multipart data.
+    def refresh(url:, form:, form_encoding: :urlencoded, headers: {},
+                timeout: DEFAULT_TIMEOUT, strict_4xx: false)
+      raise ArgumentError, "url is required" if url.blank?
+      raise ArgumentError, "form must be a hash" unless form.is_a?(Hash)
+      unless %i[urlencoded multipart].include?(form_encoding)
+        raise ArgumentError, "unsupported form encoding #{form_encoding.inspect}"
       end
 
-      response = perform(token_endpoint, form, headers, timeout, form_encoding: form_encoding)
+      response = perform(url, form, headers, timeout, form_encoding: form_encoding)
 
       if response.status / 100 != 2
         return classify_error(
           response.status,
           response.body,
-          strict_4xx: preqin_grant?(grant)
+          strict_4xx: strict_4xx
         )
       end
 
@@ -66,51 +54,6 @@ module Broker
     end
 
     private
-
-    def requires_client_id?(grant)
-      !preqin_grant?(grant)
-    end
-
-    def preqin_grant?(grant)
-      %w[preqin preqin_refresh_token].include?(grant)
-    end
-
-    def form_for_grant(grant:, client_id:, refresh_token:, username:, password:, api_key:)
-      case grant
-      when "refresh_token"
-        raise ArgumentError, "refresh_token is required" if refresh_token.blank?
-
-        [ {
-          "grant_type" => "refresh_token",
-          "refresh_token" => refresh_token,
-          "client_id" => client_id
-        }, :urlencoded ]
-      when "password"
-        raise ArgumentError, "username is required" if username.blank?
-        raise ArgumentError, "password is required" if password.blank?
-
-        [ {
-          "grant_type" => "password",
-          "username" => username,
-          "password" => password,
-          "client_id" => client_id
-        }, :urlencoded ]
-      when "preqin"
-        raise ArgumentError, "username is required" if username.blank?
-        raise ArgumentError, "api_key is required" if api_key.blank?
-
-        [ {
-          "username" => username,
-          "apikey" => api_key
-        }, :multipart ]
-      when "preqin_refresh_token"
-        raise ArgumentError, "refresh_token is required" if refresh_token.blank?
-
-        [ { "refresh_token" => refresh_token }, :multipart ]
-      else
-        raise ArgumentError, "unsupported grant #{grant.inspect}"
-      end
-    end
 
     def perform(url, form, headers, timeout, form_encoding:)
       if @http

--- a/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
@@ -36,6 +36,7 @@ module Api
         refute data.key?("client_secret")
         refute data.key?("username")
         refute data.key?("password")
+        refute data.key?("api_key")
         refute data.key?("access_token")
         refute data.key?("refresh_token")
       end
@@ -118,6 +119,33 @@ module Api
         assert created.next_attempt_at.present?
       end
 
+      test "create preqin grant stores username and API key and redacts secrets" do
+        body = {
+          data: {
+            namespace: "acme", foreign_id: "preqin",
+            grant: "preqin",
+            username: "preqin-user",
+            api_key: "preqin-api-key"
+          }
+        }
+
+        assert_difference -> { BrokerCredential.count } => 1 do
+          post api_v1_broker_credentials_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :created
+        data = json_body.fetch("data")
+        assert_equal "preqin", data["grant"]
+        assert_equal BrokerCredential::PREQIN_TOKEN_ENDPOINT, data["token_endpoint"]
+        assert_nil data["client_id"]
+        refute data.key?("username")
+        refute data.key?("api_key")
+
+        created = BrokerCredential.find_by_oid(data["id"])
+        assert_equal "preqin-user", created.username
+        assert_equal "preqin-api-key", created.api_key
+        assert created.next_attempt_at.present?
+      end
+
       test "create rejects a missing client_id" do
         body = {
           data: {
@@ -147,6 +175,21 @@ module Api
         end
         assert_response :unprocessable_entity
         assert json_body.dig("error", "details", "password").present?
+      end
+
+      test "create preqin grant rejects missing API key" do
+        body = {
+          data: {
+            namespace: "acme", foreign_id: "preqin-incomplete",
+            grant: "preqin",
+            username: "preqin-user"
+          }
+        }
+        assert_no_difference -> { BrokerCredential.count } do
+          post api_v1_broker_credentials_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :unprocessable_entity
+        assert json_body.dig("error", "details", "api_key").present?
       end
 
       test "re-auth via PUT clears dead state and reschedules" do
@@ -194,6 +237,24 @@ module Api
         bc.reload
         assert_equal "new-user", bc.username
         assert_equal "new-pass", bc.password
+        refute bc.dead?
+        assert_nil bc.dead_reason
+        assert_equal 0, bc.failure_count
+        assert bc.next_attempt_at.present?
+      end
+
+      test "preqin API key update clears dead state and reschedules" do
+        bc = BrokerCredential.create!(namespace: "acme", foreign_id: "preqin-dead",
+                                      grant: "preqin", username: "old", api_key: "old",
+                                      dead: true, dead_reason: "http_400", failure_count: 3,
+                                      created_by: users(:acme_admin))
+
+        body = { data: { api_key: "new-key" } }
+        patch api_v1_broker_credential_url(id: bc.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        bc.reload
+        assert_equal "new-key", bc.api_key
         refute bc.dead?
         assert_nil bc.dead_reason
         assert_equal 0, bc.failure_count

--- a/services/console/test/controllers/console/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/console/broker_credentials_controller_test.rb
@@ -80,6 +80,28 @@ module Console
       assert_equal({ "x-api-key" => "alpha-key" }, cred.token_endpoint_headers)
     end
 
+    test "POST create builds a preqin credential with write-only API key" do
+      assert_difference -> { BrokerCredential.count } => 1 do
+        post console_broker_credentials_url, params: {
+          credential: {
+            namespace: "acme", foreign_id: "preqin", name: "Preqin",
+            grant: "preqin",
+            preqin_username: "preqin-user", api_key: "preqin-api-key",
+            early_refresh_fraction: "0.5", early_refresh_slack_seconds: "120",
+            max_refresh_interval_seconds: "3600", refresh_timeout_seconds: "10"
+          }
+        }
+      end
+
+      cred = BrokerCredential.find_by!(namespace: "acme", foreign_id: "preqin")
+      assert_redirected_to console_credential_path(cred.oid)
+      assert_equal "preqin", cred.grant
+      assert_equal BrokerCredential::PREQIN_TOKEN_ENDPOINT, cred.token_endpoint
+      assert_nil cred.client_id
+      assert_equal "preqin-user", cred.username
+      assert_equal "preqin-api-key", cred.api_key
+    end
+
     test "POST create without a token endpoint or client id is rejected without writing" do
       assert_no_difference "BrokerCredential.count" do
         post console_broker_credentials_url, params: {
@@ -158,6 +180,28 @@ module Console
       assert_equal "secret", cred.client_secret
       assert_equal "user", cred.username
       assert_equal "pass", cred.password
+    end
+
+    test "PATCH update with blank preqin fields leaves them in place" do
+      cred = BrokerCredential.create!(namespace: "acme", foreign_id: "preqin-console",
+                                      grant: "preqin", username: "user", api_key: "api-key",
+                                      created_by: @operator)
+
+      patch console_broker_credential_url(cred.oid), params: {
+        credential: {
+          namespace: cred.namespace, foreign_id: cred.foreign_id,
+          grant: "preqin", token_endpoint: cred.token_endpoint,
+          preqin_username: "", api_key: "",
+          early_refresh_fraction: cred.early_refresh_fraction,
+          early_refresh_slack_seconds: cred.early_refresh_slack_seconds,
+          max_refresh_interval_seconds: cred.max_refresh_interval_seconds,
+          refresh_timeout_seconds: cred.refresh_timeout_seconds
+        }
+      }
+      assert_redirected_to console_credential_path(cred.oid)
+      cred.reload
+      assert_equal "user", cred.username
+      assert_equal "api-key", cred.api_key
     end
 
     test "PATCH update with a fresh refresh_token reschedules the credential" do

--- a/services/console/test/controllers/console/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/console/broker_credentials_controller_test.rb
@@ -204,6 +204,28 @@ module Console
       assert_equal "api-key", cred.api_key
     end
 
+    test "PATCH preqin uses preqin username over hidden password username" do
+      cred = BrokerCredential.create!(namespace: "acme", foreign_id: "preqin-username",
+                                      grant: "preqin", username: "old-user", api_key: "api-key",
+                                      created_by: @operator)
+
+      patch console_broker_credential_url(cred.oid), params: {
+        credential: {
+          namespace: cred.namespace, foreign_id: cred.foreign_id,
+          grant: "preqin", token_endpoint: cred.token_endpoint,
+          username: "password-panel-user", preqin_username: "preqin-panel-user", api_key: "",
+          early_refresh_fraction: cred.early_refresh_fraction,
+          early_refresh_slack_seconds: cred.early_refresh_slack_seconds,
+          max_refresh_interval_seconds: cred.max_refresh_interval_seconds,
+          refresh_timeout_seconds: cred.refresh_timeout_seconds
+        }
+      }
+      assert_redirected_to console_credential_path(cred.oid)
+      cred.reload
+      assert_equal "preqin-panel-user", cred.username
+      assert_equal "api-key", cred.api_key
+    end
+
     test "PATCH update with a fresh refresh_token reschedules the credential" do
       cred = broker_credentials(:acme_managed_gmail)
       cred.update!(refresh_token: "old", dead: true, dead_reason: "stale", failure_count: 3)

--- a/services/console/test/jobs/broker/jobs_test.rb
+++ b/services/console/test/jobs/broker/jobs_test.rb
@@ -37,6 +37,19 @@ module Broker
       assert_includes enqueued_ids, due.id
     end
 
+    test "PollRefreshJob enqueues due preqin credentials without refresh tokens" do
+      due = make_credential(grant: "preqin", client_id: nil, username: "user",
+                            api_key: "api-key", refresh_token: nil)
+      due.update_columns(last_refresh: 1.hour.ago, next_attempt_at: 1.minute.ago)
+
+      Broker::PollRefreshJob.perform_now
+
+      enqueued_ids = enqueued_jobs
+        .select { |j| j[:job] == Broker::RefreshCredentialJob }
+        .map { |j| j[:args].first }
+      assert_includes enqueued_ids, due.id
+    end
+
     test "RefreshCredentialJob drives the credential refresh" do
       # No refresh_token seed: refresh! marks the credential dead without any
       # network call, proving the job invoked it.

--- a/services/console/test/lib/broker/refresh_client_test.rb
+++ b/services/console/test/lib/broker/refresh_client_test.rb
@@ -12,8 +12,8 @@ module Broker
         @body = body
       end
 
-      def call(url:, form:, headers:, timeout:)
-        @captured = { url: url, form: form, headers: headers, timeout: timeout }
+      def call(url:, form:, headers:, timeout:, form_encoding:)
+        @captured = { url: url, form: form, headers: headers, timeout: timeout, form_encoding: form_encoding }
         Broker::RefreshClient::Response.new(status: @status, body: @body)
       end
     end
@@ -49,6 +49,7 @@ module Broker
       assert_equal "sec", form["client_secret"]
       assert_equal "a b", form["scope"]
       assert_equal "k", http.captured[:headers]["X-Api-Key"]
+      assert_equal :urlencoded, http.captured[:form_encoding]
     end
 
     test "form carries the password grant and optional fields" do
@@ -71,6 +72,34 @@ module Broker
       assert_equal "sec", form["client_secret"]
       assert_equal "a b", form["scope"]
       assert_equal "k", http.captured[:headers]["X-Api-Key"]
+      assert_equal :urlencoded, http.captured[:form_encoding]
+    end
+
+    test "form carries the Preqin username and API key as multipart" do
+      client, http = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 60 }.to_json)
+      client.refresh(
+        token_endpoint: "https://api.preqin.com/connect/token",
+        grant: "preqin",
+        username: "preqin-user",
+        api_key: "preqin-key"
+      )
+      form = http.captured[:form]
+      assert_equal "preqin-user", form["username"]
+      assert_equal "preqin-key", form["apikey"]
+      refute form.key?("grant_type")
+      refute form.key?("client_id")
+      assert_equal :multipart, http.captured[:form_encoding]
+    end
+
+    test "form carries the Preqin refresh token as multipart" do
+      client, http = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 60 }.to_json)
+      client.refresh(
+        token_endpoint: "https://api.preqin.com/connect/refresh_token",
+        grant: "preqin_refresh_token",
+        refresh_token: "rt-old"
+      )
+      assert_equal({ "refresh_token" => "rt-old" }, http.captured[:form])
+      assert_equal :multipart, http.captured[:form_encoding]
     end
 
     test "absent refresh_token in response means no rotation" do
@@ -137,6 +166,20 @@ module Broker
         client.refresh(token_endpoint: "https://idp.example/token", grant: "device_code",
                        client_id: "cid")
       end
+      assert_raises(ArgumentError) do
+        client.refresh(token_endpoint: "https://api.preqin.com/connect/token", grant: "preqin",
+                       username: "user", api_key: "")
+      end
+    end
+
+    test "bodyless Preqin 400 is unrecoverable so broker can fall back or die" do
+      client, _ = client_with(status: 400, body: "")
+      err = assert_raises(Broker::RefreshError) do
+        client.refresh(token_endpoint: "https://api.preqin.com/connect/token", grant: "preqin",
+                       username: "user", api_key: "key")
+      end
+      refute err.retryable?
+      assert_equal "http_400", err.code
     end
   end
 end

--- a/services/console/test/lib/broker/refresh_client_test.rb
+++ b/services/console/test/lib/broker/refresh_client_test.rb
@@ -23,99 +23,63 @@ module Broker
       [ Broker::RefreshClient.new(http: http), http ]
     end
 
-    def base_args(**overrides)
+    def base_request(**overrides)
       {
-        token_endpoint: "https://idp.example/token",
-        client_id: "cid",
-        refresh_token: "rt-old"
+        url: "https://idp.example/token",
+        form: {
+          "grant_type" => "refresh_token",
+          "refresh_token" => "rt-old",
+          "client_id" => "cid"
+        }
       }.merge(overrides)
     end
 
     test "successful refresh parses the RFC 6749 body" do
       client, _ = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 3600 }.to_json)
-      result = client.refresh(**base_args)
+      result = client.refresh(**base_request)
       assert_equal "AT", result.access_token
       assert_equal "RT", result.refresh_token
       assert_equal 3600, result.expires_in
     end
 
-    test "form carries the refresh_token grant and optional fields" do
+    test "posts supplied URL-encoded form and headers" do
       client, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
-      client.refresh(**base_args(client_secret: "sec", scopes: %w[a b], headers: { "X-Api-Key" => "k" }))
-      form = http.captured[:form]
-      assert_equal "refresh_token", form["grant_type"]
-      assert_equal "rt-old", form["refresh_token"]
-      assert_equal "cid", form["client_id"]
-      assert_equal "sec", form["client_secret"]
-      assert_equal "a b", form["scope"]
+      form = {
+        "grant_type" => "refresh_token",
+        "refresh_token" => "rt-old",
+        "client_id" => "cid",
+        "client_secret" => "sec",
+        "scope" => "a b"
+      }
+      client.refresh(**base_request(form: form, headers: { "X-Api-Key" => "k" }))
+      assert_equal "https://idp.example/token", http.captured[:url]
+      assert_equal form, http.captured[:form]
       assert_equal "k", http.captured[:headers]["X-Api-Key"]
       assert_equal :urlencoded, http.captured[:form_encoding]
     end
 
-    test "form carries the password grant and optional fields" do
-      client, http = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 60 }.to_json)
-      client.refresh(
-        token_endpoint: "https://idp.example/token",
-        grant: "password",
-        client_id: "cid",
-        client_secret: "sec",
-        username: "user",
-        password: "pass",
-        scopes: %w[a b],
-        headers: { "X-Api-Key" => "k" }
-      )
-      form = http.captured[:form]
-      assert_equal "password", form["grant_type"]
-      assert_equal "user", form["username"]
-      assert_equal "pass", form["password"]
-      assert_equal "cid", form["client_id"]
-      assert_equal "sec", form["client_secret"]
-      assert_equal "a b", form["scope"]
-      assert_equal "k", http.captured[:headers]["X-Api-Key"]
-      assert_equal :urlencoded, http.captured[:form_encoding]
-    end
-
-    test "form carries the Preqin username and API key as multipart" do
-      client, http = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 60 }.to_json)
-      client.refresh(
-        token_endpoint: "https://api.preqin.com/connect/token",
-        grant: "preqin",
-        username: "preqin-user",
-        api_key: "preqin-key"
-      )
-      form = http.captured[:form]
-      assert_equal "preqin-user", form["username"]
-      assert_equal "preqin-key", form["apikey"]
-      refute form.key?("grant_type")
-      refute form.key?("client_id")
-      assert_equal :multipart, http.captured[:form_encoding]
-    end
-
-    test "form carries the Preqin refresh token as multipart" do
-      client, http = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 60 }.to_json)
-      client.refresh(
-        token_endpoint: "https://api.preqin.com/connect/refresh_token",
-        grant: "preqin_refresh_token",
-        refresh_token: "rt-old"
-      )
-      assert_equal({ "refresh_token" => "rt-old" }, http.captured[:form])
+    test "posts supplied multipart form" do
+      client, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
+      form = { "username" => "user", "apikey" => "key" }
+      client.refresh(**base_request(form: form, form_encoding: :multipart))
+      assert_equal form, http.captured[:form]
       assert_equal :multipart, http.captured[:form_encoding]
     end
 
     test "absent refresh_token in response means no rotation" do
       client, _ = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
-      result = client.refresh(**base_args)
+      result = client.refresh(**base_request)
       assert_nil result.refresh_token
     end
 
     test "missing expires_in yields nil so the caller defaults it" do
       client, _ = client_with(status: 200, body: { access_token: "AT" }.to_json)
-      assert_nil client.refresh(**base_args).expires_in
+      assert_nil client.refresh(**base_request).expires_in
     end
 
     test "invalid_grant is unrecoverable" do
       client, _ = client_with(status: 400, body: { error: "invalid_grant" }.to_json)
-      err = assert_raises(Broker::RefreshError) { client.refresh(**base_args) }
+      err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       refute err.retryable?
       assert_equal "invalid_grant", err.code
       assert_equal "invalid_grant", err.reason
@@ -123,7 +87,7 @@ module Broker
 
     test "Slack-style ok false response is unrecoverable" do
       client, _ = client_with(status: 200, body: { ok: false, error: "invalid_refresh_token" }.to_json)
-      err = assert_raises(Broker::RefreshError) { client.refresh(**base_args) }
+      err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       refute err.retryable?
       assert_equal "oauth", err.stage
       assert_equal "invalid_refresh_token", err.code
@@ -131,55 +95,41 @@ module Broker
 
     test "5xx is retryable" do
       client, _ = client_with(status: 503, body: "upstream down")
-      err = assert_raises(Broker::RefreshError) { client.refresh(**base_args) }
+      err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       assert err.retryable?
     end
 
-    test "bodyless 4xx (gateway/rate-limit) is retryable" do
+    test "bodyless 4xx is retryable by default" do
       client, _ = client_with(status: 429, body: "")
-      err = assert_raises(Broker::RefreshError) { client.refresh(**base_args) }
+      err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       assert err.retryable?
+    end
+
+    test "bodyless 4xx can be strict and unrecoverable" do
+      client, _ = client_with(status: 400, body: "")
+      err = assert_raises(Broker::RefreshError) { client.refresh(**base_request(strict_4xx: true)) }
+      refute err.retryable?
+      assert_equal "http_400", err.code
     end
 
     test "malformed 2xx body is retryable parse failure" do
       client, _ = client_with(status: 200, body: "not json{")
-      err = assert_raises(Broker::RefreshError) { client.refresh(**base_args) }
+      err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       assert err.retryable?
       assert_equal "parse", err.stage
     end
 
     test "empty access_token in 2xx is retryable" do
       client, _ = client_with(status: 200, body: { access_token: "", expires_in: 60 }.to_json)
-      err = assert_raises(Broker::RefreshError) { client.refresh(**base_args) }
+      err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       assert err.retryable?
     end
 
-    test "validates required inputs" do
+    test "validates request inputs" do
       client, _ = client_with(status: 200, body: "{}")
-      assert_raises(ArgumentError) { client.refresh(**base_args(refresh_token: "")) }
-      assert_raises(ArgumentError) { client.refresh(**base_args(client_id: "")) }
-      assert_raises(ArgumentError) do
-        client.refresh(token_endpoint: "https://idp.example/token", grant: "password",
-                       client_id: "cid", username: "", password: "pass")
-      end
-      assert_raises(ArgumentError) do
-        client.refresh(token_endpoint: "https://idp.example/token", grant: "device_code",
-                       client_id: "cid")
-      end
-      assert_raises(ArgumentError) do
-        client.refresh(token_endpoint: "https://api.preqin.com/connect/token", grant: "preqin",
-                       username: "user", api_key: "")
-      end
-    end
-
-    test "bodyless Preqin 400 is unrecoverable so broker can fall back or die" do
-      client, _ = client_with(status: 400, body: "")
-      err = assert_raises(Broker::RefreshError) do
-        client.refresh(token_endpoint: "https://api.preqin.com/connect/token", grant: "preqin",
-                       username: "user", api_key: "key")
-      end
-      refute err.retryable?
-      assert_equal "http_400", err.code
+      assert_raises(ArgumentError) { client.refresh(**base_request(url: "")) }
+      assert_raises(ArgumentError) { client.refresh(**base_request(form: nil)) }
+      assert_raises(ArgumentError) { client.refresh(**base_request(form_encoding: :xml)) }
     end
   end
 end

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -58,6 +58,20 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert bc.errors[:password].any? { |m| m.include?("password grant") }
   end
 
+  test "preqin grant is valid with username and API key and defaults endpoint" do
+    bc = build_credential(grant: "preqin", token_endpoint: nil, client_id: nil,
+                          username: "user", api_key: "api-key", refresh_token: nil)
+    assert bc.valid?, bc.errors.full_messages.to_sentence
+    assert_equal BrokerCredential::PREQIN_TOKEN_ENDPOINT, bc.token_endpoint
+  end
+
+  test "preqin grant requires username and API key" do
+    bc = build_credential(grant: "preqin", client_id: nil, username: "user",
+                          api_key: nil, refresh_token: nil)
+    refute bc.valid?
+    assert bc.errors[:api_key].any? { |m| m.include?("Preqin broker grant") }
+  end
+
   # --- oauth_app provenance (flow-minted credentials) -----------------------
 
   def build_app(**overrides)
@@ -129,18 +143,20 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert bc.valid?, bc.errors.full_messages.to_sentence
   end
 
-  test "client_secret, password grant fields, and token_endpoint_headers are encrypted at rest" do
-    bc = create_credential(client_secret: "shh", username: "alice", password: "p4ss",
+  test "client_secret, grant fields, and token_endpoint_headers are encrypted at rest" do
+    bc = create_credential(client_secret: "shh", username: "alice", password: "p4ss", api_key: "api-key",
                            token_endpoint_headers: { "X-Api-Key" => "k" })
     raw = BrokerCredential.connection.select_one(
-      "SELECT client_secret, username, password, token_endpoint_headers FROM broker_credentials WHERE id = #{bc.id}"
+      "SELECT client_secret, username, password, api_key, token_endpoint_headers FROM broker_credentials WHERE id = #{bc.id}"
     )
     refute_includes raw["client_secret"].to_s, "shh"
     refute_includes raw["username"].to_s, "alice"
     refute_includes raw["password"].to_s, "p4ss"
+    refute_includes raw["api_key"].to_s, "api-key"
     refute_includes raw["token_endpoint_headers"].to_s, "X-Api-Key"
     assert_equal "alice", bc.reload.username
     assert_equal "p4ss", bc.password
+    assert_equal "api-key", bc.api_key
     assert_equal({ "X-Api-Key" => "k" }, bc.reload.token_endpoint_headers)
   end
 
@@ -312,6 +328,54 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert_equal 1, bc.failure_count
   end
 
+  test "preqin grant uses username and API key when no refresh token exists" do
+    captured = {}
+    bc = create_credential(grant: "preqin", client_id: nil, username: "user",
+                           api_key: "api-key", refresh_token: nil)
+    bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: "RT-new") }
+    bc.refresh!
+    bc.reload
+    assert_equal "preqin", captured[:grant]
+    assert_equal BrokerCredential::PREQIN_TOKEN_ENDPOINT, captured[:token_endpoint]
+    assert_equal "user", captured[:username]
+    assert_equal "api-key", captured[:api_key]
+    assert_nil captured[:client_id]
+    assert_equal "RT-new", bc.refresh_token
+    assert_equal "AT", bc.access_token
+  end
+
+  test "preqin grant prefers the Preqin refresh endpoint when it has a refresh token" do
+    captured = {}
+    bc = create_credential(grant: "preqin", client_id: nil, username: "user",
+                           api_key: "api-key", refresh_token: "RT-old")
+    bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: nil) }
+    bc.refresh!
+    bc.reload
+    assert_equal "preqin_refresh_token", captured[:grant]
+    assert_equal Broker::CredentialGrants::PREQIN_REFRESH_TOKEN_ENDPOINT, captured[:token_endpoint]
+    assert_equal "RT-old", captured[:refresh_token]
+    assert_equal "RT-old", bc.refresh_token
+  end
+
+  test "preqin grant falls back to username and API key when stored refresh token is rejected" do
+    grants = []
+    bc = create_credential(grant: "preqin", client_id: nil, username: "user",
+                           api_key: "api-key", refresh_token: "RT-bad")
+    bc.refresh_client = StubClient.new do |**kw|
+      grants << kw[:grant]
+      if kw[:grant] == "preqin_refresh_token"
+        raise Broker::RefreshError.new("bad", stage: "http", code: "http_400", retryable: false)
+      end
+      result(access_token: "AT-preqin", refresh_token: "RT-good")
+    end
+    bc.refresh!
+    bc.reload
+    assert_equal %w[preqin_refresh_token preqin], grants
+    assert_equal "AT-preqin", bc.access_token
+    assert_equal "RT-good", bc.refresh_token
+    refute bc.dead?
+  end
+
   test "refresh with no seed marks dead as missing a seed" do
     bc = create_credential(refresh_token: "seed")
     bc.update_columns(refresh_token: nil)
@@ -330,6 +394,17 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc.reload
     assert bc.dead?
     assert_equal "password_grant_missing_initial_values", bc.dead_reason
+  end
+
+  test "preqin grant with missing initial values marks dead" do
+    bc = create_credential(grant: "preqin", client_id: nil, username: "user",
+                           api_key: "api-key", refresh_token: nil)
+    bc.update_columns(api_key: nil)
+    bc.reload
+    bc.refresh!
+    bc.reload
+    assert bc.dead?
+    assert_equal "preqin_missing_initial_values", bc.dead_reason
   end
 
   # --- scope ----------------------------------------------------------------
@@ -352,6 +427,14 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "refreshable includes password grant credentials without a refresh_token" do
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
+    bc.update_columns(last_refresh: 1.hour.ago, next_attempt_at: 1.minute.ago)
+
+    assert_includes BrokerCredential.refreshable.pluck(:id), bc.id
+  end
+
+  test "refreshable includes preqin credentials without a refresh_token" do
+    bc = create_credential(grant: "preqin", client_id: nil, username: "user",
+                           api_key: "api-key", refresh_token: nil)
     bc.update_columns(last_refresh: 1.hour.ago, next_attempt_at: 1.minute.ago)
 
     assert_includes BrokerCredential.refreshable.pluck(:id), bc.id

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -20,6 +20,13 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     }.merge(overrides))
   end
 
+  def request_grant(request)
+    return "preqin_refresh_token" if request[:url] == Broker::CredentialGrants::PREQIN_REFRESH_TOKEN_ENDPOINT
+    return "preqin" if request[:form].key?("apikey")
+
+    request[:form]["grant_type"]
+  end
+
   def create_credential(**kw)
     bc = build_credential(**kw)
     bc.save!
@@ -116,8 +123,8 @@ class BrokerCredentialTest < ActiveSupport::TestCase
                            provider_subject: "sub-4", created_by: nil, refresh_token: "rt")
     bc.refresh_client = StubClient.new { |**kw| captured = kw; result }
     bc.refresh!
-    assert_equal "app-cid", captured[:client_id]
-    assert_equal "app-secret", captured[:client_secret]
+    assert_equal "app-cid", captured[:form]["client_id"]
+    assert_equal "app-secret", captured[:form]["client_secret"]
   end
 
   test "refresh lets the provider choose refresh scopes" do
@@ -129,7 +136,7 @@ class BrokerCredentialTest < ActiveSupport::TestCase
                            scopes: %w[chat:write openid])
     bc.refresh_client = StubClient.new { |**kw| captured = kw; result }
     bc.refresh!
-    assert_equal [], captured[:scopes]
+    refute captured[:form].key?("scope")
   end
 
   test "external_user_key must be url-safe and bounded" do
@@ -250,8 +257,8 @@ class BrokerCredentialTest < ActiveSupport::TestCase
                            token_endpoint_headers: { "X-Api-Key" => "k" })
     bc.refresh_client = StubClient.new { |**kw| captured = kw; result }
     bc.refresh!
-    assert_equal "the-id", captured[:client_id]
-    assert_equal "the-secret", captured[:client_secret]
+    assert_equal "the-id", captured[:form]["client_id"]
+    assert_equal "the-secret", captured[:form]["client_secret"]
     assert_equal({ "X-Api-Key" => "k" }, captured[:headers])
   end
 
@@ -261,9 +268,9 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: "RT-new") }
     bc.refresh!
     bc.reload
-    assert_equal "password", captured[:grant]
-    assert_equal "user", captured[:username]
-    assert_equal "pass", captured[:password]
+    assert_equal "password", request_grant(captured)
+    assert_equal "user", captured[:form]["username"]
+    assert_equal "pass", captured[:form]["password"]
     assert_equal "RT-new", bc.refresh_token
     assert_equal "AT", bc.access_token
   end
@@ -274,8 +281,8 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: nil) }
     bc.refresh!
     bc.reload
-    assert_equal "refresh_token", captured[:grant]
-    assert_equal "RT-old", captured[:refresh_token]
+    assert_equal "refresh_token", request_grant(captured)
+    assert_equal "RT-old", captured[:form]["refresh_token"]
     assert_equal "RT-old", bc.refresh_token
   end
 
@@ -283,8 +290,8 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     grants = []
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-bad")
     bc.refresh_client = StubClient.new do |**kw|
-      grants << kw[:grant]
-      if kw[:grant] == "refresh_token"
+      grants << request_grant(kw)
+      if request_grant(kw) == "refresh_token"
         raise Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false)
       end
       result(access_token: "AT-password", refresh_token: "RT-good")
@@ -301,8 +308,8 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     grants = []
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-bad")
     bc.refresh_client = StubClient.new do |**kw|
-      grants << kw[:grant]
-      if kw[:grant] == "refresh_token"
+      grants << request_grant(kw)
+      if request_grant(kw) == "refresh_token"
         raise Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false)
       end
       result(access_token: "AT-password", refresh_token: nil)
@@ -318,7 +325,7 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     grants = []
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-old")
     bc.refresh_client = StubClient.new do |**kw|
-      grants << kw[:grant]
+      grants << request_grant(kw)
       raise Broker::RefreshError.new("net", stage: "network", retryable: true)
     end
     bc.refresh!
@@ -335,11 +342,13 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: "RT-new") }
     bc.refresh!
     bc.reload
-    assert_equal "preqin", captured[:grant]
-    assert_equal BrokerCredential::PREQIN_TOKEN_ENDPOINT, captured[:token_endpoint]
-    assert_equal "user", captured[:username]
-    assert_equal "api-key", captured[:api_key]
-    assert_nil captured[:client_id]
+    assert_equal "preqin", request_grant(captured)
+    assert_equal BrokerCredential::PREQIN_TOKEN_ENDPOINT, captured[:url]
+    assert_equal "user", captured[:form]["username"]
+    assert_equal "api-key", captured[:form]["apikey"]
+    refute captured[:form].key?("client_id")
+    assert_equal :multipart, captured[:form_encoding]
+    assert_equal true, captured[:strict_4xx]
     assert_equal "RT-new", bc.refresh_token
     assert_equal "AT", bc.access_token
   end
@@ -351,9 +360,11 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: nil) }
     bc.refresh!
     bc.reload
-    assert_equal "preqin_refresh_token", captured[:grant]
-    assert_equal Broker::CredentialGrants::PREQIN_REFRESH_TOKEN_ENDPOINT, captured[:token_endpoint]
-    assert_equal "RT-old", captured[:refresh_token]
+    assert_equal "preqin_refresh_token", request_grant(captured)
+    assert_equal Broker::CredentialGrants::PREQIN_REFRESH_TOKEN_ENDPOINT, captured[:url]
+    assert_equal "RT-old", captured[:form]["refresh_token"]
+    assert_equal :multipart, captured[:form_encoding]
+    assert_equal true, captured[:strict_4xx]
     assert_equal "RT-old", bc.refresh_token
   end
 
@@ -362,8 +373,8 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc = create_credential(grant: "preqin", client_id: nil, username: "user",
                            api_key: "api-key", refresh_token: "RT-bad")
     bc.refresh_client = StubClient.new do |**kw|
-      grants << kw[:grant]
-      if kw[:grant] == "preqin_refresh_token"
+      grants << request_grant(kw)
+      if request_grant(kw) == "preqin_refresh_token"
         raise Broker::RefreshError.new("bad", stage: "http", code: "http_400", retryable: false)
       end
       result(access_token: "AT-preqin", refresh_token: "RT-good")

--- a/tools/research/preqin/.env.example
+++ b/tools/research/preqin/.env.example
@@ -1,5 +1,4 @@
 PREQIN_USERNAME=Preqin API username, e.g. preqinapiuser@paradigm.xyz
 PREQIN_API_KEY=Preqin Operational API key
-PREQIN_PASSWORD=Optional Preqin password fallback
 PREQIN_CLIENT_ID=Optional OAuth client id for id.preqin.com
 PREQIN_CLIENT_SECRET=Optional OAuth client secret for id.preqin.com

--- a/tools/research/preqin/centaur_tool_preqin/client.py
+++ b/tools/research/preqin/centaur_tool_preqin/client.py
@@ -37,6 +37,10 @@ def _redact_token_payload(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _credential_present(name: str, value: str | None) -> bool:
+    return bool(value) and value != name
+
+
 class PreqinClient:
     """Client for Preqin Operational API and Feeds API."""
 
@@ -44,16 +48,10 @@ class PreqinClient:
         self,
         username: str | None = None,
         api_key: str | None = None,
-        password: str | None = None,
-        client_id: str | None = None,
-        client_secret: str | None = None,
         timeout: float = 30.0,
     ):
         self._username = _clean_secret(username)
         self._api_key = _clean_secret(api_key)
-        self._password = _clean_secret(password)
-        self._client_id = _clean_secret(client_id)
-        self._client_secret = _clean_secret(client_secret)
         self.timeout = timeout
         self._client: httpx.Client | None = None
         self._operational_token: str | None = None
@@ -70,25 +68,15 @@ class PreqinClient:
     def _api_key_value(self) -> str | None:
         return self._api_key or _clean_secret(secret("PREQIN_API_KEY", ""))
 
-    def _password_value(self) -> str | None:
-        return self._password or _clean_secret(secret("PREQIN_PASSWORD", ""))
-
-    def _client_id_value(self) -> str | None:
-        return self._client_id or _clean_secret(secret("PREQIN_CLIENT_ID", ""))
-
-    def _client_secret_value(self) -> str | None:
-        return self._client_secret or _clean_secret(secret("PREQIN_CLIENT_SECRET", ""))
-
     def credential_status(self) -> dict[str, Any]:
         """Report whether required Preqin secret names resolve, without exposing values."""
         fields = {
             "PREQIN_USERNAME": self._username_value(),
             "PREQIN_API_KEY": self._api_key_value(),
-            "PREQIN_PASSWORD": self._password_value(),
         }
         return {
             name: {
-                "present": bool(value) and value != name,
+                "present": _credential_present(name, value),
                 "length": len(value or ""),
             }
             for name, value in fields.items()
@@ -101,21 +89,16 @@ class PreqinClient:
 
         username = self._username_value()
         api_key = self._api_key_value()
-        password = self._password_value()
         if not username:
             raise RuntimeError("PREQIN_USERNAME not set.")
         if not api_key:
             raise RuntimeError("PREQIN_API_KEY not set.")
-        if not password:
-            raise RuntimeError("PREQIN_PASSWORD not set.")
 
         response = self.client.post(
             f"{OPERATIONAL_BASE_URL}/connect/token",
-            data={
-                "grant_type": "password",
-                "username": username,
-                "password": password,
-                "client_id": api_key,
+            files={
+                "username": (None, username),
+                "apikey": (None, api_key),
             },
             headers={"Accept": "application/json"},
         )
@@ -124,7 +107,7 @@ class PreqinClient:
             detail = f" - {body}" if body else ""
             raise RuntimeError(
                 "Preqin Operational API auth failed "
-                f"({response.status_code}) at /connect/token using password grant{detail}"
+                f"({response.status_code}) at /connect/token using username/api key{detail}"
             )
 
         data = response.json()
@@ -144,26 +127,33 @@ class PreqinClient:
             return {
                 "ok": True,
                 "auth_url": f"{OPERATIONAL_BASE_URL}/connect/token",
-                "method": "password grant",
+                "method": "username_api_key",
                 "token_length": len(token),
             }
         except Exception as exc:
             return {
                 "ok": False,
                 "auth_url": f"{OPERATIONAL_BASE_URL}/connect/token",
-                "method": "password grant",
+                "method": "username_api_key",
                 "error": str(exc),
                 "credentials": self.credential_status(),
             }
 
     def _operational_get(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         token = self._operational_token or _clean_secret(secret(OPERATIONAL_TOKEN_PLACEHOLDER, ""))
-        if not token:
+        username = self._username_value()
+        api_key = self._api_key_value()
+        if not token and _credential_present("PREQIN_USERNAME", username) and _credential_present(
+            "PREQIN_API_KEY", api_key
+        ):
             token = self._operational_access_token()
+        headers = {"Accept": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
         response = self.client.get(
             f"{OPERATIONAL_BASE_URL}{endpoint}",
             params={key: value for key, value in (params or {}).items() if value is not None},
-            headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
+            headers=headers,
         )
         if response.status_code >= 400:
             body = response.text.strip()

--- a/tools/research/preqin/pyproject.toml
+++ b/tools/research/preqin/pyproject.toml
@@ -23,8 +23,3 @@ build-backend = "hatchling.build"
 [tool.centaur]
 module = "client.py"
 hosts = ["api.preqin.com", "id.preqin.com", "feeds.preqin.com"]
-secrets = [
-    { type = "brokered_token", name = "PREQIN_OPERATIONAL_TOKEN", credential = "preqin-operational", hosts = [
-        "api.preqin.com",
-    ] },
-]

--- a/tools/research/preqin/pyproject.toml
+++ b/tools/research/preqin/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "hatchling.build"
 module = "client.py"
 hosts = ["api.preqin.com", "id.preqin.com", "feeds.preqin.com"]
 secrets = [
-    { type = "oauth_token", name = "PREQIN_OPERATIONAL_TOKEN", grant = "password", token_endpoint = "https://api.preqin.com/connect/token", hosts = [
+    { type = "brokered_token", name = "PREQIN_OPERATIONAL_TOKEN", credential = "preqin-operational", hosts = [
         "api.preqin.com",
-    ], fields = { username = "PREQIN_USERNAME", password = "PREQIN_PASSWORD", client_id = "PREQIN_API_KEY" } },
+    ] },
 ]

--- a/tools/research/preqin/tests/test_client.py
+++ b/tools/research/preqin/tests/test_client.py
@@ -39,24 +39,19 @@ def test_credential_status_does_not_treat_stub_placeholders_as_present():
 
     assert status["PREQIN_USERNAME"]["present"] is False
     assert status["PREQIN_API_KEY"]["present"] is False
-    assert status["PREQIN_PASSWORD"]["present"] is False
 
 
-def test_auth_uses_password_grant_with_username_password_and_api_key():
+def test_auth_uses_username_and_api_key_multipart_form():
     fake = FakeHttpClient()
-    client = PreqinClient(username="user", password="pass", api_key="api-key")
+    client = PreqinClient(username="user", api_key="api-key")
     client._client = fake
 
     assert client._operational_access_token(force_refresh=True) == "token-123"
 
     request = fake.posts[0]
     assert request["url"] == "https://api.preqin.com/connect/token"
-    assert request["data"] == {
-        "grant_type": "password",
-        "username": "user",
-        "password": "pass",
-        "client_id": "api-key",
-    }
+    assert request["files"] == {"username": (None, "user"), "apikey": (None, "api-key")}
+    assert request["headers"] == {"Accept": "application/json"}
 
 
 def test_operational_get_uses_proxy_token_placeholder_before_direct_auth():
@@ -69,3 +64,16 @@ def test_operational_get_uses_proxy_token_placeholder_before_direct_auth():
 
     assert not fake.posts
     assert fake.gets[0]["headers"]["Authorization"] == f"Bearer {OPERATIONAL_TOKEN_PLACEHOLDER}"
+
+
+def test_operational_get_without_proxy_token_or_direct_credentials_leaves_auth_to_proxy(monkeypatch):
+    monkeypatch.setenv(OPERATIONAL_TOKEN_PLACEHOLDER, "")
+    configure(StubBackend())
+    fake = FakeHttpClient()
+    client = PreqinClient()
+    client._client = fake
+
+    client.get_funds(fund_name="Paradigm", size=1)
+
+    assert not fake.posts
+    assert fake.gets[0]["headers"] == {"Accept": "application/json"}


### PR DESCRIPTION
Adds a Preqin-specific broker credential grant in console so iron-control stores the username/API key material, mints Operational API tokens with Preqin's multipart flow, and refreshes through Preqin's refresh endpoint when available. Updates the Preqin tool client to remove the old password-grant fallback while leaving credential injection configuration outside the tool metadata.