### PR TITLE
fix: configure Slack DM OAuth slug

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.73
+version: 0.1.74
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -135,6 +135,10 @@ spec:
 {{- end }}
             - name: RAILS_ENV
               value: {{ $console.railsEnv | quote }}
+{{- with $console.slackDmSync.oauthAppSlug }}
+            - name: SLACK_DM_SYNC_OAUTH_APP_SLUG
+              value: {{ . | quote }}
+{{- end }}
             - name: RAILS_LOG_TO_STDOUT
               value: "1"
           securityContext:

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -163,6 +163,10 @@ spec:
 {{- end }}
             - name: RAILS_ENV
               value: {{ $console.railsEnv | quote }}
+{{- with $console.slackDmSync.oauthAppSlug }}
+            - name: SLACK_DM_SYNC_OAUTH_APP_SLUG
+              value: {{ . | quote }}
+{{- end }}
             - name: PORT
               value: {{ $console.service.httpPort | quote }}
             - name: RAILS_LOG_TO_STDOUT

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -22,6 +22,12 @@
             "name": { "type": "string" }
           }
         },
+        "slackDmSync": {
+          "type": "object",
+          "properties": {
+            "oauthAppSlug": { "type": "string" }
+          }
+        },
         "service": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -106,6 +106,10 @@ console:
   # _SECRET), which must exist or the console pods CreateContainerConfigError.
   googleOauth:
     enabled: false
+  # OAuth app slug whose user-level Slack credentials are used by the DM sync
+  # worker. Keep this aligned with the Console OAuth app users authorize.
+  slackDmSync:
+    oauthAppSlug: slack
   service:
     httpPort: 3000
   # Optional Ingress for the console. Bring your own controller — Tailscale


### PR DESCRIPTION
## Summary
- Add `console.slackDmSync.oauthAppSlug` with default `slack`.
- Render `SLACK_DM_SYNC_OAUTH_APP_SLUG` into both console web and console worker pods.
- Update the chart values schema for the new console setting.

## Why
The Slack DM sync poller defaults to `slack-dms` when the env var is unset, but staging currently has the user OAuth credential under the existing `slack` OAuth app slug. Setting the chart value makes staging and production use that app slug when console is enabled.

## Validation
- `git diff --check`
- `helm lint contrib/chart --set console.enabled=true --set console.worker.enabled=true`
- `helm template centaur contrib/chart --set console.enabled=true --set console.worker.enabled=true --show-only templates/console.yaml --show-only templates/console-worker.yaml` confirmed `SLACK_DM_SYNC_OAUTH_APP_SLUG=slack` on both console deployments.