### PR TITLE
fix: prefix Slack DM sync env

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.74
+version: 0.1.75
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -136,7 +136,7 @@ spec:
             - name: RAILS_ENV
               value: {{ $console.railsEnv | quote }}
 {{- with $console.slackDmSync.oauthAppSlug }}
-            - name: SLACK_DM_SYNC_OAUTH_APP_SLUG
+            - name: CENTAUR_CONSOLE_SLACK_DM_SYNC_OAUTH_APP_SLUG
               value: {{ . | quote }}
 {{- end }}
             - name: RAILS_LOG_TO_STDOUT

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -164,7 +164,7 @@ spec:
             - name: RAILS_ENV
               value: {{ $console.railsEnv | quote }}
 {{- with $console.slackDmSync.oauthAppSlug }}
-            - name: SLACK_DM_SYNC_OAUTH_APP_SLUG
+            - name: CENTAUR_CONSOLE_SLACK_DM_SYNC_OAUTH_APP_SLUG
               value: {{ . | quote }}
 {{- end }}
             - name: PORT

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -18,7 +18,7 @@ module SlackDm
       attr_accessor :slack_api_http
 
       def oauth_app_slug
-        ConsoleEnv["SLACK_DM_SYNC_OAUTH_APP_SLUG"].presence || "slack-dms"
+        ConsoleEnv["SLACK_DM_SYNC_OAUTH_APP_SLUG"].presence || "slack"
       end
 
       def required_scopes_granted?(scopes)

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -51,6 +51,30 @@ module SlackDm
       )
     end
 
+    test "oauth_app_slug defaults to slack and honors console env prefix" do
+      env_key = "CENTAUR_CONSOLE_SLACK_DM_SYNC_OAUTH_APP_SLUG"
+      legacy_env_key = "IRON_CONTROL_SLACK_DM_SYNC_OAUTH_APP_SLUG"
+      previous = {
+        env_key => ENV[env_key],
+        legacy_env_key => ENV[legacy_env_key]
+      }
+      ENV.delete(env_key)
+      ENV.delete(legacy_env_key)
+
+      assert_equal "slack", SlackDm::SyncCredential.oauth_app_slug
+
+      ENV[env_key] = "custom-slack"
+      assert_equal "custom-slack", SlackDm::SyncCredential.oauth_app_slug
+    ensure
+      previous.each do |key, value|
+        if value.nil?
+          ENV.delete(key)
+        else
+          ENV[key] = value
+        end
+      end
+    end
+
     test "sync normalizes conversations members messages files and checkpoints" do
       api_client = FakeApiClient.new
       slack_http = lambda do |endpoint:, params:, access_token:|


### PR DESCRIPTION
## Summary
- Rename the rendered Slack DM sync OAuth slug env var to `CENTAUR_CONSOLE_SLACK_DM_SYNC_OAUTH_APP_SLUG`.
- Change the Ruby fallback OAuth app slug from `slack-dms` to `slack`.
- Add a focused test for the fallback and `CENTAUR_CONSOLE_` env override.
- Bump the Centaur chart version to `0.1.75`.

## Why
`SlackDm::SyncCredential.oauth_app_slug` reads `ConsoleEnv["SLACK_DM_SYNC_OAUTH_APP_SLUG"]`, and `ConsoleEnv` maps that suffix to `CENTAUR_CONSOLE_SLACK_DM_SYNC_OAUTH_APP_SLUG` with legacy `IRON_CONTROL_` fallback. The previous chart env name was unprefixed, so Rails ignored it. The code fallback now matches the existing Console OAuth app slug, `slack`.

## Validation
- `git diff --check`
- `helm lint contrib/chart --set console.enabled=true --set console.worker.enabled=true`
- `helm template centaur contrib/chart --set console.enabled=true --set console.worker.enabled=true --show-only templates/console.yaml --show-only templates/console-worker.yaml` confirmed the prefixed env var renders on both console web and worker, and the old unprefixed name is absent.

## Not run
- `bin/rails test test/services/slack_dm/sync_credential_test.rb test/jobs/slack_dm/jobs_test.rb` could not run on this machine because it picked up system Ruby 2.6/Bundler instead of the console Ruby 3.4.8 / Bundler 4.0.10 toolchain.