### PR TITLE
fix: broaden company context retrieval

### DIFF
--- a/.agents/skills/company-context/SKILL.md
+++ b/.agents/skills/company-context/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: company-context
+description: "Use Centaur's indexed company context together with direct Slack, Linear, Google Drive, or Calendar searches when answering internal company-history, prior-decision, project-context, meeting-context, roadmap/status, or cross-source memory questions. Use for questions like what was discussed, decided, planned, mentioned, or documented internally, especially when the user did not name one exact source."
+---
+
+# Company Context
+
+Use `company_context` as the first retrieval step for internal historical context. Its `search` command queries indexed company memory across enabled sources such as Slack, Google Drive/Docs, Google Calendar, and Linear. Always pair indexed results with the relevant direct source tools, then reconcile and collate both evidence sets before answering.
+
+## Default Workflow
+
+1. Search company context first:
+
+```bash
+company_context search "QUERY" --limit 10 --json
+```
+
+2. Read promising documents before answering:
+
+```bash
+company_context read "DOCUMENT_ID" --max-chars 8000 --related --json
+```
+
+3. Check live/source tools for the same query and relevant source filters. Do this even when indexed results look strong:
+
+```bash
+slack search "QUERY"
+linear search "QUERY"
+gsuite drive list --query "QUERY"
+gsuite calendar events --query "QUERY"
+```
+
+Use the source-specific tools that match the question. For broad cross-source questions, check all likely sources.
+
+4. For time-sensitive or "latest" asks, check index freshness:
+
+```bash
+company_context latest-date --json
+company_context latest-date --source slack --json
+company_context latest-date --source linear --json
+```
+
+5. If results are weak, broaden or target source filters:
+
+```bash
+company_context search "QUERY" --source slack --limit 10 --json
+company_context search "QUERY" --source google_drive --limit 10 --json
+company_context search "QUERY" --source google_calendar --limit 10 --json
+company_context search "QUERY" --source linear --limit 10 --json
+```
+
+6. Collate indexed and live results before answering:
+
+- Prefer direct live-tool evidence for current state, exact source objects, and canonical fields.
+- Prefer indexed context for historical recall, older discussions, and cross-source semantic matches.
+- Treat disagreement as a signal to explain the mismatch, including dates and source links when available.
+- Avoid claiming completeness unless the direct source tool or owning API supports that claim.
+
+## When To Fall Back
+
+Use extra direct-tool depth after the default indexed-plus-live pass when:
+
+- The user asks for the current Slack thread, a specific Slack channel/message/file, or a direct source object that `company_context` did not return.
+- The user asks to create, update, comment on, or inspect an exact Linear issue/project.
+- The user gives an exact Google Doc, Drive, Calendar, or Linear URL/id.
+- `company_context` returns an auth, permission, connection, or malformed-response error.
+- The question requires a canonical exhaustive answer. Company context is indexed retrieval; use the owning API/database for definitive inventories or yes/no internal-history claims when the user asks for completeness.
+
+## Answering Rules
+
+- Lead with the answer and include the evidence source when it matters: source, source type, date, title, and URL/permalink if present.
+- Say how indexed context and live source-tool results agree, differ, or complement each other.
+- If freshness matters, use `latest-date` to inspect the indexed cutoff and direct source tools for live corroboration.
+- Do not copy long private documents or message dumps into the reply. Summarize narrowly and quote only short snippets when useful.
+- If no indexed context is found after reasonable query variants, say that plainly and name the live tools checked.

--- a/tools/productivity/company_context/cli.py
+++ b/tools/productivity/company_context/cli.py
@@ -51,7 +51,7 @@ def search(
     occurred_before: str | None = typer.Option(None, "--before", help="Only results before this time."),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
-    """Search company context documents."""
+    """Search indexed company context documents."""
     result = CompanyContextClient().search(
         query=query,
         limit=limit,

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -3,18 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-import importlib.util
 import json
 import os
 import re
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 import asyncpg
 
-from centaur_sdk.tool_sdk import get_tool_context, secret
+from centaur_sdk.tool_sdk import secret
 
 DEFAULT_SEARCH_LIMIT = 10
 MAX_SEARCH_LIMIT = 50
@@ -25,11 +23,9 @@ THREAD_SCORE_MULTIPLIER = 1.25
 CHANNEL_DAY_SCORE_MULTIPLIER = 0.75
 DEFAULT_PREVIEW_CHARS = 280
 MAX_RELATED_CHILDREN = 25
-SLACK_LIVE_SOURCE_TYPE = "slack_live_message"
 COMPANY_CONTEXT_DSN_ENV = "CENTAUR_POSTGRES_DSN"
 COMPANY_CONTEXT_DATABASE_ENV = "COMPANY_CONTEXT_POSTGRES_DATABASE"
 DEFAULT_POSTGRES_DATABASE = "ai_v2"
-_SLACK_AFTER_RE = re.compile(r"\bafter:\d{4}-\d{2}-\d{2}\b", re.IGNORECASE)
 
 _SEARCH_TERM_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:/-]*")
 _STOP_WORDS = {
@@ -246,111 +242,6 @@ def _document_summary(row: Any) -> dict[str, Any]:
     }
 
 
-def _slack_ts_to_iso(ts: str | None) -> str | None:
-    """Convert a Slack timestamp string to ISO 8601 when possible."""
-    if not ts:
-        return None
-    try:
-        return datetime.fromtimestamp(float(ts), tz=UTC).isoformat()
-    except (TypeError, ValueError, OSError):
-        return None
-
-
-def _slack_after_query(query: str, latest_date: str | None) -> str:
-    """Append a Slack after:YYYY-MM-DD modifier unless the query already has one."""
-    if not latest_date or _SLACK_AFTER_RE.search(query):
-        return query
-    return f"{query} after:{latest_date[:10]}"
-
-
-def _current_slack_channel_id() -> str | None:
-    """Return the channel/group id for the active Slack thread, or None for DMs."""
-    try:
-        thread_key = get_tool_context().thread_key
-    except LookupError:
-        return None
-    if not thread_key:
-        return None
-    for segment in str(thread_key).split(":")[1:]:
-        clean = segment.strip()
-        if clean.startswith(("C", "G")):
-            return clean
-        if clean.startswith("D"):
-            return None
-    return None
-
-
-def _context_scope_clause(
-    param_index: int,
-    source_expr: str = "source",
-    metadata_expr: str = "metadata",
-) -> str:
-    """SQL predicate matching the app-level company_context visibility boundary."""
-    return (
-        f"${param_index}::text IS NOT NULL "
-        f"AND {source_expr} = 'slack' "
-        f"AND {metadata_expr} ->> 'channel_id' = ${param_index}::text"
-    )
-
-
-def _load_slack_client() -> Any:
-    """Load the sibling Slack tool client without making company_context import it eagerly."""
-    candidate_roots = [
-        Path("/app/tools/productivity/slack"),
-        Path(__file__).resolve().parent.parent / "slack",
-    ]
-    slack_dir = next((path for path in candidate_roots if (path / "client.py").exists()), None)
-    if slack_dir is None:
-        raise RuntimeError("slack tool client not found")
-
-    module_name = "_company_context_slack_client"
-    spec = importlib.util.spec_from_file_location(module_name, slack_dir / "client.py")
-    if spec is None or spec.loader is None:
-        raise RuntimeError("failed to load slack tool client")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module._client()
-
-
-def _live_slack_result(message: dict[str, Any]) -> dict[str, Any]:
-    """Normalize slack.search_messages results into company_context search result shape."""
-    channel = str(message.get("channel") or "")
-    user = str(message.get("user") or "")
-    timestamp = str(message.get("timestamp") or "")
-    title_bits = []
-    if channel:
-        title_bits.append(f"#{channel}")
-    if user:
-        title_bits.append(f"from {user}")
-    return {
-        "document_id": "",
-        "source": "slack",
-        "source_type": SLACK_LIVE_SOURCE_TYPE,
-        "source_document_id": str(message.get("thread_ts") or timestamp),
-        "source_chunk_id": timestamp,
-        "parent_document_id": None,
-        "title": " ".join(title_bits) or "Slack message",
-        "url": str(message.get("permalink") or ""),
-        "author_name": user,
-        "access_scope": "",
-        "score": None,
-        "preview": str(message.get("text") or ""),
-        "occurred_at": _slack_ts_to_iso(timestamp),
-        "source_updated_at": None,
-        "lane": "live",
-        "result_type": SLACK_LIVE_SOURCE_TYPE,
-        "metadata": {
-            "channel_name": channel,
-            "channel_id": str(message.get("channel_id") or ""),
-            "user_name": user,
-            "user_id": str(message.get("user_id") or ""),
-            "message_ts": timestamp,
-            "thread_ts": message.get("thread_ts"),
-            "reply_count": int(message.get("reply_count") or 0),
-        },
-    }
-
-
 class CompanyContextClient:
     """Query the shared company context document table."""
 
@@ -380,7 +271,6 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
-            slack_channel_id = _current_slack_channel_id()
             terms = _search_terms(query)
             search_terms = [query, *terms]
             source_param = len(search_terms) + 1
@@ -388,7 +278,6 @@ class CompanyContextClient:
             occurred_after_param = len(search_terms) + 3
             occurred_before_param = len(search_terms) + 4
             limit_param = len(search_terms) + 5
-            slack_channel_param = len(search_terms) + 6
             rows = await conn.fetch(
                 f"""
                 SELECT
@@ -409,7 +298,6 @@ class CompanyContextClient:
                     paradedb.score(document_id) AS score
                 FROM company_context_documents
                 WHERE {_search_where_clause(len(terms))}
-                  AND ({_context_scope_clause(slack_channel_param)})
                   AND (${source_param}::text IS NULL OR source = ${source_param})
                   AND (${source_type_param}::text IS NULL OR source_type = ${source_type_param})
                   AND (${occurred_after_param}::timestamptz IS NULL
@@ -432,7 +320,6 @@ class CompanyContextClient:
                 occurred_after,
                 occurred_before,
                 limit,
-                slack_channel_id,
             )
             results = []
             for row in rows:
@@ -446,35 +333,6 @@ class CompanyContextClient:
                 result["result_type"] = str(result["source_type"] or "indexed_document")
                 results.append(result)
 
-            latest = None
-            live_results: list[dict[str, Any]] = []
-            live_error = None
-            should_search_live_slack = source == "slack" and (
-                source_type is None or source_type.startswith("slack")
-            )
-            should_search_live_slack = (
-                should_search_live_slack and occurred_after is None and occurred_before is None
-            )
-            if should_search_live_slack:
-                latest = await self._latest_date_for_connection(
-                    conn,
-                    source="slack",
-                    source_type=source_type,
-                )
-                try:
-                    if slack_channel_id is None:
-                        live_error = "live Slack search requires a channel-scoped thread"
-                    else:
-                        live_query = _slack_after_query(query, latest.get("latest_date"))
-                        live_messages = _load_slack_client().search_messages(
-                            live_query,
-                            max_results=limit,
-                            channels=[slack_channel_id],
-                        )
-                        live_results = [_live_slack_result(message) for message in live_messages]
-                except Exception as exc:
-                    live_error = str(exc)
-
             return {
                 "status": "ok",
                 "query": query,
@@ -482,16 +340,9 @@ class CompanyContextClient:
                 "source_type": source_type,
                 "occurred_after": _isoformat(occurred_after),
                 "occurred_before": _isoformat(occurred_before),
-                "count": len(results) + len(live_results),
+                "count": len(results),
                 "indexed_count": len(results),
-                "live_count": len(live_results),
-                "indexed_cutoff": latest.get("latest_date") if latest else None,
-                "latest_source_updated_at": (
-                    latest.get("latest_source_updated_at") if latest else None
-                ),
-                "latest_occurred_at": latest.get("latest_occurred_at") if latest else None,
-                "live_error": live_error,
-                "results": [*results, *live_results],
+                "results": results,
             }
         finally:
             await conn.close()
@@ -505,18 +356,16 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         """Return latest indexed date using an existing DB connection."""
         row = await conn.fetchrow(
-            f"""
+            """
             SELECT
                 MAX(COALESCE(source_updated_at, occurred_at)) AS latest_date,
                 MAX(source_updated_at) AS latest_source_updated_at,
                 MAX(occurred_at) AS latest_occurred_at,
                 COUNT(*)::bigint AS document_count
             FROM company_context_documents
-            WHERE ({_context_scope_clause(1)})
-              AND ($2::text IS NULL OR source = $2)
-              AND ($3::text IS NULL OR source_type = $3)
+            WHERE ($1::text IS NULL OR source = $1)
+              AND ($2::text IS NULL OR source_type = $2)
             """,
-            _current_slack_channel_id(),
             source,
             source_type,
         )
@@ -549,7 +398,7 @@ class CompanyContextClient:
         occurred_after: str | datetime | None = None,
         occurred_before: str | datetime | None = None,
     ) -> dict:
-        """Search company context documents and return candidate document ids."""
+        """Search indexed company context documents and return candidate document ids."""
         normalized_query = query.strip()
         if not normalized_query:
             return {"status": "error", "error": "query cannot be empty"}
@@ -588,9 +437,8 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
-            slack_channel_id = _current_slack_channel_id()
             rows = await conn.fetch(
-                f"""
+                """
                 SELECT
                     document_id,
                     source,
@@ -607,16 +455,14 @@ class CompanyContextClient:
                     source_updated_at,
                     metadata
                 FROM company_context_documents
-                WHERE ({_context_scope_clause(1)})
-                  AND ($2::text IS NULL OR source = $2)
-                  AND ($3::text IS NULL OR source_type = $3)
-                  AND ($4::timestamptz IS NULL OR occurred_at >= $4)
-                  AND ($5::timestamptz IS NULL OR occurred_at < $5)
+                WHERE ($1::text IS NULL OR source = $1)
+                  AND ($2::text IS NULL OR source_type = $2)
+                  AND ($3::timestamptz IS NULL OR occurred_at >= $3)
+                  AND ($4::timestamptz IS NULL OR occurred_at < $4)
                 ORDER BY occurred_at ASC NULLS LAST, source_updated_at DESC NULLS LAST,
                          document_id ASC
-                LIMIT $6
+                LIMIT $5
                 """,
-                slack_channel_id,
                 source,
                 source_type,
                 occurred_after,
@@ -708,9 +554,8 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         parent = None
         if row["parent_document_id"]:
-            slack_channel_id = _current_slack_channel_id()
             parent_row = await conn.fetchrow(
-                f"""
+                """
                 SELECT
                     document_id,
                     source,
@@ -727,16 +572,14 @@ class CompanyContextClient:
                     metadata
                 FROM company_context_documents
                 WHERE document_id = $1
-                  AND ({_context_scope_clause(2)})
                 """,
                 row["parent_document_id"],
-                slack_channel_id,
             )
             if parent_row:
                 parent = _document_summary(parent_row)
 
         child_rows = await conn.fetch(
-            f"""
+            """
             SELECT
                 document_id,
                 source,
@@ -753,13 +596,11 @@ class CompanyContextClient:
                 metadata
             FROM company_context_documents
             WHERE parent_document_id = $1
-              AND ({_context_scope_clause(3)})
             ORDER BY occurred_at ASC NULLS LAST, document_id ASC
             LIMIT $2
             """,
             row["document_id"],
             max_children,
-            _current_slack_channel_id(),
         )
         children = [_document_summary(child_row) for child_row in child_rows]
         return {
@@ -778,9 +619,8 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
-            slack_channel_id = _current_slack_channel_id()
             row = await conn.fetchrow(
-                f"""
+                """
                 SELECT
                     document_id,
                     source,
@@ -798,10 +638,8 @@ class CompanyContextClient:
                     metadata
                 FROM company_context_documents
                 WHERE document_id = $1
-                  AND ({_context_scope_clause(2)})
                 """,
                 document_id,
-                slack_channel_id,
             )
             if not row:
                 return {

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "asyncpg>=0.30.0",
     "python-dotenv>=1.0.0",
     "rich>=13.0.0",
-    "slack-sdk>=3.27.0",
     "typer>=0.12.0",
 ]
 

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -42,16 +42,6 @@ class _FakeConnection:
         self.closed = True
 
 
-class _FakeSlackClient:
-    def __init__(self, messages=None) -> None:
-        self.messages = messages or []
-        self.calls = []
-
-    def search_messages(self, query, max_results=20, channels=None):
-        self.calls.append((query, max_results, channels))
-        return self.messages
-
-
 @pytest.mark.parametrize("query", ["", "   "])
 def test_search_rejects_empty_query(query):
     result = CompanyContextClient("postgresql://example").search(query)
@@ -140,14 +130,10 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
             "document_count": 42,
         },
     )
-    fake_slack = _FakeSlackClient()
-
     async def fake_connect(*args, **kwargs):
         return fake
 
     monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
-    monkeypatch.setattr(company_context_client, "_load_slack_client", lambda: fake_slack)
-    monkeypatch.setattr(company_context_client, "_current_slack_channel_id", lambda: "C123")
 
     result = CompanyContextClient("postgresql://example").search(
         "ParadeDB BM25",
@@ -159,9 +145,6 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
     assert result["status"] == "ok"
     assert result["count"] == 1
     assert result["indexed_count"] == 1
-    assert result["live_count"] == 0
-    assert result["indexed_cutoff"] == "2026-05-10T15:30:00+00:00"
-    assert fake_slack.calls == [("ParadeDB BM25 after:2026-05-10", 5, ["C123"])]
     assert result["results"][0] == {
         "document_id": "slack:thread:C123:1770000000.000000",
         "source": "slack",
@@ -190,6 +173,7 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
     assert "WHEN 'slack_channel_day' THEN 0.75" in query
     assert "END DESC" in query
     assert "paradedb.score(document_id)" in query
+    assert "metadata ->> 'channel_id'" not in query
     assert args == (
         "ParadeDB BM25",
         "ParadeDB",
@@ -199,114 +183,8 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
         None,
         None,
         5,
-        "C123",
     )
     assert fake.closed is True
-
-
-def test_search_appends_live_slack_gap_results(monkeypatch):
-    fake = _FakeConnection(
-        rows=[],
-        row={
-            "latest_date": dt.datetime(2026, 5, 10, 15, 30, tzinfo=dt.UTC),
-            "latest_source_updated_at": dt.datetime(2026, 5, 10, 15, 30, tzinfo=dt.UTC),
-            "latest_occurred_at": dt.datetime(2026, 5, 10, 14, 0, tzinfo=dt.UTC),
-            "document_count": 42,
-        },
-    )
-    fake_slack = _FakeSlackClient(
-        [
-            {
-                "channel": "eng-ai",
-                "channel_id": "C123",
-                "user": "alice",
-                "user_id": "U123",
-                "text": "New state root mismatch update",
-                "timestamp": "1770000000.000000",
-                "permalink": "https://slack.example/archives/C123/p1770000000000000",
-                "thread_ts": "1770000000.000000",
-                "reply_count": 3,
-            }
-        ]
-    )
-
-    async def fake_connect(*args, **kwargs):
-        return fake
-
-    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
-    monkeypatch.setattr(company_context_client, "_load_slack_client", lambda: fake_slack)
-    monkeypatch.setattr(company_context_client, "_current_slack_channel_id", lambda: "C123")
-
-    result = CompanyContextClient("postgresql://example").search(
-        "state root mismatch",
-        limit=7,
-        source="slack",
-    )
-
-    assert result["status"] == "ok"
-    assert result["count"] == 1
-    assert result["indexed_count"] == 0
-    assert result["live_count"] == 1
-    assert result["indexed_cutoff"] == "2026-05-10T15:30:00+00:00"
-    assert result["live_error"] is None
-    assert fake_slack.calls == [("state root mismatch after:2026-05-10", 7, ["C123"])]
-    assert result["results"] == [
-        {
-            "document_id": "",
-            "source": "slack",
-            "source_type": "slack_live_message",
-            "source_document_id": "1770000000.000000",
-            "source_chunk_id": "1770000000.000000",
-            "parent_document_id": None,
-            "title": "#eng-ai from alice",
-            "url": "https://slack.example/archives/C123/p1770000000000000",
-            "author_name": "alice",
-            "access_scope": "",
-            "score": None,
-            "preview": "New state root mismatch update",
-            "occurred_at": "2026-02-02T02:40:00+00:00",
-            "source_updated_at": None,
-            "lane": "live",
-            "result_type": "slack_live_message",
-            "metadata": {
-                "channel_name": "eng-ai",
-                "channel_id": "C123",
-                "user_name": "alice",
-                "user_id": "U123",
-                "message_ts": "1770000000.000000",
-                "thread_ts": "1770000000.000000",
-                "reply_count": 3,
-            },
-        }
-    ]
-
-
-def test_search_preserves_existing_slack_after_modifier(monkeypatch):
-    fake = _FakeConnection(
-        rows=[],
-        row={
-            "latest_date": dt.datetime(2026, 5, 10, 15, 30, tzinfo=dt.UTC),
-            "latest_source_updated_at": dt.datetime(2026, 5, 10, 15, 30, tzinfo=dt.UTC),
-            "latest_occurred_at": dt.datetime(2026, 5, 10, 14, 0, tzinfo=dt.UTC),
-            "document_count": 42,
-        },
-    )
-    fake_slack = _FakeSlackClient()
-
-    async def fake_connect(*args, **kwargs):
-        return fake
-
-    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
-    monkeypatch.setattr(company_context_client, "_load_slack_client", lambda: fake_slack)
-    monkeypatch.setattr(company_context_client, "_current_slack_channel_id", lambda: "C123")
-
-    result = CompanyContextClient("postgresql://example").search(
-        "state root after:2026-05-11",
-        source="slack",
-    )
-
-    assert result["status"] == "ok"
-    assert fake_slack.calls == [("state root after:2026-05-11", 10, ["C123"])]
 
 
 def test_search_uses_or_terms_and_drops_stop_words(monkeypatch):
@@ -332,6 +210,7 @@ def test_search_uses_or_terms_and_drops_stop_words(monkeypatch):
     assert "title ||| $6::text::pdb.boost(4)" not in query
     placeholders = {int(match.group(1)) for match in re.finditer(r"\$(\d+)", query)}
     assert placeholders == set(range(1, len(args) + 1))
+    assert "metadata ->> 'channel_id'" not in query
     assert args == (
         "what is the state root state mismatch in prod",
         "state",
@@ -343,7 +222,6 @@ def test_search_uses_or_terms_and_drops_stop_words(monkeypatch):
         None,
         None,
         3,
-        None,
     )
 
 
@@ -370,6 +248,7 @@ def test_search_applies_occurred_at_filters(monkeypatch):
     query, args = fake.fetch_calls[0]
     assert "OR occurred_at >= $5" in query
     assert "OR occurred_at < $6" in query
+    assert "metadata ->> 'channel_id'" not in query
     assert args == (
         "planning",
         "planning",
@@ -378,7 +257,6 @@ def test_search_applies_occurred_at_filters(monkeypatch):
         dt.datetime(2026, 5, 1, tzinfo=dt.UTC),
         dt.datetime(2026, 5, 8, 12, 30, tzinfo=dt.UTC),
         4,
-        None,
     )
 
 
@@ -470,8 +348,8 @@ def test_list_documents_returns_date_bounded_document_summaries(monkeypatch):
     }
     query, args = fake.fetch_calls[0]
     assert "ORDER BY occurred_at ASC NULLS LAST" in query
+    assert "metadata ->> 'channel_id'" not in query
     assert args == (
-        None,
         "google_calendar",
         "calendar_event",
         dt.datetime(2026, 5, 1, tzinfo=dt.UTC),
@@ -511,7 +389,7 @@ def test_latest_date_returns_latest_indexed_slack_timestamp(monkeypatch):
         "latest_occurred_at": "2026-05-10T14:00:00+00:00",
     }
     _, args = fake.fetchrow_calls[0]
-    assert args == (None, "slack", "slack_thread")
+    assert args == ("slack", "slack_thread")
     assert fake.closed is True
 
 
@@ -577,7 +455,7 @@ def test_read_document_returns_full_content_by_default(monkeypatch):
     assert result["content"] == body
     assert result["metadata"] == {"channel_name": "eng-ai"}
     _, args = fake.fetchrow_calls[0]
-    assert args == ("slack:channel_day:C123:2026-05-08", None)
+    assert args == ("slack:channel_day:C123:2026-05-08",)
     assert fake.closed is True
 
 
@@ -615,7 +493,7 @@ def test_read_document_can_return_bounded_content(monkeypatch):
     assert result["content"] == "x" * 1_200
     assert result["metadata"] == {"channel_name": "eng-ai"}
     _, args = fake.fetchrow_calls[0]
-    assert args == ("slack:channel_day:C123:2026-05-08", None)
+    assert args == ("slack:channel_day:C123:2026-05-08",)
     assert fake.closed is True
 
 


### PR DESCRIPTION
## Summary

- Remove the Python-side Slack/current-channel predicate from `company_context` indexed SQL queries so retrieval relies on the database role/RLS boundary.
- Keep `company_context search` focused on indexed company context only; remove the in-tool live Slack/Linear/Google fanout and sibling-client imports.
- Add a `company-context` skill that teaches agents to search indexed company context first, always check the relevant direct Slack, Linear, Google Drive, or Calendar tools, then reconcile and collate indexed plus live/source results before answering.

## Validation

- `uv run --with pyyaml python /Users/akshaan/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/company-context`
- `uv run --with pytest --with asyncpg --with rich pytest tools/productivity/company_context/tests/test_client.py -q`
- `uv run --with ruff ruff check tools/productivity/company_context/client.py tools/productivity/company_context/cli.py tools/productivity/company_context/tests/test_client.py`
- `git diff --check`
