### PR TITLE
fix: wire console worker to api-rs

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.75
+version: 0.1.76
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -2,6 +2,7 @@
 {{- if and $console.enabled $console.worker.enabled }}
 {{- $secretEnv := include "centaur.secretEnvName" . }}
 {{- $prefix := .Values.secretManager.envPrefix }}
+{{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") }}
 # console background job worker — runs Solid Queue (`bin/jobs`) so
 # console's enqueued jobs actually execute. The most important of these is
 # the broker-credential OAuth refresh loop, which mints and refreshes the access
@@ -141,6 +142,10 @@ spec:
 {{- end }}
             - name: RAILS_LOG_TO_STDOUT
               value: "1"
+{{- if .Values.apiRs.enabled }}
+            - name: CENTAUR_CONSOLE_CENTAUR_API_URL
+              value: {{ printf "http://%s:%v" $apiRsName .Values.apiRs.port | quote }}
+{{- end }}
           securityContext:
 {{ toYaml .Values.containerSecurityContext | nindent 12 }}
             # No readOnlyRootFilesystem — Rails writes to tmp/ at runtime.
@@ -173,6 +178,15 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+{{- end }}
+{{- if .Values.apiRs.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.apiRs.port }}
 {{- end }}
     # Outbound HTTPS to OAuth token endpoints for the broker refresh loop.
     - ports:


### PR DESCRIPTION
## Summary

Wire the Console worker to api-rs the same way the Console web pod is wired.

## Details

- Adds `CENTAUR_CONSOLE_CENTAUR_API_URL` to the `console-worker` deployment when api-rs is enabled.
- Allows `console-worker` NetworkPolicy egress to api-rs on the configured api-rs port.
- Bumps the chart version to `0.1.76`.

The Slack DM sync routes do not currently require a Centaur API key; the Console client only sends `Authorization` when a key is configured. This PR keeps the fix scoped to the missing worker URL and network path.

## Validation

- `helm dependency build contrib/chart`
- `helm template centaur contrib/chart --set console.enabled=true --set console.worker.enabled=true --set apiRs.enabled=true --set postgres.enabled=true --set networkPolicy.enabled=true`
- `helm lint contrib/chart`
- `git diff --check`
