### PR TITLE
fix(discord): bot User-Agent + suppress_embeds on post_message

### DIFF
--- a/tools/comms/discord/cli.py
+++ b/tools/comms/discord/cli.py
@@ -177,6 +177,9 @@ def post(
     channel: str = typer.Argument(..., help="Channel name or ID"),
     message: str = typer.Argument(..., help="Message text"),
     reply_to: str = typer.Option(None, "--reply-to", "-r", help="Message ID to reply to"),
+    suppress_embeds: bool = typer.Option(
+        False, "--suppress-embeds", help="Suppress link/embed unfurling on the message"
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """Post a message to a channel."""
@@ -184,6 +187,7 @@ def post(
         channel=channel,
         content=message,
         reply_to_message_id=reply_to,
+        suppress_embeds=suppress_embeds,
     )
     if _emit(result, json_output):
         return

--- a/tools/comms/discord/client.py
+++ b/tools/comms/discord/client.py
@@ -12,6 +12,17 @@ from centaur_sdk import secret
 BASE_URL = "https://discord.com/api/v10"
 INVITE_RE = re.compile(r"(?:https?://)?(?:discord(?:\.gg|\.com/invite)/)?([A-Za-z0-9-]+)")
 
+# Discord asks automated clients to identify themselves with a descriptive
+# User-Agent (https://discord.com/developers/docs/reference#user-agent). When
+# this client runs under a *bot* token (Authorization: ``Bot <token>``), sending
+# a browser User-Agent trips Discord's edge anti-automation: guild/channel reads
+# come back ``403`` with body ``internal network error`` while ``/users/@me``
+# still succeeds. A proper bot UA keeps reads working under a bot token (and is
+# harmless under a user token).
+USER_AGENT = "DiscordBot (https://github.com/paradigmxyz/centaur, 0.1.0)"
+# Message flag that suppresses link/embed unfurling on a posted message (1 << 2).
+SUPPRESS_EMBEDS = 1 << 2
+
 # Discord thread channel types
 # (https://discord.com/developers/docs/resources/channel#channel-object-channel-types).
 THREAD_TYPES = {10: "announcement_thread", 11: "public_thread", 12: "private_thread"}
@@ -36,10 +47,7 @@ class DiscordClient:
         headers = {
             "Authorization": self._get_token(),
             "Content-Type": "application/json",
-            "User-Agent": (
-                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-                "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-            ),
+            "User-Agent": USER_AGENT,
         }
         with httpx.Client(timeout=self.timeout) as client:
             response = client.request(method, f"{BASE_URL}{endpoint}", headers=headers, **kwargs)
@@ -183,10 +191,17 @@ class DiscordClient:
         channel: str,
         content: str,
         reply_to_message_id: str | None = None,
+        suppress_embeds: bool = False,
     ) -> dict[str, Any]:
-        """Post a message to a channel by name or ID."""
+        """Post a message to a channel by name or ID.
+
+        Set ``suppress_embeds`` to stop Discord unfurling link previews — useful
+        for status/alert posts whose URLs should stay compact.
+        """
         resolved = self._find_channel(channel)
         payload: dict[str, Any] = {"content": content}
+        if suppress_embeds:
+            payload["flags"] = SUPPRESS_EMBEDS
         if reply_to_message_id:
             payload["message_reference"] = {"message_id": reply_to_message_id}
         msg = self._request("POST", f"/channels/{resolved['id']}/messages", json=payload)


### PR DESCRIPTION
## Problem

The `discord` tool sends a **browser `User-Agent`** (`Mozilla/… Chrome/120 …`) on every request (`client.py` `_request`). When the tool runs under a **bot** token (`Authorization: Bot <token>`), Discord's Cloudflare edge flags "bot token + browser UA hitting guild/channel resource endpoints" as self-bot behavior and returns:

```
403  {"message": "internal network error"}
```

for `GET /guilds/{id}/channels`, `GET /channels/{id}`, and `GET /channels/{id}/messages`, while `GET /users/@me` and `GET /users/@me/guilds` still return `200`. Net effect: `discord me` works, but `messages` / `channels` / `context` / `search-all` all fail. Note the body is the edge's `internal network error`, **not** the API permission error `Missing Access` / `50001` — i.e. it's an edge rejection, not a permissions issue (verified the bot is a member with access via the gateway).

## Fix

- Replace the browser `User-Agent` with a descriptive `DiscordBot (...)` UA, as the [Discord API reference](https://discord.com/developers/docs/reference#user-agent) asks automated clients to do. Reads then succeed under a bot token; it's harmless under a user token.
- Add `suppress_embeds` to `post_message` (+ CLI `--suppress-embeds`) so status/alert posts can keep URLs from unfurling (sets the `SUPPRESS_EMBEDS` message flag).

## Notes

Draft — happy to add a unit test asserting the bot UA + the `flags` payload if useful. Diagnosed on a deployment where this tool is used with a bot token; the UA issue reproduces on plain `main`.