### PR TITLE
Support injected auth in Preqin health check

### DIFF
--- a/tools/research/preqin/centaur_tool_preqin/client.py
+++ b/tools/research/preqin/centaur_tool_preqin/client.py
@@ -122,19 +122,20 @@ class PreqinClient:
 
     def auth_health(self) -> dict[str, Any]:
         """Check Preqin auth and return a redacted diagnostic result."""
+        url = f"{OPERATIONAL_BASE_URL}/api/FundManager"
         try:
-            token = self._operational_access_token(force_refresh=True)
+            data = self._operational_get("/api/FundManager", {"Size": 1, "Page": 1})
             return {
                 "ok": True,
-                "auth_url": f"{OPERATIONAL_BASE_URL}/connect/token",
-                "method": "username_api_key",
-                "token_length": len(token),
+                "url": url,
+                "method": "operational_get",
+                "records_seen": len(data) if isinstance(data, list) else None,
             }
         except Exception as exc:
             return {
                 "ok": False,
-                "auth_url": f"{OPERATIONAL_BASE_URL}/connect/token",
-                "method": "username_api_key",
+                "url": url,
+                "method": "operational_get",
                 "error": str(exc),
                 "credentials": self.credential_status(),
             }

--- a/tools/research/preqin/tests/test_client.py
+++ b/tools/research/preqin/tests/test_client.py
@@ -77,3 +77,36 @@ def test_operational_get_without_proxy_token_or_direct_credentials_leaves_auth_t
 
     assert not fake.posts
     assert fake.gets[0]["headers"] == {"Accept": "application/json"}
+
+
+def test_auth_health_uses_injected_auth_without_direct_credentials(monkeypatch):
+    monkeypatch.setenv(OPERATIONAL_TOKEN_PLACEHOLDER, "")
+    configure(StubBackend())
+    fake = FakeHttpClient()
+    client = PreqinClient()
+    client._client = fake
+
+    result = client.auth_health()
+
+    assert result["ok"] is True
+    assert result["method"] == "operational_get"
+    assert not fake.posts
+    assert fake.gets[0]["url"] == "https://api.preqin.com/api/FundManager"
+    assert fake.gets[0]["params"] == {"Size": 1, "Page": 1}
+    assert fake.gets[0]["headers"] == {"Accept": "application/json"}
+
+
+def test_auth_health_uses_direct_credentials_for_local_runs(monkeypatch):
+    monkeypatch.setenv(OPERATIONAL_TOKEN_PLACEHOLDER, "")
+    fake = FakeHttpClient()
+    client = PreqinClient(username="user", api_key="api-key")
+    client._client = fake
+
+    result = client.auth_health()
+
+    assert result["ok"] is True
+    assert result["method"] == "operational_get"
+    assert fake.posts[0]["url"] == "https://api.preqin.com/connect/token"
+    assert fake.posts[0]["files"] == {"username": (None, "user"), "apikey": (None, "api-key")}
+    assert fake.gets[0]["url"] == "https://api.preqin.com/api/FundManager"
+    assert fake.gets[0]["headers"]["Authorization"] == "Bearer token-123"


### PR DESCRIPTION
## Summary
- Update Preqin auth-health to use a lightweight `/api/FundManager` request when direct username/API key credentials are absent
- Preserve direct username/API key token auth when those legacy credentials are explicitly configured
- Add regression coverage that verifies auth-health does not POST for direct auth when running with injected sandbox auth

## Testing
- `PYTHONPATH=.:tools/research/preqin uv run --with pytest pytest tools/research/preqin/tests`
- `PYTHONPATH=.:tools/research/preqin uv run --with ./centaur_sdk --project tools/research/preqin preqin auth-health --json` reached `https://api.preqin.com/api/FundManager` and returned 401 in this sandbox without injected Preqin auth, confirming it no longer fails locally before making the request.