### PR TITLE
fix: allow console worker to reach api-rs

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.76
+version: 0.1.77
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -178,6 +178,12 @@ spec:
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console") | nindent 14 }}
+{{- if $console.worker.enabled }}
+        # Console background jobs call api-rs for sync ingestion/checkpoints.
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-worker") | nindent 14 }}
+{{- end }}
 {{- end }}
         # Sandboxes call back into the control plane. agent-k8s labels its pods
         # centaur.ai/managed-by=api-rs (MANAGED_BY_VALUE in centaur-sandbox-agent-k8s),


### PR DESCRIPTION
## Summary

Allow the Console Solid Queue worker to call api-rs through the api-rs NetworkPolicy ingress rules.

## Why

Slack DM sync now renders `CENTAUR_CONSOLE_CENTAUR_API_URL` on `console-worker` and gives the worker egress to api-rs, but staging still timed out opening TCP to `centaur-api-rs:8080`. The missing side was api-rs ingress: it allowed `console`, `slackbotv2`, managed sandboxes, and monitoring, but not `console-worker`.

## Changes

- Add `console-worker` as an allowed api-rs ingress source when Console worker is enabled.
- Bump chart version to `0.1.77`.

## Validation

- `helm dependency build contrib/chart`
- `helm template centaur contrib/chart --set console.enabled=true --set console.worker.enabled=true --set apiRs.enabled=true --set postgres.enabled=true --set networkPolicy.enabled=true`
- `helm lint contrib/chart`
- `git diff --check`
- Local `orbstack` deployment with `console.enabled=true`:
  - api-rs NetworkPolicy includes `console-worker`
  - TCP from `console-worker` to `centaur-centaur-api-rs:8080` opens
  - `CentaurApiClient#list_slack_dm_sync_checkpoints` returns `{"ok":true,"checkpoints":[]}` from inside the worker
