### PR TITLE
[codex] restore stdout pump reattach after EOF

### DIFF
--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -49,6 +49,8 @@ pub const SESSION_FIRST_TOKEN_EVENT: &str = "session.first_token";
 const EVENT_STREAM_SAFETY_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
+const SESSION_PIPE_MAX_REATTACH_ATTEMPTS: u32 = 3;
+const SESSION_PIPE_REATTACH_DELAY: Duration = Duration::from_millis(500);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 
 type SandboxSpecFactory = Arc<
@@ -1728,12 +1730,11 @@ impl SessionRuntime {
                 .open_io(&SandboxId::new(sandbox_id))
                 .await?
                 .into_parts();
-            let pipe = SessionPipe {
-                stdin: Arc::new(Mutex::new(FramedWrite::new(io.stdin, LinesCodec::new()))),
-            };
+            let pipe = session_pipe_from_stdin(io.stdin);
 
             self.sandbox_pipes
                 .insert(sandbox_id.to_owned(), pipe.clone());
+            drop(_open_guard);
             let ctx = self.context();
             let thread_key = thread_key.clone();
             let pump_thread_key = thread_key.clone();
@@ -1744,54 +1745,17 @@ impl SessionRuntime {
             let guard = io.guard;
             let stderr_key = pump_key.clone();
 
-            tokio::spawn(async move {
-                let result = run_stdout_pump(
-                    ctx.clone(),
-                    pump_thread_key.clone(),
-                    &pump_key,
-                    stdout,
-                    guard,
-                )
-                .await;
-                if let Err(error) = result {
-                    warn!(
-                        component = COMPONENT_SESSION_RUNTIME,
-                        event = "session_stdout_pump_failed",
-                        thread_key = %pump_thread_key,
-                        sandbox_id = %pump_key,
-                        %error,
-                        "session stdout pump failed"
-                    );
-                    let _ = ctx
-                        .store
-                        .append_event(
-                            &pump_thread_key,
-                            None,
-                            "session.stdout_pump_failed",
-                            json!({
-                                "sandbox_id": pump_key.as_str(),
-                                "error": error.to_string(),
-                            }),
-                        )
-                        .await;
-                }
-                ctx.sandbox_pipes
-                    .remove_if(&pump_key, |_sandbox_id, current| {
-                        Arc::ptr_eq(&current.stdin, &pump_pipe.stdin)
-                    });
+            spawn_stdout_pump_loop(StdoutPumpLoop {
+                ctx,
+                open_lock,
+                thread_key: pump_thread_key,
+                sandbox_id: pump_key,
+                pipe: pump_pipe,
+                stdout,
+                guard,
             });
 
-            tokio::spawn(async move {
-                if let Err(error) = drain_stderr(stderr).await {
-                    warn!(
-                        component = COMPONENT_SESSION_RUNTIME,
-                        event = "session_stderr_drain_failed",
-                        sandbox_id = %stderr_key,
-                        %error,
-                        "session stderr drain failed"
-                    );
-                }
-            });
+            spawn_stderr_drain(stderr_key, stderr);
 
             info!(
                 component = COMPONENT_SESSION_RUNTIME,
@@ -2340,13 +2304,365 @@ fn session_event_stream(
     )
 }
 
+/// How a stdout pump pass ended once the attach stream closed.
+enum StdoutPumpEnd {
+    /// The stream closed with no execution in flight, or the execution was
+    /// already terminalized by a read/codec failure.
+    Idle,
+    /// The stream closed while an execution was still active. Treat this as a
+    /// transport detach; the pump loop decides whether to recover or fail.
+    EofActiveExecution {
+        execution: Box<SessionExecution>,
+        lines_pumped: u64,
+    },
+}
+
+struct StdoutPumpLoop {
+    ctx: RuntimeContext,
+    open_lock: Arc<Mutex<()>>,
+    thread_key: ThreadKey,
+    sandbox_id: String,
+    pipe: SessionPipe,
+    stdout: SandboxRead,
+    guard: SandboxIoGuard,
+}
+
+enum ReattachOutcome {
+    Reattached {
+        pipe: SessionPipe,
+        stdout: SandboxRead,
+        guard: SandboxIoGuard,
+    },
+    /// Another pipe replaced ours; that pump now owns the sandbox stream.
+    Superseded,
+    /// A retryable attach/status failure. The caller bounds attempts.
+    Retryable(String),
+    /// The sandbox cannot serve IO anymore.
+    Dead(String),
+}
+
+fn session_pipe_from_stdin(stdin: SandboxWrite) -> SessionPipe {
+    SessionPipe {
+        stdin: Arc::new(Mutex::new(FramedWrite::new(stdin, LinesCodec::new()))),
+    }
+}
+
+fn spawn_stderr_drain(sandbox_id: String, stderr: SandboxRead) {
+    tokio::spawn(async move {
+        if let Err(error) = drain_stderr(stderr).await {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_stderr_drain_failed",
+                sandbox_id = %sandbox_id,
+                %error,
+                "session stderr drain failed"
+            );
+        }
+    });
+}
+
+fn remove_pipe_if_current(sandbox_pipes: &SessionPipeMap, sandbox_id: &str, pipe: &SessionPipe) {
+    sandbox_pipes.remove_if(sandbox_id, |_sandbox_id, current| {
+        Arc::ptr_eq(&current.stdin, &pipe.stdin)
+    });
+}
+
+/// Runs the stdout pump and reattaches when Kubernetes closes the attach
+/// stream before the active execution emits terminal output.
+fn spawn_stdout_pump_loop(state: StdoutPumpLoop) {
+    tokio::spawn(async move {
+        let StdoutPumpLoop {
+            ctx,
+            open_lock,
+            thread_key,
+            sandbox_id,
+            mut pipe,
+            mut stdout,
+            mut guard,
+        } = state;
+        let mut reattach_attempts = 0_u32;
+        let mut last_reattach_detail = "stdout reattach attempts exhausted".to_owned();
+
+        'pump: loop {
+            let result =
+                run_stdout_pump(ctx.clone(), thread_key.clone(), &sandbox_id, stdout, guard).await;
+            let (execution, lines_pumped) = match result {
+                Ok(StdoutPumpEnd::Idle) => break,
+                Ok(StdoutPumpEnd::EofActiveExecution {
+                    execution,
+                    lines_pumped,
+                }) => (execution, lines_pumped),
+                Err(error) => {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_stdout_pump_failed",
+                        thread_key = %thread_key,
+                        sandbox_id = %sandbox_id,
+                        %error,
+                        "session stdout pump failed"
+                    );
+                    let _ = ctx
+                        .store
+                        .append_event(
+                            &thread_key,
+                            None,
+                            "session.stdout_pump_failed",
+                            json!({
+                                "sandbox_id": sandbox_id.as_str(),
+                                "error": error.to_string(),
+                            }),
+                        )
+                        .await;
+                    break;
+                }
+            };
+
+            if recover_detached_terminal_output(&ctx, &thread_key, &sandbox_id, &execution)
+                .await
+                .unwrap_or_else(|error| {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_stdout_recovery_failed",
+                        thread_key = %thread_key,
+                        sandbox_id = %sandbox_id,
+                        execution_id = %execution.execution_id,
+                        %error,
+                        "failed to recover detached stdout from recorded output"
+                    );
+                    false
+                })
+            {
+                break;
+            }
+
+            if lines_pumped > 0 {
+                reattach_attempts = 0;
+            }
+
+            loop {
+                if reattach_attempts >= SESSION_PIPE_MAX_REATTACH_ATTEMPTS {
+                    fail_detached_execution(
+                        &ctx,
+                        &thread_key,
+                        &sandbox_id,
+                        &execution.execution_id,
+                        &last_reattach_detail,
+                    )
+                    .await;
+                    break 'pump;
+                }
+                reattach_attempts += 1;
+                if reattach_attempts > 1 {
+                    sleep(SESSION_PIPE_REATTACH_DELAY).await;
+                }
+
+                match reattach_session_pipe(&ctx, &open_lock, &sandbox_id, &pipe).await {
+                    ReattachOutcome::Reattached {
+                        pipe: new_pipe,
+                        stdout: new_stdout,
+                        guard: new_guard,
+                    } => {
+                        info!(
+                            component = COMPONENT_SESSION_RUNTIME,
+                            event = "session_stdout_pump_reattached",
+                            thread_key = %thread_key,
+                            sandbox_id = %sandbox_id,
+                            execution_id = %execution.execution_id,
+                            attempt = reattach_attempts,
+                            "reattached session stdout pump after eof"
+                        );
+                        let _ = ctx
+                            .store
+                            .append_event(
+                                &thread_key,
+                                Some(&execution.execution_id),
+                                "session.stdout_pump_reattached",
+                                json!({
+                                    "sandbox_id": sandbox_id.as_str(),
+                                    "attempt": reattach_attempts,
+                                }),
+                            )
+                            .await;
+                        pipe = new_pipe;
+                        stdout = new_stdout;
+                        guard = new_guard;
+                        continue 'pump;
+                    }
+                    ReattachOutcome::Superseded => return,
+                    ReattachOutcome::Retryable(detail) => {
+                        warn!(
+                            component = COMPONENT_SESSION_RUNTIME,
+                            event = "session_stdout_pump_reattach_failed",
+                            thread_key = %thread_key,
+                            sandbox_id = %sandbox_id,
+                            execution_id = %execution.execution_id,
+                            attempt = reattach_attempts,
+                            detail = %detail,
+                            "session stdout pump reattach attempt failed"
+                        );
+                        last_reattach_detail = detail;
+                    }
+                    ReattachOutcome::Dead(detail) => {
+                        fail_detached_execution(
+                            &ctx,
+                            &thread_key,
+                            &sandbox_id,
+                            &execution.execution_id,
+                            &detail,
+                        )
+                        .await;
+                        break 'pump;
+                    }
+                }
+            }
+        }
+
+        remove_pipe_if_current(&ctx.sandbox_pipes, &sandbox_id, &pipe);
+    });
+}
+
+async fn reattach_session_pipe(
+    ctx: &RuntimeContext,
+    open_lock: &Arc<Mutex<()>>,
+    sandbox_id: &str,
+    pipe: &SessionPipe,
+) -> ReattachOutcome {
+    let _open_guard = open_lock.lock().await;
+    if ctx
+        .sandbox_pipes
+        .get(sandbox_id)
+        .is_none_or(|current| !Arc::ptr_eq(&current.stdin, &pipe.stdin))
+    {
+        return ReattachOutcome::Superseded;
+    }
+
+    let id = SandboxId::new(sandbox_id);
+    match ctx.manager.status(&id).await {
+        Ok(status) if status.can_open_io() => match ctx.manager.open_io(&id).await {
+            Ok(io) => {
+                let parts = io.into_parts();
+                let new_pipe = session_pipe_from_stdin(parts.stdin);
+                ctx.sandbox_pipes
+                    .insert(sandbox_id.to_owned(), new_pipe.clone());
+                spawn_stderr_drain(sandbox_id.to_owned(), parts.stderr);
+                ReattachOutcome::Reattached {
+                    pipe: new_pipe,
+                    stdout: parts.stdout,
+                    guard: parts.guard,
+                }
+            }
+            Err(error) => {
+                ReattachOutcome::Retryable(format!("sandbox stdout reattach failed: {error}"))
+            }
+        },
+        Ok(status) => {
+            ReattachOutcome::Dead(format!("sandbox no longer accepts io (status {status:?})"))
+        }
+        Err(SandboxError::NotFound(_)) => {
+            ReattachOutcome::Dead("sandbox no longer exists".to_owned())
+        }
+        Err(error) => ReattachOutcome::Retryable(format!("sandbox status check failed: {error}")),
+    }
+}
+
+async fn recover_detached_terminal_output(
+    ctx: &RuntimeContext,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+    execution: &SessionExecution,
+) -> Result<bool, SessionRuntimeError> {
+    let since = execution.started_at.unwrap_or(execution.created_at);
+    let id = SandboxId::new(sandbox_id);
+    let lines = match ctx
+        .manager
+        .read_output_since(&id, Some(SystemTime::from(since)))
+        .await
+    {
+        Ok(lines) => lines,
+        Err(SandboxError::Unsupported { .. }) => return Ok(false),
+        Err(error) => {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_stdout_recorded_output_read_failed",
+                thread_key = %thread_key,
+                execution_id = %execution.execution_id,
+                sandbox_id,
+                %error,
+                "failed to read recorded sandbox output; reattaching live"
+            );
+            return Ok(false);
+        }
+    };
+
+    let Some(terminal) = terminal_output_from_lines(&lines) else {
+        return Ok(false);
+    };
+
+    info!(
+        component = COMPONENT_SESSION_RUNTIME,
+        event = "session_stdout_pump_recovered",
+        thread_key = %thread_key,
+        execution_id = %execution.execution_id,
+        sandbox_id,
+        mode = "recorded_output",
+        "recovered detached stdout pump from recorded sandbox output"
+    );
+    let _ = ctx
+        .store
+        .append_event(
+            thread_key,
+            Some(&execution.execution_id),
+            "session.stdout_pump_recovered",
+            json!({ "sandbox_id": sandbox_id, "mode": "recorded_output" }),
+        )
+        .await;
+    record_terminal_output(
+        ctx,
+        thread_key,
+        sandbox_id,
+        &execution.execution_id,
+        terminal,
+    )
+    .await?;
+    Ok(true)
+}
+
+async fn fail_detached_execution(
+    ctx: &RuntimeContext,
+    thread_key: &ThreadKey,
+    sandbox_id: &str,
+    execution_id: &str,
+    detail: &str,
+) {
+    let error = format!("sandbox stdout closed before terminal output; {detail}");
+    if let Err(record_error) = record_terminal_output(
+        ctx,
+        thread_key,
+        sandbox_id,
+        execution_id,
+        TerminalOutput::Failed { error },
+    )
+    .await
+    {
+        warn!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_stdout_detached_fail_record_failed",
+            thread_key = %thread_key,
+            execution_id,
+            sandbox_id,
+            error = %record_error,
+            "failed to record detached stdout failure"
+        );
+    }
+}
+
 async fn run_stdout_pump(
     ctx: RuntimeContext,
     thread_key: ThreadKey,
     sandbox_id: &str,
     stdout: SandboxRead,
     _guard: SandboxIoGuard,
-) -> Result<(), SessionRuntimeError> {
+) -> Result<StdoutPumpEnd, SessionRuntimeError> {
     let span = info_span!(
         "centaur.api_rs.session.stdout_pump",
         component = COMPONENT_SESSION_RUNTIME,
@@ -2379,7 +2695,7 @@ async fn run_stdout_pump(
                 Err(error) => {
                     let message = stdout_pump_error_message(&error);
                     record_stdout_pump_failure(&ctx, &thread_key, sandbox_id, message).await?;
-                    return Ok(());
+                    return Ok(StdoutPumpEnd::Idle);
                 }
             };
             line_count += 1;
@@ -2462,33 +2778,7 @@ async fn run_stdout_pump(
                 output_state.forget(&output_execution_id);
             }
         }
-        if let Some(execution) = ctx.store.active_execution_for_thread(&thread_key).await? {
-            let execution_span = ctx
-                .execution_spans
-                .lock()
-                .await
-                .get(&execution.execution_id)
-                .cloned();
-            let output_span = output_state.stdout_span_for_execution(
-                execution_span.as_ref(),
-                &thread_key,
-                sandbox_id,
-                &execution.execution_id,
-            );
-            record_terminal_output(
-                &ctx,
-                &thread_key,
-                sandbox_id,
-                &execution.execution_id,
-                TerminalOutput::Failed {
-                    error: "sandbox stdout closed before terminal output".to_owned(),
-                },
-            )
-            .instrument(output_span)
-            .await?;
-            ctx.execution_spans.lock().await.remove(&execution.execution_id);
-            output_state.forget(&execution.execution_id);
-        }
+        let active_execution = ctx.store.active_execution_for_thread(&thread_key).await?;
         ctx.store
             .append_event(
                 &thread_key,
@@ -2507,7 +2797,13 @@ async fn run_stdout_pump(
             output_line_count = line_count,
             "session stdout pump completed"
         );
-        Ok(())
+        match active_execution {
+            Some(execution) => Ok(StdoutPumpEnd::EofActiveExecution {
+                execution: Box::new(execution),
+                lines_pumped: line_count,
+            }),
+            None => Ok(StdoutPumpEnd::Idle),
+        }
     }
     .instrument(span)
     .await
@@ -5400,7 +5696,7 @@ mod adoption_tests {
 
     struct MockBackend {
         ios: Mutex<VecDeque<SandboxIo>>,
-        recorded_output: Vec<String>,
+        recorded_output: std::sync::Mutex<Vec<String>>,
         open_count: AtomicUsize,
         status: std::sync::Mutex<SandboxStatus>,
         create_id: String,
@@ -5413,7 +5709,7 @@ mod adoption_tests {
         fn new(status: SandboxStatus, recorded_output: Vec<String>) -> Self {
             Self {
                 ios: Mutex::new(VecDeque::new()),
-                recorded_output,
+                recorded_output: std::sync::Mutex::new(recorded_output),
                 open_count: AtomicUsize::new(0),
                 status: std::sync::Mutex::new(status),
                 create_id: "mock-sbx".to_owned(),
@@ -5429,6 +5725,14 @@ mod adoption_tests {
 
         fn opens(&self) -> usize {
             self.open_count.load(Ordering::SeqCst)
+        }
+
+        fn set_recorded_output(&self, recorded_output: Vec<String>) {
+            *self.recorded_output.lock().unwrap() = recorded_output;
+        }
+
+        fn set_status(&self, status: SandboxStatus) {
+            *self.status.lock().unwrap() = status;
         }
 
         fn fail_resume(&self) {
@@ -5474,7 +5778,7 @@ mod adoption_tests {
             _id: &SandboxId,
             _since: Option<SystemTime>,
         ) -> SandboxResult<Vec<String>> {
-            Ok(self.recorded_output.clone())
+            Ok(self.recorded_output.lock().unwrap().clone())
         }
 
         async fn status(&self, _id: &SandboxId) -> SandboxResult<SandboxStatus> {
@@ -5520,6 +5824,29 @@ mod adoption_tests {
             Box::pin(stderr_near),
         );
         (io, stdout_far, stdin_far)
+    }
+
+    fn completed_output_lines(result_text: &str) -> Vec<String> {
+        vec![
+            json!({
+                "type": "item.completed",
+                "item": {
+                    "id": "msg-1",
+                    "type": "agentMessage",
+                    "text": result_text,
+                    "phase": "final_answer"
+                }
+            })
+            .to_string(),
+            json!({"type": "turn.completed", "turn": {"id": "turn-1", "status": "completed"}})
+                .to_string(),
+        ]
+    }
+
+    fn completed_output_bytes(result_text: &str) -> Vec<u8> {
+        let mut output = completed_output_lines(result_text).join("\n");
+        output.push('\n');
+        output.into_bytes()
     }
 
     async fn test_store() -> Option<PgSessionStore> {
@@ -5830,6 +6157,152 @@ mod adoption_tests {
 
         first.expect("first pipe ensure should succeed");
         second.expect("second pipe ensure should reuse the first pipe");
+        assert_eq!(backend.opens(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stdout_eof_recovers_terminal_output_from_recorded_logs() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:eof-recorded-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-recorded"), true).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+
+        let runtime = runtime_with(&store, backend.clone());
+        runtime
+            .ensure_session_pipe(&thread_key, "sbx-recorded")
+            .await
+            .expect("open initial pipe");
+        backend.set_recorded_output(completed_output_lines("Recovered from pod logs."));
+        drop(stdout);
+
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
+        let all = events(&store, &thread_key).await;
+        assert!(
+            all.iter()
+                .any(|event| event.event_type == "session.stdout_pump_recovered"),
+            "expected recorded-output recovery event"
+        );
+        assert!(
+            !all.iter()
+                .any(|event| event.event_type == "session.stdout_pump_reattached"),
+            "recorded terminal output should avoid a live reattach"
+        );
+        assert!(
+            !all.iter()
+                .any(|event| event.event_type == "session.execution_failed"),
+            "stdout eof should not fail an active execution when logs contain a terminal turn"
+        );
+        let completed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_completed")
+            .expect("completed event");
+        assert_eq!(
+            completed.payload["result_text"].as_str(),
+            Some("Recovered from pod logs.")
+        );
+        assert_eq!(backend.opens(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stdout_eof_reattaches_and_delivers_late_terminal_output() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:eof-reattach-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-reattach"), true).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (first_io, mut first_stdout, _first_stdin) = mock_io();
+        let (second_io, mut second_stdout, _second_stdin) = mock_io();
+        backend.push_io(first_io).await;
+        backend.push_io(second_io).await;
+
+        let runtime = runtime_with(&store, backend.clone());
+        runtime
+            .ensure_session_pipe(&thread_key, "sbx-reattach")
+            .await
+            .expect("open initial pipe");
+        first_stdout
+            .write_all(b"{\"type\":\"thread.started\",\"thread_id\":\"mock-thread\"}\n")
+            .await
+            .unwrap();
+        drop(first_stdout);
+
+        wait_for_event(&store, &thread_key, "session.stdout_pump_reattached").await;
+        second_stdout
+            .write_all(&completed_output_bytes("Completed after reattach."))
+            .await
+            .unwrap();
+
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
+        let all = events(&store, &thread_key).await;
+        assert!(
+            !all.iter()
+                .any(|event| event.event_type == "session.execution_failed"),
+            "reattached stdout should not produce the old false failure"
+        );
+        let completed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_completed")
+            .expect("completed event");
+        assert_eq!(
+            completed.payload["result_text"].as_str(),
+            Some("Completed after reattach.")
+        );
+        assert_eq!(backend.opens(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stdout_eof_fails_when_sandbox_no_longer_accepts_io() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:eof-gone-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-gone"), true).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+
+        let runtime = runtime_with(&store, backend.clone());
+        runtime
+            .ensure_session_pipe(&thread_key, "sbx-gone")
+            .await
+            .expect("open initial pipe");
+        backend.set_status(SandboxStatus::Gone);
+        drop(stdout);
+
+        wait_for_event(&store, &thread_key, "session.execution_failed").await;
+        let all = events(&store, &thread_key).await;
+        let failed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_failed")
+            .expect("failed event");
+        let error = failed.payload["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("sandbox stdout closed before terminal output"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error.contains("sandbox no longer accepts io"),
+            "expected sandbox status detail: {error}"
+        );
+        assert!(
+            !all.iter()
+                .any(|event| event.event_type == "session.stdout_pump_reattached"),
+            "gone sandbox should not reattach"
+        );
         assert_eq!(backend.opens(), 1);
     }
 


### PR DESCRIPTION
## Summary

Restore the missing api-rs stdout pump recovery behavior from the old closed PR #477, scoped to `centaur-session-runtime`.

- Treat stdout EOF with an active execution as a transport detach instead of immediate harness failure.
- Before reattaching, replay recorded sandbox output with `read_output_since` so terminal output emitted while detached can still complete the execution.
- Reattach the stdout pump under the existing per-sandbox open lock while the sandbox still accepts IO, with bounded retry attempts and `session.stdout_pump_reattached` telemetry.
- Fail only when the sandbox is gone/no longer accepts IO or reattach attempts are exhausted, preserving the existing `sandbox stdout closed before terminal output` failure class with status detail.

## Root Cause

The old combined PR #477 was closed unmerged and split into follow-ups. Main later received startup orphan adoption/replay and pipe-open serialization, but not the live EOF reattach loop. As a result, a Kubernetes attach-stream EOF could still terminalize a running execution even when the sandbox continued and emitted `turn.completed` later.

## Validation

- `cargo test -p centaur-session-runtime`
- `cargo clippy -p centaur-session-runtime --all-targets -- -D warnings`
- `git diff --check`
- `cargo test -p centaur-session-runtime stdout_eof -- --nocapture` (compiled; Postgres-gated bodies skipped locally because `SESSION_RUNTIME_TEST_DATABASE_URL` is not set)
- `just build-one api-rs`

I also attempted the repo-guide local deploy smoke. `just deploy` upgraded Helm successfully, but the new local api-rs pod exited before serving with `Store(Migrate(VersionMismatch(26))`, caused by the existing local DB migration state. I rolled the local deployment back to the previously serving api-rs ReplicaSet; the in-cluster API request was not run because the rebuilt pod could not start against that local DB.