### PR TITLE
feat: add Slack DM context search tool

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0029_slack_dm_conversation_context_documents.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0029_slack_dm_conversation_context_documents.sql
@@ -1,0 +1,422 @@
+create extension if not exists pg_search;
+
+create table if not exists slack_dm_conversation_context_documents (
+    document_id text primary key,
+    home_team_id text not null,
+    conversation_id text not null,
+    conversation_type text not null default '',
+    title text not null default '',
+    body text not null default '',
+    participant_user_ids text[] not null default array[]::text[],
+    participant_labels text[] not null default array[]::text[],
+    participant_count integer not null default 0,
+    is_ext_shared boolean not null default false,
+    last_seen_at timestamptz,
+    source_updated_at timestamptz,
+    content_hash text not null default '',
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (home_team_id, conversation_id),
+    foreign key (home_team_id, conversation_id)
+        references slack_dm_sync_conversations(home_team_id, conversation_id)
+        on delete cascade,
+    check (document_id <> ''),
+    check (home_team_id <> ''),
+    check (conversation_id <> '')
+);
+
+create index if not exists idx_slack_dm_conversation_context_documents_seen
+    on slack_dm_conversation_context_documents (home_team_id, last_seen_at desc);
+
+create index if not exists idx_slack_dm_conversation_context_documents_participants
+    on slack_dm_conversation_context_documents using gin (participant_user_ids);
+
+create index if not exists idx_slack_dm_conversation_context_documents_metadata
+    on slack_dm_conversation_context_documents using gin (metadata);
+
+drop index if exists idx_slack_dm_conversation_context_documents_bm25;
+
+create index idx_slack_dm_conversation_context_documents_bm25
+    on slack_dm_conversation_context_documents
+    using bm25 (
+        document_id,
+        title,
+        body,
+        home_team_id,
+        conversation_id,
+        conversation_type,
+        last_seen_at,
+        source_updated_at,
+        metadata
+    )
+    with (
+        key_field = 'document_id',
+        text_fields = '{
+            "document_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "home_team_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "conversation_id": {
+                "tokenizer": {"type": "keyword"}
+            }
+        }'
+    );
+
+create or replace function centaur_refresh_slack_dm_conversation_context_document(
+    p_home_team_id text,
+    p_conversation_id text
+)
+returns void
+language sql
+as $$
+    with participant_rows as (
+        select
+            c.home_team_id,
+            c.conversation_id,
+            c.conversation_type,
+            c.is_ext_shared,
+            c.last_seen_at,
+            c.updated_at as conversation_updated_at,
+            c.raw_payload as conversation_raw_payload,
+            m.user_id,
+            m.user_team_id,
+            m.is_external,
+            m.updated_at as member_updated_at,
+            u.updated_at as user_updated_at,
+            coalesce(
+                nullif(m.raw_payload ->> 'display_name', ''),
+                nullif(m.raw_payload #>> '{profile,display_name}', ''),
+                nullif(u.display_name, ''),
+                nullif(m.raw_payload ->> 'real_name', ''),
+                nullif(m.raw_payload #>> '{profile,real_name}', ''),
+                nullif(u.real_name, ''),
+                nullif(m.raw_payload ->> 'name', ''),
+                nullif(m.raw_payload #>> '{profile,name}', ''),
+                nullif(u.user_name, ''),
+                m.user_id
+            ) as participant_label,
+            nullif(
+                concat_ws(
+                    ' ',
+                    m.user_id,
+                    m.user_team_id,
+                    m.raw_payload ->> 'display_name',
+                    m.raw_payload #>> '{profile,display_name}',
+                    u.display_name,
+                    m.raw_payload ->> 'real_name',
+                    m.raw_payload #>> '{profile,real_name}',
+                    u.real_name,
+                    m.raw_payload ->> 'name',
+                    m.raw_payload #>> '{profile,name}',
+                    u.user_name,
+                    m.raw_payload ->> 'email',
+                    m.raw_payload #>> '{profile,email}',
+                    u.raw_payload ->> 'email',
+                    u.raw_payload #>> '{profile,email}',
+                    c.conversation_id
+                ),
+                ''
+            ) as participant_search_text
+        from slack_dm_sync_conversations c
+        left join slack_dm_sync_conversation_members m
+          on m.home_team_id = c.home_team_id
+         and m.conversation_id = c.conversation_id
+         and m.is_current_member
+        left join slack_sync_users u
+          on u.user_id = m.user_id
+        where c.home_team_id = p_home_team_id
+          and c.conversation_id = p_conversation_id
+    ),
+    aggregated as (
+        select
+            home_team_id,
+            conversation_id,
+            conversation_type,
+            is_ext_shared,
+            last_seen_at,
+            conversation_updated_at,
+            conversation_raw_payload,
+            coalesce(
+                array_agg(user_id order by participant_label, user_id)
+                    filter (where user_id is not null),
+                array[]::text[]
+            ) as participant_user_ids,
+            coalesce(
+                array_agg(participant_label order by participant_label, user_id)
+                    filter (where participant_label is not null),
+                array[]::text[]
+            ) as participant_labels,
+            count(user_id)::integer as participant_count,
+            string_agg(
+                participant_search_text,
+                E'\n'
+                order by participant_label, user_id
+            ) filter (where participant_search_text is not null) as participant_search_text,
+            coalesce(
+                jsonb_agg(
+                    jsonb_build_object(
+                        'user_id', user_id,
+                        'user_team_id', user_team_id,
+                        'label', participant_label,
+                        'is_external', is_external
+                    )
+                    order by participant_label, user_id
+                ) filter (where user_id is not null),
+                '[]'::jsonb
+            ) as participants,
+            greatest(
+                conversation_updated_at,
+                coalesce(max(member_updated_at), conversation_updated_at),
+                coalesce(max(user_updated_at), conversation_updated_at)
+            ) as source_updated_at
+        from participant_rows
+        group by
+            home_team_id,
+            conversation_id,
+            conversation_type,
+            is_ext_shared,
+            last_seen_at,
+            conversation_updated_at,
+            conversation_raw_payload
+    ),
+    projected as (
+        select
+            concat_ws(':', 'slack_dm_conversation', home_team_id, conversation_id)
+                as document_id,
+            home_team_id,
+            conversation_id,
+            conversation_type,
+            case
+                when participant_count > 0 and conversation_type = 'mpim'
+                    then 'Slack group DM: ' || array_to_string(participant_labels, ', ')
+                when participant_count > 0
+                    then 'Slack DM: ' || array_to_string(participant_labels, ', ')
+                when conversation_type = 'mpim' then 'Slack group DM'
+                else 'Slack DM'
+            end as title,
+            trim(both E'\n' from concat_ws(
+                E'\n',
+                conversation_id,
+                conversation_type,
+                participant_search_text
+            )) as body,
+            participant_user_ids,
+            participant_labels,
+            participant_count,
+            is_ext_shared,
+            last_seen_at,
+            source_updated_at,
+            jsonb_build_object(
+                'source', 'slack_dm_conversation',
+                'home_team_id', home_team_id,
+                'conversation_id', conversation_id,
+                'conversation_type', conversation_type,
+                'participant_count', participant_count,
+                'participant_user_ids', to_jsonb(participant_user_ids),
+                'participant_labels', to_jsonb(participant_labels),
+                'participants', participants,
+                'is_ext_shared', is_ext_shared,
+                'raw_conversation', conversation_raw_payload
+            ) as metadata
+        from aggregated
+    ),
+    hashed as (
+        select
+            projected.*,
+            md5(concat_ws(
+                E'\x1f',
+                title,
+                body,
+                array_to_string(participant_user_ids, E'\x1e'),
+                array_to_string(participant_labels, E'\x1e'),
+                coalesce(last_seen_at::text, ''),
+                metadata::text
+            )) as content_hash
+        from projected
+    )
+    insert into slack_dm_conversation_context_documents (
+        document_id,
+        home_team_id,
+        conversation_id,
+        conversation_type,
+        title,
+        body,
+        participant_user_ids,
+        participant_labels,
+        participant_count,
+        is_ext_shared,
+        last_seen_at,
+        source_updated_at,
+        content_hash,
+        metadata,
+        updated_at
+    )
+    select
+        document_id,
+        home_team_id,
+        conversation_id,
+        conversation_type,
+        title,
+        body,
+        participant_user_ids,
+        participant_labels,
+        participant_count,
+        is_ext_shared,
+        last_seen_at,
+        source_updated_at,
+        content_hash,
+        metadata,
+        now()
+    from hashed
+    on conflict (document_id) do update set
+        home_team_id = excluded.home_team_id,
+        conversation_id = excluded.conversation_id,
+        conversation_type = excluded.conversation_type,
+        title = excluded.title,
+        body = excluded.body,
+        participant_user_ids = excluded.participant_user_ids,
+        participant_labels = excluded.participant_labels,
+        participant_count = excluded.participant_count,
+        is_ext_shared = excluded.is_ext_shared,
+        last_seen_at = excluded.last_seen_at,
+        source_updated_at = excluded.source_updated_at,
+        content_hash = excluded.content_hash,
+        metadata = excluded.metadata,
+        updated_at = now()
+    where slack_dm_conversation_context_documents.content_hash
+        is distinct from excluded.content_hash;
+$$;
+
+create or replace function centaur_refresh_slack_dm_conversation_context_from_conversation()
+returns trigger
+language plpgsql
+as $$
+begin
+    perform centaur_refresh_slack_dm_conversation_context_document(
+        new.home_team_id,
+        new.conversation_id
+    );
+    return new;
+end;
+$$;
+
+create or replace function centaur_refresh_slack_dm_conversation_context_from_member()
+returns trigger
+language plpgsql
+as $$
+declare
+    row_ref record;
+begin
+    if tg_op = 'DELETE' then
+        row_ref := old;
+    else
+        row_ref := new;
+    end if;
+
+    perform centaur_refresh_slack_dm_conversation_context_document(
+        row_ref.home_team_id,
+        row_ref.conversation_id
+    );
+
+    if tg_op = 'DELETE' then
+        return old;
+    end if;
+    return new;
+end;
+$$;
+
+create or replace function centaur_refresh_slack_dm_conversation_context_from_user()
+returns trigger
+language plpgsql
+as $$
+declare
+    row_ref record;
+    membership record;
+begin
+    if tg_op = 'DELETE' then
+        row_ref := old;
+    else
+        row_ref := new;
+    end if;
+
+    for membership in
+        select home_team_id, conversation_id
+        from slack_dm_sync_conversation_members
+        where user_id = row_ref.user_id
+          and is_current_member
+    loop
+        perform centaur_refresh_slack_dm_conversation_context_document(
+            membership.home_team_id,
+            membership.conversation_id
+        );
+    end loop;
+
+    if tg_op = 'DELETE' then
+        return old;
+    end if;
+    return new;
+end;
+$$;
+
+drop trigger if exists trg_slack_dm_conversations_refresh_context
+    on slack_dm_sync_conversations;
+create trigger trg_slack_dm_conversations_refresh_context
+    after insert or update on slack_dm_sync_conversations
+    for each row
+    execute function centaur_refresh_slack_dm_conversation_context_from_conversation();
+
+drop trigger if exists trg_slack_dm_members_refresh_conversation_context
+    on slack_dm_sync_conversation_members;
+create trigger trg_slack_dm_members_refresh_conversation_context
+    after insert or update or delete on slack_dm_sync_conversation_members
+    for each row
+    execute function centaur_refresh_slack_dm_conversation_context_from_member();
+
+drop trigger if exists trg_slack_sync_users_refresh_dm_conversation_context
+    on slack_sync_users;
+create trigger trg_slack_sync_users_refresh_dm_conversation_context
+    after insert or update or delete on slack_sync_users
+    for each row
+    execute function centaur_refresh_slack_dm_conversation_context_from_user();
+
+select centaur_refresh_slack_dm_conversation_context_document(
+    conversations.home_team_id,
+    conversations.conversation_id
+)
+from slack_dm_sync_conversations conversations;
+
+grant select on slack_dm_conversation_context_documents
+    to centaur_slack_reader, centaur_readonly;
+
+alter table slack_dm_conversation_context_documents enable row level security;
+
+drop policy if exists centaur_slack_dm_conversation_context_documents_reader_select
+    on slack_dm_conversation_context_documents;
+create policy centaur_slack_dm_conversation_context_documents_reader_select
+    on slack_dm_conversation_context_documents
+    for select
+    to centaur_slack_reader
+    using (
+        exists (
+            select 1
+            from slack_dm_sync_conversation_members members
+            where members.home_team_id =
+                slack_dm_conversation_context_documents.home_team_id
+              and members.home_team_id = centaur_current_slack_team_id()
+              and members.conversation_id =
+                slack_dm_conversation_context_documents.conversation_id
+              and members.user_id = centaur_current_slack_user_id()
+              and members.is_current_member
+        )
+    );
+
+drop policy if exists centaur_readonly_slack_dm_conversation_context_documents_select
+    on slack_dm_conversation_context_documents;
+create policy centaur_readonly_slack_dm_conversation_context_documents_select
+    on slack_dm_conversation_context_documents
+    for select
+    to centaur_readonly
+    using (false);

--- a/services/api-rs/crates/centaur-session-sqlx/tests/slack_dm_context_rls.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/slack_dm_context_rls.rs
@@ -6,9 +6,12 @@ use std::{
 
 use sqlx::{Connection, Executor, PgConnection, Row};
 
+const SLACK_SYNC_SQL: &str = include_str!("../migrations/0011_slack_sync_tables.sql");
 const SLACK_DM_SYNC_SQL: &str = include_str!("../migrations/0027_slack_dm_sync_tables.sql");
 const SLACK_DM_CONTEXT_DOCUMENTS_SQL: &str =
     include_str!("../migrations/0028_slack_dm_context_documents.sql");
+const SLACK_DM_CONVERSATION_CONTEXT_DOCUMENTS_SQL: &str =
+    include_str!("../migrations/0029_slack_dm_conversation_context_documents.sql");
 
 const RLS_TABLES: &[&str] = &[
     "slack_dm_sync_conversations",
@@ -19,6 +22,7 @@ const RLS_TABLES: &[&str] = &[
     "slack_dm_sync_runs",
     "slack_dm_sync_backfill_jobs",
     "slack_dm_context_documents",
+    "slack_dm_conversation_context_documents",
 ];
 
 #[derive(Debug, PartialEq, Eq)]
@@ -29,6 +33,7 @@ struct VisibleDmRows {
     attachments: Vec<String>,
     checkpoints: Vec<String>,
     context_docs: Vec<String>,
+    conversation_context_docs: Vec<String>,
     runs: i64,
     backfill_jobs: i64,
 }
@@ -49,8 +54,10 @@ async fn slack_dm_rls_requires_current_membership_and_user_setting() -> Result<(
 async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(), Box<dyn Error>> {
     set_search_path(conn, schema).await?;
     create_roles(conn).await?;
+    execute_migration(conn, SLACK_SYNC_SQL).await?;
     execute_migration(conn, SLACK_DM_SYNC_SQL).await?;
     execute_slack_dm_context_documents_migration(conn).await?;
+    execute_slack_dm_conversation_context_documents_migration(conn).await?;
     grant_schema_usage(conn, schema).await?;
 
     assert_rls_enabled(conn).await?;
@@ -81,6 +88,10 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
                 "slack_dm:T_HOME:D_A:1000.000001".to_owned(),
                 "slack_dm:T_HOME:G_MPIM:1000.000003".to_owned(),
             ],
+            conversation_context_docs: vec![
+                "slack_dm_conversation:T_HOME:D_A".to_owned(),
+                "slack_dm_conversation:T_HOME:G_MPIM".to_owned(),
+            ],
             runs: 0,
             backfill_jobs: 0,
         }
@@ -108,6 +119,10 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
             context_docs: vec![
                 "slack_dm:T_HOME:D_B:1000.000002".to_owned(),
                 "slack_dm:T_HOME:G_MPIM:1000.000003".to_owned(),
+            ],
+            conversation_context_docs: vec![
+                "slack_dm_conversation:T_HOME:D_B".to_owned(),
+                "slack_dm_conversation:T_HOME:G_MPIM".to_owned(),
             ],
             runs: 0,
             backfill_jobs: 0,
@@ -149,6 +164,7 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
             attachments: vec![],
             checkpoints: vec![],
             context_docs: vec!["slack_dm:T_OTHER:D_A:1000.000004".to_owned()],
+            conversation_context_docs: vec!["slack_dm_conversation:T_OTHER:D_A".to_owned()],
             runs: 0,
             backfill_jobs: 0,
         }
@@ -252,6 +268,17 @@ async fn execute_slack_dm_context_documents_migration(
     execute_migration(conn, &sql).await
 }
 
+async fn execute_slack_dm_conversation_context_documents_migration(
+    conn: &mut PgConnection,
+) -> Result<(), sqlx::Error> {
+    if pg_search_available(conn).await? {
+        return execute_migration(conn, SLACK_DM_CONVERSATION_CONTEXT_DOCUMENTS_SQL).await;
+    }
+
+    let sql = slack_dm_conversation_context_documents_without_bm25();
+    execute_migration(conn, &sql).await
+}
+
 async fn pg_search_available(conn: &mut PgConnection) -> Result<bool, sqlx::Error> {
     sqlx::query_scalar(
         "select exists (select 1 from pg_available_extensions where name = 'pg_search')",
@@ -277,9 +304,30 @@ fn slack_dm_context_documents_without_bm25() -> String {
     )
 }
 
+fn slack_dm_conversation_context_documents_without_bm25() -> String {
+    let sql = SLACK_DM_CONVERSATION_CONTEXT_DOCUMENTS_SQL.replace(
+        "create extension if not exists pg_search;",
+        "-- search extension unavailable in this test database",
+    );
+    let (before_bm25, rest) = sql
+        .split_once("drop index if exists idx_slack_dm_conversation_context_documents_bm25;")
+        .expect("Slack DM conversation context migration should contain BM25 index block");
+    let (_, after_bm25) = rest
+        .split_once(
+            "create or replace function centaur_refresh_slack_dm_conversation_context_document(",
+        )
+        .expect("Slack DM conversation context migration should define refresh function");
+
+    format!(
+        "{before_bm25}create or replace function \
+         centaur_refresh_slack_dm_conversation_context_document({after_bm25}"
+    )
+}
+
 #[test]
 fn slack_dm_context_documents_test_migration_omits_bm25_when_extension_is_unavailable() {
     let sql = slack_dm_context_documents_without_bm25();
+    let conversation_sql = slack_dm_conversation_context_documents_without_bm25();
 
     assert!(!sql.contains("create extension if not exists pg_search"));
     assert!(!sql.contains("using bm25"));
@@ -287,6 +335,22 @@ fn slack_dm_context_documents_test_migration_omits_bm25_when_extension_is_unavai
     assert!(sql.contains("create table if not exists slack_dm_context_documents"));
     assert!(sql.contains("create or replace function centaur_refresh_slack_dm_context_document("));
     assert!(sql.contains("create policy centaur_slack_dm_context_documents_reader_select"));
+
+    assert!(!conversation_sql.contains("create extension if not exists pg_search"));
+    assert!(!conversation_sql.contains("using bm25"));
+    assert!(!conversation_sql.contains("key_field = 'document_id'"));
+    assert!(
+        conversation_sql
+            .contains("create table if not exists slack_dm_conversation_context_documents")
+    );
+    assert!(conversation_sql.contains(
+        "create or replace function centaur_refresh_slack_dm_conversation_context_document("
+    ));
+    assert!(
+        conversation_sql.contains(
+            "create policy centaur_slack_dm_conversation_context_documents_reader_select"
+        )
+    );
 }
 
 async fn assert_rls_enabled(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
@@ -352,6 +416,10 @@ async fn assert_expected_policies(conn: &mut PgConnection) -> Result<(), sqlx::E
             "centaur_slack_dm_context_documents_reader_select",
         ),
         (
+            "slack_dm_conversation_context_documents",
+            "centaur_slack_dm_conversation_context_documents_reader_select",
+        ),
+        (
             "slack_dm_sync_conversations",
             "centaur_readonly_slack_dm_sync_conversations_select",
         ),
@@ -382,6 +450,10 @@ async fn assert_expected_policies(conn: &mut PgConnection) -> Result<(), sqlx::E
         (
             "slack_dm_context_documents",
             "centaur_readonly_slack_dm_context_documents_select",
+        ),
+        (
+            "slack_dm_conversation_context_documents",
+            "centaur_readonly_slack_dm_conversation_context_documents_select",
         ),
     ] {
         assert!(
@@ -416,6 +488,14 @@ async fn insert_fixture_rows(conn: &mut PgConnection) -> Result<(), sqlx::Error>
             ('T_HOME', 'G_MPIM', 'U_B', true),
             ('T_HOME', 'G_MPIM', 'U_C', false),
             ('T_OTHER', 'D_A', 'U_A', true);
+
+        insert into slack_sync_users
+            (user_id, user_name, real_name, display_name, team_id)
+        values
+            ('U_A', 'alice', 'Alice Example', 'Alice', 'T_HOME'),
+            ('U_B', 'bob', 'Bob Example', 'Bobby', 'T_HOME'),
+            ('U_C', 'charlie', 'Charlie Example', 'Charlie', 'T_HOME'),
+            ('U_OTHER', 'tom', 'Tom Example', 'Tom', 'T_HOME');
 
         insert into slack_dm_sync_runs (run_id, status, broker_credential_id)
         values ('run_a', 'completed', 'bcr_a');
@@ -472,6 +552,31 @@ async fn assert_projected_documents(conn: &mut PgConnection) -> Result<(), sqlx:
     );
     assert_eq!(metadata["attachment_count"], 1);
     assert_eq!(metadata["conversation_type"], "im");
+
+    let conversation_row = sqlx::query(
+        r#"
+        select title, body, participant_labels
+        from slack_dm_conversation_context_documents
+        where document_id = 'slack_dm_conversation:T_HOME:D_A'
+        "#,
+    )
+    .fetch_one(&mut *conn)
+    .await?;
+    let title: String = conversation_row.get("title");
+    let body: String = conversation_row.get("body");
+    let participant_labels: Vec<String> = conversation_row.get("participant_labels");
+    assert!(
+        title.contains("Alice") && title.contains("Tom"),
+        "projected conversation title should contain participant labels"
+    );
+    assert!(
+        body.contains("U_A") && body.contains("Tom"),
+        "projected conversation body should contain ids and searchable names"
+    );
+    assert_eq!(
+        participant_labels,
+        vec!["Alice".to_owned(), "Tom".to_owned()]
+    );
     Ok(())
 }
 
@@ -530,6 +635,11 @@ async fn visible_rows(
             "select coalesce(array_agg(document_id order by document_id), '{}') from slack_dm_context_documents",
         )
         .await?,
+        conversation_context_docs: text_array(
+            &mut tx,
+            "select coalesce(array_agg(document_id order by document_id), '{}') from slack_dm_conversation_context_documents",
+        )
+        .await?,
         runs: count(&mut tx, "slack_dm_sync_runs").await?,
         backfill_jobs: count(&mut tx, "slack_dm_sync_backfill_jobs").await?,
     };
@@ -563,6 +673,7 @@ fn empty_visible_dm_rows() -> VisibleDmRows {
         attachments: vec![],
         checkpoints: vec![],
         context_docs: vec![],
+        conversation_context_docs: vec![],
         runs: 0,
         backfill_jobs: 0,
     }

--- a/tools/productivity/company_context/cli.py
+++ b/tools/productivity/company_context/cli.py
@@ -47,8 +47,12 @@ def search(
     limit: int = typer.Option(10, "--limit", "-n", help="Max results."),
     source: str | None = typer.Option(None, "--source", help="Filter by source."),
     source_type: str | None = typer.Option(None, "--source-type", help="Filter by source type."),
-    occurred_after: str | None = typer.Option(None, "--after", help="Only results on/after this time."),
-    occurred_before: str | None = typer.Option(None, "--before", help="Only results before this time."),
+    occurred_after: str | None = typer.Option(
+        None, "--after", help="Only results on/after this time."
+    ),
+    occurred_before: str | None = typer.Option(
+        None, "--before", help="Only results before this time."
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
     """Search indexed company context documents."""
@@ -81,13 +85,106 @@ def search(
     console.print(table)
 
 
+@app.command("search-dm-conversations")
+def search_dm_conversations(
+    query: str = typer.Argument(..., help="Person, user id, or conversation search query."),
+    limit: int = typer.Option(10, "--limit", "-n", help="Max conversations."),
+    json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
+) -> None:
+    """Find Slack DM/group DM conversations visible to the current user."""
+    result = CompanyContextClient().search_dm_conversations(query=query, limit=limit)
+    _require_ok(result)
+    if json_output:
+        _print_json(result)
+        return
+
+    results = result.get("results") or []
+    if not results:
+        console.print(f"[yellow]No Slack DM conversations found for: {query}[/yellow]")
+        return
+
+    table = Table(title=f"Slack DM Conversations ({len(results)})")
+    table.add_column("Conversation", style="magenta", max_width=16)
+    table.add_column("Type", style="cyan", max_width=10)
+    table.add_column("Participants", style="bold", max_width=42)
+    table.add_column("Matched", max_width=32)
+    table.add_column("Last Seen", style="green", max_width=20)
+    for item in results:
+        table.add_row(
+            str(item.get("conversation_id") or ""),
+            str(item.get("conversation_type") or ""),
+            ", ".join(str(label) for label in item.get("participant_labels") or []),
+            ", ".join(str(label) for label in item.get("matched_labels") or []),
+            str(item.get("last_seen_at") or ""),
+        )
+    console.print(table)
+
+
+@app.command("search-dms")
+def search_dms(
+    query: str = typer.Argument(..., help="Search query."),
+    limit: int = typer.Option(10, "--limit", "-n", help="Max results."),
+    conversation_id: str | None = typer.Option(
+        None,
+        "--conversation-id",
+        help="Filter to one Slack DM/MPIM conversation id.",
+    ),
+    occurred_after: str | None = typer.Option(
+        None, "--after", help="Only results on/after this time."
+    ),
+    occurred_before: str | None = typer.Option(
+        None, "--before", help="Only results before this time."
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
+) -> None:
+    """Search Slack DMs and group DMs visible to the current user."""
+    result = CompanyContextClient().search_dms(
+        query=query,
+        limit=limit,
+        conversation_id=conversation_id,
+        occurred_after=occurred_after,
+        occurred_before=occurred_before,
+    )
+    _require_ok(result)
+    if json_output:
+        _print_json(result)
+        return
+
+    results = result.get("results") or []
+    if not results:
+        console.print(f"[yellow]No Slack DMs found for: {query}[/yellow]")
+        return
+
+    table = Table(title=f"Slack DM Search ({len(results)})")
+    table.add_column("Document ID", style="dim", max_width=40)
+    table.add_column("Conversation", style="magenta", max_width=16)
+    table.add_column("Type", style="cyan", max_width=10)
+    table.add_column("Occurred", style="green", max_width=20)
+    table.add_column("Title", style="bold", max_width=24)
+    table.add_column("Preview", max_width=72)
+    for item in results:
+        table.add_row(
+            str(item.get("document_id") or ""),
+            str(item.get("conversation_id") or ""),
+            str(item.get("conversation_type") or ""),
+            str(item.get("occurred_at") or ""),
+            str(item.get("title") or ""),
+            str(item.get("preview") or ""),
+        )
+    console.print(table)
+
+
 @app.command("list")
 def list_documents(
     limit: int = typer.Option(10, "--limit", "-n", help="Max documents."),
     source: str | None = typer.Option(None, "--source", help="Filter by source."),
     source_type: str | None = typer.Option(None, "--source-type", help="Filter by source type."),
-    occurred_after: str | None = typer.Option(None, "--after", help="Only documents on/after this time."),
-    occurred_before: str | None = typer.Option(None, "--before", help="Only documents before this time."),
+    occurred_after: str | None = typer.Option(
+        None, "--after", help="Only documents on/after this time."
+    ),
+    occurred_before: str | None = typer.Option(
+        None, "--before", help="Only documents before this time."
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
     """List indexed company context documents."""
@@ -123,8 +220,12 @@ def list_documents(
 def read_document(
     document_id: str = typer.Argument(..., help="Document ID returned by search/list."),
     max_chars: int = typer.Option(0, "--max-chars", help="Maximum content chars; 0 means full."),
-    related: bool = typer.Option(False, "--related", help="Include parent/child document summaries."),
-    max_related_children: int = typer.Option(10, "--max-related-children", help="Max related children."),
+    related: bool = typer.Option(
+        False, "--related", help="Include parent/child document summaries."
+    ),
+    max_related_children: int = typer.Option(
+        10, "--max-related-children", help="Max related children."
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
     """Read a company context document."""

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -23,6 +23,7 @@ THREAD_SCORE_MULTIPLIER = 1.25
 CHANNEL_DAY_SCORE_MULTIPLIER = 0.75
 DEFAULT_PREVIEW_CHARS = 280
 MAX_RELATED_CHILDREN = 25
+SLACK_DM_SOURCE = "slack_dm"
 COMPANY_CONTEXT_DSN_ENV = "CENTAUR_POSTGRES_DSN"
 COMPANY_CONTEXT_DATABASE_ENV = "COMPANY_CONTEXT_POSTGRES_DATABASE"
 DEFAULT_POSTGRES_DATABASE = "ai_v2"
@@ -242,6 +243,59 @@ def _document_summary(row: Any) -> dict[str, Any]:
     }
 
 
+def _dm_document_summary(row: Any) -> dict[str, Any]:
+    """Return the common metadata we expose for Slack DM context records."""
+    metadata = _as_dict(_row_value(row, "metadata", {}))
+    conversation_type = str(_row_value(row, "conversation_type", ""))
+    conversation_id = str(_row_value(row, "conversation_id", ""))
+    message_ts = str(_row_value(row, "message_ts", ""))
+    user_id = str(_row_value(row, "user_id", ""))
+    bot_id = str(_row_value(row, "bot_id", ""))
+    return {
+        "document_id": str(_row_value(row, "document_id", "")),
+        "source": SLACK_DM_SOURCE,
+        "source_type": f"slack_{conversation_type}" if conversation_type else SLACK_DM_SOURCE,
+        "source_document_id": conversation_id,
+        "source_chunk_id": message_ts,
+        "parent_document_id": None,
+        "title": str(_row_value(row, "title", "")),
+        "url": str(_row_value(row, "permalink", "")),
+        "author_name": user_id or bot_id,
+        "access_scope": "slack_dm",
+        "occurred_at": _isoformat(_row_value(row, "occurred_at")),
+        "source_updated_at": _isoformat(_row_value(row, "source_updated_at")),
+        "conversation_id": conversation_id,
+        "conversation_type": conversation_type,
+        "message_ts": message_ts,
+        "thread_ts": _row_value(row, "thread_ts"),
+        "user_id": user_id,
+        "bot_id": bot_id,
+        "attachment_count": int(metadata.get("attachment_count") or 0),
+        "metadata": metadata,
+    }
+
+
+def _dm_conversation_summary(row: Any) -> dict[str, Any]:
+    """Return visible metadata for a Slack DM/MPIM conversation."""
+    return {
+        "document_id": str(_row_value(row, "document_id", "")),
+        "source": SLACK_DM_SOURCE,
+        "source_type": "slack_dm_conversation",
+        "home_team_id": str(_row_value(row, "home_team_id", "")),
+        "conversation_id": str(_row_value(row, "conversation_id", "")),
+        "conversation_type": str(_row_value(row, "conversation_type", "")),
+        "title": str(_row_value(row, "title", "")),
+        "is_ext_shared": bool(_row_value(row, "is_ext_shared", False)),
+        "last_seen_at": _isoformat(_row_value(row, "last_seen_at")),
+        "source_updated_at": _isoformat(_row_value(row, "source_updated_at")),
+        "participant_user_ids": list(_row_value(row, "participant_user_ids", []) or []),
+        "participant_labels": list(_row_value(row, "participant_labels", []) or []),
+        "participant_count": int(_row_value(row, "participant_count", 0) or 0),
+        "matched_labels": list(_row_value(row, "matched_labels", []) or []),
+        "metadata": _as_dict(_row_value(row, "metadata", {})),
+    }
+
+
 class CompanyContextClient:
     """Query the shared company context document table."""
 
@@ -419,6 +473,208 @@ class CompanyContextClient:
                     limit=_clamp(limit, minimum=1, maximum=MAX_SEARCH_LIMIT),
                     source=source.strip() if source else None,
                     source_type=source_type.strip() if source_type else None,
+                    occurred_after=parsed_occurred_after,
+                    occurred_before=parsed_occurred_before,
+                )
+            )
+        except Exception as exc:
+            return {"status": "error", "error": str(exc)}
+
+    async def _search_dm_conversations_async(
+        self,
+        *,
+        query: str,
+        limit: int,
+    ) -> dict[str, Any]:
+        conn = await self._connect()
+        try:
+            terms = _search_terms(query)
+            search_terms = [query, *terms]
+            limit_param = len(search_terms) + 1
+            rows = await conn.fetch(
+                f"""
+                SELECT
+                    document_id,
+                    home_team_id,
+                    conversation_id,
+                    conversation_type,
+                    title,
+                    body,
+                    is_ext_shared,
+                    last_seen_at,
+                    source_updated_at,
+                    participant_user_ids,
+                    participant_labels,
+                    participant_count,
+                    metadata,
+                    paradedb.score(document_id) AS score
+                FROM slack_dm_conversation_context_documents
+                WHERE {_search_where_clause(len(terms))}
+                ORDER BY paradedb.score(document_id) DESC,
+                         last_seen_at DESC NULLS LAST,
+                         source_updated_at DESC NULLS LAST
+                LIMIT ${limit_param}
+                """,
+                *search_terms,
+                limit,
+            )
+            results = []
+            query_terms = [term.lower() for term in _search_terms(query)]
+            for row in rows:
+                result = _dm_conversation_summary(row)
+                result["score"] = float(_row_value(row, "score", 0.0) or 0.0)
+                result["preview"] = _body_preview(
+                    str(_row_value(row, "body", "") or ""),
+                    query=query,
+                )
+                result["matched_labels"] = [
+                    label
+                    for label in result["participant_labels"]
+                    if any(term in str(label).lower() for term in query_terms)
+                ]
+                results.append(result)
+            return {
+                "status": "ok",
+                "query": query,
+                "source": SLACK_DM_SOURCE,
+                "count": len(results),
+                "results": results,
+            }
+        finally:
+            await conn.close()
+
+    def search_dm_conversations(
+        self,
+        query: str,
+        limit: int = DEFAULT_SEARCH_LIMIT,
+    ) -> dict:
+        """Find Slack DM and group DM conversations visible to the current Slack user."""
+        normalized_query = query.strip()
+        if not normalized_query:
+            return {"status": "error", "error": "query cannot be empty"}
+
+        try:
+            return asyncio.run(
+                self._search_dm_conversations_async(
+                    query=normalized_query,
+                    limit=_clamp(limit, minimum=1, maximum=MAX_SEARCH_LIMIT),
+                )
+            )
+        except Exception as exc:
+            return {"status": "error", "error": str(exc)}
+
+    async def _search_dms_async(
+        self,
+        *,
+        query: str,
+        limit: int,
+        conversation_id: str | None,
+        occurred_after: datetime | None,
+        occurred_before: datetime | None,
+    ) -> dict[str, Any]:
+        conn = await self._connect()
+        try:
+            terms = _search_terms(query)
+            search_terms = [query, *terms]
+            conversation_id_param = len(search_terms) + 1
+            occurred_after_param = len(search_terms) + 2
+            occurred_before_param = len(search_terms) + 3
+            limit_param = len(search_terms) + 4
+            rows = await conn.fetch(
+                f"""
+                SELECT
+                    document_id,
+                    home_team_id,
+                    conversation_id,
+                    message_ts,
+                    conversation_type,
+                    thread_ts,
+                    parent_message_ts,
+                    is_thread_root,
+                    user_id,
+                    user_team_id,
+                    bot_id,
+                    message_type,
+                    message_subtype,
+                    title,
+                    body,
+                    permalink,
+                    occurred_at,
+                    source_updated_at,
+                    metadata,
+                    paradedb.score(document_id) AS score
+                FROM slack_dm_context_documents
+                WHERE {_search_where_clause(len(terms))}
+                  AND (${conversation_id_param}::text IS NULL
+                       OR conversation_id = ${conversation_id_param})
+                  AND (${occurred_after_param}::timestamptz IS NULL
+                       OR occurred_at >= ${occurred_after_param})
+                  AND (${occurred_before_param}::timestamptz IS NULL
+                       OR occurred_at < ${occurred_before_param})
+                ORDER BY paradedb.score(document_id) DESC,
+                         occurred_at DESC NULLS LAST,
+                         source_updated_at DESC NULLS LAST
+                LIMIT ${limit_param}
+                """,
+                *search_terms,
+                conversation_id,
+                occurred_after,
+                occurred_before,
+                limit,
+            )
+            results = []
+            for row in rows:
+                result = _dm_document_summary(row)
+                result["score"] = float(_row_value(row, "score", 0.0) or 0.0)
+                result["preview"] = _body_preview(
+                    str(_row_value(row, "body", "") or ""),
+                    query=query,
+                )
+                result["lane"] = "indexed"
+                result["result_type"] = str(result["source_type"] or SLACK_DM_SOURCE)
+                results.append(result)
+
+            return {
+                "status": "ok",
+                "query": query,
+                "source": SLACK_DM_SOURCE,
+                "conversation_id": conversation_id,
+                "occurred_after": _isoformat(occurred_after),
+                "occurred_before": _isoformat(occurred_before),
+                "count": len(results),
+                "results": results,
+            }
+        finally:
+            await conn.close()
+
+    def search_dms(
+        self,
+        query: str,
+        limit: int = DEFAULT_SEARCH_LIMIT,
+        conversation_id: str | None = None,
+        occurred_after: str | datetime | None = None,
+        occurred_before: str | datetime | None = None,
+    ) -> dict:
+        """Search Slack DM and group DM context visible to the current Slack user."""
+        normalized_query = query.strip()
+        if not normalized_query:
+            return {"status": "error", "error": "query cannot be empty"}
+
+        try:
+            parsed_occurred_after = _parse_datetime_filter(
+                occurred_after,
+                name="occurred_after",
+            )
+            parsed_occurred_before = _parse_datetime_filter(
+                occurred_before,
+                name="occurred_before",
+            )
+            _validate_date_window(parsed_occurred_after, parsed_occurred_before)
+            return asyncio.run(
+                self._search_dms_async(
+                    query=normalized_query,
+                    limit=_clamp(limit, minimum=1, maximum=MAX_SEARCH_LIMIT),
+                    conversation_id=conversation_id.strip() if conversation_id else None,
                     occurred_after=parsed_occurred_after,
                     occurred_before=parsed_occurred_before,
                 )

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "company_context"
-description = "Search indexed company history across multiple sources. Prefer this over direct Slack search for historical queries. Current sources: Slack, Google Drive, Google Calendar, Linear."
+description = "Search indexed company history and user-visible Slack DMs. Prefer this over direct Slack search for historical queries. Current sources: Slack, Slack DMs, Google Drive, Google Calendar, Linear."
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -285,6 +285,233 @@ def test_search_rejects_inverted_occurred_at_filter():
     }
 
 
+@pytest.mark.parametrize("query", ["", "   "])
+def test_search_dms_rejects_empty_query(query):
+    result = CompanyContextClient("postgresql://example").search_dms(query)
+
+    assert result == {"status": "error", "error": "query cannot be empty"}
+
+
+@pytest.mark.parametrize("query", ["", "   "])
+def test_search_dm_conversations_rejects_empty_query(query):
+    result = CompanyContextClient("postgresql://example").search_dm_conversations(query)
+
+    assert result == {"status": "error", "error": "query cannot be empty"}
+
+
+def test_search_dm_conversations_queries_projection(monkeypatch):
+    last_seen_at = dt.datetime(2026, 5, 8, 12, 0, tzinfo=dt.UTC)
+    source_updated_at = dt.datetime(2026, 5, 8, 12, 5, tzinfo=dt.UTC)
+    fake = _FakeConnection(
+        rows=[
+            {
+                "document_id": "slack_dm_conversation:T_HOME:D123",
+                "home_team_id": "T_HOME",
+                "conversation_id": "D123",
+                "conversation_type": "im",
+                "title": "Slack DM: Akshaan, Tom",
+                "body": "D123 U_SELF Akshaan U_TOM Tom tom@example.com",
+                "is_ext_shared": False,
+                "last_seen_at": last_seen_at,
+                "source_updated_at": source_updated_at,
+                "participant_user_ids": ["U_SELF", "U_TOM"],
+                "participant_labels": ["Akshaan", "Tom"],
+                "participant_count": 2,
+                "metadata": {"source": "slack_dm_conversation"},
+                "score": 3.25,
+            }
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").search_dm_conversations(
+        " Tom ",
+        limit=500,
+    )
+
+    assert result == {
+        "status": "ok",
+        "query": "Tom",
+        "source": "slack_dm",
+        "count": 1,
+        "results": [
+            {
+                "document_id": "slack_dm_conversation:T_HOME:D123",
+                "source": "slack_dm",
+                "source_type": "slack_dm_conversation",
+                "home_team_id": "T_HOME",
+                "conversation_id": "D123",
+                "conversation_type": "im",
+                "title": "Slack DM: Akshaan, Tom",
+                "is_ext_shared": False,
+                "last_seen_at": "2026-05-08T12:00:00+00:00",
+                "source_updated_at": "2026-05-08T12:05:00+00:00",
+                "participant_user_ids": ["U_SELF", "U_TOM"],
+                "participant_labels": ["Akshaan", "Tom"],
+                "participant_count": 2,
+                "matched_labels": ["Tom"],
+                "metadata": {"source": "slack_dm_conversation"},
+                "score": 3.25,
+                "preview": "D123 U_SELF Akshaan U_TOM Tom tom@example.com",
+            }
+        ],
+    }
+    query, args = fake.fetch_calls[0]
+    assert "FROM slack_dm_conversation_context_documents" in query
+    assert "title ||| $1::text::pdb.boost(8) OR body ||| $1::text::pdb.boost(2)" in query
+    assert "OR (title ||| $2::text::pdb.boost(4) OR body ||| $2::text)" in query
+    assert "LIMIT $3" in query
+    assert "centaur_search_slack_dm_conversations" not in query
+    assert args == ("Tom", "Tom", 50)
+    assert fake.closed is True
+
+
+def test_search_dms_queries_bm25_and_returns_compact_results(monkeypatch):
+    occurred_at = dt.datetime(2026, 5, 8, 12, 0, tzinfo=dt.UTC)
+    source_updated_at = dt.datetime(2026, 5, 8, 12, 5, tzinfo=dt.UTC)
+    fake = _FakeConnection(
+        rows=[
+            {
+                "document_id": "slack_dm:T_HOME:D123:1770000000.000000",
+                "home_team_id": "T_HOME",
+                "conversation_id": "D123",
+                "message_ts": "1770000000.000000",
+                "conversation_type": "im",
+                "thread_ts": None,
+                "user_id": "U123",
+                "bot_id": "",
+                "title": "Slack DM",
+                "body": "launch plan\nAlpha attachment",
+                "permalink": "https://slack.example/archives/D123/p1770000000000000",
+                "occurred_at": occurred_at,
+                "source_updated_at": source_updated_at,
+                "metadata": {"attachment_count": 1, "conversation_type": "im"},
+                "score": 2.5,
+            }
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").search_dms(
+        "launch plan",
+        limit=5,
+        conversation_id=" D123 ",
+    )
+
+    assert result == {
+        "status": "ok",
+        "query": "launch plan",
+        "source": "slack_dm",
+        "conversation_id": "D123",
+        "occurred_after": None,
+        "occurred_before": None,
+        "count": 1,
+        "results": [
+            {
+                "document_id": "slack_dm:T_HOME:D123:1770000000.000000",
+                "source": "slack_dm",
+                "source_type": "slack_im",
+                "source_document_id": "D123",
+                "source_chunk_id": "1770000000.000000",
+                "parent_document_id": None,
+                "title": "Slack DM",
+                "url": "https://slack.example/archives/D123/p1770000000000000",
+                "author_name": "U123",
+                "access_scope": "slack_dm",
+                "occurred_at": "2026-05-08T12:00:00+00:00",
+                "source_updated_at": "2026-05-08T12:05:00+00:00",
+                "conversation_id": "D123",
+                "conversation_type": "im",
+                "message_ts": "1770000000.000000",
+                "thread_ts": None,
+                "user_id": "U123",
+                "bot_id": "",
+                "attachment_count": 1,
+                "metadata": {"attachment_count": 1, "conversation_type": "im"},
+                "score": 2.5,
+                "preview": "launch plan Alpha attachment",
+                "lane": "indexed",
+                "result_type": "slack_im",
+            }
+        ],
+    }
+    query, args = fake.fetch_calls[0]
+    assert "FROM slack_dm_context_documents" in query
+    assert "title ||| $1::text::pdb.boost(8) OR body ||| $1::text::pdb.boost(2)" in query
+    assert "OR (title ||| $2::text::pdb.boost(4) OR body ||| $2::text)" in query
+    assert "OR (title ||| $3::text::pdb.boost(4) OR body ||| $3::text)" in query
+    assert "conversation_id = $4" in query
+    assert "OR occurred_at >= $5" in query
+    assert "OR occurred_at < $6" in query
+    assert "LIMIT $7" in query
+    assert "centaur.slack_user_id" not in query
+    assert "centaur.slack_team_id" not in query
+    assert args == ("launch plan", "launch", "plan", "D123", None, None, 5)
+    assert fake.closed is True
+
+
+def test_search_dms_applies_occurred_at_filters(monkeypatch):
+    fake = _FakeConnection(rows=[])
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").search_dms(
+        "planning",
+        limit=4,
+        occurred_after="2026-05-01",
+        occurred_before="2026-05-08T12:30:00Z",
+    )
+
+    assert result["status"] == "ok"
+    assert result["occurred_after"] == "2026-05-01T00:00:00+00:00"
+    assert result["occurred_before"] == "2026-05-08T12:30:00+00:00"
+    _, args = fake.fetch_calls[0]
+    assert args == (
+        "planning",
+        "planning",
+        None,
+        dt.datetime(2026, 5, 1, tzinfo=dt.UTC),
+        dt.datetime(2026, 5, 8, 12, 30, tzinfo=dt.UTC),
+        4,
+    )
+
+
+def test_search_dms_rejects_invalid_occurred_at_filter():
+    result = CompanyContextClient("postgresql://example").search_dms(
+        "planning",
+        occurred_after="not-a-date",
+    )
+
+    assert result == {
+        "status": "error",
+        "error": "occurred_after must be an ISO 8601 date or timestamp",
+    }
+
+
+def test_search_dms_rejects_inverted_occurred_at_filter():
+    result = CompanyContextClient("postgresql://example").search_dms(
+        "planning",
+        occurred_after="2026-05-08",
+        occurred_before="2026-05-01",
+    )
+
+    assert result == {
+        "status": "error",
+        "error": "occurred_after must be earlier than occurred_before",
+    }
+
+
 def test_list_documents_returns_date_bounded_document_summaries(monkeypatch):
     fake = _FakeConnection(
         rows=[


### PR DESCRIPTION
## Summary
- add `slack_dm_conversation_context_documents`, a BM25-indexed projection for visible Slack DM/MPIM conversation resolution
- refresh conversation projection rows from conversation, membership, and Slack user-profile changes, with RLS matching current Slack membership
- add `company_context.search_dm_conversations` / `company_context search-dm-conversations` to resolve people/conversations before searching messages
- add `company_context.search_dms` / `company_context search-dms` for BM25 search over `slack_dm_context_documents`, with optional conversation/time filters

## Tests
- `uvx ruff check tools/productivity/company_context/client.py tools/productivity/company_context/cli.py tools/productivity/company_context/tests/test_client.py`
- `python3 -m compileall -q tools/productivity/company_context`
- `uv run --with pytest --with asyncpg --with rich --with typer --with python-dotenv --with slack-sdk pytest tools/productivity/company_context/tests/test_client.py`
- `cargo test -p centaur-session-sqlx --test slack_dm_context_rls -- --nocapture`
- `SESSION_SQLX_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/postgres cargo test -p centaur-session-sqlx --test slack_dm_context_rls -- --nocapture`
