### PR TITLE
fix: expose Slack upload context to agents

### DIFF
--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1437,6 +1437,10 @@ function codexInputContent(
   contextPreamble?: string
 ): JsonValue[] {
   const content: JsonValue[] = []
+  const slackSessionContext = slackUploadSessionContext(message.threadId)
+  if (slackSessionContext) {
+    content.push({ type: 'text', text: slackSessionContext })
+  }
   const requesterContext = requesterIdentityContext(requesterIdentity)
   if (requesterContext) {
     content.push({ type: 'text', text: requesterContext })
@@ -1468,6 +1472,45 @@ function codexInputContent(
     content.push(codexAttachmentInput(attachment, staged.get(attachment)))
   }
   return content.length > 0 ? content : [{ type: 'text', text: 'continue' }]
+}
+
+type SlackThreadDestination = {
+  channelId: string
+  teamId?: string
+  threadTs: string
+}
+
+function slackUploadSessionContext(threadId: string): string | undefined {
+  const destination = slackThreadDestination(threadId)
+  if (!destination) return undefined
+
+  const lines = [
+    '# Slack Session Context',
+    '',
+    'API-owned Slack upload destination for this turn:',
+    ...(destination.teamId ? [`- session_context.slack.team_id: ${destination.teamId}`] : []),
+    `- session_context.slack.channel_id: ${destination.channelId}`,
+    `- session_context.slack.thread_ts: ${destination.threadTs}`,
+    `- thread_key: ${threadId}`,
+    '',
+    'Use these exact IDs for Slack file uploads in this thread.',
+    `Example: slack upload ${destination.channelId} /path/to/file --thread ${destination.threadTs}`,
+    'Do not recover this destination with Slack search.',
+    '---'
+  ]
+  return lines.join('\n')
+}
+
+function slackThreadDestination(threadId: string): SlackThreadDestination | undefined {
+  const parts = threadId.split(':')
+  if (parts[0] !== 'slack') return undefined
+  if (parts.length === 3 && parts[1] && parts[2]) {
+    return { channelId: parts[1], threadTs: parts[2] }
+  }
+  if (parts.length === 4 && parts[1] && parts[2] && parts[3]) {
+    return { teamId: parts[1], channelId: parts[2], threadTs: parts[3] }
+  }
+  return undefined
 }
 
 function slackThreadContext(

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -35,6 +35,14 @@ const CHANNEL_ID = 'C000000001'
 /** How real Slack renders a streamed message whose stream broke or was never stopped. */
 const BROKEN_STREAM_TEXT = ':warning: Something went wrong'
 
+function contentTextWithHeading(
+  content: Array<{ text?: string; type: string }>,
+  heading: string
+): string {
+  return content.find(part => typeof part.text === 'string' && part.text.includes(heading))?.text
+    ?? ''
+}
+
 describe('normalizeSlackText', () => {
   it('preserves Slack channel IDs when rendering labeled channel mentions', () => {
     expect(normalizeSlackText('<#C0AJ07U8Z1N|eng-centaur>')).toBe(
@@ -474,12 +482,13 @@ describe('slackbotv2', () => {
     const input = JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!) as {
       message: { content: Array<{ text?: string; type: string }> }
     }
-    expect(input.message.content[0]?.text).toContain('# Requester Context')
-    expect(input.message.content[0]?.text).toContain(`Slack user ID: ${USER_ID}`)
-    expect(input.message.content[0]?.text).toContain('Slack username: akshaan')
-    expect(input.message.content[0]?.text).toContain('GitHub handle from Slack profile: @decofe')
-    expect(input.message.content[0]?.text).toContain('Prompted by: @decofe')
-    expect(input.message.content[1]?.text).toBe(`@${BOT_USER_ID} what is my name?`)
+    const requesterContext = contentTextWithHeading(input.message.content, '# Requester Context')
+    expect(requesterContext).toContain('# Requester Context')
+    expect(requesterContext).toContain(`Slack user ID: ${USER_ID}`)
+    expect(requesterContext).toContain('Slack username: akshaan')
+    expect(requesterContext).toContain('GitHub handle from Slack profile: @decofe')
+    expect(requesterContext).toContain('Prompted by: @decofe')
+    expect(input.message.content.at(-1)?.text).toBe(`@${BOT_USER_ID} what is my name?`)
   })
 
   it('caches Slack requester identity across mentions from the same user', async () => {
@@ -523,7 +532,9 @@ describe('slackbotv2', () => {
       const input = JSON.parse(execute.body.input_lines.at(-1)!) as {
         message: { content: Array<{ text?: string; type: string }> }
       }
-      expect(input.message.content[0]?.text).toContain('GitHub handle from Slack profile: @decofe')
+      expect(contentTextWithHeading(input.message.content, '# Requester Context')).toContain(
+        'GitHub handle from Slack profile: @decofe'
+      )
     }
   })
 
@@ -603,8 +614,8 @@ describe('slackbotv2', () => {
     const replyInput = JSON.parse(codexApi.executes[1]!.body.input_lines.at(-1)!) as {
       message: { content: Array<{ text?: string; type: string }> }
     }
-    const rootContext = rootInput.message.content[0]?.text ?? ''
-    const replyContext = replyInput.message.content[0]?.text ?? ''
+    const rootContext = contentTextWithHeading(rootInput.message.content, '# Requester Context')
+    const replyContext = contentTextWithHeading(replyInput.message.content, '# Requester Context')
 
     expect(rootContext).toContain(`Slack user ID: ${USER_ID}`)
     expect(rootContext).toContain('GitHub handle from Slack profile: @alice-gh')

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -122,6 +122,10 @@ function lineContent(line: JsonObject): JsonObject[] {
   return Array.isArray(message.content) ? message.content.filter(isJsonRecord) : []
 }
 
+function textPartIncludes(part: JsonObject, text: string): boolean {
+  return typeof part.text === 'string' && part.text.includes(text)
+}
+
 function isJsonRecord(value: JsonValue | undefined): value is JsonObject {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
@@ -199,6 +203,36 @@ describe('Slack display text fallback', () => {
       })
     )
     expect(lineContent(line).at(-1)).toEqual({ type: 'text', text: expected })
+  })
+
+  test('includes API-owned Slack upload destination in visible Codex input', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('make an image')))
+
+    const context = lineContent(executeLine(requests)).find(part =>
+      typeof part.text === 'string' && part.text.includes('# Slack Session Context')
+    )
+    expect(context?.text).toContain('session_context.slack.channel_id: C1')
+    expect(context?.text).toContain('session_context.slack.thread_ts: 1700000000.000100')
+    expect(context?.text).toContain('thread_key: slack:C1:1700000000.000100')
+    expect(context?.text).toContain('slack upload C1 /path/to/file --thread 1700000000.000100')
+    expect(context?.text).toContain('Do not recover this destination with Slack search.')
+  })
+
+  test('includes team id for team-qualified Slack thread keys', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('make an image', { threadId: 'slack:T1:C1:1700000000.000100' }))
+    )
+
+    const context = lineContent(executeLine(requests)).find(part =>
+      typeof part.text === 'string' && part.text.includes('# Slack Session Context')
+    )
+    expect(context?.text).toContain('session_context.slack.team_id: T1')
+    expect(context?.text).toContain('session_context.slack.channel_id: C1')
+    expect(context?.text).toContain('session_context.slack.thread_ts: 1700000000.000100')
+    expect(context?.text).toContain('thread_key: slack:T1:C1:1700000000.000100')
   })
 
   test('uses raw Slack block text in prior thread context instead of no text', async () => {
@@ -368,7 +402,7 @@ describe('forwardToSessionApi overrides', () => {
     expect(inputLines).toHaveLength(1)
     const line = JSON.parse(inputLines[0]!)
     expect(line.model).toBe('claude-sonnet-4-6')
-    expect(line.message.content[0].text).toContain('# Requester Context')
+    expect(lineContent(line).some(part => textPartIncludes(part, '# Requester Context'))).toBe(true)
     expect(line.message.content.at(-1)).toEqual({ type: 'text', text: 'review this' })
   })
 
@@ -514,15 +548,20 @@ describe('forwardToSessionApi harness restart', () => {
     expect(restarted).toBe(true)
     const execute = requests.find(request => request.url.endsWith('/execute'))
     const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
-    const [requesterContext, preamble, current] = line.message.content
-    expect(requesterContext.type).toBe('text')
-    expect(requesterContext.text).toContain('# Requester Context')
-    expect(requesterContext.text).not.toContain('restarted on a different agent harness')
-    expect(preamble.type).toBe('text')
-    expect(preamble.text).toContain('restarted on a different agent harness')
-    expect(preamble.text).toContain('[test]: earlier question')
-    expect(preamble.text).toContain('[assistant]: earlier answer')
-    expect(preamble.text).not.toContain('continue with codex')
+    const content = lineContent(line)
+    const requesterContext = content.find(part => textPartIncludes(part, '# Requester Context'))
+    const preamble = content.find(part =>
+      textPartIncludes(part, 'restarted on a different agent harness')
+    )
+    const current = content.at(-1)
+    expect(requesterContext?.type).toBe('text')
+    expect(requesterContext?.text).toContain('# Requester Context')
+    expect(requesterContext?.text).not.toContain('restarted on a different agent harness')
+    expect(preamble?.type).toBe('text')
+    expect(preamble?.text).toContain('restarted on a different agent harness')
+    expect(preamble?.text).toContain('[test]: earlier question')
+    expect(preamble?.text).toContain('[assistant]: earlier answer')
+    expect(preamble?.text).not.toContain('continue with codex')
     expect(current).toEqual({ type: 'text', text: 'continue with codex' })
   })
 
@@ -538,8 +577,11 @@ describe('forwardToSessionApi harness restart', () => {
     expect(restarted).toBe(false)
     const execute = requests.find(request => request.url.endsWith('/execute'))
     const line = JSON.parse((execute?.body as { input_lines: string[] }).input_lines[0]!)
-    expect(line.message.content[0].text).toContain('# Requester Context')
-    expect(line.message.content[0].text).not.toContain('restarted on a different agent harness')
+    const requesterContext = lineContent(line).find(part =>
+      textPartIncludes(part, '# Requester Context')
+    )
+    expect(requesterContext?.text).toContain('# Requester Context')
+    expect(requesterContext?.text).not.toContain('restarted on a different agent harness')
     expect(line.message.content.at(-1)).toEqual({ type: 'text', text: 'plain message' })
   })
 })


### PR DESCRIPTION
## Summary

- add a visible Slack Session Context block to Slackbot execute input, derived from the API-owned thread id
- include channel id, optional team id, thread timestamp, thread key, and the explicit slack upload command shape
- update Slackbot tests to assert the upload destination is visible and avoid relying on requester context being the first content block

## Root cause

Slackbot passed thread_key on the NDJSON envelope, and api-rs/harness-server consumed it as operational trace metadata. The agent-visible content only included requester metadata, thread history, and the user text, so the new upload guardrail correctly refused because it could not see session_context.slack.channel_id or session_context.slack.thread_ts.

## Validation

- bun test test/session-api.test.ts test/chat-sdk-emulate.test.ts
- pnpm --dir services/slackbotv2 check:types