### PR TITLE
feat: add tool CLI health commands

### DIFF
--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -23,9 +23,8 @@ The smoke test passes only when all core workflows work from the running agent s
 - Slack overall message search works.
 - Current thread history works.
 - Company context can connect to the Paradigm database and return indexed documents or a valid empty result.
-- AI-team critical tools load as packaged CLIs and can initialize with brokered auth.
-- AlphaSense, PitchBook, and company context connectivity checks exercise real authenticated paths.
-- PitchBook validation uses a real `/search?query=...` call, not `pitchbook health` or `GET /`; PitchBook may return a benign 404 for non-endpoint root/health probes.
+- AI-team critical tools load as packaged CLIs and pass their `health` commands through brokered auth.
+- Focused tool validation uses `<tool> health` as the canonical smoke surface. Do not invent ad hoc probes or substitute raw endpoint/search calls unless a health check fails and you are triaging that failure.
 - VictoriaLogs and VictoriaMetrics are reachable, and VictoriaMetrics proves metric existence without asserting exact metric values.
 
 Treat auth, permission, DNS, schema, and timeout errors as failures. Treat empty search results as warnings only when the tool successfully queried the backing service.
@@ -205,17 +204,26 @@ alphasense --help
 company_context --help
 ```
 
-Then exercise authenticated paths without requiring local env-only secrets:
+Then exercise each tool's focused health command without requiring local env-only secrets:
 
 ```bash
-env -u PITCHBOOK_API_KEY pitchbook raw GET /search --params-json '{"query":"Anduril Industries","perPage":3}' --json
-alphasense whoami
-alphasense search "NVIDIA data center demand" --limit 3
-company_context list --limit 3 --json
-company_context search "paradigm" --limit 3 --json
+env -u PITCHBOOK_API_KEY pitchbook health
+alphasense health
+company_context health
 ```
 
-Pass only when each command reaches the intended upstream and returns a valid success or valid empty result. For PitchBook, require the `/search` command to return structured JSON for the search request; `pitchbook health` and `pitchbook raw GET /` are not valid QA checks because the PitchBook API root/health path may return a benign 404. Fail when a CLI import/package error prevents startup, a client crashes because an env var is absent despite brokered auth being expected, an authenticated real endpoint returns `401`/`403`, or company context returns upstream/proxy errors.
+Pass only when each health command exits zero and returns valid JSON with `ok: true`. Fail when a CLI import/package error prevents startup, a client crashes because an env var is absent despite brokered auth being expected, an authenticated real endpoint returns `401`/`403`, or company context returns upstream/proxy errors.
+
+If a health command fails, triage the specific failing tool with the smallest safe read-only command that exercises the same path. Examples:
+
+```bash
+pitchbook --help
+alphasense --help
+company_context --help
+vlogs tool_calls --tool-name pitchbook --start 2h
+```
+
+Only run bespoke search or raw endpoint calls after recording the failed health result and only when needed to classify the failure.
 
 ## Extended Checks
 
@@ -308,8 +316,9 @@ responses; Slack does not render them reliably. Use this exact shape:
 - *VictoriaMetrics:* PASS - reachable, metric existence confirmed, series found
 
 *AI Tools*
-- *PitchBook:* PASS - CLI imports, brokered-auth `/search` query returned structured JSON
-- *AlphaSense:* PASS - whoami ok, search returned results
+- *PitchBook:* PASS - health ok, brokered auth path reached
+- *AlphaSense:* PASS - health ok, authenticated upstream reached
+- *Company context:* PASS - health ok, database path reached
 
 *Extended*
 - *Requested extended checks:* SKIP - not requested
@@ -351,8 +360,8 @@ one Slack message.
 | Search cannot find just-uploaded token | Slack search indexing lag | Retry up to three total attempts, then warn and run the separate overall message search |
 | `company_context` permission denied | Principal lacks DB-backed reader grant | Report principal/channel and ask owner to grant company context access |
 | `company_context` upstream connection failed | Database proxy upstream, database selection, or secret-resolution failure | Check thread logs and vlogs for upstream connect and secret fetch errors before proposing a code change |
-| Tool CLI import error | Package entrypoint or relative import packaging regression | Run `<tool> --help`, package build checks, and report the broken console script |
-| Tool crashes when an API key env var is absent | Client assumes local env auth despite brokered credentials | Re-run with the env var unset and verify client construction does not raise |
+| Tool CLI import error | Package entrypoint or relative import packaging regression | Run `<tool> health`, `<tool> --help`, package build checks, and report the broken console script |
+| Tool crashes when an API key env var is absent | Client assumes local env auth despite brokered credentials | Re-run `<tool> health` with the env var unset and verify client construction does not raise |
 | AlphaSense `/auth` or `/gql` returns 401/403 | Upstream credential or header injection problem | Compare `/auth` and GraphQL logs; verify bearer/client headers reach the expected upstream path |
 | `vlogs` or `vmetrics` DNS failure | Observability service unavailable from sandbox | Check local stack or cluster service deployment |
 | Expected tools missing | Tool catalog did not load or overlay masked base tools | Report the missing tool names and include `centaur-tools list` output |
@@ -375,7 +384,8 @@ When a flow fails, inspect runtime evidence before redesigning:
 
 | Reference | When To Read |
 |-----------|--------------|
-| [references/test-inputs.md](references/test-inputs.md) | When doing broader tool-by-tool QA beyond the smoke test |
+| [../tool-health-smoke/SKILL.md](../tool-health-smoke/SKILL.md) | When doing broad all-tool health smoke coverage |
+| [references/test-inputs.md](references/test-inputs.md) | Only for deeper read-only triage after a tool health check fails |
 
 ## Templates
 

--- a/.agents/skills/qa/references/test-inputs.md
+++ b/.agents/skills/qa/references/test-inputs.md
@@ -1,6 +1,12 @@
 # Test Inputs by Tool Category
 
-Default test inputs to use when QA'ing tools. Use these as starting points — adjust based on what the tool's method schema requires.
+Default test inputs to use only when triaging a failed tool `health` check or when the user explicitly requests deeper per-method coverage. Do not use these as the first-pass smoke test. First run:
+
+```bash
+<tool> health
+```
+
+Use the inputs below only after recording the health result and only for safe read-only follow-up checks.
 
 ## Database / Structured-Data Tools
 
@@ -107,8 +113,9 @@ Tools: `gsuite`
 
 ## General Rules
 
-1. **Always use `limit: 2` or `3`** to keep responses small
-2. **Use well-known addresses** for blockchain lookups (vitalik.eth, WETH contract)
-3. **Use broad search terms** that are likely to return results ("bitcoin", "ethereum", "open source")
-4. **Never use real credentials** as test inputs
-5. **Prefer read-only methods** — skip anything that creates, updates, or deletes
+1. **Run `<tool> health` first** and keep the health output as the primary smoke result.
+2. **Always use `limit: 2` or `3`** to keep responses small.
+3. **Use well-known addresses** for blockchain lookups (vitalik.eth, WETH contract).
+4. **Use broad search terms** that are likely to return results ("bitcoin", "ethereum", "open source").
+5. **Never use real credentials** as test inputs.
+6. **Prefer read-only methods**. Skip anything that creates, updates, or deletes.

--- a/.agents/skills/tool-health-smoke/SKILL.md
+++ b/.agents/skills/tool-health-smoke/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tool-health-smoke
+description: "Run a focused Centaur tool health smoke test across every live tool CLI. Use when asked to smoke test tools, check all tool auth/connectivity, validate brokered credential injection, or produce a Slack-ready health report for the current deployment."
+---
+
+# Tool Health Smoke
+
+## Overview
+
+Use this skill for broad tool-by-tool smoke checks. It is narrower than the full `qa` skill: it only verifies that each live tool CLI is installed and that its `health` command succeeds through the normal sandbox credential path.
+
+Do not invent one-off probes for each tool. The canonical smoke surface is:
+
+```bash
+<tool> health
+```
+
+## Workflow
+
+1. Run the bundled runner from a sandbox or environment where `centaur-tools` and tool shims are installed:
+
+   ```bash
+   uv run .agents/skills/tool-health-smoke/scripts/run_tool_health_smoke.py
+   ```
+
+2. The runner discovers tools with `centaur-tools json`, then executes each `<tool> health` command with a bounded timeout.
+
+3. Review the generated Slack-friendly report. The first line is the overall result:
+
+   ```text
+   Overall: PASS|FAIL|PARTIAL - <reason>
+   ```
+
+4. Return the report in the Slack thread as the assistant response. Do not call the Slack posting API unless the user explicitly asks you to post through the Slack tool.
+
+## Report Rules
+
+- Treat `returncode != 0`, invalid JSON, missing `ok`, or `ok: false` as a failed tool health check.
+- Treat a missing `health` command as a failure. Tools are expected to expose `health`.
+- Do not paste raw JSON, stack traces, credentials, or full command output into Slack.
+- Keep evidence compact: include the tool name, status, and one short detail or error.
+- Use Slack mrkdwn bullets, not Markdown tables.
+- Include all failed rows. If all tools pass, include a compact pass list or pass count.
+
+## Useful Options
+
+```bash
+uv run .agents/skills/tool-health-smoke/scripts/run_tool_health_smoke.py --timeout 45
+uv run .agents/skills/tool-health-smoke/scripts/run_tool_health_smoke.py --concurrency 4
+uv run .agents/skills/tool-health-smoke/scripts/run_tool_health_smoke.py --only slack,websearch,vlogs
+uv run .agents/skills/tool-health-smoke/scripts/run_tool_health_smoke.py --json
+```
+
+Use `--json` only when you need machine-readable results for follow-up analysis. Use the default text output for Slack.
+
+## Interpreting Results
+
+- `PASS`: every discovered tool health command returned valid JSON with `ok: true`.
+- `FAIL`: one or more tools failed, timed out, returned malformed output, or omitted the required health result.
+- `PARTIAL`: discovery succeeded but no tools were found, or the run was intentionally filtered.
+
+When a tool fails because a credential is missing, check whether the client incorrectly requires an environment variable instead of using `secret()` or proxy-injected auth.

--- a/.agents/skills/tool-health-smoke/SKILL.md
+++ b/.agents/skills/tool-health-smoke/SKILL.md
@@ -37,7 +37,7 @@ Do not invent one-off probes for each tool. The canonical smoke surface is:
 
 - Treat `returncode != 0`, invalid JSON, missing `ok`, or `ok: false` as a failed tool health check.
 - Treat a missing `health` command as a failure. Tools are expected to expose `health`.
-- Do not paste raw JSON, stack traces, credentials, or full command output into Slack.
+- Report the runner output directly. Health commands are responsible for returning compact, safe JSON.
 - Keep evidence compact: include the tool name, status, and one short detail or error.
 - Use Slack mrkdwn bullets, not Markdown tables.
 - Include all failed rows. If all tools pass, include a compact pass list or pass count.

--- a/.agents/skills/tool-health-smoke/agents/openai.yaml
+++ b/.agents/skills/tool-health-smoke/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Tool Health Smoke"
+  short_description: "Run health checks for every tool CLI"
+  default_prompt: "Use $tool-health-smoke to run every available tool health check and report the results."

--- a/.agents/skills/tool-health-smoke/scripts/run_tool_health_smoke.py
+++ b/.agents/skills/tool-health-smoke/scripts/run_tool_health_smoke.py
@@ -7,20 +7,11 @@ import argparse
 import asyncio
 from dataclasses import asdict, dataclass
 import json
-import re
 import shutil
 import subprocess
 import sys
 import time
 from typing import Any
-
-
-SECRET_PATTERNS = (
-    re.compile(r"(?i)(api[_-]?key=)[^&\s]+"),
-    re.compile(r"(?i)(authorization:\s*bearer\s+)[^\s]+"),
-    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{12,}"),
-    re.compile(r"(?i)(token[\"'=:\s]+)[A-Za-z0-9._~+/=-]{12,}"),
-)
 
 
 @dataclass
@@ -34,18 +25,6 @@ class ToolResult:
     output: dict[str, Any] | None = None
 
 
-def sanitize(text: str | None, limit: int = 240) -> str:
-    if not text:
-        return ""
-    value = text.replace("\n", " ").replace("\r", " ").strip()
-    for pattern in SECRET_PATTERNS:
-        value = pattern.sub(r"\1<redacted>", value)
-    value = re.sub(r"\s+", " ", value)
-    if len(value) > limit:
-        value = value[: limit - 3].rstrip() + "..."
-    return value
-
-
 def load_tools() -> list[str]:
     if shutil.which("centaur-tools") is None:
         raise RuntimeError("centaur-tools is not installed in PATH")
@@ -57,9 +36,8 @@ def load_tools() -> list[str]:
         check=False,
     )
     if result.returncode != 0:
-        raise RuntimeError(
-            sanitize(result.stderr or result.stdout or "centaur-tools json failed")
-        )
+        message = result.stderr or result.stdout or "centaur-tools json failed"
+        raise RuntimeError(message)
 
     try:
         payload = json.loads(result.stdout)
@@ -82,7 +60,7 @@ def parse_csv(value: str | None) -> set[str]:
 def pick_detail(payload: dict[str, Any]) -> str:
     details = payload.get("details")
     if not isinstance(details, dict):
-        return sanitize(json.dumps(details, default=str) if details is not None else "")
+        return json.dumps(details, default=str) if details is not None else ""
 
     preferred: list[str] = []
     for key, value in details.items():
@@ -100,7 +78,7 @@ def pick_detail(payload: dict[str, Any]) -> str:
             preferred.append(f"{key}={value}")
             if len(preferred) >= 3:
                 break
-    return sanitize(", ".join(preferred) if preferred else "health ok")
+    return ", ".join(preferred) if preferred else "health ok"
 
 
 async def run_one(tool: str, timeout: float) -> ToolResult:
@@ -140,7 +118,7 @@ async def run_one(tool: str, timeout: float) -> ToolResult:
                 tool=tool,
                 status="FAIL",
                 seconds=seconds,
-                error=sanitize(stderr or stdout or f"exit {proc.returncode}"),
+                error=stderr or stdout or f"exit {proc.returncode}",
                 returncode=proc.returncode,
             )
         return ToolResult(
@@ -159,7 +137,7 @@ async def run_one(tool: str, timeout: float) -> ToolResult:
             tool=tool,
             status="FAIL",
             seconds=seconds,
-            error=sanitize(str(error or stderr or f"exit {proc.returncode}")),
+            error=str(error or stderr or f"exit {proc.returncode}"),
             returncode=proc.returncode,
             output=payload if isinstance(payload, dict) else None,
         )
@@ -179,9 +157,7 @@ async def run_one(tool: str, timeout: float) -> ToolResult:
         tool=tool,
         status="PASS" if ok else "FAIL",
         seconds=seconds,
-        error=None
-        if ok
-        else sanitize(str(payload.get("error") or "health returned ok=false")),
+        error=None if ok else str(payload.get("error") or "health returned ok=false"),
         detail=pick_detail(payload) if ok else None,
         returncode=proc.returncode,
         output=payload,
@@ -226,9 +202,7 @@ def render_report(results: list[ToolResult], filtered: bool) -> str:
         lines.append("")
         lines.append("*Failures*")
         for row in failures:
-            lines.append(
-                f"- *{row.tool}:* FAIL - {sanitize(row.error) or 'unknown error'}"
-            )
+            lines.append(f"- *{row.tool}:* FAIL - {row.error or 'unknown error'}")
 
     if passes:
         lines.append("")
@@ -261,11 +235,11 @@ def main(argv: list[str]) -> int:
         if args.json:
             print(
                 json.dumps(
-                    {"ok": False, "error": sanitize(str(exc)), "results": []}, indent=2
+                    {"ok": False, "error": str(exc), "results": []}, indent=2
                 )
             )
         else:
-            print(f"Overall: FAIL - {sanitize(str(exc))}")
+            print(f"Overall: FAIL - {exc}")
         return 1
 
     only = parse_csv(args.only)

--- a/.agents/skills/tool-health-smoke/scripts/run_tool_health_smoke.py
+++ b/.agents/skills/tool-health-smoke/scripts/run_tool_health_smoke.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Run health checks for all live Centaur tool CLIs."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import asdict, dataclass
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+SECRET_PATTERNS = (
+    re.compile(r"(?i)(api[_-]?key=)[^&\s]+"),
+    re.compile(r"(?i)(authorization:\s*bearer\s+)[^\s]+"),
+    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{12,}"),
+    re.compile(r"(?i)(token[\"'=:\s]+)[A-Za-z0-9._~+/=-]{12,}"),
+)
+
+
+@dataclass
+class ToolResult:
+    tool: str
+    status: str
+    seconds: float
+    error: str | None = None
+    detail: str | None = None
+    returncode: int | None = None
+    output: dict[str, Any] | None = None
+
+
+def sanitize(text: str | None, limit: int = 240) -> str:
+    if not text:
+        return ""
+    value = text.replace("\n", " ").replace("\r", " ").strip()
+    for pattern in SECRET_PATTERNS:
+        value = pattern.sub(r"\1<redacted>", value)
+    value = re.sub(r"\s+", " ", value)
+    if len(value) > limit:
+        value = value[: limit - 3].rstrip() + "..."
+    return value
+
+
+def load_tools() -> list[str]:
+    if shutil.which("centaur-tools") is None:
+        raise RuntimeError("centaur-tools is not installed in PATH")
+
+    result = subprocess.run(
+        ["centaur-tools", "json"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            sanitize(result.stderr or result.stdout or "centaur-tools json failed")
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"centaur-tools json returned invalid JSON: {exc}") from exc
+
+    tools: list[str] = []
+    for item in payload:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            tools.append(item["name"])
+    return sorted(set(tools))
+
+
+def parse_csv(value: str | None) -> set[str]:
+    if not value:
+        return set()
+    return {part.strip() for part in value.split(",") if part.strip()}
+
+
+def pick_detail(payload: dict[str, Any]) -> str:
+    details = payload.get("details")
+    if not isinstance(details, dict):
+        return sanitize(json.dumps(details, default=str) if details is not None else "")
+
+    preferred: list[str] = []
+    for key, value in details.items():
+        if isinstance(value, (dict, list)):
+            continue
+        key_l = str(key).lower()
+        if key_l in {"status", "ready", "count", "records_checked", "records_seen"}:
+            preferred.append(f"{key}={value}")
+        elif key_l.endswith(("_checked", "_count", "_results", "_seen")):
+            preferred.append(f"{key}={value}")
+    if not preferred:
+        for key, value in details.items():
+            if isinstance(value, (dict, list)):
+                continue
+            preferred.append(f"{key}={value}")
+            if len(preferred) >= 3:
+                break
+    return sanitize(", ".join(preferred) if preferred else "health ok")
+
+
+async def run_one(tool: str, timeout: float) -> ToolResult:
+    start = time.monotonic()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            tool,
+            "health",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return ToolResult(tool=tool, status="FAIL", seconds=0.0, error="CLI not found")
+
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        return ToolResult(
+            tool=tool,
+            status="FAIL",
+            seconds=time.monotonic() - start,
+            error=f"timed out after {timeout:g}s",
+        )
+
+    seconds = time.monotonic() - start
+    stdout = stdout_b.decode(errors="replace")
+    stderr = stderr_b.decode(errors="replace")
+
+    payload: Any | None = None
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        if proc.returncode != 0:
+            return ToolResult(
+                tool=tool,
+                status="FAIL",
+                seconds=seconds,
+                error=sanitize(stderr or stdout or f"exit {proc.returncode}"),
+                returncode=proc.returncode,
+            )
+        return ToolResult(
+            tool=tool,
+            status="FAIL",
+            seconds=seconds,
+            error=f"invalid health JSON: {exc}",
+            returncode=proc.returncode,
+        )
+
+    if proc.returncode != 0:
+        error = None
+        if isinstance(payload, dict):
+            error = payload.get("error")
+        return ToolResult(
+            tool=tool,
+            status="FAIL",
+            seconds=seconds,
+            error=sanitize(str(error or stderr or f"exit {proc.returncode}")),
+            returncode=proc.returncode,
+            output=payload if isinstance(payload, dict) else None,
+        )
+
+    if not isinstance(payload, dict) or "ok" not in payload:
+        return ToolResult(
+            tool=tool,
+            status="FAIL",
+            seconds=seconds,
+            error="health output missing ok field",
+            returncode=proc.returncode,
+            output=payload if isinstance(payload, dict) else None,
+        )
+
+    ok = bool(payload.get("ok"))
+    return ToolResult(
+        tool=tool,
+        status="PASS" if ok else "FAIL",
+        seconds=seconds,
+        error=None
+        if ok
+        else sanitize(str(payload.get("error") or "health returned ok=false")),
+        detail=pick_detail(payload) if ok else None,
+        returncode=proc.returncode,
+        output=payload,
+    )
+
+
+async def run_all(
+    tools: list[str], timeout: float, concurrency: int
+) -> list[ToolResult]:
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    async def guarded(tool: str) -> ToolResult:
+        async with semaphore:
+            return await run_one(tool, timeout)
+
+    return await asyncio.gather(*(guarded(tool) for tool in tools))
+
+
+def render_report(results: list[ToolResult], filtered: bool) -> str:
+    failures = [row for row in results if row.status == "FAIL"]
+    passes = [row for row in results if row.status == "PASS"]
+
+    if not results:
+        overall = "PARTIAL"
+        reason = "no tools discovered"
+    elif failures:
+        overall = "FAIL"
+        reason = f"{len(failures)} of {len(results)} tool health checks failed"
+    elif filtered:
+        overall = "PARTIAL"
+        reason = f"{len(passes)} filtered tool health checks passed"
+    else:
+        overall = "PASS"
+        reason = f"{len(passes)} tool health checks passed"
+
+    lines = [f"Overall: {overall} - {reason}", "", "*Tool Health*"]
+    lines.append(f"- *Discovered:* {len(results)} checked")
+    lines.append(f"- *Passed:* {len(passes)}")
+    lines.append(f"- *Failed:* {len(failures)}")
+
+    if failures:
+        lines.append("")
+        lines.append("*Failures*")
+        for row in failures:
+            lines.append(
+                f"- *{row.tool}:* FAIL - {sanitize(row.error) or 'unknown error'}"
+            )
+
+    if passes:
+        lines.append("")
+        lines.append("*Passes*")
+        for row in passes:
+            detail = f" - {row.detail}" if row.detail else ""
+            lines.append(f"- *{row.tool}:* PASS{detail}")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--timeout", type=float, default=60.0, help="Seconds per tool health command"
+    )
+    parser.add_argument(
+        "--concurrency", type=int, default=4, help="Concurrent health commands"
+    )
+    parser.add_argument("--only", help="Comma-separated tool names to include")
+    parser.add_argument("--exclude", help="Comma-separated tool names to exclude")
+    parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        tools = load_tools()
+    except Exception as exc:
+        if args.json:
+            print(
+                json.dumps(
+                    {"ok": False, "error": sanitize(str(exc)), "results": []}, indent=2
+                )
+            )
+        else:
+            print(f"Overall: FAIL - {sanitize(str(exc))}")
+        return 1
+
+    only = parse_csv(args.only)
+    exclude = parse_csv(args.exclude)
+    filtered = bool(only or exclude)
+    if only:
+        tools = [tool for tool in tools if tool in only]
+    if exclude:
+        tools = [tool for tool in tools if tool not in exclude]
+
+    results = asyncio.run(run_all(tools, args.timeout, args.concurrency))
+    results = sorted(results, key=lambda row: row.tool)
+    failures = [row for row in results if row.status == "FAIL"]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": not failures and bool(results),
+                    "checked": len(results),
+                    "passed": len(results) - len(failures),
+                    "failed": len(failures),
+                    "results": [asdict(row) for row in results],
+                },
+                indent=2,
+                default=str,
+            )
+        )
+    else:
+        print(render_report(results, filtered))
+
+    return 1 if failures or not results else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -92,11 +92,14 @@
 [Tool CLI access — use shell commands]
 |centaur-tools list              → list available deployment tool CLIs
 |<tool> --help                   → inspect commands/options for one tool
+|<tool> health                   → smoke test one tool's configured auth/connectivity path
 |websearch search "query"        → web research
 |slack search "query"            → Slack search
 |linear search "query"           → Linear issue search
 |vlogs query "level:error"       → recent service errors
 |Tool commands are normal CLIs backed by mounted repo packages. Use direct tool CLIs for tools.
+|For tool smoke tests, use `<tool> health` as the canonical check. Do not invent ad hoc "test this tool" probes or raw upstream calls unless `health` fails and you are triaging the failure.
+|For broad tool smoke tests, use the `tool-health-smoke` skill or run its health runner when it is available.
 |
 |[Parallel tool calls]
 |When multiple CLI lookups are independent, issue them in the same assistant turn as separate tool calls instead of waiting for one to finish before starting the next.
@@ -149,6 +152,7 @@
 |IMPORTANT: Before using any unfamiliar tool CLI, run `<tool> --help` to see commands, parameters, and descriptions.
 |This tells you exactly which command to use and avoids redundant calls.
 |Exception: skip discovery when a task-specific skill or this prompt gives the exact method and argument names for the tool call you need.
+|For smoke-test requests, prefer `<tool> health` over choosing a search/list/raw endpoint yourself.
 |If you're unsure which tool has what you need, run `centaur-tools list` to list everything available.
 |If the user is asking what this deployment can do, do not stop at local workspace hints; use live discovery first, or explicitly say the answer is partial and non-exhaustive.
 |Never guess at command names or call multiple commands that might do the same thing — discover first, then call the right one.

--- a/tools/business/ashby/cli.py
+++ b/tools/business/ashby/cli.py
@@ -14,6 +14,28 @@ from centaur_sdk import Table
 from rich.console import Console
 
 app = typer.Typer(name="ashby", help="Ashby ATS CLI for AI agents")
+
+
+@app.command("health")
+def health():
+    """Assert ashby connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.api_key_info()
+        payload = {"ok": True, "tool": "ashby", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "ashby", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/business/attio/cli.py
+++ b/tools/business/attio/cli.py
@@ -13,6 +13,28 @@ from .client import AttioClient
 load_dotenv()
 
 app = typer.Typer(name="attio", help="Attio CRM CLI for AI agents")
+
+
+@app.command("health")
+def health():
+    """Assert attio connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_objects()
+        payload = {"ok": True, "tool": "attio", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "attio", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -468,9 +490,7 @@ def list_meetings(
     """List meetings, optionally filtered to a linked Attio record."""
     client = _get_client()
     participant_values = (
-        [part.strip() for part in participants.split(",") if part.strip()]
-        if participants
-        else None
+        [part.strip() for part in participants.split(",") if part.strip()] if participants else None
     )
     result = client.list_meetings(
         limit=limit,
@@ -502,7 +522,9 @@ def list_meetings(
     for meeting in meetings:
         meeting_id = meeting.get("id", {}).get("meeting_id", "") or meeting.get("id", "")
         title = meeting.get("title") or meeting.get("subject") or meeting.get("name") or ""
-        start = meeting.get("start_at") or meeting.get("starts_at") or meeting.get("start_time") or ""
+        start = (
+            meeting.get("start_at") or meeting.get("starts_at") or meeting.get("start_time") or ""
+        )
         end = meeting.get("end_at") or meeting.get("ends_at") or meeting.get("end_time") or ""
         table.add_row(meeting_id[:8] + "...", title, str(start)[:19], str(end)[:19])
 
@@ -552,8 +574,8 @@ def list_call_recordings(
     table.add_column("Created", style="white", max_width=20)
 
     for recording in recordings:
-        recording_id = (
-            recording.get("id", {}).get("call_recording_id", "") or recording.get("id", "")
+        recording_id = recording.get("id", {}).get("call_recording_id", "") or recording.get(
+            "id", ""
         )
         title = recording.get("title") or recording.get("name") or ""
         created = recording.get("created_at", "")[:19]

--- a/tools/business/pylon/cli.py
+++ b/tools/business/pylon/cli.py
@@ -12,6 +12,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="pylon", help="Pylon CLI for AI agents")
+
+
+@app.command("health")
+def health():
+    """Assert pylon connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_me()
+        payload = {"ok": True, "tool": "pylon", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "pylon", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/comms/discord/cli.py
+++ b/tools/comms/discord/cli.py
@@ -12,6 +12,28 @@ from rich.console import Console  # noqa: E402
 from centaur_sdk import Table  # noqa: E402
 
 app = typer.Typer(name="discord", help="Discord self-token CLI for AI agents")
+
+
+@app.command("health")
+def health():
+    """Assert discord connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_me()
+        payload = {"ok": True, "tool": "discord", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "discord", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -66,7 +88,9 @@ def servers(
     table.add_column("ID", style="dim")
     table.add_column("Members", style="green")
     for guild in results:
-        table.add_row(guild.get("name", ""), guild.get("id", ""), str(guild.get("member_count", "")))
+        table.add_row(
+            guild.get("name", ""), guild.get("id", ""), str(guild.get("member_count", ""))
+        )
     console.print(table)
 
 
@@ -191,7 +215,9 @@ def post(
     )
     if _emit(result, json_output):
         return
-    console.print(f"[green]Sent[/] message {result.get('id')} to channel {result.get('channel_id')}")
+    console.print(
+        f"[green]Sent[/] message {result.get('id')} to channel {result.get('channel_id')}"
+    )
 
 
 @app.command("create-thread")

--- a/tools/comms/synoptic/cli.py
+++ b/tools/comms/synoptic/cli.py
@@ -15,6 +15,28 @@ from centaur_sdk import Table  # noqa: E402
 from .client import _client  # noqa: E402
 
 app = typer.Typer(name="synoptic", help="Synoptic Twitter API CLI")
+
+
+@app.command("health")
+def health():
+    """Assert synoptic connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_usage()
+        payload = {"ok": True, "tool": "synoptic", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "synoptic", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/comms/synoptic/client.py
+++ b/tools/comms/synoptic/client.py
@@ -13,6 +13,7 @@ from .sdk import TwitterClient
 logger = logging.getLogger(__name__)
 
 FXTWITTER_BASE = "https://api.fxtwitter.com"
+SYNOPTIC_BASE_URL = "https://api.synoptic.com"
 _ARTICLE_URL_RE = re.compile(r"x\.com/i/article/(\d+)")
 _TWEET_URL_RE = re.compile(r"(?:x|twitter)\.com/([^/]+)/status/(\d+)")
 
@@ -55,7 +56,7 @@ class SynopticClient:
         base_url: str | None = None,
     ):
         self._api_key = api_key or secret("SYNOPTIC_API_KEY", "")
-        url = base_url or secret("SYNOPTIC_BASE_URL", "https://api.synoptic.com")
+        url = base_url or SYNOPTIC_BASE_URL
         if url and not url.startswith(("http://", "https://")):
             url = f"https://{url}"
         self._base_url = url

--- a/tools/comms/synoptic/pyproject.toml
+++ b/tools/comms/synoptic/pyproject.toml
@@ -4,6 +4,7 @@ description = "Synoptic-backed Twitter CLI for user profiles, followers, tweets,
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
     "typer>=0.12.0",
     "rich>=13.0.0",
     "httpx>=0.28.1",
@@ -12,9 +13,18 @@ dependencies = [
     "pydantic-settings>=2.0.0",
 ]
 
+[project.scripts]
+synoptic = "centaur_tool_synoptic.cli:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_synoptic"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/comms/telegram/cli.py
+++ b/tools/comms/telegram/cli.py
@@ -13,6 +13,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="telegram", help="Telegram CLI for AI agents")
+
+
+@app.command("health")
+def health():
+    """Assert telegram connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = asyncio.run(client.get_me())
+        payload = {"ok": True, "tool": "telegram", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "telegram", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/comms/twitter/cli.py
+++ b/tools/comms/twitter/cli.py
@@ -15,6 +15,28 @@ from centaur_sdk import Table  # noqa: E402
 from .client import _client  # noqa: E402
 
 app = typer.Typer(name="twitter", help="Twitter CLI")
+
+
+@app.command("health")
+def health():
+    """Assert twitter connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_usage()
+        payload = {"ok": True, "tool": "twitter", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "twitter", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/alchemy/cli.py
+++ b/tools/crypto/alchemy/cli.py
@@ -18,6 +18,28 @@ app = typer.Typer(
     name="alchemy",
     help="Alchemy CLI for blockchain data, token balances, transfers, and prices",
 )
+
+
+@app.command("health")
+def health():
+    """Assert alchemy connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_block_number()
+        payload = {"ok": True, "tool": "alchemy", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "alchemy", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/allium/cli.py
+++ b/tools/crypto/allium/cli.py
@@ -15,6 +15,28 @@ from centaur_sdk import Table
 from .client import AlliumClient, get_example_queries
 
 app = typer.Typer(name="allium", help="Allium CLI for on-chain stablecoin and DeFi analytics")
+
+
+@app.command("health")
+def health():
+    """Assert allium connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.search_schemas("ethereum")
+        payload = {"ok": True, "tool": "allium", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "allium", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/arkham/cli.py
+++ b/tools/crypto/arkham/cli.py
@@ -65,10 +65,20 @@ def print_markdown_table(headers: list[str], rows: list[list[str]]) -> None:
 
 @app.command()
 def health():
-    """Check API health status."""
-    client = get_client()
-    data = client.health()
-    print(json.dumps(data, indent=2))
+    """Assert Arkham API connectivity and auth."""
+    try:
+        details = get_client().health()
+    except Exception as exc:
+        print(
+            json.dumps(
+                {"ok": False, "tool": "arkham", "error": str(exc), "details": {}},
+                indent=2,
+                default=str,
+            )
+        )
+        raise typer.Exit(1) from exc
+    payload = {"ok": True, "tool": "arkham", "error": None, "details": details}
+    print(json.dumps(payload, indent=2, default=str))
 
 
 @app.command()

--- a/tools/crypto/coindesk/cli.py
+++ b/tools/crypto/coindesk/cli.py
@@ -14,6 +14,28 @@ from centaur_sdk import Table
 from .client import CoinDeskClient
 
 app = typer.Typer(name="coindesk", help="CoinDesk CLI for crypto news")
+
+
+@app.command("health")
+def health():
+    """Assert coindesk connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.news(limit=1)
+        payload = {"ok": True, "tool": "coindesk", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "coindesk", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/coingecko/cli.py
+++ b/tools/crypto/coingecko/cli.py
@@ -12,6 +12,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="coingecko", help="CoinGecko CLI for cryptocurrency market data")
+
+
+@app.command("health")
+def health():
+    """Assert coingecko connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_markets(per_page=1)
+        payload = {"ok": True, "tool": "coingecko", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "coingecko", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/coinmetrics/cli.py
+++ b/tools/crypto/coinmetrics/cli.py
@@ -12,6 +12,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="coinmetrics", help="Coin Metrics CLI for crypto market and on-chain data")
+
+
+@app.command("health")
+def health():
+    """Assert coinmetrics connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_assets()
+        payload = {"ok": True, "tool": "coinmetrics", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "coinmetrics", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/databento/cli.py
+++ b/tools/crypto/databento/cli.py
@@ -9,6 +9,28 @@ from rich.console import Console
 load_dotenv()
 
 app = typer.Typer(name="databento", help="Databento Historical API — stock market OHLCV data")
+
+
+@app.command("health")
+def health():
+    """Assert databento connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_stock_prices("AAPL", "2024-01-03", "2024-01-04")
+        payload = {"ok": True, "tool": "databento", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "databento", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -17,7 +39,9 @@ def prices(
     symbol: str = typer.Option(..., "--symbol", "-s", help="Ticker symbol (e.g., AAPL)"),
     start: str = typer.Option(..., "--start", help="Start date (YYYY-MM-DD)"),
     end: str = typer.Option(..., "--end", help="End date (YYYY-MM-DD)"),
-    schema: str = typer.Option("ohlcv-1d", "--schema", help="Data schema (ohlcv-1d, ohlcv-1m, ohlcv-1h)"),
+    schema: str = typer.Option(
+        "ohlcv-1d", "--schema", help="Data schema (ohlcv-1d, ohlcv-1m, ohlcv-1h)"
+    ),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
 ):
     """Get OHLCV stock prices.

--- a/tools/crypto/debank/cli.py
+++ b/tools/crypto/debank/cli.py
@@ -7,6 +7,28 @@ from rich.console import Console
 from rich.table import Table
 
 app = typer.Typer(name="debank", help="DeBank CLI for DeFi wallet data and protocol positions")
+
+
+@app.command("health")
+def health():
+    """Assert debank connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_chain_list()
+        payload = {"ok": True, "tool": "debank", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "debank", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/defillama/cli.py
+++ b/tools/crypto/defillama/cli.py
@@ -13,6 +13,28 @@ from .client import DefiLlamaClient
 load_dotenv()
 
 app = typer.Typer(name="defillama", help="DefiLlama CLI for stablecoin and DeFi analytics")
+
+
+@app.command("health")
+def health():
+    """Assert defillama connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_protocols()
+        payload = {"ok": True, "tool": "defillama", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "defillama", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/dune/cli.py
+++ b/tools/crypto/dune/cli.py
@@ -23,7 +23,30 @@ def _get_client() -> DuneClient:
         _client = DuneClient()
     return _client
 
+
 app = typer.Typer(name="dune", help="Dune Analytics CLI for executing queries and fetching results")
+
+
+@app.command("health")
+def health():
+    """Assert dune connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.raw_request("GET", "/query/2408388/results")
+        payload = {"ok": True, "tool": "dune", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "dune", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/eodhd/cli.py
+++ b/tools/crypto/eodhd/cli.py
@@ -11,6 +11,28 @@ from .client import EodhdClient
 load_dotenv()
 
 app = typer.Typer(name="eodhd", help="EODHD CLI for equity quotes and historical prices")
+
+
+@app.command("health")
+def health():
+    """Assert eodhd connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_quote("AAPL")
+        payload = {"ok": True, "tool": "eodhd", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "eodhd", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/eodhd/client.py
+++ b/tools/crypto/eodhd/client.py
@@ -4,18 +4,17 @@ from typing import Any
 
 import httpx
 
+from centaur_sdk.tool_sdk import secret
+
 BASE_URL = "https://eodhd.com/api"
 
 
 class EodhdClient:
-
     def __init__(self, api_key: str | None = None):
         self._api_key = api_key or secret("EODHD_API_KEY", "")
         if not self._api_key:
             raise RuntimeError(
-                "EODHD API key not set.\n"
-                "Required: EODHD_API_KEY\n"
-                "Get a key at https://eodhd.com/"
+                "EODHD API key not set.\nRequired: EODHD_API_KEY\nGet a key at https://eodhd.com/"
             )
 
     def _request(self, path: str, params: dict[str, Any] | None = None) -> Any:
@@ -71,6 +70,4 @@ class EodhdClient:
 
 
 def _client() -> EodhdClient:
-    from centaur_sdk.tool_sdk import secret
-
     return EodhdClient(api_key=secret("EODHD_API_KEY"))

--- a/tools/crypto/etherscan/cli.py
+++ b/tools/crypto/etherscan/cli.py
@@ -1,0 +1,42 @@
+"""CLI for Etherscan."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="etherscan",
+    help="Etherscan — Ethereum block explorer, transactions, contracts, and tokens",
+)
+
+
+@app.callback()
+def main() -> None:
+    """etherscan CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert etherscan connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_eth_price()
+        payload = {"ok": True, "tool": "etherscan", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "etherscan", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/crypto/etherscan/pyproject.toml
+++ b/tools/crypto/etherscan/pyproject.toml
@@ -10,9 +10,18 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+etherscan = "centaur_tool_etherscan.cli:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_etherscan"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/crypto/kalshi/cli.py
+++ b/tools/crypto/kalshi/cli.py
@@ -9,6 +9,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="kalshi", help="Kalshi prediction market CLI for market data and analytics")
+
+
+@app.command("health")
+def health():
+    """Assert kalshi connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_markets(limit=1)
+        payload = {"ok": True, "tool": "kalshi", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "kalshi", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/karma/cli.py
+++ b/tools/crypto/karma/cli.py
@@ -1,0 +1,42 @@
+"""CLI for Karma."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="karma",
+    help="Karma — DAO delegate reputation, contributor scores, and governance analytics",
+)
+
+
+@app.callback()
+def main() -> None:
+    """karma CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert karma connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_daos()
+        payload = {"ok": True, "tool": "karma", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "karma", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/crypto/karma/pyproject.toml
+++ b/tools/crypto/karma/pyproject.toml
@@ -10,9 +10,18 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+karma = "centaur_tool_karma.cli:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_karma"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/crypto/messari/cli.py
+++ b/tools/crypto/messari/cli.py
@@ -13,6 +13,28 @@ from .client import MessariClient
 load_dotenv()
 
 app = typer.Typer(name="messari", help="Messari CLI for crypto asset data and analytics")
+
+
+@app.command("health")
+def health():
+    """Assert messari connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_assets(limit=1)
+        payload = {"ok": True, "tool": "messari", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "messari", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/mpp/cli.py
+++ b/tools/crypto/mpp/cli.py
@@ -1,0 +1,42 @@
+"""CLI for Market data via MPP (Machine Payments Protocol)."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="mpp",
+    help="Market data via MPP (Machine Payments Protocol) — token prices, web search, on-chain data, trending tokens, wallet balances, and Dune SQL queries. Paid per-query with Tempo stablecoins.",
+)
+
+
+@app.callback()
+def main() -> None:
+    """mpp CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert mpp connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_trending()
+        payload = {"ok": True, "tool": "mpp", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "mpp", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/crypto/mpp/client.py
+++ b/tools/crypto/mpp/client.py
@@ -265,7 +265,7 @@ class MppClient:
 
         if not coin_id:
             # Resolve via search
-            price = self.get_token_price(token_name)
+            self.get_token_price(token_name)
             coin_id = COINGECKO_ID_MAP.get(normalized.upper()) or self._coingecko_id_cache.get(normalized.lower())
             if not coin_id:
                 return []

--- a/tools/crypto/mpp/pyproject.toml
+++ b/tools/crypto/mpp/pyproject.toml
@@ -4,9 +4,25 @@ description = "Market data via MPP (Machine Payments Protocol) — token prices,
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
     "httpx>=0.27.0",
     "centaur_sdk",
 ]
+
+[project.scripts]
+mpp = "centaur_tool_mpp.cli:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_mpp"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/crypto/mpp/pyproject.toml
+++ b/tools/crypto/mpp/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "rich>=13.0.0",
     "typer>=0.12.0",
     "httpx>=0.27.0",
-    "centaur_sdk",
 ]
 
 [project.scripts]

--- a/tools/crypto/nansen/cli.py
+++ b/tools/crypto/nansen/cli.py
@@ -8,6 +8,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="nansen", help="Nansen CLI for blockchain analytics and wallet labels")
+
+
+@app.command("health")
+def health():
+    """Assert nansen connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_token_screener(per_page=1)
+        payload = {"ok": True, "tool": "nansen", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "nansen", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/polymarket/cli.py
+++ b/tools/crypto/polymarket/cli.py
@@ -8,6 +8,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="polymarket", help="Polymarket CLI for prediction market data")
+
+
+@app.command("health")
+def health():
+    """Assert polymarket connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_markets(limit=1)
+        payload = {"ok": True, "tool": "polymarket", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "polymarket", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/snapshot/cli.py
+++ b/tools/crypto/snapshot/cli.py
@@ -1,0 +1,41 @@
+"""CLI for Snapshot."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="snapshot", help="Snapshot — off-chain governance voting, proposals, and spaces"
+)
+
+
+@app.callback()
+def main() -> None:
+    """snapshot CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert snapshot connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_spaces(first=1)
+        payload = {"ok": True, "tool": "snapshot", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "snapshot", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/crypto/snapshot/pyproject.toml
+++ b/tools/crypto/snapshot/pyproject.toml
@@ -10,9 +10,18 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+snapshot = "centaur_tool_snapshot.cli:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_snapshot"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/crypto/standard-metrics/cli.py
+++ b/tools/crypto/standard-metrics/cli.py
@@ -11,6 +11,28 @@ from rich.console import Console
 from centaur_sdk.cli_tables import Table
 
 app = typer.Typer(name="standard-metrics", help="Standard Metrics CLI for portfolio company data")
+
+
+@app.command("health")
+def health():
+    """Assert standard-metrics connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_companies(page_size=1)
+        payload = {"ok": True, "tool": "standard-metrics", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "standard-metrics", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/tally/cli.py
+++ b/tools/crypto/tally/cli.py
@@ -1,0 +1,39 @@
+"""CLI for Tally."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(name="tally", help="Tally — on-chain governance proposals, voting, and delegates")
+
+
+@app.callback()
+def main() -> None:
+    """tally CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert tally connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_organizations(limit=1)
+        payload = {"ok": True, "tool": "tally", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "tally", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/crypto/tally/pyproject.toml
+++ b/tools/crypto/tally/pyproject.toml
@@ -10,9 +10,18 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+tally = "centaur_tool_tally.cli:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_tally"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/crypto/tenderly/cli.py
+++ b/tools/crypto/tenderly/cli.py
@@ -19,11 +19,35 @@ app = typer.Typer(
     name="tenderly",
     help="Tenderly CLI for transaction simulation, tracing, and Virtual TestNets",
 )
+
+
+@app.command("health")
+def health():
+    """Assert tenderly connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_user()
+        payload = {"ok": True, "tool": "tenderly", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "tenderly", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 vnet_app = typer.Typer(name="vnet", help="Manage and interact with Virtual TestNets")
 app.add_typer(vnet_app)
 console = Console()
 
-SHOW_CHOICES = "summary, trace, skeleton, events, state, assets, balances, failures, error-path, json"
+SHOW_CHOICES = (
+    "summary, trace, skeleton, events, state, assets, balances, failures, error-path, json"
+)
 
 
 def print_rows(rows: list[dict], output: str) -> None:
@@ -416,7 +440,9 @@ def vnet_txs(
 @vnet_app.command("send")
 def vnet_send(
     vnet_id: str = typer.Argument(..., help="Virtual TestNet ID"),
-    from_address: str = typer.Option(..., "--from", "-f", help="Sender (impersonated, no key needed)"),
+    from_address: str = typer.Option(
+        ..., "--from", "-f", help="Sender (impersonated, no key needed)"
+    ),
     to_address: str = typer.Option(..., "--to", "-t", help="Target address"),
     input_data: str = typer.Option("0x", "--input", "-i", help="Calldata (0x...)"),
     value: int = typer.Option(0, "--value", "-v", help="Native value in wei"),
@@ -476,9 +502,7 @@ def vnet_call(
     """Execute a read-only eth_call on a Virtual TestNet."""
     try:
         with TenderlyClient() as client:
-            result = client.vnet_call(
-                vnet_id, to_address, input_data, from_address=from_address
-            )
+            result = client.vnet_call(vnet_id, to_address, input_data, from_address=from_address)
             print(result)
     except Exception as e:
         console.print(f"[red]Error: {e}[/]")

--- a/tools/crypto/theblock/cli.py
+++ b/tools/crypto/theblock/cli.py
@@ -10,6 +10,28 @@ from rich.table import Table
 load_dotenv()
 
 app = typer.Typer(name="theblock", help="The Block CLI for crypto news")
+
+
+@app.command("health")
+def health():
+    """Assert theblock connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.news(limit=1)
+        payload = {"ok": True, "tool": "theblock", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "theblock", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/crypto/token-terminal/cli.py
+++ b/tools/crypto/token-terminal/cli.py
@@ -1,0 +1,42 @@
+"""CLI for Token Terminal."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="token-terminal",
+    help="Token Terminal — protocol revenue, fees, financial statements, and metrics",
+)
+
+
+@app.callback()
+def main() -> None:
+    """token-terminal CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert token-terminal connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_projects(limit=1)
+        payload = {"ok": True, "tool": "token-terminal", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "token-terminal", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/crypto/token-terminal/pyproject.toml
+++ b/tools/crypto/token-terminal/pyproject.toml
@@ -10,9 +10,18 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+token-terminal = "centaur_tool_token_terminal.cli:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_token_terminal"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/crypto/tokenomist/cli.py
+++ b/tools/crypto/tokenomist/cli.py
@@ -1,0 +1,42 @@
+"""CLI for Tokenomist."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="tokenomist",
+    help="Tokenomist — token unlock schedules, vesting, emissions, and allocations",
+)
+
+
+@app.callback()
+def main() -> None:
+    """tokenomist CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert tokenomist connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_tokens(limit=1)
+        payload = {"ok": True, "tool": "tokenomist", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "tokenomist", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/crypto/tokenomist/pyproject.toml
+++ b/tools/crypto/tokenomist/pyproject.toml
@@ -10,9 +10,18 @@ dependencies = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+tokenomist = "centaur_tool_tokenomist.cli:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_tokenomist"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/infra/amplitude/cli.py
+++ b/tools/infra/amplitude/cli.py
@@ -8,6 +8,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="amplitude", help="Amplitude product analytics (Dashboard REST + Taxonomy)")
+
+
+@app.command("health")
+def health():
+    """Assert amplitude connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.events_list()
+        payload = {"ok": True, "tool": "amplitude", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "amplitude", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -165,9 +187,7 @@ def user_activity(
     """Fetch a single user's event stream by Amplitude ID."""
     client = get_client()
     result = _run(
-        lambda: client.user_activity(
-            user=user, limit=limit, offset=offset, direction=direction
-        )
+        lambda: client.user_activity(user=user, limit=limit, offset=offset, direction=direction)
     )
     _dump(result)
 

--- a/tools/infra/centaur_investigator/cli.py
+++ b/tools/infra/centaur_investigator/cli.py
@@ -19,6 +19,32 @@ app = typer.Typer(
     name="centaur-investigator",
     help="Investigate Centaur threads and sessions from readonly Postgres.",
 )
+
+
+@app.command("health")
+def health():
+    """Assert centaur-investigator connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.search_sessions(limit=1)
+        if isinstance(details, dict) and details.get("status") == "error":
+            raise RuntimeError(
+                str(details.get("error") or "centaur-investigator health check failed")
+            )
+        payload = {"ok": True, "tool": "centaur-investigator", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "centaur-investigator", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/infra/chart/cli.py
+++ b/tools/infra/chart/cli.py
@@ -1,0 +1,52 @@
+"""CLI for Chart generation for Centaur. Single render_chart method returns base64 PNG images ready for Slack upload.."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="chart",
+    help="Chart generation for Centaur. Single render_chart method returns base64 PNG images ready for Slack upload.",
+)
+
+
+@app.callback()
+def main() -> None:
+    """chart CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert chart connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = {
+            "png_base64_length": len(
+                client.render_chart(
+                    chart_type="bar",
+                    data=[{"label": "health", "value": 1}],
+                    title="Health",
+                    x="label",
+                    y="value",
+                )
+            )
+        }
+        payload = {"ok": True, "tool": "chart", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "chart", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/infra/chart/pyproject.toml
+++ b/tools/infra/chart/pyproject.toml
@@ -4,9 +4,25 @@ description = "Chart generation for Centaur. Single render_chart method returns 
 version = "0.2.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
     "matplotlib>=3.7.0",
     "pandas>=2.0.0",
 ]
+
+[project.scripts]
+chart = "centaur_tool_chart.cli:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_chart"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/infra/cloudwatch/cli.py
+++ b/tools/infra/cloudwatch/cli.py
@@ -21,6 +21,26 @@ app = typer.Typer(
 )
 
 
+@app.command("health")
+def health():
+    """Assert cloudwatch connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_log_groups(limit=1)
+        payload = {"ok": True, "tool": "cloudwatch", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "cloudwatch", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 def get_client():
     from .client import CloudWatchClient
 
@@ -149,11 +169,7 @@ def describe_alarms(
     limit: int = typer.Option(50, "--limit", "-n", help="Max alarms (1-100)"),
 ):
     """List metric alarms (pass --state ALARM for currently-firing alarms)."""
-    _emit(
-        get_client().describe_alarms(
-            state_value=state, alarm_name_prefix=prefix, limit=limit
-        )
-    )
+    _emit(get_client().describe_alarms(state_value=state, alarm_name_prefix=prefix, limit=limit))
 
 
 @app.command("get-alarm-history")

--- a/tools/infra/demo/cli.py
+++ b/tools/infra/demo/cli.py
@@ -1,0 +1,39 @@
+"""CLI for Demo tool for testing CD hot."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(name="demo", help="Demo tool for testing CD hot-reload")
+
+
+@app.callback()
+def main() -> None:
+    """demo CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert demo connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.ping()
+        payload = {"ok": True, "tool": "demo", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "demo", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/infra/demo/pyproject.toml
+++ b/tools/infra/demo/pyproject.toml
@@ -2,7 +2,24 @@
 name = "demo"
 version = "0.1.0"
 description = "Demo tool for testing CD hot-reload"
-dependencies = []
+dependencies = [
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
+]
+
+[project.scripts]
+demo = "centaur_tool_demo.cli:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_demo"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/infra/grafana/cli.py
+++ b/tools/infra/grafana/cli.py
@@ -273,10 +273,20 @@ def thread_debug_url(
 
 @app.command()
 def health():
-    """Check Grafana health."""
-    client = get_client()
-    result = client.health()
-    console.print(f"[green]Grafana: {result.get('version', '?')} — {result.get('database', '?')}[/]")
+    """Assert Grafana API connectivity and auth."""
+    try:
+        details = get_client().health()
+    except Exception as exc:
+        print(
+            json.dumps(
+                {"ok": False, "tool": "grafana", "error": str(exc), "details": {}},
+                indent=2,
+                default=str,
+            )
+        )
+        raise typer.Exit(1) from exc
+    payload = {"ok": True, "tool": "grafana", "error": None, "details": details}
+    print(json.dumps(payload, indent=2, default=str))
 
 
 if __name__ == "__main__":

--- a/tools/infra/laminar/cli.py
+++ b/tools/infra/laminar/cli.py
@@ -1,0 +1,41 @@
+"""CLI for Laminar trace investigation for Centaur agent executions."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(name="laminar", help="Laminar trace investigation for Centaur agent executions")
+
+
+@app.callback()
+def main() -> None:
+    """laminar CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert laminar connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.health()
+        if isinstance(details, dict) and not details.get("ready", False):
+            raise RuntimeError(str(details.get("response") or "laminar health check failed"))
+        payload = {"ok": True, "tool": "laminar", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "laminar", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/infra/laminar/client.py
+++ b/tools/infra/laminar/client.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import httpx
 
+from centaur_sdk.tool_sdk import secret
+
 DEFAULT_BASE_URL = "http://laminar-app-server.laminar.svc.cluster.local:8000"
 DEFAULT_EXTERNAL_URL = "http://prd-centaur-na-laminar.tail388b2e.ts.net"
 DEFAULT_PROJECT_ID = "202e8d91-1311-40f8-9217-ad375d3ab4df"
@@ -79,8 +81,7 @@ class LaminarClient:
     @property
     def base_url(self) -> str:
         url = (
-            self._base_url
-            or os.getenv("LAMINAR_BASE_URL", DEFAULT_BASE_URL)  # noqa: TID251
+            self._base_url or os.getenv("LAMINAR_BASE_URL", DEFAULT_BASE_URL)  # noqa: TID251
         ).rstrip("/")
         if url and not url.startswith(("http://", "https://")):
             url = f"http://{url}"
@@ -89,19 +90,17 @@ class LaminarClient:
     @property
     def external_url(self) -> str:
         return (
-            self._external_url
-            or os.getenv("LAMINAR_EXTERNAL_URL", DEFAULT_EXTERNAL_URL)  # noqa: TID251
+            self._external_url or os.getenv("LAMINAR_EXTERNAL_URL", DEFAULT_EXTERNAL_URL)  # noqa: TID251
         ).rstrip("/")
 
     @property
     def api_key(self) -> str:
-        return (self._api_key or os.getenv("LAMINAR_API_KEY", "")).strip()  # noqa: TID251
+        return (self._api_key or secret("LAMINAR_API_KEY", "")).strip()
 
     @property
     def project_id(self) -> str:
         return (
-            self._project_id
-            or os.getenv("LAMINAR_PROJECT_ID", DEFAULT_PROJECT_ID)  # noqa: TID251
+            self._project_id or os.getenv("LAMINAR_PROJECT_ID", DEFAULT_PROJECT_ID)  # noqa: TID251
         ).strip()
 
     @property
@@ -203,7 +202,9 @@ class LaminarClient:
         filters = [f"s.start_time >= now() - INTERVAL {minutes} MINUTE"]
         parameters: dict[str, Any] = {}
         if thread_key:
-            filters.append("JSONExtractString(s.attributes, 'centaur.thread_key') = {thread_key:String}")
+            filters.append(
+                "JSONExtractString(s.attributes, 'centaur.thread_key') = {thread_key:String}"
+            )
             parameters["thread_key"] = thread_key
         if execution_id:
             filters.append(

--- a/tools/infra/laminar/client.py
+++ b/tools/infra/laminar/client.py
@@ -8,8 +8,6 @@ from typing import Any
 
 import httpx
 
-from centaur_sdk.tool_sdk import secret
-
 DEFAULT_BASE_URL = "http://laminar-app-server.laminar.svc.cluster.local:8000"
 DEFAULT_EXTERNAL_URL = "http://prd-centaur-na-laminar.tail388b2e.ts.net"
 DEFAULT_PROJECT_ID = "202e8d91-1311-40f8-9217-ad375d3ab4df"
@@ -95,7 +93,7 @@ class LaminarClient:
 
     @property
     def api_key(self) -> str:
-        return (self._api_key or secret("LAMINAR_API_KEY", "")).strip()
+        return (self._api_key or os.getenv("LAMINAR_API_KEY", "")).strip()  # noqa: TID251
 
     @property
     def project_id(self) -> str:

--- a/tools/infra/laminar/pyproject.toml
+++ b/tools/infra/laminar/pyproject.toml
@@ -4,13 +4,25 @@ description = "Laminar trace investigation for Centaur agent executions"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
     "httpx>=0.27.0",
 ]
+
+[project.scripts]
+laminar = "centaur_tool_laminar.cli:app"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_laminar"
+
 [tool.centaur]
 module = "client.py"
-secrets = []
+secrets = ["LAMINAR_API_KEY"]

--- a/tools/infra/laminar/pyproject.toml
+++ b/tools/infra/laminar/pyproject.toml
@@ -25,4 +25,4 @@ packages = ["."]
 
 [tool.centaur]
 module = "client.py"
-secrets = ["LAMINAR_API_KEY"]
+secrets = []

--- a/tools/infra/posthog/cli.py
+++ b/tools/infra/posthog/cli.py
@@ -8,6 +8,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="posthog", help="PostHog CLI for product analytics and HogQL queries")
+
+
+@app.command("health")
+def health():
+    """Assert posthog connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.events(limit=1)
+        payload = {"ok": True, "tool": "posthog", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "posthog", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/infra/profslice/cli.py
+++ b/tools/infra/profslice/cli.py
@@ -16,6 +16,28 @@ app = typer.Typer(
     name="profslice",
     help="Firefox Profiler data extraction for LLM analysis. No browser required.",
 )
+
+
+@app.command("health")
+def health():
+    """Assert profslice connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = {"resolved_url": client.resolve_url("https://profiler.firefox.com/public/health")}
+        payload = {"ok": True, "tool": "profslice", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "profslice", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/infra/reth-log-analyzer/cli.py
+++ b/tools/infra/reth-log-analyzer/cli.py
@@ -7,6 +7,7 @@ load_dotenv()
 from pathlib import Path
 from typing import Optional
 
+import json
 import typer
 from rich.console import Console
 
@@ -15,6 +16,28 @@ from centaur_sdk import Table
 from .client import _client
 
 app = typer.Typer(help="Parse reth logs and generate performance graphs")
+
+
+@app.command("health")
+def health():
+    """Assert reth-log-analyzer connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = {"auth_mode": "local-only", "live_probe": False}
+        payload = {"ok": True, "tool": "reth-log-analyzer", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "reth-log-analyzer", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -131,9 +154,7 @@ def summary(
     if markdown:
         print("## Reth Big Blocks Performance Analysis\n")
         print("### Dataset Overview")
-        print(
-            f"- **{stats['total_blocks']:,} blocks** analyzed ({block_min} - {block_max})"
-        )
+        print(f"- **{stats['total_blocks']:,} blocks** analyzed ({block_min} - {block_max})")
         print(f"- {stats['empty_blocks']:,} empty blocks, {stats['non_empty_blocks']:,} non-empty")
         print(
             f"- Max gas: **{stats['max_gas_mgas']:.0f} Mgas** | Max latency: **{stats['max_latency_ms']:.0f}ms**\n"
@@ -170,20 +191,20 @@ def summary(
             )
     else:
         console.print("[bold]Reth Big Blocks Performance Analysis[/bold]\n")
+        console.print(f"Blocks analyzed: {stats['total_blocks']:,} ({block_min} - {block_max})")
         console.print(
-            f"Blocks analyzed: {stats['total_blocks']:,} ({block_min} - {block_max})"
+            f"Empty: {stats['empty_blocks']:,} | Non-empty: {stats['non_empty_blocks']:,}"
         )
-        console.print(f"Empty: {stats['empty_blocks']:,} | Non-empty: {stats['non_empty_blocks']:,}")
         console.print(
             f"Max gas: {stats['max_gas_mgas']:.0f} Mgas | Max latency: {stats['max_latency_ms']:.0f}ms\n"
         )
 
         big = stats.get("big_blocks")
         if big:
-            console.print(f"[bold]Big blocks (>{big['min_gas_threshold']:.0f}M gas): {big['count']}[/bold]")
             console.print(
-                f"  Avg throughput: {big['avg_throughput_ggas_s']:.2f} Ggas/s"
+                f"[bold]Big blocks (>{big['min_gas_threshold']:.0f}M gas): {big['count']}[/bold]"
             )
+            console.print(f"  Avg throughput: {big['avg_throughput_ggas_s']:.2f} Ggas/s")
             console.print(f"  Avg execution %: {big['avg_execution_pct']:.1f}%")
             console.print(f"  Avg state root %: {big['avg_state_root_pct']:.1f}%")
 

--- a/tools/infra/reth/cli.py
+++ b/tools/infra/reth/cli.py
@@ -1,5 +1,6 @@
 """CLI for Reth execution timings and performance metrics."""
 
+import json
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -12,6 +13,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="reth", help="Reth CLI for execution timings and performance metrics")
+
+
+@app.command("health")
+def health():
+    """Assert reth connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_execution_timings(hours=1, page_size=1)
+        payload = {"ok": True, "tool": "reth", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "reth", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/infra/sentry/cli.py
+++ b/tools/infra/sentry/cli.py
@@ -1,0 +1,42 @@
+"""CLI for Sentry issues."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="sentry",
+    help="Sentry issues — list/search issues, issue details, events, stacktraces, and tag values (read-only)",
+)
+
+
+@app.callback()
+def main() -> None:
+    """sentry CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert sentry connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_organizations()
+        payload = {"ok": True, "tool": "sentry", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "sentry", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/infra/sentry/pyproject.toml
+++ b/tools/infra/sentry/pyproject.toml
@@ -4,13 +4,24 @@ description = "Sentry issues — list/search issues, issue details, events, stac
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
     "httpx>=0.27.0",
 ]
+
+[project.scripts]
+sentry = "centaur_tool_sentry.cli:app"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_sentry"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/infra/vlogs/cli.py
+++ b/tools/infra/vlogs/cli.py
@@ -22,7 +22,7 @@ def get_client():
 
 @app.command("query")
 def query_logs(
-    query: str = typer.Argument(..., help='LogsQL expression (e.g. \'_time:5m error\')'),
+    query: str = typer.Argument(..., help="LogsQL expression (e.g. '_time:5m error')"),
     start: str = typer.Option(None, "--start", "-s", help="Range start (RFC3339 or epoch)"),
     end: str = typer.Option(None, "--end", "-e", help="Range end"),
     limit: int = typer.Option(100, "--limit", "-n", help="Max log lines"),
@@ -117,12 +117,17 @@ def list_streams(
 
 @app.command()
 def health():
-    """Check VictoriaLogs readiness."""
+    """Assert VictoriaLogs readiness."""
     client = get_client()
-    if client.ready():
-        console.print("[green]VictoriaLogs is ready[/]")
-    else:
-        console.print("[red]VictoriaLogs is not ready[/]")
+    ready = client.ready()
+    payload = {
+        "ok": ready,
+        "tool": "vlogs",
+        "error": None if ready else "VictoriaLogs is not ready",
+        "details": {"ready": ready},
+    }
+    print(json.dumps(payload, indent=2, default=str))
+    if not ready:
         raise typer.Exit(1)
 
 

--- a/tools/infra/vmetrics/cli.py
+++ b/tools/infra/vmetrics/cli.py
@@ -93,11 +93,16 @@ def metric_names(
 
 @app.command()
 def health():
-    """Check VictoriaMetrics readiness."""
-    if get_client().ready():
-        console.print("[green]VictoriaMetrics is ready[/]")
-    else:
-        console.print("[red]VictoriaMetrics is not ready[/]")
+    """Assert VictoriaMetrics readiness."""
+    ready = get_client().ready()
+    payload = {
+        "ok": ready,
+        "tool": "vmetrics",
+        "error": None if ready else "VictoriaMetrics is not ready",
+        "details": {"ready": ready},
+    }
+    print(json.dumps(payload, indent=2, default=str))
+    if not ready:
         raise typer.Exit(1)
 
 

--- a/tools/media/nano-banana/cli.py
+++ b/tools/media/nano-banana/cli.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import json
 import typer
 from dotenv import load_dotenv
 from rich.console import Console
@@ -12,6 +13,33 @@ from .client import DEFAULT_MODEL, MODELS
 load_dotenv()
 
 app = typer.Typer(name="nano-banana", help="Nano Banana CLI for Google Gemini image generation")
+
+
+@app.command("health")
+def health():
+    """Assert nano-banana connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = {
+            "models": [
+                getattr(model, "name", str(model))
+                for model in list(client.client.models.list())[:3]
+            ]
+        }
+        payload = {"ok": True, "tool": "nano-banana", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "nano-banana", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/media/transcriber/cli.py
+++ b/tools/media/transcriber/cli.py
@@ -14,6 +14,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
+import json
 import typer
 from rich.console import Console
 from rich.panel import Panel
@@ -21,6 +22,28 @@ from rich.panel import Panel
 from .client import DEFAULT_MODEL, END_PHRASE, IS_MACOS, TranscriberClient
 
 app = typer.Typer(help="Local-first voice transcription with live streaming")
+
+
+@app.command("health")
+def health():
+    """Assert transcriber connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = {"models": client.list_models(), "recorder": client.find_recorder()}
+        payload = {"ok": True, "tool": "transcriber", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "transcriber", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 _client = TranscriberClient()
@@ -355,9 +378,7 @@ def _copy_to_clipboard(text: str):
         if IS_MACOS:
             subprocess.run(["pbcopy"], input=text.encode(), check=True)
         else:
-            subprocess.run(
-                ["xclip", "-selection", "clipboard"], input=text.encode(), check=True
-            )
+            subprocess.run(["xclip", "-selection", "clipboard"], input=text.encode(), check=True)
         console.print("[dim]Copied to clipboard[/]")
     except Exception:
         pass

--- a/tools/media/veo3/cli.py
+++ b/tools/media/veo3/cli.py
@@ -1,5 +1,6 @@
 """CLI for Veo 3 video generation."""
 
+import json
 import typer
 from dotenv import load_dotenv
 from rich.console import Console
@@ -8,6 +9,33 @@ from rich.table import Table
 load_dotenv()
 
 app = typer.Typer(name="veo3", help="Veo 3 CLI for Google's video generation model")
+
+
+@app.command("health")
+def health():
+    """Assert veo3 connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = {
+            "models": [
+                getattr(model, "name", str(model))
+                for model in list(client.client.models.list())[:3]
+            ]
+        }
+        payload = {"ok": True, "tool": "veo3", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "veo3", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/productivity/airtable/cli.py
+++ b/tools/productivity/airtable/cli.py
@@ -11,6 +11,28 @@ from .client import AirtableClient
 load_dotenv()
 
 app = typer.Typer(name="airtable", help="Airtable API client")
+
+
+@app.command("health")
+def health():
+    """Assert airtable connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.preflight_access()
+        payload = {"ok": True, "tool": "airtable", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "airtable", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/productivity/company_context/cli.py
+++ b/tools/productivity/company_context/cli.py
@@ -16,6 +16,30 @@ from .client import CompanyContextClient
 load_dotenv()
 
 app = typer.Typer(name="company_context", help="Search indexed company history.")
+
+
+@app.command("health")
+def health():
+    """Assert company-context connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.latest_date()
+        if isinstance(details, dict) and details.get("status") == "error":
+            raise RuntimeError(str(details.get("error") or "company-context health check failed"))
+        payload = {"ok": True, "tool": "company-context", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "company-context", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/productivity/composio/cli.py
+++ b/tools/productivity/composio/cli.py
@@ -1,0 +1,42 @@
+"""CLI for Execute tools from 1000+ services via Composio (GitHub, Gmail, Slack, Notion, etc.)."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="composio",
+    help="Execute tools from 1000+ services via Composio (GitHub, Gmail, Slack, Notion, etc.)",
+)
+
+
+@app.callback()
+def main() -> None:
+    """composio CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert composio connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_tools("github")
+        payload = {"ok": True, "tool": "composio", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "composio", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/productivity/composio/pyproject.toml
+++ b/tools/productivity/composio/pyproject.toml
@@ -4,8 +4,14 @@ version = "0.1.0"
 description = "Execute tools from 1000+ services via Composio (GitHub, Gmail, Slack, Notion, etc.)"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
     "composio>=0.13.0",
 ]
+
+[project.scripts]
+composio = "centaur_tool_composio.cli:app"
 
 [build-system]
 requires = ["hatchling"]
@@ -13,6 +19,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_composio"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/productivity/figma/cli.py
+++ b/tools/productivity/figma/cli.py
@@ -1,5 +1,7 @@
 """CLI entrypoint for Figma tool."""
 
+import json
+
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -10,6 +12,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="figma", help="Figma design system extraction")
+
+
+@app.command("health")
+def health():
+    """Assert figma connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client._request("/me")
+        payload = {"ok": True, "tool": "figma", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "figma", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/productivity/granola/cli.py
+++ b/tools/productivity/granola/cli.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+import json
 import typer
 from rich.console import Console
 from rich.markdown import Markdown
@@ -13,6 +14,28 @@ from rich.panel import Panel
 from centaur_sdk import Table
 
 app = typer.Typer(name="granola", help="Query Granola meeting notes and transcripts")
+
+
+@app.command("health")
+def health():
+    """Assert granola connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_notes(page_size=1)
+        payload = {"ok": True, "tool": "granola", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "granola", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -79,9 +102,7 @@ def get_note(
     owner = note.get("owner", {})
     owner_name = owner.get("name") or owner.get("email", "")
     attendees = note.get("attendees", [])
-    attendee_names = ", ".join(
-        a.get("name") or a.get("email", "") for a in attendees
-    )
+    attendee_names = ", ".join(a.get("name") or a.get("email", "") for a in attendees)
     summary = note.get("summary_markdown") or note.get("summary_text") or ""
 
     if raw:

--- a/tools/productivity/gsuite/cli.py
+++ b/tools/productivity/gsuite/cli.py
@@ -1,5 +1,6 @@
 """CLI for GSuite operations - Gmail, Calendar, Drive."""
 
+import json
 from pathlib import Path
 
 import typer
@@ -7,6 +8,28 @@ from centaur_sdk import Table
 from rich.console import Console
 
 app = typer.Typer(name="gsuite", help="GSuite CLI for AI agents - Gmail, Calendar, Drive")
+
+
+@app.command("health")
+def health():
+    """Assert gsuite connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.gmail_labels()
+        payload = {"ok": True, "tool": "gsuite", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "gsuite", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 # Sub-apps for each service

--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -10,6 +10,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="linear", help="Linear CLI for AI agents")
+
+
+@app.command("health")
+def health():
+    """Assert linear connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.me()
+        payload = {"ok": True, "tool": "linear", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "linear", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -202,8 +224,7 @@ def fetch_asset(
 
         Path(output).write_bytes(base64.b64decode(result["data"]))
         console.print(
-            f"[green]Wrote {result['byte_length']} bytes[/] to {output} "
-            f"({result['mime_type']})"
+            f"[green]Wrote {result['byte_length']} bytes[/] to {output} ({result['mime_type']})"
         )
         raise typer.Exit()
 
@@ -572,16 +593,15 @@ def list_labels(
 def add_label(
     issue_id: str = typer.Argument(..., help="Issue ID or identifier (e.g., ENG-123)"),
     label: str = typer.Argument(..., help="Label name to add"),
-    team: str = typer.Option(
-        None, "--team", "-t", help="Team key, to bind a team-scoped label"
-    ),
+    team: str = typer.Option(None, "--team", "-t", help="Team key, to bind a team-scoped label"),
 ):
     """Add a single label to an issue (leaves other labels untouched)."""
     client = get_client()
     result = client.add_label(issue_id, label, team_key=team)
     ok = result.get("success")
     console.print(
-        f"[green]Added[/] '{label}' to {issue_id}." if ok
+        f"[green]Added[/] '{label}' to {issue_id}."
+        if ok
         else f"[red]Failed[/] to add '{label}' to {issue_id}."
     )
     if not ok:
@@ -592,16 +612,15 @@ def add_label(
 def remove_label(
     issue_id: str = typer.Argument(..., help="Issue ID or identifier (e.g., ENG-123)"),
     label: str = typer.Argument(..., help="Label name to remove"),
-    team: str = typer.Option(
-        None, "--team", "-t", help="Team key, to bind a team-scoped label"
-    ),
+    team: str = typer.Option(None, "--team", "-t", help="Team key, to bind a team-scoped label"),
 ):
     """Remove a single label from an issue (leaves other labels untouched)."""
     client = get_client()
     result = client.remove_label(issue_id, label, team_key=team)
     ok = result.get("success")
     console.print(
-        f"[green]Removed[/] '{label}' from {issue_id}." if ok
+        f"[green]Removed[/] '{label}' from {issue_id}."
+        if ok
         else f"[red]Failed[/] to remove '{label}' from {issue_id}."
     )
     if not ok:

--- a/tools/productivity/notion/cli.py
+++ b/tools/productivity/notion/cli.py
@@ -10,6 +10,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="notion", help="Notion CLI for AI agents")
+
+
+@app.command("health")
+def health():
+    """Assert notion connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.me()
+        payload = {"ok": True, "tool": "notion", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "notion", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/productivity/opentable/cli.py
+++ b/tools/productivity/opentable/cli.py
@@ -15,6 +15,28 @@ from .client import _client
 app = typer.Typer(
     name="opentable", help="Search OpenTable for available reservations (search only, cannot book)"
 )
+
+
+@app.command("health")
+def health():
+    """Assert opentable connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.search(term="", limit=1)
+        payload = {"ok": True, "tool": "opentable", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "opentable", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/productivity/opentable/pyproject.toml
+++ b/tools/productivity/opentable/pyproject.toml
@@ -25,5 +25,7 @@ build-backend = "hatchling.build"
 
 [tool.centaur]
 module = "client.py"
-hosts = ["www.opentable.com"]
-secrets = []
+hosts = ["www.opentable.com", "api.browser-use.com", "llm.api.browser-use.com"]
+secrets = [
+    {type = "http", name = "BROWSER_USE_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.browser-use.com", "llm.api.browser-use.com"]},
+]

--- a/tools/productivity/opentable/scraper.py
+++ b/tools/productivity/opentable/scraper.py
@@ -3,9 +3,12 @@
 import ast
 import asyncio
 import json
+import os
 import re
 from datetime import datetime
 from urllib.parse import urlencode
+
+from centaur_sdk import secret
 
 
 def build_search_url(
@@ -57,6 +60,10 @@ async def search_restaurants(
     limit: int = 10,
 ) -> list[dict]:
     """Search OpenTable for available reservations using browser automation."""
+    os.environ.setdefault(
+        "BROWSER_USE_API_KEY", secret("BROWSER_USE_API_KEY", "BROWSER_USE_API_KEY")
+    )
+
     # Lazy import: browser_use touches ~/.config on import, which fails in the
     # non-root sandbox tool-server and breaks tool loading.
     from browser_use import Agent, Browser, ChatBrowserUse

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -11,6 +11,28 @@ from centaur_sdk import Table
 load_dotenv()
 
 app = typer.Typer(name="slack", help="Slack CLI for AI agents")
+
+
+@app.command("health")
+def health():
+    """Assert slack connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_bot_channels(limit=1)
+        payload = {"ok": True, "tool": "slack", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "slack", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 stderr_console = Console(stderr=True)
 

--- a/tools/research/archiver/cli.py
+++ b/tools/research/archiver/cli.py
@@ -13,12 +13,32 @@ import typer
 from .client import _client
 from .utils import dump_json, normalize_url
 
-app = typer.Typer(name="archiver", help="Reducto-first document extraction for investment materials.")
-
-DEFAULT_GOOGLE_ACCOUNT = (
-    (os.getenv("GOOGLE_ACCOUNT") or "").strip()
-    or ""
+app = typer.Typer(
+    name="archiver", help="Reducto-first document extraction for investment materials."
 )
+
+
+@app.command("health")
+def health():
+    """Assert archiver connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = {"auth_mode": "local-only", "live_probe": False}
+        payload = {"ok": True, "tool": "archiver", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "archiver", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+DEFAULT_GOOGLE_ACCOUNT = (os.getenv("GOOGLE_ACCOUNT") or "").strip() or ""
 
 
 def _read_context(
@@ -26,7 +46,11 @@ def _read_context(
     context_file: str | None,
 ) -> dict | None:
     if context and context_file:
-        print(dump_json({"status": "error", "error": "Cannot specify both --context and --context-file"}))
+        print(
+            dump_json(
+                {"status": "error", "error": "Cannot specify both --context and --context-file"}
+            )
+        )
         raise typer.Exit(1)
     if context:
         return json.loads(context)
@@ -148,7 +172,9 @@ def download(
         and _looks_password_required(payload)
         and _is_interactive()
     ):
-        entered_password = typer.prompt("DocSend password", hide_input=True, confirmation_prompt=False)
+        entered_password = typer.prompt(
+            "DocSend password", hide_input=True, confirmation_prompt=False
+        )
         entered_password = entered_password.strip()
         if entered_password:
             payload = client.download(
@@ -230,13 +256,17 @@ def extract(
         payload = client.extract_manifest(manifest, context=ctx)
     elif source:
         if not output:
-            print(dump_json({"status": "error", "error": "--output is required when using --source"}))
+            print(
+                dump_json({"status": "error", "error": "--output is required when using --source"})
+            )
             raise typer.Exit(1)
-        source_kind, resolved_account, resolved_password, resolved_email = _resolve_source_auth_inputs(
-            source_url=source,
-            account=account,
-            password=password,
-            email=email,
+        source_kind, resolved_account, resolved_password, resolved_email = (
+            _resolve_source_auth_inputs(
+                source_url=source,
+                account=account,
+                password=password,
+                email=email,
+            )
         )
         payload = client.extract_source(
             source_url=source,
@@ -255,7 +285,9 @@ def extract(
             and _looks_password_required(payload)
             and _is_interactive()
         ):
-            entered_password = typer.prompt("DocSend password", hide_input=True, confirmation_prompt=False)
+            entered_password = typer.prompt(
+                "DocSend password", hide_input=True, confirmation_prompt=False
+            )
             entered_password = entered_password.strip()
             if entered_password:
                 payload = client.extract_source(

--- a/tools/research/archiver/docsend/playwright.py
+++ b/tools/research/archiver/docsend/playwright.py
@@ -35,15 +35,15 @@ from centaur_sdk import secret
 
 # Configuration
 DEFAULT_EMAIL = ""
-API_KEY = secret("BROWSER_USE_API_KEY", "")
 BROWSER_USE_PROXY_COUNTRY = os.environ.get("BROWSER_USE_PROXY_COUNTRY", "")  # noqa: TID251
 BROWSER_USE_PROFILE_ID = os.environ.get("BROWSER_USE_PROFILE_ID", "")  # noqa: TID251
 
 
 def browser_use_api_key() -> str:
     # Server mode returns the stub key name; the proxy swaps it for the real
-    # key in the query string (match_query). Local mode returns the env value.
-    return secret("BROWSER_USE_API_KEY", "")
+    # key in the query string (match_query). Local mode uses .env when present
+    # and otherwise keeps the stub so sandbox runs do not fail before proxying.
+    return secret("BROWSER_USE_API_KEY", "BROWSER_USE_API_KEY")
 
 
 def prepare_playwright_tls() -> None:
@@ -104,6 +104,7 @@ async def _stop_browser_session(client: AsyncBrowserUse, session_id: str) -> Non
 
 class ScrapeStatus(Enum):
     """Possible scrape outcomes."""
+
     SUCCESS = "success"
     PARTIAL = "partial"  # Some slides failed but got most
     PASSWORD_REQUIRED = "password_required"
@@ -117,6 +118,7 @@ class ScrapeStatus(Enum):
 @dataclass
 class ScrapeConfig:
     """Configuration for scraping behavior."""
+
     # Timeouts (in ms)
     page_load_timeout: int = 45000
     auth_timeout: int = 5000  # Short timeout - email field should appear quickly
@@ -138,6 +140,7 @@ class ScrapeConfig:
 @dataclass
 class ScrapeResult:
     """Result of a scrape operation."""
+
     url: str
     company: str
     status: ScrapeStatus = ScrapeStatus.ERROR
@@ -175,7 +178,7 @@ async def retry_async(
         except exceptions as e:
             last_exception = e
             if attempt < max_retries - 1:
-                wait_time = delay * (2 ** attempt)  # Exponential backoff
+                wait_time = delay * (2**attempt)  # Exponential backoff
                 if on_retry:
                     on_retry(attempt + 1, max_retries, e, wait_time)
                 await asyncio.sleep(wait_time)
@@ -199,7 +202,7 @@ async def enter_password(page, password: str, config: ScrapeConfig = DEFAULT_CON
         # DocSend passcode fields use type="text", not type="password"
         pw_selectors = [
             'input[type="password"]',
-            '#link_auth_form_passcode',
+            "#link_auth_form_passcode",
             'input[name*="passcode"]',
         ]
 
@@ -207,7 +210,7 @@ async def enter_password(page, password: str, config: ScrapeConfig = DEFAULT_CON
         for sel in pw_selectors:
             loc = page.locator(sel).first
             try:
-                await loc.wait_for(state='visible', timeout=3000)
+                await loc.wait_for(state="visible", timeout=3000)
                 password_field = loc
                 break
             except Exception:
@@ -221,16 +224,16 @@ async def enter_password(page, password: str, config: ScrapeConfig = DEFAULT_CON
         # feedback/chat email field (#feedback_sender_email).
         # Includes folder-style ReactModal email fields.
         email_selectors = [
-            '#link_auth_form_email',
+            "#link_auth_form_email",
             '#new_link_auth_form input[type="email"]',
-            '.js-auth-form_email-field',
+            ".js-auth-form_email-field",
             '.ReactModal__Content input[type="email"]',
             '#email[type="email"]',
         ]
         for em_sel in email_selectors:
             try:
                 email_input = page.locator(em_sel).first
-                await email_input.wait_for(state='visible', timeout=2000)
+                await email_input.wait_for(state="visible", timeout=2000)
                 await email_input.fill(DEFAULT_EMAIL)
                 await asyncio.sleep(0.5)
                 break
@@ -261,10 +264,10 @@ async def enter_password(page, password: str, config: ScrapeConfig = DEFAULT_CON
                 continue
 
         if not clicked:
-            await page.keyboard.press('Enter')
+            await page.keyboard.press("Enter")
 
         # Wait for navigation/load
-        await page.wait_for_load_state('networkidle', timeout=config.network_idle_timeout)
+        await page.wait_for_load_state("networkidle", timeout=config.network_idle_timeout)
         await asyncio.sleep(2)
         # Check if still on password/passcode page (single-doc form or folder modal)
         still_on_auth = await page.query_selector(
@@ -291,13 +294,13 @@ async def enter_password(page, password: str, config: ScrapeConfig = DEFAULT_CON
 
 async def get_slide_count(page) -> int:
     """Get total slide count from page indicator."""
-    selectors = ['.toolbar-page-indicator', '.page-label', '[class*="page-indicator"]']
+    selectors = [".toolbar-page-indicator", ".page-label", '[class*="page-indicator"]']
     for selector in selectors:
         try:
             indicator = await page.query_selector(selector)
             if indicator:
                 text = await indicator.text_content()
-                match = re.search(r'(\d+)\s*/\s*(\d+)', text)
+                match = re.search(r"(\d+)\s*/\s*(\d+)", text)
                 if match:
                     return int(match.group(2))
         except Exception:
@@ -318,7 +321,7 @@ async def fetch_slide_urls(
     """
     urls = []
     failed = []
-    base_url = page.url.split('?')[0]
+    base_url = page.url.split("?")[0]
 
     for i in range(1, total_pages + 1):
         url = None
@@ -337,12 +340,12 @@ async def fetch_slide_urls(
                     }})()
                 """)
 
-                if result and result.get('url'):
-                    url = result['url']
+                if result and result.get("url"):
+                    url = result["url"]
                     break
-                elif result and result.get('error'):
-                    last_error = result['error']
-                    if 'HTTP 4' in last_error:  # 4xx errors - don't retry
+                elif result and result.get("error"):
+                    last_error = result["error"]
+                    if "HTTP 4" in last_error:  # 4xx errors - don't retry
                         break
             except Exception as e:
                 last_error = str(e)
@@ -415,12 +418,14 @@ async def create_pdf(image_paths: list[Path], output_path: Path):
         return
 
     images = [Image.open(p) for p in sorted(image_paths)]
-    rgb_images = [img.convert('RGB') if img.mode != 'RGB' else img for img in images]
+    rgb_images = [img.convert("RGB") if img.mode != "RGB" else img for img in images]
 
     if rgb_images:
         rgb_images[0].save(
-            output_path, "PDF", save_all=True,
-            append_images=rgb_images[1:] if len(rgb_images) > 1 else []
+            output_path,
+            "PDF",
+            save_all=True,
+            append_images=rgb_images[1:] if len(rgb_images) > 1 else [],
         )
 
 
@@ -453,10 +458,6 @@ async def scrape_docsend(
         company_dir.mkdir(parents=True, exist_ok=True)
 
         api_key = browser_use_api_key()
-        if not api_key:
-            result.status = ScrapeStatus.ERROR
-            result.error = "BROWSER_USE_API_KEY not configured"
-            return result
         playwright_browser = None
 
         try:
@@ -479,7 +480,7 @@ async def scrape_docsend(
                 # Step 3: Navigate to DocSend URL with retry
 
                 async def navigate():
-                    await page.goto(url, wait_until='networkidle', timeout=config.page_load_timeout)
+                    await page.goto(url, wait_until="networkidle", timeout=config.page_load_timeout)
 
                 try:
                     await retry_async(
@@ -499,7 +500,7 @@ async def scrape_docsend(
 
                 # Check for error states
                 title = await page.title()
-                if '404' in title or 'not found' in title.lower():
+                if "404" in title or "not found" in title.lower():
                     result.status = ScrapeStatus.LINK_EXPIRED
                     return result
 
@@ -530,15 +531,17 @@ async def scrape_docsend(
                 email_field = None
                 try:
                     email_field = page.locator('#prompt input[type="email"]').first
-                    await email_field.wait_for(state='visible', timeout=config.auth_timeout)
+                    await email_field.wait_for(state="visible", timeout=config.auth_timeout)
                 except Exception:
                     # Try fallback - find visible email input (not the feedback one)
                     try:
                         # Look for email input in a modal/prompt container
-                        modal_email = page.locator('.modal input[type="email"], #prompt input[type="email"], [class*="auth"] input[type="email"]').first
+                        modal_email = page.locator(
+                            '.modal input[type="email"], #prompt input[type="email"], [class*="auth"] input[type="email"]'
+                        ).first
                         if await modal_email.count() > 0:
                             box = await modal_email.bounding_box(timeout=2000)
-                            if box and box['width'] > 50:
+                            if box and box["width"] > 50:
                                 email_field = modal_email
                     except Exception:
                         pass
@@ -554,12 +557,14 @@ async def scrape_docsend(
                             if await submit_btn.is_visible(timeout=2000):
                                 await submit_btn.click(timeout=5000)
                             else:
-                                await page.keyboard.press('Enter')
+                                await page.keyboard.press("Enter")
                         except Exception:
-                            await page.keyboard.press('Enter')
+                            await page.keyboard.press("Enter")
 
                         # Wait for document to load
-                        await page.wait_for_load_state('networkidle', timeout=config.network_idle_timeout)
+                        await page.wait_for_load_state(
+                            "networkidle", timeout=config.network_idle_timeout
+                        )
                         await asyncio.sleep(2)
                     except PlaywrightTimeout:
                         pass
@@ -582,7 +587,9 @@ async def scrape_docsend(
                 result.total_pages = total_pages
 
                 # Fetch all slide URLs via API
-                slide_urls, fetch_failed = await fetch_slide_urls(page, total_pages, company, config)
+                slide_urls, fetch_failed = await fetch_slide_urls(
+                    page, total_pages, company, config
+                )
                 valid_urls = [u for u in slide_urls if u]
 
                 if len(valid_urls) == 0:
@@ -592,7 +599,9 @@ async def scrape_docsend(
                     return result
 
                 # Download images
-                downloaded, download_failed = await download_images(slide_urls, company_dir, company, config)
+                downloaded, download_failed = await download_images(
+                    slide_urls, company_dir, company, config
+                )
                 result.downloaded = len(downloaded)
                 result.failed_slides = list(set(fetch_failed + download_failed))
 

--- a/tools/research/archiver/download/docsend.py
+++ b/tools/research/archiver/download/docsend.py
@@ -20,7 +20,6 @@ from browser_use_sdk import AsyncBrowserUse
 from playwright.async_api import Page, async_playwright
 from playwright.async_api import TimeoutError as PlaywrightTimeout
 
-from centaur_sdk import secret
 
 # Import slide scraper functions
 from ..docsend.playwright import (
@@ -41,7 +40,6 @@ from ..docsend.playwright import (
 )
 
 # Configuration
-API_KEY = secret("BROWSER_USE_API_KEY", "")
 BROWSER_USE_PROXY_COUNTRY = os.environ.get("BROWSER_USE_PROXY_COUNTRY", "")  # noqa: TID251
 BROWSER_USE_PROFILE_ID = os.environ.get("BROWSER_USE_PROFILE_ID", "")  # noqa: TID251
 DOCSEND_DEBUG_DIR = os.environ.get("DOCSEND_DEBUG_DIR")  # noqa: TID251
@@ -77,26 +75,28 @@ async def _stop_browser_session(client: AsyncBrowserUse, session_id: str) -> Non
 
 class DocSendState(Enum):
     """Possible states of a DocSend link."""
-    LINK_EXPIRED = "link_expired"           # 404 or "not found"
+
+    LINK_EXPIRED = "link_expired"  # 404 or "not found"
     PASSWORD_REQUIRED = "password_required"  # Password field visible
-    EMAIL_GATED = "email_gated"             # Email required to view
-    DOWNLOAD_ENABLED = "download_enabled"    # Download button available
+    EMAIL_GATED = "email_gated"  # Email required to view
+    DOWNLOAD_ENABLED = "download_enabled"  # Download button available
     DOWNLOAD_DISABLED = "download_disabled"  # View-only, need to scrape slides
-    FOLDER = "folder"                        # Folder/space with ZIP download
-    BLOCKED = "blocked"                      # CloudFront or WAF block
-    UNKNOWN = "unknown"                      # Couldn't determine
+    FOLDER = "folder"  # Folder/space with ZIP download
+    BLOCKED = "blocked"  # CloudFront or WAF block
+    UNKNOWN = "unknown"  # Couldn't determine
 
 
 def is_folder_url(url: str) -> bool:
     """Check if a DocSend URL is a folder/space link (contains /s/ segment)."""
     path = urlparse(url).path
     # Folder URLs: /view/s/xxx or /v/xxx/s/yyy
-    return '/s/' in path
+    return "/s/" in path
 
 
 @dataclass
 class StateDetectionResult:
     """Result of state detection."""
+
     state: DocSendState
     title: str | None = None
     page_count: int | None = None
@@ -126,7 +126,7 @@ async def enter_email(page: Page, email: str, config: ScrapeConfig = DEFAULT_CON
                 field = page.locator(selector).first
                 if await field.count() > 0:
                     box = await field.bounding_box(timeout=2000)
-                    if box and box['width'] > 50:
+                    if box and box["width"] > 50:
                         email_field = field
                         break
             except Exception:
@@ -155,10 +155,10 @@ async def enter_email(page: Page, email: str, config: ScrapeConfig = DEFAULT_CON
             except Exception:
                 continue
         if not clicked:
-            await page.keyboard.press('Enter')
+            await page.keyboard.press("Enter")
 
         # Wait for document to load
-        await page.wait_for_load_state('networkidle', timeout=config.network_idle_timeout)
+        await page.wait_for_load_state("networkidle", timeout=config.network_idle_timeout)
         await asyncio.sleep(2)
 
         return True
@@ -206,7 +206,7 @@ async def detect_docsend_state(
 
         try:
             blocked_text = await page.locator(
-                'text=/request could not be satisfied|cloudfront|access denied|request blocked/i'
+                "text=/request could not be satisfied|cloudfront|access denied|request blocked/i"
             ).first.text_content(timeout=2000)
             if blocked_text:
                 result.state = DocSendState.BLOCKED
@@ -215,7 +215,7 @@ async def detect_docsend_state(
         except Exception:
             pass
 
-        if '404' in title or 'not found' in title.lower() or 'expired' in title.lower():
+        if "404" in title or "not found" in title.lower() or "expired" in title.lower():
             result.state = DocSendState.LINK_EXPIRED
             return result
 
@@ -229,7 +229,11 @@ async def detect_docsend_state(
         if not password_field:
             # Fallback: try selectors individually (some CDP connections
             # have issues with comma-separated selectors)
-            for pw_sel in ['input[type="password"]', '#link_auth_form_passcode', 'input[name*="passcode"]']:
+            for pw_sel in [
+                'input[type="password"]',
+                "#link_auth_form_passcode",
+                'input[name*="passcode"]',
+            ]:
                 password_field = await page.query_selector(pw_sel)
                 if password_field:
                     break
@@ -251,7 +255,7 @@ async def detect_docsend_state(
             has_email_field = False
             try:
                 email_locator = page.locator('#prompt input[type="email"]').first
-                await email_locator.wait_for(state='visible', timeout=config.auth_timeout)
+                await email_locator.wait_for(state="visible", timeout=config.auth_timeout)
                 has_email_field = True
             except Exception:
                 # Try fallback selectors (including folder-style ReactModal email)
@@ -266,7 +270,7 @@ async def detect_docsend_state(
                         modal_email = page.locator(fb_sel).first
                         if await modal_email.count() > 0:
                             box = await modal_email.bounding_box(timeout=2000)
-                            if box and box['width'] > 50:
+                            if box and box["width"] > 50:
                                 has_email_field = True
                     except Exception:
                         pass
@@ -280,7 +284,9 @@ async def detect_docsend_state(
             # available" text hidden in the DOM).  Only count it as
             # expired if the element is actually *visible* on screen.
             try:
-                expired_locator = page.locator('text=/link.*expired|no longer available|not available|not found/i').first
+                expired_locator = page.locator(
+                    "text=/link.*expired|no longer available|not available|not found/i"
+                ).first
                 if await expired_locator.is_visible(timeout=2000):
                     expired_text = await expired_locator.text_content(timeout=2000)
                     if expired_text:
@@ -308,7 +314,7 @@ async def detect_docsend_state(
         # Check for download button
         download_selectors = [
             '[data-testid="download"]',
-            '.download-button',
+            ".download-button",
             'button:has-text("Download")',
             'a:has-text("Download PDF")',
             '[class*="download"]',
@@ -363,7 +369,7 @@ async def download_docsend_pdf(
     """
     download_selectors = [
         '[data-testid="download"]',
-        '.download-button',
+        ".download-button",
         'button:has-text("Download")',
         'a:has-text("Download PDF")',
         'a:has-text("Download")',
@@ -404,16 +410,16 @@ async def _intercept_cloudfront_download(
     def on_response(response):
         nonlocal download_url, suggested_filename
         # Skip Dropbox analytics noise
-        if 'dropbox.com/log' in response.url:
+        if "dropbox.com/log" in response.url:
             return
-        content_disp = response.headers.get('content-disposition', '')
-        if 'cloudfront.net' in response.url and 'attachment' in content_disp:
+        content_disp = response.headers.get("content-disposition", "")
+        if "cloudfront.net" in response.url and "attachment" in content_disp:
             download_url = response.url
             fn_match = re.search(r'filename="?([^";\n]+)"?', content_disp)
             if fn_match:
                 suggested_filename = fn_match.group(1)
 
-    page.on('response', on_response)
+    page.on("response", on_response)
 
     await click_locator.click()
 
@@ -422,7 +428,7 @@ async def _intercept_cloudfront_download(
             break
         await asyncio.sleep(3)
 
-    page.remove_listener('response', on_response)
+    page.remove_listener("response", on_response)
     return download_url, suggested_filename
 
 
@@ -462,9 +468,9 @@ async def download_folder(
             save_path = output_dir / f"{filename}.zip"
             try:
                 async with httpx.AsyncClient(follow_redirects=True, timeout=300) as client:
-                    async with client.stream('GET', url) as resp:
+                    async with client.stream("GET", url) as resp:
                         resp.raise_for_status()
-                        with open(save_path, 'wb') as f:
+                        with open(save_path, "wb") as f:
                             async for chunk in resp.aiter_bytes(chunk_size=65536):
                                 f.write(chunk)
                 return save_path
@@ -490,14 +496,14 @@ async def download_folder(
                 if not url:
                     continue
 
-                safe_fname = fname or f"file_{i+1}"
+                safe_fname = fname or f"file_{i + 1}"
                 # Sanitize filename
-                safe_fname = safe_fname.replace('/', '_').replace('\\', '_')
+                safe_fname = safe_fname.replace("/", "_").replace("\\", "_")
                 save_path = output_dir / safe_fname
 
-                async with client.stream('GET', url) as resp:
+                async with client.stream("GET", url) as resp:
                     resp.raise_for_status()
-                    with open(save_path, 'wb') as f:
+                    with open(save_path, "wb") as f:
                         async for chunk in resp.aiter_bytes(chunk_size=65536):
                             f.write(chunk)
 
@@ -621,14 +627,11 @@ async def route_docsend(
     Returns:
         ScrapeResult with status and details
     """
+
     async def _route():
         result = ScrapeResult(url=url, company=company)
 
         api_key = browser_use_api_key()
-        if not api_key:
-            result.status = ScrapeStatus.ERROR
-            result.error = "BROWSER_USE_API_KEY not configured"
-            return result
         playwright_browser = None
 
         try:
@@ -650,7 +653,9 @@ async def route_docsend(
                 # Navigate to URL
                 await asyncio.sleep(15)
                 try:
-                    response = await page.goto(url, wait_until='networkidle', timeout=config.page_load_timeout)
+                    response = await page.goto(
+                        url, wait_until="networkidle", timeout=config.page_load_timeout
+                    )
                 except PlaywrightTimeout:
                     result.status = ScrapeStatus.TIMEOUT
                     result.error = "Page load timeout"
@@ -668,8 +673,10 @@ async def route_docsend(
                 if DOCSEND_DEBUG_DIR:
                     debug_dir = Path(DOCSEND_DEBUG_DIR)
                     debug_dir.mkdir(parents=True, exist_ok=True)
-                    debug_prefix = company.replace(' ', '_').replace('/', '_') or 'unknown'
-                    await page.screenshot(path=str(debug_dir / f"{debug_prefix}.png"), full_page=True)
+                    debug_prefix = company.replace(" ", "_").replace("/", "_") or "unknown"
+                    await page.screenshot(
+                        path=str(debug_dir / f"{debug_prefix}.png"), full_page=True
+                    )
                     html_path = debug_dir / f"{debug_prefix}.html"
                     html_path.write_text(await page.content())
 
@@ -695,7 +702,9 @@ async def route_docsend(
 
                     case DocSendState.PASSWORD_REQUIRED:
                         result.status = ScrapeStatus.PASSWORD_REQUIRED
-                        result.error = state_result.error or "Password required but not provided or rejected"
+                        result.error = (
+                            state_result.error or "Password required but not provided or rejected"
+                        )
                         return result
 
                     case DocSendState.EMAIL_GATED:
@@ -708,7 +717,7 @@ async def route_docsend(
                             # attempting entry.
                             try:
                                 expired_el = page.locator(
-                                    'text=/link.*expired|no longer available|not found/i'
+                                    "text=/link.*expired|no longer available|not found/i"
                                 ).first
                                 expired_text = await expired_el.text_content(timeout=2000)
                                 if expired_text:
@@ -727,7 +736,9 @@ async def route_docsend(
                             # Folder — download as ZIP
                             company_dir = output_dir / company.replace(" ", "_").replace("/", "_")
                             company_dir.mkdir(parents=True, exist_ok=True)
-                            zip_path = await download_folder(page, company_dir, company.replace(" ", "_"), config)
+                            zip_path = await download_folder(
+                                page, company_dir, company.replace(" ", "_"), config
+                            )
                             if zip_path:
                                 result.status = ScrapeStatus.SUCCESS
                                 result.pdf_path = str(zip_path)
@@ -739,7 +750,9 @@ async def route_docsend(
                             # Download directly
                             company_dir = output_dir / company.replace(" ", "_").replace("/", "_")
                             company_dir.mkdir(parents=True, exist_ok=True)
-                            pdf_path = await download_docsend_pdf(page, company_dir, company.replace(" ", "_"), config)
+                            pdf_path = await download_docsend_pdf(
+                                page, company_dir, company.replace(" ", "_"), config
+                            )
                             if pdf_path:
                                 result.status = ScrapeStatus.SUCCESS
                                 result.pdf_path = str(pdf_path)
@@ -754,7 +767,9 @@ async def route_docsend(
                         # Folder already authenticated — download as ZIP
                         company_dir = output_dir / company.replace(" ", "_").replace("/", "_")
                         company_dir.mkdir(parents=True, exist_ok=True)
-                        zip_path = await download_folder(page, company_dir, company.replace(" ", "_"), config)
+                        zip_path = await download_folder(
+                            page, company_dir, company.replace(" ", "_"), config
+                        )
                         if zip_path:
                             result.status = ScrapeStatus.SUCCESS
                             result.pdf_path = str(zip_path)
@@ -767,7 +782,9 @@ async def route_docsend(
                         # Download directly
                         company_dir = output_dir / company.replace(" ", "_").replace("/", "_")
                         company_dir.mkdir(parents=True, exist_ok=True)
-                        pdf_path = await download_docsend_pdf(page, company_dir, company.replace(" ", "_"), config)
+                        pdf_path = await download_docsend_pdf(
+                            page, company_dir, company.replace(" ", "_"), config
+                        )
                         if pdf_path:
                             result.status = ScrapeStatus.SUCCESS
                             result.pdf_path = str(pdf_path)
@@ -827,11 +844,7 @@ async def route_all_docsends(
     if not urls:
         return []
 
-    if not API_KEY:
-        return []
-
     output_dir.mkdir(parents=True, exist_ok=True)
-
 
     semaphore = asyncio.Semaphore(max_parallel)
 
@@ -857,11 +870,13 @@ async def route_all_docsends(
             processed_results.append(r)
         else:
             # Exception occurred
-            processed_results.append(ScrapeResult(
-                url=urls[i]["url"],
-                company=urls[i].get("company", "Unknown"),
-                status=ScrapeStatus.ERROR,
-                error=str(r),
-            ))
+            processed_results.append(
+                ScrapeResult(
+                    url=urls[i]["url"],
+                    company=urls[i].get("company", "Unknown"),
+                    status=ScrapeStatus.ERROR,
+                    error=str(r),
+                )
+            )
 
     return processed_results

--- a/tools/research/congress/cli.py
+++ b/tools/research/congress/cli.py
@@ -13,6 +13,28 @@ from centaur_sdk.cli_tables import Table
 from .client import CongressClient
 
 app = typer.Typer(name="congress", help="Congress.gov API CLI")
+
+
+@app.command("health")
+def health():
+    """Assert congress connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_bills(limit=1)
+        payload = {"ok": True, "tool": "congress", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "congress", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/research/crunchbase/cli.py
+++ b/tools/research/crunchbase/cli.py
@@ -9,6 +9,28 @@ from rich.table import Table
 app = typer.Typer(
     name="crunchbase", help="Crunchbase Enterprise API CLI for company and funding data"
 )
+
+
+@app.command("health")
+def health():
+    """Assert crunchbase connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_deleted_entities()
+        payload = {"ok": True, "tool": "crunchbase", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "crunchbase", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 ORG_DEFAULT_FIELDS = [

--- a/tools/research/docsend/cli.py
+++ b/tools/research/docsend/cli.py
@@ -1,0 +1,39 @@
+"""CLI for DocSend document downloader."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(name="docsend", help="DocSend document downloader — cloud browser + Playwright")
+
+
+@app.callback()
+def main() -> None:
+    """docsend CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert docsend connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = {"auth_mode": "local-only", "live_probe": False}
+        payload = {"ok": True, "tool": "docsend", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "docsend", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/research/docsend/client.py
+++ b/tools/research/docsend/client.py
@@ -30,8 +30,9 @@ BROWSER_USE_PROFILE_ID = os.environ.get("BROWSER_USE_PROFILE_ID", "")  # noqa: T
 
 def _browser_use_api_key() -> str:
     # Server mode returns the stub key name; the proxy swaps it for the real
-    # key in the query string (match_query). Local mode returns the env value.
-    return secret("BROWSER_USE_API_KEY", "")
+    # key in the query string (match_query). Local mode uses .env when present
+    # and otherwise keeps the stub so sandbox runs do not fail before proxying.
+    return secret("BROWSER_USE_API_KEY", "BROWSER_USE_API_KEY")
 
 
 def _prepare_playwright_tls() -> None:
@@ -63,8 +64,6 @@ def _redact_browser_use_secret(error: Exception, api_key: str) -> str:
     return re.sub(r"apiKey=[^&\\s]+", "apiKey=<redacted>", text)
 
 
-
-
 class DocsendClient:
     """Download DocSend documents as PDF via cloud browser."""
 
@@ -94,6 +93,7 @@ class DocsendClient:
             loop = None
         if loop and loop.is_running():
             import concurrent.futures
+
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 return pool.submit(
                     asyncio.run, self._run(url, email, passcode, verification_link)
@@ -108,8 +108,6 @@ class DocsendClient:
             url = f"https://{url}"
 
         api_key = _browser_use_api_key()
-        if not api_key:
-            return _err("BROWSER_USE_API_KEY not configured")
 
         try:
             from playwright.async_api import async_playwright
@@ -220,7 +218,9 @@ class DocsendClient:
                 # 8. Assemble PDF
                 buf = BytesIO()
                 good[0].save(
-                    buf, "PDF", save_all=True,
+                    buf,
+                    "PDF",
+                    save_all=True,
                     append_images=good[1:] if len(good) > 1 else [],
                 )
 

--- a/tools/research/docsend/pyproject.toml
+++ b/tools/research/docsend/pyproject.toml
@@ -4,15 +4,27 @@ description = "DocSend document downloader — cloud browser + Playwright"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
     "browser-use-sdk>=2.0.14",
     "httpx>=0.28.0",
     "pillow>=12.0.0",
     "playwright>=1.50.0",
 ]
 
+[project.scripts]
+docsend = "centaur_tool_docsend.cli:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_docsend"
 
 [tool.centaur]
 module = "client.py"

--- a/tools/research/fedreg/cli.py
+++ b/tools/research/fedreg/cli.py
@@ -11,6 +11,28 @@ from rich.console import Console
 from centaur_sdk.cli_tables import Table
 
 app = typer.Typer(name="fedreg", help="Federal Register CLI for regulatory data")
+
+
+@app.command("health")
+def health():
+    """Assert fedreg connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_agencies()
+        payload = {"ok": True, "tool": "fedreg", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "fedreg", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/research/googlenews/cli.py
+++ b/tools/research/googlenews/cli.py
@@ -12,6 +12,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="googlenews", help="Google News CLI for news search and headlines")
+
+
+@app.command("health")
+def health():
+    """Assert googlenews connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.headlines()
+        payload = {"ok": True, "tool": "googlenews", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "googlenews", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/research/harmonic/cli.py
+++ b/tools/research/harmonic/cli.py
@@ -13,6 +13,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="harmonic", help="Harmonic.AI API CLI for startup discovery and enrichment")
+
+
+@app.command("health")
+def health():
+    """Assert harmonic connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_saved_searches()
+        payload = {"ok": True, "tool": "harmonic", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "harmonic", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/research/invest_intake/cli.py
+++ b/tools/research/invest_intake/cli.py
@@ -1,0 +1,42 @@
+"""CLI for Normalize mixed raw invest inputs into a clean context pack."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(
+    name="invest-intake", help="Normalize mixed raw invest inputs into a clean context pack"
+)
+
+
+@app.callback()
+def main() -> None:
+    """invest-intake CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert invest-intake connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        client._load_archiver_client()
+        details = {"auth_mode": "local-only", "live_probe": False}
+        payload = {"ok": True, "tool": "invest-intake", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "invest-intake", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/research/invest_intake/pyproject.toml
+++ b/tools/research/invest_intake/pyproject.toml
@@ -4,15 +4,25 @@ description = "Normalize mixed raw invest inputs into a clean context pack"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
     "typer>=0.12.0",
 ]
+
+[project.scripts]
+invest-intake = "centaur_tool_invest_intake.cli:app"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_invest_intake"
+
 [tool.centaur]
 module = "client.py"
 hosts = ["docs.google.com", "drive.google.com", "docsend.com"]
 secrets = []
-

--- a/tools/research/investmemos/cli.py
+++ b/tools/research/investmemos/cli.py
@@ -1,0 +1,41 @@
+"""CLI for Postgres."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import typer
+
+app = typer.Typer(name="investmemos", help="Postgres-backed investment memo search and retrieval")
+
+
+@app.callback()
+def main() -> None:
+    """investmemos CLI."""
+
+
+@app.command("health")
+def health():
+    """Assert investmemos connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_memos(limit=1)
+        if isinstance(details, dict) and details.get("status") == "error":
+            raise RuntimeError(str(details.get("error") or "investmemos health check failed"))
+        payload = {"ok": True, "tool": "investmemos", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "investmemos", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/research/investmemos/client.py
+++ b/tools/research/investmemos/client.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import asyncpg
 
+from centaur_sdk.tool_sdk import secret
+
 
 DEFAULT_MEMO_SOURCE = "invest_memo_corpus"
 DEFAULT_MEMO_KIND = "invest_memo_chunk"
@@ -76,7 +78,9 @@ class InvestmemosClient:
     """Search and read investment memos from Postgres-backed corpus chunks."""
 
     def __init__(self, database_url: str | None = None) -> None:
-        self._database_url = (database_url or os.getenv("DATABASE_URL") or "").strip()
+        self._database_url = (
+            database_url or os.getenv("DATABASE_URL") or secret("DATABASE_URL", "")
+        ).strip()
         self._default_source = (os.getenv("INVEST_MEMO_SOURCE") or DEFAULT_MEMO_SOURCE).strip()
         self._default_kind = (os.getenv("INVEST_MEMO_KIND") or DEFAULT_MEMO_KIND).strip()
 
@@ -126,7 +130,9 @@ class InvestmemosClient:
         finally:
             await conn.close()
 
-    def list_memos(self, query: str | None = None, limit: int = 50, source: str | None = None) -> dict:
+    def list_memos(
+        self, query: str | None = None, limit: int = 50, source: str | None = None
+    ) -> dict:
         """List memo documents from the indexed memo corpus."""
         try:
             return asyncio.run(
@@ -219,8 +225,7 @@ class InvestmemosClient:
             for row in rows:
                 metadata = _as_dict(row["metadata"])
                 document_id = str(
-                    metadata.get("document_id")
-                    or str(row["source_id"]).split(":")[0]
+                    metadata.get("document_id") or str(row["source_id"]).split(":")[0]
                 )
                 memo_name = str(metadata.get("memo_name") or document_id)
                 content = str(row["content"] or "")

--- a/tools/research/investmemos/client.py
+++ b/tools/research/investmemos/client.py
@@ -11,8 +11,6 @@ from typing import Any
 
 import asyncpg
 
-from centaur_sdk.tool_sdk import secret
-
 
 DEFAULT_MEMO_SOURCE = "invest_memo_corpus"
 DEFAULT_MEMO_KIND = "invest_memo_chunk"
@@ -78,9 +76,7 @@ class InvestmemosClient:
     """Search and read investment memos from Postgres-backed corpus chunks."""
 
     def __init__(self, database_url: str | None = None) -> None:
-        self._database_url = (
-            database_url or os.getenv("DATABASE_URL") or secret("DATABASE_URL", "")
-        ).strip()
+        self._database_url = (database_url or os.getenv("DATABASE_URL") or "").strip()
         self._default_source = (os.getenv("INVEST_MEMO_SOURCE") or DEFAULT_MEMO_SOURCE).strip()
         self._default_kind = (os.getenv("INVEST_MEMO_KIND") or DEFAULT_MEMO_KIND).strip()
 

--- a/tools/research/investmemos/pyproject.toml
+++ b/tools/research/investmemos/pyproject.toml
@@ -25,4 +25,3 @@ packages = ["."]
 
 [tool.centaur]
 module = "client.py"
-secrets = ["DATABASE_URL"]

--- a/tools/research/investmemos/pyproject.toml
+++ b/tools/research/investmemos/pyproject.toml
@@ -4,12 +4,25 @@ description = "Postgres-backed investment memo search and retrieval"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "python-dotenv>=1.0.0",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
     "asyncpg>=0.30.0",
 ]
+
+[project.scripts]
+investmemos = "centaur_tool_investmemos.cli:app"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_investmemos"
+
 [tool.centaur]
 module = "client.py"
+secrets = ["DATABASE_URL"]

--- a/tools/research/legistorm/cli.py
+++ b/tools/research/legistorm/cli.py
@@ -8,6 +8,28 @@ from centaur_sdk.cli_tables import Table
 from rich.console import Console
 
 app = typer.Typer(name="legistorm", help="LegiStorm CLI for congressional data")
+
+
+@app.command("health")
+def health():
+    """Assert legistorm connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_staff_retired_ids()
+        payload = {"ok": True, "tool": "legistorm", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "legistorm", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -63,9 +85,17 @@ def member_fields(row: dict) -> tuple[str, str, str, str, str]:
         f"{profile.get('preferred_last_name') or profile.get('last_name') or member.get('last_name', '')}"
     ).strip()
 
-    office = next((office for office in row.get("member_offices", []) if office.get("status") == "In Office"), {})
+    office = next(
+        (office for office in row.get("member_offices", []) if office.get("status") == "In Office"),
+        {},
+    )
     state = office.get("state_id") or row.get("state") or ""
-    party = office.get("party") or row.get("party") or profile.get("bio_details", {}).get("party_name") or ""
+    party = (
+        office.get("party")
+        or row.get("party")
+        or profile.get("bio_details", {}).get("party_name")
+        or ""
+    )
     chamber = office.get("office_type_id") or row.get("chamber") or ""
     member_id = member.get("member_id") or row.get("id") or ""
     return str(member_id), name, state, party, chamber
@@ -78,7 +108,11 @@ def staff_fields(row: dict) -> tuple[str, str, str, str]:
         f"{staff.get('preferred_first_name') or staff.get('first_name', '')} "
         f"{staff.get('preferred_last_name') or staff.get('last_name', '')}"
     ).strip()
-    current_titles = [position.get("position_title", "") for position in row.get("positions", []) if position.get("is_current")]
+    current_titles = [
+        position.get("position_title", "")
+        for position in row.get("positions", [])
+        if position.get("is_current")
+    ]
     title = " | ".join(title for title in current_titles if title) or row.get("title", "") or ""
     emails = row.get("staff_emails", [])
     email = emails[0].get("contact_string", "") if emails else row.get("email", "") or ""

--- a/tools/research/listennotes/cli.py
+++ b/tools/research/listennotes/cli.py
@@ -12,6 +12,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="listennotes", help="Listen Notes CLI for podcast data")
+
+
+@app.command("health")
+def health():
+    """Assert listennotes connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.search("technology", type="podcast")
+        payload = {"ok": True, "tool": "listennotes", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "listennotes", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/research/newsapi/cli.py
+++ b/tools/research/newsapi/cli.py
@@ -12,6 +12,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="newsapi", help="NewsAPI CLI for news search and headlines")
+
+
+@app.command("health")
+def health():
+    """Assert newsapi connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.sources()
+        payload = {"ok": True, "tool": "newsapi", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "newsapi", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/research/openfec/cli.py
+++ b/tools/research/openfec/cli.py
@@ -11,6 +11,28 @@ from rich.console import Console
 from centaur_sdk.cli_tables import Table
 
 app = typer.Typer(name="openfec", help="OpenFEC CLI for federal election data")
+
+
+@app.command("health")
+def health():
+    """Assert openfec connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.search_candidates(per_page=1)
+        payload = {"ok": True, "tool": "openfec", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "openfec", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/research/plural/cli.py
+++ b/tools/research/plural/cli.py
@@ -12,7 +12,32 @@ from centaur_sdk.cli_tables import Table
 
 from .client import PluralClient
 
-app = typer.Typer(name="plural", help="Plural (Open States) API — state legislation, legislators, committees, events")
+app = typer.Typer(
+    name="plural",
+    help="Plural (Open States) API — state legislation, legislators, committees, events",
+)
+
+
+@app.command("health")
+def health():
+    """Assert plural connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.list_jurisdictions()
+        payload = {"ok": True, "tool": "plural", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "plural", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -30,7 +55,9 @@ def truncate(text: str | None, max_len: int = 50) -> str:
 
 @app.command()
 def jurisdictions(
-    classification: str = typer.Option(None, "--classification", "-c", help="Filter by type (state, municipality)"),
+    classification: str = typer.Option(
+        None, "--classification", "-c", help="Filter by type (state, municipality)"
+    ),
     page: int = typer.Option(1, "--page", "-p", help="Page number"),
     per_page: int = typer.Option(52, "--per-page", "-n", help="Results per page"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
@@ -38,7 +65,9 @@ def jurisdictions(
     """List available jurisdictions."""
     client = get_client()
     try:
-        data = client.list_jurisdictions(classification=classification, page=page, per_page=per_page)
+        data = client.list_jurisdictions(
+            classification=classification, page=page, per_page=per_page
+        )
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
         raise typer.Exit(1)
@@ -65,9 +94,13 @@ def jurisdictions(
 
 @app.command()
 def people(
-    jurisdiction: str = typer.Option(None, "--jurisdiction", "-j", help="State name or abbreviation"),
+    jurisdiction: str = typer.Option(
+        None, "--jurisdiction", "-j", help="State name or abbreviation"
+    ),
     name: str = typer.Option(None, "--name", help="Filter by name"),
-    org_classification: str = typer.Option(None, "--role", help="Role (upper, lower, legislature, executive)"),
+    org_classification: str = typer.Option(
+        None, "--role", help="Role (upper, lower, legislature, executive)"
+    ),
     page: int = typer.Option(1, "--page", "-p", help="Page number"),
     per_page: int = typer.Option(10, "--per-page", "-n", help="Results per page"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
@@ -117,7 +150,9 @@ def people(
 
 @app.command()
 def bills(
-    jurisdiction: str = typer.Option(None, "--jurisdiction", "-j", help="State name or abbreviation"),
+    jurisdiction: str = typer.Option(
+        None, "--jurisdiction", "-j", help="State name or abbreviation"
+    ),
     session: str = typer.Option(None, "--session", "-s", help="Session identifier"),
     q: str = typer.Option(None, "--query", "-q", help="Full text search"),
     sort: str = typer.Option("updated_desc", "--sort", help="Sort order"),
@@ -161,7 +196,9 @@ def bills(
             b.get("identifier", ""),
             truncate(b.get("title", ""), 60),
             b.get("session", ""),
-            b.get("jurisdiction", {}).get("name", "") if isinstance(b.get("jurisdiction"), dict) else "",
+            b.get("jurisdiction", {}).get("name", "")
+            if isinstance(b.get("jurisdiction"), dict)
+            else "",
             (b.get("updated_at", "") or "")[:10],
         )
 
@@ -179,7 +216,9 @@ def committees(
     """List committees for a jurisdiction."""
     client = get_client()
     try:
-        data = client.list_committees(jurisdiction=jurisdiction, chamber=chamber, page=page, per_page=per_page)
+        data = client.list_committees(
+            jurisdiction=jurisdiction, chamber=chamber, page=page, per_page=per_page
+        )
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
         raise typer.Exit(1)
@@ -199,14 +238,20 @@ def committees(
     table.add_column("Chamber", style="green")
 
     for c in results:
-        table.add_row(c.get("name", ""), c.get("classification", ""), c.get("parent", {}).get("name", "") if isinstance(c.get("parent"), dict) else "")
+        table.add_row(
+            c.get("name", ""),
+            c.get("classification", ""),
+            c.get("parent", {}).get("name", "") if isinstance(c.get("parent"), dict) else "",
+        )
 
     console.print(table)
 
 
 @app.command()
 def events(
-    jurisdiction: str = typer.Option(None, "--jurisdiction", "-j", help="State name or abbreviation"),
+    jurisdiction: str = typer.Option(
+        None, "--jurisdiction", "-j", help="State name or abbreviation"
+    ),
     after: str = typer.Option(None, "--after", help="Events after this datetime (ISO)"),
     before: str = typer.Option(None, "--before", help="Events before this datetime (ISO)"),
     page: int = typer.Option(1, "--page", "-p", help="Page number"),
@@ -216,7 +261,9 @@ def events(
     """List legislative events."""
     client = get_client()
     try:
-        data = client.list_events(jurisdiction=jurisdiction, after=after, before=before, page=page, per_page=per_page)
+        data = client.list_events(
+            jurisdiction=jurisdiction, after=after, before=before, page=page, per_page=per_page
+        )
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
         raise typer.Exit(1)
@@ -242,7 +289,9 @@ def events(
             truncate(e.get("name", ""), 60),
             (e.get("start_date", "") or "")[:16],
             loc.get("name", "") if isinstance(loc, dict) else "",
-            e.get("jurisdiction", {}).get("name", "") if isinstance(e.get("jurisdiction"), dict) else "",
+            e.get("jurisdiction", {}).get("name", "")
+            if isinstance(e.get("jurisdiction"), dict)
+            else "",
         )
 
     console.print(table)

--- a/tools/research/preqin/centaur_tool_preqin/cli.py
+++ b/tools/research/preqin/centaur_tool_preqin/cli.py
@@ -8,13 +8,34 @@ import json
 from typing import Any
 
 import typer
-from centaur_sdk.backends import EnvBackend, configure
 from rich.console import Console
 from rich.table import Table
 
-configure(EnvBackend())
-
 app = typer.Typer(name="preqin", help="Preqin Operational API and Feeds API CLI")
+
+
+@app.command("health")
+def health():
+    """Assert preqin connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.auth_health()
+        if isinstance(details, dict) and not details.get("ok", False):
+            raise RuntimeError(str(details.get("error") or "preqin health check failed"))
+        payload = {"ok": True, "tool": "preqin", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "preqin", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 
@@ -66,7 +87,10 @@ def _print_records(data: dict[str, Any] | list[dict[str, Any]], title: str) -> N
     table.add_column("Strategy")
     for record in records[:25]:
         table.add_row(
-            str(_first(record, "FundId", "FundID", "fundId", "FundManagerID", "FundManagerId", "id") or ""),
+            str(
+                _first(record, "FundId", "FundID", "fundId", "FundManagerID", "FundManagerId", "id")
+                or ""
+            ),
             str(_first(record, "FundName", "name", "fundName", "FundManagerName") or ""),
             str(_first(record, "FundManagerName", "manager", "firmName") or ""),
             str(_first(record, "Status", "FundStatus", "status") or ""),
@@ -117,8 +141,12 @@ def auth_health(json_output: bool = typer.Option(False, "--json", help="Output a
 def fund_managers(
     name: str | None = typer.Option(None, "--name", help="Fund manager name search"),
     fund_manager_id: str | None = typer.Option(None, "--id", help="Fund manager ID"),
-    asset_class: str | None = typer.Option(None, "--asset-class", help="Asset class, e.g. pe,re,hf"),
-    include: str | None = typer.Option(None, "--include", help="Asset-class-specific data to include"),
+    asset_class: str | None = typer.Option(
+        None, "--asset-class", help="Asset class, e.g. pe,re,hf"
+    ),
+    include: str | None = typer.Option(
+        None, "--include", help="Asset-class-specific data to include"
+    ),
     size: int = typer.Option(20, "--size", help="Records per page, max 200"),
     page: int = typer.Option(1, "--page", help="Page number"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
@@ -147,10 +175,14 @@ def funds(
     fund_id: str | None = typer.Option(None, "--id", help="Fund ID"),
     manager: str | None = typer.Option(None, "--manager", help="Fund manager name search"),
     manager_id: str | None = typer.Option(None, "--manager-id", help="Fund manager ID"),
-    asset_class: str | None = typer.Option(None, "--asset-class", help="Asset class, e.g. pe,re,hf"),
+    asset_class: str | None = typer.Option(
+        None, "--asset-class", help="Asset class, e.g. pe,re,hf"
+    ),
     strategy: str | None = typer.Option(None, "--strategy", help="Fund strategy"),
     status: str | None = typer.Option(None, "--status", help="Fund status"),
-    include: str | None = typer.Option(None, "--include", help="Asset-class-specific data to include"),
+    include: str | None = typer.Option(
+        None, "--include", help="Asset-class-specific data to include"
+    ),
     size: int = typer.Option(20, "--size", help="Records per page, max 200"),
     page: int = typer.Option(1, "--page", help="Page number"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),

--- a/tools/research/preqin/pyproject.toml
+++ b/tools/research/preqin/pyproject.toml
@@ -16,6 +16,9 @@ preqin = "centaur_tool_preqin.cli:app"
 [tool.hatch.build.targets.wheel]
 packages = ["centaur_tool_preqin"]
 
+[tool.hatch.build.targets.wheel.sources]
+"centaur_tool_preqin" = "centaur_tool_preqin"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tools/research/sensortower/cli.py
+++ b/tools/research/sensortower/cli.py
@@ -13,6 +13,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="sensortower", help="SensorTower CLI for mobile app analytics")
+
+
+@app.command("health")
+def health():
+    """Assert sensortower connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.search_apps("OpenAI", platform="ios", limit=1)
+        payload = {"ok": True, "tool": "sensortower", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "sensortower", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/research/similarweb/cli.py
+++ b/tools/research/similarweb/cli.py
@@ -9,6 +9,28 @@ from rich.console import Console
 from centaur_sdk import Table
 
 app = typer.Typer(name="similarweb", help="SimilarWeb CLI for web traffic and market intelligence")
+
+
+@app.command("health")
+def health():
+    """Assert similarweb connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.get_top_sites()
+        payload = {"ok": True, "tool": "similarweb", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "similarweb", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 

--- a/tools/research/websearch/cli.py
+++ b/tools/research/websearch/cli.py
@@ -14,6 +14,34 @@ from .client import _client
 load_dotenv()
 
 app = typer.Typer(name="websearch", help="Web search and deep research via Parallel")
+
+
+@app.command("health")
+def health(
+    timeout_seconds: float = typer.Option(30.0, "--timeout-seconds", help="Request timeout"),
+):
+    """Assert websearch connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = asyncio.run(
+            client.search(
+                "health check", num_results=1, timeout_seconds=timeout_seconds, synthesize=False
+            )
+        )
+        payload = {"ok": True, "tool": "websearch", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "websearch", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console(stderr=True)
 
 

--- a/tools/research/youtube/cli.py
+++ b/tools/research/youtube/cli.py
@@ -12,6 +12,28 @@ from rich.table import Table
 load_dotenv()
 
 app = typer.Typer(name="youtube", help="YouTube CLI for video data")
+
+
+@app.command("health")
+def health():
+    """Assert youtube connectivity and auth with a safe read-only check."""
+    from .client import _client
+
+    client = _client()
+    try:
+        details = client.search("OpenAI", max_results=1)
+        payload = {"ok": True, "tool": "youtube", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "youtube", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
 console = Console()
 
 


### PR DESCRIPTION
Adds PR-146-style JSON health subcommands across tool CLIs, using safe read-only probes or local readiness stubs where appropriate. Fills missing console-script packaging metadata and updates a few clients so sandbox/proxy-injected credentials work without relying on environment-only secrets.