### PR TITLE
fix: attribute Slack PR requesters

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -70,6 +70,12 @@
 |*NEVER run git commit/push inside* ~/github/ — it is read-only. Always use git-branch first.
 |Prefer `rg` (ripgrep) over `grep` for all codebase operations.
 
+[GitHub PR Attribution]
+|When opening a GitHub PR for a Slack request, attribute the requester in the PR body with one standalone `Prompted by: ...` line.
+|Use the [Requester Context] block when present: prefer the verified GitHub handle resolved from the requester's Slack profile; if none is configured, use the requester's Slack display name or username.
+|If [Requester Context] provides an exact `Prompted by:` line, copy that line exactly into the PR body.
+|Do not infer a GitHub username from a Slack name, email, or thread history. The credited prompter is the user who prompted the current turn, not necessarily the Slack thread root author.
+
 [Python policy — ALWAYS use uv]
 |ALWAYS use `uv run python` for inline Python and scripts. NEVER invoke `python` or `python3` directly.
 |ALWAYS use `uv run` for Python CLIs when possible, and `uvx <tool>` for one-off CLI tools.

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1385,6 +1385,7 @@ function stagedAttachmentInputLines(
 
 function requesterIdentityContext(identity: RequesterIdentity | undefined): string | undefined {
   if (!identity?.slackUserId && !identity?.slackUserName && !identity?.githubHandle) return undefined
+  const slackAttributionName = requesterSlackAttributionName(identity)
 
   const lines = [
     '# Requester Context',
@@ -1412,6 +1413,7 @@ function requesterIdentityContext(identity: RequesterIdentity | undefined): stri
       `- Assign the PR to the requester when possible: \`${githubLogin}\``
     )
   } else {
+    const promptedBy = slackAttributionName ?? 'unknown Slack requester'
     lines.push(
       '- GitHub handle from Slack profile: unavailable',
       `- GitHub handle unavailable reason: ${identity.githubUnavailableReason ?? 'not resolved'}`,
@@ -1419,14 +1421,32 @@ function requesterIdentityContext(identity: RequesterIdentity | undefined): stri
       '',
       '## GitHub PR Attribution',
       '',
-      '- If you create a GitHub PR for this Slack request, do not infer a GitHub '
-        + 'username from Slack display name, real name, or email.',
-      '- Omit the `Prompted by` line unless a verified GitHub handle is present.'
+      '- If you create a GitHub PR for this Slack request, '
+        + `the PR body MUST contain this standalone line: \`Prompted by: ${promptedBy}\``,
+      '- Use the requester\'s Slack display name or username because no verified GitHub '
+        + 'handle is available.',
+      '- Do not infer a GitHub username from Slack display name, real name, or email.',
+      '- The credited prompter is the requester in this section, not the Slack thread OP/root author.',
+      '- This is a GitHub PR body requirement, not a Slack response mention rule.'
     )
   }
 
   lines.push('', 'The user message follows in the next content block.', '---')
   return lines.join('\n')
+}
+
+function requesterSlackAttributionName(identity: RequesterIdentity): string | undefined {
+  return (
+    nonEmptyString(identity.slackDisplayName)
+    ?? nonEmptyString(identity.slackUserName)
+    ?? nonEmptyString(identity.slackMention)
+    ?? nonEmptyString(identity.slackUserId)
+  )
+}
+
+function nonEmptyString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
 }
 
 function codexInputContent(

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -644,6 +644,81 @@ describe('session principal display name', () => {
     }
   }
 
+  test('uses the GitHub handle from the requester Slack profile for PR attribution', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await withSlackStub(
+      url => {
+        if (url.includes('conversations.info')) {
+          return Response.json({ channel: { id: 'C1', name_normalized: 'eng-oncall' }, ok: true })
+        }
+        if (url.includes('users.profile.get')) {
+          return Response.json({
+            ok: true,
+            profile: {
+              display_name: 'Ada Lovelace',
+              fields: {
+                XfGithub: { label: 'GitHub', value: 'https://github.com/ada-lovelace' }
+              },
+              name: 'ada'
+            }
+          })
+        }
+        if (url.includes('users.info')) {
+          return Response.json({ ok: true, user: { profile: { display_name: 'Ada Lovelace' } } })
+        }
+        return Response.json({ ok: true })
+      },
+      async () => {
+        await forwardToSessionApi(slackOptions(fetchFn), forwardInput(apiMessage('please PR')))
+      }
+    )
+
+    const requesterContext = lineContent(executeLine(requests)).find(part =>
+      textPartIncludes(part, '# Requester Context')
+    )
+    expect(requesterContext?.text).toContain('GitHub handle from Slack profile: @ada-lovelace')
+    expect(requesterContext?.text).toContain('Prompted by: @ada-lovelace')
+    expect(requesterContext?.text).toContain('Assign the PR to the requester when possible: `ada-lovelace`')
+  })
+
+  test('uses the requester Slack display name for PR attribution when no GitHub handle exists', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await withSlackStub(
+      url => {
+        if (url.includes('conversations.info')) {
+          return Response.json({ channel: { id: 'C1', name_normalized: 'eng-oncall' }, ok: true })
+        }
+        if (url.includes('users.profile.get')) {
+          return Response.json({
+            ok: true,
+            profile: {
+              display_name: 'Ada Lovelace',
+              fields: {},
+              name: 'ada'
+            }
+          })
+        }
+        if (url.includes('users.info')) {
+          return Response.json({ ok: true, user: { profile: { display_name: 'Ada Lovelace' } } })
+        }
+        return Response.json({ ok: true })
+      },
+      async () => {
+        await forwardToSessionApi(slackOptions(fetchFn), forwardInput(apiMessage('please PR')))
+      }
+    )
+
+    const requesterContext = lineContent(executeLine(requests)).find(part =>
+      textPartIncludes(part, '# Requester Context')
+    )
+    expect(requesterContext?.text).toContain('GitHub handle from Slack profile: unavailable')
+    expect(requesterContext?.text).toContain('Prompted by: Ada Lovelace')
+    expect(requesterContext?.text).toContain(
+      'Use the requester\'s Slack display name or username because no verified GitHub handle is available.'
+    )
+    expect(requesterContext?.text).not.toContain('Omit the `Prompted by` line')
+  })
+
   test('channel sessions name the principal after the channel', async () => {
     const { fetchFn, requests } = fakeApi()
     await withSlackStub(


### PR DESCRIPTION
Updates the sandbox prompt and Slack requester context so PRs prompted from Slack are credited with the requester's verified GitHub handle when available, or their Slack display name or username otherwise. Adds slackbotv2 coverage for both attribution paths.