### PR TITLE
Add PVC storage mode for repo cache

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.77
+version: 0.1.78
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -59,6 +59,22 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 {{- end -}}
 
+{{- define "centaur.repoCachePvcName" -}}
+{{- if .Values.repoCache.storage.persistentVolumeClaim.existingClaim -}}
+{{- .Values.repoCache.storage.persistentVolumeClaim.existingClaim | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-repo-cache" (include "centaur.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "centaur.repoCacheStorageType" -}}
+{{- $storageType := default "hostPath" .Values.repoCache.storage.type -}}
+{{- if and (ne $storageType "hostPath") (ne $storageType "persistentVolumeClaim") -}}
+{{- fail "repoCache.storage.type must be either hostPath or persistentVolumeClaim" -}}
+{{- end -}}
+{{- $storageType -}}
+{{- end -}}
+
 {{- define "centaur.overlaySources" -}}
 {{- $sources := list -}}
 {{- with .Values.overlays.sources -}}

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.apiRs.enabled }}
 {{- $console := include "centaur.consoleValues" . | fromYaml -}}
 {{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") -}}
+{{- $repoCacheStorageType := include "centaur.repoCacheStorageType" . -}}
+{{- $repoCacheUsePvc := eq $repoCacheStorageType "persistentVolumeClaim" -}}
+{{- $repoCachePvcName := include "centaur.repoCachePvcName" . -}}
 {{- $reposPath := .Values.sandbox.reposPath -}}
 {{- if and .Values.repoCache.enabled (not $reposPath) -}}
 {{- $reposPath = .Values.repoCache.hostPath -}}
@@ -215,6 +218,10 @@ spec:
 {{- if $reposPath }}
             - name: REPOS_PATH
               value: {{ $reposPath | quote }}
+{{- if $repoCacheUsePvc }}
+            - name: REPOS_PVC
+              value: {{ $repoCachePvcName | quote }}
+{{- end }}
 {{- end }}
             - name: KUBERNETES_SANDBOX_IRON_PROXY_MODE
               value: {{ .Values.apiRs.ironProxy.mode | quote }}
@@ -321,6 +328,10 @@ spec:
 {{- if $toolsUseRepoCache }}
             - name: KUBERNETES_TOOLS_REPO_CACHE_PATH
               value: {{ .Values.repoCache.hostPath | quote }}
+{{- if $repoCacheUsePvc }}
+            - name: KUBERNETES_TOOLS_REPO_CACHE_PVC
+              value: {{ $repoCachePvcName | quote }}
+{{- end }}
 {{- end }}
             - name: KUBERNETES_TOOLS_RUNNER_IMAGE
               value: {{ printf "%s:%s" (default .Values.sandbox.image.repository .Values.toolServer.runnerImage.repository) (default .Values.sandbox.image.tag .Values.toolServer.runnerImage.tag) | quote }}
@@ -381,9 +392,15 @@ spec:
 {{- if $useOverlayRepoCache }}
       volumes:
         - name: repo-cache
+{{- if $repoCacheUsePvc }}
+          persistentVolumeClaim:
+            claimName: {{ $repoCachePvcName | quote }}
+            readOnly: true
+{{- else }}
           hostPath:
             path: {{ .Values.repoCache.hostPath | quote }}
             type: DirectoryOrCreate
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -15,6 +15,10 @@
 {{- $repoCacheImageRepository := default .Values.sandbox.image.repository .Values.repoCache.image.repository -}}
 {{- $repoCacheImageTag := default .Values.sandbox.image.tag .Values.repoCache.image.tag -}}
 {{- $repoCacheImagePullPolicy := default .Values.sandbox.image.pullPolicy .Values.repoCache.image.pullPolicy -}}
+{{- $repoCacheStorageType := include "centaur.repoCacheStorageType" . -}}
+{{- $repoCacheUsePvc := eq $repoCacheStorageType "persistentVolumeClaim" -}}
+{{- $repoCachePvcName := include "centaur.repoCachePvcName" . -}}
+{{- $repoCacheCreatePvc := and $repoCacheUsePvc .Values.repoCache.storage.persistentVolumeClaim.create (not .Values.repoCache.storage.persistentVolumeClaim.existingClaim) -}}
 {{- $repoCacheRepositoryRefs := list -}}
 {{- $repoCacheRepositoryRefRepos := list -}}
 {{- range $repo, $ref := .Values.repoCache.repositoryRefs }}
@@ -29,13 +33,34 @@
 {{- $repoCacheRepositoryRefRepos = append $repoCacheRepositoryRefRepos $repo -}}
 {{- end }}
 {{- end }}
+{{- if $repoCacheCreatePvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $repoCachePvcName }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
+spec:
+  accessModes:
+{{ toYaml .Values.repoCache.storage.persistentVolumeClaim.accessModes | nindent 4 }}
+{{- with .Values.repoCache.storage.persistentVolumeClaim.storageClassName }}
+  storageClassName: {{ . | quote }}
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.repoCache.storage.persistentVolumeClaim.size | quote }}
+---
+{{- end }}
 apiVersion: apps/v1
-kind: DaemonSet
+kind: {{ ternary "Deployment" "DaemonSet" $repoCacheUsePvc }}
 metadata:
   name: {{ include "centaur.componentName" (dict "root" . "component" "repo-cache") }}
   labels:
 {{ include "centaur.componentLabels" (dict "root" . "component" "repo-cache") | nindent 4 }}
 spec:
+{{- if $repoCacheUsePvc }}
+  replicas: 1
+{{- end }}
   selector:
     matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "repo-cache") | nindent 6 }}
@@ -230,9 +255,14 @@ spec:
 {{- end }}
       volumes:
         - name: repo-cache
+{{- if $repoCacheUsePvc }}
+          persistentVolumeClaim:
+            claimName: {{ $repoCachePvcName | quote }}
+{{- else }}
           hostPath:
             path: {{ .Values.repoCache.hostPath | quote }}
             type: DirectoryOrCreate
+{{- end }}
 {{- if $repoCacheHasGithubToken }}
         - name: github-token
           secret:

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -227,6 +227,20 @@ sandbox:
 repoCache:
   enabled: true
   hostPath: /var/lib/centaur/repos
+  storage:
+    # hostPath preserves the existing DaemonSet/node-local behavior. Set to
+    # persistentVolumeClaim for GKE Autopilot or other clusters that disallow
+    # writable hostPath.
+    type: hostPath
+    persistentVolumeClaim:
+      # When set, use this existing claim. It must support ReadWriteMany if
+      # repo-cache, api-rs, and sandboxes can schedule on different nodes.
+      existingClaim: ""
+      create: false
+      accessModes:
+        - ReadWriteMany
+      storageClassName: ""
+      size: 20Gi
   # Additional repos to cache. toolServer.repo is cached automatically when the
   # tool server is enabled.
   repositories: []

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -580,6 +580,8 @@ struct SandboxArgs {
     centaur_api_url: Option<String>,
     #[arg(long = "repos-path", env = "REPOS_PATH")]
     repos_path: Option<String>,
+    #[arg(long = "repos-pvc", env = "REPOS_PVC")]
+    repos_pvc: Option<String>,
     #[arg(
         long = "session-sandbox-passthrough-env",
         env = "SESSION_SANDBOX_PASSTHROUGH_ENV",
@@ -839,13 +841,7 @@ impl SandboxArgs {
             && let Some(repos_path) = clean_optional_value(self.repos_path.as_deref())
         {
             spec = spec.mount(
-                Mount::new(
-                    MountKind::Bind {
-                        source_path: repos_path,
-                    },
-                    SANDBOX_REPOS_MOUNT_PATH,
-                )
-                .read_only(),
+                Mount::new(self.repos_mount_kind(repos_path), SANDBOX_REPOS_MOUNT_PATH).read_only(),
             );
         }
         for (name, value) in self.workflow_host_env_template()? {
@@ -920,17 +916,21 @@ impl SandboxArgs {
                 );
                 if let Some(repos_path) = clean_optional_value(self.repos_path.as_deref()) {
                     workload = workload.mount(
-                        Mount::new(
-                            MountKind::Bind {
-                                source_path: repos_path,
-                            },
-                            SANDBOX_REPOS_MOUNT_PATH,
-                        )
-                        .read_only(),
+                        Mount::new(self.repos_mount_kind(repos_path), SANDBOX_REPOS_MOUNT_PATH)
+                            .read_only(),
                     );
                 }
                 Ok(workload)
             }
+        }
+    }
+
+    fn repos_mount_kind(&self, repos_path: String) -> MountKind {
+        if let Some(claim_name) = clean_optional_value(self.repos_pvc.as_deref()) {
+            return MountKind::NamedVolume(claim_name);
+        }
+        MountKind::Bind {
+            source_path: repos_path,
         }
     }
 
@@ -1417,6 +1417,14 @@ struct ToolsArgs {
         env = "KUBERNETES_TOOLS_REPO_CACHE_PATH"
     )]
     repo_cache_path: Option<String>,
+    // Optional PVC claim backing the repo-cache root. When set, sandbox pods mount
+    // the repo cache from this PVC instead of using a hostPath.
+    #[arg(
+        id = "tools_repo_cache_pvc",
+        long = "kubernetes-tools-repo-cache-pvc",
+        env = "KUBERNETES_TOOLS_REPO_CACHE_PVC"
+    )]
+    repo_cache_pvc: Option<String>,
     #[arg(
         id = "tools_extra_sources",
         long = "kubernetes-tools-extra-sources",
@@ -1469,6 +1477,7 @@ impl ToolsArgs {
             });
         }
         config.repo_cache_path = clean_optional_value(self.repo_cache_path.as_deref());
+        config.repo_cache_pvc = clean_optional_value(self.repo_cache_pvc.as_deref());
         config.extra_sources = self.extra_sources();
         Some(config)
     }
@@ -2218,6 +2227,32 @@ mod tests {
     }
 
     #[test]
+    fn agent_k8s_workflow_host_mounts_repos_pvc_read_only() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-backend",
+            "agent-k8s",
+            "--kubernetes-sandbox-iron-proxy-mode",
+            "disabled",
+            "--repos-path",
+            "/var/lib/centaur/repos",
+            "--repos-pvc",
+            "centaur-repo-cache",
+        ])
+        .unwrap();
+
+        let spec = args.sandbox.workflow_host_spec(None).unwrap();
+
+        assert!(spec.mounts.iter().any(|mount| {
+            mount.target_path == SANDBOX_REPOS_MOUNT_PATH
+                && mount.read_only
+                && mount.kind == MountKind::NamedVolume("centaur-repo-cache".to_owned())
+        }));
+    }
+
+    #[test]
     fn workflow_host_env_template_splits_passthrough_env_from_environment() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _env = EnvGuard::set(&[
@@ -2633,6 +2668,33 @@ mod tests {
                     == (MountKind::Bind {
                         source_path: "/var/lib/centaur/repos".to_owned(),
                     })
+        }));
+    }
+
+    #[test]
+    fn codex_workload_mounts_repos_pvc_read_only() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-workload",
+            "codex-app-server",
+            "--repos-path",
+            "/var/lib/centaur/repos",
+            "--repos-pvc",
+            "centaur-repo-cache",
+        ])
+        .unwrap();
+
+        let workload = args.sandbox.container_workload_mode().unwrap();
+        let SandboxWorkloadMode::CodexAppServer { mounts, .. } = workload else {
+            panic!("expected codex app server workload");
+        };
+
+        assert!(mounts.iter().any(|mount| {
+            mount.target_path == SANDBOX_REPOS_MOUNT_PATH
+                && mount.read_only
+                && mount.kind == MountKind::NamedVolume("centaur-repo-cache".to_owned())
         }));
     }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
@@ -58,11 +58,15 @@ pub struct ToolsConfig {
     pub image_pull_policy: Option<String>,
     /// GitHub token secret for private-repo clones. `None` => unauthenticated clone.
     pub github_token: Option<GitHubTokenRef>,
-    /// Optional repo-cache root path mounted from the host. When set,
+    /// Optional repo-cache root path mounted into the sandbox. When set,
     /// tools-bootstrap publishes from `<repo_cache_path>/<repo>/<source_subdir>`
     /// and `centaur-tools refresh` republishes from the same cache instead of
-    /// fetching.
+    /// fetching. By default this path is mounted from the host; set
+    /// `repo_cache_pvc` to mount the path from a PersistentVolumeClaim instead.
     pub repo_cache_path: Option<String>,
+    /// Optional PVC backing for `repo_cache_path`. This lets Autopilot clusters use
+    /// repoCache without hostPath volumes.
+    pub repo_cache_pvc: Option<String>,
     /// Additional tool sources copied after the base tree. Duplicate tool names
     /// are skipped by the copy helper.
     pub extra_sources: Vec<ToolSource>,
@@ -93,6 +97,7 @@ impl ToolsConfig {
             image_pull_policy: None,
             github_token: None,
             repo_cache_path: None,
+            repo_cache_pvc: None,
             extra_sources: Vec::new(),
         }
     }
@@ -354,13 +359,23 @@ pub(crate) fn volumes_json(tools: Option<&ToolsConfig>) -> Vec<Value> {
             }));
         }
         if let Some(repo_cache_path) = &tools.repo_cache_path {
-            volumes.push(json!({
-                "name": REPO_CACHE_VOLUME,
-                "hostPath": {
-                    "path": repo_cache_path,
-                    "type": "DirectoryOrCreate",
-                },
-            }));
+            if let Some(claim_name) = &tools.repo_cache_pvc {
+                volumes.push(json!({
+                    "name": REPO_CACHE_VOLUME,
+                    "persistentVolumeClaim": {
+                        "claimName": claim_name,
+                        "readOnly": true,
+                    },
+                }));
+            } else {
+                volumes.push(json!({
+                    "name": REPO_CACHE_VOLUME,
+                    "hostPath": {
+                        "path": repo_cache_path,
+                        "type": "DirectoryOrCreate",
+                    },
+                }));
+            }
         }
     }
     volumes
@@ -539,6 +554,26 @@ mod tests {
                 && mount["mountPath"] == "/var/lib/centaur/repos"
                 && mount["readOnly"] == true
         }));
+    }
+
+    #[test]
+    fn tools_init_can_mount_repo_cache_from_pvc() {
+        let mut tools = ToolsConfig::new("paradigmxyz/centaur", "centaur-agent:test");
+        tools.repo_cache_path = Some("/var/lib/centaur/repos".to_owned());
+        tools.repo_cache_pvc = Some("centaur-repo-cache".to_owned());
+
+        let volumes = volumes_json(Some(&tools));
+        let volume = volumes
+            .iter()
+            .find(|volume| volume["name"] == REPO_CACHE_VOLUME)
+            .expect("repo-cache volume");
+
+        assert_eq!(
+            volume["persistentVolumeClaim"]["claimName"],
+            "centaur-repo-cache"
+        );
+        assert_eq!(volume["persistentVolumeClaim"]["readOnly"], true);
+        assert!(volume.get("hostPath").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a `repoCache.storage.type` chart option so repo cache storage can use either the existing node-local `hostPath` behavior or a `PersistentVolumeClaim`.

PVC mode is intended for clusters such as GKE Autopilot that reject writable `hostPath` volumes. In PVC mode, the chart creates or references a PVC, runs `repo-cache` as a single Deployment, and wires the PVC into `api-rs` plus sandbox/tool pods through the existing named-volume mount path.

The default remains `hostPath`, so existing installs keep their current DaemonSet/node-local behavior.

## Notes

- `repoCache.storage.type` accepts `hostPath` or `persistentVolumeClaim` and fails Helm rendering for invalid values.
- PVC mode supports either an existing claim or a chart-created claim.
- The PVC should support `ReadWriteMany` when repo-cache, api-rs, and sandboxes can schedule on different nodes.
- Consumers mount the repo cache read-only; only the repo-cache workload writes to it.
