### PR TITLE
feat: add slack retention workflow

### DIFF
--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -74,6 +74,10 @@ once Slack ETL is enabled, but can be tuned independently.
 | `SLACK_ETL_ATTACHMENTS_ENABLED` | `true` | Download Slack message attachment bytes into Postgres. Metadata rows are still written when downloads are disabled. |
 | `SLACK_ETL_ATTACHMENT_MAX_BYTES` | `10485760` | Per-file byte cap for Slack attachment downloads. Oversized files keep metadata with `skipped_too_large` status. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | empty | Comma-separated channel-name globs to skip, without needing the leading `#`. |
+| `SLACK_RETENTION_ENABLED` | `true` | Allows the `slack_retention` schedule to run when at least one Slack retention TTL is positive. |
+| `SLACK_RETENTION_INTERVAL_MINUTES` | `60` | How often to prune Slack retention-managed rows. |
+| `SLACK_ETL_RETENTION_DAYS` | `0` | Deletes public Slack ETL messages, derived Slack documents, and terminal ETL run/job rows older than this many days. `0` disables public ETL retention. |
+| `SLACK_DM_RETENTION_DAYS` | `0` | Deletes Slack DM messages, stale empty DM conversations, and terminal DM run/job rows older than this many days. `0` disables DM retention. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
 
@@ -112,6 +116,11 @@ The lookback values are read windows, not retention windows. Lowering
 `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS` or `SLACK_SYNC_THREAD_LOOKBACK_DAYS` limits
 future backfill and refresh work, but it does not delete Slack rows or company
 context documents that were already synced.
+
+Retention is handled by the separate `slack_retention` workflow. Public Slack
+ETL and Slack DM data have independent TTLs so deployments can keep DM data for
+a shorter period than channel ETL data. The workflow only runs when at least one
+TTL is positive.
 
 ## Run it manually
 

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -214,6 +214,7 @@ Slack ETL workflows:
 | `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS`, `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `api.slackSync*LookbackDays`. | Slack history/thread lookback windows. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | `api.slackEtlExcludedChannelPatterns`. | Comma-separated channel-name globs to skip. |
 | `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `api.extraEnv` or chart batch limit. | Backfill enablement and batch sizing. |
+| `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `api.extraEnv`. | Slack retention cadence and separate public ETL/DM TTLs. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `api.extraEnv`. | Enables company-context projection when Slack ETL is on. |
 
 Google Workspace ETL workflows:

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -74,6 +74,10 @@ once Slack ETL is enabled, but can be tuned independently.
 | `SLACK_ETL_ATTACHMENTS_ENABLED` | `true` | Download Slack message attachment bytes into Postgres. Metadata rows are still written when downloads are disabled. |
 | `SLACK_ETL_ATTACHMENT_MAX_BYTES` | `10485760` | Per-file byte cap for Slack attachment downloads. Oversized files keep metadata with `skipped_too_large` status. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | empty | Comma-separated channel-name globs to skip, without needing the leading `#`. |
+| `SLACK_RETENTION_ENABLED` | `true` | Allows the `slack_retention` schedule to run when at least one Slack retention TTL is positive. |
+| `SLACK_RETENTION_INTERVAL_MINUTES` | `60` | How often to prune Slack retention-managed rows. |
+| `SLACK_ETL_RETENTION_DAYS` | `0` | Deletes public Slack ETL messages, derived Slack documents, and terminal ETL run/job rows older than this many days. `0` disables public ETL retention. |
+| `SLACK_DM_RETENTION_DAYS` | `0` | Deletes Slack DM messages, stale empty DM conversations, and terminal DM run/job rows older than this many days. `0` disables DM retention. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
 
@@ -112,6 +116,11 @@ The lookback values are read windows, not retention windows. Lowering
 `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS` or `SLACK_SYNC_THREAD_LOOKBACK_DAYS` limits
 future backfill and refresh work, but it does not delete Slack rows or company
 context documents that were already synced.
+
+Retention is handled by the separate `slack_retention` workflow. Public Slack
+ETL and Slack DM data have independent TTLs so deployments can keep DM data for
+a shorter period than channel ETL data. The workflow only runs when at least one
+TTL is positive.
 
 ## Run it manually
 

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -216,6 +216,7 @@ Slack ETL workflows:
 | `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS`, `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `api.slackSync*LookbackDays`. | Slack history/thread lookback windows. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | `api.slackEtlExcludedChannelPatterns`. | Comma-separated channel-name globs to skip. |
 | `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `api.extraEnv` or chart batch limit. | Backfill enablement and batch sizing. |
+| `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `api.extraEnv`. | Slack retention cadence and separate public ETL/DM TTLs. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `api.extraEnv`. | Enables company-context projection when Slack ETL is on. |
 
 Google Workspace ETL workflows:

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -878,6 +878,7 @@ fn workflow_queue_class(workflow_name: &str) -> WorkflowQueueClass {
         | "google_drive_sync"
         | "linear_sync"
         | "company_context_documents"
+        | "slack_retention"
         | "chief_of_staff_daily" => WorkflowQueueClass::Etl,
         _ => WorkflowQueueClass::Standard,
     }
@@ -3722,6 +3723,7 @@ mod tests {
             "google_drive_sync",
             "linear_sync",
             "company_context_documents",
+            "slack_retention",
             "chief_of_staff_daily",
         ] {
             assert_eq!(workflow_queue_class(workflow_name), WorkflowQueueClass::Etl);

--- a/workflows/slack/retention.py
+++ b/workflows/slack/retention.py
@@ -1,0 +1,304 @@
+"""Workflow: prune old Slack ETL and Slack DM rows from Postgres."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from api.vm_metrics import record_etl_items_deleted
+from api.workflow_engine import WorkflowContext
+from workflows.slack.shared import env_flag_enabled, positive_int
+
+WORKFLOW_NAME = "slack_retention"
+
+DEFAULT_RETENTION_INTERVAL_MINUTES = 60
+DISABLED_RETENTION_DAYS = 0
+
+
+def _nonnegative_int(value: int | str | None, default: int) -> int:
+    """Coerce nonnegative integer config values with a safe default."""
+    try:
+        parsed = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _configured_etl_retention_days() -> int:
+    return _nonnegative_int(
+        os.getenv("SLACK_ETL_RETENTION_DAYS"),
+        DISABLED_RETENTION_DAYS,
+    )
+
+
+def _configured_dm_retention_days() -> int:
+    return _nonnegative_int(
+        os.getenv("SLACK_DM_RETENTION_DAYS"),
+        DISABLED_RETENTION_DAYS,
+    )
+
+
+def _schedule_enabled() -> bool:
+    if not env_flag_enabled("SLACK_RETENTION_ENABLED", default=True):
+        return False
+    return _configured_etl_retention_days() > 0 or _configured_dm_retention_days() > 0
+
+
+SCHEDULE = {
+    "schedule_id": "slack_retention",
+    "interval_seconds": positive_int(
+        os.getenv("SLACK_RETENTION_INTERVAL_MINUTES"),
+        DEFAULT_RETENTION_INTERVAL_MINUTES,
+    )
+    * 60,
+    "enabled": _schedule_enabled(),
+    "no_delivery": True,
+}
+
+
+@dataclass
+class Input:
+    """Runtime options for Slack retention cleanup."""
+
+    etl_retention_days: int | None = None
+    dm_retention_days: int | None = None
+    dry_run: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+async def _count_or_delete(
+    pool,
+    *,
+    count_sql: str,
+    delete_sql: str,
+    days: int,
+    dry_run: bool,
+) -> int:
+    sql = count_sql if dry_run else delete_sql
+    deleted = await pool.fetchval(sql, days)
+    return int(deleted or 0)
+
+
+async def prune_slack_etl(pool, *, retention_days: int, dry_run: bool = False) -> dict[str, int]:
+    """Delete public Slack ETL rows older than the configured retention window."""
+    if retention_days <= 0:
+        return {
+            "company_context_documents": 0,
+            "messages": 0,
+            "backfill_jobs": 0,
+            "runs": 0,
+        }
+
+    counts = {
+        "company_context_documents": await _count_or_delete(
+            pool,
+            count_sql=(
+                "SELECT COUNT(*) FROM company_context_documents "
+                "WHERE source = 'slack' "
+                "  AND occurred_at < NOW() - make_interval(days => $1)"
+            ),
+            delete_sql=(
+                "WITH deleted AS ("
+                "    DELETE FROM company_context_documents "
+                "    WHERE source = 'slack' "
+                "      AND occurred_at < NOW() - make_interval(days => $1) "
+                "    RETURNING 1"
+                ") SELECT COUNT(*) FROM deleted"
+            ),
+            days=retention_days,
+            dry_run=dry_run,
+        ),
+        "messages": await _count_or_delete(
+            pool,
+            count_sql=(
+                "SELECT COUNT(*) FROM slack_sync_messages "
+                "WHERE occurred_at < NOW() - make_interval(days => $1)"
+            ),
+            delete_sql=(
+                "WITH deleted AS ("
+                "    DELETE FROM slack_sync_messages "
+                "    WHERE occurred_at < NOW() - make_interval(days => $1) "
+                "    RETURNING 1"
+                ") SELECT COUNT(*) FROM deleted"
+            ),
+            days=retention_days,
+            dry_run=dry_run,
+        ),
+        "backfill_jobs": await _count_or_delete(
+            pool,
+            count_sql=(
+                "SELECT COUNT(*) FROM slack_sync_backfill_jobs "
+                "WHERE status IN ('completed', 'failed') "
+                "  AND updated_at < NOW() - make_interval(days => $1)"
+            ),
+            delete_sql=(
+                "WITH deleted AS ("
+                "    DELETE FROM slack_sync_backfill_jobs "
+                "    WHERE status IN ('completed', 'failed') "
+                "      AND updated_at < NOW() - make_interval(days => $1) "
+                "    RETURNING 1"
+                ") SELECT COUNT(*) FROM deleted"
+            ),
+            days=retention_days,
+            dry_run=dry_run,
+        ),
+        "runs": await _count_or_delete(
+            pool,
+            count_sql=(
+                "SELECT COUNT(*) FROM slack_sync_runs "
+                "WHERE status <> 'running' "
+                "  AND COALESCE(finished_at, started_at) < NOW() - make_interval(days => $1)"
+            ),
+            delete_sql=(
+                "WITH deleted AS ("
+                "    DELETE FROM slack_sync_runs "
+                "    WHERE status <> 'running' "
+                "      AND COALESCE(finished_at, started_at) "
+                "          < NOW() - make_interval(days => $1) "
+                "    RETURNING 1"
+                ") SELECT COUNT(*) FROM deleted"
+            ),
+            days=retention_days,
+            dry_run=dry_run,
+        ),
+    }
+    return counts
+
+
+async def prune_slack_dm(pool, *, retention_days: int, dry_run: bool = False) -> dict[str, int]:
+    """Delete Slack DM sync rows older than the configured retention window."""
+    if retention_days <= 0:
+        return {
+            "messages": 0,
+            "conversations": 0,
+            "backfill_jobs": 0,
+            "runs": 0,
+        }
+
+    counts = {
+        "messages": await _count_or_delete(
+            pool,
+            count_sql=(
+                "SELECT COUNT(*) FROM slack_dm_sync_messages "
+                "WHERE occurred_at < NOW() - make_interval(days => $1)"
+            ),
+            delete_sql=(
+                "WITH deleted AS ("
+                "    DELETE FROM slack_dm_sync_messages "
+                "    WHERE occurred_at < NOW() - make_interval(days => $1) "
+                "    RETURNING 1"
+                ") SELECT COUNT(*) FROM deleted"
+            ),
+            days=retention_days,
+            dry_run=dry_run,
+        ),
+        "conversations": await _count_or_delete(
+            pool,
+            count_sql=(
+                "SELECT COUNT(*) FROM slack_dm_sync_conversations c "
+                "WHERE c.last_seen_at < NOW() - make_interval(days => $1) "
+                "  AND NOT EXISTS ("
+                "      SELECT 1 FROM slack_dm_sync_messages m "
+                "      WHERE m.home_team_id = c.home_team_id "
+                "        AND m.conversation_id = c.conversation_id"
+                "  )"
+            ),
+            delete_sql=(
+                "WITH deleted AS ("
+                "    DELETE FROM slack_dm_sync_conversations c "
+                "    WHERE c.last_seen_at < NOW() - make_interval(days => $1) "
+                "      AND NOT EXISTS ("
+                "          SELECT 1 FROM slack_dm_sync_messages m "
+                "          WHERE m.home_team_id = c.home_team_id "
+                "            AND m.conversation_id = c.conversation_id"
+                "      ) "
+                "    RETURNING 1"
+                ") SELECT COUNT(*) FROM deleted"
+            ),
+            days=retention_days,
+            dry_run=dry_run,
+        ),
+        "backfill_jobs": await _count_or_delete(
+            pool,
+            count_sql=(
+                "SELECT COUNT(*) FROM slack_dm_sync_backfill_jobs "
+                "WHERE status IN ('completed', 'failed') "
+                "  AND updated_at < NOW() - make_interval(days => $1)"
+            ),
+            delete_sql=(
+                "WITH deleted AS ("
+                "    DELETE FROM slack_dm_sync_backfill_jobs "
+                "    WHERE status IN ('completed', 'failed') "
+                "      AND updated_at < NOW() - make_interval(days => $1) "
+                "    RETURNING 1"
+                ") SELECT COUNT(*) FROM deleted"
+            ),
+            days=retention_days,
+            dry_run=dry_run,
+        ),
+        "runs": await _count_or_delete(
+            pool,
+            count_sql=(
+                "SELECT COUNT(*) FROM slack_dm_sync_runs "
+                "WHERE status <> 'running' "
+                "  AND COALESCE(finished_at, started_at) < NOW() - make_interval(days => $1)"
+            ),
+            delete_sql=(
+                "WITH deleted AS ("
+                "    DELETE FROM slack_dm_sync_runs "
+                "    WHERE status <> 'running' "
+                "      AND COALESCE(finished_at, started_at) "
+                "          < NOW() - make_interval(days => $1) "
+                "    RETURNING 1"
+                ") SELECT COUNT(*) FROM deleted"
+            ),
+            days=retention_days,
+            dry_run=dry_run,
+        ),
+    }
+    return counts
+
+
+def _emit_deleted_metrics(prefix: str, counts: dict[str, int]) -> None:
+    for item_type, count in counts.items():
+        if count:
+            record_etl_items_deleted(prefix, "retention", item_type, count)
+
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    etl_days = (
+        _nonnegative_int(inp.etl_retention_days, DISABLED_RETENTION_DAYS)
+        if inp.etl_retention_days is not None
+        else _configured_etl_retention_days()
+    )
+    dm_days = (
+        _nonnegative_int(inp.dm_retention_days, DISABLED_RETENTION_DAYS)
+        if inp.dm_retention_days is not None
+        else _configured_dm_retention_days()
+    )
+
+    etl_counts = await prune_slack_etl(
+        ctx._pool,
+        retention_days=etl_days,
+        dry_run=inp.dry_run,
+    )
+    dm_counts = await prune_slack_dm(
+        ctx._pool,
+        retention_days=dm_days,
+        dry_run=inp.dry_run,
+    )
+
+    if not inp.dry_run:
+        _emit_deleted_metrics("slack", etl_counts)
+        _emit_deleted_metrics("slack_dm", dm_counts)
+
+    return {
+        "ok": True,
+        "dry_run": inp.dry_run,
+        "etl_retention_days": etl_days,
+        "dm_retention_days": dm_days,
+        "slack_etl": etl_counts,
+        "slack_dm": dm_counts,
+        "metadata": inp.metadata,
+    }

--- a/workflows/slack/tests/test_retention.py
+++ b/workflows/slack/tests/test_retention.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def _load_retention():
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    api_module = types.ModuleType("api")
+    runtime_control = types.ModuleType("api.runtime_control")
+    runtime_control.canonical_json = lambda value: json.dumps(value, sort_keys=True)
+    api_module.runtime_control = runtime_control
+    sys.modules["api"] = api_module
+    sys.modules["api.runtime_control"] = runtime_control
+
+    vm_metrics = types.ModuleType("api.vm_metrics")
+    vm_metrics.metric_calls = []
+
+    def record_etl_items_deleted(*args):
+        vm_metrics.metric_calls.append(args)
+
+    for name in (
+        "record_slack_etl_rate_limit",
+        "set_etl_active_scopes",
+        "set_etl_failed_scopes",
+        "set_etl_scope_sync_freshness_seconds",
+    ):
+        setattr(vm_metrics, name, lambda *_args, **_kwargs: None)
+    vm_metrics.record_etl_items_deleted = record_etl_items_deleted
+    api_module.vm_metrics = vm_metrics
+    sys.modules["api.vm_metrics"] = vm_metrics
+
+    workflow_engine = types.ModuleType("api.workflow_engine")
+
+    class WorkflowContext:
+        pass
+
+    workflow_engine.WorkflowContext = WorkflowContext
+    api_module.workflow_engine = workflow_engine
+    sys.modules["api.workflow_engine"] = workflow_engine
+
+    centaur_sdk = types.ModuleType("centaur_sdk")
+    centaur_sdk.secret = lambda _name, default=None: default
+    sys.modules["centaur_sdk"] = centaur_sdk
+
+    for module_name in ("workflows.slack.shared", "workflows.slack.retention"):
+        sys.modules.pop(module_name, None)
+    return importlib.import_module("workflows.slack.retention")
+
+
+class FakePool:
+    def __init__(self, values: list[int]) -> None:
+        self.values = values
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetchval(self, sql: str, *args: object) -> int:
+        self.calls.append((sql, args))
+        return self.values.pop(0)
+
+
+def test_schedule_disabled_without_positive_ttl(monkeypatch):
+    monkeypatch.delenv("SLACK_ETL_RETENTION_DAYS", raising=False)
+    monkeypatch.delenv("SLACK_DM_RETENTION_DAYS", raising=False)
+    monkeypatch.delenv("SLACK_RETENTION_ENABLED", raising=False)
+
+    retention = _load_retention()
+
+    assert retention.SCHEDULE["enabled"] is False
+
+
+def test_schedule_uses_minute_interval_and_positive_ttl(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_RETENTION_DAYS", "30")
+    monkeypatch.setenv("SLACK_DM_RETENTION_DAYS", "0")
+    monkeypatch.setenv("SLACK_RETENTION_INTERVAL_MINUTES", "5")
+
+    retention = _load_retention()
+
+    assert retention.SCHEDULE["enabled"] is True
+    assert retention.SCHEDULE["interval_seconds"] == 300
+
+
+def test_prune_slack_etl_deletes_expected_tables():
+    retention = _load_retention()
+    pool = FakePool([1, 2, 3, 4])
+
+    counts = asyncio.run(
+        retention.prune_slack_etl(pool, retention_days=14, dry_run=False)
+    )
+
+    assert counts == {
+        "company_context_documents": 1,
+        "messages": 2,
+        "backfill_jobs": 3,
+        "runs": 4,
+    }
+    assert [args for _sql, args in pool.calls] == [(14,), (14,), (14,), (14,)]
+    sql = "\n".join(call[0] for call in pool.calls)
+    assert "DELETE FROM company_context_documents" in sql
+    assert "source = 'slack'" in sql
+    assert "DELETE FROM slack_sync_messages" in sql
+    assert "DELETE FROM slack_sync_backfill_jobs" in sql
+    assert "status IN ('completed', 'failed')" in sql
+    assert "DELETE FROM slack_sync_runs" in sql
+    assert "status <> 'running'" in sql
+
+
+def test_prune_slack_dm_dry_run_counts_expected_tables():
+    retention = _load_retention()
+    pool = FakePool([5, 6, 7, 8])
+
+    counts = asyncio.run(retention.prune_slack_dm(pool, retention_days=7, dry_run=True))
+
+    assert counts == {
+        "messages": 5,
+        "conversations": 6,
+        "backfill_jobs": 7,
+        "runs": 8,
+    }
+    sql = "\n".join(call[0] for call in pool.calls)
+    assert "SELECT COUNT(*) FROM slack_dm_sync_messages" in sql
+    assert "SELECT COUNT(*) FROM slack_dm_sync_conversations" in sql
+    assert "NOT EXISTS" in sql
+    assert "SELECT COUNT(*) FROM slack_dm_sync_backfill_jobs" in sql
+    assert "SELECT COUNT(*) FROM slack_dm_sync_runs" in sql
+    assert "DELETE FROM" not in sql
+
+
+def test_handler_records_metrics_for_non_dry_run():
+    retention = _load_retention()
+    pool = FakePool([1, 0, 2, 0, 0, 3, 0, 4])
+    ctx = types.SimpleNamespace(_pool=pool)
+    inp = retention.Input(etl_retention_days=10, dm_retention_days=20)
+
+    result = asyncio.run(retention.handler(inp, ctx))
+
+    assert result["slack_etl"]["company_context_documents"] == 1
+    assert result["slack_dm"]["conversations"] == 3
+    metric_calls = sys.modules["api.vm_metrics"].metric_calls
+    assert ("slack", "retention", "company_context_documents", 1) in metric_calls
+    assert ("slack", "retention", "backfill_jobs", 2) in metric_calls
+    assert ("slack_dm", "retention", "conversations", 3) in metric_calls
+    assert ("slack_dm", "retention", "runs", 4) in metric_calls


### PR DESCRIPTION
## What changed

- Added a scheduled `slack_retention` workflow with a configurable cadence via `SLACK_RETENTION_INTERVAL_MINUTES`.
- Added separate retention TTLs for public Slack ETL and Slack DM data via `SLACK_ETL_RETENTION_DAYS` and `SLACK_DM_RETENTION_DAYS`; `0` disables that family.
- Prunes old Slack messages, derived public Slack context documents, stale empty DM conversations, and terminal run/backfill job rows while leaving active checkpoints and non-terminal jobs intact.
- Routes `slack_retention` onto the ETL workflow queue and documents the new settings.

## Validation

- `uvx ruff check workflows/slack/retention.py workflows/slack/tests/test_retention.py`
- `uvx --from pytest pytest workflows/slack/tests/test_retention.py`
- `cargo fmt --check`
- `cargo test -p centaur-workflows scheduled_etls_use_isolated_etl_queues`
- `JUST_NO_DOTENV=true just --no-dotenv build-one api-rs`
- Deployed the built API-RS image locally with `RUN_MIGRATIONS=false` because the local DB has an extra applied migration version not present on `origin/main`; rollout succeeded.

## Notes

A live `slack_retention` dry-run request was accepted by the local API, but I cancelled it after confirming this dev chart loads workflow files from the repo-cache checkout rather than the test image's `/app/workflows`, so the worktree-only workflow file was not available to the local worker. The local deployment was restored to its previous healthy image/config afterward.
