### PR TITLE
fix: emit Slack user ID in Slackbot usage logs

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -351,9 +351,27 @@ function createHandoffTrace(
     messageId: message.id,
     mode,
     openStream: mode === 'execute',
+    slackUserId: slackUserIdForMessage(message),
     startedAtMs: nowMs(),
     threadId: thread.id
   }
+}
+
+function slackUserIdForMessage(message: ChatMessage): string | undefined {
+  return stringValue(message.author.userId) ?? rawSlackUserId(message.raw)
+}
+
+function rawSlackUserId(raw: unknown): string | undefined {
+  if (!isJsonObject(raw)) return undefined
+  const directUser = stringValue(raw.user)
+  if (directUser) return directUser
+  const user = raw.user
+  if (isJsonObject(user)) {
+    return stringValue(user.id) ?? stringValue(user.user_id)
+  }
+  const botProfile = raw.bot_profile
+  if (isJsonObject(botProfile)) return stringValue(botProfile.user_id)
+  return undefined
 }
 
 function slackWebhookEventType(rawBody: string): string {
@@ -516,6 +534,7 @@ async function syncThreadMessageToSession(
     messageId: message.id,
     mode: input.mode,
     openStream: shouldStartExecution,
+    slackUserId: slackUserIdForMessage(message),
     startedAtMs: traceStartedAtMs,
     threadId: thread.id
   }

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -23,6 +23,7 @@ import {
 import { conflateChatSdkStream } from './conflate'
 import { observeSeconds, slackbotMetrics } from './metrics'
 import { renderSlackDisplayText, slackMessagePromptText } from './slack-display-text'
+import { slackUserIdForMessage } from './slack-user'
 import {
   collectInitialContext,
   forwardToSessionApi,
@@ -355,23 +356,6 @@ function createHandoffTrace(
     startedAtMs: nowMs(),
     threadId: thread.id
   }
-}
-
-function slackUserIdForMessage(message: ChatMessage): string | undefined {
-  return stringValue(message.author.userId) ?? rawSlackUserId(message.raw)
-}
-
-function rawSlackUserId(raw: unknown): string | undefined {
-  if (!isJsonObject(raw)) return undefined
-  const directUser = stringValue(raw.user)
-  if (directUser) return directUser
-  const user = raw.user
-  if (isJsonObject(user)) {
-    return stringValue(user.id) ?? stringValue(user.user_id)
-  }
-  const botProfile = raw.bot_profile
-  if (isJsonObject(botProfile)) return stringValue(botProfile.user_id)
-  return undefined
 }
 
 function slackWebhookEventType(rawBody: string): string {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -18,6 +18,7 @@ import type {
   SlackbotV2SessionMessage
 } from './types'
 import { observeSeconds, slackbotMetrics } from './metrics'
+import { rawSlackUserId } from './slack-user'
 import {
   elapsedMs,
   errorMessage,
@@ -726,19 +727,6 @@ function messageRequesterUserId(message: SlackbotV2ApiMessage | undefined): stri
   const rawUserId = rawSlackUserId(message.raw)
   const authorUserId = stringValue(message.author.userId)
   return authorUserId ?? rawUserId
-}
-
-function rawSlackUserId(raw: unknown): string | undefined {
-  if (!isJsonObject(raw)) return undefined
-  const directUser = stringValue(raw.user)
-  if (directUser) return directUser
-  const user = raw.user
-  if (isJsonObject(user)) {
-    return stringValue(user.id) ?? stringValue(user.user_id)
-  }
-  const botProfile = raw.bot_profile
-  if (isJsonObject(botProfile)) return stringValue(botProfile.user_id)
-  return undefined
 }
 
 async function resolveRequesterIdentity(

--- a/services/slackbotv2/src/slack-user.ts
+++ b/services/slackbotv2/src/slack-user.ts
@@ -1,0 +1,25 @@
+import { isJsonObject, stringValue } from './utils'
+
+type MessageWithSlackUser = {
+  author?: {
+    userId?: unknown
+  }
+  raw?: unknown
+}
+
+export function slackUserIdForMessage(message: MessageWithSlackUser): string | undefined {
+  return stringValue(message.author?.userId) ?? rawSlackUserId(message.raw)
+}
+
+export function rawSlackUserId(raw: unknown): string | undefined {
+  if (!isJsonObject(raw)) return undefined
+  const directUser = stringValue(raw.user)
+  if (directUser) return directUser
+  const user = raw.user
+  if (isJsonObject(user)) {
+    return stringValue(user.id) ?? stringValue(user.user_id)
+  }
+  const botProfile = raw.bot_profile
+  if (isJsonObject(botProfile)) return stringValue(botProfile.user_id)
+  return undefined
+}

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -158,6 +158,7 @@ export type SlackbotV2Trace = {
   messageId: string
   mode: SlackbotV2MessageMode
   openStream: boolean
+  slackUserId?: string
   startedAtMs: number
   threadId: string
 }

--- a/services/slackbotv2/src/utils.ts
+++ b/services/slackbotv2/src/utils.ts
@@ -78,6 +78,7 @@ function traceFields(trace?: SlackbotV2Trace): JsonObject {
         message_id: trace.messageId,
         mode: trace.mode,
         open_stream: trace.openStream,
+        ...(trace.slackUserId ? { slack_user_id: trace.slackUserId } : {}),
         thread_id: trace.threadId
       }
     : {}

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -2633,14 +2633,24 @@ describe('slackbotv2', () => {
         assistant_status_requested: true,
         message_id: mention.ts,
         mode: 'execute',
+        slack_user_id: USER_ID,
         thread_id: threadKey(parent.ts),
         trigger: 'new_mention'
+      })
+    )
+    expect(logData(logs, 'slackbotv2_forward_started')).toEqual(
+      expect.objectContaining({
+        message_id: mention.ts,
+        mode: 'execute',
+        slack_user_id: USER_ID,
+        thread_id: threadKey(parent.ts)
       })
     )
     expect(logData(logs, 'slackbotv2_assistant_status_started')).toEqual(
       expect.objectContaining({
         message_id: mention.ts,
         operation: 'set',
+        slack_user_id: USER_ID,
         thread_id: threadKey(parent.ts)
       })
     )

--- a/services/slackbotv2/test/slack-user.test.ts
+++ b/services/slackbotv2/test/slack-user.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import { rawSlackUserId, slackUserIdForMessage } from '../src/slack-user'
+
+describe('Slack user ID extraction', () => {
+  test('prefers the Chat SDK author user ID', () => {
+    expect(
+      slackUserIdForMessage({
+        author: { userId: 'UAUTHOR' },
+        raw: { user: 'URAW' }
+      })
+    ).toBe('UAUTHOR')
+  })
+
+  test('falls back to a raw Slack user string', () => {
+    expect(slackUserIdForMessage({ raw: { user: 'URAW' } })).toBe('URAW')
+    expect(rawSlackUserId({ user: 'URAW' })).toBe('URAW')
+  })
+
+  test('falls back to raw Slack user object ids', () => {
+    expect(rawSlackUserId({ user: { id: 'UOBJECT' } })).toBe('UOBJECT')
+    expect(rawSlackUserId({ user: { user_id: 'UOBJECT_ALT' } })).toBe('UOBJECT_ALT')
+  })
+
+  test('falls back to bot profile user ID', () => {
+    expect(rawSlackUserId({ bot_profile: { user_id: 'UBOT' } })).toBe('UBOT')
+  })
+
+  test('returns undefined when no Slack user ID is present', () => {
+    expect(slackUserIdForMessage({ raw: { user: {} } })).toBeUndefined()
+    expect(rawSlackUserId({ bot_profile: {} })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Adds slack_user_id to Slackbot trace log fields so usage dashboards can count distinct active Slack users. The field is populated from the Chat SDK author ID with a raw Slack payload fallback, and the emulator coverage now asserts it on forward-start logs.