### PR TITLE
Support GitHub App broker credentials

### DIFF
--- a/services/console/lib/broker/credential_grants.rb
+++ b/services/console/lib/broker/credential_grants.rb
@@ -3,15 +3,24 @@ module Broker
   # owns persistence and scheduling; these strategies own provider-specific
   # request shapes and bootstrap validation.
   module CredentialGrants
+    require "base64"
+    require "json"
+    require "net/http"
+    require "openssl"
+    require "time"
+    require "uri"
+
     PREQIN_TOKEN_ENDPOINT = "https://api.preqin.com/connect/token".freeze
     PREQIN_REFRESH_TOKEN_ENDPOINT = "https://api.preqin.com/connect/refresh_token".freeze
 
-    GRANTS = %w[refresh_token client_credentials password preqin].freeze
-    REFRESHABLE_WITHOUT_TOKEN_GRANTS = %w[client_credentials password preqin].freeze
+    GRANTS = %w[refresh_token client_credentials password preqin github_app].freeze
+    REFRESHABLE_WITHOUT_TOKEN_GRANTS = %w[client_credentials password preqin github_app].freeze
 
     Outcome = Data.define(:result, :clear_refresh_token, :dead_reason)
 
     class << self
+      attr_writer :github_app_http_client
+
       def default_token_endpoint(grant)
         PREQIN_TOKEN_ENDPOINT if grant == "preqin"
       end
@@ -28,6 +37,8 @@ module Broker
           validate_password(credential)
         when "preqin"
           validate_preqin(credential)
+        when "github_app"
+          validate_github_app(credential)
         end
       end
 
@@ -39,6 +50,8 @@ module Broker
           refresh_password(credential)
         when "preqin"
           refresh_preqin(credential)
+        when "github_app"
+          refresh_github_app(credential)
         else
           refresh_token(credential)
         end
@@ -129,6 +142,63 @@ module Broker
         success(result, clear_refresh_token: clear_stale_refresh_token && result.refresh_token.blank?)
       end
 
+      def refresh_github_app(credential)
+        now = Time.current
+        require_value!("client_id", credential.client_id)
+        require_value!("client_secret", credential.client_secret)
+        require_value!("token_endpoint", credential.token_endpoint)
+
+        uri = URI.parse(credential.token_endpoint)
+        request = Net::HTTP::Post.new(uri)
+        request["Authorization"] = "Bearer #{github_app_jwt(credential, now)}"
+        request["Accept"] = "application/vnd.github+json"
+        request["X-GitHub-Api-Version"] = "2022-11-28"
+
+        response = github_app_http_request(uri, request, credential.refresh_timeout_seconds)
+        unless response.is_a?(Net::HTTPSuccess)
+          raise github_app_http_error(response)
+        end
+
+        parsed = JSON.parse(response.body)
+        token = parsed["token"].to_s
+        raise Broker::RefreshError.new("GitHub App token response missing token", stage: "parse", retryable: true) if token.blank?
+
+        expires_at = Time.iso8601(parsed.fetch("expires_at"))
+        expires_in = [ (expires_at - now).to_i, 1 ].max
+        result = Broker::RefreshClient::Result.new(
+          access_token: token,
+          refresh_token: nil,
+          expires_in: expires_in
+        )
+        success(result, clear_refresh_token: true)
+      rescue JSON::ParserError, KeyError, ArgumentError, TypeError => e
+        raise Broker::RefreshError.new(
+          "GitHub App token response could not be parsed: #{e.class}",
+          stage: "parse",
+          retryable: true
+        )
+      rescue OpenSSL::PKey::PKeyError => e
+        raise Broker::RefreshError.new(
+          "GitHub App private key is invalid: #{e.class}",
+          stage: "config",
+          code: "invalid_private_key",
+          retryable: false
+        )
+      rescue URI::InvalidURIError => e
+        raise Broker::RefreshError.new(
+          "GitHub App token endpoint is invalid: #{e.class}",
+          stage: "config",
+          code: "invalid_token_endpoint",
+          retryable: false
+        )
+      rescue IOError, SystemCallError, Timeout::Error, Net::OpenTimeout, Net::ReadTimeout => e
+        raise Broker::RefreshError.new(
+          "GitHub App token endpoint request failed: #{e.class}",
+          stage: "network",
+          retryable: true
+        )
+      end
+
       def oauth_refresh_token(credential)
         post_token_form(
           credential,
@@ -202,6 +272,55 @@ module Broker
         { "refresh_token" => credential.refresh_token }
       end
 
+      def github_app_jwt(credential, now)
+        header = base64url(JSON.generate({ alg: "RS256", typ: "JWT" }))
+        payload = base64url(JSON.generate({
+          iat: now.to_i - 60,
+          exp: now.to_i + 9.minutes.to_i,
+          iss: credential.client_id
+        }))
+        signing_input = "#{header}.#{payload}"
+        key = OpenSSL::PKey::RSA.new(github_app_private_key_pem(credential.client_secret))
+        signature = key.sign(OpenSSL::Digest.new("SHA256"), signing_input)
+        "#{signing_input}.#{base64url(signature)}"
+      end
+
+      def github_app_private_key_pem(value)
+        text = value.to_s
+        return text if text.include?("-----BEGIN")
+
+        Base64.strict_decode64(text)
+      rescue ArgumentError
+        text
+      end
+
+      def github_app_http_request(uri, request, timeout)
+        if @github_app_http_client
+          return @github_app_http_client.call(uri, request)
+        end
+
+        Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
+                        open_timeout: timeout, read_timeout: timeout) do |http|
+          http.request(request)
+        end
+      end
+
+      def github_app_http_error(response)
+        status = response.code.to_i
+        retryable = status / 100 == 5 || status == 429
+        Broker::RefreshError.new(
+          "GitHub App installation token endpoint returned HTTP #{status}",
+          stage: "http",
+          code: "http_#{status}",
+          status: status,
+          retryable: retryable
+        )
+      end
+
+      def base64url(value)
+        Base64.urlsafe_encode64(value, padding: false)
+      end
+
       def add_oauth_optional_fields(form, credential)
         form["client_secret"] = credential.effective_client_secret if credential.effective_client_secret.present?
 
@@ -228,6 +347,12 @@ module Broker
       def validate_preqin(credential)
         credential.errors.add(:username, "can't be blank for the Preqin broker grant") if credential.username.blank?
         credential.errors.add(:api_key, "can't be blank for the Preqin broker grant") if credential.api_key.blank?
+      end
+
+      def validate_github_app(credential)
+        if credential.client_secret.blank?
+          credential.errors.add(:client_secret, "can't be blank for the GitHub App broker grant")
+        end
       end
 
       def password_values_present?(credential)

--- a/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
@@ -173,6 +173,36 @@ module Api
         assert created.next_attempt_at.present?
       end
 
+      test "create github_app grant stores private key and redacts it" do
+        private_key = OpenSSL::PKey::RSA.generate(2048).to_pem
+        body = {
+          data: {
+            namespace: "acme", foreign_id: "github-app",
+            grant: "github_app",
+            token_endpoint: "https://api.github.com/app/installations/456/access_tokens",
+            client_id: "123",
+            client_secret: private_key
+          }
+        }
+
+        assert_difference -> { BrokerCredential.count } => 1 do
+          post api_v1_broker_credentials_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :created
+        data = json_body.fetch("data")
+        assert_equal "github_app", data["grant"]
+        assert_equal "123", data["client_id"]
+        refute data.key?("client_secret")
+        refute data.key?("access_token")
+
+        created = BrokerCredential.find_by_oid(data["id"])
+        assert_equal private_key, created.client_secret
+        # A freshly-created github_app credential must be due for its first mint.
+        # next_attempt_at is left nil on create here, which the refreshable scope
+        # treats as immediately due (next_attempt_at IS NULL).
+        assert BrokerCredential.refreshable.exists?(id: created.id)
+      end
+
       test "create rejects a missing client_id" do
         body = {
           data: {

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -41,6 +41,26 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc
   end
 
+  def github_private_key
+    @github_private_key ||= OpenSSL::PKey::RSA.generate(2048)
+  end
+
+  def github_app_response(token: "ghs_installation", expires_at: 1.hour.from_now)
+    response = Net::HTTPOK.new("1.1", "200", "OK")
+    response.instance_variable_set(
+      :@body,
+      JSON.generate({ "token" => token, "expires_at" => expires_at.iso8601 })
+    )
+    # Mark the body as already read; otherwise Net::HTTPResponse#body tries to
+    # read from a (nil) socket and raises "attempt to read body out of block".
+    response.instance_variable_set(:@read, true)
+    response
+  end
+
+  teardown do
+    Broker::CredentialGrants.github_app_http_client = nil
+  end
+
   # --- validations ----------------------------------------------------------
 
   test "valid with a client_id" do
@@ -98,6 +118,29 @@ class BrokerCredentialTest < ActiveSupport::TestCase
                           api_key: nil, refresh_token: nil)
     refute bc.valid?
     assert bc.errors[:api_key].any? { |m| m.include?("Preqin broker grant") }
+  end
+
+  test "github_app grant is valid with app id, private key, and installation token endpoint" do
+    bc = build_credential(
+      grant: "github_app",
+      token_endpoint: "https://api.github.com/app/installations/456/access_tokens",
+      client_id: "123",
+      client_secret: github_private_key.to_pem,
+      refresh_token: nil
+    )
+    assert bc.valid?, bc.errors.full_messages.to_sentence
+  end
+
+  test "github_app grant requires a private key" do
+    bc = build_credential(
+      grant: "github_app",
+      token_endpoint: "https://api.github.com/app/installations/456/access_tokens",
+      client_id: "123",
+      client_secret: nil,
+      refresh_token: nil
+    )
+    refute bc.valid?
+    assert bc.errors[:client_secret].any? { |m| m.include?("GitHub App broker grant") }
   end
 
   # --- oauth_app provenance (flow-minted credentials) -----------------------
@@ -436,6 +479,86 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert_equal "AT", bc.access_token
   end
 
+  test "github_app grant mints and stores an installation access token" do
+    captured = {}
+    expires_at = 1.hour.from_now
+    Broker::CredentialGrants.github_app_http_client = ->(uri, request) {
+      captured = { uri: uri, request: request }
+      github_app_response(token: "ghs_installation", expires_at: expires_at)
+    }
+    now = Time.current
+    bc = create_credential(
+      grant: "github_app",
+      token_endpoint: "https://api.github.com/app/installations/456/access_tokens",
+      client_id: "123",
+      client_secret: github_private_key.to_pem,
+      refresh_token: nil
+    )
+
+    bc.refresh!(now: now)
+    bc.reload
+
+    assert_equal "ghs_installation", bc.access_token
+    assert_nil bc.refresh_token
+    assert_in_delta expires_at.to_f, bc.expires_at.to_f, 2
+    assert_equal "https://api.github.com/app/installations/456/access_tokens", captured[:uri].to_s
+    assert_match(/\ABearer /, captured[:request]["Authorization"])
+    assert_equal "application/vnd.github+json", captured[:request]["Accept"]
+  end
+
+  test "github_app grant output is delivered through existing token_broker sources" do
+    Broker::CredentialGrants.github_app_http_client = ->(_uri, _request) {
+      github_app_response(token: "ghs_brokered", expires_at: 1.hour.from_now)
+    }
+    bc = create_credential(
+      grant: "github_app",
+      token_endpoint: "https://api.github.com/app/installations/456/access_tokens",
+      client_id: "123",
+      client_secret: github_private_key.to_pem,
+      refresh_token: nil
+    )
+    bc.refresh!
+
+    source = SecretSource.new(source_type: "token_broker", config: { "credential_id" => bc.oid })
+
+    assert_equal({ "type" => "control_plane", "value" => "ghs_brokered" }, source.to_proxy_source)
+    assert source.deliverable?
+  end
+
+  test "github_app grant accepts a base64 encoded private key" do
+    Broker::CredentialGrants.github_app_http_client = ->(_uri, _request) {
+      github_app_response(token: "ghs_encoded", expires_at: 1.hour.from_now)
+    }
+    bc = create_credential(
+      grant: "github_app",
+      token_endpoint: "https://api.github.com/app/installations/456/access_tokens",
+      client_id: "123",
+      client_secret: Base64.strict_encode64(github_private_key.to_pem),
+      refresh_token: nil
+    )
+
+    bc.refresh!
+    bc.reload
+
+    assert_equal "ghs_encoded", bc.access_token
+  end
+
+  test "github_app grant marks invalid private keys dead" do
+    bc = create_credential(
+      grant: "github_app",
+      token_endpoint: "https://api.github.com/app/installations/456/access_tokens",
+      client_id: "123",
+      client_secret: "not-a-private-key",
+      refresh_token: nil
+    )
+
+    bc.refresh!
+    bc.reload
+
+    assert bc.dead?
+    assert_equal "invalid_private_key", bc.dead_reason
+  end
+
   test "preqin grant prefers the Preqin refresh endpoint when it has a refresh token" do
     client = Minitest::Mock.new
     expect_refresh(client, returns: result(access_token: "AT", refresh_token: nil)) do |request|
@@ -542,6 +665,19 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   test "refreshable includes client_credentials without a refresh_token after a prior refresh" do
     bc = create_credential(grant: "client_credentials", refresh_token: nil,
                            client_id: "cid", client_secret: "sec")
+    bc.update_columns(last_refresh: 1.hour.ago, next_attempt_at: 1.minute.ago)
+
+    assert_includes BrokerCredential.refreshable.pluck(:id), bc.id
+  end
+
+  test "refreshable includes github_app credentials without a refresh_token" do
+    bc = create_credential(
+      grant: "github_app",
+      token_endpoint: "https://api.github.com/app/installations/456/access_tokens",
+      client_id: "123",
+      client_secret: github_private_key.to_pem,
+      refresh_token: nil
+    )
     bc.update_columns(last_refresh: 1.hour.ago, next_attempt_at: 1.minute.ago)
 
     assert_includes BrokerCredential.refreshable.pluck(:id), bc.id


### PR DESCRIPTION
## Summary

This replaces the earlier proxy-source-specific approach with a smaller, broker-native implementation:

- adds a new `github_app` `BrokerCredential` grant
- mints GitHub App installation access tokens from an App ID, private key, and installation token endpoint
- stores the minted token in the existing `BrokerCredential.access_token` / `expires_at` fields
- delivers the token through the existing `token_broker` `SecretSource` path unchanged

This is purely additive: no new `SecretSource` type, no schema migration, no chart changes, and no proxy/tool-discovery changes.

## Why this is necessary

GitHub App authentication is not a static credential. A private key signs a short-lived GitHub App JWT, which is then exchanged for an installation access token. That installation token expires, so treating it like a static secret or relying on a sandbox-local placeholder exchange can leave agents with stale GitHub auth and repeated `401` failures.

Centaur already has the right lifecycle primitive for this: brokered credentials. By adding GitHub App support as a broker grant, the console keeps the App private key encrypted at rest, refreshes the installation token on the normal broker schedule, and exposes only the current access token through the existing `token_broker` delivery path. That preserves the security model while avoiding a new secret-source mechanism.

## Testing

Passed:

- `ASDF_RUBY_VERSION=3.4.8 ruby -c services/console/lib/broker/credential_grants.rb`
- `ASDF_RUBY_VERSION=3.4.8 ruby -c services/console/test/models/broker_credential_test.rb`
- `ASDF_RUBY_VERSION=3.4.8 ruby -c services/console/test/controllers/api/v1/broker_credentials_controller_test.rb`
- `git diff --check upstream/main`

Attempted but blocked locally before tests executed:

- `ASDF_RUBY_VERSION=3.4.8 bin/rails test test/models/broker_credential_test.rb test/controllers/api/v1/broker_credentials_controller_test.rb`

Local blocker: Postgres test DB auth fails with `127.0.0.1:5432 failed: fe_sendauth: no password supplied`.