### PR TITLE
fix: configure postgres shared memory volume

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.78
+version: 0.1.79
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/workloads.yaml
+++ b/contrib/chart/templates/workloads.yaml
@@ -75,6 +75,19 @@ spec:
               {{- with .Values.postgres.persistence.subPath }}
               subPath: {{ . | quote }}
               {{- end }}
+            {{- if .Values.postgres.sharedMemory.enabled }}
+            - name: shared-memory
+              mountPath: /dev/shm
+            {{- end }}
+      {{- if .Values.postgres.sharedMemory.enabled }}
+      volumes:
+        - name: shared-memory
+          emptyDir:
+            medium: Memory
+            {{- with .Values.postgres.sharedMemory.sizeLimit }}
+            sizeLimit: {{ . | quote }}
+            {{- end }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -287,6 +287,13 @@
           "properties": {
             "subPath": { "type": "string" }
           }
+        },
+        "sharedMemory": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "sizeLimit": { "type": "string" }
+          }
         }
       }
     },

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -450,6 +450,11 @@ postgres:
     size: 20Gi
     storageClassName: ""
     subPath: ""
+  # PostgreSQL uses /dev/shm for dynamic shared memory during parallel queries.
+  # This memory-backed volume counts against the pod's memory limit.
+  sharedMemory:
+    enabled: true
+    sizeLimit: 1Gi
   resources: {}
 
 ingress:


### PR DESCRIPTION
Adds a configurable memory-backed /dev/shm volume for the bundled Postgres StatefulSet so dynamic shared memory allocations have more room during queries. The default is enabled at 1Gi, with values and schema support for operators to resize or disable it.