### PR TITLE
fix: propagate google oauth identity to principals

### DIFF
--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -74,6 +74,7 @@ class PrincipalCredentialReconciliation
 
       requested += 1
       created += 1 if grant_credential(principal, credential)
+      sync_principal_provider_labels(principal, [ credential ])
     end
     { requested: requested, created: created }
   end
@@ -95,7 +96,26 @@ class PrincipalCredentialReconciliation
     created = entry.actionable_credentials.count do |credential|
       grant_credential(entry.principal, credential)
     end
+    sync_principal_provider_labels(entry.principal, entry.google_credentials)
     { requested: requested, created: created }
+  end
+
+  def sync_principal_provider_labels(principal, credentials)
+    google_credentials = credentials.select do |credential|
+      credential.oauth_app&.provider == GOOGLE_PROVIDER
+    end
+    return if google_credentials.empty?
+
+    labels = principal.labels || {}
+    updates = {}
+    subject = unique_present_value(google_credentials.map(&:provider_subject))
+    email = unique_present_value(google_credentials.map(&:provider_email))
+
+    updates["google_subject"] = subject if subject && labels["google_subject"].blank?
+    updates["google_email"] = email if email && labels["google_email"].blank?
+    return if updates.empty?
+
+    principal.update!(labels: labels.merge(updates))
   end
 
   def grant_credential(principal, credential)
@@ -281,5 +301,14 @@ class PrincipalCredentialReconciliation
 
   def normalize_email(value)
     value.to_s.strip.downcase.presence
+  end
+
+  def unique_present_value(values)
+    present = values.filter_map do |value|
+      stripped = value.to_s.strip
+      stripped.presence
+    end.uniq { |value| value.downcase }
+
+    present.one? ? present.first : nil
   end
 end

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -128,11 +128,20 @@ class PgDsnSecretTest < ActiveSupport::TestCase
 
   test "to_proxy_dsn resolves value_from principal labels and fields" do
     principal = principals(:acme_channel)
-    principal.update!(labels: { "slack_channel_id" => "C0123456789" })
+    principal.update!(
+      labels: {
+        "slack_channel_id" => "C0123456789",
+        "google_subject" => "google-sub-alice"
+      }
+    )
     secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
       {
         "name" => "centaur.slack_channel_id",
         "value_from" => { "principal_label" => "slack_channel_id" }
+      },
+      {
+        "name" => "centaur.google_subject",
+        "value_from" => { "principal_label" => "google_subject" }
       },
       { "name" => "centaur.principal", "value_from" => { "principal_field" => "foreign_id" } },
       { "name" => "centaur.principal_id", "value_from" => { "principal_field" => "id" } },
@@ -143,6 +152,7 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     assert_equal(
       [
         { "name" => "centaur.slack_channel_id", "value" => "C0123456789" },
+        { "name" => "centaur.google_subject", "value" => "google-sub-alice" },
         { "name" => "centaur.principal", "value" => principal.foreign_id },
         { "name" => "centaur.principal_id", "value" => principal.oid },
         { "name" => "app.tenant", "value" => "centaur" }

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -19,6 +19,8 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
 
     assert principal.grants.exists?(static_secret: @slack_secret)
     assert principal.grants.exists?(static_secret: @google_secret)
+    assert_equal "google-sub-alice", principal.reload.labels["google_subject"]
+    assert_equal "alice@example.com", principal.labels["google_email"]
 
     entry = PrincipalCredentialReconciliation.new.entries.find do |candidate|
       candidate.principal == principal
@@ -76,6 +78,8 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     assert_equal [ google ], entry.google_credentials
     assert principal.grants.exists?(static_secret: slack.static_secret)
     assert principal.grants.exists?(static_secret: google.static_secret)
+    assert_equal "google-sub-alice", principal.reload.labels["google_subject"]
+    assert_equal "wrong-google@example.com", principal.labels["google_email"]
     refute principal.grants.exists?(static_secret: email_only_slack.static_secret)
     refute principal.grants.exists?(static_secret: email_only_google.static_secret)
   end
@@ -114,6 +118,32 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
       credential.update!(provider_email: "alice@example.com")
     end
     assert principal.grants.exists?(static_secret: secret)
+    assert_equal "google-sub-alice", principal.reload.labels["google_subject"]
+    assert_equal "alice@example.com", principal.labels["google_email"]
+  end
+
+  test "does not overwrite an existing Google subject label" do
+    principal = principals(:acme_user_alice)
+    principal.update!(
+      labels: principal.labels.merge(
+        "google_subject" => "google-sub-existing",
+        "email" => "alice@example.com"
+      )
+    )
+    credential = create_credential(
+      oauth_apps(:acme_google),
+      "google-sub-other",
+      "alice@example.com"
+    )
+    secret = wrap(credential)
+
+    entry = PrincipalCredentialReconciliation.new.entries.find do |candidate|
+      candidate.principal == principal
+    end
+    assert_nil entry
+    refute principal.grants.exists?(static_secret: secret)
+    assert_equal "google-sub-existing", principal.reload.labels["google_subject"]
+    assert_nil principal.labels["google_email"]
   end
 
   test "automatic grant is idempotent" do


### PR DESCRIPTION
## Summary
- populate `google_subject` and `google_email` principal labels from matched Google OAuth credentials during reconciliation
- keep existing labels authoritative by filling blanks only
- cover `centaur.google_subject` resolution through the existing PG DSN `principal_label` setting path

## Tests
- `docker run --rm --network container:centaur-console-ui-postgres -v /Users/akshaan/Desktop/centaur-google-docs-principal-setting/services/console:/rails -w /rails -e RAILS_ENV=test -e CENTAUR_CONSOLE_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/iron_control_test -e SECRET_KEY_BASE=test-secret -e CENTAUR_CONSOLE_AR_ENCRYPTION_PRIMARY_KEY=local_primary_key_000000000000000000000000000000 -e CENTAUR_CONSOLE_AR_ENCRYPTION_DETERMINISTIC_KEY=local_deterministic_key_00000000000000000000 -e CENTAUR_CONSOLE_AR_ENCRYPTION_KEY_DERIVATION_SALT=local_key_derivation_salt_00000000000000 centaur-console:latest sh -lc 'bin/rails db:test:prepare && bin/rails test test/services/principal_credential_reconciliation_test.rb test/models/pg_dsn_secret_test.rb'`\n- `docker run --rm -v /Users/akshaan/Desktop/centaur-google-docs-principal-setting/services/console:/rails -w /rails centaur-console:latest sh -lc 'bundle exec rubocop app/services/principal_credential_reconciliation.rb test/services/principal_credential_reconciliation_test.rb test/models/pg_dsn_secret_test.rb'`