### PR TITLE
Fix vmetrics series and health checks

### DIFF
--- a/tools/infra/vmetrics/cli.py
+++ b/tools/infra/vmetrics/cli.py
@@ -53,10 +53,11 @@ def series(
     match: str = typer.Argument(..., help='Series selector, e.g. {__name__=~"agent_.*"}'),
     start: str = typer.Option(None, "--start", "-s", help="Range start timestamp"),
     end: str = typer.Option(None, "--end", "-e", help="Range end timestamp"),
+    limit: int | None = typer.Option(None, "--limit", "-n", help="Max returned series"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """Find matching time series."""
-    result = get_client().series(match=match, start=start, end=end)
+    result = get_client().series(match=match, start=start, end=end, limit=limit)
     if json_output:
         print(json.dumps(result, indent=2))
         return
@@ -93,16 +94,10 @@ def metric_names(
 
 @app.command()
 def health():
-    """Assert VictoriaMetrics readiness."""
-    ready = get_client().ready()
-    payload = {
-        "ok": ready,
-        "tool": "vmetrics",
-        "error": None if ready else "VictoriaMetrics is not ready",
-        "details": {"ready": ready},
-    }
+    """Assert VictoriaMetrics readiness and basic query functionality."""
+    payload = get_client().health()
     print(json.dumps(payload, indent=2, default=str))
-    if not ready:
+    if not payload.get("ok"):
         raise typer.Exit(1)
 
 

--- a/tools/infra/vmetrics/client.py
+++ b/tools/infra/vmetrics/client.py
@@ -13,14 +13,21 @@ class VictoriaMetricsClient:
     Connects directly to VictoriaMetrics (default: http://victoriametrics:8428).
     """
 
-    def __init__(self, url: str | None = None, timeout: float = 30.0):
+    def __init__(
+        self,
+        url: str | None = None,
+        timeout: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ):
         self._url = url
         self.timeout = timeout
+        self._transport = transport
         self._client: httpx.Client | None = None
 
     @property
     def base_url(self) -> str:
-        url = (self._url or os.getenv("VICTORIAMETRICS_URL", "http://victoriametrics:8428")).rstrip("/")
+        # Non-secret endpoint config. VictoriaMetrics is in-cluster by default.
+        url = (self._url or os.getenv("VICTORIAMETRICS_URL", "http://victoriametrics:8428")).rstrip("/")  # noqa: TID251
         if url and not url.startswith(("http://", "https://")):
             url = f"http://{url}"
         return url
@@ -28,7 +35,11 @@ class VictoriaMetricsClient:
     @property
     def client(self) -> httpx.Client:
         if self._client is None:
-            self._client = httpx.Client(base_url=self.base_url, timeout=self.timeout)
+            self._client = httpx.Client(
+                base_url=self.base_url,
+                timeout=self.timeout,
+                transport=self._transport,
+            )
         return self._client
 
     def query(self, expr: str, time: str | None = None) -> dict[str, Any]:
@@ -74,6 +85,7 @@ class VictoriaMetricsClient:
         match: str,
         start: str | None = None,
         end: str | None = None,
+        limit: int | None = None,
     ) -> list[dict[str, str]]:
         """Find time series matching a label selector.
 
@@ -81,6 +93,7 @@ class VictoriaMetricsClient:
             match: Series selector (e.g. '{__name__=~"agent_.*"}').
             start: Optional start time.
             end: Optional end time.
+            limit: Optional maximum number of returned series.
         """
         params: dict[str, str] = {"match[]": match}
         if start:
@@ -88,8 +101,17 @@ class VictoriaMetricsClient:
         if end:
             params["end"] = end
         resp = self.client.get("/api/v1/series", params=params)
-        resp.raise_for_status()
-        return resp.json().get("data", [])
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            detail = _response_error_detail(exc.response)
+            raise RuntimeError(f"VictoriaMetrics series query failed: {detail}") from exc
+        results = resp.json().get("data", [])
+        if limit is not None:
+            if limit < 0:
+                raise ValueError("limit must be non-negative")
+            return results[:limit]
+        return results
 
     def label_values(self, label: str) -> list[str]:
         """Get all values for a label (e.g. '__name__' for all metric names).
@@ -119,6 +141,54 @@ class VictoriaMetricsClient:
             return resp.status_code == 200
         except Exception:
             return False
+
+    def health(self) -> dict[str, Any]:
+        """Run a meaningful readiness check against VictoriaMetrics.
+
+        This proves the service responds, accepts PromQL, exposes metric names,
+        and can return at least one bounded series selector.
+        """
+        details: dict[str, Any] = {
+            "ready": False,
+            "query_ok": False,
+            "metric_names_count": 0,
+            "series_count": 0,
+        }
+        try:
+            ready_resp = self.client.get("/health")
+            details["ready"] = ready_resp.status_code == 200
+            if not details["ready"]:
+                return {
+                    "ok": False,
+                    "tool": "vmetrics",
+                    "error": f"VictoriaMetrics health returned HTTP {ready_resp.status_code}",
+                    "details": details,
+                }
+
+            query_result = self.query("count({__name__=~\".+\"})")
+            details["query_ok"] = query_result.get("status") == "success"
+            details["query_result_count"] = len(query_result.get("results", []))
+
+            metric_names = self.metric_names(prefix="")
+            details["metric_names_count"] = len(metric_names)
+
+            series = self.series('{__name__="up"}', limit=1)
+            details["series_count"] = len(series)
+
+            ok = bool(details["query_ok"] and details["metric_names_count"] and details["series_count"])
+            return {
+                "ok": ok,
+                "tool": "vmetrics",
+                "error": None if ok else "VictoriaMetrics checks returned no query, metric, or series data",
+                "details": details,
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "tool": "vmetrics",
+                "error": str(exc),
+                "details": details,
+            }
 
     def close(self):
         if self._client:
@@ -159,6 +229,14 @@ def _format_result(data: dict[str, Any]) -> dict[str, Any]:
         "type": result_type,
         "results": formatted,
     }
+
+
+def _response_error_detail(response: httpx.Response) -> str:
+    try:
+        body = response.json()
+    except ValueError:
+        body = response.text
+    return f"HTTP {response.status_code} - {body}"
 
 
 def _client() -> VictoriaMetricsClient:

--- a/tools/infra/vmetrics/test_client.py
+++ b/tools/infra/vmetrics/test_client.py
@@ -1,0 +1,79 @@
+import httpx
+import pytest
+from client import VictoriaMetricsClient
+
+
+def make_client(handler):
+    return VictoriaMetricsClient(
+        url="http://victoriametrics:8428",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def json_response(payload, status_code=200):
+    return httpx.Response(status_code, json=payload)
+
+
+def test_series_accepts_limit_for_tool_bridge():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/series"
+        assert request.url.params.get("match[]") == '{__name__="up"}'
+        return json_response(
+            {
+                "status": "success",
+                "data": [
+                    {"__name__": "up", "instance": "one"},
+                    {"__name__": "up", "instance": "two"},
+                ],
+            }
+        )
+
+    assert make_client(handler).series('{__name__="up"}', limit=1) == [
+        {"__name__": "up", "instance": "one"}
+    ]
+
+
+def test_series_wraps_http_errors_with_response_body():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return json_response({"error": "too many series selected"}, status_code=422)
+
+    with pytest.raises(RuntimeError, match="HTTP 422"):
+        make_client(handler).series('{__name__=~".+"}')
+
+
+def test_health_checks_query_metric_names_and_series():
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path == "/health":
+            return httpx.Response(200)
+        if request.url.path == "/api/v1/query":
+            return json_response(
+                {
+                    "status": "success",
+                    "data": {
+                        "resultType": "vector",
+                        "result": [{"metric": {}, "value": [1, "3"]}],
+                    },
+                }
+            )
+        if request.url.path == "/api/v1/label/__name__/values":
+            return json_response({"status": "success", "data": ["up", "centaur_sessions_total"]})
+        if request.url.path == "/api/v1/series":
+            return json_response({"status": "success", "data": [{"__name__": "up"}]})
+        raise AssertionError(f"unexpected path: {request.url.path}")
+
+    result = make_client(handler).health()
+
+    assert result["ok"] is True
+    assert result["details"]["ready"] is True
+    assert result["details"]["query_ok"] is True
+    assert result["details"]["metric_names_count"] == 2
+    assert result["details"]["series_count"] == 1
+    assert seen_paths == [
+        "/health",
+        "/api/v1/query",
+        "/api/v1/label/__name__/values",
+        "/api/v1/series",
+    ]


### PR DESCRIPTION
## Summary
- add bridge-compatible `limit` support to `vmetrics.series` and CLI `--limit`
- wrap VictoriaMetrics series HTTP failures with response details
- make `vmetrics health` verify readiness, PromQL query, metric-name discovery, and a bounded series lookup
- add mocked client tests for series limit, error reporting, and health behavior

## Test Plan
- `uvx ruff check tools/infra/vmetrics`
- `uv run --no-editable --with pytest --with httpx pytest -q` from `tools/infra/vmetrics`
- `uv run --no-editable vmetrics health` from `tools/infra/vmetrics`
- `uv run --no-editable vmetrics series '{__name__="up"}' --limit 1 --json` from `tools/infra/vmetrics`
- branch-copy Python bridge-style calls for `VictoriaMetricsClient().series(..., limit=1)` and `.health()`

Prompted by: mslipper