### PR TITLE
fix: repair missing sandbox iron proxies on reuse

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -184,15 +184,12 @@ impl AgentSandboxBackend {
         let pg = self.resolved_pg();
         let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
 
-        Ok(Some(ResolvedIronProxy {
-            proxy_host: iron_proxy_service_name(id),
-            proxy_pod_name: new_iron_proxy_pod_name(id),
-            proxy_port: PROXY_TUNNEL_PORT,
+        Ok(Some(self.resolved_iron_proxy_for_principal(
+            id,
             principal_id,
             pg,
             replace_placeholders,
-            management_api_key: new_proxy_management_api_key(),
-        }))
+        )))
     }
 
     /// Read the principal's effective config from iron-control for the
@@ -264,7 +261,22 @@ impl AgentSandboxBackend {
         };
         let pg = self.resolved_pg();
         let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
-        Ok(Some(ResolvedIronProxy {
+        Ok(Some(self.resolved_iron_proxy_for_principal(
+            id,
+            principal_id,
+            pg,
+            replace_placeholders,
+        )))
+    }
+
+    fn resolved_iron_proxy_for_principal(
+        &self,
+        id: &SandboxId,
+        principal_id: String,
+        pg: Option<ResolvedPg>,
+        replace_placeholders: BTreeMap<String, String>,
+    ) -> ResolvedIronProxy {
+        ResolvedIronProxy {
             proxy_host: iron_proxy_service_name(id),
             proxy_pod_name: new_iron_proxy_pod_name(id),
             proxy_port: PROXY_TUNNEL_PORT,
@@ -272,7 +284,7 @@ impl AgentSandboxBackend {
             pg,
             replace_placeholders,
             management_api_key: new_proxy_management_api_key(),
-        }))
+        }
     }
 
     pub(crate) async fn create_iron_proxy_resources(
@@ -448,9 +460,21 @@ impl AgentSandboxBackend {
                 backend: crate::BACKEND_NAME,
                 operation: "assign_iron_control_proxy_principal",
             })?;
-        let proxy_id = self.proxy_id_for_sandbox(id).await?.ok_or_else(|| {
+        let mut proxy_id = self.proxy_id_for_sandbox(id).await?;
+        if proxy_id.is_none() || !self.has_usable_iron_proxy_resources(id).await? {
+            tracing::warn!(
+                sandbox_id = id.as_str(),
+                principal_id,
+                "iron-proxy resources are missing or not running; recreating before assignment"
+            );
+            proxy_id = Some(
+                self.recreate_iron_proxy_resources_for_principal(id, principal_id)
+                    .await?,
+            );
+        }
+        let proxy_id = proxy_id.ok_or_else(|| {
             SandboxError::backend(format!(
-                "iron-control proxy id for sandbox {} was not found",
+                "iron-control proxy id for sandbox {} was not found after repair",
                 id.as_str()
             ))
         })?;
@@ -468,6 +492,50 @@ impl AgentSandboxBackend {
         self.wait_for_proxy_principal_applied(id, principal_id)
             .await;
         Ok(())
+    }
+
+    async fn recreate_iron_proxy_resources_for_principal(
+        &self,
+        id: &SandboxId,
+        principal_id: &str,
+    ) -> SandboxResult<String> {
+        if self.config.iron_proxy.is_none() {
+            return Err(SandboxError::Unsupported {
+                backend: crate::BACKEND_NAME,
+                operation: "assign_iron_control_proxy_principal",
+            });
+        }
+        let pg = self.resolved_pg();
+        let principal_id = principal_id.to_owned();
+        let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
+        let resolved =
+            self.resolved_iron_proxy_for_principal(id, principal_id, pg, replace_placeholders);
+        self.create_iron_proxy_resources(id, Some(&resolved))
+            .await?;
+        match self.sandboxes().get(id.as_str()).await {
+            Ok(sandbox) => {
+                if let Err(error) = self.adopt_iron_proxy_resources(id, &sandbox).await {
+                    tracing::warn!(
+                        sandbox_id = id.as_str(),
+                        %error,
+                        "failed to set ownerReferences on recreated iron-proxy resources"
+                    );
+                }
+            }
+            Err(err) if is_not_found(&err) => {}
+            Err(err) => return Err(map_kube_error("get sandbox for iron-proxy repair", err)),
+        }
+        self.proxy_ids
+            .lock()
+            .await
+            .get(id.as_str())
+            .cloned()
+            .ok_or_else(|| {
+                SandboxError::backend(format!(
+                    "iron-control proxy id for sandbox {} was not recorded after repair",
+                    id.as_str()
+                ))
+            })
     }
 
     /// Barrier between reassigning the proxy principal in iron-control and
@@ -667,6 +735,26 @@ impl AgentSandboxBackend {
             }
         }
         Ok(None)
+    }
+
+    async fn has_usable_iron_proxy_resources(&self, id: &SandboxId) -> SandboxResult<bool> {
+        let params = ListParams::default().labels(&format!(
+            "{IRON_PROXY_LABEL}=true,{SANDBOX_ID_LABEL}={}",
+            id.as_str()
+        ));
+        let pods = self
+            .pods()
+            .list(&params)
+            .await
+            .map_err(|err| map_kube_error("list iron-proxy pods", err))?;
+        if !pods.items.iter().any(pod_running) {
+            return Ok(false);
+        }
+        match self.services().get(&iron_proxy_service_name(id)).await {
+            Ok(_) => Ok(true),
+            Err(err) if is_not_found(&err) => Ok(false),
+            Err(err) => Err(map_kube_error("get iron-proxy service", err)),
+        }
     }
 
     async fn patch_iron_control_principal_annotation(

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -494,6 +494,37 @@ impl AgentSandboxBackend {
         Ok(())
     }
 
+    pub(crate) async fn ensure_proxy_resources_for_principal(
+        &self,
+        id: &SandboxId,
+        principal_id: &str,
+    ) -> SandboxResult<()> {
+        if self.config.iron_proxy.is_none() {
+            return Ok(());
+        }
+        if self.config.iron_control.is_none() {
+            return Err(SandboxError::Unsupported {
+                backend: crate::BACKEND_NAME,
+                operation: "ensure_iron_control_proxy_resources",
+            });
+        }
+        let proxy_id = self.proxy_id_for_sandbox(id).await?;
+        if proxy_id.is_some() && self.has_usable_iron_proxy_resources(id).await? {
+            return Ok(());
+        }
+
+        tracing::warn!(
+            sandbox_id = id.as_str(),
+            principal_id,
+            "iron-proxy resources are missing or not running; recreating before reuse"
+        );
+        self.recreate_iron_proxy_resources_for_principal(id, principal_id)
+            .await?;
+        self.patch_iron_control_principal_annotation(id, principal_id)
+            .await?;
+        Ok(())
+    }
+
     async fn recreate_iron_proxy_resources_for_principal(
         &self,
         id: &SandboxId,
@@ -505,25 +536,26 @@ impl AgentSandboxBackend {
                 operation: "assign_iron_control_proxy_principal",
             });
         }
-        let pg = self.resolved_pg();
+        let sandbox = match self.sandboxes().get(id.as_str()).await {
+            Ok(sandbox) => Some(sandbox),
+            Err(err) if is_not_found(&err) => None,
+            Err(err) => return Err(map_kube_error("get sandbox for iron-proxy repair", err)),
+        };
+        let pg = self.resolved_pg_for_repair(sandbox.as_ref());
         let principal_id = principal_id.to_owned();
         let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
         let resolved =
             self.resolved_iron_proxy_for_principal(id, principal_id, pg, replace_placeholders);
         self.create_iron_proxy_resources(id, Some(&resolved))
             .await?;
-        match self.sandboxes().get(id.as_str()).await {
-            Ok(sandbox) => {
-                if let Err(error) = self.adopt_iron_proxy_resources(id, &sandbox).await {
-                    tracing::warn!(
-                        sandbox_id = id.as_str(),
-                        %error,
-                        "failed to set ownerReferences on recreated iron-proxy resources"
-                    );
-                }
-            }
-            Err(err) if is_not_found(&err) => {}
-            Err(err) => return Err(map_kube_error("get sandbox for iron-proxy repair", err)),
+        if let Some(sandbox) = sandbox
+            && let Err(error) = self.adopt_iron_proxy_resources(id, &sandbox).await
+        {
+            tracing::warn!(
+                sandbox_id = id.as_str(),
+                %error,
+                "failed to set ownerReferences on recreated iron-proxy resources"
+            );
         }
         self.proxy_ids
             .lock()
@@ -536,6 +568,20 @@ impl AgentSandboxBackend {
                     id.as_str()
                 ))
             })
+    }
+
+    fn resolved_pg_for_repair(&self, sandbox: Option<&crate::crd::Sandbox>) -> Option<ResolvedPg> {
+        let fallback = self.resolved_pg()?;
+        sandbox
+            .and_then(|sandbox| {
+                pg_from_sandbox_env(
+                    sandbox,
+                    &self.config.container_name,
+                    &fallback.listen,
+                    fallback.port,
+                )
+            })
+            .or(Some(fallback))
     }
 
     /// Barrier between reassigning the proxy principal in iron-control and
@@ -1414,6 +1460,46 @@ fn env_value(spec: &SandboxSpec, name: &str) -> Option<String> {
         .map(|env| env.value.clone())
 }
 
+fn pg_from_sandbox_env(
+    sandbox: &crate::crd::Sandbox,
+    container_name: &str,
+    listen: &str,
+    port: u16,
+) -> Option<ResolvedPg> {
+    let container = sandbox
+        .spec
+        .pod_template
+        .spec
+        .containers
+        .iter()
+        .find(|container| container.name == container_name)
+        .or_else(|| sandbox.spec.pod_template.spec.containers.first())?;
+    let dsn = container
+        .env
+        .as_ref()?
+        .iter()
+        .find(|env| env.name == CENTAUR_POSTGRES_DSN_ENV)
+        .and_then(|env| env.value.as_deref())?;
+    pg_from_sandbox_dsn(dsn, listen, port)
+}
+
+fn pg_from_sandbox_dsn(dsn: &str, listen: &str, port: u16) -> Option<ResolvedPg> {
+    let rest = dsn
+        .strip_prefix("postgresql://")
+        .or_else(|| dsn.strip_prefix("postgres://"))?;
+    let auth = rest.split_once('@')?.0;
+    let (user, password) = auth.split_once(':')?;
+    if user.is_empty() || password.is_empty() {
+        return None;
+    }
+    Some(ResolvedPg {
+        listen: listen.to_owned(),
+        port,
+        user: user.to_owned(),
+        password: password.to_owned(),
+    })
+}
+
 fn current_env_values<const N: usize>(spec: &SandboxSpec, names: [&str; N]) -> Vec<String> {
     names
         .into_iter()
@@ -1755,6 +1841,27 @@ mod tests {
             .and_then(|var| var.value.as_deref());
 
         assert_eq!(timeout, Some("120s"));
+    }
+
+    #[test]
+    fn pg_repair_reuses_credentials_from_existing_sandbox_dsn() {
+        let pg = pg_from_sandbox_dsn(
+            "postgresql://pg-user-original:pg-password-original@asbx-test-iron-proxy:5432",
+            "0.0.0.0:5432",
+            5432,
+        )
+        .unwrap();
+
+        assert_eq!(pg.listen, "0.0.0.0:5432");
+        assert_eq!(pg.port, 5432);
+        assert_eq!(pg.user, "pg-user-original");
+        assert_eq!(pg.password, "pg-password-original");
+    }
+
+    #[test]
+    fn pg_repair_ignores_unparseable_sandbox_dsn() {
+        assert!(pg_from_sandbox_dsn("not-a-postgres-dsn", "0.0.0.0:5432", 5432).is_none());
+        assert!(pg_from_sandbox_dsn("postgresql://@host:5432", "0.0.0.0:5432", 5432).is_none());
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -451,6 +451,15 @@ impl SandboxBackend for AgentSandboxBackend {
         self.assign_proxy_principal(id, principal_id).await
     }
 
+    async fn ensure_iron_control_proxy_resources(
+        &self,
+        id: &SandboxId,
+        principal_id: &str,
+    ) -> SandboxResult<()> {
+        self.ensure_proxy_resources_for_principal(id, principal_id)
+            .await
+    }
+
     async fn pause(&self, id: &SandboxId) -> SandboxResult<()> {
         self.patch_sandbox_merge(id, sandbox_pause_patch(jiff::Timestamp::now()))
             .await

--- a/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
@@ -66,6 +66,17 @@ pub trait SandboxBackend: Send + Sync {
         })
     }
 
+    /// Ensure a running sandbox's managed iron-proxy resources are present and
+    /// usable for the supplied iron-control principal without otherwise
+    /// changing the sandbox lifecycle.
+    async fn ensure_iron_control_proxy_resources(
+        &self,
+        _id: &SandboxId,
+        _principal_id: &str,
+    ) -> SandboxResult<()> {
+        Ok(())
+    }
+
     /// Suspend the sandbox while preserving any backend-supported runtime state.
     async fn pause(&self, id: &SandboxId) -> SandboxResult<()>;
 

--- a/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
@@ -249,6 +249,16 @@ where
             .await
     }
 
+    pub async fn ensure_iron_control_proxy_resources(
+        &self,
+        id: &SandboxId,
+        principal_id: &str,
+    ) -> SandboxResult<()> {
+        self.backend
+            .ensure_iron_control_proxy_resources(id, principal_id)
+            .await
+    }
+
     pub async fn reconcile_one(&self, id: &SandboxId) -> SandboxResult<ReconcileOutcome> {
         let Some(desired) = self.store.get(id) else {
             return Ok(ReconcileOutcome::Drift(DriftReason::NoDesiredState));

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1336,6 +1336,12 @@ impl SessionRuntime {
                 match self.sandbox_runtime.manager.status(&id).await {
                     Ok(status) => match existing_sandbox_action(&status) {
                         ExistingSandboxAction::Reuse => {
+                            if let Some(principal_id) = iron_control_principal {
+                                self.sandbox_runtime
+                                    .manager
+                                    .ensure_iron_control_proxy_resources(&id, principal_id)
+                                    .await?;
+                            }
                             span.record("centaur.sandbox_id", sandbox_id);
                             span.record("sandbox_id", sandbox_id);
                             let ready_duration = ensure_started.elapsed();
@@ -5702,6 +5708,7 @@ mod adoption_tests {
         create_id: String,
         resume_fails: AtomicBool,
         stopped: std::sync::Mutex<Vec<String>>,
+        proxy_ensures: std::sync::Mutex<Vec<(String, String)>>,
         missing_on_stop: std::sync::Mutex<BTreeSet<String>>,
     }
 
@@ -5715,6 +5722,7 @@ mod adoption_tests {
                 create_id: "mock-sbx".to_owned(),
                 resume_fails: AtomicBool::new(false),
                 stopped: std::sync::Mutex::new(Vec::new()),
+                proxy_ensures: std::sync::Mutex::new(Vec::new()),
                 missing_on_stop: std::sync::Mutex::new(BTreeSet::new()),
             }
         }
@@ -5748,6 +5756,10 @@ mod adoption_tests {
 
         fn stopped(&self) -> Vec<String> {
             self.stopped.lock().unwrap().clone()
+        }
+
+        fn proxy_ensures(&self) -> Vec<(String, String)> {
+            self.proxy_ensures.lock().unwrap().clone()
         }
     }
 
@@ -5799,6 +5811,18 @@ mod adoption_tests {
                 return Err(SandboxError::NotFound(id.as_str().to_owned()));
             }
             self.stopped.lock().unwrap().push(id.as_str().to_owned());
+            Ok(())
+        }
+
+        async fn ensure_iron_control_proxy_resources(
+            &self,
+            id: &SandboxId,
+            principal_id: &str,
+        ) -> SandboxResult<()> {
+            self.proxy_ensures
+                .lock()
+                .unwrap()
+                .push((id.as_str().to_owned(), principal_id.to_owned()));
             Ok(())
         }
 
@@ -5921,6 +5945,46 @@ mod adoption_tests {
             store.clone(),
             SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
         )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn existing_running_sandbox_ensures_proxy_before_reuse() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:proxy-reuse-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        let execution_id = store
+            .create_execution(&thread_key, None, json!({}))
+            .await
+            .expect("create execution")
+            .execution
+            .execution_id;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        let sandbox_id = runtime
+            .ensure_session_sandbox(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some("sbx-existing"),
+                Some("principal-existing"),
+                &execution_id,
+            )
+            .await
+            .expect("reuse existing sandbox");
+
+        assert_eq!(sandbox_id, "sbx-existing");
+        assert_eq!(
+            backend.proxy_ensures(),
+            vec![("sbx-existing".to_owned(), "principal-existing".to_owned())]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

- Rebase PR #740 onto current main and keep its warm-pool claim-time proxy repair.
- Add a sandbox backend ensure hook so existing running session sandboxes verify/recreate their iron-proxy resources before reuse.
- Preserve existing sandbox Postgres proxy credentials from `CENTAUR_POSTGRES_DSN` when recreating a proxy, so repaired proxies remain compatible with already-running agent pods.

## Validation

- `cargo fmt`
- `cargo test -p centaur-sandbox-agent-k8s`
- `cargo test -p centaur-session-runtime`
- `cargo check -p centaur-api-server`
- `just build-one api-rs`
- `just deploy` attempted locally; Helm upgrade completed, but the new local api-rs pod exited with `Store(Migrate(VersionMismatch(10))` from the existing local DB migration state before runtime smoke could run. Rolled the local Helm release back to revision 59 and confirmed `deployment/centaur-centaur-api-rs` rolled out successfully.

Closes paradigmxyz/centaur#792
Closes paradigmxyz/centaur#740