### PR TITLE
chore: log sandbox tool shim usage

### DIFF
--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -390,8 +390,82 @@ def _write_executable(path: Path, content: str) -> None:
 
 def _write_tool_shim(path: Path, script: dict[str, str], pythonpath: str) -> None:
     content = f"""#!/bin/sh
-set -e
 _centaur_tool_pythonpath={shlex.quote(pythonpath)}
+_centaur_tool_name={shlex.quote(script["name"])}
+_centaur_tool_package={shlex.quote(script["package"])}
+_centaur_now_ms() {{
+  date +%s%3N 2>/dev/null || printf '%s000' "$(date +%s)"
+}}
+_centaur_emit_tool_usage_log() {{
+  _centaur_tool_event="$1"
+  _centaur_tool_status="$2"
+  _centaur_tool_duration_ms="$3"
+  CENTAUR_TOOL_LOG_EVENT="$_centaur_tool_event" \\
+  CENTAUR_TOOL_LOG_NAME="$_centaur_tool_name" \\
+  CENTAUR_TOOL_LOG_PACKAGE="$_centaur_tool_package" \\
+  CENTAUR_TOOL_LOG_METHOD="cli" \\
+  CENTAUR_TOOL_LOG_STATUS="$_centaur_tool_status" \\
+  CENTAUR_TOOL_LOG_DURATION_MS="$_centaur_tool_duration_ms" \\
+  python3 - <<'PY' >/dev/null 2>&1 || true
+import json
+import os
+
+
+def _clean_env(name):
+    value = os.environ.get(name, "").strip()
+    return value or None
+
+
+sink = os.environ.get("CENTAUR_TOOL_USAGE_LOG", "/proc/1/fd/2").strip()
+if sink.lower() in {{"", "0", "false", "no", "off"}}:
+    raise SystemExit(0)
+
+event = os.environ.get("CENTAUR_TOOL_LOG_EVENT", "tool_call_completed")
+tool_name = os.environ.get("CENTAUR_TOOL_LOG_NAME", "unknown").strip() or "unknown"
+method = os.environ.get("CENTAUR_TOOL_LOG_METHOD", "cli").strip() or "cli"
+payload = {{
+    "level": "info",
+    "service": "sandbox",
+    "component": "tool_shim",
+    "event": event,
+    "message": event.replace("_", " "),
+    "tool_name": tool_name,
+    "tool_method": method,
+    "tool_call_source": "cli_shim",
+}}
+
+if tool_package := _clean_env("CENTAUR_TOOL_LOG_PACKAGE"):
+    payload["tool_package"] = tool_package
+if thread_key := _clean_env("CENTAUR_THREAD_KEY"):
+    payload["thread_key"] = thread_key
+if workload := _clean_env("CENTAUR_WORKLOAD"):
+    payload["workload"] = workload
+if persona := _clean_env("AGENT_PERSONA"):
+    payload["persona"] = persona
+
+status = _clean_env("CENTAUR_TOOL_LOG_STATUS")
+if status is not None:
+    try:
+        exit_code = int(status)
+    except ValueError:
+        exit_code = 1
+    payload["exit_code"] = exit_code
+    payload["success"] = "true" if exit_code == 0 else "false"
+
+duration_ms = _clean_env("CENTAUR_TOOL_LOG_DURATION_MS")
+if duration_ms is not None:
+    try:
+        payload["duration_ms"] = max(0, int(duration_ms))
+    except ValueError:
+        payload["duration_ms"] = 0
+
+try:
+    with open(sink, "a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\\n")
+except OSError:
+    pass
+PY
+}}
 if [ -n "$_centaur_tool_pythonpath" ]; then
   if [ -n "${{PYTHONPATH:-}}" ]; then
     export PYTHONPATH="$_centaur_tool_pythonpath:$PYTHONPATH"
@@ -399,7 +473,20 @@ if [ -n "$_centaur_tool_pythonpath" ]; then
     export PYTHONPATH="$_centaur_tool_pythonpath"
   fi
 fi
-exec uvx --from {shlex.quote(script["project_dir"])} {shlex.quote(script["name"])} "$@"
+_centaur_start_ms="$(_centaur_now_ms)"
+_centaur_emit_tool_usage_log tool_call_started "" ""
+uvx --from {shlex.quote(script["project_dir"])} {shlex.quote(script["name"])} "$@"
+_centaur_status=$?
+_centaur_end_ms="$(_centaur_now_ms)"
+case "$_centaur_start_ms$_centaur_end_ms" in
+  ""|*[!0-9]*) _centaur_duration_ms=0 ;;
+  *) _centaur_duration_ms=$((_centaur_end_ms - _centaur_start_ms)) ;;
+esac
+if [ "$_centaur_duration_ms" -lt 0 ] 2>/dev/null; then
+  _centaur_duration_ms=0
+fi
+_centaur_emit_tool_usage_log tool_call_completed "$_centaur_status" "$_centaur_duration_ms"
+exit "$_centaur_status"
 """
     _write_executable(path, content)
 
@@ -413,6 +500,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import time
 
 INDEX = {str(index_path)!r}
 PYTHONPATH_VALUE = {pythonpath!r}
@@ -426,6 +514,50 @@ def load():
 def usage():
     print("usage: centaur-tools [list|json|refresh|which <name>|run <name> [args...]|call <name> <method> [json]]", file=sys.stderr)
     return 2
+
+
+def _clean_env(name):
+    value = os.environ.get(name, "").strip()
+    return value or None
+
+
+def tool_usage_log_sink():
+    sink = os.environ.get("CENTAUR_TOOL_USAGE_LOG", "/proc/1/fd/2").strip()
+    if sink.lower() in {{"", "0", "false", "no", "off"}}:
+        return None
+    return sink
+
+
+def emit_tool_usage_log(event, tool_name, method, *, returncode=None, duration_ms=None):
+    sink = tool_usage_log_sink()
+    if sink is None:
+        return
+    payload = {{
+        "level": "info",
+        "service": "sandbox",
+        "component": "tool_shim",
+        "event": event,
+        "message": event.replace("_", " "),
+        "tool_name": tool_name or "unknown",
+        "tool_method": method or "call",
+        "tool_call_source": "centaur_tools_call",
+    }}
+    if thread_key := _clean_env("CENTAUR_THREAD_KEY"):
+        payload["thread_key"] = thread_key
+    if workload := _clean_env("CENTAUR_WORKLOAD"):
+        payload["workload"] = workload
+    if persona := _clean_env("AGENT_PERSONA"):
+        payload["persona"] = persona
+    if returncode is not None:
+        payload["exit_code"] = int(returncode)
+        payload["success"] = "true" if int(returncode) == 0 else "false"
+    if duration_ms is not None:
+        payload["duration_ms"] = max(0, int(duration_ms))
+    try:
+        with open(sink, "a", encoding="utf-8") as f:
+            f.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\\n")
+    except OSError:
+        pass
 
 
 CALL_RUNNER = r'''
@@ -495,24 +627,46 @@ def call_tool(tool, method, payload):
             env["PYTHONPATH"] = f"{{PYTHONPATH_VALUE}}:{{env['PYTHONPATH']}}"
         else:
             env["PYTHONPATH"] = PYTHONPATH_VALUE
-    return subprocess.run(
-        [
-            "uvx",
-            "--from",
-            str(project_dir),
-            "python",
-            "-c",
-            CALL_RUNNER,
-            str(project_dir),
-            client_module,
+    started_at = time.monotonic()
+    emit_tool_usage_log("tool_call_started", tool.get("name"), method)
+    try:
+        result = subprocess.run(
+            [
+                "uvx",
+                "--from",
+                str(project_dir),
+                "python",
+                "-c",
+                CALL_RUNNER,
+                str(project_dir),
+                client_module,
+                method,
+                json.dumps(payload, separators=(",", ":")),
+            ],
+            check=False,
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+    except Exception:
+        duration_ms = int((time.monotonic() - started_at) * 1000)
+        emit_tool_usage_log(
+            "tool_call_completed",
+            tool.get("name"),
             method,
-            json.dumps(payload, separators=(",", ":")),
-        ],
-        check=False,
-        text=True,
-        capture_output=True,
-        env=env,
+            returncode=1,
+            duration_ms=duration_ms,
+        )
+        raise
+    duration_ms = int((time.monotonic() - started_at) * 1000)
+    emit_tool_usage_log(
+        "tool_call_completed",
+        tool.get("name"),
+        method,
+        returncode=result.returncode,
+        duration_ms=duration_ms,
     )
+    return result
 
 
 def main(argv):

--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -390,81 +390,17 @@ def _write_executable(path: Path, content: str) -> None:
 
 def _write_tool_shim(path: Path, script: dict[str, str], pythonpath: str) -> None:
     content = f"""#!/bin/sh
+set -e
 _centaur_tool_pythonpath={shlex.quote(pythonpath)}
 _centaur_tool_name={shlex.quote(script["name"])}
 _centaur_tool_package={shlex.quote(script["package"])}
-_centaur_now_ms() {{
-  date +%s%3N 2>/dev/null || printf '%s000' "$(date +%s)"
-}}
-_centaur_emit_tool_usage_log() {{
-  _centaur_tool_event="$1"
-  _centaur_tool_status="$2"
-  _centaur_tool_duration_ms="$3"
-  CENTAUR_TOOL_LOG_EVENT="$_centaur_tool_event" \\
-  CENTAUR_TOOL_LOG_NAME="$_centaur_tool_name" \\
-  CENTAUR_TOOL_LOG_PACKAGE="$_centaur_tool_package" \\
-  CENTAUR_TOOL_LOG_METHOD="cli" \\
-  CENTAUR_TOOL_LOG_STATUS="$_centaur_tool_status" \\
-  CENTAUR_TOOL_LOG_DURATION_MS="$_centaur_tool_duration_ms" \\
-  python3 - <<'PY' >/dev/null 2>&1 || true
-import json
-import os
-
-
-def _clean_env(name):
-    value = os.environ.get(name, "").strip()
-    return value or None
-
-
-sink = os.environ.get("CENTAUR_TOOL_USAGE_LOG", "/proc/1/fd/2").strip()
-if sink.lower() in {{"", "0", "false", "no", "off"}}:
-    raise SystemExit(0)
-
-event = os.environ.get("CENTAUR_TOOL_LOG_EVENT", "tool_call_completed")
-tool_name = os.environ.get("CENTAUR_TOOL_LOG_NAME", "unknown").strip() or "unknown"
-method = os.environ.get("CENTAUR_TOOL_LOG_METHOD", "cli").strip() or "cli"
-payload = {{
-    "level": "info",
-    "service": "sandbox",
-    "component": "tool_shim",
-    "event": event,
-    "message": event.replace("_", " "),
-    "tool_name": tool_name,
-    "tool_method": method,
-    "tool_call_source": "cli_shim",
-}}
-
-if tool_package := _clean_env("CENTAUR_TOOL_LOG_PACKAGE"):
-    payload["tool_package"] = tool_package
-if thread_key := _clean_env("CENTAUR_THREAD_KEY"):
-    payload["thread_key"] = thread_key
-if workload := _clean_env("CENTAUR_WORKLOAD"):
-    payload["workload"] = workload
-if persona := _clean_env("AGENT_PERSONA"):
-    payload["persona"] = persona
-
-status = _clean_env("CENTAUR_TOOL_LOG_STATUS")
-if status is not None:
-    try:
-        exit_code = int(status)
-    except ValueError:
-        exit_code = 1
-    payload["exit_code"] = exit_code
-    payload["success"] = "true" if exit_code == 0 else "false"
-
-duration_ms = _clean_env("CENTAUR_TOOL_LOG_DURATION_MS")
-if duration_ms is not None:
-    try:
-        payload["duration_ms"] = max(0, int(duration_ms))
-    except ValueError:
-        payload["duration_ms"] = 0
-
-try:
-    with open(sink, "a", encoding="utf-8") as f:
-        f.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\\n")
-except OSError:
-    pass
-PY
+_centaur_log_tool_invocation() {{
+  _centaur_tool_log_sink="${{CENTAUR_TOOL_USAGE_LOG:-/proc/1/fd/2}}"
+  case "$_centaur_tool_log_sink" in
+    ""|0|false|False|FALSE|no|No|NO|off|Off|OFF) return 0 ;;
+  esac
+  printf 'centaur_tool_invoked tool=%s package=%s source=cli_shim\\n' \\
+    "$_centaur_tool_name" "$_centaur_tool_package" >>"$_centaur_tool_log_sink" 2>/dev/null || true
 }}
 if [ -n "$_centaur_tool_pythonpath" ]; then
   if [ -n "${{PYTHONPATH:-}}" ]; then
@@ -473,20 +409,8 @@ if [ -n "$_centaur_tool_pythonpath" ]; then
     export PYTHONPATH="$_centaur_tool_pythonpath"
   fi
 fi
-_centaur_start_ms="$(_centaur_now_ms)"
-_centaur_emit_tool_usage_log tool_call_started "" ""
-uvx --from {shlex.quote(script["project_dir"])} {shlex.quote(script["name"])} "$@"
-_centaur_status=$?
-_centaur_end_ms="$(_centaur_now_ms)"
-case "$_centaur_start_ms$_centaur_end_ms" in
-  ""|*[!0-9]*) _centaur_duration_ms=0 ;;
-  *) _centaur_duration_ms=$((_centaur_end_ms - _centaur_start_ms)) ;;
-esac
-if [ "$_centaur_duration_ms" -lt 0 ] 2>/dev/null; then
-  _centaur_duration_ms=0
-fi
-_centaur_emit_tool_usage_log tool_call_completed "$_centaur_status" "$_centaur_duration_ms"
-exit "$_centaur_status"
+_centaur_log_tool_invocation
+exec uvx --from {shlex.quote(script["project_dir"])} {shlex.quote(script["name"])} "$@"
 """
     _write_executable(path, content)
 
@@ -500,7 +424,6 @@ import os
 from pathlib import Path
 import subprocess
 import sys
-import time
 
 INDEX = {str(index_path)!r}
 PYTHONPATH_VALUE = {pythonpath!r}
@@ -516,46 +439,28 @@ def usage():
     return 2
 
 
-def _clean_env(name):
-    value = os.environ.get(name, "").strip()
-    return value or None
-
-
-def tool_usage_log_sink():
+def tool_invocation_log_sink():
     sink = os.environ.get("CENTAUR_TOOL_USAGE_LOG", "/proc/1/fd/2").strip()
     if sink.lower() in {{"", "0", "false", "no", "off"}}:
         return None
     return sink
 
 
-def emit_tool_usage_log(event, tool_name, method, *, returncode=None, duration_ms=None):
-    sink = tool_usage_log_sink()
+def log_tool_invocation(tool, method):
+    sink = tool_invocation_log_sink()
     if sink is None:
         return
-    payload = {{
-        "level": "info",
-        "service": "sandbox",
-        "component": "tool_shim",
-        "event": event,
-        "message": event.replace("_", " "),
-        "tool_name": tool_name or "unknown",
-        "tool_method": method or "call",
-        "tool_call_source": "centaur_tools_call",
-    }}
-    if thread_key := _clean_env("CENTAUR_THREAD_KEY"):
-        payload["thread_key"] = thread_key
-    if workload := _clean_env("CENTAUR_WORKLOAD"):
-        payload["workload"] = workload
-    if persona := _clean_env("AGENT_PERSONA"):
-        payload["persona"] = persona
-    if returncode is not None:
-        payload["exit_code"] = int(returncode)
-        payload["success"] = "true" if int(returncode) == 0 else "false"
-    if duration_ms is not None:
-        payload["duration_ms"] = max(0, int(duration_ms))
+    package = tool.get("package")
+    parts = [
+        f"centaur_tool_invoked tool={{tool.get('name') or 'unknown'}}",
+        f"method={{method or 'call'}}",
+        "source=centaur_tools_call",
+    ]
+    if package:
+        parts.insert(1, f"package={{package}}")
     try:
         with open(sink, "a", encoding="utf-8") as f:
-            f.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\\n")
+            f.write(" ".join(parts) + "\\n")
     except OSError:
         pass
 
@@ -627,46 +532,25 @@ def call_tool(tool, method, payload):
             env["PYTHONPATH"] = f"{{PYTHONPATH_VALUE}}:{{env['PYTHONPATH']}}"
         else:
             env["PYTHONPATH"] = PYTHONPATH_VALUE
-    started_at = time.monotonic()
-    emit_tool_usage_log("tool_call_started", tool.get("name"), method)
-    try:
-        result = subprocess.run(
-            [
-                "uvx",
-                "--from",
-                str(project_dir),
-                "python",
-                "-c",
-                CALL_RUNNER,
-                str(project_dir),
-                client_module,
-                method,
-                json.dumps(payload, separators=(",", ":")),
-            ],
-            check=False,
-            text=True,
-            capture_output=True,
-            env=env,
-        )
-    except Exception:
-        duration_ms = int((time.monotonic() - started_at) * 1000)
-        emit_tool_usage_log(
-            "tool_call_completed",
-            tool.get("name"),
+    log_tool_invocation(tool, method)
+    return subprocess.run(
+        [
+            "uvx",
+            "--from",
+            str(project_dir),
+            "python",
+            "-c",
+            CALL_RUNNER,
+            str(project_dir),
+            client_module,
             method,
-            returncode=1,
-            duration_ms=duration_ms,
-        )
-        raise
-    duration_ms = int((time.monotonic() - started_at) * 1000)
-    emit_tool_usage_log(
-        "tool_call_completed",
-        tool.get("name"),
-        method,
-        returncode=result.returncode,
-        duration_ms=duration_ms,
+            json.dumps(payload, separators=(",", ":")),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
     )
-    return result
 
 
 def main(argv):

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -99,6 +102,122 @@ class CopyPublishedToolsTest(unittest.TestCase):
                 scripts_all = install_tool_shims._discover_scripts([root])
             self.assertIn("websearch", scripts_all)
             self.assertIn("linear", scripts_all)
+
+
+class ToolUsageLoggingTest(unittest.TestCase):
+    def test_tool_shim_logs_usage_to_configured_sink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            uvx = fake_bin / "uvx"
+            uvx.write_text("#!/bin/sh\nexit 7\n")
+            uvx.chmod(0o755)
+
+            shim = root / "websearch"
+            install_tool_shims._write_tool_shim(
+                shim,
+                {
+                    "name": "websearch",
+                    "package": "centaur-tool-websearch",
+                    "project_dir": str(root / "project"),
+                },
+                "",
+            )
+
+            log_path = root / "tool-usage.jsonl"
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+            env["CENTAUR_TOOL_USAGE_LOG"] = str(log_path)
+            env["CENTAUR_THREAD_KEY"] = "slack:T123:C123:1.000"
+
+            result = subprocess.run(
+                [str(shim), "search", "secret query"],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 7)
+            self.assertEqual(result.stdout, "")
+            self.assertEqual(result.stderr, "")
+
+            raw_log = log_path.read_text()
+            self.assertNotIn("secret query", raw_log)
+            entries = [json.loads(line) for line in raw_log.splitlines()]
+            self.assertEqual(
+                [entry["event"] for entry in entries],
+                ["tool_call_started", "tool_call_completed"],
+            )
+            completed = entries[-1]
+            self.assertEqual(completed["tool_name"], "websearch")
+            self.assertEqual(completed["tool_method"], "cli")
+            self.assertEqual(completed["tool_package"], "centaur-tool-websearch")
+            self.assertEqual(completed["tool_call_source"], "cli_shim")
+            self.assertEqual(completed["thread_key"], "slack:T123:C123:1.000")
+            self.assertEqual(completed["exit_code"], 7)
+            self.assertEqual(completed["success"], "false")
+            self.assertIsInstance(completed["duration_ms"], int)
+
+    def test_catalog_call_logs_usage_to_configured_sink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            uvx = fake_bin / "uvx"
+            uvx.write_text("#!/bin/sh\nprintf '%s\\n' '{\"ok\":true}'\n")
+            uvx.chmod(0o755)
+
+            index_path = root / ".centaur-tools.json"
+            index_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": "demo",
+                            "package": "centaur-tool-demo",
+                            "project_dir": str(root / "project"),
+                            "client_module": "client.py",
+                        }
+                    ]
+                )
+            )
+            catalog = root / "centaur-tools"
+            install_tool_shims._write_catalog(catalog, index_path, "")
+
+            log_path = root / "tool-usage.jsonl"
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+            env["CENTAUR_TOOL_USAGE_LOG"] = str(log_path)
+            env["CENTAUR_THREAD_KEY"] = "slack:T123:C123:1.000"
+
+            result = subprocess.run(
+                [str(catalog), "call", "demo", "ping", '{"value":1}'],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, '{"ok":true}\n')
+            self.assertEqual(result.stderr, "")
+
+            raw_log = log_path.read_text()
+            self.assertNotIn('"value":1', raw_log)
+            entries = [json.loads(line) for line in raw_log.splitlines()]
+            self.assertEqual(
+                [entry["event"] for entry in entries],
+                ["tool_call_started", "tool_call_completed"],
+            )
+            completed = entries[-1]
+            self.assertEqual(completed["tool_name"], "demo")
+            self.assertEqual(completed["tool_method"], "ping")
+            self.assertEqual(completed["tool_call_source"], "centaur_tools_call")
+            self.assertEqual(completed["thread_key"], "slack:T123:C123:1.000")
+            self.assertEqual(completed["exit_code"], 0)
+            self.assertEqual(completed["success"], "true")
+            self.assertIsInstance(completed["duration_ms"], int)
 
 
 if __name__ == "__main__":

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -145,20 +145,13 @@ class ToolUsageLoggingTest(unittest.TestCase):
 
             raw_log = log_path.read_text()
             self.assertNotIn("secret query", raw_log)
-            entries = [json.loads(line) for line in raw_log.splitlines()]
             self.assertEqual(
-                [entry["event"] for entry in entries],
-                ["tool_call_started", "tool_call_completed"],
+                raw_log,
+                "centaur_tool_invoked "
+                "tool=websearch "
+                "package=centaur-tool-websearch "
+                "source=cli_shim\n",
             )
-            completed = entries[-1]
-            self.assertEqual(completed["tool_name"], "websearch")
-            self.assertEqual(completed["tool_method"], "cli")
-            self.assertEqual(completed["tool_package"], "centaur-tool-websearch")
-            self.assertEqual(completed["tool_call_source"], "cli_shim")
-            self.assertEqual(completed["thread_key"], "slack:T123:C123:1.000")
-            self.assertEqual(completed["exit_code"], 7)
-            self.assertEqual(completed["success"], "false")
-            self.assertIsInstance(completed["duration_ms"], int)
 
     def test_catalog_call_logs_usage_to_configured_sink(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -205,19 +198,14 @@ class ToolUsageLoggingTest(unittest.TestCase):
 
             raw_log = log_path.read_text()
             self.assertNotIn('"value":1', raw_log)
-            entries = [json.loads(line) for line in raw_log.splitlines()]
             self.assertEqual(
-                [entry["event"] for entry in entries],
-                ["tool_call_started", "tool_call_completed"],
+                raw_log,
+                "centaur_tool_invoked "
+                "tool=demo "
+                "package=centaur-tool-demo "
+                "method=ping "
+                "source=centaur_tools_call\n",
             )
-            completed = entries[-1]
-            self.assertEqual(completed["tool_name"], "demo")
-            self.assertEqual(completed["tool_method"], "ping")
-            self.assertEqual(completed["tool_call_source"], "centaur_tools_call")
-            self.assertEqual(completed["thread_key"], "slack:T123:C123:1.000")
-            self.assertEqual(completed["exit_code"], 0)
-            self.assertEqual(completed["success"], "true")
-            self.assertIsInstance(completed["duration_ms"], int)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds structured usage JSONL events around sandbox tool shim execution and centaur-tools call. The logs include tool identity, source, status, duration, and session context while avoiding command arguments and call payload contents.