### PR TITLE
chore: update copy

### DIFF
--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -913,10 +913,10 @@ Password-grant providers use the same endpoint with `grant: "password"`:
 {
   "data": {
     "namespace": "default",
-    "foreign_id": "alphasense",
-    "name": "AlphaSense",
+    "foreign_id": "password-provider",
+    "name": "Password Provider",
     "grant": "password",
-    "token_endpoint": "https://api.alpha-sense.com/auth",
+    "token_endpoint": "https://auth.example.com/token",
     "client_id": "client-id",
     "client_secret": "client-secret",
     "username": "user@example.com",
@@ -926,7 +926,7 @@ Password-grant providers use the same endpoint with `grant: "password"`:
 }
 ```
 
-For AlphaSense API calls, grant static secrets alongside the broker token so the proxy also injects the required `x-api-key` and `clientid` headers on `api.alpha-sense.com`. The broker credential itself only supplies the current bearer token through a `token_broker` source.
+For API calls that require static headers alongside the broker token, grant static secrets with the broker credential so the proxy also injects headers such as `x-api-key` and `clientid`. The broker credential itself only supplies the current bearer token through a `token_broker` source.
 
 Preqin Operational API credentials use the provider-specific `preqin` grant. iron-control submits Preqin's multipart `username` and `apikey` form, stores any returned `refresh_token`, and later uses Preqin's refresh endpoint when possible:
 

--- a/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
@@ -89,14 +89,14 @@ module Api
       test "create password grant stores initial values and redacts secrets" do
         body = {
           data: {
-            namespace: "acme", foreign_id: "alphasense",
+            namespace: "acme", foreign_id: "password-provider",
             grant: "password",
-            token_endpoint: "https://api.alpha-sense.com/auth",
-            client_id: "alpha-client",
-            client_secret: "alpha-secret",
-            username: "alpha-user",
-            password: "alpha-password",
-            token_endpoint_headers: { "x-api-key" => "alpha-key" }
+            token_endpoint: "https://auth.example.com/token",
+            client_id: "password-client",
+            client_secret: "password-secret",
+            username: "password-user",
+            password: "password-value",
+            token_endpoint_headers: { "x-api-key" => "password-key" }
           }
         }
 
@@ -112,10 +112,10 @@ module Api
         assert_equal [ "x-api-key" ], data["token_endpoint_header_names"]
 
         created = BrokerCredential.find_by_oid(data["id"])
-        assert_equal "alpha-user", created.username
-        assert_equal "alpha-password", created.password
-        assert_equal "alpha-secret", created.client_secret
-        assert_equal({ "x-api-key" => "alpha-key" }, created.token_endpoint_headers)
+        assert_equal "password-user", created.username
+        assert_equal "password-value", created.password
+        assert_equal "password-secret", created.client_secret
+        assert_equal({ "x-api-key" => "password-key" }, created.token_endpoint_headers)
         assert created.next_attempt_at.present?
       end
 

--- a/services/console/test/controllers/api/v1/oauth_token_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/oauth_token_secrets_controller_test.rb
@@ -81,18 +81,18 @@ module Api
         body = {
           data: {
             namespace: "acme",
-            foreign_id: "alphasense",
+            foreign_id: "password-provider",
             grant: "password",
-            token_endpoint: "https://api.alpha-sense.com/token",
+            token_endpoint: "https://auth.example.com/token",
             credentials: {
-              username: { source_type: "env", config: { var: "AS_USER" } },
-              password: { source_type: "env", config: { var: "AS_PASS" } },
-              client_id: { source_type: "env", config: { var: "AS_CID" } }
+              username: { source_type: "env", config: { var: "PROVIDER_USER" } },
+              password: { source_type: "env", config: { var: "PROVIDER_PASS" } },
+              client_id: { source_type: "env", config: { var: "PROVIDER_CID" } }
             },
             token_endpoint_headers: {
-              "x-api-key": { source_type: "env", config: { var: "AS_KEY" } }
+              "x-api-key": { source_type: "env", config: { var: "PROVIDER_KEY" } }
             },
-            rules: [ { host: "api.alpha-sense.com" } ]
+            rules: [ { host: "api.example.com" } ]
           }
         }
 
@@ -102,7 +102,7 @@ module Api
         secret = OauthTokenSecret.find_by_oid(json_body.dig("data", "id"))
         header = secret.sources.find(&:endpoint_header?)
         assert_equal "x-api-key", header.role
-        assert_equal({ "x-api-key" => { "source_type" => "env", "config" => { "var" => "AS_KEY" } } },
+        assert_equal({ "x-api-key" => { "source_type" => "env", "config" => { "var" => "PROVIDER_KEY" } } },
                      json_body.dig("data", "token_endpoint_headers"))
       end
 

--- a/services/console/test/controllers/console/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/console/broker_credentials_controller_test.rb
@@ -60,24 +60,24 @@ module Console
       assert_difference -> { BrokerCredential.count } => 1 do
         post console_broker_credentials_url, params: {
           credential: {
-            namespace: "acme", foreign_id: "alphasense", name: "AlphaSense",
-            grant: "password", token_endpoint: "https://api.alpha-sense.com/auth",
-            client_id: "alpha-client", client_secret: "alpha-secret",
-            username: "alpha-user", password: "alpha-password",
+            namespace: "acme", foreign_id: "password-provider", name: "Password Provider",
+            grant: "password", token_endpoint: "https://auth.example.com/token",
+            client_id: "password-client", client_secret: "password-secret",
+            username: "password-user", password: "password-value",
             early_refresh_fraction: "0.5", early_refresh_slack_seconds: "120",
             max_refresh_interval_seconds: "3600", refresh_timeout_seconds: "10"
           },
-          headers: { "0" => { key: "x-api-key", value: "alpha-key" } }
+          headers: { "0" => { key: "x-api-key", value: "password-key" } }
         }
       end
 
-      cred = BrokerCredential.find_by!(namespace: "acme", foreign_id: "alphasense")
+      cred = BrokerCredential.find_by!(namespace: "acme", foreign_id: "password-provider")
       assert_redirected_to console_credential_path(cred.oid)
       assert_equal "password", cred.grant
-      assert_equal "alpha-user", cred.username
-      assert_equal "alpha-password", cred.password
-      assert_equal "alpha-secret", cred.client_secret
-      assert_equal({ "x-api-key" => "alpha-key" }, cred.token_endpoint_headers)
+      assert_equal "password-user", cred.username
+      assert_equal "password-value", cred.password
+      assert_equal "password-secret", cred.client_secret
+      assert_equal({ "x-api-key" => "password-key" }, cred.token_endpoint_headers)
     end
 
     test "POST create builds a preqin credential with write-only API key" do


### PR DESCRIPTION
Updates password-grant API examples and related test fixtures to use neutral provider placeholders. Keeps the broker credential behavior coverage unchanged.