### PR TITLE
chore: add curl to api-rs image

### DIFF
--- a/services/api-rs/Dockerfile
+++ b/services/api-rs/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 FROM debian:bookworm-slim
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends ca-certificates python3 python3-pip
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl python3 python3-pip
 COPY --from=builder /usr/local/bin/centaur-api-server /usr/local/bin/centaur-api-server
 WORKDIR /app
 COPY services/workflow-python/ /app/workflow-python/


### PR DESCRIPTION
Adds curl to the api-rs runtime image so pod-level debugging can use HTTP requests directly.