### PR TITLE
feat: add slack retention metrics

### DIFF
--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -80,6 +80,41 @@ pub const WORKFLOW_QUEUE_TASKS_BY_WORKFLOW: &str = "workflow_queue_tasks_by_work
 pub const WORKFLOW_QUEUE_OLDEST_TASK_AGE_SECONDS: &str = "workflow_queue_oldest_task_age_seconds";
 pub const WORKFLOW_QUEUE_OLDEST_TASK_AGE_BY_WORKFLOW_SECONDS: &str =
     "workflow_queue_oldest_task_age_by_workflow_seconds";
+pub const SLACK_ARCHIVE_IMPORT_RUNS_TOTAL: &str = "slack_archive_import_runs_total";
+pub const SLACK_ARCHIVE_IMPORT_DURATION_SECONDS: &str = "slack_archive_import_duration_seconds";
+pub const SLACK_ARCHIVE_IMPORT_BYTES_TOTAL: &str = "slack_archive_import_bytes_total";
+pub const SLACK_ARCHIVE_IMPORT_CHANNELS_TOTAL: &str = "slack_archive_import_channels_total";
+pub const SLACK_ARCHIVE_IMPORT_USERS_TOTAL: &str = "slack_archive_import_users_total";
+pub const SLACK_ARCHIVE_IMPORT_MESSAGES_TOTAL: &str = "slack_archive_import_messages_total";
+pub const SLACK_ARCHIVE_IMPORT_MESSAGE_FILES_TOTAL: &str =
+    "slack_archive_import_message_files_total";
+pub const SLACK_ARCHIVE_IMPORT_ATTACHMENTS_TOTAL: &str = "slack_archive_import_attachments_total";
+pub const SLACK_ARCHIVE_IMPORT_BATCH_DURATION_SECONDS: &str =
+    "slack_archive_import_batch_duration_seconds";
+pub const SLACK_ARCHIVE_IMPORT_BATCH_SIZE: &str = "slack_archive_import_batch_size";
+pub const SLACK_ARCHIVE_IMPORT_FAILURES_TOTAL: &str = "slack_archive_import_failures_total";
+pub const SLACK_ARCHIVE_IMPORT_SKIPPED_ITEMS_TOTAL: &str =
+    "slack_archive_import_skipped_items_total";
+pub const SLACK_ARCHIVE_IMPORT_BATCH_FAILURES_TOTAL: &str =
+    "slack_archive_import_batch_failures_total";
+pub const SLACK_ARCHIVE_IMPORT_LAST_FAILURE_TIMESTAMP_SECONDS: &str =
+    "slack_archive_import_last_failure_timestamp_seconds";
+pub const SLACK_RETENTION_RUNS_TOTAL: &str = "slack_retention_runs_total";
+pub const SLACK_RETENTION_RUN_DURATION_SECONDS: &str = "slack_retention_run_duration_seconds";
+pub const SLACK_RETENTION_MESSAGES_PROCESSED_TOTAL: &str =
+    "slack_retention_messages_processed_total";
+pub const SLACK_RETENTION_BACKFILL_JOBS_TOTAL: &str = "slack_retention_backfill_jobs_total";
+pub const SLACK_RETENTION_FAILURES_TOTAL: &str = "slack_retention_failures_total";
+pub const SLACK_RETENTION_API_REQUESTS_TOTAL: &str = "slack_retention_api_requests_total";
+pub const SLACK_RETENTION_API_RATE_LIMITED_TOTAL: &str = "slack_retention_api_rate_limited_total";
+pub const SLACK_RETENTION_BACKFILL_JOB_FAILURES_TOTAL: &str =
+    "slack_retention_backfill_job_failures_total";
+pub const SLACK_RETENTION_BACKFILL_TERMINAL_SKIPS_TOTAL: &str =
+    "slack_retention_backfill_terminal_skips_total";
+pub const SLACK_RETENTION_CHANNEL_FAILURES_TOTAL: &str = "slack_retention_channel_failures_total";
+pub const SLACK_RETENTION_LAST_FAILURE_TIMESTAMP_SECONDS: &str =
+    "slack_retention_last_failure_timestamp_seconds";
+pub const SLACK_RETENTION_WATERMARK_LAG_SECONDS: &str = "slack_retention_watermark_lag_seconds";
 
 const HTTP_REQUEST_DURATION_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
@@ -95,6 +130,13 @@ const SANDBOX_STARTUP_DURATION_BUCKETS: &[f64] =
 const COMPANY_CONTEXT_DOCUMENT_SIZE_BUCKETS: &[f64] = &[
     100.0, 500.0, 1_000.0, 5_000.0, 10_000.0, 25_000.0, 50_000.0, 100_000.0, 250_000.0, 500_000.0,
 ];
+const SLACK_ARCHIVE_IMPORT_DURATION_BUCKETS: &[f64] = &[
+    1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1_200.0, 3_600.0,
+];
+const SLACK_ARCHIVE_IMPORT_BATCH_SIZE_BUCKETS: &[f64] =
+    &[1.0, 10.0, 100.0, 500.0, 1_000.0, 5_000.0, 10_000.0];
+const SLACK_RETENTION_DURATION_BUCKETS: &[f64] =
+    &[1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1_200.0];
 
 static PROMETHEUS_HANDLE: LazyLock<Mutex<Option<PrometheusHandle>>> =
     LazyLock::new(|| Mutex::new(None));
@@ -227,6 +269,22 @@ pub fn prometheus_handle() -> Result<PrometheusHandle, TelemetryError> {
         .set_buckets_for_metric(
             Matcher::Full(COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS.to_owned()),
             COMPANY_CONTEXT_DOCUMENT_SIZE_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full(SLACK_ARCHIVE_IMPORT_DURATION_SECONDS.to_owned()),
+            SLACK_ARCHIVE_IMPORT_DURATION_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full(SLACK_ARCHIVE_IMPORT_BATCH_DURATION_SECONDS.to_owned()),
+            SLACK_ARCHIVE_IMPORT_DURATION_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full(SLACK_ARCHIVE_IMPORT_BATCH_SIZE.to_owned()),
+            SLACK_ARCHIVE_IMPORT_BATCH_SIZE_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full(SLACK_RETENTION_RUN_DURATION_SECONDS.to_owned()),
+            SLACK_RETENTION_DURATION_BUCKETS,
         )?
         .install_recorder()?;
     describe_metrics();
@@ -963,6 +1021,116 @@ fn describe_metrics() {
         WORKFLOW_QUEUE_OLDEST_TASK_AGE_BY_WORKFLOW_SECONDS,
         metrics::Unit::Seconds,
         "Oldest non-terminal workflow task age in seconds by queue, state, and workflow name."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_RUNS_TOTAL,
+        "Slack archive import lifecycle events by status and reason."
+    );
+    metrics::describe_histogram!(
+        SLACK_ARCHIVE_IMPORT_DURATION_SECONDS,
+        metrics::Unit::Seconds,
+        "Slack archive import run duration in seconds by status."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_BYTES_TOTAL,
+        "Slack archive import zip bytes processed."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_CHANNELS_TOTAL,
+        "Slack archive import channel rows by result."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_USERS_TOTAL,
+        "Slack archive import user rows by result."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_MESSAGES_TOTAL,
+        "Slack archive import message rows by result."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_MESSAGE_FILES_TOTAL,
+        "Slack archive import message files by result."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_ATTACHMENTS_TOTAL,
+        "Slack archive import attachment rows by result."
+    );
+    metrics::describe_histogram!(
+        SLACK_ARCHIVE_IMPORT_BATCH_DURATION_SECONDS,
+        metrics::Unit::Seconds,
+        "Slack archive import batch write duration in seconds by entity."
+    );
+    metrics::describe_histogram!(
+        SLACK_ARCHIVE_IMPORT_BATCH_SIZE,
+        "Slack archive import batch size by entity."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_FAILURES_TOTAL,
+        "Slack archive import failures by stage and reason."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_SKIPPED_ITEMS_TOTAL,
+        "Slack archive import skipped items by type and reason."
+    );
+    metrics::describe_counter!(
+        SLACK_ARCHIVE_IMPORT_BATCH_FAILURES_TOTAL,
+        "Slack archive import batch failures by entity and reason."
+    );
+    metrics::describe_gauge!(
+        SLACK_ARCHIVE_IMPORT_LAST_FAILURE_TIMESTAMP_SECONDS,
+        metrics::Unit::Seconds,
+        "Unix timestamp of the most recent Slack archive import failure."
+    );
+    metrics::describe_counter!(
+        SLACK_RETENTION_RUNS_TOTAL,
+        "Slack retention workflow lifecycle events by workflow, status, mode, and reason."
+    );
+    metrics::describe_histogram!(
+        SLACK_RETENTION_RUN_DURATION_SECONDS,
+        metrics::Unit::Seconds,
+        "Slack retention workflow run duration in seconds."
+    );
+    metrics::describe_counter!(
+        SLACK_RETENTION_MESSAGES_PROCESSED_TOTAL,
+        "Slack retention messages processed by workflow, mode, and result."
+    );
+    metrics::describe_counter!(
+        SLACK_RETENTION_BACKFILL_JOBS_TOTAL,
+        "Slack retention backfill job transitions by job type, result, and reason."
+    );
+    metrics::describe_counter!(
+        SLACK_RETENTION_FAILURES_TOTAL,
+        "Slack retention failures by workflow, operation, and reason."
+    );
+    metrics::describe_counter!(
+        SLACK_RETENTION_API_REQUESTS_TOTAL,
+        "Slack API requests made by retention workflows by operation, result, and reason."
+    );
+    metrics::describe_counter!(
+        SLACK_RETENTION_API_RATE_LIMITED_TOTAL,
+        "Slack API rate-limit events observed by retention workflows by operation."
+    );
+    metrics::describe_counter!(
+        SLACK_RETENTION_BACKFILL_JOB_FAILURES_TOTAL,
+        "Slack retention backfill job failures by job type and reason."
+    );
+    metrics::describe_counter!(
+        SLACK_RETENTION_BACKFILL_TERMINAL_SKIPS_TOTAL,
+        "Slack retention backfill jobs terminally skipped by job type and reason."
+    );
+    metrics::describe_counter!(
+        SLACK_RETENTION_CHANNEL_FAILURES_TOTAL,
+        "Slack retention channel failures by workflow and reason."
+    );
+    metrics::describe_gauge!(
+        SLACK_RETENTION_LAST_FAILURE_TIMESTAMP_SECONDS,
+        metrics::Unit::Seconds,
+        "Unix timestamp of the most recent Slack retention failure by workflow."
+    );
+    metrics::describe_gauge!(
+        SLACK_RETENTION_WATERMARK_LAG_SECONDS,
+        metrics::Unit::Seconds,
+        "Slack retention watermark lag in seconds by mode."
     );
 }
 

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -284,6 +284,38 @@ _COMPANY_CONTEXT_DOCUMENT_SIZE_BUCKETS = [
     250_000,
     500_000,
 ]
+_SLACK_ARCHIVE_IMPORT_BATCH_SIZE_BUCKETS = [
+    1,
+    10,
+    100,
+    500,
+    1_000,
+    5_000,
+    10_000,
+]
+_SLACK_ARCHIVE_IMPORT_DURATION_BUCKETS = [
+    1,
+    5,
+    10,
+    30,
+    60,
+    120,
+    300,
+    600,
+    1_200,
+    3_600,
+]
+_SLACK_RETENTION_DURATION_BUCKETS = [
+    1,
+    5,
+    10,
+    30,
+    60,
+    120,
+    300,
+    600,
+    1_200,
+]
 
 
 def install_vm_metrics_compat_module(api_mod: types.ModuleType) -> None:
@@ -305,6 +337,74 @@ def install_vm_metrics_compat_module(api_mod: types.ModuleType) -> None:
     vm_metrics.record_etl_items_seen = record_etl_items_seen
     vm_metrics.record_etl_items_upserted = record_etl_items_upserted
     vm_metrics.record_slack_etl_rate_limit = record_slack_etl_rate_limit
+    vm_metrics.record_slack_archive_import_batch_failure = (
+        record_slack_archive_import_batch_failure
+    )
+    vm_metrics.record_slack_archive_import_batch_size = (
+        record_slack_archive_import_batch_size
+    )
+    vm_metrics.record_slack_archive_import_bytes = record_slack_archive_import_bytes
+    vm_metrics.record_slack_archive_import_channels = (
+        record_slack_archive_import_channels
+    )
+    vm_metrics.record_slack_archive_import_failure = (
+        record_slack_archive_import_failure
+    )
+    vm_metrics.record_slack_archive_import_message_files = (
+        record_slack_archive_import_message_files
+    )
+    vm_metrics.record_slack_archive_import_messages = (
+        record_slack_archive_import_messages
+    )
+    vm_metrics.record_slack_archive_import_attachments = (
+        record_slack_archive_import_attachments
+    )
+    vm_metrics.record_slack_archive_import_run = record_slack_archive_import_run
+    vm_metrics.record_slack_archive_import_skipped_items = (
+        record_slack_archive_import_skipped_items
+    )
+    vm_metrics.record_slack_archive_import_users = record_slack_archive_import_users
+    vm_metrics.observe_slack_archive_import_batch_duration = (
+        observe_slack_archive_import_batch_duration
+    )
+    vm_metrics.observe_slack_archive_import_duration = (
+        observe_slack_archive_import_duration
+    )
+    vm_metrics.record_slack_retention_backfill_job = (
+        record_slack_retention_backfill_job
+    )
+    vm_metrics.record_slack_retention_backfill_job_failure = (
+        record_slack_retention_backfill_job_failure
+    )
+    vm_metrics.record_slack_retention_backfill_terminal_skip = (
+        record_slack_retention_backfill_terminal_skip
+    )
+    vm_metrics.record_slack_retention_channel_failure = (
+        record_slack_retention_channel_failure
+    )
+    vm_metrics.record_slack_retention_failure = record_slack_retention_failure
+    vm_metrics.record_slack_retention_messages_processed = (
+        record_slack_retention_messages_processed
+    )
+    vm_metrics.record_slack_retention_api_request = (
+        record_slack_retention_api_request
+    )
+    vm_metrics.record_slack_retention_api_rate_limited = (
+        record_slack_retention_api_rate_limited
+    )
+    vm_metrics.record_slack_retention_run = record_slack_retention_run
+    vm_metrics.observe_slack_retention_run_duration = (
+        observe_slack_retention_run_duration
+    )
+    vm_metrics.set_slack_archive_import_last_failure_timestamp = (
+        set_slack_archive_import_last_failure_timestamp
+    )
+    vm_metrics.set_slack_retention_last_failure_timestamp = (
+        set_slack_retention_last_failure_timestamp
+    )
+    vm_metrics.set_slack_retention_watermark_lag_seconds = (
+        set_slack_retention_watermark_lag_seconds
+    )
     vm_metrics.set_etl_active_scopes = set_etl_active_scopes
     vm_metrics.set_etl_backfill_job_age_seconds = set_etl_backfill_job_age_seconds
     vm_metrics.set_etl_backfill_jobs = set_etl_backfill_jobs
@@ -407,6 +507,269 @@ def record_slack_etl_rate_limit(
         "slack_etl_rate_limit_retry_after_seconds_total",
         retry_after,
         **labels,
+    )
+
+
+def record_slack_archive_import_run(
+    status: str,
+    reason: str = "none",
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_archive_import_runs_total",
+        count,
+        status=status,
+        reason=reason,
+    )
+
+
+def observe_slack_archive_import_duration(status: str, duration_s: float) -> None:
+    observe_histogram(
+        "slack_archive_import_duration_seconds",
+        max(duration_s, 0.0),
+        _SLACK_ARCHIVE_IMPORT_DURATION_BUCKETS,
+        status=status,
+    )
+
+
+def record_slack_archive_import_bytes(count: int) -> None:
+    increment_metric("slack_archive_import_bytes_total", count)
+
+
+def record_slack_archive_import_channels(result: str, count: int) -> None:
+    increment_metric("slack_archive_import_channels_total", count, result=result)
+
+
+def record_slack_archive_import_users(result: str, count: int) -> None:
+    increment_metric("slack_archive_import_users_total", count, result=result)
+
+
+def record_slack_archive_import_messages(result: str, count: int) -> None:
+    increment_metric("slack_archive_import_messages_total", count, result=result)
+
+
+def record_slack_archive_import_message_files(result: str, count: int) -> None:
+    increment_metric("slack_archive_import_message_files_total", count, result=result)
+
+
+def record_slack_archive_import_attachments(result: str, count: int) -> None:
+    increment_metric("slack_archive_import_attachments_total", count, result=result)
+
+
+def observe_slack_archive_import_batch_duration(entity: str, duration_s: float) -> None:
+    observe_histogram(
+        "slack_archive_import_batch_duration_seconds",
+        max(duration_s, 0.0),
+        _SLACK_ARCHIVE_IMPORT_DURATION_BUCKETS,
+        entity=entity,
+    )
+
+
+def record_slack_archive_import_batch_size(entity: str, count: int) -> None:
+    observe_histogram(
+        "slack_archive_import_batch_size",
+        max(count, 0),
+        _SLACK_ARCHIVE_IMPORT_BATCH_SIZE_BUCKETS,
+        entity=entity,
+    )
+
+
+def record_slack_archive_import_failure(
+    stage: str,
+    reason: str,
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_archive_import_failures_total",
+        count,
+        stage=stage,
+        reason=reason,
+    )
+
+
+def record_slack_archive_import_skipped_items(
+    item_type: str,
+    reason: str,
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_archive_import_skipped_items_total",
+        count,
+        item_type=item_type,
+        reason=reason,
+    )
+
+
+def record_slack_archive_import_batch_failure(
+    entity: str,
+    reason: str,
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_archive_import_batch_failures_total",
+        count,
+        entity=entity,
+        reason=reason,
+    )
+
+
+def set_slack_archive_import_last_failure_timestamp(timestamp_s: float) -> None:
+    set_gauge("slack_archive_import_last_failure_timestamp_seconds", timestamp_s)
+
+
+def record_slack_retention_run(
+    workflow: str,
+    status: str,
+    mode: str,
+    reason: str = "none",
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_retention_runs_total",
+        count,
+        workflow=workflow,
+        status=status,
+        mode=mode,
+        reason=reason,
+    )
+
+
+def observe_slack_retention_run_duration(
+    workflow: str,
+    mode: str,
+    status: str,
+    duration_s: float,
+) -> None:
+    observe_histogram(
+        "slack_retention_run_duration_seconds",
+        max(duration_s, 0.0),
+        _SLACK_RETENTION_DURATION_BUCKETS,
+        workflow=workflow,
+        mode=mode,
+        status=status,
+    )
+
+
+def record_slack_retention_messages_processed(
+    workflow: str,
+    mode: str,
+    result: str,
+    count: int,
+) -> None:
+    increment_metric(
+        "slack_retention_messages_processed_total",
+        count,
+        workflow=workflow,
+        mode=mode,
+        result=result,
+    )
+
+
+def record_slack_retention_backfill_job(
+    job_type: str,
+    result: str,
+    reason: str = "none",
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_retention_backfill_jobs_total",
+        count,
+        job_type=job_type,
+        result=result,
+        reason=reason,
+    )
+
+
+def record_slack_retention_failure(
+    workflow: str,
+    operation: str,
+    reason: str,
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_retention_failures_total",
+        count,
+        workflow=workflow,
+        operation=operation,
+        reason=reason,
+    )
+
+
+def record_slack_retention_api_request(
+    operation: str,
+    result: str,
+    reason: str = "none",
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_retention_api_requests_total",
+        count,
+        operation=operation,
+        result=result,
+        reason=reason,
+    )
+
+
+def record_slack_retention_api_rate_limited(operation: str, count: int = 1) -> None:
+    increment_metric(
+        "slack_retention_api_rate_limited_total",
+        count,
+        operation=operation,
+    )
+
+
+def record_slack_retention_backfill_job_failure(
+    job_type: str,
+    reason: str,
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_retention_backfill_job_failures_total",
+        count,
+        job_type=job_type,
+        reason=reason,
+    )
+
+
+def record_slack_retention_backfill_terminal_skip(
+    job_type: str,
+    reason: str,
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_retention_backfill_terminal_skips_total",
+        count,
+        job_type=job_type,
+        reason=reason,
+    )
+
+
+def record_slack_retention_channel_failure(
+    workflow: str,
+    reason: str,
+    count: int = 1,
+) -> None:
+    increment_metric(
+        "slack_retention_channel_failures_total",
+        count,
+        workflow=workflow,
+        reason=reason,
+    )
+
+
+def set_slack_retention_last_failure_timestamp(workflow: str, timestamp_s: float) -> None:
+    set_gauge(
+        "slack_retention_last_failure_timestamp_seconds",
+        timestamp_s,
+        workflow=workflow,
+    )
+
+
+def set_slack_retention_watermark_lag_seconds(mode: str, lag_s: float) -> None:
+    set_gauge(
+        "slack_retention_watermark_lag_seconds",
+        max(lag_s, 0.0),
+        mode=mode,
     )
 
 

--- a/workflows/slack/archive_import.py
+++ b/workflows/slack/archive_import.py
@@ -7,6 +7,7 @@ import datetime as dt
 import json
 import os
 import shutil
+import time
 import tempfile
 import urllib.parse
 import urllib.request
@@ -16,6 +17,22 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from api.runtime_control import canonical_json
+from api.vm_metrics import (
+    observe_slack_archive_import_batch_duration,
+    observe_slack_archive_import_duration,
+    record_slack_archive_import_attachments,
+    record_slack_archive_import_batch_failure,
+    record_slack_archive_import_batch_size,
+    record_slack_archive_import_bytes,
+    record_slack_archive_import_channels,
+    record_slack_archive_import_failure,
+    record_slack_archive_import_message_files,
+    record_slack_archive_import_messages,
+    record_slack_archive_import_run,
+    record_slack_archive_import_skipped_items,
+    record_slack_archive_import_users,
+    set_slack_archive_import_last_failure_timestamp,
+)
 from api.workflow_engine import WorkflowContext
 from workflows.slack.shared import record_run_finish, record_run_start
 
@@ -49,6 +66,38 @@ def _safe_int(value: Any, default: int = 0) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed >= 0 else default
+
+
+def _archive_failure_reason(error: BaseException | str) -> str:
+    known_reasons = {
+        "download_error",
+        "invalid_archive",
+        "invalid_payload",
+        "timeout",
+        "unknown_error",
+        "write_error",
+    }
+    if isinstance(error, str) and error in known_reasons:
+        return error
+    lowered = str(error).lower()
+    if "missing required" in lowered or "must be a list" in lowered:
+        return "invalid_archive"
+    if "download" in lowered or "s3" in lowered or "object" in lowered:
+        return "download_error"
+    if "zip" in lowered or "bad magic" in lowered:
+        return "invalid_archive"
+    if "write" in lowered or "database" in lowered or "postgres" in lowered:
+        return "write_error"
+    if "timeout" in lowered:
+        return "timeout"
+    return "unknown_error"
+
+
+def _record_archive_failure(stage: str, error: BaseException | str) -> None:
+    record_slack_archive_import_failure(stage, _archive_failure_reason(error))
+    set_slack_archive_import_last_failure_timestamp(
+        dt.datetime.now(dt.timezone.utc).timestamp()
+    )
 
 
 def _slack_ts_to_datetime(ts: str | None) -> dt.datetime | None:
@@ -481,20 +530,34 @@ def _attachment_params(row: dict[str, Any]) -> tuple[Any, ...]:
 async def _flush_message_batch(pool, rows: list[dict[str, Any]]) -> int:
     if not rows:
         return 0
+    started_at = time.monotonic()
     attachment_rows = [
         attachment for row in rows for attachment in _attachment_rows(row)
     ]
-    async with pool.acquire() as conn:
-        async with conn.transaction():
-            await conn.executemany(
-                _MESSAGE_UPSERT_SQL, [_message_params(row) for row in rows]
-            )
-            for start in range(0, len(attachment_rows), ATTACHMENT_BATCH_SIZE):
-                batch = attachment_rows[start : start + ATTACHMENT_BATCH_SIZE]
+    record_slack_archive_import_attachments("seen", len(attachment_rows))
+    try:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
                 await conn.executemany(
-                    _ATTACHMENT_UPSERT_SQL,
-                    [_attachment_params(row) for row in batch],
+                    _MESSAGE_UPSERT_SQL, [_message_params(row) for row in rows]
                 )
+                record_slack_archive_import_batch_size("message", len(rows))
+                for start in range(0, len(attachment_rows), ATTACHMENT_BATCH_SIZE):
+                    batch = attachment_rows[start : start + ATTACHMENT_BATCH_SIZE]
+                    await conn.executemany(
+                        _ATTACHMENT_UPSERT_SQL,
+                        [_attachment_params(row) for row in batch],
+                    )
+                    record_slack_archive_import_batch_size("attachment", len(batch))
+        record_slack_archive_import_attachments("upserted", len(attachment_rows))
+        observe_slack_archive_import_batch_duration(
+            "message", time.monotonic() - started_at
+        )
+    except Exception as exc:
+        reason = _archive_failure_reason(exc)
+        record_slack_archive_import_batch_failure("message", reason)
+        _record_archive_failure("upsert_messages", exc)
+        raise
     return len(rows)
 
 
@@ -550,10 +613,12 @@ async def import_archive_path(
             pool,
             [c for c in channels if isinstance(c, dict)],
         )
+        record_slack_archive_import_channels("upserted", counts["channels_imported"])
         counts["users_imported"] = await _upsert_archive_users(
             pool,
             [u for u in users if isinstance(u, dict)],
         )
+        record_slack_archive_import_users("upserted", counts["users_imported"])
 
         message_batch: list[dict[str, Any]] = []
         for archive_file in _message_files(zip_file):
@@ -561,14 +626,25 @@ async def import_archive_path(
             channel_id = channel_id_by_name.get(channel_name)
             if not channel_id:
                 counts["message_files_skipped"] += 1
+                record_slack_archive_import_message_files("skipped", 1)
+                record_slack_archive_import_skipped_items(
+                    "message_file", "missing_channel"
+                )
                 continue
             messages = _json_member(zip_file, archive_file)
             if not isinstance(messages, list):
                 counts["message_files_skipped"] += 1
+                record_slack_archive_import_message_files("skipped", 1)
+                record_slack_archive_import_skipped_items(
+                    "message_file", "invalid_json"
+                )
                 continue
+            record_slack_archive_import_message_files("seen", 1)
             for message in messages:
                 if not isinstance(message, dict):
                     counts["messages_skipped"] += 1
+                    record_slack_archive_import_messages("skipped", 1)
+                    record_slack_archive_import_skipped_items("message", "non_object")
                     continue
                 row = _archive_message_row(
                     channel_id,
@@ -578,6 +654,13 @@ async def import_archive_path(
                 )
                 if row is None:
                     counts["messages_skipped"] += 1
+                    reason = (
+                        "deleted_message"
+                        if _as_text(message.get("subtype")) == "message_deleted"
+                        else "missing_ts"
+                    )
+                    record_slack_archive_import_messages("skipped", 1)
+                    record_slack_archive_import_skipped_items("message", reason)
                     continue
                 message_batch.append(row)
                 if len(message_batch) >= MESSAGE_BATCH_SIZE:
@@ -587,6 +670,7 @@ async def import_archive_path(
                     )
                     message_batch = []
         counts["messages_imported"] += await _flush_message_batch(pool, message_batch)
+        record_slack_archive_import_messages("upserted", counts["messages_imported"])
 
     await record_run_finish(
         pool,
@@ -650,20 +734,50 @@ async def _download_archive(import_row: dict[str, Any], destination: Path) -> No
 
 
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    started_at = time.monotonic()
+    record_slack_archive_import_run("started")
     if not inp.import_id:
+        record_slack_archive_import_run("failed", "invalid_payload")
+        _record_archive_failure("load_import", "import_id is required")
+        observe_slack_archive_import_duration(
+            "failed", time.monotonic() - started_at
+        )
         raise RuntimeError("import_id is required")
-    import_row = await _load_archive_import(ctx._pool, inp.import_id)
+    try:
+        import_row = await _load_archive_import(ctx._pool, inp.import_id)
+    except Exception as exc:
+        record_slack_archive_import_run("failed", _archive_failure_reason(exc))
+        _record_archive_failure("load_import", exc)
+        observe_slack_archive_import_duration(
+            "failed", time.monotonic() - started_at
+        )
+        raise
     if import_row.get("status") not in {"uploaded", "importing"}:
+        reason = "invalid_payload"
+        record_slack_archive_import_run("failed", reason)
+        _record_archive_failure("load_import", reason)
+        observe_slack_archive_import_duration(
+            "failed", time.monotonic() - started_at
+        )
         raise RuntimeError(
             f"archive import {inp.import_id} must be uploaded before ingestion; "
             f"got {import_row.get('status')}"
         )
 
-    await _mark_import_running(ctx._pool, import_id=inp.import_id, run_id=ctx.run_id)
+    try:
+        await _mark_import_running(ctx._pool, import_id=inp.import_id, run_id=ctx.run_id)
+    except Exception as exc:
+        record_slack_archive_import_run("failed", _archive_failure_reason(exc))
+        _record_archive_failure("mark_running", exc)
+        observe_slack_archive_import_duration(
+            "failed", time.monotonic() - started_at
+        )
+        raise
     with tempfile.TemporaryDirectory(prefix="slack-archive-import-") as temp_dir:
         archive_path = Path(temp_dir) / "archive.zip"
         try:
             await _download_archive(import_row, archive_path)
+            record_slack_archive_import_bytes(archive_path.stat().st_size)
             counts = await import_archive_path(
                 ctx._pool,
                 archive_path,
@@ -676,9 +790,19 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                 counts=counts,
             )
         except Exception as exc:
+            reason = _archive_failure_reason(exc)
             await _mark_import_failed(
                 ctx._pool, import_id=inp.import_id, error_text=str(exc)
             )
+            record_slack_archive_import_run("failed", reason)
+            _record_archive_failure("import_archive", exc)
+            observe_slack_archive_import_duration(
+                "failed", time.monotonic() - started_at
+            )
             raise
 
+    record_slack_archive_import_run("completed")
+    observe_slack_archive_import_duration(
+        "completed", time.monotonic() - started_at
+    )
     return {"status": "completed", "import_id": inp.import_id, "counts": counts}

--- a/workflows/slack/backfill.py
+++ b/workflows/slack/backfill.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -13,6 +15,17 @@ from api.vm_metrics import (
     record_etl_items_failed,
     record_etl_items_seen,
     record_etl_items_upserted,
+    observe_slack_retention_run_duration,
+    record_slack_retention_api_rate_limited,
+    record_slack_retention_api_request,
+    record_slack_retention_backfill_job,
+    record_slack_retention_backfill_job_failure,
+    record_slack_retention_backfill_terminal_skip,
+    record_slack_retention_failure,
+    record_slack_retention_messages_processed,
+    record_slack_retention_run,
+    set_slack_retention_last_failure_timestamp,
+    set_slack_retention_watermark_lag_seconds,
     set_etl_backfill_job_age_seconds,
     set_etl_backfill_jobs,
 )
@@ -181,13 +194,32 @@ def _thread_refresh_payload(job: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _watermark_lag_seconds(ts: str | None) -> float | None:
+    if not ts:
+        return None
+    try:
+        occurred_at = dt.datetime.fromtimestamp(float(ts), tz=dt.timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+    return max((dt.datetime.now(dt.timezone.utc) - occurred_at).total_seconds(), 0.0)
+
+
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     """Drain queued Slack backfill continuations in small, bounded batches."""
+    started_at = time.monotonic()
+    mode = "backfill"
+    record_slack_retention_run(WORKFLOW_NAME, "started", mode)
     if not (
         env_flag_enabled("SLACK_ETL_ENABLED", default=False)
         and env_flag_enabled("SLACK_BACKFILL_ENABLED", default=True)
     ):
         ctx.log("slack_backfill_skipped_disabled")
+        record_slack_retention_run(
+            WORKFLOW_NAME, "skipped", mode, "slack_backfill_disabled"
+        )
+        observe_slack_retention_run_duration(
+            WORKFLOW_NAME, mode, "skipped", time.monotonic() - started_at
+        )
         return {
             "status": "skipped",
             "reason": "slack_backfill_disabled",
@@ -208,6 +240,10 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     jobs = await claim_backfill_jobs(ctx._pool, channel_batch_limit)
     if not jobs:
         ctx.log("slack_backfill_skipped_no_jobs")
+        record_slack_retention_run(WORKFLOW_NAME, "skipped", mode, "no_pending_backfills")
+        observe_slack_retention_run_duration(
+            WORKFLOW_NAME, mode, "skipped", time.monotonic() - started_at
+        )
         return {
             "status": "skipped",
             "reason": "no_pending_backfills",
@@ -254,8 +290,10 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     for job in jobs:
         job_id = int(job["job_id"])
         channel_id = str(job["channel_id"] or "")
+        job_type = str(job.get("job_type") or "backfill")
+        record_slack_retention_backfill_job(job_type, "claimed")
         try:
-            if str(job.get("job_type") or "") == BACKFILL_JOB_THREAD_REFRESH:
+            if job_type == BACKFILL_JOB_THREAD_REFRESH:
                 payload = _thread_refresh_payload(job)
                 thread_ts = str(payload["thread_ts"])
                 reply_cursor = None
@@ -270,6 +308,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                         cursor=reply_cursor,
                         inclusive=True,
                     )
+                    record_slack_retention_api_request("fetch_thread_replies", "success")
                     replies = [
                         reply
                         for reply in replies_page.get("messages", [])
@@ -280,6 +319,9 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     ]
                     all_reply_rows.extend(reply_rows)
                     counts["replies_fetched"] += len(reply_rows)
+                    record_slack_retention_messages_processed(
+                        WORKFLOW_NAME, mode, "seen", len(reply_rows)
+                    )
                     record_etl_items_seen(
                         "slack",
                         "channel",
@@ -303,6 +345,12 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     reply_rows=all_reply_rows,
                 )
                 counts["replies_upserted"] += replies_upserted
+                record_slack_retention_messages_processed(
+                    WORKFLOW_NAME, mode, "upserted", replies_upserted
+                )
+                record_slack_retention_messages_processed(
+                    WORKFLOW_NAME, mode, "deleted", replies_deleted
+                )
                 record_etl_items_upserted(
                     "slack",
                     "channel",
@@ -323,6 +371,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                 await mark_backfill_job_completed(
                     ctx._pool, job_id=job_id, run_id=run_id
                 )
+                record_slack_retention_backfill_job(job_type, "completed")
                 synced.append(channel_ref({"id": channel_id, "name": channel_id}))
                 ctx.log(
                     "slack_backfill_thread_refresh_completed",
@@ -350,10 +399,14 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     limit=limit,
                     lookback_days=int(payload.get("lookback_days") or 0),
                 )
+                record_slack_retention_api_request("fetch_history", "success")
                 messages = page.get("messages") or []
                 message_count += len(messages)
                 message_rows = [message_row(msg, run_id) for msg in messages]
                 counts["messages_fetched"] += len(message_rows)
+                record_slack_retention_messages_processed(
+                    WORKFLOW_NAME, mode, "seen", len(message_rows)
+                )
                 record_etl_items_seen(
                     "slack",
                     "channel",
@@ -362,6 +415,9 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                 )
                 messages_upserted = await upsert_messages(ctx._pool, message_rows)
                 counts["messages_upserted"] += messages_upserted
+                record_slack_retention_messages_processed(
+                    WORKFLOW_NAME, mode, "upserted", messages_upserted
+                )
                 record_etl_items_upserted(
                     "slack",
                     "channel",
@@ -390,6 +446,9 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     record_etl_items_enqueued(
                         "slack", "channel", "thread_refresh_job", 1
                     )
+                    record_slack_retention_backfill_job(
+                        BACKFILL_JOB_THREAD_REFRESH, "enqueued"
+                    )
 
                 next_state = page.get("sync_state") or {}
                 if not next_state.get("cursor") or page_count >= channel_pages_per_job:
@@ -412,6 +471,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     f"{str(job['job_type'])}_job",
                     1,
                 )
+                record_slack_retention_backfill_job(job_type, "requeued")
             else:
                 await mark_backfill_job_completed(
                     ctx._pool,
@@ -419,6 +479,10 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     run_id=run_id,
                     payload=_next_channel_payload(job, payload, next_state),
                 )
+                record_slack_retention_backfill_job(job_type, "completed")
+                lag_s = _watermark_lag_seconds(next_state.get("watermark"))
+                if lag_s is not None:
+                    set_slack_retention_watermark_lag_seconds(mode, lag_s)
 
             synced.append(channel_ref({"id": channel_id, "name": channel_id}))
             ctx.log(
@@ -443,6 +507,15 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                 error=error,
             )
             if is_permanent_slack_backfill_error(error):
+                reason = failure_reason(error)
+                operation = (
+                    "fetch_thread_replies"
+                    if job_type == BACKFILL_JOB_THREAD_REFRESH
+                    else "fetch_history"
+                )
+                record_slack_retention_api_request(operation, "failed", reason)
+                if reason == "rate_limited":
+                    record_slack_retention_api_rate_limited(operation)
                 skipped.append(
                     channel_ref({"id": channel_id, "name": channel_id}, error)
                 )
@@ -460,13 +533,30 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     run_id=run_id,
                     error=error,
                 )
+                record_slack_retention_backfill_terminal_skip(job_type, reason)
+                record_slack_retention_backfill_job(job_type, "terminal_skipped", reason)
                 continue
             failed.append(channel_ref({"id": channel_id, "name": channel_id}, error))
+            reason = failure_reason(error)
+            operation = (
+                "fetch_thread_replies"
+                if job_type == BACKFILL_JOB_THREAD_REFRESH
+                else "fetch_history"
+            )
+            record_slack_retention_api_request(operation, "failed", reason)
+            if reason == "rate_limited":
+                record_slack_retention_api_rate_limited(operation)
+            record_slack_retention_failure(WORKFLOW_NAME, "backfill_job", reason)
+            record_slack_retention_backfill_job_failure(job_type, reason)
+            record_slack_retention_backfill_job(job_type, "failed", reason)
+            set_slack_retention_last_failure_timestamp(
+                WORKFLOW_NAME, dt.datetime.now(dt.timezone.utc).timestamp()
+            )
             record_etl_items_failed(
                 "slack",
                 "channel",
                 f"{str(job.get('job_type') or 'backfill')}_job",
-                failure_reason(error),
+                reason,
             )
             await mark_backfill_job_failed(
                 ctx._pool,
@@ -496,6 +586,11 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     )
     await emit_slack_checkpoint_metrics(ctx._pool)
     await _emit_backfill_job_metrics(ctx._pool)
+    run_reason = "backfill_job_failed" if failed else "none"
+    record_slack_retention_run(WORKFLOW_NAME, status, mode, run_reason)
+    observe_slack_retention_run_duration(
+        WORKFLOW_NAME, mode, status, time.monotonic() - started_at
+    )
 
     return {
         "status": status,

--- a/workflows/slack/sync.py
+++ b/workflows/slack/sync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import fnmatch
 import os
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -14,6 +15,15 @@ from api.vm_metrics import (
     record_etl_items_failed,
     record_etl_items_seen,
     record_etl_items_upserted,
+    observe_slack_retention_run_duration,
+    record_slack_retention_api_rate_limited,
+    record_slack_retention_api_request,
+    record_slack_retention_channel_failure,
+    record_slack_retention_failure,
+    record_slack_retention_messages_processed,
+    record_slack_retention_run,
+    set_slack_retention_last_failure_timestamp,
+    set_slack_retention_watermark_lag_seconds,
 )
 from api.workflow_engine import WorkflowContext
 from workflows.slack.shared import (
@@ -170,6 +180,16 @@ def _ts_within_days(ts: str | None, days: int, *, now: dt.datetime) -> bool:
     return occurred_at >= now - dt.timedelta(days=days)
 
 
+def _watermark_lag_seconds(ts: str | None) -> float | None:
+    if not ts:
+        return None
+    try:
+        occurred_at = dt.datetime.fromtimestamp(float(ts), tz=dt.timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+    return max((dt.datetime.now(dt.timezone.utc) - occurred_at).total_seconds(), 0.0)
+
+
 async def _upsert_channels(pool, channels: list[dict[str, Any]]) -> None:
     """Refresh public Slack sync channel rows and mark absent channels out of scope."""
     async with pool.acquire() as conn:
@@ -311,8 +331,17 @@ async def _update_checkpoint_failure(
 
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     """Sync public Slack channels visible through the configured ETL user token."""
+    started_at = time.monotonic()
+    mode = "incremental"
+    record_slack_retention_run(WORKFLOW_NAME, "started", mode)
     if not _env_flag_enabled("SLACK_ETL_ENABLED"):
         ctx.log("slack_sync_skipped_disabled")
+        record_slack_retention_run(
+            WORKFLOW_NAME, "skipped", mode, "slack_etl_disabled"
+        )
+        observe_slack_retention_run_duration(
+            WORKFLOW_NAME, mode, "skipped", time.monotonic() - started_at
+        )
         return {
             "status": "skipped",
             "reason": "slack_etl_disabled",
@@ -330,7 +359,19 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     limit = positive_int(inp.limit, DEFAULT_CHANNEL_PAGE_LIMIT)
     client = _client()
     access_mode = client._etl_access_mode()
-    public_channels = client._list_etl_channels(limit=10_000, force_refresh=True)
+    try:
+        public_channels = client._list_etl_channels(limit=10_000, force_refresh=True)
+        record_slack_retention_api_request("list_channels", "success")
+    except Exception as exc:
+        reason = failure_reason(str(exc))
+        record_slack_retention_api_request("list_channels", "failed", reason)
+        if reason == "rate_limited":
+            record_slack_retention_api_rate_limited("list_channels")
+        record_slack_retention_failure(WORKFLOW_NAME, "list_channels", reason)
+        set_slack_retention_last_failure_timestamp(
+            WORKFLOW_NAME, dt.datetime.now(dt.timezone.utc).timestamp()
+        )
+        raise
     record_etl_items_seen("slack", "channel", "channel", len(public_channels))
     exclusion_patterns = _channel_exclusion_patterns(os.getenv(EXCLUDED_CHANNELS_ENV))
     channels_to_sync, excluded_channels = _filter_excluded_channels(
@@ -355,6 +396,10 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             reason=reason,
         )
         await emit_slack_checkpoint_metrics(ctx._pool)
+        record_slack_retention_run(WORKFLOW_NAME, "skipped", mode, reason)
+        observe_slack_retention_run_duration(
+            WORKFLOW_NAME, mode, "skipped", time.monotonic() - started_at
+        )
         return {
             "status": "skipped",
             "reason": reason,
@@ -370,13 +415,29 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             channels_skipped=excluded_channels,
         )
         await emit_slack_checkpoint_metrics(ctx._pool)
+        record_slack_retention_run(WORKFLOW_NAME, "skipped", mode, reason)
+        observe_slack_retention_run_duration(
+            WORKFLOW_NAME, mode, "skipped", time.monotonic() - started_at
+        )
         return {
             "status": "skipped",
             "reason": reason,
             "channels_skipped": excluded_channels,
         }
 
-    users = client._list_etl_users(limit=10_000)
+    try:
+        users = client._list_etl_users(limit=10_000)
+        record_slack_retention_api_request("list_users", "success")
+    except Exception as exc:
+        reason = failure_reason(str(exc))
+        record_slack_retention_api_request("list_users", "failed", reason)
+        if reason == "rate_limited":
+            record_slack_retention_api_rate_limited("list_users")
+        record_slack_retention_failure(WORKFLOW_NAME, "list_users", reason)
+        set_slack_retention_last_failure_timestamp(
+            WORKFLOW_NAME, dt.datetime.now(dt.timezone.utc).timestamp()
+        )
+        raise
     record_etl_items_seen("slack", "user", "user", len(users))
     users_upserted = await _upsert_users(ctx._pool, users)
     record_etl_items_upserted("slack", "user", "user", users_upserted)
@@ -439,12 +500,19 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                 oldest=oldest,
                 latest=inp.latest,
             )
+            record_slack_retention_api_request("fetch_history", "success")
             messages = page.get("messages") or []
             message_rows = [message_row(msg, run_id) for msg in messages]
             counts["messages_fetched"] += len(message_rows)
+            record_slack_retention_messages_processed(
+                WORKFLOW_NAME, mode, "seen", len(message_rows)
+            )
             record_etl_items_seen("slack", "channel", "root_message", len(message_rows))
             messages_upserted = await _upsert_messages(ctx._pool, message_rows)
             counts["messages_upserted"] += messages_upserted
+            record_slack_retention_messages_processed(
+                WORKFLOW_NAME, mode, "upserted", messages_upserted
+            )
             record_etl_items_upserted(
                 "slack",
                 "channel",
@@ -568,6 +636,9 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                 watermark_ts=next_state.get("watermark"),
                 run_id=run_id,
             )
+            lag_s = _watermark_lag_seconds(next_state.get("watermark"))
+            if lag_s is not None:
+                set_slack_retention_watermark_lag_seconds(mode, lag_s)
             synced.append(channel_ref(channel))
             ctx.log(
                 "slack_sync_channel_completed",
@@ -588,11 +659,20 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                 error=error,
             )
             failed.append(channel_ref(channel, error))
+            reason = failure_reason(error)
+            record_slack_retention_api_request("fetch_history", "failed", reason)
+            if reason == "rate_limited":
+                record_slack_retention_api_rate_limited("fetch_history")
+            record_slack_retention_failure(WORKFLOW_NAME, "sync_channel", reason)
+            record_slack_retention_channel_failure(WORKFLOW_NAME, reason)
+            set_slack_retention_last_failure_timestamp(
+                WORKFLOW_NAME, dt.datetime.now(dt.timezone.utc).timestamp()
+            )
             record_etl_items_failed(
                 "slack",
                 "channel",
                 "channel",
-                failure_reason(error),
+                reason,
             )
             await _update_checkpoint_failure(
                 ctx._pool,
@@ -621,6 +701,11 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         error_text=error_text,
     )
     await emit_slack_checkpoint_metrics(ctx._pool)
+    run_reason = "channel_failed" if failed else "none"
+    record_slack_retention_run(WORKFLOW_NAME, status, mode, run_reason)
+    observe_slack_retention_run_duration(
+        WORKFLOW_NAME, mode, status, time.monotonic() - started_at
+    )
 
     return {
         "status": status,

--- a/workflows/slack/tests/test_archive_import.py
+++ b/workflows/slack/tests/test_archive_import.py
@@ -30,7 +30,21 @@ def _load_archive_import():
 
     vm_metrics = types.ModuleType("api.vm_metrics")
     for name in (
+        "observe_slack_archive_import_batch_duration",
+        "observe_slack_archive_import_duration",
+        "record_slack_archive_import_attachments",
+        "record_slack_archive_import_batch_failure",
+        "record_slack_archive_import_batch_size",
+        "record_slack_archive_import_bytes",
+        "record_slack_archive_import_channels",
+        "record_slack_archive_import_failure",
+        "record_slack_archive_import_message_files",
+        "record_slack_archive_import_messages",
+        "record_slack_archive_import_run",
+        "record_slack_archive_import_skipped_items",
+        "record_slack_archive_import_users",
         "record_slack_etl_rate_limit",
+        "set_slack_archive_import_last_failure_timestamp",
         "set_etl_active_scopes",
         "set_etl_failed_scopes",
         "set_etl_scope_sync_freshness_seconds",

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -44,12 +44,23 @@ def _load_backfill():
 
     vm_metrics = types.ModuleType("api.vm_metrics")
     for name in (
+        "observe_slack_retention_run_duration",
         "record_etl_items_deleted",
         "record_etl_items_enqueued",
         "record_etl_items_failed",
         "record_etl_items_seen",
         "record_etl_items_upserted",
         "record_slack_etl_rate_limit",
+        "record_slack_retention_api_rate_limited",
+        "record_slack_retention_api_request",
+        "record_slack_retention_backfill_job",
+        "record_slack_retention_backfill_job_failure",
+        "record_slack_retention_backfill_terminal_skip",
+        "record_slack_retention_failure",
+        "record_slack_retention_messages_processed",
+        "record_slack_retention_run",
+        "set_slack_retention_last_failure_timestamp",
+        "set_slack_retention_watermark_lag_seconds",
         "set_etl_active_scopes",
         "set_etl_backfill_job_age_seconds",
         "set_etl_backfill_jobs",

--- a/workflows/slack/tests/test_sync_cold_start.py
+++ b/workflows/slack/tests/test_sync_cold_start.py
@@ -22,11 +22,20 @@ def _load_sync():
 
     vm_metrics = types.ModuleType("api.vm_metrics")
     for name in (
+        "observe_slack_retention_run_duration",
         "record_etl_items_enqueued",
         "record_etl_items_failed",
         "record_etl_items_seen",
         "record_etl_items_upserted",
         "record_slack_etl_rate_limit",
+        "record_slack_retention_api_rate_limited",
+        "record_slack_retention_api_request",
+        "record_slack_retention_channel_failure",
+        "record_slack_retention_failure",
+        "record_slack_retention_messages_processed",
+        "record_slack_retention_run",
+        "set_slack_retention_last_failure_timestamp",
+        "set_slack_retention_watermark_lag_seconds",
         "set_etl_active_scopes",
         "set_etl_failed_scopes",
         "set_etl_scope_sync_freshness_seconds",


### PR DESCRIPTION
## Summary

- add Slack archive import metrics under the `slack_archive_import_*` prefix
- add Slack retention sync/backfill metrics under the `slack_retention_*` prefix
- cover run lifecycle, durations, item counts, API requests, rate limits, failures, skipped items, backfill transitions, and watermark lag

## Validation

- `python3 -m py_compile workflows/slack/sync.py workflows/slack/backfill.py workflows/slack/archive_import.py services/workflow-python/workflow_host.py workflows/slack/tests/test_archive_import.py workflows/slack/tests/test_sync_cold_start.py workflows/slack/tests/test_shared_attachments.py`
- `python3 workflows/slack/tests/test_archive_import.py && python3 workflows/slack/tests/test_sync_cold_start.py && python3 workflows/slack/tests/test_shared_attachments.py`
- `cargo fmt --check -p centaur-telemetry`
- `cargo test -p centaur-telemetry prometheus_metrics_render_workflow_metrics`
