### PR TITLE
feat: add google docs oauth ingest

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -250,6 +250,14 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
             "/api/admin/slack/dm-sync/batch",
             post(ingest_slack_dm_sync_batch).layer(DefaultBodyLimit::disable()),
         )
+        .route(
+            "/api/admin/google/docs-sync/checkpoint",
+            get(get_google_docs_sync_checkpoint),
+        )
+        .route(
+            "/api/admin/google/docs-sync/batch",
+            post(ingest_google_docs_sync_batch).layer(DefaultBodyLimit::disable()),
+        )
         .route("/api/webhooks/{slug}", any(invoke_workflow_webhook))
         .layer(
             TraceLayer::new_for_http()
@@ -790,6 +798,218 @@ struct SlackDmSyncCheckpointPayload {
     last_run_id: Option<String>,
     #[serde(default)]
     last_error: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsSyncCheckpointQuery {
+    broker_credential_id: String,
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+struct GoogleDocsSyncCheckpointResponse {
+    broker_credential_id: String,
+    provider_subject: String,
+    provider_email: String,
+    start_page_token: String,
+    changes_page_token: String,
+    #[serde(with = "time::serde::rfc3339::option")]
+    last_full_sync_at: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    last_incremental_sync_at: Option<OffsetDateTime>,
+    last_run_id: Option<String>,
+    last_error: String,
+    metadata: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsSyncBatchRequest {
+    #[serde(default)]
+    run: Option<GoogleDocsSyncRunPayload>,
+    #[serde(default)]
+    files: Vec<GoogleDocsSyncFilePayload>,
+    #[serde(default)]
+    observations: Vec<GoogleDocsSyncObservationPayload>,
+    #[serde(default)]
+    contents: Vec<GoogleDocsSyncContentPayload>,
+    #[serde(default)]
+    context_documents: Vec<GoogleDocsContextDocumentPayload>,
+    #[serde(default)]
+    checkpoint: Option<GoogleDocsSyncCheckpointPayload>,
+    #[serde(default = "default_true")]
+    replace_context_documents: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsSyncRunPayload {
+    run_id: String,
+    #[serde(default)]
+    workflow_run_id: Option<String>,
+    #[serde(default = "default_google_docs_sync_mode")]
+    mode: String,
+    status: String,
+    broker_credential_id: String,
+    #[serde(default)]
+    provider_subject: String,
+    #[serde(default)]
+    provider_email: String,
+    #[serde(default)]
+    files_seen: i32,
+    #[serde(default)]
+    files_upserted: i32,
+    #[serde(default)]
+    docs_fetched: i32,
+    #[serde(default)]
+    docs_upserted: i32,
+    #[serde(default)]
+    chunks_upserted: i32,
+    #[serde(default)]
+    finished: bool,
+    #[serde(default)]
+    error_text: String,
+    #[serde(default = "empty_object")]
+    metadata: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsSyncFilePayload {
+    file_id: String,
+    #[serde(default)]
+    drive_id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    mime_type: String,
+    #[serde(default)]
+    web_view_link: String,
+    #[serde(default = "empty_array")]
+    owners: Value,
+    #[serde(default = "empty_object")]
+    last_modifying_user: Value,
+    #[serde(default = "empty_object")]
+    capabilities: Value,
+    #[serde(default = "empty_object")]
+    labels: Value,
+    #[serde(default)]
+    trashed: bool,
+    #[serde(default)]
+    explicitly_trashed: bool,
+    #[serde(default)]
+    source_created_at: Option<String>,
+    #[serde(default)]
+    source_modified_at: Option<String>,
+    #[serde(default)]
+    source_version: String,
+    #[serde(default = "empty_object")]
+    raw_payload: Value,
+    #[serde(default)]
+    source_run_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsSyncObservationPayload {
+    broker_credential_id: String,
+    observed_file_id: String,
+    file_id: String,
+    #[serde(default)]
+    provider_subject: String,
+    #[serde(default)]
+    provider_email: String,
+    #[serde(default)]
+    observed_name: String,
+    #[serde(default)]
+    observed_mime_type: String,
+    #[serde(default)]
+    observed_web_view_link: String,
+    #[serde(default)]
+    shortcut_target_file_id: String,
+    #[serde(default)]
+    role_hint: String,
+    #[serde(default = "empty_array")]
+    permission_ids: Value,
+    #[serde(default = "default_true")]
+    active: bool,
+    #[serde(default = "empty_object")]
+    raw_payload: Value,
+    #[serde(default)]
+    source_run_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsSyncContentPayload {
+    file_id: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    text_content: String,
+    #[serde(default)]
+    text_hash: String,
+    #[serde(default)]
+    export_mime_type: String,
+    #[serde(default)]
+    exported_at: Option<String>,
+    #[serde(default)]
+    source_modified_at: Option<String>,
+    #[serde(default)]
+    source_version: String,
+    #[serde(default)]
+    source_run_id: Option<String>,
+    #[serde(default)]
+    last_error: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsContextDocumentPayload {
+    document_id: String,
+    file_id: String,
+    #[serde(default)]
+    chunk_id: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    provider_author_id: String,
+    #[serde(default)]
+    provider_author_name: String,
+    #[serde(default)]
+    mime_type: String,
+    #[serde(default)]
+    drive_id: String,
+    #[serde(default)]
+    source_created_at: Option<String>,
+    #[serde(default)]
+    source_modified_at: Option<String>,
+    #[serde(default)]
+    source_version: String,
+    #[serde(default)]
+    content_hash: String,
+    #[serde(default = "empty_object")]
+    metadata: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsSyncCheckpointPayload {
+    broker_credential_id: String,
+    #[serde(default)]
+    provider_subject: String,
+    #[serde(default)]
+    provider_email: String,
+    #[serde(default)]
+    start_page_token: String,
+    #[serde(default)]
+    changes_page_token: String,
+    #[serde(default)]
+    last_full_sync_at: Option<String>,
+    #[serde(default)]
+    last_incremental_sync_at: Option<String>,
+    #[serde(default)]
+    last_run_id: Option<String>,
+    #[serde(default)]
+    last_error: String,
+    #[serde(default = "empty_object")]
+    metadata: Value,
 }
 
 impl From<SlackArchiveImportRow> for SlackArchiveImportResponse {
@@ -1364,6 +1584,291 @@ async fn ingest_slack_dm_sync_batch(
     })))
 }
 
+async fn get_google_docs_sync_checkpoint(
+    State(state): State<AppState>,
+    Query(query): Query<GoogleDocsSyncCheckpointQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let pool = db_pool(&state)?;
+    require_non_empty("broker_credential_id", &query.broker_credential_id)?;
+    let checkpoint = sqlx::query_as::<_, GoogleDocsSyncCheckpointResponse>(
+        "SELECT broker_credential_id, provider_subject, provider_email, \
+         start_page_token, changes_page_token, last_full_sync_at, \
+         last_incremental_sync_at, last_run_id, last_error, metadata \
+         FROM google_docs_sync_checkpoints WHERE broker_credential_id = $1",
+    )
+    .bind(&query.broker_credential_id)
+    .fetch_optional(&pool)
+    .await?;
+
+    Ok(Json(json!({ "ok": true, "checkpoint": checkpoint })))
+}
+
+async fn ingest_google_docs_sync_batch(
+    State(state): State<AppState>,
+    Json(request): Json<GoogleDocsSyncBatchRequest>,
+) -> Result<Json<Value>, ApiError> {
+    validate_google_docs_sync_batch(&request)?;
+    let pool = db_pool(&state)?;
+    let mut tx = pool.begin().await?;
+
+    if let Some(run) = &request.run {
+        upsert_google_docs_sync_run(&mut tx, run).await?;
+    }
+
+    for file in &request.files {
+        sqlx::query(
+            "INSERT INTO google_docs_sync_files (\
+             file_id, drive_id, name, mime_type, web_view_link, owners, \
+             last_modifying_user, capabilities, labels, trashed, explicitly_trashed, \
+             source_created_at, source_modified_at, source_version, raw_payload, \
+             source_run_id, last_seen_at, updated_at\
+             ) VALUES (\
+             $1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, \
+             $10, $11, $12, $13, $14, $15::jsonb, $16, NOW(), NOW()) \
+             ON CONFLICT (file_id) DO UPDATE SET \
+             drive_id = EXCLUDED.drive_id, \
+             name = EXCLUDED.name, \
+             mime_type = EXCLUDED.mime_type, \
+             web_view_link = EXCLUDED.web_view_link, \
+             owners = EXCLUDED.owners, \
+             last_modifying_user = EXCLUDED.last_modifying_user, \
+             capabilities = EXCLUDED.capabilities, \
+             labels = EXCLUDED.labels, \
+             trashed = EXCLUDED.trashed, \
+             explicitly_trashed = EXCLUDED.explicitly_trashed, \
+             source_created_at = EXCLUDED.source_created_at, \
+             source_modified_at = EXCLUDED.source_modified_at, \
+             source_version = EXCLUDED.source_version, \
+             raw_payload = EXCLUDED.raw_payload, \
+             source_run_id = COALESCE(EXCLUDED.source_run_id, google_docs_sync_files.source_run_id), \
+             last_seen_at = NOW(), \
+             updated_at = NOW()",
+        )
+        .bind(&file.file_id)
+        .bind(&file.drive_id)
+        .bind(&file.name)
+        .bind(&file.mime_type)
+        .bind(&file.web_view_link)
+        .bind(&file.owners)
+        .bind(&file.last_modifying_user)
+        .bind(&file.capabilities)
+        .bind(&file.labels)
+        .bind(file.trashed)
+        .bind(file.explicitly_trashed)
+        .bind(parse_rfc3339_option("file.source_created_at", file.source_created_at.as_deref())?)
+        .bind(parse_rfc3339_option("file.source_modified_at", file.source_modified_at.as_deref())?)
+        .bind(&file.source_version)
+        .bind(&file.raw_payload)
+        .bind(empty_to_none(file.source_run_id.as_deref()))
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    for observation in &request.observations {
+        sqlx::query(
+            "INSERT INTO google_docs_sync_file_observations (\
+             broker_credential_id, observed_file_id, file_id, provider_subject, \
+             provider_email, observed_name, observed_mime_type, observed_web_view_link, \
+             shortcut_target_file_id, role_hint, permission_ids, active, raw_payload, \
+             source_run_id, last_seen_at, updated_at\
+             ) VALUES (\
+             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12, $13::jsonb, \
+             $14, NOW(), NOW()) \
+             ON CONFLICT (broker_credential_id, observed_file_id) DO UPDATE SET \
+             file_id = EXCLUDED.file_id, \
+             provider_subject = EXCLUDED.provider_subject, \
+             provider_email = EXCLUDED.provider_email, \
+             observed_name = EXCLUDED.observed_name, \
+             observed_mime_type = EXCLUDED.observed_mime_type, \
+             observed_web_view_link = EXCLUDED.observed_web_view_link, \
+             shortcut_target_file_id = EXCLUDED.shortcut_target_file_id, \
+             role_hint = EXCLUDED.role_hint, \
+             permission_ids = EXCLUDED.permission_ids, \
+             active = EXCLUDED.active, \
+             raw_payload = EXCLUDED.raw_payload, \
+             source_run_id = COALESCE(EXCLUDED.source_run_id, google_docs_sync_file_observations.source_run_id), \
+             last_seen_at = NOW(), \
+             updated_at = NOW()",
+        )
+        .bind(&observation.broker_credential_id)
+        .bind(&observation.observed_file_id)
+        .bind(&observation.file_id)
+        .bind(&observation.provider_subject)
+        .bind(&observation.provider_email)
+        .bind(&observation.observed_name)
+        .bind(&observation.observed_mime_type)
+        .bind(&observation.observed_web_view_link)
+        .bind(&observation.shortcut_target_file_id)
+        .bind(&observation.role_hint)
+        .bind(&observation.permission_ids)
+        .bind(observation.active)
+        .bind(&observation.raw_payload)
+        .bind(empty_to_none(observation.source_run_id.as_deref()))
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    for content in &request.contents {
+        sqlx::query(
+            "INSERT INTO google_docs_sync_document_contents (\
+             file_id, title, text_content, text_hash, export_mime_type, exported_at, \
+             source_modified_at, source_version, source_run_id, last_error, updated_at\
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW()) \
+             ON CONFLICT (file_id) DO UPDATE SET \
+             title = EXCLUDED.title, \
+             text_content = EXCLUDED.text_content, \
+             text_hash = EXCLUDED.text_hash, \
+             export_mime_type = EXCLUDED.export_mime_type, \
+             exported_at = EXCLUDED.exported_at, \
+             source_modified_at = EXCLUDED.source_modified_at, \
+             source_version = EXCLUDED.source_version, \
+             source_run_id = COALESCE(EXCLUDED.source_run_id, google_docs_sync_document_contents.source_run_id), \
+             last_error = EXCLUDED.last_error, \
+             updated_at = NOW()",
+        )
+        .bind(&content.file_id)
+        .bind(&content.title)
+        .bind(&content.text_content)
+        .bind(&content.text_hash)
+        .bind(&content.export_mime_type)
+        .bind(parse_rfc3339_option("content.exported_at", content.exported_at.as_deref())?)
+        .bind(parse_rfc3339_option(
+            "content.source_modified_at",
+            content.source_modified_at.as_deref(),
+        )?)
+        .bind(&content.source_version)
+        .bind(empty_to_none(content.source_run_id.as_deref()))
+        .bind(&content.last_error)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    for document in &request.context_documents {
+        sqlx::query(
+            "INSERT INTO google_docs_context_documents (\
+             document_id, file_id, chunk_id, title, body, url, provider_author_id, \
+             provider_author_name, mime_type, drive_id, source_created_at, source_modified_at, \
+             source_version, content_hash, metadata, updated_at\
+             ) VALUES (\
+             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb, NOW()) \
+             ON CONFLICT (document_id) DO UPDATE SET \
+             file_id = EXCLUDED.file_id, \
+             chunk_id = EXCLUDED.chunk_id, \
+             title = EXCLUDED.title, \
+             body = EXCLUDED.body, \
+             url = EXCLUDED.url, \
+             provider_author_id = EXCLUDED.provider_author_id, \
+             provider_author_name = EXCLUDED.provider_author_name, \
+             mime_type = EXCLUDED.mime_type, \
+             drive_id = EXCLUDED.drive_id, \
+             source_created_at = EXCLUDED.source_created_at, \
+             source_modified_at = EXCLUDED.source_modified_at, \
+             source_version = EXCLUDED.source_version, \
+             content_hash = EXCLUDED.content_hash, \
+             metadata = EXCLUDED.metadata, \
+             updated_at = NOW()",
+        )
+        .bind(&document.document_id)
+        .bind(&document.file_id)
+        .bind(&document.chunk_id)
+        .bind(&document.title)
+        .bind(&document.body)
+        .bind(&document.url)
+        .bind(&document.provider_author_id)
+        .bind(&document.provider_author_name)
+        .bind(&document.mime_type)
+        .bind(&document.drive_id)
+        .bind(parse_rfc3339_option(
+            "context_document.source_created_at",
+            document.source_created_at.as_deref(),
+        )?)
+        .bind(parse_rfc3339_option(
+            "context_document.source_modified_at",
+            document.source_modified_at.as_deref(),
+        )?)
+        .bind(&document.source_version)
+        .bind(&document.content_hash)
+        .bind(&document.metadata)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    if request.replace_context_documents {
+        let mut chunks_by_file: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for document in &request.context_documents {
+            chunks_by_file
+                .entry(document.file_id.clone())
+                .or_default()
+                .push(document.chunk_id.clone());
+        }
+        for content in &request.contents {
+            chunks_by_file.entry(content.file_id.clone()).or_default();
+        }
+        for (file_id, chunk_ids) in chunks_by_file {
+            sqlx::query(
+                "DELETE FROM google_docs_context_documents \
+                 WHERE file_id = $1 AND NOT (chunk_id = ANY($2::text[]))",
+            )
+            .bind(file_id)
+            .bind(chunk_ids)
+            .execute(&mut *tx)
+            .await?;
+        }
+    }
+
+    if let Some(checkpoint) = &request.checkpoint {
+        sqlx::query(
+            "INSERT INTO google_docs_sync_checkpoints (\
+             broker_credential_id, provider_subject, provider_email, start_page_token, \
+             changes_page_token, last_full_sync_at, last_incremental_sync_at, last_run_id, \
+             last_error, metadata, updated_at\
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, NOW()) \
+             ON CONFLICT (broker_credential_id) DO UPDATE SET \
+             provider_subject = EXCLUDED.provider_subject, \
+             provider_email = EXCLUDED.provider_email, \
+             start_page_token = COALESCE(NULLIF(EXCLUDED.start_page_token, ''), google_docs_sync_checkpoints.start_page_token), \
+             changes_page_token = COALESCE(NULLIF(EXCLUDED.changes_page_token, ''), google_docs_sync_checkpoints.changes_page_token), \
+             last_full_sync_at = COALESCE(EXCLUDED.last_full_sync_at, google_docs_sync_checkpoints.last_full_sync_at), \
+             last_incremental_sync_at = COALESCE(EXCLUDED.last_incremental_sync_at, google_docs_sync_checkpoints.last_incremental_sync_at), \
+             last_run_id = EXCLUDED.last_run_id, \
+             last_error = EXCLUDED.last_error, \
+             metadata = EXCLUDED.metadata, \
+             updated_at = NOW()",
+        )
+        .bind(&checkpoint.broker_credential_id)
+        .bind(&checkpoint.provider_subject)
+        .bind(&checkpoint.provider_email)
+        .bind(&checkpoint.start_page_token)
+        .bind(&checkpoint.changes_page_token)
+        .bind(parse_rfc3339_option(
+            "checkpoint.last_full_sync_at",
+            checkpoint.last_full_sync_at.as_deref(),
+        )?)
+        .bind(parse_rfc3339_option(
+            "checkpoint.last_incremental_sync_at",
+            checkpoint.last_incremental_sync_at.as_deref(),
+        )?)
+        .bind(empty_to_none(checkpoint.last_run_id.as_deref()))
+        .bind(&checkpoint.last_error)
+        .bind(&checkpoint.metadata)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    tx.commit().await?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "counts": {
+            "files": request.files.len(),
+            "observations": request.observations.len(),
+            "contents": request.contents.len(),
+            "context_documents": request.context_documents.len(),
+            "checkpoint": request.checkpoint.is_some(),
+        }
+    })))
+}
+
 async fn create_workflow_run(
     State(state): State<AppState>,
     Json(request): Json<CreateWorkflowRunRequest>,
@@ -1687,6 +2192,58 @@ async fn upsert_slack_dm_sync_run(
     Ok(())
 }
 
+async fn upsert_google_docs_sync_run(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    run: &GoogleDocsSyncRunPayload,
+) -> Result<(), ApiError> {
+    let finished_at = if run.finished {
+        Some(OffsetDateTime::now_utc())
+    } else {
+        None
+    };
+    sqlx::query(
+        "INSERT INTO google_docs_sync_runs (\
+         run_id, workflow_run_id, mode, status, broker_credential_id, provider_subject, \
+         provider_email, files_seen, files_upserted, docs_fetched, docs_upserted, \
+         chunks_upserted, finished_at, error_text, metadata\
+         ) VALUES (\
+         $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb) \
+         ON CONFLICT (run_id) DO UPDATE SET \
+         workflow_run_id = EXCLUDED.workflow_run_id, \
+         mode = EXCLUDED.mode, \
+         status = EXCLUDED.status, \
+         broker_credential_id = EXCLUDED.broker_credential_id, \
+         provider_subject = EXCLUDED.provider_subject, \
+         provider_email = EXCLUDED.provider_email, \
+         files_seen = EXCLUDED.files_seen, \
+         files_upserted = EXCLUDED.files_upserted, \
+         docs_fetched = EXCLUDED.docs_fetched, \
+         docs_upserted = EXCLUDED.docs_upserted, \
+         chunks_upserted = EXCLUDED.chunks_upserted, \
+         finished_at = COALESCE(EXCLUDED.finished_at, google_docs_sync_runs.finished_at), \
+         error_text = EXCLUDED.error_text, \
+         metadata = EXCLUDED.metadata",
+    )
+    .bind(&run.run_id)
+    .bind(&run.workflow_run_id)
+    .bind(&run.mode)
+    .bind(&run.status)
+    .bind(&run.broker_credential_id)
+    .bind(&run.provider_subject)
+    .bind(&run.provider_email)
+    .bind(run.files_seen)
+    .bind(run.files_upserted)
+    .bind(run.docs_fetched)
+    .bind(run.docs_upserted)
+    .bind(run.chunks_upserted)
+    .bind(finished_at)
+    .bind(&run.error_text)
+    .bind(&run.metadata)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
 fn slack_archive_upload_config() -> Result<SlackArchiveUploadConfig, ApiError> {
     let bucket = env::var("SLACK_ARCHIVE_UPLOAD_BUCKET")
         .unwrap_or_default()
@@ -1733,6 +2290,10 @@ fn prefixed_id(prefix: &str) -> String {
 }
 
 fn default_slack_dm_sync_mode() -> String {
+    "incremental".to_owned()
+}
+
+fn default_google_docs_sync_mode() -> String {
     "incremental".to_owned()
 }
 
@@ -1784,6 +2345,18 @@ fn slack_ts_to_datetime(value: Option<&str>) -> Result<Option<OffsetDateTime>, A
         .checked_add(TimeDuration::microseconds(micros))
         .ok_or_else(|| ApiError::BadRequest(format!("invalid Slack timestamp {value}")))?;
     Ok(Some(timestamp))
+}
+
+fn parse_rfc3339_option(
+    field: &str,
+    value: Option<&str>,
+) -> Result<Option<OffsetDateTime>, ApiError> {
+    let Some(value) = empty_to_none(value) else {
+        return Ok(None);
+    };
+    OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+        .map(Some)
+        .map_err(|_| ApiError::BadRequest(format!("{field} must be RFC3339")))
 }
 
 fn validate_json_shape(field: &str, value: &Value, object: bool) -> Result<(), ApiError> {
@@ -1851,6 +2424,83 @@ fn validate_slack_dm_sync_batch(request: &SlackDmSyncBatchRequest) -> Result<(),
         )?;
         require_non_empty("checkpoint.home_team_id", &checkpoint.home_team_id)?;
         require_non_empty("checkpoint.conversation_id", &checkpoint.conversation_id)?;
+    }
+    Ok(())
+}
+
+fn validate_google_docs_sync_batch(request: &GoogleDocsSyncBatchRequest) -> Result<(), ApiError> {
+    if let Some(run) = &request.run {
+        require_non_empty("run.run_id", &run.run_id)?;
+        require_non_empty("run.status", &run.status)?;
+        require_non_empty("run.broker_credential_id", &run.broker_credential_id)?;
+        validate_json_shape("run.metadata", &run.metadata, true)?;
+    }
+    for file in &request.files {
+        require_non_empty("file.file_id", &file.file_id)?;
+        validate_json_shape("file.owners", &file.owners, false)?;
+        validate_json_shape("file.last_modifying_user", &file.last_modifying_user, true)?;
+        validate_json_shape("file.capabilities", &file.capabilities, true)?;
+        validate_json_shape("file.labels", &file.labels, true)?;
+        validate_json_shape("file.raw_payload", &file.raw_payload, true)?;
+        parse_rfc3339_option("file.source_created_at", file.source_created_at.as_deref())?;
+        parse_rfc3339_option(
+            "file.source_modified_at",
+            file.source_modified_at.as_deref(),
+        )?;
+    }
+    for observation in &request.observations {
+        require_non_empty(
+            "observation.broker_credential_id",
+            &observation.broker_credential_id,
+        )?;
+        require_non_empty(
+            "observation.observed_file_id",
+            &observation.observed_file_id,
+        )?;
+        require_non_empty("observation.file_id", &observation.file_id)?;
+        validate_json_shape(
+            "observation.permission_ids",
+            &observation.permission_ids,
+            false,
+        )?;
+        validate_json_shape("observation.raw_payload", &observation.raw_payload, true)?;
+    }
+    for content in &request.contents {
+        require_non_empty("content.file_id", &content.file_id)?;
+        parse_rfc3339_option("content.exported_at", content.exported_at.as_deref())?;
+        parse_rfc3339_option(
+            "content.source_modified_at",
+            content.source_modified_at.as_deref(),
+        )?;
+    }
+    for document in &request.context_documents {
+        require_non_empty("context_document.document_id", &document.document_id)?;
+        require_non_empty("context_document.file_id", &document.file_id)?;
+        require_non_empty("context_document.chunk_id", &document.chunk_id)?;
+        validate_json_shape("context_document.metadata", &document.metadata, true)?;
+        parse_rfc3339_option(
+            "context_document.source_created_at",
+            document.source_created_at.as_deref(),
+        )?;
+        parse_rfc3339_option(
+            "context_document.source_modified_at",
+            document.source_modified_at.as_deref(),
+        )?;
+    }
+    if let Some(checkpoint) = &request.checkpoint {
+        require_non_empty(
+            "checkpoint.broker_credential_id",
+            &checkpoint.broker_credential_id,
+        )?;
+        validate_json_shape("checkpoint.metadata", &checkpoint.metadata, true)?;
+        parse_rfc3339_option(
+            "checkpoint.last_full_sync_at",
+            checkpoint.last_full_sync_at.as_deref(),
+        )?;
+        parse_rfc3339_option(
+            "checkpoint.last_incremental_sync_at",
+            checkpoint.last_incremental_sync_at.as_deref(),
+        )?;
     }
     Ok(())
 }

--- a/services/console/app/jobs/google_docs/poll_sync_job.rb
+++ b/services/console/app/jobs/google_docs/poll_sync_job.rb
@@ -1,0 +1,24 @@
+module GoogleDocs
+  class PollSyncJob < ApplicationJob
+    queue_as :default
+
+    def perform(oauth_app_slug = GoogleDocs::SyncCredential.oauth_app_slug)
+      credentials = BrokerCredential
+        .includes(:oauth_app)
+        .joins(:oauth_app)
+        .where(dead: false)
+        .where(oauth_apps: {
+          provider: Oauth::Providers::Google::KEY,
+          slug: oauth_app_slug,
+          enabled: true
+        })
+
+      credentials.find_each do |credential|
+        next if credential.access_token.blank?
+        next unless GoogleDocs::SyncCredential.required_scopes_granted?(credential.scopes)
+
+        GoogleDocs::SyncCredentialJob.perform_later(credential.id)
+      end
+    end
+  end
+end

--- a/services/console/app/jobs/google_docs/sync_credential_job.rb
+++ b/services/console/app/jobs/google_docs/sync_credential_job.rb
@@ -1,0 +1,18 @@
+module GoogleDocs
+  class SyncCredentialJob < ApplicationJob
+    queue_as :default
+
+    limits_concurrency to: 1, key: ->(credential_id) { "google_docs_sync_#{credential_id}" }
+
+    def perform(credential_id)
+      credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
+      return unless credential
+      return if credential.dead?
+      return if credential.access_token.blank?
+      return unless credential.oauth_app&.provider == Oauth::Providers::Google::KEY
+      return unless GoogleDocs::SyncCredential.required_scopes_granted?(credential.scopes)
+
+      GoogleDocs::SyncCredential.new(credential).call
+    end
+  end
+end

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -58,6 +58,17 @@ class CentaurApiClient
     post("/api/admin/slack/dm-sync/batch", payload)
   end
 
+  def get_google_docs_sync_checkpoint(broker_credential_id:)
+    get(
+      "/api/admin/google/docs-sync/checkpoint",
+      broker_credential_id: broker_credential_id
+    )
+  end
+
+  def ingest_google_docs_sync_batch(payload)
+    post("/api/admin/google/docs-sync/batch", payload)
+  end
+
   private
 
   def get(path, params = {})

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -1,0 +1,391 @@
+require "digest"
+require "cgi"
+require "json"
+require "net/http"
+require "uri"
+
+module GoogleDocs
+  class SyncCredential
+    DRIVE_METADATA_SCOPE = "https://www.googleapis.com/auth/drive.metadata.readonly"
+    DRIVE_READONLY_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
+    DOCS_READONLY_SCOPE = "https://www.googleapis.com/auth/documents.readonly"
+    GOOGLE_DOC_MIME_TYPE = "application/vnd.google-apps.document"
+    EXPORT_MIME_TYPE = "text/plain"
+
+    FILES_LIST_ENDPOINT = "https://www.googleapis.com/drive/v3/files"
+    DOCS_GET_ENDPOINT = "https://docs.googleapis.com/v1/documents"
+
+    GoogleApiError = Class.new(StandardError)
+
+    class << self
+      attr_accessor :google_api_http
+
+      def oauth_app_slug
+        ConsoleEnv["GOOGLE_DOCS_SYNC_OAUTH_APP_SLUG"].presence || "google"
+      end
+
+      def required_scopes_granted?(scopes)
+        granted = Array(scopes)
+        granted.include?(DOCS_READONLY_SCOPE) &&
+          (granted.include?(DRIVE_METADATA_SCOPE) || granted.include?(DRIVE_READONLY_SCOPE))
+      end
+
+      def page_size
+        positive_int(ConsoleEnv["GOOGLE_DOCS_SYNC_PAGE_SIZE"], 100)
+      end
+
+      def max_pages
+        positive_int(ConsoleEnv["GOOGLE_DOCS_SYNC_MAX_PAGES"], 10)
+      end
+
+      def chunk_chars
+        positive_int(ConsoleEnv["GOOGLE_DOCS_SYNC_CHUNK_CHARS"], 12_000)
+      end
+
+      def positive_int(value, default)
+        parsed = value.to_i
+        parsed.positive? ? parsed : default
+      end
+    end
+
+    def initialize(credential, api_client: CentaurApiClient.new, google_api_http: nil)
+      @credential = credential
+      @api_client = api_client
+      @google_api_http = google_api_http || self.class.google_api_http
+      @run_id = "gdocs_#{SecureRandom.hex(16)}"
+      @files_seen = 0
+      @docs_fetched = 0
+      @docs_failed = 0
+      @chunks_upserted = 0
+      @max_modified_at = nil
+      @truncated = false
+    end
+
+    def call
+      checkpoint = load_checkpoint
+      batch = empty_batch
+      modified_after = checkpoint && checkpoint["last_incremental_sync_at"].presence
+
+      files = list_files(modified_after: modified_after)
+      batch[:run][:files_seen] = files.length
+
+      files.each do |file|
+        normalize_file(file, batch)
+        normalize_observation(file, batch)
+        sync_content(file, batch)
+      rescue StandardError => e
+        raise if Rails.env.test?
+
+        @docs_failed += 1
+        Rails.logger.warn do
+          "Google Docs sync failed for file #{file['id']}: #{e.class}: #{e.message}"
+        end
+      end
+
+      finish_batch(batch)
+      @api_client.ingest_google_docs_sync_batch(batch)
+    end
+
+    private
+
+    def load_checkpoint
+      @api_client
+        .get_google_docs_sync_checkpoint(broker_credential_id: @credential.oid)
+        .fetch("checkpoint")
+    end
+
+    def empty_batch
+      {
+        run: {
+          run_id: @run_id,
+          mode: "incremental",
+          status: "running",
+          broker_credential_id: @credential.oid,
+          provider_subject: @credential.provider_subject.to_s,
+          provider_email: @credential.provider_email.to_s,
+          files_seen: 0,
+          files_upserted: 0,
+          docs_fetched: 0,
+          docs_upserted: 0,
+          chunks_upserted: 0,
+          metadata: {
+            oauth_app_slug: @credential.oauth_app&.slug,
+            credential_id: @credential.oid
+          }
+        },
+        replace_context_documents: true,
+        files: [],
+        observations: [],
+        contents: [],
+        context_documents: []
+      }
+    end
+
+    def list_files(modified_after:)
+      files = []
+      page_token = nil
+      self.class.max_pages.times do |index|
+        page = google_api(
+          FILES_LIST_ENDPOINT,
+          files_list_params(modified_after: modified_after, page_token: page_token)
+        )
+        page_files = Array(page["files"]).select do |file|
+          file["id"].present? && file["mimeType"] == GOOGLE_DOC_MIME_TYPE
+        end
+        files.concat(page_files)
+        page_files.each { |file| track_modified_at(file["modifiedTime"]) }
+        page_token = page["nextPageToken"].presence
+        if page_token.present? && index == self.class.max_pages - 1
+          @truncated = true
+        end
+        break if page_token.blank?
+      end
+      @files_seen = files.length
+      files
+    end
+
+    def files_list_params(modified_after:, page_token:)
+      query = [
+        "mimeType = '#{GOOGLE_DOC_MIME_TYPE}'",
+        "trashed = false"
+      ]
+      query << "modifiedTime > '#{drive_literal(modified_after)}'" if modified_after.present?
+      {
+        "q" => query.join(" and "),
+        "pageSize" => self.class.page_size,
+        "fields" => [
+          "nextPageToken",
+          "files(id,name,mimeType,webViewLink,driveId,owners,lastModifyingUser,",
+          "capabilities,labelInfo,trashed,explicitlyTrashed,createdTime,modifiedTime,version)"
+        ].join,
+        "includeItemsFromAllDrives" => "true",
+        "supportsAllDrives" => "true",
+        "orderBy" => "modifiedTime",
+        "pageToken" => page_token
+      }.compact
+    end
+
+    def normalize_file(file, batch)
+      batch[:files] << {
+        file_id: file.fetch("id"),
+        drive_id: file["driveId"].to_s,
+        name: file["name"].to_s,
+        mime_type: file["mimeType"].to_s,
+        web_view_link: file["webViewLink"].to_s,
+        owners: Array(file["owners"]),
+        last_modifying_user: file["lastModifyingUser"].is_a?(Hash) ? file["lastModifyingUser"] : {},
+        capabilities: file["capabilities"].is_a?(Hash) ? file["capabilities"] : {},
+        labels: file["labelInfo"].is_a?(Hash) ? file["labelInfo"] : {},
+        trashed: file["trashed"] == true,
+        explicitly_trashed: file["explicitlyTrashed"] == true,
+        source_created_at: file["createdTime"],
+        source_modified_at: file["modifiedTime"],
+        source_version: file["version"].to_s,
+        raw_payload: file,
+        source_run_id: @run_id
+      }
+    end
+
+    def normalize_observation(file, batch)
+      batch[:observations] << {
+        broker_credential_id: @credential.oid,
+        observed_file_id: file.fetch("id"),
+        file_id: file.fetch("id"),
+        provider_subject: @credential.provider_subject.to_s,
+        provider_email: @credential.provider_email.to_s,
+        observed_name: file["name"].to_s,
+        observed_mime_type: file["mimeType"].to_s,
+        observed_web_view_link: file["webViewLink"].to_s,
+        role_hint: role_hint(file),
+        permission_ids: [],
+        active: true,
+        raw_payload: { "source" => "drive.files.list" },
+        source_run_id: @run_id
+      }
+    end
+
+    def sync_content(file, batch)
+      doc = docs_get(file.fetch("id"))
+      text = docs_text_from_document(doc)
+      @docs_fetched += 1
+      title = doc["title"].presence || file["name"].to_s
+      text_hash = content_hash(text)
+      exported_at = Time.current.iso8601
+      batch[:contents] << {
+        file_id: file.fetch("id"),
+        title: title,
+        text_content: text,
+        text_hash: text_hash,
+        export_mime_type: EXPORT_MIME_TYPE,
+        exported_at: exported_at,
+        source_modified_at: file["modifiedTime"],
+        source_version: file["version"].to_s,
+        source_run_id: @run_id
+      }
+
+      chunks_for(text).each_with_index do |chunk, index|
+        chunk_id = format("chunk-%04d", index)
+        batch[:context_documents] << context_document(file, title, chunk, chunk_id)
+        @chunks_upserted += 1
+      end
+    rescue StandardError => e
+      @docs_failed += 1
+      batch[:contents] << {
+        file_id: file.fetch("id"),
+        title: file["name"].to_s,
+        text_hash: "",
+        export_mime_type: EXPORT_MIME_TYPE,
+        source_modified_at: file["modifiedTime"],
+        source_version: file["version"].to_s,
+        source_run_id: @run_id,
+        last_error: "#{e.class}: #{e.message}"
+      }
+    end
+
+    def context_document(file, title, body, chunk_id)
+      owner = Array(file["owners"]).find { |candidate| candidate.is_a?(Hash) } || {}
+      {
+        document_id: "google_docs:#{file.fetch('id')}:#{chunk_id}",
+        file_id: file.fetch("id"),
+        chunk_id: chunk_id,
+        title: title,
+        body: body,
+        url: file["webViewLink"].to_s,
+        provider_author_id: owner["permissionId"].to_s,
+        provider_author_name: owner["displayName"].presence || owner["emailAddress"].to_s,
+        mime_type: file["mimeType"].to_s,
+        drive_id: file["driveId"].to_s,
+        source_created_at: file["createdTime"],
+        source_modified_at: file["modifiedTime"],
+        source_version: file["version"].to_s,
+        content_hash: content_hash(file.fetch("id"), chunk_id, title, body),
+        metadata: {
+          source: "google_docs",
+          provider_subject: @credential.provider_subject.to_s,
+          provider_email: @credential.provider_email.to_s,
+          broker_credential_id: @credential.oid
+        }
+      }
+    end
+
+    def finish_batch(batch)
+      batch[:run][:files_upserted] = batch[:files].length
+      batch[:run][:docs_fetched] = @docs_fetched
+      batch[:run][:docs_upserted] = batch[:contents].count { |content| content[:last_error].blank? }
+      batch[:run][:chunks_upserted] = @chunks_upserted
+      batch[:run][:finished] = true
+
+      successful = @docs_failed.zero? && !@truncated
+      batch[:run][:status] = successful ? "completed" : "partial_failed"
+      batch[:run][:error_text] = if @truncated
+        "Google Docs sync hit max page limit"
+      elsif @docs_failed.positive?
+        "#{@docs_failed} Google Doc(s) failed"
+      else
+        ""
+      end
+
+      batch[:checkpoint] = {
+        broker_credential_id: @credential.oid,
+        provider_subject: @credential.provider_subject.to_s,
+        provider_email: @credential.provider_email.to_s,
+        last_run_id: @run_id,
+        last_error: batch[:run][:error_text].to_s,
+        metadata: { "page_size" => self.class.page_size, "max_pages" => self.class.max_pages }
+      }
+      if successful
+        now = Time.current.iso8601
+        batch[:checkpoint][:last_incremental_sync_at] = (@max_modified_at&.iso8601 || now)
+        batch[:checkpoint][:last_full_sync_at] = now
+      end
+    end
+
+    def docs_get(file_id)
+      google_api("#{DOCS_GET_ENDPOINT}/#{CGI.escape(file_id)}", { "includeTabsContent" => "true" })
+    end
+
+    def docs_text_from_document(doc)
+      if doc["tabs"].is_a?(Array)
+        return doc["tabs"].map do |tab|
+          extract_text_from_content(tab.dig("documentTab", "body", "content"))
+        end.join("\n")
+      end
+
+      extract_text_from_content(doc.dig("body", "content"))
+    end
+
+    def extract_text_from_content(content)
+      Array(content).filter_map do |element|
+        if element["paragraph"]
+          Array(element.dig("paragraph", "elements")).filter_map do |paragraph_element|
+            paragraph_element.dig("textRun", "content")
+          end.join
+        elsif element["table"]
+          Array(element.dig("table", "tableRows")).map do |row|
+            Array(row["tableCells"]).map { |cell| extract_text_from_content(cell["content"]) }.join("\n")
+          end.join("\n")
+        end
+      end.join
+    end
+
+    def chunks_for(text)
+      return [ "" ] if text.blank?
+
+      text.scan(/.{1,#{self.class.chunk_chars}}/m)
+    end
+
+    def role_hint(file)
+      capabilities = file["capabilities"]
+      return "" unless capabilities.is_a?(Hash)
+      return "writer" if capabilities["canEdit"] == true
+      return "commenter" if capabilities["canComment"] == true
+      "reader"
+    end
+
+    def track_modified_at(value)
+      parsed = Time.iso8601(value.to_s)
+      @max_modified_at = parsed if @max_modified_at.nil? || parsed > @max_modified_at
+    rescue ArgumentError
+      nil
+    end
+
+    def drive_literal(value)
+      value.to_s.gsub("\\", "\\\\").gsub("'", "\\\\'")
+    end
+
+    def content_hash(*parts)
+      Digest::SHA256.hexdigest(JSON.generate(parts))
+    end
+
+    def google_api(endpoint, params = {})
+      uri = URI.parse(endpoint)
+      query = URI.decode_www_form(uri.query.to_s) + params.compact.map { |key, value| [ key, value.to_s ] }
+      uri.query = URI.encode_www_form(query)
+      response = if @google_api_http
+        @google_api_http.call(endpoint: endpoint, params: params, access_token: @credential.access_token)
+      else
+        net_http_get(uri)
+      end
+      return response if response.is_a?(Hash)
+
+      raise GoogleApiError, "Google API returned invalid response"
+    end
+
+    def net_http_get(uri)
+      request = Net::HTTP::Get.new(uri)
+      request["Accept"] = "application/json"
+      request["Authorization"] = "Bearer #{@credential.access_token}"
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
+        http.request(request)
+      end
+      body = response.body.to_s
+      parsed = body.present? ? JSON.parse(body) : {}
+      return parsed if response.code.to_i.between?(200, 299)
+
+      message = parsed.dig("error", "message") if parsed.is_a?(Hash)
+      raise GoogleApiError, message.presence || "Google API returned HTTP #{response.code}"
+    rescue JSON::ParserError
+      raise GoogleApiError, "Google API returned invalid JSON"
+    end
+  end
+end

--- a/services/console/config/recurring.yml
+++ b/services/console/config/recurring.yml
@@ -22,6 +22,9 @@ production:
   slack_dm_poll_sync:
     class: "SlackDm::PollSyncJob"
     schedule: every 10 minutes
+  google_docs_poll_sync:
+    class: "GoogleDocs::PollSyncJob"
+    schedule: every 30 minutes
   prune_principal_sync_config_snapshots:
     class: "PrunePrincipalSyncConfigSnapshotsJob"
     schedule: every 10 minutes

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -88,4 +88,30 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     assert_equal "http://api.internal:8080/api/admin/slack/dm-sync/batch", request[:url]
     assert_equal({ "run" => { "run_id" => "sdms_1" }, "messages" => [] }, JSON.parse(request[:body]))
   end
+
+  test "gets Google Docs sync checkpoint for a broker credential" do
+    http = StubHTTP.new(status: 200, body: { checkpoint: nil }.to_json)
+    client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
+
+    client.get_google_docs_sync_checkpoint(broker_credential_id: "bcr_123")
+
+    request = http.requests.first
+    assert_equal :get, request[:method]
+    assert_equal(
+      "http://api.internal:8080/api/admin/google/docs-sync/checkpoint?broker_credential_id=bcr_123",
+      request[:url]
+    )
+  end
+
+  test "posts Google Docs sync batches" do
+    http = StubHTTP.new(status: 200, body: { ok: true }.to_json)
+    client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
+
+    client.ingest_google_docs_sync_batch(run: { run_id: "gdocs_1" }, files: [])
+
+    request = http.requests.first
+    assert_equal :post, request[:method]
+    assert_equal "http://api.internal:8080/api/admin/google/docs-sync/batch", request[:url]
+    assert_equal({ "run" => { "run_id" => "gdocs_1" }, "files" => [] }, JSON.parse(request[:body]))
+  end
 end

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -1,0 +1,169 @@
+require "test_helper"
+
+module GoogleDocs
+  class SyncCredentialTest < ActiveSupport::TestCase
+    class FakeApiClient
+      attr_reader :batch
+
+      def get_google_docs_sync_checkpoint(broker_credential_id:)
+        {
+          "checkpoint" => {
+            "broker_credential_id" => broker_credential_id,
+            "last_incremental_sync_at" => "2026-06-01T00:00:00Z"
+          }
+        }
+      end
+
+      def ingest_google_docs_sync_batch(payload)
+        @batch = payload
+        { "ok" => true }
+      end
+    end
+
+    def google_app
+      OauthApp.create!(
+        provider: "google",
+        slug: "google-docs-#{SecureRandom.hex(6)}",
+        client_id: "google-client-#{SecureRandom.hex(4)}",
+        client_secret: "secret",
+        allowed_scopes: [
+          GoogleDocs::SyncCredential::DRIVE_METADATA_SCOPE,
+          GoogleDocs::SyncCredential::DOCS_READONLY_SCOPE
+        ],
+        credential_namespace: "acme",
+        created_by: users(:acme_admin)
+      )
+    end
+
+    def credential
+      @credential ||= BrokerCredential.create!(
+        oauth_app: google_app,
+        namespace: "acme",
+        foreign_id: "google-docs-#{SecureRandom.hex(6)}",
+        token_endpoint: "https://oauth2.googleapis.com/token",
+        access_token: "ya29.live",
+        refresh_token: "refresh",
+        last_refresh: Time.current,
+        expires_at: 1.hour.from_now,
+        scopes: [
+          GoogleDocs::SyncCredential::DRIVE_METADATA_SCOPE,
+          GoogleDocs::SyncCredential::DOCS_READONLY_SCOPE
+        ],
+        provider_subject: "google-sub-alice",
+        provider_email: "alice@example.com"
+      )
+    end
+
+    test "oauth_app_slug defaults to google and honors console env prefix" do
+      env_key = "CENTAUR_CONSOLE_GOOGLE_DOCS_SYNC_OAUTH_APP_SLUG"
+      legacy_env_key = "IRON_CONTROL_GOOGLE_DOCS_SYNC_OAUTH_APP_SLUG"
+      previous = {
+        env_key => ENV[env_key],
+        legacy_env_key => ENV[legacy_env_key]
+      }
+      ENV.delete(env_key)
+      ENV.delete(legacy_env_key)
+
+      assert_equal "google", GoogleDocs::SyncCredential.oauth_app_slug
+
+      ENV[env_key] = "custom-google"
+      assert_equal "custom-google", GoogleDocs::SyncCredential.oauth_app_slug
+    ensure
+      previous.each do |key, value|
+        if value.nil?
+          ENV.delete(key)
+        else
+          ENV[key] = value
+        end
+      end
+    end
+
+    test "required scopes allow drive readonly or metadata plus docs readonly" do
+      assert GoogleDocs::SyncCredential.required_scopes_granted?([
+        GoogleDocs::SyncCredential::DRIVE_METADATA_SCOPE,
+        GoogleDocs::SyncCredential::DOCS_READONLY_SCOPE
+      ])
+      assert GoogleDocs::SyncCredential.required_scopes_granted?([
+        GoogleDocs::SyncCredential::DRIVE_READONLY_SCOPE,
+        GoogleDocs::SyncCredential::DOCS_READONLY_SCOPE
+      ])
+      refute GoogleDocs::SyncCredential.required_scopes_granted?([
+        GoogleDocs::SyncCredential::DRIVE_METADATA_SCOPE
+      ])
+    end
+
+    test "sync normalizes files observations contents context docs and checkpoint" do
+      api_client = FakeApiClient.new
+      google_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "ya29.live", access_token
+        case endpoint
+        when GoogleDocs::SyncCredential::FILES_LIST_ENDPOINT
+          assert_includes params["q"], "modifiedTime > '2026-06-01T00:00:00Z'"
+          {
+            "files" => [
+              {
+                "id" => "doc-123",
+                "name" => "Launch Plan",
+                "mimeType" => GoogleDocs::SyncCredential::GOOGLE_DOC_MIME_TYPE,
+                "webViewLink" => "https://docs.google.com/document/d/doc-123/edit",
+                "driveId" => "drive-1",
+                "owners" => [
+                  {
+                    "permissionId" => "perm-owner",
+                    "displayName" => "Alice",
+                    "emailAddress" => "alice@example.com"
+                  }
+                ],
+                "lastModifyingUser" => { "displayName" => "Bob" },
+                "capabilities" => { "canEdit" => true },
+                "labelInfo" => { "labels" => [] },
+                "trashed" => false,
+                "explicitlyTrashed" => false,
+                "createdTime" => "2026-06-01T12:00:00Z",
+                "modifiedTime" => "2026-06-02T12:00:00Z",
+                "version" => "7"
+              }
+            ],
+            "nextPageToken" => ""
+          }
+        when "#{GoogleDocs::SyncCredential::DOCS_GET_ENDPOINT}/doc-123"
+          {
+            "title" => "Launch Plan",
+            "body" => {
+              "content" => [
+                {
+                  "paragraph" => {
+                    "elements" => [
+                      { "textRun" => { "content" => "Ship the Google Docs ingest flow.\n" } }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        else
+          flunk "unexpected Google endpoint #{endpoint}"
+        end
+      end
+
+      GoogleDocs::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        google_api_http: google_http
+      ).call
+
+      batch = api_client.batch
+      assert_equal "completed", batch[:run][:status]
+      assert_equal credential.oid, batch[:run][:broker_credential_id]
+      assert_equal "google-sub-alice", batch[:run][:provider_subject]
+      assert_equal 1, batch[:files].length
+      assert_equal "doc-123", batch[:files].first[:file_id]
+      assert_equal "writer", batch[:observations].first[:role_hint]
+      assert_equal "Ship the Google Docs ingest flow.\n", batch[:contents].first[:text_content]
+      assert_equal "google_docs:doc-123:chunk-0000", batch[:context_documents].first[:document_id]
+      assert_equal "Launch Plan", batch[:context_documents].first[:title]
+      assert_equal "2026-06-02T12:00:00Z", batch[:checkpoint][:last_incremental_sync_at]
+      assert_equal "", batch[:checkpoint][:last_error]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add API-RS admin endpoints for Google Docs sync checkpoints and ETL batch ingest into the new `google_docs_sync_*` / `google_docs_context_documents` tables
- add Console Google Docs polling and per-credential sync jobs using Google OAuth broker credentials
- fetch Drive metadata + Docs text, normalize observations/content/context chunks, and schedule sync every 30 minutes for the configured Google OAuth app slug

## Notes
- uses `CENTAUR_CONSOLE_GOOGLE_DOCS_SYNC_OAUTH_APP_SLUG` with fallback `google`
- bounded by `CENTAUR_CONSOLE_GOOGLE_DOCS_SYNC_PAGE_SIZE` default 100 and `CENTAUR_CONSOLE_GOOGLE_DOCS_SYNC_MAX_PAGES` default 10
- requires `documents.readonly` plus either `drive.metadata.readonly` or `drive.readonly`

## Tests
- `cargo fmt -p centaur-api-server && cargo check -p centaur-api-server`
- `docker run --rm --network container:centaur-console-ui-postgres -v /Users/akshaan/Desktop/centaur-google-docs-oauth-ingest/services/console:/rails -w /rails -e RAILS_ENV=test -e CENTAUR_CONSOLE_DATABASE_URL=postgresql://postgres@127.0.0.1:5432/iron_control_test -e SECRET_KEY_BASE=test-secret -e CENTAUR_CONSOLE_AR_ENCRYPTION_PRIMARY_KEY=local_primary_key_000000000000000000000000000000 -e CENTAUR_CONSOLE_AR_ENCRYPTION_DETERMINISTIC_KEY=local_deterministic_key_00000000000000000000 -e CENTAUR_CONSOLE_AR_ENCRYPTION_KEY_DERIVATION_SALT=local_key_derivation_salt_00000000000000 centaur-console:latest sh -lc 'bin/rails db:test:prepare && bin/rails test test/services/google_docs/sync_credential_test.rb test/services/centaur_api_client_test.rb'`\n- `docker run --rm -v /Users/akshaan/Desktop/centaur-google-docs-oauth-ingest/services/console:/rails -w /rails centaur-console:latest sh -lc 'bundle exec rubocop app/services/google_docs/sync_credential.rb app/jobs/google_docs/poll_sync_job.rb app/jobs/google_docs/sync_credential_job.rb app/services/centaur_api_client.rb test/services/google_docs/sync_credential_test.rb test/services/centaur_api_client_test.rb'`