### PR TITLE
fix: keep base tools without repo cache

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -606,13 +606,18 @@ fn build_agent_sandbox(
         .iter()
         .map(|env| (env.name.clone(), env.value.clone()))
         .collect();
-    let effective_tools = config
+    let repo_cache_tools = config
         .tools
         .as_ref()
         .filter(|_| spec.capabilities.repo_cache_enabled);
+    let baked_base_tools = config.tools.is_some() && !spec.capabilities.repo_cache_enabled;
 
-    if effective_tools.is_some() {
-        for (name, value) in tools::agent_env(effective_tools) {
+    if repo_cache_tools.is_some() {
+        for (name, value) in tools::agent_env(repo_cache_tools) {
+            upsert_env(&mut agent_env, &name, value);
+        }
+    } else if baked_base_tools {
+        for (name, value) in tools::baked_base_agent_env() {
             upsert_env(&mut agent_env, &name, value);
         }
     }
@@ -644,9 +649,9 @@ fn build_agent_sandbox(
     // Tool sources are bootstrapped into an emptyDir by an init container and
     // mounted into the agent at the same path `TOOL_DIRS` points at. The mount is
     // writable so `centaur-tools refresh` can fetch and republish the tree.
-    if effective_tools.is_some() {
-        volume_mounts.extend(tools::agent_volume_mounts_json(effective_tools));
-        volumes.extend(tools::volumes_json(effective_tools));
+    if repo_cache_tools.is_some() {
+        volume_mounts.extend(tools::agent_volume_mounts_json(repo_cache_tools));
+        volumes.extend(tools::volumes_json(repo_cache_tools));
     }
     insert_optional(
         &mut container,
@@ -655,7 +660,7 @@ fn build_agent_sandbox(
     );
 
     // tools-bootstrap publishes the tools repo into /app/tools.
-    if let Some(tools) = effective_tools {
+    if let Some(tools) = repo_cache_tools {
         // The sandbox NetworkPolicy only allows egress to the per-sandbox proxy
         // (plus api-rs and DNS), so when iron-proxy is on the clone must ride it.
         // `apply_proxy_env` ran before this builder, so the resolved proxy URL is
@@ -682,7 +687,7 @@ fn build_agent_sandbox(
         "automountServiceAccountToken": false,
         "enableServiceLinks": false,
     });
-    if effective_tools.is_some() {
+    if repo_cache_tools.is_some() {
         pod_spec["securityContext"] = tools::pod_security_context_json();
     }
     insert_optional(
@@ -951,7 +956,7 @@ mod tests {
     }
 
     #[test]
-    fn disabled_repo_cache_disables_tools_bootstrap() {
+    fn disabled_repo_cache_uses_baked_base_tools_without_bootstrap() {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache_enabled: false,
             observability_enabled: true,
@@ -963,6 +968,14 @@ mod tests {
         let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
         let pod_spec = &sandbox.spec.pod_template.spec;
         assert!(pod_spec.init_containers.as_ref().is_none_or(Vec::is_empty));
+        let tool_dirs = pod_spec.containers[0]
+            .env
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|env| env.name == "TOOL_DIRS")
+            .and_then(|env| env.value.as_deref());
+        assert_eq!(tool_dirs, Some("/opt/centaur/tools"));
         assert!(
             pod_spec.containers[0]
                 .volume_mounts

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
@@ -28,6 +28,10 @@ const AGENT_UID: i64 = 1001;
 
 /// Base tools path inside both the api-rs pod and the agent sandbox.
 pub(crate) const BASE_TOOL_DIR: &str = "/app/tools";
+/// Base Centaur tools baked into the sandbox image. Restricted sandboxes use
+/// this path so they keep first-party tool shims without mounting repo-cache or
+/// publishing overlay sources.
+pub(crate) const BAKED_BASE_TOOL_DIR: &str = "/opt/centaur/tools";
 /// emptyDir the `tools-bootstrap` init container publishes the tools tree into.
 const TOOLS_VOLUME: &str = "tools-root";
 /// Staging path where `tools-bootstrap` mounts the tools emptyDir. The agent
@@ -136,6 +140,12 @@ pub(crate) fn agent_tool_dirs() -> String {
     BASE_TOOL_DIR.to_owned()
 }
 
+/// `TOOL_DIRS` for restricted sandboxes that should not receive repo-cache or
+/// overlay-derived tool sources.
+pub(crate) fn baked_base_tool_dirs() -> String {
+    BAKED_BASE_TOOL_DIR.to_owned()
+}
+
 /// Agent env added for tools wiring.
 pub(crate) fn agent_env(tools: Option<&ToolsConfig>) -> Vec<(String, String)> {
     let mut env = vec![("TOOL_DIRS".to_owned(), agent_tool_dirs())];
@@ -149,6 +159,12 @@ pub(crate) fn agent_env(tools: Option<&ToolsConfig>) -> Vec<(String, String)> {
         ));
     }
     env
+}
+
+/// Agent env for baked base tools only. No GitHub token is exposed because
+/// restricted sandboxes do not refresh from git or repo-cache.
+pub(crate) fn baked_base_agent_env() -> Vec<(String, String)> {
+    vec![("TOOL_DIRS".to_owned(), baked_base_tool_dirs())]
 }
 
 /// Routes the tools clone through the per-sandbox egress proxy. The sandbox
@@ -416,9 +432,22 @@ mod tests {
     }
 
     #[test]
+    fn baked_base_tool_dirs_point_at_image_tools() {
+        assert_eq!(baked_base_tool_dirs(), "/opt/centaur/tools");
+    }
+
+    #[test]
     fn agent_env_sets_tool_dirs() {
         let env = agent_env(None);
         assert_eq!(env, vec![("TOOL_DIRS".to_owned(), "/app/tools".to_owned())]);
+    }
+
+    #[test]
+    fn baked_base_agent_env_sets_baked_tool_dirs() {
+        assert_eq!(
+            baked_base_agent_env(),
+            vec![("TOOL_DIRS".to_owned(), "/opt/centaur/tools".to_owned())]
+        );
     }
 
     #[test]

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -215,6 +215,7 @@ RUN rm -f /etc/sudoers.d/agent
 # Pre-create it as 0755 so the agent user can traverse into it at runtime.
 RUN install -d -m 0755 /etc/centaur /opt/centaur
 COPY --link centaur_sdk/ /opt/centaur/centaur_sdk/
+COPY --link --chown=1001:1001 tools/ /opt/centaur/tools/
 COPY --link --chmod=644 services/sandbox/codex-auth.json /etc/centaur/codex-auth.default.json
 COPY --link --chmod=644 services/sandbox/claude-credentials.json /etc/centaur/claude-credentials.default.json
 COPY --link --chmod=755 services/sandbox/md2docx.py /usr/local/bin/md2docx


### PR DESCRIPTION
## Summary
- bake the base Centaur `tools/` tree into the sandbox image at `/opt/centaur/tools`
- keep `centaur-tools` available for repo-cache-disabled sandboxes by pointing `TOOL_DIRS` at the baked base tools
- continue skipping repo-cache mounts, `/app/tools`, tools-bootstrap, and overlay-derived tool publishing when repo cache is disabled

## Why
Repo-cache-disabled sandboxes should not expose workspace repos or overlay tool sources, but they still need the base tool catalog and non-overlay tool shims. The previous fix avoided private clone fallback by disabling all tool bootstrap, which also removed `centaur-tools`.

## Validation
- `cargo fmt -p centaur-sandbox-agent-k8s`
- `cargo test -p centaur-sandbox-agent-k8s`
