### PR TITLE
refactor: route tool shims through centaur-tools

### DIFF
--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -408,7 +408,7 @@ def _write_tool_shim(path: Path, script: dict[str, str], _pythonpath: str) -> No
     catalog = path.parent / "centaur-tools"
     content = f"""#!/bin/sh
 set -e
-exec {shlex.quote(str(catalog))} exec {shlex.quote(script["name"])} "$@"
+exec {shlex.quote(str(catalog))} run {shlex.quote(script["name"])} "$@"
 """
     _write_executable(path, content)
 
@@ -433,7 +433,7 @@ def load():
 
 
 def usage():
-    print("usage: centaur-tools [list|json|refresh|which <name>|exec <name> [args...]|run <name> [args...]|call <name> <method> [json]]", file=sys.stderr)
+    print("usage: centaur-tools [list|json|refresh|which <name>|run <name> [args...]|call <name> <method> [json]]", file=sys.stderr)
     return 2
 
 
@@ -505,7 +505,7 @@ def tool_env():
     return env
 
 
-def exec_tool(tool, args):
+def run_tool(tool, args):
     project_dir = Path(tool["project_dir"])
     return subprocess.call(
         ["uvx", "--from", str(project_dir), tool["name"], *args],
@@ -556,12 +556,12 @@ def main(argv):
             return 1
         print(tool["project_dir"])
         return 0
-    if command in {{"exec", "run"}} and len(argv) >= 3:
+    if command == "run" and len(argv) >= 3:
         name = argv[2]
         if name not in by_name:
             print(f"unknown tool: {{name}}", file=sys.stderr)
             return 1
-        return exec_tool(by_name[name], argv[3:])
+        return run_tool(by_name[name], argv[3:])
     if command == "call" and len(argv) >= 4:
         # Internal compatibility for Python workflow ctx.call_tool(...). Agents
         # should use direct tool CLIs (`<tool> --help`, `<tool> ...`) instead.

--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -404,18 +404,11 @@ def _write_executable(path: Path, content: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def _write_tool_shim(path: Path, script: dict[str, str], pythonpath: str) -> None:
+def _write_tool_shim(path: Path, script: dict[str, str], _pythonpath: str) -> None:
+    catalog = path.parent / "centaur-tools"
     content = f"""#!/bin/sh
 set -e
-_centaur_tool_pythonpath={shlex.quote(pythonpath)}
-if [ -n "$_centaur_tool_pythonpath" ]; then
-  if [ -n "${{PYTHONPATH:-}}" ]; then
-    export PYTHONPATH="$_centaur_tool_pythonpath:$PYTHONPATH"
-  else
-    export PYTHONPATH="$_centaur_tool_pythonpath"
-  fi
-fi
-exec uvx --from {shlex.quote(script["project_dir"])} {shlex.quote(script["name"])} "$@"
+exec {shlex.quote(str(catalog))} exec {shlex.quote(script["name"])} "$@"
 """
     _write_executable(path, content)
 
@@ -440,7 +433,7 @@ def load():
 
 
 def usage():
-    print("usage: centaur-tools [list|json|refresh|which <name>|run <name> [args...]|call <name> <method> [json]]", file=sys.stderr)
+    print("usage: centaur-tools [list|json|refresh|which <name>|exec <name> [args...]|run <name> [args...]|call <name> <method> [json]]", file=sys.stderr)
     return 2
 
 
@@ -502,15 +495,27 @@ print(json.dumps(result, default=str, separators=(",", ":")))
 '''
 
 
-def call_tool(tool, method, payload):
-    project_dir = Path(tool["project_dir"])
-    client_module = tool.get("client_module", "client.py")
+def tool_env():
     env = os.environ.copy()
     if PYTHONPATH_VALUE:
         if env.get("PYTHONPATH"):
             env["PYTHONPATH"] = f"{{PYTHONPATH_VALUE}}:{{env['PYTHONPATH']}}"
         else:
             env["PYTHONPATH"] = PYTHONPATH_VALUE
+    return env
+
+
+def exec_tool(tool, args):
+    project_dir = Path(tool["project_dir"])
+    return subprocess.call(
+        ["uvx", "--from", str(project_dir), tool["name"], *args],
+        env=tool_env(),
+    )
+
+
+def call_tool(tool, method, payload):
+    project_dir = Path(tool["project_dir"])
+    client_module = tool.get("client_module", "client.py")
     return subprocess.run(
         [
             "uvx",
@@ -527,7 +532,7 @@ def call_tool(tool, method, payload):
         check=False,
         text=True,
         capture_output=True,
-        env=env,
+        env=tool_env(),
     )
 
 
@@ -551,12 +556,12 @@ def main(argv):
             return 1
         print(tool["project_dir"])
         return 0
-    if command == "run" and len(argv) >= 3:
+    if command in {{"exec", "run"}} and len(argv) >= 3:
         name = argv[2]
         if name not in by_name:
             print(f"unknown tool: {{name}}", file=sys.stderr)
             return 1
-        return subprocess.call([name, *argv[3:]])
+        return exec_tool(by_name[name], argv[3:])
     if command == "call" and len(argv) >= 4:
         # Internal compatibility for Python workflow ctx.call_tool(...). Agents
         # should use direct tool CLIs (`<tool> --help`, `<tool> ...`) instead.

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -140,6 +143,99 @@ class CopyPublishedToolsTest(unittest.TestCase):
             self.assertNotIn("vlogs", scripts)
             self.assertNotIn("centaur-investigator", scripts)
             self.assertIn("websearch", scripts)
+
+
+class GeneratedShimTest(unittest.TestCase):
+    def test_tool_shim_delegates_to_centaur_tools_exec(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = Path(tmp)
+            script = {
+                "name": "websearch",
+                "project_dir": "/app/tools/research/websearch",
+                "package": "websearch",
+                "entrypoint": "websearch.cli:app",
+                "client_module": "client.py",
+            }
+
+            install_tool_shims._write_tool_shim(bin_dir / "websearch", script, "/opt/centaur")
+
+            content = (bin_dir / "websearch").read_text()
+            self.assertIn(f"exec {bin_dir / 'centaur-tools'} exec websearch", content)
+            self.assertNotIn("uvx --from", content)
+            self.assertNotIn("/app/tools/research/websearch", content)
+
+    def test_centaur_tools_exec_and_run_use_catalog_entry_directly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bin_dir = root / "bin"
+            fake_bin = root / "fake-bin"
+            project_dir = root / "tools" / "research" / "websearch"
+            bin_dir.mkdir()
+            fake_bin.mkdir()
+            project_dir.mkdir(parents=True)
+
+            index_path = bin_dir / ".centaur-tools.json"
+            index_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": "websearch",
+                            "project_dir": str(project_dir),
+                            "package": "websearch",
+                            "entrypoint": "websearch.cli:app",
+                            "client_module": "client.py",
+                        }
+                    ]
+                )
+                + "\n"
+            )
+            install_tool_shims._write_catalog(
+                bin_dir / "centaur-tools",
+                index_path,
+                os.pathsep.join(["/opt/centaur", "/opt/extra"]),
+            )
+
+            uvx_log = root / "uvx.log"
+            pythonpath_log = root / "pythonpath.log"
+            fake_uvx = fake_bin / "uvx"
+            fake_uvx.write_text(
+                "#!/usr/bin/env python3\n"
+                "from pathlib import Path\n"
+                "import os\n"
+                "import sys\n"
+                "Path(os.environ['UVX_LOG']).write_text('\\n'.join(sys.argv[1:]) + '\\n')\n"
+                "Path(os.environ['PYTHONPATH_LOG']).write_text(os.environ.get('PYTHONPATH', ''))\n"
+            )
+            fake_uvx.chmod(0o755)
+
+            path_websearch = fake_bin / "websearch"
+            path_websearch.write_text("#!/bin/sh\nexit 42\n")
+            path_websearch.chmod(0o755)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+            env["UVX_LOG"] = str(uvx_log)
+            env["PYTHONPATH_LOG"] = str(pythonpath_log)
+            env["PYTHONPATH"] = "existing"
+
+            for command in ("exec", "run"):
+                result = subprocess.run(
+                    [str(bin_dir / "centaur-tools"), command, "websearch", "search", "hello"],
+                    check=False,
+                    env=env,
+                    text=True,
+                    capture_output=True,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(
+                    uvx_log.read_text().splitlines(),
+                    ["--from", str(project_dir), "websearch", "search", "hello"],
+                )
+                self.assertEqual(
+                    pythonpath_log.read_text(),
+                    f"/opt/centaur{os.pathsep}/opt/extra{os.pathsep}existing",
+                )
 
 
 if __name__ == "__main__":

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -160,11 +160,11 @@ class GeneratedShimTest(unittest.TestCase):
             install_tool_shims._write_tool_shim(bin_dir / "websearch", script, "/opt/centaur")
 
             content = (bin_dir / "websearch").read_text()
-            self.assertIn(f"exec {bin_dir / 'centaur-tools'} exec websearch", content)
+            self.assertIn(f"exec {bin_dir / 'centaur-tools'} run websearch", content)
             self.assertNotIn("uvx --from", content)
             self.assertNotIn("/app/tools/research/websearch", content)
 
-    def test_centaur_tools_exec_and_run_use_catalog_entry_directly(self) -> None:
+    def test_centaur_tools_run_uses_catalog_entry_directly(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             bin_dir = root / "bin"
@@ -218,24 +218,34 @@ class GeneratedShimTest(unittest.TestCase):
             env["PYTHONPATH_LOG"] = str(pythonpath_log)
             env["PYTHONPATH"] = "existing"
 
-            for command in ("exec", "run"):
-                result = subprocess.run(
-                    [str(bin_dir / "centaur-tools"), command, "websearch", "search", "hello"],
-                    check=False,
-                    env=env,
-                    text=True,
-                    capture_output=True,
-                )
+            result = subprocess.run(
+                [str(bin_dir / "centaur-tools"), "run", "websearch", "search", "hello"],
+                check=False,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
 
-                self.assertEqual(result.returncode, 0, result.stderr)
-                self.assertEqual(
-                    uvx_log.read_text().splitlines(),
-                    ["--from", str(project_dir), "websearch", "search", "hello"],
-                )
-                self.assertEqual(
-                    pythonpath_log.read_text(),
-                    f"/opt/centaur{os.pathsep}/opt/extra{os.pathsep}existing",
-                )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                uvx_log.read_text().splitlines(),
+                ["--from", str(project_dir), "websearch", "search", "hello"],
+            )
+            self.assertEqual(
+                pythonpath_log.read_text(),
+                f"/opt/centaur{os.pathsep}/opt/extra{os.pathsep}existing",
+            )
+
+            result = subprocess.run(
+                [str(bin_dir / "centaur-tools"), "exec", "websearch"],
+                check=False,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("usage: centaur-tools", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Routes generated tool shims through the existing centaur-tools run path instead of embedding uvx execution details in each shim. This keeps shim files as thin aliases while centaur-tools owns catalog lookup, PYTHONPATH setup, and tool execution. The call command remains separate for workflow-style Python method invocation.