### PR TITLE
Log sandbox tool shim calls

### DIFF
--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -422,6 +422,8 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+from datetime import datetime, timezone
+import time
 
 INDEX = {str(index_path)!r}
 PYTHONPATH_VALUE = {pythonpath!r}
@@ -505,35 +507,89 @@ def tool_env():
     return env
 
 
+def analytics_log_path():
+    configured = os.environ.get("CENTAUR_TOOL_ANALYTICS_LOG_PATH")
+    if configured is not None:
+        return configured.strip()
+    return "/proc/1/fd/2"
+
+
+def emit_tool_call_event(event, tool, method, started_at=None, returncode=None):
+    path = analytics_log_path()
+    if path.lower() in {{"", "0", "false", "none", "off"}}:
+        return
+
+    payload = {{
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "level": "info",
+        "service": "sandbox",
+        "component": "tool_shim",
+        "event": event,
+        "msg": f"Centaur tool shim {{event}}",
+        "tool_name": str(tool.get("name") or "unknown"),
+        "tool_method": method,
+    }}
+    thread_key = os.environ.get("CENTAUR_THREAD_KEY", "").strip()
+    if thread_key:
+        payload["thread_key"] = thread_key
+    if started_at is not None:
+        payload["duration_ms"] = round((time.monotonic() - started_at) * 1000, 3)
+    if returncode is not None:
+        payload["exit_code"] = returncode
+        payload["success"] = "true" if returncode == 0 else "false"
+
+    try:
+        with open(path, "a", encoding="utf-8") as log_file:
+            log_file.write(json.dumps(payload, separators=(",", ":"), default=str) + "\\n")
+    except Exception:
+        pass
+
+
 def run_tool(tool, args):
     project_dir = Path(tool["project_dir"])
-    return subprocess.call(
-        ["uvx", "--from", str(project_dir), tool["name"], *args],
-        env=tool_env(),
-    )
+    started_at = time.monotonic()
+    emit_tool_call_event("tool_call_started", tool, "cli")
+    try:
+        returncode = subprocess.call(
+            ["uvx", "--from", str(project_dir), tool["name"], *args],
+            env=tool_env(),
+        )
+    except Exception:
+        emit_tool_call_event("tool_call_completed", tool, "cli", started_at, 1)
+        raise
+    emit_tool_call_event("tool_call_completed", tool, "cli", started_at, returncode)
+    return returncode
 
 
 def call_tool(tool, method, payload):
     project_dir = Path(tool["project_dir"])
     client_module = tool.get("client_module", "client.py")
-    return subprocess.run(
-        [
-            "uvx",
-            "--from",
-            str(project_dir),
-            "python",
-            "-c",
-            CALL_RUNNER,
-            str(project_dir),
-            client_module,
-            method,
-            json.dumps(payload, separators=(",", ":")),
-        ],
-        check=False,
-        text=True,
-        capture_output=True,
-        env=tool_env(),
-    )
+    started_at = time.monotonic()
+    emit_tool_call_event("tool_call_started", tool, method)
+    try:
+        result = subprocess.run(
+            [
+                "uvx",
+                "--from",
+                str(project_dir),
+                "python",
+                "-c",
+                CALL_RUNNER,
+                str(project_dir),
+                client_module,
+                method,
+                json.dumps(payload, separators=(",", ":")),
+            ],
+            check=False,
+            text=True,
+            capture_output=True,
+            env=tool_env(),
+        )
+    except Exception:
+        emit_tool_call_event("tool_call_completed", tool, method, started_at, 1)
+        raise
+    emit_tool_call_event("tool_call_completed", tool, method, started_at, result.returncode)
+    return result
 
 
 def main(argv):

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -197,6 +197,7 @@ class GeneratedShimTest(unittest.TestCase):
 
             uvx_log = root / "uvx.log"
             pythonpath_log = root / "pythonpath.log"
+            analytics_log = root / "tool-analytics.log"
             fake_uvx = fake_bin / "uvx"
             fake_uvx.write_text(
                 "#!/usr/bin/env python3\n"
@@ -217,9 +218,17 @@ class GeneratedShimTest(unittest.TestCase):
             env["UVX_LOG"] = str(uvx_log)
             env["PYTHONPATH_LOG"] = str(pythonpath_log)
             env["PYTHONPATH"] = "existing"
+            env["CENTAUR_THREAD_KEY"] = "cli:test-thread"
+            env["CENTAUR_TOOL_ANALYTICS_LOG_PATH"] = str(analytics_log)
 
             result = subprocess.run(
-                [str(bin_dir / "centaur-tools"), "run", "websearch", "search", "hello"],
+                [
+                    str(bin_dir / "centaur-tools"),
+                    "run",
+                    "websearch",
+                    "lookup",
+                    "sensitive-payload",
+                ],
                 check=False,
                 env=env,
                 text=True,
@@ -229,12 +238,37 @@ class GeneratedShimTest(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(
                 uvx_log.read_text().splitlines(),
-                ["--from", str(project_dir), "websearch", "search", "hello"],
+                [
+                    "--from",
+                    str(project_dir),
+                    "websearch",
+                    "lookup",
+                    "sensitive-payload",
+                ],
             )
             self.assertEqual(
                 pythonpath_log.read_text(),
                 f"/opt/centaur{os.pathsep}/opt/extra{os.pathsep}existing",
             )
+            analytics_events = [
+                json.loads(line) for line in analytics_log.read_text().splitlines()
+            ]
+            self.assertEqual(
+                [event["event"] for event in analytics_events],
+                ["tool_call_started", "tool_call_completed"],
+            )
+            for event in analytics_events:
+                self.assertEqual(event["service"], "sandbox")
+                self.assertEqual(event["component"], "tool_shim")
+                self.assertEqual(event["tool_name"], "websearch")
+                self.assertEqual(event["tool_method"], "cli")
+                self.assertEqual(event["thread_key"], "cli:test-thread")
+            self.assertEqual(analytics_events[1]["exit_code"], 0)
+            self.assertEqual(analytics_events[1]["success"], "true")
+            self.assertIn("duration_ms", analytics_events[1])
+            serialized_analytics = json.dumps(analytics_events, sort_keys=True)
+            self.assertNotIn("lookup", serialized_analytics)
+            self.assertNotIn("sensitive-payload", serialized_analytics)
 
             result = subprocess.run(
                 [str(bin_dir / "centaur-tools"), "exec", "websearch"],


### PR DESCRIPTION
## Summary
- emit structured `tool_call_started` and `tool_call_completed` events from the generated `centaur-tools` runner
- include bounded analytics fields (`tool_name`, `tool_method`, `thread_key`, `duration_ms`, `exit_code`, `success`) without logging CLI args, outputs, payloads, or results
- cover the generated runner path with a unit test that verifies analytics logging and argument redaction

## Tests
- `uv run --python 3.11 python -m unittest test_install_tool_shims.py`
- `uv run --python 3.11 python -m py_compile services/sandbox/install_tool_shims.py services/sandbox/test_install_tool_shims.py`
- `uvx ruff check services/sandbox/install_tool_shims.py services/sandbox/test_install_tool_shims.py`
- `git diff --check`

Skipped sandbox image build/deploy per request.