### PR TITLE
[codex] keep Slack handoff waits best-effort

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -93,6 +93,7 @@ type SlackAssistantAdapter = {
 }
 
 const MAX_SLACK_MESSAGE_ATTACHMENTS = 20
+const DEFAULT_SLACK_BEST_EFFORT_TIMEOUT_MS = 5_000
 
 type SlackbotV2RequestContext = {
   retryableErrors: unknown[]
@@ -277,20 +278,29 @@ async function handleSlackMessageHandoff(
     subscribe: input.subscribe === true,
     trigger: input.trigger
   })
+  let initialAssistantStatusVisible = false
   const assistantStatus = input.assistantStatusRequested
     ? setInitialAssistantStatus(thread, input.options, trace)
+        .then(visible => {
+          initialAssistantStatusVisible = visible
+          return visible
+        })
     : Promise.resolve(false)
+  if (input.assistantStatusRequested) {
+    backgroundWaitUntil(assistantStatus.then(() => undefined).catch(() => undefined))
+  }
   try {
     if (input.subscribe) {
       await subscribeSlackThreadForHandoff(thread, input.options, trace, input.trigger)
     }
-    const assistantStatusVisible = await assistantStatus
     traceLog(input.options, 'slackbotv2_handoff_sync_starting', trace, {
-      initial_assistant_status_visible: assistantStatusVisible,
+      initial_assistant_status_deferred:
+        input.assistantStatusRequested && !initialAssistantStatusVisible,
+      initial_assistant_status_visible: initialAssistantStatusVisible,
       trigger: input.trigger
     })
     await syncThreadMessageToSession(thread, message, {
-      initialAssistantStatusVisible: assistantStatusVisible,
+      initialAssistantStatusVisible,
       mode: input.mode,
       options: input.options,
       state: input.state
@@ -303,7 +313,14 @@ async function handleSlackMessageHandoff(
       error: errorMessage(error),
       trigger: input.trigger
     })
-    if (await assistantStatus) await setAssistantStatus(thread, '', input.options, trace)
+    backgroundWaitUntil(
+      assistantStatus
+        .then(visible =>
+          visible ? setAssistantStatus(thread, '', input.options, trace) : undefined
+        )
+        .then(() => undefined)
+        .catch(() => undefined)
+    )
     throw error
   }
 }
@@ -535,15 +552,21 @@ async function syncThreadMessageToSession(
     history_forwarded: state.historyForwarded === true
   })
   const assistantStatusVisible = shouldStartExecution
-    ? input.initialAssistantStatusVisible ??
-      (await setInitialAssistantStatus(thread, input.options, trace))
+    ? input.initialAssistantStatusVisible === true
     : false
+  if (shouldStartExecution && input.initialAssistantStatusVisible === undefined) {
+    backgroundWaitUntil(
+      setInitialAssistantStatus(thread, input.options, trace)
+        .then(() => undefined)
+        .catch(() => undefined)
+    )
+  }
   if (!shouldStartExecution && input.initialAssistantStatusVisible) {
     await setAssistantStatus(thread, '', input.options, trace)
   }
 
   const serializeStartedAtMs = nowMs()
-  const serializedMessage = await serializeMessage(message)
+  const serializedMessage = await serializeMessage(message, input.options)
   const overrides = extractMessageOverrides(serializedMessage.text)
   setMessageText(serializedMessage, overrides.cleanedText)
   if (overrides.harnessType || overrides.model || overrides.provider || overrides.reasoning) {
@@ -563,18 +586,33 @@ async function syncThreadMessageToSession(
     phase_ms: elapsedMs(serializeStartedAtMs)
   })
   let context: SlackbotV2ApiMessage[] | undefined
+  let contextDegraded = false
 
   if (shouldIncludeContext) {
     const contextStartedAtMs = nowMs()
-    context = shouldRefreshThreadContext
-      ? await collectSlackThreadContext(input.options, message)
-      : await collectInitialContext(thread, message)
+    try {
+      context = shouldRefreshThreadContext
+        ? await withBestEffortTimeout(input.options, 'collect Slack thread context', () =>
+            collectSlackThreadContext(input.options, message)
+          )
+        : await withBestEffortTimeout(input.options, 'collect initial thread context', () =>
+            collectInitialContext(thread, message, input.options)
+          )
+    } catch (error) {
+      contextDegraded = true
+      context = [serializedMessage]
+      traceWarn(input.options, 'slackbotv2_forward_context_degraded', trace, {
+        error: errorMessage(error),
+        phase_ms: elapsedMs(contextStartedAtMs)
+      })
+    }
     // collectInitialContext re-serializes the current message; mirror the
     // flag-stripped text on that copy too.
     for (const item of context) {
       if (item.id === serializedMessage.id) copyMessageTextFields(item, serializedMessage)
     }
     traceLog(input.options, 'slackbotv2_forward_context_collected', trace, {
+      degraded: contextDegraded,
       message_count: context.length,
       phase_ms: elapsedMs(contextStartedAtMs)
     })
@@ -612,9 +650,28 @@ async function syncThreadMessageToSession(
   // The previous harness's conversation state dies with its sandbox on a
   // restart, so re-feed the Slack thread transcript with this turn.
   const handleSessionRestarted = async (): Promise<void> => {
-    const history = context ?? (await collectInitialContext(thread, message))
+    let history = context
+    let restartContextDegraded = contextDegraded
+    if (!history) {
+      const restartContextStartedAtMs = nowMs()
+      try {
+        history = await withBestEffortTimeout(
+          input.options,
+          'collect restart thread context',
+          () => collectInitialContext(thread, message, input.options)
+        )
+      } catch (error) {
+        restartContextDegraded = true
+        history = [serializedMessage]
+        traceWarn(input.options, 'slackbotv2_forward_restart_context_degraded', trace, {
+          error: errorMessage(error),
+          phase_ms: elapsedMs(restartContextStartedAtMs)
+        })
+      }
+    }
     forwardInput.contextPreamble = harnessRestartPreamble(history, serializedMessage.id)
     traceLog(input.options, 'slackbotv2_forward_restart_context_built', trace, {
+      degraded: restartContextDegraded,
       history_message_count: history.length,
       preamble_chars: forwardInput.contextPreamble?.length ?? 0
     })
@@ -626,7 +683,7 @@ async function syncThreadMessageToSession(
     for (const item of messagesToAppend) latestMessageIds.add(item.id)
     await thread.setState({
       forwardedMessageIds: Array.from(latestMessageIds).slice(-1000),
-      historyForwarded: latest.historyForwarded || shouldIncludeContext,
+      historyForwarded: latest.historyForwarded || (shouldIncludeContext && !contextDegraded),
       lastEventId
     })
     traceLog(input.options, 'slackbotv2_forward_messages_committed', trace, {
@@ -1688,7 +1745,7 @@ async function renderExecutionStream(
     return { diverged: false }
   }
   const titleStartedAtMs = nowMs()
-  await setAssistantTitle(thread, titleFromMessage(promptText, options.userName))
+  await setAssistantTitle(thread, titleFromMessage(promptText, options.userName), options, trace)
   if (!assistantStatusVisible) {
     await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   }
@@ -1738,7 +1795,7 @@ async function renderRecoveredExecutionStream(
     return { diverged: false }
   }
   const titleStartedAtMs = nowMs()
-  await setAssistantTitle(thread, titleFromMessage(promptText, options.userName))
+  await setAssistantTitle(thread, titleFromMessage(promptText, options.userName), options, trace)
   await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   traceLog(options, 'slackbotv2_render_slack_metadata_set', trace, {
     phase_ms: elapsedMs(titleStartedAtMs)
@@ -1781,7 +1838,12 @@ async function renderPlainTextExecutionStream(
 ): Promise<void> {
   const fallback = new SlackRenderFallback()
   const titleStartedAtMs = nowMs()
-  await setAssistantTitle(thread, titleFromMessage(slackMessagePromptText(message), options.userName))
+  await setAssistantTitle(
+    thread,
+    titleFromMessage(slackMessagePromptText(message), options.userName),
+    options,
+    trace
+  )
   if (!assistantStatusVisible) {
     await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   }
@@ -1972,6 +2034,41 @@ function backgroundWaitUntil(promise: Promise<unknown>): void {
   void promise.catch(() => undefined)
 }
 
+class SlackBestEffortTimeoutError extends Error {
+  constructor(action: string, timeoutMs: number) {
+    super(`${action} timed out after ${timeoutMs}ms`)
+    this.name = 'AbortError'
+  }
+}
+
+function slackBestEffortTimeoutMs(options?: SlackbotV2Options): number | undefined {
+  return options ? options.slackApiTimeoutMs ?? DEFAULT_SLACK_BEST_EFFORT_TIMEOUT_MS : undefined
+}
+
+async function withBestEffortTimeout<T>(
+  options: SlackbotV2Options | undefined,
+  action: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const timeoutMs = slackBestEffortTimeoutMs(options)
+  if (!timeoutMs) return fn()
+
+  let timer: ReturnType<typeof globalThis.setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = globalThis.setTimeout(() => {
+      reject(new SlackBestEffortTimeoutError(action, timeoutMs))
+    }, timeoutMs)
+    const unref = (timer as { unref?: () => void }).unref
+    if (unref) unref.call(timer)
+  })
+
+  try {
+    return await Promise.race([fn(), timeout])
+  } finally {
+    if (timer !== undefined) globalThis.clearTimeout(timer)
+  }
+}
+
 function shouldAwaitSlackHandoff(rawBody: string): boolean {
   try {
     const payload = JSON.parse(rawBody) as { event?: { type?: unknown }; type?: unknown }
@@ -2025,19 +2122,21 @@ async function collectSlackThreadContext(
   const channel = stringField(raw.channel)
   const threadTs = stringField(raw.thread_ts)
   const currentTs = stringField(raw.ts) || currentMessage.id
-  if (!channel || !threadTs) return [await serializeMessage(currentMessage)]
+  if (!channel || !threadTs) return [await serializeMessage(currentMessage, options)]
 
   const messages: SlackbotV2ApiMessage[] = []
   let cursor: string | undefined
   do {
-    const response = await fetchSlackThreadReplies({
-      apiUrl: options.slackApiUrl,
-      channel,
-      cursor,
-      limit: 200,
-      token: options.botToken,
-      ts: threadTs
-    })
+    const response = await withBestEffortTimeout(options, 'fetch Slack thread replies', () =>
+      fetchSlackThreadReplies({
+        apiUrl: options.slackApiUrl,
+        channel,
+        cursor,
+        limit: 200,
+        token: options.botToken,
+        ts: threadTs
+      })
+    )
     const slackMessages = Array.isArray(response.messages) ? response.messages : []
     for (const rawMessage of slackMessages) {
       const message = rawMessage as Record<string, unknown>
@@ -2050,7 +2149,7 @@ async function collectSlackThreadContext(
   } while (cursor)
 
   const currentIndex = messages.findIndex(message => message.id === currentMessage.id)
-  const serializedCurrent = await serializeMessage(currentMessage)
+  const serializedCurrent = await serializeMessage(currentMessage, options)
   if (currentIndex >= 0) {
     messages[currentIndex] = serializedCurrent
   } else {
@@ -2112,7 +2211,7 @@ async function slackApiAttachmentsFromFiles(
     || stringField(rawCurrent.team_id)
   const attachments: SlackbotV2ApiAttachment[] = []
   for (const file of files.slice(0, MAX_SLACK_MESSAGE_ATTACHMENTS)) {
-    attachments.push(await serializeAttachment(slackFileAttachment(options, file, teamId)))
+    attachments.push(await serializeAttachment(slackFileAttachment(options, file, teamId), options))
   }
   if (files.length > MAX_SLACK_MESSAGE_ATTACHMENTS) {
     attachments.push({
@@ -2158,13 +2257,25 @@ function slackFileAttachment(
 
 async function fetchSlackFile(options: SlackbotV2Options, url: string): Promise<Buffer> {
   const fetchFn = options.fetch ?? fetch
-  const response = await fetchFn(url, {
-    headers: { authorization: `Bearer ${options.botToken}` }
-  })
-  if (!response.ok) {
-    throw new Error(`failed to fetch Slack file: ${response.status} ${response.statusText}`)
+  const controller = new AbortController()
+  try {
+    const response = await withBestEffortTimeout(options, 'fetch Slack file', () =>
+      fetchFn(url, {
+        headers: { authorization: `Bearer ${options.botToken}` },
+        signal: controller.signal
+      })
+    )
+    if (!response.ok) {
+      throw new Error(`failed to fetch Slack file: ${response.status} ${response.statusText}`)
+    }
+    const body = await withBestEffortTimeout(options, 'read Slack file', () =>
+      response.arrayBuffer()
+    )
+    return Buffer.from(body)
+  } catch (error) {
+    controller.abort()
+    throw error
   }
-  return Buffer.from(await response.arrayBuffer())
 }
 
 function slackFileAttachmentType(mimeType: string): Attachment['type'] {
@@ -2270,7 +2381,7 @@ function rendererOptions(
     async onRendererEvent(event: RendererEvent) {
       await mapper?.onRendererEvent?.(event)
       if (event.type === 'renderer.title.update') {
-        await setAssistantTitle(thread, event.title)
+        await setAssistantTitle(thread, event.title, options)
       }
     }
   }
@@ -2359,12 +2470,14 @@ async function setAssistantStatus(
       )
     : () => undefined
   try {
-    const visible = await ignoreAssistantError(() =>
-      adapter.setAssistantStatus!(
-        target.channel,
-        target.threadTs,
-        status,
-        status ? [status] : undefined
+    const visible = await withBestEffortTimeout(options, 'set assistant status', () =>
+      ignoreAssistantError(() =>
+        adapter.setAssistantStatus!(
+          target.channel,
+          target.threadTs,
+          status,
+          status ? [status] : undefined
+        )
       )
     )
     if (options) {
@@ -2383,21 +2496,38 @@ async function setAssistantStatus(
         phase_ms: elapsedMs(startedAtMs)
       })
     }
-    throw error
+    return false
   } finally {
     stopPendingLog()
   }
 }
 
-async function setAssistantTitle(thread: Thread, title: string | undefined): Promise<void> {
+async function setAssistantTitle(
+  thread: Thread,
+  title: string | undefined,
+  options?: SlackbotV2Options,
+  trace?: SlackbotV2Trace
+): Promise<void> {
   const normalized = title?.trim()
   if (!normalized) return
+  const startedAtMs = nowMs()
   const target = slackAssistantTarget(thread)
   const adapter = thread.adapter as SlackAssistantAdapter
   if (!target || !adapter.setAssistantTitle) return
-  await ignoreAssistantError(() =>
-    adapter.setAssistantTitle!(target.channel, target.threadTs, clipOneLine(normalized, 80))
-  )
+  try {
+    await withBestEffortTimeout(options, 'set assistant title', () =>
+      ignoreAssistantError(() =>
+        adapter.setAssistantTitle!(target.channel, target.threadTs, clipOneLine(normalized, 80))
+      )
+    )
+  } catch (error) {
+    if (options) {
+      traceWarn(options, 'slackbotv2_assistant_title_failed', trace, {
+        error: errorMessage(error),
+        phase_ms: elapsedMs(startedAtMs)
+      })
+    }
+  }
 }
 
 async function ignoreAssistantError(fn: () => Promise<void>): Promise<boolean> {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -33,8 +33,8 @@ import {
   serializeAttachment,
   serializeMessageLinks,
   serializeMessage,
-  slackApiTimeoutMs,
-  sessionStreamError
+  sessionStreamError,
+  withSlackApiTimeout
 } from './session-api'
 import { extractMessageOverrides } from './overrides'
 import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from './slack-events'
@@ -592,10 +592,10 @@ async function syncThreadMessageToSession(
     const contextStartedAtMs = nowMs()
     try {
       context = shouldRefreshThreadContext
-        ? await withBestEffortTimeout(input.options, 'collect Slack thread context', () =>
+        ? await withSlackApiTimeout(input.options, 'collect Slack thread context', () =>
             collectSlackThreadContext(input.options, message)
           )
-        : await withBestEffortTimeout(input.options, 'collect initial thread context', () =>
+        : await withSlackApiTimeout(input.options, 'collect initial thread context', () =>
             collectInitialContext(thread, message, input.options)
           )
     } catch (error) {
@@ -655,7 +655,7 @@ async function syncThreadMessageToSession(
     if (!history) {
       const restartContextStartedAtMs = nowMs()
       try {
-        history = await withBestEffortTimeout(
+        history = await withSlackApiTimeout(
           input.options,
           'collect restart thread context',
           () => collectInitialContext(thread, message, input.options)
@@ -2034,41 +2034,6 @@ function backgroundWaitUntil(promise: Promise<unknown>): void {
   void promise.catch(() => undefined)
 }
 
-class SlackBestEffortTimeoutError extends Error {
-  constructor(action: string, timeoutMs: number) {
-    super(`${action} timed out after ${timeoutMs}ms`)
-    this.name = 'AbortError'
-  }
-}
-
-function slackBestEffortTimeoutMs(options?: SlackbotV2Options): number | undefined {
-  return options ? slackApiTimeoutMs(options) : undefined
-}
-
-async function withBestEffortTimeout<T>(
-  options: SlackbotV2Options | undefined,
-  action: string,
-  fn: () => Promise<T>
-): Promise<T> {
-  const timeoutMs = slackBestEffortTimeoutMs(options)
-  if (!timeoutMs) return fn()
-
-  let timer: ReturnType<typeof globalThis.setTimeout> | undefined
-  const timeout = new Promise<never>((_, reject) => {
-    timer = globalThis.setTimeout(() => {
-      reject(new SlackBestEffortTimeoutError(action, timeoutMs))
-    }, timeoutMs)
-    const unref = (timer as { unref?: () => void }).unref
-    if (unref) unref.call(timer)
-  })
-
-  try {
-    return await Promise.race([fn(), timeout])
-  } finally {
-    if (timer !== undefined) globalThis.clearTimeout(timer)
-  }
-}
-
 function shouldAwaitSlackHandoff(rawBody: string): boolean {
   try {
     const payload = JSON.parse(rawBody) as { event?: { type?: unknown }; type?: unknown }
@@ -2127,7 +2092,7 @@ async function collectSlackThreadContext(
   const messages: SlackbotV2ApiMessage[] = []
   let cursor: string | undefined
   do {
-    const response = await withBestEffortTimeout(options, 'fetch Slack thread replies', () =>
+    const response = await withSlackApiTimeout(options, 'fetch Slack thread replies', () =>
       fetchSlackThreadReplies({
         apiUrl: options.slackApiUrl,
         channel,
@@ -2259,7 +2224,7 @@ async function fetchSlackFile(options: SlackbotV2Options, url: string): Promise<
   const fetchFn = options.fetch ?? fetch
   const controller = new AbortController()
   try {
-    const response = await withBestEffortTimeout(options, 'fetch Slack file', () =>
+    const response = await withSlackApiTimeout(options, 'fetch Slack file', () =>
       fetchFn(url, {
         headers: { authorization: `Bearer ${options.botToken}` },
         signal: controller.signal
@@ -2268,7 +2233,7 @@ async function fetchSlackFile(options: SlackbotV2Options, url: string): Promise<
     if (!response.ok) {
       throw new Error(`failed to fetch Slack file: ${response.status} ${response.statusText}`)
     }
-    const body = await withBestEffortTimeout(options, 'read Slack file', () =>
+    const body = await withSlackApiTimeout(options, 'read Slack file', () =>
       response.arrayBuffer()
     )
     return Buffer.from(body)
@@ -2470,7 +2435,7 @@ async function setAssistantStatus(
       )
     : () => undefined
   try {
-    const visible = await withBestEffortTimeout(options, 'set assistant status', () =>
+    const visible = await withSlackApiTimeout(options, 'set assistant status', () =>
       ignoreAssistantError(() =>
         adapter.setAssistantStatus!(
           target.channel,
@@ -2515,7 +2480,7 @@ async function setAssistantTitle(
   const adapter = thread.adapter as SlackAssistantAdapter
   if (!target || !adapter.setAssistantTitle) return
   try {
-    await withBestEffortTimeout(options, 'set assistant title', () =>
+    await withSlackApiTimeout(options, 'set assistant title', () =>
       ignoreAssistantError(() =>
         adapter.setAssistantTitle!(target.channel, target.threadTs, clipOneLine(normalized, 80))
       )

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -33,6 +33,7 @@ import {
   serializeAttachment,
   serializeMessageLinks,
   serializeMessage,
+  slackApiTimeoutMs,
   sessionStreamError
 } from './session-api'
 import { extractMessageOverrides } from './overrides'
@@ -93,7 +94,6 @@ type SlackAssistantAdapter = {
 }
 
 const MAX_SLACK_MESSAGE_ATTACHMENTS = 20
-const DEFAULT_SLACK_BEST_EFFORT_TIMEOUT_MS = 5_000
 
 type SlackbotV2RequestContext = {
   retryableErrors: unknown[]
@@ -2042,7 +2042,7 @@ class SlackBestEffortTimeoutError extends Error {
 }
 
 function slackBestEffortTimeoutMs(options?: SlackbotV2Options): number | undefined {
-  return options ? options.slackApiTimeoutMs ?? DEFAULT_SLACK_BEST_EFFORT_TIMEOUT_MS : undefined
+  return options ? slackApiTimeoutMs(options) : undefined
 }
 
 async function withBestEffortTimeout<T>(

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -158,7 +158,8 @@ type ForwardSessionApiCallbacks = {
 
 export async function collectInitialContext(
   thread: { allMessages: AsyncIterable<Message> },
-  currentMessage: Message
+  currentMessage: Message,
+  options?: SlackbotV2Options
 ): Promise<SlackbotV2ApiMessage[]> {
   const messages: Message[] = []
   try {
@@ -167,7 +168,7 @@ export async function collectInitialContext(
     }
   } catch (error) {
     if (!isSlackThreadNotFoundError(error)) throw error
-    return [await serializeMessage(currentMessage)]
+    return [await serializeMessage(currentMessage, options)]
   }
 
   const currentIndex = messages.findIndex(message => message.id === currentMessage.id)
@@ -179,7 +180,7 @@ export async function collectInitialContext(
 
   const serialized: SlackbotV2ApiMessage[] = []
   for (const message of messages) {
-    serialized.push(await serializeMessage(message))
+    serialized.push(await serializeMessage(message, options))
   }
   return serialized
 }
@@ -196,10 +197,13 @@ function isSlackThreadNotFoundError(error: unknown): boolean {
   return error instanceof Error && error.message.includes('thread_not_found')
 }
 
-export async function serializeMessage(message: Message): Promise<SlackbotV2ApiMessage> {
+export async function serializeMessage(
+  message: Message,
+  options?: SlackbotV2Options
+): Promise<SlackbotV2ApiMessage> {
   const attachments: SlackbotV2ApiAttachment[] = []
   for (const attachment of message.attachments) {
-    attachments.push(await serializeAttachment(attachment))
+    attachments.push(await serializeAttachment(attachment, options))
   }
   const displayText = renderSlackDisplayText({ raw: message.raw, text: message.text })
 
@@ -512,7 +516,10 @@ export const MAX_INLINE_ATTACHMENT_BYTES = 100 * 1024 * 1024
 const MAX_CODEX_INPUT_LINE_CHARS = 900 * 1024
 const STAGED_ATTACHMENT_CHUNK_CHARS = 700 * 1024
 
-export async function serializeAttachment(attachment: Attachment): Promise<SlackbotV2ApiAttachment> {
+export async function serializeAttachment(
+  attachment: Attachment,
+  options?: SlackbotV2Options
+): Promise<SlackbotV2ApiAttachment> {
   const serialized: SlackbotV2ApiAttachment = {
     fetchMetadata: attachment.fetchMetadata,
     height: attachment.height,
@@ -530,7 +537,7 @@ export async function serializeAttachment(attachment: Attachment): Promise<Slack
   }
 
   try {
-    const data = attachment.data ?? (await attachment.fetchData?.())
+    const data = attachment.data ?? (await fetchAttachmentData(attachment, options))
     if (data) {
       // Re-check the actual byte count: Slack size metadata can be absent.
       const byteLength = Buffer.isBuffer(data) ? data.length : data.size
@@ -545,6 +552,17 @@ export async function serializeAttachment(attachment: Attachment): Promise<Slack
   }
 
   return serialized
+}
+
+async function fetchAttachmentData(
+  attachment: Attachment,
+  options?: SlackbotV2Options
+): Promise<Buffer | Blob | undefined> {
+  if (!attachment.fetchData) return undefined
+  if (!options) return attachment.fetchData()
+  return withTimeout('fetch Slack attachment', slackApiTimeoutMs(options), () =>
+    attachment.fetchData?.() ?? Promise.resolve(undefined)
+  )
 }
 
 function attachmentTooLargeError(bytes: number): string {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -140,7 +140,7 @@ function sessionApiTimeoutMs(options: SlackbotV2Options): number {
   return options.sessionApiTimeoutMs ?? DEFAULT_SESSION_API_TIMEOUT_MS
 }
 
-function slackApiTimeoutMs(options: SlackbotV2Options): number {
+export function slackApiTimeoutMs(options: SlackbotV2Options): number {
   return options.slackApiTimeoutMs ?? DEFAULT_SLACK_API_TIMEOUT_MS
 }
 

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -144,6 +144,14 @@ export function slackApiTimeoutMs(options: SlackbotV2Options): number {
   return options.slackApiTimeoutMs ?? DEFAULT_SLACK_API_TIMEOUT_MS
 }
 
+export async function withSlackApiTimeout<T>(
+  options: SlackbotV2Options | undefined,
+  action: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  return options ? withTimeout(action, slackApiTimeoutMs(options), fn) : fn()
+}
+
 type ForwardSessionApiCallbacks = {
   onExecutionStarted?(execution: SlackbotV2ExecuteSessionResponse): Promise<void>
   onMessagesAppended?(): Promise<void>
@@ -560,7 +568,7 @@ async function fetchAttachmentData(
 ): Promise<Buffer | Blob | undefined> {
   if (!attachment.fetchData) return undefined
   if (!options) return attachment.fetchData()
-  return withTimeout('fetch Slack attachment', slackApiTimeoutMs(options), () =>
+  return withSlackApiTimeout(options, 'fetch Slack attachment', () =>
     attachment.fetchData?.() ?? Promise.resolve(undefined)
   )
 }
@@ -959,7 +967,7 @@ async function slackApiGet(
 ): Promise<JsonObject | null> {
   const url = slackApiMethodUrl(options.slackApiUrl, method)
   for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value)
-  return withTimeout(`Slack API ${method}`, slackApiTimeoutMs(options), async () => {
+  return withSlackApiTimeout(options, `Slack API ${method}`, async () => {
     const response = await fetchWithTimeout(
       fetch,
       url,

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -294,7 +294,10 @@ describe('slackbotv2', () => {
     const assistantStatuses = slackApi.calls
       .filter(call => call.method === 'assistant.threads.setStatus')
       .map(call => stringField(call.body.status))
-    expect(assistantStatuses).toEqual(['Thinking...', '', 'Thinking...', ''])
+    expect(assistantStatuses[0]).toBe('Thinking...')
+    expect(assistantStatuses.at(-1)).toBe('')
+    expect(assistantStatuses.filter(status => status === 'Thinking...').length).toBeGreaterThanOrEqual(2)
+    expect(assistantStatuses.filter(status => status === '').length).toBeGreaterThanOrEqual(2)
     expect(
       slackApi.calls
         .filter(call => call.method === 'assistant.threads.setTitle')
@@ -2662,7 +2665,7 @@ describe('slackbotv2', () => {
     )
     expect(logData(logs, 'slackbotv2_handoff_sync_starting')).toEqual(
       expect.objectContaining({
-        initial_assistant_status_visible: true,
+        initial_assistant_status_visible: expect.any(Boolean),
         trigger: 'new_mention'
       })
     )
@@ -2696,7 +2699,59 @@ describe('slackbotv2', () => {
       slackApi.calls
         .filter(call => call.method === 'assistant.threads.setStatus')
         .map(call => stringField(call.body.status))
-    ).toEqual(['Thinking...', ''])
+    ).toEqual(expect.arrayContaining(['Thinking...', '']))
+  })
+
+  it('does not wait for hung assistant status before creating Slack sessions', async () => {
+    const logs: CapturedLog[] = []
+    bot = createTestBot({ logger: captureLogger(logs), slackApiTimeoutMs: 25 })
+    const releaseStatus = slackApi.holdAssistantStatus()
+    const waits: Promise<unknown>[] = []
+
+    try {
+      const parent = await postUserMessage('Context before hung status.')
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> keep going`, parent.ts)
+      const responsePromise = bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: 'Ev-slackbotv2-hung-status',
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parent.ts,
+            text: `<@${BOT_USER_ID}> keep going`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+
+      await waitFor(() => codexApi.creates.length === 1 && codexApi.executes.length === 1)
+      const response = await responsePromise
+      expect(response.status).toBe(200)
+      expect(codexApi.creates[0]?.threadKey).toBe(threadKey(parent.ts))
+      expect(codexApi.executes[0]?.threadKey).toBe(threadKey(parent.ts))
+      expect(logData(logs, 'slackbotv2_handoff_sync_starting')).toEqual(
+        expect.objectContaining({
+          initial_assistant_status_deferred: true,
+          initial_assistant_status_visible: false,
+          trigger: 'new_mention'
+        })
+      )
+      await waitFor(() => hasLog(logs, 'slackbotv2_assistant_status_failed'))
+      expect(logData(logs, 'slackbotv2_assistant_status_failed')).toEqual(
+        expect.objectContaining({
+          error: 'set assistant status timed out after 25ms',
+          operation: 'set'
+        })
+      )
+    } finally {
+      releaseStatus()
+    }
+    await Promise.all(waits)
   })
 
   it('recovers unfinished render obligations from Chat SDK state on startup', async () => {
@@ -4082,6 +4137,7 @@ type PatchedSlackApi = {
   failRepliesWithThreadNotFound(channel: string, ts: string): void
   failStreamAppendsAfter(count: number, error: string): void
   failStreamStopsLongerThan(maxChars: number): void
+  holdAssistantStatus(): () => void
   reset(): void
   setUserProfile(userId: string, profile: Record<string, unknown>): void
   userProfileMethodRequestCount(userId: string, method: string): number
@@ -4123,13 +4179,22 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
   const userProfiles = new Map<string, Record<string, unknown>>()
   const userProfileRequests = new Map<string, number>()
   const threadNotFoundReplies = new Set<string>()
+  let assistantStatusGate: Promise<void> | null = null
+  let releaseAssistantStatusGate: (() => void) | null = null
   let maxStreamStopChars: number | null = null
   const appendFailure: { error: string; remaining: number } = { error: '', remaining: -1 }
   const streams = new Map<string, StreamRecord>()
+  const releaseCurrentAssistantStatusGate = () => {
+    const release = releaseAssistantStatusGate
+    assistantStatusGate = null
+    releaseAssistantStatusGate = null
+    release?.()
+  }
   const port = await availablePort(4053)
   const server = createServer((req, res) => {
     void handlePatchedSlackRequest(req, res, {
       appendFailure,
+      assistantStatusGate: () => assistantStatusGate,
       calls,
       maxStreamStopChars,
       port,
@@ -4162,7 +4227,15 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
     failStreamStopsLongerThan(maxChars: number) {
       maxStreamStopChars = maxChars
     },
+    holdAssistantStatus() {
+      if (assistantStatusGate) throw new Error('assistant status is already held')
+      assistantStatusGate = new Promise(resolve => {
+        releaseAssistantStatusGate = resolve
+      })
+      return releaseCurrentAssistantStatusGate
+    },
     reset() {
+      releaseCurrentAssistantStatusGate()
       calls.length = 0
       maxStreamStopChars = null
       appendFailure.remaining = -1
@@ -4191,6 +4264,7 @@ async function handlePatchedSlackRequest(
   res: ServerResponse,
   input: {
     appendFailure: { error: string; remaining: number }
+    assistantStatusGate: () => Promise<void> | null
     calls: StreamCall[]
     maxStreamStopChars: number | null
     port: number
@@ -4232,6 +4306,8 @@ async function handlePatchedSlackRequest(
   if (path === '/api/assistant.threads.setStatus') {
     const body = await requestBody(request)
     input.calls.push({ method: 'assistant.threads.setStatus', body })
+    const gate = input.assistantStatusGate()
+    if (gate) await gate
     await sendWebResponse(res, Response.json({ ok: true }))
     return
   }

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -4,6 +4,7 @@ import {
   clearRequesterIdentityCacheForTests,
   forwardToSessionApi,
   harnessRestartPreamble,
+  serializeAttachment,
   serializeMessage
 } from '../src/session-api'
 import { renderSlackDisplayText } from '../src/slack-display-text'
@@ -367,6 +368,24 @@ describe('Slack display text fallback', () => {
 
     expect(appendedTextParts(requests)).toContain(`continue (${slackUrl})`)
     expect(appendedTextParts(requests).join('\n')).not.toContain('Links included in the Slack message')
+  })
+})
+
+describe('Slack attachment serialization', () => {
+  test('records timeout errors when attachment fetchData hangs', async () => {
+    const fetchFn = (async () => Response.json({ ok: true })) as SlackbotV2Options['fetch']
+    const startedAt = Date.now()
+    const attachment = await serializeAttachment(
+      {
+        fetchData: () => new Promise<Buffer>(() => undefined),
+        name: 'hung.txt',
+        type: 'file'
+      } as Parameters<typeof serializeAttachment>[0],
+      { ...options(fetchFn), slackApiTimeoutMs: 25 }
+    )
+
+    expect(Date.now() - startedAt).toBeLessThan(500)
+    expect(attachment.fetchError).toBe('fetch Slack attachment timed out after 25ms')
   })
 })
 


### PR DESCRIPTION
## Summary

This keeps optional Slackbot v2 work out of the durable handoff path:

- start assistant status updates in the background instead of awaiting them before `syncThreadMessageToSession`
- make assistant status/title calls bounded by `slackApiTimeoutMs` and fail best-effort
- bound Slack thread context collection and harness-restart context rebuilds, falling back to the current message without marking full history as forwarded
- bound Slack attachment/file fetches so file enrichment records `fetchError` instead of stalling handoff

## Root Cause

The incident path could wedge before `POST /api/session/{thread_key}` because pre-session Slack UI/context work was awaited inline. A hung assistant status update or enrichment fetch could prevent durable session-create work from completing.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter slackbotv2 test`
- `pnpm --filter slackbotv2 run check:types`
- `git diff --check`