### PR TITLE
feat: expose tool CLI args in analytics

### DIFF
--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -427,6 +427,9 @@ import time
 
 INDEX = {str(index_path)!r}
 PYTHONPATH_VALUE = {pythonpath!r}
+MAX_ANALYTICS_ARGS = 32
+MAX_ANALYTICS_ARGS_LENGTH = 512
+TRUNCATION_SUFFIX = "..."
 
 
 def load():
@@ -514,7 +517,35 @@ def analytics_log_path():
     return "/proc/1/fd/2"
 
 
-def emit_tool_call_event(event, tool, method, started_at=None, returncode=None):
+def analytics_tool_args(args):
+    normalized = []
+    truncated = False
+    raw_args = list(args or [])
+    remaining_length = MAX_ANALYTICS_ARGS_LENGTH
+    for arg in raw_args[:MAX_ANALYTICS_ARGS]:
+        if remaining_length <= 0:
+            truncated = True
+            break
+        value = str(arg)
+        if len(value) > remaining_length:
+            truncated = True
+            if remaining_length <= len(TRUNCATION_SUFFIX):
+                value = TRUNCATION_SUFFIX[:remaining_length]
+            else:
+                value = value[: remaining_length - len(TRUNCATION_SUFFIX)] + TRUNCATION_SUFFIX
+            normalized.append(value)
+            remaining_length = 0
+            break
+        normalized.append(value)
+        remaining_length -= len(value)
+    if len(raw_args) > MAX_ANALYTICS_ARGS:
+        truncated = True
+    if len(normalized) < len(raw_args):
+        truncated = True
+    return normalized, len(raw_args), truncated
+
+
+def emit_tool_call_event(event, tool, method, tool_args=None, started_at=None, returncode=None):
     path = analytics_log_path()
     if path.lower() in {{"", "0", "false", "none", "off"}}:
         return
@@ -529,6 +560,12 @@ def emit_tool_call_event(event, tool, method, started_at=None, returncode=None):
         "tool_name": str(tool.get("name") or "unknown"),
         "tool_method": method,
     }}
+    if tool_args is not None:
+        normalized_args, arg_count, args_truncated = analytics_tool_args(tool_args)
+        payload["tool_args"] = normalized_args
+        payload["tool_args_count"] = arg_count
+        if args_truncated:
+            payload["tool_args_truncated"] = "true"
     thread_key = os.environ.get("CENTAUR_THREAD_KEY", "").strip()
     if thread_key:
         payload["thread_key"] = thread_key
@@ -548,16 +585,30 @@ def emit_tool_call_event(event, tool, method, started_at=None, returncode=None):
 def run_tool(tool, args):
     project_dir = Path(tool["project_dir"])
     started_at = time.monotonic()
-    emit_tool_call_event("tool_call_started", tool, "cli")
+    emit_tool_call_event("tool_call_started", tool, "cli", tool_args=args)
     try:
         returncode = subprocess.call(
             ["uvx", "--from", str(project_dir), tool["name"], *args],
             env=tool_env(),
         )
     except Exception:
-        emit_tool_call_event("tool_call_completed", tool, "cli", started_at, 1)
+        emit_tool_call_event(
+            "tool_call_completed",
+            tool,
+            "cli",
+            tool_args=args,
+            started_at=started_at,
+            returncode=1,
+        )
         raise
-    emit_tool_call_event("tool_call_completed", tool, "cli", started_at, returncode)
+    emit_tool_call_event(
+        "tool_call_completed",
+        tool,
+        "cli",
+        tool_args=args,
+        started_at=started_at,
+        returncode=returncode,
+    )
     return returncode
 
 
@@ -586,9 +637,21 @@ def call_tool(tool, method, payload):
             env=tool_env(),
         )
     except Exception:
-        emit_tool_call_event("tool_call_completed", tool, method, started_at, 1)
+        emit_tool_call_event(
+            "tool_call_completed",
+            tool,
+            method,
+            started_at=started_at,
+            returncode=1,
+        )
         raise
-    emit_tool_call_event("tool_call_completed", tool, method, started_at, result.returncode)
+    emit_tool_call_event(
+        "tool_call_completed",
+        tool,
+        method,
+        started_at=started_at,
+        returncode=result.returncode,
+    )
     return result
 
 

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -262,13 +262,43 @@ class GeneratedShimTest(unittest.TestCase):
                 self.assertEqual(event["component"], "tool_shim")
                 self.assertEqual(event["tool_name"], "websearch")
                 self.assertEqual(event["tool_method"], "cli")
+                self.assertEqual(event["tool_args"], ["lookup", "sensitive-payload"])
+                self.assertEqual(event["tool_args_count"], 2)
                 self.assertEqual(event["thread_key"], "cli:test-thread")
             self.assertEqual(analytics_events[1]["exit_code"], 0)
             self.assertEqual(analytics_events[1]["success"], "true")
             self.assertIn("duration_ms", analytics_events[1])
             serialized_analytics = json.dumps(analytics_events, sort_keys=True)
-            self.assertNotIn("lookup", serialized_analytics)
-            self.assertNotIn("sensitive-payload", serialized_analytics)
+            self.assertIn("lookup", serialized_analytics)
+            self.assertIn("sensitive-payload", serialized_analytics)
+
+            analytics_log.write_text("")
+            first_arg = "a" * 400
+            second_arg = "b" * 400
+            result = subprocess.run(
+                [
+                    str(bin_dir / "centaur-tools"),
+                    "run",
+                    "websearch",
+                    first_arg,
+                    second_arg,
+                ],
+                check=False,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            analytics_events = [
+                json.loads(line) for line in analytics_log.read_text().splitlines()
+            ]
+            for event in analytics_events:
+                self.assertEqual(event["tool_args_count"], 2)
+                self.assertEqual(event["tool_args"][0], first_arg)
+                self.assertEqual(event["tool_args"][1], ("b" * 109) + "...")
+                self.assertEqual(sum(len(arg) for arg in event["tool_args"]), 512)
+                self.assertEqual(event["tool_args_truncated"], "true")
 
             result = subprocess.run(
                 [str(bin_dir / "centaur-tools"), "exec", "websearch"],

--- a/tools/infra/vlogs/client.py
+++ b/tools/infra/vlogs/client.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+import shlex
 from typing import Any
 
 import httpx
@@ -224,6 +225,27 @@ class VictoriaLogsClient:
                 return 0.0
         return 0.0
 
+    @staticmethod
+    def _format_tool_args(value: Any) -> str:
+        if value is None:
+            return "(no args)"
+        if isinstance(value, list | tuple):
+            if not value:
+                return "(no args)"
+            return shlex.join(str(item) for item in value)
+        if isinstance(value, dict):
+            if not value:
+                return "(no args)"
+            return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+        text = str(value)
+        return text if text else "(no args)"
+
+    @classmethod
+    def _tool_args_label(cls, entry: dict) -> str:
+        if "tool_args" not in entry:
+            return "(not captured)"
+        return cls._format_tool_args(entry.get("tool_args"))
+
     @classmethod
     def _hits_step(cls, start: str) -> str:
         """Choose a reasonable bucket size for `/select/logsql/hits`."""
@@ -405,6 +427,9 @@ class VictoriaLogsClient:
             "_msg",
             "duration_ms",
             "success",
+            "tool_args",
+            "tool_args_count",
+            "tool_args_truncated",
             "tool_name",
             "tool_method",
             "thread_key",
@@ -493,6 +518,7 @@ class VictoriaLogsClient:
                 "calls": 0,
                 "failures": 0,
                 "total_duration_ms": 0,
+                "args": defaultdict(int),
                 "methods": defaultdict(int),
                 "threads": set(),
             }
@@ -502,6 +528,7 @@ class VictoriaLogsClient:
                 continue
             tool = entry.get("tool_name", "unknown")
             method = entry.get("tool_method", "unknown")
+            args = self._tool_args_label(entry)
             success = entry.get("success", "true") == "true"
             duration = round(self._coerce_float(entry.get("duration_ms", 0)))
             thread = entry.get("thread_key", "")
@@ -510,6 +537,7 @@ class VictoriaLogsClient:
             if not success:
                 stats[tool]["failures"] += 1
             stats[tool]["total_duration_ms"] += duration
+            stats[tool]["args"][args] += 1
             stats[tool]["methods"][method] += 1
             if thread:
                 stats[tool]["threads"].add(thread)
@@ -526,6 +554,9 @@ class VictoriaLogsClient:
                     "failure_rate_pct": failure_rate,
                     "avg_duration_ms": avg_ms,
                     "unique_threads": len(s["threads"]),
+                    "args": dict(
+                        sorted(s["args"].items(), key=lambda item: item[1], reverse=True)
+                    ),
                     "methods": dict(s["methods"]),
                 }
             )
@@ -550,12 +581,18 @@ class VictoriaLogsClient:
                 f"AND {_field_expr('thread_key', thread_key)}"
             )
             results = self.query(q, limit=limit, **self._time_params(start))
+            keep_fields = {
+                "_time",
+                "tool_args",
+                "tool_args_count",
+                "tool_args_truncated",
+                "tool_name",
+                "tool_method",
+                "duration_ms",
+                "success",
+            }
             return [
-                {
-                    k: v
-                    for k, v in self._clean_entry(e).items()
-                    if k in ("_time", "tool_name", "tool_method", "duration_ms", "success")
-                }
+                {k: v for k, v in self._clean_entry(e).items() if k in keep_fields}
                 for e in results
                 if "_note" not in e
             ]

--- a/tools/infra/vlogs/tests/test_client.py
+++ b/tools/infra/vlogs/tests/test_client.py
@@ -1,6 +1,23 @@
 from __future__ import annotations
 
-from vlogs.client import _field_expr, _quote_logsql_value
+from typing import Any
+
+from vlogs.client import VictoriaLogsClient, _field_expr, _quote_logsql_value
+
+
+class StubVictoriaLogsClient(VictoriaLogsClient):
+    def __init__(self, entries: list[dict[str, Any]]) -> None:
+        super().__init__(url="http://unused")
+        self.entries = entries
+
+    def query(
+        self,
+        query: str,
+        limit: int = 100,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> list[dict]:
+        return self.entries
 
 
 def test_quote_logsql_value_handles_slack_thread_key() -> None:
@@ -12,3 +29,96 @@ def test_quote_logsql_value_handles_slack_thread_key() -> None:
 
 def test_quote_logsql_value_escapes_quotes_and_backslashes() -> None:
     assert _quote_logsql_value('a"b\\c') == '"a\\"b\\\\c"'
+
+
+def test_tool_calls_exposes_tool_args() -> None:
+    client = StubVictoriaLogsClient(
+        [
+            {
+                "_time": "2026-06-29T12:00:00Z",
+                "_stream": "ignored",
+                "event": "tool_call_completed",
+                "tool_name": "websearch",
+                "tool_method": "cli",
+                "tool_args": ["lookup", "openai"],
+                "tool_args_count": 2,
+                "duration_ms": "42",
+                "success": "true",
+                "thread_key": "cli:test-thread",
+            }
+        ]
+    )
+
+    assert client.tool_calls() == [
+        {
+            "_time": "2026-06-29T12:00:00Z",
+            "duration_ms": "42",
+            "success": "true",
+            "tool_args": ["lookup", "openai"],
+            "tool_args_count": 2,
+            "tool_name": "websearch",
+            "tool_method": "cli",
+            "thread_key": "cli:test-thread",
+        }
+    ]
+
+
+def test_tool_analytics_counts_cli_arg_patterns() -> None:
+    client = StubVictoriaLogsClient(
+        [
+            {
+                "tool_name": "websearch",
+                "tool_method": "cli",
+                "tool_args": ["lookup", "openai"],
+                "duration_ms": "10",
+                "success": "true",
+                "thread_key": "cli:test-thread-a",
+            },
+            {
+                "tool_name": "websearch",
+                "tool_method": "cli",
+                "tool_args": ["lookup", "openai"],
+                "duration_ms": "20",
+                "success": "true",
+                "thread_key": "cli:test-thread-b",
+            },
+            {
+                "tool_name": "websearch",
+                "tool_method": "cli",
+                "tool_args": ["lookup", "anthropic"],
+                "duration_ms": "30",
+                "success": "false",
+                "thread_key": "cli:test-thread-b",
+            },
+            {
+                "tool_name": "slack",
+                "tool_method": "cli",
+                "tool_args": [],
+                "duration_ms": "5",
+                "success": "true",
+            },
+        ]
+    )
+
+    assert client.tool_analytics() == [
+        {
+            "tool": "websearch",
+            "calls": 3,
+            "failures": 1,
+            "failure_rate_pct": 33.3,
+            "avg_duration_ms": 20,
+            "unique_threads": 2,
+            "args": {"lookup openai": 2, "lookup anthropic": 1},
+            "methods": {"cli": 3},
+        },
+        {
+            "tool": "slack",
+            "calls": 1,
+            "failures": 0,
+            "failure_rate_pct": 0.0,
+            "avg_duration_ms": 5,
+            "unique_threads": 0,
+            "args": {"(no args)": 1},
+            "methods": {"cli": 1},
+        },
+    ]


### PR DESCRIPTION
## Summary
- emit bounded `tool_args` metadata from direct Centaur tool CLI shim analytics events
- surface `tool_args` in vlogs tool call history and per-thread usage
- aggregate tool analytics by CLI argument pattern in addition to method

## Tests
- `uv run --with ruff ruff check services/sandbox/install_tool_shims.py services/sandbox/test_install_tool_shims.py tools/infra/vlogs/client.py tools/infra/vlogs/tests/test_client.py`
- `uv run python -m unittest test_install_tool_shims.py`
- `PYTHONPATH=tools/infra uv run --no-project --with pytest --with httpx pytest tools/infra/vlogs/tests/test_client.py`
- `PYTHONPATH=tools/infra uv run --no-project --with pytest --with httpx pytest tools/infra/vlogs/test_client.py`