### PR TITLE
Fix workflow host api compat imports

### DIFF
--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import sys
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -36,6 +37,15 @@ class FakeRpc:
 
 
 class WorkflowHostTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        for name in [
+            "api",
+            "api.runtime_control",
+            "api.vm_metrics",
+            "api.workflow_engine",
+        ]:
+            sys.modules.pop(name, None)
+
     def test_workflow_result_includes_grouping_identifiers(self) -> None:
         host = load_workflow_host()
         pool = FakePool()
@@ -92,6 +102,21 @@ class WorkflowHostTests(unittest.TestCase):
         )
         self.assertTrue(rpc.drained)
         self.assertTrue(pool.closed)
+
+    def test_api_compat_marks_existing_api_module_as_package(self) -> None:
+        host = load_workflow_host()
+        api_module = types.ModuleType("api")
+        sys.modules["api"] = api_module
+
+        host.install_api_compat_module()
+
+        self.assertTrue(hasattr(api_module, "__path__"))
+        self.assertIs(sys.modules["api.runtime_control"], api_module.runtime_control)
+        self.assertIs(sys.modules["api.vm_metrics"], api_module.vm_metrics)
+        self.assertEqual(
+            host.canonical_json({"b": 1, "a": 2}),
+            '{"a":2,"b":1}',
+        )
 
 
 if __name__ == "__main__":

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import ast
 import dataclasses
+import importlib.machinery
 import importlib.util
 import inspect
 import json
@@ -218,8 +219,12 @@ def install_api_compat_module() -> None:
             api_mod = imported_api
         except ImportError:
             api_mod = types.ModuleType("api")
-            api_mod.__path__ = []  # Mark as package so compat submodules can import.
             sys.modules["api"] = api_mod
+    if not hasattr(api_mod, "__path__"):
+        # Some workflow-host environments have an unrelated top-level api.py on
+        # sys.path. Mark it as a namespace package so our compat submodules can
+        # satisfy imports like api.runtime_control and api.vm_metrics.
+        api_mod.__path__ = []  # type: ignore[attr-defined]
 
     workflow_engine = types.ModuleType("api.workflow_engine")
     workflow_engine.WorkflowContext = WorkflowContext
@@ -1160,7 +1165,13 @@ def discover_workflows() -> dict[str, RegisteredWorkflow]:
             try:
                 registered = load_workflow_file(path)
             except Exception as exc:
-                print(f"workflow_load_error path={path} error={exc}", file=sys.stderr)
+                print(
+                    "workflow_load_error "
+                    f"path={path} "
+                    f"error={exc} "
+                    f"diagnostics={json.dumps(workflow_import_diagnostics(dirs), sort_keys=True)}",
+                    file=sys.stderr,
+                )
                 continue
             if registered is None:
                 continue
@@ -1170,6 +1181,37 @@ def discover_workflows() -> dict[str, RegisteredWorkflow]:
                 raise RuntimeError(f"duplicate workflow name {registered.workflow_name!r}")
             discovered[registered.workflow_name] = registered
     return discovered
+
+
+def workflow_import_diagnostics(dirs: list[Path]) -> dict[str, Any]:
+    api_mod = sys.modules.get("api")
+    module_specs: dict[str, dict[str, Any] | None] = {}
+    for module_name in ("api", "api.runtime_control", "api.vm_metrics"):
+        try:
+            spec = importlib.util.find_spec(module_name)
+        except (ImportError, AttributeError, ValueError):
+            spec = None
+        module_specs[module_name] = import_spec_diagnostics(spec)
+    return {
+        "workflow_dirs": [str(path) for path in dirs],
+        "cwd": os.getcwd(),
+        "sys_path_head": sys.path[:8],
+        "api_module_file": getattr(api_mod, "__file__", None),
+        "api_module_is_package": hasattr(api_mod, "__path__"),
+        "module_specs": module_specs,
+    }
+
+
+def import_spec_diagnostics(
+    spec: importlib.machinery.ModuleSpec | None,
+) -> dict[str, Any] | None:
+    if spec is None:
+        return None
+    return {
+        "origin": spec.origin,
+        "is_package": spec.submodule_search_locations is not None,
+        "submodule_search_locations": list(spec.submodule_search_locations or []),
+    }
 
 
 def coerce_value(value: Any, target_type: type) -> Any:


### PR DESCRIPTION
## Summary
- mark an existing top-level `api` module as a package before installing workflow-host compat submodules
- include workflow import diagnostics in `workflow_load_error` logs
- add a regression test for the non-package `api` module case

## Validation
- `uv run python -m unittest services.workflow-python.tests.test_workflow_host`
- `WORKFLOW_DIRS=/home/agent/branches/paradigmxyz/centaur/workflows uv run services/workflow-python/workflow_host.py <<'EOF'
{"type":"workflow.discover"}
EOF`

Prompted by: mslipper