### PR TITLE
Remove api compat imports from Slack sync workflows

### DIFF
--- a/workflows/slack/backfill.py
+++ b/workflows/slack/backfill.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
-from api.vm_metrics import (
+from workflows.slack.compat import (
     record_etl_items_deleted,
     record_etl_items_enqueued,
     record_etl_items_failed,
@@ -29,7 +29,6 @@ from api.vm_metrics import (
     set_etl_backfill_job_age_seconds,
     set_etl_backfill_jobs,
 )
-from api.workflow_engine import WorkflowContext
 from workflows.slack.shared import (
     BACKFILL_JOB_CHANNEL_BOOTSTRAP,
     BACKFILL_JOB_CHANNEL_CONTINUATION,
@@ -204,7 +203,7 @@ def _watermark_lag_seconds(ts: str | None) -> float | None:
     return max((dt.datetime.now(dt.timezone.utc) - occurred_at).total_seconds(), 0.0)
 
 
-async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+async def handler(inp: Input, ctx: Any) -> dict[str, Any]:
     """Drain queued Slack backfill continuations in small, bounded batches."""
     started_at = time.monotonic()
     mode = "backfill"

--- a/workflows/slack/compat.py
+++ b/workflows/slack/compat.py
@@ -1,0 +1,122 @@
+"""Workflow-owned runtime helpers for Slack ETL.
+
+Slack ETL should be importable without the legacy Python ``api`` package. Metric
+helpers forward to the workflow host when it provides ``api.vm_metrics`` and
+otherwise become no-ops, which keeps local import/discovery paths lightweight.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _call_metric(name: str, *args: Any, **kwargs: Any) -> None:
+    try:
+        from api import vm_metrics  # type: ignore
+    except ImportError:
+        return
+
+    metric = getattr(vm_metrics, name, None)
+    if metric is None:
+        return
+    try:
+        metric(*args, **kwargs)
+    except Exception:
+        return
+
+
+def observe_slack_retention_run_duration(*args: Any, **kwargs: Any) -> None:
+    _call_metric("observe_slack_retention_run_duration", *args, **kwargs)
+
+
+def record_etl_items_deleted(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_etl_items_deleted", *args, **kwargs)
+
+
+def record_etl_items_enqueued(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_etl_items_enqueued", *args, **kwargs)
+
+
+def record_etl_items_failed(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_etl_items_failed", *args, **kwargs)
+
+
+def record_etl_items_seen(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_etl_items_seen", *args, **kwargs)
+
+
+def record_etl_items_upserted(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_etl_items_upserted", *args, **kwargs)
+
+
+def record_slack_etl_rate_limit(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_etl_rate_limit", *args, **kwargs)
+
+
+def record_slack_retention_api_rate_limited(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_retention_api_rate_limited", *args, **kwargs)
+
+
+def record_slack_retention_api_request(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_retention_api_request", *args, **kwargs)
+
+
+def record_slack_retention_backfill_job(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_retention_backfill_job", *args, **kwargs)
+
+
+def record_slack_retention_backfill_job_failure(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_retention_backfill_job_failure", *args, **kwargs)
+
+
+def record_slack_retention_backfill_terminal_skip(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_retention_backfill_terminal_skip", *args, **kwargs)
+
+
+def record_slack_retention_channel_failure(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_retention_channel_failure", *args, **kwargs)
+
+
+def record_slack_retention_failure(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_retention_failure", *args, **kwargs)
+
+
+def record_slack_retention_messages_processed(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_retention_messages_processed", *args, **kwargs)
+
+
+def record_slack_retention_run(*args: Any, **kwargs: Any) -> None:
+    _call_metric("record_slack_retention_run", *args, **kwargs)
+
+
+def set_etl_active_scopes(*args: Any, **kwargs: Any) -> None:
+    _call_metric("set_etl_active_scopes", *args, **kwargs)
+
+
+def set_etl_backfill_job_age_seconds(*args: Any, **kwargs: Any) -> None:
+    _call_metric("set_etl_backfill_job_age_seconds", *args, **kwargs)
+
+
+def set_etl_backfill_jobs(*args: Any, **kwargs: Any) -> None:
+    _call_metric("set_etl_backfill_jobs", *args, **kwargs)
+
+
+def set_etl_failed_scopes(*args: Any, **kwargs: Any) -> None:
+    _call_metric("set_etl_failed_scopes", *args, **kwargs)
+
+
+def set_etl_scope_sync_freshness_seconds(*args: Any, **kwargs: Any) -> None:
+    _call_metric("set_etl_scope_sync_freshness_seconds", *args, **kwargs)
+
+
+def set_slack_retention_last_failure_timestamp(*args: Any, **kwargs: Any) -> None:
+    _call_metric("set_slack_retention_last_failure_timestamp", *args, **kwargs)
+
+
+def set_slack_retention_watermark_lag_seconds(*args: Any, **kwargs: Any) -> None:
+    _call_metric("set_slack_retention_watermark_lag_seconds", *args, **kwargs)

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -15,8 +15,8 @@ from urllib import error as urllib_error
 from urllib import request as urllib_request
 
 from centaur_sdk import secret
-from api.runtime_control import canonical_json
-from api.vm_metrics import (
+from workflows.slack.compat import (
+    canonical_json,
     record_slack_etl_rate_limit,
     set_etl_active_scopes,
     set_etl_failed_scopes,

--- a/workflows/slack/sync.py
+++ b/workflows/slack/sync.py
@@ -9,8 +9,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
-from api.runtime_control import canonical_json
-from api.vm_metrics import (
+from workflows.slack.compat import (
+    canonical_json,
     record_etl_items_enqueued,
     record_etl_items_failed,
     record_etl_items_seen,
@@ -25,7 +25,6 @@ from api.vm_metrics import (
     set_slack_retention_last_failure_timestamp,
     set_slack_retention_watermark_lag_seconds,
 )
-from api.workflow_engine import WorkflowContext
 from workflows.slack.shared import (
     BACKFILL_JOB_CHANNEL_BOOTSTRAP,
     BACKFILL_JOB_CHANNEL_CONTINUATION,
@@ -329,7 +328,7 @@ async def _update_checkpoint_failure(
     )
 
 
-async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+async def handler(inp: Input, ctx: Any) -> dict[str, Any]:
     """Sync public Slack channels visible through the configured ETL user token."""
     started_at = time.monotonic()
     mode = "incremental"

--- a/workflows/slack/tests/test_sync_cold_start.py
+++ b/workflows/slack/tests/test_sync_cold_start.py
@@ -8,6 +8,12 @@ import types
 from pathlib import Path
 
 
+def _clear_api_modules():
+    for name in list(sys.modules):
+        if name == "api" or name.startswith("api."):
+            del sys.modules[name]
+
+
 def _load_sync():
     repo_root = Path(__file__).resolve().parents[3]
     if str(repo_root) not in sys.path:
@@ -53,6 +59,32 @@ def _load_sync():
     centaur_sdk.secret = lambda _name, default=None: default
 
     return importlib.import_module("workflows.slack.sync")
+
+
+def test_sync_and_backfill_import_without_api_compat_modules(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    _clear_api_modules()
+    for name in (
+        "workflows.slack.compat",
+        "workflows.slack.shared",
+        "workflows.slack.sync",
+        "workflows.slack.backfill",
+    ):
+        sys.modules.pop(name, None)
+
+    centaur_sdk = types.ModuleType("centaur_sdk")
+    centaur_sdk.secret = lambda _name, default=None: default
+    monkeypatch.setitem(sys.modules, "centaur_sdk", centaur_sdk)
+
+    sync = importlib.import_module("workflows.slack.sync")
+    backfill = importlib.import_module("workflows.slack.backfill")
+
+    assert sync.WORKFLOW_NAME == "slack_sync"
+    assert backfill.WORKFLOW_NAME == "slack_backfill"
+    assert "api" not in sys.modules
 
 
 class FakeContext:


### PR DESCRIPTION
## Summary
- Add a Slack ETL-local compat helper for canonical JSON and lazy metric forwarding
- Update `slack_sync`, `slack_backfill`, and shared Slack ETL helpers to avoid import-time `api.*` dependencies
- Add a regression test that imports sync/backfill with no `api` modules installed

Prompted by: mslipper

## Tests
- `uv run --with pytest pytest workflows/slack/tests`
- `WORKFLOW_DIRS=/home/agent/branches/paradigmxyz/centaur/workflows uv run services/workflow-python/workflow_host.py` with `workflow.discover` input
