### PR TITLE
Materialize Slack image attachments

### DIFF
--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -1546,4 +1546,32 @@ mod tests {
         assert!(text.starts_with("[Attached file saved to "));
         assert!(text.ends_with("notes.txt]"));
     }
+
+    #[test]
+    fn inline_image_attachment_block_becomes_local_image_input() {
+        let _upload_dir = temp_upload_dir();
+        let mut state = BlocksState::default();
+        let user = r#"{"type":"user","message":{"role":"user","content":[{"type":"attachment","attachment_type":"image","dataBase64":"aGVsbG8=","name":"image.png","mimeType":"image/png","size":5}]}}"#;
+        let BlocksCommand::User { input, .. } =
+            parse_blocks_line_with_state(user, &mut state).expect("user parses")
+        else {
+            panic!("expected user command");
+        };
+
+        assert_eq!(input.len(), 2);
+        let UserInput::Text { text, .. } = &input[0] else {
+            panic!("expected image attachment notice");
+        };
+        assert!(text.starts_with("[Attached image saved to "));
+        assert!(text.ends_with("image.png]"));
+
+        let UserInput::LocalImage { path, .. } = &input[1] else {
+            panic!("expected inline image attachment to become a local image");
+        };
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("image.png")
+        );
+        assert_eq!(std::fs::read(path).expect("read image bytes"), b"hello");
+    }
 }

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1623,18 +1623,6 @@ function codexAttachmentInput(
       size: attachment.size
     }
   }
-  const dataUrl =
-    attachment.dataBase64 && attachment.mimeType
-      ? `data:${attachment.mimeType};base64,${attachment.dataBase64}`
-      : undefined
-  if (attachment.type === 'image' && (dataUrl || attachment.url)) {
-    return {
-      type: 'image',
-      url: dataUrl ?? attachment.url,
-      detail: 'auto',
-      name: attachment.name
-    }
-  }
   if (attachment.dataBase64) {
     return {
       type: 'attachment',

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -268,7 +268,22 @@ describe('slackbotv2', () => {
         thread_key: threadKey(parent.ts)
       })
     )
-    expect(JSON.stringify(firstInputLine)).toContain('data:image/png;base64')
+    expect(firstInputLine).toEqual(
+      expect.objectContaining({
+        message: expect.objectContaining({
+          content: expect.arrayContaining([
+            expect.objectContaining({
+              attachment_type: 'image',
+              dataBase64: Buffer.from('captured-image').toString('base64'),
+              mimeType: 'image/png',
+              name: 'captured.png',
+              type: 'attachment'
+            })
+          ])
+        })
+      })
+    )
+    expect(JSON.stringify(firstInputLine)).not.toContain('data:image/png;base64')
 
     const followUpAppend = codexApi.appends[1]!
     expect(followUpAppend.threadKey).toBe(threadKey(parent.ts))
@@ -430,9 +445,10 @@ describe('slackbotv2', () => {
     const executeInput = JSON.stringify(JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!))
     expect(executeInput).toContain('Screenshot is attached here.')
     expect(executeInput).toContain('Earlier Slack thread attachment')
-    expect(executeInput).toContain(
-      `data:image/png;base64,${Buffer.from('captured-image').toString('base64')}`
-    )
+    expect(executeInput).toContain('"attachment_type":"image"')
+    expect(executeInput).toContain('"type":"attachment"')
+    expect(executeInput).toContain(`"dataBase64":"${Buffer.from('captured-image').toString('base64')}"`)
+    expect(executeInput).not.toContain('data:image/png;base64')
   })
 
   it('injects Slack requester identity and verified GitHub handle into Codex input', async () => {


### PR DESCRIPTION
## Summary
- send Slack image attachments through the same attachment block path as other files instead of inline data-url image content
- update Slackbotv2 tests to assert image attachments reach execute input as attachment blocks
- add harness-server coverage that inline image attachment blocks are saved and exposed as LocalImage inputs

## Tests
- cargo test --manifest-path crates/harness-server/Cargo.toml attachment_block
- bun test services/slackbotv2/test/chat-sdk-emulate.test.ts
- pnpm --filter slackbotv2 check:types

Prompted by: @akshaan