### PR TITLE
fix: expose ETL toggles under apiRs values

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.79
+version: 0.1.80
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -52,6 +52,45 @@
 {{- $apiRsMetricsAnnotations = dict "prometheus.io/scrape" "true" "prometheus.io/path" .Values.apiRs.metrics.path "prometheus.io/port" (printf "%v" .Values.apiRs.port) -}}
 {{- $apiRsMetricsAnnotations = mergeOverwrite $apiRsMetricsAnnotations (.Values.apiRs.metrics.annotations | default dict) -}}
 {{- end -}}
+{{- $apiRsEtl := .Values.apiRs.etl | default dict -}}
+{{- $apiRsEtlEnv := list
+  (dict "name" "SLACK_ETL_ENABLED" "value" (dig "slack" "enabled" false $apiRsEtl))
+  (dict "name" "SLACK_SYNC_INTERVAL_SECONDS" "value" (dig "slack" "syncIntervalSeconds" 3600 $apiRsEtl))
+  (dict "name" "SLACK_SYNC_BACKFILL_LOOKBACK_DAYS" "value" (dig "slack" "syncBackfillLookbackDays" 30 $apiRsEtl))
+  (dict "name" "SLACK_SYNC_THREAD_LOOKBACK_DAYS" "value" (dig "slack" "syncThreadLookbackDays" 3 $apiRsEtl))
+  (dict "name" "SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS" "value" (dig "slack" "excludedChannelPatterns" "" $apiRsEtl))
+  (dict "name" "SLACK_ETL_ATTACHMENTS_ENABLED" "value" (dig "slack" "attachments" "enabled" true $apiRsEtl))
+  (dict "name" "SLACK_ETL_ATTACHMENT_MAX_BYTES" "value" (dig "slack" "attachments" "maxBytes" 10485760 $apiRsEtl))
+  (dict "name" "SLACK_BACKFILL_ENABLED" "value" (dig "slack" "backfill" "enabled" true $apiRsEtl))
+  (dict "name" "SLACK_BACKFILL_INTERVAL_SECONDS" "value" (dig "slack" "backfill" "intervalSeconds" 600 $apiRsEtl))
+  (dict "name" "SLACK_BACKFILL_CHANNEL_BATCH_LIMIT" "value" (dig "slack" "backfill" "channelBatchLimit" 50 $apiRsEtl))
+  (dict "name" "SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB" "value" (dig "slack" "backfill" "channelPagesPerJob" 5 $apiRsEtl))
+  (dict "name" "SLACK_RETENTION_ENABLED" "value" (dig "slack" "retention" "enabled" true $apiRsEtl))
+  (dict "name" "SLACK_RETENTION_INTERVAL_MINUTES" "value" (dig "slack" "retention" "intervalMinutes" 60 $apiRsEtl))
+  (dict "name" "SLACK_ETL_RETENTION_DAYS" "value" (dig "slack" "retention" "etlDays" 0 $apiRsEtl))
+  (dict "name" "SLACK_DM_RETENTION_DAYS" "value" (dig "slack" "retention" "dmDays" 0 $apiRsEtl))
+  (dict "name" "LINEAR_ETL_ENABLED" "value" (dig "linear" "enabled" false $apiRsEtl))
+  (dict "name" "LINEAR_SYNC_INTERVAL_SECONDS" "value" (dig "linear" "syncIntervalSeconds" 14400 $apiRsEtl))
+  (dict "name" "GOOGLE_DRIVE_ETL_ENABLED" "value" (dig "googleDrive" "enabled" false $apiRsEtl))
+  (dict "name" "GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS" "value" (dig "googleDrive" "syncIntervalSeconds" 14400 $apiRsEtl))
+  (dict "name" "GOOGLE_CALENDAR_ETL_ENABLED" "value" (dig "googleCalendar" "enabled" false $apiRsEtl))
+  (dict "name" "GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS" "value" (dig "googleCalendar" "syncIntervalSeconds" 14400 $apiRsEtl))
+  (dict "name" "COMPANY_CONTEXT_DOCUMENTS_ENABLED" "value" (dig "companyContextDocuments" "enabled" true $apiRsEtl))
+  (dict "name" "COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS" "value" (dig "companyContextDocuments" "intervalSeconds" 14400 $apiRsEtl))
+-}}
+{{- $apiRsEtlPassthroughNames := list -}}
+{{- range $env := $apiRsEtlEnv -}}
+{{- $apiRsEtlPassthroughNames = append $apiRsEtlPassthroughNames $env.name -}}
+{{- end -}}
+{{- with (get .Values.apiRs.extraEnv "SESSION_SANDBOX_PASSTHROUGH_ENV") -}}
+{{- range $name := splitList "," (toString .) -}}
+{{- $trimmedName := trim $name -}}
+{{- if $trimmedName -}}
+{{- $apiRsEtlPassthroughNames = append $apiRsEtlPassthroughNames $trimmedName -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $apiRsEtlPassthroughNames = uniq $apiRsEtlPassthroughNames -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -174,6 +213,17 @@ spec:
             - name: WORKFLOW_ALLOWED_NAMES
               value: {{ .Values.apiRs.workflowAllowedNames | quote }}
 {{- end }}
+{{- range $env := $apiRsEtlEnv }}
+{{- if not (hasKey $.Values.apiRs.extraEnv $env.name) }}
+            - name: {{ $env.name }}
+              value: {{ $env.value | toString | quote }}
+{{- end }}
+{{- end }}
+            # Forward the chart-rendered ETL workflow config into workflow-host
+            # sandboxes. Operators should set apiRs.etl.* values, not maintain
+            # SESSION_SANDBOX_PASSTHROUGH_ENV by hand.
+            - name: SESSION_SANDBOX_PASSTHROUGH_ENV
+              value: {{ join "," $apiRsEtlPassthroughNames | quote }}
 {{- if .Values.overlay.systemPrompt }}
             - name: CENTAUR_OVERLAY_DIR
               value: {{ .Values.overlay.mountPath | quote }}
@@ -345,8 +395,10 @@ spec:
 {{- end }}
 {{- end }}
 {{- range $name, $value := .Values.apiRs.extraEnv }}
+{{- if ne $name "SESSION_SANDBOX_PASSTHROUGH_ENV" }}
             - name: {{ $name }}
               value: {{ $value | quote }}
+{{- end }}
 {{- end }}
           envFrom:
             - secretRef:

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -242,6 +242,74 @@
       "type": "object",
       "properties": {
         "syncInfraSecrets": { "type": "boolean" },
+        "etl": {
+          "type": "object",
+          "properties": {
+            "slack": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "syncIntervalSeconds": { "type": "integer" },
+                "syncBackfillLookbackDays": { "type": "integer" },
+                "syncThreadLookbackDays": { "type": "integer" },
+                "excludedChannelPatterns": { "type": "string" },
+                "attachments": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "maxBytes": { "type": "integer" }
+                  }
+                },
+                "backfill": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "intervalSeconds": { "type": "integer" },
+                    "channelBatchLimit": { "type": "integer" },
+                    "channelPagesPerJob": { "type": "integer" }
+                  }
+                },
+                "retention": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "intervalMinutes": { "type": "integer" },
+                    "etlDays": { "type": "integer" },
+                    "dmDays": { "type": "integer" }
+                  }
+                }
+              }
+            },
+            "linear": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "syncIntervalSeconds": { "type": "integer" }
+              }
+            },
+            "googleDrive": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "syncIntervalSeconds": { "type": "integer" }
+              }
+            },
+            "googleCalendar": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "syncIntervalSeconds": { "type": "integer" }
+              }
+            },
+            "companyContextDocuments": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "intervalSeconds": { "type": "integer" }
+              }
+            }
+          }
+        },
         "metrics": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -308,6 +308,41 @@ apiRs:
   # in workflowAllowedNames as a comma/whitespace-separated string.
   workflowEnableMode: all
   workflowAllowedNames: ""
+  # Scheduled ETL workflow configuration. The chart renders these into api-rs
+  # env so workflow discovery sees the right schedules, then derives the
+  # workflow-host passthrough list from the same non-secret config.
+  etl:
+    slack:
+      enabled: false
+      syncIntervalSeconds: 3600
+      syncBackfillLookbackDays: 30
+      syncThreadLookbackDays: 3
+      excludedChannelPatterns: ""
+      attachments:
+        enabled: true
+        maxBytes: 10485760
+      backfill:
+        enabled: true
+        intervalSeconds: 600
+        channelBatchLimit: 50
+        channelPagesPerJob: 5
+      retention:
+        enabled: true
+        intervalMinutes: 60
+        etlDays: 0
+        dmDays: 0
+    linear:
+      enabled: false
+      syncIntervalSeconds: 14400
+    googleDrive:
+      enabled: false
+      syncIntervalSeconds: 14400
+    googleCalendar:
+      enabled: false
+      syncIntervalSeconds: 14400
+    companyContextDocuments:
+      enabled: true
+      intervalSeconds: 14400
   # Reaper: stop sandboxes idle-paused longer than the idle TTL or older than
   # the max lifetime. 0 disables that sweep. Interval must be >= 1.
   sandboxIdleStopTtlSecs: 10800 # 3 hours

--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -6,7 +6,7 @@ description: Sync Slack channel history into Postgres, drain historical backfill
 # Slack ETL
 
 :::warning[Off by default in production]
-Slack ETL is disabled unless the API service has `SLACK_ETL_ENABLED=true`.
+Slack ETL is disabled unless Helm values set `apiRs.etl.slack.enabled=true`.
 Production deployments should enable it deliberately after choosing the Slack
 token, channel scope, exclusion patterns, and data boundary they want agents to
 use.
@@ -58,8 +58,17 @@ events.
 
 ## Enable the schedules
 
-Set `SLACK_ETL_ENABLED=true` on the API service. The other schedules default on
-once Slack ETL is enabled, but can be tuned independently.
+Set `apiRs.etl.slack.enabled=true` in Helm values. The chart renders the
+corresponding API and workflow-host env automatically; do not set
+`SESSION_SANDBOX_PASSTHROUGH_ENV` by hand for these ETLs. The other schedules
+default on once Slack ETL is enabled, but can be tuned independently.
+
+```yaml
+apiRs:
+  etl:
+    slack:
+      enabled: true
+```
 
 | Environment variable | Default | Effect |
 |----------------------|---------|--------|
@@ -244,7 +253,7 @@ setting alerts.
 | Symptom | What to check |
 |---------|---------------|
 | Schedules are missing | Confirm `WORKFLOW_DIRS` includes `/app/workflows` and the API restarted after the workflow files were deployed. |
-| Schedules exist but are disabled | Confirm `SLACK_ETL_ENABLED=true` is present in the API environment. |
+| Schedules exist but are disabled | Confirm Helm values set `apiRs.etl.slack.enabled=true` and the API pod was restarted. |
 | `slack_sync` skips with `no_public_channels` | Confirm the ETL user token can see the expected public channels. |
 | Channels are all skipped | Check `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` for broad globs. |
 | Checkpoints show `missing_scope` or `not_allowed_token_type` | Add the missing Slack OAuth scope or use the expected user-token class. |

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -209,22 +209,29 @@ Slack ETL workflows:
 
 | Env var | Set from | Controls |
 | --- | --- | --- |
-| `SLACK_ETL_ENABLED` | `api.slackEtlEnabled`. | Master switch for Slack sync/backfill/context schedules. |
-| `SLACK_SYNC_INTERVAL_SECONDS`, `SLACK_BACKFILL_INTERVAL_SECONDS`, `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `api.*IntervalSeconds`. | Slack ETL schedule intervals. |
-| `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS`, `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `api.slackSync*LookbackDays`. | Slack history/thread lookback windows. |
-| `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | `api.slackEtlExcludedChannelPatterns`. | Comma-separated channel-name globs to skip. |
-| `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `api.extraEnv` or chart batch limit. | Backfill enablement and batch sizing. |
-| `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `api.extraEnv`. | Slack retention cadence and separate public ETL/DM TTLs. |
-| `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `api.extraEnv`. | Enables company-context projection when Slack ETL is on. |
+| `SLACK_ETL_ENABLED` | `apiRs.etl.slack.enabled`. | Master switch for Slack sync/backfill/context schedules. |
+| `SLACK_SYNC_INTERVAL_SECONDS`, `SLACK_BACKFILL_INTERVAL_SECONDS`, `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `apiRs.etl.slack.syncIntervalSeconds`, `apiRs.etl.slack.backfill.intervalSeconds`, `apiRs.etl.companyContextDocuments.intervalSeconds`. | Slack ETL schedule intervals. |
+| `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS`, `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `apiRs.etl.slack.syncBackfillLookbackDays`, `apiRs.etl.slack.syncThreadLookbackDays`. | Slack history/thread lookback windows. |
+| `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | `apiRs.etl.slack.excludedChannelPatterns`. | Comma-separated channel-name globs to skip. |
+| `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `apiRs.etl.slack.backfill.*`. | Backfill enablement and batch sizing. |
+| `SLACK_RETENTION_ENABLED`, `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `apiRs.etl.slack.retention.*`. | Slack retention enablement, cadence, and separate public ETL/DM TTLs. |
+| `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `apiRs.etl.companyContextDocuments.enabled`. | Enables company-context projection when any ETL is on. |
 
 Google Workspace ETL workflows:
 
 | Env var | Set from | Controls |
 | --- | --- | --- |
-| `GOOGLE_DRIVE_ETL_ENABLED` | `api.googleDriveEtlEnabled`. | Enables Google Drive Docs sync. |
-| `GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS` | `api.googleDriveSyncIntervalSeconds`. | Google Drive Docs sync schedule interval. |
-| `GOOGLE_CALENDAR_ETL_ENABLED` | `api.googleCalendarEtlEnabled`. | Enables Google Calendar sync. |
-| `GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS` | `api.googleCalendarSyncIntervalSeconds`. | Google Calendar sync schedule interval. |
+| `GOOGLE_DRIVE_ETL_ENABLED` | `apiRs.etl.googleDrive.enabled`. | Enables Google Drive Docs sync. |
+| `GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS` | `apiRs.etl.googleDrive.syncIntervalSeconds`. | Google Drive Docs sync schedule interval. |
+| `GOOGLE_CALENDAR_ETL_ENABLED` | `apiRs.etl.googleCalendar.enabled`. | Enables Google Calendar sync. |
+| `GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS` | `apiRs.etl.googleCalendar.syncIntervalSeconds`. | Google Calendar sync schedule interval. |
+
+Linear ETL workflows:
+
+| Env var | Set from | Controls |
+| --- | --- | --- |
+| `LINEAR_ETL_ENABLED` | `apiRs.etl.linear.enabled`. | Enables Linear project/issue/comment sync. |
+| `LINEAR_SYNC_INTERVAL_SECONDS` | `apiRs.etl.linear.syncIntervalSeconds`. | Linear sync schedule interval. |
 
 ## Observability and Retention
 

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -6,7 +6,7 @@ description: Sync Slack channel history into Postgres, drain historical backfill
 # Slack ETL
 
 :::warning[Off by default in production]
-Slack ETL is disabled unless the API service has `SLACK_ETL_ENABLED=true`.
+Slack ETL is disabled unless Helm values set `apiRs.etl.slack.enabled=true`.
 Production deployments should enable it deliberately after choosing the Slack
 token, channel scope, exclusion patterns, and data boundary they want agents to
 use.
@@ -58,8 +58,17 @@ events.
 
 ## Enable the schedules
 
-Set `SLACK_ETL_ENABLED=true` on the API service. The other schedules default on
-once Slack ETL is enabled, but can be tuned independently.
+Set `apiRs.etl.slack.enabled=true` in Helm values. The chart renders the
+corresponding API and workflow-host env automatically; do not set
+`SESSION_SANDBOX_PASSTHROUGH_ENV` by hand for these ETLs. The other schedules
+default on once Slack ETL is enabled, but can be tuned independently.
+
+```yaml
+apiRs:
+  etl:
+    slack:
+      enabled: true
+```
 
 | Environment variable | Default | Effect |
 |----------------------|---------|--------|
@@ -244,7 +253,7 @@ setting alerts.
 | Symptom | What to check |
 |---------|---------------|
 | Schedules are missing | Confirm `WORKFLOW_DIRS` includes `/app/workflows` and the API restarted after the workflow files were deployed. |
-| Schedules exist but are disabled | Confirm `SLACK_ETL_ENABLED=true` is present in the API environment. |
+| Schedules exist but are disabled | Confirm Helm values set `apiRs.etl.slack.enabled=true` and the API pod was restarted. |
 | `slack_sync` skips with `no_public_channels` | Confirm the ETL user token can see the expected public channels. |
 | Channels are all skipped | Check `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` for broad globs. |
 | Checkpoints show `missing_scope` or `not_allowed_token_type` | Add the missing Slack OAuth scope or use the expected user-token class. |

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -211,22 +211,29 @@ Slack ETL workflows:
 
 | Env var | Set from | Controls |
 | --- | --- | --- |
-| `SLACK_ETL_ENABLED` | `api.slackEtlEnabled`. | Master switch for Slack sync/backfill/context schedules. |
-| `SLACK_SYNC_INTERVAL_SECONDS`, `SLACK_BACKFILL_INTERVAL_SECONDS`, `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `api.*IntervalSeconds`. | Slack ETL schedule intervals. |
-| `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS`, `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `api.slackSync*LookbackDays`. | Slack history/thread lookback windows. |
-| `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | `api.slackEtlExcludedChannelPatterns`. | Comma-separated channel-name globs to skip. |
-| `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `api.extraEnv` or chart batch limit. | Backfill enablement and batch sizing. |
-| `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `api.extraEnv`. | Slack retention cadence and separate public ETL/DM TTLs. |
-| `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `api.extraEnv`. | Enables company-context projection when Slack ETL is on. |
+| `SLACK_ETL_ENABLED` | `apiRs.etl.slack.enabled`. | Master switch for Slack sync/backfill/context schedules. |
+| `SLACK_SYNC_INTERVAL_SECONDS`, `SLACK_BACKFILL_INTERVAL_SECONDS`, `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `apiRs.etl.slack.syncIntervalSeconds`, `apiRs.etl.slack.backfill.intervalSeconds`, `apiRs.etl.companyContextDocuments.intervalSeconds`. | Slack ETL schedule intervals. |
+| `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS`, `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `apiRs.etl.slack.syncBackfillLookbackDays`, `apiRs.etl.slack.syncThreadLookbackDays`. | Slack history/thread lookback windows. |
+| `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | `apiRs.etl.slack.excludedChannelPatterns`. | Comma-separated channel-name globs to skip. |
+| `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `apiRs.etl.slack.backfill.*`. | Backfill enablement and batch sizing. |
+| `SLACK_RETENTION_ENABLED`, `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `apiRs.etl.slack.retention.*`. | Slack retention enablement, cadence, and separate public ETL/DM TTLs. |
+| `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `apiRs.etl.companyContextDocuments.enabled`. | Enables company-context projection when any ETL is on. |
 
 Google Workspace ETL workflows:
 
 | Env var | Set from | Controls |
 | --- | --- | --- |
-| `GOOGLE_DRIVE_ETL_ENABLED` | `api.googleDriveEtlEnabled`. | Enables Google Drive Docs sync. |
-| `GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS` | `api.googleDriveSyncIntervalSeconds`. | Google Drive Docs sync schedule interval. |
-| `GOOGLE_CALENDAR_ETL_ENABLED` | `api.googleCalendarEtlEnabled`. | Enables Google Calendar sync. |
-| `GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS` | `api.googleCalendarSyncIntervalSeconds`. | Google Calendar sync schedule interval. |
+| `GOOGLE_DRIVE_ETL_ENABLED` | `apiRs.etl.googleDrive.enabled`. | Enables Google Drive Docs sync. |
+| `GOOGLE_DRIVE_SYNC_INTERVAL_SECONDS` | `apiRs.etl.googleDrive.syncIntervalSeconds`. | Google Drive Docs sync schedule interval. |
+| `GOOGLE_CALENDAR_ETL_ENABLED` | `apiRs.etl.googleCalendar.enabled`. | Enables Google Calendar sync. |
+| `GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS` | `apiRs.etl.googleCalendar.syncIntervalSeconds`. | Google Calendar sync schedule interval. |
+
+Linear ETL workflows:
+
+| Env var | Set from | Controls |
+| --- | --- | --- |
+| `LINEAR_ETL_ENABLED` | `apiRs.etl.linear.enabled`. | Enables Linear project/issue/comment sync. |
+| `LINEAR_SYNC_INTERVAL_SECONDS` | `apiRs.etl.linear.syncIntervalSeconds`. | Linear sync schedule interval. |
 
 ## Observability and Retention
 


### PR DESCRIPTION
## Summary
- add apiRs.etl values for Slack, Linear, Google Drive, Google Calendar, and company-context document ETLs
- render ETL env vars for api-rs workflow discovery and derive workflow-host passthrough from the same chart mapping
- update Slack ETL and configuration docs to point operators at apiRs.etl.* instead of raw env plumbing

## Tests
- helm lint contrib/chart
- helm template centaur contrib/chart -n centaur --set apiRs.etl.slack.enabled=true --set apiRs.etl.linear.enabled=true --set apiRs.etl.googleDrive.enabled=true --set apiRs.etl.googleCalendar.enabled=true --set apiRs.etl.slack.backfill.channelBatchLimit=7
- helm template centaur contrib/chart -n centaur --set apiRs.etl.slack.enabled=true --set-string apiRs.extraEnv.SLACK_ETL_ENABLED=custom --set-string 'apiRs.extraEnv.SESSION_SANDBOX_PASSTHROUGH_ENV=EXTRA_ONE\,SLACK_ETL_ENABLED'
- cargo test -p centaur-api-server workflow_host_env_template_splits_passthrough_env_from_environment
- git diff --check