### PR TITLE
fix: make `centaur_sdk` importable without rich

### DIFF
--- a/centaur_sdk/__init__.py
+++ b/centaur_sdk/__init__.py
@@ -8,7 +8,8 @@ Public API:
 
 from __future__ import annotations
 
-from centaur_sdk.cli_tables import Table, render_text_table
+from typing import Any
+
 from centaur_sdk.tool_sdk import (
     ToolContext,
     current_session_context,
@@ -36,3 +37,11 @@ __all__ = [
     "secret",
     "set_tool_context",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in ("Table", "render_text_table"):
+        from centaur_sdk import cli_tables
+
+        return getattr(cli_tables, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/centaur_sdk/cli_tables.py
+++ b/centaur_sdk/cli_tables.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from rich.table import Table as RichTable
+from typing import Any
 
-Table = RichTable
+
+def __getattr__(name: str) -> Any:
+    if name == "Table":
+        from rich.table import Table as RichTable
+
+        return RichTable
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def render_text_table(headers: list[str], rows: list[list[str]]) -> str:

--- a/centaur_sdk/tests/test_import_without_rich.py
+++ b/centaur_sdk/tests/test_import_without_rich.py
@@ -1,0 +1,52 @@
+"""Regression: the SDK must import in the isolated tool runner, which has no `rich`.
+
+Centaur's generated tool runner imports `centaur_sdk.tool_sdk` with PYTHONPATH
+pointing at /opt/centaur, inside a uvx env built from the tool's own (often
+stdlib-only) dependencies. Importing the package must not pull in `rich`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_SNIPPET = """
+import importlib.abc, importlib.machinery, sys
+
+
+class _BlockRich(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path, target=None):
+        if name == "rich" or name.startswith("rich."):
+            raise ModuleNotFoundError("No module named 'rich'")
+        return None
+
+
+sys.meta_path.insert(0, _BlockRich())
+
+# Importing the package and the tool SDK must work with rich absent.
+import centaur_sdk
+from centaur_sdk.tool_sdk import secret  # noqa: F401
+
+# render_text_table is pure stdlib and must stay reachable.
+assert centaur_sdk.render_text_table(["a"], [["1"]])
+
+# Table is rich-backed and must only fail when actually accessed.
+try:
+    centaur_sdk.Table
+except ModuleNotFoundError:
+    pass
+else:
+    raise AssertionError("expected centaur_sdk.Table to require rich")
+
+print("ok")
+"""
+
+
+def test_tool_sdk_imports_without_rich():
+    result = subprocess.run(
+        [sys.executable, "-c", _SNIPPET],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -7,12 +7,12 @@ import contextlib
 import json
 import logging
 import mimetypes
-from urllib.parse import quote
 import urllib.request
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #823.

- Lazy-load `Table`/`render_text_table` so importing `centaur_sdk` / `centaur_sdk.tool_sdk` no longer pulls in `rich`, which the offline, stdlib-only tool runner does not have.
- Stop the sandbox tool runner (`install_tool_shims.py` `CALL_RUNNER`) from importing `centaur_sdk` at all — derive `ToolContext` from `CENTAUR_TOOL_NAME`/`CENTAUR_THREAD_KEY` env in the SDK so tool envs never have to satisfy SDK deps.