### PR TITLE
refactor: keep the sandbox tool runner `stdlib`-only

### DIFF
--- a/centaur_sdk/__init__.py
+++ b/centaur_sdk/__init__.py
@@ -8,7 +8,8 @@ Public API:
 
 from __future__ import annotations
 
-from centaur_sdk.cli_tables import Table, render_text_table
+from typing import Any
+
 from centaur_sdk.tool_sdk import (
     ToolContext,
     current_session_context,
@@ -36,3 +37,11 @@ __all__ = [
     "secret",
     "set_tool_context",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in ("Table", "render_text_table"):
+        from centaur_sdk import cli_tables
+
+        return getattr(cli_tables, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/centaur_sdk/cli_tables.py
+++ b/centaur_sdk/cli_tables.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from rich.table import Table as RichTable
+from typing import Any
 
-Table = RichTable
+
+def __getattr__(name: str) -> Any:
+    if name == "Table":
+        from rich.table import Table as RichTable
+
+        return RichTable
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def render_text_table(headers: list[str], rows: list[list[str]]) -> str:

--- a/centaur_sdk/tests/test_env_context.py
+++ b/centaur_sdk/tests/test_env_context.py
@@ -1,0 +1,46 @@
+"""The sandbox tool runner no longer sets ToolContext; the SDK derives it from env.
+
+When no context is set via ``set_tool_context`` (the in-process server path), the
+tool subprocess reads ``CENTAUR_TOOL_NAME`` / ``CENTAUR_THREAD_KEY`` from the
+environment so ``secret()`` / ``current_thread_key()`` keep working.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from centaur_sdk.tool_sdk import (
+    ToolContext,
+    current_thread_key,
+    get_tool_context,
+    set_tool_context,
+)
+
+
+def test_get_tool_context_falls_back_to_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CENTAUR_TOOL_NAME", "cl_dapp_api")
+    monkeypatch.setenv("CENTAUR_THREAD_KEY", "thread-123")
+
+    ctx = get_tool_context()
+    assert ctx.name == "cl_dapp_api"
+    assert ctx.thread_key == "thread-123"
+    assert current_thread_key() == "thread-123"
+
+
+def test_set_context_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CENTAUR_TOOL_NAME", "from-env")
+    token = set_tool_context(ToolContext(name="from-context"))
+    try:
+        assert get_tool_context().name == "from-context"
+    finally:
+        from centaur_sdk.tool_sdk import reset_tool_context
+
+        reset_tool_context(token)
+
+
+def test_no_context_and_no_env_raises(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("CENTAUR_TOOL_NAME", raising=False)
+    monkeypatch.delenv("CENTAUR_THREAD_KEY", raising=False)
+    monkeypatch.delenv("CENTAUR_CONTAINER_ID", raising=False)
+    with pytest.raises(LookupError):
+        get_tool_context()

--- a/centaur_sdk/tests/test_env_context.py
+++ b/centaur_sdk/tests/test_env_context.py
@@ -1,8 +1,10 @@
-"""The sandbox tool runner no longer sets ToolContext; the SDK derives it from env.
+"""The sandbox tool runner no longer binds a ToolContext; current_thread_key()
+falls back to the CENTAUR_THREAD_KEY the sandbox sets in the environment.
 
-When no context is set via ``set_tool_context`` (the in-process server path), the
-tool subprocess reads ``CENTAUR_TOOL_NAME`` / ``CENTAUR_THREAD_KEY`` from the
-environment so ``secret()`` / ``current_thread_key()`` keep working.
+get_tool_context() must keep raising LookupError when nothing is bound: tools
+use "a context is bound" as the signal that ctx.secrets is authoritative, so an
+env-derived context with empty secrets would wrongly suppress the secret()
+backend fallback (e.g. tools/research/websearch/client.py).
 """
 
 from __future__ import annotations
@@ -13,34 +15,33 @@ from centaur_sdk.tool_sdk import (
     ToolContext,
     current_thread_key,
     get_tool_context,
+    reset_tool_context,
     set_tool_context,
 )
 
 
-def test_get_tool_context_falls_back_to_env(monkeypatch: pytest.MonkeyPatch):
+def test_get_tool_context_raises_without_binding_even_with_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("CENTAUR_TOOL_NAME", "cl_dapp_api")
     monkeypatch.setenv("CENTAUR_THREAD_KEY", "thread-123")
+    with pytest.raises(LookupError):
+        get_tool_context()
 
-    ctx = get_tool_context()
-    assert ctx.name == "cl_dapp_api"
-    assert ctx.thread_key == "thread-123"
+
+def test_current_thread_key_falls_back_to_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CENTAUR_THREAD_KEY", "thread-123")
     assert current_thread_key() == "thread-123"
 
 
-def test_set_context_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("CENTAUR_TOOL_NAME", "from-env")
-    token = set_tool_context(ToolContext(name="from-context"))
+def test_bound_context_thread_key_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CENTAUR_THREAD_KEY", "from-env")
+    token = set_tool_context(ToolContext(name="t", thread_key="from-context"))
     try:
-        assert get_tool_context().name == "from-context"
+        assert current_thread_key() == "from-context"
     finally:
-        from centaur_sdk.tool_sdk import reset_tool_context
-
         reset_tool_context(token)
 
 
-def test_no_context_and_no_env_raises(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("CENTAUR_TOOL_NAME", raising=False)
+def test_current_thread_key_raises_without_context_or_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("CENTAUR_THREAD_KEY", raising=False)
-    monkeypatch.delenv("CENTAUR_CONTAINER_ID", raising=False)
-    with pytest.raises(LookupError):
-        get_tool_context()
+    with pytest.raises(RuntimeError):
+        current_thread_key()

--- a/centaur_sdk/tests/test_import_without_rich.py
+++ b/centaur_sdk/tests/test_import_without_rich.py
@@ -1,0 +1,52 @@
+"""Regression: the SDK must import in the isolated tool runner, which has no `rich`.
+
+Centaur's generated tool runner imports `centaur_sdk.tool_sdk` with PYTHONPATH
+pointing at /opt/centaur, inside a uvx env built from the tool's own (often
+stdlib-only) dependencies. Importing the package must not pull in `rich`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_SNIPPET = """
+import importlib.abc, importlib.machinery, sys
+
+
+class _BlockRich(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path, target=None):
+        if name == "rich" or name.startswith("rich."):
+            raise ModuleNotFoundError("No module named 'rich'")
+        return None
+
+
+sys.meta_path.insert(0, _BlockRich())
+
+# Importing the package and the tool SDK must work with rich absent.
+import centaur_sdk
+from centaur_sdk.tool_sdk import secret  # noqa: F401
+
+# render_text_table is pure stdlib and must stay reachable.
+assert centaur_sdk.render_text_table(["a"], [["1"]])
+
+# Table is rich-backed and must only fail when actually accessed.
+try:
+    centaur_sdk.Table
+except ModuleNotFoundError:
+    pass
+else:
+    raise AssertionError("expected centaur_sdk.Table to require rich")
+
+print("ok")
+"""
+
+
+def test_tool_sdk_imports_without_rich():
+    result = subprocess.run(
+        [sys.executable, "-c", _SNIPPET],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -7,12 +7,12 @@ import contextlib
 import json
 import logging
 import mimetypes
-from urllib.parse import quote
 import urllib.request
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 log = logging.getLogger(__name__)
 

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -37,23 +37,8 @@ def reset_tool_context(token: Any) -> None:
     _tool_ctx.reset(token)
 
 
-def _context_from_env() -> ToolContext | None:
-    name = os.environ.get("CENTAUR_TOOL_NAME", "").strip()
-    thread_key = os.environ.get("CENTAUR_THREAD_KEY", "").strip() or None
-    container_id = os.environ.get("CENTAUR_CONTAINER_ID", "").strip() or None
-    if not name and thread_key is None and container_id is None:
-        return None
-    return ToolContext(name=name or "tool", thread_key=thread_key, container_id=container_id)
-
-
 def get_tool_context() -> ToolContext:
-    try:
-        return _tool_ctx.get()
-    except LookupError:
-        ctx = _context_from_env()
-        if ctx is None:
-            raise
-        return ctx
+    return _tool_ctx.get()
 
 
 # ---------------------------------------------------------------------------
@@ -68,9 +53,9 @@ def secret(key: str, default: str | None = None) -> str:
     - **Pluggable backend**: Configured via ``centaur_sdk.backends.registry``
       (env vars, HTTP sidecar, etc.).
     """
-    # 1. Check tool context if available (server mode or env-derived)
+    # 1. Check tool context if available (server mode)
     try:
-        ctx = get_tool_context()
+        ctx = _tool_ctx.get()
         val = ctx.secrets.get(key)
         if val is not None:
             return val
@@ -89,16 +74,20 @@ def secret(key: str, default: str | None = None) -> str:
 
     ctx_name = ""
     with contextlib.suppress(LookupError):
-        ctx_name = f" for tool '{get_tool_context().name}'"
+        ctx_name = f" for tool '{_tool_ctx.get().name}'"
     raise KeyError(f"Missing secret '{key}'{ctx_name}")
 
 
 def current_thread_key() -> str:
-    """Return the active thread key for a tool call."""
+    """Return the active thread key for a tool call.
+
+    Prefers a bound ToolContext (server mode); in the isolated tool runner no
+    context is bound, so fall back to the CENTAUR_THREAD_KEY the sandbox sets.
+    """
     try:
-        thread_key = get_tool_context().thread_key
+        thread_key = _tool_ctx.get().thread_key
     except LookupError:
-        thread_key = None
+        thread_key = os.environ.get("CENTAUR_THREAD_KEY", "").strip() or None
     if not thread_key:
         raise RuntimeError(
             "this operation must run inside a scoped thread: no thread_key "

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import logging
 import mimetypes
+import os
 import urllib.request
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -36,8 +37,23 @@ def reset_tool_context(token: Any) -> None:
     _tool_ctx.reset(token)
 
 
+def _context_from_env() -> ToolContext | None:
+    name = os.environ.get("CENTAUR_TOOL_NAME", "").strip()
+    thread_key = os.environ.get("CENTAUR_THREAD_KEY", "").strip() or None
+    container_id = os.environ.get("CENTAUR_CONTAINER_ID", "").strip() or None
+    if not name and thread_key is None and container_id is None:
+        return None
+    return ToolContext(name=name or "tool", thread_key=thread_key, container_id=container_id)
+
+
 def get_tool_context() -> ToolContext:
-    return _tool_ctx.get()
+    try:
+        return _tool_ctx.get()
+    except LookupError:
+        ctx = _context_from_env()
+        if ctx is None:
+            raise
+        return ctx
 
 
 # ---------------------------------------------------------------------------
@@ -52,9 +68,9 @@ def secret(key: str, default: str | None = None) -> str:
     - **Pluggable backend**: Configured via ``centaur_sdk.backends.registry``
       (env vars, HTTP sidecar, etc.).
     """
-    # 1. Check tool context if available (server mode)
+    # 1. Check tool context if available (server mode or env-derived)
     try:
-        ctx = _tool_ctx.get()
+        ctx = get_tool_context()
         val = ctx.secrets.get(key)
         if val is not None:
             return val
@@ -73,14 +89,14 @@ def secret(key: str, default: str | None = None) -> str:
 
     ctx_name = ""
     with contextlib.suppress(LookupError):
-        ctx_name = f" for tool '{_tool_ctx.get().name}'"
+        ctx_name = f" for tool '{get_tool_context().name}'"
     raise KeyError(f"Missing secret '{key}'{ctx_name}")
 
 
 def current_thread_key() -> str:
     """Return the active thread key for a tool call."""
     try:
-        thread_key = _tool_ctx.get().thread_key
+        thread_key = get_tool_context().thread_key
     except LookupError:
         thread_key = None
     if not thread_key:

--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -489,17 +489,13 @@ print(json.dumps(result, default=str, separators=(",", ":")))
 '''
 
 
-def tool_env(tool=None):
+def tool_env():
     env = os.environ.copy()
     if PYTHONPATH_VALUE:
         if env.get("PYTHONPATH"):
             env["PYTHONPATH"] = f"{{PYTHONPATH_VALUE}}:{{env['PYTHONPATH']}}"
         else:
             env["PYTHONPATH"] = PYTHONPATH_VALUE
-    if tool is not None:
-        name = Path(tool["project_dir"]).name
-        if name:
-            env["CENTAUR_TOOL_NAME"] = name
     return env
 
 
@@ -582,7 +578,7 @@ def run_tool(tool, args):
     try:
         returncode = subprocess.call(
             ["uvx", "--from", str(project_dir), tool["name"], *args],
-            env=tool_env(tool),
+            env=tool_env(),
         )
     except Exception:
         emit_tool_call_event(
@@ -627,7 +623,7 @@ def call_tool(tool, method, payload):
             check=False,
             text=True,
             capture_output=True,
-            env=tool_env(tool),
+            env=tool_env(),
         )
     except Exception:
         emit_tool_call_event(

--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -448,11 +448,8 @@ import importlib
 import importlib.util
 import inspect
 import json
-import os
 from pathlib import Path
 import sys
-
-from centaur_sdk.tool_sdk import ToolContext, reset_tool_context, set_tool_context
 
 project_dir = Path(sys.argv[1])
 client_module = sys.argv[2]
@@ -480,33 +477,29 @@ if target is None and hasattr(module, "_client"):
 if target is None:
     raise RuntimeError(f"tool has no method {{method}}")
 
-ctx_token = None
-thread_key = os.environ.get("CENTAUR_THREAD_KEY", "").strip()
-if thread_key:
-    ctx_token = set_tool_context(ToolContext(name=project_dir.name, thread_key=thread_key))
-try:
-    if isinstance(payload, dict):
-        result = target(**payload)
-    elif payload is None:
-        result = target()
-    else:
-        result = target(payload)
-    if inspect.isawaitable(result):
-        result = asyncio.run(result)
-finally:
-    if ctx_token is not None:
-        reset_tool_context(ctx_token)
+if isinstance(payload, dict):
+    result = target(**payload)
+elif payload is None:
+    result = target()
+else:
+    result = target(payload)
+if inspect.isawaitable(result):
+    result = asyncio.run(result)
 print(json.dumps(result, default=str, separators=(",", ":")))
 '''
 
 
-def tool_env():
+def tool_env(tool=None):
     env = os.environ.copy()
     if PYTHONPATH_VALUE:
         if env.get("PYTHONPATH"):
             env["PYTHONPATH"] = f"{{PYTHONPATH_VALUE}}:{{env['PYTHONPATH']}}"
         else:
             env["PYTHONPATH"] = PYTHONPATH_VALUE
+    if tool is not None:
+        name = Path(tool["project_dir"]).name
+        if name:
+            env["CENTAUR_TOOL_NAME"] = name
     return env
 
 
@@ -589,7 +582,7 @@ def run_tool(tool, args):
     try:
         returncode = subprocess.call(
             ["uvx", "--from", str(project_dir), tool["name"], *args],
-            env=tool_env(),
+            env=tool_env(tool),
         )
     except Exception:
         emit_tool_call_event(
@@ -634,7 +627,7 @@ def call_tool(tool, method, payload):
             check=False,
             text=True,
             capture_output=True,
-            env=tool_env(),
+            env=tool_env(tool),
         )
     except Exception:
         emit_tool_call_event(

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import contextlib
 import io
 import json
@@ -310,6 +311,27 @@ class GeneratedShimTest(unittest.TestCase):
 
             self.assertEqual(result.returncode, 2)
             self.assertIn("usage: centaur-tools", result.stderr)
+
+
+class CatalogRunnerTest(unittest.TestCase):
+    def _render_catalog(self) -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            catalog = Path(tmp) / "centaur-tools"
+            index = Path(tmp) / ".centaur-tools.json"
+            index.write_text("[]")
+            install_tool_shims._write_catalog(catalog, index, "/opt/centaur")
+            return catalog.read_text()
+
+    def test_generated_catalog_is_valid_python(self) -> None:
+        ast.parse(self._render_catalog())
+
+    def test_call_runner_does_not_import_centaur_sdk(self) -> None:
+        content = self._render_catalog()
+        self.assertNotIn("centaur_sdk", content)
+        self.assertNotIn("set_tool_context", content)
+
+    def test_tool_env_exports_tool_name(self) -> None:
+        self.assertIn("CENTAUR_TOOL_NAME", self._render_catalog())
 
 
 if __name__ == "__main__":

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -330,9 +330,6 @@ class CatalogRunnerTest(unittest.TestCase):
         self.assertNotIn("centaur_sdk", content)
         self.assertNotIn("set_tool_context", content)
 
-    def test_tool_env_exports_tool_name(self) -> None:
-        self.assertIn("CENTAUR_TOOL_NAME", self._render_catalog())
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stacked on #824, proposes a more long-term solution for https://github.com/paradigmxyz/centaur/issues/823.

Stop the generated `CALL_RUNNER` in `services/sandbox/install_tool_shims.py` from importing `centaur_sdk`. 

It only imported the SDK to seed the `ToolContext` contextvar; derive that context from `CENTAUR_TOOL_NAME`/`CENTAUR_THREAD_KEY` env in the SDK instead, so the runner stays stdlib-only and tool envs never have to satisfy SDK deps.