### PR TITLE
fix: repair delayed Slack file shares

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -3,6 +3,8 @@ import { randomUUID } from 'node:crypto'
 import { Hono, type Context } from 'hono'
 import {
   Chat,
+  Message as ChatSdkMessage,
+  parseMarkdown,
   type Adapter,
   type Attachment,
   type Logger,
@@ -115,6 +117,21 @@ const SLACK_TASK_DETAILS_MAX_CHARS = 500
 const SLACK_FALLBACK_TEXT_MAX_CHARS = 35_000
 const POSTGRES_CONNECT_INITIAL_DELAY_MS = 250
 const POSTGRES_CONNECT_MAX_DELAY_MS = 10_000
+const LATE_SLACK_FILE_MATCH_WINDOW_MS = 15_000
+const LATE_SLACK_FILE_PENDING_TTL_MS = 60_000
+const LATE_SLACK_FILE_CONSUMED_TTL_MS = 5 * 60_000
+const LATE_SLACK_FILE_IDLE_WAIT_MS = 90_000
+const LATE_SLACK_FILE_IDLE_POLL_MS = 500
+const LATE_SLACK_FILE_MESSAGE_TEXT = 'Late Slack file attachment for the previous message.'
+
+type PendingLateSlackFileMention = {
+  channel: string
+  message: ChatMessage
+  mentionTs: string
+  teamId: string
+  thread: Thread<SlackbotV2ThreadState>
+  user: string
+}
 
 export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   const userName = options.userName ?? 'centaur'
@@ -135,9 +152,11 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     onLockConflict: 'force',
     logger
   })
+  const lateSlackFiles = createLateSlackFileRepair(options, state)
 
   chat.onNewMention(async (thread, message) => {
     if (!isAllowedSlackMessage(message, options, logger)) return
+    lateSlackFiles.rememberFilelessMention(thread, message)
     await handleSlackMessageHandoff(thread, message, {
       assistantStatusRequested: true,
       mode: 'execute',
@@ -150,6 +169,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
 
   chat.onSubscribedMessage(async (thread, message) => {
     if (!isAllowedSlackMessage(message, options, logger)) return
+    lateSlackFiles.rememberFilelessMention(thread, message)
     await handleSlackMessageHandoff(thread, message, {
       assistantStatusRequested: message.isMention === true,
       mode: message.isMention === true ? 'execute' : 'append',
@@ -234,6 +254,8 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
           return new globalThis.Response('temporary upstream unavailable', { status: 503 })
         }
       }
+      const lateFileTask = lateSlackFiles.repairFromWebhook(rawBody)
+      if (lateFileTask) waitUntil(c, lateFileTask)
       outcome = response.ok ? 'success' : 'error'
       return new globalThis.Response(await response.text(), {
         headers: response.headers,
@@ -2032,6 +2054,328 @@ function backgroundWaitUntil(promise: Promise<unknown>): void {
     return
   }
   void promise.catch(() => undefined)
+}
+
+function createLateSlackFileRepair(options: SlackbotV2Options, state: StateAdapter) {
+  const pending = new Map<string, PendingLateSlackFileMention[]>()
+  const consumed = new Map<string, number>()
+
+  const cleanup = () => {
+    const cutoff = Date.now() - LATE_SLACK_FILE_PENDING_TTL_MS
+    for (const [key, entries] of pending) {
+      const fresh = entries.filter(entry => slackTsToMs(entry.mentionTs) >= cutoff)
+      if (fresh.length > 0) pending.set(key, fresh)
+      else pending.delete(key)
+    }
+    const consumedCutoff = Date.now() - LATE_SLACK_FILE_CONSUMED_TTL_MS
+    for (const [key, timestamp] of consumed) {
+      if (timestamp < consumedCutoff) consumed.delete(key)
+    }
+  }
+
+  return {
+    rememberFilelessMention(thread: Thread<SlackbotV2ThreadState>, message: ChatMessage): void {
+      if (message.isMention !== true) return
+      const raw = slackRawRecord(message)
+      if (slackFiles(raw).length > 0 || message.attachments.length > 0) return
+      const teamId = stringField(raw.team) || stringField(raw.team_id)
+      const channel = stringField(raw.channel)
+      const user = stringField(raw.user)
+      const mentionTs = stringField(raw.ts) || message.id
+      if (!teamId || !channel || !user || !mentionTs) return
+
+      cleanup()
+      const key = lateSlackFilePendingKey(teamId, channel, user)
+      const entry: PendingLateSlackFileMention = {
+        channel,
+        message,
+        mentionTs,
+        teamId,
+        thread,
+        user
+      }
+      const entries = [entry, ...(pending.get(key) ?? [])]
+        .filter(item => slackTsToMs(item.mentionTs) >= Date.now() - LATE_SLACK_FILE_PENDING_TTL_MS)
+        .slice(0, 20)
+      pending.set(key, entries)
+      traceLog(options, 'slackbotv2_late_file_pending_mention_recorded', undefined, {
+        slack_channel: channel,
+        slack_message_ts: mentionTs,
+        slack_team_id: teamId,
+        slack_user_id: user,
+        thread_id: thread.id
+      })
+    },
+
+    repairFromWebhook(rawBody: string): Promise<void> | null {
+      const payload = slackWebhookPayload(rawBody)
+      if (!payload) return null
+      const event = slackWebhookEvent(payload)
+      if (!event || !isLateSlackFileEvent(event, options)) return null
+      cleanup()
+
+      const dedupeKey = lateSlackFileDedupeKey(payload, event)
+      if (consumed.has(dedupeKey)) {
+        traceLog(options, 'slackbotv2_late_file_duplicate_skipped', undefined, {
+          dedupe_key: dedupeKey
+        })
+        return null
+      }
+
+      const match = matchLateSlackFileMention(pending, payload, event)
+      if (!match) {
+        traceLog(options, 'slackbotv2_late_file_no_match', undefined, {
+          slack_channel: stringField(event.channel),
+          slack_event_id: stringField(payload.event_id),
+          slack_message_ts: stringField(event.ts),
+          slack_team_id: slackEventTeamId(payload, event),
+          slack_thread_ts: stringField(event.thread_ts),
+          slack_user_id: stringField(event.user)
+        })
+        return null
+      }
+
+      consumed.set(dedupeKey, Date.now())
+      return repairLateSlackFileMessage(options, state, match, event).catch(error => {
+        traceWarn(options, 'slackbotv2_late_file_repair_failed', undefined, {
+          dedupe_key: dedupeKey,
+          error: errorMessage(error),
+          slack_channel: stringField(event.channel),
+          slack_message_ts: stringField(event.ts),
+          thread_id: match.thread.id
+        })
+      })
+    }
+  }
+}
+
+async function repairLateSlackFileMessage(
+  options: SlackbotV2Options,
+  state: StateAdapter,
+  pending: PendingLateSlackFileMention,
+  event: Record<string, unknown>
+): Promise<void> {
+  const startedAtMs = nowMs()
+  const eventTs = stringField(event.ts)
+  const hydratedEvent = await hydrateLateSlackFileEvent(options, event)
+  const ready = await waitForThreadIdle(pending.thread, options, {
+    includeContext: true,
+    messageId: eventTs,
+    mode: 'execute',
+    openStream: true,
+    startedAtMs: nowMs(),
+    threadId: pending.thread.id
+  })
+  if (!ready) {
+    traceWarn(options, 'slackbotv2_late_file_repair_idle_timeout', undefined, {
+      slack_channel: pending.channel,
+      slack_message_ts: eventTs,
+      thread_id: pending.thread.id
+    })
+    return
+  }
+
+  const message = lateSlackFileSyntheticMessage(pending, hydratedEvent)
+  await handleSlackMessageHandoff(pending.thread, message, {
+    assistantStatusRequested: true,
+    mode: 'execute',
+    options,
+    state,
+    trigger: 'late_file_message'
+  })
+  traceLog(options, 'slackbotv2_late_file_repair_complete', undefined, {
+    phase_ms: elapsedMs(startedAtMs),
+    slack_channel: pending.channel,
+    slack_message_ts: eventTs,
+    thread_id: pending.thread.id
+  })
+}
+
+async function waitForThreadIdle(
+  thread: Thread<SlackbotV2ThreadState>,
+  options: SlackbotV2Options,
+  trace: SlackbotV2Trace
+): Promise<boolean> {
+  const startedAtMs = nowMs()
+  while (elapsedMs(startedAtMs) < LATE_SLACK_FILE_IDLE_WAIT_MS) {
+    const latest = (await thread.state) ?? {}
+    if (latest.activeExecution !== true) return true
+    traceLog(options, 'slackbotv2_late_file_repair_waiting_for_idle', trace, {
+      waited_ms: elapsedMs(startedAtMs)
+    })
+    await sleep(LATE_SLACK_FILE_IDLE_POLL_MS)
+  }
+  return false
+}
+
+function lateSlackFileSyntheticMessage(
+  pending: PendingLateSlackFileMention,
+  event: Record<string, unknown>
+): ChatMessage {
+  const eventTs = stringField(event.ts) || randomUUID()
+  const raw: Record<string, unknown> = {
+    ...event,
+    channel: pending.channel,
+    team: stringField(event.team) || pending.teamId,
+    team_id: stringField(event.team_id) || pending.teamId,
+    text: stringField(event.text) || LATE_SLACK_FILE_MESSAGE_TEXT,
+    thread_ts: stringField(event.thread_ts) || pending.mentionTs,
+    ts: eventTs
+  }
+  return new ChatSdkMessage({
+    attachments: [],
+    author: {
+      ...pending.message.author,
+      userId: stringField(event.user) || pending.user,
+      userName: stringField(event.user) || pending.user,
+      fullName: stringField(event.user) || pending.user,
+      isBot: Boolean(event.bot_id),
+      isMe: false
+    },
+    formatted: parseMarkdown(LATE_SLACK_FILE_MESSAGE_TEXT),
+    id: eventTs,
+    isMention: true,
+    links: [],
+    metadata: {
+      dateSent: new Date(slackTsToMs(eventTs)),
+      edited: false
+    },
+    raw,
+    text: LATE_SLACK_FILE_MESSAGE_TEXT,
+    threadId: pending.thread.id
+  })
+}
+
+async function hydrateLateSlackFileEvent(
+  options: SlackbotV2Options,
+  event: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const files = slackFiles(event)
+  if (!files.some(file => stringField(file.file_access) === 'check_file_info')) return event
+  const hydratedFiles: Record<string, unknown>[] = []
+  for (const file of files) {
+    if (stringField(file.file_access) !== 'check_file_info') {
+      hydratedFiles.push(file)
+      continue
+    }
+    const id = stringField(file.id)
+    if (!id) {
+      hydratedFiles.push(file)
+      continue
+    }
+    const hydrated = await slackFilesInfo(options, id)
+    hydratedFiles.push(hydrated ?? file)
+  }
+  return { ...event, files: hydratedFiles }
+}
+
+async function slackFilesInfo(
+  options: SlackbotV2Options,
+  fileId: string
+): Promise<Record<string, unknown> | null> {
+  const fetchFn = options.fetch ?? fetch
+  const url = new URL('files.info', options.slackApiUrl ?? 'https://slack.com/api/')
+  url.searchParams.set('file', fileId)
+  const response = await withSlackApiTimeout(options, 'Slack files.info', () =>
+    fetchFn(url, {
+      headers: { authorization: `Bearer ${options.botToken}` }
+    })
+  )
+  if (!response.ok) {
+    throw new Error(`Slack files.info failed: ${response.status} ${response.statusText}`)
+  }
+  const payload = (await response.json()) as unknown
+  if (!isJsonObject(payload) || payload.ok !== true || !isJsonObject(payload.file)) return null
+  traceLog(options, 'slackbotv2_late_file_hydrated_file_info', undefined, {
+    slack_file_id: fileId
+  })
+  return payload.file as Record<string, unknown>
+}
+
+function matchLateSlackFileMention(
+  pending: Map<string, PendingLateSlackFileMention[]>,
+  payload: Record<string, unknown>,
+  event: Record<string, unknown>
+): PendingLateSlackFileMention | null {
+  const teamId = slackEventTeamId(payload, event)
+  const channel = stringField(event.channel)
+  const user = stringField(event.user)
+  const eventTs = stringField(event.ts)
+  if (!teamId || !channel || !user || !eventTs) return null
+
+  const entries = pending.get(lateSlackFilePendingKey(teamId, channel, user)) ?? []
+  const threadTs = stringField(event.thread_ts)
+  const eventMs = slackTsToMs(eventTs)
+  return (
+    entries.find(entry => {
+      if (threadTs && threadTs !== slackThreadTsForPendingMention(entry)) return false
+      const mentionMs = slackTsToMs(entry.mentionTs)
+      return eventMs > mentionMs && eventMs - mentionMs <= LATE_SLACK_FILE_MATCH_WINDOW_MS
+    }) ?? null
+  )
+}
+
+function isLateSlackFileEvent(
+  event: Record<string, unknown>,
+  options: SlackbotV2Options
+): boolean {
+  if (stringField(event.type) !== 'message') return false
+  if (stringField(event.subtype) && stringField(event.subtype) !== 'file_share') return false
+  if (slackFiles(event).length === 0) return false
+  if (stringField(event.user) === options.botUserId) return false
+  const text = stringField(event.text)
+  if (options.botUserId && text.includes(`<@${options.botUserId}>`)) return false
+  return true
+}
+
+function slackWebhookPayload(rawBody: string): Record<string, unknown> | null {
+  try {
+    const payload = JSON.parse(rawBody)
+    return isJsonObject(payload) ? (payload as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+function slackWebhookEvent(payload: Record<string, unknown>): Record<string, unknown> | null {
+  return isJsonObject(payload.event) ? (payload.event as Record<string, unknown>) : null
+}
+
+function lateSlackFilePendingKey(teamId: string, channel: string, user: string): string {
+  return `${teamId}:${channel}:${user}`
+}
+
+function lateSlackFileDedupeKey(
+  payload: Record<string, unknown>,
+  event: Record<string, unknown>
+): string {
+  const eventId = stringField(payload.event_id)
+  if (eventId) return `event:${eventId}`
+  const fileIds = slackFiles(event).map(file => stringField(file.id)).filter(Boolean).join(',')
+  return [
+    'file',
+    slackEventTeamId(payload, event),
+    stringField(event.channel),
+    stringField(event.ts),
+    fileIds
+  ].join(':')
+}
+
+function slackEventTeamId(
+  payload: Record<string, unknown>,
+  event: Record<string, unknown>
+): string {
+  return stringField(event.team) || stringField(event.team_id) || stringField(payload.team_id)
+}
+
+function slackThreadTsForPendingMention(entry: PendingLateSlackFileMention): string {
+  const raw = slackRawRecord(entry.message)
+  return stringField(raw.thread_ts) || entry.mentionTs
+}
+
+function slackTsToMs(ts: string): number {
+  const seconds = Number(ts)
+  return Number.isFinite(seconds) ? seconds * 1000 : 0
 }
 
 function shouldAwaitSlackHandoff(rawBody: string): boolean {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -446,6 +446,231 @@ describe('slackbotv2', () => {
     expect(executeInput).toContain('"attachment_type":"image"')
   })
 
+  it('repairs delayed Slack Connect file-only messages as a follow-up turn', async () => {
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> what's in this image`)
+    const mentionWaits: Promise<unknown>[] = []
+    const mentionResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-late-file-mention',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> what's in this image`
+        }
+      }),
+      {},
+      waitUntilContext(mentionWaits)
+    )
+    expect(mentionResponse.status).toBe(200)
+    await Promise.all(mentionWaits)
+
+    const fileUrl = `${slackApi.url}/files/captured.png`
+    const fileTs = incrementSlackTs(mention.ts, 2)
+    const fileWaits: Promise<unknown>[] = []
+    const fileResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-late-file-message',
+        event: {
+          type: 'message',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: fileTs,
+          text: '',
+          files: [
+            {
+              id: 'F-late-captured',
+              mimetype: 'image/png',
+              name: 'late-captured.png',
+              original_h: 600,
+              original_w: 800,
+              size: 16,
+              url_private: fileUrl
+            }
+          ]
+        }
+      }),
+      {},
+      waitUntilContext(fileWaits)
+    )
+
+    expect(fileResponse.status).toBe(200)
+    await Promise.all(fileWaits)
+
+    expect(codexApi.executes).toHaveLength(2)
+    expect(codexApi.executes.map(execute => execute.threadKey)).toEqual([
+      threadKey(mention.ts),
+      threadKey(mention.ts)
+    ])
+    expect(codexApi.executes[1]!.body.idempotency_key).toBe(fileTs)
+    const appendedAttachment = codexApi.appends[1]!.body.messages
+      .flatMap(message => message.parts)
+      .find(part => isRecord(part) && part.type === 'attachment')
+    expect(appendedAttachment).toEqual(
+      expect.objectContaining({
+        attachment_type: 'image',
+        dataBase64: Buffer.from('captured-image').toString('base64'),
+        mimeType: 'image/png',
+        name: 'late-captured.png',
+        type: 'attachment',
+        url: fileUrl
+      })
+    )
+    const secondExecuteInput = JSON.stringify(
+      JSON.parse(codexApi.executes[1]!.body.input_lines.at(-1)!)
+    )
+    expect(secondExecuteInput).toContain('Late Slack file attachment')
+    expect(secondExecuteInput).toContain('"attachment_type":"image"')
+  })
+
+  it('hydrates Slack Connect check_file_info placeholders before late-file repair', async () => {
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> inspect the delayed file`)
+    const mentionWaits: Promise<unknown>[] = []
+    await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-check-file-info-mention',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> inspect the delayed file`
+        }
+      }),
+      {},
+      waitUntilContext(mentionWaits)
+    )
+    await Promise.all(mentionWaits)
+
+    const fileUrl = `${slackApi.url}/files/captured.png`
+    slackApi.setFileInfo('F-check-file-info', {
+      id: 'F-check-file-info',
+      mimetype: 'image/png',
+      name: 'hydrated.png',
+      original_h: 600,
+      original_w: 800,
+      size: 16,
+      url_private: fileUrl
+    })
+
+    const fileWaits: Promise<unknown>[] = []
+    const fileTs = incrementSlackTs(mention.ts, 2)
+    const fileResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-check-file-info-message',
+        event: {
+          type: 'message',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: fileTs,
+          text: '',
+          files: [{ id: 'F-check-file-info', file_access: 'check_file_info' }]
+        }
+      }),
+      {},
+      waitUntilContext(fileWaits)
+    )
+
+    expect(fileResponse.status).toBe(200)
+    await Promise.all(fileWaits)
+
+    expect(slackApi.fileInfoRequestCount('F-check-file-info')).toBe(1)
+    expect(codexApi.executes).toHaveLength(2)
+    const appendedAttachment = codexApi.appends[1]!.body.messages
+      .flatMap(message => message.parts)
+      .find(part => isRecord(part) && part.type === 'attachment')
+    expect(appendedAttachment).toEqual(
+      expect.objectContaining({
+        dataBase64: Buffer.from('captured-image').toString('base64'),
+        mimeType: 'image/png',
+        name: 'hydrated.png',
+        type: 'attachment',
+        url: fileUrl
+      })
+    )
+  })
+
+  it('ignores unmatched and duplicate delayed file-only messages', async () => {
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> maybe an image follows`)
+    const mentionWaits: Promise<unknown>[] = []
+    await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-dedupe-late-file-mention',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> maybe an image follows`
+        }
+      }),
+      {},
+      waitUntilContext(mentionWaits)
+    )
+    await Promise.all(mentionWaits)
+
+    const unrelatedWaits: Promise<unknown>[] = []
+    await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-unmatched-late-file',
+        event: {
+          type: 'message',
+          user: USER_B_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: incrementSlackTs(mention.ts, 2),
+          text: '',
+          files: [{ id: 'F-unmatched', mimetype: 'image/png', name: 'unmatched.png' }]
+        }
+      }),
+      {},
+      waitUntilContext(unrelatedWaits)
+    )
+    await Promise.all(unrelatedWaits)
+    expect(codexApi.executes).toHaveLength(1)
+
+    const fileEvent = signedSlackEvent({
+      event_id: 'Ev-slackbotv2-duplicate-late-file',
+      event: {
+        type: 'message',
+        user: USER_ID,
+        channel: CHANNEL_ID,
+        team: TEAM_ID,
+        ts: incrementSlackTs(mention.ts, 3),
+        text: '',
+        files: [
+          {
+            id: 'F-dedupe-late',
+            mimetype: 'image/png',
+            name: 'dedupe.png',
+            url_private: `${slackApi.url}/files/captured.png`
+          }
+        ]
+      }
+    })
+    const firstWaits: Promise<unknown>[] = []
+    await bot.app.request('/api/webhooks/slack', fileEvent, {}, waitUntilContext(firstWaits))
+    await Promise.all(firstWaits)
+    const duplicateWaits: Promise<unknown>[] = []
+    await bot.app.request('/api/webhooks/slack', fileEvent, {}, waitUntilContext(duplicateWaits))
+    await Promise.all(duplicateWaits)
+
+    expect(codexApi.executes).toHaveLength(2)
+    expect(codexApi.executes[1]!.body.idempotency_key).toBe(incrementSlackTs(mention.ts, 3))
+  })
+
   it('fetches attachments from preceding Slack thread messages for a mid-thread mention', async () => {
     const parent = await postUserMessage('Root context before an attachment.')
     const priorReply = await postUserMessage('Screenshot is attached here.', parent.ts)
@@ -4207,8 +4432,10 @@ type PatchedSlackApi = {
   failRepliesWithThreadNotFound(channel: string, ts: string): void
   failStreamAppendsAfter(count: number, error: string): void
   failStreamStopsLongerThan(maxChars: number): void
+  fileInfoRequestCount(fileId: string): number
   holdAssistantStatus(): () => void
   reset(): void
+  setFileInfo(fileId: string, file: Record<string, unknown>): void
   setUserProfile(userId: string, profile: Record<string, unknown>): void
   userProfileMethodRequestCount(userId: string, method: string): number
   userProfileRequestCount(userId: string): number
@@ -4245,6 +4472,8 @@ type SlackStreamTranscript = {
 async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackApi> {
   const upstreamUrl = loopbackUrl(emulatorUrl)
   const calls: StreamCall[] = []
+  const fileInfo = new Map<string, Record<string, unknown>>()
+  const fileInfoRequests = new Map<string, number>()
   const threadMessageFiles = new Map<string, Record<string, unknown>[]>()
   const userProfiles = new Map<string, Record<string, unknown>>()
   const userProfileRequests = new Map<string, number>()
@@ -4266,6 +4495,8 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       appendFailure,
       assistantStatusGate: () => assistantStatusGate,
       calls,
+      fileInfo,
+      fileInfoRequests,
       maxStreamStopChars,
       port,
       streams,
@@ -4297,6 +4528,9 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
     failStreamStopsLongerThan(maxChars: number) {
       maxStreamStopChars = maxChars
     },
+    fileInfoRequestCount(fileId: string) {
+      return fileInfoRequests.get(fileId) ?? 0
+    },
     holdAssistantStatus() {
       if (assistantStatusGate) throw new Error('assistant status is already held')
       assistantStatusGate = new Promise(resolve => {
@@ -4312,9 +4546,14 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       appendFailure.error = ''
       threadNotFoundReplies.clear()
       threadMessageFiles.clear()
+      fileInfo.clear()
+      fileInfoRequests.clear()
       streams.clear()
       userProfiles.clear()
       userProfileRequests.clear()
+    },
+    setFileInfo(fileId: string, file: Record<string, unknown>) {
+      fileInfo.set(fileId, file)
     },
     setUserProfile(userId: string, profile: Record<string, unknown>) {
       userProfiles.set(userId, profile)
@@ -4336,6 +4575,8 @@ async function handlePatchedSlackRequest(
     appendFailure: { error: string; remaining: number }
     assistantStatusGate: () => Promise<void> | null
     calls: StreamCall[]
+    fileInfo: Map<string, Record<string, unknown>>
+    fileInfoRequests: Map<string, number>
     maxStreamStopChars: number | null
     port: number
     streams: Map<string, StreamRecord>
@@ -4413,6 +4654,19 @@ async function handlePatchedSlackRequest(
       return
     }
     await sendWebResponse(res, Response.json({ ok: true, profile }))
+    return
+  }
+  if (path === '/api/files.info') {
+    const body = await requestBody(request.clone())
+    const fileId = url.searchParams.get('file') ?? stringField(body.file)
+    input.fileInfoRequests.set(fileId, (input.fileInfoRequests.get(fileId) ?? 0) + 1)
+    const file = input.fileInfo.get(fileId)
+    await sendWebResponse(
+      res,
+      file
+        ? Response.json({ ok: true, file })
+        : Response.json({ ok: false, error: 'file_not_found' })
+    )
     return
   }
   if (path === '/api/chat.startStream') {
@@ -4894,6 +5148,11 @@ function streamKey(channel: string, ts: string): string {
 
 function slackReplyKey(channel: string, ts: string): string {
   return `${channel}:${ts}`
+}
+
+function incrementSlackTs(ts: string, seconds: number): string {
+  const [whole = '0', fractional = '000000'] = ts.split('.')
+  return `${Number.parseInt(whole, 10) + seconds}.${fractional.padEnd(6, '0').slice(0, 6)}`
 }
 
 function stringField(value: unknown): string {


### PR DESCRIPTION
Summary
- Track recent fileless Slack mentions and repair Slack Connect split file-only events as synthetic follow-up turns in the original thread.
- Hydrate Slack `check_file_info` file placeholders through `files.info` before attachment serialization.
- Add emulator coverage for delayed file repair, placeholder hydration, no-match behavior, and duplicate suppression.

Validation
- pnpm --filter slackbotv2 check:types
- pnpm --filter slackbotv2 test test/chat-sdk-emulate.test.ts
- docker build -t centaur-slackbotv2:latest -f services/slackbotv2/Dockerfile .

Local deploy
- just --no-dotenv deploy is blocked by an existing Helm apply conflict on centaur/centaur-centaur-api-rs fields managed by kubectl-set; I did not force the local cluster.

Prompted by: @akshaan