### PR TITLE
fix: persist Slack model overrides per thread

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -116,6 +116,49 @@ const SLACK_FALLBACK_TEXT_MAX_CHARS = 35_000
 const POSTGRES_CONNECT_INITIAL_DELAY_MS = 250
 const POSTGRES_CONNECT_MAX_DELAY_MS = 10_000
 
+type StickyThreadOverrides = Pick<SlackbotV2ThreadState, 'harnessType' | 'model' | 'provider'>
+
+function stickyThreadOverrideUpdate(
+  overrides: StickyThreadOverrides
+): StickyThreadOverrides | undefined {
+  const update: StickyThreadOverrides = {}
+  if (overrides.harnessType) {
+    update.harnessType = overrides.harnessType
+    if (!overrides.model) update.model = null
+    if (!overrides.provider) update.provider = null
+  }
+  if (overrides.model) update.model = overrides.model
+  if (overrides.provider) {
+    update.provider = overrides.provider
+    if (!overrides.model) update.model = null
+  }
+  return Object.keys(update).length > 0 ? update : undefined
+}
+
+function resolveStickyThreadOverrides(
+  state: SlackbotV2ThreadState,
+  update: StickyThreadOverrides | undefined
+): {
+  harnessType?: string
+  model?: string
+  provider?: string
+} {
+  return {
+    harnessType: stickyOverrideValue(state, update, 'harnessType'),
+    model: stickyOverrideValue(state, update, 'model'),
+    provider: stickyOverrideValue(state, update, 'provider')
+  }
+}
+
+function stickyOverrideValue(
+  state: SlackbotV2ThreadState,
+  update: StickyThreadOverrides | undefined,
+  key: keyof StickyThreadOverrides
+): string | undefined {
+  if (update && Object.prototype.hasOwnProperty.call(update, key)) return stringValue(update[key])
+  return stringValue(state[key])
+}
+
 export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   const userName = options.userName ?? 'centaur'
   const logger = options.logger ?? noopLogger
@@ -569,6 +612,8 @@ async function syncThreadMessageToSession(
   const serializedMessage = await serializeMessage(message, input.options)
   const overrides = extractMessageOverrides(serializedMessage.text)
   setMessageText(serializedMessage, overrides.cleanedText)
+  const stickyOverridesUpdate = stickyThreadOverrideUpdate(overrides)
+  const effectiveOverrides = resolveStickyThreadOverrides(state, stickyOverridesUpdate)
   if (overrides.harnessType || overrides.model || overrides.provider || overrides.reasoning) {
     traceLog(input.options, 'slackbotv2_forward_overrides_parsed', trace, {
       harness_type: overrides.harnessType,
@@ -632,12 +677,12 @@ async function syncThreadMessageToSession(
     executeContextMessages:
       shouldStartExecution && shouldIncludeContext ? candidateMessages : undefined,
     executeMessage: shouldStartExecution ? serializedMessage : undefined,
-    // A harness override only applies when this message starts an execution;
+    // Sticky harness changes only apply when a message starts an execution;
     // restarting the thread out from under an active execution would kill it.
-    harnessType: shouldStartExecution ? overrides.harnessType : undefined,
+    harnessType: shouldStartExecution ? effectiveOverrides.harnessType : undefined,
     messages: messagesToAppend,
-    model: overrides.model,
-    provider: overrides.provider,
+    model: shouldStartExecution ? effectiveOverrides.model : undefined,
+    provider: shouldStartExecution ? effectiveOverrides.provider : undefined,
     reasoning: overrides.reasoning,
     onEventId: eventId => {
       lastEventId = Math.max(lastEventId, eventId)
@@ -682,6 +727,7 @@ async function syncThreadMessageToSession(
     const latestMessageIds = new Set(latest.forwardedMessageIds ?? [])
     for (const item of messagesToAppend) latestMessageIds.add(item.id)
     await thread.setState({
+      ...(stickyOverridesUpdate ?? {}),
       forwardedMessageIds: Array.from(latestMessageIds).slice(-1000),
       historyForwarded: latest.historyForwarded || (shouldIncludeContext && !contextDegraded),
       lastEventId
@@ -710,6 +756,7 @@ async function syncThreadMessageToSession(
       })
     }
     await thread.setState({
+      ...(stickyOverridesUpdate ?? {}),
       activeExecution: true,
       executedMessageIds: Array.from(latestExecutedMessageIds).slice(-1000),
       lastEventId,

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -8,16 +8,16 @@
  *
  * Flags are stripped from the text before it reaches the agent. The harness
  * applies at session creation — an explicit harness flag on a thread pinned to
- * another harness restarts the thread on the requested one. The model and
- * reasoning effort apply per turn via the blocks-protocol `model` / `reasoning`
- * fields; `--model` accepts either a full model id (claude-sonnet-4-6, gpt-5.2,
- * ...), an amp mode (deep/fast), or a Claude alias (fable/opus/sonnet/haiku)
- * which expands to the full id. Reasoning effort only affects the codex harness
- * (it maps to codex's `turn/start` `effort`); other harnesses ignore it. The
- * provider rides the blocks-protocol `provider` field and is fixed when the
- * codex thread starts; `--bedrock` selects codex's built-in `amazon-bedrock`
- * provider (and implies the codex harness). Pair it with `--model <bedrock-id>`
- * to choose the Bedrock model.
+ * another harness restarts the thread on the requested one. Harness/model/provider
+ * choices are sticky at the Slack thread level: the last flag wins for later
+ * turns in the same thread. `--model` accepts either a full model id
+ * (claude-sonnet-4-6, gpt-5.2, ...), an amp mode (deep/fast), or a Claude alias
+ * (fable/opus/sonnet/haiku) which expands to the full id. Reasoning effort only
+ * affects the codex harness (it maps to codex's `turn/start` `effort`) and stays
+ * per-turn; other harnesses ignore it. The provider rides the blocks-protocol
+ * `provider` field and is fixed when the codex thread starts; `--bedrock`
+ * selects codex's built-in `amazon-bedrock` provider (and implies the codex
+ * harness). Pair it with `--model <bedrock-id>` to choose the Bedrock model.
  */
 
 export type MessageOverrides = {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -157,7 +157,7 @@ type ForwardSessionApiCallbacks = {
   onMessagesAppended?(): Promise<void>
   /**
    * Fires when session creation restarted the thread onto a new harness
-   * (explicit --claude/--amp/--codex on a thread pinned to another harness).
+   * (sticky --claude/--amp/--codex state on a thread pinned to another harness).
    * Runs before append/execute, so the callback may set
    * `input.contextPreamble` to re-feed thread history to the fresh harness.
    */
@@ -703,8 +703,8 @@ async function createSession(
   message?: SlackbotV2ApiMessage
 ): Promise<CreateSessionOutcome> {
   const requested = harnessType ?? options.defaultHarnessType ?? DEFAULT_HARNESS_TYPE
-  // An explicit --claude/--amp/--codex restarts a thread pinned to another
-  // harness; the implicit default never forces a switch.
+  // A sticky --claude/--amp/--codex selection restarts a thread pinned to
+  // another harness; the implicit default never forces a switch.
   const response = await postCreateSession(
     options,
     threadId,

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -138,8 +138,14 @@ export type SlackbotV2ThreadState = {
   activeExecution?: boolean
   executedMessageIds?: string[]
   forwardedMessageIds?: string[]
+  /** Last thread-level harness selected by Slack flags. Null clears persisted state. */
+  harnessType?: string | null
   historyForwarded?: boolean
   lastEventId?: number
+  /** Last thread-level model selected by Slack flags. Null clears persisted state. */
+  model?: string | null
+  /** Last thread-level model provider selected by Slack flags. Null clears persisted state. */
+  provider?: string | null
   renderObligation?: SlackbotV2RenderObligation | null
 }
 
@@ -174,12 +180,12 @@ export type ForwardSessionInput = {
   contextPreamble?: string
   executionId?: string
   executeMessage?: SlackbotV2ApiMessage
-  /** Harness override parsed from message flags (--claude/--amp/--codex). */
+  /** Effective harness selected by sticky thread flags (--claude/--amp/--codex). */
   harnessType?: string
   messages: SlackbotV2ApiMessage[]
-  /** Per-turn model override parsed from message flags (--model/--opus/...). */
+  /** Effective model selected by sticky thread flags (--model/--opus/...). */
   model?: string
-  /** Model provider override parsed from message flags (--bedrock); codex only. */
+  /** Effective model provider selected by sticky thread flags (--bedrock); codex only. */
   provider?: string
   /** Per-turn reasoning effort parsed from the `-rsn` flag (codex only). */
   reasoning?: string

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -343,6 +343,92 @@ describe('slackbotv2', () => {
     expectSlackRenderedReply(renderedReplies[1]!, 'Executed request 2.')
   })
 
+  it('keeps harness and model flags sticky within a Slack thread', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ state: sharedState })
+
+    const parent = await postUserMessage('Thread default context.')
+    const firstMention = await postUserMessage(
+      `<@${BOT_USER_ID}> --claude --model claude-opus-4-8 first pass`,
+      parent.ts
+    )
+    const firstWaits: Promise<unknown>[] = []
+    const firstResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-sticky-overrides-first',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: firstMention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> --claude --model claude-opus-4-8 first pass`
+        }
+      }),
+      {},
+      waitUntilContext(firstWaits)
+    )
+    expect(firstResponse.status).toBe(200)
+    await Promise.all(firstWaits)
+
+    const secondMention = await postUserMessage(
+      `<@${BOT_USER_ID}> continue without flags`,
+      parent.ts
+    )
+    const secondWaits: Promise<unknown>[] = []
+    const secondResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-sticky-overrides-second',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: secondMention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> continue without flags`
+        }
+      }),
+      {},
+      waitUntilContext(secondWaits)
+    )
+    expect(secondResponse.status).toBe(200)
+    await Promise.all(secondWaits)
+
+    expect(codexApi.creates.map(create => create.body.harness_type)).toEqual([
+      'claudecode',
+      'claudecode'
+    ])
+    expect(codexApi.executes).toHaveLength(2)
+    const firstInput = JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!) as Record<
+      string,
+      unknown
+    >
+    const secondInput = JSON.parse(codexApi.executes[1]!.body.input_lines.at(-1)!) as Record<
+      string,
+      unknown
+    >
+    expect(firstInput.model).toBe('claude-opus-4-8')
+    expect(secondInput.model).toBe('claude-opus-4-8')
+    expect(JSON.stringify(firstInput)).not.toContain('--claude')
+    expect(JSON.stringify(firstInput)).not.toContain('--model')
+    expect(JSON.stringify(secondInput)).toContain('continue without flags')
+
+    const state = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${threadKey(parent.ts)}`
+    )
+    expect(state).toEqual(
+      expect.objectContaining({
+        harnessType: 'claudecode',
+        model: 'claude-opus-4-8'
+      })
+    )
+  })
+
   it('includes all preceding Slack thread messages for a first mid-thread mention', async () => {
     const parent = await postUserMessage('Root context for the thread.')
     const firstReply = await postUserMessage('First preceding reply.', parent.ts)


### PR DESCRIPTION
## Summary
- persist sticky Slack thread harness/model/provider selections after flag overrides
- apply sticky harness/model/provider settings to subsequent executions in the same thread
- add emulator coverage for flagged then unflagged Slack mentions preserving harness/model

## Tests
- bun run check:types
- bun test test/overrides.test.ts test/session-api.test.ts
- bun test test/chat-sdk-emulate.test.ts -t "keeps harness and model flags sticky within a Slack thread"

Note: the full chat-sdk-emulate suite still has existing stream-rendering expectation failures outside this change path.