### PR TITLE
Fix Linear issue search GraphQL argument

### DIFF
--- a/tools/productivity/linear/readonly.py
+++ b/tools/productivity/linear/readonly.py
@@ -377,8 +377,8 @@ class LinearReadonlyClient(LinearGraphQLClient):
     def search_issues(self, query_str: str, limit: int = 25) -> list[dict[str, Any]]:
         """Search issues by text."""
         query = """
-        query SearchIssues($query: String!, $first: Int!, $after: String) {
-            searchIssues(query: $query, first: $first, after: $after) {
+        query SearchIssues($term: String!, $first: Int!, $after: String) {
+            searchIssues(term: $term, first: $first, after: $after) {
                 nodes {
                     id
                     identifier
@@ -396,7 +396,7 @@ class LinearReadonlyClient(LinearGraphQLClient):
         return self._connection_nodes(
             query,
             connection_path=("searchIssues",),
-            variables={"query": query_str},
+            variables={"term": query_str},
             limit=limit,
         )
 

--- a/tools/productivity/linear/test_readonly.py
+++ b/tools/productivity/linear/test_readonly.py
@@ -1,0 +1,42 @@
+"""Tests for Linear read-only GraphQL helpers.
+
+Run from this directory: uv run --no-project --with pytest --with httpx pytest test_readonly.py
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+if "centaur_sdk" not in sys.modules:
+    sdk_mod = types.ModuleType("centaur_sdk")
+    sdk_mod.secret = lambda name, default="": default
+    sys.modules["centaur_sdk"] = sdk_mod
+
+from centaur_tool_linear.readonly import LinearReadonlyClient
+
+
+class RecordingReadonlyClient(LinearReadonlyClient):
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def _query(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append({"query": query, "variables": variables})
+        return {
+            "searchIssues": {
+                "nodes": [{"identifier": "ENG-1", "title": "Search result"}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }
+        }
+
+
+def test_search_issues_uses_linear_term_argument():
+    client = RecordingReadonlyClient()
+
+    result = client.search_issues("auth", limit=1)
+
+    assert result == [{"identifier": "ENG-1", "title": "Search result"}]
+    assert "searchIssues(term: $term" in client.calls[0]["query"]
+    assert "query:" not in client.calls[0]["query"]
+    assert client.calls[0]["variables"] == {"term": "auth", "first": 1, "after": None}


### PR DESCRIPTION
## Summary
- update Linear issue search to use the current `searchIssues(term: ...)` GraphQL argument
- add a regression test for the search query variables

## Verification
- `uv run --no-project --with . --with pytest pytest test_readonly.py test_client.py`
- `uv run --no-project --with . linear search test --limit 3`
- `uv run --no-project --with ruff ruff check tools/productivity/linear/readonly.py tools/productivity/linear/test_readonly.py`

Prompted by: @akshaan