### PR TITLE
[codex] Add console MCP OAuth JWT auth

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.81
+version: 0.1.82
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.apiRs.enabled }}
 {{- $console := include "centaur.consoleValues" . | fromYaml -}}
+{{- $mcpPublicUrl := default .Values.slackbotv2.mcpPublicUrl .Values.apiRs.mcpPublicUrl -}}
 {{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") -}}
 {{- $repoCacheStorageType := include "centaur.repoCacheStorageType" . -}}
 {{- $repoCacheUsePvc := eq $repoCacheStorageType "persistentVolumeClaim" -}}
@@ -191,6 +192,14 @@ spec:
                   key: {{ printf "%sDATABASE_URL" .Values.secretManager.envPrefix }}
             - name: BIND_ADDR
               value: {{ printf "0.0.0.0:%v" .Values.apiRs.port | quote }}
+{{- if $mcpPublicUrl }}
+            - name: CENTAUR_MCP_PUBLIC_URL
+              value: {{ $mcpPublicUrl | quote }}
+{{- end }}
+{{- if $console.publicUrl }}
+            - name: CENTAUR_CONSOLE_PUBLIC_URL
+              value: {{ $console.publicUrl | quote }}
+{{- end }}
             - name: RUN_MIGRATIONS
               value: {{ .Values.apiRs.runMigrations | quote }}
             - name: IRON_CONTROL_SYNC_INFRA_SECRETS

--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -3,6 +3,7 @@
 {{- $secretEnv := include "centaur.secretEnvName" . }}
 {{- $prefix := .Values.secretManager.envPrefix }}
 {{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") }}
+{{- $mcpPublicUrl := default .Values.slackbotv2.mcpPublicUrl .Values.apiRs.mcpPublicUrl }}
 # console background job worker — runs Solid Queue (`bin/jobs`) so
 # console's enqueued jobs actually execute. The most important of these is
 # the broker-credential OAuth refresh loop, which mints and refreshes the access
@@ -120,6 +121,19 @@ spec:
                 secretKeyRef:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+            - name: CENTAUR_JWT_SIGNING_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sCENTAUR_JWT_SIGNING_SECRET" $prefix }}
+{{- if $console.publicUrl }}
+            - name: CENTAUR_CONSOLE_PUBLIC_URL
+              value: {{ $console.publicUrl | quote }}
+{{- end }}
+{{- if $mcpPublicUrl }}
+            - name: CENTAUR_MCP_PUBLIC_URL
+              value: {{ $mcpPublicUrl | quote }}
+{{- end }}
 {{- if $console.googleOauth.enabled }}
             # Google OAuth app credentials, needed by the broker-credential
             # OAuth refresh loop. Gated on console.googleOauth.enabled.

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -4,6 +4,7 @@
 {{- $prefix := .Values.secretManager.envPrefix }}
 {{- $dbName := $console.database.name }}
 {{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") }}
+{{- $mcpPublicUrl := default .Values.slackbotv2.mcpPublicUrl .Values.apiRs.mcpPublicUrl }}
 # console — Rails control plane for authenticated API access and encrypted
 # secret storage. The chart owns the Deployment shape (image, port, env,
 # security context) so operators tune it via `helm upgrade`. It runs against a
@@ -146,6 +147,19 @@ spec:
                 secretKeyRef:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sIRON_CONTROL_SECRET_KEY_BASE" $prefix }}
+            - name: CENTAUR_JWT_SIGNING_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sCENTAUR_JWT_SIGNING_SECRET" $prefix }}
+{{- if $console.publicUrl }}
+            - name: CENTAUR_CONSOLE_PUBLIC_URL
+              value: {{ $console.publicUrl | quote }}
+{{- end }}
+{{- if $mcpPublicUrl }}
+            - name: CENTAUR_MCP_PUBLIC_URL
+              value: {{ $mcpPublicUrl | quote }}
+{{- end }}
 {{- if $console.googleOauth.enabled }}
             # Google OAuth app credentials (sign-in + brokered token refresh).
             # Gated on console.googleOauth.enabled; the keys must exist in the

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -7,6 +7,7 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "replicaCount": { "type": "integer" },
+        "publicUrl": { "type": "string" },
         "railsEnv": { "type": "string" },
         "image": {
           "type": "object",

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -85,6 +85,9 @@ toolServer:
 console:
   enabled: false
   replicaCount: 1
+  # Public URL users reach in a browser. Set this when console is exposed behind
+  # Tailscale/Ingress so MCP OAuth issuer metadata and JWT validation agree.
+  publicUrl: ""
   image:
     repository: centaur-console
     tag: latest
@@ -292,6 +295,9 @@ apiRs:
     tag: latest
     pullPolicy: Always
   port: 8080
+  # Public/local MCP endpoint advertised through OAuth protected-resource
+  # metadata. Empty falls back to slackbotv2.mcpPublicUrl.
+  mcpPublicUrl: ""
   runMigrations: true
   sandboxBackend: agent-k8s
   sandboxWorkload: codex-app-server
@@ -393,6 +399,9 @@ slackbotv2:
     pullPolicy: Always
   userName: centaur
   assistantStatus: ""
+  # Public/local MCP endpoint shown in MCP SSO setup messages. The default
+  # assumes users connect through `kubectl port-forward ... 3000:8080`.
+  mcpPublicUrl: "http://localhost:3000"
   externalOrgAllowlist: ""
   triggerBotAllowlist: ""
   metrics:

--- a/contrib/scripts/bootstrap-k8s-secrets.sh
+++ b/contrib/scripts/bootstrap-k8s-secrets.sh
@@ -9,8 +9,10 @@ usage() {
 Usage: scripts/bootstrap-k8s-secrets.sh [--namespace NAMESPACE] [--force]
 
 Creates the required local-dev Kubernetes infra Secrets consumed by the Helm chart.
-Requires OP_SERVICE_ACCOUNT_TOKEN, OP_VAULT, SLACK_BOT_TOKEN,
-SLACK_SIGNING_SECRET, and SLACKBOT_API_KEY in the shell environment.
+When creating centaur-infra-env from scratch or with --force, requires
+OP_SERVICE_ACCOUNT_TOKEN, OP_VAULT, SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET,
+and SLACKBOT_API_KEY in the shell environment. Existing Secrets are only topped
+up with newly generated optional keys when absent.
 
 Optional 1Password Connect bootstrap (when ironProxy.manager.secretSource is
 set to onepassword-connect in the Helm values):
@@ -127,11 +129,6 @@ rand_hex() {
 
 require_cmd kubectl
 require_cmd openssl
-require_env OP_SERVICE_ACCOUNT_TOKEN
-require_env OP_VAULT
-require_env SLACK_BOT_TOKEN
-require_env SLACK_SIGNING_SECRET
-require_env SLACKBOT_API_KEY
 
 # Linear config is optional but must be complete: a token without the webhook
 # secret (or vice versa) deploys a linearbot that boots and then rejects every
@@ -162,6 +159,14 @@ delete_if_forced centaur-infra-env
 delete_if_forced centaur-firewall-ca
 delete_if_forced centaur-firewall-ca-key
 delete_if_forced centaur-onepassword-connect-credentials
+
+if ! secret_exists centaur-infra-env; then
+  require_env OP_SERVICE_ACCOUNT_TOKEN
+  require_env OP_VAULT
+  require_env SLACK_BOT_TOKEN
+  require_env SLACK_SIGNING_SECRET
+  require_env SLACKBOT_API_KEY
+fi
 
 secret_key_present() {
   local key="$1"
@@ -249,6 +254,9 @@ if secret_exists centaur-infra-env; then
   if ! secret_key_present IRON_CONTROL_SECRET_KEY_BASE; then
     patch_data+=("\"IRON_CONTROL_SECRET_KEY_BASE\":\"$(printf '%s%s' "$(rand_hex)" "$(rand_hex)" | base64 | tr -d '\n')\"")
   fi
+  if ! secret_key_present CENTAUR_JWT_SIGNING_SECRET; then
+    patch_data+=("\"CENTAUR_JWT_SIGNING_SECRET\":\"$(printf '%s%s' "$(rand_hex)" "$(rand_hex)" | base64 | tr -d '\n')\"")
+  fi
   # Linear bot credentials. Set whenever present so the OAuth token can be
   # rotated; the api-rs bearer is generated once and kept stable.
   if [[ -n "${LINEAR_ACCESS_TOKEN:-}" ]]; then
@@ -295,6 +303,7 @@ else
     --from-literal=IRON_CONTROL_AR_ENCRYPTION_DETERMINISTIC_KEY="$(rand_hex)"
     --from-literal=IRON_CONTROL_AR_ENCRYPTION_KEY_DERIVATION_SALT="$(rand_hex)"
     --from-literal=IRON_CONTROL_SECRET_KEY_BASE="$(rand_hex)$(rand_hex)"
+    --from-literal=CENTAUR_JWT_SIGNING_SECRET="$(rand_hex)$(rand_hex)"
   )
   if [[ -n "${DISCORD_BOT_TOKEN:-}" ]]; then
     secret_args+=(

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -17,6 +17,8 @@ pub enum ApiError {
     #[error("{0}")]
     Unauthorized(String),
     #[error("{0}")]
+    Forbidden(String),
+    #[error("{0}")]
     NotFound(String),
     #[error("{0}")]
     MethodNotAllowed(String),
@@ -49,6 +51,7 @@ impl IntoResponse for ApiError {
         let status = match &self {
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+            Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::MethodNotAllowed(_) => StatusCode::METHOD_NOT_ALLOWED,
             Self::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mcp_initialize_is_available_without_auth_before_runtime_is_ready() {
+    async fn mcp_requires_bearer_before_runtime_is_ready() {
         let app = build_router_with_app_state(AppState::unready());
 
         let response = app
@@ -250,14 +250,16 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(body["result"]["serverInfo"]["name"], "centaur");
-        assert_eq!(
-            body["result"]["capabilities"]["tools"]["listChanged"],
-            false
-        );
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let challenge = response
+            .headers()
+            .get(header::WWW_AUTHENTICATE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap();
+        assert!(challenge.contains("Bearer"));
+        assert!(challenge.contains(
+            "resource_metadata=\"http://centaur.local/.well-known/oauth-protected-resource/mcp\""
+        ));
     }
 
     #[tokio::test]

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -3,12 +3,16 @@ use std::{collections::BTreeSet, env, fs, path::PathBuf, time::Duration};
 use axum::{
     Json,
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
 };
+use base64::{Engine as _, engine::general_purpose};
 use centaur_session_runtime::{PersistentToolCallInput, SessionRuntime};
+use hmac::{Hmac, Mac};
 use serde::Deserialize;
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
 
 use crate::{
     ApiError,
@@ -25,6 +29,15 @@ pub(crate) async fn mcp_get() -> Response {
         })),
     )
         .into_response()
+}
+
+pub(crate) async fn mcp_protected_resource_metadata(headers: HeaderMap) -> Json<Value> {
+    Json(json!({
+        "resource": mcp_resource_url(&headers),
+        "authorization_servers": [mcp_authorization_server_url(&headers)],
+        "bearer_methods_supported": ["header"],
+        "scopes_supported": ["mcp:tools"],
+    }))
 }
 
 #[derive(Debug, Deserialize)]
@@ -51,16 +64,23 @@ struct CentaurToolMcpArguments {
     arguments: Value,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct McpPrincipal {
+    token_id: String,
     principal_id: String,
+    name: String,
+    scopes: Vec<String>,
+    expires_at: Option<OffsetDateTime>,
 }
 
 pub(crate) async fn mcp_post(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(request): Json<McpJsonRpcRequest>,
 ) -> Result<Response, ApiError> {
-    let principal = anonymous_mcp_principal();
+    let Some(principal) = authenticate_mcp_bearer(&headers)? else {
+        return Ok(mcp_unauthorized(&headers));
+    };
     if request.jsonrpc.as_deref().unwrap_or("2.0") != "2.0" {
         return Ok(mcp_json_error(
             request.id.unwrap_or(Value::Null),
@@ -87,6 +107,7 @@ pub(crate) async fn mcp_post(
         }),
         "ping" => json!({}),
         "tools/list" => {
+            ensure_mcp_scope(&principal.scopes, "mcp:tools")?;
             let mut tools = vec![mcp_whoami_tool()];
             tools.extend(mcp_centaur_tool_entries()?);
             json!({
@@ -94,6 +115,7 @@ pub(crate) async fn mcp_post(
             })
         }
         "tools/call" => {
+            ensure_mcp_scope(&principal.scopes, "mcp:tools")?;
             let params = serde_json::from_value::<McpToolCallParams>(request.params.clone())
                 .map_err(|error| ApiError::BadRequest(error.to_string()))?;
             if params.name == "centaur_whoami" {
@@ -119,7 +141,7 @@ pub(crate) async fn mcp_post(
 fn mcp_whoami_tool() -> Value {
     json!({
         "name": "centaur_whoami",
-        "description": "Show the Centaur MCP runner principal.",
+        "description": "Show the authenticated Centaur MCP principal and token metadata.",
         "inputSchema": {
             "type": "object",
             "properties": {},
@@ -239,6 +261,14 @@ fn mcp_whoami_result(principal: &McpPrincipal, arguments: Value) -> Result<Value
     Ok(mcp_text_result(
         serde_json::to_string_pretty(&json!({
             "principal_id": principal.principal_id,
+            "token_id": principal.token_id,
+            "token_name": principal.name,
+            "scopes": principal.scopes,
+            "expires_at": principal
+                .expires_at
+                .map(|value| value.format(&time::format_description::well_known::Rfc3339))
+                .transpose()
+                .map_err(|error| ApiError::Internal(error.to_string()))?,
         }))?,
         false,
     ))
@@ -287,13 +317,10 @@ async fn run_persistent_centaur_tool(
     method: &str,
     arguments: Value,
 ) -> Result<Value, ApiError> {
-    let runner_principal_id = runtime
-        .register_mcp_runner_principal(&principal.principal_id)
-        .await?;
     let output = runtime
         .run_persistent_tool_call(PersistentToolCallInput {
-            principal_id: runner_principal_id,
-            token_id: None,
+            principal_id: principal.principal_id.clone(),
+            token_id: Some(principal.token_id.clone()),
             tool_name: tool.name.clone(),
             method: method.to_owned(),
             arguments,
@@ -354,9 +381,191 @@ fn mcp_text_result(text: String, is_error: bool) -> Value {
     })
 }
 
-fn anonymous_mcp_principal() -> McpPrincipal {
-    McpPrincipal {
-        principal_id: "mcp-anonymous".to_owned(),
+fn authenticate_mcp_bearer(headers: &HeaderMap) -> Result<Option<McpPrincipal>, ApiError> {
+    let Some(token) = bearer_token(headers) else {
+        return Ok(None);
+    };
+    verify_mcp_jwt(&token, headers)
+}
+
+#[derive(Debug, Deserialize)]
+struct McpJwtHeader {
+    alg: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpJwtClaims {
+    aud: Value,
+    exp: i64,
+    iss: String,
+    #[serde(default)]
+    jti: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    nbf: Option<i64>,
+    principal_id: String,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    scopes: Option<Vec<String>>,
+    #[serde(default)]
+    sub: Option<String>,
+}
+
+fn verify_mcp_jwt(token: &str, headers: &HeaderMap) -> Result<Option<McpPrincipal>, ApiError> {
+    let secret = env::var("CENTAUR_JWT_SIGNING_SECRET").map_err(|_| {
+        ApiError::ServiceUnavailable("CENTAUR_JWT_SIGNING_SECRET is not configured".to_owned())
+    })?;
+    if secret.trim().is_empty() {
+        return Err(ApiError::ServiceUnavailable(
+            "CENTAUR_JWT_SIGNING_SECRET is not configured".to_owned(),
+        ));
+    }
+
+    let parts = token.split('.').collect::<Vec<_>>();
+    if parts.len() != 3 {
+        return Ok(None);
+    }
+    let Some(header) = decode_base64url_json::<McpJwtHeader>(parts[0]) else {
+        return Ok(None);
+    };
+    if header.alg != "HS256" {
+        return Ok(None);
+    }
+
+    let signing_input = format!("{}.{}", parts[0], parts[1]);
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).map_err(|_| {
+        ApiError::Internal("CENTAUR_JWT_SIGNING_SECRET is not valid HMAC key material".to_owned())
+    })?;
+    mac.update(signing_input.as_bytes());
+    let expected = mac.finalize().into_bytes();
+    let Some(presented) = decode_base64url(parts[2]) else {
+        return Ok(None);
+    };
+    if !constant_time_eq(&presented, expected.as_slice()) {
+        return Ok(None);
+    }
+
+    let Some(claims) = decode_base64url_json::<McpJwtClaims>(parts[1]) else {
+        return Ok(None);
+    };
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    if claims.exp <= now {
+        return Ok(None);
+    }
+    if claims.nbf.is_some_and(|nbf| nbf > now + 30) {
+        return Ok(None);
+    }
+    if !same_url(&claims.iss, &mcp_authorization_server_url(headers)) {
+        return Ok(None);
+    }
+    if !audience_contains(&claims.aud, &mcp_resource_url(headers)) {
+        return Ok(None);
+    }
+    if claims.principal_id.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let mut scopes = claims.scopes.unwrap_or_default();
+    if let Some(scope) = claims.scope {
+        scopes.extend(scope.split_whitespace().map(ToOwned::to_owned));
+    }
+    scopes = normalize_scope_list(scopes);
+    if scopes.is_empty() {
+        return Ok(None);
+    }
+    let expires_at = OffsetDateTime::from_unix_timestamp(claims.exp).ok();
+    let token_id = claims.jti.unwrap_or_else(|| {
+        let digest = Sha256::digest(token.as_bytes());
+        format!("mcp_jwt_{}", hex::encode(&digest[..12]))
+    });
+    let name = first_non_empty_owned([
+        claims.name,
+        claims.email,
+        claims.sub,
+        Some(claims.principal_id.clone()),
+    ])
+    .unwrap_or_else(|| claims.principal_id.clone());
+
+    Ok(Some(McpPrincipal {
+        token_id,
+        principal_id: claims.principal_id,
+        name,
+        scopes,
+        expires_at,
+    }))
+}
+
+fn decode_base64url_json<T: for<'de> Deserialize<'de>>(value: &str) -> Option<T> {
+    let decoded = decode_base64url(value)?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+fn decode_base64url(value: &str) -> Option<Vec<u8>> {
+    general_purpose::URL_SAFE_NO_PAD
+        .decode(value)
+        .or_else(|_| general_purpose::URL_SAFE.decode(value))
+        .ok()
+}
+
+fn normalize_scope_list(scopes: Vec<String>) -> Vec<String> {
+    let mut scopes = scopes
+        .into_iter()
+        .map(|scope| scope.trim().to_owned())
+        .filter(|scope| !scope.is_empty())
+        .collect::<Vec<_>>();
+    scopes.sort();
+    scopes.dedup();
+    scopes
+}
+
+fn first_non_empty_owned(values: impl IntoIterator<Item = Option<String>>) -> Option<String> {
+    values
+        .into_iter()
+        .flatten()
+        .map(|value| value.trim().to_owned())
+        .find(|value| !value.is_empty())
+}
+
+fn audience_contains(audience: &Value, resource: &str) -> bool {
+    match audience {
+        Value::String(value) => same_url(value, resource),
+        Value::Array(values) => values
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|value| same_url(value, resource)),
+        _ => false,
+    }
+}
+
+fn same_url(left: &str, right: &str) -> bool {
+    normalize_public_url(left)
+        .is_some_and(|left| normalize_public_url(right).is_some_and(|right| left == right))
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    let value = header_value(headers, "Authorization")?;
+    let token = value
+        .strip_prefix("Bearer ")
+        .or_else(|| value.strip_prefix("bearer "))
+        .unwrap_or(value.as_str())
+        .trim();
+    (!token.is_empty()).then(|| token.to_owned())
+}
+
+fn ensure_mcp_scope(scopes: &[String], required: &str) -> Result<(), ApiError> {
+    if scopes
+        .iter()
+        .any(|scope| scope == "*" || scope == required || scope == "mcp:*")
+    {
+        Ok(())
+    } else {
+        Err(ApiError::Forbidden(format!(
+            "missing required scope {required}"
+        )))
     }
 }
 
@@ -386,11 +595,148 @@ fn mcp_json_error(id: Value, code: i64, message: &str) -> Response {
     .into_response()
 }
 
+fn mcp_unauthorized(headers: &HeaderMap) -> Response {
+    let metadata = format!(
+        "{}/.well-known/oauth-protected-resource/mcp",
+        mcp_public_base_url(headers)
+    );
+    let challenge = format!(r#"Bearer resource_metadata="{metadata}", scope="mcp:tools""#);
+    let mut response = (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "ok": false,
+            "error": "missing or invalid MCP bearer token",
+        })),
+    )
+        .into_response();
+    if let Ok(value) = HeaderValue::from_str(&challenge) {
+        response.headers_mut().insert("WWW-Authenticate", value);
+    }
+    response
+}
+
+fn mcp_resource_url(headers: &HeaderMap) -> String {
+    if let Ok(public_url) = env::var("CENTAUR_MCP_PUBLIC_URL") {
+        if let Some(url) = normalize_mcp_endpoint_url(&public_url) {
+            return url;
+        }
+    }
+    format!("{}/mcp", request_base_url(headers))
+}
+
+fn mcp_authorization_server_url(headers: &HeaderMap) -> String {
+    for env_name in [
+        "CENTAUR_CONSOLE_PUBLIC_URL",
+        "IRON_CONTROL_PUBLIC_URL",
+        "CENTAUR_CONSOLE_URL",
+        "IRON_CONTROL_URL",
+    ] {
+        if let Ok(url) = env::var(env_name) {
+            if let Some(url) = normalize_public_url(&url) {
+                return url;
+            }
+        }
+    }
+    request_base_url(headers)
+}
+
+fn mcp_public_base_url(headers: &HeaderMap) -> String {
+    if let Ok(public_url) = env::var("CENTAUR_MCP_PUBLIC_URL") {
+        if let Some(url) = normalize_public_url(&public_url) {
+            return url.strip_suffix("/mcp").unwrap_or(&url).to_owned();
+        }
+    }
+    request_base_url(headers)
+}
+
+fn normalize_mcp_endpoint_url(value: &str) -> Option<String> {
+    let mut url = normalize_public_url(value)?;
+    if !url.ends_with("/mcp") {
+        url.push_str("/mcp");
+    }
+    Some(url)
+}
+
+fn normalize_public_url(value: &str) -> Option<String> {
+    let trimmed = value.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_owned())
+}
+
+fn request_base_url(headers: &HeaderMap) -> String {
+    let proto = header_value(headers, "X-Forwarded-Proto").unwrap_or_else(|| "http".to_owned());
+    let host = header_value(headers, "X-Forwarded-Host")
+        .or_else(|| header_value(headers, "Host"))
+        .unwrap_or_else(|| "127.0.0.1:8080".to_owned());
+    format!("{}://{}", proto.trim(), host.trim())
+}
+
+fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+/// Compare two byte strings in constant time (modulo length, which is not
+/// secret here).
+fn constant_time_eq(actual: &[u8], expected: &[u8]) -> bool {
+    use subtle::ConstantTimeEq;
+
+    actual.ct_eq(expected).into()
+}
+
 #[cfg(test)]
 mod mcp_tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{
+        sync::Mutex,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use futures_util::FutureExt;
 
     use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn set(vars: &[(&'static str, &'static str)]) -> Self {
+            let saved = vars
+                .iter()
+                .map(|(name, _)| (*name, env::var(name).ok()))
+                .collect();
+            for (name, value) in vars {
+                // SAFETY: tests that mutate process env hold ENV_LOCK for the
+                // duration of the guard, so concurrent tests in this module
+                // cannot observe partial mutations.
+                unsafe {
+                    env::set_var(name, value);
+                }
+            }
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in self.saved.drain(..) {
+                // SAFETY: see EnvGuard::set; the lock outlives the guard.
+                unsafe {
+                    if let Some(value) = value {
+                        env::set_var(name, value);
+                    } else {
+                        env::remove_var(name);
+                    }
+                }
+            }
+        }
+    }
 
     fn temp_dir(prefix: &str) -> PathBuf {
         let suffix = SystemTime::now()
@@ -408,6 +754,26 @@ mod mcp_tests {
             client_module: "client.py".to_owned(),
             project_dir,
         }
+    }
+
+    fn test_jwt(secret: &str, claims: Value) -> String {
+        let header = general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&json!({"alg": "HS256", "typ": "JWT"})).unwrap());
+        let payload = general_purpose::URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
+        let signing_input = format!("{header}.{payload}");
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(signing_input.as_bytes());
+        let signature = general_purpose::URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+        format!("{signing_input}.{signature}")
+    }
+
+    fn mcp_auth_headers(token: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+        headers
     }
 
     #[test]
@@ -463,7 +829,11 @@ def search(query, limit=20):
         let result = mcp_centaur_tool_result(
             &AppState::unready(),
             &McpPrincipal {
-                principal_id: "mcp-test".to_owned(),
+                principal_id: "mcp:test".to_owned(),
+                token_id: "mcp_tok_test".to_owned(),
+                name: "test".to_owned(),
+                scopes: vec!["mcp:tools".to_owned()],
+                expires_at: None,
             },
             test_tool(temp.clone()),
             json!({"method": "missing", "arguments": {}}),
@@ -477,5 +847,115 @@ def search(query, limit=20):
         assert!(text.contains("search"));
 
         let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn mcp_jwt_authenticates_console_principal() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[
+            ("CENTAUR_JWT_SIGNING_SECRET", "test-secret"),
+            ("CENTAUR_MCP_PUBLIC_URL", "http://localhost:3000/mcp"),
+            ("CENTAUR_CONSOLE_PUBLIC_URL", "http://localhost:3001"),
+        ]);
+        let token = test_jwt(
+            "test-secret",
+            json!({
+                "iss": "http://localhost:3001",
+                "sub": "usr_test",
+                "aud": "http://localhost:3000/mcp",
+                "exp": OffsetDateTime::now_utc().unix_timestamp() + 3600,
+                "iat": OffsetDateTime::now_utc().unix_timestamp(),
+                "jti": "mcpjwt_test",
+                "scope": "mcp:tools",
+                "principal_id": "prn_test",
+                "email": "test@example.com",
+            }),
+        );
+
+        let principal = authenticate_mcp_bearer(&mcp_auth_headers(&token))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(principal.token_id, "mcpjwt_test");
+        assert_eq!(principal.principal_id, "prn_test");
+        assert_eq!(principal.name, "test@example.com");
+        assert_eq!(principal.scopes, vec!["mcp:tools"]);
+        assert!(principal.expires_at.is_some());
+    }
+
+    #[test]
+    fn mcp_jwt_rejects_wrong_audience() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[
+            ("CENTAUR_JWT_SIGNING_SECRET", "test-secret"),
+            ("CENTAUR_MCP_PUBLIC_URL", "http://localhost:3000/mcp"),
+            ("CENTAUR_CONSOLE_PUBLIC_URL", "http://localhost:3001"),
+        ]);
+        let token = test_jwt(
+            "test-secret",
+            json!({
+                "iss": "http://localhost:3001",
+                "aud": "http://other.example/mcp",
+                "exp": OffsetDateTime::now_utc().unix_timestamp() + 3600,
+                "principal_id": "prn_test",
+                "scope": "mcp:tools",
+            }),
+        );
+
+        assert!(
+            authenticate_mcp_bearer(&mcp_auth_headers(&token))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn mcp_non_jwt_bearer_values_are_not_accepted() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[("CENTAUR_JWT_SIGNING_SECRET", "test-secret")]);
+
+        assert!(
+            authenticate_mcp_bearer(&mcp_auth_headers("not-a-jwt-token"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn mcp_protected_resource_metadata_uses_configured_urls() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[
+            ("CENTAUR_MCP_PUBLIC_URL", "http://localhost:3000"),
+            ("CENTAUR_CONSOLE_PUBLIC_URL", "http://localhost:3001"),
+        ]);
+
+        let Json(metadata) = mcp_protected_resource_metadata(HeaderMap::new())
+            .now_or_never()
+            .unwrap();
+
+        assert_eq!(metadata["resource"], "http://localhost:3000/mcp");
+        assert_eq!(
+            metadata["authorization_servers"][0],
+            "http://localhost:3001"
+        );
+    }
+
+    #[test]
+    fn mcp_unauthorized_challenge_uses_public_metadata_url() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[("CENTAUR_MCP_PUBLIC_URL", "http://localhost:3000/mcp")]);
+
+        let response = mcp_unauthorized(&HeaderMap::new());
+        let challenge = response
+            .headers()
+            .get("WWW-Authenticate")
+            .unwrap()
+            .to_str()
+            .unwrap();
+
+        assert!(challenge.contains(
+            r#"resource_metadata="http://localhost:3000/.well-known/oauth-protected-resource/mcp""#
+        ));
+        assert!(!challenge.contains("/mcp/.well-known"));
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -54,7 +54,7 @@ use uuid::Uuid;
 
 use crate::{
     ApiError,
-    mcp::{mcp_get, mcp_post},
+    mcp::{mcp_get, mcp_post, mcp_protected_resource_metadata},
     types::{
         AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
         EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
@@ -191,6 +191,14 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route("/metrics", get(metrics))
         .route("/api/personas", get(list_personas))
         .route("/mcp", post(mcp_post).get(mcp_get))
+        .route(
+            "/.well-known/oauth-protected-resource",
+            get(mcp_protected_resource_metadata),
+        )
+        .route(
+            "/.well-known/oauth-protected-resource/mcp",
+            get(mcp_protected_resource_metadata),
+        )
         .route(
             "/api/session/{thread_key}",
             post(create_or_get_session).get(get_session_context),

--- a/services/api-rs/rfcs/0004-console-mcp-jwt-auth.md
+++ b/services/api-rs/rfcs/0004-console-mcp-jwt-auth.md
@@ -1,0 +1,745 @@
+# RFC 0004: Console OAuth for MCP Auth
+
+Status: Draft
+Owner: TBD
+Target: `services/console`, `services/api-rs`
+
+## Summary
+
+Make Centaur's remote MCP endpoint use the MCP HTTP authorization flow, with
+console acting as the OAuth authorization server and api-rs acting as the MCP
+protected resource server.
+
+The user should not need to copy a JWT from a console page into Amp. Instead:
+
+1. A harness connects to `POST /mcp` without a token.
+2. api-rs returns `401 Unauthorized` with a `WWW-Authenticate: Bearer ...`
+   challenge that points at MCP Protected Resource Metadata.
+3. The harness fetches the Protected Resource Metadata and learns that console
+   is the authorization server.
+4. The harness discovers console's OAuth metadata.
+5. The harness registers as an OAuth client, or uses preconfigured client
+   metadata.
+6. The harness opens a browser to console's authorization endpoint with PKCE.
+7. The user signs in with the normal console login/SSO flow.
+8. Console ensures the signed-in user has an iron-control principal and returns
+   an authorization code to the harness.
+9. The harness exchanges the code for a bearer access token.
+10. The harness calls `POST /mcp` with `Authorization: Bearer <access_token>`.
+11. api-rs verifies the token and uses the encoded principal for MCP tool
+    execution.
+
+This matches the MCP authorization model used by HTTP-based MCP clients and
+harnesses, while keeping console as the identity and permission UX.
+
+## Motivation
+
+The current MCP branch exposes the HTTP MCP transport and persistent tool
+runners without a user-facing auth flow. That keeps the transport work small,
+but MCP clients still need a standard way to sign in and bind tool execution to
+the right console principal.
+
+Remote MCP clients already know how to follow an OAuth-style authorization
+flow. We should use that instead of asking users to paste bearer tokens.
+
+Console already owns:
+
+- user login and SSO
+- user approval/disable state
+- principals, roles, grants, and effective permissions
+- the operator UI where users can understand what identity they are using
+
+MCP auth should use that surface.
+
+The important product property is that MCP permissions are controlled by the
+principal. The access token should identify the principal. It should not copy
+the principal's current grants into the token. If an operator changes the
+principal's roles or grants, the next per-user tool runner/proxy sync should see
+the updated permissions without reissuing the token.
+
+## Goals
+
+- Use MCP-standard HTTP authorization so Amp and other harnesses can start auth
+  themselves.
+- Keep the existing MCP endpoint as `POST /mcp`.
+- Keep api-rs as the MCP protected resource server.
+- Make console the OAuth authorization server for Centaur MCP.
+- Use console login/SSO as the user authentication ceremony.
+- Return bearer access tokens from a token endpoint, not from a copy-token page.
+- Encode the iron-control principal id in the access token.
+- Keep MCP authorization based on live principal grants in iron-control.
+- Keep the current per-principal persistent MCP tool runner model.
+- Support Dynamic Client Registration initially, since generic MCP clients may
+  not be pre-registered with our console.
+
+## Non-Goals
+
+- Implement a local bridge.
+- Make Slackbot the long-term issuer of MCP credentials.
+- Put live credential grants or secret names inside access tokens.
+- Build a full general-purpose OAuth provider for arbitrary third-party apps.
+- Support every OAuth client authentication method in the first version.
+- Require Tailscale identity for MCP auth.
+
+## Current State
+
+The MCP branch has:
+
+- `POST /mcp` in api-rs.
+- No MCP token issuer.
+- An unauthenticated transport path used as the base for this authorization
+  work.
+- Persistent tool runners keyed by `principal_id`.
+
+The persistent runner already wants the iron-control principal id. For a
+proxied tool, api-rs creates or reuses a runner whose sandbox spec carries:
+
+```text
+iron_control_principal = <principal id>
+CENTAUR_MCP_PRINCIPAL_ID = <principal id>
+```
+
+That means the access token should encode the iron-control principal id, not
+only the console user id or email.
+
+## Protocol Design
+
+### Roles
+
+Centaur maps MCP/OAuth roles as follows:
+
+| Role | Centaur Component |
+|------|-------------------|
+| MCP protected resource server | api-rs `/mcp` |
+| OAuth authorization server | console |
+| OAuth client | Amp, Codex, VS Code, or another MCP harness/client |
+| Resource owner | signed-in console user |
+
+### Discovery Flow
+
+When a harness calls `/mcp` without a valid token, api-rs returns:
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer realm="mcp",
+  resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp",
+  scope="mcp:tools"
+```
+
+api-rs serves Protected Resource Metadata at both:
+
+```text
+/.well-known/oauth-protected-resource
+/.well-known/oauth-protected-resource/mcp
+```
+
+Example:
+
+```json
+{
+  "resource": "https://api.example.com/mcp",
+  "authorization_servers": ["https://console.example.com"],
+  "scopes_supported": ["mcp:tools"]
+}
+```
+
+The `resource` value must be the canonical externally visible MCP endpoint.
+For local preview dogfooding this can be `http://localhost:3000/mcp`; for
+production it should be the public HTTPS MCP URL.
+
+The harness then fetches authorization server metadata from console.
+
+Console should serve OAuth Authorization Server Metadata at:
+
+```text
+/.well-known/oauth-authorization-server
+```
+
+Optionally, console can also serve:
+
+```text
+/.well-known/openid-configuration
+```
+
+Example metadata:
+
+```json
+{
+  "issuer": "https://console.example.com",
+  "authorization_endpoint": "https://console.example.com/mcp/oauth/authorize",
+  "token_endpoint": "https://console.example.com/mcp/oauth/token",
+  "registration_endpoint": "https://console.example.com/mcp/oauth/register",
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "code_challenge_methods_supported": ["S256"],
+  "scopes_supported": ["mcp:tools"],
+  "token_endpoint_auth_methods_supported": ["none"],
+  "resource_indicators_supported": true
+}
+```
+
+### Client Registration
+
+First version should support Dynamic Client Registration because generic MCP
+harnesses may not have a pre-registered Centaur client id.
+
+Console endpoint:
+
+```text
+POST /mcp/oauth/register
+```
+
+Allowed registration shape:
+
+```json
+{
+  "client_name": "Amp",
+  "redirect_uris": ["http://127.0.0.1:49152/callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+Console returns:
+
+```json
+{
+  "client_id": "mcp_client_...",
+  "client_name": "Amp",
+  "redirect_uris": ["http://127.0.0.1:49152/callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none",
+  "client_id_issued_at": 1782749000
+}
+```
+
+Registration constraints:
+
+- public clients only in v1 (`token_endpoint_auth_method = "none"`)
+- require PKCE S256 at authorize/token time
+- allow loopback redirect URIs (`http://127.0.0.1`, `http://localhost`, `[::1]`)
+- allow HTTPS redirect URIs
+- reject wildcard redirect URIs
+- reject non-loopback plain HTTP redirect URIs
+- store only client metadata and timestamps, not user authorization
+
+Future versions can add OAuth Client ID Metadata Documents. Do not advertise
+`client_id_metadata_document_supported` until console actually validates those
+documents.
+
+### Authorization Endpoint
+
+Console endpoint:
+
+```text
+GET /mcp/oauth/authorize
+```
+
+Required parameters:
+
+```text
+response_type=code
+client_id=<registered client id>
+redirect_uri=<one registered redirect URI>
+code_challenge=<PKCE S256 challenge>
+code_challenge_method=S256
+resource=<canonical MCP resource URI>
+scope=mcp:tools
+state=<client state>
+```
+
+Behavior:
+
+- If signed out, redirect through existing console login/SSO and return to the
+  authorize request.
+- If the console user is pending or disabled, deny authorization.
+- Validate `client_id`, `redirect_uri`, `scope`, `resource`, and PKCE params.
+- Ensure the signed-in user has an MCP principal.
+- Optionally show a compact consent/confirmation page.
+- Create a short-lived one-time authorization code.
+- Redirect to the client `redirect_uri` with `code` and original `state`.
+
+The authorization code stores:
+
+- `client_id`
+- `redirect_uri`
+- `code_challenge`
+- `code_challenge_method`
+- `resource`
+- `scope`
+- `user_id`
+- `principal_id`
+- expiration timestamp, suggested 5 minutes
+- consumed timestamp, initially null
+
+### Token Endpoint
+
+Console endpoint:
+
+```text
+POST /mcp/oauth/token
+```
+
+Authorization code exchange request:
+
+```text
+grant_type=authorization_code
+code=<authorization code>
+redirect_uri=<same redirect URI>
+client_id=<client id>
+code_verifier=<PKCE verifier>
+resource=<canonical MCP resource URI>
+```
+
+Console validates:
+
+- code exists, is unexpired, and is unused
+- code belongs to `client_id`
+- `redirect_uri` matches the code
+- `resource` matches the code
+- PKCE verifier matches the stored S256 challenge
+- user is still active
+- principal still exists
+
+Console returns:
+
+```json
+{
+  "access_token": "<jwt>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "cmcpr_...",
+  "scope": "mcp:tools"
+}
+```
+
+The access token is a JWT signed by console with the shared Centaur signing
+secret. Refresh tokens are opaque random strings stored hashed by console.
+
+Refresh token request:
+
+```text
+grant_type=refresh_token
+refresh_token=<opaque refresh token>
+client_id=<client id>
+resource=<canonical MCP resource URI>
+scope=mcp:tools
+```
+
+Refresh behavior:
+
+- validate refresh token hash, client id, user status, principal, resource, and
+  scope
+- rotate refresh token on each use
+- return a fresh access token
+
+### Access Token Claims
+
+Example JWT payload:
+
+```json
+{
+  "iss": "https://console.example.com",
+  "aud": "https://api.example.com/mcp",
+  "sub": "usr_abc123",
+  "jti": "mcp_at_018f...",
+  "iat": 1782749000,
+  "nbf": 1782749000,
+  "exp": 1782752600,
+  "scope": "mcp:tools",
+  "client_id": "mcp_client_abc123",
+  "principal_id": "prn_abc123",
+  "principal_foreign_id": "console-user-alice-example-com",
+  "principal_namespace": "default",
+  "email": "alice@example.com",
+  "name": "Alice Example"
+}
+```
+
+Claim semantics:
+
+| Claim | Purpose |
+|-------|---------|
+| `iss` | Console issuer URL from authorization server metadata. |
+| `aud` | Canonical MCP resource URI from the authorization request. |
+| `sub` | Console user oid. Useful for audit/debugging. |
+| `jti` | Access token instance id. Used as `token_id` in MCP whoami/logs. |
+| `iat`/`nbf`/`exp` | Token lifetime. |
+| `scope` | MCP protocol scopes, not credential grants. |
+| `client_id` | Registered OAuth client id. |
+| `principal_id` | iron-control principal oid used for tool runner/proxy binding. |
+| `principal_foreign_id` | Human/debug identifier. Not authoritative for proxy binding. |
+| `principal_namespace` | Human/debug namespace. |
+| `email`/`name` | Display only. |
+
+The JWT must not include:
+
+- secret ids
+- role ids
+- grant details
+- actual credential values
+- provider refresh tokens
+
+### Principal Model
+
+Console creates or finds one MCP principal per active console user.
+
+Default mapping:
+
+```text
+namespace:  <configured namespace, default "default">
+foreign_id: console-user-<slugified email>
+name:       Console User <email>
+labels:
+  managed-by: centaur
+  principal-kind: console-user
+  console-user-id: <usr_...>
+  email: <email>
+```
+
+The access token includes the resulting principal oid, for example `prn_...`.
+
+The oid is what api-rs uses to bind the per-sandbox iron-proxy. The foreign id
+and email are included for diagnostics only.
+
+This gives us the permissions flexibility we want:
+
+- grant tools/secrets directly to the user's console principal
+- assign roles to the user's console principal
+- later change grants/roles without changing MCP tokens
+- later support group/team based assignment through console policy without
+  changing MCP transport
+
+### Signing Secret
+
+Add one general Centaur JWT signing secret instead of an MCP-specific secret:
+
+```text
+CENTAUR_JWT_SIGNING_SECRET
+```
+
+This should live in the shared infra Secret and be mounted into both console and
+api-rs.
+
+Why not reuse Rails `SECRET_KEY_BASE`?
+
+- It is tied to Rails cookies and framework internals.
+- Rotating it has Rails-specific blast radius.
+- api-rs should not need to treat Rails session signing material as an API auth
+  root.
+- A general Centaur JWT secret can support other future service-issued JWTs with
+  issuer/audience separation.
+
+The first version can use HS256 with this shared secret.
+
+JWT verification in api-rs must require:
+
+- known algorithm: `HS256`
+- trusted issuer matching console metadata
+- audience matching the canonical MCP resource URI
+- `exp` in the future
+- `nbf` absent or not in the future
+- `iat` not unreasonably in the future
+- required `principal_id`
+- required `scope` containing `mcp:tools` or `mcp:*`
+
+Future rotation can add:
+
+```text
+CENTAUR_JWT_SIGNING_KID
+CENTAUR_JWT_VERIFYING_SECRETS
+```
+
+where the verifying env var is a JSON map of `kid -> secret`.
+
+### MCP Endpoint Auth
+
+api-rs should accept only console-issued OAuth access JWTs.
+
+```text
+Authorization: Bearer <value>
+
+verify as console OAuth MCP access token
+```
+
+The verified identity should normalize into the existing MCP principal shape:
+
+```text
+McpAuthenticatedPrincipal {
+  token_id: <jti>
+  principal_id: <iron-control principal oid>
+  name: <principal or user display name>
+  scopes: ["mcp:tools"]
+  expires_at: <jwt exp>
+}
+```
+
+Everything after auth should stay the same:
+
+- `tools/list` checks `mcp:tools`.
+- `tools/call` checks `mcp:tools`.
+- proxied tools use persistent runner keyed by `principal_id`.
+- the runner sandbox uses that same `principal_id` for iron-proxy.
+
+## Deployment Config
+
+Add the shared secret to the infra Secret:
+
+```text
+CENTAUR_JWT_SIGNING_SECRET=<random 32+ bytes, base64 or hex encoded>
+```
+
+`just bootstrap-secrets` should generate it if absent and never rotate it in
+place.
+
+Chart wiring:
+
+- api-rs already imports the shared infra Secret with `envFrom`, so it can read
+  `CENTAUR_JWT_SIGNING_SECRET`.
+- console should explicitly mount `CENTAUR_JWT_SIGNING_SECRET` from the shared
+  infra Secret, because console intentionally does not use `envFrom`.
+- api-rs needs a canonical MCP public URL for Protected Resource Metadata.
+- console needs the same canonical MCP public URL for OAuth resource validation.
+- console needs its own public issuer URL.
+
+Suggested env vars:
+
+```text
+CENTAUR_JWT_SIGNING_SECRET
+CENTAUR_MCP_PUBLIC_URL
+CENTAUR_CONSOLE_PUBLIC_URL
+CENTAUR_MCP_ACCESS_TOKEN_TTL_SECONDS
+CENTAUR_MCP_REFRESH_TOKEN_TTL_SECONDS
+CENTAUR_MCP_PRINCIPAL_NAMESPACE
+```
+
+`CENTAUR_JWT_SIGNING_SECRET` is intentionally general. The other env vars are
+MCP-specific policy/display knobs.
+
+## Security Considerations
+
+### Bearer Token Risk
+
+The OAuth access token is a bearer token. Anyone who obtains it can use the
+encoded principal's MCP permissions until it expires.
+
+Mitigations:
+
+- short access token TTL, suggested 1 hour
+- refresh tokens stored hashed by console
+- refresh token rotation
+- no access token values in logs
+- no access token persistence in console DB
+- no token values in Slack messages
+- no grants embedded in access tokens
+- future `jti` denylist if needed
+
+### Disabled Users
+
+Console checks user status when authorizing and refreshing.
+
+Because access tokens are stateless, disabling a user does not automatically
+invalidate already-issued access tokens until they expire. Short access token
+TTL limits this window. Refresh tokens must stop working immediately for
+disabled users.
+
+### Permission Changes
+
+Permission changes should not require new access tokens.
+
+The token identifies `principal_id`; iron-control remains the live source of
+truth for grants. If a role is revoked from the principal, the next proxy sync
+should remove that credential from the user's runner.
+
+### Audience and Resource Binding
+
+The API must require `aud` to match the canonical MCP resource URI. Console must
+issue access tokens only for the `resource` value supplied by the client and
+accepted by console policy.
+
+Do not accept generic audiences like `api` or `centaur`.
+
+### DCR Abuse
+
+Unauthenticated Dynamic Client Registration can be abused if unconstrained.
+
+Initial constraints:
+
+- only public clients
+- loopback or HTTPS redirect URIs only
+- no wildcard redirects
+- no custom schemes initially
+- rate limit registration
+- audit client registrations
+- optionally prune unused clients
+
+### Secret Rotation
+
+Initial implementation can use one shared signing secret.
+
+Before production reliance, add a `kid` strategy:
+
+- console signs with active `kid`
+- api-rs verifies against active plus previous keys
+- old keys stay in verify-only mode until all access tokens signed with them
+  expire
+
+## Alternatives Considered
+
+### Manual Copyable JWT Page
+
+Pros:
+
+- simplest to implement
+- no OAuth client registration, auth codes, or token endpoint
+
+Cons:
+
+- not the MCP-supported HTTP auth flow harnesses are built around
+- poor UX for Amp and other clients
+- users manually handle long bearer secrets
+- harder to refresh tokens cleanly
+
+This RFC replaces the copy-token page with MCP OAuth.
+
+### Keep Opaque DB Tokens
+
+Pros:
+
+- simple revocation
+- simple for a Slack-first prototype
+
+Cons:
+
+- api-rs remains an issuer
+- Slackbot remains an issuance UX
+- every non-Slack surface needs another token flow
+- console login/SSO is not the source of user identity
+- not the harness-native MCP auth path
+
+### External OAuth Provider Only
+
+We could point the MCP Protected Resource Metadata directly at Okta, Google, or
+another IdP.
+
+Pros:
+
+- mature OAuth implementation
+- less auth code in console
+
+Cons:
+
+- the access token still needs Centaur principal claims
+- we still need a principal mapping layer
+- group/role policy becomes split between IdP and iron-control
+- local/dev and preview flows are harder
+
+Console can still federate login to Okta/Google while issuing the Centaur MCP
+access token itself.
+
+### Tailscale MCP Auth
+
+Pros:
+
+- strong device/user identity on a tailnet
+
+Cons:
+
+- not every user is on the same tailnet
+- does not solve Discord or external users
+- still need to map tailnet identity to iron-control principals
+
+### Reuse Rails `SECRET_KEY_BASE`
+
+Pros:
+
+- already exists
+- console and api-rs can be wired to read it
+
+Cons:
+
+- wrong blast radius
+- tied to Rails cookies/framework behavior
+- not obviously safe to expose as a general API signing root
+
+Use `CENTAUR_JWT_SIGNING_SECRET` instead.
+
+## Rollout Plan
+
+1. Add this RFC.
+2. Add `CENTAUR_JWT_SIGNING_SECRET` bootstrap and chart wiring.
+3. Add api-rs Protected Resource Metadata with console authorization server URL.
+4. Add console OAuth authorization server metadata.
+5. Add console Dynamic Client Registration.
+6. Add console authorization code + PKCE flow.
+7. Add console token endpoint with JWT access tokens and opaque refresh tokens.
+8. Add console principal resolution for signed-in users.
+9. Add api-rs JWT access token verification for MCP bearer auth.
+10. Replace the unauthenticated MCP path with JWT bearer verification.
+11. Dogfood with Amp using a local port-forwarded preview API.
+
+## Test Plan
+
+api-rs tests:
+
+- missing bearer returns `401` with `WWW-Authenticate` containing
+  `resource_metadata` and `scope="mcp:tools"`
+- Protected Resource Metadata returns the configured resource and console
+  authorization server
+- expired JWT is rejected
+- wrong issuer is rejected
+- wrong audience/resource is rejected
+- missing `principal_id` is rejected
+- missing `mcp:tools` scope is rejected
+- valid JWT authenticates and `centaur_whoami` reports principal and `jti`
+
+Console tests:
+
+- authorization metadata includes required endpoints and supported capabilities
+- DCR accepts loopback redirect URIs
+- DCR rejects wildcard and non-loopback HTTP redirect URIs
+- signed-out authorize request redirects to login and resumes
+- pending user cannot authorize
+- disabled user cannot authorize
+- active user can authorize
+- authorization code is one-time-use
+- wrong PKCE verifier is rejected
+- token endpoint returns bearer JWT with expected issuer, audience, subject,
+  principal, scope, and expiration
+- refresh token is stored hashed and rotates on use
+- disabled users cannot refresh
+- raw signing secret is never rendered
+
+Chart/script tests:
+
+- `just bootstrap-secrets` creates `CENTAUR_JWT_SIGNING_SECRET` only when absent
+- console deployment receives `CENTAUR_JWT_SIGNING_SECRET`
+- api-rs receives the same secret
+- Helm lint/template pass
+
+Manual dogfood:
+
+- port-forward preview api-rs
+- configure Amp with the preview MCP URL
+- verify Amp opens browser auth automatically
+- sign in through console
+- complete PKCE code exchange
+- call `centaur_whoami`
+- call a non-secret tool
+- call a proxied tool granted to the console principal
+- revoke a grant and verify subsequent proxied calls lose access
+
+## Open Questions
+
+- Do we need refresh tokens in v1, or will access-token-only be acceptable for
+  the harnesses we care about?
+- Should we support OAuth Client ID Metadata Documents in v1, or is DCR enough
+  for Amp/Codex/VS Code?
+- Default access token TTL: 1 hour, 8 hours, or environment-specific?
+- Default refresh token TTL: 7 days, 30 days, or environment-specific?
+- Should the console principal namespace default to `default` or a dedicated
+  namespace like `mcp`?
+- Do we want a first-version access-token `jti` denylist, or is short TTL
+  enough?

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -82,13 +82,21 @@ class ApplicationController < ActionController::Base
       return redirect_to login_path, alert: "Your account is disabled."
     end
 
+    return_to = session[:return_to]
     reset_session
     session[:user_id] = user.id
+    session[:return_to] = return_to if return_to.present?
     if user.active?
-      redirect_to console_principals_path, notice: "Signed in as #{user.email}."
+      redirect_to post_login_redirect_path, notice: "Signed in as #{user.email}."
     else
       redirect_to pending_path, notice: "Your account is awaiting approval."
     end
+  end
+
+  def post_login_redirect_path
+    path = session.delete(:return_to).to_s
+    return console_principals_path unless path.start_with?("/") && !path.start_with?("//")
+    path
   end
 
   def render_not_found(e)

--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -1,0 +1,414 @@
+require "base64"
+require "digest"
+require "uri"
+
+module Mcp
+  class OauthController < ApplicationController
+    layout "auth"
+
+    skip_before_action :require_login, only: %i[metadata register authorize token]
+    skip_before_action :require_active_account, only: %i[metadata register authorize token]
+    skip_forgery_protection only: %i[register token]
+
+    ACCESS_TOKEN_TTL_SECONDS = 1.hour.to_i
+
+    # GET /.well-known/oauth-authorization-server
+    def metadata
+      render json: {
+        issuer: public_base_url,
+        authorization_endpoint: URI.join(public_base_url, "/mcp/oauth/authorize").to_s,
+        token_endpoint: URI.join(public_base_url, "/mcp/oauth/token").to_s,
+        registration_endpoint: URI.join(public_base_url, "/mcp/oauth/register").to_s,
+        response_types_supported: [ "code" ],
+        grant_types_supported: McpOauthClient::DEFAULT_GRANT_TYPES,
+        code_challenge_methods_supported: [ "S256" ],
+        token_endpoint_auth_methods_supported: [ "none" ],
+        scopes_supported: McpOauthClient::DEFAULT_SCOPES,
+        resource_parameter_supported: true
+      }
+    end
+
+    # POST /mcp/oauth/register
+    def register
+      requested_redirect_uris =
+        Array(params[:redirect_uris]).map(&:to_s).map(&:strip).reject(&:blank?)
+      client = McpOauthClient.create!(
+        name: params[:client_name].presence || "MCP client",
+        redirect_uris: requested_redirect_uris,
+        grant_types: normalize_list_param(
+          params[:grant_types],
+          McpOauthClient::DEFAULT_GRANT_TYPES
+        ),
+        response_types: normalize_list_param(
+          params[:response_types],
+          McpOauthClient::DEFAULT_RESPONSE_TYPES
+        ),
+        scopes: normalize_scope_param(params[:scope], McpOauthClient::DEFAULT_SCOPES),
+        metadata: registration_metadata
+      )
+
+      render json: {
+        client_id: client.public_client_id,
+        client_name: client.name,
+        redirect_uris: client.redirect_uris,
+        grant_types: client.grant_types,
+        response_types: client.response_types,
+        scope: client.scopes.join(" "),
+        token_endpoint_auth_method: "none"
+      }, status: :created
+    rescue ActiveRecord::RecordInvalid => e
+      oauth_error(
+        :invalid_client_metadata,
+        e.record.errors.full_messages.to_sentence,
+        status: :bad_request
+      )
+    end
+
+    # GET /mcp/oauth/authorize
+    def authorize
+      return redirect_to_login unless current_user
+      return redirect_to pending_path if current_user.pending?
+      return redirect_to login_path, alert: "Your account is disabled." if current_user.disabled?
+
+      client = resolve_client(params[:client_id])
+      return authorization_error(nil, :invalid_request, "Unknown client.") unless client
+      unless params[:response_type] == "code"
+        return authorization_error(
+          client,
+          :unsupported_response_type,
+          "Only response_type=code is supported."
+        )
+      end
+      unless client.redirect_uri_allowed?(params[:redirect_uri])
+        return authorization_error(
+          client,
+          :invalid_request,
+          "redirect_uri is not registered for this client."
+        )
+      end
+      unless params[:code_challenge_method] == "S256"
+        return authorization_error(
+          client,
+          :invalid_request,
+          "code_challenge_method must be S256."
+        )
+      end
+      if params[:code_challenge].blank?
+        return authorization_error(client, :invalid_request, "code_challenge is required.")
+      end
+
+      scopes = normalize_scope_param(params[:scope], McpOauthClient::DEFAULT_SCOPES)
+      unsupported = scopes - McpOauthClient::DEFAULT_SCOPES
+      if unsupported.any?
+        return authorization_error(
+          client,
+          :invalid_scope,
+          "Unsupported scope: #{unsupported.join(' ')}."
+        )
+      end
+
+      resource = resolve_requested_resource
+      return authorization_error(client, :invalid_target, "resource is required.") if resource.blank?
+
+      principal = principal_for_current_user
+      code = McpOauthAuthorizationCode.create!(
+        mcp_oauth_client: client,
+        user: current_user,
+        principal: principal,
+        redirect_uri: params[:redirect_uri].to_s,
+        code_challenge: params[:code_challenge].to_s,
+        resource: resource,
+        scopes: scopes
+      )
+      client.touch(:last_used_at)
+
+      uri = URI.parse(params[:redirect_uri])
+      query = Rack::Utils.parse_nested_query(uri.query)
+      query["code"] = code.plaintext_code
+      query["state"] = params[:state] if params[:state].present?
+      uri.query = query.to_query
+      redirect_to uri.to_s, allow_other_host: true
+    rescue ActiveRecord::RecordInvalid => e
+      authorization_error(nil, :server_error, e.record.errors.full_messages.to_sentence)
+    end
+
+    # POST /mcp/oauth/token
+    def token
+      case params[:grant_type]
+      when "authorization_code"
+        exchange_authorization_code
+      when "refresh_token"
+        exchange_refresh_token
+      else
+        oauth_error(:unsupported_grant_type, "Unsupported grant_type.", status: :bad_request)
+      end
+    end
+
+    private
+
+    def exchange_authorization_code
+      client = resolve_client(params[:client_id])
+      return oauth_error(:invalid_client, "Unknown client.", status: :unauthorized) unless client
+      code = McpOauthAuthorizationCode.find_usable(params[:code])
+      unless code
+        return oauth_error(
+          :invalid_grant,
+          "Authorization code is invalid or expired.",
+          status: :bad_request
+        )
+      end
+      unless code.mcp_oauth_client == client
+        return oauth_error(
+          :invalid_grant,
+          "Authorization code was not issued to this client.",
+          status: :bad_request
+        )
+      end
+      unless code.redirect_uri == params[:redirect_uri].to_s
+        return oauth_error(
+          :invalid_grant,
+          "redirect_uri does not match the authorization request.",
+          status: :bad_request
+        )
+      end
+      unless pkce_valid?(code.code_challenge, params[:code_verifier].to_s)
+        return oauth_error(:invalid_grant, "PKCE verification failed.", status: :bad_request)
+      end
+
+      refresh = nil
+      invalid_grant = false
+      McpOauthAuthorizationCode.transaction do
+        code.lock!
+        if code.consumed_at.present? || code.expires_at <= Time.current
+          invalid_grant = true
+        else
+          code.consume!
+          refresh = McpOauthRefreshToken.create!(
+            mcp_oauth_client: client,
+            user: code.user,
+            principal: code.principal,
+            resource: code.resource,
+            scopes: code.scopes
+          )
+        end
+      end
+      if invalid_grant
+        return oauth_error(
+          :invalid_grant,
+          "Authorization code is invalid or expired.",
+          status: :bad_request
+        )
+      end
+
+      client.touch(:last_used_at)
+      render_token_response(
+        client: client,
+        user: code.user,
+        principal: code.principal,
+        resource: code.resource,
+        scopes: code.scopes,
+        refresh_token: refresh.plaintext_token
+      )
+    end
+
+    def exchange_refresh_token
+      client = resolve_client(params[:client_id])
+      return oauth_error(:invalid_client, "Unknown client.", status: :unauthorized) unless client
+      refresh = McpOauthRefreshToken.find_usable(params[:refresh_token])
+      unless refresh
+        return oauth_error(
+          :invalid_grant,
+          "Refresh token is invalid or expired.",
+          status: :bad_request
+        )
+      end
+      unless refresh.mcp_oauth_client == client
+        return oauth_error(
+          :invalid_grant,
+          "Refresh token was not issued to this client.",
+          status: :bad_request
+        )
+      end
+
+      rotated = nil
+      invalid_grant = false
+      McpOauthRefreshToken.transaction do
+        refresh.lock!
+        if refresh.revoked_at.present? || refresh.expires_at <= Time.current
+          invalid_grant = true
+        else
+          refresh.update!(revoked_at: Time.current, last_used_at: Time.current)
+          rotated = McpOauthRefreshToken.create!(
+            mcp_oauth_client: client,
+            user: refresh.user,
+            principal: refresh.principal,
+            resource: refresh.resource,
+            scopes: refresh.scopes
+          )
+        end
+      end
+      if invalid_grant
+        return oauth_error(
+          :invalid_grant,
+          "Refresh token is invalid or expired.",
+          status: :bad_request
+        )
+      end
+
+      client.touch(:last_used_at)
+      render_token_response(
+        client: client,
+        user: refresh.user,
+        principal: refresh.principal,
+        resource: refresh.resource,
+        scopes: refresh.scopes,
+        refresh_token: rotated.plaintext_token
+      )
+    end
+
+    def render_token_response(client:, user:, principal:, resource:, scopes:, refresh_token:)
+      now = Time.current.to_i
+      ttl = access_token_ttl_seconds
+      payload = {
+        iss: public_base_url,
+        sub: user.oid,
+        aud: resource,
+        exp: now + ttl,
+        nbf: now - 5,
+        iat: now,
+        jti: "mcpjwt_#{SecureRandom.hex(16)}",
+        scope: scopes.join(" "),
+        client_id: client.public_client_id,
+        principal_id: principal.oid,
+        principal_foreign_id: principal.foreign_id,
+        email: user.email,
+        name: user.name.presence || user.email
+      }
+      render json: {
+        access_token: Mcp::Jwt.encode(payload),
+        token_type: "Bearer",
+        expires_in: ttl,
+        scope: scopes.join(" "),
+        refresh_token: refresh_token
+      }
+    rescue KeyError => e
+      oauth_error(:server_error, e.message, status: :service_unavailable)
+    end
+
+    def redirect_to_login
+      session[:return_to] = request.fullpath if request.request_method == "GET"
+      redirect_to login_path
+    end
+
+    def authorization_error(client, error, description)
+      if client&.redirect_uri_allowed?(params[:redirect_uri])
+        uri = URI.parse(params[:redirect_uri])
+        query = Rack::Utils.parse_nested_query(uri.query)
+        query["error"] = error.to_s
+        query["error_description"] = description
+        query["state"] = params[:state] if params[:state].present?
+        uri.query = query.to_query
+        redirect_to uri.to_s, allow_other_host: true
+      else
+        render plain: description, status: :bad_request
+      end
+    end
+
+    def oauth_error(error, description, status:)
+      render json: { error: error.to_s, error_description: description }, status: status
+    end
+
+    def resolve_client(client_id)
+      McpOauthClient.find_by_oid(client_id)
+    end
+
+    def resolve_requested_resource
+      resource = params[:resource].presence || configured_mcp_resource_url
+      return nil unless resource.present?
+      configured = configured_mcp_resource_url
+      if configured.present? &&
+          normalize_mcp_resource_url(resource) != normalize_mcp_resource_url(configured)
+        return nil
+      end
+      normalize_mcp_resource_url(resource)
+    end
+
+    def configured_mcp_resource_url
+      ENV["CENTAUR_MCP_PUBLIC_URL"].presence || ConsoleEnv["MCP_PUBLIC_URL"].presence
+    end
+
+    def normalize_mcp_resource_url(value)
+      uri = URI.parse(value.to_s.strip)
+      return nil unless %w[http https].include?(uri.scheme) && uri.host.present?
+      uri.fragment = nil
+      path = uri.path.to_s.sub(%r{/+\z}, "")
+      uri.path = path.end_with?("/mcp") ? path : "#{path}/mcp"
+      uri.to_s.sub(/\?\z/, "")
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def principal_for_current_user
+      foreign_id = principal_foreign_id(current_user.email)
+      Principal
+        .find_or_initialize_by(namespace: mcp_principal_namespace, foreign_id: foreign_id)
+        .tap do |principal|
+        principal.created_by ||= current_user
+        principal.name = current_user.name.presence || current_user.email
+        principal.labels = principal.labels.merge(
+          "managed-by" => "centaur",
+          "kind" => "console_user",
+          "console-user-id" => current_user.oid,
+          "email" => current_user.email
+        )
+        principal.save!
+      end
+    end
+
+    def principal_foreign_id(email)
+      normalized = email.to_s.downcase.strip
+      safe = normalized.gsub(/[^A-Za-z0-9\-._~]/, "-").gsub(/-+/, "-").first(48)
+      digest = Digest::SHA256.hexdigest(normalized).first(12)
+      "console-user-#{safe}-#{digest}"
+    end
+
+    def mcp_principal_namespace
+      ENV["CENTAUR_MCP_PRINCIPAL_NAMESPACE"].presence ||
+        ConsoleEnv["MCP_PRINCIPAL_NAMESPACE"].presence ||
+        "default"
+    end
+
+    def access_token_ttl_seconds
+      raw =
+        ENV["CENTAUR_MCP_ACCESS_TOKEN_TTL_SECONDS"].presence ||
+        ConsoleEnv["MCP_ACCESS_TOKEN_TTL_SECONDS"].presence
+      seconds = raw.to_i
+      seconds.positive? ? seconds : ACCESS_TOKEN_TTL_SECONDS
+    end
+
+    def registration_metadata
+      params
+        .to_unsafe_h
+        .slice("client_uri", "logo_uri", "contacts", "software_id", "software_version")
+        .compact
+    end
+
+    def normalize_list_param(value, default)
+      list = value.presence || default
+      Array(list).map(&:to_s).map(&:strip).reject(&:blank?).presence || default
+    end
+
+    def normalize_scope_param(value, default)
+      return default if value.blank?
+      value.to_s.split(/[,\s]+/).map(&:strip).reject(&:blank?)
+    end
+
+    def pkce_valid?(challenge, verifier)
+      return false if verifier.blank?
+      actual = Base64.urlsafe_encode64(Digest::SHA256.digest(verifier), padding: false)
+      ActiveSupport::SecurityUtils.secure_compare(actual, challenge.to_s)
+    rescue ArgumentError
+      false
+    end
+  end
+end

--- a/services/console/app/models/mcp_oauth_authorization_code.rb
+++ b/services/console/app/models/mcp_oauth_authorization_code.rb
@@ -1,0 +1,43 @@
+require "digest"
+
+class McpOauthAuthorizationCode < ApplicationRecord
+  oid_prefix "moa"
+
+  CODE_TTL = 10.minutes
+  TOKEN_PREFIX = "mcpauth_".freeze
+
+  attr_accessor :plaintext_code
+
+  belongs_to :mcp_oauth_client
+  belongs_to :user
+  belongs_to :principal
+
+  before_validation :issue_code, on: :create
+
+  validates :code_hash, presence: true, uniqueness: true
+  validates :redirect_uri, :code_challenge, :resource, :expires_at, presence: true
+  validates :scopes, presence: true
+
+  scope :usable, -> { where(consumed_at: nil).where("expires_at > ?", Time.current) }
+
+  def self.hash_token(value)
+    Digest::SHA256.hexdigest(value.to_s)
+  end
+
+  def self.find_usable(value)
+    usable.find_by(code_hash: hash_token(value))
+  end
+
+  def consume!
+    update!(consumed_at: Time.current)
+  end
+
+  private
+
+  def issue_code
+    self.expires_at ||= CODE_TTL.from_now
+    return if code_hash.present?
+    self.plaintext_code = "#{TOKEN_PREFIX}#{SecureRandom.urlsafe_base64(48)}"
+    self.code_hash = self.class.hash_token(plaintext_code)
+  end
+end

--- a/services/console/app/models/mcp_oauth_client.rb
+++ b/services/console/app/models/mcp_oauth_client.rb
@@ -1,0 +1,89 @@
+require "uri"
+
+class McpOauthClient < ApplicationRecord
+  oid_prefix "moc"
+
+  DEFAULT_GRANT_TYPES = %w[authorization_code refresh_token].freeze
+  DEFAULT_RESPONSE_TYPES = %w[code].freeze
+  DEFAULT_SCOPES = %w[mcp:tools].freeze
+
+  has_many :authorization_codes, class_name: "McpOauthAuthorizationCode", dependent: :destroy
+  has_many :refresh_tokens, class_name: "McpOauthRefreshToken", dependent: :destroy
+
+  validates :redirect_uris, presence: true
+  validate :redirect_uris_valid
+  validate :grant_types_supported
+  validate :response_types_supported
+  validate :scopes_supported
+
+  def public_client_id = oid
+
+  def redirect_uri_allowed?(uri)
+    requested = URI.parse(uri.to_s)
+    redirect_uris.any? do |registered|
+      next true if registered == uri.to_s
+
+      registered_uri = URI.parse(registered.to_s)
+      loopback_redirect_uri_match?(registered_uri, requested)
+    rescue URI::InvalidURIError
+      false
+    end
+  rescue URI::InvalidURIError
+    false
+  end
+
+  private
+
+  def redirect_uris_valid
+    return errors.add(:redirect_uris, "must be an array") unless redirect_uris.is_a?(Array)
+    errors.add(:redirect_uris, "must not be empty") if redirect_uris.empty?
+    redirect_uris.each do |uri|
+      errors.add(:redirect_uris, "#{uri.inspect} is not an allowed public-client redirect URI") unless self.class.allowed_redirect_uri?(uri)
+    end
+  end
+
+  def grant_types_supported
+    return errors.add(:grant_types, "must be an array") unless grant_types.is_a?(Array)
+    unsupported = grant_types - DEFAULT_GRANT_TYPES
+    errors.add(:grant_types, "contains unsupported values: #{unsupported.join(', ')}") if unsupported.any?
+  end
+
+  def response_types_supported
+    return errors.add(:response_types, "must be an array") unless response_types.is_a?(Array)
+    unsupported = response_types - DEFAULT_RESPONSE_TYPES
+    errors.add(:response_types, "contains unsupported values: #{unsupported.join(', ')}") if unsupported.any?
+  end
+
+  def scopes_supported
+    return errors.add(:scopes, "must be an array") unless scopes.is_a?(Array)
+    unsupported = scopes - DEFAULT_SCOPES
+    errors.add(:scopes, "contains unsupported values: #{unsupported.join(', ')}") if unsupported.any?
+  end
+
+  def self.allowed_redirect_uri?(value)
+    uri = URI.parse(value.to_s)
+    return true if uri.scheme == "https" && uri.host.present?
+    return false unless uri.scheme == "http"
+    host = uri.host.to_s.downcase
+    host == "localhost" || host == "127.0.0.1" || host == "::1" || host.start_with?("127.")
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def loopback_redirect_uri_match?(registered_uri, requested_uri)
+    return false unless registered_uri.scheme == "http" && requested_uri.scheme == "http"
+    return false unless self.class.loopback_host?(registered_uri.host)
+    return false unless self.class.loopback_host?(requested_uri.host)
+    return false if registered_uri.port && registered_uri.port != registered_uri.default_port
+    return false unless registered_uri.path == requested_uri.path
+    return false unless registered_uri.query == requested_uri.query
+
+    true
+  end
+
+  def self.loopback_host?(host)
+    normalized = host.to_s.downcase
+    normalized == "localhost" || normalized == "127.0.0.1" || normalized == "::1" ||
+      normalized.start_with?("127.")
+  end
+end

--- a/services/console/app/models/mcp_oauth_refresh_token.rb
+++ b/services/console/app/models/mcp_oauth_refresh_token.rb
@@ -1,0 +1,43 @@
+require "digest"
+
+class McpOauthRefreshToken < ApplicationRecord
+  oid_prefix "mor"
+
+  DEFAULT_TTL = 90.days
+  TOKEN_PREFIX = "mcprt_".freeze
+
+  attr_accessor :plaintext_token
+
+  belongs_to :mcp_oauth_client
+  belongs_to :user
+  belongs_to :principal
+
+  before_validation :issue_token, on: :create
+
+  validates :token_hash, presence: true, uniqueness: true
+  validates :resource, :expires_at, presence: true
+  validates :scopes, presence: true
+
+  scope :usable, -> { where(revoked_at: nil).where("expires_at > ?", Time.current) }
+
+  def self.hash_token(value)
+    Digest::SHA256.hexdigest(value.to_s)
+  end
+
+  def self.find_usable(value)
+    usable.find_by(token_hash: hash_token(value))
+  end
+
+  def revoke!
+    update!(revoked_at: Time.current)
+  end
+
+  private
+
+  def issue_token
+    self.expires_at ||= DEFAULT_TTL.from_now
+    return if token_hash.present?
+    self.plaintext_token = "#{TOKEN_PREFIX}#{SecureRandom.urlsafe_base64(48)}"
+    self.token_hash = self.class.hash_token(plaintext_token)
+  end
+end

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -22,6 +22,14 @@ Rails.application.routes.draw do
   get "auth/:provider/start", to: "session_oauth#start", as: :auth_start
   get "auth/:provider/callback", to: "session_oauth#callback", as: :auth_callback
 
+  # MCP OAuth authorization server. MCP clients discover this from api-rs'
+  # OAuth protected-resource metadata and register public PKCE clients here.
+  get ".well-known/oauth-authorization-server", to: "mcp/oauth#metadata"
+  get ".well-known/openid-configuration", to: "mcp/oauth#metadata"
+  post "mcp/oauth/register", to: "mcp/oauth#register"
+  get "mcp/oauth/authorize", to: "mcp/oauth#authorize"
+  post "mcp/oauth/token", to: "mcp/oauth#token"
+
   # Operator console (server-rendered HTML UI).
   root "console#principals"
   get "console/principals", to: "console#principals", as: :console_principals

--- a/services/console/db/migrate/20260630090000_create_mcp_oauth_clients.rb
+++ b/services/console/db/migrate/20260630090000_create_mcp_oauth_clients.rb
@@ -1,0 +1,15 @@
+class CreateMcpOauthClients < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mcp_oauth_clients do |t|
+      t.string :name
+      t.jsonb :redirect_uris, null: false, default: []
+      t.jsonb :grant_types, null: false, default: []
+      t.jsonb :response_types, null: false, default: []
+      t.jsonb :scopes, null: false, default: []
+      t.jsonb :metadata, null: false, default: {}
+      t.datetime :last_used_at
+
+      t.timestamps
+    end
+  end
+end

--- a/services/console/db/migrate/20260630090001_create_mcp_oauth_authorization_codes.rb
+++ b/services/console/db/migrate/20260630090001_create_mcp_oauth_authorization_codes.rb
@@ -1,0 +1,21 @@
+class CreateMcpOauthAuthorizationCodes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mcp_oauth_authorization_codes do |t|
+      t.references :mcp_oauth_client, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :principal, null: false, foreign_key: true
+      t.string :code_hash, null: false
+      t.string :redirect_uri, null: false
+      t.string :code_challenge, null: false
+      t.string :resource, null: false
+      t.jsonb :scopes, null: false, default: []
+      t.datetime :expires_at, null: false
+      t.datetime :consumed_at
+
+      t.timestamps
+    end
+
+    add_index :mcp_oauth_authorization_codes, :code_hash, unique: true
+    add_index :mcp_oauth_authorization_codes, :expires_at
+  end
+end

--- a/services/console/db/migrate/20260630090002_create_mcp_oauth_refresh_tokens.rb
+++ b/services/console/db/migrate/20260630090002_create_mcp_oauth_refresh_tokens.rb
@@ -1,0 +1,20 @@
+class CreateMcpOauthRefreshTokens < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mcp_oauth_refresh_tokens do |t|
+      t.references :mcp_oauth_client, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :principal, null: false, foreign_key: true
+      t.string :token_hash, null: false
+      t.string :resource, null: false
+      t.jsonb :scopes, null: false, default: []
+      t.datetime :expires_at, null: false
+      t.datetime :revoked_at
+      t.datetime :last_used_at
+
+      t.timestamps
+    end
+
+    add_index :mcp_oauth_refresh_tokens, :token_hash, unique: true
+    add_index :mcp_oauth_refresh_tokens, :expires_at
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_25_030000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_30_090002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -174,6 +174,57 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_030000) do
     t.index ["created_by_id"], name: "index_hmac_secrets_on_created_by_id"
     t.index ["labels"], name: "index_hmac_secrets_on_labels", using: :gin
     t.index ["namespace", "foreign_id"], name: "index_hmac_secrets_on_namespace_and_foreign_id", unique: true
+  end
+
+  create_table "mcp_oauth_authorization_codes", force: :cascade do |t|
+    t.string "code_challenge", null: false
+    t.string "code_hash", null: false
+    t.datetime "consumed_at"
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "mcp_oauth_client_id", null: false
+    t.bigint "principal_id", null: false
+    t.string "redirect_uri", null: false
+    t.string "resource", null: false
+    t.jsonb "scopes", default: [], null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["code_hash"], name: "index_mcp_oauth_authorization_codes_on_code_hash", unique: true
+    t.index ["expires_at"], name: "index_mcp_oauth_authorization_codes_on_expires_at"
+    t.index ["mcp_oauth_client_id"], name: "index_mcp_oauth_authorization_codes_on_mcp_oauth_client_id"
+    t.index ["principal_id"], name: "index_mcp_oauth_authorization_codes_on_principal_id"
+    t.index ["user_id"], name: "index_mcp_oauth_authorization_codes_on_user_id"
+  end
+
+  create_table "mcp_oauth_clients", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.jsonb "grant_types", default: [], null: false
+    t.datetime "last_used_at"
+    t.jsonb "metadata", default: {}, null: false
+    t.string "name"
+    t.jsonb "redirect_uris", default: [], null: false
+    t.jsonb "response_types", default: [], null: false
+    t.jsonb "scopes", default: [], null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "mcp_oauth_refresh_tokens", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "last_used_at"
+    t.bigint "mcp_oauth_client_id", null: false
+    t.bigint "principal_id", null: false
+    t.string "resource", null: false
+    t.datetime "revoked_at"
+    t.jsonb "scopes", default: [], null: false
+    t.string "token_hash", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["expires_at"], name: "index_mcp_oauth_refresh_tokens_on_expires_at"
+    t.index ["mcp_oauth_client_id"], name: "index_mcp_oauth_refresh_tokens_on_mcp_oauth_client_id"
+    t.index ["principal_id"], name: "index_mcp_oauth_refresh_tokens_on_principal_id"
+    t.index ["token_hash"], name: "index_mcp_oauth_refresh_tokens_on_token_hash", unique: true
+    t.index ["user_id"], name: "index_mcp_oauth_refresh_tokens_on_user_id"
   end
 
   create_table "oauth_apps", force: :cascade do |t|
@@ -404,6 +455,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_030000) do
   add_foreign_key "grants", "static_secrets"
   add_foreign_key "grants", "users", column: "created_by_id"
   add_foreign_key "hmac_secrets", "users", column: "created_by_id"
+  add_foreign_key "mcp_oauth_authorization_codes", "mcp_oauth_clients"
+  add_foreign_key "mcp_oauth_authorization_codes", "principals"
+  add_foreign_key "mcp_oauth_authorization_codes", "users"
+  add_foreign_key "mcp_oauth_refresh_tokens", "mcp_oauth_clients"
+  add_foreign_key "mcp_oauth_refresh_tokens", "principals"
+  add_foreign_key "mcp_oauth_refresh_tokens", "users"
   add_foreign_key "oauth_apps", "users", column: "created_by_id"
   add_foreign_key "oauth_token_secrets", "users", column: "created_by_id"
   add_foreign_key "pg_dsn_secrets", "users", column: "created_by_id"

--- a/services/console/lib/mcp/jwt.rb
+++ b/services/console/lib/mcp/jwt.rb
@@ -1,0 +1,23 @@
+require "base64"
+require "json"
+require "openssl"
+
+module Mcp
+  module Jwt
+    module_function
+
+    def encode(payload)
+      signing_secret = ENV["CENTAUR_JWT_SIGNING_SECRET"].to_s
+      raise KeyError, "CENTAUR_JWT_SIGNING_SECRET is not configured" if signing_secret.blank?
+
+      header = { "alg" => "HS256", "typ" => "JWT" }
+      signing_input = [ base64url_json(header), base64url_json(payload) ].join(".")
+      signature = OpenSSL::HMAC.digest("SHA256", signing_secret, signing_input)
+      "#{signing_input}.#{Base64.urlsafe_encode64(signature, padding: false)}"
+    end
+
+    def base64url_json(value)
+      Base64.urlsafe_encode64(JSON.generate(value), padding: false)
+    end
+  end
+end

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -1,0 +1,160 @@
+require "test_helper"
+require "base64"
+require "digest"
+require "uri"
+
+module Mcp
+  class OauthControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @operator = users(:acme_admin)
+      @saved_env = {
+        "CENTAUR_JWT_SIGNING_SECRET" => ENV["CENTAUR_JWT_SIGNING_SECRET"],
+        "CENTAUR_MCP_PUBLIC_URL" => ENV["CENTAUR_MCP_PUBLIC_URL"],
+        "CENTAUR_CONSOLE_PUBLIC_URL" => ENV["CENTAUR_CONSOLE_PUBLIC_URL"]
+      }
+      ENV["CENTAUR_JWT_SIGNING_SECRET"] = "test-secret"
+      ENV["CENTAUR_MCP_PUBLIC_URL"] = "http://localhost:3000/mcp"
+      ENV["CENTAUR_CONSOLE_PUBLIC_URL"] = "http://www.example.com"
+    end
+
+    teardown do
+      @saved_env.each do |key, value|
+        if value.nil?
+          ENV.delete(key)
+        else
+          ENV[key] = value
+        end
+      end
+    end
+
+    test "metadata advertises MCP OAuth endpoints" do
+      get "/.well-known/oauth-authorization-server"
+
+      assert_response :ok
+      body = JSON.parse(response.body)
+      assert_equal "http://www.example.com", body.fetch("issuer")
+      assert_equal "http://www.example.com/mcp/oauth/authorize", body.fetch("authorization_endpoint")
+      assert_equal "http://www.example.com/mcp/oauth/token", body.fetch("token_endpoint")
+      assert_equal "http://www.example.com/mcp/oauth/register", body.fetch("registration_endpoint")
+      assert_includes body.fetch("code_challenge_methods_supported"), "S256"
+    end
+
+    test "dynamic client registration creates a public PKCE client" do
+      assert_difference -> { McpOauthClient.count }, 1 do
+        post "/mcp/oauth/register",
+             params: {
+               client_name: "Amp",
+               redirect_uris: [ "http://127.0.0.1:49152/callback" ],
+               scope: "mcp:tools"
+             },
+             as: :json
+      end
+
+      assert_response :created
+      body = JSON.parse(response.body)
+      assert_match(/\Amoc_/, body.fetch("client_id"))
+      assert_equal "none", body.fetch("token_endpoint_auth_method")
+      assert_equal "mcp:tools", body.fetch("scope")
+    end
+
+    test "authorize redirects signed-out users through login and preserves the request" do
+      client = create_client
+      get "/mcp/oauth/authorize", params: authorize_params(client)
+
+      assert_redirected_to login_path
+
+      post login_url, params: { email: @operator.email, password: "password123456" }
+      assert_match %r{\Ahttp://www.example.com/mcp/oauth/authorize\?}, response.location
+    end
+
+    test "authorize accepts dynamic loopback redirect ports" do
+      client = create_client(redirect_uris: [ "http://localhost/callback" ])
+      post login_url, params: { email: @operator.email, password: "password123456" }
+
+      get "/mcp/oauth/authorize",
+          params: authorize_params(client).merge(
+            redirect_uri: "http://localhost:49153/callback"
+          )
+
+      assert_response :redirect
+      redirect = URI.parse(response.location)
+      assert_equal "localhost", redirect.host
+      assert_equal 49153, redirect.port
+      assert Rack::Utils.parse_nested_query(redirect.query).key?("code")
+    end
+
+    test "authorization code exchange returns a JWT access token for the console principal" do
+      client = create_client
+      post login_url, params: { email: @operator.email, password: "password123456" }
+
+      get "/mcp/oauth/authorize", params: authorize_params(client)
+      assert_response :redirect
+      redirect = URI.parse(response.location)
+      code = Rack::Utils.parse_nested_query(redirect.query).fetch("code")
+      stored_code = McpOauthAuthorizationCode.find_usable(code)
+      assert_equal @operator, stored_code.user
+      assert_equal "http://localhost:3000/mcp", stored_code.resource
+      assert_match(/\Aprn_/, stored_code.principal.oid)
+
+      post "/mcp/oauth/token",
+           params: {
+             grant_type: "authorization_code",
+             client_id: client.public_client_id,
+             code: code,
+             redirect_uri: redirect_uri,
+             code_verifier: code_verifier
+           }
+
+      assert_response :ok
+      body = JSON.parse(response.body)
+      assert_equal "Bearer", body.fetch("token_type")
+      assert_equal "mcp:tools", body.fetch("scope")
+      assert_match(/\Amcprt_/, body.fetch("refresh_token"))
+
+      jwt_payload = decode_jwt_payload(body.fetch("access_token"))
+      assert_equal "http://www.example.com", jwt_payload.fetch("iss")
+      assert_equal "http://localhost:3000/mcp", jwt_payload.fetch("aud")
+      assert_equal stored_code.principal.oid, jwt_payload.fetch("principal_id")
+      assert_equal @operator.email, jwt_payload.fetch("email")
+      assert_equal "mcp:tools", jwt_payload.fetch("scope")
+    end
+
+    private
+
+    def create_client(redirect_uris: [ redirect_uri ])
+      McpOauthClient.create!(
+        name: "Amp",
+        redirect_uris: redirect_uris,
+        grant_types: McpOauthClient::DEFAULT_GRANT_TYPES,
+        response_types: McpOauthClient::DEFAULT_RESPONSE_TYPES,
+        scopes: McpOauthClient::DEFAULT_SCOPES
+      )
+    end
+
+    def authorize_params(client)
+      {
+        response_type: "code",
+        client_id: client.public_client_id,
+        redirect_uri: redirect_uri,
+        scope: "mcp:tools",
+        state: "state-test",
+        resource: "http://localhost:3000/mcp",
+        code_challenge: code_challenge,
+        code_challenge_method: "S256"
+      }
+    end
+
+    def redirect_uri = "http://127.0.0.1:49152/callback"
+
+    def code_verifier = "test-code-verifier"
+
+    def code_challenge
+      Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
+    end
+
+    def decode_jwt_payload(token)
+      _header, payload, _signature = token.split(".")
+      JSON.parse(Base64.urlsafe_decode64(payload))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This stacks on #718 and adds console-backed MCP OAuth/JWT auth. #718 owns the authless MCP transport and persistent runner; this PR is only the SSO/auth layer on top.

- Add console MCP OAuth authorization, token, refresh, metadata, and Dynamic Client Registration endpoints.
- Issue HS256 JWT access tokens with the console principal encoded in the claims.
- Make api-rs expose MCP protected-resource metadata and validate console JWTs for MCP requests.
- Wire `CENTAUR_JWT_SIGNING_SECRET`, MCP public URL, and console public URL through chart/bootstrap config.
- Add the RFC and focused console/api tests for the flow.

## Validation

- `cargo fmt --all`
- `cargo test -p centaur-api-server`
- `helm lint contrib/chart -f contrib/chart/values.dev.yaml`
- Dockerized console validation against Postgres 16: `bin/rubocop -f simple`, `bin/brakeman --no-pager`, `bundle exec rails db:prepare`, and `bundle exec rails test test/controllers/mcp/oauth_controller_test.rb`
- Earlier before the rebase/cleanup: built `api-rs`, `console`, and `slackbotv2` images locally, deployed to the local OrbStack cluster, and verified `amp mcp add` + OAuth + `amp mcp doctor` against port-forwarded api-rs/console; Amp connected and listed 79 tools.

## Notes

No Slackbot command changes remain in this PR. Clients should follow the MCP protected-resource/OAuth discovery flow and get credentials through console auth.
