### PR TITLE
Expose service image and repo-cache metrics

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -32,6 +32,30 @@
 {{- end -}}
 {{- $toolsUseRepoCache := and .Values.repoCache.enabled (gt (len $toolSources) 0) -}}
 {{- $useOverlayRepoCache := and .Values.repoCache.enabled (gt (len $overlaySources) 0) -}}
+{{- $repoCacheRepositories := list -}}
+{{- range .Values.repoCache.repositories }}
+{{- $repoCacheRepositories = append $repoCacheRepositories . -}}
+{{- end }}
+{{- range $source := $overlaySources }}
+{{- with (get $source "repo") }}
+{{- $repoCacheRepositories = append $repoCacheRepositories . -}}
+{{- end }}
+{{- end }}
+{{- $repoCacheRepositories = uniq $repoCacheRepositories -}}
+{{- $repoCacheRepositoryRefs := list -}}
+{{- $repoCacheRepositoryRefRepos := list -}}
+{{- range $repo, $ref := .Values.repoCache.repositoryRefs }}
+{{- $repoCacheRepositoryRefs = append $repoCacheRepositoryRefs (printf "%s=%s" $repo $ref) -}}
+{{- $repoCacheRepositoryRefRepos = append $repoCacheRepositoryRefRepos $repo -}}
+{{- end }}
+{{- range $source := $overlaySources }}
+{{- $repo := get $source "repo" | default "" -}}
+{{- $ref := get $source "ref" | default "" -}}
+{{- if and $repo $ref (not (has $repo $repoCacheRepositoryRefRepos)) }}
+{{- $repoCacheRepositoryRefs = append $repoCacheRepositoryRefs (printf "%s=%s" $repo $ref) -}}
+{{- $repoCacheRepositoryRefRepos = append $repoCacheRepositoryRefRepos $repo -}}
+{{- end }}
+{{- end }}
 {{- $toolDirs := list "/app/tools" -}}
 {{- $workflowDirs := "/app/workflows" -}}
 {{- if $toolsUseRepoCache -}}
@@ -197,10 +221,24 @@ spec:
               value: {{ .Values.apiRs.syncInfraSecrets | quote }}
             - name: RUST_LOG
               value: info
+            - name: CENTAUR_IMAGE_REPOSITORY
+              value: {{ .Values.apiRs.image.repository | quote }}
+            - name: CENTAUR_IMAGE_TAG
+              value: {{ .Values.apiRs.image.tag | quote }}
+            - name: CENTAUR_IMAGE
+              value: {{ printf "%s:%s" .Values.apiRs.image.repository .Values.apiRs.image.tag | quote }}
             - name: TOOL_DIRS
               value: {{ join ":" $toolDirs | quote }}
             - name: WORKFLOW_DIRS
               value: {{ $workflowDirs | quote }}
+{{- if and .Values.repoCache.enabled (gt (len $repoCacheRepositories) 0) }}
+            - name: CENTAUR_REPO_CACHE_PATH
+              value: {{ .Values.repoCache.hostPath | quote }}
+            - name: CENTAUR_REPO_CACHE_REPOSITORIES
+              value: {{ join " " $repoCacheRepositories | quote }}
+            - name: CENTAUR_REPO_CACHE_REPOSITORY_REFS
+              value: {{ join " " $repoCacheRepositoryRefs | quote }}
+{{- end }}
 {{- if $sandboxWorkflowDirs }}
             - name: KUBERNETES_WORKFLOW_DIRS
               value: {{ $sandboxWorkflowDirs | quote }}

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -4,6 +4,11 @@
 {{- $prefix := .Values.secretManager.envPrefix }}
 {{- $dbName := $console.database.name }}
 {{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") }}
+{{- $consoleMetricsAnnotations := dict -}}
+{{- if $console.metrics.scrapeAnnotations -}}
+{{- $consoleMetricsAnnotations = dict "prometheus.io/scrape" "true" "prometheus.io/path" $console.metrics.path "prometheus.io/port" (printf "%v" $console.service.httpPort) -}}
+{{- $consoleMetricsAnnotations = mergeOverwrite $consoleMetricsAnnotations ($console.metrics.annotations | default dict) -}}
+{{- end -}}
 # console — Rails control plane for authenticated API access and encrypted
 # secret storage. The chart owns the Deployment shape (image, port, env,
 # security context) so operators tune it via `helm upgrade`. It runs against a
@@ -18,6 +23,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "centaur.consoleName" . }}
+{{- with $consoleMetricsAnnotations }}
+  annotations:
+{{ toYaml . | nindent 4 }}
+{{- end }}
   labels:
 {{ include "centaur.componentLabels" (dict "root" . "component" "console") | nindent 4 }}
 spec:
@@ -43,8 +52,12 @@ spec:
     metadata:
       annotations:
         checksum/infra-secrets: {{ include "centaur.infraSecretsChecksum" . }}
+{{- with $consoleMetricsAnnotations }}
+{{ toYaml . | nindent 8 }}
+{{- end }}
       labels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console") | nindent 8 }}
+        centaur.ai/metrics: console
     spec:
       automountServiceAccountToken: false
       {{- with .Values.global.imagePullSecrets }}
@@ -163,6 +176,12 @@ spec:
 {{- end }}
             - name: RAILS_ENV
               value: {{ $console.railsEnv | quote }}
+            - name: CENTAUR_IMAGE_REPOSITORY
+              value: {{ $console.image.repository | quote }}
+            - name: CENTAUR_IMAGE_TAG
+              value: {{ $console.image.tag | quote }}
+            - name: CENTAUR_IMAGE
+              value: {{ printf "%s:%s" $console.image.repository $console.image.tag | quote }}
 {{- with $console.slackDmSync.oauthAppSlug }}
             - name: CENTAUR_CONSOLE_SLACK_DM_SYNC_OAUTH_APP_SLUG
               value: {{ . | quote }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -34,6 +34,17 @@
             "httpPort": { "type": "integer" }
           }
         },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "scrapeAnnotations": { "type": "boolean" },
+            "path": { "type": "string" },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
         "ingress": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -112,6 +112,13 @@ console:
     oauthAppSlug: slack
   service:
     httpPort: 3000
+  metrics:
+    # The Rails console serves Prometheus text metrics at /metrics. This flag
+    # only controls scrape annotations for Prometheus/VictoriaMetrics-style
+    # discovery.
+    scrapeAnnotations: true
+    path: /metrics
+    annotations: {}
   # Optional Ingress for the console. Bring your own controller — Tailscale
   # operator, Cloudflare, ingress-nginx, etc. — via className + annotations +
   # tls. Mirrors the top-level `ingress` block (which is wired to the

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -16,6 +16,7 @@ Use these as the main extension points:
 | `api.extraEnv` | API feature flags, worker tuning, retention, observability, and deployment-specific overrides. |
 | `apiRs.extraEnv` | Rust API feature flags, telemetry exporter settings, and deployment-specific overrides. |
 | `apiRs.metrics.*` | Prometheus/VictoriaMetrics scrape metadata for the Rust API `/metrics` endpoint. |
+| `console.metrics.*` | Prometheus/VictoriaMetrics scrape metadata for the Rails console `/metrics` endpoint. |
 | `slackbot.extraEnv` | Slackbot HTTP, Slack, feedback, and cross-org behavior. |
 | `sandbox.extraEnv` | Extra variables copied into every sandbox pod through `KUBERNETES_SANDBOX_EXTRA_ENV`. |
 | `overlays.sources` | Ordered repo-cache-backed overlay repos for tools, workflows, and skills; subdirs default to `tools`, `workflows`, and `.agents/skills`. |
@@ -81,9 +82,14 @@ Optional required-by-mode variables:
 | `CENTAUR_ENVIRONMENT`, `DEPLOY_ENV`, `ENVIRONMENT` | `apiRs.extraEnv` or deployment env. | Deployment environment resource attribute for telemetry. |
 | `OTEL_TRACES_EXPORTER` | `apiRs.extraEnv`. | Set to `otlp` to force OTLP trace export, or `none`/`off` to disable it. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `apiRs.extraEnv`. | Enables OTLP trace export to Tempo, Jaeger, or another OTLP collector. |
+| `CENTAUR_IMAGE_REPOSITORY`, `CENTAUR_IMAGE_TAG`, `CENTAUR_IMAGE` | Chart-rendered from `apiRs.image.*`. | Labels for the synthetic `centaur_service_image_info` metric. |
+| `CENTAUR_REPO_CACHE_PATH`, `CENTAUR_REPO_CACHE_REPOSITORIES`, `CENTAUR_REPO_CACHE_REPOSITORY_REFS` | Chart-rendered from repo-cache and overlay values. | Inputs for the synthetic `centaur_repo_cache_info` metric. |
 | `apiRs.metrics.scrapeAnnotations` | Helm value, default `true`. | Adds Prometheus scrape annotations to the API-RS Pod template and Service. |
 | `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
 | `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
+| `console.metrics.scrapeAnnotations` | Helm value, default `true`. | Adds Prometheus scrape annotations to the console Pod template and Service. |
+| `console.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
+| `console.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
 
 Execution tuning:
 

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -16,6 +16,7 @@ Use these as the main extension points:
 | `api.extraEnv` | API feature flags, worker tuning, retention, observability, and deployment-specific overrides. |
 | `apiRs.extraEnv` | Rust API feature flags, telemetry exporter settings, and deployment-specific overrides. |
 | `apiRs.metrics.*` | Prometheus/VictoriaMetrics scrape metadata for the Rust API `/metrics` endpoint. |
+| `console.metrics.*` | Prometheus/VictoriaMetrics scrape metadata for the Rails console `/metrics` endpoint. |
 | `slackbot.extraEnv` | Slackbot HTTP, Slack, feedback, and cross-org behavior. |
 | `sandbox.extraEnv` | Extra variables copied into every sandbox pod through `KUBERNETES_SANDBOX_EXTRA_ENV`. |
 | `overlays.sources` | Ordered repo-cache-backed overlay repos for tools, workflows, and skills; subdirs default to `tools`, `workflows`, and `.agents/skills`. |
@@ -81,9 +82,14 @@ Optional required-by-mode variables:
 | `CENTAUR_ENVIRONMENT`, `DEPLOY_ENV`, `ENVIRONMENT` | `apiRs.extraEnv` or deployment env. | Deployment environment resource attribute for telemetry. |
 | `OTEL_TRACES_EXPORTER` | `apiRs.extraEnv`. | Set to `otlp` to force OTLP trace export, or `none`/`off` to disable it. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `apiRs.extraEnv`. | Enables OTLP trace export to Tempo, Jaeger, or another OTLP collector. |
+| `CENTAUR_IMAGE_REPOSITORY`, `CENTAUR_IMAGE_TAG`, `CENTAUR_IMAGE` | Chart-rendered from `apiRs.image.*`. | Labels for the synthetic `centaur_service_image_info` metric. |
+| `CENTAUR_REPO_CACHE_PATH`, `CENTAUR_REPO_CACHE_REPOSITORIES`, `CENTAUR_REPO_CACHE_REPOSITORY_REFS` | Chart-rendered from repo-cache and overlay values. | Inputs for the synthetic `centaur_repo_cache_info` metric. |
 | `apiRs.metrics.scrapeAnnotations` | Helm value, default `true`. | Adds Prometheus scrape annotations to the API-RS Pod template and Service. |
 | `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
 | `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
+| `console.metrics.scrapeAnnotations` | Helm value, default `true`. | Adds Prometheus scrape annotations to the console Pod template and Service. |
+| `console.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
+| `console.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
 
 Execution tuning:
 

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -2,8 +2,8 @@ use std::{
     collections::BTreeMap,
     convert::Infallible,
     convert::TryFrom,
-    env,
-    path::Path as FsPath,
+    env, fs,
+    path::{Path as FsPath, PathBuf},
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
@@ -34,8 +34,9 @@ use centaur_session_runtime::{
 };
 use centaur_session_sqlx::PgSessionStore;
 use centaur_telemetry::{
-    PrometheusHandle, http_status_class, prometheus_handle, record_http_request_finished,
-    record_http_request_started, set_span_parent_trace,
+    PrometheusHandle, RepoCacheInfoSample, http_status_class, prometheus_handle,
+    record_http_request_finished, record_http_request_started, set_repo_cache_info,
+    set_service_image_info_from_env, set_span_parent_trace,
 };
 use centaur_workflows::{
     CreateWorkflowRunRequest, WebhookFilter, WorkflowRuntime, WorkflowWebhookAuth,
@@ -327,6 +328,7 @@ async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 async fn metrics(State(state): State<AppState>) -> Response {
+    record_synthetic_metrics();
     (
         [("Content-Type", "text/plain; version=0.0.4; charset=utf-8")],
         Body::from(state.metrics.render()),
@@ -350,6 +352,174 @@ async fn http_metrics(req: Request, next: Next) -> Response {
     record_http_request_finished(method.as_str(), route.as_str(), status.as_u16(), duration);
 
     response
+}
+
+fn record_synthetic_metrics() {
+    set_service_image_info_from_env("api-rs");
+    set_repo_cache_info(repo_cache_info_samples());
+}
+
+fn repo_cache_info_samples() -> Vec<RepoCacheInfoSample> {
+    let Some(repo_cache_path) = first_nonempty_env(&[
+        "CENTAUR_REPO_CACHE_PATH",
+        "KUBERNETES_TOOLS_REPO_CACHE_PATH",
+        "REPOS_PATH",
+    ]) else {
+        return Vec::new();
+    };
+    let repositories = repo_cache_repositories();
+    if repositories.is_empty() {
+        return Vec::new();
+    }
+    let requested_refs = parse_repo_cache_repository_refs(
+        env::var("CENTAUR_REPO_CACHE_REPOSITORY_REFS")
+            .unwrap_or_default()
+            .as_str(),
+    );
+    let repo_cache_path = PathBuf::from(repo_cache_path);
+
+    repositories
+        .into_iter()
+        .map(|repository| {
+            let repo_path = repo_cache_path.join(&repository);
+            let version = repo_cache_revision(&repo_path);
+            let status = match (&version, repo_path.is_dir()) {
+                (Some(_), _) => "synced",
+                (None, true) => "unreadable",
+                (None, false) => "missing",
+            };
+
+            RepoCacheInfoSample {
+                requested_ref: requested_refs
+                    .get(&repository)
+                    .cloned()
+                    .unwrap_or_else(|| "default".to_owned()),
+                repository,
+                status: status.to_owned(),
+                version: version.unwrap_or_else(|| "unknown".to_owned()),
+            }
+        })
+        .collect()
+}
+
+fn repo_cache_repositories() -> Vec<String> {
+    let mut repositories = split_env_words("CENTAUR_REPO_CACHE_REPOSITORIES");
+    if repositories.is_empty()
+        && let Some(repo) = first_nonempty_env(&["KUBERNETES_TOOLS_REPO"])
+    {
+        repositories.push(repo);
+        repositories.extend(extra_tool_source_repositories());
+    }
+    repositories.sort();
+    repositories.dedup();
+    repositories
+}
+
+fn extra_tool_source_repositories() -> Vec<String> {
+    let Some(value) = first_nonempty_env(&["KUBERNETES_TOOLS_EXTRA_SOURCES"]) else {
+        return Vec::new();
+    };
+    let Ok(sources) = serde_json::from_str::<Vec<Value>>(&value) else {
+        return Vec::new();
+    };
+
+    sources
+        .into_iter()
+        .filter_map(|source| {
+            source
+                .get("repo")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|repo| !repo.is_empty())
+                .map(str::to_owned)
+        })
+        .collect()
+}
+
+fn parse_repo_cache_repository_refs(value: &str) -> BTreeMap<String, String> {
+    value
+        .split_whitespace()
+        .filter_map(|entry| {
+            let (repo, requested_ref) = entry.split_once('=')?;
+            let repo = repo.trim();
+            let requested_ref = requested_ref.trim();
+            if repo.is_empty() || requested_ref.is_empty() {
+                None
+            } else {
+                Some((repo.to_owned(), requested_ref.to_owned()))
+            }
+        })
+        .collect()
+}
+
+fn split_env_words(name: &str) -> Vec<String> {
+    env::var(name)
+        .ok()
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split_whitespace()
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn first_nonempty_env(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        env::var(name)
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn repo_cache_revision(repo_path: &FsPath) -> Option<String> {
+    let git_dir = repo_path.join(".git");
+    if !git_dir.is_dir() {
+        return None;
+    }
+    let head = fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head = head.trim();
+    if let Some(reference) = head.strip_prefix("ref: ") {
+        return repo_cache_ref_revision(&git_dir, reference.trim());
+    }
+    if is_git_revision(head) {
+        Some(head.to_owned())
+    } else {
+        None
+    }
+}
+
+fn repo_cache_ref_revision(git_dir: &FsPath, reference: &str) -> Option<String> {
+    if let Ok(value) = fs::read_to_string(git_dir.join(reference)) {
+        let value = value.trim();
+        if is_git_revision(value) {
+            return Some(value.to_owned());
+        }
+    }
+
+    let packed_refs = fs::read_to_string(git_dir.join("packed-refs")).ok()?;
+    packed_refs.lines().find_map(|line| {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with('^') {
+            return None;
+        }
+        let mut fields = line.split_whitespace();
+        let revision = fields.next()?;
+        let packed_ref = fields.next()?;
+        if packed_ref == reference && is_git_revision(revision) {
+            Some(revision.to_owned())
+        } else {
+            None
+        }
+    })
+}
+
+fn is_git_revision(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn matched_route<B>(request: &Request<B>) -> String {
@@ -2924,6 +3094,66 @@ fn webhook_filter_matches(filter: &WebhookFilter, headers: &HeaderMap, body: &Va
             .as_deref()
             .is_some_and(|prefix| actual.trim_start().starts_with(prefix)),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod synthetic_metrics_tests {
+    use super::*;
+
+    #[test]
+    fn repo_cache_revision_reads_loose_branch_ref() {
+        let root = env::temp_dir().join(format!("centaur-repo-cache-test-{}", Uuid::new_v4()));
+        let repo = root.join("paradigmxyz").join("centaur");
+        let git_refs = repo.join(".git").join("refs").join("heads");
+        fs::create_dir_all(&git_refs).unwrap();
+        fs::write(repo.join(".git").join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        fs::write(
+            git_refs.join("main"),
+            "0123456789abcdef0123456789abcdef01234567\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            repo_cache_revision(&repo).as_deref(),
+            Some("0123456789abcdef0123456789abcdef01234567")
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn repo_cache_revision_reads_packed_branch_ref() {
+        let root = env::temp_dir().join(format!("centaur-repo-cache-test-{}", Uuid::new_v4()));
+        let repo = root.join("paradigmxyz").join("centaur");
+        let git_dir = repo.join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        fs::write(
+            git_dir.join("packed-refs"),
+            "# pack-refs\nfedcba9876543210fedcba9876543210fedcba98 refs/heads/main\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            repo_cache_revision(&repo).as_deref(),
+            Some("fedcba9876543210fedcba9876543210fedcba98")
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn parse_repo_cache_repository_refs_ignores_empty_entries() {
+        assert_eq!(
+            parse_repo_cache_repository_refs(
+                "paradigmxyz/centaur=main missing= tempoxyz/overlay=release"
+            ),
+            BTreeMap::from([
+                ("paradigmxyz/centaur".to_owned(), "main".to_owned()),
+                ("tempoxyz/overlay".to_owned(), "release".to_owned()),
+            ])
+        );
     }
 }
 

--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -55,6 +55,8 @@ pub const FIELD_THREAD_KEY: &str = "thread_key";
 pub const HTTP_REQUESTS_TOTAL: &str = "http_server_requests_total";
 pub const HTTP_REQUEST_DURATION_SECONDS: &str = "http_server_request_duration_seconds";
 pub const HTTP_REQUESTS_IN_FLIGHT: &str = "http_server_requests_in_flight";
+pub const SERVICE_IMAGE_INFO: &str = "centaur_service_image_info";
+pub const REPO_CACHE_INFO: &str = "centaur_repo_cache_info";
 pub const SESSION_EXECUTIONS_TOTAL: &str = "centaur_session_executions_total";
 pub const SESSION_EXECUTION_DURATION_SECONDS: &str = "centaur_session_execution_duration_seconds";
 pub const SESSION_FIRST_TOKEN_LATENCY_SECONDS: &str = "centaur_session_first_token_latency_seconds";
@@ -142,6 +144,16 @@ static PROMETHEUS_HANDLE: LazyLock<Mutex<Option<PrometheusHandle>>> =
     LazyLock::new(|| Mutex::new(None));
 static EXPORTED_THREAD_ROOT_SPANS: LazyLock<Mutex<HashSet<String>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
+static REPO_CACHE_INFO_LABELS: LazyLock<Mutex<HashSet<RepoCacheInfoSample>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RepoCacheInfoSample {
+    pub repository: String,
+    pub requested_ref: String,
+    pub version: String,
+    pub status: String,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TelemetryConfig {
@@ -294,6 +306,52 @@ pub fn prometheus_handle() -> Result<PrometheusHandle, TelemetryError> {
 
 pub fn render_metrics() -> Result<String, TelemetryError> {
     Ok(prometheus_handle()?.render())
+}
+
+pub fn set_service_image_info(service: &str, image: &str, image_repository: &str, image_tag: &str) {
+    metrics::gauge!(
+        SERVICE_IMAGE_INFO,
+        "service" => info_label_or_unknown(service),
+        "image" => info_label_or_unknown(image),
+        "image_repository" => info_label_or_unknown(image_repository),
+        "image_tag" => info_label_or_unknown(image_tag),
+        "version" => info_label_or_unknown(image_tag),
+    )
+    .set(1.0);
+}
+
+pub fn set_service_image_info_from_env(service: &str) {
+    let image_repository =
+        first_nonempty_env(&["CENTAUR_IMAGE_REPOSITORY"]).unwrap_or_else(|| "unknown".to_owned());
+    let image_tag = first_nonempty_env(&["CENTAUR_IMAGE_TAG", "CENTAUR_IMAGE_VERSION"])
+        .unwrap_or_else(|| "unknown".to_owned());
+    let image = first_nonempty_env(&["CENTAUR_IMAGE"])
+        .unwrap_or_else(|| format!("{image_repository}:{image_tag}"));
+
+    set_service_image_info(service, &image, &image_repository, &image_tag);
+}
+
+pub fn set_repo_cache_info(samples: impl IntoIterator<Item = RepoCacheInfoSample>) {
+    let current: HashSet<RepoCacheInfoSample> = samples
+        .into_iter()
+        .map(|sample| RepoCacheInfoSample {
+            repository: info_label_or_unknown(&sample.repository),
+            requested_ref: info_label_or_unknown(&sample.requested_ref),
+            version: info_label_or_unknown(&sample.version),
+            status: info_label_or_unknown(&sample.status),
+        })
+        .collect();
+
+    let mut previous = REPO_CACHE_INFO_LABELS
+        .lock()
+        .expect("repo-cache info labels lock poisoned");
+    for sample in current.iter() {
+        set_repo_cache_info_sample(sample, 1.0);
+    }
+    for sample in previous.difference(&current) {
+        set_repo_cache_info_sample(sample, 0.0);
+    }
+    *previous = current;
 }
 
 pub fn record_http_request_started() {
@@ -924,6 +982,14 @@ fn describe_metrics() {
         HTTP_REQUESTS_IN_FLIGHT,
         "Number of in-flight HTTP requests in the Rust API."
     );
+    metrics::describe_gauge!(
+        SERVICE_IMAGE_INFO,
+        "Static container image metadata for a Centaur service."
+    );
+    metrics::describe_gauge!(
+        REPO_CACHE_INFO,
+        "Current repo-cache checkout metadata observed by the Rust API."
+    );
     metrics::describe_counter!(
         SESSION_EXECUTIONS_TOTAL,
         "Session execution lifecycle events by harness and status."
@@ -1141,6 +1207,26 @@ fn workflow_metric_labels(labels: &[(String, String)]) -> Vec<metrics::Label> {
         .collect()
 }
 
+fn set_repo_cache_info_sample(sample: &RepoCacheInfoSample, value: f64) {
+    metrics::gauge!(
+        REPO_CACHE_INFO,
+        "repository" => sample.repository.clone(),
+        "requested_ref" => sample.requested_ref.clone(),
+        "version" => sample.version.clone(),
+        "status" => sample.status.clone(),
+    )
+    .set(value);
+}
+
+fn info_label_or_unknown(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        "unknown".to_owned()
+    } else {
+        value.to_owned()
+    }
+}
+
 fn build_otlp_tracer_provider(
     config: &TelemetryConfig,
 ) -> Result<SdkTracerProvider, TelemetryError> {
@@ -1351,6 +1437,18 @@ mod tests {
     #[test]
     fn prometheus_metrics_render_domain_metrics() {
         prometheus_handle().unwrap();
+        set_service_image_info(
+            "api-rs",
+            "ghcr.io/paradigmxyz/centaur/centaur-api-rs:main-sha-abc123",
+            "ghcr.io/paradigmxyz/centaur/centaur-api-rs",
+            "main-sha-abc123",
+        );
+        set_repo_cache_info([RepoCacheInfoSample {
+            repository: "paradigmxyz/centaur".to_owned(),
+            requested_ref: "main".to_owned(),
+            version: "0123456789abcdef0123456789abcdef01234567".to_owned(),
+            status: "synced".to_owned(),
+        }]);
         record_session_execution_started("codex");
         record_session_execution_finished("codex", "completed", Some(Duration::from_secs(2)));
         record_session_first_token_latency("codex", Duration::from_millis(750));
@@ -1387,6 +1485,12 @@ mod tests {
             r#"centaur_sandbox_startup_duration_seconds_count{backend="local",status="success"}"#
         ));
         assert!(metrics.contains(r#"centaur_sandbox_warm_pool_claims_total{result="hit"}"#));
+        assert!(metrics.contains(
+            r#"centaur_service_image_info{service="api-rs",image="ghcr.io/paradigmxyz/centaur/centaur-api-rs:main-sha-abc123",image_repository="ghcr.io/paradigmxyz/centaur/centaur-api-rs",image_tag="main-sha-abc123",version="main-sha-abc123"} 1"#
+        ));
+        assert!(metrics.contains(
+            r#"centaur_repo_cache_info{repository="paradigmxyz/centaur",requested_ref="main",version="0123456789abcdef0123456789abcdef01234567",status="synced"} 1"#
+        ));
     }
 
     #[test]

--- a/services/console/app/controllers/metrics_controller.rb
+++ b/services/console/app/controllers/metrics_controller.rb
@@ -1,0 +1,6 @@
+class MetricsController < ActionController::API
+  def show
+    render plain: ConsoleMetrics.render,
+           content_type: "text/plain; version=0.0.4; charset=utf-8"
+  end
+end

--- a/services/console/app/services/console_metrics.rb
+++ b/services/console/app/services/console_metrics.rb
@@ -1,0 +1,50 @@
+class ConsoleMetrics
+  METRIC_NAME = "centaur_service_image_info"
+
+  def self.render
+    labels = {
+      service: "console",
+      image: image,
+      image_repository: env_value("CENTAUR_IMAGE_REPOSITORY"),
+      image_tag: image_tag,
+      version: image_tag
+    }
+
+    [
+      "# HELP #{METRIC_NAME} Static container image metadata for a Centaur service.",
+      "# TYPE #{METRIC_NAME} gauge",
+      "#{METRIC_NAME}{#{format_labels(labels)}} 1",
+      ""
+    ].join("\n")
+  end
+
+  def self.image
+    env_value("CENTAUR_IMAGE", default: "#{env_value("CENTAUR_IMAGE_REPOSITORY")}:#{image_tag}")
+  end
+
+  def self.image_tag
+    env_value("CENTAUR_IMAGE_TAG", default: env_value("CENTAUR_IMAGE_VERSION"))
+  end
+
+  def self.env_value(name, default: "unknown")
+    value = ENV[name].to_s.strip
+    value.empty? ? default : value
+  end
+
+  def self.format_labels(labels)
+    labels.map { |key, value| "#{key}=\"#{escape_label_value(value)}\"" }.join(",")
+  end
+
+  def self.escape_label_value(value)
+    value.to_s.gsub(/[\\\n"]/) do |character|
+      case character
+      when "\\"
+        "\\\\"
+      when "\n"
+        "\\n"
+      else
+        "\\\""
+      end
+    end
+  end
+end

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
+  get "metrics" => "metrics#show"
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/services/console/test/controllers/metrics_controller_test.rb
+++ b/services/console/test/controllers/metrics_controller_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class MetricsControllerTest < ActionDispatch::IntegrationTest
+  test "serves image info metrics without login" do
+    get "/metrics"
+
+    assert_response :ok
+    assert_includes @response.media_type, "text/plain"
+    assert_includes @response.body, "# HELP centaur_service_image_info"
+    assert_includes @response.body, "# TYPE centaur_service_image_info gauge"
+    assert_includes @response.body, 'centaur_service_image_info{service="console"'
+    assert_includes @response.body, 'image_repository="'
+    assert_includes @response.body, 'image_tag="'
+    assert_includes @response.body, 'version="'
+  end
+end


### PR DESCRIPTION
## Summary
- add API-RS synthetic Prometheus gauges for service image metadata and repo-cache checkout revisions
- add console /metrics with image metadata and chart scrape annotations
- wire Helm env/defaults/schema/docs for API-RS and console metrics

## Testing
- cargo test -p centaur-api-server
- cargo test -p centaur-telemetry
- mise exec -- ruby bin/rails test test/controllers/metrics_controller_test.rb
- helm lint contrib/chart -f contrib/chart/values.dev.yaml --set console.enabled=true
- helm template centaur contrib/chart -f contrib/chart/values.dev.yaml --set console.enabled=true
- git diff --check