### PR TITLE
Add deployment metrics exporter log labels

### DIFF
--- a/contrib/chart/templates/deployment-metrics.yaml
+++ b/contrib/chart/templates/deployment-metrics.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.deploymentMetrics.enabled }}
+{{- $name := include "centaur.componentName" (dict "root" . "component" "deployment-metrics") -}}
+{{- $metricsAnnotations := dict -}}
+{{- if .Values.deploymentMetrics.metrics.scrapeAnnotations -}}
+{{- $metricsAnnotations = dict "prometheus.io/scrape" "true" "prometheus.io/path" .Values.deploymentMetrics.metrics.path "prometheus.io/port" (printf "%v" .Values.deploymentMetrics.service.port) -}}
+{{- $metricsAnnotations = mergeOverwrite $metricsAnnotations (.Values.deploymentMetrics.metrics.annotations | default dict) -}}
+{{- end -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "deployment-metrics") | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "deployment-metrics") | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "deployment-metrics") | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "deployment-metrics") | nindent 4 }}
+spec:
+  replicas: {{ .Values.deploymentMetrics.replicaCount }}
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "deployment-metrics") | nindent 6 }}
+  template:
+    metadata:
+{{- with $metricsAnnotations }}
+      annotations:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "deployment-metrics") | nindent 8 }}
+{{- with .Values.deploymentMetrics.podLabels }}
+{{ toYaml . | nindent 8 }}
+{{- end }}
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: {{ $name }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: deployment-metrics
+          image: {{ printf "%s:%s" .Values.deploymentMetrics.image.repository .Values.deploymentMetrics.image.tag | quote }}
+          imagePullPolicy: {{ .Values.deploymentMetrics.image.pullPolicy }}
+{{- with .Values.deploymentMetrics.extraEnv }}
+          env:
+{{- range $name, $value := . }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+          ports:
+            - containerPort: {{ .Values.deploymentMetrics.service.port }}
+              name: metrics
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.deploymentMetrics.metrics.path }}
+              port: metrics
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.deploymentMetrics.metrics.path }}
+              port: metrics
+            timeoutSeconds: 5
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources:
+{{ toYaml .Values.deploymentMetrics.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "deployment-metrics") | nindent 4 }}
+spec:
+  selector:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "deployment-metrics") | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.deploymentMetrics.service.port }}
+      targetPort: metrics
+{{- end }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -347,6 +347,47 @@
         }
       }
     },
+    "deploymentMetrics": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicaCount": { "type": "integer" },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string" }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "port": { "type": "integer" }
+          }
+        },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "scrapeAnnotations": { "type": "boolean" },
+            "path": { "type": "string" },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
+        "podLabels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "extraEnv": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "resources": { "type": "object" }
+      }
+    },
     "postgres": {
       "type": "object",
       "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -404,6 +404,29 @@ slackbotv2:
   extraEnv: {}
   resources: {}
 
+# Optional deployment-metadata exporter. Some deployments run this alongside
+# Argo CD to expose current Centaur deploy labels and timestamps; label its pods
+# so the log collector can ingest and query exporter logs directly.
+deploymentMetrics:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: centaur-deployment-metrics
+    tag: latest
+    pullPolicy: Always
+  service:
+    port: 8080
+  metrics:
+    scrapeAnnotations: true
+    path: /metrics
+    annotations: {}
+  podLabels:
+    centaur.ai/metrics: deployment-metrics
+    centaur.ai/component: deployment-metrics
+    centaur.ai/logs: deployment-metrics
+  extraEnv: {}
+  resources: {}
+
 # Chat SDK Linear bot — Linear agent (actor=app) ingress. Receives
 # AgentSessionEvent webhooks on /api/webhooks/linear, forwards sessions to the
 # api-rs control plane (:8080), and renders runs as Linear agent activities.


### PR DESCRIPTION
## Summary
- add disabled-by-default deploymentMetrics chart resources for the deployment-metadata exporter
- label deployment metrics pods with Centaur metrics/log labels so log collectors can select them
- add values schema coverage for the new deploymentMetrics block

Prompted by: mslipper

## Testing
- jq empty contrib/chart/values.schema.json
- helm template not run: helm is not installed in this sandbox