### PR TITLE
Remove legacy agent API leftovers

### DIFF
--- a/docs/pages/architecture.mdx
+++ b/docs/pages/architecture.mdx
@@ -52,7 +52,7 @@ https://api.acme.com/api/webhooks/slack
 The webhook does not use a Centaur API key. Slack signs every request with
 `X-Slack-Signature` and `X-Slack-Request-Timestamp`; the Slackbot validates that
 HMAC signature with `SLACK_SIGNING_SECRET` before it routes the event to the API.
-After validation, the Slackbot calls Centaur's agent API with
+After validation, the Slackbot calls Centaur's api-rs session API with
 `SLACKBOT_API_KEY`.
 
 During a Slack delivery, the API owns the execution state while Slackbot owns

--- a/docs/public/md/architecture.md
+++ b/docs/public/md/architecture.md
@@ -18,7 +18,7 @@ an event trail clients can replay.
 | Plane | Responsibility | Main components |
 |-------|----------------|-----------------|
 | Ingress | Accept user and client input. | Slack Events API, Slackbot webhook, external API clients. |
-| Control | Persist requests and coordinate runtime state. | FastAPI, Postgres, execution worker. |
+| Control | Persist requests and coordinate runtime state. | api-rs, Postgres, session runtime, workflow runtime. |
 | Execution | Run one assigned agent session per thread. | Kubernetes sandbox pods. |
 | Capabilities | Give agents approved actions. | Tool plugins, workflow engine, overlays. |
 | Secrets and egress | Let agents call third-party APIs without receiving raw keys. | Kubernetes Secret, [iron-proxy](https://docs.iron.sh), per-sandbox proxy token mapping. |
@@ -30,11 +30,10 @@ the API and follow the event stream.
 
 | Step | Endpoint | What it saves |
 |------|----------|----------------|
-| Start or reuse a sandbox | `POST /agent/spawn` | The thread's current sandbox assignment. |
-| Persist input | `POST /agent/message` | Writes the user turn and extracts large multimodal attachments. |
-| Run the agent | `POST /agent/execute` | A run row with status and final result. |
-| Follow output | `GET /agent/threads/{thread}/events` | Tool calls, model output, status changes, and final text. |
-| Clean up | `POST /agent/threads/{thread}/release` | Releases the sandbox and can cancel running work. |
+| Start or reuse a session | `POST /api/session/{thread}` | The thread's current sandbox assignment. |
+| Persist input | `POST /api/session/{thread}/messages` | Writes one or more durable transcript messages. |
+| Run the agent | `POST /api/session/{thread}/execute` | An execution row with status and final result events. |
+| Follow output | `GET /api/session/{thread}/events` | Model output, status changes, and final text. |
 
 Because each step is stored, a Slack reconnect, browser refresh, API restart,
 pod replacement, or worker failover does not erase the run. The event stream is
@@ -53,7 +52,7 @@ https://api.acme.com/api/webhooks/slack
 The webhook does not use a Centaur API key. Slack signs every request with
 `X-Slack-Signature` and `X-Slack-Request-Timestamp`; the Slackbot validates that
 HMAC signature with `SLACK_SIGNING_SECRET` before it routes the event to the API.
-After validation, the Slackbot calls Centaur's agent API with
+After validation, the Slackbot calls Centaur's api-rs session API with
 `SLACKBOT_API_KEY`.
 
 During a Slack delivery, the API owns the execution state while Slackbot owns
@@ -80,16 +79,21 @@ third-party API keys.
 
 ## Tool and workflow layer
 
-Tools are Python plugin directories. Each public client method becomes a REST
-method at `/tools/{name}/{method}`. Agents discover tools when they start.
+Tools are Python plugin directories. api-rs discovers their metadata for
+secret grants, while sandbox startup scans `TOOL_DIRS` for
+`pyproject.toml [project.scripts]` and installs each script as a local CLI
+shim. Agents discover tools with `centaur-tools list`, inspect one with
+`<tool> --help`, and run the direct CLI.
 
 Use tools for search, Slack, GitHub, market data, calendars, internal systems,
 and deployment-specific APIs. Tool code should read credentials with
 `secret("NAME")` so the same code works locally and in production.
 
-Workflows are Python handlers that save step results. When a worker restarts,
-the handler runs again, but `ctx.step(...)` returns cached results for completed
-work.
+Workflows are Python handlers run by `services/workflow-python` under the
+api-rs Absurd workflow runtime. When a worker restarts, the handler runs again,
+but `ctx.step(...)` returns cached results for completed work. Workflow
+`ctx.call_tool(...)` remains available through the generated `centaur-tools`
+compatibility bridge.
 
 Use workflows for scheduled digests, monitoring loops, approval gates, jobs that
 sleep for minutes or days, and parent/child workflow trees.
@@ -112,7 +116,7 @@ and does not protect against.
 |---------|-------------------|
 | Client disconnects | Reconnect to the event stream with `after_event_id`. |
 | API restarts | Reload assignments, executions, and terminal state from Postgres. |
-| Sandbox pod dies | The execution becomes terminal, the event trail remains in Postgres, and operators inspect `GET /agent/executions/{execution_id}` plus API/sandbox logs before retrying the turn. |
+| Sandbox pod dies | The execution becomes terminal, the event trail remains in Postgres, and operators inspect `GET /api/session/{thread}` plus api-rs/sandbox logs before retrying the turn. |
 | Workflow worker restarts | Re-run the handler and skip completed checkpoints. |
 | Proxy restarts | Rebuild the key-injection map from the secret-manager cache. |
-| Tool changes | Discovery reloads plugin metadata; agents see the updated methods. |
+| Tool changes | api-rs reloads plugin metadata; new or refreshed sandboxes install updated CLI shims. |

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -81,7 +81,6 @@ Store one secret per enabled harness credential:
 |---------|-----------|----------------|---------------------|----------|
 | Codex default | `codex` | none or `--codex` | `OPENAI_API_KEY` | `api.openai.com` |
 | Codex with OpenRouter provider | `codex` | none or `--codex` | `OPENROUTER_API_KEY` | `openrouter.ai` |
-| Codex with Bedrock provider | `codex` | `--bedrock` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | `bedrock-mantle.<region>.api.aws` |
 | Amp | `amp` | `--amp` | `AMP_API_KEY` | `ampcode.com` |
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
@@ -104,48 +103,6 @@ Whatever source you pick, the vault is shared across the whole deployment,
 so any thread can use any configured credential. Per-user and per-channel
 scoping is on the roadmap; until then, scope tool and harness access
 accordingly. See [Security](/security) for the full threat model.
-
-### Codex with Amazon Bedrock
-
-Codex can run against [Amazon Bedrock](https://aws.amazon.com/bedrock/) through
-its built-in `amazon-bedrock` provider, which talks to the Bedrock
-OpenAI-compatible Responses endpoint (`bedrock-mantle.<region>.api.aws`). It is
-opt-in and is never the default provider.
-
-Authentication uses AWS SigV4, not a bearer token, but the sandbox never sees
-real AWS credentials. Codex signs each request with *placeholder* credentials
-and [iron-proxy](https://docs.iron.sh) re-signs it with the real read-only IAM
-keys — the same placeholder-swap model as every other harness credential, just
-for SigV4 (this is exactly how the `cloudwatch` tool works). The re-signing is
-scoped to the `bedrock` service and the configured region only.
-
-To enable it:
-
-1. Store `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in the vault. Scope the
-   IAM principal to Bedrock inference only (e.g. `bedrock:InvokeModel`,
-   `bedrock:InvokeModelWithResponseStream`) — least privilege, like the
-   read-only CloudWatch user. If the keys are temporary (STS) and carry a
-   session token, also store `AWS_SESSION_TOKEN` and set
-   `CODEX_BEDROCK_SESSION_TOKEN=1` (via `sandbox.extraEnv`).
-2. Set `CODEX_BEDROCK_REGION` (via `sandbox.extraEnv`) to your Bedrock region.
-   This single setting opts the provider in and is the one source of truth for
-   the region: it registers the SigV4 re-signing credential (scoped to that
-   region), injects the placeholder AWS env into sandboxes, and pins codex's
-   `amazon-bedrock` provider to the same region at sandbox boot — so the
-   in-sandbox client and the proxy can never disagree. Defaults to `us-east-1`
-   when unset. (You can still layer further codex provider config via
-   `CODEX_CONFIG_OVERLAY`, which is applied on top.)
-3. If you have locked egress down (it is open by default), allowlist
-   `bedrock-mantle.<region>.api.aws`.
-
-Select it per thread with the `--bedrock` Slack flag (it implies the codex
-harness), and pick the Bedrock model with `--model <bedrock-model-id>` (for
-example `--model anthropic.claude-sonnet-4-...` or `--model openai.gpt-oss-120b`)
-or by setting a default `CODEX_MODEL`. The provider is fixed when the codex
-thread starts. `--bedrock` on a thread pinned to another harness restarts it onto
-codex+Bedrock; to move an existing codex thread between providers, start a new
-thread (a mid-thread provider switch is logged and ignored rather than applied
-silently).
 
 ### Codex Auth Modes
 
@@ -310,59 +267,37 @@ helm upgrade --install centaur contrib/chart \
 
 ## 6. Verify the deployment
 
-Check health from inside the API deployment first. Localhost is accepted for
-operator-only routes, so this avoids needing an external admin key for the first
-smoke check:
+Check health from inside the api-rs deployment first:
 
 ```bash
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS http://localhost:8000/health
+kubectl exec -n centaur-system deploy/centaur-centaur-api-rs -- \
+  curl -fsS http://localhost:8080/healthz
 
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS http://localhost:8000/health/ready | jq
-
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS http://localhost:8000/health/tools | jq
+kubectl exec -n centaur-system deploy/centaur-centaur-api-rs -- \
+  curl -fsS http://localhost:8080/readyz | jq
 ```
 
-If you need to call operator routes from outside the cluster, create an admin
-API key from inside the API deployment and save the returned plaintext key:
+Run one agent turn from inside the api-rs deployment:
 
 ```bash
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS -X POST http://localhost:8000/admin/api-keys \
-    -H "Content-Type: application/json" \
-    -d '{"name":"operator","scopes":["admin"],"created_by":"ops"}' | jq
-```
+THREAD_KEY=cli:production-smoke-codex
+THREAD_PATH=$(jq -rn --arg v "$THREAD_KEY" '$v|@uri')
 
-External operator calls then use:
-
-```bash
-curl -s "$CENTAUR_API_URL/health/tools" \
-  -H "X-Api-Key: $ADMIN_KEY" | jq
-```
-
-Run one agent turn from inside the API deployment:
-
-```bash
-THREAD_KEY=production-smoke-codex
-
-SPAWN=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/spawn \
+SESSION=$(kubectl exec -n centaur-system deploy/centaur-centaur-api-rs -- curl -s -X POST "http://localhost:8080/api/session/${THREAD_PATH}" \
   -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\"}")
-ASSIGNMENT_GENERATION=$(printf '%s' "$SPAWN" | jq -r '.assignment_generation')
+  -d '{"harness_type":"codex","on_harness_conflict":"restart"}')
 
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/message \
+kubectl exec -n centaur-system deploy/centaur-centaur-api-rs -- curl -s -X POST "http://localhost:8080/api/session/${THREAD_PATH}/messages" \
   -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG.\"}]}"
+  -d '{"messages":[{"role":"user","parts":[{"type":"text","text":"Reply with exactly PONG."}]}]}'
 
-EXECUTE=$(kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s -X POST http://localhost:8000/agent/execute \
+EXECUTE=$(kubectl exec -n centaur-system deploy/centaur-centaur-api-rs -- curl -s -X POST "http://localhost:8080/api/session/${THREAD_PATH}/execute" \
   -H "Content-Type: application/json" \
-  -d "{\"thread_key\":\"${THREAD_KEY}\",\"assignment_generation\":${ASSIGNMENT_GENERATION},\"delivery\":{\"platform\":\"dev\"}}")
+  -d '{"input_lines":["{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG.\"}]}}"]}')
 EXECUTION_ID=$(printf '%s' "$EXECUTE" | jq -r '.execution_id')
 
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s \
-  "http://localhost:8000/agent/executions/${EXECUTION_ID}" | jq
+kubectl exec -n centaur-system deploy/centaur-centaur-api-rs -- curl -s -N \
+  "http://localhost:8080/api/session/${THREAD_PATH}/events?execution_id=${EXECUTION_ID}&after_event_id=0"
 ```
 
 Then run the same prompt through Slack:
@@ -378,16 +313,17 @@ Inspect sandbox pods with the labels Centaur actually sets:
 
 ```bash
 kubectl get pods -n centaur-system -l centaur.ai/managed=true
+kubectl exec -n centaur-system <agent-sandbox-pod> -- centaur-tools list
 ```
 
 If a run fails because the sandbox pod exits or is deleted, inspect the durable
-execution before retrying:
+session and api-rs logs before retrying:
 
 ```bash
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- curl -s \
-  "http://localhost:8000/agent/executions/${EXECUTION_ID}" | jq
+kubectl exec -n centaur-system deploy/centaur-centaur-api-rs -- curl -s \
+  "http://localhost:8080/api/session/${THREAD_PATH}" | jq
 
-kubectl logs -n centaur-system deploy/centaur-centaur-api --tail=200
+kubectl logs -n centaur-system deploy/centaur-centaur-api-rs --tail=200
 kubectl get pods -n centaur-system -l centaur.ai/managed=true
 ```
 

--- a/docs/public/md/extend/acme-example.md
+++ b/docs/public/md/extend/acme-example.md
@@ -220,11 +220,11 @@ Expected paths include:
 /home/agent/github/your-org/centaur-acme/.agents/skills
 ```
 
-You can also inspect the runtime payload for a thread:
+You can also inspect the api-rs session context for a thread:
 
 ```bash
-curl -s "$CENTAUR_API_URL/agent/runtime?key=$THREAD_KEY" \
-  -H "X-Api-Key: $RUNTIME_API_KEY" | jq '.overlay'
+THREAD_PATH=$(jq -rn --arg v "$THREAD_KEY" '$v|@uri')
+curl -s "$CENTAUR_API_URL/api/session/${THREAD_PATH}" | jq
 ```
 
 ## What to change first

--- a/docs/public/md/extend/tools.md
+++ b/docs/public/md/extend/tools.md
@@ -5,11 +5,14 @@ description: Add Centaur tool plugins with client.py, pyproject metadata, and ty
 
 # Creating Tools
 
-Tools are Python plugins that Centaur discovers at API startup and exposes as
-REST endpoints at `/tools/{name}/{method}`. Put organization-specific tools in
-an overlay repo under `tools/` so the base Centaur repo stays generic. See
-[Using an overlay](/extend/overlay) for packaging, mount paths, and chart
-configuration.
+Tools are Python plugins that Centaur discovers from ordered tool directories.
+api-rs reads their metadata for secret grants, while agent sandboxes install
+their `[project.scripts]` entries as local CLI shims. Agents use
+`centaur-tools list`, `<tool> --help`, and the direct tool CLI; api-rs does not
+serve legacy HTTP tool-method routes as the current sandbox registry. Put
+organization-specific tools in an overlay repo under `tools/` so the base
+Centaur repo stays generic. See [Using an overlay](/extend/overlay) for
+packaging, mount paths, and chart configuration.
 
 Tools are loaded from `TOOL_DIRS`. In an overlay deployment, the tool must exist
 under the source's `toolsSubdir` — by default `tools/` — in its repo-cache
@@ -33,6 +36,9 @@ description = "Internal warehouse queries"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = ["httpx>=0.27.0"]
+
+[project.scripts]
+warehouse = "warehouse.cli:app"
 
 [build-system]
 requires = ["hatchling"]
@@ -119,16 +125,40 @@ Do not call `load_dotenv()` in `client.py`. Server-side tools should use
 `secret("KEY")`; standalone CLIs may load local `.env` files in their CLI
 wrapper.
 
-## Verify
+## Write the CLI
 
-After deploy:
+The sandbox shim installer only exposes tools with `[project.scripts]`. Keep
+the CLI thin: parse command-line arguments, call the client, and print JSON or
+plain text that an agent can read.
 
-```bash
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- \
-  curl -fsS http://localhost:8000/health/tools | jq
+```python
+import json
+import typer
+
+from .client import _client
+
+app = typer.Typer()
+
+
+@app.command()
+def query(sql: str) -> None:
+    print(json.dumps(_client().query(sql)))
 ```
 
-Check that the tool appears and that missing-secret warnings match what you
-expect. If a tool is missing, inspect the configured repo/ref in repo-cache,
-`TOOL_DIRS`, the tool directory name, and
-`[tool.centaur] module = "client.py"`.
+
+## Verify
+
+After deploy, verify from a fresh sandbox:
+
+```bash
+kubectl exec -n centaur-system <agent-sandbox-pod> -- centaur-tools list
+kubectl exec -n centaur-system <agent-sandbox-pod> -- warehouse --help
+kubectl exec -n centaur-system <agent-sandbox-pod> -- warehouse query "select 1"
+```
+
+Check that the tool appears, the CLI help is useful, and a real invocation
+works through iron-proxy when credentials are needed. If a tool is missing,
+inspect the configured repo/ref in repo-cache, `TOOL_DIRS`, the tool directory
+name, `[tool.centaur] module = "client.py"`, and the `[project.scripts]` entry.
+For workflow-only use, also run a small workflow that exercises
+`ctx.call_tool(...)`, which uses the generated `centaur-tools call` bridge.

--- a/docs/public/md/extend/workflows-v2.md
+++ b/docs/public/md/extend/workflows-v2.md
@@ -59,7 +59,7 @@ Supported v2 primitives:
 | `handler(inp, ctx)` | Supported |
 | `ctx.step(name, fn)` | Supported |
 | `ctx.agent_turn(...)` / `ctx.run_agent(...)` | Supported |
-| `ctx.call_tool(...)` | Supported through the configured tool API proxy |
+| `ctx.call_tool(...)` | Supported through the generated `centaur-tools call` bridge in the workflow-host sandbox |
 | `ctx.post_to_slack(...)` | Supported |
 | `ctx._pool` | Supported when the workflow-host sandbox receives `DATABASE_URL` |
 | `WEBHOOKS` | Supported |
@@ -197,9 +197,10 @@ Workflows that import unrelated API-service internals should move that behavior
 into the workflow-host API surface or a small local helper owned by the workflow
 domain before they are v2-ready.
 
-The tool runtime is also still proxied. `ctx.call_tool(...)` works through the
-configured tool API, but a fully native `api-rs` tool runtime is a separate
-migration step.
+`ctx.call_tool(...)` is a compatibility surface in the Python workflow host. It
+uses the generated `centaur-tools call` bridge against the installed tool
+package; agent sandboxes should use direct tool CLIs instead of deprecated
+`/tools/...` HTTP routes.
 
 ## Verify a migration
 
@@ -217,7 +218,6 @@ Then create a real run:
 ```bash
 curl -s "$CENTAUR_API_URL/api/workflows/runs" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: $WORKFLOW_API_KEY" \
   -d '{
     "workflow_name": "nightly_report",
     "input": {"topic": "open incidents"}

--- a/docs/public/md/extend/workflows.md
+++ b/docs/public/md/extend/workflows.md
@@ -97,9 +97,8 @@ These primitives compose into larger automations:
 Create a run through the API:
 
 ```bash
-curl -s "$CENTAUR_API_URL/workflows/runs" \
+curl -s "$CENTAUR_API_URL/api/workflows/runs" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: $WORKFLOW_API_KEY" \
   -d '{
     "workflow_name": "nightly_report",
     "input": {"channel": "ops", "topic": "open incidents"},
@@ -110,8 +109,7 @@ curl -s "$CENTAUR_API_URL/workflows/runs" \
 Inspect it:
 
 ```bash
-curl -s "$CENTAUR_API_URL/workflows/runs/$RUN_ID" \
-  -H "X-Api-Key: $WORKFLOW_API_KEY" | jq
+curl -s "$CENTAUR_API_URL/api/workflows/runs/$RUN_ID" | jq
 ```
 
 ## Schedule a workflow

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -9,9 +9,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@centaur/harness-events": "workspace:*",
-    "axios": "^1.13.6",
-    "eventsource-parser": "^3.0.6"
+    "axios": "^1.13.6"
   },
   "devDependencies": {
     "typescript": "5.9.3",

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,72 +1,4 @@
-import { EventSourceParserStream, type EventSourceMessage } from "eventsource-parser/stream";
 import axios, { type AxiosInstance } from "axios";
-
-export type InputContentBlock =
-  | { type: "text"; text: string }
-  | {
-      type: "image";
-      source_path?: string;
-      source: { type: "base64"; media_type: string; data: string };
-    }
-  | {
-      type: "document";
-      source_path?: string;
-      source: { type: "base64"; media_type: string; data: string };
-    };
-
-export interface SpawnOptions {
-  threadKey: string;
-  spawnId?: string;
-  harness?: string;
-  engine?: string;
-  personaId?: string;
-  agentsMdOverride?: string;
-}
-
-export interface SpawnResult {
-  ok: boolean;
-  runtime_id: string;
-  thread_key: string;
-  trace_id?: string;
-  assignment_state: string;
-  assignment_generation: number;
-  persona_id?: string | null;
-  prompt_ref?: string | null;
-  effective_agents_md_sha256?: string | null;
-}
-
-export interface MessageOptions {
-  threadKey: string;
-  assignmentGeneration: number;
-  messageId?: string;
-  role?: string;
-  event?: Record<string, unknown>;
-  parts?: InputContentBlock[];
-  userId?: string;
-  metadata?: Record<string, unknown>;
-}
-
-export interface ExecuteOptions {
-  threadKey: string;
-  assignmentGeneration: number;
-  executeId?: string;
-  harness?: string;
-  platform?: string;
-  userId?: string;
-  metadata?: Record<string, unknown>;
-  delivery?: Record<string, unknown>;
-}
-
-export interface ExecutionAccepted {
-  ok: boolean;
-  execution_id: string;
-  execute_id: string;
-  assignment_generation: number;
-  status: string;
-  final_key: string;
-  delivery_token: string;
-  idempotent?: boolean;
-}
 
 export interface WorkflowRunOptions {
   workflowName: string;
@@ -99,32 +31,14 @@ export interface WorkflowRunAccepted {
   idempotent?: boolean;
 }
 
-export interface ThreadMessageRecord {
-  id: string;
-  role: string;
-  parts: Array<Record<string, unknown>>;
-  user_id?: string | null;
-  metadata?: Record<string, unknown> | null;
-  created_at?: string | null;
-}
-
-export interface StreamEvent {
-  eventId: number;
-  eventKind: string;
-  data: Record<string, unknown>;
-}
-
 export class CentaurClient {
   readonly http: AxiosInstance;
-  private log?: { info: Function; warn: Function; error: Function };
 
   constructor(opts: {
     apiUrl: string;
     apiKey: string;
     timeoutMs?: number;
-    logger?: { info: Function; warn: Function; error: Function };
   }) {
-    this.log = opts.logger;
     this.http = axios.create({
       baseURL: opts.apiUrl,
       headers: { Authorization: `Bearer ${opts.apiKey}` },
@@ -132,71 +46,24 @@ export class CentaurClient {
     });
   }
 
-  private get authHeader(): string {
-    return (this.http.defaults.headers["Authorization"] ??
-      this.http.defaults.headers.common?.["Authorization"]) as string;
-  }
-
-  async spawn(opts: SpawnOptions): Promise<SpawnResult> {
-    const { data } = await this.http.post("/agent/spawn", {
-      thread_key: opts.threadKey,
-      spawn_id: opts.spawnId,
-      harness: opts.harness,
-      engine: opts.engine,
-      persona_id: opts.personaId,
-      agents_md_override: opts.agentsMdOverride,
-    });
-    return data as SpawnResult;
-  }
-
-  async message(opts: MessageOptions): Promise<{ ok: boolean; message_id: string; attachment_ids: string[] }> {
-    const body: Record<string, unknown> = {
-      thread_key: opts.threadKey,
-      assignment_generation: opts.assignmentGeneration,
-      message_id: opts.messageId,
-      metadata: opts.metadata,
-      user_id: opts.userId,
-    };
-
-    if (opts.event) {
-      body.event = opts.event;
-    } else {
-      body.role = opts.role ?? "user";
-      body.parts = opts.parts ?? [];
-    }
-
-    const { data } = await this.http.post("/agent/message", body);
-    return data as { ok: boolean; message_id: string; attachment_ids: string[] };
-  }
-
-  async execute(opts: ExecuteOptions): Promise<ExecutionAccepted> {
-    const { data } = await this.http.post("/agent/execute", {
-      thread_key: opts.threadKey,
-      assignment_generation: opts.assignmentGeneration,
-      execute_id: opts.executeId,
-      harness: opts.harness,
-      platform: opts.platform,
-      user_id: opts.userId,
-      metadata: opts.metadata,
-      delivery: opts.delivery,
-    });
-    return data as ExecutionAccepted;
-  }
-
   async startWorkflowRun(opts: WorkflowRunOptions): Promise<WorkflowRunAccepted> {
-    const { data } = await this.http.post("/workflows/runs", {
-      workflow_name: opts.workflowName,
-      trigger_key: opts.triggerKey,
-      input: opts.input ?? {},
-      eager_start: opts.eagerStart ?? false,
-    }, {
-      timeout: opts.timeoutMs,
-    });
+    const { data } = await this.http.post(
+      "/api/workflows/runs",
+      {
+        workflow_name: opts.workflowName,
+        trigger_key: opts.triggerKey,
+        input: opts.input ?? {},
+        eager_start: opts.eagerStart ?? false,
+      },
+      {
+        timeout: opts.timeoutMs,
+      },
+    );
     return data as WorkflowRunAccepted;
   }
 
   async getWorkflowRun(runId: string): Promise<WorkflowRunAccepted> {
-    const { data } = await this.http.get(`/workflows/runs/${encodeURIComponent(runId)}`);
+    const { data } = await this.http.get(`/api/workflows/runs/${encodeURIComponent(runId)}`);
     return data as WorkflowRunAccepted;
   }
 
@@ -207,7 +74,7 @@ export class CentaurClient {
     parentRunId?: string;
     limit?: number;
   }): Promise<{ ok: boolean; items: WorkflowRunAccepted[] }> {
-    const { data } = await this.http.get("/workflows/runs", {
+    const { data } = await this.http.get("/api/workflows/runs", {
       params: {
         workflow_name: opts?.workflowName,
         thread_key: opts?.threadKey,
@@ -219,15 +86,21 @@ export class CentaurClient {
     return data as { ok: boolean; items: WorkflowRunAccepted[] };
   }
 
-  async getWorkflowChildren(runId: string, limit = 200): Promise<{ ok: boolean; items: WorkflowRunAccepted[] }> {
-    const { data } = await this.http.get(`/workflows/runs/${encodeURIComponent(runId)}/children`, {
-      params: { limit },
-    });
+  async getWorkflowChildren(
+    runId: string,
+    limit = 200,
+  ): Promise<{ ok: boolean; items: WorkflowRunAccepted[] }> {
+    const { data } = await this.http.get(
+      `/api/workflows/runs/${encodeURIComponent(runId)}/children`,
+      {
+        params: { limit },
+      },
+    );
     return data as { ok: boolean; items: WorkflowRunAccepted[] };
   }
 
   async cancelWorkflowRun(runId: string): Promise<WorkflowRunAccepted> {
-    const { data } = await this.http.post(`/workflows/runs/${encodeURIComponent(runId)}/cancel`);
+    const { data } = await this.http.post(`/api/workflows/runs/${encodeURIComponent(runId)}/cancel`);
     return data as WorkflowRunAccepted;
   }
 
@@ -236,184 +109,11 @@ export class CentaurClient {
     correlationId: string;
     payload?: Record<string, unknown>;
   }): Promise<Record<string, unknown>> {
-    const { data } = await this.http.post("/workflows/events", {
+    const { data } = await this.http.post("/api/workflows/events", {
       event_type: opts.eventType,
       correlation_id: opts.correlationId,
       payload: opts.payload ?? {},
     });
-    return data as Record<string, unknown>;
-  }
-
-  async *streamEvents(opts: {
-    threadKey: string;
-    afterEventId?: number;
-    executionId?: string;
-    pollMs?: number;
-    signal?: AbortSignal;
-  }): AsyncGenerator<StreamEvent, void, undefined> {
-    const params = new URLSearchParams();
-    if (opts.afterEventId !== undefined) params.set("after_event_id", String(opts.afterEventId));
-    if (opts.executionId) params.set("execution_id", opts.executionId);
-    if (opts.pollMs !== undefined) params.set("poll_ms", String(opts.pollMs));
-
-    const url = `${this.http.defaults.baseURL}/agent/threads/${encodeURIComponent(opts.threadKey)}/events?${params.toString()}`;
-    const res = await fetch(url, {
-      method: "GET",
-      headers: {
-        Authorization: this.authHeader,
-        "X-Centaur-Thread-Key": opts.threadKey,
-      },
-      signal: opts.signal,
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      throw new Error(`/agent/threads/{thread}/events failed (${res.status}): ${text.slice(0, 300)}`);
-    }
-    if (!res.body) return;
-
-    const stream = (res.body as ReadableStream<Uint8Array>)
-      .pipeThrough(new TextDecoderStream() as unknown as TransformStream<Uint8Array, string>)
-      .pipeThrough(new EventSourceParserStream());
-
-    for await (const event of stream as unknown as AsyncIterable<EventSourceMessage>) {
-      if (!event.data || event.data === "[DONE]") continue;
-      let parsed: Record<string, unknown> = { type: "unknown", raw: event.data };
-      try {
-        parsed = JSON.parse(event.data) as Record<string, unknown>;
-      } catch {
-        // keep raw fallback
-      }
-      yield {
-        eventId: Number(event.id || 0),
-        eventKind: event.event || "message",
-        data: parsed,
-      };
-    }
-  }
-
-  async getExecution(executionId: string) {
-    const { data } = await this.http.get(`/agent/executions/${encodeURIComponent(executionId)}`);
-    return data as Record<string, unknown>;
-  }
-
-  async getMessages(threadKey: string, opts?: { cursor?: string; limit?: number }) {
-    const { data } = await this.http.get("/agent/messages", {
-      params: {
-        thread_key: threadKey,
-        cursor: opts?.cursor,
-        limit: opts?.limit ?? 50,
-      },
-    });
-    return data as {
-      messages: ThreadMessageRecord[];
-      cursor: string | null;
-      has_more: boolean;
-    };
-  }
-
-  async listExecutions(threadKey: string, limit = 20) {
-    const { data } = await this.http.get(
-      `/agent/threads/${encodeURIComponent(threadKey)}/executions`,
-      { params: { limit } },
-    );
-    return data as { thread_key: string; executions: Array<Record<string, unknown>> };
-  }
-
-  async cancelExecution(executionId: string) {
-    const { data } = await this.http.post(`/agent/executions/${encodeURIComponent(executionId)}/cancel`);
-    return data as Record<string, unknown>;
-  }
-
-  async steerExecution(
-    executionId: string,
-    opts?: {
-      contentBlocks?: Array<Record<string, unknown>>;
-      messageId?: string;
-      userId?: string;
-      metadata?: Record<string, unknown>;
-      suppressCancellationDelivery?: boolean;
-    },
-  ) {
-    const { data } = await this.http.post(`/agent/executions/${encodeURIComponent(executionId)}/steer`, {
-      content_blocks: opts?.contentBlocks,
-      message_id: opts?.messageId,
-      user_id: opts?.userId,
-      metadata: {
-        ...(opts?.metadata || {}),
-        ...(opts?.suppressCancellationDelivery === undefined
-          ? {}
-          : { steer_replacement: opts.suppressCancellationDelivery }),
-      },
-    });
-    return data as Record<string, unknown>;
-  }
-
-  async releaseThread(threadKey: string, opts?: { releaseId?: string; cancelInflight?: boolean }) {
-    const { data } = await this.http.post(
-      `/agent/threads/${encodeURIComponent(threadKey)}/release`,
-      {
-        release_id: opts?.releaseId,
-        cancel_inflight: opts?.cancelInflight ?? false,
-      },
-    );
-    return data as Record<string, unknown>;
-  }
-
-  async claimFinalDeliveries(opts: { consumerId: string; limit?: number; leaseSeconds?: number; platform?: string }) {
-    const { data } = await this.http.post("/agent/final-deliveries/claim", {
-      consumer_id: opts.consumerId,
-      limit: opts.limit ?? 1,
-      lease_seconds: opts.leaseSeconds ?? 60,
-      platform: opts.platform,
-    });
-    return data as { deliveries: Array<Record<string, unknown>> };
-  }
-
-  async renewFinalDeliveryLease(executionId: string, opts: { consumerId: string; leaseSeconds?: number }) {
-    const { data } = await this.http.post(
-      `/agent/final-deliveries/${encodeURIComponent(executionId)}/heartbeat`,
-      {
-        consumer_id: opts.consumerId,
-        lease_seconds: opts.leaseSeconds ?? 60,
-      },
-    );
-    return data as Record<string, unknown>;
-  }
-
-  async markFinalDelivered(executionId: string, consumerId?: string) {
-    const { data } = await this.http.post(
-      `/agent/final-deliveries/${encodeURIComponent(executionId)}/delivered`,
-      { consumer_id: consumerId },
-    );
-    return data as Record<string, unknown>;
-  }
-
-  async markFinalFailed(
-    executionId: string,
-    error: string,
-    opts?: {
-      consumerId?: string;
-      retryAfterSeconds?: number;
-      nonRetryable?: boolean;
-      errorClass?: string;
-    },
-  ) {
-    const { data } = await this.http.post(
-      `/agent/final-deliveries/${encodeURIComponent(executionId)}/failed`,
-      {
-        consumer_id: opts?.consumerId,
-        error,
-        retry_after_seconds: opts?.retryAfterSeconds ?? 15,
-        non_retryable: opts?.nonRetryable ?? false,
-        error_class: opts?.errorClass,
-      },
-    );
-    return data as Record<string, unknown>;
-  }
-
-  async getStatus(threadKey: string) {
-    const { data } = await this.http.get("/agent/status", { params: { key: threadKey } });
     return data as Record<string, unknown>;
   }
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,10 +1,6 @@
 export { ApiError } from "./types";
 export { CentaurClient } from "./client";
 export type {
-  ExecuteOptions,
-  MessageOptions,
-  InputContentBlock,
-  ThreadMessageRecord,
   WorkflowRunOptions,
   WorkflowRunAccepted,
 } from "./client";

--- a/packages/api-client/test/client.test.ts
+++ b/packages/api-client/test/client.test.ts
@@ -1,233 +1,99 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { CentaurClient, type StreamEvent } from "../src/client";
-
-async function collectEvents(events: AsyncIterable<StreamEvent>): Promise<StreamEvent[]> {
-  const collected: StreamEvent[] = [];
-  for await (const event of events) {
-    collected.push(event);
-  }
-  return collected;
-}
-
-function sseResponse(body: string, init?: ResponseInit): Response {
-  return new Response(
-    new ReadableStream({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode(body));
-        controller.close();
-      },
-    }),
-    {
-      status: 200,
-      headers: { "Content-Type": "text/event-stream" },
-      ...init,
-    },
-  );
-}
+import { CentaurClient } from "../src/client";
 
 describe("CentaurClient", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
 
-  it("parses SSE ids, events, JSON data, [DONE], and invalid JSON payloads", async () => {
-    const fetchMock = vi.fn(async () => sseResponse([
-      "id: 11",
-      "event: amp_raw_event",
-      'data: {"type":"assistant","message":{"content":"hello"}}',
-      "",
-      "id: 12",
-      "event: done",
-      "data: [DONE]",
-      "",
-      "id: 13",
-      "data: not-json",
-      "",
-      "",
-    ].join("\n")));
-    vi.stubGlobal("fetch", fetchMock);
-
+  it("starts workflow runs through the workflow API", async () => {
     const client = new CentaurClient({
       apiUrl: "http://api.local",
       apiKey: "test-key",
     });
-
-    await expect(collectEvents(client.streamEvents({ threadKey: "thread-1" }))).resolves.toEqual([
-      {
-        eventId: 11,
-        eventKind: "amp_raw_event",
-        data: { type: "assistant", message: { content: "hello" } },
-      },
-      {
-        eventId: 13,
-        eventKind: "message",
-        data: { type: "unknown", raw: "not-json" },
-      },
-    ]);
-  });
-
-  it("URL encodes Slack thread keys in event stream URLs", async () => {
-    const fetchMock = vi.fn(async () => sseResponse(""));
-    vi.stubGlobal("fetch", fetchMock);
-    const client = new CentaurClient({
-      apiUrl: "http://api.local",
-      apiKey: "test-key",
+    const postMock = vi.spyOn(client.http, "post").mockResolvedValue({
+      data: { ok: true, run_id: "run-123", workflow_name: "nightly", status: "queued" },
     });
 
-    await collectEvents(client.streamEvents({
-      threadKey: "slack:C123:1700000000.000100",
-      executionId: "exe-1",
-      afterEventId: 42,
-      pollMs: 250,
-    }));
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://api.local/agent/threads/slack%3AC123%3A1700000000.000100/events?after_event_id=42&execution_id=exe-1&poll_ms=250",
-      expect.objectContaining({
-        method: "GET",
-        headers: {
-          Authorization: "Bearer test-key",
-          "X-Centaur-Thread-Key": "slack:C123:1700000000.000100",
-        },
+    await expect(
+      client.startWorkflowRun({
+        workflowName: "nightly",
+        triggerKey: "trigger-1",
+        input: { topic: "incidents" },
+        eagerStart: true,
+        timeoutMs: 5000,
       }),
+    ).resolves.toMatchObject({ run_id: "run-123" });
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/api/workflows/runs",
+      {
+        workflow_name: "nightly",
+        trigger_key: "trigger-1",
+        input: { topic: "incidents" },
+        eager_start: true,
+      },
+      { timeout: 5000 },
     );
   });
 
-  it("URL encodes Slack thread keys in path-based API calls", async () => {
+  it("reads and mutates workflow runs through workflow endpoints", async () => {
     const client = new CentaurClient({
       apiUrl: "http://api.local",
       apiKey: "test-key",
     });
     const getMock = vi.spyOn(client.http, "get").mockResolvedValue({
-      data: { thread_key: "slack:C123:1700000000.000100", executions: [] },
+      data: { ok: true, run_id: "run:123", workflow_name: "nightly", status: "completed" },
     });
-    const postMock = vi.spyOn(client.http, "post").mockResolvedValue({ data: { ok: true } });
-
-    await client.listExecutions("slack:C123:1700000000.000100", 2);
-    await client.releaseThread("slack:C123:1700000000.000100", {
-      releaseId: "release:1",
-      cancelInflight: true,
+    const postMock = vi.spyOn(client.http, "post").mockResolvedValue({
+      data: { ok: true, run_id: "run:123", workflow_name: "nightly", status: "cancelled" },
     });
 
-    expect(getMock).toHaveBeenCalledWith(
-      "/agent/threads/slack%3AC123%3A1700000000.000100/executions",
-      { params: { limit: 2 } },
-    );
-    expect(postMock).toHaveBeenCalledWith(
-      "/agent/threads/slack%3AC123%3A1700000000.000100/release",
-      {
-        release_id: "release:1",
-        cancel_inflight: true,
+    await client.getWorkflowRun("run:123");
+    await client.listWorkflowRuns({
+      workflowName: "nightly",
+      threadKey: "slack:C:1",
+      status: "running",
+      parentRunId: "root",
+      limit: 5,
+    });
+    await client.getWorkflowChildren("run:123", 10);
+    await client.cancelWorkflowRun("run:123");
+
+    expect(getMock).toHaveBeenNthCalledWith(1, "/api/workflows/runs/run%3A123");
+    expect(getMock).toHaveBeenNthCalledWith(2, "/api/workflows/runs", {
+      params: {
+        workflow_name: "nightly",
+        thread_key: "slack:C:1",
+        status: "running",
+        parent_run_id: "root",
+        limit: 5,
       },
-    );
-  });
-
-  it("throws useful errors for non-OK event stream responses", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(
-      "upstream unavailable",
-      { status: 503, statusText: "Service Unavailable" },
-    )));
-    const client = new CentaurClient({
-      apiUrl: "http://api.local",
-      apiKey: "test-key",
     });
-
-    await expect(
-      collectEvents(client.streamEvents({ threadKey: "slack:C123:1700000000.000100" })),
-    ).rejects.toThrow(
-      "/agent/threads/{thread}/events failed (503): upstream unavailable",
-    );
+    expect(getMock).toHaveBeenNthCalledWith(3, "/api/workflows/runs/run%3A123/children", {
+      params: { limit: 10 },
+    });
+    expect(postMock).toHaveBeenCalledWith("/api/workflows/runs/run%3A123/cancel");
   });
 
-  it("posts the expected steerExecution payload", async () => {
+  it("sends workflow events", async () => {
     const client = new CentaurClient({
       apiUrl: "http://api.local",
       apiKey: "test-key",
     });
     const postMock = vi.spyOn(client.http, "post").mockResolvedValue({ data: { ok: true } });
 
-    await client.steerExecution("exe:123", {
-      contentBlocks: [{ type: "text", text: "replacement" }],
-      messageId: "slack:1700000000.000200",
-      userId: "U123",
-      metadata: { platform: "slack" },
-      suppressCancellationDelivery: true,
+    await client.sendWorkflowEvent({
+      eventType: "approval.received",
+      correlationId: "corr-1",
+      payload: { approved: true },
     });
 
-    expect(postMock).toHaveBeenCalledWith(
-      "/agent/executions/exe%3A123/steer",
-      {
-        content_blocks: [{ type: "text", text: "replacement" }],
-        message_id: "slack:1700000000.000200",
-        user_id: "U123",
-        metadata: {
-          platform: "slack",
-          steer_replacement: true,
-        },
-      },
-    );
-  });
-
-  it("posts the expected final-delivery payloads", async () => {
-    const client = new CentaurClient({
-      apiUrl: "http://api.local",
-      apiKey: "test-key",
+    expect(postMock).toHaveBeenCalledWith("/api/workflows/events", {
+      event_type: "approval.received",
+      correlation_id: "corr-1",
+      payload: { approved: true },
     });
-    const postMock = vi.spyOn(client.http, "post").mockResolvedValue({ data: { ok: true, deliveries: [] } });
-
-    await client.claimFinalDeliveries({
-      consumerId: "slackbot-1",
-      limit: 3,
-      leaseSeconds: 120,
-      platform: "slack",
-    });
-    await client.renewFinalDeliveryLease("exe:123", {
-      consumerId: "slackbot-1",
-      leaseSeconds: 90,
-    });
-    await client.markFinalDelivered("exe:123", "slackbot-1");
-    await client.markFinalFailed("exe:123", "rate limited", {
-      consumerId: "slackbot-1",
-      retryAfterSeconds: 45,
-      nonRetryable: true,
-      errorClass: "slack_rate_limit",
-    });
-
-    expect(postMock).toHaveBeenNthCalledWith(
-      1,
-      "/agent/final-deliveries/claim",
-      {
-        consumer_id: "slackbot-1",
-        limit: 3,
-        lease_seconds: 120,
-        platform: "slack",
-      },
-    );
-    expect(postMock).toHaveBeenNthCalledWith(
-      2,
-      "/agent/final-deliveries/exe%3A123/heartbeat",
-      {
-        consumer_id: "slackbot-1",
-        lease_seconds: 90,
-      },
-    );
-    expect(postMock).toHaveBeenNthCalledWith(
-      3,
-      "/agent/final-deliveries/exe%3A123/delivered",
-      { consumer_id: "slackbot-1" },
-    );
-    expect(postMock).toHaveBeenNthCalledWith(
-      4,
-      "/agent/final-deliveries/exe%3A123/failed",
-      {
-        consumer_id: "slackbot-1",
-        error: "rate limited",
-        retry_after_seconds: 45,
-        non_retryable: true,
-        error_class: "slack_rate_limit",
-      },
-    );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,15 +24,9 @@ importers:
 
   packages/api-client:
     dependencies:
-      '@centaur/harness-events':
-        specifier: workspace:*
-        version: link:../harness-events
       axios:
         specifier: ^1.13.6
         version: 1.18.0
-      eventsource-parser:
-        specifier: ^3.0.6
-        version: 3.1.0
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -879,10 +873,6 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
-
-  eventsource-parser@3.1.0:
-    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
-    engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -2416,8 +2406,6 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
-
-  eventsource-parser@3.1.0: {}
 
   expect-type@1.3.0: {}
 

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -3313,13 +3313,11 @@ async fn call_python_workflow_tool(message: &Value) -> Result<Value, WorkflowRun
         return serde_json::to_value(run_time_now_tool()).map_err(WorkflowRuntimeError::from);
     }
 
-    let base_url = env::var(WORKFLOW_TOOL_API_URL_ENV)
-        .or_else(|_| env::var("CENTAUR_PYTHON_API_URL"))
-        .map_err(|_| {
-            WorkflowRuntimeError::BadRequest(format!(
-                "{WORKFLOW_TOOL_API_URL_ENV} must be set for ctx.call_tool({tool}.{method})"
-            ))
-        })?;
+    let base_url = env::var(WORKFLOW_TOOL_API_URL_ENV).map_err(|_| {
+        WorkflowRuntimeError::BadRequest(format!(
+            "{WORKFLOW_TOOL_API_URL_ENV} must be set for ctx.call_tool({tool}.{method})"
+        ))
+    })?;
     let base_url = base_url.trim_end_matches('/');
     let url = format!("{base_url}/tools/{tool}/{method}");
     let args = message.get("args").cloned().unwrap_or_else(|| json!({}));

--- a/tools/productivity/slack/feedback.py
+++ b/tools/productivity/slack/feedback.py
@@ -9,6 +9,7 @@ import os
 import re
 import sqlite3
 import urllib.error
+import urllib.parse
 import urllib.request
 import uuid
 from dataclasses import dataclass, field
@@ -113,15 +114,17 @@ class SaveFeedbackResult:
 
 
 class CentaurAgentClient:
-    """Minimal client for starting a background improvement agent run."""
+    """Minimal client for starting a background improvement agent session."""
 
     def __init__(self, base_url: str | None = None, api_key: str | None = None):
-        self.base_url = (base_url or os.environ.get("CENTAUR_API_URL") or "http://api:8000").rstrip("/")
+        self.base_url = (base_url or os.getenv("CENTAUR_API_URL") or "http://api:8000").rstrip("/")
         self.api_key = api_key or _load_centaur_api_key()
         if not self.api_key:
-            raise RuntimeError("CENTAUR_AGENT_API_KEY not set")
+            raise RuntimeError("SLACK_FEEDBACK_API_KEY not set")
 
-    def _request_json(self, method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    def _request_json(
+        self, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Accept": "application/json",
@@ -159,57 +162,62 @@ class CentaurAgentClient:
         persona_id: str = "eng",
         thread_key: str | None = None,
     ) -> dict[str, Any]:
-        """Spawn, message, and execute a background improvement agent run."""
-        thread_key = thread_key or f"feedback-improvement:{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}:{uuid.uuid4().hex[:8]}"
-        spawn = self._request_json(
-            "POST",
-            "/agent/spawn",
-            {
-                "thread_key": thread_key,
-                "harness": harness,
-                "persona_id": persona_id,
-            },
+        """Create a session, persist the prompt, and execute it."""
+        thread_key = thread_key or (
+            f"feedback-improvement:{datetime.now(datetime.UTC).strftime('%Y%m%dT%H%M%SZ')}:{uuid.uuid4().hex[:8]}"
         )
-        assignment_generation = spawn["assignment_generation"]
+        thread_path = urllib.parse.quote(thread_key, safe="")
 
         self._request_json(
             "POST",
-            "/agent/message",
+            f"/api/session/{thread_path}",
             {
-                "thread_key": thread_key,
-                "assignment_generation": assignment_generation,
-                "role": "user",
-                "parts": [{"type": "text", "text": prompt}],
+                "harness_type": harness,
+                "persona_id": persona_id,
                 "metadata": {"source": "slack-feedback-loop"},
+                "on_harness_conflict": "restart",
+            },
+        )
+
+        parts = [{"type": "text", "text": prompt}]
+        self._request_json(
+            "POST",
+            f"/api/session/{thread_path}/messages",
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "parts": parts,
+                        "metadata": {"source": "slack-feedback-loop"},
+                    }
+                ],
             },
         )
 
         execute = self._request_json(
             "POST",
-            "/agent/execute",
+            f"/api/session/{thread_path}/execute",
             {
-                "thread_key": thread_key,
-                "assignment_generation": assignment_generation,
-                "execute_id": f"feedback-improvement-{uuid.uuid4().hex[:12]}",
-                "harness": harness,
-                "delivery": {"platform": "dev"},
-                "metadata": {"source": "slack-feedback-loop"},
+                "idempotency_key": f"feedback-improvement-{uuid.uuid4().hex[:12]}",
+                "metadata": {"source": "slack-feedback-loop", "delivery": {"platform": "dev"}},
+                "input_lines": [
+                    json.dumps(
+                        {"type": "user", "message": {"content": parts}},
+                        separators=(",", ":"),
+                    )
+                ],
             },
         )
 
         return {
             "thread_key": thread_key,
-            "assignment_generation": assignment_generation,
             "execution_id": execute["execution_id"],
             "status": execute.get("status"),
         }
 
 
 def _ensure_column(conn: sqlite3.Connection, table: str, column: str, definition: str) -> None:
-    columns = {
-        row["name"]
-        for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
-    }
+    columns = {row["name"] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
     if column not in columns:
         conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
 
@@ -244,7 +252,7 @@ def _severity_filter_clause(min_severity: str | None) -> tuple[str, list[str]]:
 
 
 def _load_centaur_api_key() -> str | None:
-    return os.environ.get("CENTAUR_AGENT_API_KEY")
+    return os.getenv("SLACK_FEEDBACK_API_KEY")
 
 
 def _bot_message_looks_like_error(text: str) -> bool:
@@ -430,8 +438,10 @@ def classify_feedback(signals: FeedbackSignals, messages: list[dict]) -> tuple[s
     if signals.has_bot_error:
         category = "cli_bug"
     elif (
-        signals.has_positive_reaction or signals.positive_keywords_found
-    ) and not signals.has_negative_reaction and not signals.negative_keywords_found:
+        (signals.has_positive_reaction or signals.positive_keywords_found)
+        and not signals.has_negative_reaction
+        and not signals.negative_keywords_found
+    ):
         category = "success"
     elif signals.repeated_requests:
         category = "routing_error"

--- a/tools/productivity/slack/tests/test_feedback.py
+++ b/tools/productivity/slack/tests/test_feedback.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 
 from slack import feedback
@@ -52,8 +53,12 @@ def test_run_improvement_cycle_dispatches_only_actionable_items(tmp_path, monkey
     monkeypatch.setattr(feedback, "FEEDBACK_DB_PATH", tmp_path / "feedback.db")
 
     conn = feedback.init_db()
-    actionable_id = feedback.save_feedback_item(conn, _sample_item(category="cli_bug", severity="high")).item_id
-    success_id = feedback.save_feedback_item(conn, _sample_item(category="success", severity="low")).item_id
+    actionable_id = feedback.save_feedback_item(
+        conn, _sample_item(category="cli_bug", severity="high")
+    ).item_id
+    success_id = feedback.save_feedback_item(
+        conn, _sample_item(category="success", severity="low")
+    ).item_id
     conn.close()
 
     monkeypatch.setattr(
@@ -74,7 +79,6 @@ def test_run_improvement_cycle_dispatches_only_actionable_items(tmp_path, monkey
             assert "git-branch paradigmxyz/centaur" in prompt
             return {
                 "thread_key": "feedback-improvement:test",
-                "assignment_generation": 7,
                 "execution_id": "exec-test-123",
                 "status": "queued",
             }
@@ -103,6 +107,54 @@ def test_run_improvement_cycle_dispatches_only_actionable_items(tmp_path, monkey
     assert row_by_id[actionable_id]["agent_execution_id"] == "exec-test-123"
     assert row_by_id[success_id]["status"] == "new"
     assert row_by_id[success_id]["agent_execution_id"] is None
+
+
+def test_agent_client_uses_session_api_for_improvement_runs():
+    class RecordingAgentClient(feedback.CentaurAgentClient):
+        def __init__(self):
+            super().__init__(base_url="http://api.local", api_key="test-key")
+            self.calls = []
+
+        def _request_json(self, method: str, path: str, payload: dict | None = None):
+            self.calls.append((method, path, payload))
+            if path.endswith("/execute"):
+                return {"execution_id": "exec-test-123", "status": "queued"}
+            return {"ok": True}
+
+    client = RecordingAgentClient()
+
+    result = client.start_improvement_run(
+        "Improve the Slack tool",
+        harness="codex",
+        persona_id="eng",
+        thread_key="feedback-improvement:test:1",
+    )
+
+    assert result == {
+        "thread_key": "feedback-improvement:test:1",
+        "execution_id": "exec-test-123",
+        "status": "queued",
+    }
+    assert [path for _, path, _ in client.calls] == [
+        "/api/session/feedback-improvement%3Atest%3A1",
+        "/api/session/feedback-improvement%3Atest%3A1/messages",
+        "/api/session/feedback-improvement%3Atest%3A1/execute",
+    ]
+    assert client.calls[0][2] == {
+        "harness_type": "codex",
+        "persona_id": "eng",
+        "metadata": {"source": "slack-feedback-loop"},
+        "on_harness_conflict": "restart",
+    }
+    execute_payload = client.calls[2][2]
+    assert execute_payload["metadata"] == {
+        "source": "slack-feedback-loop",
+        "delivery": {"platform": "dev"},
+    }
+    assert json.loads(execute_payload["input_lines"][0]) == {
+        "type": "user",
+        "message": {"content": [{"type": "text", "text": "Improve the Slack tool"}]},
+    }
 
 
 def test_analyze_thread_signals_does_not_treat_exceptional_as_error():


### PR DESCRIPTION
## Summary
- Rebased PR #640's legacy agent API cleanup onto the current api-rs session/workflow route shape
- Trimmed @centaur/api-client to workflow APIs and updated them to /api/workflows routes
- Updated Slack feedback improvement dispatch to use /api/session instead of legacy /agent endpoints
- Refreshed generated docs/public markdown for stale /agent, /health/tools, and unprefixed workflow route examples

Closes paradigmxyz/centaur#640

## Validation
- pnpm --filter @centaur/api-client test
- PYTHONPATH=tools/productivity:. uv run --with pytest --with slack-sdk --with structlog --with aiohttp pytest tools/productivity/slack/tests/test_feedback.py
- cargo fmt --check (services/api-rs)
- cargo test -p centaur-workflows ctx_call_tool_supports_builtin_time_now
- git diff --check && git diff --cached --check