### PR TITLE
feat: persist session titles

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -981,6 +981,7 @@ dependencies = [
  "centaur-telemetry",
  "dashmap",
  "futures-util",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -60,7 +60,8 @@ async fn initialize_runtime(args: Args, app_state: AppState) -> Result<(), Serve
     }
     let pool = store.pool().clone();
     let sandbox_runtime = args.sandbox_runtime().await?;
-    let mut runtime = SessionRuntime::new(store.clone(), sandbox_runtime);
+    let mut runtime = SessionRuntime::new(store.clone(), sandbox_runtime)
+        .with_openai_session_title_generator_from_env();
     let mut warm_pool_bootstrap_principal = None;
     let mut workflow_host_principal = None;
     if let Some(iron_control) = args.iron_control_runtime().await? {

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -404,10 +404,22 @@ async fn get_session_context(
     State(state): State<AppState>,
     Path(raw_thread_key): Path<String>,
 ) -> Result<Json<SessionContextResponse>, ApiError> {
-    let _runtime = state.runtime()?;
+    let runtime = state.runtime()?;
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
+    let title = match runtime.session_title(&thread_key).await {
+        Ok(title) => title,
+        Err(error) => {
+            tracing::warn!(
+                thread_key = %thread_key,
+                %error,
+                "failed to load optional session title"
+            );
+            None
+        }
+    };
     Ok(Json(SessionContextResponse {
         slack: slack_thread_context(&thread_key),
+        title,
         thread_key,
     }))
 }

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -37,6 +37,8 @@ pub struct CreateSessionResponse {
 pub struct SessionContextResponse {
     pub thread_key: ThreadKey,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub slack: Option<SlackThreadContext>,
 }
 

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -165,6 +165,8 @@ impl Default for SandboxCapabilities {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Session {
     pub thread_key: ThreadKey,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     pub sandbox_id: Option<String>,
     /// Capabilities applied to the currently assigned sandbox. `None` means the
     /// sandbox predates capability tracking; callers may treat it as compatible

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -14,6 +14,7 @@ centaur-session-sqlx.workspace = true
 centaur-telemetry.workspace = true
 dashmap.workspace = true
 futures-util.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1,7 +1,9 @@
 mod cleanup;
+mod title_generator;
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    future::Future,
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -27,8 +29,8 @@ use centaur_telemetry::{
     record_session_execution_finished, record_session_execution_started, record_session_failure,
     record_session_first_token_latency, set_span_parent_trace,
 };
-use dashmap::DashMap;
-use futures_util::{SinkExt, Stream, StreamExt, stream};
+use dashmap::{DashMap, DashSet};
+use futures_util::{FutureExt, SinkExt, Stream, StreamExt, future::BoxFuture, stream};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -42,6 +44,10 @@ use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
 use tracing::{Instrument, Span, error, info, info_span, warn};
 
 pub use cleanup::SessionSandboxCleanupConfig;
+pub use title_generator::SessionTitleGenerationError;
+use title_generator::{
+    OpenAiSessionTitleGenerator, sanitize_session_title, session_title_source_from_parts,
+};
 
 pub const SESSION_OUTPUT_LINE_EVENT: &str = "session.output.line";
 pub const SESSION_FIRST_TOKEN_EVENT: &str = "session.first_token";
@@ -63,6 +69,10 @@ type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
 type ExecutionSpanRegistry = Arc<Mutex<HashMap<String, Span>>>;
 type SessionPipeMap = Arc<DashMap<String, SessionPipe>>;
 type SessionPipeOpenLocks = Arc<DashMap<String, Arc<Mutex<()>>>>;
+type SessionTitleThreadSet = Arc<DashSet<ThreadKey>>;
+type SessionTitleGenerator = Arc<
+    dyn Fn(String) -> BoxFuture<'static, Result<String, SessionTitleGenerationError>> + Send + Sync,
+>;
 
 #[derive(Clone)]
 pub struct SessionRuntime {
@@ -74,6 +84,9 @@ pub struct SessionRuntime {
     iron_control: Option<SessionRegistrar>,
     warm_pool: Option<Arc<WarmPoolManager>>,
     personas: Option<Arc<PersonaRegistry>>,
+    session_title_generator: Option<SessionTitleGenerator>,
+    session_title_in_flight: SessionTitleThreadSet,
+    session_title_rerun_requested: SessionTitleThreadSet,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -319,7 +332,30 @@ impl SessionRuntime {
             iron_control: None,
             warm_pool: None,
             personas: None,
+            session_title_generator: None,
+            session_title_in_flight: Arc::new(DashSet::new()),
+            session_title_rerun_requested: Arc::new(DashSet::new()),
         }
+    }
+
+    pub fn with_session_title_generator<F, Fut>(mut self, generator: F) -> Self
+    where
+        F: Fn(String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<String, SessionTitleGenerationError>> + Send + 'static,
+    {
+        self.session_title_generator = Some(Arc::new(move |source| generator(source).boxed()));
+        self
+    }
+
+    pub fn with_openai_session_title_generator_from_env(mut self) -> Self {
+        let Some(generator) = OpenAiSessionTitleGenerator::from_env() else {
+            return self;
+        };
+        self.session_title_generator = Some(Arc::new(move |source| {
+            let generator = generator.clone();
+            async move { generator.generate(source).await }.boxed()
+        }));
+        self
     }
 
     pub fn with_personas(mut self, personas: PersonaRegistry) -> Self {
@@ -332,6 +368,13 @@ impl SessionRuntime {
             .as_ref()
             .map(|personas| personas.summaries())
             .unwrap_or_default()
+    }
+
+    pub async fn session_title(
+        &self,
+        thread_key: &ThreadKey,
+    ) -> Result<Option<String>, SessionRuntimeError> {
+        Ok(self.store.get_session_title(thread_key).await?)
     }
 
     fn resolve_persona_for_create(
@@ -712,7 +755,43 @@ impl SessionRuntime {
         };
         self.forward_messages_to_active_execution(thread_key, messages, &message_ids)
             .await;
+        self.spawn_session_title_generation(thread_key);
         Ok(message_ids)
+    }
+
+    fn spawn_session_title_generation(&self, thread_key: &ThreadKey) {
+        let Some(generator) = self.session_title_generator.clone() else {
+            return;
+        };
+        if !self.session_title_in_flight.insert(thread_key.clone()) {
+            self.session_title_rerun_requested
+                .insert(thread_key.clone());
+            return;
+        }
+        let store = self.store.clone();
+        let in_flight = self.session_title_in_flight.clone();
+        let rerun_requested = self.session_title_rerun_requested.clone();
+        let thread_key = thread_key.clone();
+        tokio::spawn(async move {
+            // Appends skipped while generation is in flight request one more pass,
+            // which lets low-signal wakeups defer to a later substantive message.
+            loop {
+                rerun_requested.remove(&thread_key);
+                maybe_generate_session_title(store.clone(), generator.clone(), thread_key.clone())
+                    .await;
+                if rerun_requested.remove(&thread_key).is_some() {
+                    continue;
+                }
+
+                in_flight.remove(&thread_key);
+                if rerun_requested.remove(&thread_key).is_some()
+                    && in_flight.insert(thread_key.clone())
+                {
+                    continue;
+                }
+                break;
+            }
+        });
     }
 
     /// Stop every non-terminal sandbox the backend currently owns.
@@ -2091,6 +2170,73 @@ impl SessionRuntime {
                 execution_id,
                 error = %record_error,
                 "failed to record orphaned execution failure"
+            );
+        }
+    }
+}
+
+async fn maybe_generate_session_title(
+    store: PgSessionStore,
+    generator: SessionTitleGenerator,
+    thread_key: ThreadKey,
+) {
+    let parts = match store.title_generation_candidate(&thread_key).await {
+        Ok(Some(parts)) => parts,
+        Ok(None) => return,
+        Err(error) => {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_title_candidate_failed",
+                thread_key = %thread_key,
+                %error,
+                "failed to load session title candidate"
+            );
+            return;
+        }
+    };
+    let Some(source) = session_title_source_from_parts(&parts) else {
+        return;
+    };
+    let raw_title = match generator(source).await {
+        Ok(title) => title,
+        Err(error) => {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_title_generation_failed",
+                thread_key = %thread_key,
+                %error,
+                "failed to generate session title"
+            );
+            return;
+        }
+    };
+    let Some(title) = sanitize_session_title(&raw_title) else {
+        warn!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_title_generation_empty",
+            thread_key = %thread_key,
+            "session title generation returned an empty title"
+        );
+        return;
+    };
+    match store.set_session_title_if_empty(&thread_key, &title).await {
+        Ok(true) => {
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_title_set",
+                thread_key = %thread_key,
+                title,
+                "session title set"
+            );
+        }
+        Ok(false) => {}
+        Err(error) => {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_title_set_failed",
+                thread_key = %thread_key,
+                %error,
+                "failed to set session title"
             );
         }
     }
@@ -5774,6 +5920,7 @@ mod tests {
         let now = OffsetDateTime::now_utc();
         Session {
             thread_key,
+            title: None,
             sandbox_id: Some(sandbox_id.to_owned()),
             sandbox_capabilities: None,
             harness_type: HarnessType::Codex,
@@ -6087,6 +6234,22 @@ mod adoption_tests {
         }
     }
 
+    async fn wait_for_session_title(
+        store: &PgSessionStore,
+        thread_key: &ThreadKey,
+        expected: &str,
+    ) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let session = store.get_session(thread_key).await.expect("get session");
+            if session.title.as_deref() == Some(expected) {
+                return;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for title");
+            sleep(Duration::from_millis(25)).await;
+        }
+    }
+
     async fn events(store: &PgSessionStore, thread_key: &ThreadKey) -> Vec<SessionEvent> {
         store
             .list_events_after(thread_key, 0, None, 1000)
@@ -6099,6 +6262,116 @@ mod adoption_tests {
             store.clone(),
             SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
         )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn append_messages_generates_missing_session_title_once() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key = ThreadKey::parse(format!("test:title-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let sources = Arc::new(Mutex::new(Vec::<String>::new()));
+        let generator_started = Arc::new(tokio::sync::Notify::new());
+        let generator_release = Arc::new(tokio::sync::Notify::new());
+        let calls_for_generator = calls.clone();
+        let sources_for_generator = sources.clone();
+        let started_for_generator = generator_started.clone();
+        let release_for_generator = generator_release.clone();
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        )
+        .with_session_title_generator(move |source| {
+            let calls = calls_for_generator.clone();
+            let sources = sources_for_generator.clone();
+            let started = started_for_generator.clone();
+            let release = release_for_generator.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                sources.lock().await.push(source);
+                started.notify_one();
+                release.notified().await;
+                Ok("Fix worker memory leak".to_owned())
+            }
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            runtime.append_messages(
+                &thread_key,
+                &[SessionMessageInput {
+                    client_message_id: Some("first".to_owned()),
+                    role: MessageRole::User,
+                    parts: vec![
+                        json!({
+                            "type": "text",
+                            "text": "# Requester Context\n\nThe Slack user who prompted this turn is Alice."
+                        }),
+                        json!({
+                            "type": "text",
+                            "text": "<@U123> please fix the memory leak in the worker"
+                        }),
+                    ],
+                    metadata: json!({}),
+                }],
+            ),
+        )
+        .await
+        .expect("append first message should not wait for title generation")
+        .expect("append first message");
+
+        generator_started.notified().await;
+
+        let session = store.get_session(&thread_key).await.unwrap();
+        assert_eq!(session.title, None);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            sources.lock().await.clone(),
+            vec!["please fix the memory leak in the worker".to_owned()]
+        );
+
+        runtime
+            .append_messages(
+                &thread_key,
+                &[SessionMessageInput {
+                    client_message_id: Some("burst".to_owned()),
+                    role: MessageRole::User,
+                    parts: vec![json!({"type": "text", "text": "add more logging"})],
+                    metadata: json!({}),
+                }],
+            )
+            .await
+            .expect("append burst message");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        generator_release.notify_one();
+        wait_for_session_title(&store, &thread_key, "Fix worker memory leak").await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        runtime
+            .append_messages(
+                &thread_key,
+                &[SessionMessageInput {
+                    client_message_id: Some("second".to_owned()),
+                    role: MessageRole::User,
+                    parts: vec![json!({"type": "text", "text": "add more logging"})],
+                    metadata: json!({}),
+                }],
+            )
+            .await
+            .expect("append second message");
+
+        let session = store.get_session(&thread_key).await.unwrap();
+        assert_eq!(session.title.as_deref(), Some("Fix worker memory leak"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     fn env_value<'a>(spec: &'a SandboxSpec, name: &str) -> Option<&'a str> {

--- a/services/api-rs/crates/centaur-session-runtime/src/title_generator.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/title_generator.rs
@@ -1,0 +1,438 @@
+use std::{env, sync::Arc, time::Duration};
+
+use serde_json::{Value, json};
+use thiserror::Error;
+
+const SESSION_TITLE_MODEL: &str = "gpt-5.4-nano";
+const SESSION_TITLE_MAX_SOURCE_CHARS: usize = 4_000;
+const SESSION_TITLE_MAX_CHARS: usize = 80;
+const SESSION_TITLE_REQUEST_TIMEOUT: Duration = Duration::from_secs(4);
+
+#[derive(Clone)]
+pub(crate) struct OpenAiSessionTitleGenerator {
+    api_key: Arc<str>,
+    client: reqwest::Client,
+}
+
+impl OpenAiSessionTitleGenerator {
+    pub(crate) fn from_env() -> Option<Self> {
+        let api_key = env::var("OPENAI_API_KEY").ok()?;
+        let api_key = api_key.trim();
+        if api_key.is_empty() || api_key == "OPENAI_API_KEY" {
+            return None;
+        }
+        let client = reqwest::Client::builder()
+            .timeout(SESSION_TITLE_REQUEST_TIMEOUT)
+            .build()
+            .ok()?;
+        Some(Self {
+            api_key: Arc::from(api_key.to_owned()),
+            client,
+        })
+    }
+
+    pub(crate) async fn generate(
+        &self,
+        source: String,
+    ) -> Result<String, SessionTitleGenerationError> {
+        let body = json!({
+            "model": SESSION_TITLE_MODEL,
+            "instructions": "Generate a short session title for the user's request. Return only the title. Use commit-message style with an imperative verb first, such as Fix, Investigate, Add, Update, Debug, Review, Explain, or Analyze. Keep it to 5 words max; 6-7 words are okay only when needed for a product name. Do not include punctuation, quotes, emoji, markdown, or a trailing period.",
+            "input": format!("User request:\n{}", source),
+            "max_output_tokens": 24,
+        });
+        let response = self
+            .client
+            .post("https://api.openai.com/v1/responses")
+            .bearer_auth(self.api_key.as_ref())
+            .json(&body)
+            .send()
+            .await?;
+        let status = response.status();
+        let text = response.text().await?;
+        if !status.is_success() {
+            return Err(SessionTitleGenerationError::HttpStatus { status, body: text });
+        }
+        openai_response_output_text(&text).ok_or(SessionTitleGenerationError::MissingOutput)
+    }
+}
+
+pub(crate) fn session_title_source_from_parts(parts: &[Value]) -> Option<String> {
+    let mut text_blocks = Vec::new();
+    let mut slack_thread_source = None;
+    let mut attachment_names = Vec::new();
+    for part in parts {
+        match part {
+            Value::String(text) => {
+                collect_title_source_text(text, &mut text_blocks, &mut slack_thread_source);
+            }
+            Value::Object(object) => {
+                if let Some(text) = object.get("text").and_then(Value::as_str) {
+                    collect_title_source_text(text, &mut text_blocks, &mut slack_thread_source);
+                }
+                for key in ["name", "title", "filename"] {
+                    if let Some(name) = object.get(key).and_then(Value::as_str)
+                        && let Some(name) = clean_nonempty(name)
+                    {
+                        attachment_names.push(name.to_owned());
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    let source = slack_thread_source
+        .or_else(|| text_blocks.first().cloned())
+        .or_else(|| {
+            attachment_names
+                .first()
+                .map(|name| format!("Analyze attachment {name}"))
+        })?;
+    Some(truncate_chars(&source, SESSION_TITLE_MAX_SOURCE_CHARS))
+}
+
+fn collect_title_source_text(
+    raw_text: &str,
+    text_blocks: &mut Vec<String>,
+    slack_thread_source: &mut Option<String>,
+) {
+    if slack_thread_source.is_none()
+        && let Some(text) = slack_thread_context_title_source(raw_text)
+        && title_source_has_signal(&text)
+    {
+        *slack_thread_source = Some(text);
+    }
+    if is_session_context_text(raw_text) {
+        return;
+    }
+    if let Some(text) = clean_title_source_text(raw_text)
+        && title_source_has_signal(&text)
+    {
+        text_blocks.push(text);
+    }
+}
+
+fn slack_thread_context_title_source(text: &str) -> Option<String> {
+    if !text.trim_start().starts_with("# Slack Thread Context") {
+        return None;
+    }
+
+    let mut in_first_message = false;
+    let mut lines = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed == "# Current Request" {
+            break;
+        }
+        if !in_first_message {
+            if trimmed.starts_with("1. ") && trimmed.ends_with(':') {
+                in_first_message = true;
+            }
+            continue;
+        }
+        if trimmed.starts_with("2. ") && trimmed.ends_with(':') {
+            break;
+        }
+        if trimmed.is_empty() {
+            if lines.is_empty() {
+                continue;
+            }
+            break;
+        }
+        lines.push(trimmed);
+    }
+
+    let text = lines.join(" ");
+    clean_title_source_text(&text)
+}
+
+fn title_source_has_signal(text: &str) -> bool {
+    let normalized = normalize_low_signal_text(text);
+    if normalized.is_empty() {
+        return false;
+    }
+    if is_low_signal_phrase(&normalized) {
+        return false;
+    }
+
+    let words = normalized.split_whitespace().collect::<Vec<_>>();
+    if words.iter().all(|word| is_low_signal_word(word)) {
+        return false;
+    }
+
+    true
+}
+
+fn normalize_low_signal_text(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let lowercase = text.to_lowercase();
+    let mut chars = lowercase.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == ':' {
+            let mut emoji_name = String::new();
+            while let Some(next) = chars.peek().copied() {
+                chars.next();
+                if next == ':' {
+                    break;
+                }
+                if next.is_ascii_alphanumeric() || matches!(next, '_' | '-' | '+') {
+                    emoji_name.push(next);
+                    continue;
+                }
+                output.push(' ');
+                output.push_str(&emoji_name);
+                output.push(next);
+                emoji_name.clear();
+                break;
+            }
+            continue;
+        }
+        if ch.is_alphanumeric() {
+            output.push(ch);
+        } else {
+            output.push(' ');
+        }
+    }
+    output.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn is_low_signal_phrase(text: &str) -> bool {
+    matches!(
+        text,
+        "hey"
+            | "hi"
+            | "hello"
+            | "yo"
+            | "hey bot"
+            | "hi bot"
+            | "hello bot"
+            | "hey ai"
+            | "hi ai"
+            | "hello ai"
+            | "thread"
+            | "help"
+            | "can you help"
+            | "can you help me"
+            | "please help"
+            | "pls help"
+    )
+}
+
+fn is_low_signal_word(word: &str) -> bool {
+    matches!(
+        word,
+        "hey" | "hi" | "hello" | "yo" | "bot" | "ai" | "thread" | "please" | "pls"
+    )
+}
+
+fn clean_title_source_text(text: &str) -> Option<String> {
+    let text = strip_slack_user_mentions(text)
+        .replace('\r', "\n")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut text = clean_nonempty(&text)?.to_owned();
+    if text.starts_with('@') {
+        text = text
+            .char_indices()
+            .find(|(_, ch)| ch.is_whitespace())
+            .map(|(index, _)| text[index..].trim_start().to_owned())
+            .unwrap_or_default();
+    }
+    clean_nonempty(&text).map(str::to_owned)
+}
+
+fn strip_slack_user_mentions(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("<@") {
+        output.push_str(&rest[..start]);
+        let mention = &rest[start + 2..];
+        let Some(end) = mention.find('>') else {
+            output.push_str(&rest[start..]);
+            return output;
+        };
+        rest = &mention[end + 1..];
+    }
+    output.push_str(rest);
+    output
+}
+
+fn is_session_context_text(text: &str) -> bool {
+    let text = text.trim_start();
+    [
+        "# Requester Context",
+        "# Slack Session Context",
+        "# Slack Thread Context",
+        "Earlier Slack thread attachment",
+    ]
+    .iter()
+    .any(|prefix| text.starts_with(prefix))
+}
+
+pub(crate) fn sanitize_session_title(title: &str) -> Option<String> {
+    let title = title
+        .trim()
+        .trim_matches(|ch: char| {
+            matches!(
+                ch,
+                '"' | '\'' | '`' | '*' | '_' | '-' | ':' | ';' | ',' | '.'
+            )
+        })
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let title = clean_nonempty(&title)?;
+    let words = title
+        .split_whitespace()
+        .take(7)
+        .map(|word| {
+            word.trim_matches(|ch: char| matches!(ch, '"' | '\'' | '`' | ',' | '.' | ':' | ';'))
+        })
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>();
+    if words.is_empty() {
+        return None;
+    }
+    Some(truncate_chars(&words.join(" "), SESSION_TITLE_MAX_CHARS))
+}
+
+fn openai_response_output_text(body: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(body).ok()?;
+    if let Some(text) = value.get("output_text").and_then(Value::as_str)
+        && clean_nonempty(text).is_some()
+    {
+        return Some(text.to_owned());
+    }
+    for output in value.get("output").and_then(Value::as_array)? {
+        let Some(content) = output.get("content").and_then(Value::as_array) else {
+            continue;
+        };
+        for item in content {
+            if let Some(text) = item.get("text").and_then(Value::as_str)
+                && clean_nonempty(text).is_some()
+            {
+                return Some(text.to_owned());
+            }
+        }
+    }
+    None
+}
+
+fn clean_nonempty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut truncated = value.chars().take(max_chars).collect::<String>();
+    if truncated.ends_with(char::is_whitespace) {
+        truncated = truncated.trim_end().to_owned();
+    }
+    truncated
+}
+
+#[derive(Debug, Error)]
+pub enum SessionTitleGenerationError {
+    #[error("OpenAI title response did not include output text")]
+    MissingOutput,
+    #[error("OpenAI title request failed with status {status}: {body}")]
+    HttpStatus {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_title_source_prefers_user_ask_over_slack_context() {
+        let parts = vec![
+            json!({
+                "type": "text",
+                "text": "# Requester Context\n\nThe Slack user who prompted this turn is Alice."
+            }),
+            json!({
+                "type": "text",
+                "text": "<@U123> please fix the memory leak in the worker"
+            }),
+        ];
+
+        assert_eq!(
+            session_title_source_from_parts(&parts),
+            Some("please fix the memory leak in the worker".to_owned())
+        );
+    }
+
+    #[test]
+    fn session_title_source_uses_first_slack_thread_message() {
+        let parts = vec![
+            json!({
+                "type": "text",
+                "text": "# Slack Thread Context\n\nEarlier messages in this Slack thread, in chronological order:\n\n1. Alice:\n   Planning to replace the billing export job with a streaming worker because the nightly batch keeps timing out\n\n# Current Request\n\nThe user message follows in the next content block.\n---"
+            }),
+            json!({
+                "type": "text",
+                "text": "<@U123> investigate this"
+            }),
+        ];
+
+        assert_eq!(
+            session_title_source_from_parts(&parts),
+            Some(
+                "Planning to replace the billing export job with a streaming worker because the nightly batch keeps timing out"
+                    .to_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn session_title_source_skips_low_signal_wakeups() {
+        assert_eq!(
+            session_title_source_from_parts(&[
+                json!({"type": "text", "text": "<@U123> Hey"}),
+                json!({"type": "text", "text": ":thread:"}),
+            ]),
+            None
+        );
+
+        assert_eq!(
+            session_title_source_from_parts(&[
+                json!({"type": "text", "text": "<@U123> Hey"}),
+                json!({"type": "text", "text": "Can you investigate queue stalls?"}),
+            ]),
+            Some("Can you investigate queue stalls?".to_owned())
+        );
+    }
+
+    #[test]
+    fn sanitize_session_title_keeps_model_wording() {
+        assert_eq!(
+            sanitize_session_title("Memory leak in worker queue needs investigation immediately"),
+            Some("Memory leak in worker queue needs investigation".to_owned())
+        );
+        assert_eq!(
+            sanitize_session_title("\"Fix worker memory leak.\""),
+            Some("Fix worker memory leak".to_owned())
+        );
+    }
+
+    #[test]
+    fn openai_response_output_text_reads_responses_api_shapes() {
+        assert_eq!(
+            openai_response_output_text(r#"{"output_text":"Fix worker memory leak"}"#),
+            Some("Fix worker memory leak".to_owned())
+        );
+        assert_eq!(
+            openai_response_output_text(
+                r#"{"output":[{"content":[{"type":"output_text","text":"Add Tempo Explorer filter"}]}]}"#
+            ),
+            Some("Add Tempo Explorer filter".to_owned())
+        );
+    }
+}

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0032_session_title.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0032_session_title.sql
@@ -1,0 +1,2 @@
+alter table sessions
+    add column if not exists title text;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -3,8 +3,8 @@
 use std::str::FromStr;
 
 use centaur_session_core::{
-    ExecutionStatus, HarnessType, SandboxCapabilities, Session, SessionEvent, SessionExecution,
-    SessionMessage, SessionMessageInput, SessionStatus, ThreadKey, empty_object,
+    ExecutionStatus, HarnessType, MessageRole, SandboxCapabilities, Session, SessionEvent,
+    SessionExecution, SessionMessage, SessionMessageInput, SessionStatus, ThreadKey, empty_object,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -126,7 +126,7 @@ impl PgSessionStore {
     pub async fn get_session(&self, thread_key: &ThreadKey) -> Result<Session, SessionStoreError> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            select thread_key, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
+            select thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
             from sessions
             where thread_key = $1
             "#,
@@ -139,6 +139,25 @@ impl PgSessionStore {
         })?;
 
         row.try_into()
+    }
+
+    pub async fn get_session_title(
+        &self,
+        thread_key: &ThreadKey,
+    ) -> Result<Option<String>, SessionStoreError> {
+        let title = sqlx::query_scalar::<_, Option<String>>(
+            r#"
+            select title
+            from sessions
+            where thread_key = $1
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .fetch_optional(&self.pool)
+        .await?
+        .flatten();
+
+        Ok(title)
     }
 
     pub async fn append_messages(
@@ -176,6 +195,59 @@ impl PgSessionStore {
 
         tx.commit().await?;
         Ok(message_ids)
+    }
+
+    pub async fn title_generation_candidate(
+        &self,
+        thread_key: &ThreadKey,
+    ) -> Result<Option<Vec<Value>>, SessionStoreError> {
+        let rows = sqlx::query_scalar::<_, Value>(
+            r#"
+            select m.parts
+            from sessions s
+            join session_messages m on m.thread_key = s.thread_key
+            where s.thread_key = $1 and s.title is null
+                and m.role = $2
+            order by m.created_at, m.message_id
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(MessageRole::User.as_ref())
+        .fetch_all(&self.pool)
+        .await?;
+
+        if rows.is_empty() {
+            return Ok(None);
+        }
+
+        let parts = rows
+            .into_iter()
+            .flat_map(|parts| match parts {
+                Value::Array(parts) => parts,
+                other => vec![other],
+            })
+            .collect();
+        Ok(Some(parts))
+    }
+
+    pub async fn set_session_title_if_empty(
+        &self,
+        thread_key: &ThreadKey,
+        title: &str,
+    ) -> Result<bool, SessionStoreError> {
+        let result = sqlx::query(
+            r#"
+            update sessions
+            set title = $2, updated_at = now()
+            where thread_key = $1 and title is null
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(title)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     pub async fn list_messages(
@@ -618,7 +690,7 @@ impl PgSessionStore {
                 sandbox_observability_enabled = null,
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -644,7 +716,7 @@ impl PgSessionStore {
                 sandbox_observability_enabled = $4,
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -700,7 +772,7 @@ impl PgSessionStore {
                 status = $3,
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -725,7 +797,7 @@ impl PgSessionStore {
             update sessions
             set iron_control_principal = $2, updated_at = now()
             where thread_key = $1
-            returning thread_key, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -833,7 +905,7 @@ impl PgSessionStore {
             update sessions
             set harness_thread_id = $2, updated_at = now()
             where thread_key = $1
-            returning thread_key, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -931,6 +1003,7 @@ pub enum SessionStoreError {
 #[derive(Debug, FromRow)]
 struct SessionRow {
     thread_key: String,
+    title: Option<String>,
     sandbox_id: Option<String>,
     sandbox_repo_cache_enabled: Option<bool>,
     sandbox_observability_enabled: Option<bool>,
@@ -949,6 +1022,7 @@ impl TryFrom<SessionRow> for Session {
     fn try_from(row: SessionRow) -> Result<Self, Self::Error> {
         Ok(Self {
             thread_key: parse_persisted(row.thread_key)?,
+            title: row.title,
             sandbox_id: row.sandbox_id,
             sandbox_capabilities: match (
                 row.sandbox_repo_cache_enabled,


### PR DESCRIPTION
## Summary
- add nullable `sessions.title` storage and SQLx migration
- generate first-turn session titles with GPT-5.4-nano via OpenAI Responses
- expose optional `title` on session context responses

## Tests
- `cargo test -p centaur-session-runtime --lib`
- `cargo check -p centaur-api-server`
- `cargo fmt --check`
- `git diff --check`
- `just build-one api-rs`
- clean local Helm validation in `centaur-pr-verify`: create session,
  append first user message, then `GET /api/session/...` returned
  `{"title":"Add Stored Session Summaries"}`

Note: the existing local `centaur` namespace has stale SQLx migration metadata
(`VersionMismatch(10)`), so the clean Helm validation used a temporary
namespace and the original namespace rollout was restored afterward.
