### PR TITLE
fix: time slackbot session create at api request

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -102,6 +102,75 @@ type SlackbotV2RequestContext = {
   waitUntil(promise: Promise<unknown>): void
 }
 
+type SlackWebhookHandoffHealthSnapshot = {
+  healthy: boolean
+  oldestPendingMs: number
+  pendingCount: number
+  staleCount: number
+  timeoutMs: number
+}
+
+type PendingSlackWebhookHandoff = {
+  startedAtMs: number
+}
+
+class SlackWebhookHandoffHealth {
+  private nextId = 1
+  private readonly pending = new Map<number, PendingSlackWebhookHandoff>()
+
+  constructor(private readonly timeoutMs: number) {}
+
+  start(startedAtMs: number): () => void {
+    const id = this.nextId++
+    this.pending.set(id, { startedAtMs })
+    this.recordMetrics(this.snapshot())
+    return () => {
+      this.pending.delete(id)
+      this.recordMetrics(this.snapshot())
+    }
+  }
+
+  snapshot(): SlackWebhookHandoffHealthSnapshot {
+    const now = nowMs()
+    let oldestPendingMs = 0
+    let staleCount = 0
+    for (const pending of this.pending.values()) {
+      const ageMs = elapsedMs(pending.startedAtMs)
+      oldestPendingMs = Math.max(oldestPendingMs, ageMs)
+      if (now - pending.startedAtMs > this.timeoutMs) staleCount += 1
+    }
+    return {
+      healthy: staleCount === 0,
+      oldestPendingMs,
+      pendingCount: this.pending.size,
+      staleCount,
+      timeoutMs: this.timeoutMs
+    }
+  }
+
+  recordMetrics(snapshot: SlackWebhookHandoffHealthSnapshot): void {
+    slackbotMetrics.webhookHandoffsPending.set({}, snapshot.pendingCount)
+    slackbotMetrics.webhookHandoffsStale.set({}, snapshot.staleCount)
+    slackbotMetrics.webhookOldestPendingHandoffAge.set({}, snapshot.oldestPendingMs / 1000)
+  }
+}
+
+function webhookHandoffHealthTimeoutMs(options: SlackbotV2Options): number {
+  return options.webhookHandoffHealthTimeoutMs ?? WEBHOOK_HANDOFF_HEALTH_TIMEOUT_MS
+}
+
+function slackbotHealthResponse(snapshot: SlackWebhookHandoffHealthSnapshot): JsonObject {
+  return {
+    ok: snapshot.healthy,
+    service: 'slackbotv2',
+    oldest_pending_slack_webhook_handoff_ms: snapshot.oldestPendingMs,
+    pending_slack_webhook_handoffs: snapshot.pendingCount,
+    stale_slack_webhook_handoffs: snapshot.staleCount,
+    webhook_handoff_health_timeout_ms: snapshot.timeoutMs,
+    ...(snapshot.healthy ? {} : { reason: 'stale_slack_webhook_handoff' })
+  }
+}
+
 const requestContext = new AsyncLocalStorage<SlackbotV2RequestContext>()
 const RENDER_OBLIGATION_INDEX_KEY = 'slackbotv2:render:index'
 const RENDER_OBLIGATION_INDEX_MAX_LENGTH = 2000
@@ -114,6 +183,7 @@ const RENDER_RECOVERY_MAX_THREAD_FAILURES = 5
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
 const RENDER_RETRY_MAX_DELAY_MS = 5_000
 const ASSISTANT_STATUS_MAX_CHARS = 50
+const WEBHOOK_HANDOFF_HEALTH_TIMEOUT_MS = 90_000
 const SLACK_TASK_DETAILS_MAX_CHARS = 500
 const SLACK_FALLBACK_TEXT_MAX_CHARS = 35_000
 const POSTGRES_CONNECT_INITIAL_DELAY_MS = 250
@@ -189,6 +259,9 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     logger
   })
   const state = options.state ?? createDefaultState(options, logger)
+  const webhookHandoffHealth = new SlackWebhookHandoffHealth(
+    webhookHandoffHealthTimeoutMs(options)
+  )
   const chat = new Chat<{ slack: typeof slack }, SlackbotV2ThreadState>({
     userName,
     adapters: { slack },
@@ -224,17 +297,23 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   })
 
   const app = new Hono()
-  app.get('/health', c => c.json({ ok: true, service: 'slackbotv2' }))
-  app.get('/metrics', c =>
-    c.text(slackbotMetrics.expose(), 200, {
+  app.get('/health', c => {
+    const snapshot = webhookHandoffHealth.snapshot()
+    webhookHandoffHealth.recordMetrics(snapshot)
+    return c.json(slackbotHealthResponse(snapshot), snapshot.healthy ? 200 : 503)
+  })
+  app.get('/metrics', c => {
+    webhookHandoffHealth.recordMetrics(webhookHandoffHealth.snapshot())
+    return c.text(slackbotMetrics.expose(), 200, {
       'Content-Type': 'text/plain; version=0.0.4; charset=utf-8'
     })
-  )
+  })
   const handleSlackWebhook = async (c: Context) => {
     const webhookStartedAtMs = nowMs()
     const route = c.req.path
     const rawBody = await c.req.raw.clone().text()
     const eventType = slackWebhookEventType(rawBody)
+    let finishWebhookHealth: (() => void) | undefined
     let outcome = 'success'
     try {
       if (!isAllowedSlackWebhookBody(rawBody, options, logger)) {
@@ -243,6 +322,9 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
       }
       const awaitHandoff = shouldAwaitSlackHandoff(rawBody)
       const webhookFields = slackWebhookLogFields(rawBody)
+      if (awaitHandoff) {
+        finishWebhookHealth = webhookHandoffHealth.start(webhookStartedAtMs)
+      }
       const handoffTasks: Promise<unknown>[] = []
       const context: SlackbotV2RequestContext = {
         retryableErrors: [],
@@ -309,6 +391,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
       outcome = 'error'
       throw error
     } finally {
+      finishWebhookHealth?.()
       slackbotMetrics.webhookRequests.inc({ event_type: eventType, outcome, route })
       slackbotMetrics.webhookDuration.observe(
         { event_type: eventType, outcome, route },

--- a/services/slackbotv2/src/metrics.ts
+++ b/services/slackbotv2/src/metrics.ts
@@ -326,6 +326,18 @@ export const slackbotMetrics = {
     labelNames: ['route', 'event_type', 'outcome'],
     name: 'slackbotv2_slack_webhook_duration_seconds'
   }),
+  webhookHandoffsPending: gauge({
+    help: 'Awaited Slack webhook handoffs currently in progress.',
+    name: 'slackbotv2_slack_webhook_handoffs_pending'
+  }),
+  webhookHandoffsStale: gauge({
+    help: 'Awaited Slack webhook handoffs older than the health timeout.',
+    name: 'slackbotv2_slack_webhook_handoffs_stale'
+  }),
+  webhookOldestPendingHandoffAge: gauge({
+    help: 'Age of the oldest awaited Slack webhook handoff currently in progress, in seconds.',
+    name: 'slackbotv2_slack_webhook_oldest_pending_handoff_age_seconds'
+  }),
   webhookRequests: counter({
     help: 'Slack webhook requests handled by Slackbot.',
     labelNames: ['route', 'event_type', 'outcome'],

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -46,6 +46,9 @@ const options: SlackbotV2Options = {
   slackApiUrl: optionalEnv('SLACK_API_URL'),
   slackApiTimeoutMs: optionalNumberEnv('SLACKBOTV2_SLACK_API_TIMEOUT_MS'),
   stateKeyPrefix: optionalEnv('SLACKBOTV2_STATE_KEY_PREFIX'),
+  webhookHandoffHealthTimeoutMs: optionalNumberEnv(
+    'SLACKBOTV2_WEBHOOK_HANDOFF_HEALTH_TIMEOUT_MS'
+  ),
   userName: stringEnv('SLACKBOTV2_USER_NAME', 'centaur'),
   logger: consoleLogger
 }

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -15,7 +15,8 @@ import type {
   SlackbotV2Fetch,
   SlackbotV2Options,
   SlackbotV2RendererSource,
-  SlackbotV2SessionMessage
+  SlackbotV2SessionMessage,
+  SlackbotV2Trace
 } from './types'
 import { observeSeconds, slackbotMetrics } from './metrics'
 import { rawSlackUserId } from './slack-user'
@@ -83,14 +84,12 @@ class FetchTimeoutError extends Error {
 
 async function recordSessionApiOperation<T>(
   operation: string,
-  fn: () => Promise<T>,
-  timeoutMs?: number,
-  timeoutAction = operation
+  fn: () => Promise<T>
 ): Promise<T> {
   const startedAtMs = nowMs()
   let outcome = 'success'
   try {
-    return await withTimeout(timeoutAction, timeoutMs, fn)
+    return await fn()
   } catch (error) {
     outcome = isRetryableSessionApiError(error) ? 'retryable_error' : 'error'
     throw error
@@ -474,10 +473,9 @@ export async function forwardToSessionApi(
       options,
       input.threadId,
       input.harnessType,
-      sessionRequesterMessage(input)
-    ),
-    sessionApiTimeoutMs(options),
-    'create session'
+      sessionRequesterMessage(input),
+      input.trace
+    )
   )
   traceLog(options, 'slackbotv2_session_create_complete', input.trace, {
     harness_switched: created.harnessSwitched,
@@ -490,9 +488,7 @@ export async function forwardToSessionApi(
     const appendStartedAtMs = nowMs()
     await recordSessionApiOperation(
       'append_messages',
-      () => appendSessionMessages(options, input.threadId, input.messages, !input.executeMessage),
-      sessionApiTimeoutMs(options),
-      'append session messages'
+      () => appendSessionMessages(options, input.threadId, input.messages, !input.executeMessage)
     )
     traceLog(options, 'slackbotv2_session_append_complete', input.trace, {
       message_count: input.messages.length,
@@ -518,9 +514,7 @@ export async function forwardToSessionApi(
       input.contextPreamble,
       input.reasoning,
       input.provider
-    ),
-    sessionApiTimeoutMs(options),
-    'execute session'
+    )
   )
   traceLog(options, 'slackbotv2_session_execute_complete', input.trace, {
     execution_id: execution.execution_id,
@@ -544,9 +538,7 @@ export async function openSessionEventStream(
       input.afterEventId,
       input.executionId,
       input.onEventId
-    ),
-    sessionApiTimeoutMs(options),
-    'stream events'
+    )
   )
   traceLog(options, 'slackbotv2_session_events_opened', input.trace, {
     after_event_id: input.afterEventId,
@@ -709,7 +701,8 @@ async function createSession(
   options: SlackbotV2Options,
   threadId: string,
   harnessType?: string,
-  message?: SlackbotV2ApiMessage
+  message?: SlackbotV2ApiMessage,
+  trace?: SlackbotV2Trace
 ): Promise<CreateSessionOutcome> {
   const requested = harnessType ?? options.defaultHarnessType ?? DEFAULT_HARNESS_TYPE
   // A sticky --claude/--amp/--codex selection restarts a thread pinned to
@@ -719,7 +712,8 @@ async function createSession(
     threadId,
     requested,
     message,
-    harnessType ? 'restart' : undefined
+    harnessType ? 'restart' : undefined,
+    trace
   )
   if (response.ok) {
     return { harnessSwitched: await harnessSwitchedFromResponse(response) }
@@ -737,7 +731,7 @@ async function createSession(
   // harness instead of failing the message.
   const existing = response.status === 409 ? existingHarnessFromConflict(body) : undefined
   if (existing && existing !== requested) {
-    const retry = await postCreateSession(options, threadId, existing, message)
+    const retry = await postCreateSession(options, threadId, existing, message, undefined, trace)
     await ensureApiOk(retry, 'create session')
     return { harnessSwitched: false }
   }
@@ -755,13 +749,16 @@ async function postCreateSession(
   threadId: string,
   harnessType: string,
   message?: SlackbotV2ApiMessage,
-  onHarnessConflict?: 'reject' | 'restart'
+  onHarnessConflict?: 'reject' | 'restart',
+  trace?: SlackbotV2Trace
 ): Promise<Response> {
   const fetchFn = options.fetch ?? fetch
   // The conversation name becomes the session principal's display name in
   // iron-control; resolve it here so it rides the create-session metadata that
   // api-rs reads when it registers the principal.
-  const conversationName = message ? await resolveConversationName(options, message) : undefined
+  const conversationName = message
+    ? await resolveCreateSessionConversationName(options, message, trace)
+    : undefined
   const body: SlackbotV2CreateSessionRequest = {
     harness_type: harnessType,
     metadata: {
@@ -773,17 +770,65 @@ async function postCreateSession(
     },
     ...(onHarnessConflict ? { on_harness_conflict: onHarnessConflict } : {})
   }
-  return fetchWithTimeout(
-    fetchFn,
-    apiSessionUrl(options.apiUrl, threadId),
-    {
-      method: 'POST',
-      headers: apiHeaders(options),
-      body: JSON.stringify(body)
-    },
-    sessionApiTimeoutMs(options),
-    'create session'
-  )
+  const requestStartedAtMs = nowMs()
+  traceLog(options, 'slackbotv2_session_create_request_started', trace, {
+    harness_type: harnessType,
+    has_conversation_name: Boolean(conversationName),
+    on_harness_conflict: onHarnessConflict ?? 'reject'
+  })
+  try {
+    const response = await fetchWithTimeout(
+      fetchFn,
+      apiSessionUrl(options.apiUrl, threadId),
+      {
+        method: 'POST',
+        headers: apiHeaders(options),
+        body: JSON.stringify(body)
+      },
+      sessionApiTimeoutMs(options),
+      'create session'
+    )
+    traceLog(options, 'slackbotv2_session_create_request_complete', trace, {
+      ok: response.ok,
+      phase_ms: elapsedMs(requestStartedAtMs),
+      status: response.status
+    })
+    return response
+  } catch (error) {
+    traceLog(
+      options,
+      'slackbotv2_session_create_request_failed',
+      trace,
+      {
+        error: errorMessage(error),
+        phase_ms: elapsedMs(requestStartedAtMs)
+      },
+      'warn'
+    )
+    throw error
+  }
+}
+
+async function resolveCreateSessionConversationName(
+  options: SlackbotV2Options,
+  message: SlackbotV2ApiMessage,
+  trace?: SlackbotV2Trace
+): Promise<string | undefined> {
+  const conversationId = slackConversationId(message)
+  const conversationKind = slackConversationKind(conversationId)
+  const startedAtMs = nowMs()
+  traceLog(options, 'slackbotv2_session_create_preflight_started', trace, {
+    conversation_id: conversationId,
+    conversation_kind: conversationKind
+  })
+  const conversationName = await resolveConversationName(options, message)
+  traceLog(options, 'slackbotv2_session_create_preflight_complete', trace, {
+    conversation_id: conversationId,
+    conversation_kind: conversationKind,
+    conversation_name_resolved: conversationName !== undefined,
+    phase_ms: elapsedMs(startedAtMs)
+  })
+  return conversationName
 }
 
 async function harnessSwitchedFromResponse(response: Response): Promise<boolean> {

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -125,6 +125,11 @@ export type SlackbotV2Options = {
   sessionApiTimeoutMs?: number
   signingSecret: string
   slackApiUrl?: string
+  /**
+   * Maximum age for an awaited Slack webhook handoff before /health reports
+   * unhealthy. Defaults to 90s.
+   */
+  webhookHandoffHealthTimeoutMs?: number
   /** Deadline for optional Slack Web API metadata lookups. */
   slackApiTimeoutMs?: number
   state?: StateAdapter

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3084,6 +3084,80 @@ describe('slackbotv2', () => {
     ).toEqual(expect.arrayContaining(['Thinking...', '']))
   })
 
+  it('marks health unhealthy while an awaited Slack webhook handoff is stale', async () => {
+    const logs: CapturedLog[] = []
+    bot = createTestBot({
+      logger: captureLogger(logs),
+      webhookHandoffHealthTimeoutMs: 25
+    })
+    codexApi.autoRespond = false
+    const releaseExecute = codexApi.holdNextExecute()
+    const waits: Promise<unknown>[] = []
+
+    try {
+      const parent = await postUserMessage('Context before the stale handoff.')
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> start slowly`, parent.ts)
+      const responsePromise = bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: 'Ev-slackbotv2-stale-handoff-health',
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parent.ts,
+            text: `<@${BOT_USER_ID}> start slowly`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+
+      await waitFor(() => hasLog(logs, 'slackbotv2_webhook_handoff_wait_started'))
+      await waitFor(async () => (await bot.app.request('/health')).status === 503)
+
+      const unhealthy = await bot.app.request('/health')
+      expect(unhealthy.status).toBe(503)
+      expect(await unhealthy.json()).toEqual(
+        expect.objectContaining({
+          ok: false,
+          pending_slack_webhook_handoffs: 1,
+          reason: 'stale_slack_webhook_handoff',
+          service: 'slackbotv2',
+          stale_slack_webhook_handoffs: 1,
+          webhook_handoff_health_timeout_ms: 25
+        })
+      )
+
+      const metrics = await (await bot.app.request('/metrics')).text()
+      expect(metrics).toContain('slackbotv2_slack_webhook_handoffs_pending 1')
+      expect(metrics).toContain('slackbotv2_slack_webhook_handoffs_stale 1')
+
+      releaseExecute()
+      const response = await responsePromise
+      expect(response.status).toBe(200)
+      await waitFor(() => codexApi.eventRequests.length === 1)
+      await waitFor(() => codexApi.streamCount === 1)
+      codexApi.closeStreams()
+      await waitFor(async () => (await bot.app.request('/health')).status === 200)
+
+      const healthy = await bot.app.request('/health')
+      expect(await healthy.json()).toEqual(
+        expect.objectContaining({
+          ok: true,
+          pending_slack_webhook_handoffs: 0,
+          service: 'slackbotv2',
+          stale_slack_webhook_handoffs: 0
+        })
+      )
+    } finally {
+      releaseExecute()
+    }
+    await Promise.all(waits)
+  })
+
   it('does not wait for hung assistant status before creating Slack sessions', async () => {
     const logs: CapturedLog[] = []
     bot = createTestBot({ logger: captureLogger(logs), slackApiTimeoutMs: 25 })

--- a/services/slackbotv2/test/metrics.test.ts
+++ b/services/slackbotv2/test/metrics.test.ts
@@ -33,6 +33,9 @@ describe('slackbotv2 metrics', () => {
     expect(body).toContain(
       'slackbotv2_slack_webhook_requests_total{route="/api/webhooks/slack",event_type="app_mention",outcome="success"} 1'
     )
+    expect(body).toContain('slackbotv2_slack_webhook_handoffs_pending 0')
+    expect(body).toContain('slackbotv2_slack_webhook_handoffs_stale 0')
+    expect(body).toContain('slackbotv2_slack_webhook_oldest_pending_handoff_age_seconds 0')
     expect(body).toContain(
       'centaur_session_delivery_total{delivery_status="streamed"} 1'
     )

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -23,6 +23,12 @@ type RecordedRequest = {
   url: string
 }
 
+type CapturedLog = {
+  data?: unknown
+  event: string
+  level: 'debug' | 'error' | 'info' | 'warn'
+}
+
 function apiMessage(
   text: string,
   overrides: Partial<SlackbotV2ApiMessage> = {}
@@ -101,6 +107,17 @@ function options(fetchFn: SlackbotV2Options['fetch']): SlackbotV2Options {
   }
 }
 
+function captureLogger(logs: CapturedLog[]): NonNullable<SlackbotV2Options['logger']> {
+  const logger: NonNullable<SlackbotV2Options['logger']> = {
+    debug: (event: string, data?: unknown) => logs.push({ data, event, level: 'debug' }),
+    error: (event: string, data?: unknown) => logs.push({ data, event, level: 'error' }),
+    info: (event: string, data?: unknown) => logs.push({ data, event, level: 'info' }),
+    warn: (event: string, data?: unknown) => logs.push({ data, event, level: 'warn' }),
+    child: () => logger
+  }
+  return logger
+}
+
 function executeBody(requests: RecordedRequest[]): Record<string, unknown> {
   const execute = requests.find(request => request.url.endsWith('/execute'))
   return (execute?.body ?? {}) as Record<string, unknown>
@@ -135,6 +152,16 @@ function textPartIncludes(part: JsonObject, text: string): boolean {
 
 function isJsonRecord(value: JsonValue | undefined): value is JsonObject {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function logData(logs: CapturedLog[], event: string): Record<string, unknown> | undefined {
+  const data = logs.find(log => log.event === event)?.data
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return undefined
+  return data as Record<string, unknown>
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 describe('session event streaming', () => {
@@ -854,6 +881,60 @@ describe('session principal display name', () => {
     expect(slackCalls).toBe(1)
     expect('slack_conversation_name' in (createBody(requests).metadata ?? {})).toBe(false)
     expect(requests.some(request => request.url.endsWith('/execute'))).toBe(true)
+  })
+
+  test('times session API create from the request after Slack preflight', async () => {
+    const requests: RecordedRequest[] = []
+    const logs: CapturedLog[] = []
+    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      requests.push({ body, url })
+      return new Promise<Response>(() => undefined)
+    }) as SlackbotV2Options['fetch']
+
+    await withSlackStub(
+      async url => {
+        if (url.includes('conversations.info')) {
+          await sleep(35)
+          return Response.json({ channel: { id: 'C1', name_normalized: 'eng-oncall' }, ok: true })
+        }
+        return Response.json({ ok: true })
+      },
+      async () => {
+        await expect(
+          forwardToSessionApi(
+            {
+              ...slackOptions(fetchFn),
+              logger: captureLogger(logs),
+              sessionApiTimeoutMs: 25,
+              slackApiTimeoutMs: 100
+            },
+            forwardInput(apiMessage('hi'))
+          )
+        ).rejects.toThrow('create session timed out after 25ms')
+      }
+    )
+
+    expect(requests.some(request => request.url.endsWith('.000100'))).toBe(true)
+    expect(logData(logs, 'slackbotv2_session_create_preflight_complete')).toEqual(
+      expect.objectContaining({
+        conversation_kind: 'channel',
+        conversation_name_resolved: true
+      })
+    )
+    expect(logData(logs, 'slackbotv2_session_create_request_started')).toEqual(
+      expect.objectContaining({
+        harness_type: 'codex',
+        has_conversation_name: true,
+        on_harness_conflict: 'reject'
+      })
+    )
+    expect(logData(logs, 'slackbotv2_session_create_request_failed')).toEqual(
+      expect.objectContaining({
+        error: 'create session timed out after 25ms'
+      })
+    )
   })
 
   test('DM sessions name the principal after the DM partner', async () => {


### PR DESCRIPTION
## Summary
- remove the duplicate outer Slackbot session-operation timeout so Slack metadata preflight no longer consumes the session API request budget
- add create-session preflight/request boundary logs for future production diagnosis
- add a Slack webhook handoff watchdog: `/health` now returns 503 when an awaited Slack webhook has been stuck longer than the health threshold, and `/metrics` exposes pending/stale/oldest-age gauges
- add regression coverage proving the create POST is attempted after a slower Slack preflight and proving stale awaited webhooks make health unhealthy

## Validation
- `pnpm --filter slackbotv2 exec bun test ./test/session-api.test.ts`
- `pnpm --filter slackbotv2 exec bun test ./test/chat-sdk-emulate.test.ts ./test/metrics.test.ts`
- `pnpm --filter slackbotv2 run check:types`
- `pnpm --filter slackbotv2 test`
- `git diff --check`
- `just build-one slackbotv2`
- local `orbstack`: `just deploy` initially hit a repo-cache server-side apply conflict caused by the earlier local rollback; reran Helm with `--force-conflicts`, then restarted `deploy/centaur-centaur-slackbotv2` and verified rollout
- local Slackbot pod image `docker://sha256:5e2223a2a44ad2a469eeb08513b52a4962b8b21b3a5f7b838f25f82bf8d6b2bc`
- local `/health` returned `200 {"ok":true,"service":"slackbotv2","oldest_pending_slack_webhook_handoff_ms":0,"pending_slack_webhook_handoffs":0,"stale_slack_webhook_handoffs":0,"webhook_handoff_health_timeout_ms":90000}`
- local `/metrics` exposed `slackbotv2_slack_webhook_handoffs_pending`, `slackbotv2_slack_webhook_handoffs_stale`, and `slackbotv2_slack_webhook_oldest_pending_handoff_age_seconds`

Note: the local Helm deploy exposed unrelated local `api-rs`/repo-cache template churn; I rolled those local resources back to their prior stable revisions and verified `api-rs`, repo-cache, and slackbotv2 pods were running before pushing.
