### PR TITLE
fix: gate activity summary status rendering

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.82
+version: 0.1.83
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -67,6 +67,8 @@ spec:
                   key: {{ printf "%sDATABASE_URL" .Values.secretManager.envPrefix }}
             - name: SLACKBOTV2_USER_NAME
               value: {{ .Values.slackbotv2.userName | quote }}
+            - name: SLACKBOTV2_ACTIVITY_SUMMARY_STATUS_ENABLED
+              value: {{ .Values.apiRs.activitySummary.enabled | quote }}
 {{- if .Values.slackbotv2.assistantStatus }}
             - name: SLACKBOTV2_ASSISTANT_STATUS
               value: {{ .Values.slackbotv2.assistantStatus | quote }}

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -2015,7 +2015,7 @@ async function* slackSafeChatSdkStream(
 type SlackStreamTaskDisplayMode = NonNullable<SlackbotV2Options['streamTaskDisplayMode']>
 
 function slackStreamTaskDisplayMode(options: SlackbotV2Options): SlackStreamTaskDisplayMode {
-  return options.streamTaskDisplayMode ?? 'none'
+  return options.streamTaskDisplayMode ?? (options.activitySummaryStatusEnabled ? 'none' : 'plan')
 }
 
 async function* slackVisibleChatSdkStream(
@@ -2768,7 +2768,7 @@ function rendererOptions(
       if (event.type === 'renderer.title.update') {
         await setAssistantTitle(thread, event.title, options)
       }
-      if (event.type === 'renderer.status') {
+      if (event.type === 'renderer.status' && options.activitySummaryStatusEnabled) {
         await setAssistantStatus(thread, event.status, options, trace)
       }
     }

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -28,6 +28,7 @@ const options: SlackbotV2Options = {
   apiUrl,
   apiKey: optionalEnv('SLACKBOT_API_KEY'),
   assistantStatus: optionalEnv('SLACKBOTV2_ASSISTANT_STATUS'),
+  activitySummaryStatusEnabled: booleanEnv('SLACKBOTV2_ACTIVITY_SUMMARY_STATUS_ENABLED', false),
   botToken,
   botUserId: optionalEnv('SLACK_BOT_USER_ID'),
   defaultHarnessType: optionalEnv('SLACKBOTV2_DEFAULT_HARNESS'),
@@ -61,6 +62,7 @@ console.log(
     level: 'info',
     event: 'slackbotv2_started',
     service: 'slackbotv2',
+    activity_summary_status_enabled: options.activitySummaryStatusEnabled,
     port: server.port,
     api_url: apiUrl
   })
@@ -85,6 +87,14 @@ function stringEnv(name: string, fallback: string): string {
 
 function numberEnv(name: string, fallback: number): number {
   return optionalNumberEnv(name) ?? fallback
+}
+
+function booleanEnv(name: string, fallback: boolean): boolean {
+  const value = optionalEnv(name)
+  if (!value) return fallback
+  if (['1', 'true', 'yes', 'on'].includes(value.toLowerCase())) return true
+  if (['0', 'false', 'no', 'off'].includes(value.toLowerCase())) return false
+  throw new Error(`${name} must be a boolean`)
 }
 
 function optionalNumberEnv(name: string): number | undefined {

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -98,6 +98,11 @@ export type SlackbotV2Options = {
   apiKey?: string
   apiUrl: string
   assistantStatus?: string
+  /**
+   * When enabled, session.activity_summary events update Slack's assistant
+   * status and structured task output is hidden from the Slack stream.
+   */
+  activitySummaryStatusEnabled?: boolean
   botToken: string
   botUserId?: string
   /**

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3136,8 +3136,77 @@ describe('slackbotv2', () => {
     await Promise.all(waits)
   })
 
-  it('uses session activity summaries as assistant status instead of visible text', async () => {
+  it('shows visible task progress by default when activity summary status is disabled', async () => {
     bot = createProductionDefaultTestBot()
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before default progress.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> summarize progress`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-default-visible-progress',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> summarize progress`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    const key = threadKey(parent.ts)
+    const summary = "I'm checking the event stream so I can explain the current state."
+    codexApi.emitSessionEvent(key, 'session.activity_summary', {
+      execution_id: 'exe-default-visible-progress',
+      summary
+    })
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.started',
+        item: {
+          id: 'cmd-default-progress',
+          type: 'commandExecution',
+          command: 'rg activity summary',
+          status: 'inProgress'
+        }
+      })
+    )
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'turn.done',
+        result: 'Default progress done.'
+      })
+    )
+
+    await Promise.all(waits)
+    const statusCalls = slackApi.calls.filter(call => call.method === 'assistant.threads.setStatus')
+    expect(statusCalls.map(call => stringField(call.body.status))).toEqual(['Thinking...', ''])
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts).toHaveLength(1)
+    expect(transcripts[0]!.start.body.task_display_mode).toBe('plan')
+    expect(transcripts[0]!.chunks.some(chunk => chunk.type === 'task_update')).toBe(true)
+    const text = await threadText(parent.ts)
+    expect(text).toContain('Command execution')
+    expect(text).toContain('Default progress done.')
+    expect(text).not.toContain(summary)
+  })
+
+  it('uses session activity summaries as assistant status instead of visible text', async () => {
+    bot = createProductionDefaultTestBot({ activitySummaryStatusEnabled: true })
     codexApi.autoRespond = false
 
     const parent = await postUserMessage('Context before status update.')
@@ -3887,8 +3956,7 @@ function createTestBot(
   overrides: Partial<Parameters<typeof createSlackbotV2>[0]> = {}
 ): SlackbotV2 {
   return createProductionDefaultTestBot({
-    // Most tests in this file exercise the legacy structured-card renderer.
-    // Production omits this option and uses assistant status for live activity.
+    // Most tests in this file pin the structured progress renderer explicitly.
     streamTaskDisplayMode: 'plan',
     ...overrides
   })


### PR DESCRIPTION
## Summary
- default Slackbot production rendering now shows structured progress cards unless activity summary status rendering is explicitly enabled
- gate renderer status updates behind the same activity summary status option
- wire Slackbot's status-only rendering flag from the chart's apiRs.activitySummary.enabled value

## Tests
- pnpm install --frozen-lockfile
- bun test test/chat-sdk-emulate.test.ts --test-name-pattern "activity summary|visible task progress"
- bun test test/chat-sdk-emulate.test.ts --test-name-pattern "uses session activity summaries as assistant status instead of visible text"
- bun test test
- bun tsgo --project tsconfig.json --noEmit
- helm dependency build contrib/chart
- helm template centaur contrib/chart --set apiRs.activitySummary.enabled=false | rg -n "SESSION_ACTIVITY_SUMMARY_ENABLED|SLACKBOTV2_ACTIVITY_SUMMARY_STATUS_ENABLED" -A 1
- helm template centaur contrib/chart --set apiRs.activitySummary.enabled=true | rg -n "SESSION_ACTIVITY_SUMMARY_ENABLED|SLACKBOTV2_ACTIVITY_SUMMARY_STATUS_ENABLED|SESSION_ACTIVITY_SUMMARY_MODEL" -A 1
- helm lint contrib/chart
- just build-one slackbotv2

## Note
- just deploy was attempted locally but the existing cluster has unrelated server-side apply field-manager conflicts on Helm-managed objects, so I did not force-reconcile it.