### PR TITLE
Guide crypto tool usage away from bad raw endpoints

### DIFF
--- a/tools/crypto/coingecko/cli.py
+++ b/tools/crypto/coingecko/cli.py
@@ -10,7 +10,14 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-app = typer.Typer(name="coingecko", help="CoinGecko CLI for cryptocurrency market data")
+app = typer.Typer(
+    name="coingecko",
+    help=(
+        "CoinGecko CLI for cryptocurrency market data. Prefer typed commands "
+        "for common work: price, markets, coin, history, categories, exchanges. "
+        "Raw exchange volume_chart endpoints are not supported by this wrapper."
+    ),
+)
 
 
 @app.command("health")
@@ -480,7 +487,15 @@ def raw(
     endpoint: str = typer.Argument(..., help="API endpoint (e.g., /ping, /coins/list)"),
     params: str = typer.Option(None, "--params", "-p", help="Query params as key=value,key=value"),
 ):
-    """Make a raw API call."""
+    """Make a raw API call.
+
+    Prefer typed commands when available:
+      - coingecko history bitcoin --days 365 --json for token history
+      - coingecko exchanges --json for exchange volume/rank snapshots
+
+    This wrapper does not support exchange volume_chart raw endpoints such as
+    /exchanges/binance/volume_chart or /exchanges/binance/volume_chart/range.
+    """
     client = get_client()
 
     query_params = None
@@ -490,6 +505,25 @@ def raw(
             if "=" in pair:
                 k, v = pair.split("=", 1)
                 query_params[k.strip()] = v.strip()
+
+    endpoint_lower = endpoint.lower()
+    if endpoint_lower.startswith("/exchanges/") and "/volume_chart" in endpoint_lower:
+        console.print(
+            "[red]CoinGecko exchange volume_chart raw endpoints are not supported by this CLI. "
+            "For token history use: coingecko history <coin-id> --days <n> --json. "
+            "For exchange snapshots use: coingecko exchanges --json.[/]"
+        )
+        raise typer.Exit(2)
+    if endpoint_lower.startswith("/derivatives/exchanges/") and (
+        endpoint_lower.endswith("/open_interest_chart")
+        or endpoint_lower.endswith("/volume_chart")
+    ):
+        console.print(
+            "[red]CoinGecko derivatives exchange chart raw endpoints are not supported by this CLI. "
+            "Use a market-data source with first-class derivatives/OI support, or DefiLlama "
+            "derivatives-volume for venue volume context.[/]"
+        )
+        raise typer.Exit(2)
 
     try:
         data = client._request(endpoint, params=query_params)

--- a/tools/crypto/defillama/cli.py
+++ b/tools/crypto/defillama/cli.py
@@ -7,11 +7,19 @@ from dotenv import load_dotenv
 from rich.console import Console
 from rich.table import Table
 
-from .client import DefiLlamaClient
+from .client import DefiLlamaClient, _looks_like_perps
 
 load_dotenv()
 
-app = typer.Typer(name="defillama", help="DefiLlama CLI for stablecoin and DeFi analytics")
+app = typer.Typer(
+    name="defillama",
+    help=(
+        "DefiLlama CLI for stablecoin and DeFi analytics. Prefer typed commands "
+        "over raw endpoints; use derivatives-volume/derivatives-summary/open-interest "
+        "for "
+        "perps venues such as Hyperliquid, Lighter, GMX, and dYdX."
+    ),
+)
 
 
 @app.command("health")
@@ -251,10 +259,29 @@ def protocols(
 
 @app.command()
 def protocol(
-    slug: str = typer.Argument(..., help="Protocol slug (e.g., aave, uniswap)"),
+    slug: str = typer.Argument(
+        ...,
+        help=(
+            "TVL protocol slug (e.g., aave, uniswap). For perps venues use "
+            "derivatives-summary instead, e.g. defillama derivatives-summary hyperliquid."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """Get protocol details including historical TVL."""
+    if _looks_like_perps(slug):
+        console.print(
+            "[red]This looks like a perpetuals venue. Use: "
+            f"defillama derivatives-summary {slug} --json[/]"
+        )
+        raise typer.Exit(2)
+    if slug in {"trade-xyz", "trade.xyz"}:
+        console.print(
+            "[red]No DefiLlama TVL protocol is known for this slug. Check the canonical "
+            "slug with `defillama protocols --json` before calling protocol details.[/]"
+        )
+        raise typer.Exit(2)
+
     client = get_client()
     data = client.get_protocol(slug)
 
@@ -423,6 +450,140 @@ def dex_volume(
         console.print(f"\n[bold]Total 24h Volume: {format_number(total_24h)}[/]")
 
 
+@app.command("derivatives-volume")
+def derivatives_volume(
+    chain: str = typer.Option(None, "--chain", "-c", help="Filter by chain"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    markdown: bool = typer.Option(False, "--markdown", "-m", help="Output as markdown table"),
+):
+    """Perpetual futures venue volumes.
+
+    Use this for perps venues such as Hyperliquid, Lighter, GMX, dYdX, Drift, and Vertex.
+    These venues are under DefiLlama derivatives endpoints, not DEX volume endpoints.
+    """
+    client = get_client()
+    data = client.get_derivatives_volumes(chain)
+
+    if json_output:
+        print(json.dumps(data, indent=2))
+        return
+
+    protocols = data.get("protocols", [])
+    protocols = sorted(protocols, key=lambda x: x.get("total24h") or 0, reverse=True)[:limit]
+
+    if markdown:
+        rows = []
+        for p in protocols:
+            vol_24h = p.get("total24h", 0) or 0
+            vol_7d = p.get("total7d", 0) or 0
+            change = p.get("change_1d", 0) or 0
+            rows.append(
+                [
+                    p.get("name", ""),
+                    format_number(vol_24h),
+                    format_number(vol_7d),
+                    f"{change:+.1f}%",
+                ]
+            )
+        print_markdown_table(["Venue", "24h Volume", "7d Volume", "Change"], rows)
+        total_24h = data.get("total24h", 0)
+        if total_24h:
+            print(f"\nTotal 24h Derivatives Volume: {format_number(total_24h)}")
+        return
+
+    table = Table(title=f"Derivatives Volumes{f' ({chain})' if chain else ''}")
+    table.add_column("Venue", style="cyan", max_width=25)
+    table.add_column("24h Volume", style="yellow", justify="right")
+    table.add_column("7d Volume", style="green", justify="right")
+    table.add_column("Change", style="dim", justify="right")
+
+    for p in protocols:
+        change = p.get("change_1d", 0) or 0
+        change_color = "green" if change >= 0 else "red"
+        table.add_row(
+            p.get("name", ""),
+            format_number(p.get("total24h", 0) or 0),
+            format_number(p.get("total7d", 0) or 0),
+            f"[{change_color}]{change:+.1f}%[/]",
+        )
+
+    console.print(table)
+
+    total_24h = data.get("total24h", 0)
+    if total_24h:
+        console.print(f"\n[bold]Total 24h Derivatives Volume: {format_number(total_24h)}[/]")
+
+
+@app.command("derivatives-summary")
+def derivatives_summary(
+    protocol: str = typer.Argument(
+        ..., help="Derivatives protocol slug, e.g. hyperliquid, lighter, gmx-v2, dydx-v4"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Volume details for a specific perpetual futures venue."""
+    client = get_client()
+    data = client.get_derivatives_summary(protocol)
+
+    if json_output:
+        print(json.dumps(data, indent=2))
+        return
+
+    console.print(f"\n[bold cyan]{data.get('name', protocol)}[/] Derivatives\n")
+    console.print(f"24h Volume: [yellow]{format_number(data.get('total24h', 0) or 0)}[/]")
+    console.print(f"7d Volume: [green]{format_number(data.get('total7d', 0) or 0)}[/]")
+
+
+@app.command("open-interest")
+def open_interest(
+    chain: str = typer.Option(None, "--chain", "-c", help="Filter by chain"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Perpetual futures open interest overview.
+
+    Uses DefiLlama's kebab-case open-interest endpoint. Do not use camelCase
+    /overview/openInterest.
+    """
+    client = get_client()
+    data = client.get_open_interest_overview(chain)
+
+    if json_output:
+        print(json.dumps(data, indent=2))
+        return
+
+    console.print(f"\n[bold]Open Interest{f' ({chain})' if chain else ''}[/]\n")
+    total_24h = data.get("total24h")
+    total_30d = data.get("total30d")
+    if total_24h:
+        console.print(f"24h: [yellow]{format_number(total_24h)}[/]")
+    if total_30d:
+        console.print(f"30d: [green]{format_number(total_30d)}[/]")
+    chains = data.get("allChains", [])
+    if chains:
+        console.print(f"Chains: {', '.join(chains[:10])}")
+
+
+@app.command("open-interest-summary")
+def open_interest_summary(
+    protocol: str = typer.Argument(
+        ..., help="Open-interest protocol slug, e.g. hyperliquid, lighter, dydx-v4"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Open interest details for a specific perpetual futures venue."""
+    client = get_client()
+    data = client.get_open_interest_summary(protocol)
+
+    if json_output:
+        print(json.dumps(data, indent=2))
+        return
+
+    console.print(f"\n[bold cyan]{data.get('name', protocol)}[/] Open Interest\n")
+    console.print(f"Category: [green]{data.get('category', 'Unknown')}[/]")
+    console.print(f"Chains: {', '.join(data.get('chains', [])[:10])}")
+
+
 @app.command()
 def bridges(
     chain: str = typer.Option(None, "--chain", "-c", help="Filter by chain"),
@@ -548,7 +709,13 @@ def raw(
         None, "--base", "-b", help="Base URL (main, stablecoins, bridges, coins). Default: main"
     ),
 ):
-    """Make a raw API call. Params as key=value,key=value
+    """Make a raw API call. Params as key=value,key=value.
+
+    Prefer typed commands when available:
+      - defillama derivatives-volume, not raw /overview/derivatives
+      - defillama derivatives-summary hyperliquid, not protocol hyperliquid
+      - defillama raw /overview/open-interest, not /overview/openInterest
+      - defillama open-interest-summary hyperliquid, not raw /summary/openInterest/hyperliquid
 
     Base URLs:
       main: https://api.llama.fi (default)
@@ -579,6 +746,31 @@ def raw(
         if not base_url:
             console.print(f"[red]Unknown base: {base}. Use: main, stablecoins, bridges, coins[/]")
             raise typer.Exit(1)
+
+    endpoint_lower = endpoint.lower()
+    if endpoint == "/overview/openInterest":
+        console.print(
+            "[red]Use /overview/open-interest, not /overview/openInterest. "
+            "Prefer: defillama open-interest --json[/]"
+        )
+        raise typer.Exit(2)
+    if endpoint_lower.startswith("/overview/derivatives") and pro:
+        console.print(
+            "[red]/overview/derivatives is a public main API endpoint; do not pass --pro. "
+            "Prefer: defillama derivatives-volume --json[/]"
+        )
+        raise typer.Exit(2)
+    if endpoint_lower.startswith("/summary/open-interest"):
+        console.print(
+            "[red]Prefer the typed command: defillama open-interest-summary <protocol> --json[/]"
+        )
+        raise typer.Exit(2)
+    if endpoint.startswith("/summary/openInterest"):
+        console.print(
+            "[red]Use /summary/open-interest/<protocol>, not /summary/openInterest/<protocol>. "
+            "Prefer: defillama open-interest-summary <protocol> --json[/]"
+        )
+        raise typer.Exit(2)
 
     try:
         data = client._request(endpoint, params=query_params, pro=pro, base=base_url)

--- a/tools/crypto/defillama/client.py
+++ b/tools/crypto/defillama/client.py
@@ -317,6 +317,30 @@ class DefiLlamaClient:
         """
         return self._request(f"/summary/derivatives/{protocol}")
 
+    def get_open_interest_overview(self, chain: str | None = None) -> dict:
+        """Get perpetual-futures open interest overview.
+
+        Args:
+            chain: Optional chain name to filter
+
+        Returns:
+            Open interest overview data
+        """
+        if chain:
+            return self._request(f"/overview/open-interest/{chain}")
+        return self._request("/overview/open-interest")
+
+    def get_open_interest_summary(self, protocol: str) -> dict:
+        """Get open interest details for a specific perpetuals venue.
+
+        Args:
+            protocol: Protocol slug (e.g., "hyperliquid", "lighter", "dydx-v4")
+
+        Returns:
+            Protocol open interest details
+        """
+        return self._request(f"/summary/open-interest/{protocol}")
+
     # === Bridges ===
 
     def list_bridges(self) -> list[dict]:


### PR DESCRIPTION
Summary:
- add DefiLlama derivatives-volume and derivatives-summary commands for perps venue data
- add CLI help and preflight hints for bad DefiLlama raw paths/options observed in vlogs
- add CoinGecko raw endpoint guardrails for unsupported exchange and derivatives chart paths

Validation:
- PYTHONPATH=/home/agent/branches/paradigmxyz/centaur uv run --no-project --with typer --with rich --with python-dotenv --with httpx python -m py_compile tools/crypto/defillama/cli.py tools/crypto/defillama/client.py tools/crypto/coingecko/cli.py tools/crypto/coingecko/client.py
- Typer CliRunner checks for known-bad DefiLlama and CoinGecko invocations

Prompted by: mslipper