### PR TITLE
feat: delay slack assistant progress status

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -100,6 +100,14 @@ type SlackAssistantAdapter = {
   setAssistantTitle?(channelId: string, threadTs: string, title: string): Promise<void>
 }
 
+type AssistantStatusController = {
+  cancelEscalation(): void
+  clear(): Promise<void>
+  isVisible(): boolean
+  markVisible(visible: boolean): void
+  readonly done: Promise<void>
+}
+
 const MAX_SLACK_MESSAGE_ATTACHMENTS = 20
 
 type SlackbotV2RequestContext = {
@@ -119,6 +127,8 @@ const RENDER_RECOVERY_MAX_THREAD_FAILURES = 5
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
 const RENDER_RETRY_MAX_DELAY_MS = 5_000
 const ASSISTANT_STATUS_MAX_CHARS = 50
+const ASSISTANT_STATUS_DELAY_MS = 30_000
+const ASSISTANT_LONG_STATUS = 'Still working...'
 const SLACK_TASK_DETAILS_MAX_CHARS = 500
 const SLACK_FALLBACK_TEXT_MAX_CHARS = 35_000
 const POSTGRES_CONNECT_INITIAL_DELAY_MS = 250
@@ -349,16 +359,11 @@ async function handleSlackMessageHandoff(
     subscribe: input.subscribe === true,
     trigger: input.trigger
   })
-  let initialAssistantStatusVisible = false
   const assistantStatus = input.assistantStatusRequested
-    ? setInitialAssistantStatus(thread, input.options, trace)
-        .then(visible => {
-          initialAssistantStatusVisible = visible
-          return visible
-        })
-    : Promise.resolve(false)
+    ? startAssistantStatusController(thread, input.options, trace)
+    : undefined
   if (input.assistantStatusRequested) {
-    backgroundWaitUntil(assistantStatus.then(() => undefined).catch(() => undefined))
+    backgroundWaitUntil(assistantStatus?.done.catch(() => undefined) ?? Promise.resolve())
   }
   try {
     if (input.subscribe) {
@@ -366,13 +371,12 @@ async function handleSlackMessageHandoff(
     }
     traceLog(input.options, 'slackbotv2_handoff_sync_starting', trace, {
       initial_assistant_status_deferred:
-        input.assistantStatusRequested && !initialAssistantStatusVisible,
-      initial_assistant_status_visible: initialAssistantStatusVisible,
+        input.assistantStatusRequested && !assistantStatus?.isVisible(),
+      initial_assistant_status_visible: assistantStatus?.isVisible() === true,
       trigger: input.trigger
     })
     await syncThreadMessageToSession(thread, message, {
-      initialAssistantStatusRequested: input.assistantStatusRequested,
-      initialAssistantStatusVisible,
+      initialAssistantStatus: assistantStatus,
       mode: input.mode,
       options: input.options,
       state: input.state
@@ -386,12 +390,7 @@ async function handleSlackMessageHandoff(
       trigger: input.trigger
     })
     backgroundWaitUntil(
-      assistantStatus
-        .then(visible =>
-          visible ? setAssistantStatus(thread, '', input.options, trace) : undefined
-        )
-        .then(() => undefined)
-        .catch(() => undefined)
+      assistantStatus?.clear().catch(() => undefined) ?? Promise.resolve()
     )
     throw error
   }
@@ -585,8 +584,7 @@ async function syncThreadMessageToSession(
   thread: Thread<SlackbotV2ThreadState>,
   message: ChatMessage,
   input: {
-    initialAssistantStatusRequested?: boolean
-    initialAssistantStatusVisible?: boolean
+    initialAssistantStatus?: AssistantStatusController
     mode: SlackbotV2MessageMode
     options: SlackbotV2Options
     state: StateAdapter
@@ -614,9 +612,7 @@ async function syncThreadMessageToSession(
   }
   if (isDuplicateIncrementalMessage) {
     traceLog(input.options, 'slackbotv2_forward_duplicate_skipped', trace)
-    if (input.initialAssistantStatusVisible) {
-      await setAssistantStatus(thread, '', input.options, trace)
-    }
+    await input.initialAssistantStatus?.clear()
     recordForward(input.mode, 'duplicate_skipped', traceStartedAtMs)
     return
   }
@@ -625,18 +621,10 @@ async function syncThreadMessageToSession(
     history_forwarded: state.historyForwarded === true
   })
   const assistantStatusVisible = shouldStartExecution
-    ? input.initialAssistantStatusVisible === true ||
-      input.initialAssistantStatusRequested === true
+    ? input.initialAssistantStatus?.isVisible() === true
     : false
-  if (shouldStartExecution && input.initialAssistantStatusVisible === undefined) {
-    backgroundWaitUntil(
-      setInitialAssistantStatus(thread, input.options, trace)
-        .then(() => undefined)
-        .catch(() => undefined)
-    )
-  }
-  if (!shouldStartExecution && input.initialAssistantStatusVisible) {
-    await setAssistantStatus(thread, '', input.options, trace)
+  if (!shouldStartExecution) {
+    await input.initialAssistantStatus?.clear()
   }
 
   const serializeStartedAtMs = nowMs()
@@ -882,6 +870,7 @@ async function syncThreadMessageToSession(
       forwardInput,
       () => lastEventId,
       renderLease,
+      input.initialAssistantStatus,
       assistantStatusVisible,
       trace,
       consoleSessionBlock
@@ -913,7 +902,7 @@ async function syncThreadMessageToSession(
         traceLog(input.options, 'slackbotv2_webhook_retry_marked', trace, {
           error: errorMessage(error)
         })
-        if (assistantStatusVisible) await setAssistantStatus(thread, '', input.options, trace)
+        await input.initialAssistantStatus?.clear()
         recordForward(input.mode, 'retry_requested', traceStartedAtMs)
         throw error
       }
@@ -925,6 +914,7 @@ async function syncThreadMessageToSession(
         serializedMessage,
         input.options,
         trace,
+        input.initialAssistantStatus,
         assistantStatusVisible
       )
     } catch (renderError) {
@@ -949,6 +939,7 @@ function scheduleExecutionRender(
   input: ForwardSessionInput,
   getLastEventId: () => number,
   renderLease: { release: (() => Promise<void>) | null },
+  assistantStatus: AssistantStatusController | undefined,
   assistantStatusVisible: boolean,
   trace?: SlackbotV2Trace,
   consoleSessionBlock?: SlackContextBlock
@@ -964,6 +955,7 @@ function scheduleExecutionRender(
           options,
           input,
           getLastEventId,
+          assistantStatus,
           assistantStatusVisible,
           trace,
           consoleSessionBlock
@@ -1008,6 +1000,7 @@ async function renderExecutionAttempt(
   options: SlackbotV2Options,
   input: ForwardSessionInput,
   getLastEventId: () => number,
+  assistantStatus: AssistantStatusController | undefined,
   assistantStatusVisible: boolean,
   trace?: SlackbotV2Trace,
   consoleSessionBlock?: SlackContextBlock
@@ -1024,6 +1017,7 @@ async function renderExecutionAttempt(
       message,
       options,
       trace,
+      assistantStatus,
       assistantStatusVisible,
       consoleSessionBlock
     )
@@ -1836,6 +1830,7 @@ async function renderExecutionStream(
   message: SlackbotV2ApiMessage,
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace,
+  assistantStatus?: AssistantStatusController,
   assistantStatusVisible = false,
   consoleSessionBlock?: SlackContextBlock
 ): Promise<{ diverged: boolean; messageId?: string }> {
@@ -1847,13 +1842,14 @@ async function renderExecutionStream(
       message,
       options,
       trace,
+      assistantStatus,
       assistantStatusVisible
     )
     return { diverged: false }
   }
   const titleStartedAtMs = nowMs()
   await setAssistantTitle(thread, titleFromMessage(promptText, options.userName), options, trace)
-  if (!assistantStatusVisible) {
+  if (!assistantStatus && !assistantStatusVisible) {
     await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   }
   traceLog(options, 'slackbotv2_render_slack_metadata_set', trace, {
@@ -1869,7 +1865,7 @@ async function renderExecutionStream(
           slackVisibleChatSdkStream(
             codexAppServerToChatSdkStream(
               stream,
-              rendererOptions(thread, options, capture, trace)
+              rendererOptions(thread, options, capture, trace, assistantStatus)
             ),
             taskDisplayMode
           )
@@ -1893,7 +1889,7 @@ async function renderExecutionStream(
     })
     return { diverged: capture.diverged, messageId: sent?.id }
   } finally {
-    await setAssistantStatus(thread, '', options, trace)
+    await (assistantStatus?.clear() ?? setAssistantStatus(thread, '', options, trace))
   }
 }
 
@@ -1953,6 +1949,7 @@ async function renderPlainTextExecutionStream(
   message: SlackbotV2ApiMessage,
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace,
+  assistantStatus?: AssistantStatusController,
   assistantStatusVisible = false
 ): Promise<void> {
   const fallback = new SlackRenderFallback()
@@ -1963,7 +1960,7 @@ async function renderPlainTextExecutionStream(
     options,
     trace
   )
-  if (!assistantStatusVisible) {
+  if (!assistantStatus && !assistantStatusVisible) {
     await setAssistantStatus(thread, options.assistantStatus ?? 'Thinking...', options, trace)
   }
   traceLog(options, 'slackbotv2_render_plain_text_metadata_set', trace, {
@@ -1975,7 +1972,7 @@ async function renderPlainTextExecutionStream(
       slackSafeChatSdkStream(
         codexAppServerToChatSdkStream(
           fallback.collectSource(stream),
-          rendererOptions(thread, options, undefined, trace)
+          rendererOptions(thread, options, undefined, trace, assistantStatus)
         )
       )
     )
@@ -1992,7 +1989,7 @@ async function renderPlainTextExecutionStream(
     })
     await thread.post(text)
   } finally {
-    await setAssistantStatus(thread, '', options, trace)
+    await (assistantStatus?.clear() ?? setAssistantStatus(thread, '', options, trace))
   }
 }
 
@@ -2795,7 +2792,8 @@ function rendererOptions(
   thread: Thread,
   options: SlackbotV2Options,
   capture?: { diverged: boolean },
-  trace?: SlackbotV2Trace
+  trace?: SlackbotV2Trace,
+  assistantStatus?: AssistantStatusController
 ): CodexAppServerToChatStreamOptions {
   const mapper = options.mapper
   return {
@@ -2807,7 +2805,9 @@ function rendererOptions(
         await setAssistantTitle(thread, event.title, options)
       }
       if (event.type === 'renderer.status' && options.activitySummaryStatusEnabled) {
-        await setAssistantStatus(thread, event.status, options, trace)
+        assistantStatus?.cancelEscalation()
+        const visible = await setAssistantStatus(thread, event.status, options, trace)
+        assistantStatus?.markVisible(visible)
       }
     }
   }
@@ -2841,23 +2841,125 @@ async function sleep(ms: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, ms))
 }
 
-async function setInitialAssistantStatus(
+function startAssistantStatusController(
   thread: Thread,
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace
-): Promise<boolean> {
+): AssistantStatusController {
+  const delayMs = options.assistantStatusDelayMs ?? ASSISTANT_STATUS_DELAY_MS
   const startedAtMs = nowMs()
-  const visible = await setAssistantStatus(
-    thread,
-    options.assistantStatus ?? 'Thinking...',
-    options,
-    trace
-  )
-  traceLog(options, 'slackbotv2_forward_initial_status_set', trace, {
-    phase_ms: elapsedMs(startedAtMs),
-    visible
+  const initialStatus = options.assistantStatus ?? 'Thinking...'
+  const longStatus = ASSISTANT_LONG_STATUS
+  let cleared = false
+  let escalationCancelled = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let visible = false
+  let resolveDone: () => void = () => undefined
+  const done = new Promise<void>(resolve => {
+    resolveDone = resolve
+    const scheduleEscalation = () => {
+      if (cleared || escalationCancelled || !visible) {
+        resolve()
+        return
+      }
+      if (
+        delayMs <= 0 ||
+        normalizeAssistantStatus(longStatus) === normalizeAssistantStatus(initialStatus)
+      ) {
+        void escalate().catch(error => {
+          traceWarn(options, 'slackbotv2_forward_long_status_failed', trace, {
+            error: errorMessage(error),
+            phase_ms: elapsedMs(startedAtMs)
+          })
+          resolve()
+        })
+        return
+      }
+      timer = setTimeout(() => {
+        void escalate().catch(error => {
+          traceWarn(options, 'slackbotv2_forward_long_status_failed', trace, {
+            error: errorMessage(error),
+            phase_ms: elapsedMs(startedAtMs)
+          })
+          resolve()
+        })
+      }, delayMs)
+    }
+    const escalate = async () => {
+      timer = undefined
+      if (cleared || escalationCancelled || !visible) {
+        resolve()
+        return
+      }
+      const statusVisible = await setAssistantStatus(thread, longStatus, options, trace)
+      if (cleared || escalationCancelled) {
+        if (statusVisible) await setAssistantStatus(thread, '', options, trace)
+        resolve()
+        return
+      }
+      visible = statusVisible
+      traceLog(options, 'slackbotv2_forward_long_status_set', trace, {
+        delay_ms: delayMs,
+        phase_ms: elapsedMs(startedAtMs),
+        visible
+      })
+      resolve()
+    }
+    void (async () => {
+      const statusVisible = await setAssistantStatus(thread, initialStatus, options, trace)
+      if (cleared) {
+        if (statusVisible) await setAssistantStatus(thread, '', options, trace)
+        resolve()
+        return
+      }
+      visible = statusVisible
+      traceLog(options, 'slackbotv2_forward_initial_status_set', trace, {
+        phase_ms: elapsedMs(startedAtMs),
+        visible
+      })
+      if (statusVisible) scheduleEscalation()
+      else resolve()
+    })().catch(error => {
+      traceWarn(options, 'slackbotv2_forward_initial_status_failed', trace, {
+        error: errorMessage(error),
+        phase_ms: elapsedMs(startedAtMs)
+      })
+      resolve()
+    })
   })
-  return visible
+  return {
+    cancelEscalation() {
+      if (!timer) return
+      clearTimeout(timer)
+      timer = undefined
+      escalationCancelled = true
+      resolveDone()
+      traceLog(options, 'slackbotv2_forward_long_status_cancelled', trace, {
+        delay_ms: delayMs,
+        phase_ms: elapsedMs(startedAtMs),
+        visible
+      })
+    },
+    async clear() {
+      if (timer) {
+        clearTimeout(timer)
+        timer = undefined
+        resolveDone()
+      }
+      cleared = true
+      if (visible) {
+        visible = false
+        await setAssistantStatus(thread, '', options, trace)
+      }
+    },
+    done,
+    isVisible() {
+      return visible
+    },
+    markVisible(nextVisible: boolean) {
+      visible = nextVisible
+    }
+  }
 }
 
 async function setAssistantStatus(

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -28,6 +28,7 @@ const options: SlackbotV2Options = {
   apiUrl,
   apiKey: optionalEnv('SLACKBOT_API_KEY'),
   assistantStatus: optionalEnv('SLACKBOTV2_ASSISTANT_STATUS'),
+  assistantStatusDelayMs: optionalNumberEnv('SLACKBOTV2_ASSISTANT_STATUS_DELAY_MS'),
   activitySummaryStatusEnabled: booleanEnv('SLACKBOTV2_ACTIVITY_SUMMARY_STATUS_ENABLED', false),
   botToken,
   botUserId: optionalEnv('SLACK_BOT_USER_ID'),

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -98,6 +98,8 @@ export type SlackbotV2Options = {
   apiKey?: string
   apiUrl: string
   assistantStatus?: string
+  /** Delay before changing assistant status for a long-running turn. Defaults to 30s. */
+  assistantStatusDelayMs?: number
   /**
    * When enabled, session.activity_summary events update Slack's assistant
    * status and structured task output is hidden from the Slack stream.

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3106,7 +3106,7 @@ describe('slackbotv2', () => {
 
   it('shows assistant status while waiting for slow session execute', async () => {
     const logs: CapturedLog[] = []
-    bot = createTestBot({ logger: captureLogger(logs) })
+    bot = createTestBot({ assistantStatusDelayMs: 25, logger: captureLogger(logs) })
     codexApi.autoRespond = false
     const releaseExecute = codexApi.holdNextExecute()
 
@@ -3138,6 +3138,11 @@ describe('slackbotv2', () => {
     })
 
     await waitFor(() => codexApi.executes.length === 1)
+    expect(
+      slackApi.calls
+        .filter(call => call.method === 'assistant.threads.setStatus')
+        .map(call => stringField(call.body.status))
+    ).toEqual([])
     await sleep(50)
     expect(responseSettled).toBe(false)
     expect(
@@ -3221,7 +3226,11 @@ describe('slackbotv2', () => {
 
   it('does not wait for hung assistant status before creating Slack sessions', async () => {
     const logs: CapturedLog[] = []
-    bot = createTestBot({ logger: captureLogger(logs), slackApiTimeoutMs: 25 })
+    bot = createTestBot({
+      assistantStatusDelayMs: 1,
+      logger: captureLogger(logs),
+      slackApiTimeoutMs: 25
+    })
     const releaseStatus = slackApi.holdAssistantStatus()
     const waits: Promise<unknown>[] = []
 
@@ -3401,12 +3410,11 @@ describe('slackbotv2', () => {
     await Promise.all(waits)
     const statusCalls = slackApi.calls.filter(call => call.method === 'assistant.threads.setStatus')
     expect(statusCalls.map(call => stringField(call.body.status))).toEqual([
-      'Thinking...',
       clippedSummary,
       ''
     ])
     expect(Array.from(clippedSummary)).toHaveLength(50)
-    expect(statusCalls[1]?.body).toEqual(
+    expect(statusCalls[0]?.body).toEqual(
       expect.objectContaining({
         channel_id: CHANNEL_ID,
         thread_ts: parent.ts,

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3142,14 +3142,14 @@ describe('slackbotv2', () => {
       slackApi.calls
         .filter(call => call.method === 'assistant.threads.setStatus')
         .map(call => stringField(call.body.status))
-    ).toEqual([])
+    ).toEqual(['Thinking...'])
     await sleep(50)
     expect(responseSettled).toBe(false)
     expect(
       slackApi.calls
         .filter(call => call.method === 'assistant.threads.setStatus')
         .map(call => stringField(call.body.status))
-    ).toEqual(['Thinking...'])
+    ).toEqual(['Thinking...', 'Still working...'])
     expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
     expect(codexApi.eventRequests).toHaveLength(0)
     await waitFor(() => hasLog(logs, 'slackbotv2_webhook_handoff_wait_started'))
@@ -3221,7 +3221,7 @@ describe('slackbotv2', () => {
       slackApi.calls
         .filter(call => call.method === 'assistant.threads.setStatus')
         .map(call => stringField(call.body.status))
-    ).toEqual(expect.arrayContaining(['Thinking...', '']))
+    ).toEqual(expect.arrayContaining(['Thinking...', 'Still working...', '']))
   })
 
   it('does not wait for hung assistant status before creating Slack sessions', async () => {
@@ -3410,11 +3410,12 @@ describe('slackbotv2', () => {
     await Promise.all(waits)
     const statusCalls = slackApi.calls.filter(call => call.method === 'assistant.threads.setStatus')
     expect(statusCalls.map(call => stringField(call.body.status))).toEqual([
+      'Thinking...',
       clippedSummary,
       ''
     ])
     expect(Array.from(clippedSummary)).toHaveLength(50)
-    expect(statusCalls[0]?.body).toEqual(
+    expect(statusCalls[1]?.body).toEqual(
       expect.objectContaining({
         channel_id: CHANNEL_ID,
         thread_ts: parent.ts,


### PR DESCRIPTION
Keeps the immediate Slack assistant status so users see `Thinking...` as soon as a turn starts. If the turn keeps running past the configured delay, the status changes to `Still working...`, while richer activity summaries can still replace the generic status and completion clears it.