### PR TITLE
fix: improve activity summary quality

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.83
+version: 0.1.84
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -363,7 +363,7 @@ apiRs:
     enabled: false
     model: gpt-5.4-nano
     openaiBaseUrl: https://api.openai.com/v1
-    minIntervalSecs: 8
+    minIntervalSecs: 20
     timeoutSecs: 5
     maxFacts: 12
     maxOutputTokens: 128

--- a/services/api-rs/crates/centaur-api-server/src/activity_summary.rs
+++ b/services/api-rs/crates/centaur-api-server/src/activity_summary.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use centaur_session_core::{SessionEvent, ThreadKey, ThreadKeyError};
+use centaur_session_core::{MessageRole, SessionEvent, ThreadKey, ThreadKeyError};
 use centaur_session_runtime::SESSION_OUTPUT_LINE_EVENT;
 use centaur_session_sqlx::{PgSessionStore, SessionEventNotification, SessionStoreError};
 use reqwest::StatusCode;
@@ -16,17 +16,17 @@ pub(crate) const SESSION_ACTIVITY_SUMMARY_EVENT: &str = "session.activity_summar
 
 const SYSTEM_PROMPT: &str = "\
 You write live status text for a software agent. Use only the supplied event facts. \
-Write one short, conversational first-person present-tense sentence under 45 characters, \
-including spaces, as if you are the agent. Describe the goal you are working toward, \
-not the exact command, file path, ID, flag, or implementation step you are using. \
-Avoid mechanics like running tests, reading output, building images, checking logs, \
-or watching rollouts unless they are the user's explicit goal. If the facts are mostly \
-mechanics, infer the higher-level outcome and omit those mechanics. Prefer short \
-outcomes like \"I'm checking the fix\" or \"I'm getting the preview ready\". \
-Do not mention tests, output, builds, logs, rollouts, commands, paths, IDs, or flags unless the user asked for them. \
-Use user-facing words like fix, preview, update, or summary behavior instead of \
-infrastructure words like server, deployment, or rollout. Do not refer to \"the agent\". \
-Never write more than 45 characters. No markdown, no quotes, no event IDs, and no speculation.";
+Write one conversational first-person present-tense sentence under 45 characters, \
+including spaces, as if you are the agent. Describe the current user-facing goal or \
+question you are resolving, not the exact command, file path, ID, flag, or \
+implementation step. Prefer specific noun phrases from the session goal over \
+generic phrases like details, info, items, update, or summary. Use the session goal \
+and facts labeled commentary, plan, or tool before any lower-level facts. If the facts only show \
+setup, help output, dependency installs, builds, command output, logs, tests, or \
+other mechanics, output exactly SKIP. If you cannot say a meaningful new status \
+that differs from the previous one, output exactly SKIP. Do not mention tests, \
+output, builds, logs, rollouts, commands, paths, IDs, or flags unless the user asked \
+for them. Do not refer to \"the agent\". No markdown, no quotes, no event IDs, and no speculation.";
 
 #[derive(Clone)]
 pub(crate) struct ActivitySummaryConfig {
@@ -133,18 +133,17 @@ impl ActivitySummaryWorker {
         let Some(fact) = activity_fact_from_output_event(&event) else {
             return Ok(());
         };
+        let goal = if self.states.contains_key(execution_id) {
+            None
+        } else {
+            self.activity_goal_context(&event.thread_key).await?
+        };
         let now = Instant::now();
         let publish = {
             let state = self
                 .states
                 .entry(execution_id.to_owned())
-                .or_insert_with(|| ExecutionActivity {
-                    facts: VecDeque::with_capacity(self.config.max_facts),
-                    last_attempt_at: None,
-                    last_published_signature: None,
-                    last_summary: None,
-                    max_facts: self.config.max_facts,
-                });
+                .or_insert_with(|| ExecutionActivity::new(self.config.max_facts, goal));
             state.push(fact);
             state.prepare_publish(now, self.config.min_interval)
         };
@@ -164,6 +163,15 @@ impl ActivitySummaryWorker {
             debug!("discarded empty session activity summary");
             return Ok(());
         };
+        if self
+            .states
+            .get(execution_id)
+            .and_then(|state| state.last_summary.as_deref())
+            .is_some_and(|last| summaries_are_similar(last, &summary))
+        {
+            debug!(summary, "discarded redundant session activity summary");
+            return Ok(());
+        }
 
         self.store
             .append_event(
@@ -185,11 +193,30 @@ impl ActivitySummaryWorker {
         }
         Ok(())
     }
+
+    async fn activity_goal_context(
+        &self,
+        thread_key: &ThreadKey,
+    ) -> Result<Option<String>, ActivitySummaryError> {
+        if let Some(title) = self.store.get_session_title(thread_key).await?
+            && let Some(title) = clean_goal_text(&title)
+        {
+            return Ok(Some(title));
+        }
+
+        let messages = self.store.list_messages(thread_key).await?;
+        let goal = messages
+            .iter()
+            .find(|message| message.role == MessageRole::User)
+            .and_then(|message| message_parts_text(&message.parts));
+        Ok(goal.and_then(|goal| clean_goal_text(&goal)))
+    }
 }
 
 #[derive(Debug)]
 struct ExecutionActivity {
     facts: VecDeque<ActivityFact>,
+    goal: Option<String>,
     last_attempt_at: Option<Instant>,
     last_published_signature: Option<String>,
     last_summary: Option<String>,
@@ -197,11 +224,25 @@ struct ExecutionActivity {
 }
 
 impl ExecutionActivity {
+    fn new(max_facts: usize, goal: Option<String>) -> Self {
+        Self {
+            facts: VecDeque::with_capacity(max_facts),
+            goal,
+            last_attempt_at: None,
+            last_published_signature: None,
+            last_summary: None,
+            max_facts,
+        }
+    }
+
     fn push(&mut self, fact: ActivityFact) {
+        if !fact.is_publishable() {
+            return;
+        }
         if self
             .facts
-            .back()
-            .is_some_and(|existing| existing.kind == fact.kind && existing.text == fact.text)
+            .iter()
+            .any(|existing| existing.kind == fact.kind && existing.text == fact.text)
         {
             return;
         }
@@ -213,6 +254,9 @@ impl ExecutionActivity {
 
     fn prepare_publish(&mut self, now: Instant, min_interval: Duration) -> Option<String> {
         if self.facts.is_empty() {
+            return None;
+        }
+        if !self.facts.iter().any(ActivityFact::is_publishable) {
             return None;
         }
         if self
@@ -238,26 +282,95 @@ impl ExecutionActivity {
         if let Some(summary) = self.last_summary.as_deref() {
             lines.push(format!("Previous status sentence: {summary}"));
         }
+        if let Some(goal) = self.goal.as_deref() {
+            lines.push(format!("Session goal: {goal}"));
+        }
         lines.push("Recent activity facts, oldest to newest:".to_owned());
-        for fact in &self.facts {
+        for fact in self.facts.iter().filter(|fact| fact.is_publishable()) {
             lines.push(format!("- {}: {}", fact.kind, fact.text));
         }
         lines.join("\n")
     }
 
     fn signature(&self) -> String {
-        self.facts
-            .iter()
-            .map(|fact| format!("{}={}", fact.kind, fact.text))
+        let goal = self.goal.as_deref().unwrap_or_default();
+        std::iter::once(format!("goal={goal}"))
+            .chain(
+                self.facts
+                    .iter()
+                    .filter(|fact| fact.is_publishable())
+                    .map(|fact| format!("{}={}", fact.kind, fact.text)),
+            )
             .collect::<Vec<_>>()
             .join("\n")
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ActivitySignal {
+    High,
+    Low,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ActivityFact {
     kind: &'static str,
+    signal: ActivitySignal,
     text: String,
+}
+
+impl ActivityFact {
+    fn high(kind: &'static str, text: impl Into<String>) -> Self {
+        Self {
+            kind,
+            signal: ActivitySignal::High,
+            text: text.into(),
+        }
+    }
+
+    fn low(kind: &'static str, text: impl Into<String>) -> Self {
+        Self {
+            kind,
+            signal: ActivitySignal::Low,
+            text: text.into(),
+        }
+    }
+
+    fn is_publishable(&self) -> bool {
+        self.signal == ActivitySignal::High
+    }
+}
+
+fn message_parts_text(parts: &[Value]) -> Option<String> {
+    let text = parts
+        .iter()
+        .filter_map(message_part_text)
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!text.trim().is_empty()).then_some(text)
+}
+
+fn message_part_text(part: &Value) -> Option<String> {
+    if let Some(text) = part.as_str() {
+        return Some(text.trim().to_owned()).filter(|text| !text.is_empty());
+    }
+    string_at(part, &["text"])
+        .or_else(|| string_at(part, &["content"]))
+        .or_else(|| string_at(part, &["title"]))
+}
+
+fn clean_goal_text(value: &str) -> Option<String> {
+    let text = one_line(value, 160);
+    let lower = text.to_ascii_lowercase();
+    if lower.is_empty()
+        || matches!(
+            lower.as_str(),
+            "continue" | "go on" | "ok" | "okay" | "yes" | "yep" | "sure"
+        )
+    {
+        return None;
+    }
+    Some(text)
 }
 
 fn activity_fact_from_output_event(event: &SessionEvent) -> Option<ActivityFact> {
@@ -271,24 +384,14 @@ fn activity_fact_from_value(value: &Value) -> Option<ActivityFact> {
     let normalized = event_type.replace('/', ".");
     match normalized.as_str() {
         "turn.plan.updated" => plan_fact(value),
-        "item.plan.delta" => string_field(value, &["delta", "text"]).map(|text| ActivityFact {
-            kind: "plan",
-            text: format!("planning {}", one_line(&text, 180)),
-        }),
+        "item.plan.delta" => string_field(value, &["delta", "text"])
+            .map(|text| ActivityFact::high("plan", format!("planning {}", one_line(&text, 180)))),
         "item.reasoning.summaryTextDelta" | "item.reasoning.textDelta" => {
-            string_field(value, &["delta", "text"]).map(|text| ActivityFact {
-                kind: "thinking",
-                text: one_line(&text, 220),
-            })
+            string_field(value, &["delta", "text"])
+                .map(|text| ActivityFact::high("thinking", one_line(&text, 220)))
         }
-        "item.commandExecution.outputDelta" => Some(ActivityFact {
-            kind: "command",
-            text: "reading command output".to_owned(),
-        }),
-        "item.mcpToolCall.progress" => Some(ActivityFact {
-            kind: "tool",
-            text: progress_fact_text(value),
-        }),
+        "item.commandExecution.outputDelta" => None,
+        "item.mcpToolCall.progress" => Some(ActivityFact::high("tool", progress_fact_text(value))),
         "item.started" | "item.updated" | "item.completed" => item_fact(value, &normalized),
         "assistant" => assistant_tool_fact(value),
         "tool" | "user" => tool_result_fact(value),
@@ -320,10 +423,10 @@ fn plan_fact(value: &Value) -> Option<ActivityFact> {
     let step = string_at(current, &["step"])
         .or_else(|| string_at(current, &["title"]))
         .or_else(|| string_at(current, &["text"]))?;
-    Some(ActivityFact {
-        kind: "plan",
-        text: format!("working on {}", one_line(&strip_plan_marker(&step), 180)),
-    })
+    Some(ActivityFact::high(
+        "plan",
+        format!("working on {}", one_line(&strip_plan_marker(&step), 180)),
+    ))
 }
 
 fn item_fact(value: &Value, normalized_event_type: &str) -> Option<ActivityFact> {
@@ -333,38 +436,52 @@ fn item_fact(value: &Value, normalized_event_type: &str) -> Option<ActivityFact>
     match item_type.as_str() {
         "commandExecution" | "command_execution" => {
             let command = string_at(item, &["command"]).unwrap_or_else(|| "command".to_owned());
-            let action = if completed { "finished" } else { "running" };
-            Some(ActivityFact {
-                kind: "command",
-                text: format!(
-                    "{action} {}",
-                    one_line(&unwrap_shell_command(&command), 220)
-                ),
-            })
+            command_fact(&command, completed)
         }
-        "fileChange" | "file_change" => Some(ActivityFact {
-            kind: "files",
-            text: file_change_text(item, completed),
-        }),
+        "fileChange" | "file_change" => Some(ActivityFact::high(
+            "files",
+            file_change_text(item, completed),
+        )),
         "reasoning" => reasoning_item_fact(item, completed),
         "mcpToolCall" | "mcp_tool_call" | "dynamicToolCall" | "dynamic_tool_call" => {
             let name = tool_name(item);
             let action = if completed { "finished using" } else { "using" };
-            Some(ActivityFact {
-                kind: "tool",
-                text: format!("{action} {name}"),
-            })
+            Some(ActivityFact::high("tool", format!("{action} {name}")))
         }
-        // Assistant messages are the user-visible answer/commentary stream, not
-        // a useful live activity signal. Tool, plan, and command events carry
-        // the actual work in progress.
-        "agentMessage" | "agent_message" => None,
-        "plan" => string_at(item, &["text"]).map(|text| ActivityFact {
-            kind: "plan",
-            text: format!("updated plan {}", one_line(&text, 180)),
+        "agentMessage" | "agent_message" => agent_message_fact(item, completed),
+        "plan" => string_at(item, &["text"]).map(|text| {
+            ActivityFact::high("plan", format!("updated plan {}", one_line(&text, 180)))
         }),
         _ => None,
     }
+}
+
+fn command_fact(command: &str, completed: bool) -> Option<ActivityFact> {
+    let command = unwrap_shell_command(command);
+    if is_low_signal_command(&command) {
+        return Some(ActivityFact::low(
+            "command",
+            low_signal_command_label(&command),
+        ));
+    }
+    let tool = command_tool_name(&command)?;
+    let action = if completed { "finished using" } else { "using" };
+    Some(ActivityFact::high("tool", format!("{action} {tool}")))
+}
+
+fn agent_message_fact(item: &Value, completed: bool) -> Option<ActivityFact> {
+    if !completed {
+        return None;
+    }
+    let phase = string_at(item, &["phase"]).unwrap_or_default();
+    if phase != "commentary" {
+        return None;
+    }
+    let text = string_at(item, &["text"])?;
+    if is_low_signal_commentary(&text) {
+        return None;
+    }
+    Some(ActivityFact::high("commentary", one_line(&text, 220)))
 }
 
 fn protocol_item(value: &Value) -> Option<&Value> {
@@ -377,14 +494,14 @@ fn reasoning_item_fact(item: &Value, completed: bool) -> Option<ActivityFact> {
     let text = string_at(item, &["text"])
         .or_else(|| array_text(item.get("summary")))
         .or_else(|| array_text(item.get("content")))?;
-    Some(ActivityFact {
-        kind: "thinking",
-        text: if completed {
+    Some(ActivityFact::high(
+        "thinking",
+        if completed {
             format!("finished thinking about {}", one_line(&text, 180))
         } else {
             one_line(&text, 220)
         },
-    })
+    ))
 }
 
 fn file_change_text(item: &Value, completed: bool) -> String {
@@ -431,10 +548,10 @@ fn assistant_tool_fact(value: &Value) -> Option<ActivityFact> {
     let tool = content
         .iter()
         .find(|item| string_at(item, &["type"]).as_deref() == Some("tool_use"))?;
-    Some(ActivityFact {
-        kind: "tool",
-        text: format!("using {}", tool_name(tool)),
-    })
+    Some(ActivityFact::high(
+        "tool",
+        format!("using {}", tool_name(tool)),
+    ))
 }
 
 fn tool_result_fact(value: &Value) -> Option<ActivityFact> {
@@ -443,10 +560,7 @@ fn tool_result_fact(value: &Value) -> Option<ActivityFact> {
         string_at(item, &["type"]).as_deref() == Some("tool_result")
             || string_at(item, &["tool_use_id"]).is_some()
     }) {
-        return Some(ActivityFact {
-            kind: "tool",
-            text: "reading tool results".to_owned(),
-        });
+        return Some(ActivityFact::low("tool", "reading tool results"));
     }
     None
 }
@@ -458,6 +572,112 @@ fn tool_name(item: &Value) -> String {
         .or_else(|| string_at(item, &["serverLabel"]))
         .or_else(|| string_at(item, &["server_label"]))
         .unwrap_or_else(|| "tool".to_owned())
+}
+
+fn command_tool_name(command: &str) -> Option<String> {
+    let first = command
+        .split_whitespace()
+        .next()?
+        .trim_matches(|ch| ch == '"' || ch == '\'');
+    let name = first.rsplit('/').next().unwrap_or(first);
+    if name.is_empty() || is_shell_or_package_command(name) {
+        return None;
+    }
+    Some(name.to_owned())
+}
+
+fn is_low_signal_command(command: &str) -> bool {
+    let lower = command.to_ascii_lowercase();
+    let first = lower.split_whitespace().next().unwrap_or_default();
+    lower.is_empty()
+        || lower == "command"
+        || lower.contains(" --help")
+        || lower.ends_with(" --help")
+        || lower.contains(" -h")
+        || lower.contains("centaur-tools list")
+        || lower.contains("centaur-tools refresh")
+        || lower.contains("uv sync")
+        || lower.contains("uv pip install")
+        || lower.contains("pip install")
+        || lower.contains("pnpm install")
+        || lower.contains("npm install")
+        || lower.contains("cargo build")
+        || lower.contains("cargo check")
+        || lower.contains("cargo test")
+        || lower.contains("cargo fmt")
+        || lower.contains("ruff ")
+        || lower.contains("pytest")
+        || lower.contains("helm template")
+        || lower.contains("helm lint")
+        || matches!(
+            first,
+            "rg" | "grep"
+                | "sed"
+                | "awk"
+                | "cat"
+                | "ls"
+                | "find"
+                | "git"
+                | "kubectl"
+                | "jq"
+                | "curl"
+                | "python"
+                | "python3"
+                | "node"
+                | "sh"
+                | "bash"
+        )
+}
+
+fn low_signal_command_label(command: &str) -> String {
+    let lower = command.to_ascii_lowercase();
+    if lower.contains(" --help") || lower.ends_with(" --help") || lower.contains(" -h") {
+        "checking tool help".to_owned()
+    } else if lower.contains("install") || lower.contains("build") {
+        "setup work".to_owned()
+    } else {
+        "mechanical command".to_owned()
+    }
+}
+
+fn is_shell_or_package_command(name: &str) -> bool {
+    matches!(
+        name,
+        "bash"
+            | "sh"
+            | "zsh"
+            | "python"
+            | "python3"
+            | "node"
+            | "bun"
+            | "uv"
+            | "pip"
+            | "pnpm"
+            | "npm"
+            | "cargo"
+            | "git"
+            | "kubectl"
+            | "rg"
+            | "grep"
+            | "sed"
+            | "awk"
+            | "cat"
+            | "ls"
+            | "find"
+            | "jq"
+            | "curl"
+    )
+}
+
+fn is_low_signal_commentary(text: &str) -> bool {
+    let lower = text.trim().to_ascii_lowercase();
+    lower.is_empty()
+        || lower == "i'll take a look."
+        || lower == "i\u{2019}ll take a look."
+        || lower == "i'll check."
+        || lower == "i\u{2019}ll check."
+        || lower == "i'm working on it."
+        || lower == "i\u{2019}m working on it."
 }
 
 fn array_text(value: Option<&Value>) -> Option<String> {
@@ -531,8 +751,88 @@ fn one_line(value: &str, max_chars: usize) -> String {
 }
 
 fn sanitize_summary(summary: &str) -> Option<String> {
-    let summary = one_line(summary.trim().trim_matches('"').trim_matches('\''), 180);
+    let summary = summary
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .trim_end_matches('.')
+        .to_owned();
+    if summary.eq_ignore_ascii_case("skip") || summary.chars().count() > 45 {
+        return None;
+    }
+    if is_generic_summary(&summary) {
+        return None;
+    }
     (!summary.is_empty()).then_some(summary)
+}
+
+fn is_generic_summary(summary: &str) -> bool {
+    let normalized = normalize_summary(summary);
+    normalized.is_empty()
+        || normalized.contains("gathering details")
+        || normalized.contains("gathering info")
+        || (normalized.contains("gathering") && normalized.contains("info"))
+        || normalized.contains("listing available")
+        || normalized.contains("available items")
+        || normalized.contains("preparing your update")
+        || normalized.contains("preparing your summary")
+        || (normalized.contains("preparing your") && normalized.contains("summary"))
+        || normalized.contains("checking the request")
+        || normalized.contains("working on it")
+        || normalized.contains("making progress")
+        || normalized.contains("handling the task")
+}
+
+fn summaries_are_similar(previous: &str, candidate: &str) -> bool {
+    let previous = summary_keywords(previous);
+    let candidate = summary_keywords(candidate);
+    if previous.is_empty() || candidate.is_empty() {
+        return false;
+    }
+    let shared = candidate
+        .iter()
+        .filter(|word| previous.contains(*word))
+        .count();
+    let smaller = previous.len().min(candidate.len());
+    shared * 4 >= smaller * 3
+}
+
+fn summary_keywords(summary: &str) -> Vec<String> {
+    normalize_summary(summary)
+        .split_whitespace()
+        .filter(|word| {
+            !matches!(
+                *word,
+                "i" | "m"
+                    | "im"
+                    | "i'm"
+                    | "am"
+                    | "the"
+                    | "a"
+                    | "an"
+                    | "for"
+                    | "to"
+                    | "on"
+                    | "your"
+                    | "my"
+                    | "this"
+                    | "that"
+            )
+        })
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn normalize_summary(summary: &str) -> String {
+    summary
+        .to_ascii_lowercase()
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn is_terminal_session_event(event_type: &str) -> bool {
@@ -687,22 +987,54 @@ mod tests {
 
         assert_eq!(
             fact,
-            ActivityFact {
-                kind: "plan",
-                text: "working on Add activity summary worker".to_owned(),
-            }
+            ActivityFact::high("plan", "working on Add activity summary worker")
         );
     }
 
     #[test]
-    fn projects_command_event_without_output() {
+    fn drops_low_signal_command_events() {
         let fact = activity_fact_from_output_event(&event(json!({
             "method": "item/started",
             "params": {
                 "item": {
                     "id": "cmd-1",
                     "type": "commandExecution",
-                    "command": "/bin/bash -lc 'rg session.activity'"
+                    "command": "/bin/bash -lc 'centaur-tools list'"
+                }
+            }
+        })))
+        .unwrap();
+
+        assert_eq!(fact, ActivityFact::low("command", "mechanical command"));
+    }
+
+    #[test]
+    fn projects_tool_command_by_tool_name() {
+        let fact = activity_fact_from_output_event(&event(json!({
+            "method": "item/started",
+            "params": {
+                "item": {
+                    "id": "cmd-1",
+                    "type": "commandExecution",
+                    "command": "/bin/bash -lc 'websearch search --query usdG yield'"
+                }
+            }
+        })))
+        .unwrap();
+
+        assert_eq!(fact, ActivityFact::high("tool", "using websearch"));
+    }
+
+    #[test]
+    fn captures_completed_agent_commentary_as_activity() {
+        let fact = activity_fact_from_output_event(&event(json!({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "id": "msg-1",
+                    "phase": "commentary",
+                    "text": "I'll trace the USDG vault yield source.",
+                    "type": "agentMessage"
                 }
             }
         })))
@@ -710,42 +1042,19 @@ mod tests {
 
         assert_eq!(
             fact,
-            ActivityFact {
-                kind: "command",
-                text: "running rg session.activity".to_owned(),
-            }
+            ActivityFact::high("commentary", "I'll trace the USDG vault yield source.")
         );
-    }
-
-    #[test]
-    fn ignores_agent_commentary_messages_as_activity() {
-        let fact = activity_fact_from_output_event(&event(json!({
-            "method": "item/started",
-            "params": {
-                "item": {
-                    "id": "msg-1",
-                    "phase": "commentary",
-                    "text": "",
-                    "type": "agentMessage"
-                }
-            }
-        })));
-
-        assert_eq!(fact, None);
     }
 
     #[test]
     fn system_prompt_requires_conversational_goal_status() {
         assert!(SYSTEM_PROMPT.contains("first-person"));
         assert!(SYSTEM_PROMPT.contains("under 45 characters"));
-        assert!(SYSTEM_PROMPT.contains("Describe the goal"));
+        assert!(SYSTEM_PROMPT.contains("user-facing goal"));
         assert!(SYSTEM_PROMPT.contains("not the exact"));
-        assert!(SYSTEM_PROMPT.contains("Avoid mechanics"));
-        assert!(SYSTEM_PROMPT.contains("infer the"));
+        assert!(SYSTEM_PROMPT.contains("specific noun phrases"));
+        assert!(SYSTEM_PROMPT.contains("output exactly SKIP"));
         assert!(SYSTEM_PROMPT.contains("Do not mention tests"));
-        assert!(SYSTEM_PROMPT.contains("Use user-facing words"));
-        assert!(SYSTEM_PROMPT.contains("\"I'm checking the fix\""));
-        assert!(SYSTEM_PROMPT.contains("Never write more than 45 characters"));
         assert!(SYSTEM_PROMPT.contains("Do not refer to \"the agent\""));
     }
 
@@ -795,18 +1104,9 @@ mod tests {
 
     #[test]
     fn throttles_unchanged_activity() {
-        let mut state = ExecutionActivity {
-            facts: VecDeque::new(),
-            last_attempt_at: None,
-            last_published_signature: None,
-            last_summary: None,
-            max_facts: 4,
-        };
+        let mut state = ExecutionActivity::new(4, Some("Investigate USDG vault yield".to_owned()));
         let now = Instant::now();
-        state.push(ActivityFact {
-            kind: "tool",
-            text: "using github".to_owned(),
-        });
+        state.push(ActivityFact::high("tool", "using websearch"));
         assert!(state.prepare_publish(now, Duration::from_secs(8)).is_some());
         state.last_published_signature = Some(state.signature());
         assert!(
@@ -814,5 +1114,58 @@ mod tests {
                 .prepare_publish(now + Duration::from_secs(9), Duration::from_secs(8))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn skips_low_signal_only_activity() {
+        let mut state = ExecutionActivity::new(4, Some("Investigate USDG vault yield".to_owned()));
+        let now = Instant::now();
+        state.push(ActivityFact::low("command", "checking tool help"));
+
+        assert!(state.prepare_publish(now, Duration::from_secs(8)).is_none());
+    }
+
+    #[test]
+    fn prompt_includes_session_goal() {
+        let mut state = ExecutionActivity::new(4, Some("Investigate USDG vault yield".to_owned()));
+        state.push(ActivityFact::high("tool", "using websearch"));
+
+        let prompt = state.prompt();
+
+        assert!(prompt.contains("Session goal: Investigate USDG vault yield"));
+        assert!(prompt.contains("- tool: using websearch"));
+    }
+
+    #[test]
+    fn sanitizes_useless_summaries() {
+        assert_eq!(sanitize_summary("SKIP"), None);
+        assert_eq!(
+            sanitize_summary("I'm gathering details for the USDG info."),
+            None
+        );
+        assert_eq!(
+            sanitize_summary("I'm preparing your USDG vault update summary"),
+            None
+        );
+        assert_eq!(
+            sanitize_summary("I'm checking USDG yield sources."),
+            Some("I'm checking USDG yield sources".to_owned())
+        );
+        assert_eq!(
+            sanitize_summary("I'm checking a summary that is far too long for Slack status text"),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_redundant_summary_phrasing() {
+        assert!(summaries_are_similar(
+            "I'm checking USDG yield sources",
+            "I'm checking USDG yield source"
+        ));
+        assert!(!summaries_are_similar(
+            "I'm checking USDG yield sources",
+            "I'm comparing vault contract events"
+        ));
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -143,7 +143,7 @@ struct ActivitySummaryArgs {
     #[arg(
         long = "session-activity-summary-min-interval-secs",
         env = "SESSION_ACTIVITY_SUMMARY_MIN_INTERVAL_SECS",
-        default_value_t = 8,
+        default_value_t = 20,
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     min_interval_secs: u64,


### PR DESCRIPTION
## Summary
- feed activity summaries with session goal context from the session title or first user message
- suppress low-signal setup/help/build/command-output facts before they reach the model
- reject SKIP, long statuses, generic filler, and near-duplicate summaries
- raise the default activity-summary interval from 8s to 20s to reduce status churn

## Root Cause
The worker was summarizing mostly low-level `session.output.line` mechanics, then asking the model not to mention mechanics. That left the model with little useful semantic context, so it emitted generic statuses like "I'm gathering details" or "I'm preparing your update summary".

## Validation
- `cargo test -p centaur-api-server --bin centaur-api-server activity_summary`
- `cargo check -p centaur-api-server`
- `cargo fmt`
- `git diff --check`
