### PR TITLE
fix: lease session stdout ownership

### DIFF
--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -58,6 +58,8 @@ const STEERING_STARTUP_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const STEERING_STARTUP_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
 const SESSION_PIPE_MAX_REATTACH_ATTEMPTS: u32 = 3;
 const SESSION_PIPE_REATTACH_DELAY: Duration = Duration::from_millis(500);
+const STDOUT_OWNER_LEASE: Duration = Duration::from_secs(45);
+const STDOUT_OWNER_RENEW_INTERVAL: Duration = Duration::from_secs(10);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
 const OBSERVABILITY_TOOL_BLOCKLIST: &str =
@@ -89,6 +91,7 @@ pub struct SessionRuntime {
     session_title_in_flight: SessionTitleThreadSet,
     session_title_rerun_requested: SessionTitleThreadSet,
     capacity: Option<Arc<SandboxCapacityController>>,
+    stdout_owner_id: String,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -293,6 +296,7 @@ struct RuntimeContext {
     manager: Arc<SandboxManager>,
     sandbox_pipes: SessionPipeMap,
     execution_spans: ExecutionSpanRegistry,
+    stdout_owner_id: String,
 }
 
 struct SandboxCapacityController {
@@ -672,6 +676,7 @@ impl SessionRuntime {
             session_title_in_flight: Arc::new(DashSet::new()),
             session_title_rerun_requested: Arc::new(DashSet::new()),
             capacity: None,
+            stdout_owner_id: format!("api-rs-{}", uuid::Uuid::new_v4().simple()),
         }
     }
 
@@ -768,7 +773,36 @@ impl SessionRuntime {
             manager: self.sandbox_runtime.manager.clone(),
             sandbox_pipes: self.sandbox_pipes.clone(),
             execution_spans: self.execution_spans.clone(),
+            stdout_owner_id: self.stdout_owner_id.clone(),
         }
+    }
+
+    async fn claim_stdout_owner(&self, execution_id: &str) -> Result<(), SessionRuntimeError> {
+        let claimed = self
+            .store
+            .claim_stdout_owner(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
+            .await?;
+        if !claimed {
+            return Err(SessionRuntimeError::BadRequest(format!(
+                "execution {execution_id} stdout is owned by another control plane process"
+            )));
+        }
+        spawn_stdout_owner_renewer(self.context(), execution_id.to_owned());
+        Ok(())
+    }
+
+    async fn claim_expired_stdout_owner(
+        &self,
+        execution_id: &str,
+    ) -> Result<bool, SessionRuntimeError> {
+        let claimed = self
+            .store
+            .claim_expired_stdout_owner(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
+            .await?;
+        if claimed {
+            spawn_stdout_owner_renewer(self.context(), execution_id.to_owned());
+        }
+        Ok(claimed)
     }
 
     /// Attach an iron-control registrar so each new session upserts its
@@ -1421,6 +1455,11 @@ impl SessionRuntime {
                 );
                 return Ok(execution);
             }
+            if let Err(error) = self.claim_stdout_owner(&execution.execution_id).await {
+                self.record_execution_failure(thread_key, &execution.execution_id, &error)
+                    .await;
+                return Err(error);
+            }
             let execution_trace_span = info_span!(
                 "centaur.api_rs.session.execution",
                 component = COMPONENT_SESSION_RUNTIME,
@@ -1562,6 +1601,19 @@ impl SessionRuntime {
     ) {
         self.execution_spans.lock().await.remove(execution_id);
         let error_message = error.to_string();
+        let execution = match self
+            .store
+            .fail_execution_if_active_and_stdout_owner(
+                execution_id,
+                &self.stdout_owner_id,
+                &error_message,
+            )
+            .await
+        {
+            Ok(Some(execution)) => execution,
+            Ok(None) => return,
+            Err(_) => return,
+        };
         let _ = self
             .store
             .append_event(
@@ -1575,20 +1627,14 @@ impl SessionRuntime {
                 }),
             )
             .await;
-        if let Ok(execution) = self
-            .store
-            .fail_execution(execution_id, &error_message)
-            .await
-        {
-            record_finished_execution_metric(
-                &self.store,
-                thread_key,
-                &execution,
-                "failed",
-                Some(runtime_error_failure_class(error)),
-            )
-            .await;
-        }
+        record_finished_execution_metric(
+            &self.store,
+            thread_key,
+            &execution,
+            "failed",
+            Some(runtime_error_failure_class(error)),
+        )
+        .await;
     }
 
     async fn forward_messages_to_active_execution(
@@ -2472,6 +2518,26 @@ impl SessionRuntime {
             .await;
             return Ok(());
         }
+        if !self.claim_expired_stdout_owner(execution_id).await? {
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "execution_adoption_deferred",
+                thread_key = %thread_key,
+                execution_id,
+                sandbox_id,
+                "active stdout owner lease still exists; deferring adoption"
+            );
+            let _ = self
+                .store
+                .append_event(
+                    thread_key,
+                    Some(execution_id),
+                    "session.execution_adoption_deferred",
+                    json!({ "sandbox_id": sandbox_id, "reason": "stdout_owner_lease_active" }),
+                )
+                .await;
+            return Ok(());
+        }
 
         // The turn may have finished while no control plane was attached. An
         // attach stream cannot replay that output, but the backend's recorded
@@ -2531,7 +2597,13 @@ impl SessionRuntime {
         // No terminal in the recorded output: treat the turn as still in
         // flight. Re-attach the stdout pump and re-arm the remaining
         // max-duration budget so an adopted-but-silent turn stays bounded.
-        self.ensure_session_pipe(thread_key, sandbox_id).await?;
+        if let Err(error) = self.ensure_session_pipe(thread_key, sandbox_id).await {
+            let _ = self
+                .store
+                .release_stdout_owner(execution_id, &self.stdout_owner_id)
+                .await;
+            return Err(error);
+        }
         info!(
             component = COMPONENT_SESSION_RUNTIME,
             event = "execution_adopted",
@@ -2572,6 +2644,10 @@ impl SessionRuntime {
         sandbox_id: &str,
         detail: &str,
     ) {
+        let _ = self
+            .store
+            .claim_stdout_owner(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
+            .await;
         let error = format!("execution orphaned by control plane restart; {detail}");
         if let Err(record_error) = record_terminal_output(
             &self.context(),
@@ -3349,6 +3425,7 @@ async fn run_stdout_pump(
             "session stdout pump started"
         );
         let mut output_state = StdoutPumpState::default();
+        let mut lost_stdout_ownership = HashSet::new();
         let mut line_count = 0_u64;
         while let Some(line) = stdout.next().await {
             let line = match line {
@@ -3377,6 +3454,9 @@ async fn run_stdout_pump(
             else {
                 continue;
             };
+            if lost_stdout_ownership.contains(&output_execution_id) {
+                continue;
+            }
             let first_token_execution = active_execution
                 .as_ref()
                 .filter(|execution| {
@@ -3399,10 +3479,24 @@ async fn run_stdout_pump(
                 sandbox_id,
                 &output_execution_id,
             );
-            let output_event =
-                append_output_line(&ctx.store, &thread_key, Some(&output_execution_id), &line)
-                .instrument(output_span.clone())
-                .await?;
+            let Some(output_event) =
+                append_output_line(&ctx, &thread_key, &output_execution_id, &line)
+                    .instrument(output_span.clone())
+                    .await?
+            else {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_stdout_owner_lost",
+                    thread_key = %thread_key,
+                    execution_id = %output_execution_id,
+                    sandbox_id,
+                    stdout_owner_id = %ctx.stdout_owner_id,
+                    "stdout pump no longer owns execution output; suppressing further rows"
+                );
+                lost_stdout_ownership.insert(output_execution_id.clone());
+                output_state.forget(&output_execution_id);
+                continue;
+            };
             if let Some(execution) = first_token_execution {
                 record_first_token_observation(
                     &ctx,
@@ -4171,7 +4265,10 @@ async fn record_terminal_output(
             reason,
             result_text,
         } => {
-            let Some(execution) = ctx.store.complete_execution_if_active(execution_id).await?
+            let Some(execution) = ctx
+                .store
+                .complete_execution_if_active_and_stdout_owner(execution_id, &ctx.stdout_owner_id)
+                .await?
             else {
                 return Ok(());
             };
@@ -4199,7 +4296,11 @@ async fn record_terminal_output(
             failure_class = Some(terminal_failure_class(&error));
             let Some(execution) = ctx
                 .store
-                .fail_execution_if_active(execution_id, &error)
+                .fail_execution_if_active_and_stdout_owner(
+                    execution_id,
+                    &ctx.stdout_owner_id,
+                    &error,
+                )
                 .await?
             else {
                 return Ok(());
@@ -4278,6 +4379,33 @@ fn spawn_max_duration_failure(
     });
 }
 
+fn spawn_stdout_owner_renewer(ctx: RuntimeContext, execution_id: String) {
+    tokio::spawn(async move {
+        loop {
+            sleep(STDOUT_OWNER_RENEW_INTERVAL).await;
+            match ctx
+                .store
+                .renew_stdout_owner(&execution_id, &ctx.stdout_owner_id, STDOUT_OWNER_LEASE)
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => break,
+                Err(error) => {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_stdout_owner_renew_failed",
+                        execution_id,
+                        stdout_owner_id = %ctx.stdout_owner_id,
+                        %error,
+                        "failed to renew stdout owner lease"
+                    );
+                    break;
+                }
+            }
+        }
+    });
+}
+
 async fn record_max_duration_failure(
     ctx: &RuntimeContext,
     thread_key: &ThreadKey,
@@ -4289,7 +4417,7 @@ async fn record_max_duration_failure(
     let error = format!("execution exceeded max_duration_ms={max_duration_ms}");
     let Some(execution) = ctx
         .store
-        .fail_execution_if_active(execution_id, &error)
+        .fail_execution_if_active_and_stdout_owner(execution_id, &ctx.stdout_owner_id, &error)
         .await?
     else {
         return Ok(());
@@ -5142,16 +5270,19 @@ fn steering_input_line(
 }
 
 async fn append_output_line(
-    store: &PgSessionStore,
+    ctx: &RuntimeContext,
     thread_key: &ThreadKey,
-    execution_id: Option<&str>,
+    execution_id: &str,
     line: &str,
-) -> Result<SessionEvent, SessionRuntimeError> {
+) -> Result<Option<SessionEvent>, SessionRuntimeError> {
     let safe_line = redact_sensitive_text(line);
-    let event = store
-        .append_event(
+    let event = ctx
+        .store
+        .append_event_if_stdout_owner(
             thread_key,
             execution_id,
+            &ctx.stdout_owner_id,
+            STDOUT_OWNER_LEASE,
             SESSION_OUTPUT_LINE_EVENT,
             Value::String(safe_line),
         )

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0034_session_execution_stdout_owner.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0034_session_execution_stdout_owner.sql
@@ -1,0 +1,7 @@
+alter table session_executions
+    add column if not exists stdout_owner_id text,
+    add column if not exists stdout_owner_lease_expires_at timestamptz;
+
+create index if not exists session_executions_stdout_owner_lease_idx
+    on session_executions (stdout_owner_lease_expires_at)
+    where status in ('queued', 'running') and stdout_owner_id is not null;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -13,7 +13,7 @@ use sqlx::{
     postgres::{PgListener, PgPoolOptions},
 };
 use thiserror::Error;
-use time::OffsetDateTime;
+use time::{Duration as TimeDuration, OffsetDateTime};
 use uuid::Uuid;
 
 // The API binary embeds these migrations at compile time.
@@ -425,6 +425,121 @@ impl PgSessionStore {
         })
     }
 
+    pub async fn claim_stdout_owner(
+        &self,
+        execution_id: &str,
+        owner_id: &str,
+        lease: Duration,
+    ) -> Result<bool, SessionStoreError> {
+        let lease_expires_at = stdout_lease_expires_at(lease);
+        let result = sqlx::query(
+            r#"
+            update session_executions
+            set stdout_owner_id = $2,
+                stdout_owner_lease_expires_at = $3,
+                updated_at = now()
+            where execution_id = $1
+              and status in ($4, $5)
+              and (
+                stdout_owner_id is null
+                or stdout_owner_id = $2
+                or stdout_owner_lease_expires_at < now()
+              )
+            "#,
+        )
+        .bind(execution_id)
+        .bind(owner_id)
+        .bind(lease_expires_at)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn claim_expired_stdout_owner(
+        &self,
+        execution_id: &str,
+        owner_id: &str,
+        lease: Duration,
+    ) -> Result<bool, SessionStoreError> {
+        let lease_expires_at = stdout_lease_expires_at(lease);
+        let result = sqlx::query(
+            r#"
+            update session_executions
+            set stdout_owner_id = $2,
+                stdout_owner_lease_expires_at = $3,
+                updated_at = now()
+            where execution_id = $1
+              and status in ($4, $5)
+              and (
+                stdout_owner_id is null
+                or stdout_owner_lease_expires_at < now()
+              )
+            "#,
+        )
+        .bind(execution_id)
+        .bind(owner_id)
+        .bind(lease_expires_at)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn renew_stdout_owner(
+        &self,
+        execution_id: &str,
+        owner_id: &str,
+        lease: Duration,
+    ) -> Result<bool, SessionStoreError> {
+        let lease_expires_at = stdout_lease_expires_at(lease);
+        let result = sqlx::query(
+            r#"
+            update session_executions
+            set stdout_owner_lease_expires_at = $3,
+                updated_at = now()
+            where execution_id = $1
+              and stdout_owner_id = $2
+              and status in ($4, $5)
+            "#,
+        )
+        .bind(execution_id)
+        .bind(owner_id)
+        .bind(lease_expires_at)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn release_stdout_owner(
+        &self,
+        execution_id: &str,
+        owner_id: &str,
+    ) -> Result<bool, SessionStoreError> {
+        let result = sqlx::query(
+            r#"
+            update session_executions
+            set stdout_owner_id = null,
+                stdout_owner_lease_expires_at = null,
+                updated_at = now()
+            where execution_id = $1 and stdout_owner_id = $2
+            "#,
+        )
+        .bind(execution_id)
+        .bind(owner_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     pub async fn complete_execution(
         &self,
         execution_id: &str,
@@ -463,6 +578,41 @@ impl PgSessionStore {
         .bind(ExecutionStatus::Completed.as_ref())
         .bind(ExecutionStatus::Queued.as_ref())
         .bind(ExecutionStatus::Running.as_ref())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        self.set_session_status(&row.thread_key, SessionStatus::Idle)
+            .await?;
+        row.try_into().map(Some)
+    }
+
+    pub async fn complete_execution_if_active_and_stdout_owner(
+        &self,
+        execution_id: &str,
+        owner_id: &str,
+    ) -> Result<Option<SessionExecution>, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2,
+                completed_at = coalesce(completed_at, now()),
+                stdout_owner_id = null,
+                stdout_owner_lease_expires_at = null,
+                updated_at = now()
+            where execution_id = $1
+              and status in ($3, $4)
+              and stdout_owner_id = $5
+            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Completed.as_ref())
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .bind(owner_id)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -527,6 +677,44 @@ impl PgSessionStore {
         row.try_into().map(Some)
     }
 
+    pub async fn fail_execution_if_active_and_stdout_owner(
+        &self,
+        execution_id: &str,
+        owner_id: &str,
+        error: &str,
+    ) -> Result<Option<SessionExecution>, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2,
+                error = $3,
+                completed_at = coalesce(completed_at, now()),
+                stdout_owner_id = null,
+                stdout_owner_lease_expires_at = null,
+                updated_at = now()
+            where execution_id = $1
+              and status in ($4, $5)
+              and stdout_owner_id = $6
+            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Failed.as_ref())
+        .bind(error)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .bind(owner_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        self.set_session_status(&row.thread_key, SessionStatus::Failed)
+            .await?;
+        row.try_into().map(Some)
+    }
+
     pub async fn append_event(
         &self,
         thread_key: &ThreadKey,
@@ -549,6 +737,60 @@ impl PgSessionStore {
         .await?;
 
         row.try_into()
+    }
+
+    pub async fn append_event_if_stdout_owner(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: &str,
+        owner_id: &str,
+        lease: Duration,
+        event_type: &str,
+        payload: Value,
+    ) -> Result<Option<SessionEvent>, SessionStoreError> {
+        let lease_expires_at = stdout_lease_expires_at(lease);
+        let mut tx = self.pool.begin().await?;
+        let result = sqlx::query(
+            r#"
+            update session_executions
+            set stdout_owner_lease_expires_at = $3,
+                updated_at = now()
+            where execution_id = $1
+              and stdout_owner_id = $2
+              and status in ($4, $5)
+              and thread_key = $6
+            "#,
+        )
+        .bind(execution_id)
+        .bind(owner_id)
+        .bind(lease_expires_at)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .bind(thread_key.as_str())
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.commit().await?;
+            return Ok(None);
+        }
+
+        let row = sqlx::query_as::<_, SessionEventRow>(
+            r#"
+            insert into session_events (thread_key, execution_id, event_type, payload)
+            values ($1, $2, $3, $4)
+            returning event_id, thread_key, execution_id, event_type, payload, created_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(execution_id)
+        .bind(event_type)
+        .bind(payload)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        row.try_into().map(Some)
     }
 
     pub async fn list_events_after(
@@ -1471,6 +1713,11 @@ pub fn default_metadata(metadata: Option<Value>) -> Value {
     metadata.unwrap_or_else(empty_object)
 }
 
+fn stdout_lease_expires_at(lease: Duration) -> OffsetDateTime {
+    let seconds = i64::try_from(lease.as_secs()).unwrap_or(i64::MAX);
+    OffsetDateTime::now_utc() + TimeDuration::new(seconds, lease.subsec_nanos() as i32)
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -1620,6 +1867,101 @@ mod tests {
         assert_eq!(candidate.sandbox_id, sandbox_id);
         assert_eq!(candidate.execution_id, execution_id);
         assert_eq!(candidate.idle_timeout, Duration::from_secs(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stdout_owner_fences_output_and_terminal_updates() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key = ThreadKey::parse(format!("test:stdout-owner-{}", Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        let execution_id = store
+            .create_execution(&thread_key, None, json!({}))
+            .await
+            .expect("create execution")
+            .execution
+            .execution_id;
+        store
+            .mark_execution_running(&execution_id)
+            .await
+            .expect("mark running");
+
+        assert!(
+            store
+                .claim_stdout_owner(&execution_id, "owner-a", Duration::from_millis(25))
+                .await
+                .expect("owner-a claims stdout")
+        );
+        assert!(
+            store
+                .append_event_if_stdout_owner(
+                    &thread_key,
+                    &execution_id,
+                    "owner-a",
+                    Duration::from_millis(25),
+                    "session.output.line",
+                    json!("line-from-owner-a"),
+                )
+                .await
+                .expect("owner-a appends")
+                .is_some()
+        );
+        assert!(
+            store
+                .append_event_if_stdout_owner(
+                    &thread_key,
+                    &execution_id,
+                    "owner-b",
+                    Duration::from_millis(25),
+                    "session.output.line",
+                    json!("line-from-stale-owner-b"),
+                )
+                .await
+                .expect("owner-b append is fenced")
+                .is_none()
+        );
+        assert!(
+            store
+                .complete_execution_if_active_and_stdout_owner(&execution_id, "owner-b")
+                .await
+                .expect("owner-b terminal update is fenced")
+                .is_none()
+        );
+
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(
+            store
+                .claim_expired_stdout_owner(&execution_id, "owner-b", Duration::from_secs(5))
+                .await
+                .expect("owner-b claims after lease expiry")
+        );
+        assert!(
+            store
+                .append_event_if_stdout_owner(
+                    &thread_key,
+                    &execution_id,
+                    "owner-a",
+                    Duration::from_secs(5),
+                    "session.output.line",
+                    json!("line-from-expired-owner-a"),
+                )
+                .await
+                .expect("expired owner-a append is fenced")
+                .is_none()
+        );
+        let completed = store
+            .complete_execution_if_active_and_stdout_owner(&execution_id, "owner-b")
+            .await
+            .expect("owner-b completes")
+            .expect("completion should be recorded");
+        assert_eq!(
+            completed.status,
+            centaur_session_core::ExecutionStatus::Completed
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

Adds a database-backed stdout owner lease to session executions so only one API-rs process can persist sandbox stdout or terminalize a running execution.

## Root cause

During a rolling restart, the new API-rs pod can adopt a still-live sandbox while the old pod is still attached to stdout. Both pumps can observe the same harness output, and before this change both could insert `session.output.line` rows. Slack fallback then replayed duplicated output instead of the clean terminal result.

## Changes

- Add `stdout_owner_id` and `stdout_owner_lease_expires_at` to `session_executions`.
- Claim and renew stdout ownership before sending execution input.
- Defer live adoption while another process has an active stdout lease.
- Fence output-row insertion, completion, failure, and max-duration failure by stdout owner.
- Add a SQLx regression test proving stale owners cannot append output or terminalize an execution, and that ownership can transfer after lease expiry.

## Validation

- `cargo test -p centaur-session-sqlx stdout_owner`
- `cargo check -p centaur-session-runtime`
- `docker build -t centaur-api-rs:latest -f services/api-rs/Dockerfile .`
- Fresh local Kubernetes rebuild after deleting namespace `centaur`.
- Local mock session smoke completed with `PONG model=local-mock harness=codex`.
- Local rollout race repro hit `session.execution_adoption_deferred` and finished with `duplicate_rows=0` for execution `exe_591f53ea0cb740b9aca2c7aa2c3fa571`.
