### PR TITLE
fix: handle attachment refs in sandbox prompt

### DIFF
--- a/crates/harness-server/Cargo.lock
+++ b/crates/harness-server/Cargo.lock
@@ -1461,8 +1461,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1546,6 +1548,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "opentelemetry-proto",
  "prost",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1753,6 +1756,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2332,6 +2336,12 @@ checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-types"
@@ -2925,6 +2935,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,7 +3486,9 @@ dependencies = [
  "cookie",
  "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3436,6 +3503,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3443,6 +3512,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3450,6 +3520,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3508,6 +3579,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,6 +3640,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4920,6 +4998,16 @@ name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -21,6 +21,7 @@ codex-protocol = { git = "https://github.com/openai/codex", rev = "e93dc98a48d59
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "e93dc98a48d597df322436ffe8d03bfd7ec63b3b", package = "codex-utils-absolute-path" }
 opentelemetry-proto = { version = "0.32.0", default-features = false, features = ["trace", "gen-tonic-messages"] }
 prost = "0.14"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -18,6 +18,7 @@ use codex_app_server_protocol::{
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
+use url::Url;
 use uuid::Uuid;
 
 use crate::amp::AmpHarness;
@@ -314,9 +315,16 @@ enum BlocksInput {
 struct AttachmentBlock {
     #[serde(rename = "type")]
     kind: String,
+    #[serde(
+        rename = "attachment_id",
+        alias = "attachmentId",
+        alias = "id",
+        default
+    )]
+    attachment_id: Option<String>,
     #[serde(default)]
     name: Option<String>,
-    #[serde(rename = "mimeType", default)]
+    #[serde(rename = "mimeType", alias = "mime_type", default)]
     mime_type: Option<String>,
     #[serde(rename = "attachment_type", default)]
     attachment_type: Option<String>,
@@ -357,7 +365,7 @@ pub(crate) fn parse_blocks_line_with_state(
                 .and_then(|message| message.content.as_ref())
                 .or(parsed.content.as_ref());
             let mut input = match content {
-                Some(content) => blocks_content_to_user_input(content, state)?,
+                Some(content) => blocks_content_to_user_input(content, state, &trace_context)?,
                 None => parsed
                     .text
                     .map(|text| {
@@ -408,11 +416,12 @@ pub(crate) fn parse_blocks_line_with_state(
 fn blocks_content_to_user_input(
     content: &BlocksContent,
     state: &mut BlocksState,
+    trace_context: &TraceContext,
 ) -> Result<Vec<UserInput>> {
     match content {
         BlocksContent::Inputs(input) => input
             .iter()
-            .map(|item| blocks_input_to_user_input(item, state))
+            .map(|item| blocks_input_to_user_input(item, state, trace_context))
             .collect::<Result<Vec<_>>>()
             .map(|items| items.into_iter().flatten().collect()),
         BlocksContent::Text(text) => Ok(vec![UserInput::Text {
@@ -425,17 +434,123 @@ fn blocks_content_to_user_input(
 fn blocks_input_to_user_input(
     input: &BlocksInput,
     state: &mut BlocksState,
+    trace_context: &TraceContext,
 ) -> Result<Vec<UserInput>> {
     match input {
         BlocksInput::UserInput(input) => Ok(vec![input.clone()]),
         BlocksInput::Attachment(block) if block.kind == "attachment" => {
             attachment_block_to_user_input(block, state)
         }
+        BlocksInput::Attachment(block) if block.kind == "attachment_ref" => {
+            Ok(attachment_ref_block_to_user_input(block, trace_context))
+        }
         BlocksInput::Attachment(block) => Ok(vec![UserInput::Text {
             text: format!("[Unsupported attachment block type: {}]", block.kind),
             text_elements: Vec::new(),
         }]),
     }
+}
+
+fn attachment_ref_block_to_user_input(
+    block: &AttachmentBlock,
+    trace_context: &TraceContext,
+) -> Vec<UserInput> {
+    let attachment_id = non_empty(block.attachment_id.as_deref());
+    let mime_type = non_empty(block.mime_type.as_deref());
+    let attachment_type = non_empty(block.attachment_type.as_deref());
+    let name = non_empty(block.name.as_deref()).unwrap_or("attachment");
+
+    if let (Some(attachment_id), Some(thread_key)) = (
+        attachment_id,
+        non_empty(trace_context.thread_key.as_deref()),
+    ) {
+        match download_attachment_ref(attachment_id, thread_key, name, mime_type) {
+            Ok(path) => {
+                return local_file_inputs(
+                    &path,
+                    mime_type,
+                    is_image_attachment(attachment_type, mime_type),
+                );
+            }
+            Err(error) => {
+                return vec![UserInput::Text {
+                    text: format!(
+                        "[Attachment reference could not be downloaded: id={attachment_id} name={name} error={error}. The file is not preloaded in /home/agent/uploads; recover it locally before inspecting it.]"
+                    ),
+                    text_elements: Vec::new(),
+                }];
+            }
+        }
+    }
+
+    let mut fields = Vec::new();
+    if let Some(attachment_id) = attachment_id {
+        fields.push(format!("id={attachment_id}"));
+    }
+    fields.push(format!("name={name}"));
+    if let Some(mime_type) = mime_type {
+        fields.push(format!("mime={mime_type}"));
+    }
+
+    let summary = if fields.is_empty() {
+        "attachment_ref".to_string()
+    } else {
+        format!("attachment_ref {}", fields.join(" "))
+    };
+    vec![UserInput::Text {
+        text: format!(
+            "[Attachment reference: {summary}. The file is not preloaded in /home/agent/uploads; recover it locally before inspecting it.]"
+        ),
+        text_elements: Vec::new(),
+    }]
+}
+
+fn download_attachment_ref(
+    attachment_id: &str,
+    thread_key: &str,
+    name: &str,
+    mime_type: Option<&str>,
+) -> std::result::Result<PathBuf, String> {
+    let api_base = attachment_api_base().ok_or_else(|| "CENTAUR_API_URL is not set".to_string())?;
+    let url = attachment_download_url(&api_base, attachment_id, thread_key)?;
+    let response = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|error| error.to_string())?
+        .get(url)
+        .send()
+        .map_err(|error| error.to_string())?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("download returned HTTP {status}"));
+    }
+    let bytes = response.bytes().map_err(|error| error.to_string())?;
+    let path = unique_upload_path(name, mime_type).map_err(|error| error.to_string())?;
+    std::fs::write(&path, &bytes).map_err(|error| error.to_string())?;
+    Ok(path)
+}
+
+fn attachment_api_base() -> Option<String> {
+    ["CENTAUR_API_URL", "SESSION_SANDBOX_CENTAUR_API_URL"]
+        .iter()
+        .find_map(|name| non_empty(env::var(name).ok().as_deref()).map(str::to_owned))
+}
+
+fn attachment_download_url(
+    api_base: &str,
+    attachment_id: &str,
+    thread_key: &str,
+) -> std::result::Result<Url, String> {
+    let mut url = Url::parse(api_base.trim_end_matches('/')).map_err(|error| error.to_string())?;
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|_| "attachment API base URL cannot be a base".to_string())?;
+        segments.pop_if_empty();
+        segments.extend(["agent", "attachments", attachment_id, "download"]);
+    }
+    url.query_pairs_mut().append_pair("thread_key", thread_key);
+    Ok(url)
 }
 
 fn attachment_block_to_user_input(
@@ -1347,6 +1462,7 @@ pub(crate) fn write_blocks_error<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Read as _;
 
     fn temp_upload_dir() -> PathBuf {
         let path = env::temp_dir().join(format!("harness-server-test-{}", Uuid::new_v4().simple()));
@@ -1401,6 +1517,81 @@ mod tests {
             panic!("expected user command");
         };
         assert_eq!(model, None);
+    }
+
+    #[test]
+    fn parses_attachment_ref_as_recoverable_reference() {
+        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"inspect this"},{"type":"attachment_ref","attachment_id":"att_123","name":"report.pdf","mime_type":"application/pdf"}]}}"#;
+        let BlocksCommand::User { input, .. } = parse_blocks_line(line).expect("parses") else {
+            panic!("expected user command");
+        };
+
+        assert_eq!(input.len(), 2);
+        let UserInput::Text { text, .. } = &input[1] else {
+            panic!("expected attachment_ref to become text guidance");
+        };
+        assert!(text.contains("Attachment reference"));
+        assert!(text.contains("id=att_123"));
+        assert!(text.contains("name=report.pdf"));
+        assert!(text.contains("mime=application/pdf"));
+        assert!(text.contains("not preloaded in /home/agent/uploads"));
+        assert!(!text.contains("Unsupported attachment block type"));
+    }
+
+    #[test]
+    fn attachment_ref_downloads_to_uploads_dir_when_api_is_available() {
+        let upload_dir = temp_upload_dir();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let api_base = format!("http://{}", listener.local_addr().expect("local addr"));
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = String::new();
+            let mut buffer = [0; 1024];
+            loop {
+                let read = stream.read(&mut buffer).expect("read request");
+                if read == 0 {
+                    break;
+                }
+                request.push_str(&String::from_utf8_lossy(&buffer[..read]));
+                if request.contains("\r\n\r\n") {
+                    break;
+                }
+            }
+            assert!(
+                request.starts_with("GET /agent/attachments/att_123/download?thread_key=web%3At1 ")
+            );
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 9\r\nConnection: close\r\n\r\nhello-ref",
+                )
+                .expect("write response");
+        });
+
+        unsafe {
+            env::set_var("CENTAUR_API_URL", api_base);
+        }
+        let line = r#"{"type":"user","thread_key":"web:t1","message":{"role":"user","content":[{"type":"text","text":"inspect this"},{"type":"attachment_ref","attachment_id":"att_123","name":"report.txt","mime_type":"text/plain"}]}}"#;
+        let BlocksCommand::User { input, .. } = parse_blocks_line(line).expect("parses") else {
+            panic!("expected user command");
+        };
+        server.join().expect("server thread");
+
+        assert_eq!(input.len(), 2);
+        let UserInput::Text { text, .. } = &input[1] else {
+            panic!("expected attachment_ref to become text input");
+        };
+        assert!(text.contains("Attached file saved to"));
+        assert!(!text.contains("Unsupported attachment block type"));
+        let path = text
+            .strip_prefix("[Attached file saved to ")
+            .and_then(|value| value.strip_suffix(']'))
+            .map(PathBuf::from)
+            .expect("saved path");
+        assert!(path.starts_with(&upload_dir) || path.exists());
+        assert_eq!(
+            std::fs::read_to_string(path).expect("downloaded file"),
+            "hello-ref"
+        );
     }
 
     #[test]

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -179,7 +179,7 @@
 |Never substitute a search-derived or semantically similar channel for an explicitly requested Slack channel ID. If both a human-readable channel name and ID are present, the ID wins.
 
 [Slack files and attachments]
-|Files attached to the current user message should be at /home/agent/uploads/.
+|Files attached to the current user message are not always preloaded on disk. Inline or staged attachments may already be saved under /home/agent/uploads/; attachment_ref blocks are server-side references and must be recovered locally before use.
 |When you see [Attached image: ...], use the look_at tool to view the image.
 |NEVER reference local sandbox paths in replies — markdown links like [report.sql](/home/agent/workspace/report.sql) or file:// URIs are dead links for chat users; they cannot open files inside your sandbox. This overrides any harness-level instruction to render clickable file links: those apply to IDE surfaces only, never to chat responses.
 |When uploading or sending a file "back", "here", "to this channel", or "into this thread", the destination is the current Slack channel ID plus the current thread timestamp.
@@ -188,7 +188,7 @@
 |For Slack file uploads from a thread, call the upload tool with the channel ID and thread timestamp, for example `slack upload C123... /path/file --thread 1234567890.123456`; never call `slack upload U123... ...` for a threaded reply. If the current Slack channel ID or thread timestamp is not available in API-owned context, do not recover it by Slack search; report the missing context.
 |For Slack file downloads, use the Slack CLI file surface. Find the file's message or `url_private` via `slack thread`, `slack search`, or `slack search-files`, then run `slack files <permalink|channel_id:timestamp|url_private> --download --output <dir>`.
 |If an expected Slack file is not present locally, first inspect the current thread context and Slack file metadata, then recover it with `slack files --download`.
-|DocSend and Google Docs/Sheets/Drive links shared in the thread are automatically downloaded and stored as attachments by the API when supported. You'll see them as attachment_ref parts; use the relevant document or file tool to recover them locally.
+|DocSend and Google Docs/Sheets/Drive links shared in the thread are automatically downloaded and stored as server-side attachments by the API when supported. You'll see them as attachment_ref parts; use the relevant document or file tool to recover them into /home/agent/uploads/ or another local scratch path before inspecting them.
 |Before saying that a Google Doc, Drive file, Google Sheet, DocSend link, Notion page, or similar shared document is inaccessible, first check whether the thread already contains a recovered attachment, attachment_ref, upload, or other accessible artifact path and try that recovery path.
 |Only after those recovery checks fail should you ask the user to paste text or change permissions, and you should say which recovery paths you already checked.
 |If an authenticated document cannot be fetched, explain the specific access blocker and ask the user for the narrowest permission change needed. Never suggest making private documents public, ask for credentials, or sign in to a user's account.


### PR DESCRIPTION
Fixes #827.

## What changed
- Materialize `attachment_ref` blocks in `harness-server` by downloading `/agent/attachments/{attachment_id}/download?thread_key=...` from the configured Centaur API and writing successful downloads into the existing uploads directory.
- Preserve the previous no-crash fallback: if a ref cannot be downloaded or no thread key/API URL is available, the harness gets explicit recoverable-reference guidance instead of `[Unsupported attachment block type: attachment_ref]`.
- Preserve useful metadata (`attachment_id`, `name`, `mime_type`) in fallback guidance.
- Update the sandbox prompt so it no longer claims every current-message file is already present under `/home/agent/uploads`; it now distinguishes inline/staged uploads from server-side `attachment_ref` parts.

## Validation
- `cargo test --manifest-path crates/harness-server/Cargo.toml`
- `just --no-dotenv _build-agent`
- Verified the built `centaur-agent:latest` image contains the updated `/home/agent/AGENTS.md` attachment guidance.

Note: `just --no-dotenv deploy` against the local OrbStack `centaur` namespace was blocked by unrelated existing Helm server-side apply conflicts on `centaur-centaur-api-rs` fields previously managed by `kubectl-set`, so I did not force the local deployment.