### PR TITLE
fix: prefer slack etl for historical slack search

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -100,7 +100,8 @@
 |<tool> --help                   → inspect commands/options for one tool
 |<tool> health                   → smoke test one tool's configured auth/connectivity path
 |websearch search "query"        → web research
-|slack search "query"            → Slack search
+|company_context search "query" --source slack --json → indexed Slack ETL search
+|slack search "query"            → live/direct Slack API search fallback
 |linear search "query"           → Linear issue search
 |vlogs query "level:error"       → recent service errors
 |centaur-tools call vmetrics query '{"expr":"centaur_deployment_info"}' → live Centaur deployment image/version/SHA metadata
@@ -172,6 +173,13 @@
 |If you're unsure which tool has what you need, run `centaur-tools list` to list everything available.
 |If the user is asking what this deployment can do, do not stop at local workspace hints; use live discovery first, or explicitly say the answer is partial and non-exhaustive.
 |Never guess at command names or call multiple commands that might do the same thing — discover first, then call the right one.
+
+[Slack historical search]
+|For broad, historical, semantic, or "what was discussed/decided/mentioned" Slack questions, prefer the indexed Slack ETL path first: `company_context search "QUERY" --source slack --limit 10 --json`.
+|Read promising hits with `company_context read "DOCUMENT_ID" --related --json` before answering when the preview is not enough.
+|Use `company_context latest-date --source slack --json` when freshness affects the answer, and say plainly if the Slack ETL index is stale or unavailable.
+|Use direct Slack CLI calls instead of the ETL path for exact current-thread reads, exact channel windows by ID, files/downloads/uploads, Slack DM search, live verification of current state, and fallback when the indexed ETL path has no useful results or fails.
+|Do not start with `slack search` for general historical Slack recall. It uses live Slack API search or bot-channel scanning and is less reliable for broad internal-memory questions than the ETL-backed company context index.
 
 [Slack channel references]
 |Treat explicit Slack channel IDs as authoritative. If a user refers to a channel as `#name (C123...)`, `<#C123...|name>`, `#C123...`, or otherwise provides a channel ID, use that exact ID for Slack history/search/file operations.

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -10,7 +10,13 @@ from rich.table import Table
 
 load_dotenv()
 
-app = typer.Typer(name="slack", help="Slack CLI for AI agents")
+app = typer.Typer(
+    name="slack",
+    help=(
+        "Direct/live Slack operations. Prefer "
+        "`company_context search --source slack` for historical Slack search."
+    ),
+)
 
 
 @app.command("health")
@@ -114,15 +120,21 @@ def search(
     from_user: str = typer.Option(None, "--from", help="Filter by username"),
     depth: int = typer.Option(200, "--depth", "-d", help="Messages per channel to scan"),
 ):
-    """Search messages in bot-accessible channels.
+    """Live/direct Slack message search fallback.
 
-    Searches across all channels the bot is a member of. Results are ranked by
-    relevance (exact phrase matches score higher). Use --channels to limit scope.
+    Prefer `company_context search "query" --source slack --json` for broad,
+    historical, or semantic Slack recall. Use this command when you need live
+    Slack API search, an exact Slack search modifier, or a fallback after the
+    indexed Slack ETL path is unavailable or insufficient.
+
+    Searches across Slack's native search API when available, or scans channels
+    the bot is a member of as a fallback. Use --channels to limit scope.
 
     Note: Only searches channels where the bot is a member. To search more channels,
     invite the bot to those channels first.
 
     Examples:
+        company_context search "deploy" --source slack --json
         slack search "deploy"
         slack search "kubernetes error" --channels eng-infra,eng-ai
         slack search "database migration" --from alice --depth 500

--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack"
-description = "Search Slack messages, channels, threads, users"
+description = "Direct/live Slack operations for exact channels, threads, files, users, and fallback message search. Prefer company_context --source slack for historical Slack search."
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -2,9 +2,8 @@ import sys
 import types
 from pathlib import Path
 
-from typer.testing import CliRunner
-
 from slack.cli import _channel_arg_is_id, app
+from typer.testing import CliRunner
 
 
 def test_channel_arg_is_id_accepts_channel_id_forms() -> None:
@@ -16,6 +15,20 @@ def test_channel_arg_is_id_accepts_channel_id_forms() -> None:
 def test_channel_arg_is_id_rejects_names() -> None:
     assert not _channel_arg_is_id("eng-centaur")
     assert not _channel_arg_is_id("#eng-centaur")
+
+
+def test_slack_help_prefers_company_context_for_historical_search() -> None:
+    result = CliRunner().invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "company_context search --source slack" in result.output
+
+
+def test_search_help_prefers_company_context_for_historical_search() -> None:
+    result = CliRunner().invoke(app, ["search", "--help"])
+
+    assert result.exit_code == 0
+    assert 'company_context search "query" --source slack --json' in result.output
 
 
 def test_upload_requires_explicit_channel_and_thread(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Updates the sandbox prompt and Slack tool help so agents prefer the ETL-backed company context index for broad historical Slack recall. Direct Slack search remains documented as the live/API fallback for exact current-thread, channel, file, and verification workflows.