### PR TITLE
fix: scope console thread direct-selection to the owner

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -218,7 +218,10 @@ class ApplicationController < ActionController::Base
     return if thread_key.blank?
     return if threads.any? { |thread| thread.thread_key == thread_key }
 
-    CentaurSession.find_by(thread_key: thread_key)
+    # Resolve through the owner scope, not a raw find_by, so a directly linked
+    # thread only surfaces in the sidebar when the current user started it. This
+    # mirrors Console::ThreadsController#selected_session.
+    console_sidebar_visible_thread_scope.where(thread_key: thread_key).first
   end
 
   def console_sidebar_selected_thread_key

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -198,10 +198,11 @@ class ApplicationController < ActionController::Base
   end
 
   def console_sidebar_visible_thread_scope
-    conditions = [ console_sidebar_console_thread_owner_sql ].compact
-
     slack_owners = console_sidebar_slack_thread_owners_for_current_user
-    conditions << console_sidebar_slack_thread_owner_sql(slack_owners) if slack_owners.any?
+    conditions = [
+      console_sidebar_console_thread_owner_sql,
+      (console_sidebar_slack_thread_owner_sql(slack_owners) if slack_owners.any?)
+    ].compact
 
     return CentaurSession.where("1=0") if conditions.empty?
 
@@ -267,13 +268,15 @@ class ApplicationController < ActionController::Base
           )
           next if user_id.blank?
 
-          ConsoleSidebarSlackThreadOwner.new(
-            user_id: user_id,
-            team_id: console_sidebar_first_present(
-              credential.labels&.[](CONSOLE_SIDEBAR_SLACK_TEAM_LABEL),
-              credential.oauth_app&.labels&.[](CONSOLE_SIDEBAR_SLACK_TEAM_LABEL)
-            )
+          team_id = console_sidebar_first_present(
+            credential.labels&.[](CONSOLE_SIDEBAR_SLACK_TEAM_LABEL),
+            credential.oauth_app&.labels&.[](CONSOLE_SIDEBAR_SLACK_TEAM_LABEL)
           )
+          # Require a resolvable workspace; see Console::ThreadsController for why
+          # a team-less credential cannot own threads.
+          next if team_id.blank?
+
+          ConsoleSidebarSlackThreadOwner.new(user_id: user_id, team_id: team_id)
         end.uniq { |owner| [ console_sidebar_normalize_key(owner.user_id), console_sidebar_normalize_key(owner.team_id) ] }
       end
     end
@@ -321,24 +324,24 @@ class ApplicationController < ActionController::Base
       "metadata ->> 'source' = 'slackbotv2'"
     ].join(" OR ")
 
-    owner_clauses = owners.map do |owner|
+    owner_clauses = owners.filter_map do |owner|
+      team_id = console_sidebar_normalize_key(owner.team_id)
+      # Team scoping is mandatory: never match a Slack thread on user id alone.
+      next if team_id.blank?
+
       user_id = console_sidebar_normalize_key(owner.user_id)
       user_clauses = CONSOLE_SIDEBAR_SLACK_THREAD_OWNER_METADATA_KEYS.map do |key|
         "lower(metadata ->> #{console_sidebar_sql_quote(key)}) = #{console_sidebar_sql_quote(user_id)}"
       end
-      owner_clause = "(#{user_clauses.join(" OR ")})"
-
-      if owner.team_id.present?
-        team_id = console_sidebar_normalize_key(owner.team_id)
-        team_clauses = CONSOLE_SIDEBAR_SLACK_THREAD_TEAM_METADATA_KEYS.map do |key|
-          "lower(metadata ->> #{console_sidebar_sql_quote(key)}) = #{console_sidebar_sql_quote(team_id)}"
-        end
-        team_clauses << "lower(split_part(thread_key, ':', 2)) = #{console_sidebar_sql_quote(team_id)}"
-        owner_clause = "(#{owner_clause} AND (#{team_clauses.join(" OR ")}))"
+      team_clauses = CONSOLE_SIDEBAR_SLACK_THREAD_TEAM_METADATA_KEYS.map do |key|
+        "lower(metadata ->> #{console_sidebar_sql_quote(key)}) = #{console_sidebar_sql_quote(team_id)}"
       end
+      team_clauses << "lower(split_part(thread_key, ':', 2)) = #{console_sidebar_sql_quote(team_id)}"
 
-      owner_clause
+      "((#{user_clauses.join(" OR ")}) AND (#{team_clauses.join(" OR ")}))"
     end
+
+    return if owner_clauses.empty?
 
     "(#{slack_source}) AND (#{owner_clauses.join(" OR ")})"
   end

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -131,10 +131,11 @@ class Console::ThreadsController < ApplicationController
   end
 
   def visible_thread_scope
-    conditions = [ console_thread_owner_sql ].compact
-
     slack_owners = slack_thread_owners_for_current_user
-    conditions << slack_thread_owner_sql(slack_owners) if slack_owners.any?
+    conditions = [
+      console_thread_owner_sql,
+      (slack_thread_owner_sql(slack_owners) if slack_owners.any?)
+    ].compact
 
     return CentaurSession.where("1=0") if conditions.empty?
 
@@ -179,13 +180,16 @@ class Console::ThreadsController < ApplicationController
             )
             next if user_id.blank?
 
-            SlackThreadOwner.new(
-              user_id: user_id,
-              team_id: first_present(
-                credential.labels&.[](SLACK_TEAM_LABEL),
-                credential.oauth_app&.labels&.[](SLACK_TEAM_LABEL)
-              )
+            team_id = first_present(
+              credential.labels&.[](SLACK_TEAM_LABEL),
+              credential.oauth_app&.labels&.[](SLACK_TEAM_LABEL)
             )
+            # Require a resolvable workspace. Slack user IDs are not unique across
+            # workspaces, so matching on user id alone could surface another
+            # workspace's threads. A credential with no team cannot own threads.
+            next if team_id.blank?
+
+            SlackThreadOwner.new(user_id: user_id, team_id: team_id)
           end.uniq { |owner| [ normalize_key(owner.user_id), normalize_key(owner.team_id) ] }
         end
       else
@@ -236,24 +240,24 @@ class Console::ThreadsController < ApplicationController
       "metadata ->> 'source' = 'slackbotv2'"
     ].join(" OR ")
 
-    owner_clauses = owners.map do |owner|
+    owner_clauses = owners.filter_map do |owner|
+      team_id = normalize_key(owner.team_id)
+      # Team scoping is mandatory: never match a Slack thread on user id alone.
+      next if team_id.blank?
+
       user_id = normalize_key(owner.user_id)
       user_clauses = SLACK_THREAD_OWNER_METADATA_KEYS.map do |key|
         "lower(metadata ->> #{sql_quote(key)}) = #{sql_quote(user_id)}"
       end
-      owner_clause = "(#{user_clauses.join(" OR ")})"
-
-      if owner.team_id.present?
-        team_id = normalize_key(owner.team_id)
-        team_clauses = SLACK_THREAD_TEAM_METADATA_KEYS.map do |key|
-          "lower(metadata ->> #{sql_quote(key)}) = #{sql_quote(team_id)}"
-        end
-        team_clauses << "lower(split_part(thread_key, ':', 2)) = #{sql_quote(team_id)}"
-        owner_clause = "(#{owner_clause} AND (#{team_clauses.join(" OR ")}))"
+      team_clauses = SLACK_THREAD_TEAM_METADATA_KEYS.map do |key|
+        "lower(metadata ->> #{sql_quote(key)}) = #{sql_quote(team_id)}"
       end
+      team_clauses << "lower(split_part(thread_key, ':', 2)) = #{sql_quote(team_id)}"
 
-      owner_clause
+      "((#{user_clauses.join(" OR ")}) AND (#{team_clauses.join(" OR ")}))"
     end
+
+    return if owner_clauses.empty?
 
     "(#{slack_source}) AND (#{owner_clauses.join(" OR ")})"
   end

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -103,8 +103,10 @@ class Console::ThreadsController < ApplicationController
     selected = nil
     if @selected_thread_key.present?
       selected = base_sessions.find { |session| session.thread_key == @selected_thread_key }
+      # Resolve the key through the owner scope so a directly linked thread only
+      # loads when the current user started it. base_sessions is capped at
+      # THREAD_LIMIT, so this also recovers an owned thread beyond that window.
       selected ||= session_scope.where(thread_key: @selected_thread_key).first
-      selected ||= direct_selected_session(@selected_thread_key)
     end
     selected || @sessions.first
   end
@@ -126,13 +128,6 @@ class Console::ThreadsController < ApplicationController
     @latest_executions.merge!(latest_executions_for(selected_key))
     @message_counts.merge!(count_records(CentaurSessionMessage, selected_key))
     @execution_counts.merge!(count_records(CentaurSessionExecution, selected_key))
-  end
-
-  def direct_selected_session(thread_key)
-    return if thread_key.blank?
-    return unless thread_key.to_s.start_with?("slack:")
-
-    CentaurSession.where(thread_key: thread_key).first
   end
 
   def visible_thread_scope

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -363,6 +363,26 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     refute_includes sql, "slack_user_id"
   end
 
+  test "visible thread scope ignores Slack credentials without a resolvable team" do
+    app = oauth_apps(:acme_slack)
+    app.update!(client_secret: "slack-secret", labels: {})
+    create_slack_oauth_credential(
+      app,
+      subject: "UOWNER",
+      email: @operator.email,
+      labels: {}
+    )
+    controller = threads_controller_for(@operator)
+
+    sql = controller.send(:visible_thread_scope).to_sql
+
+    # A credential with no team cannot own threads: no Slack matching is emitted,
+    # so the scope falls back to the current user's console threads only.
+    refute_includes sql, "thread_key LIKE 'slack:%'"
+    refute_includes sql, "uowner"
+    assert_includes sql, "thread_key LIKE 'console:%'"
+  end
+
   test "selected session resolves a directly linked thread only within the owner scope" do
     controller = Console::ThreadsController.new
     owned_thread = SelectedSession.new(thread_key: "slack:C123:1782339173.755169")

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -67,7 +67,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to console_threads_path(thread: thread_key)
   end
 
-  test "direct selected thread appears in sidebar when outside owner filtered list" do
+  test "direct selected thread is hidden when the current user did not start it" do
     skip_unless_session_table
 
     thread_key = "slack:C0DIRECT:#{SecureRandom.hex(6)}"
@@ -77,12 +77,14 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       slack_user_name: "someone-else"
     )
 
+    # @operator has no Slack OAuth credential matching U_OTHER, so this thread is
+    # outside their owner scope. A direct ?thread= link must not surface it.
     get console_threads_url(thread: thread_key)
 
     assert_response :ok
     assert_select ".console-thread-list a.console-thread-link-active[href=?]",
                   console_threads_path(thread: thread_key),
-                  count: 1
+                  count: 0
   end
 
   test "slack assistant-role messages from the current Slack user render as user authored" do
@@ -361,27 +363,23 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     refute_includes sql, "slack_user_id"
   end
 
-  test "direct selected thread can load outside visible Slack list scope" do
+  test "selected session resolves a directly linked thread only within the owner scope" do
     controller = Console::ThreadsController.new
-    direct_thread = SelectedSession.new(thread_key: "slack:C123:1782339173.755169")
+    owned_thread = SelectedSession.new(thread_key: "slack:C123:1782339173.755169")
     scoped_relation = Object.new
-    scoped_relation.define_singleton_method(:where) { |**_kwargs| [] }
-    controller.instance_variable_set(:@selected_thread_key, direct_thread.thread_key)
+    scoped_relation.define_singleton_method(:where) do |thread_key:|
+      thread_key == owned_thread.thread_key ? [ owned_thread ] : []
+    end
     controller.instance_variable_set(:@starting_new_thread, false)
     controller.instance_variable_set(:@sessions, [])
-    controller.define_singleton_method(:direct_selected_session) do |thread_key|
-      direct_thread if thread_key == direct_thread.thread_key
-    end
 
-    selected = controller.send(:selected_session, scoped_relation, [])
+    # An owned key outside the base window is recovered through the scope.
+    controller.instance_variable_set(:@selected_thread_key, owned_thread.thread_key)
+    assert_equal owned_thread, controller.send(:selected_session, scoped_relation, [])
 
-    assert_equal direct_thread, selected
-  end
-
-  test "direct selected thread fallback does not bypass console thread scope" do
-    controller = Console::ThreadsController.new
-
-    assert_nil controller.send(:direct_selected_session, "console:someone-else")
+    # A key the scope does not own has no unscoped fallback, so it stays hidden.
+    controller.instance_variable_set(:@selected_thread_key, "slack:C999:1782339173.999999")
+    assert_nil controller.send(:selected_session, scoped_relation, [])
   end
 
   test "starting a thread is blocked without calling the session api" do


### PR DESCRIPTION
Fixes the two cross-user data-leak paths from the #843 review (findings 1 & 2).

Direct `?thread=` links bypassed the per-user visibility scope: `Console::ThreadsController#direct_selected_session` loaded any `slack:` thread by raw thread_key, and `ApplicationController#console_sidebar_direct_selected_thread` did an unscoped `find_by` for any key — so a signed-in user could view another user's full transcript (main pane) or their thread title + latest-message preview (sidebar) via a crafted link.

**Principle:** a thread is only accessible to the user who started it. Both direct-selection paths now resolve through the existing owner scope (`visible_thread_scope` / `console_sidebar_visible_thread_scope`) instead of a raw lookup:
- Slack threads match via the user's linked Slack OAuth identity (subject/team).
- Console threads match via owner-email — which also covers **future console-created threads** automatically.
- The scoped lookup still recovers an owned thread that falls outside the recent-list window.

Tests updated to assert the secure behavior (a non-owned directly-linked thread is hidden from both sidebar and main pane; `selected_session` has no unscoped fallback).

---
_Stacked on top of #843. Verified via `ruby -c` and (for the markdown loop) a standalone termination reproduction; the full Rails suite must run in CI/the container, which was sandboxed here._