### PR TITLE
fix: harden console markdown rendering and thread-title metadata

### DIFF
--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -374,8 +374,8 @@ class Console::ThreadsController < ApplicationController
       metadata["generated_title"].presence ||
       metadata["summary_title"].presence ||
       metadata["thread_title"].presence ||
-      metadata.dig("thread", "title").presence ||
-      metadata.dig("summary", "title").presence ||
+      (metadata["thread"].is_a?(Hash) ? metadata["thread"]["title"] : nil).presence ||
+      (metadata["summary"].is_a?(Hash) ? metadata["summary"]["title"] : nil).presence ||
       (summary if summary.is_a?(String)).presence ||
       metadata["subject"].presence ||
       metadata["issue_title"].presence

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -155,8 +155,8 @@ module ApplicationHelper
       metadata["generated_title"].presence ||
       metadata["summary_title"].presence ||
       metadata["thread_title"].presence ||
-      metadata.dig("thread", "title").presence ||
-      metadata.dig("summary", "title").presence ||
+      (metadata["thread"].is_a?(Hash) ? metadata["thread"]["title"] : nil).presence ||
+      (metadata["summary"].is_a?(Hash) ? metadata["summary"]["title"] : nil).presence ||
       (summary if summary.is_a?(String)).presence ||
       metadata["subject"].presence ||
       metadata["issue_title"].presence
@@ -261,6 +261,7 @@ module ApplicationHelper
 
     while index < lines.length
       line = lines[index]
+      start_index = index
 
       if line.blank?
         index += 1
@@ -306,6 +307,15 @@ module ApplicationHelper
           index += 1
         end
         blocks << %(<p class="mb-3 last:mb-0">#{markdown_inline(paragraph.join(" "))}</p>)
+      end
+
+      # Guarantee forward progress: a block-start marker with no content (e.g.
+      # a bare "- ", "1. ", or "# ") matches a branch guard but not its inner
+      # consuming regex, which would otherwise spin this loop forever. Emit such
+      # a line as an escaped paragraph and advance.
+      if index == start_index
+        blocks << %(<p class="mb-3 last:mb-0">#{markdown_inline(line)}</p>)
+        index += 1
       end
     end
 

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -322,6 +322,30 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Investigate rollout failure", controller.send(:thread_title, session)
   end
 
+  test "thread title tolerates a plain string summary without raising" do
+    controller = Console::ThreadsController.new
+    session = TranscriptSession.new(
+      metadata_hash: { "summary" => "a plain string" },
+      harness_type: "codex"
+    )
+
+    assert_nothing_raised do
+      assert_equal "a plain string", controller.send(:thread_title, session)
+    end
+  end
+
+  test "thread title tolerates a string thread metadata without raising" do
+    controller = Console::ThreadsController.new
+    session = TranscriptSession.new(
+      metadata_hash: { "thread" => "x", "subject" => "Fallback subject" },
+      harness_type: "codex"
+    )
+
+    assert_nothing_raised do
+      assert_equal "Fallback subject", controller.send(:thread_title, session)
+    end
+  end
+
   test "thread source and harness labels are display cased" do
     controller = Console::ThreadsController.new
     session = TranscriptSession.new(

--- a/services/console/test/helpers/application_helper_test.rb
+++ b/services/console/test/helpers/application_helper_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "timeout"
 
 class ApplicationHelperTest < ActionView::TestCase
   test "truncate_middle leaves short values unchanged" do
@@ -69,6 +70,15 @@ class ApplicationHelperTest < ActionView::TestCase
 
     refute_includes html, "<script>"
     assert_select_in html, "strong", text: "safe"
+  end
+
+  test "console_markdown terminates on bare list and heading markers" do
+    # A line that is only a block-start marker (no content) once spun the
+    # markdown parser forever, pinning a worker. It must render and return.
+    ["- ", "* ", "+ ", "1. ", "# ", "## ", "hello\n- \nworld"].each do |input|
+      html = Timeout.timeout(3) { console_markdown(input) }
+      assert html.present?, "expected markdown for #{input.inspect}"
+    end
   end
 
   test "console_icon renders theme toggle icons" do


### PR DESCRIPTION
Fixes the request-DoS and every-page-500 from the #843 review (findings 3 & 4).

**Markdown DoS:** `markdown_blocks` looped forever on a transcript line that is only a list/heading marker (`- `, `1. `, `# `) — the branch-entry regex matched but the inner consuming regex required content, so the cursor never advanced (Puma worker pinned at 100% CPU). Reachable via the execution-event transcript path, which doesn't squish its text. Fixed by guaranteeing forward progress: a marker-only line now renders as escaped plain text and the parser always advances. Confirmed with a standalone termination reproduction over all marker inputs.

**Thread-title 500:** `thread_title` / `console_sidebar_thread_title` called `metadata.dig("summary", "title")` before the string-summary fallback, raising `TypeError` when `metadata["summary"]`/`["thread"]` is a String. Since the sidebar renders in the shared layout, one such row 500'd every console page for that user. Now digs only when the intermediate is a Hash (fixed in both copies).

---
_Stacked on top of #843. Verified via `ruby -c` and (for the markdown loop) a standalone termination reproduction; the full Rails suite must run in CI/the container, which was sandboxed here._