### PR TITLE
fix: transcript ordering, sidebar query scope, and session DB fallback

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -37,7 +37,15 @@ class ApplicationController < ActionController::Base
   # and pending controllers skip this so pending users can reach the holding page
   # and sign out.
   before_action :require_active_account
-  before_action :load_console_sidebar_threads
+  # The sidebar thread list is global chrome (rendered by layouts/console.html.erb
+  # on every page), but populating it issues several queries against the api-rs
+  # ai_v2 sessions DB, including an unindexed sequential scan + sort of the
+  # sessions table. Running that in every console request blocked pages that only
+  # render the empty-state list (principals, roles, secrets, ...). Instead we
+  # initialize the ivars empty here and load the real list lazily via a Turbo
+  # Frame (Console::ThreadsController#sidebar), so the cross-database work happens
+  # once, out of band, and never blocks the primary page render.
+  before_action :init_console_sidebar_threads
 
   CONSOLE_SIDEBAR_THREAD_LIMIT = 30
   CONSOLE_SIDEBAR_SLACK_PROVIDER = Oauth::Providers::Slack::KEY
@@ -78,6 +86,14 @@ class ApplicationController < ActionController::Base
   # Guard for admin-only controllers (e.g. user management). Not a global gate.
   def require_admin
     redirect_to root_path, alert: "That page is restricted to admins." unless current_user&.admin?
+  end
+
+  # Cheap default so every page renders the empty sidebar list without touching
+  # the sessions DB. The real list is filled in by #load_console_sidebar_threads,
+  # invoked only from the lazy sidebar Turbo Frame.
+  def init_console_sidebar_threads
+    @console_sidebar_threads = []
+    @console_sidebar_latest_messages = {}
   end
 
   def load_console_sidebar_threads

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -49,6 +49,15 @@ class Console::ThreadsController < ApplicationController
     )
   end
 
+  # Lazily-loaded sidebar thread list, requested by the Turbo Frame in
+  # layouts/console.html.erb. Runs the cross-database sessions query out of band
+  # so it never blocks the primary page render. Renders only the frame partial
+  # (no layout). DB errors leave the list empty via load_console_sidebar_threads.
+  def sidebar
+    load_console_sidebar_threads
+    render partial: "console/threads/sidebar_threads", layout: false
+  end
+
   private
 
   def load_threads
@@ -285,11 +294,15 @@ class Console::ThreadsController < ApplicationController
   def selected_messages
     return [] unless @selected_session
 
+    # Fetch the newest MESSAGE_LIMIT messages, then reverse for oldest-first
+    # display. Ordering ascending before LIMIT would return the OLDEST N and
+    # drop the newest for long threads (mirrors selected_events below).
     CentaurSessionMessage
       .where(thread_key: @selected_session.thread_key)
-      .order(:created_at, :message_id)
+      .order(created_at: :desc, message_id: :desc)
       .limit(MESSAGE_LIMIT)
       .to_a
+      .reverse
   end
 
   def selected_executions

--- a/services/console/app/models/centaur_session_record.rb
+++ b/services/console/app/models/centaur_session_record.rb
@@ -19,6 +19,24 @@ class CentaurSessionRecord < ActiveRecord::Base
       end
 
       config = primary_database_configuration.deep_symbolize_keys
+
+      # When the primary config carries a :url (the common single-URL dev setup
+      # where database.yml's default block sets url: <DATABASE_URL>), Rails'
+      # UrlConfig merges the URL-derived keys OVER sibling hash keys. That means
+      # a database path inside the primary URL would override any :database we
+      # set here, silently pointing the session models at the console's own DB.
+      # Resolve the URL into discrete connection params and drop :url so the
+      # ai_v2 database name below is authoritative.
+      if config[:url].present?
+        resolved = ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver
+          .new(config.delete(:url))
+          .to_hash
+          .symbolize_keys
+        config = config.merge(resolved)
+      else
+        config.delete(:url)
+      end
+
       config[:database] = session_database_name(config)
       config
     end

--- a/services/console/app/views/console/threads/_sidebar_threads.html.erb
+++ b/services/console/app/views/console/threads/_sidebar_threads.html.erb
@@ -1,0 +1,30 @@
+<%# Sidebar thread list, rendered inside the lazy console_sidebar_threads Turbo
+    Frame. The turbo-frame id must match the one in layouts/console.html.erb so
+    the deferred fetch replaces the loading placeholder. %>
+<%= turbo_frame_tag "console_sidebar_threads" do %>
+  <% selected_sidebar_thread_key = params[:thread].to_s %>
+  <% if @console_sidebar_threads.blank? %>
+    <div class="console-thread-empty">No recent threads</div>
+  <% else %>
+    <% @console_sidebar_threads.each_with_index do |thread, index| %>
+      <% active_thread = selected_sidebar_thread_key == thread.thread_key %>
+      <% latest_message = @console_sidebar_latest_messages[thread.thread_key] %>
+      <% title = console_sidebar_thread_title(thread, latest_message) %>
+      <%= link_to console_threads_path(thread: thread.thread_key),
+                  class: "console-thread-link #{active_thread ? "console-thread-link-active" : ""} #{index >= 5 && !active_thread ? "console-thread-link-hidden" : ""}",
+                  data: { console_thread_link: true, turbo_frame: "_top" },
+                  title: title do %>
+        <span class="console-thread-title"><%= title %></span>
+        <span class="console-thread-time"><%= local_time(thread.updated_at || thread.created_at, relative: true, format: :compact) %></span>
+      <% end %>
+    <% end %>
+    <% if @console_sidebar_threads.size > 5 %>
+      <button type="button"
+              class="console-thread-show-all"
+              data-console-thread-show-more
+              data-page-size="5">
+        Show more
+      </button>
+    <% end %>
+  <% end %>
+<% end %>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -829,7 +829,6 @@
         </div>
 
         <div class="console-sidebar-scroll">
-          <% selected_sidebar_thread_key = params[:thread].to_s %>
           <nav class="console-nav-list" aria-label="Console sections">
             <% nav_items.each do |item| %>
               <% active = request.path == item[:path] ||
@@ -852,29 +851,14 @@
               <span class="console-nav-label">Threads</span>
             </a>
             <div class="console-thread-list">
-              <% if @console_sidebar_threads.blank? %>
-                <div class="console-thread-empty">No recent threads</div>
-              <% else %>
-                <% @console_sidebar_threads.each_with_index do |thread, index| %>
-                  <% active_thread = selected_sidebar_thread_key == thread.thread_key %>
-                  <% latest_message = @console_sidebar_latest_messages[thread.thread_key] %>
-                  <% title = console_sidebar_thread_title(thread, latest_message) %>
-                  <%= link_to console_threads_path(thread: thread.thread_key),
-                              class: "console-thread-link #{active_thread ? "console-thread-link-active" : ""} #{index >= 5 && !active_thread ? "console-thread-link-hidden" : ""}",
-                              data: { console_thread_link: true },
-                              title: title do %>
-                    <span class="console-thread-title"><%= title %></span>
-                    <span class="console-thread-time"><%= local_time(thread.updated_at || thread.created_at, relative: true, format: :compact) %></span>
-                  <% end %>
-                <% end %>
-                <% if @console_sidebar_threads.size > 5 %>
-                  <button type="button"
-                          class="console-thread-show-all"
-                          data-console-thread-show-more
-                          data-page-size="5">
-                    Show more
-                  </button>
-                <% end %>
+              <%# The thread list is loaded lazily via a Turbo Frame so the
+                  unindexed cross-database sessions query never blocks the primary
+                  page render. See ApplicationController#init_console_sidebar_threads
+                  and Console::ThreadsController#sidebar. %>
+              <%= turbo_frame_tag "console_sidebar_threads",
+                                  src: console_sidebar_threads_path,
+                                  loading: :lazy do %>
+                <div class="console-thread-empty">Loading threads…</div>
               <% end %>
             </div>
           </div>
@@ -1003,29 +987,40 @@
       })();
 
       (() => {
-        const showMoreButton = document.querySelector("[data-console-thread-show-more]");
-        if (!showMoreButton) return;
+        // The thread list is loaded lazily into a Turbo Frame, so the show-more
+        // button does not exist on initial page load. Wire it up both now (in
+        // case the frame is already populated) and each time the frame loads.
+        const wireShowMore = () => {
+          const showMoreButton = document.querySelector("[data-console-thread-show-more]");
+          if (!showMoreButton || showMoreButton.dataset.consoleThreadShowMoreWired === "true") return;
 
-        const list = showMoreButton.closest(".console-thread-list");
-        if (!list) return;
+          const list = showMoreButton.closest(".console-thread-list");
+          if (!list) return;
 
-        const revealNextThreads = () => {
-          const pageSize = Number.parseInt(showMoreButton.dataset.pageSize || "5", 10);
-          const hiddenThreads = Array.from(list.querySelectorAll(".console-thread-link-hidden"));
-          hiddenThreads.slice(0, Number.isFinite(pageSize) ? pageSize : 5).forEach((link) => {
-            link.classList.remove("console-thread-link-hidden");
-          });
+          const revealNextThreads = () => {
+            const pageSize = Number.parseInt(showMoreButton.dataset.pageSize || "5", 10);
+            const hiddenThreads = Array.from(list.querySelectorAll(".console-thread-link-hidden"));
+            hiddenThreads.slice(0, Number.isFinite(pageSize) ? pageSize : 5).forEach((link) => {
+              link.classList.remove("console-thread-link-hidden");
+            });
+
+            if (!list.querySelector(".console-thread-link-hidden")) {
+              showMoreButton.hidden = true;
+            }
+          };
 
           if (!list.querySelector(".console-thread-link-hidden")) {
             showMoreButton.hidden = true;
+          } else {
+            showMoreButton.addEventListener("click", revealNextThreads);
           }
+          showMoreButton.dataset.consoleThreadShowMoreWired = "true";
         };
 
-        if (!list.querySelector(".console-thread-link-hidden")) {
-          showMoreButton.hidden = true;
-        } else {
-          showMoreButton.addEventListener("click", revealNextThreads);
-        }
+        wireShowMore();
+        document.addEventListener("turbo:frame-load", (event) => {
+          if (event.target && event.target.id === "console_sidebar_threads") wireShowMore();
+        });
       })();
     </script>
   </body>

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -28,6 +28,10 @@ Rails.application.routes.draw do
   get "console/principals/:id", to: "console#principal", as: :console_principal
   namespace :console do
     resources :threads, only: %i[index create]
+    # Lazily-loaded sidebar thread list (Turbo Frame src). Kept off the main
+    # page render so the unindexed cross-database sessions query does not block
+    # every console page. See ApplicationController#load_console_sidebar_threads.
+    get "sidebar_threads", to: "threads#sidebar", as: :sidebar_threads
   end
   namespace :console do
     resources :roles, only: %i[index show new create edit update] do

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -486,11 +486,9 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   # oldest-first display order. A previous ascending order + limit returned the
   # oldest N and dropped the newest for long threads.
   test "selected_messages query fetches newest messages first with a limit" do
-    controller = Console::ThreadsController.new
-    controller.instance_variable_set(
-      :@selected_session,
-      SelectedSession.new(thread_key: "console:ordering")
-    )
+    # Building the SQL type-casts against the session_messages schema, which
+    # only exists where the api-rs session tables are present.
+    skip_unless_session_table
 
     relation = CentaurSessionMessage
       .where(thread_key: "console:ordering")

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -445,6 +445,88 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Threads are read-only while browsing a mirrored production snapshot.", flash[:alert]
   end
 
+  # Fix 6: the sidebar thread list is loaded lazily via a Turbo Frame so the
+  # cross-database sessions query never runs during the primary page render.
+  test "console pages defer the sidebar thread list to a lazy turbo frame" do
+    # A non-thread page must not run the sessions query during its render: if it
+    # did, load_console_sidebar_threads would be invoked. Track invocations and
+    # assert none happen while rendering the primary page.
+    original = ApplicationController.instance_method(:load_console_sidebar_threads)
+    Thread.current[:sidebar_loaded] = false
+    ApplicationController.send(:define_method, :load_console_sidebar_threads) do
+      Thread.current[:sidebar_loaded] = true
+      original.bind(self).call
+    end
+
+    begin
+      get console_principals_url
+
+      assert_response :ok
+      assert_not Thread.current[:sidebar_loaded],
+                 "primary page render must not load the sidebar thread list"
+      assert_select "turbo-frame#console_sidebar_threads[src=?]", console_sidebar_threads_path
+      assert_select "turbo-frame#console_sidebar_threads[loading=?]", "lazy"
+    ensure
+      ApplicationController.send(:define_method, :load_console_sidebar_threads, original)
+      Thread.current[:sidebar_loaded] = nil
+    end
+  end
+
+  test "sidebar action renders the empty thread list when the session DB is unavailable" do
+    with_recent_first_error do
+      get console_sidebar_threads_url
+    end
+
+    assert_response :ok
+    assert_select "turbo-frame#console_sidebar_threads"
+    assert_select ".console-thread-empty", text: /No recent threads/
+  end
+
+  # Fix 5: selected_messages must return the NEWEST MESSAGE_LIMIT messages, in
+  # oldest-first display order. A previous ascending order + limit returned the
+  # oldest N and dropped the newest for long threads.
+  test "selected_messages query fetches newest messages first with a limit" do
+    controller = Console::ThreadsController.new
+    controller.instance_variable_set(
+      :@selected_session,
+      SelectedSession.new(thread_key: "console:ordering")
+    )
+
+    relation = CentaurSessionMessage
+      .where(thread_key: "console:ordering")
+      .order(created_at: :desc, message_id: :desc)
+      .limit(Console::ThreadsController::MESSAGE_LIMIT)
+    sql = relation.to_sql
+
+    assert_match(/ORDER BY.*created_at.*DESC.*message_id.*DESC/i, sql)
+    assert_match(/LIMIT #{Console::ThreadsController::MESSAGE_LIMIT}\b/, sql)
+  end
+
+  test "selected_messages returns newest messages in ascending display order" do
+    skip_unless_session_table
+
+    thread_key = "console:transcript-order"
+    insert_console_session(thread_key)
+
+    limit = Console::ThreadsController::MESSAGE_LIMIT
+    total = limit + 5
+    total.times do |i|
+      insert_session_message(thread_key, index: i)
+    end
+
+    controller = Console::ThreadsController.new
+    controller.instance_variable_set(:@selected_session, SelectedSession.new(thread_key: thread_key))
+
+    messages = controller.send(:selected_messages)
+
+    assert_equal limit, messages.size
+    indices = messages.map { |m| m.message_id.split("-").last.to_i }
+    # Oldest-first display order over the newest `limit` messages: the earliest
+    # (index 0..4) are dropped, and what remains is ascending.
+    assert_equal (total - limit...total).to_a, indices
+    assert_equal indices, indices.sort
+  end
+
   private
 
   def with_recent_first_error
@@ -497,6 +579,22 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       slack_user_name: slack_user_name
     }.to_json
     insert_session(thread_key, metadata)
+  end
+
+  def insert_session_message(thread_key, index:)
+    connection = CentaurSession.connection
+    parts = [ { type: "text", text: "message #{index}" } ].to_json
+    connection.execute(<<~SQL.squish)
+      insert into session_messages (message_id, thread_key, role, parts, metadata, created_at)
+      values (
+        #{connection.quote("#{thread_key}-msg-#{index}")},
+        #{connection.quote(thread_key)},
+        'user',
+        #{connection.quote(parts)}::jsonb,
+        '{}'::jsonb,
+        now() + (#{index} * interval '1 second')
+      )
+    SQL
   end
 
   def insert_session(thread_key, metadata)

--- a/services/console/test/helpers/application_helper_test.rb
+++ b/services/console/test/helpers/application_helper_test.rb
@@ -75,7 +75,7 @@ class ApplicationHelperTest < ActionView::TestCase
   test "console_markdown terminates on bare list and heading markers" do
     # A line that is only a block-start marker (no content) once spun the
     # markdown parser forever, pinning a worker. It must render and return.
-    ["- ", "* ", "+ ", "1. ", "# ", "## ", "hello\n- \nworld"].each do |input|
+    [ "- ", "* ", "+ ", "1. ", "# ", "## ", "hello\n- \nworld" ].each do |input|
       html = Timeout.timeout(3) { console_markdown(input) }
       assert html.present?, "expected markdown for #{input.inspect}"
     end

--- a/services/console/test/models/centaur_session_record_test.rb
+++ b/services/console/test/models/centaur_session_record_test.rb
@@ -7,6 +7,14 @@ require "test_helper"
 # UrlConfig merges url-derived keys over sibling hash keys. The fallback must
 # resolve the url into discrete params, drop :url, and force the ai_v2 name.
 class CentaurSessionRecordTest < ActiveSupport::TestCase
+  # session_database_configuration is environment-sensitive and the class body
+  # calls establish_connection with its result the first time the constant is
+  # referenced. Force that (clean, real-test-env) load here, at file-require
+  # time, so the tests below can stub Rails.env / the primary config to exercise
+  # the production path WITHOUT repointing the process-wide session connection
+  # at a database that does not exist in CI (ai_v2).
+  CentaurSessionRecord
+
   def build_config
     CentaurSessionRecord.send(:session_database_configuration)
   end
@@ -30,21 +38,22 @@ class CentaurSessionRecordTest < ActiveSupport::TestCase
     CentaurSessionRecord.stub(:primary_database_configuration, config) { yield }
   end
 
-  test "fallback targets ai_v2 even when the primary url has another database path" do
-    with_env(
-      "CENTAUR_CONSOLE_CENTAUR_DATABASE_URL" => nil,
-      "CENTAUR_DATABASE_URL" => nil,
-      "CENTAUR_CONSOLE_CENTAUR_DATABASE_NAME" => nil,
-      "CENTAUR_DATABASE_NAME" => "ai_v2"
-    ) do
-      primary = {
-        "adapter" => "postgresql",
-        "encoding" => "unicode",
-        "pool" => 5,
-        "url" => "postgres://console_user:secret@db-host:6543/iron_control_development"
-      }
+  # Stub the production (non-test) branch of session_database_name without
+  # mutating ENV, so building the config here never rebinds the live connection.
+  def as_production
+    Rails.env.stub(:test?, false) { yield }
+  end
 
-      stub_primary(primary) do
+  test "fallback targets ai_v2 even when the primary url has another database path" do
+    primary = {
+      "adapter" => "postgresql",
+      "encoding" => "unicode",
+      "pool" => 5,
+      "url" => "postgres://console_user:secret@db-host:6543/iron_control_development"
+    }
+
+    stub_primary(primary) do
+      as_production do
         config = build_config
 
         assert_equal "ai_v2", config[:database]
@@ -57,27 +66,41 @@ class CentaurSessionRecordTest < ActiveSupport::TestCase
   end
 
   test "fallback keeps ai_v2 for a host/port style primary config without a url" do
-    with_env(
-      "CENTAUR_CONSOLE_CENTAUR_DATABASE_URL" => nil,
-      "CENTAUR_DATABASE_URL" => nil,
-      "CENTAUR_CONSOLE_CENTAUR_DATABASE_NAME" => nil,
-      "CENTAUR_DATABASE_NAME" => "ai_v2"
-    ) do
-      primary = {
-        "adapter" => "postgresql",
-        "host" => "localhost",
-        "port" => 5432,
-        "username" => "postgres",
-        "database" => "iron_control_development"
-      }
+    primary = {
+      "adapter" => "postgresql",
+      "host" => "localhost",
+      "port" => 5432,
+      "username" => "postgres",
+      "database" => "iron_control_development"
+    }
 
-      stub_primary(primary) do
+    stub_primary(primary) do
+      as_production do
         config = build_config
 
         assert_equal "ai_v2", config[:database]
         assert_not config.key?(:url)
         assert_equal "localhost", config[:host]
       end
+    end
+  end
+
+  test "test environment points the session models at the console database" do
+    primary = {
+      "adapter" => "postgresql",
+      "host" => "localhost",
+      "port" => 5432,
+      "username" => "postgres",
+      "database" => "iron_control_test"
+    }
+
+    stub_primary(primary) do
+      # Real (test) env: the session connection must resolve to the console's
+      # own test database, which exists in CI, so session-table-dependent tests
+      # can skip rather than error on a missing ai_v2 database.
+      config = build_config
+
+      assert_equal "iron_control_test", config[:database]
     end
   end
 

--- a/services/console/test/models/centaur_session_record_test.rb
+++ b/services/console/test/models/centaur_session_record_test.rb
@@ -10,9 +10,9 @@ class CentaurSessionRecordTest < ActiveSupport::TestCase
   # session_database_configuration is environment-sensitive and the class body
   # calls establish_connection with its result the first time the constant is
   # referenced. Force that (clean, real-test-env) load here, at file-require
-  # time, so the tests below can stub Rails.env / the primary config to exercise
-  # the production path WITHOUT repointing the process-wide session connection
-  # at a database that does not exist in CI (ai_v2).
+  # time, so the tests below can override the primary config / database name
+  # WITHOUT repointing the process-wide session connection at a database that
+  # does not exist in CI (ai_v2).
   CentaurSessionRecord
 
   def build_config
@@ -34,14 +34,15 @@ class CentaurSessionRecordTest < ActiveSupport::TestCase
     originals.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
   end
 
-  def stub_primary(config)
-    CentaurSessionRecord.stub(:primary_database_configuration, config) { yield }
-  end
-
-  # Stub the production (non-test) branch of session_database_name without
-  # mutating ENV, so building the config here never rebinds the live connection.
-  def as_production
-    Rails.env.stub(:test?, false) { yield }
+  # Override the (private) primary-config source without touching the live
+  # connection, matching the define_singleton_method pattern used elsewhere in
+  # the suite.
+  def with_primary(config)
+    original = CentaurSessionRecord.method(:primary_database_configuration)
+    CentaurSessionRecord.define_singleton_method(:primary_database_configuration) { config }
+    yield
+  ensure
+    CentaurSessionRecord.define_singleton_method(:primary_database_configuration, original)
   end
 
   test "fallback targets ai_v2 even when the primary url has another database path" do
@@ -52,8 +53,8 @@ class CentaurSessionRecordTest < ActiveSupport::TestCase
       "url" => "postgres://console_user:secret@db-host:6543/iron_control_development"
     }
 
-    stub_primary(primary) do
-      as_production do
+    with_primary(primary) do
+      with_env("CENTAUR_DATABASE_NAME" => "ai_v2") do
         config = build_config
 
         assert_equal "ai_v2", config[:database]
@@ -74,8 +75,8 @@ class CentaurSessionRecordTest < ActiveSupport::TestCase
       "database" => "iron_control_development"
     }
 
-    stub_primary(primary) do
-      as_production do
+    with_primary(primary) do
+      with_env("CENTAUR_DATABASE_NAME" => "ai_v2") do
         config = build_config
 
         assert_equal "ai_v2", config[:database]
@@ -94,13 +95,16 @@ class CentaurSessionRecordTest < ActiveSupport::TestCase
       "database" => "iron_control_test"
     }
 
-    stub_primary(primary) do
-      # Real (test) env: the session connection must resolve to the console's
-      # own test database, which exists in CI, so session-table-dependent tests
-      # can skip rather than error on a missing ai_v2 database.
-      config = build_config
+    with_primary(primary) do
+      with_env("CENTAUR_DATABASE_NAME" => nil, "CENTAUR_CONSOLE_CENTAUR_DATABASE_NAME" => nil) do
+        # No explicit name override: in the test environment the session
+        # connection must resolve to the console's own test database, which
+        # exists in CI, so session-table-dependent tests can skip rather than
+        # error on a missing ai_v2 database.
+        config = build_config
 
-      assert_equal "iron_control_test", config[:database]
+        assert_equal "iron_control_test", config[:database]
+      end
     end
   end
 

--- a/services/console/test/models/centaur_session_record_test.rb
+++ b/services/console/test/models/centaur_session_record_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+# Fix 7: when CENTAUR_CONSOLE_CENTAUR_DATABASE_URL is unset, the session DB
+# config falls back to the primary config with the database name overridden to
+# ai_v2. The primary config commonly carries a :url (single-URL dev setup); a
+# database path inside that url used to override the ai_v2 name because Rails'
+# UrlConfig merges url-derived keys over sibling hash keys. The fallback must
+# resolve the url into discrete params, drop :url, and force the ai_v2 name.
+class CentaurSessionRecordTest < ActiveSupport::TestCase
+  def build_config
+    CentaurSessionRecord.send(:session_database_configuration)
+  end
+
+  def with_env(overrides)
+    originals = {}
+    overrides.each do |key, value|
+      originals[key] = ENV[key]
+      if value.nil?
+        ENV.delete(key)
+      else
+        ENV[key] = value
+      end
+    end
+    yield
+  ensure
+    originals.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+
+  def stub_primary(config)
+    CentaurSessionRecord.stub(:primary_database_configuration, config) { yield }
+  end
+
+  test "fallback targets ai_v2 even when the primary url has another database path" do
+    with_env(
+      "CENTAUR_CONSOLE_CENTAUR_DATABASE_URL" => nil,
+      "CENTAUR_DATABASE_URL" => nil,
+      "CENTAUR_CONSOLE_CENTAUR_DATABASE_NAME" => nil,
+      "CENTAUR_DATABASE_NAME" => "ai_v2"
+    ) do
+      primary = {
+        "adapter" => "postgresql",
+        "encoding" => "unicode",
+        "pool" => 5,
+        "url" => "postgres://console_user:secret@db-host:6543/iron_control_development"
+      }
+
+      stub_primary(primary) do
+        config = build_config
+
+        assert_equal "ai_v2", config[:database]
+        assert_not config.key?(:url), "resolved config should not carry a :url key"
+        assert_equal "db-host", config[:host]
+        assert_equal 6543, config[:port]
+        assert_equal "console_user", config[:username]
+      end
+    end
+  end
+
+  test "fallback keeps ai_v2 for a host/port style primary config without a url" do
+    with_env(
+      "CENTAUR_CONSOLE_CENTAUR_DATABASE_URL" => nil,
+      "CENTAUR_DATABASE_URL" => nil,
+      "CENTAUR_CONSOLE_CENTAUR_DATABASE_NAME" => nil,
+      "CENTAUR_DATABASE_NAME" => "ai_v2"
+    ) do
+      primary = {
+        "adapter" => "postgresql",
+        "host" => "localhost",
+        "port" => 5432,
+        "username" => "postgres",
+        "database" => "iron_control_development"
+      }
+
+      stub_primary(primary) do
+        config = build_config
+
+        assert_equal "ai_v2", config[:database]
+        assert_not config.key?(:url)
+        assert_equal "localhost", config[:host]
+      end
+    end
+  end
+
+  test "explicit session url is used verbatim without touching the primary config" do
+    with_env(
+      "CENTAUR_CONSOLE_CENTAUR_DATABASE_URL" => "postgres://u:p@remote:5432/ai_v2",
+      "CENTAUR_DATABASE_URL" => nil
+    ) do
+      config = build_config
+
+      assert_equal "postgres://u:p@remote:5432/ai_v2", config[:url]
+      assert_equal "postgresql", config[:adapter]
+      assert_nil config[:database]
+    end
+  end
+end


### PR DESCRIPTION
Fixes findings 5, 6, and 7 from the #843 review.

**5 — Transcript dropped the newest messages:** `selected_messages` ordered ascending then `limit(80)`, returning the *oldest* 80 for long threads while the view auto-scrolls to the bottom. Now fetches newest-first then reverses for display, matching `selected_events`.

**6 — Sidebar query ran on every console page:** `load_console_sidebar_threads` was a global `before_action` issuing unindexed cross-DB queries against the api-rs `ai_v2` sessions table on every page (principals, roles, secrets, ...), even where no threads render. The thread list is global sidebar chrome, so it's now loaded lazily via a Turbo Frame (`Console::ThreadsController#sidebar`); the primary page render no longer blocks on the sessions DB. The ownership scoping from the access-control PR is preserved.

**7 — Session DB fallback hit the wrong database:** the no-`CENTAUR_CONSOLE_CENTAUR_DATABASE_URL` fallback kept the primary config's `url:` key, so a DB path in `CENTAUR_CONSOLE_DATABASE_URL` (the shared-URL dev setup) overrode `ai_v2` and broke the Threads page. Now resolves the URL to discrete params via `ConnectionUrlResolver`, drops `url:`, and forces the `ai_v2` database name.

---
_Stacked on top of #843. Verified via `ruby -c` and (for the markdown loop) a standalone termination reproduction; the full Rails suite must run in CI/the container, which was sandboxed here._