### PR TITLE
fix: remove passwordless ?auth= console sign-in backdoor

### DIFF
--- a/services/console/README.md
+++ b/services/console/README.md
@@ -35,12 +35,10 @@ The Threads tab reads api-rs session rows from the Centaur API database. Set
 the console's primary database. In the Helm chart this is sourced from the
 shared `DATABASE_URL` secret key.
 
-For local-only browser sessions, `CENTAUR_CONSOLE_LOCAL_AUTH_PARAM_ENABLED=1`
-enables a passwordless query-param shortcut on localhost hosts. Use
-`http://localhost:3000/console/threads?auth=1` to sign in as
-`CENTAUR_CONSOLE_LOCAL_AUTH_EMAIL`, `CENTAUR_CONSOLE_INITIAL_USER_EMAIL`, or the
-first active admin user. Use `?auth=user@example.com` to choose a specific
-active user. The shortcut is ignored on non-local hosts.
+For local development, sign in through the normal login form at
+`http://localhost:3000/login` with the seeded initial user's
+`CENTAUR_CONSOLE_INITIAL_USER_EMAIL` / `CENTAUR_CONSOLE_INITIAL_USER_PASSWORD`
+credentials, the same as every other environment.
 
 To build the Threads UX against production-shaped data without connecting the
 Console to production, create a bounded local snapshot:

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -1,7 +1,4 @@
 class ApplicationController < ActionController::Base
-  LOCAL_AUTH_HOSTS = %w[localhost 127.0.0.1 ::1 0.0.0.0].freeze
-  TRUE_PARAM_VALUES = %w[1 true yes on local dev].freeze
-
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
@@ -31,11 +28,6 @@ class ApplicationController < ActionController::Base
     URI.join(public_base_url, "/oauth/#{slug}/callback").to_s
   end
 
-  # A development shortcut for local browser sessions. It is gated by host and
-  # env so production deployments do not accidentally expose a passwordless
-  # sign-in flow.
-  before_action :apply_local_auth_param
-
   # Gate every UI route behind a console session by default. Controllers that
   # must stay reachable while signed out (e.g. the login form) skip this. API
   # controllers descend from ActionController::API, not this class, so they keep
@@ -63,23 +55,6 @@ class ApplicationController < ActionController::Base
   # from Api::BaseController#current_user, which resolves a User from an API key.
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
-  end
-
-  def apply_local_auth_param
-    return unless request.get? || request.head?
-    return unless params.key?(:auth)
-    return if current_user
-    return unless local_auth_param_allowed?
-
-    user = local_auth_param_user
-    unless user
-      Rails.logger.warn("console local auth param did not match an active user")
-      return
-    end
-
-    reset_session
-    session[:user_id] = user.id
-    @current_user = user
   end
 
   # before_action gate for console pages: bounce anonymous requests to the login
@@ -156,41 +131,6 @@ class ApplicationController < ActionController::Base
     uri.to_s
   rescue URI::InvalidURIError
     default
-  end
-
-  def local_auth_param_allowed?
-    local_auth_param_enabled? && local_auth_host? && local_auth_path?
-  end
-
-  def local_auth_param_enabled?
-    Rails.env.development? ||
-      Rails.env.test? ||
-      TRUE_PARAM_VALUES.include?(ConsoleEnv["LOCAL_AUTH_PARAM_ENABLED"].to_s.strip.downcase)
-  end
-
-  def local_auth_host?
-    LOCAL_AUTH_HOSTS.include?(request.host.to_s.downcase)
-  end
-
-  def local_auth_path?
-    request.path == "/" || request.path == login_path || request.path.start_with?("/console")
-  end
-
-  def local_auth_param_user
-    users = User.active.order(admin: :desc, id: :asc)
-    email = local_auth_param_email
-    return users.find_by(email: email) if email.present?
-
-    configured_email = ConsoleEnv["LOCAL_AUTH_EMAIL"].presence ||
-      ConsoleEnv["INITIAL_USER_EMAIL"].presence
-    users.find_by(email: configured_email.to_s.strip.downcase) || users.first
-  end
-
-  def local_auth_param_email
-    value = params[:auth].to_s.strip
-    return if value.blank? || TRUE_PARAM_VALUES.include?(value.downcase)
-
-    value.downcase
   end
 
   def render_not_found(e)

--- a/services/console/test/controllers/sessions_controller_test.rb
+++ b/services/console/test/controllers/sessions_controller_test.rb
@@ -9,51 +9,6 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[action=?]", login_path
   end
 
-  test "local auth param signs in and redirects to requested console path" do
-    host! "localhost"
-
-    get login_url, params: { auth: @operator.email, next: console_threads_path }
-
-    assert_redirected_to console_threads_path
-    assert_equal @operator.id, session[:user_id]
-  end
-
-  test "local auth param can sign in directly on a console URL" do
-    host! "localhost"
-
-    get console_threads_url, params: { auth: @operator.email }
-
-    assert_response :ok
-    assert_equal @operator.id, session[:user_id]
-  end
-
-  test "local auth param falls back to the first active admin for true values" do
-    host! "localhost"
-
-    get login_url, params: { auth: "1" }
-
-    assert_redirected_to console_principals_path
-    assert_equal @operator.id, session[:user_id]
-  end
-
-  test "auth param is ignored for non-local hosts" do
-    host! "console.example"
-
-    get login_url, params: { auth: @operator.email }
-
-    assert_response :ok
-    assert_nil session[:user_id]
-  end
-
-  test "local auth return path rejects external redirects" do
-    host! "localhost"
-
-    get login_url, params: { auth: @operator.email, next: "https://example.test/console/threads" }
-
-    assert_redirected_to console_principals_path
-    assert_equal @operator.id, session[:user_id]
-  end
-
   test "valid credentials sign in and redirect to the console" do
     post login_url, params: { email: @operator.email, password: "password123456" }
     assert_redirected_to console_principals_path


### PR DESCRIPTION
Removes the passwordless local-auth mechanism (finding 8 from the #843 review).

`?auth=<email>` (or `?auth=1`) signed a browser in with no password, gated only by an env flag and a `request.host` check. `request.host` comes from the attacker-controllable Host header and Rails host authorization isn't configured, so enabling the flag on a reachable deploy allowed passwordless admin sign-in via a spoofed `Host: localhost`.

Removed entirely: the `apply_local_auth_param` before_action and all `local_auth_*` helpers, the `LOCAL_AUTH_HOSTS`/`TRUE_PARAM_VALUES` constants (confirmed unused elsewhere), the 5 dedicated tests, and the README shortcut. Local development uses the seeded `CENTAUR_CONSOLE_INITIAL_USER_EMAIL`/`_PASSWORD` login like every other environment. (No chart/compose wiring for the flag existed.)

---
_Stacked on top of #843. Verified via `ruby -c` and (for the markdown loop) a standalone termination reproduction; the full Rails suite must run in CI/the container, which was sandboxed here._