### PR TITLE
fix: avoid api attachment downloads from sandbox

### DIFF
--- a/centaur_sdk/tests/test_tool_sdk.py
+++ b/centaur_sdk/tests/test_tool_sdk.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -9,6 +10,7 @@ from centaur_sdk import (
     current_session_context,
     current_slack_thread,
     reset_tool_context,
+    save_attachment,
     secret,
     set_tool_context,
 )
@@ -137,6 +139,53 @@ def test_current_slack_thread_returns_api_slack_destination(
         assert current_slack_thread() == {"channel_id": "C123", "thread_ts": "123.456"}
     finally:
         reset_tool_context(token)
+
+
+def test_save_attachment_writes_to_sandbox_uploads_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    def fail_urlopen(*_args, **_kwargs):
+        raise AssertionError("save_attachment should not call the API in sandbox mode")
+
+    monkeypatch.setenv("CENTAUR_UPLOADS_DIR", str(tmp_path))
+    monkeypatch.setattr("urllib.request.urlopen", fail_urlopen)
+
+    result = save_attachment(
+        name="../report.txt",
+        data=b"hello",
+        mime_type="text/plain",
+        source_url="https://example.test/report",
+    )
+
+    saved_path = tmp_path / "report.txt"
+    assert saved_path.read_bytes() == b"hello"
+    assert result == {
+        "attachment_id": None,
+        "filename": "report.txt",
+        "mime_type": "text/plain",
+        "download_url": None,
+        "path": str(saved_path),
+        "local_path": str(saved_path),
+        "source_url": "https://example.test/report",
+        "size_bytes": 5,
+    }
+
+
+def test_save_attachment_uses_unique_local_name_on_collision(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    monkeypatch.setenv("CENTAUR_UPLOADS_DIR", str(tmp_path))
+
+    first = save_attachment(name="same.txt", data=b"first")
+    second = save_attachment(name="same.txt", data=b"second")
+
+    assert first["path"] != second["path"]
+    assert (tmp_path / "same.txt").read_bytes() == b"first"
+    second_path = Path(str(second["path"]))
+    assert second_path.exists()
+    assert second_path.read_bytes() == b"second"
+    assert second_path.name.startswith("same-")
+    assert second_path.suffix == ".txt"
 
 
 @pytest.mark.asyncio

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -7,12 +7,14 @@ import contextlib
 import json
 import logging
 import mimetypes
-from urllib.parse import quote
+import os
 import urllib.request
+import uuid
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 log = logging.getLogger(__name__)
 
@@ -125,6 +127,47 @@ def current_slack_thread() -> dict[str, str]:
     }
 
 
+def _sandbox_uploads_dir() -> Path | None:
+    configured = os.environ.get("CENTAUR_UPLOADS_DIR", "").strip()
+    if configured:
+        return Path(configured)
+    if os.environ.get("CENTAUR_THREAD_KEY", "").strip():
+        return Path.home() / "uploads"
+    return None
+
+
+def _unique_upload_path(uploads_dir: Path, name: str) -> Path:
+    candidate = uploads_dir / name
+    if not candidate.exists():
+        return candidate
+    suffix = candidate.suffix
+    stem = candidate.stem or "attachment"
+    return uploads_dir / f"{stem}-{uuid.uuid4().hex}{suffix}"
+
+
+def _save_local_attachment(
+    *,
+    name: str,
+    data: bytes,
+    mime_type: str,
+    source_url: str | None,
+    uploads_dir: Path,
+) -> dict[str, Any]:
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+    path = _unique_upload_path(uploads_dir, name)
+    path.write_bytes(data)
+    return {
+        "attachment_id": None,
+        "filename": name,
+        "mime_type": mime_type,
+        "download_url": None,
+        "path": str(path),
+        "local_path": str(path),
+        "source_url": source_url,
+        "size_bytes": len(data),
+    }
+
+
 def save_attachment(
     *,
     name: str,
@@ -133,9 +176,19 @@ def save_attachment(
     source_url: str | None = None,
 ) -> dict[str, Any]:
     """Persist bytes as a Centaur attachment scoped to the current tool thread."""
-    thread_key = current_thread_key()
     safe_name = Path(name).name or "attachment"
     resolved_mime = mime_type or mimetypes.guess_type(safe_name)[0] or "application/octet-stream"
+    uploads_dir = _sandbox_uploads_dir()
+    if uploads_dir is not None:
+        return _save_local_attachment(
+            name=safe_name,
+            data=data,
+            mime_type=resolved_mime,
+            source_url=source_url,
+            uploads_dir=uploads_dir,
+        )
+
+    thread_key = current_thread_key()
     base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
     payload = json.dumps(
         {

--- a/crates/harness-server/Cargo.lock
+++ b/crates/harness-server/Cargo.lock
@@ -1461,10 +1461,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1548,7 +1546,6 @@ dependencies = [
  "codex-utils-absolute-path",
  "opentelemetry-proto",
  "prost",
- "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1756,7 +1753,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2336,12 +2332,6 @@ checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-types"
@@ -2935,61 +2925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases 0.2.1",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases 0.2.1",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,9 +3421,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "encoding_rs",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3503,8 +3436,6 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3512,7 +3443,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3520,7 +3450,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3579,12 +3508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3640,7 +3563,6 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -4998,16 +4920,6 @@ name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -21,7 +21,6 @@ codex-protocol = { git = "https://github.com/openai/codex", rev = "e93dc98a48d59
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "e93dc98a48d597df322436ffe8d03bfd7ec63b3b", package = "codex-utils-absolute-path" }
 opentelemetry-proto = { version = "0.32.0", default-features = false, features = ["trace", "gen-tonic-messages"] }
 prost = "0.14"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -18,7 +18,6 @@ use codex_app_server_protocol::{
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
-use url::Url;
 use uuid::Uuid;
 
 use crate::amp::AmpHarness;
@@ -434,7 +433,7 @@ fn blocks_content_to_user_input(
 fn blocks_input_to_user_input(
     input: &BlocksInput,
     state: &mut BlocksState,
-    trace_context: &TraceContext,
+    _trace_context: &TraceContext,
 ) -> Result<Vec<UserInput>> {
     match input {
         BlocksInput::UserInput(input) => Ok(vec![input.clone()]),
@@ -442,7 +441,7 @@ fn blocks_input_to_user_input(
             attachment_block_to_user_input(block, state)
         }
         BlocksInput::Attachment(block) if block.kind == "attachment_ref" => {
-            Ok(attachment_ref_block_to_user_input(block, trace_context))
+            Ok(attachment_ref_block_to_user_input(block))
         }
         BlocksInput::Attachment(block) => Ok(vec![UserInput::Text {
             text: format!("[Unsupported attachment block type: {}]", block.kind),
@@ -451,37 +450,10 @@ fn blocks_input_to_user_input(
     }
 }
 
-fn attachment_ref_block_to_user_input(
-    block: &AttachmentBlock,
-    trace_context: &TraceContext,
-) -> Vec<UserInput> {
+fn attachment_ref_block_to_user_input(block: &AttachmentBlock) -> Vec<UserInput> {
     let attachment_id = non_empty(block.attachment_id.as_deref());
     let mime_type = non_empty(block.mime_type.as_deref());
-    let attachment_type = non_empty(block.attachment_type.as_deref());
     let name = non_empty(block.name.as_deref()).unwrap_or("attachment");
-
-    if let (Some(attachment_id), Some(thread_key)) = (
-        attachment_id,
-        non_empty(trace_context.thread_key.as_deref()),
-    ) {
-        match download_attachment_ref(attachment_id, thread_key, name, mime_type) {
-            Ok(path) => {
-                return local_file_inputs(
-                    &path,
-                    mime_type,
-                    is_image_attachment(attachment_type, mime_type),
-                );
-            }
-            Err(error) => {
-                return vec![UserInput::Text {
-                    text: format!(
-                        "[Attachment reference could not be downloaded: id={attachment_id} name={name} error={error}. The file is not preloaded in /home/agent/uploads; recover it locally before inspecting it.]"
-                    ),
-                    text_elements: Vec::new(),
-                }];
-            }
-        }
-    }
 
     let mut fields = Vec::new();
     if let Some(attachment_id) = attachment_id {
@@ -499,58 +471,10 @@ fn attachment_ref_block_to_user_input(
     };
     vec![UserInput::Text {
         text: format!(
-            "[Attachment reference: {summary}. The file is not preloaded in /home/agent/uploads; recover it locally before inspecting it.]"
+            "[Attachment reference: {summary}. The file was not provided to this sandbox. Ask the caller to resend the attachment as an upload, inline file data, or staged attachment chunk before inspecting it.]"
         ),
         text_elements: Vec::new(),
     }]
-}
-
-fn download_attachment_ref(
-    attachment_id: &str,
-    thread_key: &str,
-    name: &str,
-    mime_type: Option<&str>,
-) -> std::result::Result<PathBuf, String> {
-    let api_base = attachment_api_base().ok_or_else(|| "CENTAUR_API_URL is not set".to_string())?;
-    let url = attachment_download_url(&api_base, attachment_id, thread_key)?;
-    let response = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-        .map_err(|error| error.to_string())?
-        .get(url)
-        .send()
-        .map_err(|error| error.to_string())?;
-    let status = response.status();
-    if !status.is_success() {
-        return Err(format!("download returned HTTP {status}"));
-    }
-    let bytes = response.bytes().map_err(|error| error.to_string())?;
-    let path = unique_upload_path(name, mime_type).map_err(|error| error.to_string())?;
-    std::fs::write(&path, &bytes).map_err(|error| error.to_string())?;
-    Ok(path)
-}
-
-fn attachment_api_base() -> Option<String> {
-    ["CENTAUR_API_URL", "SESSION_SANDBOX_CENTAUR_API_URL"]
-        .iter()
-        .find_map(|name| non_empty(env::var(name).ok().as_deref()).map(str::to_owned))
-}
-
-fn attachment_download_url(
-    api_base: &str,
-    attachment_id: &str,
-    thread_key: &str,
-) -> std::result::Result<Url, String> {
-    let mut url = Url::parse(api_base.trim_end_matches('/')).map_err(|error| error.to_string())?;
-    {
-        let mut segments = url
-            .path_segments_mut()
-            .map_err(|_| "attachment API base URL cannot be a base".to_string())?;
-        segments.pop_if_empty();
-        segments.extend(["agent", "attachments", attachment_id, "download"]);
-    }
-    url.query_pairs_mut().append_pair("thread_key", thread_key);
-    Ok(url)
 }
 
 fn attachment_block_to_user_input(
@@ -1462,7 +1386,6 @@ pub(crate) fn write_blocks_error<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Read as _;
 
     fn temp_upload_dir() -> PathBuf {
         let path = env::temp_dir().join(format!("harness-server-test-{}", Uuid::new_v4().simple()));
@@ -1534,64 +1457,8 @@ mod tests {
         assert!(text.contains("id=att_123"));
         assert!(text.contains("name=report.pdf"));
         assert!(text.contains("mime=application/pdf"));
-        assert!(text.contains("not preloaded in /home/agent/uploads"));
+        assert!(text.contains("not provided to this sandbox"));
         assert!(!text.contains("Unsupported attachment block type"));
-    }
-
-    #[test]
-    fn attachment_ref_downloads_to_uploads_dir_when_api_is_available() {
-        let upload_dir = temp_upload_dir();
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test server");
-        let api_base = format!("http://{}", listener.local_addr().expect("local addr"));
-        let server = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("accept request");
-            let mut request = String::new();
-            let mut buffer = [0; 1024];
-            loop {
-                let read = stream.read(&mut buffer).expect("read request");
-                if read == 0 {
-                    break;
-                }
-                request.push_str(&String::from_utf8_lossy(&buffer[..read]));
-                if request.contains("\r\n\r\n") {
-                    break;
-                }
-            }
-            assert!(
-                request.starts_with("GET /agent/attachments/att_123/download?thread_key=web%3At1 ")
-            );
-            stream
-                .write_all(
-                    b"HTTP/1.1 200 OK\r\nContent-Length: 9\r\nConnection: close\r\n\r\nhello-ref",
-                )
-                .expect("write response");
-        });
-
-        unsafe {
-            env::set_var("CENTAUR_API_URL", api_base);
-        }
-        let line = r#"{"type":"user","thread_key":"web:t1","message":{"role":"user","content":[{"type":"text","text":"inspect this"},{"type":"attachment_ref","attachment_id":"att_123","name":"report.txt","mime_type":"text/plain"}]}}"#;
-        let BlocksCommand::User { input, .. } = parse_blocks_line(line).expect("parses") else {
-            panic!("expected user command");
-        };
-        server.join().expect("server thread");
-
-        assert_eq!(input.len(), 2);
-        let UserInput::Text { text, .. } = &input[1] else {
-            panic!("expected attachment_ref to become text input");
-        };
-        assert!(text.contains("Attached file saved to"));
-        assert!(!text.contains("Unsupported attachment block type"));
-        let path = text
-            .strip_prefix("[Attached file saved to ")
-            .and_then(|value| value.strip_suffix(']'))
-            .map(PathBuf::from)
-            .expect("saved path");
-        assert!(path.starts_with(&upload_dir) || path.exists());
-        assert_eq!(
-            std::fs::read_to_string(path).expect("downloaded file"),
-            "hello-ref"
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Stop the harness from trying to download `attachment_ref` blocks through the missing `/agent/attachments/{id}/download` API route.
- Keep `attachment_ref` handling recoverable by surfacing a clear text reference instead of marking the block unsupported.
- Make `centaur_sdk.save_attachment()` write directly into the sandbox uploads directory when running in a sandbox, with collision-safe local paths and no API upload call.
- Leave the existing API upload fallback in place for non-sandbox producers.

## Validation
- `uv run --with ruff ruff check centaur_sdk/tool_sdk.py centaur_sdk/tests/test_tool_sdk.py`
- `PYTHONPATH=/Users/akshaan/Desktop/centaur-attachment-ref-fix uv run --with pytest --with pytest-asyncio pytest centaur_sdk/tests/test_tool_sdk.py`
- `cargo test --manifest-path crates/harness-server/Cargo.toml`

- Rebuilt `centaur-agent:latest` locally from this branch and refreshed local OrbStack sandbox pods to image `sha256:9e26ee1cce10f07f685887a12b80a1bb67782213d77c223a2fb5af1c00ac011b`.
- Ran the rebuilt sandbox image with `attachment.chunk` + `stagedAttachmentId`; verified `/uploads/repro.txt` contained `hello-local-repro` and Codex received `[Attached file saved to /uploads/repro.txt]`.
- Ran the rebuilt sandbox image with an `attachment_ref`; verified Codex received the recoverable `The file was not provided to this sandbox` guidance instead of a download attempt.
