### PR TITLE
fix: relax console Slack thread scope to team-when-present

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -224,15 +224,13 @@ class ApplicationController < ActionController::Base
           )
           next if user_id.blank?
 
-          team_id = console_sidebar_first_present(
-            credential.labels&.[](CONSOLE_SIDEBAR_SLACK_TEAM_LABEL),
-            credential.oauth_app&.labels&.[](CONSOLE_SIDEBAR_SLACK_TEAM_LABEL)
+          ConsoleSidebarSlackThreadOwner.new(
+            user_id: user_id,
+            team_id: console_sidebar_first_present(
+              credential.labels&.[](CONSOLE_SIDEBAR_SLACK_TEAM_LABEL),
+              credential.oauth_app&.labels&.[](CONSOLE_SIDEBAR_SLACK_TEAM_LABEL)
+            )
           )
-          # Require a resolvable workspace; see Console::ThreadsController for why
-          # a team-less credential cannot own threads.
-          next if team_id.blank?
-
-          ConsoleSidebarSlackThreadOwner.new(user_id: user_id, team_id: team_id)
         end.uniq { |owner| [ console_sidebar_normalize_key(owner.user_id), console_sidebar_normalize_key(owner.team_id) ] }
       end
     end
@@ -280,24 +278,26 @@ class ApplicationController < ActionController::Base
       "metadata ->> 'source' = 'slackbotv2'"
     ].join(" OR ")
 
-    owner_clauses = owners.filter_map do |owner|
-      team_id = console_sidebar_normalize_key(owner.team_id)
-      # Team scoping is mandatory: never match a Slack thread on user id alone.
-      next if team_id.blank?
-
+    owner_clauses = owners.map do |owner|
       user_id = console_sidebar_normalize_key(owner.user_id)
       user_clauses = CONSOLE_SIDEBAR_SLACK_THREAD_OWNER_METADATA_KEYS.map do |key|
         "lower(metadata ->> #{console_sidebar_sql_quote(key)}) = #{console_sidebar_sql_quote(user_id)}"
       end
-      team_clauses = CONSOLE_SIDEBAR_SLACK_THREAD_TEAM_METADATA_KEYS.map do |key|
-        "lower(metadata ->> #{console_sidebar_sql_quote(key)}) = #{console_sidebar_sql_quote(team_id)}"
+      owner_clause = "(#{user_clauses.join(" OR ")})"
+
+      # Team scoping narrows the match only when the credential exposes a team;
+      # see Console::ThreadsController#slack_thread_owner_sql.
+      if owner.team_id.present?
+        team_id = console_sidebar_normalize_key(owner.team_id)
+        team_clauses = CONSOLE_SIDEBAR_SLACK_THREAD_TEAM_METADATA_KEYS.map do |key|
+          "lower(metadata ->> #{console_sidebar_sql_quote(key)}) = #{console_sidebar_sql_quote(team_id)}"
+        end
+        team_clauses << "lower(split_part(thread_key, ':', 2)) = #{console_sidebar_sql_quote(team_id)}"
+        owner_clause = "(#{owner_clause} AND (#{team_clauses.join(" OR ")}))"
       end
-      team_clauses << "lower(split_part(thread_key, ':', 2)) = #{console_sidebar_sql_quote(team_id)}"
 
-      "((#{user_clauses.join(" OR ")}) AND (#{team_clauses.join(" OR ")}))"
+      owner_clause
     end
-
-    return if owner_clauses.empty?
 
     "(#{slack_source}) AND (#{owner_clauses.join(" OR ")})"
   end

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -189,16 +189,13 @@ class Console::ThreadsController < ApplicationController
             )
             next if user_id.blank?
 
-            team_id = first_present(
-              credential.labels&.[](SLACK_TEAM_LABEL),
-              credential.oauth_app&.labels&.[](SLACK_TEAM_LABEL)
+            SlackThreadOwner.new(
+              user_id: user_id,
+              team_id: first_present(
+                credential.labels&.[](SLACK_TEAM_LABEL),
+                credential.oauth_app&.labels&.[](SLACK_TEAM_LABEL)
+              )
             )
-            # Require a resolvable workspace. Slack user IDs are not unique across
-            # workspaces, so matching on user id alone could surface another
-            # workspace's threads. A credential with no team cannot own threads.
-            next if team_id.blank?
-
-            SlackThreadOwner.new(user_id: user_id, team_id: team_id)
           end.uniq { |owner| [ normalize_key(owner.user_id), normalize_key(owner.team_id) ] }
         end
       else
@@ -249,24 +246,27 @@ class Console::ThreadsController < ApplicationController
       "metadata ->> 'source' = 'slackbotv2'"
     ].join(" OR ")
 
-    owner_clauses = owners.filter_map do |owner|
-      team_id = normalize_key(owner.team_id)
-      # Team scoping is mandatory: never match a Slack thread on user id alone.
-      next if team_id.blank?
-
+    owner_clauses = owners.map do |owner|
       user_id = normalize_key(owner.user_id)
       user_clauses = SLACK_THREAD_OWNER_METADATA_KEYS.map do |key|
         "lower(metadata ->> #{sql_quote(key)}) = #{sql_quote(user_id)}"
       end
-      team_clauses = SLACK_THREAD_TEAM_METADATA_KEYS.map do |key|
-        "lower(metadata ->> #{sql_quote(key)}) = #{sql_quote(team_id)}"
+      owner_clause = "(#{user_clauses.join(" OR ")})"
+
+      # Team scoping narrows the match only when the owning credential exposes a
+      # team. slackbotv2 uses slack:CHANNEL:TS thread keys and does not record a
+      # slack_team_id, so requiring a team would hide otherwise-owned threads.
+      if owner.team_id.present?
+        team_id = normalize_key(owner.team_id)
+        team_clauses = SLACK_THREAD_TEAM_METADATA_KEYS.map do |key|
+          "lower(metadata ->> #{sql_quote(key)}) = #{sql_quote(team_id)}"
+        end
+        team_clauses << "lower(split_part(thread_key, ':', 2)) = #{sql_quote(team_id)}"
+        owner_clause = "(#{owner_clause} AND (#{team_clauses.join(" OR ")}))"
       end
-      team_clauses << "lower(split_part(thread_key, ':', 2)) = #{sql_quote(team_id)}"
 
-      "((#{user_clauses.join(" OR ")}) AND (#{team_clauses.join(" OR ")}))"
+      owner_clause
     end
-
-    return if owner_clauses.empty?
 
     "(#{slack_source}) AND (#{owner_clauses.join(" OR ")})"
   end

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -387,7 +387,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     refute_includes sql, "slack_user_id"
   end
 
-  test "visible thread scope ignores Slack credentials without a resolvable team" do
+  test "visible thread scope matches Slack threads by user id when the credential has no team" do
     app = oauth_apps(:acme_slack)
     app.update!(client_secret: "slack-secret", labels: {})
     create_slack_oauth_credential(
@@ -400,11 +400,13 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
 
     sql = controller.send(:visible_thread_scope).to_sql
 
-    # A credential with no team cannot own threads: no Slack matching is emitted,
-    # so the scope falls back to the current user's console threads only.
-    refute_includes sql, "thread_key LIKE 'slack:%'"
-    refute_includes sql, "uowner"
-    assert_includes sql, "thread_key LIKE 'console:%'"
+    # slackbotv2 threads carry no team (slack:CHANNEL:TS keys, no slack_team_id),
+    # so a team-less credential still matches on slack_user_id alone; team scoping
+    # is added only when the credential exposes a team.
+    assert_includes sql, "thread_key LIKE 'slack:%'"
+    assert_includes sql, "metadata ->> 'slack_user_id'"
+    assert_includes sql, "uowner"
+    refute_includes sql, "split_part(thread_key, ':', 2)"
   end
 
   test "selected session resolves a directly linked thread only within the owner scope" do


### PR DESCRIPTION
Stacked on #843.

## Problem
#854 hardened Slack thread ownership to **require** a resolvable team: it dropped team-less credentials and always `AND`-ed a team clause onto the owner match. In practice this hid **every** Slack thread from its owner in the Console.

Confirmed on the `pr-860` preview cluster — the Slack thread has:
- `slack_user_id` set, **`slack_team_id` empty**
- `thread_key = slack:C0B7GN7JV2S:…` (second segment is the *channel*, not a team)

and across all Slack sessions in that DB, **0 carry a team id** and **0 have a 4-segment `slack:TEAM:…` key**. slackbotv2 uses `slack:CHANNEL:TS` keys and doesn't persist `slack_team_id`, so the mandatory team clause could never match → the owner saw nothing.

## Fix
Revert to **team-when-present**:
- Match on `slack_user_id` again.
- Add the team clause **only when the owning credential exposes a team** (so deployments that *do* carry team info still get narrowed by workspace).

Applied to both the main-pane scope (`visible_thread_scope`) and the sidebar scope. Test updated: a team-less credential now matches by user id with no team clause; the existing with-team test still asserts team scoping is applied.

## Trade-off / follow-up
This reopens the cross-workspace `slack_user_id` collision edge #854 guarded against (acceptable for single-workspace today). The proper long-term fix is a separate change to **slackbotv2** to persist `slack_team_id` in session metadata (and/or include team in the thread key), after which mandatory team scoping can be reinstated for true multi-workspace isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)