### PR TITLE
feat(chart): add console.slackOauth flag for Slack console sign-in

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.83
+version: 0.1.84
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -161,6 +161,22 @@ spec:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sIRON_CONTROL_GOOGLE_CLIENT_SECRET" $prefix }}
 {{- end }}
+{{- if $console.slackOauth.enabled }}
+            # Slack OIDC app credentials (console sign-in only — distinct from
+            # the DB-managed Slack OAuth app the bot/DM sync uses). Gated on
+            # console.slackOauth.enabled; the keys must exist in the shared
+            # infra Secret when enabled.
+            - name: IRON_CONTROL_SLACK_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_SLACK_CLIENT_ID" $prefix }}
+            - name: IRON_CONTROL_SLACK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sIRON_CONTROL_SLACK_CLIENT_SECRET" $prefix }}
+{{- end }}
             - name: RAILS_ENV
               value: {{ $console.railsEnv | quote }}
 {{- with $console.slackDmSync.oauthAppSlug }}

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -165,17 +165,19 @@ spec:
             # Slack OIDC app credentials (console sign-in only — distinct from
             # the DB-managed Slack OAuth app the bot/DM sync uses). Gated on
             # console.slackOauth.enabled; the keys must exist in the shared
-            # infra Secret when enabled.
-            - name: IRON_CONTROL_SLACK_CLIENT_ID
+            # infra Secret when enabled. Uses the modern CENTAUR_CONSOLE_*
+            # names (unlike the legacy IRON_CONTROL_* keys above) since this
+            # block postdates the rename.
+            - name: CENTAUR_CONSOLE_SLACK_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ $secretEnv }}
-                  key: {{ printf "%sIRON_CONTROL_SLACK_CLIENT_ID" $prefix }}
-            - name: IRON_CONTROL_SLACK_CLIENT_SECRET
+                  key: {{ printf "%sCENTAUR_CONSOLE_SLACK_CLIENT_ID" $prefix }}
+            - name: CENTAUR_CONSOLE_SLACK_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ $secretEnv }}
-                  key: {{ printf "%sIRON_CONTROL_SLACK_CLIENT_SECRET" $prefix }}
+                  key: {{ printf "%sCENTAUR_CONSOLE_SLACK_CLIENT_SECRET" $prefix }}
 {{- end }}
             - name: RAILS_ENV
               value: {{ $console.railsEnv | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -106,6 +106,17 @@ console:
   # _SECRET), which must exist or the console pods CreateContainerConfigError.
   googleOauth:
     enabled: false
+  # Slack as an OIDC identity provider for console sign-in. Off by default —
+  # not every deployment uses Slack to log in. When enabled, the
+  # IRON_CONTROL_SLACK_CLIENT_ID and IRON_CONTROL_SLACK_CLIENT_SECRET env vars
+  # are sourced from the shared infra Secret (keys
+  # <secretManager.envPrefix>IRON_CONTROL_SLACK_CLIENT_ID / _SECRET), which
+  # must exist or the console pods CreateContainerConfigError. This is the
+  # Sign-in-with-Slack OIDC app (scopes openid/email/profile, redirect URL
+  # <publicUrl>/auth/slack/callback) — not the DB-managed Slack OAuth app the
+  # bot and DM sync use.
+  slackOauth:
+    enabled: false
   # OAuth app slug whose user-level Slack credentials are used by the DM sync
   # worker. Keep this aligned with the Console OAuth app users authorize.
   slackDmSync:

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -108,9 +108,9 @@ console:
     enabled: false
   # Slack as an OIDC identity provider for console sign-in. Off by default —
   # not every deployment uses Slack to log in. When enabled, the
-  # IRON_CONTROL_SLACK_CLIENT_ID and IRON_CONTROL_SLACK_CLIENT_SECRET env vars
-  # are sourced from the shared infra Secret (keys
-  # <secretManager.envPrefix>IRON_CONTROL_SLACK_CLIENT_ID / _SECRET), which
+  # CENTAUR_CONSOLE_SLACK_CLIENT_ID and CENTAUR_CONSOLE_SLACK_CLIENT_SECRET
+  # env vars are sourced from the shared infra Secret (keys
+  # <secretManager.envPrefix>CENTAUR_CONSOLE_SLACK_CLIENT_ID / _SECRET), which
   # must exist or the console pods CreateContainerConfigError. This is the
   # Sign-in-with-Slack OIDC app (scopes openid/email/profile, redirect URL
   # <publicUrl>/auth/slack/callback) — not the DB-managed Slack OAuth app the


### PR DESCRIPTION
## Why

The console supports Sign in with Slack via OIDC (`ConsoleAuth::SUPPORTED` includes `slack`, `Login::Providers::Slack`), but the button only renders when `CENTAUR_CONSOLE_SLACK_CLIENT_ID`/`_SECRET` are present. The chart never injected them — it only wires Google — so no chart-based deployment (staging/prod included) could show the Slack sign-in option, even with the credentials already in 1Password.

## What

- New `console.slackOauth.enabled` value (default `false`), mirroring `console.googleOauth`.
- When enabled, the console web pod gets `CENTAUR_CONSOLE_SLACK_CLIENT_ID` and `CENTAUR_CONSOLE_SLACK_CLIENT_SECRET` via explicit `secretKeyRef`s from the shared infra Secret (keys `<secretManager.envPrefix>CENTAUR_CONSOLE_SLACK_CLIENT_ID` / `_SECRET`). This block uses the modern `CENTAUR_CONSOLE_*` names — matching how the 1P items are provisioned — rather than the legacy `IRON_CONTROL_*` names the older blocks use.
- The console worker is untouched: unlike Google (broker token refresh loop), Slack sign-in is login-only.

## Notes for deployers

- The secret keys must exist in the infra Secret when the flag is on, or console pods hit `CreateContainerConfigError` — same contract as `googleOauth`.
- This is the Sign-in-with-Slack OIDC app (scopes `openid email profile`, redirect `<publicUrl>/auth/slack/callback`), NOT the DB-managed Slack OAuth app used by the bot/DM sync (per `services/console/docs/API.md`, those use normal API scopes). A separate Slack app is required if only the bot app exists today.

## Validation

`helm template` with the flag off renders no Slack env vars (unchanged output); with the flag on, both secretKeyRefs render on the console Deployment. Values schema passes.

Companion infra change: tempoxyz/prd-centaur-infra#538 enabling `console.slackOauth.enabled` for stg/prod (inert until the chart pin there is bumped past this commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
