### PR TITLE
feat: console threads split view and thinking traces

### DIFF
--- a/scripts/mirror-prod-threads-snapshot.sh
+++ b/scripts/mirror-prod-threads-snapshot.sh
@@ -35,6 +35,7 @@ Snapshot sizing:
   MESSAGE_LIMIT_PER_THREAD=120
   EXECUTION_LIMIT_PER_THREAD=20
   EVENT_LIMIT_PER_THREAD=40
+  THINKING_EVENT_LIMIT_PER_THREAD=200
 
 Safety:
   TRUNCATE_LOCAL_SESSION_TABLES=1
@@ -241,7 +242,7 @@ create_snapshot() {
     order by thread_key, created_at, execution_id
   "
 
-  info "exporting up to ${EVENT_LIMIT_PER_THREAD} terminal events per thread"
+  info "exporting up to ${EVENT_LIMIT_PER_THREAD} terminal events and ${THINKING_EVENT_LIMIT_PER_THREAD} reasoning lines per thread"
   copy_to_csv "$source_url" "$snapshot_dir/session_events.csv" "
     with recent_sessions as (${recent_sessions_sql}),
     ranked as (
@@ -262,10 +263,36 @@ create_snapshot() {
         'session.execution_failed',
         'session.execution_cancelled'
       )
+    ),
+    -- Reasoning traces live in the session.output.line firehose as
+    -- item/completed notifications for reasoning items. The LIKE filter keeps
+    -- the export from paging every stdout line; Console re-filters exactly.
+    ranked_thinking as (
+      select
+        ev.thread_key,
+        ev.execution_id,
+        ev.event_type,
+        ev.payload,
+        ev.created_at,
+        row_number() over (
+          partition by ev.thread_key
+          order by ev.event_id desc
+        ) as rn
+      from session_events ev
+      join recent_sessions r using (thread_key)
+      where ev.event_type = 'session.output.line'
+        and ev.payload::text like '%reasoning%'
     )
     select thread_key, execution_id, event_type, payload, created_at
-    from ranked
-    where rn <= ${EVENT_LIMIT_PER_THREAD}
+    from (
+      select thread_key, execution_id, event_type, payload, created_at
+      from ranked
+      where rn <= ${EVENT_LIMIT_PER_THREAD}
+      union all
+      select thread_key, execution_id, event_type, payload, created_at
+      from ranked_thinking
+      where rn <= ${THINKING_EVENT_LIMIT_PER_THREAD}
+    ) combined
     order by thread_key, created_at
   "
 
@@ -337,6 +364,7 @@ create_snapshot() {
     echo "message_limit_per_thread=${MESSAGE_LIMIT_PER_THREAD}"
     echo "execution_limit_per_thread=${EXECUTION_LIMIT_PER_THREAD}"
     echo "event_limit_per_thread=${EVENT_LIMIT_PER_THREAD}"
+    echo "thinking_event_limit_per_thread=${THINKING_EVENT_LIMIT_PER_THREAD}"
     echo "slack_sync_users=referenced"
   } > "$snapshot_dir/manifest.env"
 
@@ -667,6 +695,7 @@ main() {
   MESSAGE_LIMIT_PER_THREAD="${MESSAGE_LIMIT_PER_THREAD:-120}"
   EXECUTION_LIMIT_PER_THREAD="${EXECUTION_LIMIT_PER_THREAD:-20}"
   EVENT_LIMIT_PER_THREAD="${EVENT_LIMIT_PER_THREAD:-40}"
+  THINKING_EVENT_LIMIT_PER_THREAD="${THINKING_EVENT_LIMIT_PER_THREAD:-200}"
   TRUNCATE_LOCAL_SESSION_TABLES="${TRUNCATE_LOCAL_SESSION_TABLES:-1}"
 
   validate_integer THREAD_LIMIT "$THREAD_LIMIT"

--- a/services/console/README.md
+++ b/services/console/README.md
@@ -49,11 +49,22 @@ scripts/mirror-prod-threads-snapshot.sh all
 ```
 
 The script exports recent `sessions`, `session_messages`,
-`session_executions`, terminal `session_events`, and referenced
-`slack_sync_users` rows with the source connection forced read-only, then
-imports them into the local `ai_v2` database used by the Console dev container.
-The Threads surface is read-only: it does not render a composer and rejects
-POSTs server-side.
+`session_executions`, terminal `session_events` plus reasoning
+`session.output.line` events (capped by `THINKING_EVENT_LIMIT_PER_THREAD`,
+default 200 per thread), and referenced `slack_sync_users` rows with the source
+connection forced read-only, then imports them into the local `ai_v2` database
+used by the Console dev container. The Threads surface is read-only: it does
+not render a composer and rejects POSTs server-side.
+
+Threads extras beyond the Slack surface:
+
+- Thinking traces: reasoning items the harness streamed over stdout are
+  persisted by api-rs as `session.output.line` events; the transcript renders
+  each completed reasoning block as a collapsed "Thinking" disclosure.
+- Split view: open up to four threads side by side with `?thread=<primary>` and
+  `?panes=<key2>,<key3>,<key4>`, or hover a sidebar thread and use its
+  "Open in split view" button. Panes resolve through the same owner scope as
+  the primary thread, and each panel has a close control.
 
 ## First Boot
 

--- a/services/console/README.md
+++ b/services/console/README.md
@@ -61,10 +61,11 @@ Threads extras beyond the Slack surface:
 - Thinking traces: reasoning items the harness streamed over stdout are
   persisted by api-rs as `session.output.line` events; the transcript renders
   each completed reasoning block as a collapsed "Thinking" disclosure.
-- Split view: open up to four threads side by side with `?thread=<primary>` and
-  `?panes=<key2>,<key3>,<key4>`, or hover a sidebar thread and use its
-  "Open in split view" button. Panes resolve through the same owner scope as
-  the primary thread, and each panel has a close control.
+- Split view: Cmd/Ctrl-click a sidebar thread to open it alongside the current
+  one, up to four threads in a grid. The `thread` param carries the open keys
+  comma-separated (`?thread=<primary>,<key2>,<key3>,<key4>`), primary first.
+  All keys resolve through the same owner scope as a single thread, and each
+  panel has a close control.
 
 ## First Boot
 

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -166,25 +166,27 @@ class ApplicationController < ActionController::Base
   end
 
   def console_sidebar_threads_with_direct_selection(threads)
-    selected = console_sidebar_direct_selected_thread(threads)
-    selected ? [ selected, *threads ] : threads
+    selected = console_sidebar_direct_selected_threads(threads)
+    selected.any? ? [ *selected, *threads ] : threads
   end
 
-  def console_sidebar_direct_selected_thread(threads)
-    thread_key = console_sidebar_selected_thread_key
-    return if thread_key.blank?
-    return if threads.any? { |thread| thread.thread_key == thread_key }
+  def console_sidebar_direct_selected_threads(threads)
+    thread_keys = console_sidebar_selected_thread_keys - threads.map(&:thread_key)
+    return [] if thread_keys.empty?
 
     # Resolve through the owner scope, not a raw find_by, so a directly linked
     # thread only surfaces in the sidebar when the current user started it. This
     # mirrors Console::ThreadsController#selected_session.
-    console_sidebar_visible_thread_scope.where(thread_key: thread_key).first
+    console_sidebar_visible_thread_scope.where(thread_key: thread_keys).to_a
   end
 
-  def console_sidebar_selected_thread_key
-    return unless params[:controller] == "console/threads"
+  # The thread param carries up to PANEL_LIMIT comma-separated keys when the
+  # split view is open; every open thread should surface and highlight.
+  def console_sidebar_selected_thread_keys
+    return [] unless params[:controller] == "console/threads"
 
-    params[:thread].to_s.presence
+    params[:thread].to_s.split(",").map(&:strip).reject(&:blank?).uniq
+      .first(Console::ThreadsController::PANEL_LIMIT)
   end
 
   def console_sidebar_console_thread_owner_sql

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -5,6 +5,10 @@ class Console::ThreadsController < ApplicationController
   MESSAGE_LIMIT = 80
   EXECUTION_LIMIT = 8
   TRANSCRIPT_EVENT_LIMIT = 80
+  PANEL_LIMIT = 4
+  THINKING_EVENT_LIMIT = 200
+  # Messages and thinking precede the terminal event for a same-timestamp tie.
+  TRANSCRIPT_SOURCE_ORDER = { message: 0, thinking: 1, event: 2 }.freeze
   SLACK_PROVIDER = Oauth::Providers::Slack::KEY
   SLACK_THREAD_OWNER_METADATA_KEYS = %w[slack_user_id actor_user_id user_id].freeze
   SLACK_THREAD_TEAM_METADATA_KEYS = %w[slack_team_id team_id home_team_id].freeze
@@ -31,6 +35,7 @@ class Console::ThreadsController < ApplicationController
   def index
     @query = params[:q].to_s.strip
     @selected_thread_key = params[:thread].to_s
+    @pane_thread_keys = requested_pane_thread_keys
     @starting_new_thread = params[:new].present?
     @thread_db_unavailable = false
 
@@ -72,17 +77,18 @@ class Console::ThreadsController < ApplicationController
 
     @sessions = base_sessions.select { |session| matches_query?(session) }
     @selected_session = selected_session(session_scope, base_sessions)
+    @pane_sessions = resolve_pane_sessions(session_scope, base_sessions)
     load_selected_session_summaries(keys)
     @selected_thread_key = @selected_session&.thread_key.to_s
-    @selected_messages = selected_messages
-    @selected_executions = selected_executions
-    @selected_events = selected_events
-    @selected_transcript_items = selected_transcript_items
+    @thread_panels = build_thread_panels
+    @selected_transcript_items = @thread_panels.first&.dig(:transcript_items) || []
   end
 
   def empty_thread_state
     @sessions = []
     @selected_session = nil
+    @pane_sessions = []
+    @thread_panels = []
     @selected_messages = []
     @selected_executions = []
     @selected_events = []
@@ -121,7 +127,56 @@ class Console::ThreadsController < ApplicationController
   end
 
   def auto_select_first_thread?
-    params[:thread].blank? && !@starting_new_thread && @query.blank? && @selected_session.present?
+    params[:thread].blank? && params[:panes].blank? && !@starting_new_thread &&
+      @query.blank? && @selected_session.present?
+  end
+
+  def requested_pane_thread_keys
+    params[:panes].to_s.split(",").map(&:strip).reject(&:blank?).uniq.first(PANEL_LIMIT - 1)
+  end
+
+  # Extra split-view panes resolve through the same owner scope as the primary
+  # thread, so a crafted ?panes= value cannot surface another user's thread.
+  # Unowned keys are dropped silently.
+  def resolve_pane_sessions(session_scope, base_sessions)
+    keys = @pane_thread_keys - [ @selected_session&.thread_key ]
+    keys.filter_map do |key|
+      base_sessions.find { |session| session.thread_key == key } ||
+        session_scope.where(thread_key: key).first
+    end
+  end
+
+  def build_thread_panels
+    sessions = ([ @selected_session ] + Array(@pane_sessions)).compact
+      .uniq(&:thread_key)
+      .first(PANEL_LIMIT)
+    return [] if sessions.empty?
+
+    # Build the primary panel last so the @selected_* thread state (used by the
+    # page header and mention-resolution memos) ends on the primary thread.
+    extra_panels = sessions.drop(1).map { |session| thread_panel_for(session) }
+    [ thread_panel_for(sessions.first) ] + extra_panels
+  end
+
+  def thread_panel_for(session)
+    @selected_session = session
+    @selected_messages = selected_messages
+    @selected_executions = selected_executions
+    @selected_events = selected_events
+    reset_selected_thread_memos
+
+    {
+      session: session,
+      thread_key: session.thread_key,
+      transcript_items: selected_transcript_items
+    }
+  end
+
+  # Mention labels and inferred bot ids are memoized off the selected thread's
+  # messages and events, so they must be recomputed per panel.
+  def reset_selected_thread_memos
+    @slack_mention_labels_by_id = nil
+    @slack_bot_user_ids = nil
   end
 
   def redirect_to_first_thread
@@ -129,14 +184,16 @@ class Console::ThreadsController < ApplicationController
   end
 
   def load_selected_session_summaries(loaded_keys)
-    return unless @selected_session
-    return if loaded_keys.include?(@selected_session.thread_key)
+    missing_keys = ([ @selected_session ] + Array(@pane_sessions)).compact
+      .map(&:thread_key)
+      .uniq
+      .reject { |key| loaded_keys.include?(key) }
+    return if missing_keys.empty?
 
-    selected_key = [ @selected_session.thread_key ]
-    @latest_messages.merge!(latest_messages_for(selected_key))
-    @latest_executions.merge!(latest_executions_for(selected_key))
-    @message_counts.merge!(count_records(CentaurSessionMessage, selected_key))
-    @execution_counts.merge!(count_records(CentaurSessionExecution, selected_key))
+    @latest_messages.merge!(latest_messages_for(missing_keys))
+    @latest_executions.merge!(latest_executions_for(missing_keys))
+    @message_counts.merge!(count_records(CentaurSessionMessage, missing_keys))
+    @execution_counts.merge!(count_records(CentaurSessionExecution, missing_keys))
   end
 
   def visible_thread_scope
@@ -336,9 +393,78 @@ class Console::ThreadsController < ApplicationController
 
     event_items = @selected_events.filter_map { |event| transcript_item_for_event(event) }
 
-    (message_items + event_items).sort_by do |item|
-      [ item[:created_at] || Time.zone.at(0), item[:source] == :event ? 1 : 0 ]
+    thinking_items = selected_thinking_items
+
+    (message_items + thinking_items + event_items).sort_by do |item|
+      [ item[:created_at] || Time.zone.at(0), TRANSCRIPT_SOURCE_ORDER[item[:source]] || 0 ]
     end
+  end
+
+  # The api-rs stdout pump persists every harness output line verbatim as a
+  # session.output.line event whose payload is a JSON-encoded string. Reasoning
+  # blocks arrive as item/completed notifications with item.type == "reasoning"
+  # carrying the full accumulated thinking text. The SQL LIKE filter keeps the
+  # query from paging through the whole firehose; exact matching happens here.
+  def selected_thinking_items
+    return [] unless @selected_session
+
+    CentaurSessionEvent
+      .where(thread_key: @selected_session.thread_key)
+      .where(event_type: "session.output.line")
+      .where("payload::text LIKE '%reasoning%'")
+      .order(event_id: :desc)
+      .limit(THINKING_EVENT_LIMIT)
+      .to_a
+      .reverse
+      .filter_map { |event| thinking_transcript_item(event) }
+  end
+
+  def thinking_transcript_item(event)
+    line = event.payload
+    return nil unless line.is_a?(String)
+
+    value = JSON.parse(line)
+    return nil unless value.is_a?(Hash)
+
+    method = (value["method"] || value["type"]).to_s.tr("/", ".")
+    return nil unless method == "item.completed"
+
+    item = value.dig("params", "item") || value["item"]
+    return nil unless item.is_a?(Hash) && item["type"].to_s == "reasoning"
+
+    text = reasoning_item_text(item)
+    return nil if text.blank?
+
+    {
+      role: "thinking",
+      label: "Thinking",
+      align: :start,
+      text: text,
+      created_at: event.created_at,
+      source: :thinking
+    }
+  rescue JSON::ParserError
+    nil
+  end
+
+  # Claude/Amp reasoning lands in content (full text); Codex-native reasoning
+  # may only carry a summary. Prefer the fullest field available.
+  def reasoning_item_text(item)
+    [
+      item["text"],
+      reasoning_part_text(item["content"]),
+      reasoning_part_text(item["summary"])
+    ].find(&:present?)
+  end
+
+  def reasoning_part_text(value)
+    entries = value.is_a?(Array) ? value : [ value ]
+    entries.filter_map do |part|
+      case part
+      when String then part
+      when Hash then part["text"].to_s
+      end
+    end.join("\n").strip.presence
   end
 
   def latest_messages_for(keys)

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -34,8 +34,9 @@ class Console::ThreadsController < ApplicationController
 
   def index
     @query = params[:q].to_s.strip
-    @selected_thread_key = params[:thread].to_s
-    @pane_thread_keys = requested_pane_thread_keys
+    requested_keys = requested_thread_keys
+    @selected_thread_key = requested_keys.first.to_s
+    @pane_thread_keys = requested_keys.drop(1)
     @starting_new_thread = params[:new].present?
     @thread_db_unavailable = false
 
@@ -127,16 +128,18 @@ class Console::ThreadsController < ApplicationController
   end
 
   def auto_select_first_thread?
-    params[:thread].blank? && params[:panes].blank? && !@starting_new_thread &&
-      @query.blank? && @selected_session.present?
+    params[:thread].blank? && !@starting_new_thread && @query.blank? && @selected_session.present?
   end
 
-  def requested_pane_thread_keys
-    params[:panes].to_s.split(",").map(&:strip).reject(&:blank?).uniq.first(PANEL_LIMIT - 1)
+  # The thread param carries up to PANEL_LIMIT comma-separated thread keys; the
+  # first is the primary thread and the rest are extra split-view panes
+  # (Cmd/Ctrl-click on a sidebar thread appends its key).
+  def requested_thread_keys
+    params[:thread].to_s.split(",").map(&:strip).reject(&:blank?).uniq.first(PANEL_LIMIT)
   end
 
   # Extra split-view panes resolve through the same owner scope as the primary
-  # thread, so a crafted ?panes= value cannot surface another user's thread.
+  # thread, so a crafted ?thread= list cannot surface another user's thread.
   # Unowned keys are dropped silently.
   def resolve_pane_sessions(session_scope, base_sessions)
     keys = @pane_thread_keys - [ @selected_session&.thread_key ]

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -105,6 +105,10 @@ module ApplicationHelper
       )
     when "plus"
       outline_icon(classes, "M12 4.5v15m7.5-7.5h-15")
+    when "chevron-right"
+      outline_icon(classes, "m8.25 4.5 7.5 7.5-7.5 7.5")
+    when "x-mark"
+      outline_icon(classes, "M6 18 18 6M6 6l12 12")
     when "shield-check"
       outline_icon(
         classes,

--- a/services/console/app/views/console/threads/_sidebar_threads.html.erb
+++ b/services/console/app/views/console/threads/_sidebar_threads.html.erb
@@ -8,11 +8,15 @@
     <div class="console-thread-empty">No recent threads</div>
   <% else %>
     <% @console_sidebar_threads.each_with_index do |thread, index| %>
-      <% active_thread = open_thread_keys.include?(thread.thread_key) %>
+      <%# The primary (first) open thread gets the filled pill; other open
+          split-view panes get a subtle dot marker so a full grid does not
+          render as a stack of touching highlight blocks. %>
+      <% primary_thread = open_thread_keys.first == thread.thread_key %>
+      <% open_thread = !primary_thread && open_thread_keys.include?(thread.thread_key) %>
       <% latest_message = @console_sidebar_latest_messages[thread.thread_key] %>
       <% title = console_sidebar_thread_title(thread, latest_message) %>
       <%= link_to console_threads_path(thread: thread.thread_key),
-                  class: "console-thread-link #{active_thread ? "console-thread-link-active" : ""} #{index >= 5 && !active_thread ? "console-thread-link-hidden" : ""}",
+                  class: "console-thread-link #{primary_thread ? "console-thread-link-active" : ""} #{open_thread ? "console-thread-link-open" : ""} #{index >= 5 && !primary_thread && !open_thread ? "console-thread-link-hidden" : ""}",
                   data: { console_thread_link: true, turbo_frame: "_top" },
                   title: title do %>
         <span class="console-thread-title"><%= title %></span>

--- a/services/console/app/views/console/threads/_sidebar_threads.html.erb
+++ b/services/console/app/views/console/threads/_sidebar_threads.html.erb
@@ -20,7 +20,7 @@
                   data: {
                     console_thread_link: true,
                     turbo_frame: "_top",
-                    console_pane_index: (pane_index + 1 if open_thread)
+                    console_pane_index: (pane_index + 1 if open_thread && open_thread_keys.size > 1)
                   }.compact,
                   title: title do %>
         <span class="console-thread-title"><%= title %></span>

--- a/services/console/app/views/console/threads/_sidebar_threads.html.erb
+++ b/services/console/app/views/console/threads/_sidebar_threads.html.erb
@@ -8,16 +8,20 @@
     <div class="console-thread-empty">No recent threads</div>
   <% else %>
     <% @console_sidebar_threads.each_with_index do |thread, index| %>
-      <%# The primary (first) open thread gets the filled pill; other open
-          split-view panes get a subtle dot marker so a full grid does not
-          render as a stack of touching highlight blocks. %>
-      <% primary_thread = open_thread_keys.first == thread.thread_key %>
-      <% open_thread = !primary_thread && open_thread_keys.include?(thread.thread_key) %>
+      <%# Open threads carry their 1-based pane number, rendered as a small
+          numeral in the indent gutter (matches the grid order). No filled
+          pill on thread rows; the Threads group title keeps its own. %>
+      <% pane_index = open_thread_keys.index(thread.thread_key) %>
+      <% open_thread = !pane_index.nil? %>
       <% latest_message = @console_sidebar_latest_messages[thread.thread_key] %>
       <% title = console_sidebar_thread_title(thread, latest_message) %>
       <%= link_to console_threads_path(thread: thread.thread_key),
-                  class: "console-thread-link #{primary_thread ? "console-thread-link-active" : ""} #{open_thread ? "console-thread-link-open" : ""} #{index >= 5 && !primary_thread && !open_thread ? "console-thread-link-hidden" : ""}",
-                  data: { console_thread_link: true, turbo_frame: "_top" },
+                  class: "console-thread-link #{open_thread ? "console-thread-link-open" : ""} #{index >= 5 && !open_thread ? "console-thread-link-hidden" : ""}",
+                  data: {
+                    console_thread_link: true,
+                    turbo_frame: "_top",
+                    console_pane_index: (pane_index + 1 if open_thread)
+                  }.compact,
                   title: title do %>
         <span class="console-thread-title"><%= title %></span>
         <span class="console-thread-time"><%= local_time(thread.updated_at || thread.created_at, relative: true, format: :compact) %></span>

--- a/services/console/app/views/console/threads/_sidebar_threads.html.erb
+++ b/services/console/app/views/console/threads/_sidebar_threads.html.erb
@@ -10,13 +10,23 @@
       <% active_thread = selected_sidebar_thread_key == thread.thread_key %>
       <% latest_message = @console_sidebar_latest_messages[thread.thread_key] %>
       <% title = console_sidebar_thread_title(thread, latest_message) %>
-      <%= link_to console_threads_path(thread: thread.thread_key),
-                  class: "console-thread-link #{active_thread ? "console-thread-link-active" : ""} #{index >= 5 && !active_thread ? "console-thread-link-hidden" : ""}",
-                  data: { console_thread_link: true, turbo_frame: "_top" },
-                  title: title do %>
-        <span class="console-thread-title"><%= title %></span>
-        <span class="console-thread-time"><%= local_time(thread.updated_at || thread.created_at, relative: true, format: :compact) %></span>
-      <% end %>
+      <div class="console-thread-row <%= index >= 5 && !active_thread ? "console-thread-link-hidden" : "" %>">
+        <%= link_to console_threads_path(thread: thread.thread_key),
+                    class: "console-thread-link #{active_thread ? "console-thread-link-active" : ""}",
+                    data: { console_thread_link: true, turbo_frame: "_top" },
+                    title: title do %>
+          <span class="console-thread-title"><%= title %></span>
+          <span class="console-thread-time"><%= local_time(thread.updated_at || thread.created_at, relative: true, format: :compact) %></span>
+        <% end %>
+        <button type="button"
+                class="console-thread-split"
+                data-console-thread-split
+                data-thread-key="<%= thread.thread_key %>"
+                title="Open in split view"
+                aria-label="Open in split view">
+          <%= console_icon("panel-right", classes: "size-3.5") %>
+        </button>
+      </div>
     <% end %>
     <% if @console_sidebar_threads.size > 5 %>
       <button type="button"

--- a/services/console/app/views/console/threads/_sidebar_threads.html.erb
+++ b/services/console/app/views/console/threads/_sidebar_threads.html.erb
@@ -1,32 +1,23 @@
 <%# Sidebar thread list, rendered inside the lazy console_sidebar_threads Turbo
     Frame. The turbo-frame id must match the one in layouts/console.html.erb so
-    the deferred fetch replaces the loading placeholder. %>
+    the deferred fetch replaces the loading placeholder. Cmd/Ctrl-click on a
+    thread link adds it to the split-view grid (wired in the console layout). %>
 <%= turbo_frame_tag "console_sidebar_threads" do %>
-  <% selected_sidebar_thread_key = params[:thread].to_s %>
+  <% open_thread_keys = params[:thread].to_s.split(",").map(&:strip).reject(&:blank?) %>
   <% if @console_sidebar_threads.blank? %>
     <div class="console-thread-empty">No recent threads</div>
   <% else %>
     <% @console_sidebar_threads.each_with_index do |thread, index| %>
-      <% active_thread = selected_sidebar_thread_key == thread.thread_key %>
+      <% active_thread = open_thread_keys.include?(thread.thread_key) %>
       <% latest_message = @console_sidebar_latest_messages[thread.thread_key] %>
       <% title = console_sidebar_thread_title(thread, latest_message) %>
-      <div class="console-thread-row <%= index >= 5 && !active_thread ? "console-thread-link-hidden" : "" %>">
-        <%= link_to console_threads_path(thread: thread.thread_key),
-                    class: "console-thread-link #{active_thread ? "console-thread-link-active" : ""}",
-                    data: { console_thread_link: true, turbo_frame: "_top" },
-                    title: title do %>
-          <span class="console-thread-title"><%= title %></span>
-          <span class="console-thread-time"><%= local_time(thread.updated_at || thread.created_at, relative: true, format: :compact) %></span>
-        <% end %>
-        <button type="button"
-                class="console-thread-split"
-                data-console-thread-split
-                data-thread-key="<%= thread.thread_key %>"
-                title="Open in split view"
-                aria-label="Open in split view">
-          <%= console_icon("panel-right", classes: "size-3.5") %>
-        </button>
-      </div>
+      <%= link_to console_threads_path(thread: thread.thread_key),
+                  class: "console-thread-link #{active_thread ? "console-thread-link-active" : ""} #{index >= 5 && !active_thread ? "console-thread-link-hidden" : ""}",
+                  data: { console_thread_link: true, turbo_frame: "_top" },
+                  title: title do %>
+        <span class="console-thread-title"><%= title %></span>
+        <span class="console-thread-time"><%= local_time(thread.updated_at || thread.created_at, relative: true, format: :compact) %></span>
+      <% end %>
     <% end %>
     <% if @console_sidebar_threads.size > 5 %>
       <button type="button"

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -30,7 +30,7 @@
       <%= console_icon("x-mark", classes: "size-4") %>
     </a>
   </header>
-  <div class="min-h-0 flex-1 overflow-y-auto px-4 py-4" data-thread-transcript-scroll>
+  <div class="console-transcript-scroll min-h-0 flex-1 overflow-y-auto px-4 py-4">
     <div class="flex flex-col gap-5">
       <%= render "console/threads/transcript", items: panel[:transcript_items] %>
     </div>

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -1,0 +1,40 @@
+<%# One panel of the split-view grid. panel: {session:, thread_key:,
+    transcript_items:}; panels: all panels, used to build the close link that
+    drops this panel and promotes the first remaining thread to primary. %>
+<% session = panel[:session] %>
+<% remaining_keys = panels.map { |other| other[:thread_key] } - [ panel[:thread_key] ] %>
+<% close_path = console_threads_path(
+     thread: remaining_keys.first,
+     panes: remaining_keys.drop(1).join(",").presence
+   ) %>
+<section class="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-ink-700 bg-ink-900/35"
+         data-thread-panel="<%= session.thread_key %>">
+  <header class="flex shrink-0 items-center gap-2 border-b border-ink-700 px-4 py-2.5">
+    <div class="min-w-0 flex-1">
+      <% panel_title = thread_title(session) %>
+      <a href="<%= console_threads_path(thread: session.thread_key) %>"
+         class="block truncate text-sm font-semibold text-zinc-100 hover:text-centaur-300"
+         title="<%= panel_title %>">
+        <%= panel_title %>
+      </a>
+      <div class="mt-0.5 flex min-w-0 items-center gap-1.5 truncate text-xs text-zinc-500">
+        <span class="truncate"><%= thread_source_label(session) %></span>
+        <span>·</span>
+        <span><%= thread_harness_label(session) %></span>
+        <span>·</span>
+        <%= local_time(session.updated_at || session.created_at, relative: true, format: :compact) %>
+      </div>
+    </div>
+    <a href="<%= close_path %>"
+       class="grid size-7 shrink-0 place-items-center rounded-lg text-zinc-500 transition hover:bg-ink-700/60 hover:text-zinc-200"
+       aria-label="Close panel"
+       title="Close panel">
+      <%= console_icon("x-mark", classes: "size-4") %>
+    </a>
+  </header>
+  <div class="min-h-0 flex-1 overflow-y-auto px-4 py-4" data-thread-transcript-scroll>
+    <div class="flex flex-col gap-5">
+      <%= render "console/threads/transcript", items: panel[:transcript_items] %>
+    </div>
+  </div>
+</section>

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -24,7 +24,7 @@
       </div>
     </div>
     <a href="<%= close_path %>"
-       class="grid size-7 shrink-0 place-items-center rounded-lg text-zinc-500 transition hover:bg-ink-700/60 hover:text-zinc-200"
+       class="console-panel-close"
        aria-label="Close panel"
        title="Close panel">
       <%= console_icon("x-mark", classes: "size-4") %>

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -1,12 +1,10 @@
 <%# One panel of the split-view grid. panel: {session:, thread_key:,
     transcript_items:}; panels: all panels, used to build the close link that
-    drops this panel and promotes the first remaining thread to primary. %>
+    drops this panel and promotes the first remaining thread to primary. The
+    thread param carries all open keys comma-separated, primary first. %>
 <% session = panel[:session] %>
 <% remaining_keys = panels.map { |other| other[:thread_key] } - [ panel[:thread_key] ] %>
-<% close_path = console_threads_path(
-     thread: remaining_keys.first,
-     panes: remaining_keys.drop(1).join(",").presence
-   ) %>
+<% close_path = console_threads_path(thread: remaining_keys.join(",")) %>
 <section class="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-ink-700 bg-ink-900/35"
          data-thread-panel="<%= session.thread_key %>">
   <header class="flex shrink-0 items-center gap-2 border-b border-ink-700 px-4 py-2.5">

--- a/services/console/app/views/console/threads/_transcript.html.erb
+++ b/services/console/app/views/console/threads/_transcript.html.erb
@@ -1,0 +1,40 @@
+<%# Shared transcript stream for the single-thread view and split-view panels.
+    items: transcript items built by Console::ThreadsController. Thinking items
+    (source: :thinking) render as collapsed disclosures, Claude-app style. %>
+<% if items.empty? %>
+  <div class="rounded-xl border border-dashed border-ink-800/80 bg-ink-850/40 px-5 py-6 text-sm text-zinc-600">
+    No messages have been persisted for this thread yet.
+  </div>
+<% end %>
+
+<% items.each do |item| %>
+  <% if item[:source] == :thinking %>
+    <div class="flex justify-start">
+      <details class="console-thinking w-full max-w-3xl">
+        <summary class="console-thinking-summary">
+          <span class="console-thinking-chevron" aria-hidden="true"><%= console_icon("chevron-right", classes: "size-3") %></span>
+          <span class="font-medium">Thinking</span>
+          <span class="console-thinking-preview"><%= item[:text].to_s.gsub(/\s+/, " ").truncate(96) %></span>
+        </summary>
+        <div class="console-thinking-body console-markdown text-sm leading-6">
+          <%= console_markdown(item[:text]) %>
+        </div>
+      </details>
+    </div>
+  <% else %>
+    <% user_message = item[:align] == :end %>
+    <div class="group flex <%= user_message ? "justify-end" : "justify-start" %>">
+      <div class="console-message-stack flex flex-col <%= user_message ? "max-w-[72%] items-end" : "w-full max-w-3xl items-start" %>">
+        <div class="<%= user_message ? "w-full rounded-[24px] bg-ink-700 px-4 py-3 text-zinc-100" : "w-full text-zinc-300" %>">
+          <% unless user_message %>
+            <div class="mb-1 text-xs font-medium text-zinc-500"><%= item[:label] || item[:role] %></div>
+          <% end %>
+          <div class="console-markdown text-sm leading-6"><%= console_markdown(item[:text].presence || "No text content.") %></div>
+        </div>
+        <div class="console-message-timestamp <%= "text-right" if user_message %>">
+          <%= local_time(item[:created_at]) if item[:created_at] %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -8,94 +8,88 @@
 <% end %>
 
 <div class="flex min-h-0 flex-1 overflow-hidden bg-ink-950/15">
-  <section class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-ink-900/25">
-    <div class="console-thread-detail-header">
-      <div class="console-thread-content">
-        <% if @selected_session %>
-          <% selected_thread_title = thread_title(@selected_session) %>
-          <% thread_meta = capture do %>
-            <div class="flex min-w-0 items-center gap-2">
-              <span class="truncate"><%= thread_source_label(@selected_session) %></span>
-              <span>·</span>
-              <span><%= thread_harness_label(@selected_session) %></span>
-              <span>·</span>
-              <%= local_time(@selected_session.updated_at || @selected_session.created_at, relative: true, format: :compact) %>
-            </div>
-          <% end %>
+  <% if @thread_panels.size > 1 %>
+    <% grid_classes =
+         case @thread_panels.size
+         when 2 then "grid-cols-2"
+         when 3 then "grid-cols-3"
+         else "grid-cols-2 grid-rows-2"
+         end %>
+    <section class="grid min-h-0 min-w-0 flex-1 gap-3 overflow-hidden pb-3 <%= grid_classes %>">
+      <% @thread_panels.each do |panel| %>
+        <%= render "console/threads/thread_panel", panel: panel, panels: @thread_panels %>
+      <% end %>
+    </section>
+  <% else %>
+    <section class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-ink-900/25">
+      <div class="console-thread-detail-header">
+        <div class="console-thread-content">
+          <% if @selected_session %>
+            <% selected_thread_title = thread_title(@selected_session) %>
+            <% thread_meta = capture do %>
+              <div class="flex min-w-0 items-center gap-2">
+                <span class="truncate"><%= thread_source_label(@selected_session) %></span>
+                <span>·</span>
+                <span><%= thread_harness_label(@selected_session) %></span>
+                <span>·</span>
+                <%= local_time(@selected_session.updated_at || @selected_session.created_at, relative: true, format: :compact) %>
+              </div>
+            <% end %>
 
-          <%= render "console/page_header",
-                     title: selected_thread_title,
-                     title_attr: selected_thread_title,
-                     subtitle: thread_meta,
-                     title_class: "truncate text-base font-semibold text-zinc-100",
-                     subtitle_class: "mt-0.5 text-xs text-zinc-500",
-                     class: "mb-0 min-h-16 items-center" %>
+            <%= render "console/page_header",
+                       title: selected_thread_title,
+                       title_attr: selected_thread_title,
+                       subtitle: thread_meta,
+                       title_class: "truncate text-base font-semibold text-zinc-100",
+                       subtitle_class: "mt-0.5 text-xs text-zinc-500",
+                       class: "mb-0 min-h-16 items-center" %>
+          <% else %>
+            <%= render "console/page_header",
+                       title: "New thread",
+                       subtitle: "Select a mirrored thread from the sidebar.",
+                       title_class: "text-base font-semibold text-zinc-100",
+                       subtitle_class: "mt-0.5 text-xs text-zinc-500",
+                       class: "mb-0 min-h-16 items-center" %>
+          <% end %>
+        </div>
+      </div>
+
+      <div id="thread-transcript-scroll" class="min-h-0 flex-1 overflow-y-auto py-6" data-thread-transcript-scroll>
+        <% if @selected_session %>
+          <div class="console-thread-content flex flex-col gap-6">
+            <%= render "console/threads/transcript", items: @selected_transcript_items %>
+          </div>
         <% else %>
-          <%= render "console/page_header",
-                     title: "New thread",
-                     subtitle: "Select a mirrored thread from the sidebar.",
-                     title_class: "text-base font-semibold text-zinc-100",
-                     subtitle_class: "mt-0.5 text-xs text-zinc-500",
-                     class: "mb-0 min-h-16 items-center" %>
+          <div class="flex h-full items-center justify-center text-sm text-zinc-600">
+            <% if @sessions.empty? %>
+              No threads yet.
+            <% else %>
+              Select a thread from the sidebar.
+            <% end %>
+          </div>
         <% end %>
       </div>
-    </div>
-
-    <div id="thread-transcript-scroll" class="min-h-0 flex-1 overflow-y-auto py-6">
-      <% if @selected_session %>
-        <div class="console-thread-content flex flex-col gap-6">
-          <% if @selected_transcript_items.empty? %>
-            <div class="rounded-xl border border-dashed border-ink-800/80 bg-ink-850/40 px-5 py-6 text-sm text-zinc-600">
-              No messages have been persisted for this thread yet.
-            </div>
-          <% end %>
-
-          <% @selected_transcript_items.each do |item| %>
-            <% user_message = item[:align] == :end %>
-            <div class="group flex <%= user_message ? "justify-end" : "justify-start" %>">
-              <div class="console-message-stack flex flex-col <%= user_message ? "max-w-[72%] items-end" : "w-full max-w-3xl items-start" %>">
-                <div class="<%= user_message ? "w-full rounded-[24px] bg-ink-700 px-4 py-3 text-zinc-100" : "w-full text-zinc-300" %>">
-                  <% unless user_message %>
-                    <div class="mb-1 text-xs font-medium text-zinc-500"><%= item[:label] || item[:role] %></div>
-                  <% end %>
-                  <div class="console-markdown text-sm leading-6"><%= console_markdown(item[:text].presence || "No text content.") %></div>
-                </div>
-                <div class="console-message-timestamp <%= "text-right" if user_message %>">
-                  <%= local_time(item[:created_at]) if item[:created_at] %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-
-        </div>
-      <% else %>
-        <div class="flex h-full items-center justify-center text-sm text-zinc-600">
-          <% if @sessions.empty? %>
-            No threads yet.
-          <% else %>
-            Select a thread from the sidebar.
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-  </section>
+    </section>
+  <% end %>
 </div>
 
 <script>
   (() => {
-    const scrollThreadTranscript = () => {
-      const transcript = document.getElementById("thread-transcript-scroll");
-      if (!transcript) return;
+    const scrollThreadTranscripts = () => {
+      const transcripts = document.querySelectorAll("[data-thread-transcript-scroll]");
+      if (!transcripts.length) return;
 
       window.requestAnimationFrame(() => {
-        transcript.scrollTop = transcript.scrollHeight;
+        transcripts.forEach((transcript) => {
+          transcript.scrollTop = transcript.scrollHeight;
+        });
       });
     };
 
     if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", scrollThreadTranscript, { once: true });
+      document.addEventListener("DOMContentLoaded", scrollThreadTranscripts, { once: true });
     } else {
-      scrollThreadTranscript();
+      scrollThreadTranscripts();
     }
   })();
 </script>

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -54,7 +54,7 @@
         </div>
       </div>
 
-      <div id="thread-transcript-scroll" class="min-h-0 flex-1 overflow-y-auto py-6" data-thread-transcript-scroll>
+      <div id="thread-transcript-scroll" class="console-transcript-scroll min-h-0 flex-1 overflow-y-auto py-6">
         <% if @selected_session %>
           <div class="console-thread-content flex flex-col gap-6">
             <%= render "console/threads/transcript", items: @selected_transcript_items %>
@@ -73,23 +73,3 @@
   <% end %>
 </div>
 
-<script>
-  (() => {
-    const scrollThreadTranscripts = () => {
-      const transcripts = document.querySelectorAll("[data-thread-transcript-scroll]");
-      if (!transcripts.length) return;
-
-      window.requestAnimationFrame(() => {
-        transcripts.forEach((transcript) => {
-          transcript.scrollTop = transcript.scrollHeight;
-        });
-      });
-    };
-
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", scrollThreadTranscripts, { once: true });
-    } else {
-      scrollThreadTranscripts();
-    }
-  })();
-</script>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -222,8 +222,8 @@
 
       .console-thread-list {
         display: grid;
-        gap: 0.125rem;
-        margin-top: 0.15rem;
+        gap: 0.3rem;
+        margin-top: 0.3rem;
       }
 
       .console-thread-link {
@@ -265,6 +265,22 @@
       .console-thread-time {
         color: #71717a;
         font-size: 0.75rem;
+      }
+
+      .console-panel-close {
+        display: grid;
+        height: 1.75rem;
+        width: 1.75rem;
+        flex: 0 0 auto;
+        place-items: center;
+        border-radius: 0.5rem;
+        color: #71717a;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .console-panel-close:hover {
+        background: rgba(255, 255, 255, 0.08);
+        color: #f4f4f5;
       }
 
       .console-thinking {
@@ -506,6 +522,9 @@
         display: flex;
         flex-direction: column;
         align-items: center;
+        /* Reserve symmetric scrollbar gutters so the centered transcript
+           column lines up with the (non-scrolling) header above it. */
+        scrollbar-gutter: stable both-edges;
       }
 
       .console-markdown {
@@ -660,6 +679,15 @@
 
       html[data-console-theme="light"] .console-thread-show-all:hover {
         color: #303438;
+      }
+
+      html[data-console-theme="light"] .console-panel-close {
+        color: #7a7f86;
+      }
+
+      html[data-console-theme="light"] .console-panel-close:hover {
+        background: #e8e9e3;
+        color: #24272b;
       }
 
       html[data-console-theme="light"] .console-thinking {

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -227,6 +227,7 @@
       }
 
       .console-thread-link {
+        position: relative;
         display: grid;
         min-width: 0;
         grid-template-columns: minmax(0, 1fr) auto;
@@ -237,6 +238,24 @@
         color: #d4d4d8;
         text-decoration: none;
         transition: background 120ms ease, color 120ms ease;
+      }
+
+      /* A thread open as a non-primary split-view pane: bright title plus a
+         small dot in the indent gutter, instead of another filled pill. */
+      .console-thread-link-open {
+        color: #f4f4f5;
+      }
+
+      .console-thread-link-open::before {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 1.35rem;
+        height: 0.3rem;
+        width: 0.3rem;
+        transform: translateY(-50%);
+        border-radius: 999px;
+        background: #28c26a;
       }
 
       .console-thread-link:hover {
@@ -676,6 +695,14 @@
         color: #303438;
       }
 
+      html[data-console-theme="light"] .console-thread-link-open {
+        color: #24272b;
+      }
+
+      html[data-console-theme="light"] .console-thread-link-open::before {
+        background: #28a65d;
+      }
+
       html[data-console-theme="light"] .console-thread-time,
       html[data-console-theme="light"] .console-thread-empty,
       html[data-console-theme="light"] .console-thread-show-all,
@@ -960,23 +987,27 @@
               <span class="console-nav-icon"><%= console_icon("message-square", classes: "size-4") %></span>
               <span class="console-nav-label">Threads</span>
             </a>
-            <div class="console-thread-list">
-              <%# The thread list is loaded lazily via a Turbo Frame so the
-                  unindexed cross-database sessions query never blocks the primary
-                  page render. See ApplicationController#init_console_sidebar_threads
-                  and Console::ThreadsController#sidebar. %>
-              <%# The current thread selection rides along on the frame src so the
-                  initial out-of-band render can surface and highlight the open
-                  thread(s). The frame is turbo-permanent: Turbo Drive carries
-                  the loaded list across page visits instead of refetching it,
-                  so thread navigation does not repaint the sidebar; the active
-                  highlight is re-synced client-side from the page URL. %>
+            <%# The thread list is loaded lazily via a Turbo Frame so the
+                unindexed cross-database sessions query never blocks the primary
+                page render. See ApplicationController#init_console_sidebar_threads
+                and Console::ThreadsController#sidebar.
+
+                The current thread selection rides along on the frame src so the
+                initial out-of-band render can surface and highlight the open
+                thread(s). The wrapper div (not the frame itself — a permanent
+                turbo-frame trips Turbo's frame lifecycle and can wedge the
+                visit progress bar) is turbo-permanent: Turbo Drive carries the
+                loaded list across page visits instead of refetching it, so
+                thread navigation does not repaint the sidebar; the active
+                highlight is re-synced client-side from the page URL. %>
+            <div id="console_sidebar_thread_list"
+                 class="console-thread-list"
+                 data-turbo-permanent>
               <%= turbo_frame_tag "console_sidebar_threads",
                                   src: console_sidebar_threads_path(
                                     thread: (params[:thread].to_s.presence if threads_view)
                                   ),
-                                  loading: :lazy,
-                                  data: { turbo_permanent: true } do %>
+                                  loading: :lazy do %>
                 <div class="console-thread-empty">Loading threads…</div>
               <% end %>
             </div>
@@ -1157,9 +1188,11 @@
 
           document.querySelectorAll("[data-console-thread-link]").forEach((link) => {
             const key = new URL(link.href, window.location.origin).searchParams.get("thread");
-            const active = openKeys.includes(key);
-            link.classList.toggle("console-thread-link-active", active);
-            if (active) link.classList.remove("console-thread-link-hidden");
+            const primary = openKeys[0] === key;
+            const open = !primary && openKeys.includes(key);
+            link.classList.toggle("console-thread-link-active", primary);
+            link.classList.toggle("console-thread-link-open", open);
+            if (primary || open) link.classList.remove("console-thread-link-hidden");
           });
         };
 

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -240,22 +240,22 @@
         transition: background 120ms ease, color 120ms ease;
       }
 
-      /* A thread open as a non-primary split-view pane: bright title plus a
-         small dot in the indent gutter, instead of another filled pill. */
+      /* An open thread: bright title plus its pane number (grid order) as a
+         small numeral in the indent gutter — no filled pill on thread rows. */
       .console-thread-link-open {
         color: #f4f4f5;
       }
 
       .console-thread-link-open::before {
-        content: "";
+        content: attr(data-console-pane-index);
         position: absolute;
         top: 50%;
-        left: 1.35rem;
-        height: 0.3rem;
-        width: 0.3rem;
+        left: 1.05rem;
         transform: translateY(-50%);
-        border-radius: 999px;
-        background: #28c26a;
+        color: #3ace79;
+        font-size: 0.6875rem;
+        font-weight: 700;
+        line-height: 1;
       }
 
       .console-thread-link:hover {
@@ -700,7 +700,7 @@
       }
 
       html[data-console-theme="light"] .console-thread-link-open::before {
-        background: #28a65d;
+        color: #168f4a;
       }
 
       html[data-console-theme="light"] .console-thread-time,
@@ -1188,11 +1188,15 @@
 
           document.querySelectorAll("[data-console-thread-link]").forEach((link) => {
             const key = new URL(link.href, window.location.origin).searchParams.get("thread");
-            const primary = openKeys[0] === key;
-            const open = !primary && openKeys.includes(key);
-            link.classList.toggle("console-thread-link-active", primary);
+            const paneIndex = openKeys.indexOf(key);
+            const open = paneIndex !== -1;
             link.classList.toggle("console-thread-link-open", open);
-            if (primary || open) link.classList.remove("console-thread-link-hidden");
+            if (open) {
+              link.dataset.consolePaneIndex = String(paneIndex + 1);
+              link.classList.remove("console-thread-link-hidden");
+            } else {
+              delete link.dataset.consolePaneIndex;
+            }
           });
         };
 
@@ -1203,39 +1207,56 @@
       })();
 
       (() => {
-        // Cmd/Ctrl-click on a sidebar thread adds it to the split-view grid.
-        // The thread param carries up to PANEL_LIMIT comma-separated keys, the
-        // first being the primary thread. Delegated on document because the
-        // thread list arrives later via the lazy Turbo Frame; Turbo already
-        // ignores modified clicks, so only the browser's new-tab default needs
-        // preventing.
+        // Sidebar thread clicks against the split-view grid. The thread param
+        // carries up to PANEL_LIMIT comma-separated keys in grid order.
+        //   - click or Cmd/Ctrl-click on an already-open thread closes it
+        //   - Cmd/Ctrl-click on a closed thread adds it as a pane
+        //   - plain click on a closed thread falls through to Turbo (replaces
+        //     the selection with that single thread)
+        // Capture phase so the close case wins over Turbo's own link handling;
+        // delegated on document because the list arrives via a lazy frame.
         const THREADS_PATH = "<%= console_threads_path %>";
         const PANEL_LIMIT = <%= Console::ThreadsController::PANEL_LIMIT %>;
 
         document.addEventListener("click", (event) => {
-          if (!(event.metaKey || event.ctrlKey)) return;
-
           const link = event.target.closest("[data-console-thread-link]");
           if (!link) return;
 
           const key = new URL(link.href, window.location.origin).searchParams.get("thread");
           if (!key) return;
 
-          event.preventDefault();
-
           const current = new URL(window.location.href);
-          const open = current.pathname.startsWith(THREADS_PATH)
+          const openKeys = current.pathname.startsWith(THREADS_PATH)
             ? (current.searchParams.get("thread") || "").split(",").filter(Boolean)
             : [];
-          if (!open.includes(key)) open.push(key);
+          const isOpen = openKeys.includes(key);
+          const modified = event.metaKey || event.ctrlKey;
 
-          // Keep the primary thread and the newest panes when over the limit.
-          const capped = open.length > PANEL_LIMIT
-            ? [open[0], ...open.slice(-(PANEL_LIMIT - 1))]
-            : open;
+          let nextKeys;
+          if (isOpen) {
+            nextKeys = openKeys.filter((openKey) => openKey !== key);
+          } else if (modified) {
+            nextKeys = [...openKeys, key];
+            // Keep the primary thread and the newest panes when over the limit.
+            if (nextKeys.length > PANEL_LIMIT) {
+              nextKeys = [nextKeys[0], ...nextKeys.slice(-(PANEL_LIMIT - 1))];
+            }
+          } else {
+            return;
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
 
           const next = new URL(THREADS_PATH, window.location.origin);
-          next.searchParams.set("thread", capped.join(","));
+          if (nextKeys.length) {
+            next.searchParams.set("thread", nextKeys.join(","));
+          } else {
+            // Closing the last open thread lands on the empty state instead of
+            // bouncing straight back via the auto-select redirect.
+            next.searchParams.set("new", "1");
+          }
+
           // Turbo visit keeps the turbo-permanent sidebar list mounted; a
           // plain location.assign would full-load and repaint it.
           if (window.Turbo) {
@@ -1243,7 +1264,7 @@
           } else {
             window.location.assign(next.toString());
           }
-        });
+        }, true);
       })();
     </script>
   </body>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1203,7 +1203,13 @@
 
           const next = new URL(THREADS_PATH, window.location.origin);
           next.searchParams.set("thread", capped.join(","));
-          window.location.assign(next.toString());
+          // Turbo visit keeps the turbo-permanent sidebar list mounted; a
+          // plain location.assign would full-load and repaint it.
+          if (window.Turbo) {
+            window.Turbo.visit(next.toString());
+          } else {
+            window.location.assign(next.toString());
+          }
         });
       })();
     </script>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -267,6 +267,95 @@
         font-size: 0.75rem;
       }
 
+      .console-thread-row {
+        position: relative;
+        min-width: 0;
+      }
+
+      .console-thread-split {
+        position: absolute;
+        top: 50%;
+        right: 0.5rem;
+        display: none;
+        height: 1.5rem;
+        width: 1.5rem;
+        transform: translateY(-50%);
+        cursor: pointer;
+        place-items: center;
+        border-radius: 0.5rem;
+        color: #71717a;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .console-thread-row:hover .console-thread-split,
+      .console-thread-split:focus-visible {
+        display: grid;
+      }
+
+      .console-thread-row:hover .console-thread-time {
+        opacity: 0;
+      }
+
+      .console-thread-split:hover {
+        background: rgba(255, 255, 255, 0.08);
+        color: #f4f4f5;
+      }
+
+      .console-thinking {
+        min-width: 0;
+        border-left: 2px solid rgba(255, 255, 255, 0.12);
+        padding-left: 0.875rem;
+      }
+
+      .console-thinking-summary {
+        display: flex;
+        min-width: 0;
+        align-items: center;
+        gap: 0.375rem;
+        cursor: pointer;
+        list-style: none;
+        user-select: none;
+        color: #71717a;
+        font-size: 0.75rem;
+      }
+
+      .console-thinking-summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .console-thinking-summary:hover {
+        color: #a1a1aa;
+      }
+
+      .console-thinking-chevron {
+        display: grid;
+        flex: 0 0 auto;
+        place-items: center;
+        transition: transform 120ms ease;
+      }
+
+      .console-thinking[open] .console-thinking-chevron {
+        transform: rotate(90deg);
+      }
+
+      .console-thinking-preview {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-style: italic;
+        color: #5f6068;
+      }
+
+      .console-thinking[open] .console-thinking-preview {
+        display: none;
+      }
+
+      .console-thinking-body {
+        margin-top: 0.5rem;
+        color: #8b8b94;
+      }
+
       .console-thread-empty,
       .console-thread-show-all {
         display: block;
@@ -605,6 +694,31 @@
 
       html[data-console-theme="light"] .console-thread-show-all:hover {
         color: #303438;
+      }
+
+      html[data-console-theme="light"] .console-thread-split:hover {
+        background: #e8e9e3;
+        color: #24272b;
+      }
+
+      html[data-console-theme="light"] .console-thinking {
+        border-left-color: #d8d8d0;
+      }
+
+      html[data-console-theme="light"] .console-thinking-summary {
+        color: #7a7f86;
+      }
+
+      html[data-console-theme="light"] .console-thinking-summary:hover {
+        color: #303438;
+      }
+
+      html[data-console-theme="light"] .console-thinking-preview {
+        color: #8c9198;
+      }
+
+      html[data-console-theme="light"] .console-thinking-body {
+        color: #565c63;
       }
 
       html[data-console-theme="light"] .console-user-avatar {
@@ -1020,6 +1134,42 @@
         wireShowMore();
         document.addEventListener("turbo:frame-load", (event) => {
           if (event.target && event.target.id === "console_sidebar_threads") wireShowMore();
+        });
+      })();
+
+      (() => {
+        // Sidebar "open in split view" buttons. Delegated on document because
+        // the thread list arrives later via the lazy Turbo Frame. Adds the
+        // thread as an extra pane of the threads grid (?panes=), or opens it as
+        // the primary thread when the current page has none.
+        const THREADS_PATH = "<%= console_threads_path %>";
+        const MAX_EXTRA_PANES = 3;
+
+        document.addEventListener("click", (event) => {
+          const button = event.target.closest("[data-console-thread-split]");
+          if (!button) return;
+
+          event.preventDefault();
+          const key = button.dataset.threadKey;
+          if (!key) return;
+
+          const current = new URL(window.location.href);
+          const primary = current.pathname.startsWith(THREADS_PATH)
+            ? current.searchParams.get("thread")
+            : null;
+
+          const next = new URL(THREADS_PATH, window.location.origin);
+          if (!primary || primary === key) {
+            next.searchParams.set("thread", key);
+          } else {
+            const panes = (current.searchParams.get("panes") || "")
+              .split(",")
+              .filter((pane) => pane && pane !== primary);
+            if (!panes.includes(key)) panes.push(key);
+            next.searchParams.set("thread", primary);
+            next.searchParams.set("panes", panes.slice(0, MAX_EXTRA_PANES).join(","));
+          }
+          window.location.assign(next.toString());
         });
       })();
     </script>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -267,40 +267,6 @@
         font-size: 0.75rem;
       }
 
-      .console-thread-row {
-        position: relative;
-        min-width: 0;
-      }
-
-      .console-thread-split {
-        position: absolute;
-        top: 50%;
-        right: 0.5rem;
-        display: none;
-        height: 1.5rem;
-        width: 1.5rem;
-        transform: translateY(-50%);
-        cursor: pointer;
-        place-items: center;
-        border-radius: 0.5rem;
-        color: #71717a;
-        transition: background 120ms ease, color 120ms ease;
-      }
-
-      .console-thread-row:hover .console-thread-split,
-      .console-thread-split:focus-visible {
-        display: grid;
-      }
-
-      .console-thread-row:hover .console-thread-time {
-        opacity: 0;
-      }
-
-      .console-thread-split:hover {
-        background: rgba(255, 255, 255, 0.08);
-        color: #f4f4f5;
-      }
-
       .console-thinking {
         min-width: 0;
         border-left: 2px solid rgba(255, 255, 255, 0.12);
@@ -694,11 +660,6 @@
 
       html[data-console-theme="light"] .console-thread-show-all:hover {
         color: #303438;
-      }
-
-      html[data-console-theme="light"] .console-thread-split:hover {
-        background: #e8e9e3;
-        color: #24272b;
       }
 
       html[data-console-theme="light"] .console-thinking {
@@ -1138,37 +1099,39 @@
       })();
 
       (() => {
-        // Sidebar "open in split view" buttons. Delegated on document because
-        // the thread list arrives later via the lazy Turbo Frame. Adds the
-        // thread as an extra pane of the threads grid (?panes=), or opens it as
-        // the primary thread when the current page has none.
+        // Cmd/Ctrl-click on a sidebar thread adds it to the split-view grid.
+        // The thread param carries up to PANEL_LIMIT comma-separated keys, the
+        // first being the primary thread. Delegated on document because the
+        // thread list arrives later via the lazy Turbo Frame; Turbo already
+        // ignores modified clicks, so only the browser's new-tab default needs
+        // preventing.
         const THREADS_PATH = "<%= console_threads_path %>";
-        const MAX_EXTRA_PANES = 3;
+        const PANEL_LIMIT = <%= Console::ThreadsController::PANEL_LIMIT %>;
 
         document.addEventListener("click", (event) => {
-          const button = event.target.closest("[data-console-thread-split]");
-          if (!button) return;
+          if (!(event.metaKey || event.ctrlKey)) return;
 
-          event.preventDefault();
-          const key = button.dataset.threadKey;
+          const link = event.target.closest("[data-console-thread-link]");
+          if (!link) return;
+
+          const key = new URL(link.href, window.location.origin).searchParams.get("thread");
           if (!key) return;
 
+          event.preventDefault();
+
           const current = new URL(window.location.href);
-          const primary = current.pathname.startsWith(THREADS_PATH)
-            ? current.searchParams.get("thread")
-            : null;
+          const open = current.pathname.startsWith(THREADS_PATH)
+            ? (current.searchParams.get("thread") || "").split(",").filter(Boolean)
+            : [];
+          if (!open.includes(key)) open.push(key);
+
+          // Keep the primary thread and the newest panes when over the limit.
+          const capped = open.length > PANEL_LIMIT
+            ? [open[0], ...open.slice(-(PANEL_LIMIT - 1))]
+            : open;
 
           const next = new URL(THREADS_PATH, window.location.origin);
-          if (!primary || primary === key) {
-            next.searchParams.set("thread", key);
-          } else {
-            const panes = (current.searchParams.get("panes") || "")
-              .split(",")
-              .filter((pane) => pane && pane !== primary);
-            if (!panes.includes(key)) panes.push(key);
-            next.searchParams.set("thread", primary);
-            next.searchParams.set("panes", panes.slice(0, MAX_EXTRA_PANES).join(","));
-          }
+          next.searchParams.set("thread", capped.join(","));
           window.location.assign(next.toString());
         });
       })();

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -930,8 +930,13 @@
                   unindexed cross-database sessions query never blocks the primary
                   page render. See ApplicationController#init_console_sidebar_threads
                   and Console::ThreadsController#sidebar. %>
+              <%# The current thread selection rides along on the frame src so the
+                  out-of-band sidebar render can highlight the open thread(s);
+                  without it the lazy fetch has no params. %>
               <%= turbo_frame_tag "console_sidebar_threads",
-                                  src: console_sidebar_threads_path,
+                                  src: console_sidebar_threads_path(
+                                    thread: (params[:thread].to_s.presence if threads_view)
+                                  ),
                                   loading: :lazy do %>
                 <div class="console-thread-empty">Loading threads…</div>
               <% end %>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -518,9 +518,16 @@
         flex: 0 0 auto;
       }
 
-      #thread-transcript-scroll {
+      /* Transcript scroll containers hold a single content child inside a
+         column-reverse flex, which makes the scroll origin the bottom: threads
+         open already scrolled to the newest message, with no post-render JS
+         jump and no reflow drift when webfonts land. */
+      .console-transcript-scroll {
         display: flex;
-        flex-direction: column;
+        flex-direction: column-reverse;
+      }
+
+      #thread-transcript-scroll {
         align-items: center;
         /* Reserve symmetric scrollbar gutters so the centered transcript
            column lines up with the (non-scrolling) header above it. */

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -240,18 +240,33 @@
         transition: background 120ms ease, color 120ms ease;
       }
 
-      /* An open thread: bright title plus its pane number (grid order) as a
-         small numeral in the indent gutter — no filled pill on thread rows. */
+      /* An open thread: bright title plus a marker in the indent gutter — no
+         filled pill on thread rows. A single open thread gets a dot; once a
+         second pane opens, rows carry data-console-pane-index and the marker
+         becomes the pane number in grid order. */
       .console-thread-link-open {
         color: #f4f4f5;
       }
 
       .console-thread-link-open::before {
-        content: attr(data-console-pane-index);
+        content: "";
         position: absolute;
         top: 50%;
-        left: 1.05rem;
+        left: 1.35rem;
+        height: 0.3rem;
+        width: 0.3rem;
         transform: translateY(-50%);
+        border-radius: 999px;
+        background: #28c26a;
+      }
+
+      .console-thread-link-open[data-console-pane-index]::before {
+        content: attr(data-console-pane-index);
+        left: 1.05rem;
+        height: auto;
+        width: auto;
+        border-radius: 0;
+        background: none;
         color: #3ace79;
         font-size: 0.6875rem;
         font-weight: 700;
@@ -700,6 +715,11 @@
       }
 
       html[data-console-theme="light"] .console-thread-link-open::before {
+        background: #28a65d;
+      }
+
+      html[data-console-theme="light"] .console-thread-link-open[data-console-pane-index]::before {
+        background: none;
         color: #168f4a;
       }
 
@@ -1192,7 +1212,12 @@
             const open = paneIndex !== -1;
             link.classList.toggle("console-thread-link-open", open);
             if (open) {
-              link.dataset.consolePaneIndex = String(paneIndex + 1);
+              // Dot for a single open thread; numbers once a second pane opens.
+              if (openKeys.length > 1) {
+                link.dataset.consolePaneIndex = String(paneIndex + 1);
+              } else {
+                delete link.dataset.consolePaneIndex;
+              }
               link.classList.remove("console-thread-link-hidden");
             } else {
               delete link.dataset.consolePaneIndex;

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -966,13 +966,17 @@
                   page render. See ApplicationController#init_console_sidebar_threads
                   and Console::ThreadsController#sidebar. %>
               <%# The current thread selection rides along on the frame src so the
-                  out-of-band sidebar render can highlight the open thread(s);
-                  without it the lazy fetch has no params. %>
+                  initial out-of-band render can surface and highlight the open
+                  thread(s). The frame is turbo-permanent: Turbo Drive carries
+                  the loaded list across page visits instead of refetching it,
+                  so thread navigation does not repaint the sidebar; the active
+                  highlight is re-synced client-side from the page URL. %>
               <%= turbo_frame_tag "console_sidebar_threads",
                                   src: console_sidebar_threads_path(
                                     thread: (params[:thread].to_s.presence if threads_view)
                                   ),
-                                  loading: :lazy do %>
+                                  loading: :lazy,
+                                  data: { turbo_permanent: true } do %>
                 <div class="console-thread-empty">Loading threads…</div>
               <% end %>
             </div>
@@ -1135,6 +1139,33 @@
         wireShowMore();
         document.addEventListener("turbo:frame-load", (event) => {
           if (event.target && event.target.id === "console_sidebar_threads") wireShowMore();
+        });
+      })();
+
+      (() => {
+        // The sidebar thread list is turbo-permanent, so it is not re-rendered
+        // when navigating between threads. Re-derive the active highlight from
+        // the page URL after every Turbo visit and after the frame's initial
+        // lazy load, un-hiding an open thread that sits in the collapsed tail.
+        const THREADS_PATH = "<%= console_threads_path %>";
+
+        const syncSidebarActiveThreads = () => {
+          const url = new URL(window.location.href);
+          const openKeys = url.pathname.startsWith(THREADS_PATH)
+            ? (url.searchParams.get("thread") || "").split(",").filter(Boolean)
+            : [];
+
+          document.querySelectorAll("[data-console-thread-link]").forEach((link) => {
+            const key = new URL(link.href, window.location.origin).searchParams.get("thread");
+            const active = openKeys.includes(key);
+            link.classList.toggle("console-thread-link-active", active);
+            if (active) link.classList.remove("console-thread-link-hidden");
+          });
+        };
+
+        document.addEventListener("turbo:load", syncSidebarActiveThreads);
+        document.addEventListener("turbo:frame-load", (event) => {
+          if (event.target && event.target.id === "console_sidebar_threads") syncSidebarActiveThreads();
         });
       })();
 

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -647,7 +647,8 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_select "[data-thread-panel]", count: 0
-    assert_select "#thread-transcript-scroll[data-thread-transcript-scroll]"
+    # column-reverse scroll container opens the thread at its newest message.
+    assert_select "#thread-transcript-scroll.console-transcript-scroll"
   end
 
   test "sidebar thread links carry the cmd-click split view hook" do

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -580,13 +580,13 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: non_string, created_at: now))
   end
 
-  test "requested pane thread keys are deduped, stripped, and capped" do
+  test "requested thread keys are deduped, stripped, and capped at the panel limit" do
     controller = Console::ThreadsController.new
     controller.params = ActionController::Parameters.new(
-      panes: " a , b,a,, c ,d,e "
+      thread: " a , b,a,, c ,d,e "
     )
 
-    assert_equal %w[a b c], controller.send(:requested_pane_thread_keys)
+    assert_equal %w[a b c d], controller.send(:requested_thread_keys)
   end
 
   test "thinking trace renders as a collapsed disclosure in the transcript" do
@@ -614,7 +614,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     insert_console_session(pane_key)
     insert_slack_session(unowned_key, slack_user_id: "U_OTHER", slack_user_name: "someone-else")
 
-    get console_threads_url(thread: primary_key, panes: [ pane_key, unowned_key ].join(","))
+    get console_threads_url(thread: [ primary_key, pane_key, unowned_key ].join(","))
 
     assert_response :ok
     assert_select "[data-thread-panel]", count: 2
@@ -631,7 +631,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     keys = Array.new(5) { |i| "console:panel-cap-#{i}-#{SecureRandom.hex(4)}" }
     keys.each { |key| insert_console_session(key) }
 
-    get console_threads_url(thread: keys.first, panes: keys.drop(1).join(","))
+    get console_threads_url(thread: keys.join(","))
 
     assert_response :ok
     assert_select "[data-thread-panel]", count: Console::ThreadsController::PANEL_LIMIT
@@ -650,7 +650,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "#thread-transcript-scroll[data-thread-transcript-scroll]"
   end
 
-  test "sidebar thread rows expose a split view button" do
+  test "sidebar thread links carry the cmd-click split view hook" do
     skip_unless_session_table
 
     thread_key = "console:sidebar-split-#{SecureRandom.hex(8)}"
@@ -659,7 +659,29 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     get console_sidebar_threads_url
 
     assert_response :ok
-    assert_select "button[data-console-thread-split][data-thread-key=?]", thread_key
+    # The layout's Cmd/Ctrl-click handler targets this attribute to add the
+    # thread to the split-view grid.
+    assert_select "a[data-console-thread-link][href=?]",
+                  console_threads_path(thread: thread_key)
+  end
+
+  test "split view close control drops one thread and keeps the rest open" do
+    skip_unless_session_table
+
+    keys = Array.new(3) { |i| "console:panel-close-#{i}-#{SecureRandom.hex(4)}" }
+    keys.each { |key| insert_console_session(key) }
+
+    get console_threads_url(thread: keys.join(","))
+
+    assert_response :ok
+    # Closing the middle panel keeps the primary and the last pane.
+    assert_select "[data-thread-panel=?] a[aria-label='Close panel'][href=?]",
+                  keys[1],
+                  console_threads_path(thread: [ keys[0], keys[2] ].join(","))
+    # Closing the primary panel promotes the next thread to primary.
+    assert_select "[data-thread-panel=?] a[aria-label='Close panel'][href=?]",
+                  keys[0],
+                  console_threads_path(thread: [ keys[1], keys[2] ].join(","))
   end
 
   private

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -691,11 +691,13 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     get console_sidebar_threads_url(thread: keys.join(","))
 
     assert_response :ok
-    # Primary thread gets the filled pill; other open panes get the dot marker.
-    assert_select "a.console-thread-link-active[href=?]",
+    # Open threads carry their 1-based pane number in grid order; no filled
+    # pill on thread rows.
+    assert_select "a.console-thread-link-open[data-console-pane-index='1'][href=?]",
                   console_threads_path(thread: keys.first)
-    assert_select "a.console-thread-link-open[href=?]",
+    assert_select "a.console-thread-link-open[data-console-pane-index='2'][href=?]",
                   console_threads_path(thread: keys.last)
+    assert_select "a.console-thread-link-active", count: 0
   end
 
   test "split view close control drops one thread and keeps the rest open" do

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -691,10 +691,11 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     get console_sidebar_threads_url(thread: keys.join(","))
 
     assert_response :ok
-    keys.each do |key|
-      assert_select "a.console-thread-link-active[href=?]",
-                    console_threads_path(thread: key)
-    end
+    # Primary thread gets the filled pill; other open panes get the dot marker.
+    assert_select "a.console-thread-link-active[href=?]",
+                  console_threads_path(thread: keys.first)
+    assert_select "a.console-thread-link-open[href=?]",
+                  console_threads_path(thread: keys.last)
   end
 
   test "split view close control drops one thread and keeps the rest open" do

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -665,6 +665,37 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
                   console_threads_path(thread: thread_key)
   end
 
+  # The sidebar list loads out of band via a lazy Turbo Frame, so the page must
+  # forward the current thread selection on the frame src for the active
+  # highlight to render.
+  test "threads page forwards the thread selection to the sidebar frame src" do
+    skip_unless_session_table
+
+    thread_key = "console:sidebar-active-#{SecureRandom.hex(8)}"
+    insert_console_session(thread_key)
+
+    get console_threads_url(thread: thread_key)
+
+    assert_response :ok
+    assert_select "turbo-frame#console_sidebar_threads[src=?]",
+                  console_sidebar_threads_path(thread: thread_key)
+  end
+
+  test "sidebar highlights every open thread of a split view" do
+    skip_unless_session_table
+
+    keys = Array.new(2) { |i| "console:sidebar-open-#{i}-#{SecureRandom.hex(4)}" }
+    keys.each { |key| insert_console_session(key) }
+
+    get console_sidebar_threads_url(thread: keys.join(","))
+
+    assert_response :ok
+    keys.each do |key|
+      assert_select "a.console-thread-link-active[href=?]",
+                    console_threads_path(thread: key)
+    end
+  end
+
   test "split view close control drops one thread and keeps the rest open" do
     skip_unless_session_table
 

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -527,6 +527,141 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal indices, indices.sort
   end
 
+  OutputLineEvent = Struct.new(:payload, :created_at, keyword_init: true)
+
+  test "thinking transcript item is extracted from a completed reasoning output line" do
+    controller = Console::ThreadsController.new
+    line = {
+      method: "item/completed",
+      params: {
+        item: {
+          type: "reasoning",
+          content: [ "First I will check the schema.", "Then write the query." ]
+        }
+      }
+    }.to_json
+    event = OutputLineEvent.new(payload: line, created_at: Time.zone.parse("2026-06-26 17:15:58 UTC"))
+
+    item = controller.send(:thinking_transcript_item, event)
+
+    assert_equal "thinking", item[:role]
+    assert_equal "Thinking", item[:label]
+    assert_equal :thinking, item[:source]
+    assert_equal :start, item[:align]
+    assert_equal "First I will check the schema.\nThen write the query.", item[:text]
+    assert_equal event.created_at, item[:created_at]
+  end
+
+  test "thinking extraction accepts dot-form types and summary-only reasoning" do
+    controller = Console::ThreadsController.new
+    line = {
+      type: "item.completed",
+      item: { type: "reasoning", summary: [ { text: "Condensed thought." } ] }
+    }.to_json
+    event = OutputLineEvent.new(payload: line, created_at: Time.zone.now)
+
+    item = controller.send(:thinking_transcript_item, event)
+
+    assert_equal "Condensed thought.", item[:text]
+  end
+
+  test "thinking extraction ignores non-reasoning and non-completed output lines" do
+    controller = Console::ThreadsController.new
+    now = Time.zone.now
+
+    delta = { method: "item/reasoning/textDelta", params: { delta: "partial" } }.to_json
+    tool = { method: "item/completed", params: { item: { type: "mcpToolCall" } } }.to_json
+    non_json = "plain stdout noise mentioning reasoning"
+    non_string = { "result" => "reasoning" }
+
+    assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: delta, created_at: now))
+    assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: tool, created_at: now))
+    assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: non_json, created_at: now))
+    assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: non_string, created_at: now))
+  end
+
+  test "requested pane thread keys are deduped, stripped, and capped" do
+    controller = Console::ThreadsController.new
+    controller.params = ActionController::Parameters.new(
+      panes: " a , b,a,, c ,d,e "
+    )
+
+    assert_equal %w[a b c], controller.send(:requested_pane_thread_keys)
+  end
+
+  test "thinking trace renders as a collapsed disclosure in the transcript" do
+    skip_unless_session_table
+
+    thread_key = "console:thinking-#{SecureRandom.hex(8)}"
+    insert_console_session(thread_key)
+    insert_session_message(thread_key, index: 0)
+    insert_reasoning_event(thread_key, text: "I should compare the two schemas before answering.")
+
+    get console_threads_url(thread: thread_key)
+
+    assert_response :ok
+    assert_select "details.console-thinking summary", text: /Thinking/
+    assert_select "details.console-thinking", text: /compare the two schemas/
+  end
+
+  test "split view renders owned panes as panels and drops unowned keys" do
+    skip_unless_session_table
+
+    primary_key = "console:panel-a-#{SecureRandom.hex(6)}"
+    pane_key = "console:panel-b-#{SecureRandom.hex(6)}"
+    unowned_key = "slack:C0PANEL:#{SecureRandom.hex(6)}"
+    insert_console_session(primary_key)
+    insert_console_session(pane_key)
+    insert_slack_session(unowned_key, slack_user_id: "U_OTHER", slack_user_name: "someone-else")
+
+    get console_threads_url(thread: primary_key, panes: [ pane_key, unowned_key ].join(","))
+
+    assert_response :ok
+    assert_select "[data-thread-panel]", count: 2
+    assert_select "[data-thread-panel=?]", primary_key
+    assert_select "[data-thread-panel=?]", pane_key
+    assert_select "[data-thread-panel=?]", unowned_key, count: 0
+    # Each panel exposes a close control back to the remaining threads.
+    assert_select "[data-thread-panel] a[aria-label='Close panel']", count: 2
+  end
+
+  test "split view caps the grid at four panels" do
+    skip_unless_session_table
+
+    keys = Array.new(5) { |i| "console:panel-cap-#{i}-#{SecureRandom.hex(4)}" }
+    keys.each { |key| insert_console_session(key) }
+
+    get console_threads_url(thread: keys.first, panes: keys.drop(1).join(","))
+
+    assert_response :ok
+    assert_select "[data-thread-panel]", count: Console::ThreadsController::PANEL_LIMIT
+  end
+
+  test "single thread view does not render the split grid" do
+    skip_unless_session_table
+
+    thread_key = "console:solo-#{SecureRandom.hex(8)}"
+    insert_console_session(thread_key)
+
+    get console_threads_url(thread: thread_key)
+
+    assert_response :ok
+    assert_select "[data-thread-panel]", count: 0
+    assert_select "#thread-transcript-scroll[data-thread-transcript-scroll]"
+  end
+
+  test "sidebar thread rows expose a split view button" do
+    skip_unless_session_table
+
+    thread_key = "console:sidebar-split-#{SecureRandom.hex(8)}"
+    insert_console_session(thread_key)
+
+    get console_sidebar_threads_url
+
+    assert_response :ok
+    assert_select "button[data-console-thread-split][data-thread-key=?]", thread_key
+  end
+
   private
 
   def with_recent_first_error
@@ -593,6 +728,25 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
         #{connection.quote(parts)}::jsonb,
         '{}'::jsonb,
         now() + (#{index} * interval '1 second')
+      )
+    SQL
+  end
+
+  # Mirrors how api-rs persists harness stdout: the payload column is a
+  # JSON-encoded *string* holding one protocol notification line.
+  def insert_reasoning_event(thread_key, text:)
+    connection = CentaurSession.connection
+    line = {
+      method: "item/completed",
+      params: { item: { type: "reasoning", content: [ text ] } }
+    }.to_json
+    connection.execute(<<~SQL.squish)
+      insert into session_events (thread_key, event_type, payload, created_at)
+      values (
+        #{connection.quote(thread_key)},
+        'session.output.line',
+        #{connection.quote(line.to_json)}::jsonb,
+        now()
       )
     SQL
   end


### PR DESCRIPTION
Stacked on #843. Adds two Console-only features the Slack surface can't offer, to showcase the Threads view.

## Split view (Claude-app-style panels)

- Cmd/Ctrl-click a sidebar thread to open it alongside the current one, up to four threads in a grid: 2 render side by side, 3 as columns, 4 as a 2x2 grid.
- The `thread` param simply carries the open keys comma-separated (`?thread=<primary>,<key2>,<key3>,<key4>`), primary first — no separate panes param. When over the limit, the primary and newest panes are kept.
- Each panel header links to the thread solo and has a close control that drops that key (closing the primary promotes the next thread).
- All keys resolve through the same owner scope as a single thread, so crafted URLs cannot surface another user's threads; unowned keys are dropped silently.
- Mention-label and inferred-bot memos are reset per panel; the primary panel is built last so the existing `@selected_*` state (page header, tests) still reflects the primary thread.

## Thinking traces

- api-rs persists every harness stdout line verbatim as `session.output.line` events, including `item/completed` notifications with `item.type == "reasoning"` carrying the full accumulated thinking text (Claude Code and Amp via harness-server normalization, Codex natively — summary-only reasoning is also handled).
- The transcript now extracts those (SQL `LIKE '%reasoning%'` pre-filter, exact matching in Ruby, capped at 200 events) and renders each thought as a collapsed "Thinking" disclosure interleaved at its true timestamp, Claude-app style.
- `scripts/mirror-prod-threads-snapshot.sh` additionally exports reasoning output lines (new `THINKING_EVENT_LIMIT_PER_THREAD`, default 200/thread) so mirrored local snapshots show traces.

## Tests

- `docker exec -e CENTAUR_CONSOLE_THREADS_READ_ONLY=0 codex-centaur-console-web bin/rails test test/controllers/console/threads_controller_test.rb` — 38 runs, 0 failures (new coverage: reasoning-line extraction incl. dot-form/summary/noise cases, thread-list parsing, owned/unowned pane resolution, 4-panel cap, close-control links, sidebar cmd-click hook, thinking disclosure rendering).
- Full console suite: 972 runs, 3 pre-existing env-related failures in `centaur_session_record_test.rb` (fallback DB-name assertions that fail whenever `CENTAUR_CONSOLE_CENTAUR_DATABASE_URL` is set in the container; reproduce without this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
